### PR TITLE
fix: Add Helm chart publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,28 @@ jobs:
           git push origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-helm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.13.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary

- Adds `release-helm` job to the release workflow using `chart-releaser-action`
- Automatically publishes Helm charts to GitHub Pages when a version tag is pushed
- Fixes issue where Helm chart v0.4.0 was not available via `helm repo`

## Setup Required

After merging, ensure GitHub Pages is configured:
1. Go to Settings → Pages
2. Source: "Deploy from a branch"
3. Branch: `gh-pages` / `/ (root)`

The `gh-pages` branch will be created automatically on first release.

## Test plan

- [ ] Merge this PR
- [ ] Configure GitHub Pages if not already done
- [ ] Re-tag v0.4.0 or create v0.4.1 to trigger the workflow
- [ ] Verify chart appears in `helm search repo llmkube --versions`