### PR TITLE
refactor(controller): extract GPU sharding helpers (part 2/7)

### DIFF
--- a/internal/controller/gpu_sharding.go
+++ b/internal/controller/gpu_sharding.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Multi-GPU sharding helpers. Translate the Model CRD's GPUShardingSpec into
+// the llama.cpp --split-mode and --tensor-split flag values, including the
+// layer-range → ratio math when a custom LayerSplit is provided.
+
+// llama.cpp --split-mode values.
+const (
+	splitModeLayer = "layer"
+	splitModeRow   = "row"
+	splitModeNone  = "none"
+)
+
+// resolveSplitMode maps the Model CRD's sharding.Strategy enum to the llama.cpp
+// --split-mode value. Unknown or missing values fall back to layer. The
+// "pipeline" strategy is accepted for forward compatibility but falls back to
+// layer since llama.cpp has no pipeline split-mode.
+func resolveSplitMode(sharding *inferencev1alpha1.GPUShardingSpec) string {
+	if sharding == nil {
+		return splitModeLayer
+	}
+	switch sharding.Strategy {
+	case splitModeRow, "tensor":
+		return splitModeRow
+	case splitModeNone:
+		return splitModeNone
+	case "pipeline":
+		// llama.cpp has no pipeline split-mode; fall back to layer.
+		return splitModeLayer
+	case splitModeLayer, "":
+		return splitModeLayer
+	default:
+		return splitModeLayer
+	}
+}
+
+// calculateTensorSplit returns comma-separated ratios for llama.cpp --tensor-split flag.
+// When sharding.LayerSplit is provided, layer ranges are converted to proportional ratios
+// (e.g., ["0-24", "25-39"] becomes "5,3"). Falls back to equal split on any error.
+func calculateTensorSplit(gpuCount int32, sharding *inferencev1alpha1.GPUShardingSpec) string {
+	if gpuCount <= 1 {
+		return ""
+	}
+
+	//nolint:gosec // G115: LayerSplit slice length is bounded by user-configured GPU count (≤8 per CRD)
+	if sharding != nil && len(sharding.LayerSplit) > 0 && int32(len(sharding.LayerSplit)) == gpuCount {
+		layerCounts := make([]int, len(sharding.LayerSplit))
+		valid := true
+		for i, split := range sharding.LayerSplit {
+			start, end, err := parseLayerRange(split)
+			if err != nil {
+				valid = false
+				break
+			}
+			layerCounts[i] = end - start + 1
+		}
+		if valid {
+			g := layerCounts[0]
+			for _, c := range layerCounts[1:] {
+				g = gcd(g, c)
+			}
+			parts := make([]string, len(layerCounts))
+			for i, c := range layerCounts {
+				parts[i] = strconv.Itoa(c / g)
+			}
+			return strings.Join(parts, ",")
+		}
+	}
+
+	ratios := make([]string, gpuCount)
+	for i := range ratios {
+		ratios[i] = "1"
+	}
+	return strings.Join(ratios, ",")
+}
+
+// parseLayerRange parses a "start-end" layer range string.
+func parseLayerRange(s string) (int, int, error) {
+	parts := strings.SplitN(s, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid layer range format: %q", s)
+	}
+	start, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid start layer in %q: %w", s, err)
+	}
+	end, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid end layer in %q: %w", s, err)
+	}
+	if start < 0 || end < 0 || start > end {
+		return 0, 0, fmt.Errorf("invalid layer range %q: start must be <= end and non-negative", s)
+	}
+	return start, end, nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -888,103 +887,6 @@ func (r *InferenceServiceReconciler) resolveEffectivePriority(isvc *inferencev1a
 	}
 
 	return priorityValues["normal"]
