### PR TITLE
fix: Clean up release process - single release with proper notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -210,59 +210,57 @@ release:
   # Create release even if tag already exists
   replace_existing_draft: true
 
-  # Include release notes from CHANGELOG
-  mode: replace
+  # Keep Release Please's changelog, just add assets
+  mode: keep-existing
 
-  # Header and footer for release notes
-  header: |
-    ## LLMKube v{{ .Version }}
-
-    **Release Date**: {{ .Date }}
-
-    See [RELEASE_NOTES_v{{ .Version }}.md](https://github.com/defilantech/LLMKube/blob/main/RELEASE_NOTES_v{{ .Version }}.md) for complete details.
-
+  # Footer with installation instructions (Release Please provides the changelog)
   footer: |
     ---
 
     ## Installation
 
-    ### macOS
+    ### Homebrew (Recommended for macOS)
     ```bash
-    # AMD64
-    curl -L https://github.com/defilantech/LLMKube/releases/download/v{{ .Version }}/llmkube_{{ .Version }}_darwin_amd64.tar.gz | tar xz
+    brew install defilantech/tap/llmkube
+    ```
+
+    ### Install Script (Linux/macOS)
+    ```bash
+    curl -sSL https://raw.githubusercontent.com/defilantech/LLMKube/main/install.sh | bash
+    ```
+
+    ### Manual Download
+
+    **macOS**
+    ```bash
+    # ARM64 (Apple Silicon)
+    curl -L https://github.com/defilantech/LLMKube/releases/download/v{{ .Version }}/LLMKube_{{ .Version }}_darwin_arm64.tar.gz | tar xz
     sudo mv llmkube /usr/local/bin/
 
-    # ARM64 (Apple Silicon)
-    curl -L https://github.com/defilantech/LLMKube/releases/download/v{{ .Version }}/llmkube_{{ .Version }}_darwin_arm64.tar.gz | tar xz
+    # AMD64
+    curl -L https://github.com/defilantech/LLMKube/releases/download/v{{ .Version }}/LLMKube_{{ .Version }}_darwin_amd64.tar.gz | tar xz
     sudo mv llmkube /usr/local/bin/
     ```
 
-    ### Linux
+    **Linux**
     ```bash
     # AMD64
-    curl -L https://github.com/defilantech/LLMKube/releases/download/v{{ .Version }}/llmkube_{{ .Version }}_linux_amd64.tar.gz | tar xz
+    curl -L https://github.com/defilantech/LLMKube/releases/download/v{{ .Version }}/LLMKube_{{ .Version }}_linux_amd64.tar.gz | tar xz
     sudo mv llmkube /usr/local/bin/
 
     # ARM64
-    curl -L https://github.com/defilantech/LLMKube/releases/download/v{{ .Version }}/llmkube_{{ .Version }}_linux_arm64.tar.gz | tar xz
+    curl -L https://github.com/defilantech/LLMKube/releases/download/v{{ .Version }}/LLMKube_{{ .Version }}_linux_arm64.tar.gz | tar xz
     sudo mv llmkube /usr/local/bin/
     ```
 
-    ### Windows
-    Download the `.zip` file for your architecture and add `llmkube.exe` to your PATH.
+    **Windows**: Download the `.zip` file and add `llmkube.exe` to your PATH.
 
     ### Verify Installation
     ```bash
     llmkube version
     ```
 
-    ## Next Steps
-
-    1. [Install the operator](https://github.com/defilantech/LLMKube#installation)
-    2. [Try the GPU quickstart](https://github.com/defilantech/LLMKube/tree/main/examples/gpu-quickstart)
-    3. [Read the documentation](https://github.com/defilantech/LLMKube#documentation)
-
-    **Full Release Notes**: [RELEASE_NOTES_v{{ .Version }}.md](https://github.com/defilantech/LLMKube/blob/main/RELEASE_NOTES_v{{ .Version }}.md)
+    **Full Changelog**: [CHANGELOG.md](https://github.com/defilantech/LLMKube/blob/main/CHANGELOG.md)
 
 # Homebrew tap
 brews:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,12 +3,12 @@
   "release-type": "go",
   "packages": {
     ".": {
-      "package-name": "llmkube",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "yaml",


### PR DESCRIPTION
## Summary
Fix the release process to create a single, clean release with proper changelog.

## Problems Fixed
1. **Two releases created**: Release Please created `llmkube-0.4.4` and GoReleaser created `v0.4.4`
2. **Missing release notes**: GoReleaser referenced non-existent `RELEASE_NOTES_v*.md` files

## Changes

### release-please-config.json
- Removed `package-name: llmkube` to prevent component prefix in release names
- Moved `include-component-in-tag: false` inside package config

### .goreleaser.yaml
- Changed `mode: replace` to `mode: keep-existing` so GoReleaser adds assets to Release Please's release instead of creating a new one
- Removed header (Release Please provides the changelog)
- Updated footer to reference `CHANGELOG.md` and use `install.sh`

## Expected Result
After merge, next release will:
1. Release Please creates release `v0.x.x` with changelog
2. GoReleaser adds binaries/Docker images to that same release
3. Single release visible on GitHub with both changelog and assets

## Test plan
- [ ] Merge and verify next release creates single release entry