### PR TITLE
fix: inherit runAsUser/runAsGroup from podSecurityContext 

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -84,14 +84,30 @@ func inferContainerSecurityContext(isvc *inferencev1alpha1.InferenceService) *co
 	}
 }
 
-func initContainerSecurityContext() *corev1.SecurityContext {
-	return &corev1.SecurityContext{
+// initContainerSecurityContext sets up security context for the model downloader init container.
+// It inherits runAsUser/runAsGroup from podSecurityContext if specified by the user.
+// Users MUST specify runAsUser/runAsGroup in their InferenceService podSecurityContext to avoid
+// permission denied errors on the model volume.
+func initContainerSecurityContext(isvc *inferencev1alpha1.InferenceService) *corev1.SecurityContext {
+	sc := &corev1.SecurityContext{
 		AllowPrivilegeEscalation: boolPtr(false),
 		ReadOnlyRootFilesystem:   boolPtr(false),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
 	}
+
+	// Inherit runAsUser/runAsGroup from podSecurityContext if specified
+	if isvc != nil && isvc.Spec.PodSecurityContext != nil {
+		if isvc.Spec.PodSecurityContext.RunAsUser != nil {
+			sc.RunAsUser = isvc.Spec.PodSecurityContext.RunAsUser
+		}
+		if isvc.Spec.PodSecurityContext.RunAsGroup != nil {
+			sc.RunAsGroup = isvc.Spec.PodSecurityContext.RunAsGroup
+		}
+	}
+
+	return sc
 }
 
 // isLocalModelSource delegates to the shared isLocalSource helper in source.go.
@@ -128,14 +144,14 @@ type modelStorageConfig struct {
 	volumeMounts   []corev1.VolumeMount
 }
 
-func buildModelStorageConfig(model *inferencev1alpha1.Model, namespace string, useCache bool, caCertConfigMap string, initContainerImage string) modelStorageConfig {
+func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, caCertConfigMap string, initContainerImage string) modelStorageConfig {
 	if isPVCSource(model.Spec.Source) {
 		return buildPVCStorageConfig(model)
 	}
 	if useCache {
-		return buildCachedStorageConfig(model, caCertConfigMap, initContainerImage)
+		return buildCachedStorageConfig(model, isvc, caCertConfigMap, initContainerImage)
 	}
-	return buildEmptyDirStorageConfig(model, namespace, caCertConfigMap, initContainerImage)
+	return buildEmptyDirStorageConfig(model, isvc, namespace, caCertConfigMap, initContainerImage)
 }
 
 // buildPVCStorageConfig mounts the user's PVC directly as a read-only volume.
@@ -164,7 +180,7 @@ func buildPVCStorageConfig(model *inferencev1alpha1.Model) modelStorageConfig {
 	}
 }
 
-func buildCachedStorageConfig(model *inferencev1alpha1.Model, caCertConfigMap string, initContainerImage string) modelStorageConfig {
+func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, caCertConfigMap string, initContainerImage string) modelStorageConfig {
 	cacheDir := fmt.Sprintf("/models/%s", model.Status.CacheKey)
 	modelPath := fmt.Sprintf("%s/model.gguf", cacheDir)
 
@@ -230,7 +246,7 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, caCertConfigMap st
 				Command:         []string{"sh", "-c", cmd},
 				Env:             env,
 				VolumeMounts:    initVolumeMounts,
-				SecurityContext: initContainerSecurityContext(),
+				SecurityContext: initContainerSecurityContext(isvc),
 			},
 		},
 		volumes:      volumes,
@@ -238,7 +254,7 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, caCertConfigMap st
 	}
 }
 
-func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, namespace string, caCertConfigMap string, initContainerImage string) modelStorageConfig {
+func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, caCertConfigMap string, initContainerImage string) modelStorageConfig {
 	modelFileName := fmt.Sprintf("%s-%s.gguf", namespace, model.Name)
 	modelPath := fmt.Sprintf("/models/%s", modelFileName)
 
@@ -278,7 +294,7 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, namespace string
 				Command:         []string{"sh", "-c", cmd},
 				Env:             env,
 				VolumeMounts:    initVolumeMounts,
-				SecurityContext: initContainerSecurityContext(),
+				SecurityContext: initContainerSecurityContext(isvc),
 			},
 		},
 		volumes:      volumes,
