### PR TITLE
feat: add memory pressure watchdog with runtime monitoring

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -45,13 +45,17 @@ var (
 )
 
 type AgentConfig struct {
-	Namespace      string
-	ModelStorePath string
-	LlamaServerBin string
-	Port           int
-	LogLevel       string
-	HostIP         string
-	MemoryFraction float64
+	Namespace              string
+	ModelStorePath         string
+	LlamaServerBin         string
+	Port                   int
+	LogLevel               string
+	HostIP                 string
+	MemoryFraction         float64
+	WatchdogInterval       time.Duration
+	MemoryPressureWarning  float64
+	MemoryPressureCritical float64
+	EvictionEnabled        bool
 }
 
 func parseLogLevel(level string) zapcore.Level {
@@ -115,6 +119,14 @@ func main() {
 	flag.StringVar(&cfg.HostIP, "host-ip", "", "IP address to register in Kubernetes endpoints (auto-detected if empty)")
 	flag.Float64Var(&cfg.MemoryFraction, "memory-fraction", 0,
 		"Fraction of system memory to budget for models (0 = auto-detect based on total RAM)")
+	flag.DurationVar(&cfg.WatchdogInterval, "memory-watchdog-interval", 10*time.Second,
+		"How often to check memory pressure (0 to disable)")
+	flag.Float64Var(&cfg.MemoryPressureWarning, "memory-pressure-warning", 0.20,
+		"Available memory fraction below which a warning is emitted")
+	flag.Float64Var(&cfg.MemoryPressureCritical, "memory-pressure-critical", 0.10,
+		"Available memory fraction below which pressure is critical")
+	flag.BoolVar(&cfg.EvictionEnabled, "eviction-enabled", false,
+		"Enable automatic process eviction under critical memory pressure")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.Parse()
 
@@ -209,7 +221,7 @@ func main() {
 
 	// Create agent
 	logger.Infow("creating Metal agent")
-	metalAgent := agent.NewMetalAgent(agent.MetalAgentConfig{
+	agentCfg := agent.MetalAgentConfig{
 		K8sClient:      k8sClient,
 		Namespace:      cfg.Namespace,
 		ModelStorePath: cfg.ModelStorePath,
@@ -218,7 +230,20 @@ func main() {
 		HostIP:         cfg.HostIP,
 		Logger:         logger,
 		MemoryFraction: cfg.MemoryFraction,
-	})
+	}
+	if cfg.WatchdogInterval > 0 {
+		agentCfg.WatchdogConfig = &agent.MemoryWatchdogConfig{
+			Interval:          cfg.WatchdogInterval,
+			WarningThreshold:  cfg.MemoryPressureWarning,
+			CriticalThreshold: cfg.MemoryPressureCritical,
+		}
+		logger.Infow("memory watchdog enabled",
+			"interval", cfg.WatchdogInterval,
+			"warningThreshold", cfg.MemoryPressureWarning,
+			"criticalThreshold", cfg.MemoryPressureCritical,
+		)
+	}
+	metalAgent := agent.NewMetalAgent(agentCfg)
 
 	// Setup context with signal handling
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -46,6 +46,9 @@ type MetalAgentConfig struct {
 	MemoryProvider MemoryProvider
 	// MemoryFraction is the fraction of total memory to budget for models (0 = auto-detect).
 	MemoryFraction float64
+
+	// WatchdogConfig configures the memory pressure watchdog. Nil disables it.
+	WatchdogConfig *MemoryWatchdogConfig
 }
 
 // MetalAgent watches Kubernetes InferenceService resources and manages
@@ -149,6 +152,18 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		a.logger.With("subsystem", "health-monitor"),
 	)
 	go monitor.Run(ctx)
+
+	// Start memory watchdog (if configured)
+	if a.config.WatchdogConfig != nil {
+		watchdog := NewMemoryWatchdog(
+			a.memoryProvider,
+			a.processMemInfoSnapshot,
+			nil, // observe-only in PR A; eviction callback added in PR B
+			*a.config.WatchdogConfig,
+			a.logger.With("subsystem", "watchdog"),
+		)
+		go watchdog.Run(ctx)
+	}
 
 	// Start watcher
 	eventChan := make(chan InferenceServiceEvent)
@@ -414,6 +429,21 @@ func (a *MetalAgent) Shutdown(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// processMemInfoSnapshot returns a snapshot of process names and PIDs for the watchdog.
+func (a *MetalAgent) processMemInfoSnapshot() []processMemInfo {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	infos := make([]processMemInfo, 0, len(a.processes))
+	for _, p := range a.processes {
+		infos = append(infos, processMemInfo{
+			Name: p.Name,
+			PID:  p.PID,
+		})
+	}
+	return infos
 }
 
 // HealthCheck returns the health status of all managed processes

--- a/pkg/agent/agentmetrics.go
+++ b/pkg/agent/agentmetrics.go
@@ -73,6 +73,42 @@ var (
 		},
 		[]string{"name", "namespace"},
 	)
+
+	systemMemoryAvailableBytes = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "llmkube_metal_agent_system_memory_available_bytes",
+			Help: "Available system memory in bytes.",
+		},
+	)
+
+	systemMemoryWiredBytes = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "llmkube_metal_agent_system_memory_wired_bytes",
+			Help: "Wired (non-pageable) system memory in bytes.",
+		},
+	)
+
+	processRSSBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llmkube_metal_agent_process_rss_bytes",
+			Help: "Actual resident set size per managed process in bytes.",
+		},
+		[]string{"name"},
+	)
+
+	memoryPressureLevelGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "llmkube_metal_agent_memory_pressure_level",
+			Help: "Current memory pressure level: 0=normal, 1=warning, 2=critical.",
+		},
+	)
+
+	evictionsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "llmkube_metal_agent_evictions_total",
+			Help: "Total number of process eviction events triggered by memory pressure.",
+		},
+	)
 )
 
 func init() {
@@ -85,5 +121,10 @@ func init() {
 		healthCheckDuration,
 		memoryBudgetBytes,
 		memoryEstimatedBytes,
+		systemMemoryAvailableBytes,
+		systemMemoryWiredBytes,
+		processRSSBytes,
+		memoryPressureLevelGauge,
+		evictionsTotal,
 	)
 }

