### PR TITLE
fix: Update operator deployment to use correct container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= ghcr.io/defilantech/llmkube-controller:0.3.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ brew tap defilantech/tap && brew install llmkube  # macOS
 # 2. Start Minikube
 minikube start --cpus 4 --memory 8192
 
-# 3. Install LLMKube operator
-kubectl apply -k https://github.com/defilantech/LLMKube/config/default
+# 3. Install LLMKube operator with Helm (recommended)
+helm install llmkube https://github.com/defilantech/LLMKube/releases/download/v0.3.0/llmkube-0.3.0.tgz \
+  --namespace llmkube-system --create-namespace
 
 # 4. Deploy a model from the catalog (one command!)
 llmkube deploy phi-3-mini --cpu 500m --memory 1Gi
@@ -93,16 +94,20 @@ llmkube deploy llama-3.1-8b --gpu
 ```
 
 <details>
-<summary><b>Option 2: Using kubectl (No CLI Installation)</b></summary>
+<summary><b>Option 2: Using kubectl (No CLI or Helm)</b></summary>
 
-If you prefer not to install the CLI, use kubectl directly:
+If you prefer not to install the CLI or Helm, use kubectl with kustomize:
 
 ```bash
 # Start Minikube
 minikube start --cpus 4 --memory 8192
 
-# Install LLMKube operator
-kubectl apply -k https://github.com/defilantech/LLMKube/config/default
+# Install LLMKube operator (note: requires cloning the repo for correct image tags)
+git clone https://github.com/defilantech/LLMKube.git
+cd LLMKube
+kubectl apply -k config/default
+
+# Or install just the CRDs and use local controller (see minikube-quickstart.md)
 
 # Deploy a model (copy-paste this whole block)
 kubectl apply -f - <<EOF
@@ -238,7 +243,13 @@ helm install llmkube charts/llmkube \
 ### Option 2: Kustomize
 
 ```bash
-kubectl apply -k https://github.com/defilantech/LLMKube/config/default
+# Clone the repo to get the correct image configuration
+git clone https://github.com/defilantech/LLMKube.git
+cd LLMKube
+kubectl apply -k config/default
+
+# Or use make deploy (requires kustomize installed)
+make deploy
 ```
 
 ### Option 3: Local Development

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: latest
+  newName: ghcr.io/defilantech/llmkube-controller
+  newTag: 0.3.0

--- a/docs/minikube-quickstart.md
+++ b/docs/minikube-quickstart.md
@@ -149,7 +149,7 @@ cd LLMKube
 make install
 
 # Deploy controller with pre-built image
-make deploy IMG=ghcr.io/defilantech/llmkube-controller:0.2.1
+make deploy IMG=ghcr.io/defilantech/llmkube-controller:0.3.0
 
 # Verify controller is running
 kubectl get pods -n llmkube-system
@@ -171,20 +171,20 @@ brew tap defilantech/tap
 brew install llmkube
 
 # Or download binary directly
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.2.0_darwin_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_darwin_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Linux:**
 ```bash
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.2.0_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_linux_amd64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Verify installation:**
 ```bash
 llmkube version
-# Output: llmkube version 0.2.0
+# Output: llmkube version 0.3.0
 ```
 
 **Deploy TinyLlama:**

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -43,12 +43,14 @@ Keep this terminal open and continue in a new terminal. See the [Minikube Quicks
 Deploy the controller to your cluster:
 
 ```bash
-# Install CRDs
-kubectl apply -f https://raw.githubusercontent.com/Defilan/LLMKube/main/config/crd/bases/inference.llmkube.dev_models.yaml
-kubectl apply -f https://raw.githubusercontent.com/Defilan/LLMKube/main/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+# Option 1: Using Helm (Recommended)
+helm install llmkube https://github.com/defilantech/LLMKube/releases/download/v0.3.0/llmkube-0.3.0.tgz \
+  --namespace llmkube-system --create-namespace
 
-# Install operator
-kubectl apply -f https://raw.githubusercontent.com/Defilan/LLMKube/main/config/manager/manager.yaml
+# Option 2: Using Kustomize
+git clone https://github.com/defilantech/LLMKube.git
+cd LLMKube
+kubectl apply -k config/default
 
 # Wait for operator to be ready
 kubectl wait --for=condition=available --timeout=60s \
@@ -76,20 +78,20 @@ brew tap defilantech/tap
 brew install llmkube
 
 # Or download binary directly
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.2.0_darwin_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_darwin_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Linux:**
 ```bash
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.2.0_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_linux_amd64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Verify installation:**
 ```bash
 llmkube version
-# Output: llmkube version 0.2.0
+# Output: llmkube version 0.3.0
 ```
 
 **Deploy TinyLlama:**


### PR DESCRIPTION
## Problem

Users following the quickstart guides were experiencing `ImagePullBackOff` errors when deploying the LLMKube operator. The pod was trying to pull `controller:latest` instead of the actual GHCR image.

**Error:**
```
Failed to pull image "controller:latest": Error response from daemon: 
pull access denied for controller, repository does not exist
```

## Root Cause

The kustomize configuration in `config/manager/kustomization.yaml` had placeholder values:
```yaml
images:
- name: controller
  newName: controller  # ❌ Not a real registry
  newTag: latest       # ❌ Wrong version
```

## Solution

This PR updates all deployment configurations and documentation to use the correct image: `ghcr.io/defilantech/llmkube-controller:0.3.0`

## Changes

### Configuration
- ✅ Updated `config/manager/kustomization.yaml` with correct GHCR image
- ✅ Updated `Makefile` IMG default

### Documentation
- ✅ Updated `README.md` to recommend Helm and clarify kustomize usage
- ✅ Updated `docs/minikube-quickstart.md` with correct image version
- ✅ Updated `examples/quickstart/README.md` with proper deployment instructions
- ✅ Standardized all CLI version references to 0.3.0

## Testing

Verified the fix works by:
1. Deleting the broken deployment
2. Redeploying with updated kustomization
3. Confirming pod starts successfully with correct image

```bash
$ kubectl get pods -n llmkube-system
NAME                                          READY   STATUS    RESTARTS   AGE
llmkube-controller-manager-58cb4bfc57-f59gb   1/1     Running   0          18s

$ kubectl get deployment -n llmkube-system llmkube-controller-manager -o jsonpath='{.spec.template.spec.containers[0].image}'
ghcr.io/defilantech/llmkube-controller:0.3.0
```

## Impact

- Users can now successfully deploy the operator following the documentation
- Both Helm and kustomize deployment methods work correctly
- No breaking changes for existing deployments