### PR TITLE
docs: add ADOPTERS.md inviting public user listings

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,23 @@
+# LLMKube Adopters
+
+Running LLMKube in production, staging, CI, a lab, or on a homelab? We'd love to
+know. Listing yourself helps future adopters justify the project to their
+teams and helps us understand the shape of real-world deployments so we
+prioritize the right things.
+
+## Add your organization
+
+Open a pull request editing this file. A row with just an org name is fine;
+environment and usage notes are welcome but optional. If you can't talk
+publicly, a generic description ("financial services firm, private cloud") is
+also great.
+
+| Organization | Environment | Notes |
+| --- | --- | --- |
+| *\[your org here — PRs welcome]* | | |
+
+## Case studies and quotes
+
+If you have a blog post, talk, or short quote you're happy for us to share,
+open a PR adding a link here or email **chris@mahercode.io** and we'll
+coordinate.


### PR DESCRIPTION
## Summary

Close the cheapest of the three community-governance quick-wins from the v0.7.0 audit (GOVERNANCE.md and MAINTAINERS.md remain as a medium arc).

Empty-but-inviting `ADOPTERS.md` is a common mature-OSS signal:

- Gives future adopters cover to justify the project to their internal teams.
- Helps us understand the shape of real-world deployments so we can prioritize the right things.
- Low-friction path for users who want to publicly endorse without writing a case study.

The file explicitly welcomes generic descriptions (e.g. _"financial services firm, private cloud"_) for users who can't disclose, and offers `chris@mahercode.io` as the coordination channel for case studies / quotes.

## Test plan

- [x] Rendered Markdown scans on GitHub preview — table renders, link to the empty row is visible
- [ ] CI green on this branch (doc-only, should be trivial)