### PR TITLE
feat(controller): make init container image configurable

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         {{- end }}
         - --model-cache-access-mode={{ .Values.modelCache.accessMode }}
         {{- end }}
+        - --init-container-image={{ .Values.controllerManager.initContainerImage }}
         {{- with .Values.controllerManager.env }}
         env:
           {{- toYaml . | nindent 10 }}

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -70,6 +70,9 @@ controllerManager:
 
   affinity: {}
 
+  # Container image used for the model downloader init container
+  initContainerImage: docker.io/curlimages/curl:latest
+
   # Additional environment variables
   env: []
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,6 +66,7 @@ func main() {
 	var modelCacheClass string
 	var modelCacheAccessMode string
 	var caCertConfigMap string
+	var initContainerImage string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -76,6 +77,8 @@ func main() {
 	flag.StringVar(&modelCacheAccessMode, "model-cache-access-mode", "ReadWriteOnce", "Access mode for model cache PVCs.")
 	flag.StringVar(&caCertConfigMap, "ca-cert-configmap", "",
 		"Name of the ConfigMap containing a custom CA certificate to trust for model downloads.")
+	flag.StringVar(&initContainerImage, "init-container-image", "docker.io/curlimages/curl:latest",
+		"Container image for the model downloader init container.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -206,6 +209,7 @@ func main() {
 		ModelCacheClass:      modelCacheClass,
 		ModelCacheAccessMode: modelCacheAccessMode,
 		CACertConfigMap:      caCertConfigMap,
+		InitContainerImage:   initContainerImage,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InferenceService")
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Add `--init-container-image` controller flag to override the model downloader init container image (default: `docker.io/curlimages/curl:latest`)
- Expose as `controllerManager.initContainerImage` in Helm chart
- Enables deployments in air-gapped environments using private registries

## Test plan
- [x] `make test` passes, including new test for custom init container image
- [x] `make vet && make fmt` clean
- [x] `helm template` renders custom image correctly with `--set controllerManager.initContainerImage=myregistry.local/curl:1.0`

Closes #127