### PR TITLE
feat: recognize runtime-resolved sources (HF repo IDs) in Model controller

### DIFF
--- a/config/samples/vllm-tinyllama.yaml
+++ b/config/samples/vllm-tinyllama.yaml
@@ -1,0 +1,46 @@
+# This sample demonstrates running vLLM with a HuggingFace repo ID source.
+# The Model controller recognizes runtime-resolved sources and skips download;
+# vLLM fetches weights at pod startup using HF_TOKEN.
+#
+# Requires:
+#   - A Secret named "hf-token" with key "HF_TOKEN" in the same namespace
+#   - skipModelInit: true on the InferenceService spec
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: tinyllama-1b
+  namespace: default
+spec:
+  source: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+  format: safetensors
+  hardware:
+    accelerator: cuda
+    gpu:
+      enabled: true
+      count: 1
+      vendor: nvidia
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: vllm-tinyllama
+  namespace: default
+spec:
+  modelRef: tinyllama-1b
+  runtime: vllm
+  image: vllm/vllm-openai:cu130-nightly
+  skipModelInit: true
+  vllmConfig:
+    maxModelLen: 2048
+    dtype: float16
+    hfTokenSecretRef:
+      name: hf-token
+      key: HF_TOKEN
+  endpoint:
+    port: 8000
+    type: ClusterIP
+  resources:
+    gpu: 1
+    cpu: "2"
+    memory: "8Gi"

