### PR TITLE
fix(inference): pass value to --flash-attn for newer llama.cpp versions

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -639,7 +639,7 @@ func appendParallelSlotsArgs(args []string, parallelSlots *int32) []string {
 
 func appendFlashAttentionArgs(args []string, flashAttention *bool, gpuCount int32) []string {
 	if gpuCount > 0 && flashAttention != nil && *flashAttention {
-		return append(args, "--flash-attn")
+		return append(args, "--flash-attn", "on")
 	}
 	return args
 }

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -953,7 +953,7 @@ var _ = Describe("Context Size Configuration", func() {
 			deployment := reconciler.constructDeployment(isvc, model, 1)
 
 			args := deployment.Spec.Template.Spec.Containers[0].Args
-			Expect(args).To(ContainElement("--flash-attn"))
+			Expect(args).To(ContainElements("--flash-attn", "on"))
 		})
 
 		It("should NOT include --flash-attn flag when flashAttention is not specified", func() {


### PR DESCRIPTION
## Summary

- Pass `--flash-attn on` instead of bare `--flash-attn` to match the updated llama.cpp CLI interface
- Newer llama.cpp builds require an explicit value (`on|off|auto`) for this flag

## Test plan

- [x] Unit tests updated to verify `--flash-attn on` is passed
- [x] Full test suite passes
- [ ] Deploy with `flashAttention: true` and verify pod starts successfully

Fixes #147