### PR TITLE
chore: polish GitHub presence with badges, updated references, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## What
+
+<!-- Brief description of the change -->
+
+## Why
+
+<!-- Why is this change needed? Link to issue if applicable -->
+
+Fixes #
+
+## How
+
+<!-- How was this implemented? Any design decisions worth noting? -->
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] `make test` passes locally
+- [ ] `make lint` passes locally
+- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
+- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
+- [ ] Documentation updated (if user-facing change)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,12 +346,11 @@ func (r *ModelReconciler) ReconcileModel(ctx context.Context, model *inferencev1
 ### Communication Channels
 
 - **GitHub Issues**: Bug reports, feature requests
-- **GitHub Discussions**: Q&A, ideas, general discussion (coming soon)
-- **Slack/Discord**: Real-time chat (coming soon)
+- **GitHub Discussions**: [Q&A, ideas, general discussion](https://github.com/defilantech/LLMKube/discussions)
 
 ### Weekly Sync
 
-**When**: Mondays, 10am PT (details in Discord when available)
+**When**: Mondays, 10am PT (details in [GitHub Discussions](https://github.com/defilantech/LLMKube/discussions))
 **Agenda**: Review PRs, discuss roadmap, unblock contributors
 
 ### Recognition

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/defilantech/llmkube-controller:0.4.0
+IMG ?= ghcr.io/defilantech/llmkube-controller:0.4.13
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/README.md
+++ b/README.md
@@ -8,15 +8,25 @@
   **17x faster inference** • **Production-ready** • **OpenAI-compatible API**
 
   <p>
+    <a href="https://github.com/defilantech/LLMKube/actions/workflows/test.yml">
+      <img src="https://github.com/defilantech/LLMKube/actions/workflows/test.yml/badge.svg" alt="Tests">
+    </a>
     <a href="https://github.com/defilantech/LLMKube/actions/workflows/helm-chart.yml">
       <img src="https://github.com/defilantech/LLMKube/actions/workflows/helm-chart.yml/badge.svg" alt="Helm Chart CI">
+    </a>
+    <a href="https://goreportcard.com/report/github.com/defilantech/llmkube">
+      <img src="https://goreportcard.com/badge/github.com/defilantech/llmkube" alt="Go Report Card">
     </a>
     <a href="https://github.com/defilantech/LLMKube/releases">
       <img src="https://img.shields.io/github/v/release/defilantech/LLMKube?label=version" alt="Version">
     </a>
+    <a href="https://github.com/defilantech/LLMKube/stargazers">
+      <img src="https://img.shields.io/github/stars/defilantech/LLMKube?style=social" alt="GitHub Stars">
+    </a>
     <a href="LICENSE">
       <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License">
     </a>
+    <img src="https://img.shields.io/github/go-mod/go-version/defilantech/LLMKube" alt="Go Version">
   </p>
 
   <p>
@@ -622,7 +632,7 @@ A: Yes! Pre-download models to PersistentVolumes and use local image registries.
 We're just getting started! Here's how to get involved:
 
 - 🐛 **Bug reports & features:** [GitHub Issues](https://github.com/defilantech/LLMKube/issues)
-- 💬 **Questions & help:** [GitHub Discussions](https://github.com/defilantech/LLMKube/discussions) (coming soon)
+- 💬 **Questions & help:** [GitHub Discussions](https://github.com/defilantech/LLMKube/discussions)
 - 📖 **Roadmap:** [ROADMAP.md](ROADMAP.md)
 - 🤝 **Contributing:** We welcome PRs! See [ROADMAP.md](ROADMAP.md) for priorities
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # LLMKube Roadmap
 
-**Current Version:** 0.4.9
-**Last Updated:** December 2025
+**Current Version:** 0.4.13
+**Last Updated:** February 2026
 **Status:** ✅ Phase 1 Complete - GPU Inference, Metal Support, Model Catalog & GPU Scheduling
 
 ---
@@ -20,7 +20,7 @@ Make GPU-accelerated LLM inference on Kubernetes **dead simple**. Deploy product
 
 ## Current Status
 
-### ✅ What's Working Now (v0.4.9)
+### ✅ What's Working Now (v0.4.13)
 
 **Core Platform:**
 - ✅ Kubernetes-native CRDs (`Model`, `InferenceService`)
@@ -139,9 +139,9 @@ Make GPU-accelerated LLM inference on Kubernetes **dead simple**. Deploy product
 
 | Metric | Current | Q1 2026 Goal | Q2 2026 Goal |
 |--------|---------|--------------|--------------|
-| **GitHub Stars** | 0 | 100 | 500 |
+| **GitHub Stars** | 17 | 100 | 500 |
 | **Contributors** | 1 | 5 | 10 |
-| **Production Deployments** | 0 | 10 | 25 |
+| **Production Deployments** | 1 | 10 | 25 |
 | **Models Supported** | Any GGUF | 20+ pre-configured | 50+ pre-configured |
 
 ---
@@ -198,7 +198,8 @@ We ship frequently with semantic versioning:
 **Next releases:**
 - **v0.4.0** - November 2025 (multi-GPU support) ✅
 - **v0.4.1** - November 2025 (persistent model cache) ✅
-- **v0.4.9** - December 2025 (GPU scheduling & priority classes) ✅ **Current**
+- **v0.4.9** - December 2025 (GPU scheduling & priority classes) ✅
+- **v0.4.13** - February 2026 (GGUF parser, init container customization, NetworkPolicy) ✅ **Current**
 - **v0.5.0** - Q1 2026 (autoscaling)
 - **v0.6.0** - Q2 2026 (edge deployment, K3s)
 - **v1.0.0** - Q4 2026 (stable, production-ready)
@@ -240,7 +241,7 @@ Apache 2.0 - See [LICENSE](LICENSE)
 
 ---
 
-**Last Updated:** December 2025
-**Next Review:** February 2026
+**Last Updated:** February 2026
+**Next Review:** April 2026
 
 *This roadmap is a living document. Priorities may shift based on community feedback and real-world usage.*

--- a/charts/llmkube/README.md
+++ b/charts/llmkube/README.md
@@ -18,9 +18,13 @@ LLMKube is a Kubernetes operator that makes it easy to deploy, manage, and scale
 ### Add the Helm Repository
 
 ```bash
-# TODO: Update when chart is published to a repository
-# helm repo add llmkube https://charts.llmkube.dev
-# helm repo update
+helm repo add llmkube https://defilantech.github.io/LLMKube
+helm repo update
+
+# Install the chart
+helm install llmkube llmkube/llmkube \
+  --namespace llmkube-system \
+  --create-namespace
 ```
 
 ### Install from Local Chart

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -415,8 +415,7 @@ kubectl delete crd inferenceservices.inference.llmkube.dev
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/Defilan/LLMKube/issues)
-- **Discussions**: Coming soon
-- **Community**: Discord/Slack (coming soon)
+- **Discussions**: [GitHub Discussions](https://github.com/defilantech/LLMKube/discussions)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Go Report Card, test status, GitHub stars, and Go version badges to README (3 → 7 badges)
- Fix stale version references in ROADMAP.md (0.4.9 → 0.4.13) and Makefile (0.4.0 → 0.4.13)
- Replace all "coming soon" placeholders with live GitHub Discussions links across README, CONTRIBUTING, and examples
- Update Helm chart README with published repo install instructions (was a stale TODO)
- Add `.github/PULL_REQUEST_TEMPLATE.md` for contributor experience

## Test plan

- [ ] Verify badge images render correctly on GitHub README
- [ ] Verify Go Report Card link resolves (may take a few minutes on first visit)
- [ ] Confirm Helm install instructions work: `helm repo add llmkube https://defilantech.github.io/LLMKube`
- [ ] Confirm GitHub Discussions links are live