### PR TITLE
docs: add CNCF/Kubernetes trademark disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,10 @@ Built on [Kubebuilder](https://kubebuilder.io), [llama.cpp](https://github.com/g
 
 Apache 2.0 — see [LICENSE](LICENSE).
 
+## Trademarks
+
+LLMKube is not affiliated with or endorsed by the Cloud Native Computing Foundation or the Kubernetes project. Kubernetes is a registered trademark of The Linux Foundation. All other trademarks are the property of their respective owners.
+
 <div align="center">
 
 **[Get started in 5 minutes →](docs/minikube-quickstart.md)**


### PR DESCRIPTION
## Summary
- Adds a Trademarks section to the README clarifying that LLMKube is not affiliated with or endorsed by the CNCF or the Kubernetes project
- Standard disclaimer consistent with how other Kubernetes ecosystem tools handle Linux Foundation trademark attribution

## Test plan
- [ ] Verify README renders correctly on GitHub