--- a/docs/model-hf-source-spec.md
+++ b/docs/model-hf-source-spec.md
@@ -1,0 +1,154 @@
+# Spec: Model Controller Support for HuggingFace Repo IDs
+
+Issue: #292
+
+## Context
+
+The Model CRD's `source` field regex accepts bare HuggingFace repo IDs like `TinyLlama/TinyLlama-1.1B-Chat-v1.0` (via the `^[a-zA-Z0-9][\w\-\.\/]+$` branch of the pattern). However the Model controller's reconcile flow only knows three source types:
+
+- PVC sources (`pvc://...`) → special PVC reconcile path
+- Local sources (`file://...` or `/absolute/path`) → copy via `io.Copy`
+- Everything else → HTTP download via `http.Get`
+
+When a HuggingFace repo ID falls into "everything else," `http.Get("TinyLlama/TinyLlama-1.1B-Chat-v1.0")` fails with `unsupported protocol scheme ""`. The model phase goes to `Failed` and any referencing InferenceService stays `Pending` forever.
+
+This blocks the intended vLLM workflow: user creates a Model with a bare repo ID, sets `skipModelInit: true` on the InferenceService, vLLM receives the repo ID as `--model` and downloads the weights itself using `HF_TOKEN` at runtime.
+
+The runtime side already supports this (`runtime_vllm.go:21-24` falls back to `model.Spec.Source` when `modelPath` is empty). Only the Model controller needs to learn that some sources are runtime-resolved.
+
+## What to implement
+
+Add a fourth source type to the Model controller: **runtime-resolved sources** (sources the runtime container will fetch itself). For these, the controller should skip download and mark the Model `Ready` immediately so referencing InferenceServices can proceed.
+
+### 1. New helper in `internal/controller/source.go`
+
+Add a helper function that detects a bare HuggingFace repo ID format:
+
+```go
+// isHFRepoSource reports whether source looks like a HuggingFace repo ID
+// (e.g., "TinyLlama/TinyLlama-1.1B-Chat-v1.0", "Qwen/Qwen3.6-35B-A3B").
+// These sources are downloaded by the runtime (vLLM) at startup, not by
+// the Model controller.
+//
+// Criteria:
+//   - Not a URL (no "://" scheme)
+//   - Not an absolute path (doesn't start with "/")
+//   - Not a PVC source (handled separately)
+//   - Contains at least one "/" separator (HF convention: owner/repo)
+//   - Matches Hugging Face's permitted character set
+func isHFRepoSource(source string) bool
+```
+
+**Detection order** must respect existing dispatch:
+1. `isPVCSource(source)` → PVC path (existing)
+2. `isLocalSource(source)` → local copy (existing)
+3. Strings matching `^https?://` → HTTP download (existing)
+4. **new** `isHFRepoSource(source)` → runtime-resolved
+5. Otherwise → fall back to HTTP download (the current behavior)
+
+Put this helper in `source.go` near `isLocalSource`.
+
+### 2. Reconcile path in `internal/controller/model_controller.go`
+
+In the `Reconcile` function (around lines 91-95), after the PVC dispatch but before the general download flow, add a branch that detects runtime-resolved sources and calls a new `reconcileRuntimeResolvedSource` method.
+
+The new method should:
+
+- Log that the source is runtime-resolved and download is being skipped
+- Set `model.Status.Phase = PhaseReady`
+- Set `model.Status.Path = ""` (intentionally empty — runtime uses `Spec.Source` directly)
+- Set `model.Status.CacheKey = ""` (not cached by the operator)
+- Set `model.Status.Size = "0"` (field is a string)
+- Set a `Ready` condition with reason like `RuntimeResolved` and a message like `"Source is runtime-resolved (e.g., HuggingFace repo ID); runtime will fetch at startup"`
+- Emit a `ModelStatus` metric with a new status value (`runtime-resolved`) or reuse `ready`
+- Return `ctrl.Result{}` (no requeue)
+
+Mirror the status update pattern used by `reconcilePVCSource` (around lines 225-290) which also sets a virtual path and skips download.
+
+### 3. InferenceService validation (optional but recommended)
+
+In `inferenceservice_controller.go`, when a referenced Model has `Status.Phase = PhaseReady` but `Status.Path = ""`, the InferenceService must have `skipModelInit: true` — otherwise the init container will try to mount a nonexistent cached file.
+
+Emit a `Warning` event if this condition is missed: reason `MissingSkipModelInit`, message like `"Model source is runtime-resolved but spec.skipModelInit is not set; init container will fail"`. Use the existing `Recorder` that was added for the hybrid offload feature (already on `InferenceServiceReconciler`).
+
+This is optional but saves users from a confusing failure mode. Put the check in `Reconcile` right after the Model is fetched and verified Ready, before `reconcileDeployment`.
+
+### 4. Tests
+
+Follow the established patterns from the Phase 1 / Phase 2 work.
+
+**`internal/controller/source_test.go`** — add tests for `isHFRepoSource`:
+- `"TinyLlama/TinyLlama-1.1B-Chat-v1.0"` → `true`
+- `"Qwen/Qwen3.6-35B-A3B"` → `true`
+- `"bartowski/Qwen_Qwen3.6-35B-A3B-GGUF"` → `true`
+- `"https://example.com/model.gguf"` → `false` (URL)
+- `"/models/local.gguf"` → `false` (absolute path)
+- `"file:///models/local.gguf"` → `false` (file:// URL)
+- `"pvc://my-claim/model.gguf"` → `false` (PVC)
+- `"just-a-filename"` → `false` (no slash, not a repo ID)
+- `""` → `false` (empty)
+- `"multi/part/path/thing"` → `true` (HF supports nested paths in source field)
+
+**`internal/controller/model_controller_test.go`** — add a Context "when source is a HuggingFace repo ID":
+- Create a Model with `source: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"`
+- Trigger reconcile
+- Assert `Status.Phase == PhaseReady`
+- Assert `Status.Path == ""`
+- Assert `Status.CacheKey == ""`
+- Assert no download attempt was made (no file in cache dir, no HTTP request)
+- Assert a `Ready` condition with reason `RuntimeResolved`
+
+Keep the existing HTTP download tests passing unchanged.
+
+### 5. Sample update
+
+Update `config/samples/vllm-tinyllama.yaml` header comment (if it exists; create a header if not) to explain this flow:
+
+```yaml
+# This sample demonstrates running vLLM with a HuggingFace repo ID source.
+# The Model controller recognizes runtime-resolved sources and skips download;
+# vLLM fetches weights at pod startup using HF_TOKEN.
+#
+# Requires:
+#   - A Secret named "hf-token" with key "HF_TOKEN" in the same namespace
+#   - skipModelInit: true on the InferenceService spec
+```
+
+### 6. Generation and Helm sync
+
+After code changes:
+- Run `make generate` to update `zz_generated.deepcopy.go` (likely no-op for this feature)
+- Run `make manifests` to regenerate CRD YAML (should also be no-op since we're not changing types)
+- Confirm `make test` passes
+- No Helm chart CRD sync needed since no CRD schema changes
+
+## Acceptance criteria
+
+1. `kubectl apply` a Model with `source: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"` → `kubectl get model` shows Phase `Ready` within one reconcile cycle
+2. Unit tests pass: `make test` clean, controller coverage holds or improves
+3. `make fmt`, `make vet` clean
+4. The four source types (PVC, local, HTTP, runtime-resolved) are all handled correctly; existing HTTP and local flows are unchanged
+5. InferenceService referencing a runtime-resolved Model with `skipModelInit: true` produces a pod where vLLM's `--model` arg receives the raw source string
+
+## Files to modify
+
+- `internal/controller/source.go` — add `isHFRepoSource`
+- `internal/controller/source_test.go` — add detection tests
+- `internal/controller/model_controller.go` — add `reconcileRuntimeResolvedSource`, route in `Reconcile`
+- `internal/controller/model_controller_test.go` — add runtime-resolved reconcile tests
+- `internal/controller/inferenceservice_controller.go` — add validation warning (optional)
+- `config/samples/vllm-tinyllama.yaml` — update header comment
+
+## Out of scope
+
+- Downloading HuggingFace weights into the cache PVC (that's option 2 from the issue; not needed for the vLLM workflow and adds significant complexity)
+- Auth for HF_TOKEN in the Model controller (runtime handles this)
+- Format validation against HF model type (leave to the runtime)
+- Supporting HF revisions/branches (user can put `owner/repo@revision` syntax in source if HF supports it via vLLM; don't special-case here)
+
+## Reference: existing code patterns to follow
+
+- **PVC special-casing**: `reconcilePVCSource` in `model_controller.go:225-290` is the model for a non-download reconcile path that still sets Ready.
+- **Helper function style**: `isPVCSource`, `isLocalSource`, `getLocalPath` in `source.go` — small, pure functions with focused tests.
+- **Test fixture pattern**: `model_controller_test.go` uses `BeforeEach` for Model creation, `httptest.NewServer` for HTTP mocking. Runtime-resolved tests need no HTTP mock.
+- **Phase 1 warning pattern**: `needsOffloadMemoryWarning` in `inferenceservice_controller.go` demonstrates the Event-emission pattern for advisory warnings that don't block reconciliation.

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -427,6 +427,11 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			"CPU/KV offloading is enabled but resources.memory/hostMemory is not set; hybrid pods consume significant host RAM")
 	}
 
+	if r.Recorder != nil && model.Status.Phase == PhaseReady && model.Status.Path == "" && !needsSkipModelInit(inferenceService) {
+		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "MissingSkipModelInit", "Reconcile",
+			"Model source is runtime-resolved but spec.skipModelInit is not set; init container will fail")
+	}
+
 	deployment, readyReplicas, result, err := r.reconcileDeployment(ctx, inferenceService, model, desiredReplicas, modelReady, isMetal)
 	if err != nil || result != nil {
 		if result != nil {
@@ -1030,6 +1035,10 @@ func needsOffloadMemoryWarning(isvc *inferencev1alpha1.InferenceService) bool {
 		(isvc.Spec.NoKvOffload != nil && *isvc.Spec.NoKvOffload)
 	memorySet := isvc.Spec.Resources != nil && (isvc.Spec.Resources.Memory != "" || isvc.Spec.Resources.HostMemory != "")
 	return needsRAM && !memorySet
+}
+
+func needsSkipModelInit(isvc *inferencev1alpha1.InferenceService) bool {
+	return isvc.Spec.SkipModelInit != nil && *isvc.Spec.SkipModelInit
 }
 
 func (r *InferenceServiceReconciler) constructDeployment(

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -92,6 +92,13 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return r.reconcilePVCSource(ctx, model)
 	}
 
+	// Runtime-resolved sources (e.g., HuggingFace repo IDs) are fetched by the
+	// runtime container at startup, not by the Model controller. The controller
+	// marks the model Ready immediately so referencing InferenceServices can proceed.
+	if isHFRepoSource(model.Spec.Source) {
+		return r.reconcileRuntimeResolvedSource(ctx, model)
+	}
+
 	cacheKey := computeCacheKey(model.Spec.Source)
 	modelDir := filepath.Join(r.StoragePath, cacheKey)
 	modelPath := filepath.Join(modelDir, "model.gguf")
@@ -286,6 +293,41 @@ func (r *ModelReconciler) reconcilePVCSource(ctx context.Context, model *inferen
 	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "Ready").Set(1)
 	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
 	logger.Info("PVC model ready", "pvc", claimName, "path", mountPath)
+	return ctrl.Result{}, nil
+}
+
+// reconcileRuntimeResolvedSource handles runtime-resolved model sources such as
+// HuggingFace repo IDs. The runtime container (e.g., vLLM) will fetch the model
+// at startup using its own mechanism (e.g., HF_TOKEN). The controller marks the
+// model Ready immediately without downloading anything.
+func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, model *inferencev1alpha1.Model) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Early exit if already Ready
+	if model.Status.Phase == PhaseReady {
+		logger.Info("Runtime-resolved model already Ready, skipping reconcile")
+		llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("Source is runtime-resolved, skipping download", "source", model.Spec.Source)
+
+	model.Status.Phase = PhaseReady
+	model.Status.Path = ""
+	model.Status.CacheKey = ""
+	model.Status.Size = "0"
+	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(model.Spec.Hardware)
+	now := metav1.Now()
+	model.Status.LastUpdated = &now
+
+	if err := r.updateStatus(ctx, model, "Available", metav1.ConditionTrue, "RuntimeResolved",
+		"Source is runtime-resolved (e.g., HuggingFace repo ID); runtime will fetch at startup"); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "ready").Set(1)
+	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
+	logger.Info("Runtime-resolved model ready", "source", model.Spec.Source)
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -96,7 +96,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// runtime container at startup, not by the Model controller. The controller
 	// marks the model Ready immediately so referencing InferenceServices can proceed.
 	if isHFRepoSource(model.Spec.Source) {
-		return r.reconcileRuntimeResolvedSource(ctx, model)
+		return ctrl.Result{}, r.reconcileRuntimeResolvedSource(ctx, model)
 	}
 
 	cacheKey := computeCacheKey(model.Spec.Source)
@@ -300,14 +300,14 @@ func (r *ModelReconciler) reconcilePVCSource(ctx context.Context, model *inferen
 // HuggingFace repo IDs. The runtime container (e.g., vLLM) will fetch the model
 // at startup using its own mechanism (e.g., HF_TOKEN). The controller marks the
 // model Ready immediately without downloading anything.
-func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, model *inferencev1alpha1.Model) (ctrl.Result, error) {
+func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, model *inferencev1alpha1.Model) error {
 	logger := log.FromContext(ctx)
 
 	// Early exit if already Ready
 	if model.Status.Phase == PhaseReady {
 		logger.Info("Runtime-resolved model already Ready, skipping reconcile")
 		llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
-		return ctrl.Result{}, nil
+		return nil
 	}
 
 	logger.Info("Source is runtime-resolved, skipping download", "source", model.Spec.Source)
@@ -322,13 +322,13 @@ func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, mo
 
 	if err := r.updateStatus(ctx, model, "Available", metav1.ConditionTrue, "RuntimeResolved",
 		"Source is runtime-resolved (e.g., HuggingFace repo ID); runtime will fetch at startup"); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "ready").Set(1)
 	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
 	logger.Info("Runtime-resolved model ready", "source", model.Spec.Source)
-	return ctrl.Result{}, nil
+	return nil
 }
 
 // verifySHA256 computes the SHA256 hash of the file and verifies it against the

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -745,6 +745,130 @@ var _ = Describe("PVC Source Reconcile", func() {
 	})
 })
 
