### PR TITLE
refactor(controller): move needsOffloadMemoryWarning to runtime_llamacpp_args.go

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -285,13 +285,6 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 	return service, nil, nil
 }
 
-func needsOffloadMemoryWarning(isvc *inferencev1alpha1.InferenceService) bool {
-	needsRAM := (isvc.Spec.MoeCPUOffload != nil && *isvc.Spec.MoeCPUOffload) ||
-		(isvc.Spec.NoKvOffload != nil && *isvc.Spec.NoKvOffload)
-	memorySet := isvc.Spec.Resources != nil && (isvc.Spec.Resources.Memory != "" || isvc.Spec.Resources.HostMemory != "")
-	return needsRAM && !memorySet
-}
-
 func needsSkipModelInit(isvc *inferencev1alpha1.InferenceService) bool {
 	return isvc.Spec.SkipModelInit != nil && *isvc.Spec.SkipModelInit
 }

--- a/internal/controller/runtime_llamacpp_args.go
+++ b/internal/controller/runtime_llamacpp_args.go
@@ -16,13 +16,29 @@ limitations under the License.
 
 package controller
 
-import "fmt"
+import (
+	"fmt"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
 
 // Argument builders for the llama.cpp runtime. Each helper takes the current
 // args slice plus the relevant CRD field and returns the appended slice (or
 // the unchanged slice when the field is unset or not applicable). Kept as
 // free functions so they are trivially testable in isolation and can be
 // composed in any order from the deployment builder.
+
+// needsOffloadMemoryWarning returns true when llama.cpp hybrid-offload flags
+// (MoeCPUOffload, NoKvOffload) are set but no host RAM budget has been given
+// via resources.memory / resources.hostMemory. In that case the controller
+// emits a warning event so users are not surprised by pods getting OOM-killed
+// under offloaded weights.
+func needsOffloadMemoryWarning(isvc *inferencev1alpha1.InferenceService) bool {
+	needsRAM := (isvc.Spec.MoeCPUOffload != nil && *isvc.Spec.MoeCPUOffload) ||
+		(isvc.Spec.NoKvOffload != nil && *isvc.Spec.NoKvOffload)
+	memorySet := isvc.Spec.Resources != nil && (isvc.Spec.Resources.Memory != "" || isvc.Spec.Resources.HostMemory != "")
+	return needsRAM && !memorySet
+}
 
 func appendContextSizeArgs(args []string, contextSize *int32) []string {
 	if contextSize != nil && *contextSize > 0 {


### PR DESCRIPTION
## Summary

Finish the semantic grouping that #313 / #316 left on the table. `needsOffloadMemoryWarning` checks llama.cpp-specific hybrid-offload flags (`MoeCPUOffload`, `NoKvOffload`) to decide whether to warn about missing host-RAM budget, so its natural home is alongside the other llama.cpp arg-emission helpers in `runtime_llamacpp_args.go` rather than the main reconciler file.

## What moves and what stays

**Moved:** `needsOffloadMemoryWarning` → `runtime_llamacpp_args.go` (with a doc comment explaining when it fires).

**Stays in `inferenceservice_controller.go`:** `needsSkipModelInit` — it is runtime-agnostic (any runtime may respect `SkipModelInit`) and small enough to live next to `sanitizeDNSName` and `boolPtr`.

## Test plan

- [x] `go vet ./...` clean
- [x] `bin/golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues
- [x] `make test` green; existing `needsOffloadMemoryWarning` tests in `inferenceservice_controller_test.go` resolve the symbol through the package unchanged
- [ ] CI green on this branch