### PR TITLE
feat(chart): add values.schema.json for Helm value validation

### DIFF
--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -1,0 +1,295 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LLMKube Helm chart values",
+  "description": "Catches typos and invalid values at 'helm install' time. Kept strict on enums and structured sub-objects; permissive on free-form maps (annotations/labels/nodeSelector) and passthrough Kubernetes fields (tolerations/affinity).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "minLength": 1
+    },
+    "controllerManager": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "registry": { "type": "string" },
+            "repository": { "type": "string", "minLength": 1 },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            },
+            "tag": { "type": "string" },
+            "digest": {
+              "type": "string",
+              "pattern": "^$|^sha256:[a-f0-9]{64}$"
+            }
+          }
+        },
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10
+        },
+        "leaderElection": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "type": "object",
+              "additionalProperties": { "type": ["string", "number"] }
+            },
+            "requests": {
+              "type": "object",
+              "additionalProperties": { "type": ["string", "number"] }
+            }
+          }
+        },
+        "podSecurityContext": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "securityContext": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "livenessProbe": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "readinessProbe": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "nodeSelector": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "tolerations": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "affinity": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "initContainer": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "registry": { "type": "string" },
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string" }
+          }
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "name": { "type": "string" }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "secure": { "type": "boolean" },
+        "service": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "nodePort": {
+              "description": "Empty string for auto-assign, or explicit int in 30000-32767.",
+              "oneOf": [
+                { "type": "string", "pattern": "^$" },
+                { "type": "integer", "minimum": 30000, "maximum": 32767 }
+              ]
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "prometheus": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "additionalLabels": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "interval": { "type": "string" },
+            "namespace": { "type": "string" }
+          }
+        },
+        "inferencePodMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "additionalLabels": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "interval": { "type": "string" }
+          }
+        },
+        "prometheusRule": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "additionalLabels": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "namespace": { "type": "string" },
+            "rules": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "gpu": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "highUtilizationThreshold": { "type": "number", "minimum": 0, "maximum": 100 },
+                    "highTemperatureThreshold": { "type": "number", "minimum": 0, "maximum": 125 },
+                    "memoryPressureThreshold": { "type": "number", "minimum": 0, "maximum": 100 },
+                    "powerLimitThreshold": { "type": "number", "minimum": 0 }
+                  }
+                },
+                "inference": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "crds": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "install": { "type": "boolean" },
+        "keep": { "type": "boolean" }
+      }
+    },
+    "modelCache": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string", "minLength": 1 },
+        "storageClass": { "type": "string" },
+        "accessMode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"]
+        },
+        "mountPath": { "type": "string", "pattern": "^/" },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "priorityClasses": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "networkPolicies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "additionalEgressCIDRs": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Close the "values.schema.json" quick-win from the v0.7.0 audit. The schema catches typos and invalid values at `helm install` time rather than surfacing them as pod-startup failures or silent no-ops.

## Design

Tuned to be **strict on enums and structured sub-objects** (so typos fail loud) and **permissive on free-form fields** (annotations, labels, tolerations, affinity) so users can still add arbitrary Kubernetes fields without having to update the schema first.

### Concrete guards it adds

- `image.pullPolicy` must be `Always` \| `IfNotPresent` \| `Never`
- `image.digest` must match `sha256:<64-hex>` if non-empty
- `metrics.service.type` must be `ClusterIP` \| `NodePort` \| `LoadBalancer`
- `metrics.service.port` must be 1–65535
- `metrics.service.nodePort` must be `""` or 30000–32767
- `modelCache.accessMode` must be one of the four valid K8s access modes
- `modelCache.mountPath` must start with `/`
- `replicaCount` must be 0–10 (matches the `InferenceService.Replicas` cap)
- Typos at top level (e.g. `controllManager`) fail via `additionalProperties: false`

### Where the schema is permissive

- `podSecurityContext`, `securityContext`, `livenessProbe`, `readinessProbe` use `additionalProperties: true` so users can pass through any Kubernetes field.
- `resources.limits`/`requests` accept both string (`"2Gi"`) and number (`1`) — Kubernetes quantity parser accepts both, and one of the packaged example value files uses the number form.

## Test plan

- [x] `helm lint ./charts/llmkube` clean
- [x] `helm template` renders cleanly with default values
- [x] All three packaged example values files still render (15 / 17 / 18 templates for basic / gpu-cluster / production)
- [x] Four negative tests reject as expected:
  - invalid `pullPolicy` → `value must be one of 'Always', 'IfNotPresent', 'Never'`
  - invalid `accessMode` → `value must be one of 'ReadWriteOnce', …`
  - top-level typo (`controllManager`) → `additional properties 'controllManager' not allowed`
  - malformed image digest → `does not match pattern '^$|^sha256:[a-f0-9]{64}$'`
- [x] CI green on this branch