### PR TITLE
Release v0.3.1: Fix controller OOM with increased memory limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/defilantech/llmkube-controller:0.3.0
+IMG ?= ghcr.io/defilantech/llmkube-controller:0.3.1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ Simpler and faster! Just 3 commands:
 ```bash
 # 1. Install the CLI (choose one)
 brew tap defilantech/tap && brew install llmkube  # macOS
-# OR: curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_linux_amd64.tar.gz | tar xz && sudo mv llmkube /usr/local/bin/  # Linux
+# OR: curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.1_linux_amd64.tar.gz | tar xz && sudo mv llmkube /usr/local/bin/  # Linux
 
 # 2. Start Minikube
 minikube start --cpus 4 --memory 8192
 
 # 3. Install LLMKube operator with Helm (recommended)
-helm install llmkube https://github.com/defilantech/LLMKube/releases/download/v0.3.0/llmkube-0.3.0.tgz \
+helm install llmkube https://github.com/defilantech/LLMKube/releases/download/v0.3.1/llmkube-0.3.1.tgz \
   --namespace llmkube-system --create-namespace
 
 # 4. Deploy a model from the catalog (one command!)
@@ -281,9 +281,9 @@ brew install llmkube
 **Manual download:**
 ```bash
 # Intel
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_darwin_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.1_darwin_amd64.tar.gz | tar xz
 # Apple Silicon
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_darwin_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.1_darwin_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 </details>
@@ -293,9 +293,9 @@ sudo mv llmkube /usr/local/bin/
 
 ```bash
 # x86_64
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.1_linux_amd64.tar.gz | tar xz
 # ARM64
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_linux_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.1_linux_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 </details>
@@ -304,7 +304,7 @@ sudo mv llmkube /usr/local/bin/
 <summary><b>Windows</b></summary>
 
 Download from [releases page](https://github.com/defilantech/LLMKube/releases/latest):
-- `llmkube_0.3.0_windows_amd64.zip`
+- `llmkube_0.3.1_windows_amd64.zip`
 
 Extract and add to PATH.
 </details>

--- a/charts/llmkube/Chart.yaml
+++ b/charts/llmkube/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed.
-appVersion: "0.3.0"
+appVersion: "0.3.1"
 
 keywords:
   - llm

--- a/charts/llmkube/README.md
+++ b/charts/llmkube/README.md
@@ -93,9 +93,9 @@ The following table lists the configurable parameters of the LLMKube chart and t
 | `controllerManager.replicaCount` | Number of controller replicas | `1` |
 | `controllerManager.leaderElection.enabled` | Enable leader election | `true` |
 | `controllerManager.resources.limits.cpu` | CPU limit | `500m` |
-| `controllerManager.resources.limits.memory` | Memory limit | `128Mi` |
+| `controllerManager.resources.limits.memory` | Memory limit | `2Gi` |
 | `controllerManager.resources.requests.cpu` | CPU request | `10m` |
-| `controllerManager.resources.requests.memory` | Memory request | `64Mi` |
+| `controllerManager.resources.requests.memory` | Memory request | `512Mi` |
 | `controllerManager.nodeSelector` | Node selector | `{}` |
 | `controllerManager.tolerations` | Tolerations | `[]` |
 | `controllerManager.affinity` | Affinity rules | `{}` |
@@ -163,10 +163,10 @@ controllerManager:
   resources:
     limits:
       cpu: 1
-      memory: 512Mi
+      memory: 4Gi
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 1Gi
 
 prometheus:
   serviceMonitor:

--- a/charts/llmkube/examples/values-basic.yaml
+++ b/charts/llmkube/examples/values-basic.yaml
@@ -11,10 +11,10 @@ controllerManager:
   resources:
     limits:
       cpu: 500m
-      memory: 128Mi
+      memory: 2Gi
     requests:
       cpu: 10m
-      memory: 64Mi
+      memory: 512Mi
 
 # Disable Prometheus integration
 prometheus:

--- a/charts/llmkube/examples/values-gpu-cluster.yaml
+++ b/charts/llmkube/examples/values-gpu-cluster.yaml
@@ -11,10 +11,10 @@ controllerManager:
   resources:
     limits:
       cpu: 1
-      memory: 256Mi
+      memory: 4Gi
     requests:
       cpu: 50m
-      memory: 128Mi
+      memory: 1Gi
 
   # Run controller on CPU nodes only
   affinity:

--- a/charts/llmkube/examples/values-production.yaml
+++ b/charts/llmkube/examples/values-production.yaml
@@ -14,10 +14,10 @@ controllerManager:
   resources:
     limits:
       cpu: 1
-      memory: 512Mi
+      memory: 4Gi
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 1Gi
 
   # Multi-architecture support
   affinity:

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -25,10 +25,10 @@ controllerManager:
   resources:
     limits:
       cpu: 500m
-      memory: 128Mi
+      memory: 2Gi
     requests:
       cpu: 10m
-      memory: 64Mi
+      memory: 512Mi
 
   # Security context for the controller pod
   podSecurityContext:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/defilantech/llmkube-controller
-  newTag: 0.3.0
+  newTag: 0.3.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -89,10 +89,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 2Gi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 512Mi
         volumeMounts:
         - name: tmp
           mountPath: /tmp

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1,0 +1,924 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+    control-plane: controller-manager
+  name: llmkube-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: inferenceservices.inference.llmkube.dev
+spec:
+  group: inference.llmkube.dev
+  names:
+    kind: InferenceService
+    listKind: InferenceServiceList
+    plural: inferenceservices
+    shortNames:
+    - isvc
+    singular: inferenceservice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.modelRef
+      name: Model
+      type: string
+    - jsonPath: .status.readyReplicas
+      name: Replicas
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: InferenceService is the Schema for the inferenceservices API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of InferenceService
+            properties:
+              endpoint:
+                description: Endpoint defines the service endpoint configuration
+                properties:
+                  path:
+                    default: /v1/chat/completions
+                    description: Path is the HTTP path for the inference endpoint
+                    type: string
+                  port:
+                    default: 8080
+                    description: Port is the service port
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  type:
+                    default: ClusterIP
+                    description: Type is the Kubernetes service type (ClusterIP, NodePort,
+                      LoadBalancer)
+                    enum:
+                    - ClusterIP
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                type: object
+              image:
+                default: ghcr.io/ggerganov/llama.cpp:server
+                description: Image is the container image for the llama.cpp runtime
+                type: string
+              modelRef:
+                description: ModelRef references the Model CR that contains the model
+                  to serve
+                type: string
+              replicas:
+                default: 1
+                description: Replicas is the desired number of inference pods
+                format: int32
+                maximum: 10
+                minimum: 0
+                type: integer
+              resources:
+                description: Resources defines compute resources for inference pods
+                properties:
+                  cpu:
+                    description: CPU requests (e.g., "2" or "2000m")
+                    type: string
+                  gpu:
+                    description: |-
+                      GPU count required per pod
+                      For multi-GPU inference, each pod gets this many GPUs
+                      Note: Multi-GPU sharding config comes from Model CRD
+                    format: int32
+                    maximum: 8
+                    minimum: 0
+                    type: integer
+                  gpuMemory:
+                    description: |-
+                      GPUMemory specifies GPU memory limit per pod (e.g., "16Gi")
+                      Used for scheduling and validation
+                    type: string
+                  memory:
+                    description: Memory requests (e.g., "4Gi")
+                    type: string
+                type: object
+            required:
+            - modelRef
+            type: object
+          status:
+            description: status defines the observed state of InferenceService
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the InferenceService resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              desiredReplicas:
+                description: DesiredReplicas is the desired number of replicas
+                format: int32
+                type: integer
+              endpoint:
+                description: Endpoint is the service URL where inference requests
+                  can be sent
+                type: string
+              lastUpdated:
+                description: LastUpdated is the timestamp of the last status update
+                format: date-time
+                type: string
+              modelReady:
+                description: ModelReady indicates if the referenced Model is in Ready
+                  state
+                type: boolean
+              phase:
+                description: Phase represents the current lifecycle phase (Pending,
+                  Creating, Ready, Failed)
+                type: string
+              readyReplicas:
+                description: Replicas tracks the number of ready vs desired pods
+                format: int32
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: models.inference.llmkube.dev
+spec:
+  group: inference.llmkube.dev
+  names:
+    kind: Model
+    listKind: ModelList
+    plural: models
+    shortNames:
+    - mdl
+    singular: model
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.size
+      name: Size
+      type: string
+    - jsonPath: .spec.hardware.accelerator
+      name: Accelerator
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Model is the Schema for the models API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Model
+            properties:
+              format:
+                default: gguf
+                description: Format specifies the model file format (currently only
+                  GGUF is supported)
+                enum:
+                - gguf
+                type: string
+              hardware:
+                description: Hardware specifies hardware acceleration preferences
+                properties:
+                  accelerator:
+                    default: cpu
+                    description: Accelerator specifies the type of hardware acceleration
+                    enum:
+                    - cpu
+                    - metal
+                    - cuda
+                    - rocm
+                    type: string
+                  gpu:
+                    description: GPU specifies GPU device requirements
+                    properties:
+                      count:
+                        description: |-
+                          Count specifies the number of GPUs required
+                          Supports multi-GPU for model sharding (future feature)
+                        format: int32
+                        maximum: 8
+                        minimum: 0
+                        type: integer
+                      enabled:
+                        description: Enabled indicates whether GPU acceleration is
+                          enabled
+                        type: boolean
+                      layers:
+                        description: |-
+                          Layers specifies layer offloading configuration for multi-GPU
+                          Format: number of layers to offload to GPU (e.g., 32 for full offload on 7B model)
+                          -1 means auto-detect optimal layer split
+                        format: int32
+                        minimum: -1
+                        type: integer
+                      memory:
+                        description: Memory specifies minimum GPU memory required
+                          per GPU (e.g., "8Gi", "16Gi")
+                        type: string
+                      sharding:
+                        description: |-
+                          Sharding defines how to shard the model across multiple GPUs
+                          Only applicable when Count > 1
+                        properties:
+                          layerSplit:
+                            description: |-
+                              LayerSplit defines custom layer splits per GPU
+                              Example: [0-15, 16-31] for 2-GPU split of 32-layer model
+                              If empty, auto-calculate even split
+                            items:
+                              type: string
+                            type: array
+                          strategy:
+                            default: layer
+                            description: |-
+                              Strategy defines the sharding approach
+                              - "layer": Shard by transformer layers (default)
+                              - "tensor": Tensor parallelism (future)
+                              - "pipeline": Pipeline parallelism (future)
+                            enum:
+                            - layer
+                            - tensor
+                            - pipeline
+                            type: string
+                        type: object
+                      vendor:
+                        default: nvidia
+                        description: |-
+                          Vendor specifies GPU vendor preference (nvidia, amd, intel)
+                          Future-proof for multi-vendor support
+                        enum:
+                        - nvidia
+                        - amd
+                        - intel
+                        type: string
+                    type: object
+                type: object
+              quantization:
+                description: Quantization describes the quantization level (e.g.,
+                  Q4_0, Q5_K_M, F16)
+                type: string
+              resources:
+                description: Resources defines resource requirements for running the
+                  model
+                properties:
+                  cpu:
+                    description: CPU specifies CPU requirements (e.g., "2" or "2000m")
+                    type: string
+                  memory:
+                    description: Memory specifies memory requirements (e.g., "4Gi")
+                    type: string
+                type: object
+              source:
+                description: |-
+                  Source defines where to obtain the model file (GGUF format)
+                  Supported schemes: http://, https://, file://
+                  Example: https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf/resolve/main/Phi-3-mini-4k-instruct-q4.gguf
+                pattern: ^(https?|file)://.*\.gguf$
+                type: string
+            required:
+            - source
+            type: object
+          status:
+            description: status defines the observed state of Model
+            properties:
+              acceleratorReady:
+                description: AcceleratorReady indicates if hardware acceleration is
+                  configured and ready
+                type: boolean
+              conditions:
+                description: |-
+                  conditions represent the current state of the Model resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the model is downloaded and ready for use
+                  - "Progressing": the model is being downloaded or processed
+                  - "Degraded": the model download or setup failed
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastUpdated:
+                description: LastUpdated is the timestamp of the last status update
+                format: date-time
+                type: string
+              path:
+                description: Path represents the local path where the model is stored
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current lifecycle phase of the model
+                  Possible values: Pending, Downloading, Ready, Failed
+                type: string
+              size:
+                description: Size represents the size of the downloaded model file
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-controller-manager
+  namespace: llmkube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-leader-election-role
+  namespace: llmkube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-inferenceservice-admin-role
+rules:
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - inferenceservices
+  verbs:
+  - '*'
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - inferenceservices/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-inferenceservice-editor-role
+rules:
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - inferenceservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - inferenceservices/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-inferenceservice-viewer-role
+rules:
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - inferenceservices/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: llmkube-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - inferenceservices
+  - models
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - inferenceservices/finalizers
+  - models/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - inferenceservices/status
+  - models/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: llmkube-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: llmkube-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-model-admin-role
+rules:
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - models
+  verbs:
+  - '*'
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - models/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-model-editor-role
+rules:
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - models
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - models/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-model-viewer-role
+rules:
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - models
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - models/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-leader-election-rolebinding
+  namespace: llmkube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: llmkube-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: llmkube-controller-manager
+  namespace: llmkube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+  name: llmkube-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llmkube-manager-role
+subjects:
+- kind: ServiceAccount
+  name: llmkube-controller-manager
+  namespace: llmkube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: llmkube-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llmkube-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: llmkube-controller-manager
+  namespace: llmkube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+    control-plane: controller-manager
+  name: llmkube-controller-manager-metrics-service
+  namespace: llmkube-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: llmkube
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: llmkube
+    control-plane: controller-manager
+  name: llmkube-controller-manager
+  namespace: llmkube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: llmkube
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: llmkube
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        command:
+        - /manager
+        image: ghcr.io/defilantech/llmkube-controller:0.3.1
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports: []
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2Gi
+          requests:
+            cpu: 10m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: llmkube-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - emptyDir: {}
+        name: tmp

--- a/docs/minikube-quickstart.md
+++ b/docs/minikube-quickstart.md
@@ -149,7 +149,7 @@ cd LLMKube
 make install
 
 # Deploy controller with pre-built image
-make deploy IMG=ghcr.io/defilantech/llmkube-controller:0.3.0
+make deploy IMG=ghcr.io/defilantech/llmkube-controller:0.3.1
 
 # Verify controller is running
 kubectl get pods -n llmkube-system
@@ -171,20 +171,20 @@ brew tap defilantech/tap
 brew install llmkube
 
 # Or download binary directly
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_darwin_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.1_darwin_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Linux:**
 ```bash
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.1_linux_amd64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Verify installation:**
 ```bash
 llmkube version
-# Output: llmkube version 0.3.0
+# Output: llmkube version 0.3.1
 ```
 
 **Deploy TinyLlama:**

