### PR TITLE
fix(agent): let the kernel pick free ports for llama-server

### DIFF
--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -50,7 +51,6 @@ type ProcessExecutor interface {
 type MetalExecutor struct {
 	llamaServerBin string
 	modelStorePath string
-	nextPort       int
 	logger         *zap.SugaredLogger
 }
 
@@ -58,7 +58,6 @@ func NewMetalExecutor(llamaServerBin, modelStorePath string, logger *zap.Sugared
 	return &MetalExecutor{
 		llamaServerBin: llamaServerBin,
 		modelStorePath: modelStorePath,
-		nextPort:       8080, // TODO: Implement proper port allocation
 		logger:         logger,
 	}
 }
@@ -69,7 +68,10 @@ func (e *MetalExecutor) StartProcess(ctx context.Context, config ExecutorConfig)
 		return nil, fmt.Errorf("failed to ensure model: %w", err)
 	}
 
-	port := e.allocatePort()
+	port, err := e.allocatePort()
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate port: %w", err)
+	}
 
 	gpuLayers := config.GPULayers
 	if gpuLayers == 0 {
@@ -227,8 +229,17 @@ func (e *MetalExecutor) waitForHealthy(port int, timeout time.Duration) error {
 	}
 }
 
-func (e *MetalExecutor) allocatePort() int {
-	port := e.nextPort
-	e.nextPort++
-	return port
+// allocatePort asks the kernel for an unused TCP port by binding to
+// "127.0.0.1:0" and immediately closing the listener. The returned port
+// is guaranteed free at the moment of the call; there is a small TOCTOU
+// window before llama-server binds on the same port. For the Metal
+// executor that window is microseconds since we exec the child process
+// synchronously, so a collision is vanishingly unlikely in practice.
+func (e *MetalExecutor) allocatePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = ln.Close() }()
+	return ln.Addr().(*net.TCPAddr).Port, nil
 }

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package agent
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,36 +33,35 @@ func TestNewMetalExecutor(t *testing.T) {
 	if executor.modelStorePath != "/models" {
 		t.Errorf("modelStorePath = %q, want %q", executor.modelStorePath, "/models")
 	}
-	if executor.nextPort != 8080 {
-		t.Errorf("nextPort = %d, want %d", executor.nextPort, 8080)
-	}
 }
 
 func TestAllocatePort(t *testing.T) {
 	executor := NewMetalExecutor("/bin/llama-server", "/models", newNopLogger())
 
-	ports := make([]int, 5)
-	for i := range ports {
-		ports[i] = executor.allocatePort()
+	port, err := executor.allocatePort()
+	if err != nil {
+		t.Fatalf("allocatePort returned error: %v", err)
 	}
-
-	expected := []int{8080, 8081, 8082, 8083, 8084}
-	for i, want := range expected {
-		if ports[i] != want {
-			t.Errorf("allocatePort() call %d = %d, want %d", i+1, ports[i], want)
-		}
+	if port < 1 || port > 65535 {
+		t.Errorf("allocatePort returned port %d outside valid range 1-65535", port)
 	}
 }
 
-func TestAllocatePort_Sequential(t *testing.T) {
+func TestAllocatePort_Listenable(t *testing.T) {
 	executor := NewMetalExecutor("/bin/llama-server", "/models", newNopLogger())
 
-	first := executor.allocatePort()
-	second := executor.allocatePort()
-
-	if second != first+1 {
-		t.Errorf("second port (%d) should be first port (%d) + 1", second, first)
+	port, err := executor.allocatePort()
+	if err != nil {
+		t.Fatalf("allocatePort returned error: %v", err)
 	}
+
+	// The returned port must be immediately re-bindable by the caller.
+	// If the kernel left it in TIME_WAIT or similar we'd fail here.
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("allocated port %d was not bindable: %v", port, err)
+	}
+	_ = ln.Close()
 }
 
 func TestEnsureModel_AlreadyExists(t *testing.T) {


### PR DESCRIPTION
## Summary

Replace the Metal executor's naive monotonic port counter with a kernel-assigned free port via `net.Listen("tcp", "127.0.0.1:0")`.

```diff
-func (e *MetalExecutor) allocatePort() int {
-    port := e.nextPort
-    e.nextPort++
-    return port
-}
+func (e *MetalExecutor) allocatePort() (int, error) {
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        return 0, err
+    }
+    defer func() { _ = ln.Close() }()
+    return ln.Addr().(*net.TCPAddr).Port, nil
+}
```

## Why

The original implementation was marked TODO in the code and called out in the v0.7.0 audit:

```go
nextPort: 8080, // TODO: Implement proper port allocation
```

It had three real-world failure modes:

1. **No collision detection.** If something else on the host already holds 8080, the allocation succeeds anyway and llama-server crashes at bind with a confusing error.
2. **TIME_WAIT hazard.** Two agent restarts in quick succession can collide if the previous llama-server is still draining.
3. **Port-number leak over lifetime.** A long-running agent that has cycled 1000 models will be handing out port 9080, even if 8080 has been free for hours.

Asking the kernel at allocation time solves all three without per-agent state.

## Changes

- `pkg/agent/executor.go`
  - Drop `nextPort int` from `MetalExecutor` struct.
  - `allocatePort()` returns `(int, error)`.
  - `StartProcess` propagates the error.
  - Comment documents the (microsecond) TOCTOU window between close and llama-server's own bind.
- `pkg/agent/executor_test.go`
  - `TestNewMetalExecutor` drops the `nextPort == 8080` check.
  - `TestAllocatePort` asserts the returned port is in the valid range.
  - `TestAllocatePort_Sequential` (testing the broken behavior) replaced with `TestAllocatePort_Listenable`, which verifies the returned port is immediately re-bindable.

## Test plan

- [x] `go vet ./...` clean
- [x] `bin/golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues
- [x] `make test` green; `pkg/agent` covers the new allocator via both tests
- [ ] CI green on this branch

Closes the port-allocation quick-win from the v0.7.0 audit.