### PR TITLE
feat: add tensor overrides and batch size controls for hybrid offloading

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -138,11 +138,32 @@ type InferenceServiceSpec struct {
 	// +optional
 	NoKvOffload *bool `json:"noKvOffload,omitempty"`
 
+	// TensorOverrides provides fine-grained tensor placement overrides for power users.
+	// Each entry specifies a tensor name and target device (e.g., "exps=CPU", "token_embd=CUDA0").
+	// Maps to llama.cpp --override-tensor flag (one flag per entry).
+	// +optional
+	TensorOverrides []string `json:"tensorOverrides,omitempty"`
+
+	// BatchSize sets the token batch size for prompt processing.
+	// Larger values improve throughput but use more memory.
+	// Maps to llama.cpp --batch-size flag.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=16384
+	// +optional
+	BatchSize *int32 `json:"batchSize,omitempty"`
+
+	// UBatchSize sets the micro-batch size for decoding.
+	// Smaller micro-batches reduce memory usage during generation.
+	// Maps to llama.cpp --ubatch-size flag.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	UBatchSize *int32 `json:"uBatchSize,omitempty"`
+
 	// ExtraArgs provides additional command-line arguments passed directly to the
 	// llama-server process. Use for flags not yet supported as typed CRD fields.
 	// Arguments are appended after all other configured flags.
 	// Only used when Runtime is "llamacpp".
-	// Example: ["--seed", "42", "--batch-size", "2048"]
+	// Example: ["--seed", "42", "--log-disable"]
 	// +optional
 	ExtraArgs []string `json:"extraArgs,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -294,6 +294,21 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.TensorOverrides != nil {
+		in, out := &in.TensorOverrides, &out.TensorOverrides
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.BatchSize != nil {
+		in, out := &in.BatchSize, &out.BatchSize
+		*out = new(int32)
+		**out = **in
+	}
+	if in.UBatchSize != nil {
+		in, out := &in.UBatchSize, &out.UBatchSize
+		*out = new(int32)
+		**out = **in
+	}
 	if in.ExtraArgs != nil {
 		in, out := &in.ExtraArgs, &out.ExtraArgs
 		*out = make([]string, len(*in))

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -136,6 +136,15 @@ spec:
                 required:
                 - maxReplicas
                 type: object
+              batchSize:
+                description: |-
+                  BatchSize sets the token batch size for prompt processing.
+                  Larger values improve throughput but use more memory.
+                  Maps to llama.cpp --batch-size flag.
+                format: int32
+                maximum: 16384
+                minimum: 1
+                type: integer
               cacheTypeK:
                 description: |-
                   CacheTypeK sets the KV cache quantization type for keys.
@@ -1462,6 +1471,14 @@ spec:
                   Use when the model is baked into the image or downloaded by the
                   container itself (e.g., via HF_TOKEN).
                 type: boolean
+              tensorOverrides:
+                description: |-
+                  TensorOverrides provides fine-grained tensor placement overrides for power users.
+                  Each entry specifies a tensor name and target device (e.g., "exps=CPU", "token_embd=CUDA0").
+                  Maps to llama.cpp --override-tensor flag (one flag per entry).
+                items:
+                  type: string
+                type: array
               tgiConfig:
                 description: |-
                   TGIConfig holds configuration for the TGI runtime.
@@ -1558,6 +1575,14 @@ spec:
                       type: string
                   type: object
                 type: array
+              uBatchSize:
+                description: |-
+                  UBatchSize sets the micro-batch size for decoding.
+                  Smaller micro-batches reduce memory usage during generation.
+                  Maps to llama.cpp --ubatch-size flag.
+                format: int32
+                minimum: 1
+                type: integer
               vllmConfig:
                 description: |-
                   VLLMConfig holds configuration for the vLLM runtime.

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -132,6 +132,15 @@ spec:
                 required:
                 - maxReplicas
                 type: object
+              batchSize:
+                description: |-
+                  BatchSize sets the token batch size for prompt processing.
+                  Larger values improve throughput but use more memory.
+                  Maps to llama.cpp --batch-size flag.
+                format: int32
+                maximum: 16384
+                minimum: 1
+                type: integer
               cacheTypeK:
                 description: |-
                   CacheTypeK sets the KV cache quantization type for keys.
@@ -374,7 +383,7 @@ spec:
                   llama-server process. Use for flags not yet supported as typed CRD fields.
                   Arguments are appended after all other configured flags.
                   Only used when Runtime is "llamacpp".
-                  Example: ["--seed", "42", "--batch-size", "2048"]
+                  Example: ["--seed", "42", "--log-disable"]
                 items:
                   type: string
                 type: array
@@ -1458,6 +1467,14 @@ spec:
                   Use when the model is baked into the image or downloaded by the
                   container itself (e.g., via HF_TOKEN).
                 type: boolean
+              tensorOverrides:
+                description: |-
+                  TensorOverrides provides fine-grained tensor placement overrides for power users.
+                  Each entry specifies a tensor name and target device (e.g., "exps=CPU", "token_embd=CUDA0").
+                  Maps to llama.cpp --override-tensor flag (one flag per entry).
+                items:
+                  type: string
+                type: array
               tgiConfig:
                 description: |-
                   TGIConfig holds configuration for the TGI runtime.
@@ -1554,6 +1571,14 @@ spec:
                       type: string
                   type: object
                 type: array
+              uBatchSize:
+                description: |-
+                  UBatchSize sets the micro-batch size for decoding.
+                  Smaller micro-batches reduce memory usage during generation.
+                  Maps to llama.cpp --ubatch-size flag.
+                format: int32
+                minimum: 1
+                type: integer
               vllmConfig:
                 description: |-
                   VLLMConfig holds configuration for the vLLM runtime.

--- a/config/samples/inference_v1alpha1_inferenceservice.yaml
+++ b/config/samples/inference_v1alpha1_inferenceservice.yaml
@@ -39,6 +39,17 @@ spec:
   # Disable KV cache GPU offloading to save VRAM for extended context (optional)
   # noKvOffload: true
 
+  # Tensor placement overrides for fine-grained GPU/CPU control (optional)
+  # tensorOverrides:
+  #   - "exps=CPU"
+  #   - "token_embd=CUDA0"
+
+  # Batch size for prompt processing (optional, default: llama.cpp default)
+  # batchSize: 2048
+
+  # Micro-batch size for decoding (optional)
+  # uBatchSize: 256
+
   # Resource requirements (optional)
   resources:
     gpu: 1        # Number of GPUs (0 for CPU-only)

--- a/docs/hybrid-offload-phase2-spec.md
+++ b/docs/hybrid-offload-phase2-spec.md
@@ -1,0 +1,174 @@
+# Hybrid Offloading Phase 2 Implementation Spec
+
+Issue: #280 (Phase 2 section)
+
+## What to implement
+
+Add three new fields to `InferenceServiceSpec` and wire them through to llama.cpp args, following the exact patterns established in Phase 1 (PR #281).
+
+### New Fields
+
+#### 1. `tensorOverrides` (`[]string`)
+
+- **Purpose**: Fine-grained tensor placement overrides for power users
+- **Maps to**: `--override-tensor` flag in llama.cpp (one flag per entry)
+- **Example values**: `["exps=CPU", "blk\\.(0|1)\\.ffn_.*=CUDA0"]`
+- **CRD location**: `InferenceServiceSpec` (top-level, after `noKvOffload`)
+- **Type**: `[]string` (string slice, same pattern as `ExtraArgs`)
+- **Marker**: `// +optional` only (no enum or min/max needed)
+
+Each entry becomes a separate `--override-tensor` flag:
+```
+tensorOverrides: ["exps=CPU", "token_embd=CUDA0"]
+```
+becomes:
+```
+--override-tensor exps=CPU --override-tensor token_embd=CUDA0
+```
+
+#### 2. `batchSize` (`*int32`)
+
+- **Purpose**: Token batch size for prompt processing
+- **Maps to**: `--batch-size N` flag in llama.cpp
+- **CRD location**: `InferenceServiceSpec` (top-level, after `tensorOverrides`)
+- **Type**: `*int32` (pointer, same pattern as `ContextSize`)
+- **Markers**: `// +kubebuilder:validation:Minimum=1`, `// +kubebuilder:validation:Maximum=16384`, `// +optional`
+- **Guard in helper**: only append when `> 0`
+
+#### 3. `uBatchSize` (`*int32`)
+
+- **Purpose**: Micro-batch size for decoding
+- **Maps to**: `--ubatch-size N` flag in llama.cpp
+- **CRD location**: `InferenceServiceSpec` (top-level, after `batchSize`)
+- **Type**: `*int32` (pointer, same pattern as `ContextSize`)
+- **Markers**: `// +kubebuilder:validation:Minimum=1`, `// +optional`
+- **Guard in helper**: only append when `> 0`
+
+## Files to modify
+
+### 1. `api/v1alpha1/inferenceservice_types.go`
+
+Add three fields to `InferenceServiceSpec` after the `NoKvOffload` field (around line 140) and before `ExtraArgs`.
+
+Follow the comment/marker style of the surrounding fields. Example for reference — this is how Phase 1 fields look in the file:
+
+```go
+// MoeCPUOffload offloads all MoE expert layers to CPU for reduced VRAM usage.
+// Enables running large MoE models (e.g., Qwen3-30B, Mixtral) on VRAM-constrained
+// hardware by keeping attention layers on GPU while expert weights use system RAM.
+// Maps to llama.cpp --cpu-moe flag. Requires sufficient system RAM via resources.memory.
+// +optional
+MoeCPUOffload *bool `json:"moeCPUOffload,omitempty"`
+```
+
+### 2. `internal/controller/inferenceservice_controller.go`
+
+Add three helper functions after `appendNoKvOffloadArgs` (around line 997):
+
+Follow these existing patterns exactly:
+
+```go
+// Bool flag pattern (reference: appendMoeCPUOffloadArgs)
+func appendMoeCPUOffloadArgs(args []string, moeCPUOffload *bool) []string {
+	if moeCPUOffload != nil && *moeCPUOffload {
+		return append(args, "--cpu-moe")
+	}
+	return args
+}
+
+// Int flag pattern (reference: appendContextSizeArgs)
+func appendContextSizeArgs(args []string, contextSize *int32) []string {
+	if contextSize != nil && *contextSize > 0 {
+		return append(args, "--ctx-size", fmt.Sprintf("%d", *contextSize))
+	}
+	return args
+}
+```
+
+For `tensorOverrides`, the helper should loop and add each entry as a separate `--override-tensor` flag:
+```go
+func appendTensorOverrideArgs(args []string, overrides []string) []string {
+	for _, override := range overrides {
+		args = append(args, "--override-tensor", override)
+	}
+	return args
+}
+```
+
+### 3. `internal/controller/runtime_llamacpp.go`
+
+In `BuildArgs()`, call the three new helpers. Insert after the existing `appendNoKvOffloadArgs` call and before the `ExtraArgs` block. The current ordering in the function is:
+
+```go
+args = appendCacheTypeArgs(args, isvc.Spec.CacheTypeK, isvc.Spec.CacheTypeV)
+args = appendMoeCPUOffloadArgs(args, isvc.Spec.MoeCPUOffload)
+args = appendMoeCPULayersArgs(args, isvc.Spec.MoeCPULayers)
+args = appendNoKvOffloadArgs(args, isvc.Spec.NoKvOffload)
+// <-- INSERT NEW CALLS HERE -->
+if len(isvc.Spec.ExtraArgs) > 0 {
+    args = append(args, isvc.Spec.ExtraArgs...)
+}
+```
+
+### 4. `internal/controller/inferenceservice_controller_test.go`
+
+Add test contexts following the existing Phase 1 test patterns. The Phase 1 tests are located after the "when cache type is configured" context block (around line 1335).
+
+**For each field, add three tests:**
+
+For `tensorOverrides`:
+- "should include --override-tensor flags when tensorOverrides is set" (set `["exps=CPU", "token_embd=CUDA0"]`, assert both `--override-tensor` entries appear)
+- "should NOT include --override-tensor when tensorOverrides is empty"
+- "should NOT include --override-tensor when tensorOverrides is nil"
+
+For `batchSize`:
+- "should include --batch-size flag with correct value when batchSize is set" (e.g., 2048)
+- "should NOT include --batch-size when batchSize is not specified"
+- "should NOT include --batch-size when batchSize is zero"
+
+For `uBatchSize`:
+- "should include --ubatch-size flag with correct value when uBatchSize is set" (e.g., 256)
+- "should NOT include --ubatch-size when uBatchSize is not specified"
+- "should NOT include --ubatch-size when uBatchSize is zero"
+
+Also update the "GPU model with all llama.cpp options" integration test context (around line 4250) to include the new fields and verify the flags appear.
+
+Use the same test fixture pattern as the Phase 1 tests — create a reconciler, model, and isvc in BeforeEach, then call `reconciler.constructDeployment(isvc, model, 1)` and assert on `container.Args`.
+
+### 5. `config/samples/inference_v1alpha1_inferenceservice.yaml`
+
+Add commented examples after the existing hybrid offloading comments:
+
+```yaml
+  # Tensor placement overrides for fine-grained GPU/CPU control (optional)
+  # tensorOverrides:
+  #   - "exps=CPU"
+  #   - "token_embd=CUDA0"
+
+  # Batch size for prompt processing (optional, default: llama.cpp default)
+  # batchSize: 2048
+
+  # Micro-batch size for decoding (optional)
+  # uBatchSize: 256
+```
+
+### 6. `charts/llmkube/templates/crds/inferenceservices.yaml`
+
+After running `make manifests`, the generated CRD at `config/crd/bases/inference.llmkube.dev_inferenceservices.yaml` will have the new fields. Copy the new field definitions into the Helm chart CRD file in alphabetical order (matching where controller-gen places them in the generated CRD).
+
+### 7. Code generation (run these commands after code changes)
+
+```bash
+make generate    # Regenerates zz_generated.deepcopy.go
+make manifests   # Regenerates CRD YAML and RBAC
+make test        # Runs all unit tests
+```
+
+## Verification
+
+After all changes:
+1. `make generate && make manifests` should complete without errors
+2. `make fmt && make vet` should be clean
+3. `make test` should pass with all new tests
+4. The generated CRD YAML should include the three new fields with correct types and validation
+5. The Helm chart CRD should be synced with the generated CRD

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -1004,6 +1004,27 @@ func appendNoKvOffloadArgs(args []string, noKvOffload *bool) []string {
 	return args
 }
 
+func appendTensorOverrideArgs(args []string, overrides []string) []string {
+	for _, override := range overrides {
+		args = append(args, "--override-tensor", override)
+	}
+	return args
+}
+
+func appendBatchSizeArgs(args []string, batchSize *int32) []string {
+	if batchSize != nil && *batchSize > 0 {
+		return append(args, "--batch-size", fmt.Sprintf("%d", *batchSize))
+	}
+	return args
+}
+
+func appendUBatchSizeArgs(args []string, uBatchSize *int32) []string {
+	if uBatchSize != nil && *uBatchSize > 0 {
+		return append(args, "--ubatch-size", fmt.Sprintf("%d", *uBatchSize))
+	}
+	return args
+}
+
 func needsOffloadMemoryWarning(isvc *inferencev1alpha1.InferenceService) bool {
 	needsRAM := (isvc.Spec.MoeCPUOffload != nil && *isvc.Spec.MoeCPUOffload) ||
 		(isvc.Spec.NoKvOffload != nil && *isvc.Spec.NoKvOffload)

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -1657,6 +1657,318 @@ var _ = Describe("Context Size Configuration", func() {
 		})
 	})
 