+var _ = Describe("Runtime-Resolved Source Reconcile", func() {
+	ctx := context.Background()
+
+	It("should set Ready immediately for HuggingFace repo ID source", func() {
+		modelName := "model-hf-repo"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseReady))
+		Expect(updated.Status.Path).To(BeEmpty())
+		Expect(updated.Status.CacheKey).To(BeEmpty())
+		Expect(updated.Status.Size).To(Equal("0"))
+		Expect(updated.Status.LastUpdated).NotTo(BeNil())
+
+		// Verify Available condition with RuntimeResolved reason
+		var hasRuntimeResolved bool
+		for _, cond := range updated.Status.Conditions {
+			if cond.Type == "Available" && cond.Reason == "RuntimeResolved" {
+				hasRuntimeResolved = true
+			}
+		}
+		Expect(hasRuntimeResolved).To(BeTrue())
+	})
+
+	It("should skip reconcile when runtime-resolved model is already Ready", func() {
+		modelName := "model-hf-repo-ready"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "Qwen/Qwen3.6-35B-A3B",
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		// First reconcile to set Ready
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify model is Ready
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseReady))
+		lastUpdated := updated.Status.LastUpdated.DeepCopy()
+
+		// Second reconcile should return immediately
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		// Verify status was NOT re-updated
+		afterSecond := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, afterSecond)).To(Succeed())
+		Expect(afterSecond.Status.LastUpdated.Equal(lastUpdated)).To(BeTrue())
+	})
+
+	It("should not create any files in cache for runtime-resolved source", func() {
+		modelName := "model-hf-no-cache"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Cache directory should be empty (no model downloaded)
+		entries, err := os.ReadDir(tempDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(BeEmpty())
+	})
+})
+
 var _ = Describe("SHA256 Verification", func() {
 	ctx := context.Background()
 

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -103,12 +103,26 @@ func isHFRepoSource(source string) bool {
 	// dots, and forward slashes. Must start with alphanumeric.
 	for i, c := range source {
 		if i == 0 {
-			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+			if !isAlphaNum(c) {
 				return false
 			}
-		} else if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' || c == '/') {
+			continue
+		}
+		if !isAlphaNum(c) && c != '-' && c != '_' && c != '.' && c != '/' {
 			return false
 		}
 	}
 	return true
+}
+
+func isAlphaNum(c rune) bool {
+	switch {
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	}
+	return false
 }

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -70,3 +70,45 @@ func getLocalPath(source string) string {
 	}
 	return source
 }
