### PR TITLE
feat: expose additional runtime controls for llama.cpp and vllm

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -145,6 +145,22 @@ type InferenceServiceSpec struct {
 	// +optional
 	NoWarmup *bool `json:"noWarmup,omitempty"`
 
+	// ReasoningBudget caps the number of reasoning tokens the model is allowed to
+	// emit per response. Zero disables visible thinking output entirely; the model
+	// still reasons internally but does not emit thinking tokens. Critical for
+	// production agentic workloads on thinking models (Qwen 3.6, GLM-5) where
+	// runaway reasoning can burn compute.
+	// Maps to llama.cpp --reasoning-budget flag.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	ReasoningBudget *int32 `json:"reasoningBudget,omitempty"`
+
+	// ReasoningBudgetMessage is injected when the reasoning budget is exhausted,
+	// forcing the model to conclude. Ignored unless ReasoningBudget is also set.
+	// Maps to llama.cpp --reasoning-budget-message flag.
+	// +optional
+	ReasoningBudgetMessage string `json:"reasoningBudgetMessage,omitempty"`
+
 	// TensorOverrides provides fine-grained tensor placement overrides for power users.
 	// Each entry specifies a tensor name and target device (e.g., "exps=CPU", "token_embd=CUDA0").
 	// Maps to llama.cpp --override-tensor flag (one flag per entry).

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -161,6 +161,14 @@ type InferenceServiceSpec struct {
 	// +optional
 	ReasoningBudgetMessage string `json:"reasoningBudgetMessage,omitempty"`
 
+	// MetadataOverrides overrides GGUF metadata key-value pairs at model load time.
+	// Each entry is passed as a separate --override-kv flag. Format: key=type:value
+	// (e.g., "qwen35moe.context_length=int:1048576" to extend context window, or
+	// "tokenizer.chat_template.thinking=bool:false" to tweak tokenizer behavior).
+	// Maps to llama.cpp --override-kv flag (one flag per entry).
+	// +optional
+	MetadataOverrides []string `json:"metadataOverrides,omitempty"`
+
 	// TensorOverrides provides fine-grained tensor placement overrides for power users.
 	// Each entry specifies a tensor name and target device (e.g., "exps=CPU", "token_embd=CUDA0").
 	// Maps to llama.cpp --override-tensor flag (one flag per entry).

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -386,6 +386,13 @@ type VLLMConfig struct {
 	// +optional
 	Dtype string `json:"dtype,omitempty"`
 
+	// EnablePrefixCaching turns on vLLM's automatic prefix caching for repeated prompts.
+	// Significantly reduces time-to-first-token for conversational and agentic workloads
+	// where requests share a common system prompt.
+	// Maps to vLLM --enable-prefix-caching flag.
+	// +optional
+	EnablePrefixCaching *bool `json:"enablePrefixCaching,omitempty"`
+
 	// HFTokenSecretRef references a Secret containing the HuggingFace token.
 	// +optional
 	HFTokenSecretRef *corev1.SecretKeySelector `json:"hfTokenSecretRef,omitempty"`

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -138,6 +138,13 @@ type InferenceServiceSpec struct {
 	// +optional
 	NoKvOffload *bool `json:"noKvOffload,omitempty"`
 
+	// NoWarmup skips the llama.cpp startup warmup inference pass.
+	// Reduces pod ready time at the cost of slightly higher first-request latency.
+	// Useful for scale-to-zero and quick redeployment patterns.
+	// Maps to llama.cpp --no-warmup flag.
+	// +optional
+	NoWarmup *bool `json:"noWarmup,omitempty"`
+
 	// TensorOverrides provides fine-grained tensor placement overrides for power users.
 	// Each entry specifies a tensor name and target device (e.g., "exps=CPU", "token_embd=CUDA0").
 	// Maps to llama.cpp --override-tensor flag (one flag per entry).

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -393,6 +393,15 @@ type VLLMConfig struct {
 	// +optional
 	EnablePrefixCaching *bool `json:"enablePrefixCaching,omitempty"`
 
+	// AttentionBackend selects the attention implementation used by vLLM.
+	// flashinfer is typically fastest on recent NVIDIA GPUs; flash_attn is a solid
+	// default; torch_sdpa and xformers are portability fallbacks. Requires a vLLM
+	// version that supports the chosen backend.
+	// Maps to vLLM --attention-backend flag.
+	// +kubebuilder:validation:Enum=flashinfer;flash_attn;xformers;torch_sdpa
+	// +optional
+	AttentionBackend string `json:"attentionBackend,omitempty"`
+
 	// HFTokenSecretRef references a Secret containing the HuggingFace token.
 	// +optional
 	HFTokenSecretRef *corev1.SecretKeySelector `json:"hfTokenSecretRef,omitempty"`

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -160,9 +160,9 @@ type InferenceServiceSpec struct {
 	UBatchSize *int32 `json:"uBatchSize,omitempty"`
 
 	// ExtraArgs provides additional command-line arguments passed directly to the
-	// llama-server process. Use for flags not yet supported as typed CRD fields.
+	// runtime process. Use for flags not yet supported as typed CRD fields.
 	// Arguments are appended after all other configured flags.
-	// Only used when Runtime is "llamacpp".
+	// Supported by the "llamacpp" and "vllm" runtimes. Ignored by others.
 	// Example: ["--seed", "42", "--log-disable"]
 	// +optional
 	ExtraArgs []string `json:"extraArgs,omitempty"`

--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -131,11 +131,15 @@ type GPUSpec struct {
 
 // GPUShardingSpec defines multi-GPU sharding strategy
 type GPUShardingSpec struct {
-	// Strategy defines the sharding approach
-	// - "layer": Shard by transformer layers (default)
-	// - "tensor": Tensor parallelism (future)
-	// - "pipeline": Pipeline parallelism (future)
-	// +kubebuilder:validation:Enum=layer;tensor;pipeline
+	// Strategy defines the sharding approach for multi-GPU model execution.
+	// - "layer" (default): shard by transformer layers. llama.cpp --split-mode layer.
+	// - "tensor" (alias: "row"): true tensor parallelism. llama.cpp --split-mode row.
+	//   Splits each tensor operation across GPUs rather than assigning whole layers
+	//   to each. Performance varies by workload; typically better on compute-bound ops.
+	// - "none": disable multi-GPU sharding (single GPU). llama.cpp --split-mode none.
+	// - "pipeline": accepted for forward compatibility but currently falls back to
+	//   "layer" with a reconciler warning; llama.cpp has no pipeline split-mode.
+	// +kubebuilder:validation:Enum=layer;tensor;row;pipeline;none
 	// +kubebuilder:default=layer
 	// +optional
 	Strategy string `json:"strategy,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -294,6 +294,11 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NoWarmup != nil {
+		in, out := &in.NoWarmup, &out.NoWarmup
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TensorOverrides != nil {
 		in, out := &in.TensorOverrides, &out.TensorOverrides
 		*out = make([]string, len(*in))

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -672,6 +672,11 @@ func (in *VLLMConfig) DeepCopyInto(out *VLLMConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.EnablePrefixCaching != nil {
+		in, out := &in.EnablePrefixCaching, &out.EnablePrefixCaching
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HFTokenSecretRef != nil {
 		in, out := &in.HFTokenSecretRef, &out.HFTokenSecretRef
 		*out = new(v1.SecretKeySelector)

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -304,6 +304,11 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MetadataOverrides != nil {
+		in, out := &in.MetadataOverrides, &out.MetadataOverrides
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.TensorOverrides != nil {
 		in, out := &in.TensorOverrides, &out.TensorOverrides
 		*out = make([]string, len(*in))

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -299,6 +299,11 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ReasoningBudget != nil {
+		in, out := &in.ReasoningBudget, &out.ReasoningBudget
+		*out = new(int32)
+		**out = **in
+	}
 	if in.TensorOverrides != nil {
 		in, out := &in.TensorOverrides, &out.TensorOverrides
 		*out = make([]string, len(*in))

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -384,10 +384,10 @@ spec:
               extraArgs:
                 description: |-
                   ExtraArgs provides additional command-line arguments passed directly to the
-                  llama-server process. Use for flags not yet supported as typed CRD fields.
+                  runtime process. Use for flags not yet supported as typed CRD fields.
                   Arguments are appended after all other configured flags.
-                  Only used when Runtime is "llamacpp".
-                  Example: ["--seed", "42", "--batch-size", "2048"]
+                  Supported by the "llamacpp" and "vllm" runtimes. Ignored by others.
+                  Example: ["--seed", "42", "--log-disable"]
                 items:
                   type: string
                 type: array
@@ -428,6 +428,16 @@ spec:
                   Jinja enables Jinja2 chat template rendering for tool/function calling support.
                   Required when using the OpenAI-compatible API with tools. Maps to llama.cpp --jinja flag.
                 type: boolean
+              metadataOverrides:
+                description: |-
+                  MetadataOverrides overrides GGUF metadata key-value pairs at model load time.
+                  Each entry is passed as a separate --override-kv flag. Format: key=type:value
+                  (e.g., "qwen35moe.context_length=int:1048576" to extend context window, or
+                  "tokenizer.chat_template.thinking=bool:false" to tweak tokenizer behavior).
+                  Maps to llama.cpp --override-kv flag (one flag per entry).
+                items:
+                  type: string
+                type: array
               modelRef:
                 description: ModelRef references the Model CR that contains the model
                   to serve
@@ -452,6 +462,13 @@ spec:
                   NoKvOffload keeps the KV cache in system RAM instead of VRAM.
                   Useful for extended context windows when VRAM is constrained by model weights.
                   Maps to llama.cpp --no-kv-offload flag. Requires sufficient system RAM via resources.memory.
+                type: boolean
+              noWarmup:
+                description: |-
+                  NoWarmup skips the llama.cpp startup warmup inference pass.
+                  Reduces pod ready time at the cost of slightly higher first-request latency.
+                  Useful for scale-to-zero and quick redeployment patterns.
+                  Maps to llama.cpp --no-warmup flag.
                 type: boolean
               nodeSelector:
                 additionalProperties:
@@ -1219,6 +1236,23 @@ spec:
                         type: integer
                     type: object
                 type: object
+              reasoningBudget:
+                description: |-
+                  ReasoningBudget caps the number of reasoning tokens the model is allowed to
+                  emit per response. Zero disables visible thinking output entirely; the model
+                  still reasons internally but does not emit thinking tokens. Critical for
+                  production agentic workloads on thinking models (Qwen 3.6, GLM-5) where
+                  runaway reasoning can burn compute.
+                  Maps to llama.cpp --reasoning-budget flag.
+                format: int32
+                minimum: 0
+                type: integer
+              reasoningBudgetMessage:
+                description: |-
+                  ReasoningBudgetMessage is injected when the reasoning budget is exhausted,
+                  forcing the model to conclude. Ignored unless ReasoningBudget is also set.
+                  Maps to llama.cpp --reasoning-budget-message flag.
+                type: string
               replicas:
                 default: 1
                 description: Replicas is the desired number of inference pods
@@ -1588,6 +1622,19 @@ spec:
                   VLLMConfig holds configuration for the vLLM runtime.
                   Only used when Runtime is "vllm".
                 properties:
+                  attentionBackend:
+                    description: |-
+                      AttentionBackend selects the attention implementation used by vLLM.
+                      flashinfer is typically fastest on recent NVIDIA GPUs; flash_attn is a solid
+                      default; torch_sdpa and xformers are portability fallbacks. Requires a vLLM
+                      version that supports the chosen backend.
+                      Maps to vLLM --attention-backend flag.
+                    enum:
+                    - flashinfer
+                    - flash_attn
+                    - xformers
+                    - torch_sdpa
+                    type: string
                   dtype:
                     description: Dtype sets the model data type (auto, float16, bfloat16).
                     enum:
@@ -1595,6 +1642,13 @@ spec:
                     - float16
                     - bfloat16
                     type: string
+                  enablePrefixCaching:
+                    description: |-
+                      EnablePrefixCaching turns on vLLM's automatic prefix caching for repeated prompts.
+                      Significantly reduces time-to-first-token for conversational and agentic workloads
+                      where requests share a common system prompt.
+                      Maps to vLLM --enable-prefix-caching flag.
+                    type: boolean
                   hfTokenSecretRef:
                     description: HFTokenSecretRef references a Secret containing the
                       HuggingFace token.

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -130,14 +130,20 @@ spec:
                           strategy:
                             default: layer
                             description: |-
-                              Strategy defines the sharding approach
-                              - "layer": Shard by transformer layers (default)
-                              - "tensor": Tensor parallelism (future)
-                              - "pipeline": Pipeline parallelism (future)
+                              Strategy defines the sharding approach for multi-GPU model execution.
+                              - "layer" (default): shard by transformer layers. llama.cpp --split-mode layer.
+                              - "tensor" (alias: "row"): true tensor parallelism. llama.cpp --split-mode row.
+                                Splits each tensor operation across GPUs rather than assigning whole layers
+                                to each. Performance varies by workload; typically better on compute-bound ops.
+                              - "none": disable multi-GPU sharding (single GPU). llama.cpp --split-mode none.
+                              - "pipeline": accepted for forward compatibility but currently falls back to
+                                "layer" with a reconciler warning; llama.cpp has no pipeline split-mode.
                             enum:
                             - layer
                             - tensor
+                            - row
                             - pipeline
+                            - none
                             type: string
                         type: object
                       vendor:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1591,6 +1591,13 @@ spec:
                     - float16
                     - bfloat16
                     type: string
+                  enablePrefixCaching:
+                    description: |-
+                      EnablePrefixCaching turns on vLLM's automatic prefix caching for repeated prompts.
+                      Significantly reduces time-to-first-token for conversational and agentic workloads
+                      where requests share a common system prompt.
+                      Maps to vLLM --enable-prefix-caching flag.
+                    type: boolean
                   hfTokenSecretRef:
                     description: HFTokenSecretRef references a Secret containing the
                       HuggingFace token.

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -424,6 +424,16 @@ spec:
                   Jinja enables Jinja2 chat template rendering for tool/function calling support.
                   Required when using the OpenAI-compatible API with tools. Maps to llama.cpp --jinja flag.
                 type: boolean
+              metadataOverrides:
+                description: |-
+                  MetadataOverrides overrides GGUF metadata key-value pairs at model load time.
+                  Each entry is passed as a separate --override-kv flag. Format: key=type:value
+                  (e.g., "qwen35moe.context_length=int:1048576" to extend context window, or
+                  "tokenizer.chat_template.thinking=bool:false" to tweak tokenizer behavior).
+                  Maps to llama.cpp --override-kv flag (one flag per entry).
+                items:
+                  type: string
+                type: array
               modelRef:
                 description: ModelRef references the Model CR that contains the model
                   to serve

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -449,6 +449,13 @@ spec:
                   Useful for extended context windows when VRAM is constrained by model weights.
                   Maps to llama.cpp --no-kv-offload flag. Requires sufficient system RAM via resources.memory.
                 type: boolean
+              noWarmup:
+                description: |-
+                  NoWarmup skips the llama.cpp startup warmup inference pass.
+                  Reduces pod ready time at the cost of slightly higher first-request latency.
+                  Useful for scale-to-zero and quick redeployment patterns.
+                  Maps to llama.cpp --no-warmup flag.
+                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1584,6 +1584,19 @@ spec:
                   VLLMConfig holds configuration for the vLLM runtime.
                   Only used when Runtime is "vllm".
                 properties:
+                  attentionBackend:
+                    description: |-
+                      AttentionBackend selects the attention implementation used by vLLM.
+                      flashinfer is typically fastest on recent NVIDIA GPUs; flash_attn is a solid
+                      default; torch_sdpa and xformers are portability fallbacks. Requires a vLLM
+                      version that supports the chosen backend.
+                      Maps to vLLM --attention-backend flag.
+                    enum:
+                    - flashinfer
+                    - flash_attn
+                    - xformers
+                    - torch_sdpa
+                    type: string
                   dtype:
                     description: Dtype sets the model data type (auto, float16, bfloat16).
                     enum:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -380,9 +380,9 @@ spec:
               extraArgs:
                 description: |-
                   ExtraArgs provides additional command-line arguments passed directly to the
-                  llama-server process. Use for flags not yet supported as typed CRD fields.
+                  runtime process. Use for flags not yet supported as typed CRD fields.
                   Arguments are appended after all other configured flags.
-                  Only used when Runtime is "llamacpp".
+                  Supported by the "llamacpp" and "vllm" runtimes. Ignored by others.
                   Example: ["--seed", "42", "--log-disable"]
                 items:
                   type: string

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1222,6 +1222,23 @@ spec:
                         type: integer
                     type: object
                 type: object
+              reasoningBudget:
+                description: |-
+                  ReasoningBudget caps the number of reasoning tokens the model is allowed to
+                  emit per response. Zero disables visible thinking output entirely; the model
+                  still reasons internally but does not emit thinking tokens. Critical for
+                  production agentic workloads on thinking models (Qwen 3.6, GLM-5) where
+                  runaway reasoning can burn compute.
+                  Maps to llama.cpp --reasoning-budget flag.
+                format: int32
+                minimum: 0
+                type: integer
+              reasoningBudgetMessage:
+                description: |-
+                  ReasoningBudgetMessage is injected when the reasoning budget is exhausted,
+                  forcing the model to conclude. Ignored unless ReasoningBudget is also set.
+                  Maps to llama.cpp --reasoning-budget-message flag.
+                type: string
               replicas:
                 default: 1
                 description: Replicas is the desired number of inference pods

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -126,14 +126,20 @@ spec:
                           strategy:
                             default: layer
                             description: |-
-                              Strategy defines the sharding approach
-                              - "layer": Shard by transformer layers (default)
-                              - "tensor": Tensor parallelism (future)
-                              - "pipeline": Pipeline parallelism (future)
+                              Strategy defines the sharding approach for multi-GPU model execution.
+                              - "layer" (default): shard by transformer layers. llama.cpp --split-mode layer.
+                              - "tensor" (alias: "row"): true tensor parallelism. llama.cpp --split-mode row.
+                                Splits each tensor operation across GPUs rather than assigning whole layers
+                                to each. Performance varies by workload; typically better on compute-bound ops.
+                              - "none": disable multi-GPU sharding (single GPU). llama.cpp --split-mode none.
+                              - "pipeline": accepted for forward compatibility but currently falls back to
+                                "layer" with a reconciler warning; llama.cpp has no pipeline split-mode.
                             enum:
                             - layer
                             - tensor
+                            - row
                             - pipeline
+                            - none
                             type: string
                         type: object
                       vendor:

--- a/config/samples/inference_v1alpha1_inferenceservice.yaml
+++ b/config/samples/inference_v1alpha1_inferenceservice.yaml
@@ -50,6 +50,19 @@ spec:
   # Micro-batch size for decoding (optional)
   # uBatchSize: 256
 
+  # Skip llama.cpp startup warmup pass for faster pod ready time (optional)
+  # noWarmup: true
+
+  # Reasoning budget for thinking models like Qwen 3.6 / GLM-5 (optional)
+  # Caps thinking tokens per response. 0 disables visible thinking entirely.
+  # reasoningBudget: 1024
+  # reasoningBudgetMessage: "thinking budget exceeded, conclude now"
+
+  # GGUF metadata overrides at model load time (optional)
+  # Used to extend context windows beyond native training limits, etc.
+  # metadataOverrides:
+  #   - "qwen35moe.context_length=int:1048576"
+
   # Resource requirements (optional)
   resources:
     gpu: 1        # Number of GPUs (0 for CPU-only)

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -879,26 +879,33 @@ func (r *InferenceServiceReconciler) resolveEffectivePriority(isvc *inferencev1a
 	return priorityValues["normal"]
 }
 
+// llama.cpp --split-mode values.
+const (
+	splitModeLayer = "layer"
+	splitModeRow   = "row"
+	splitModeNone  = "none"
+)
+
 // resolveSplitMode maps the Model CRD's sharding.Strategy enum to the llama.cpp
-// --split-mode value. Unknown or missing values fall back to "layer". The
+// --split-mode value. Unknown or missing values fall back to layer. The
 // "pipeline" strategy is accepted for forward compatibility but falls back to
-// "layer" since llama.cpp has no pipeline split-mode.
+// layer since llama.cpp has no pipeline split-mode.
 func resolveSplitMode(sharding *inferencev1alpha1.GPUShardingSpec) string {
 	if sharding == nil {
-		return "layer"
+		return splitModeLayer
 	}
 	switch sharding.Strategy {
-	case "row", "tensor":
-		return "row"
-	case "none":
-		return "none"
+	case splitModeRow, "tensor":
+		return splitModeRow
+	case splitModeNone:
+		return splitModeNone
 	case "pipeline":
 		// llama.cpp has no pipeline split-mode; fall back to layer.
-		return "layer"
-	case "layer", "":
-		return "layer"
+		return splitModeLayer
+	case splitModeLayer, "":
+		return splitModeLayer
 	default:
-		return "layer"
+		return splitModeLayer
 	}
 }
 

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -879,6 +879,29 @@ func (r *InferenceServiceReconciler) resolveEffectivePriority(isvc *inferencev1a
 	return priorityValues["normal"]
 }
 
+// resolveSplitMode maps the Model CRD's sharding.Strategy enum to the llama.cpp
+// --split-mode value. Unknown or missing values fall back to "layer". The
+// "pipeline" strategy is accepted for forward compatibility but falls back to
+// "layer" since llama.cpp has no pipeline split-mode.
+func resolveSplitMode(sharding *inferencev1alpha1.GPUShardingSpec) string {
+	if sharding == nil {
+		return "layer"
+	}
+	switch sharding.Strategy {
+	case "row", "tensor":
+		return "row"
+	case "none":
+		return "none"
+	case "pipeline":
+		// llama.cpp has no pipeline split-mode; fall back to layer.
+		return "layer"
+	case "layer", "":
+		return "layer"
+	default:
+		return "layer"
+	}
+}
+
 // calculateTensorSplit returns comma-separated ratios for llama.cpp --tensor-split flag.
 // When sharding.LayerSplit is provided, layer ranges are converted to proportional ratios
 // (e.g., ["0-24", "25-39"] becomes "5,3"). Falls back to equal split on any error.

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -1048,6 +1048,13 @@ func appendUBatchSizeArgs(args []string, uBatchSize *int32) []string {
 	return args
 }
 
+func appendNoWarmupArgs(args []string, noWarmup *bool) []string {
+	if noWarmup != nil && *noWarmup {
+		return append(args, "--no-warmup")
+	}
+	return args
+}
+
 func needsOffloadMemoryWarning(isvc *inferencev1alpha1.InferenceService) bool {
 	needsRAM := (isvc.Spec.MoeCPUOffload != nil && *isvc.Spec.MoeCPUOffload) ||
 		(isvc.Spec.NoKvOffload != nil && *isvc.Spec.NoKvOffload)

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -1034,6 +1034,13 @@ func appendTensorOverrideArgs(args []string, overrides []string) []string {
 	return args
 }
 
+func appendMetadataOverrideArgs(args []string, overrides []string) []string {
+	for _, override := range overrides {
+		args = append(args, "--override-kv", override)
+	}
+	return args
+}
+
 func appendBatchSizeArgs(args []string, batchSize *int32) []string {
 	if batchSize != nil && *batchSize > 0 {
 		return append(args, "--batch-size", fmt.Sprintf("%d", *batchSize))

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -1055,6 +1055,17 @@ func appendNoWarmupArgs(args []string, noWarmup *bool) []string {
 	return args
 }
 
+func appendReasoningBudgetArgs(args []string, budget *int32, message string) []string {
+	if budget == nil {
+		return args
+	}
+	args = append(args, "--reasoning-budget", fmt.Sprintf("%d", *budget))
+	if message != "" {
+		args = append(args, "--reasoning-budget-message", message)
+	}
+	return args
+}
+
 func needsOffloadMemoryWarning(isvc *inferencev1alpha1.InferenceService) bool {
 	needsRAM := (isvc.Spec.MoeCPUOffload != nil && *isvc.Spec.MoeCPUOffload) ||
 		(isvc.Spec.NoKvOffload != nil && *isvc.Spec.NoKvOffload)

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -2365,6 +2365,94 @@ var _ = Describe("Context Size Configuration", func() {
 		})
 	})
 
+	Context("when metadataOverrides is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "meta-override-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		buildISVC := func(overrides []string) *inferencev1alpha1.InferenceService {
+			replicas := int32(1)
+			return &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "meta-override-svc", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:          "meta-override-model",
+					Replicas:          &replicas,
+					Image:             "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					MetadataOverrides: overrides,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+		}
+
+		It("should emit one --override-kv flag per entry", func() {
+			overrides := []string{
+				"qwen35moe.context_length=int:1048576",
+				"tokenizer.chat_template.thinking=bool:false",
+			}
+			deployment := reconciler.constructDeployment(buildISVC(overrides), model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--override-kv", "qwen35moe.context_length=int:1048576"))
+			Expect(args).To(ContainElements("--override-kv", "tokenizer.chat_template.thinking=bool:false"))
+			// Count occurrences
+			count := 0
+			for _, a := range args {
+				if a == "--override-kv" {
+					count++
+				}
+			}
+			Expect(count).To(Equal(2))
+		})
+
+		It("should emit single --override-kv for one entry", func() {
+			deployment := reconciler.constructDeployment(buildISVC([]string{"foo=int:42"}), model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--override-kv", "foo=int:42"))
+		})
+
+		It("should NOT emit --override-kv when slice is empty", func() {
+			deployment := reconciler.constructDeployment(buildISVC([]string{}), model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--override-kv"))
+		})
+
+		It("should NOT emit --override-kv when slice is nil", func() {
+			deployment := reconciler.constructDeployment(buildISVC(nil), model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--override-kv"))
+		})
+	})
+
 	Context("when extraArgs is configured", func() {
 		var (
 			reconciler *InferenceServiceReconciler

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -4802,6 +4802,42 @@ var _ = Describe("RuntimeBackend interface", func() {
 			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
 			Expect(args).NotTo(ContainElement("--enable-prefix-caching"))
 		})
+
+		It("should include --attention-backend when attentionBackend is set", func() {
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{AttentionBackend: "flashinfer"},
+				},
+			}
+			model := &inferencev1alpha1.Model{}
+			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
+			Expect(args).To(ContainElements("--attention-backend", "flashinfer"))
+		})
+
+		It("should include each supported attentionBackend value", func() {
+			backends := []string{"flashinfer", "flash_attn", "xformers", "torch_sdpa"}
+			for _, b := range backends {
+				isvc := &inferencev1alpha1.InferenceService{
+					Spec: inferencev1alpha1.InferenceServiceSpec{
+						VLLMConfig: &inferencev1alpha1.VLLMConfig{AttentionBackend: b},
+					},
+				}
+				model := &inferencev1alpha1.Model{}
+				args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
+				Expect(args).To(ContainElements("--attention-backend", b))
+			}
+		})
+
+		It("should NOT include --attention-backend when empty", func() {
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{},
+				},
+			}
+			model := &inferencev1alpha1.Model{}
+			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
+			Expect(args).NotTo(ContainElement("--attention-backend"))
+		})
 	})
 
 	Context("TGIBackend", func() {

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -5594,6 +5594,8 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			noKvOffload := true
 			batchSize := int32(2048)
 			ubatchSize := int32(256)
+			noWarmup := true
+			reasoningBudget := int32(1024)
 
 			model := &inferencev1alpha1.Model{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-full", Namespace: "default"},
@@ -5619,20 +5621,24 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			isvc := &inferencev1alpha1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-full-svc", Namespace: "default"},
 				Spec: inferencev1alpha1.InferenceServiceSpec{
-					ModelRef:        "gpu-full",
-					Image:           "ghcr.io/ggml-org/llama.cpp:server-cuda13",
-					ContextSize:     &contextSize,
-					ParallelSlots:   &parallelSlots,
-					FlashAttention:  &flashAttn,
-					Jinja:           &jinja,
-					CacheTypeK:      "q8_0",
-					CacheTypeV:      "q4_0",
-					MoeCPUOffload:   &moeCPUOffload,
-					NoKvOffload:     &noKvOffload,
-					TensorOverrides: []string{"exps=CPU", "token_embd=CUDA0"},
-					BatchSize:       &batchSize,
-					UBatchSize:      &ubatchSize,
-					ExtraArgs:       []string{"--log-disable"},
+					ModelRef:               "gpu-full",
+					Image:                  "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					ContextSize:            &contextSize,
+					ParallelSlots:          &parallelSlots,
+					FlashAttention:         &flashAttn,
+					Jinja:                  &jinja,
+					CacheTypeK:             "q8_0",
+					CacheTypeV:             "q4_0",
+					MoeCPUOffload:          &moeCPUOffload,
+					NoKvOffload:            &noKvOffload,
+					TensorOverrides:        []string{"exps=CPU", "token_embd=CUDA0"},
+					BatchSize:              &batchSize,
+					UBatchSize:             &ubatchSize,
+					NoWarmup:               &noWarmup,
+					ReasoningBudget:        &reasoningBudget,
+					ReasoningBudgetMessage: "wrap it up",
+					MetadataOverrides:      []string{"qwen35moe.context_length=int:1048576"},
+					ExtraArgs:              []string{"--log-disable"},
 					Resources: &inferencev1alpha1.InferenceResourceRequirements{
 						GPU:    1,
 						CPU:    "2",
@@ -5682,6 +5688,16 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			By("verifying micro-batch size")
 			Expect(container.Args).To(ContainElements("--ubatch-size", "256"))
 
+			By("verifying no warmup")
+			Expect(container.Args).To(ContainElement("--no-warmup"))
+
+			By("verifying reasoning budget")
+			Expect(container.Args).To(ContainElements("--reasoning-budget", "1024"))
+			Expect(container.Args).To(ContainElements("--reasoning-budget-message", "wrap it up"))
+
+			By("verifying metadata overrides")
+			Expect(container.Args).To(ContainElements("--override-kv", "qwen35moe.context_length=int:1048576"))
+
 			By("verifying extra args")
 			Expect(container.Args).To(ContainElement("--log-disable"))
 
@@ -5699,6 +5715,76 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			By("verifying no multi-GPU flags for single GPU")
 			Expect(container.Args).NotTo(ContainElement("--split-mode"))
 			Expect(container.Args).NotTo(ContainElement("--tensor-split"))
+		})
+	})
+
+	Context("GPU model with all vLLM options", func() {
+		It("should produce deployment with every supported vllmConfig field", func() {
+			tp := int32(2)
+			maxLen := int32(8192)
+			enablePrefixCache := true
+
+			backend := &VLLMBackend{}
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "vllm-full", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "meta-llama/Llama-3.1-8B-Instruct",
+					Format: "safetensors",
+				},
+			}
+
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "vllm-full-svc", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "vllm-full",
+					Runtime:  "vllm",
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{
+						TensorParallelSize:  &tp,
+						MaxModelLen:         &maxLen,
+						Quantization:        "awq",
+						Dtype:               "bfloat16",
+						EnablePrefixCaching: &enablePrefixCache,
+						AttentionBackend:    "flashinfer",
+					},
+					ExtraArgs: []string{"--gpu-memory-utilization", "0.9"},
+				},
+			}
+
+			args := backend.BuildArgs(isvc, model, "/models/vllm-full", 8000)
+
+			By("verifying tensor parallel size")
+			Expect(args).To(ContainElements("--tensor-parallel-size", "2"))
+
+			By("verifying max model len")
+			Expect(args).To(ContainElements("--max-model-len", "8192"))
+
+			By("verifying quantization")
+			Expect(args).To(ContainElements("--quantization", "awq"))
+
+			By("verifying dtype")
+			Expect(args).To(ContainElements("--dtype", "bfloat16"))
+
+			By("verifying prefix caching")
+			Expect(args).To(ContainElement("--enable-prefix-caching"))
+
+			By("verifying attention backend")
+			Expect(args).To(ContainElements("--attention-backend", "flashinfer"))
+
+			By("verifying extraArgs passthrough")
+			Expect(args).To(ContainElements("--gpu-memory-utilization", "0.9"))
+
+			By("verifying extraArgs land after typed flags")
+			tpIdx, extraIdx := -1, -1
+			for i, a := range args {
+				if a == "--tensor-parallel-size" {
+					tpIdx = i
+				}
+				if a == "--gpu-memory-utilization" {
+					extraIdx = i
+				}
+			}
+			Expect(tpIdx).To(BeNumerically(">=", 0))
+			Expect(extraIdx).To(BeNumerically(">", tpIdx))
 		})
 	})
 

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -2276,6 +2276,95 @@ var _ = Describe("Context Size Configuration", func() {
 		})
 	})
 
+	Context("when reasoningBudget is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "reason-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		buildISVC := func(budget *int32, message string) *inferencev1alpha1.InferenceService {
+			replicas := int32(1)
+			return &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "reason-service", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:               "reason-model",
+					Replicas:               &replicas,
+					Image:                  "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					ReasoningBudget:        budget,
+					ReasoningBudgetMessage: message,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+		}
+
+		It("should include --reasoning-budget when budget is set (no message)", func() {
+			budget := int32(1024)
+			deployment := reconciler.constructDeployment(buildISVC(&budget, ""), model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--reasoning-budget", "1024"))
+			Expect(args).NotTo(ContainElement("--reasoning-budget-message"))
+		})
+
+		It("should include both flags when budget and message are set", func() {
+			budget := int32(2048)
+			deployment := reconciler.constructDeployment(buildISVC(&budget, "wrap it up"), model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--reasoning-budget", "2048"))
+			Expect(args).To(ContainElements("--reasoning-budget-message", "wrap it up"))
+		})
+
+		It("should emit --reasoning-budget 0 to disable visible thinking", func() {
+			budget := int32(0)
+			deployment := reconciler.constructDeployment(buildISVC(&budget, ""), model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--reasoning-budget", "0"))
+		})
+
+		It("should NOT emit reasoning-budget-message without budget", func() {
+			deployment := reconciler.constructDeployment(buildISVC(nil, "ignored"), model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--reasoning-budget"))
+			Expect(args).NotTo(ContainElement("--reasoning-budget-message"))
+		})
+
+		It("should NOT emit either flag when both are unset", func() {
+			deployment := reconciler.constructDeployment(buildISVC(nil, ""), model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--reasoning-budget"))
+			Expect(args).NotTo(ContainElement("--reasoning-budget-message"))
+		})
+	})
+
 	Context("when extraArgs is configured", func() {
 		var (
 			reconciler *InferenceServiceReconciler

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -215,6 +215,47 @@ var _ = Describe("calculateTensorSplit", func() {
 			Expect(result).To(Equal("1,1"))
 		})
 	})
+
+	Context("resolveSplitMode", func() {
+		It("should return layer for nil sharding", func() {
+			Expect(resolveSplitMode(nil)).To(Equal("layer"))
+		})
+
+		It("should return layer for empty strategy", func() {
+			sharding := &inferencev1alpha1.GPUShardingSpec{}
+			Expect(resolveSplitMode(sharding)).To(Equal("layer"))
+		})
+
+		It("should return layer for explicit layer strategy", func() {
+			sharding := &inferencev1alpha1.GPUShardingSpec{Strategy: "layer"}
+			Expect(resolveSplitMode(sharding)).To(Equal("layer"))
+		})
+
+		It("should return row for tensor strategy", func() {
+			sharding := &inferencev1alpha1.GPUShardingSpec{Strategy: "tensor"}
+			Expect(resolveSplitMode(sharding)).To(Equal("row"))
+		})
+
+		It("should return row for row strategy", func() {
+			sharding := &inferencev1alpha1.GPUShardingSpec{Strategy: "row"}
+			Expect(resolveSplitMode(sharding)).To(Equal("row"))
+		})
+
+		It("should return none for none strategy", func() {
+			sharding := &inferencev1alpha1.GPUShardingSpec{Strategy: "none"}
+			Expect(resolveSplitMode(sharding)).To(Equal("none"))
+		})
+
+		It("should fall back to layer for pipeline strategy", func() {
+			sharding := &inferencev1alpha1.GPUShardingSpec{Strategy: "pipeline"}
+			Expect(resolveSplitMode(sharding)).To(Equal("layer"))
+		})
+
+		It("should fall back to layer for unknown strategy", func() {
+			sharding := &inferencev1alpha1.GPUShardingSpec{Strategy: "bogus"}
+			Expect(resolveSplitMode(sharding)).To(Equal("layer"))
+		})
+	})
 })
 
 var _ = Describe("Multi-GPU Deployment Construction", func() {

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -4677,6 +4677,55 @@ var _ = Describe("RuntimeBackend interface", func() {
 			Expect(liveness.HTTPGet.Path).To(Equal("/health"))
 			Expect(readiness.HTTPGet.Path).To(Equal("/health"))
 		})
+
+		It("should pass extraArgs through to vllm container args", func() {
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ExtraArgs: []string{"--enable-prefix-caching", "--gpu-memory-utilization", "0.9"},
+				},
+			}
+			model := &inferencev1alpha1.Model{}
+			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
+			Expect(args).To(ContainElement("--enable-prefix-caching"))
+			Expect(args).To(ContainElements("--gpu-memory-utilization", "0.9"))
+		})
+
+		It("should not include any extraArgs when nil", func() {
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{},
+			}
+			model := &inferencev1alpha1.Model{}
+			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
+			Expect(args).To(ContainElements("--model", "/models/llama3"))
+			Expect(args).To(ContainElements("--host", "0.0.0.0"))
+			Expect(args).To(ContainElements("--port", "8000"))
+			// No additional flags beyond defaults
+			Expect(len(args)).To(Equal(6))
+		})
+
+		It("should append extraArgs after typed flags", func() {
+			tp := int32(2)
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{TensorParallelSize: &tp},
+					ExtraArgs:  []string{"--enable-prefix-caching"},
+				},
+			}
+			model := &inferencev1alpha1.Model{}
+			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
+			tpIdx := -1
+			extraIdx := -1
+			for i, a := range args {
+				if a == "--tensor-parallel-size" {
+					tpIdx = i
+				}
+				if a == "--enable-prefix-caching" {
+					extraIdx = i
+				}
+			}
+			Expect(tpIdx).To(BeNumerically(">=", 0))
+			Expect(extraIdx).To(BeNumerically(">", tpIdx))
+		})
 	})
 
 	Context("TGIBackend", func() {

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -5011,7 +5011,7 @@ var _ = Describe("RuntimeBackend interface", func() {
 			Expect(args).To(ContainElements("--host", "0.0.0.0"))
 			Expect(args).To(ContainElements("--port", "8000"))
 			// No additional flags beyond defaults
-			Expect(len(args)).To(Equal(6))
+			Expect(args).To(HaveLen(6))
 		})
 
 		It("should append extraArgs after typed flags", func() {

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -4749,7 +4749,7 @@ var _ = Describe("RuntimeBackend interface", func() {
 			isvc := &inferencev1alpha1.InferenceService{
 				Spec: inferencev1alpha1.InferenceServiceSpec{
 					VLLMConfig: &inferencev1alpha1.VLLMConfig{TensorParallelSize: &tp},
-					ExtraArgs:  []string{"--enable-prefix-caching"},
+					ExtraArgs:  []string{"--gpu-memory-utilization", "0.9"},
 				},
 			}
 			model := &inferencev1alpha1.Model{}
@@ -4760,12 +4760,47 @@ var _ = Describe("RuntimeBackend interface", func() {
 				if a == "--tensor-parallel-size" {
 					tpIdx = i
 				}
-				if a == "--enable-prefix-caching" {
+				if a == "--gpu-memory-utilization" {
 					extraIdx = i
 				}
 			}
 			Expect(tpIdx).To(BeNumerically(">=", 0))
 			Expect(extraIdx).To(BeNumerically(">", tpIdx))
+		})
+
+		It("should include --enable-prefix-caching when enablePrefixCaching is true", func() {
+			enable := true
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{EnablePrefixCaching: &enable},
+				},
+			}
+			model := &inferencev1alpha1.Model{}
+			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
+			Expect(args).To(ContainElement("--enable-prefix-caching"))
+		})
+
+		It("should NOT include --enable-prefix-caching when nil", func() {
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{},
+				},
+			}
+			model := &inferencev1alpha1.Model{}
+			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
+			Expect(args).NotTo(ContainElement("--enable-prefix-caching"))
+		})
+
+		It("should NOT include --enable-prefix-caching when false", func() {
+			enable := false
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{EnablePrefixCaching: &enable},
+				},
+			}
+			model := &inferencev1alpha1.Model{}
+			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
+			Expect(args).NotTo(ContainElement("--enable-prefix-caching"))
 		})
 	})
 

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -2183,6 +2183,99 @@ var _ = Describe("Context Size Configuration", func() {
 		})
 	})
 
+	Context("when noWarmup is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "warmup-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count:  1,
+							Layers: 64,
+						},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "test-cache-key",
+					Path:     "/tmp/llmkube/models/test-model.gguf",
+				},
+			}
+		})
+
+		It("should include --no-warmup when noWarmup is true", func() {
+			replicas := int32(1)
+			noWarmup := true
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "warmup-service", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "warmup-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					NoWarmup: &noWarmup,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElement("--no-warmup"))
+		})
+
+		It("should NOT include --no-warmup when noWarmup is not specified", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "no-warmup-unset", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "warmup-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--no-warmup"))
+		})
+
+		It("should NOT include --no-warmup when noWarmup is false", func() {
+			replicas := int32(1)
+			noWarmup := false
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "warmup-false", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "warmup-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					NoWarmup: &noWarmup,
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--no-warmup"))
+		})
+	})
+
 	Context("when extraArgs is configured", func() {
 		var (
 			reconciler *InferenceServiceReconciler

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -72,6 +72,7 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 	args = appendTensorOverrideArgs(args, isvc.Spec.TensorOverrides)
 	args = appendBatchSizeArgs(args, isvc.Spec.BatchSize)
 	args = appendUBatchSizeArgs(args, isvc.Spec.UBatchSize)
+	args = appendNoWarmupArgs(args, isvc.Spec.NoWarmup)
 	if len(isvc.Spec.ExtraArgs) > 0 {
 		args = append(args, isvc.Spec.ExtraArgs...)
 	}

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -46,14 +46,18 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 		args = append(args, "--n-gpu-layers", fmt.Sprintf("%d", layers))
 
 		if gpuCount > 1 {
-			args = append(args, "--split-mode", "layer")
-
 			var sharding *inferencev1alpha1.GPUShardingSpec
 			if model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil {
 				sharding = model.Spec.Hardware.GPU.Sharding
 			}
-			tensorSplit := calculateTensorSplit(gpuCount, sharding)
-			args = append(args, "--tensor-split", tensorSplit)
+			splitMode := resolveSplitMode(sharding)
+			args = append(args, "--split-mode", splitMode)
+
+			// --tensor-split ratios only apply to layer/row modes, not none.
+			if splitMode != "none" {
+				tensorSplit := calculateTensorSplit(gpuCount, sharding)
+				args = append(args, "--tensor-split", tensorSplit)
+			}
 		}
 	}
 

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -54,7 +54,7 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 			args = append(args, "--split-mode", splitMode)
 
 			// --tensor-split ratios only apply to layer/row modes, not none.
-			if splitMode != "none" {
+			if splitMode != splitModeNone {
 				tensorSplit := calculateTensorSplit(gpuCount, sharding)
 				args = append(args, "--tensor-split", tensorSplit)
 			}

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -73,6 +73,7 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 	args = appendBatchSizeArgs(args, isvc.Spec.BatchSize)
 	args = appendUBatchSizeArgs(args, isvc.Spec.UBatchSize)
 	args = appendNoWarmupArgs(args, isvc.Spec.NoWarmup)
+	args = appendReasoningBudgetArgs(args, isvc.Spec.ReasoningBudget, isvc.Spec.ReasoningBudgetMessage)
 	if len(isvc.Spec.ExtraArgs) > 0 {
 		args = append(args, isvc.Spec.ExtraArgs...)
 	}

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -74,6 +74,7 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 	args = appendUBatchSizeArgs(args, isvc.Spec.UBatchSize)
 	args = appendNoWarmupArgs(args, isvc.Spec.NoWarmup)
 	args = appendReasoningBudgetArgs(args, isvc.Spec.ReasoningBudget, isvc.Spec.ReasoningBudgetMessage)
+	args = appendMetadataOverrideArgs(args, isvc.Spec.MetadataOverrides)
 	if len(isvc.Spec.ExtraArgs) > 0 {
 		args = append(args, isvc.Spec.ExtraArgs...)
 	}

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -42,6 +42,9 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 		if cfg.Dtype != "" {
 			args = append(args, "--dtype", cfg.Dtype)
 		}
+		if cfg.EnablePrefixCaching != nil && *cfg.EnablePrefixCaching {
+			args = append(args, "--enable-prefix-caching")
+		}
 	}
 
 	gpuCount := resolveGPUCount(isvc, model)

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -45,6 +45,9 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 		if cfg.EnablePrefixCaching != nil && *cfg.EnablePrefixCaching {
 			args = append(args, "--enable-prefix-caching")
 		}
+		if cfg.AttentionBackend != "" {
+			args = append(args, "--attention-backend", cfg.AttentionBackend)
+		}
 	}
 
 	gpuCount := resolveGPUCount(isvc, model)

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -49,6 +49,10 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 		args = append(args, "--tensor-parallel-size", fmt.Sprintf("%d", gpuCount))
 	}
 
+	if len(isvc.Spec.ExtraArgs) > 0 {
+		args = append(args, isvc.Spec.ExtraArgs...)
+	}
+
 	return args
 }
 


### PR DESCRIPTION
## Summary

Bundle of seven quick-win additions that close gaps surfaced by the [r/LocalLLaMA hybrid offload thread](https://reddit.com/r/LocalLLaMA/comments/1so8253/). Each is a small, well-scoped addition following the established Phase 1 / Phase 2 patterns. Together they materially expand what LLMKube can do for real workloads on both runtimes.

Each commit is its own `feat:` entry so release-please produces rich changelog output, and any single Quick Win can be reverted independently.

## Contents

| Commit | Closes | Change |
|---|---|---|
| `feat: pass extraArgs through to vllm runtime` | #284 | vLLM runtime now honors `spec.extraArgs`, matching llama.cpp. Unblocks every vLLM flag not yet typed (`--speculative-config`, `--enable-expert-parallel`, GPU memory utilization, etc.) |
| `feat: honor Model sharding.strategy enum in llama.cpp split-mode` | #285 | `sharding.strategy: tensor` / `row` / `none` now actually affect `--split-mode`. Previously the enum was defined but ignored. Existing users setting `strategy: tensor` will see behavior change from layer sharding to true tensor parallelism (behavior correction). `pipeline` kept in enum with warning fallback to `layer`. |
| `feat: add enablePrefixCaching to vllm runtime config` | #286 | `vllmConfig.enablePrefixCaching` bool maps to `--enable-prefix-caching`. High-value for agentic workloads with shared system prompts. |
| `feat: add attentionBackend selector to vllm runtime config` | #287 | `vllmConfig.attentionBackend` enum (`flashinfer\|flash_attn\|xformers\|torch_sdpa`) maps to `--attention-backend`. |
| `feat: add noWarmup toggle for llama.cpp runtime` | #288 | `spec.noWarmup` bool maps to `--no-warmup`. Faster pod ready time at the cost of first-request latency. |
| `feat: add reasoning budget controls for thinking models` | #289 | `spec.reasoningBudget` + `spec.reasoningBudgetMessage` cap reasoning tokens on thinking models (Qwen 3.6, GLM-5). Budget=0 disables visible thinking entirely. |
| `feat: add metadataOverrides passthrough for llama.cpp --override-kv` | #290 | `spec.metadataOverrides []string` emits one `--override-kv` flag per entry. Enables context window extension via GGUF metadata tweaks. |
| `test: add integration coverage for all new runtime controls` | — | Extends `GPU model with all llama.cpp options` context with the new fields. Adds new `GPU model with all vLLM options` context mirroring the llama.cpp one. |
| `chore: sync helm chart CRDs with generated schemas` | — | Manual sync of Helm-installed CRDs with the kustomize-installed ones. |

## Behavior corrections to call out in release notes

- **QW-2 affects existing users with `sharding.strategy: tensor`** set on their Model CR. Previously this was silently ignored (they got layer sharding). Now they will get `--split-mode row` (true tensor parallelism). This is a semantic correction, not new behavior.

## Test plan

- [x] 34+ new unit tests across 7 new field test contexts
- [x] 2 integration test extensions (llama.cpp all-flags, vLLM all-options)
- [x] `make test` passes (controller coverage 82.7%)
- [x] `make build` clean
- [x] `make generate && make manifests` idempotent
- [x] Helm chart CRDs synced with generated CRDs (only wrapper drift remains)

## Version impact

Release-please will auto-bump to 0.7.0 since all 7 additions are `feat:` commits. Expected release notes will have each closed issue listed as its own changelog entry.

## References

- Issues: #284, #285, #286, #287, #288, #289, #290
- Supersedes: items from the quick-wins research doc in llmkube-internal