### PR TITLE
docs: add Apple Silicon Metal option to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -52,6 +52,7 @@ kubectl version
 - [ ] NVIDIA L4
 - [ ] NVIDIA V100
 - [ ] NVIDIA A100
+- [ ] Metal (Apple Silicon)
 - [ ] None (CPU only)
 - [ ] Other:
 


### PR DESCRIPTION
## What

Add `Metal (Apple Silicon)` as a selectable option in the bug report template hardware section.

## Why

This helps capture Apple Silicon + Metal environments explicitly in bug reports, which improves triage and reproducibility for Metal-related issues.

## How

Updated `.github/ISSUE_TEMPLATE/bug_report.md` by inserting `Metal (Apple Silicon)` before `None (CPU only)` in the **GPU (if applicable)** checklist.

## Checklist

- [ ] Tests added/updated
- [ ] `make test` passes locally
- [ ] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change)