--- a/pkg/agent/agentmetrics_test.go
+++ b/pkg/agent/agentmetrics_test.go
@@ -34,6 +34,11 @@ func TestAgentMetricsRegistered(t *testing.T) {
 		{"llmkube_metal_agent_health_check_duration_seconds", healthCheckDuration},
 		{"llmkube_metal_agent_memory_budget_bytes", memoryBudgetBytes},
 		{"llmkube_metal_agent_memory_estimated_bytes", memoryEstimatedBytes},
+		{"llmkube_metal_agent_system_memory_available_bytes", systemMemoryAvailableBytes},
+		{"llmkube_metal_agent_system_memory_wired_bytes", systemMemoryWiredBytes},
+		{"llmkube_metal_agent_process_rss_bytes", processRSSBytes},
+		{"llmkube_metal_agent_memory_pressure_level", memoryPressureLevelGauge},
+		{"llmkube_metal_agent_evictions_total", evictionsTotal},
 	}
 
 	for _, c := range collectors {

--- a/pkg/agent/memory.go
+++ b/pkg/agent/memory.go
@@ -27,10 +27,32 @@ import (
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
 
+// MemoryPressureLevel represents the severity of memory pressure.
+type MemoryPressureLevel int
+
+const (
+	MemoryPressureNormal   MemoryPressureLevel = 0
+	MemoryPressureWarning  MemoryPressureLevel = 1
+	MemoryPressureCritical MemoryPressureLevel = 2
+)
+
+func (l MemoryPressureLevel) String() string {
+	switch l {
+	case MemoryPressureWarning:
+		return "warning"
+	case MemoryPressureCritical:
+		return "critical"
+	default:
+		return "normal"
+	}
+}
+
 // MemoryProvider abstracts system memory queries for testability.
 type MemoryProvider interface {
 	TotalMemory() (uint64, error)
 	AvailableMemory() (uint64, error)
+	WiredMemory() (uint64, error)
+	ProcessRSS(pid int) (uint64, error)
 }
 
 // MemoryEstimate holds the estimated memory requirements for a model.

--- a/pkg/agent/memory_darwin.go
+++ b/pkg/agent/memory_darwin.go
@@ -50,30 +50,10 @@ func (p *DarwinMemoryProvider) AvailableMemory() (uint64, error) {
 		return 0, fmt.Errorf("vm_stat: %w", err)
 	}
 
-	lines := strings.Split(string(out), "\n")
-	if len(lines) == 0 {
-		return 0, fmt.Errorf("vm_stat: empty output")
-	}
-
-	// First line contains page size: "Mach Virtual Memory Statistics: (page size of 16384 bytes)"
-	var pageSize uint64
-	firstLine := lines[0]
-	if idx := strings.Index(firstLine, "page size of "); idx >= 0 {
-		sizeStr := firstLine[idx+len("page size of "):]
-		if endIdx := strings.Index(sizeStr, " "); endIdx >= 0 {
-			sizeStr = sizeStr[:endIdx]
-		}
-		pageSize, err = strconv.ParseUint(sizeStr, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("parse page size %q: %w", sizeStr, err)
-		}
-	}
-	if pageSize == 0 {
-		pageSize = 16384 // default to 16KB for Apple Silicon
-	}
+	pageSize, bodyLines := parseVMStatHeader(string(out))
 
 	var freePages, inactivePages uint64
-	for _, line := range lines[1:] {
+	for _, line := range bodyLines {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "Pages free:") {
 			freePages = parseVMStatValue(line)
@@ -83,6 +63,64 @@ func (p *DarwinMemoryProvider) AvailableMemory() (uint64, error) {
 	}
 
 	return (freePages + inactivePages) * pageSize, nil
+}
+
+// WiredMemory returns the amount of wired (non-pageable) memory by parsing vm_stat.
+func (p *DarwinMemoryProvider) WiredMemory() (uint64, error) {
+	out, err := exec.Command("vm_stat").Output()
+	if err != nil {
+		return 0, fmt.Errorf("vm_stat: %w", err)
+	}
+
+	pageSize, lines := parseVMStatHeader(string(out))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Pages wired down:") {
+			return parseVMStatValue(line) * pageSize, nil
+		}
+	}
+	return 0, fmt.Errorf("vm_stat: 'Pages wired down' not found")
+}
+
+// ProcessRSS returns the resident set size of a process in bytes.
+func (p *DarwinMemoryProvider) ProcessRSS(pid int) (uint64, error) {
+	out, err := exec.Command("ps", "-o", "rss=", "-p",
+		strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, fmt.Errorf("ps rss for pid %d: %w", pid, err)
+	}
+	// ps reports RSS in kilobytes
+	kb, err := strconv.ParseUint(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"parse rss for pid %d: %w", pid, err)
+	}
+	return kb * 1024, nil
+}
+
+// parseVMStatHeader extracts the page size and body lines from vm_stat output.
+func parseVMStatHeader(output string) (uint64, []string) {
+	lines := strings.Split(output, "\n")
+	if len(lines) == 0 {
+		return 16384, nil
+	}
+
+	var pageSize uint64
+	firstLine := lines[0]
+	if idx := strings.Index(firstLine, "page size of "); idx >= 0 {
+		sizeStr := firstLine[idx+len("page size of "):]
+		if endIdx := strings.Index(sizeStr, " "); endIdx >= 0 {
+			sizeStr = sizeStr[:endIdx]
+		}
+		parsed, err := strconv.ParseUint(sizeStr, 10, 64)
+		if err == nil {
+			pageSize = parsed
+		}
+	}
+	if pageSize == 0 {
+		pageSize = 16384 // default to 16KB for Apple Silicon
+	}
+	return pageSize, lines[1:]
 }
 
 // parseVMStatValue extracts the numeric value from a vm_stat line like "Pages free:    123456."

