### PR TITLE
Update roadmap to reflect v0.5.0 and shipped features

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # LLMKube Roadmap
 
-**Current Version:** 0.4.13
-**Last Updated:** February 2026
-**Status:** ✅ Phase 1 Complete - GPU Inference, Metal Support, Model Catalog & GPU Scheduling
+**Current Version:** 0.5.0
+**Last Updated:** March 2026
+**Status:** ✅ Phase 2 in Progress - Metal Agent, Memory Management, Observability, Benchmarking
 
 ---
 
@@ -20,25 +20,35 @@ Make GPU-accelerated LLM inference on Kubernetes **dead simple**. Deploy product
 
 ## Current Status
 
-### ✅ What's Working Now (v0.4.13)
+### ✅ What's Working Now (v0.5.0)
 
 **Core Platform:**
 - ✅ Kubernetes-native CRDs (`Model`, `InferenceService`)
 - ✅ Automatic model download from HuggingFace/HTTP
 - ✅ OpenAI-compatible `/v1/chat/completions` API
 - ✅ Multi-replica deployment support
-- ✅ Full CLI tool (`llmkube deploy/list/status/delete/queue`)
+- ✅ Full CLI tool (`llmkube deploy/list/status/delete/queue/cache/benchmark/inspect/license`)
 - ✅ Helm chart for easy installation
-- ✅ Model catalog with 10+ pre-configured models
+- ✅ Model catalog with pre-configured models and one-command deployment
+- ✅ Air-gapped mode with `file://` and local path model sources
 
 **GPU Acceleration:**
 - ✅ NVIDIA GPU support (T4, L4, A100)
 - ✅ **17x performance improvement** (64 tok/s GPU vs 4.6 tok/s CPU)
 - ✅ Automatic GPU layer offloading
-- ✅ GKE Terraform deployment configs
+- ✅ Single-node multi-GPU sharding (up to 8 GPUs, layer-based splitting)
 - ✅ Cost optimization (spot instances, auto-scale to 0)
 
-**GPU Scheduling & Queue Management:** ✅ **NEW in v0.4.9**
+**Apple Silicon (Metal) Support:**
+- ✅ Metal Agent daemon for native macOS llama-server processes
+- ✅ Pre-flight memory validation with GGUF-based estimation
+- ✅ Per-model `memoryBudget` and `memoryFraction` CRD fields
+- ✅ Continuous health monitoring of managed processes
+- ✅ Agent metrics (memory budget, process health, active count)
+- ✅ Homebrew auto-detection for llama-server binary
+- ✅ Heterogeneous clusters (mix NVIDIA and Apple Silicon nodes)
+
+**GPU Scheduling & Queue Management:**
 - ✅ GPU contention visibility (`WaitingForGPU` phase)
 - ✅ Queue position tracking for pending services
 - ✅ Priority classes (critical/high/normal/low/batch)
@@ -46,46 +56,54 @@ Make GPU-accelerated LLM inference on Kubernetes **dead simple**. Deploy product
 - ✅ Detailed scheduling status and messages
 
 **Observability:**
-- ✅ Prometheus + Grafana integration
-- ✅ GPU metrics (DCGM): utilization, temperature, power, memory
-- ✅ Pre-built dashboards
+- ✅ 10 custom Prometheus metrics (downloads, phases, queues, reconciliation)
+- ✅ OpenTelemetry tracing with Tempo export (gRPC port 4317)
+- ✅ GPU metrics via DCGM exporter (utilization, temperature, power, memory)
+- ✅ PodMonitor for llama.cpp inference metrics scraping
+- ✅ Pre-built Grafana dashboards
 - ✅ SLO alerts for GPU health and service availability
+
+**Model Management:**
+- ✅ PVC-based model caching with SHA256 cache keys
+- ✅ `llmkube cache` command (list, clear, preload, inspect)
+- ✅ Native GGUF parser with metadata extraction
+- ✅ `llmkube inspect` command for GGUF file introspection
+- ✅ License compliance scanning (`llmkube license`)
+- ✅ Init container customization with custom CA certificate support
+
+**Benchmarking:**
+- ✅ `llmkube benchmark` with load testing, stress testing, and sweep modes
+- ✅ Concurrency, context size, and token count sweeps
+- ✅ Per-request latency and throughput capture (p50, p95, p99)
+- ✅ GPU monitoring during benchmarks
 
 **Deployment Options:**
 - ✅ Minikube/Kind (local development)
