### PR TITLE
fix: Increase Helm chart CI timeout from 2m to 5m

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -243,7 +243,7 @@ jobs:
             --namespace llmkube-system \
             --create-namespace \
             --wait \
-            --timeout 2m
+            --timeout 5m
           echo "✅ Chart installed successfully"
 
       - name: Verify Installation
@@ -271,7 +271,7 @@ jobs:
             --namespace llmkube-system \
             --set controllerManager.resources.limits.cpu=1 \
             --wait \
-            --timeout 2m
+            --timeout 5m
           echo "✅ Chart upgrade successful"
 
       - name: Test Helm Uninstall


### PR DESCRIPTION
## Summary
Fixes the timeout issue in the Helm chart CI workflow where installations were failing with "context deadline exceeded" errors.

## Changes
- Increased Helm install timeout from 2m to 5m in the package-test job
- Increased Helm upgrade timeout from 2m to 5m in the upgrade test

## Why
In fresh Kind clusters, 2 minutes is insufficient for:
- Pulling the controller image from ghcr.io
- Container startup and initialization
- Readiness probe checks (initialDelaySeconds: 5s, periodSeconds: 10s)

CI environments often have additional latency due to network conditions and shared resources, making a 5-minute timeout more appropriate for reliable testing.

## Testing
The CI workflow will run automatically on this PR to verify the fix works.

Fixes #36 (if issue exists, otherwise remove this line)