+	Context("when tensorOverrides is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tensor-override-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		It("should include --override-tensor flags when tensorOverrides is set", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tensor-override-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:        "tensor-override-model",
+					Replicas:        &replicas,
+					Image:           "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					TensorOverrides: []string{"exps=CPU", "token_embd=CUDA0"},
+					Resources:       &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--override-tensor", "exps=CPU"))
+			Expect(args).To(ContainElements("--override-tensor", "token_embd=CUDA0"))
+		})
+
+		It("should NOT include --override-tensor when tensorOverrides is empty", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-tensor-override-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:        "tensor-override-model",
+					Replicas:        &replicas,
+					Image:           "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					TensorOverrides: []string{},
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--override-tensor"))
+		})
+
+		It("should NOT include --override-tensor when tensorOverrides is nil", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nil-tensor-override-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "tensor-override-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--override-tensor"))
+		})
+	})
+
+	Context("when batchSize is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "batch-size-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		It("should include --batch-size flag with correct value when batchSize is set", func() {
+			replicas := int32(1)
+			batchSize := int32(2048)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "batch-size-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:  "batch-size-model",
+					Replicas:  &replicas,
+					Image:     "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					BatchSize: &batchSize,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--batch-size", "2048"))
+		})
+
+		It("should NOT include --batch-size when batchSize is not specified", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-batch-size-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "batch-size-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--batch-size"))
+		})
+
+		It("should NOT include --batch-size when batchSize is zero", func() {
+			replicas := int32(1)
+			batchSize := int32(0)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zero-batch-size-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:  "batch-size-model",
+					Replicas:  &replicas,
+					Image:     "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					BatchSize: &batchSize,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--batch-size"))
+		})
+	})
+
+	Context("when uBatchSize is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ubatch-size-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		It("should include --ubatch-size flag with correct value when uBatchSize is set", func() {
+			replicas := int32(1)
+			ubatchSize := int32(256)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ubatch-size-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:   "ubatch-size-model",
+					Replicas:   &replicas,
+					Image:      "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					UBatchSize: &ubatchSize,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--ubatch-size", "256"))
+		})
+
+		It("should NOT include --ubatch-size when uBatchSize is not specified", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-ubatch-size-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "ubatch-size-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--ubatch-size"))
+		})
+
+		It("should NOT include --ubatch-size when uBatchSize is zero", func() {
+			replicas := int32(1)
+			ubatchSize := int32(0)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "zero-ubatch-size-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:   "ubatch-size-model",
+					Replicas:   &replicas,
+					Image:      "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					UBatchSize: &ubatchSize,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--ubatch-size"))
+		})
+	})
+
 	Context("when hybrid offloading memory warning is needed", func() {
 		It("should return true when moeCPUOffload is true and no memory set", func() {
 			moeCPUOffload := true
@@ -4849,6 +5161,8 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			jinja := true
 			moeCPUOffload := true
 			noKvOffload := true
+			batchSize := int32(2048)
+			ubatchSize := int32(256)
 
 			model := &inferencev1alpha1.Model{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-full", Namespace: "default"},
@@ -4874,17 +5188,20 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			isvc := &inferencev1alpha1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-full-svc", Namespace: "default"},
 				Spec: inferencev1alpha1.InferenceServiceSpec{
-					ModelRef:       "gpu-full",
-					Image:          "ghcr.io/ggml-org/llama.cpp:server-cuda13",
-					ContextSize:    &contextSize,
-					ParallelSlots:  &parallelSlots,
-					FlashAttention: &flashAttn,
-					Jinja:          &jinja,
-					CacheTypeK:     "q8_0",
-					CacheTypeV:     "q4_0",
-					MoeCPUOffload:  &moeCPUOffload,
-					NoKvOffload:    &noKvOffload,
-					ExtraArgs:      []string{"--log-disable"},
+					ModelRef:        "gpu-full",
+					Image:           "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					ContextSize:     &contextSize,
+					ParallelSlots:   &parallelSlots,
+					FlashAttention:  &flashAttn,
+					Jinja:           &jinja,
+					CacheTypeK:      "q8_0",
+					CacheTypeV:      "q4_0",
+					MoeCPUOffload:   &moeCPUOffload,
+					NoKvOffload:     &noKvOffload,
+					TensorOverrides: []string{"exps=CPU", "token_embd=CUDA0"},
+					BatchSize:       &batchSize,
+					UBatchSize:      &ubatchSize,
+					ExtraArgs:       []string{"--log-disable"},
 					Resources: &inferencev1alpha1.InferenceResourceRequirements{
 						GPU:    1,
 						CPU:    "2",
@@ -4923,6 +5240,16 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 
 			By("verifying no KV offload")
 			Expect(container.Args).To(ContainElement("--no-kv-offload"))
+
+			By("verifying tensor overrides")
+			Expect(container.Args).To(ContainElements("--override-tensor", "exps=CPU"))
+			Expect(container.Args).To(ContainElements("--override-tensor", "token_embd=CUDA0"))
+
+			By("verifying batch size")
+			Expect(container.Args).To(ContainElements("--batch-size", "2048"))
+
+			By("verifying micro-batch size")
+			Expect(container.Args).To(ContainElements("--ubatch-size", "256"))
 
 			By("verifying extra args")
 			Expect(container.Args).To(ContainElement("--log-disable"))

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -65,6 +65,9 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 	args = appendMoeCPUOffloadArgs(args, isvc.Spec.MoeCPUOffload)
 	args = appendMoeCPULayersArgs(args, isvc.Spec.MoeCPULayers)
 	args = appendNoKvOffloadArgs(args, isvc.Spec.NoKvOffload)
+	args = appendTensorOverrideArgs(args, isvc.Spec.TensorOverrides)
+	args = appendBatchSizeArgs(args, isvc.Spec.BatchSize)
+	args = appendUBatchSizeArgs(args, isvc.Spec.UBatchSize)
 	if len(isvc.Spec.ExtraArgs) > 0 {
 		args = append(args, isvc.Spec.ExtraArgs...)
 	}


### PR DESCRIPTION
## Summary

Phase 2 of hybrid GPU/CPU offloading (ref #280). Adds three new `InferenceServiceSpec` fields for fine-grained inference tuning:

- **`tensorOverrides`** (`[]string`): regex-based tensor placement via `--override-tensor`. Enables expert-level placement decisions beyond the typed `moeCPUOffload` flag (e.g., `[\"exps=CPU\", \"blk\\\\.(0|1)\\\\.ffn_.*=CUDA0\"]`)
- **`batchSize`** (`*int32`, 1-16384): prompt processing batch size via `--batch-size`. Tuning this amortizes PCIe overhead in hybrid MoE workloads
- **`uBatchSize`** (`*int32`, min 1): decoding micro-batch size via `--ubatch-size`

## Notable implementation detail

This feature was implemented by **Qwen3.6-35B-A3B running on dual RTX 5060 Ti GPUs with Phase 1 hybrid offloading from #281**. The model handled the full implementation in 32 minutes of active agent time: 56 tool calls, 100% success rate, 9 unit tests plus integration test updates, Helm CRD sync, and all verification commands green.

## Test plan

- [x] 9 unit tests (3 per field: positive, nil, zero/empty)
- [x] Updated \"GPU model with all llama.cpp options\" integration test
- [x] \`make test\` passes (controller coverage 82.4%)
- [x] \`make generate && make manifests\` clean
- [x] Helm chart CRD synced with generated CRD
- [x] Sample YAML shows commented examples

Ref #280 (Phase 2 of 3, Phase 3 still tracked in the issue)