### PR TITLE
fix: enable controller metrics endpoint in Helm chart

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
         - --leader-elect
         {{- end }}
         - --health-probe-bind-address=:8081
+        {{- if .Values.metrics.enabled }}
+        - --metrics-bind-address=:{{ .Values.metrics.service.port }}
+        - --metrics-secure={{ .Values.metrics.secure }}
+        {{- end }}
         {{- if .Values.modelCache.enabled }}
         - --model-cache-path={{ .Values.modelCache.mountPath }}
         - --model-cache-size={{ .Values.modelCache.size }}
@@ -50,6 +54,15 @@ spec:
         - --model-cache-access-mode={{ .Values.modelCache.accessMode }}
         {{- end }}
         - --init-container-image={{ .Values.controllerManager.initContainerImage }}
+        ports:
+        - name: health
+          containerPort: 8081
+          protocol: TCP
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          containerPort: {{ .Values.metrics.service.port }}
+          protocol: TCP
+        {{- end }}
         {{- with .Values.controllerManager.env }}
         env:
           {{- toYaml . | nindent 10 }}

--- a/charts/llmkube/templates/metrics-service.yaml
+++ b/charts/llmkube/templates/metrics-service.yaml
@@ -13,10 +13,13 @@ metadata:
 spec:
   type: {{ .Values.metrics.service.type }}
   ports:
-  - name: https
+  - name: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
     port: {{ .Values.metrics.service.port }}
     protocol: TCP
-    targetPort: https
+    targetPort: metrics
+    {{- if and (eq .Values.metrics.service.type "NodePort") .Values.metrics.service.nodePort }}
+    nodePort: {{ .Values.metrics.service.nodePort }}
+    {{- end }}
   selector:
     {{- include "llmkube.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -95,10 +95,15 @@ rbac:
 metrics:
   # Enable metrics endpoint
   enabled: true
+  # Serve metrics over HTTPS with authn/authz (true) or plain HTTP (false).
+  # Set to false when scraping from outside the cluster without a ServiceAccount token.
+  secure: true
   # Service type for metrics
   service:
     type: ClusterIP
     port: 8443
+    # NodePort to expose when service type is NodePort (optional, auto-assigned if empty)
+    nodePort: ""
     annotations: {}
 
 # Prometheus Operator integration


### PR DESCRIPTION
## Summary
- The controller-manager deployment was missing `--metrics-bind-address`, causing controller-runtime to default to `"0"` (disabled). The metrics Service existed but had no backend.
- Adds `--metrics-bind-address` and `--metrics-secure` flags from Helm values, defines named container ports, fixes Service targetPort, and adds optional NodePort support for external scraping.
- Defaults `metrics.secure: true` (HTTPS with authn/authz) — users must explicitly opt into insecure mode.

Fixes #194

## Test plan
- [ ] Deploy with default values (`metrics.secure: true`, `service.type: ClusterIP`) — verify `curl -k https://<controller-pod>:8443/metrics` returns metrics
- [ ] Deploy with `metrics.secure=false` — verify `curl http://<controller-pod>:8443/metrics` returns metrics
- [ ] Deploy with `metrics.service.type=NodePort`, `metrics.service.nodePort=30443` — verify NodePort is accessible
- [ ] Deploy with `metrics.enabled=false` — verify no metrics args or ports in pod spec
- [ ] Verify existing Prometheus ServiceMonitor still works with ClusterIP default