--- a/examples/metal-quickstart/README.md
+++ b/examples/metal-quickstart/README.md
@@ -24,37 +24,56 @@ This guide shows you how to deploy GPU-accelerated LLM inference on your Mac usi
 
 3. **LLMKube CLI**
    ```bash
-   # Download latest release
-   curl -L https://github.com/defilantech/llmkube/releases/latest/download/llmkube_$(uname -s)_$(uname -m).tar.gz | tar xz
+   # Option 1: Install via Homebrew (Recommended for macOS)
+   brew tap defilantech/tap && brew install llmkube
+
+   # Option 2: Download binary manually
+   # For macOS (Apple Silicon M1/M2/M3/M4):
+   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube_0.3.1_darwin_arm64.tar.gz | tar xz
+   sudo mv llmkube /usr/local/bin/
+
+   # For macOS (Intel):
+   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube_0.3.1_darwin_amd64.tar.gz | tar xz
    sudo mv llmkube /usr/local/bin/
    ```
 
-4. **LLMKube Operator** (for development/testing from branch)
+4. **LLMKube Operator**
    ```bash
-   # From the llmkube repository root
-   make deploy
+   # Option 1: Install from GitHub (Recommended)
+   kubectl apply -k https://github.com/defilantech/LLMKube/config/default
 
-   # This builds and deploys the controller locally
    # Wait for the operator to be ready:
    kubectl wait --for=condition=ready pod -l control-plane=controller-manager -n llmkube-system --timeout=60s
    ```
 
