### PR TITLE
feat: add hybrid GPU/CPU offloading support for MoE models

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -116,6 +116,26 @@ type InferenceServiceSpec struct {
 	// +optional
 	CacheTypeV string `json:"cacheTypeV,omitempty"`
 
+	// MoeCPUOffload offloads all MoE expert layers to CPU for reduced VRAM usage.
+	// Enables running large MoE models (e.g., Qwen3-30B, Mixtral) on VRAM-constrained
+	// hardware by keeping attention layers on GPU while expert weights use system RAM.
+	// Maps to llama.cpp --cpu-moe flag. Requires sufficient system RAM via resources.memory.
+	// +optional
+	MoeCPUOffload *bool `json:"moeCPUOffload,omitempty"`
+
+	// MoeCPULayers sets the number of MoE layers to offload to CPU.
+	// When set, only the specified number of MoE layers run on CPU rather than all.
+	// Maps to llama.cpp --n-cpu-moe flag.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MoeCPULayers *int32 `json:"moeCPULayers,omitempty"`
+
+	// NoKvOffload keeps the KV cache in system RAM instead of VRAM.
+	// Useful for extended context windows when VRAM is constrained by model weights.
+	// Maps to llama.cpp --no-kv-offload flag. Requires sufficient system RAM via resources.memory.
+	// +optional
+	NoKvOffload *bool `json:"noKvOffload,omitempty"`
+
 	// ExtraArgs provides additional command-line arguments passed directly to the
 	// llama-server process. Use for flags not yet supported as typed CRD fields.
 	// Arguments are appended after all other configured flags.
@@ -226,6 +246,14 @@ type InferenceResourceRequirements struct {
 	// Memory requests (e.g., "4Gi")
 	// +optional
 	Memory string `json:"memory,omitempty"`
+
+	// HostMemory specifies the system RAM required for hybrid GPU/CPU offloading (e.g., "64Gi").
+	// Used when MoE expert weights or KV cache are offloaded to CPU via moeCPUOffload or noKvOffload.
+	// Translated to pod resources.requests.memory, taking precedence over Memory when set.
+	// Without this, the K8s scheduler has no visibility into the pod's actual RAM consumption,
+	// which can lead to OOM kills after model load.
+	// +optional
+	HostMemory string `json:"hostMemory,omitempty"`
 
 	// GPUMemory specifies GPU memory limit per pod (e.g., "16Gi")
 	// Used for scheduling and validation

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -279,6 +279,21 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MoeCPUOffload != nil {
+		in, out := &in.MoeCPUOffload, &out.MoeCPUOffload
+		*out = new(bool)
+		**out = **in
+	}
+	if in.MoeCPULayers != nil {
+		in, out := &in.MoeCPULayers, &out.MoeCPULayers
+		*out = new(int32)
+		**out = **in
+	}
+	if in.NoKvOffload != nil {
+		in, out := &in.NoKvOffload, &out.NoKvOffload
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ExtraArgs != nil {
 		in, out := &in.ExtraArgs, &out.ExtraArgs
 		*out = make([]string, len(*in))

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -423,6 +423,27 @@ spec:
                 description: ModelRef references the Model CR that contains the model
                   to serve
                 type: string
+              moeCPULayers:
+                description: |-
+                  MoeCPULayers sets the number of MoE layers to offload to CPU.
+                  When set, only the specified number of MoE layers run on CPU rather than all.
+                  Maps to llama.cpp --n-cpu-moe flag.
+                format: int32
+                minimum: 0
+                type: integer
+              moeCPUOffload:
+                description: |-
+                  MoeCPUOffload offloads all MoE expert layers to CPU for reduced VRAM usage.
+                  Enables running large MoE models (e.g., Qwen3-30B, Mixtral) on VRAM-constrained
+                  hardware by keeping attention layers on GPU while expert weights use system RAM.
+                  Maps to llama.cpp --cpu-moe flag. Requires sufficient system RAM via resources.memory.
+                type: boolean
+              noKvOffload:
+                description: |-
+                  NoKvOffload keeps the KV cache in system RAM instead of VRAM.
+                  Useful for extended context windows when VRAM is constrained by model weights.
+                  Maps to llama.cpp --no-kv-offload flag. Requires sufficient system RAM via resources.memory.
+                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -1215,6 +1236,14 @@ spec:
                     description: |-
                       GPUMemory specifies GPU memory limit per pod (e.g., "16Gi")
                       Used for scheduling and validation
+                    type: string
+                  hostMemory:
+                    description: |-
+                      HostMemory specifies the system RAM required for hybrid GPU/CPU offloading (e.g., "64Gi").
+                      Used when MoE expert weights or KV cache are offloaded to CPU via moeCPUOffload or noKvOffload.
+                      Translated to pod resources.requests.memory, taking precedence over Memory when set.
+                      Without this, the K8s scheduler has no visibility into the pod's actual RAM consumption,
+                      which can lead to OOM kills after model load.
                     type: string
                   memory:
                     description: Memory requests (e.g., "4Gi")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -247,6 +247,7 @@ func main() {
 	if err := (&controller.InferenceServiceReconciler{
 		Client:               mgr.GetClient(),
 		Scheme:               mgr.GetScheme(),
+		Recorder:             mgr.GetEventRecorderFor("inferenceservice-controller"),
 		ModelCachePath:       modelCachePath,
 		ModelCacheSize:       modelCacheSize,
 		ModelCacheClass:      modelCacheClass,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -247,7 +247,7 @@ func main() {
 	if err := (&controller.InferenceServiceReconciler{
 		Client:               mgr.GetClient(),
 		Scheme:               mgr.GetScheme(),
-		Recorder:             mgr.GetEventRecorderFor("inferenceservice-controller"),
+		Recorder:             mgr.GetEventRecorder("inferenceservice-controller"),
 		ModelCachePath:       modelCachePath,
 		ModelCacheSize:       modelCacheSize,
 		ModelCacheClass:      modelCacheClass,

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -419,6 +419,27 @@ spec:
                 description: ModelRef references the Model CR that contains the model
                   to serve
                 type: string
+              moeCPULayers:
+                description: |-
+                  MoeCPULayers sets the number of MoE layers to offload to CPU.
+                  When set, only the specified number of MoE layers run on CPU rather than all.
+                  Maps to llama.cpp --n-cpu-moe flag.
+                format: int32
+                minimum: 0
+                type: integer
+              moeCPUOffload:
+                description: |-
+                  MoeCPUOffload offloads all MoE expert layers to CPU for reduced VRAM usage.
+                  Enables running large MoE models (e.g., Qwen3-30B, Mixtral) on VRAM-constrained
+                  hardware by keeping attention layers on GPU while expert weights use system RAM.
+                  Maps to llama.cpp --cpu-moe flag. Requires sufficient system RAM via resources.memory.
+                type: boolean
+              noKvOffload:
+                description: |-
+                  NoKvOffload keeps the KV cache in system RAM instead of VRAM.
+                  Useful for extended context windows when VRAM is constrained by model weights.
+                  Maps to llama.cpp --no-kv-offload flag. Requires sufficient system RAM via resources.memory.
+                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -1211,6 +1232,14 @@ spec:
                     description: |-
                       GPUMemory specifies GPU memory limit per pod (e.g., "16Gi")
                       Used for scheduling and validation
+                    type: string
+                  hostMemory:
+                    description: |-
+                      HostMemory specifies the system RAM required for hybrid GPU/CPU offloading (e.g., "64Gi").
+                      Used when MoE expert weights or KV cache are offloaded to CPU via moeCPUOffload or noKvOffload.
+                      Translated to pod resources.requests.memory, taking precedence over Memory when set.
+                      Without this, the K8s scheduler has no visibility into the pod's actual RAM consumption,
+                      which can lead to OOM kills after model load.
                     type: string
                   memory:
                     description: Memory requests (e.g., "4Gi")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/config/samples/inference_v1alpha1_inferenceservice.yaml
+++ b/config/samples/inference_v1alpha1_inferenceservice.yaml
@@ -30,8 +30,18 @@ spec:
   # Enable Jinja2 template rendering for tool/function calling support (optional)
   jinja: true
 
+  # MoE CPU offloading: offload expert layers to CPU for MoE models (optional)
+  # moeCPUOffload: true
+
+  # Number of MoE layers to offload to CPU (optional, alternative to moeCPUOffload)
+  # moeCPULayers: 8
+
+  # Disable KV cache GPU offloading to save VRAM for extended context (optional)
+  # noKvOffload: true
+
   # Resource requirements (optional)
   resources:
     gpu: 1        # Number of GPUs (0 for CPU-only)
     cpu: "2"      # CPU request (e.g., "2" or "2000m")
     memory: "4Gi" # Memory request (e.g., "4Gi")
+    # hostMemory: "64Gi"  # System RAM for hybrid offloading (takes precedence over memory)

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -47,6 +48,7 @@ import (
 type InferenceServiceReconciler struct {
 	client.Client
 	Scheme               *runtime.Scheme
+	Recorder             record.EventRecorder
 	ModelCachePath       string
 	ModelCacheSize       string
 	ModelCacheClass      string
@@ -363,6 +365,7 @@ func (r *InferenceServiceReconciler) ensureModelCachePVC(ctx context.Context, na
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reconcileStart := time.Now()
@@ -402,6 +405,11 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	isMetal := model.Spec.Hardware != nil && model.Spec.Hardware.Accelerator == "metal"
+
+	if r.Recorder != nil && needsOffloadMemoryWarning(inferenceService) {
+		r.Recorder.Event(inferenceService, corev1.EventTypeWarning, "MissingMemoryRequest",
+			"CPU/KV offloading is enabled but resources.memory is not set; hybrid pods consume significant host RAM")
+	}
 
 	deployment, readyReplicas, result, err := r.reconcileDeployment(ctx, inferenceService, model, desiredReplicas, modelReady, isMetal)
 	if err != nil || result != nil {
@@ -954,6 +962,34 @@ func appendCacheTypeArgs(args []string, cacheTypeK, cacheTypeV string) []string 
 	return args
 }
 
+func appendMoeCPUOffloadArgs(args []string, moeCPUOffload *bool) []string {
+	if moeCPUOffload != nil && *moeCPUOffload {
+		return append(args, "--cpu-moe")
+	}
+	return args
+}
+
+func appendMoeCPULayersArgs(args []string, moeCPULayers *int32) []string {
+	if moeCPULayers != nil && *moeCPULayers > 0 {
+		return append(args, "--n-cpu-moe", fmt.Sprintf("%d", *moeCPULayers))
+	}
+	return args
+}
+
+func appendNoKvOffloadArgs(args []string, noKvOffload *bool) []string {
+	if noKvOffload != nil && *noKvOffload {
+		return append(args, "--no-kv-offload")
+	}
+	return args
+}
+
+func needsOffloadMemoryWarning(isvc *inferencev1alpha1.InferenceService) bool {
+	needsRAM := (isvc.Spec.MoeCPUOffload != nil && *isvc.Spec.MoeCPUOffload) ||
+		(isvc.Spec.NoKvOffload != nil && *isvc.Spec.NoKvOffload)
+	memorySet := isvc.Spec.Resources != nil && (isvc.Spec.Resources.Memory != "" || isvc.Spec.Resources.HostMemory != "")
+	return needsRAM && !memorySet
+}
+
 func (r *InferenceServiceReconciler) constructDeployment(
 	isvc *inferencev1alpha1.InferenceService,
 	model *inferencev1alpha1.Model,
@@ -1059,7 +1095,9 @@ func (r *InferenceServiceReconciler) constructDeployment(
 		if isvc.Spec.Resources.CPU != "" {
 			container.Resources.Requests[corev1.ResourceCPU] = resource.MustParse(isvc.Spec.Resources.CPU)
 		}
-		if isvc.Spec.Resources.Memory != "" {
+		if isvc.Spec.Resources.HostMemory != "" {
+			container.Resources.Requests[corev1.ResourceMemory] = resource.MustParse(isvc.Spec.Resources.HostMemory)
+		} else if isvc.Spec.Resources.Memory != "" {
 			container.Resources.Requests[corev1.ResourceMemory] = resource.MustParse(isvc.Spec.Resources.Memory)
 		}
 	}

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -48,7 +48,7 @@ import (
 type InferenceServiceReconciler struct {
 	client.Client
 	Scheme               *runtime.Scheme
-	Recorder             record.EventRecorder
+	Recorder             events.EventRecorder
 	ModelCachePath       string
 	ModelCacheSize       string
 	ModelCacheClass      string
@@ -407,8 +407,8 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	isMetal := model.Spec.Hardware != nil && model.Spec.Hardware.Accelerator == "metal"
 
 	if r.Recorder != nil && needsOffloadMemoryWarning(inferenceService) {
-		r.Recorder.Event(inferenceService, corev1.EventTypeWarning, "MissingMemoryRequest",
-			"CPU/KV offloading is enabled but resources.memory is not set; hybrid pods consume significant host RAM")
+		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "MissingMemoryRequest", "Reconcile",
+			"CPU/KV offloading is enabled but resources.memory/hostMemory is not set; hybrid pods consume significant host RAM")
 	}
 
 	deployment, readyReplicas, result, err := r.reconcileDeployment(ctx, inferenceService, model, desiredReplicas, modelReady, isMetal)

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -1333,6 +1333,503 @@ var _ = Describe("Context Size Configuration", func() {
 		})
 	})
 
+	Context("when moeCPUOffload is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "moe-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		It("should include --cpu-moe flag when moeCPUOffload is true", func() {
+			replicas := int32(1)
+			moeCPUOffload := true
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "moe-offload-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:      "moe-model",
+					Replicas:      &replicas,
+					Image:         "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					MoeCPUOffload: &moeCPUOffload,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElement("--cpu-moe"))
+		})
+
+		It("should NOT include --cpu-moe flag when moeCPUOffload is not specified", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-moe-offload-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "moe-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--cpu-moe"))
+		})
+
+		It("should NOT include --cpu-moe flag when moeCPUOffload is false", func() {
+			replicas := int32(1)
+			moeCPUOffload := false
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "moe-offload-false-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:      "moe-model",
+					Replicas:      &replicas,
+					Image:         "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					MoeCPUOffload: &moeCPUOffload,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--cpu-moe"))
+		})
+	})
+
+	Context("when moeCPULayers is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "moe-layers-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		It("should include --n-cpu-moe flag with correct value when moeCPULayers is set", func() {
+			replicas := int32(1)
+			moeCPULayers := int32(8)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "moe-layers-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:     "moe-layers-model",
+					Replicas:     &replicas,
+					Image:        "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					MoeCPULayers: &moeCPULayers,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--n-cpu-moe", "8"))
+		})
+
+		It("should NOT include --n-cpu-moe flag when moeCPULayers is not specified", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-moe-layers-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "moe-layers-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--n-cpu-moe"))
+		})
+
+		It("should NOT include --n-cpu-moe flag when moeCPULayers is zero", func() {
+			replicas := int32(1)
+			moeCPULayers := int32(0)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "moe-layers-zero-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:     "moe-layers-model",
+					Replicas:     &replicas,
+					Image:        "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					MoeCPULayers: &moeCPULayers,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--n-cpu-moe"))
+		})
+	})
+
+	Context("when noKvOffload is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kv-offload-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		It("should include --no-kv-offload flag when noKvOffload is true", func() {
+			replicas := int32(1)
+			noKvOffload := true
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kv-offload-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:    "kv-offload-model",
+					Replicas:    &replicas,
+					Image:       "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					NoKvOffload: &noKvOffload,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElement("--no-kv-offload"))
+		})
+
+		It("should NOT include --no-kv-offload flag when noKvOffload is not specified", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-kv-offload-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "kv-offload-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--no-kv-offload"))
+		})
+
+		It("should NOT include --no-kv-offload flag when noKvOffload is false", func() {
+			replicas := int32(1)
+			noKvOffload := false
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kv-offload-false-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:    "kv-offload-model",
+					Replicas:    &replicas,
+					Image:       "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					NoKvOffload: &noKvOffload,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--no-kv-offload"))
+		})
+	})
+
+	Context("when hybrid offloading memory warning is needed", func() {
+		It("should return true when moeCPUOffload is true and no memory set", func() {
+			moeCPUOffload := true
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					MoeCPUOffload: &moeCPUOffload,
+				},
+			}
+			Expect(needsOffloadMemoryWarning(isvc)).To(BeTrue())
+		})
+
+		It("should return true when noKvOffload is true and no memory set", func() {
+			noKvOffload := true
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					NoKvOffload: &noKvOffload,
+				},
+			}
+			Expect(needsOffloadMemoryWarning(isvc)).To(BeTrue())
+		})
+
+		It("should return false when moeCPUOffload is true and memory is set", func() {
+			moeCPUOffload := true
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					MoeCPUOffload: &moeCPUOffload,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						Memory: "64Gi",
+					},
+				},
+			}
+			Expect(needsOffloadMemoryWarning(isvc)).To(BeFalse())
+		})
+
+		It("should return false when neither offload flag is set", func() {
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{},
+			}
+			Expect(needsOffloadMemoryWarning(isvc)).To(BeFalse())
+		})
+
+		It("should return false when moeCPUOffload is false", func() {
+			moeCPUOffload := false
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					MoeCPUOffload: &moeCPUOffload,
+				},
+			}
+			Expect(needsOffloadMemoryWarning(isvc)).To(BeFalse())
+		})
+
+		It("should return false when moeCPUOffload is true and hostMemory is set", func() {
+			moeCPUOffload := true
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					MoeCPUOffload: &moeCPUOffload,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						HostMemory: "64Gi",
+					},
+				},
+			}
+			Expect(needsOffloadMemoryWarning(isvc)).To(BeFalse())
+		})
+	})
+
+	Context("when hostMemory is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hostmem-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		It("should use hostMemory for pod memory request", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hostmem-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "hostmem-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU:        1,
+						HostMemory: "64Gi",
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("64Gi")))
+		})
+
+		It("should prefer hostMemory over memory when both are set", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hostmem-precedence-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "hostmem-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU:        1,
+						Memory:     "4Gi",
+						HostMemory: "64Gi",
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("64Gi")))
+		})
+
+		It("should fall back to memory when hostMemory is not set", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-hostmem-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "hostmem-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU:    1,
+						Memory: "4Gi",
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("4Gi")))
+		})
+	})
+
 	Context("when extraArgs is configured", func() {
 		var (
 			reconciler *InferenceServiceReconciler
@@ -4152,6 +4649,8 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			parallelSlots := int32(4)
 			flashAttn := true
 			jinja := true
+			moeCPUOffload := true
+			noKvOffload := true
 
 			model := &inferencev1alpha1.Model{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-full", Namespace: "default"},
@@ -4185,6 +4684,8 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 					Jinja:          &jinja,
 					CacheTypeK:     "q8_0",
 					CacheTypeV:     "q4_0",
+					MoeCPUOffload:  &moeCPUOffload,
+					NoKvOffload:    &noKvOffload,
 					ExtraArgs:      []string{"--log-disable"},
 					Resources: &inferencev1alpha1.InferenceResourceRequirements{
 						GPU:    1,
@@ -4218,6 +4719,12 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			By("verifying cache types")
 			Expect(container.Args).To(ContainElements("--cache-type-k", "q8_0"))
 			Expect(container.Args).To(ContainElements("--cache-type-v", "q4_0"))
+
+			By("verifying MoE CPU offload")
+			Expect(container.Args).To(ContainElement("--cpu-moe"))
+
+			By("verifying no KV offload")
+			Expect(container.Args).To(ContainElement("--no-kv-offload"))
 
 			By("verifying extra args")
 			Expect(container.Args).To(ContainElement("--log-disable"))

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -63,6 +63,9 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 	args = appendFlashAttentionArgs(args, isvc.Spec.FlashAttention, gpuCount)
 	args = appendJinjaArgs(args, isvc.Spec.Jinja)
 	args = appendCacheTypeArgs(args, isvc.Spec.CacheTypeK, isvc.Spec.CacheTypeV)
+	args = appendMoeCPUOffloadArgs(args, isvc.Spec.MoeCPUOffload)
+	args = appendMoeCPULayersArgs(args, isvc.Spec.MoeCPULayers)
+	args = appendNoKvOffloadArgs(args, isvc.Spec.NoKvOffload)
 	if len(isvc.Spec.ExtraArgs) > 0 {
 		args = append(args, isvc.Spec.ExtraArgs...)
 	}


### PR DESCRIPTION
## Summary

Adds first-class CRD fields for hybrid GPU/CPU inference (Phase 1 of #280), enabling large MoE models to run on VRAM-constrained hardware by offloading expert weights and KV cache to system RAM.

- **`moeCPUOffload`** — offloads all MoE expert layers to CPU (`--cpu-moe`)
- **`moeCPULayers`** — offloads N MoE layers to CPU (`--n-cpu-moe`)
- **`noKvOffload`** — keeps KV cache in system RAM (`--no-kv-offload`)
- **`hostMemory`** — explicit system RAM request for hybrid pods, takes precedence over `memory` for accurate K8s scheduling
- Emits a `Warning` event when offloading is enabled but memory is not declared

### Use case

A Qwen3-30B-A3B (30B total, ~3B active per token) can run on dual RTX 5060 Ti 16GB with 90K context by keeping attention layers on GPU while expert weights sit in system RAM — previously only possible via `extraArgs`.

## Test plan

- [x] 9 unit tests for flag generation (3 per flag: true/nil/false)
- [x] 6 tests for `needsOffloadMemoryWarning` helper (both flags × memory/hostMemory set/unset)
- [x] 3 tests for `hostMemory` resource precedence
- [x] Updated full-configuration integration test with all new fields
- [x] `make test` passes (controller coverage 82.6%)
- [x] `make generate && make manifests` clean
- [x] Helm chart CRD synced

Ref #280 (Phase 1 only — Phases 2 & 3 tracked in the issue)