+
+// isHFRepoSource reports whether source looks like a HuggingFace repo ID
+// (e.g., "TinyLlama/TinyLlama-1.1B-Chat-v1.0", "Qwen/Qwen3.6-35B-A3B").
+// These sources are downloaded by the runtime (vLLM) at startup, not by
+// the Model controller.
+//
+// Criteria:
+//
+//	Not a URL (no "://" scheme)
+//	Not an absolute path (doesn't start with "/")
+//	Not a PVC source (handled separately)
+//	Contains at least one "/" separator (HF convention: owner/repo)
+//	Matches Hugging Face's permitted character set
+func isHFRepoSource(source string) bool {
+	if source == "" {
+		return false
+	}
+	if isPVCSource(source) {
+		return false
+	}
+	if isLocalSource(source) {
+		return false
+	}
+	if strings.Contains(source, "://") {
+		return false
+	}
+	if !strings.Contains(source, "/") {
+		return false
+	}
+	// Match HF's permitted character set: alphanumeric, hyphens, underscores,
+	// dots, and forward slashes. Must start with alphanumeric.
+	for i, c := range source {
+		if i == 0 {
+			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+				return false
+			}
+		} else if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' || c == '/') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/source_test.go
+++ b/internal/controller/source_test.go
@@ -117,3 +117,39 @@ var _ = Describe("getLocalPath (source.go)", func() {
 		Expect(getLocalPath("/mnt/models/test.gguf")).To(Equal("/mnt/models/test.gguf"))
 	})
 })