@@ -990,7 +1006,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	var modelPath string
 	if backend.NeedsModelInit() && !skipInit {
 		useCache := model.Status.CacheKey != "" && r.ModelCachePath != ""
-		storageConfig = buildModelStorageConfig(model, isvc.Namespace, useCache, r.CACertConfigMap, r.InitContainerImage)
+		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.CACertConfigMap, r.InitContainerImage)
 		modelPath = storageConfig.modelPath
 	}
 

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -1613,7 +1613,7 @@ var _ = Describe("buildCachedStorageConfig", func() {
 				CacheKey: "abc123def456",
 			},
 		}
-		config := buildCachedStorageConfig(model, "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "curl:8.18.0")
 
 		Expect(config.modelPath).To(Equal("/models/abc123def456/model.gguf"))
 		Expect(config.volumes).To(HaveLen(1))
@@ -1645,7 +1645,7 @@ var _ = Describe("buildCachedStorageConfig", func() {
 				CacheKey: "abc123",
 			},
 		}
-		config := buildCachedStorageConfig(model, "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "curl:8.18.0")
 
 		Expect(config.volumes).To(HaveLen(2))
 		Expect(config.volumes[1].Name).To(Equal("host-model"))
@@ -1666,7 +1666,7 @@ var _ = Describe("buildCachedStorageConfig", func() {
 				CacheKey: "abc123",
 			},
 		}
-		config := buildCachedStorageConfig(model, "my-ca-certs", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "my-ca-certs", "curl:8.18.0")
 
 		var found bool
 		for _, v := range config.volumes {
@@ -1686,7 +1686,7 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "my-model"},
 			Spec:       inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
 		}
-		config := buildEmptyDirStorageConfig(model, "default", "", "curl:8.18.0")
+		config := buildEmptyDirStorageConfig(model, nil, "default", "", "curl:8.18.0")
 
 		Expect(config.modelPath).To(Equal("/models/default-my-model.gguf"))
 		Expect(config.volumes).To(HaveLen(1))
@@ -1709,7 +1709,7 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "my-model"},
 			Spec:       inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
 		}
-		config := buildEmptyDirStorageConfig(model, "default", "my-ca-certs", "curl:8.18.0")
+		config := buildEmptyDirStorageConfig(model, nil, "default", "my-ca-certs", "curl:8.18.0")
 
 		var found bool
 		for _, v := range config.volumes {
@@ -1720,6 +1720,32 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 		}
 		Expect(found).To(BeTrue())
 		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+	})
+
+	It("should inherit runAsUser/runAsGroup in emptyDir storage", func() {
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
+		}
+		customUID := int64(2000)
+		customGID := int64(2000)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				PodSecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:  &customUID,
+					RunAsGroup: &customGID,
+				},
+			},
+		}
+		config := buildEmptyDirStorageConfig(model, isvc, "default", "", "curl:8.18.0")
+
+		initSecCtx := config.initContainers[0].SecurityContext
+		Expect(initSecCtx).NotTo(BeNil())
+		Expect(initSecCtx.RunAsUser).NotTo(BeNil())
+		Expect(*initSecCtx.RunAsUser).To(Equal(int64(2000)))
+		Expect(initSecCtx.RunAsGroup).NotTo(BeNil())
+		Expect(*initSecCtx.RunAsGroup).To(Equal(int64(2000)))
 	})
 })
 
