### PR TITLE
refactor(agent): extract shared HTTP+polling helpers for daemon executors

### DIFF
--- a/pkg/agent/executor_ollama.go
+++ b/pkg/agent/executor_ollama.go
@@ -17,11 +17,9 @@ limitations under the License.
 package agent
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -170,26 +168,13 @@ func (e *OllamaExecutor) UnloadModel(ctx context.Context, modelID string) error 
 		Prompt:    "",
 		KeepAlive: &keepAlive,
 	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to marshal unload request: %w", err)
-	}
 
 	url := fmt.Sprintf("http://localhost:%d/api/generate", e.port)
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("failed to create unload request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := e.httpClient.Do(req)
+	resp, err := postJSON(ctx, e.httpClient, url, payload)
 	if err != nil {
 		return fmt.Errorf("failed to unload model %s: %w", modelID, err)
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-		_ = resp.Body.Close()
-	}()
+	defer drainAndClose(resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf(
@@ -213,10 +198,7 @@ func (e *OllamaExecutor) isHealthy(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-		_ = resp.Body.Close()
-	}()
+	defer drainAndClose(resp)
 
 	return resp.StatusCode == http.StatusOK
 }
@@ -228,17 +210,6 @@ func (e *OllamaExecutor) pullModel(ctx context.Context, ollamaModel string) erro
 		Model:  ollamaModel,
 		Stream: false,
 	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to marshal pull request: %w", err)
-	}
-
-	url := fmt.Sprintf("http://localhost:%d/api/pull", e.port)
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("failed to create pull request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
 
 	// Use a longer timeout for pulls since downloads can take minutes
 	pullClient := &http.Client{Timeout: 5 * time.Minute}
@@ -246,14 +217,12 @@ func (e *OllamaExecutor) pullModel(ctx context.Context, ollamaModel string) erro
 	e.logger.Infow("pulling Ollama model (this may take a while)",
 		"model", ollamaModel)
 
-	resp, err := pullClient.Do(req)
+	url := fmt.Sprintf("http://localhost:%d/api/pull", e.port)
+	resp, err := postJSON(ctx, pullClient, url, payload)
 	if err != nil {
 		return fmt.Errorf("pull request failed: %w", err)
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-		_ = resp.Body.Close()
-	}()
+	defer drainAndClose(resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("pull returned status %d for model %s",
@@ -272,32 +241,19 @@ func (e *OllamaExecutor) loadModel(ctx context.Context, ollamaModel string) erro
 		Model:  ollamaModel,
 		Prompt: "",
 	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to marshal load request: %w", err)
-	}
-
-	url := fmt.Sprintf("http://localhost:%d/api/generate", e.port)
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("failed to create load request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
 
 	// Use a 2-minute timeout for model loading
 	loadClient := &http.Client{Timeout: 2 * time.Minute}
 
-	resp, err := loadClient.Do(req)
+	url := fmt.Sprintf("http://localhost:%d/api/generate", e.port)
+	resp, err := postJSON(ctx, loadClient, url, payload)
 	if err != nil {
 		// Loading may timeout for large models — we poll /api/ps separately.
 		e.logger.Warnw("load request failed (model may still be loading)",
 			"model", ollamaModel, "error", err)
 		return nil
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-		_ = resp.Body.Close()
-	}()
+	defer drainAndClose(resp)
 
 	if resp.StatusCode >= 500 {
 		return fmt.Errorf("load request returned server error: %d",
@@ -314,29 +270,15 @@ func (e *OllamaExecutor) loadModel(ctx context.Context, ollamaModel string) erro
 func (e *OllamaExecutor) waitForModelLoaded(
 	ctx context.Context, ollamaModel string, timeout time.Duration,
 ) error {
-	deadline := time.After(timeout)
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-deadline:
-			return fmt.Errorf(
-				"timeout waiting for model %s to load", ollamaModel)
-		case <-ticker.C:
-			loaded, err := e.isModelLoaded(ctx, ollamaModel)
-			if err != nil {
-				e.logger.Debugw("error checking model status",
-					"model", ollamaModel, "error", err)
-				continue
-			}
-			if loaded {
-				return nil
-			}
+	return pollUntil(ctx, 500*time.Millisecond, timeout, func(ctx context.Context) (bool, error) {
+		loaded, err := e.isModelLoaded(ctx, ollamaModel)
+		if err != nil {
+			e.logger.Debugw("error checking model status",
+				"model", ollamaModel, "error", err)
+			return false, nil
 		}
-	}
+		return loaded, nil
+	})
 }
 
 // isModelLoaded checks whether the specified model is loaded in Ollama by
@@ -354,10 +296,7 @@ func (e *OllamaExecutor) isModelLoaded(
 	if err != nil {
 		return false, err
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-		_ = resp.Body.Close()
-	}()
+	defer drainAndClose(resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return false, fmt.Errorf("api/ps returned %d", resp.StatusCode)

--- a/pkg/agent/executor_omlx.go
+++ b/pkg/agent/executor_omlx.go
@@ -17,11 +17,9 @@ limitations under the License.
 package agent
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -164,10 +162,7 @@ func (e *OMLXExecutor) UnloadModel(ctx context.Context, modelID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to unload model %s: %w", modelID, err)
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-		_ = resp.Body.Close()
-	}()
+	defer drainAndClose(resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("oMLX unload returned status %d for model %s", resp.StatusCode, modelID)
@@ -227,10 +222,7 @@ func (e *OMLXExecutor) isHealthy(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-		_ = resp.Body.Close()
-	}()
+	defer drainAndClose(resp)
 
 	return resp.StatusCode == http.StatusOK
 }
@@ -267,31 +259,18 @@ func (e *OMLXExecutor) triggerModelLoad(ctx context.Context, modelID string) err
 		},
 		"max_tokens": 1,
 	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to marshal warmup request: %w", err)
-	}
 
 	// Use a longer timeout for the warmup since model loading can take a while
 	warmupClient := &http.Client{Timeout: 60 * time.Second}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("failed to create warmup request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := warmupClient.Do(req)
+	resp, err := postJSON(ctx, warmupClient, url, payload)
 	if err != nil {
 		// The warmup may timeout if the model is large — that's fine, we poll
 		// /v1/models/status separately.
 		e.logger.Warnw("warmup request failed (model may still be loading)", "modelID", modelID, "error", err)
 		return nil
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-		_ = resp.Body.Close()
-	}()
+	defer drainAndClose(resp)
 
 	if resp.StatusCode >= 500 {
 		return fmt.Errorf("warmup request returned server error: %d", resp.StatusCode)
@@ -303,27 +282,14 @@ func (e *OMLXExecutor) triggerModelLoad(ctx context.Context, modelID string) err
 
 // waitForModelLoaded polls /v1/models/status until the target model reports loaded:true.
 func (e *OMLXExecutor) waitForModelLoaded(ctx context.Context, modelID string, timeout time.Duration) error {
-	deadline := time.After(timeout)
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-deadline:
-			return fmt.Errorf("timeout waiting for model %s to load", modelID)
-		case <-ticker.C:
-			loaded, err := e.isModelLoaded(ctx, modelID)
-			if err != nil {
-				e.logger.Debugw("error checking model status", "modelID", modelID, "error", err)
-				continue
-			}
-			if loaded {
-				return nil
-			}
+	return pollUntil(ctx, 500*time.Millisecond, timeout, func(ctx context.Context) (bool, error) {
+		loaded, err := e.isModelLoaded(ctx, modelID)
+		if err != nil {
+			e.logger.Debugw("error checking model status", "modelID", modelID, "error", err)
+			return false, nil
 		}
-	}
+		return loaded, nil
+	})
 }
 
 // isModelLoaded checks whether the specified model is loaded in oMLX.
@@ -338,10 +304,7 @@ func (e *OMLXExecutor) isModelLoaded(ctx context.Context, modelID string) (bool,
 	if err != nil {
 		return false, err
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-		_ = resp.Body.Close()
-	}()
+	defer drainAndClose(resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return false, fmt.Errorf("models/status returned %d", resp.StatusCode)

--- a/pkg/agent/http_util.go
+++ b/pkg/agent/http_util.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Shared HTTP + polling helpers for the daemon-style executors
+// (Ollama, oMLX) that otherwise duplicate the same marshal / request /
+// drain / close boilerplate at every call site.
+
+// drainAndClose drains up to 64 KiB of the response body so the
+// underlying TCP connection can be reused by the client, then closes
+// the body. Safe to defer even if resp is nil.
+func drainAndClose(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	_ = resp.Body.Close()
+}
+
+// postJSON marshals payload as JSON and POSTs it to url using client.
+// The caller owns the response and must drainAndClose it. Content-Type
+// is set to application/json. Pass a custom client when a longer
+// timeout than the executor's default httpClient is needed.
+func postJSON(
+	ctx context.Context,
+	client *http.Client,
+	url string,
+	payload interface{},
+) (*http.Response, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return client.Do(req)
+}
+
+// pollUntil calls check at interval until it returns (true, nil), ctx
+// is canceled, or timeout elapses. Transient errors from check are
+// swallowed so a single failed poll does not abort the wait — the
+// check closure is expected to log/handle its own errors and simply
+// return (false, nil) when it wants polling to continue.
+func pollUntil(
+	ctx context.Context,
+	interval, timeout time.Duration,
+	check func(context.Context) (bool, error),
+) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timeout after %s", timeout)
+		case <-ticker.C:
+			ok, err := check(ctx)
+			if err == nil && ok {
+				return nil
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Close the "HTTP executor deduplication" quick-win from the v0.7.0 audit. `executor_ollama.go` and `executor_omlx.go` were running near-identical marshal / request / drain / close boilerplate at every call site, plus two copies of the same wait-for-model-loaded poll loop. Pull the shared bits into `pkg/agent/http_util.go` so a fix to the drain-and-close ordering or the poll timing only has to land once.

## New helpers in `pkg/agent/http_util.go`

- **`drainAndClose(*http.Response)`** — drain up to 64 KiB of the body so the TCP connection can be reused, then close it. Safe on nil.
- **`postJSON(ctx, client, url, payload)`** — marshal payload as JSON, POST it, return the raw response. Caller drains + closes via `drainAndClose`. Accepts a custom client so the Ollama pull path can keep its 5-minute timeout without pulling client state into the helper.
- **`pollUntil(ctx, interval, timeout, check)`** — generic ticker/deadline loop. Swallows transient errors from check so the caller can log inside the closure; returns success on first `(true, nil)`, `ctx.Err()` on cancel, and a clear timeout error otherwise.

## Call-site cleanup

- `executor_ollama.go` — `UnloadModel`, `isHealthy`, `pullModel`, `loadModel`, `waitForModelLoaded`, `isModelLoaded` all collapse into the new helpers. Drops the `bytes`, `encoding/json`, and `io` imports it no longer needs.
- `executor_omlx.go` — `UnloadModel`, `isHealthy`, `triggerModelLoad`, `waitForModelLoaded`, `isModelLoaded` same treatment. Drops `bytes` and `io` imports.

## Line deltas

| File | Delta |
|---|---|
| `executor_ollama.go` | −97 |
| `executor_omlx.go` | −61 |
| `http_util.go` | +98 (new) |
| **total** | **−60** across the package |

No behavior changes.

## Test plan

- [x] `go vet ./...` clean
- [x] `bin/golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues
- [x] `make test` green
- [ ] CI green on this branch