### PR TITLE
feat: add GPU contention visibility, queue position, and priority classes

### DIFF
--- a/charts/llmkube/templates/priority-classes.yaml
+++ b/charts/llmkube/templates/priority-classes.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.priorityClasses.enabled }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-critical
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+value: 1000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "Critical LLM inference services that can preempt all lower priority workloads"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-high
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+value: 100000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "High priority LLM inference services"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-normal
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+value: 10000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "Normal priority LLM inference services (default)"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-low
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+value: 1000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "Low priority LLM inference services for development and testing"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-batch
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+value: 100
+preemptionPolicy: Never
+globalDefault: false
+description: "Batch priority LLM inference services that cannot preempt other workloads"
+{{- end }}

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -155,6 +155,11 @@ modelCache:
   # Annotations for the PVC (e.g., for backup policies)
   annotations: {}
 
+# Priority classes for GPU scheduling
+priorityClasses:
+  # Create LLMKube priority classes (critical, high, normal, low, batch)
+  enabled: true
+
 # Image pull secrets for private registries
 imagePullSecrets: []
 

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -26,6 +26,18 @@ spec:
     - jsonPath: .status.readyReplicas
       name: Replicas
       type: string
+    - jsonPath: .status.schedulingStatus
+      name: Reason
+      priority: 1
+      type: string
+    - jsonPath: .status.queuePosition
+      name: Queue
+      priority: 1
+      type: integer
+    - jsonPath: .spec.priority
+      name: Priority
+      priority: 1
+      type: string
     - jsonPath: .status.endpoint
       name: Endpoint
       type: string
@@ -103,6 +115,23 @@ spec:
                   type: string
                 description: NodeSelector for pod placement (e.g., specific node pools)
                 type: object
+              priority:
+                default: normal
+                description: |-
+                  Priority determines scheduling priority for GPU allocation.
+                  Higher priority services can preempt lower priority ones when GPUs are scarce.
+                enum:
+                - critical
+                - high
+                - normal
+                - low
+                - batch
+                type: string
+              priorityClassName:
+                description: |-
+                  PriorityClassName allows specifying a custom Kubernetes PriorityClass.
+                  Takes precedence over the Priority field if set.
+                type: string
               replicas:
                 default: 1
                 description: Replicas is the desired number of inference pods
@@ -253,6 +282,11 @@ spec:
                 description: DesiredReplicas is the desired number of replicas
                 format: int32
                 type: integer
+              effectivePriority:
+                description: EffectivePriority shows the resolved priority value from
+                  the applied PriorityClass
+                format: int32
+                type: integer
               endpoint:
                 description: Endpoint is the service URL where inference requests
                   can be sent
@@ -269,10 +303,26 @@ spec:
                 description: Phase represents the current lifecycle phase (Pending,
                   Creating, Ready, Failed)
                 type: string
+              queuePosition:
+                description: QueuePosition indicates position among pending InferenceServices
+                  cluster-wide (0 = not queued)
+                format: int32
+                type: integer
               readyReplicas:
                 description: Replicas tracks the number of ready vs desired pods
                 format: int32
                 type: integer
