### PR TITLE
feat: auto-detect llama-server from Homebrew paths on macOS

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -73,13 +73,43 @@ func newLogger(level string) (*zap.Logger, error) {
 	return cfg.Build()
 }
 
+// defaultLlamaServerPaths is the list of paths to search for llama-server,
+// in order of preference. Apple Silicon Homebrew installs to /opt/homebrew/bin,
+// Intel Homebrew installs to /usr/local/bin.
+var defaultLlamaServerPaths = []string{
+	"/opt/homebrew/bin/llama-server",
+	"/usr/local/bin/llama-server",
+}
+
+// statFunc is the function used to check file existence (overridden in tests).
+var statFunc = os.Stat
+
+// resolveLlamaServerBin returns the llama-server binary path. If override is
+// non-empty, it is returned as-is. Otherwise the function searches
+// defaultLlamaServerPaths and returns the first one that exists.
+func resolveLlamaServerBin(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	for _, p := range defaultLlamaServerPaths {
+		if _, err := statFunc(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"llama-server not found in default paths (%v); "+
+			"install with: brew install llama.cpp, or pass --llama-server=/path/to/binary",
+		defaultLlamaServerPaths)
+}
+
 func main() {
 	cfg := &AgentConfig{}
 
 	// Parse command-line flags
+	var llamaServerFlag string
 	flag.StringVar(&cfg.Namespace, "namespace", "default", "Kubernetes namespace to watch")
 	flag.StringVar(&cfg.ModelStorePath, "model-store", "/tmp/llmkube-models", "Path to store downloaded models")
-	flag.StringVar(&cfg.LlamaServerBin, "llama-server", "/usr/local/bin/llama-server", "Path to llama-server binary")
+	flag.StringVar(&llamaServerFlag, "llama-server", "", "Path to llama-server binary (auto-detected if not set)")
 	flag.IntVar(&cfg.Port, "port", 9090, "Agent metrics/health port")
 	flag.StringVar(&cfg.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	flag.StringVar(&cfg.HostIP, "host-ip", "", "IP address to register in Kubernetes endpoints (auto-detected if empty)")
@@ -107,6 +137,18 @@ func main() {
 
 	// TODO: Wire this logger into controller-runtime via ctrl.SetLogger(...) so
 	// Kubernetes client/controller-runtime logs share the same configuration.
+
+	// Resolve llama-server binary path
+	resolvedBin, err := resolveLlamaServerBin(llamaServerFlag)
+	if err != nil {
+		logger.Errorw("llama-server binary not found",
+			"searchPaths", defaultLlamaServerPaths,
+			"installHint", "brew install llama.cpp",
+			"error", err,
+		)
+		os.Exit(1)
+	}
+	cfg.LlamaServerBin = resolvedBin
 
 	hostIP := cfg.HostIP
 	if hostIP == "" {
@@ -140,15 +182,6 @@ func main() {
 	// Create model store directory
 	if err := os.MkdirAll(cfg.ModelStorePath, 0755); err != nil {
 		logger.Errorw("failed to create model store directory", "path", cfg.ModelStorePath, "error", err)
-		os.Exit(1)
-	}
-
-	// Verify llama-server binary exists
-	if _, err := os.Stat(cfg.LlamaServerBin); os.IsNotExist(err) {
-		logger.Errorw("llama-server binary not found",
-			"path", cfg.LlamaServerBin,
-			"installHint", "brew install llama.cpp",
-		)
 		os.Exit(1)
 	}
 	logger.Infow("llama-server binary found", "path", cfg.LlamaServerBin)

--- a/cmd/metal-agent/main_test.go
+++ b/cmd/metal-agent/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"go.uber.org/zap/zapcore"
@@ -32,4 +34,72 @@ func TestParseLogLevel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveLlamaServerBin(t *testing.T) {
+	// Save and restore the original statFunc and defaultLlamaServerPaths
+	origStat := statFunc
+	origPaths := defaultLlamaServerPaths
+	t.Cleanup(func() {
+		statFunc = origStat
+		defaultLlamaServerPaths = origPaths
+	})
+
+	t.Run("explicit override is returned as-is", func(t *testing.T) {
+		got, err := resolveLlamaServerBin("/custom/path/llama-server")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/custom/path/llama-server" {
+			t.Fatalf("got %q, want /custom/path/llama-server", got)
+		}
+	})
+
+	t.Run("finds first candidate", func(t *testing.T) {
+		defaultLlamaServerPaths = []string{"/first/llama-server", "/second/llama-server"}
+		statFunc = func(name string) (os.FileInfo, error) {
+			if name == "/first/llama-server" {
+				return nil, nil
+			}
+			return nil, errors.New("not found")
+		}
+
+		got, err := resolveLlamaServerBin("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/first/llama-server" {
+			t.Fatalf("got %q, want /first/llama-server", got)
+		}
+	})
+
+	t.Run("falls through to second candidate", func(t *testing.T) {
+		defaultLlamaServerPaths = []string{"/first/llama-server", "/second/llama-server"}
+		statFunc = func(name string) (os.FileInfo, error) {
+			if name == "/second/llama-server" {
+				return nil, nil
+			}
+			return nil, errors.New("not found")
+		}
+
+		got, err := resolveLlamaServerBin("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/second/llama-server" {
+			t.Fatalf("got %q, want /second/llama-server", got)
+		}
+	})
+
+	t.Run("returns error when no candidate found", func(t *testing.T) {
+		defaultLlamaServerPaths = []string{"/nope/llama-server"}
+		statFunc = func(string) (os.FileInfo, error) {
+			return nil, errors.New("not found")
+		}
+
+		_, err := resolveLlamaServerBin("")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Closes #165. Thanks to @matiasinsaurralde for filing this.

The `--llama-server` flag previously defaulted to `/usr/local/bin/llama-server`, which is the Intel Homebrew prefix. On Apple Silicon (where most Metal agent users are), Homebrew installs to `/opt/homebrew/bin`. Users had to pass the flag explicitly every time.

Now the agent auto-detects llama-server by searching known Homebrew paths in order:
1. `/opt/homebrew/bin/llama-server` (Apple Silicon)
2. `/usr/local/bin/llama-server` (Intel)

Passing `--llama-server=/path/to/binary` still overrides auto-detection.

## Changes

- Extract `resolveLlamaServerBin()` with injectable `statFunc` for testability
- Default `--llama-server` flag to empty string (triggers auto-detection)
- Search `defaultLlamaServerPaths` in order, return first match
- Clear error message with install hint when neither path exists

## Test plan

- [x] `go test ./cmd/metal-agent/ -v` - 12/12 tests pass (4 new)
- [x] `make test` - full suite green
- [x] CI (DCO, lint, tests, e2e)