### PR TITLE
fix: Don't mark Helm chart release as latest

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -95,5 +95,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
+        with:
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
Set `mark_as_latest: false` for the Helm chart-releaser action.

## Problem
Two releases were being created per version:
- `v0.4.6` - GoReleaser (CLI binaries, Docker images)
- `llmkube-0.4.6` - Helm chart-releaser (for `helm repo add`)

The Helm release was marked as "Latest", hiding the main release on GitHub.

## Root Cause
The `helm/chart-releaser-action` creates releases named `<chart-name>-<version>` for the Helm repository. By default it marks these as "Latest".

## Solution
Set `mark_as_latest: false` so the GoReleaser `v0.4.x` release is the "Latest" shown on GitHub.

## Note
The `llmkube-X.Y.Z` releases are still needed for the Helm repository to work - they just won't be marked as the main "Latest" release.