### PR TITLE
fix: Set empty component to prevent llmkube- prefix in releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "go",
   "packages": {
     ".": {
+      "component": "",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Summary
Add `"component": ""` to explicitly prevent Release Please from using `llmkube` as a component prefix.

## Problem
Despite setting `include-component-in-tag: false`, Release Please was still creating:
- `llmkube-0.4.5` release (with component prefix)
- `v0.4.5` release (from GoReleaser)

The root cause is `release-type: go` automatically derives the component name from `go.mod` module path (`github.com/defilantech/llmkube` → `llmkube`).

## Solution
Explicitly set `"component": ""` in the package config to override the auto-derived component name.

## Test plan
- [ ] After merge, next release should only create `v0.x.x` (no `llmkube-` prefix)