### PR TITLE
Release v0.4.0 - Multi-GPU Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/defilantech/llmkube-controller:0.3.3
+IMG ?= ghcr.io/defilantech/llmkube-controller:0.4.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Simpler and faster! Just 3 commands:
 ```bash
 # 1. Install the CLI (choose one)
 brew tap defilantech/tap && brew install llmkube  # macOS
-# OR: curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.3_linux_amd64.tar.gz | tar xz && sudo mv llmkube /usr/local/bin/  # Linux
+# OR: curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.4.0_linux_amd64.tar.gz | tar xz && sudo mv llmkube /usr/local/bin/  # Linux
 
 # 2. Start Minikube
 minikube start --cpus 4 --memory 8192
@@ -288,9 +288,9 @@ brew install llmkube
 **Manual download:**
 ```bash
 # Intel
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.3_darwin_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.4.0_darwin_amd64.tar.gz | tar xz
 # Apple Silicon
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.3_darwin_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.4.0_darwin_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 </details>
@@ -300,9 +300,9 @@ sudo mv llmkube /usr/local/bin/
 
 ```bash
 # x86_64
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.3_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.4.0_linux_amd64.tar.gz | tar xz
 # ARM64
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.3_linux_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.4.0_linux_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 </details>
@@ -311,7 +311,7 @@ sudo mv llmkube /usr/local/bin/
 <summary><b>Windows</b></summary>
 
 Download from [releases page](https://github.com/defilantech/LLMKube/releases/latest):
-- `llmkube_0.3.3_windows_amd64.zip`
+- `llmkube_0.4.0_windows_amd64.zip`
 
 Extract and add to PATH.
 </details>

--- a/charts/llmkube/Chart.yaml
+++ b/charts/llmkube/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.3
+version: 0.4.0
 
 # This is the version number of the application being deployed.
-appVersion: "0.3.3"
+appVersion: "0.4.0"
 
 keywords:
   - llm

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/defilantech/llmkube-controller
-  newTag: 0.3.3
+  newTag: 0.4.0

--- a/docs/minikube-quickstart.md
+++ b/docs/minikube-quickstart.md
@@ -149,7 +149,7 @@ cd LLMKube
 make install
 
 # Deploy controller with pre-built image
-make deploy IMG=ghcr.io/defilantech/llmkube-controller:0.3.3
+make deploy IMG=ghcr.io/defilantech/llmkube-controller:0.4.0
 
 # Verify controller is running
 kubectl get pods -n llmkube-system
@@ -171,20 +171,20 @@ brew tap defilantech/tap
 brew install llmkube
 
 # Or download binary directly
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.3_darwin_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.4.0_darwin_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Linux:**
 ```bash
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.3_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.4.0_linux_amd64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Verify installation:**
 ```bash
 llmkube version
-# Output: llmkube version 0.3.3
+# Output: llmkube version 0.4.0
 ```
 
 **Deploy TinyLlama:**

--- a/examples/metal-quickstart/README.md
+++ b/examples/metal-quickstart/README.md
@@ -29,11 +29,11 @@ This guide shows you how to deploy GPU-accelerated LLM inference on your Mac usi
 
    # Option 2: Download binary manually
    # For macOS (Apple Silicon M1/M2/M3/M4):
-   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube_0.3.3_darwin_arm64.tar.gz | tar xz
+   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube_0.4.0_darwin_arm64.tar.gz | tar xz
    sudo mv llmkube /usr/local/bin/
 
    # For macOS (Intel):
-   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube_0.3.3_darwin_amd64.tar.gz | tar xz
+   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube_0.4.0_darwin_amd64.tar.gz | tar xz
    sudo mv llmkube /usr/local/bin/
    ```
 
@@ -63,11 +63,11 @@ This guide shows you how to deploy GPU-accelerated LLM inference on your Mac usi
 
    # Option 2: Download pre-built binary
    # For macOS (Apple Silicon M1/M2/M3/M4):
-   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube-metal-agent_0.3.3_darwin_arm64.tar.gz | tar xz
+   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube-metal-agent_0.4.0_darwin_arm64.tar.gz | tar xz
    sudo mv llmkube-metal-agent /usr/local/bin/
 
    # For macOS (Intel):
-   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube-metal-agent_0.3.3_darwin_amd64.tar.gz | tar xz
+   curl -L https://github.com/defilantech/LLMKube/releases/latest/download/LLMKube-metal-agent_0.4.0_darwin_amd64.tar.gz | tar xz
    sudo mv llmkube-metal-agent /usr/local/bin/
 
    # Install and start the service

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -44,7 +44,7 @@ Deploy the controller to your cluster:
 
 ```bash
 # Option 1: Using Helm (Recommended)
-helm install llmkube https://github.com/defilantech/LLMKube/releases/download/v0.3.3/llmkube-0.3.3.tgz \
+helm install llmkube https://github.com/defilantech/LLMKube/releases/download/v0.4.0/llmkube-0.4.0.tgz \
   --namespace llmkube-system --create-namespace
 
 # Option 2: Using Kustomize
@@ -78,20 +78,20 @@ brew tap defilantech/tap
 brew install llmkube
 
 # Or download binary directly
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.3_darwin_arm64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.4.0_darwin_arm64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Linux:**
 ```bash
-curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.3.3_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/defilantech/LLMKube/releases/latest/download/llmkube_0.4.0_linux_amd64.tar.gz | tar xz
 sudo mv llmkube /usr/local/bin/
 ```
 
 **Verify installation:**
 ```bash
 llmkube version
-# Output: llmkube version 0.3.3
+# Output: llmkube version 0.4.0
 ```
 
 **Deploy TinyLlama:**

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// Version is set during build
-	Version = "0.3.3"
+	Version = "0.4.0"
 	// GitCommit is set during build
 	GitCommit = "unknown"
 	// BuildDate is set during build


### PR DESCRIPTION
## Summary

Version bump to v0.4.0 for the multi-GPU support release.

## Changes

Updates all version references from 0.3.3 to 0.4.0:
- CLI version constant
- Makefile IMG tag
- Helm chart version and appVersion
- Kustomization image tag
- Documentation download URLs

## Release Highlights (v0.4.0)

- **Multi-GPU Support**: Run 13B-70B+ models across 2-8 GPUs with layer-based sharding
- **New API Fields**: `tolerations` and `nodeSelector` for flexible scheduling
- **Multi-Cloud Infrastructure**: Terraform configs for Azure AKS and AWS EKS
- **Performance**: Verified ~65 tok/s on 8B model with 2x RTX 5060 Ti

## Test Plan

- [x] Version references updated in all files
- [x] No remaining 0.3.3 references (except historical release notes)
- [ ] CI passes
- [ ] Tag and release after merge