### PR TITLE
docs: add getting started video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@
 
 ---
 
+## Getting Started Video
+
+[![Getting Started with LLMKube](https://img.youtube.com/vi/dmKnkxvC1U8/maxresdefault.jpg)](https://youtu.be/dmKnkxvC1U8)
+
+*Watch: Deploy your first LLM on Kubernetes in 5 minutes*
+
+---
+
 ## Why LLMKube?
 
 Running LLMs in production shouldn't require a PhD in distributed systems. LLMKube makes it as easy as deploying any other Kubernetes workload:


### PR DESCRIPTION
## Summary
- Adds embedded YouTube video thumbnail to README
- Placed prominently after header section, before "Why LLMKube?"
- Links to getting started tutorial: https://youtu.be/dmKnkxvC1U8

## Test plan
- [ ] Verify thumbnail renders correctly on GitHub
- [ ] Verify link opens YouTube video
- [ ] If maxresdefault.jpg doesn't render, switch to hqdefault.jpg