### PR TITLE
fix: Further increase Helm CI timeout and readiness probe delay

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -243,8 +243,18 @@ jobs:
             --namespace llmkube-system \
             --create-namespace \
             --wait \
-            --timeout 5m
+            --timeout 10m \
+            --set controllerManager.readinessProbe.initialDelaySeconds=30
           echo "✅ Chart installed successfully"
+
+      - name: Debug Pod Status (if needed)
+        if: failure()
+        run: |
+          echo "Checking pod status..."
+          kubectl get pods -n llmkube-system
+          kubectl describe pods -n llmkube-system
+          echo "Checking pod logs..."
+          kubectl logs -n llmkube-system -l control-plane=controller-manager --tail=100 || true
 
       - name: Verify Installation
         run: |
@@ -270,8 +280,9 @@ jobs:
           helm upgrade llmkube /tmp/llmkube-*.tgz \
             --namespace llmkube-system \
             --set controllerManager.resources.limits.cpu=1 \
+            --set controllerManager.readinessProbe.initialDelaySeconds=30 \
             --wait \
-            --timeout 5m
+            --timeout 10m
           echo "✅ Chart upgrade successful"
 
       - name: Test Helm Uninstall


### PR DESCRIPTION
## Problem

The Helm chart CI was timing out after the previous fix increased timeout from 2m to 5m. The issue is that Kind clusters in CI environments are resource-constrained, and the controller needs more time to:

1. Pull the container image from ghcr.io
2. Start up and initialize
3. Pass readiness probes

## Changes

- **Increased timeout from 5m to 10m** - Gives adequate time for image pull and pod startup
- **Set readinessProbe.initialDelaySeconds to 30s in CI** - Prevents premature probe failures during controller startup
- **Added debug step** - On failure, CI will now show pod status, descriptions, and logs to help diagnose issues

## Testing

This PR will trigger the CI workflow. The changes should prevent timeouts in the `package-test` job during Helm install and upgrade operations.

## Related

- Builds on #37 which initially increased timeout from 2m to 5m
- Addresses continued timeout issues in CI environment