+
+var _ = Describe("isHFRepoSource (source.go)", func() {
+	It("should return true for TinyLlama repo ID", func() {
+		Expect(isHFRepoSource("TinyLlama/TinyLlama-1.1B-Chat-v1.0")).To(BeTrue())
+	})
+	It("should return true for Qwen repo ID", func() {
+		Expect(isHFRepoSource("Qwen/Qwen3.6-35B-A3B")).To(BeTrue())
+	})
+	It("should return true for bartowski repo ID", func() {
+		Expect(isHFRepoSource("bartowski/Qwen_Qwen3.6-35B-A3B-GGUF")).To(BeTrue())
+	})
+	It("should return false for https URL", func() {
+		Expect(isHFRepoSource("https://example.com/model.gguf")).To(BeFalse())
+	})
+	It("should return false for http URL", func() {
+		Expect(isHFRepoSource("http://example.com/model.gguf")).To(BeFalse())
+	})
+	It("should return false for absolute path", func() {
+		Expect(isHFRepoSource("/models/local.gguf")).To(BeFalse())
+	})
+	It("should return false for file:// URL", func() {
+		Expect(isHFRepoSource("file:///models/local.gguf")).To(BeFalse())
+	})
+	It("should return false for PVC source", func() {
+		Expect(isHFRepoSource("pvc://my-claim/model.gguf")).To(BeFalse())
+	})
+	It("should return false for filename without slash", func() {
+		Expect(isHFRepoSource("just-a-filename")).To(BeFalse())
+	})
+	It("should return false for empty string", func() {
+		Expect(isHFRepoSource("")).To(BeFalse())
+	})
+	It("should return true for multi-part nested path", func() {
+		Expect(isHFRepoSource("multi/part/path/thing")).To(BeTrue())
+	})
+})


