### PR TITLE
fix: use Recreate strategy for GPU workloads to prevent rolling update deadlock

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -839,6 +839,13 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	}
 
 	if gpuCount > 0 {
+		// Use Recreate strategy for GPU workloads to prevent deadlock:
+		// RollingUpdate requires the new pod to be Ready before terminating the old,
+		// but the new pod cannot schedule if the old pod holds the only available GPU(s).
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		}
+
 		tolerations := []corev1.Toleration{
 			{
 				Key:      "nvidia.com/gpu",

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -255,6 +255,9 @@ var _ = Describe("Multi-GPU Deployment Construction", func() {
 			By("verifying GPU resource limits")
 			gpuLimit := container.Resources.Limits["nvidia.com/gpu"]
 			Expect(gpuLimit).To(Equal(resource.MustParse("2")))
+
+			By("verifying Recreate strategy is set to avoid GPU deadlock")
+			Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
 		})
 
 		It("should include multi-GPU args for 4 GPU model", func() {
@@ -579,6 +582,9 @@ var _ = Describe("Multi-GPU Deployment Construction", func() {
 				}
 			}
 			Expect(hasNvidiaToleration).To(BeTrue())
+
+			By("verifying Recreate strategy is set for GPU workloads")
+			Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
 		})
 
 		It("should apply custom node selector from InferenceService spec", func() {
@@ -1840,6 +1846,7 @@ var _ = Describe("constructDeployment additional cases", func() {
 		deployment := reconciler.constructDeployment(isvc, model, 1)
 		Expect(deployment.Spec.Template.Spec.Tolerations).To(BeEmpty())
 		Expect(deployment.Spec.Template.Spec.NodeSelector).To(BeEmpty())
+		Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.DeploymentStrategyType("")))
 	})
 
 	It("should use explicit GPU layers from Model spec", func() {


### PR DESCRIPTION
## Summary

- Sets deployment strategy to `Recreate` for GPU workloads (`gpuCount > 0`) to prevent scheduling deadlock during rolling updates
- Non-GPU workloads continue using the Kubernetes default (`RollingUpdate`)
- Adds test assertions for both GPU and CPU-only strategy behavior

## Problem

When all GPUs on a node are occupied, `RollingUpdate` creates a deadlock: the new pod cannot schedule without a GPU, and the old pod won't terminate until the new pod is Ready. This is especially common in homelab/small clusters with no spare GPUs.

## How it works

The fix adds a `Recreate` strategy assignment inside the existing `if gpuCount > 0` block in `constructDeployment()`, alongside the GPU toleration logic. This means the old pod terminates first, freeing the GPU for the replacement pod. Brief downtime during updates is acceptable — the alternative is a permanent deadlock.

Existing GPU InferenceService deployments will pick up the fix on the next reconcile cycle.

Fixes #192

## Test plan

- [x] `make test` passes — all existing + new tests
- [ ] Verify GPU deployment has `strategy: Recreate` via `kubectl get deploy <name> -o yaml`
- [ ] Verify CPU-only deployment retains default `RollingUpdate`
- [ ] Trigger a GPU InferenceService update and confirm old pod terminates before new pod creates