### PR TITLE
docs: backfill ⚠ BREAKING CHANGES section into 0.7.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.0](https://github.com/defilantech/LLMKube/compare/v0.6.0...v0.7.0) (2026-04-18)
 
 
+### ⚠ BREAKING CHANGES
+
+* **sharding:** `sharding.strategy: tensor` on a Model now correctly maps to llama.cpp's `--split-mode row` instead of silently falling back to `--split-mode layer`. Configs that set `strategy: tensor` expecting layer behavior may see performance regressions or new failure modes under concurrent load (particularly on consumer PCIe multi-GPU setups with quantized models). Explicitly set `strategy: layer` to retain the previous behavior. ([#291](https://github.com/defilantech/LLMKube/issues/291))
+* **vllm:** InferenceService `spec.extraArgs` is now forwarded to the vLLM runtime. Previously `extraArgs` was silently ignored when `runtime: vllm`. Configs that placed llama.cpp-only flags in `extraArgs` on a vLLM InferenceService will start failing at pod startup. Audit any vLLM InferenceService that sets `extraArgs` before upgrading. ([#291](https://github.com/defilantech/LLMKube/issues/291))
+
+
 ### Features
 
 * add hybrid GPU/CPU offloading support for MoE models ([#281](https://github.com/defilantech/LLMKube/issues/281)) ([2287f66](https://github.com/defilantech/LLMKube/commit/2287f664a638fc1a3e976ef63b902eb951adefa9))


### PR DESCRIPTION
## Summary

The 0.7.0 release shipped with two real behavior changes for existing configs, but release-please did not synthesize a `⚠ BREAKING CHANGES` section for the changelog because the per-commit `BREAKING CHANGE:` footers were stripped by GitHub's squash-merge behavior before release-please saw them.

This adds the missing section directly to `CHANGELOG.md` under the 0.7.0 entry so anyone upgrading sees the same heads-up the 0.6.0 entry provides. The GitHub release body at `v0.7.0` has already been edited to match.

## What the section flags

- **`sharding.strategy: tensor`** now maps to `--split-mode row` (previously silently fell back to `--split-mode layer`). Behavior change for any Model that set `strategy: tensor`.
- **`spec.extraArgs`** is now forwarded to the vLLM runtime (previously silently ignored for vLLM). Behavior change for any vLLM InferenceService that set `extraArgs` with llama.cpp-specific flags.

## Test plan

- [x] Matches the format of the `⚠ BREAKING CHANGES` section in the 0.6.0 entry
- [x] Release body on `v0.7.0` has the same section (done via `gh release edit`)
- [ ] After merge, confirm `CHANGELOG.md` renders cleanly on GitHub

## Follow-up (separate PR)

The `release-as: 0.7.0` override in `release-please-config.json` should be removed so future releases compute versions normally instead of forcing 0.7.0.