-}
-
-// llama.cpp --split-mode values.
-const (
-	splitModeLayer = "layer"
-	splitModeRow   = "row"
-	splitModeNone  = "none"
-)
-
-// resolveSplitMode maps the Model CRD's sharding.Strategy enum to the llama.cpp
-// --split-mode value. Unknown or missing values fall back to layer. The
-// "pipeline" strategy is accepted for forward compatibility but falls back to
-// layer since llama.cpp has no pipeline split-mode.
-func resolveSplitMode(sharding *inferencev1alpha1.GPUShardingSpec) string {
-	if sharding == nil {
-		return splitModeLayer
-	}
-	switch sharding.Strategy {
-	case splitModeRow, "tensor":
-		return splitModeRow
-	case splitModeNone:
-		return splitModeNone
-	case "pipeline":
-		// llama.cpp has no pipeline split-mode; fall back to layer.
-		return splitModeLayer
-	case splitModeLayer, "":
-		return splitModeLayer
-	default:
-		return splitModeLayer
-	}
-}
-
-// calculateTensorSplit returns comma-separated ratios for llama.cpp --tensor-split flag.
-// When sharding.LayerSplit is provided, layer ranges are converted to proportional ratios
-// (e.g., ["0-24", "25-39"] becomes "5,3"). Falls back to equal split on any error.
-func calculateTensorSplit(gpuCount int32, sharding *inferencev1alpha1.GPUShardingSpec) string {
-	if gpuCount <= 1 {
-		return ""
-	}
-
-	//nolint:gosec // G115: LayerSplit slice length is bounded by user-configured GPU count (≤8 per CRD)
-	if sharding != nil && len(sharding.LayerSplit) > 0 && int32(len(sharding.LayerSplit)) == gpuCount {
-		layerCounts := make([]int, len(sharding.LayerSplit))
-		valid := true
-		for i, split := range sharding.LayerSplit {
-			start, end, err := parseLayerRange(split)
-			if err != nil {
-				valid = false
-				break
-			}
-			layerCounts[i] = end - start + 1
-		}
-		if valid {
-			g := layerCounts[0]
-			for _, c := range layerCounts[1:] {
-				g = gcd(g, c)
-			}
-			parts := make([]string, len(layerCounts))
-			for i, c := range layerCounts {
-				parts[i] = strconv.Itoa(c / g)
-			}
-			return strings.Join(parts, ",")
-		}
-	}
-
-	ratios := make([]string, gpuCount)
-	for i := range ratios {
-		ratios[i] = "1"
-	}
-	return strings.Join(ratios, ",")
-}
-
-// parseLayerRange parses a "start-end" layer range string.
-func parseLayerRange(s string) (int, int, error) {
-	parts := strings.SplitN(s, "-", 2)
-	if len(parts) != 2 {
-		return 0, 0, fmt.Errorf("invalid layer range format: %q", s)
-	}
-	start, err := strconv.Atoi(strings.TrimSpace(parts[0]))
-	if err != nil {
-		return 0, 0, fmt.Errorf("invalid start layer in %q: %w", s, err)
-	}
-	end, err := strconv.Atoi(strings.TrimSpace(parts[1]))
-	if err != nil {
-		return 0, 0, fmt.Errorf("invalid end layer in %q: %w", s, err)
-	}
-	if start < 0 || end < 0 || start > end {
-		return 0, 0, fmt.Errorf("invalid layer range %q: start must be <= end and non-negative", s)
-	}
-	return start, end, nil
-}
-
-func gcd(a, b int) int {
-	for b != 0 {
-		a, b = b, a%b
-	}
-	return a
 }
 
 func needsOffloadMemoryWarning(isvc *inferencev1alpha1.InferenceService) bool {


### PR DESCRIPTION
## Summary

Part 2 of 7 of the god-controller split (tracking #311). Move the multi-GPU sharding helpers — which translate the Model CRDs `GPUShardingSpec` into llama.cpp `--split-mode` and `--tensor-split` flag values — out of `inferenceservice_controller.go` into a focused `gpu_sharding.go` sibling file.

**Pure relocation** — no signature changes, no behavior changes. The `strconv` import, which was only used by the moved functions, is also dropped from the controller file.

## Symbols moved

```
const ( splitModeLayer, splitModeRow, splitModeNone )
resolveSplitMode
calculateTensorSplit
parseLayerRange
gcd
```

## Line deltas

This PR is based on `main`; if #312 (part 1/7) merges first, the controller file drops another 104 lines on rebase.

| File | Before | After |
|---|---|---|
| `inferenceservice_controller.go` | 1,567 | 1,470 (−97) |
| `gpu_sharding.go` | — | 126 (new) |

## Notes

- `needsOffloadMemoryWarning` and `needsSkipModelInit` (grouped with sharding by proximity in the original file) are **not** moved here — they are about llama.cpp flag-emission decisions, not GPU sharding, and belong with the arg appenders. A later PR will regroup them.

## Test plan

- [x] `go vet ./...` clean
- [x] `bin/golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues
- [x] `make test` green; `internal/controller` coverage unchanged at 83.1%
- [ ] CI: test + lint + security + e2e green