-   For released versions, use:
+   For development/testing from branch:
    ```bash
-   kubectl apply -f https://github.com/defilantech/llmkube/releases/latest/download/install.yaml
+   # From the llmkube repository root
+   make deploy
+
+   # Wait for the operator to be ready:
+   kubectl wait --for=condition=ready pod -l control-plane=controller-manager -n llmkube-system --timeout=60s
    ```
 
 5. **Metal Agent**
    ```bash
+   # Option 1: Build and install from source (Recommended)
    # From llmkube repository
    make install-metal-agent
 
-   # Or download pre-built binary
-   curl -L https://github.com/defilantech/llmkube/releases/latest/download/llmkube-metal-agent_$(uname -s)_$(uname -m).tar.gz | tar xz
+   # Option 2: Download pre-built binary
+   # For macOS (Apple Silicon M1/M2/M3/M4):
+   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube-metal-agent_0.3.1_darwin_arm64.tar.gz | tar xz
+   sudo mv llmkube-metal-agent /usr/local/bin/
+
+   # For macOS (Intel):
+   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube-metal-agent_0.3.1_darwin_amd64.tar.gz | tar xz
    sudo mv llmkube-metal-agent /usr/local/bin/
 
    # Install and start the service
-   make install-metal-agent
+   mkdir -p ~/Library/LaunchAgents
+   cp deployment/macos/com.llmkube.metal-agent.plist ~/Library/LaunchAgents/
+   launchctl load ~/Library/LaunchAgents/com.llmkube.metal-agent.plist
    ```
 
 ## Verify Setup

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -44,7 +44,7 @@ Deploy the controller to your cluster:
 
 ```bash
 # Option 1: Using Helm (Recommended)
-helm install llmkube https://github.com/defilantech/LLMKube/releases/download/v0.3.0/llmkube-0.3.0.tgz \
+helm install llmkube https://github.com/defilantech/LLMKube/releases/download/v0.3.1/llmkube-0.3.1.tgz \
   --namespace llmkube-system --create-namespace
 
 # Option 2: Using Kustomize
@@ -78,20 +78,20 @@ brew tap defilantech/tap
 brew install llmkube
 
 # Or download binary directly
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_darwin_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.1_darwin_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Linux:**
 ```bash
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.0_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.1_linux_amd64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Verify installation:**
 ```bash
 llmkube version
-# Output: llmkube version 0.3.0
+# Output: llmkube version 0.3.1
 ```
 
 **Deploy TinyLlama:**

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// Version is set during build
-	Version = "0.3.0"
+	Version = "0.3.1"
 	// GitCommit is set during build
 	GitCommit = "unknown"
 	// BuildDate is set during build


