### PR TITLE
chore: force 0.7.0 as next release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "release-as": "0.7.0",
       "draft": false,
       "prerelease": false,
       "include-component-in-tag": false,


### PR DESCRIPTION
## Summary

PR #291 and #294 both carried `BREAKING CHANGE:` footers intended to trigger a minor version bump (0.6 → 0.7) under release-please's `bump-patch-for-minor-pre-major` mode. Both squash merges stripped the commit bodies on main, so release-please saw only plain `feat:` and `docs:` subject lines and computed 0.6.1.

Adding `"release-as": "0.7.0"` to `release-please-config.json` as a one-shot override. File-level changes survive squash merges, which the commit-message footers do not.

After 0.7.0 is cut, a follow-up PR should remove the `release-as` field so subsequent versions compute normally.

## Test plan

- [x] `release-please-config.json` parses (single-line insertion)
- [ ] After merge, confirm PR #275 ("chore: release 0.6.1") updates to "chore: release 0.7.0"
- [ ] Open a follow-up issue to remove the `release-as` override once v0.7.0 is tagged