### PR TITLE
feat(helm): add optional NetworkPolicy for controller manager

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -169,6 +169,105 @@ jobs:
           fi
           echo "✅ Custom alert thresholds work correctly"
 
+  network-policy:
+    name: Test NetworkPolicy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.13.0
+
+      - name: Test NetworkPolicy Disabled by Default
+        run: |
+          helm template llmkube charts/llmkube \
+            --namespace llmkube-system \
+            > /tmp/without-netpol.yaml
+
+          if grep -q "kind: NetworkPolicy" /tmp/without-netpol.yaml; then
+            echo "❌ NetworkPolicy found when disabled (default)"
+            exit 1
+          fi
+          echo "✅ NetworkPolicy correctly omitted by default"
+
+      - name: Test NetworkPolicy Enabled
+        run: |
+          helm template llmkube charts/llmkube \
+            --namespace llmkube-system \
+            --set networkPolicies.enabled=true \
+            > /tmp/with-netpol.yaml
+
+          if ! grep -q "kind: NetworkPolicy" /tmp/with-netpol.yaml; then
+            echo "❌ NetworkPolicy not found when enabled"
+            exit 1
+          fi
+
+          # Verify health probe port
+          if ! grep -q "port: 8081" /tmp/with-netpol.yaml; then
+            echo "❌ Health probe port 8081 not found"
+            exit 1
+          fi
+
+          # Verify DNS egress
+          if ! grep -q "port: 53" /tmp/with-netpol.yaml; then
+            echo "❌ DNS egress port 53 not found"
+            exit 1
+          fi
+          echo "✅ NetworkPolicy renders correctly when enabled"
+
+      - name: Test Metrics Port Conditional on metrics.enabled
+        run: |
+          # With metrics enabled (default), port 8443 should be present
+          helm template llmkube charts/llmkube \
+            --namespace llmkube-system \
+            --set networkPolicies.enabled=true \
+            --set metrics.enabled=true \
+            > /tmp/netpol-metrics-on.yaml
+
+          if ! grep -q "port: 8443" /tmp/netpol-metrics-on.yaml; then
+            echo "❌ Metrics port 8443 not found when metrics enabled"
+            exit 1
+          fi
+
+          # With metrics disabled, port 8443 should be absent from NetworkPolicy
+          helm template llmkube charts/llmkube \
+            --namespace llmkube-system \
+            --set networkPolicies.enabled=true \
+            --set metrics.enabled=false \
+            > /tmp/netpol-metrics-off.yaml
+
+          # Extract just the NetworkPolicy resource
+          sed -n '/kind: NetworkPolicy/,/^---/p' /tmp/netpol-metrics-off.yaml > /tmp/netpol-only.yaml
+
+          if grep -q "port: 8443" /tmp/netpol-only.yaml; then
+            echo "❌ Metrics port 8443 found in NetworkPolicy when metrics disabled"
+            exit 1
+          fi
+          echo "✅ Metrics port correctly conditional on metrics.enabled"
+
+      - name: Test Additional Egress CIDRs
+        run: |
+          helm template llmkube charts/llmkube \
+            --namespace llmkube-system \
+            --set networkPolicies.enabled=true \
+            --set 'networkPolicies.additionalEgressCIDRs[0]=10.0.0.0/8' \
+            --set 'networkPolicies.additionalEgressCIDRs[1]=172.16.0.0/12' \
+            > /tmp/netpol-cidrs.yaml
+
+          if ! grep -q "10.0.0.0/8" /tmp/netpol-cidrs.yaml; then
+            echo "❌ Additional CIDR 10.0.0.0/8 not found"
+            exit 1
+          fi
+
+          if ! grep -q "172.16.0.0/12" /tmp/netpol-cidrs.yaml; then
+            echo "❌ Additional CIDR 172.16.0.0/12 not found"
+            exit 1
+          fi
+          echo "✅ Additional egress CIDRs render correctly"
+
   crd-validation:
     name: CRD Installation Tests
     runs-on: ubuntu-latest

--- a/charts/llmkube/examples/values-production.yaml
+++ b/charts/llmkube/examples/values-production.yaml
@@ -75,3 +75,7 @@ rbac:
 serviceAccount:
   create: true
   annotations: {}
+
+# Network isolation for the controller pod
+networkPolicies:
+  enabled: true

--- a/charts/llmkube/templates/network-policy.yaml
+++ b/charts/llmkube/templates/network-policy.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "llmkube.fullname" . }}-controller-manager
+  namespace: {{ include "llmkube.namespace" . }}
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "llmkube.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8081
+  {{- if .Values.metrics.enabled }}
+  - ports:
+    - protocol: TCP
+      port: 8443
+  {{- end }}
+  egress:
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  - ports:
+    - protocol: TCP
+      port: 443
+  - ports:
+    - protocol: TCP
+      port: 80
+  {{- with .Values.networkPolicies.additionalEgressCIDRs }}
+  - to:
+    {{- range . }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -175,3 +175,8 @@ podAnnotations: {}
 
 # Pod labels
 podLabels: {}
+
+# Network policies for the controller manager pod
+networkPolicies:
+  enabled: false
+  additionalEgressCIDRs: []


### PR DESCRIPTION
## Summary
- Add NetworkPolicy template for the controller manager pod, gated by `networkPolicies.enabled` (disabled by default)
- Ingress: health probes (8081), metrics (8443, conditional on `metrics.enabled`)
- Egress: DNS (53), HTTPS/HTTP (443/80), user-configurable `additionalEgressCIDRs`
- Enable in production example values
- Add CI job to validate NetworkPolicy rendering

Closes #134

## Test plan
- [ ] `helm lint` passes
- [ ] Default render produces no NetworkPolicy
- [ ] `networkPolicies.enabled=true` renders correct NetworkPolicy
- [ ] Metrics port conditional on `metrics.enabled`
- [ ] `additionalEgressCIDRs` renders correctly
- [ ] All example values files render without errors
- [ ] New `network-policy` CI job passes