+              schedulingMessage:
+                description: SchedulingMessage provides details about scheduling issues
+                type: string
+              schedulingStatus:
+                description: SchedulingStatus indicates why pods cannot be scheduled
+                  (e.g., "InsufficientGPU")
+                type: string
+              waitingFor:
+                description: 'WaitingFor describes the resource constraint (e.g.,
+                  "nvidia.com/gpu: 1")'
+                type: string
             type: object
         required:
         - spec

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- priority_classes.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/priority_classes.yaml
+++ b/config/manager/priority_classes.yaml
@@ -1,0 +1,44 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-critical
+value: 1000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "Critical LLM inference services that can preempt all lower priority workloads"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-high
+value: 100000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "High priority LLM inference services"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-normal
+value: 10000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "Normal priority LLM inference services (default)"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-low
+value: 1000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "Low priority LLM inference services for development and testing"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: llmkube-batch
+value: 100
+preemptionPolicy: Never
+globalDefault: false
+description: "Batch priority LLM inference services that cannot preempt other workloads"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -76,3 +76,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/cli/queue.go
+++ b/pkg/cli/queue.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+type queueOptions struct {
+	allNamespaces bool
+	namespace     string
+}
+
+func NewQueueCommand() *cobra.Command {
+	opts := &queueOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "queue",
+		Short: "Show InferenceServices waiting for GPU resources",
+		Long: `Display InferenceServices that are queued waiting for GPU resources.
+
+Shows all services with phase 'WaitingForGPU' sorted by queue position.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runQueue(opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.allNamespaces, "all-namespaces", "A", false, "List across all namespaces")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Kubernetes namespace")
+
+	return cmd
+}
+
+func runQueue(opts *queueOptions) error {
+	ctx := context.Background()
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	if err := inferencev1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		return fmt.Errorf("failed to add scheme: %w", err)
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	isvcList := &inferencev1alpha1.InferenceServiceList{}
+	listOpts := []client.ListOption{}
+
+	if !opts.allNamespaces {
+		listOpts = append(listOpts, client.InNamespace(opts.namespace))
+	}
+
+	if err := k8sClient.List(ctx, isvcList, listOpts...); err != nil {
+		return fmt.Errorf("failed to list InferenceServices: %w", err)
+	}
+
+	type queuedService struct {
+		name          string
+		namespace     string
+		queuePosition int32
+		waitingFor    string
+		priority      string
+		age           time.Duration
+	}
+
+	var queued []queuedService
+	for _, isvc := range isvcList.Items {
+		if isvc.Status.Phase == "WaitingForGPU" {
+			priority := isvc.Spec.Priority
+			if priority == "" {
+				priority = "normal"
+			}
+			queued = append(queued, queuedService{
+				name:          isvc.Name,
+				namespace:     isvc.Namespace,
+				queuePosition: isvc.Status.QueuePosition,
+				waitingFor:    isvc.Status.WaitingFor,
+				priority:      priority,
+				age:           time.Since(isvc.CreationTimestamp.Time),
+			})
+		}
+	}
+
+	if len(queued) == 0 {
+		if opts.allNamespaces {
+			fmt.Println("No InferenceServices waiting for GPU resources across all namespaces")
+		} else {
+			fmt.Printf("No InferenceServices waiting for GPU resources in namespace %s\n", opts.namespace)
+		}
+		return nil
+	}
+
+	sort.Slice(queued, func(i, j int) bool {
+		return queued[i].queuePosition < queued[j].queuePosition
+	})
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	if opts.allNamespaces {
+		_, _ = fmt.Fprintln(w, "NAMESPACE\tNAME\tQUEUE\tWAITING FOR\tPRIORITY\tAGE")
+		for _, s := range queued {
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\n",
+				s.namespace,
+				s.name,
+				s.queuePosition,
+				s.waitingFor,
+				s.priority,
+				formatDuration(s.age),
+			)
+		}
+	} else {
+		_, _ = fmt.Fprintln(w, "NAME\tQUEUE\tWAITING FOR\tPRIORITY\tAGE")
+		for _, s := range queued {
+			_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\n",
+				s.name,
+				s.queuePosition,
+				s.waitingFor,
+				s.priority,
+				formatDuration(s.age),
+			)
+		}
+	}
+
+	_ = w.Flush()
+	return nil
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -42,6 +42,7 @@ built-in observability, SLO enforcement, and edge-native capabilities.`,
 	cmd.AddCommand(NewListCommand())
 	cmd.AddCommand(NewDeleteCommand())
 	cmd.AddCommand(NewStatusCommand())
+	cmd.AddCommand(NewQueueCommand())
 	cmd.AddCommand(NewVersionCommand())
 	cmd.AddCommand(NewCatalogCommand())
 	cmd.AddCommand(NewBenchmarkCommand())

--- a/pkg/cli/status.go
+++ b/pkg/cli/status.go
@@ -101,6 +101,27 @@ func runStatus(opts *statusOptions) error {
 	fmt.Printf("  Model Reference: %s\n", isvc.Spec.ModelRef)
 	fmt.Printf("  Replicas:        %d/%d ready\n", isvc.Status.ReadyReplicas, isvc.Status.DesiredReplicas)
 	fmt.Printf("  Endpoint:        %s\n", isvc.Status.Endpoint)
+
+	priority := isvc.Spec.Priority
+	if priority == "" {
+		priority = "normal"
+	}
+	fmt.Printf("  Priority:        %s\n", priority)
+
+	if isvc.Status.Phase == "WaitingForGPU" {
+		fmt.Printf("\nGPU SCHEDULING:\n")
+		fmt.Printf("  Status:          %s\n", isvc.Status.SchedulingStatus)
+		if isvc.Status.WaitingFor != "" {
+			fmt.Printf("  Waiting For:     %s\n", isvc.Status.WaitingFor)
+		}
+		if isvc.Status.QueuePosition > 0 {
+			fmt.Printf("  Queue Position:  %d\n", isvc.Status.QueuePosition)
+		}
+		if isvc.Status.SchedulingMessage != "" {
+			fmt.Printf("  Message:         %s\n", isvc.Status.SchedulingMessage)
+		}
+	}
+
 	if isvc.Status.LastUpdated != nil {
 		fmt.Printf("  Updated:         %s\n", isvc.Status.LastUpdated.Format("2006-01-02 15:04:05"))
 	}


### PR DESCRIPTION
## Summary

- Add `WaitingForGPU` phase to surface scheduling issues when pods cannot be scheduled due to insufficient GPU resources
- Add pod watching to detect `FailedScheduling` events with GPU-related messages
- Add cluster-wide queue position calculation for pending InferenceServices
- Add `priority` field (critical/high/normal/low/batch) to InferenceService spec
- Create PriorityClass manifests for kustomize and Helm chart deployments
- Add `GPUAvailable` condition to track GPU scheduling status
- Add `llmkube queue` CLI command to show pending services
- Update status command to display GPU scheduling and priority info

## New Features

### GPU Contention Visibility (#78)
When an InferenceService cannot be scheduled due to insufficient GPU resources, the status now shows:
```yaml
status:
  phase: WaitingForGPU
  schedulingStatus: InsufficientGPU
  waitingFor: "nvidia.com/gpu: 1"
  queuePosition: 2
```

### Queue Position (#79)
Cluster-wide queue position is calculated for all services waiting for GPUs:
```
$ llmkube queue
NAME            QUEUE  WAITING FOR         PRIORITY  AGE
llama-medical   1      nvidia.com/gpu: 1   normal    2m
qwen-coder      2      nvidia.com/gpu: 2   low       5m
```

### Priority Classes (#80)
Services can specify priority for GPU scheduling:
```yaml
spec:
  priority: critical  # critical > high > normal > low > batch
```

Higher priority services can preempt lower priority ones when GPUs are scarce.

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Build succeeds (`make build build-cli`)
- [x] Manual test: Deploy service with insufficient GPUs, verify WaitingForGPU phase
- [x] Manual test: Deploy multiple services, verify queue position updates
- [x] Manual test: Deploy critical priority service, verify preemption

Closes #78, closes #79, closes #80