### PR TITLE
fix: Use simple v* tag format for releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,7 @@
   },
   "versioning": "default",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "tag-separator": "",
   "pull-request-title-pattern": "chore: release ${version}",
   "pull-request-header": ":rocket: Release ${version}",


### PR DESCRIPTION
## Summary
Add `include-component-in-tag: false` to Release Please config so tags are created as `v0.4.3` instead of `llmkubev0.4.3`.

## Problem
Release Please was creating tags like `llmkubev0.4.2` but the release.yml workflow triggers on `v*.*.*` pattern, so builds weren't running.

## Solution
Set `include-component-in-tag: false` in release-please-config.json.

## Test plan
- [x] Config syntax is valid JSON
- [ ] After merge, next Release Please tag should be `v0.4.3` format