### PR TITLE
fix(agent): read contextSize from InferenceService CRD

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -147,6 +147,12 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 		gpuLayers = model.Spec.Hardware.GPU.Layers
 	}
 
+	// Get context size from InferenceService spec, default to 2048
+	contextSize := 2048
+	if isvc.Spec.ContextSize != nil && *isvc.Spec.ContextSize > 0 {
+		contextSize = int(*isvc.Spec.ContextSize)
+	}
+
 	// Start the process
 	process, err := a.executor.StartProcess(ctx, ExecutorConfig{
 		Name:        isvc.Name,
@@ -154,7 +160,7 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 		ModelSource: model.Spec.Source,
 		ModelName:   model.Name,
 		GPULayers:   gpuLayers,
-		ContextSize: 2048, // TODO: Get from model spec
+		ContextSize: contextSize,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start process: %w", err)


### PR DESCRIPTION
## Summary

- Metal Agent now reads `contextSize` from the InferenceService CRD spec instead of hardcoding 2048
- Falls back to 2048 only when the field is not set in the CRD
- Resolves context overflow errors for prompts exceeding 2048 tokens (e.g., financial analysis prompts where system prompt alone is ~800 tokens)

Fixes #159

## Test plan

- [ ] Deploy with InferenceService that has `contextSize: 8192` and verify llama-server starts with `-c 8192`
- [ ] Deploy with InferenceService without `contextSize` set and verify fallback to 2048
- [ ] Run prompts that exceed 2048 tokens and verify no context overflow errors