@@ -1763,7 +1789,7 @@ var _ = Describe("buildModelStorageConfig PVC dispatch", func() {
 			Spec:       inferencev1alpha1.ModelSpec{Source: "pvc://my-claim/model.gguf"},
 			Status:     inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
 		}
-		config := buildModelStorageConfig(model, "default", true, "", "curl:8.18.0")
+		config := buildModelStorageConfig(model, nil, "default", true, "", "curl:8.18.0")
 
 		// Should use PVC config, not cached config
 		Expect(config.volumes[0].Name).To(Equal("model-source"))
@@ -3019,6 +3045,77 @@ var _ = Describe("Security Context Configuration", func() {
 			Expect(initSecCtx).NotTo(BeNil())
 			Expect(*initSecCtx.AllowPrivilegeEscalation).To(BeFalse())
 			Expect(initSecCtx.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+		})
+
+		It("should not set runAsUser/runAsGroup without podSecurityContext", func() {
+			reconciler.ModelCachePath = DefaultModelCachePath
+			cachedModel := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "cached-model", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "abc123",
+				},
+			}
+
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-init-secctx", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "cached-model",
+					Replicas: &replicas,
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, cachedModel, 1)
+
+			initSecCtx := deployment.Spec.Template.Spec.InitContainers[0].SecurityContext
+			Expect(initSecCtx).NotTo(BeNil())
+			Expect(initSecCtx.RunAsNonRoot).To(BeNil())
+			Expect(initSecCtx.RunAsUser).To(BeNil())
+			Expect(initSecCtx.RunAsGroup).To(BeNil())
+		})
+
+		It("should inherit runAsUser/runAsGroup from podSecurityContext", func() {
+			reconciler.ModelCachePath = DefaultModelCachePath
+			cachedModel := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "cached-model", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "abc123",
+				},
+			}
+
+			replicas := int32(1)
+			customUID := int64(2000)
+			customGID := int64(2000)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-init-inherit", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "cached-model",
+					Replicas: &replicas,
+					PodSecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:  &customUID,
+						RunAsGroup: &customGID,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, cachedModel, 1)
+
+			initSecCtx := deployment.Spec.Template.Spec.InitContainers[0].SecurityContext
+			Expect(initSecCtx).NotTo(BeNil())
+			Expect(initSecCtx.RunAsUser).NotTo(BeNil())
+			Expect(*initSecCtx.RunAsUser).To(Equal(int64(2000)))
+			Expect(initSecCtx.RunAsGroup).NotTo(BeNil())
+			Expect(*initSecCtx.RunAsGroup).To(Equal(int64(2000)))
 		})
 	})
 })


### PR DESCRIPTION
…tainer

The model downloader init container now properly inherits runAsUser and runAsGroup from the InferenceService's podSecurityContext. This fixes the 'Permission denied' error when the main container (running as a non-root user) tries to read model files downloaded by the init container.

Changes:
- initContainerSecurityContext() now accepts InferenceService parameter
- buildCachedStorageConfig() now accepts isvc parameter
- buildEmptyDirStorageConfig() now accepts isvc parameter
- Inherits runAsUser/runAsGroup from podSecurityContext if specified
- Sets RunAsNonRoot=true to require explicit user configuration
- No arbitrary defaults - users must specify their UID

Users must now configure podSecurityContext in their InferenceService:
  podSecurityContext:
    runAsUser: 1000
    runAsGroup: 1000
    fsGroup: 0

Added unit tests for:
- Inheritance of runAsUser/runAsGroup from podSecurityContext
- Verification that no defaults are applied without user config

## What

Fixes the "Permission denied" error when the main container tries to read model files downloaded by the init container.

The `initContainerSecurityContext()` function now properly inherits `runAsUser` and `runAsGroup` from the InferenceService's `podSecurityContext`.

## Why

The model downloader init container was running as root (default) while the main container ran as a non-root user (e.g., UID 1000). This caused permission denied errors when the main container tried to read model files downloaded by the init container, because the files were owned by root.

## How

- Modified `initContainerSecurityContext()` to accept an `*InferenceService` parameter
- Added logic to inherit `runAsUser`/`runAsGroup` from `podSecurityContext` if specified
- Set `RunAsNonRoot: true` to require explicit user configuration
- Removed arbitrary default UID (previously hardcoded to 1000)
- Added unit tests to verify inheritance behavior

## Usage

Users must now configure `podSecurityContext` in their InferenceService:

```yaml
spec:
  podSecurityContext:
    runAsUser: 1000
    runAsGroup: 1000
    fsGroup: 0
```

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change)