### PR DESCRIPTION
## Summary
This patch release addresses a critical OOM issue where the controller was crashing during model downloads due to insufficient memory allocation.

## Problem
Users were experiencing `CrashLoopBackOff` errors with the controller pod being OOMKilled (exit code 137) when attempting to download model files. The controller had only 128Mi memory limit, which was insufficient for downloading multi-gigabyte GGUF model files.

## Solution
Increased memory allocations across all deployment configurations:
- **Default/Basic**: 128Mi → 2Gi (limit), 64Mi → 512Mi (request)
- **Production/GPU**: 512Mi/256Mi → 4Gi (limit), 128Mi → 1Gi (request)

## Changes
- ✅ Updated controller memory limits in kustomize manifests
- ✅ Updated Helm chart default values
- ✅ Updated all example Helm values files
- ✅ Updated Helm chart documentation
- ✅ Bumped version from 0.3.0 to 0.3.1 across all files
- ✅ Rebuilt installer manifests with new configuration

## Testing
Verified the fix works by:
- Patching running deployment with new limits
- Controller pod successfully started and remained healthy
- Confirmed resource limits applied correctly (`kubectl get pod -o jsonpath`)

## Impact
This fix enables users to successfully deploy and run LLMKube without hitting OOM errors during model downloads, which was blocking the quickstart experience.

## Release Process
After merge:
1. Tag with `v0.3.1`
2. Push tag to trigger release workflow
3. Workflow will automatically build & push container image and create GitHub release