### PR TITLE
chore: split go.mod directive so Dependabot can manage Go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/defilantech/llmkube
 
-go 1.25.9
+go 1.25.0
+
+toolchain go1.25.9
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1


### PR DESCRIPTION
## Summary

Split the single `go 1.25.9` directive into a floor + toolchain pair so Dependabot can propose toolchain bumps on its own schedule without forcing every user's minimum supported Go version to the bleeding-edge patch.

```diff
-go 1.25.9
+go 1.25.0
+
+toolchain go1.25.9
```

## Why

During the supply-chain MVP work (#310) govulncheck tripped twice on stdlib CVEs and each fix required a manual `go.mod` bump:

1. `go 1.25.0` → `go 1.25.3` to clear `GO-2025-4007` through `GO-2025-4011`
2. `go 1.25.3` → `go 1.25.9` to clear `GO-2026-4947` through `GO-2026-4337`

That whack-a-mole loop was predicted — the audit's **Next up** list pointed at Dependabot as the fix. `dependabot/dependabot-core#10131` (landed early 2025) teaches Dependabot's `gomod` ecosystem to track the `toolchain` directive as a separate update line. With a `toolchain` directive present, Dependabot will propose patch bumps on its existing weekly scan.

## Why the floor moves down

`go X.Y.Z` is both a language-feature floor and an implicit toolchain selector. Keeping it at `1.25.0` documents the actual language features we depend on; the `toolchain` line carries the current preferred build version. Consumers who just need to compile with Go 1.25.0+ keep working; CI / release builds pick the toolchain explicitly.

## Test plan

- [x] `go mod tidy` — no go.sum diff
- [x] `make vet` clean
- [x] CI green on this branch
- [ ] After merge, wait one Monday for Dependabot to confirm toolchain tracking. If no PR surfaces by Tuesday, fall back to a custom GH Actions workflow that bumps the directive.