### PR TITLE
chore: Optimize CI workflows to eliminate duplicate runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: Lint
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,7 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Tests
 
 on:
-  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary

Optimizes GitHub Actions workflows to eliminate duplicate runs and save CI minutes.

## Problem

Currently, test and lint workflows trigger on both `push` and `pull_request` events. This causes duplicate runs:
- When you push to a PR branch, workflows run **twice**:
  1. Once for the `push` event
  2. Once for the `pull_request` event

This wastes CI/CD resources and creates redundant checks.

## Solution

Since the repository has branch protection requiring all changes to go through PRs, running workflows only on `pull_request` events provides the same coverage without duplication.

## Changes

Updated workflow triggers from:
```yaml
on:
  push:
  pull_request:
```

To:
```yaml
on:
  pull_request:
```

**Affected workflows**:
- `lint.yml` - Code linting
- `test.yml` - Unit tests
- `test-e2e.yml` - End-to-end tests

**Not changed**:
- `release.yml` - Still triggers on tag push (v*.*.*)
- `helm-chart.yml` - Needs review separately

## Benefits

- **50% reduction** in workflow runs for PR changes
- Faster feedback (no waiting for duplicate runs)
- Lower GitHub Actions usage
- Cleaner workflow run history

## Testing

This PR itself will demonstrate the optimization - workflows will run once instead of twice.

## Checklist

- [x] Updated lint workflow
- [x] Updated test workflow  
- [x] Updated E2E test workflow
- [x] Verified release workflow unchanged