### PR TITLE
docs: add Discord community link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,6 +345,7 @@ func (r *ModelReconciler) ReconcileModel(ctx context.Context, model *inferencev1
 
 ### Communication Channels
 
+- **Discord**: [Join the community](https://discord.gg/Ktz85RFHDv) — real-time chat, support, and contributor coordination
 - **GitHub Issues**: Bug reports, feature requests
 - **GitHub Discussions**: [Q&A, ideas, general discussion](https://github.com/defilantech/LLMKube/discussions)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
       <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License">
     </a>
     <img src="https://img.shields.io/github/go-mod/go-version/defilantech/LLMKube" alt="Go Version">
+    <a href="https://discord.gg/Ktz85RFHDv">
+      <img src="https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white" alt="Discord">
+    </a>
   </p>
 
   <p>
@@ -34,7 +37,8 @@
     <a href="#the-metal-agent">Metal Agent</a> &bull;
     <a href="#how-is-this-different">Why LLMKube?</a> &bull;
     <a href="#performance">Benchmarks</a> &bull;
-    <a href="ROADMAP.md">Roadmap</a>
+    <a href="ROADMAP.md">Roadmap</a> &bull;
+    <a href="https://discord.gg/Ktz85RFHDv">Discord</a>
   </p>
 
 </div>
@@ -345,6 +349,7 @@ We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full gu
 
 ## Community
 
+- **Chat:** [Discord](https://discord.gg/Ktz85RFHDv)
 - **Bug reports & features:** [GitHub Issues](https://github.com/defilantech/LLMKube/issues)
 - **Questions & discussion:** [GitHub Discussions](https://github.com/defilantech/LLMKube/discussions)
 - **Roadmap:** [ROADMAP.md](ROADMAP.md)


### PR DESCRIPTION
## Summary

Adds the Discord invite link to the repo in three places:

- **README.md** — Discord badge in header, link in nav bar, and Community section
- **CONTRIBUTING.md** — Communication Channels section

Invite: https://discord.gg/Ktz85RFHDv

## Test plan

- [x] Docs-only change, no code