--- a/pkg/agent/memory_other.go
+++ b/pkg/agent/memory_other.go
@@ -33,3 +33,11 @@ func (p *DarwinMemoryProvider) TotalMemory() (uint64, error) {
 func (p *DarwinMemoryProvider) AvailableMemory() (uint64, error) {
 	return 0, fmt.Errorf("DarwinMemoryProvider not supported on %s", runtime.GOOS)
 }
+
+func (p *DarwinMemoryProvider) WiredMemory() (uint64, error) {
+	return 0, fmt.Errorf("DarwinMemoryProvider not supported on %s", runtime.GOOS)
+}
+
+func (p *DarwinMemoryProvider) ProcessRSS(_ int) (uint64, error) {
+	return 0, fmt.Errorf("DarwinMemoryProvider not supported on %s", runtime.GOOS)
+}

--- a/pkg/agent/memory_test.go
+++ b/pkg/agent/memory_test.go
@@ -25,8 +25,10 @@ import (
 )
 
 type mockMemoryProvider struct {
-	totalBytes, availableBytes uint64
-	totalErr, availableErr     error
+	totalBytes, availableBytes, wiredBytes uint64
+	totalErr, availableErr, wiredErr       error
+	processRSS                             map[int]uint64
+	processRSSErr                          error
 }
 
 func (m *mockMemoryProvider) TotalMemory() (uint64, error) {
@@ -35,6 +37,22 @@ func (m *mockMemoryProvider) TotalMemory() (uint64, error) {
 
 func (m *mockMemoryProvider) AvailableMemory() (uint64, error) {
 	return m.availableBytes, m.availableErr
+}
+
+func (m *mockMemoryProvider) WiredMemory() (uint64, error) {
+	return m.wiredBytes, m.wiredErr
+}
+
+func (m *mockMemoryProvider) ProcessRSS(pid int) (uint64, error) {
+	if m.processRSSErr != nil {
+		return 0, m.processRSSErr
+	}
+	if m.processRSS != nil {
+		if v, ok := m.processRSS[pid]; ok {
+			return v, nil
+		}
+	}
+	return 0, fmt.Errorf("no RSS for pid %d", pid)
 }
 
 func TestEstimateModelMemory_WithFullMetadata(t *testing.T) {

--- a/pkg/agent/watchdog.go
+++ b/pkg/agent/watchdog.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// MemoryWatchdogConfig holds configuration for the MemoryWatchdog.
+type MemoryWatchdogConfig struct {
+	Interval          time.Duration
+	WarningThreshold  float64 // available fraction below which we warn (e.g. 0.20)
+	CriticalThreshold float64 // available fraction below which we go critical (e.g. 0.10)
+}
+
+// MemoryStats holds a point-in-time snapshot of system and process memory.
+type MemoryStats struct {
+	TotalMemory     uint64
+	AvailableMemory uint64
+	WiredMemory     uint64
+	ProcessRSS      map[string]uint64 // keyed by process name
+	TotalRSS        uint64
+	PressureLevel   MemoryPressureLevel
+}
+
+// MemoryWatchdog periodically samples system memory and per-process RSS,
+// computes a pressure level, and updates Prometheus metrics.
+type MemoryWatchdog struct {
+	provider   MemoryProvider
+	processes  func() []processMemInfo
+	onPressure func(level MemoryPressureLevel, stats MemoryStats)
+	config     MemoryWatchdogConfig
+	logger     *zap.SugaredLogger
+}
+
+// processMemInfo is the minimal info needed to sample a process's RSS.
+type processMemInfo struct {
+	Name string
+	PID  int
+}
+
+// NewMemoryWatchdog creates a new watchdog.
+func NewMemoryWatchdog(
+	provider MemoryProvider,
+	processes func() []processMemInfo,
+	onPressure func(level MemoryPressureLevel, stats MemoryStats),
+	config MemoryWatchdogConfig,
+	logger *zap.SugaredLogger,
+) *MemoryWatchdog {
+	return &MemoryWatchdog{
+		provider:   provider,
+		processes:  processes,
+		onPressure: onPressure,
+		config:     config,
+		logger:     logger,
+	}
+}
+
+// Run starts the watchdog loop. It blocks until ctx is cancelled.
+func (w *MemoryWatchdog) Run(ctx context.Context) {
+	ticker := time.NewTicker(w.config.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.sample()
+		}
+	}
+}
+
+// sample performs one memory check cycle.
+func (w *MemoryWatchdog) sample() {
+	stats := MemoryStats{
+		ProcessRSS: make(map[string]uint64),
+	}
+
+	total, err := w.provider.TotalMemory()
+	if err != nil {
+		w.logger.Warnw("watchdog: failed to get total memory", "error", err)
+		return
+	}
+	stats.TotalMemory = total
+
+	avail, err := w.provider.AvailableMemory()
+	if err != nil {
+		w.logger.Warnw("watchdog: failed to get available memory", "error", err)
+	} else {
+		stats.AvailableMemory = avail
+		systemMemoryAvailableBytes.Set(float64(avail))
+	}
+
+	wired, err := w.provider.WiredMemory()
+	if err != nil {
+		w.logger.Debugw("watchdog: failed to get wired memory", "error", err)
+	} else {
+		stats.WiredMemory = wired
+		systemMemoryWiredBytes.Set(float64(wired))
+	}
+
+	// Sample per-process RSS
+	for _, p := range w.processes() {
+		rss, rssErr := w.provider.ProcessRSS(p.PID)
+		if rssErr != nil {
+			w.logger.Debugw("watchdog: failed to get process RSS",
+				"name", p.Name, "pid", p.PID, "error", rssErr)
+			continue
+		}
+		stats.ProcessRSS[p.Name] = rss
+		stats.TotalRSS += rss
+		processRSSBytes.WithLabelValues(p.Name).Set(float64(rss))
+	}
+
+	// Compute pressure level
+	stats.PressureLevel = w.computePressure(stats)
+	memoryPressureLevelGauge.Set(float64(stats.PressureLevel))
+
+	if stats.PressureLevel >= MemoryPressureWarning {
+		w.logger.Warnw("memory pressure detected",
+			"level", stats.PressureLevel.String(),
+			"available", formatMemory(stats.AvailableMemory),
+			"total", formatMemory(stats.TotalMemory),
+			"wired", formatMemory(stats.WiredMemory),
+			"totalRSS", formatMemory(stats.TotalRSS),
+		)
+		if w.onPressure != nil {
+			w.onPressure(stats.PressureLevel, stats)
+		}
+	}
+}
+
+// computePressure determines the pressure level from available/total ratio.
+func (w *MemoryWatchdog) computePressure(stats MemoryStats) MemoryPressureLevel {
+	if stats.TotalMemory == 0 {
+		return MemoryPressureNormal
+	}
+	availFraction := float64(stats.AvailableMemory) / float64(stats.TotalMemory)
+
+	if availFraction < w.config.CriticalThreshold {
+		return MemoryPressureCritical
+	}
+	if availFraction < w.config.WarningThreshold {
+		return MemoryPressureWarning
+	}
+	return MemoryPressureNormal
+}

--- a/pkg/agent/watchdog_test.go
+++ b/pkg/agent/watchdog_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"go.uber.org/zap"
+)
+
+func testLogger() *zap.SugaredLogger {
+	return zap.NewNop().Sugar()
+}
+
+func defaultTestConfig() MemoryWatchdogConfig {
+	return MemoryWatchdogConfig{
+		Interval:          50 * time.Millisecond,
+		WarningThreshold:  0.20,
+		CriticalThreshold: 0.10,
+	}
+}
+
+func TestWatchdog_NormalPressure(t *testing.T) {
+	provider := &mockMemoryProvider{
+		totalBytes:     64 * 1024 * 1024 * 1024,
+		availableBytes: 32 * 1024 * 1024 * 1024, // 50% available — normal
+		wiredBytes:     8 * 1024 * 1024 * 1024,
+		processRSS:     map[int]uint64{100: 4 * 1024 * 1024 * 1024},
+	}
+
+	var mu sync.Mutex
+	callCount := 0
+	onPressure := func(_ MemoryPressureLevel, _ MemoryStats) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+	}
+
+	procs := func() []processMemInfo {
+		return []processMemInfo{{Name: "test-model", PID: 100}}
+	}
+
+	w := NewMemoryWatchdog(provider, procs, onPressure, defaultTestConfig(), testLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if callCount != 0 {
+		t.Errorf("onPressure called %d times, want 0 (normal pressure)", callCount)
+	}
+}
+
+func TestWatchdog_PressureLevels(t *testing.T) {
+	total := uint64(64 * 1024 * 1024 * 1024)
+
+	tests := []struct {
+		name          string
+		availFraction float64
+		expected      MemoryPressureLevel
+	}{
+		{"warning at 15% available", 0.15, MemoryPressureWarning},
+		{"critical at 5% available", 0.05, MemoryPressureCritical},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &mockMemoryProvider{
+				totalBytes:     total,
+				availableBytes: uint64(float64(total) * tt.availFraction),
+				wiredBytes:     10 * 1024 * 1024 * 1024,
+			}
+
+			var mu sync.Mutex
+			var captured []MemoryPressureLevel
+			onPressure := func(level MemoryPressureLevel, _ MemoryStats) {
+				mu.Lock()
+				captured = append(captured, level)
+				mu.Unlock()
+			}
+
+			procs := func() []processMemInfo { return nil }
+			w := NewMemoryWatchdog(provider, procs, onPressure, defaultTestConfig(), testLogger())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+			w.Run(ctx)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(captured) == 0 {
+				t.Fatalf("expected onPressure to be called at %v level", tt.expected)
+			}
+			for _, level := range captured {
+				if level != tt.expected {
+					t.Errorf("got pressure level %v, want %v", level, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestWatchdog_ProcessRSSTracking(t *testing.T) {
+	provider := &mockMemoryProvider{
+		totalBytes:     64 * 1024 * 1024 * 1024,
+		availableBytes: 32 * 1024 * 1024 * 1024,
+		wiredBytes:     8 * 1024 * 1024 * 1024,
+		processRSS: map[int]uint64{
+			100: 4 * 1024 * 1024 * 1024,
+			200: 2 * 1024 * 1024 * 1024,
+		},
+	}
+
+	procs := func() []processMemInfo {
+		return []processMemInfo{
+			{Name: "model-a", PID: 100},
+			{Name: "model-b", PID: 200},
+		}
+	}
+
+	w := NewMemoryWatchdog(provider, procs, nil, defaultTestConfig(), testLogger())
+
+	// Run a single sample and check stats
+	w.sample()
+
+	// Metrics should have been set — verify via the gauge
+	rssA := processRSSBytes.WithLabelValues("model-a")
+	rssB := processRSSBytes.WithLabelValues("model-b")
+
+	var mA, mB dto.Metric
+	if err := rssA.Write(&mA); err != nil {
+		t.Fatalf("failed to read model-a RSS metric: %v", err)
+	}
+	if err := rssB.Write(&mB); err != nil {
+		t.Fatalf("failed to read model-b RSS metric: %v", err)
+	}
+
+	if mA.GetGauge().GetValue() != float64(4*1024*1024*1024) {
+		t.Errorf("model-a RSS = %f, want %d", mA.GetGauge().GetValue(), 4*1024*1024*1024)
+	}
+	if mB.GetGauge().GetValue() != float64(2*1024*1024*1024) {
+		t.Errorf("model-b RSS = %f, want %d", mB.GetGauge().GetValue(), 2*1024*1024*1024)
+	}
+}
+
+func TestWatchdog_NilOnPressureDoesNotPanic(t *testing.T) {
+	total := uint64(64 * 1024 * 1024 * 1024)
+	provider := &mockMemoryProvider{
+		totalBytes:     total,
+		availableBytes: uint64(float64(total) * 0.05), // critical
+		wiredBytes:     20 * 1024 * 1024 * 1024,
+	}
+
+	procs := func() []processMemInfo { return nil }
+	w := NewMemoryWatchdog(provider, procs, nil, defaultTestConfig(), testLogger())
+
+	// Should not panic even with nil onPressure
+	w.sample()
+}
+
+func TestComputePressure_Thresholds(t *testing.T) {
+	cfg := defaultTestConfig()
+	w := &MemoryWatchdog{config: cfg}
+
+	tests := []struct {
+		name     string
+		avail    float64
+		expected MemoryPressureLevel
+	}{
+		{"50% available — normal", 0.50, MemoryPressureNormal},
+		{"25% available — normal", 0.25, MemoryPressureNormal},
+		{"21% available — normal (above warning)", 0.21, MemoryPressureNormal},
+		{"19% available — warning", 0.19, MemoryPressureWarning},
+		{"15% available — warning", 0.15, MemoryPressureWarning},
+		{"11% available — warning (above critical)", 0.11, MemoryPressureWarning},
+		{"9% available — critical", 0.09, MemoryPressureCritical},
+		{"5% available — critical", 0.05, MemoryPressureCritical},
+		{"0% available — critical", 0.00, MemoryPressureCritical},
+	}
+
+	total := uint64(64 * 1024 * 1024 * 1024)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := MemoryStats{
+				TotalMemory:     total,
+				AvailableMemory: uint64(float64(total) * tt.avail),
+			}
+			got := w.computePressure(stats)
+			if got != tt.expected {
+				t.Errorf("computePressure(avail=%.0f%%) = %v, want %v",
+					tt.avail*100, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMemoryPressureLevel_String(t *testing.T) {
+	tests := []struct {
+		level    MemoryPressureLevel
+		expected string
+	}{
+		{MemoryPressureNormal, "normal"},
+		{MemoryPressureWarning, "warning"},
+		{MemoryPressureCritical, "critical"},
+	}
+	for _, tt := range tests {
+		if got := tt.level.String(); got != tt.expected {
+			t.Errorf("MemoryPressureLevel(%d).String() = %q, want %q",
+				tt.level, got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `MemoryWatchdog` goroutine to the Metal agent that periodically samples system memory (available, wired) and per-process RSS to detect memory pressure on macOS. This is **observe-only** -- no eviction behavior is included (that comes in a follow-up PR).

- Extends the `MemoryProvider` interface with `WiredMemory()` and `ProcessRSS(pid)` (darwin: `vm_stat` + `ps`, stubs for other platforms)
- Adds `MemoryPressureLevel` type with Normal/Warning/Critical levels
- Creates `MemoryWatchdog` with configurable interval and thresholds
- Adds 5 new Prometheus metrics: `system_memory_available_bytes`, `system_memory_wired_bytes`, `process_rss_bytes`, `memory_pressure_level`, `evictions_total`
- Adds CLI flags: `--memory-watchdog-interval`, `--memory-pressure-warning`, `--memory-pressure-critical`, `--eviction-enabled`
- Comprehensive unit tests for pressure level detection, RSS tracking, and threshold boundaries

Part of #186 (Phase 1: detection + metrics). See the issue for the full phased plan.

## Test plan

- [x] All existing agent tests pass
- [x] New watchdog tests: pressure level detection (normal/warning/critical)
- [x] New watchdog tests: per-process RSS tracking and metric updates
- [x] New watchdog tests: nil onPressure callback does not panic
- [x] New watchdog tests: threshold boundary table-driven tests
- [x] Metrics registration test updated for 5 new metrics
- [x] `golangci-lint` passes with 0 issues
- [ ] Manual: start agent on Mac, verify `/metrics` endpoint shows new gauges