### PR TITLE
fix(controller): use fully qualified image names for curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ EOF
 kubectl wait --for=condition=available --timeout=300s inferenceservice/tinyllama
 
 # Test it!
-kubectl run test --rm -i --image=curlimages/curl -- \
+kubectl run test --rm -i --image=docker.io/curlimages/curl -- \
   curl -X POST http://tinyllama.default.svc.cluster.local:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"messages":[{"role":"user","content":"What is Kubernetes?"}],"max_tokens":100}'

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -195,7 +195,7 @@ kubectl logs -l app=tinyllama-service --tail=50 -f
 
 ```bash
 # Create a test pod
-kubectl run test-curl --image=curlimages/curl --rm -it -- sh
+kubectl run test-curl --image=docker.io/curlimages/curl --rm -it -- sh
 
 # Inside the pod, run:
 curl -X POST http://tinyllama-service.default.svc.cluster.local:8080/v1/chat/completions \

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -141,7 +141,7 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model) modelStorageConfig
 		initContainers: []corev1.Container{
 			{
 				Name:         "model-downloader",
-				Image:        "curlimages/curl:latest",
+				Image:        "docker.io/curlimages/curl:latest",
 				Command:      []string{"sh", "-c", buildModelInitCommand(model.Spec.Source, cacheDir, modelPath, true)},
 				VolumeMounts: initVolumeMounts,
 			},
@@ -160,7 +160,7 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, namespace string
 		initContainers: []corev1.Container{
 			{
 				Name:         "model-downloader",
-				Image:        "curlimages/curl:latest",
+				Image:        "docker.io/curlimages/curl:latest",
 				Command:      []string{"sh", "-c", buildModelInitCommand(model.Spec.Source, "", modelPath, false)},
 				VolumeMounts: []corev1.VolumeMount{{Name: "model-storage", MountPath: "/models"}},
 			},

--- a/scripts/gpu-test-pod.yaml
+++ b/scripts/gpu-test-pod.yaml
@@ -7,7 +7,7 @@ spec:
   restartPolicy: OnFailure
   containers:
   - name: cuda-test
-    image: nvidia/cuda:12.2.0-base-ubuntu22.04
+    image: docker.io/nvidia/cuda:12.2.0-base-ubuntu22.04
     command: ["nvidia-smi"]
     resources:
       limits:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -214,13 +214,13 @@ var _ = Describe("Manager", Ordered, func() {
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,
-				"--image=curlimages/curl:latest",
+				"--image=docker.io/curlimages/curl:latest",
 				"--overrides",
 				fmt.Sprintf(`{
 					"spec": {
 						"containers": [{
 							"name": "curl",
-							"image": "curlimages/curl:latest",
+							"image": "docker.io/curlimages/curl:latest",
 							"command": ["/bin/sh", "-c"],
 							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
 							"securityContext": {

--- a/test/e2e/gpu_test.sh
+++ b/test/e2e/gpu_test.sh
@@ -185,7 +185,7 @@ test_inference() {
     log_info "Test 6: Testing inference endpoint..."
 
     # Create a test pod to call the API
-    kubectl run e2e-test-curl --rm -i --image=curlimages/curl --restart=Never -n $TEST_NAMESPACE -- \
+    kubectl run e2e-test-curl --rm -i --image=docker.io/curlimages/curl --restart=Never -n $TEST_NAMESPACE -- \
         curl -s -X POST http://$TEST_SERVICE_NAME.$TEST_NAMESPACE.svc.cluster.local:8080/v1/chat/completions \
         -H "Content-Type: application/json" \
         -d '{"messages":[{"role":"user","content":"What is 2+2? Answer in one sentence."}],"max_tokens":50}' \


### PR DESCRIPTION
## Description
Updates the controller and examples to use `docker.io/curlimages/curl` instead of `curlimages/curl`. This ensures compatibility with container runtimes like `cri-o` and `podman` that require fully qualified image names by default.

Closes #120

## Changes
- Updated `internal/controller/inferenceservice_controller.go`
- Updated `examples/quickstart/README.md`
- Updated `README.md`
- Updated `test/e2e/gpu_test.sh`
- Updated `test/e2e/e2e_test.go`
- Updated `scripts/gpu-test-pod.yaml`

## Verification
- [x] Verified all occurrences of `curlimages/curl` were updated.
- [x] Manual verification on a cri-o cluster (Verified by reporter).