### PR TITLE
fix: controller metrics port declarations and ServiceMonitor consistency

### DIFF
--- a/charts/llmkube/templates/servicemonitor.yaml
+++ b/charts/llmkube/templates/servicemonitor.yaml
@@ -12,11 +12,13 @@ metadata:
 spec:
   endpoints:
   - path: /metrics
-    port: https
-    scheme: https
+    port: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
+    scheme: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
     interval: {{ .Values.prometheus.serviceMonitor.interval }}
+    {{- if .Values.metrics.secure }}
     tlsConfig:
       insecureSkipVerify: true
+    {{- end }}
   selector:
     matchLabels:
       {{- include "llmkube.selectorLabels" . | nindent 6 }}

--- a/charts/llmkube/tests/metrics_test.yaml
+++ b/charts/llmkube/tests/metrics_test.yaml
@@ -1,0 +1,109 @@
+suite: metrics port consistency
+templates:
+  - deployment.yaml
+  - metrics-service.yaml
+  - servicemonitor.yaml
+
+tests:
+  # Deployment: container ports declared when metrics enabled
+  - it: should declare metrics container port when metrics enabled
+    template: deployment.yaml
+    set:
+      metrics.enabled: true
+      metrics.service.port: 8443
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+            containerPort: 8443
+            protocol: TCP
+
+  - it: should declare health container port
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: health
+            containerPort: 8081
+            protocol: TCP
+
+  # Service: targetPort matches container port name
+  - it: should target container port by name
+    template: metrics-service.yaml
+    set:
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.ports[0].targetPort
+          value: metrics
+
+  # Service: port name is "https" when secure
+  - it: should name service port https when metrics.secure is true
+    template: metrics-service.yaml
+    set:
+      metrics.enabled: true
+      metrics.secure: true
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: https
+
+  # Service: port name is "http" when not secure
+  - it: should name service port http when metrics.secure is false
+    template: metrics-service.yaml
+    set:
+      metrics.enabled: true
+      metrics.secure: false
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: http
+
+  # ServiceMonitor: port matches service port name (secure)
+  - it: should reference https port when metrics.secure is true
+    template: servicemonitor.yaml
+    set:
+      prometheus.serviceMonitor.enabled: true
+      metrics.secure: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: https
+      - equal:
+          path: spec.endpoints[0].scheme
+          value: https
+
+  # ServiceMonitor: port matches service port name (insecure)
+  - it: should reference http port when metrics.secure is false
+    template: servicemonitor.yaml
+    set:
+      prometheus.serviceMonitor.enabled: true
+      metrics.secure: false
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+      - equal:
+          path: spec.endpoints[0].scheme
+          value: http
+
+  # ServiceMonitor: tlsConfig only when secure
+  - it: should include tlsConfig when secure
+    template: servicemonitor.yaml
+    set:
+      prometheus.serviceMonitor.enabled: true
+      metrics.secure: true
+    asserts:
+      - isNotNull:
+          path: spec.endpoints[0].tlsConfig
+
+  - it: should omit tlsConfig when not secure
+    template: servicemonitor.yaml
+    set:
+      prometheus.serviceMonitor.enabled: true
+      metrics.secure: false
+    asserts:
+      - isNull:
+          path: spec.endpoints[0].tlsConfig

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -12,7 +12,7 @@ spec:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: 8443
+    targetPort: metrics
   selector:
     control-plane: controller-manager
     app.kubernetes.io/name: llmkube

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,9 +63,17 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          - --metrics-bind-address=:8443
+          - --metrics-secure=true
         image: controller:latest
         name: manager
-        ports: []
+        ports:
+        - name: metrics
+          containerPort: 8443
+          protocol: TCP
+        - name: health
+          containerPort: 8081
+          protocol: TCP
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https # Ensure this is the name of the port that exposes HTTPS metrics
+      port: https # Must match the service port name; change to "http" if --metrics-secure=false
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:


### PR DESCRIPTION
## Summary

Fixes #208. Resolves the remaining metrics endpoint issues from the semi-manual 0.5.0 release.

- **Kustomize `ports: []`** — Add metrics (8443) and health (8081) container port declarations plus `--metrics-bind-address` and `--metrics-secure` args. Anyone deploying via `make deploy` would have hit the same empty-endpoints issue.
- **ServiceMonitor port mismatch** — Helm ServiceMonitor hardcoded `port: https` which breaks when `metrics.secure=false` (service port becomes `http`). Now templated to match.
- **tlsConfig when insecure** — ServiceMonitor no longer includes `tlsConfig` when `metrics.secure=false`
- **Named targetPort** — Kustomize metrics service now uses `targetPort: metrics` instead of `targetPort: 8443`
- **Helm unit tests** — 9 helm-unittest cases verify port consistency across deployment, service, and ServiceMonitor

## Test plan

- [x] `make test` — all Go tests pass
- [x] `helm unittest charts/llmkube` — 9/9 tests pass
- [x] CI (DCO, lint, tests, e2e)