### PR TITLE
feat: Set up Helm repository on GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ brew tap defilantech/tap && brew install llmkube  # macOS
 minikube start --cpus 4 --memory 8192
 
 # 3. Install LLMKube operator with Helm (recommended)
-helm install llmkube https://github.com/defilantech/LLMKube/releases/download/v0.3.3/llmkube-0.3.3.tgz \
+helm repo add llmkube https://defilantech.github.io/LLMKube
+helm install llmkube llmkube/llmkube \
   --namespace llmkube-system --create-namespace
 
 # 4. Deploy a model from the catalog (one command!)
@@ -157,7 +158,8 @@ cd terraform/gke
 terraform init && terraform apply -var="project_id=YOUR_PROJECT"
 
 # 3. Install LLMKube with Helm
-helm install llmkube charts/llmkube \
+helm repo add llmkube https://defilantech.github.io/LLMKube
+helm install llmkube llmkube/llmkube \
   --namespace llmkube-system \
   --create-namespace
 
@@ -233,7 +235,12 @@ See [ROADMAP.md](ROADMAP.md) for the full development plan.
 ### Option 1: Helm Chart (Recommended)
 
 ```bash
-helm install llmkube charts/llmkube \
+# Add the Helm repository
+helm repo add llmkube https://defilantech.github.io/LLMKube
+helm repo update
+
+# Install the chart
+helm install llmkube llmkube/llmkube \
   --namespace llmkube-system \
   --create-namespace
 ```


### PR DESCRIPTION
## Summary

Sets up a professional Helm repository for LLMKube using GitHub Pages. This eliminates the need for users to clone the repository or reference non-existent packaged chart files.

## Changes

### 1. New `gh-pages` Branch
Created an orphan `gh-pages` branch containing:
- `index.yaml` - Helm repository index  
- `llmkube-0.3.3.tgz` - Packaged Helm chart
- `index.html` - Web landing page with usage instructions
- `README.md` - Repository documentation
- `.gitignore` - Ignore build artifacts

### 2. Updated Documentation  
Updated README.md to use the new Helm repository:
- **Quick Start**: Now uses `helm repo add` command
- **Installation**: Updated with proper repo add/update steps
- **GPU Deployment**: Updated Helm commands
- Removed references to non-existent `.tgz` files

## Usage

After merging and enabling GitHub Pages for the `gh-pages` branch, users can install with:

```bash
helm repo add llmkube https://defilantech.github.io/LLMKube
helm install llmkube llmkube/llmkube \
  --namespace llmkube-system \
  --create-namespace
```

## Next Steps

After merging:
1. Enable GitHub Pages in repository settings
2. Configure Pages to use the `gh-pages` branch  
3. Repository will be available at https://defilantech.github.io/LLMKube

## Benefits

- **Professional**: Standard Helm repository pattern used by major projects
- **User-friendly**: No need to clone repo or find direct URLs
- **Maintainable**: Easy to update with new chart versions
- **Discoverable**: Charts can be searched and listed via Helm commands