### PR TITLE
fix: Update version.go to 0.2.1 and add automation for future releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,31 @@ jobs:
         with:
           name: release-artifacts
           path: dist/*
+
+      - name: Update version.go to match release tag
+        run: |
+          # Extract version from tag (e.g., v0.2.1 -> 0.2.1)
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Updating version.go to $VERSION"
+
+          # Update version.go
+          sed -i.bak "s/Version = \".*\"/Version = \"$VERSION\"/" pkg/cli/version.go
+          rm -f pkg/cli/version.go.bak
+
+          # Check if there are changes
+          if git diff --quiet pkg/cli/version.go; then
+            echo "No changes needed to version.go"
+            exit 0
+          fi
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Commit and push
+          git checkout main
+          git add pkg/cli/version.go
+          git commit -m "chore: Bump version.go to $VERSION after release"
+          git push origin main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// Version is set during build
-	Version = "0.2.0"
+	Version = "0.2.1"
 	// GitCommit is set during build
 	GitCommit = "unknown"
 	// BuildDate is set during build


### PR DESCRIPTION
## Summary

Fixes #27 

Updates `version.go` to 0.2.1 and adds automation to keep it in sync with future releases.

## Problem

After releasing v0.2.1, the hardcoded version in `pkg/cli/version.go` remained at 0.2.0. While released binaries get the correct version from git tags via GoReleaser ldflags, local development builds use the hardcoded fallback, causing inconsistency.

## Changes

1. **Updated `pkg/cli/version.go`**: Bumped version from 0.2.0 to 0.2.1
2. **Added automation to `.github/workflows/release.yml`**: After each successful release, the workflow now:
   - Extracts the version from the git tag
   - Updates `version.go` to match
   - Commits and pushes the change back to main

## Benefits

- ✅ Local development builds show correct version
- ✅ Eliminates manual version bumps
- ✅ Maintains consistency across released binaries and dev builds
- ✅ Fully automated for future releases

## Testing

- [x] Verified version.go updated to 0.2.1
- [x] Reviewed automation script logic
- [ ] Will be validated on next release (v0.2.2)

## Version Management Architecture

| Context | Version Source | After This PR |
|---------|---------------|---------------|
| Released binaries | Git tag (via GoReleaser ldflags) | ✅ Correct |
| Local dev builds | version.go hardcoded value | ✅ Now synced! |
| Future releases | Automated by workflow | ✅ Automatic |