### PR TITLE
feat(agent): add --host-ip flag for remote K8s cluster support

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -47,6 +47,7 @@ type AgentConfig struct {
 	LlamaServerBin string
 	Port           int
 	LogLevel       string
+	HostIP         string
 }
 
 func main() {
@@ -58,6 +59,7 @@ func main() {
 	flag.StringVar(&cfg.LlamaServerBin, "llama-server", "/usr/local/bin/llama-server", "Path to llama-server binary")
 	flag.IntVar(&cfg.Port, "port", 9090, "Agent metrics/health port")
 	flag.StringVar(&cfg.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
+	flag.StringVar(&cfg.HostIP, "host-ip", "", "IP address to register in Kubernetes endpoints (auto-detected if empty)")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.Parse()
 
@@ -75,6 +77,11 @@ func main() {
 	fmt.Printf("Model Store:     %s\n", cfg.ModelStorePath)
 	fmt.Printf("Llama Server:    %s\n", cfg.LlamaServerBin)
 	fmt.Printf("Agent Port:      %d\n", cfg.Port)
+	if cfg.HostIP != "" {
+		fmt.Printf("Host IP:         %s\n", cfg.HostIP)
+	} else {
+		fmt.Printf("Host IP:         (auto-detect)\n")
+	}
 	fmt.Println("═══════════════════════════════════════════════")
 
 	// Verify Metal support
@@ -133,6 +140,7 @@ func main() {
 		ModelStorePath: cfg.ModelStorePath,
 		LlamaServerBin: cfg.LlamaServerBin,
 		Port:           cfg.Port,
+		HostIP:         cfg.HostIP,
 	})
 
 	// Setup context with signal handling

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -35,6 +35,7 @@ type MetalAgentConfig struct {
 	ModelStorePath string
 	LlamaServerBin string
 	Port           int
+	HostIP         string // explicit IP to register in K8s endpoints; empty = auto-detect
 }
 
 // MetalAgent watches Kubernetes InferenceService resources and manages
@@ -72,7 +73,7 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 	// Initialize components
 	a.watcher = NewInferenceServiceWatcher(a.config.K8sClient, a.config.Namespace)
 	a.executor = NewMetalExecutor(a.config.LlamaServerBin, a.config.ModelStorePath)
-	a.registry = NewServiceRegistry(a.config.K8sClient)
+	a.registry = NewServiceRegistry(a.config.K8sClient, a.config.HostIP)
 
 	// Start watcher
 	eventChan := make(chan InferenceServiceEvent)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -145,7 +145,7 @@ func TestHandleEvent_CreateMissingModel(t *testing.T) {
 	})
 	agent.watcher = NewInferenceServiceWatcher(k8sClient, "default")
 	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models")
-	agent.registry = NewServiceRegistry(k8sClient)
+	agent.registry = NewServiceRegistry(k8sClient, "")
 
 	event := InferenceServiceEvent{
 		Type: EventTypeCreated,


### PR DESCRIPTION
## Summary

- Add `--host-ip` flag to the Metal Agent CLI for specifying an explicit IP address to register in Kubernetes endpoints
- When set, the provided IP is used instead of auto-detecting via `host.minikube.internal` / `host.docker.internal`
- Enables running the Metal Agent on a separate machine from the K8s cluster (e.g. Mac Studio over Tailscale)
- Add tests for the new `resolveHostIP` behavior and explicit host IP endpoint registration

## Test plan

- [x] All 27 agent tests pass (`go test ./pkg/agent/ -v`)
- [x] `TestResolveHostIP_Explicit` verifies explicit IP is returned
- [x] `TestResolveHostIP_AutoDetect` verifies fallback when empty
- [x] `TestRegisterEndpoint_ExplicitHostIP` verifies the IP appears in created Endpoints
- [x] `GOOS=darwin GOARCH=arm64 go build ./cmd/metal-agent` compiles cleanly
- [ ] CI pipeline passes

Closes #154