### PR TITLE
test(e2e): add CR reconciliation tests for Model and InferenceService

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -96,8 +96,12 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: model-cache
+          mountPath: /models
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: model-cache
         emptyDir: {}
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -124,6 +124,9 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	size, err := r.fetchModel(ctx, model.Spec.Source, modelPath)
 	if err != nil {
 		logger.Error(err, "Failed to fetch model")
+		if removeErr := os.Remove(modelPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			logger.Error(removeErr, "Failed to clean up partial download")
+		}
 		model.Status.Phase = "Failed"
 		if statusErr := r.updateStatus(ctx, model, "Degraded", metav1.ConditionTrue, failReason, err.Error()); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status after fetch failure")


### PR DESCRIPTION
## Summary
- Adds 5 E2E test specs covering core CR reconciliation, replacing the TODO placeholder at line 268
- Deploys an in-cluster nginx pod serving a fake GGUF file via ConfigMap (no external dependencies)
- Tests run in a dedicated `e2e-cr-test` namespace to avoid interference with controller lifecycle tests
- Fixes two issues discovered during E2E testing:
  - Adds `emptyDir` volume at `/models` in kustomize base manifest (`make deploy` had no writable volume; Helm already uses a PVC)
  - Cleans up partial download files on fetch failure to prevent stale 0-byte files from being treated as cached models

## Tests Added
1. **Model CR reconciles to Ready** — verifies download, cacheKey (16-char hex), Available condition
2. **InferenceService creates Deployment + Service** — verifies labels, port 8080, selector, endpoint
3. **Bad model ref → Failed** — InferenceService referencing non-existent Model
4. **Owner reference cascade** — deleting InferenceService garbage collects Deployment + Service
5. **Unreachable source → Failed** — Model with 404 URL reports Degraded/DownloadFailed

## Test plan
- [x] `make test` — unit tests pass (including controller tests with the fix)
- [x] `make lint` — passes
- [ ] `make test-e2e` — full E2E suite passes including new CR reconciliation tests

Ref: #90