### PR TITLE
fix: bump InferenceService spec.contextSize cap from 131072 to 2097152

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -81,8 +81,11 @@ type InferenceServiceSpec struct {
 	// ContextSize sets the context window size for the llama.cpp server (-c flag).
 	// Larger values allow processing longer inputs but require more memory.
 	// If not specified, llama.cpp uses its default (typically 512 or 2048).
+	// The upper bound covers Qwen 3.6 at 1M-via-YaRN with margin and accommodates
+	// near-future hybrid-attention model architectures. KV cache memory is the
+	// user's responsibility to size via spec.resources.memory or hostMemory.
 	// +kubebuilder:validation:Minimum=128
-	// +kubebuilder:validation:Maximum=131072
+	// +kubebuilder:validation:Maximum=2097152
 	// +optional
 	ContextSize *int32 `json:"contextSize,omitempty"`
 

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -194,8 +194,11 @@ spec:
                   ContextSize sets the context window size for the llama.cpp server (-c flag).
                   Larger values allow processing longer inputs but require more memory.
                   If not specified, llama.cpp uses its default (typically 512 or 2048).
+                  The upper bound covers Qwen 3.6 at 1M-via-YaRN with margin and accommodates
+                  near-future hybrid-attention model architectures. KV cache memory is the
+                  user's responsibility to size via spec.resources.memory or hostMemory.
                 format: int32
-                maximum: 131072
+                maximum: 2097152
                 minimum: 128
                 type: integer
               endpoint:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -190,8 +190,11 @@ spec:
                   ContextSize sets the context window size for the llama.cpp server (-c flag).
                   Larger values allow processing longer inputs but require more memory.
                   If not specified, llama.cpp uses its default (typically 512 or 2048).
+                  The upper bound covers Qwen 3.6 at 1M-via-YaRN with margin and accommodates
+                  near-future hybrid-attention model architectures. KV cache memory is the
+                  user's responsibility to size via spec.resources.memory or hostMemory.
                 format: int32
-                maximum: 131072
+                maximum: 2097152
                 minimum: 128
                 type: integer
               endpoint:


### PR DESCRIPTION
## Summary

The `InferenceService.spec.contextSize` field had a kubebuilder maximum of 131072. Modern hybrid-attention MoE models train natively well above that — Qwen 3.6-35B-A3B is 262K native and 1M via YaRN. Their KV cache stays small (DeltaNet contributes only ~25% of the layers to KV), so the hardware ceiling on consumer GPUs is far above what the API allowed.

This bumps the cap to **2097152** (2M), which covers Qwen 3.6 at 1M-via-YaRN with margin and accommodates near-future architectures without needing another bump. Default and lower bound unchanged.

KV cache memory cost remains the user's responsibility via `spec.resources.memory` and `spec.resources.hostMemory` — the operator already exposes the right knobs.

Closes #299

## Files changed

- `api/v1alpha1/inferenceservice_types.go` — kubebuilder annotation
- `config/crd/bases/inference.llmkube.dev_inferenceservices.yaml` — regenerated via `make manifests`
- `charts/llmkube/templates/crds/inferenceservices.yaml` — manual sync to match the regenerated CRD

## Test plan

- [x] `make manifests` regenerates the CRD with `maximum: 2097152`
- [x] `make fmt vet test` clean (controller coverage 83.2%, holds steady)
- [x] Helm chart CRD synced with generated CRD
- [x] After merge, validate on Shadowstack: apply InferenceService with `contextSize: 262144`, confirm it accepts and the model serves