### PR TITLE
fix: Resolve staticcheck SA5011 lint errors and update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,14 +270,29 @@ git diff --exit-code  # Should be no changes
 
 ### PR Title Format
 
+**Important:** PR titles are used for automated changelog generation and version bumps via [Release Please](https://github.com/googleapis/release-please). Since we use **squash merging**, your PR title becomes the commit message on `main`.
+
 ```
 <type>: <description>
 ```
+
+| Type | Description | Version Bump |
+|------|-------------|--------------|
+| `feat:` | New feature | Minor (0.x.0) |
+| `fix:` | Bug fix | Patch (0.0.x) |
+| `docs:` | Documentation only | None |
+| `ci:` | CI/CD changes | None |
+| `chore:` | Maintenance tasks | None |
+| `refactor:` | Code refactoring | None |
+| `test:` | Adding tests | None |
 
 **Examples:**
 - `feat: Add Prometheus metrics to InferenceService controller`
 - `fix: Resolve model download timeout on slow connections`
 - `docs: Add troubleshooting guide for GPU issues`
+- `feat(helm): Add image digest support for production deployments`
+
+**Scopes** (optional): Use parentheses to specify the area of change: `feat(cli):`, `fix(controller):`, `docs(helm):`, etc.
 
 ### Review Process
 

--- a/pkg/cli/benchmark_test.go
+++ b/pkg/cli/benchmark_test.go
@@ -270,6 +270,7 @@ func TestBenchmarkCommandDefaults(t *testing.T) {
 			flag := cmd.Flags().Lookup(tc.flag)
 			if flag == nil {
 				t.Fatalf("Flag '%s' not found", tc.flag)
+				return
 			}
 			if flag.DefValue != tc.expected {
 				t.Errorf("Expected default value '%s' for flag '%s', got '%s'",

--- a/pkg/cli/catalog_test.go
+++ b/pkg/cli/catalog_test.go
@@ -29,6 +29,7 @@ func TestLoadCatalog(t *testing.T) {
 
 	if catalog == nil {
 		t.Fatal("Catalog is nil")
+		return
 	}
 
 	if catalog.Version == "" {


### PR DESCRIPTION
## Summary
- Add return after `t.Fatal` calls in test files to satisfy staticcheck SA5011 (possible nil pointer dereference warning)
- Update CONTRIBUTING.md PR Title Format section to document Release Please workflow and conventional commit requirements

## Changes
- `pkg/cli/catalog_test.go` - Add return after t.Fatal
- `pkg/cli/benchmark_test.go` - Add return after t.Fatalf  
- `CONTRIBUTING.md` - Document squash merge workflow, PR title requirements, and version bump mapping

## Test plan
- [x] `make lint` passes locally
- [x] CI will validate lint passes