### PR TITLE
fix: InferenceService stuck in Pending when Model becomes Ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ cd LLMKube
 make install
 
 # Deploy controller with pre-built image
-make deploy IMG=ghcr.io/defilantech/llmkube-controller:v0.2.0
+make deploy IMG=ghcr.io/defilantech/llmkube-controller:0.2.1
 
 # Verify controller is running
 kubectl get pods -n llmkube-system

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/defilantech/llmkube-controller
-  newTag: "0.2.0"
+  newTag: 0.2.0


### PR DESCRIPTION
## Description

Fixes a critical bug where InferenceServices would remain stuck in "Pending" state indefinitely, even after their referenced Models successfully downloaded and became Ready.

## Problem

The InferenceService controller was not watching Model resources for changes. The reconciliation flow was:
1. InferenceService created → reconcile triggered
2. Controller checks Model status → sees "Downloading"
3. Controller updates InferenceService to "Pending" state
4. Model finishes downloading → becomes "Ready"
5. **InferenceService never reconciles again** → stuck in "Pending" forever

## Solution

Added a watch for Model resources in the InferenceService controller:
- Implemented `Watches()` in `SetupWithManager()` to monitor Model changes
- Created `findInferenceServicesForModel()` function to trigger reconciliation of all InferenceServices that reference a changed Model
- When a Model transitions to "Ready", all dependent InferenceServices are now automatically reconciled

## Changes

- `internal/controller/inferenceservice_controller.go`: Added Model watch and mapping function
- `README.md`: Updated quickstart to reference v0.2.1 (which will include this fix)
- `config/manager/kustomization.yaml`: Updated during testing

## Testing

Tested on microk8s cluster with tinyllama deployment:
- ✅ Model successfully downloads and becomes "Ready"
- ✅ InferenceService automatically reconciles when Model becomes Ready
- ✅ InferenceService transitions from "Pending" → "Ready"
- ✅ Deployment and Service created successfully
- ✅ Inference endpoint responds correctly to chat completion requests

## Checklist

- [x] Code follows conventional commit format
- [x] Manually tested in Kubernetes cluster
- [x] Documentation updated (README)
- [x] No breaking changes
- [x] Fixes critical bug preventing InferenceServices from starting

## Impact

This is a critical bug fix that affects all InferenceService deployments in v0.2.0. Without this fix, users following the quickstart guide will experience timeouts when trying to deploy models.