-- ✅ GKE with GPU support
-- ✅ Works on EKS, AKS (community tested)
+- ✅ GKE with GPU support (Terraform)
+- ✅ EKS with GPU support (Terraform)
+- ✅ AKS with GPU support (Terraform)
+- ✅ Network policies in Helm chart
 
 ---
 
 ## What's Next
 
-### Q1 2026: Polish & Growth
+### Q1 2026: Polish & Growth *(in progress)*
 
 **Focus:** Make it easier to use, support more use cases
 
-**Priorities:**
-1. **Model Catalog** - Pre-configured popular models
-   - One-command deployments: `llmkube deploy llama-3-8b --gpu`
-   - Optimized settings for common models
-   - Version management
+**Completed:**
+- ✅ **Model Catalog** - Pre-configured popular models with `llmkube deploy llama-3-8b --gpu`
+- ✅ **`llmkube benchmark`** - Comprehensive performance testing (load, stress, sweeps)
+- ✅ **Health checks and readiness probes** - Three-probe pattern for llama.cpp pods
+- ✅ **Persistent model storage** - PVC-based caching (v0.4.1)
+- ✅ **GPU queue management** - Priority classes and queue tracking (v0.4.9)
+- ✅ **Multi-GPU** - Single-node sharding for 13B+ models (~65 tok/s on 8B with 2x RTX 5060 Ti)
 
-2. **Better Developer Experience**
-   - `llmkube init` - Interactive setup wizard
-   - `llmkube chat <model>` - Test inference from CLI
-   - `llmkube benchmark <model>` - Built-in performance testing
-   - Improved error messages and debugging
-
-3. **Production Features**
-   - Horizontal Pod Autoscaling (HPA) support
-   - Better health checks and readiness probes
-   - ~~Persistent model storage (stop re-downloading!)~~ ✅ v0.4.1
-   - ~~Request queuing and load shedding~~ ✅ v0.4.9 (GPU queue management)
-
-4. **Multi-GPU Support** ✅ **COMPLETED**
-   - Single-node multi-GPU for larger models (13B+)
-   - Layer distribution across GPUs (`--tensor-split`, `--split-mode layer`)
-   - Performance verified: ~65 tok/s on 8B model with 2x RTX 5060 Ti
+**Remaining:**
+- `llmkube init` - Interactive setup wizard
+- `llmkube chat <model>` - Test inference from CLI
+- Horizontal Pod Autoscaling (HPA) support
 
 ### Q2 2026: Edge & Hybrid
 
@@ -94,16 +112,18 @@ Make GPU-accelerated LLM inference on Kubernetes **dead simple**. Deploy product
 **Planned:**
 - **K3s Compatibility** - Lightweight Kubernetes for edge
 - **ARM64 Support** - Raspberry Pi, NVIDIA Jetson
-- **Air-gapped Mode** - Private model registries, offline operation
 - **Cost Tracking** - Per-deployment cost attribution
 - **Additional Model Formats** - SafeTensors, HuggingFace native
