### PR TITLE
chore: remove release-as override now that 0.7.0 is tagged

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "release-as": "0.7.0",
       "draft": false,
       "prerelease": false,
       "include-component-in-tag": false,


### PR DESCRIPTION
## Summary

Follow-up to #295. The `release-as: 0.7.0` override was added as a one-shot to force the next release to 0.7.0 after GitHub squash merges stripped the `BREAKING CHANGE:` footers that would normally have triggered a minor bump under `bump-patch-for-minor-pre-major`.

0.7.0 has now been cut (tagged `v0.7.0`, release PR #275 merged). Leaving the override in place would force every subsequent release proposal to also be `0.7.0`, which would either conflict with the existing tag or cause release-please to skip future release PRs entirely.

This removes the override so release-please computes versions normally for 0.7.1, 0.8.0, etc.

## Test plan

- [x] Single-line removal from `release-please-config.json`
- [ ] After merge, the next release-please run should compute the version from commit history (patch bump for plain `feat:`, minor bump for anything with a `BREAKING CHANGE:` footer that survives squash)
- [ ] Watch for the next release PR to propose something other than `0.7.0`