### PR DESCRIPTION
## Summary

- Adds a fourth source type to the Model controller: **runtime-resolved** sources (HuggingFace repo IDs like `TinyLlama/TinyLlama-1.1B-Chat-v1.0`). The controller detects them via a new `isHFRepoSource()` helper, skips download, and marks the Model `Ready` immediately so the runtime (vLLM) can fetch weights itself at startup using `HF_TOKEN`.
- Emits a `MissingSkipModelInit` Warning event on InferenceServices that reference a runtime-resolved Model without `spec.skipModelInit: true`, since the init container would otherwise fail trying to mount a nonexistent cache file.
- Unblocks the intended vLLM workflow that previously failed with `unsupported protocol scheme ""`.

Closes #292

## Implementation notes

This feature was implemented end-to-end by **Qwen 3.6-35B-A3B running locally through LLMKube itself** (agentic Qwen Code session against the operator's own inference endpoint). The spec at `docs/model-hf-source-spec.md` was the only human-authored input; the model produced the helper, controller branch, tests, sample YAML, and the optional warning. A small post-hoc patch to the spec (Size field type clarification) was the only human edit needed before commit.

The four source types are now:

| Source shape | Example | Handler |
|---|---|---|
| PVC | `pvc://claim/path` | `reconcilePVCSource` |
| Local | `/abs/path`, `file://...` | `io.Copy` |
| HTTP | `https://...` | `http.Get` |
| **Runtime-resolved** | `owner/repo` | **`reconcileRuntimeResolvedSource` (new)** |

## Test plan

- [x] `make generate && make manifests` — no CRD schema changes (as expected)
- [x] `make fmt && make vet` — clean
- [x] `make test` — green, controller coverage 82.4% → 82.6%
- [x] 11 new unit tests for `isHFRepoSource` covering PVC/local/URL/repo ID/empty/nested-path cases
- [x] 3 new envtest reconcile tests (happy path, idempotent re-reconcile, no cache files written)
- [ ] Live smoke test on Shadowstack: apply `config/samples/vllm-tinyllama.yaml`, confirm Model goes `Ready` without download and vLLM pod starts with `--model TinyLlama/TinyLlama-1.1B-Chat-v1.0`

## Out of scope

- Actually downloading HF weights into the cache PVC (runtime fetches them)
- HF_TOKEN plumbing in the Model controller (runtime handles it via `HFTokenSecretRef`)
- HF revision/branch syntax (leave to the runtime)