+
+**Already shipped early:**
+- ~~Air-gapped Mode~~ ✅ Shipped in v0.4.x (file:// and local path model sources)
 
 ### Q3 2026: Scale & Performance
 
 **Focus:** Larger models, better performance
 
 **Planned:**
-- **Multi-node GPU** - Shard large models (70B+) across nodes
+- **Distributed Inference** - Shard large models (70B+) across nodes via llama.cpp RPC backend
 - **Advanced Auto-scaling** - Queue depth, latency-based scaling
 - **AMD GPU Support** - ROCm backend for AMD GPUs
 - **Intel GPU Support** - oneAPI integration
@@ -129,18 +149,20 @@ Make GPU-accelerated LLM inference on Kubernetes **dead simple**. Deploy product
 |-----------|--------|--------|
 | **Single GPU (3B model)** | >60 tok/s | ✅ **Achieved** (64 tok/s on L4) |
 | **Multi-GPU (13B model)** | >40 tok/s | ✅ **Achieved** (~44 tok/s on 2x RTX 5060 Ti) |
-| **Multi-node (70B model)** | <500ms P99 latency | 🎯 Q3 2026 |
-| **Cost Efficiency** | <$0.01 per 1K tokens | 🎯 Q1 2026 |
-| **Model Load Time** | <30s for any model | 🎯 Q2 2026 |
+| **Multi-GPU (8B model)** | >60 tok/s | ✅ **Achieved** (~65 tok/s on 2x RTX 5060 Ti) |
+| **Multi-node (70B model)** | <500ms P99 latency | 🎯 Planned |
+| **Cost Efficiency** | <$0.01 per 1K tokens | 🎯 Planned |
+| **Model Load Time** | <30s for any model | 🎯 Planned |
 
 ---
 
 ## Community Metrics
 
-| Metric | Current | Q1 2026 Goal | Q2 2026 Goal |
+| Metric | Current | Q2 2026 Goal | Q4 2026 Goal |
 |--------|---------|--------------|--------------|
-| **GitHub Stars** | 17 | 100 | 500 |
-| **Contributors** | 1 | 5 | 10 |
+| **GitHub Stars** | 25 | 200 | 1,000 |
+| **Contributors** | 4 | 10 | 25 |
+| **Forks** | 4 | 15 | 50 |
 | **Production Deployments** | 1 | 10 | 25 |
 | **Models Supported** | Any GGUF | 20+ pre-configured | 50+ pre-configured |
 
@@ -172,9 +194,10 @@ We're actively looking for contributors! Here's how you can help:
 - Testing on different K8s platforms
 
 **Advanced Contributions:**
-- Multi-node GPU support (70B+ models)
+- Distributed inference via llama.cpp RPC (70B+ models)
 - Additional GPU vendors (AMD, Intel)
 - Model format support (SafeTensors)
+- Horizontal Pod Autoscaling (HPA)
 - Performance optimizations
 
 **Before starting:** Comment on the issue or open a discussion to avoid duplicate work.
@@ -195,13 +218,15 @@ We ship frequently with semantic versioning:
 - **Minor releases (0.x.0):** New features, backward compatible - Quarterly
 - **Major releases (x.0.0):** Breaking changes, major milestones - Yearly
 
-**Next releases:**
+**Past releases:**
 - **v0.4.0** - November 2025 (multi-GPU support) ✅
 - **v0.4.1** - November 2025 (persistent model cache) ✅
 - **v0.4.9** - December 2025 (GPU scheduling & priority classes) ✅
-- **v0.4.13** - February 2026 (GGUF parser, init container customization, NetworkPolicy) ✅ **Current**
-- **v0.5.0** - Q1 2026 (autoscaling)
-- **v0.6.0** - Q2 2026 (edge deployment, K3s)
+- **v0.4.13** - February 2026 (GGUF parser, init container customization, NetworkPolicy) ✅
+- **v0.5.0** - March 2026 (Metal agent, memory validation, health monitoring, benchmarking) ✅ **Current**
+
+**Upcoming releases:**
+- **v0.6.0** - Q2 2026 (edge deployment, K3s, HPA)
 - **v1.0.0** - Q4 2026 (stable, production-ready)
 
 ---
@@ -241,7 +266,7 @@ Apache 2.0 - See [LICENSE](LICENSE)
 
 ---
 
-**Last Updated:** February 2026
-**Next Review:** April 2026
+**Last Updated:** March 2026
+**Next Review:** June 2026
 
 *This roadmap is a living document. Priorities may shift based on community feedback and real-world usage.*


### PR DESCRIPTION
## Summary

- Updated version from 0.4.13 to 0.5.0 and date to March 2026
- Added all features shipped since the last roadmap update: Metal Agent, GGUF parser, benchmarking CLI, model cache management, OTel tracing, memory validation, license scanning, multi-cloud Terraform (EKS/AKS), network policies
- Restructured Q1 2026 into Completed vs. Remaining sections
- Moved air-gapped mode to "shipped early" under Q2 since it already landed
- Renamed "Multi-node GPU" to "Distributed Inference" with llama.cpp RPC as the planned approach
- Updated community metrics to actuals (25 stars, 4 contributors, 4 forks)
- Fixed release schedule (v0.5.0 was incorrectly listed as "autoscaling")

## Test plan

- [ ] Review rendered ROADMAP.md for formatting and accuracy
- [ ] Verify all listed features match what's in the codebase