### PR TITLE
feat(agent): pass Apple Silicon-optimized flags to llama-server

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -97,9 +97,14 @@ type InferenceServiceSpec struct {
 	// +optional
 	ParallelSlots *int32 `json:"parallelSlots,omitempty"`
 
-	// FlashAttention enables flash attention for faster prompt processing and reduced
-	// VRAM usage. Requires a GPU with flash attention support (NVIDIA Ampere or newer).
-	// Maps to llama.cpp --flash-attn flag. Only applied when GPU is configured.
+	// FlashAttention enables flash attention for faster prompt processing and
+	// reduced KV cache memory. Maps to llama.cpp --flash-attn flag.
+	//
+	// On NVIDIA GPUs requires Ampere or newer (compute capability 8.0+).
+	// On Apple Silicon (Metal agent path) the default is true when this field
+	// is unset, because the wired-collector + flash-attn combination prevents
+	// the ~25% decode degradation observed at long context on Qwen-class
+	// models running on M-series chips.
 	// +optional
 	FlashAttention *bool `json:"flashAttention,omitempty"`
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -396,15 +396,36 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 		}
 	}
 
+	// Apple Silicon defaults: flash-attn and mlock both ON. The user can
+	// disable flash-attn by setting spec.flashAttention=false; mlock has no
+	// CRD opt-out because the macOS wired-collector eviction it prevents is
+	// the entire reason the Metal agent exists in the first place.
+	flashAttn := true
+	if isvc.Spec.FlashAttention != nil {
+		flashAttn = *isvc.Spec.FlashAttention
+	}
+	batchSize := 0
+	if isvc.Spec.BatchSize != nil {
+		batchSize = int(*isvc.Spec.BatchSize)
+	}
+	uBatchSize := 0
+	if isvc.Spec.UBatchSize != nil {
+		uBatchSize = int(*isvc.Spec.UBatchSize)
+	}
+
 	// Start the process
 	process, err := a.executor.StartProcess(ctx, ExecutorConfig{
-		Name:        isvc.Name,
-		Namespace:   isvc.Namespace,
-		ModelSource: model.Spec.Source,
-		ModelName:   model.Name,
-		GPULayers:   gpuLayers,
-		ContextSize: contextSize,
-		Jinja:       isvc.Spec.Jinja != nil && *isvc.Spec.Jinja,
+		Name:           isvc.Name,
+		Namespace:      isvc.Namespace,
+		ModelSource:    model.Spec.Source,
+		ModelName:      model.Name,
+		GPULayers:      gpuLayers,
+		ContextSize:    contextSize,
+		Jinja:          isvc.Spec.Jinja != nil && *isvc.Spec.Jinja,
+		FlashAttention: flashAttn,
+		Mlock:          true,
+		BatchSize:      batchSize,
+		UBatchSize:     uBatchSize,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start process: %w", err)

--- a/pkg/agent/cpu_darwin.go
+++ b/pkg/agent/cpu_darwin.go
@@ -1,0 +1,50 @@
+//go:build darwin
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// detectPerfCoreCount returns the number of performance ("P") cores on Apple
+// Silicon, or 0 when the count cannot be determined. The caller is expected to
+// fall back to a sensible default (typically: omit the --threads flag and let
+// llama-server choose).
+//
+// On Apple Silicon the kernel exposes per-tier core counts via sysctl:
+//
+//	hw.perflevel0.physicalcpu  performance cores (P-cores)
+//	hw.perflevel1.physicalcpu  efficiency cores (E-cores)
+//
+// Pinning llama-server to the P-cores avoids E-core scheduling penalties on
+// the inference hot path. On Intel Macs there is no perflevel split and the
+// sysctl returns an error; we return 0 so the caller can fall back.
+func detectPerfCoreCount() int {
+	out, err := exec.Command("sysctl", "-n", "hw.perflevel0.physicalcpu").Output()
+	if err != nil {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}

--- a/pkg/agent/cpu_other.go
+++ b/pkg/agent/cpu_other.go
@@ -1,0 +1,26 @@
+//go:build !darwin
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+// detectPerfCoreCount returns 0 on non-Darwin platforms. The Metal agent only
+// runs in production on macOS, but the package compiles cross-platform so unit
+// tests can run in CI on Linux.
+func detectPerfCoreCount() int {
+	return 0
+}

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -39,6 +39,29 @@ type ExecutorConfig struct {
 	GPULayers   int32
 	ContextSize int
 	Jinja       bool
+
+	// FlashAttention enables llama.cpp's --flash-attn flag. On Apple Silicon
+	// this is a clear win for long-context agentic workloads (prevents the
+	// ~25% decode degradation observed at 4K+ context on Qwen-class models).
+	// Defaults true at the agent → executor boundary.
+	FlashAttention bool
+
+	// Mlock pins model weights and KV cache so macOS's wired collector cannot
+	// evict our Metal GPU buffers under memory pressure. Defaults true.
+	Mlock bool
+
+	// Threads sets --threads. Zero means auto-detect from performance core
+	// count via detectPerfCoreCount(); a non-positive detection result causes
+	// the flag to be omitted (let llama-server pick).
+	Threads int
+
+	// BatchSize sets --batch-size. Zero falls back to 2048, which prompt
+	// processing benchmarks on M-series chips treat as a sweet spot.
+	BatchSize int
+
+	// UBatchSize sets --ubatch-size. Zero omits the flag (use llama-server's
+	// own default).
+	UBatchSize int
 }
 
 // ProcessExecutor is the interface that both llama-server and oMLX executors
@@ -73,23 +96,7 @@ func (e *MetalExecutor) StartProcess(ctx context.Context, config ExecutorConfig)
 		return nil, fmt.Errorf("failed to allocate port: %w", err)
 	}
 
-	gpuLayers := config.GPULayers
-	if gpuLayers == 0 {
-		gpuLayers = 99
-	}
-
-	args := []string{
-		"--model", modelPath,
-		"--host", "0.0.0.0",
-		"--port", fmt.Sprintf("%d", port),
-		"--n-gpu-layers", fmt.Sprintf("%d", gpuLayers),
-		"--ctx-size", fmt.Sprintf("%d", config.ContextSize),
-		"--metrics",
-	}
-
-	if config.Jinja {
-		args = append(args, "--jinja")
-	}
+	args := buildLlamaServerArgs(modelPath, port, config)
 
 	cmd := exec.Command(e.llamaServerBin, args...)
 
@@ -227,6 +234,58 @@ func (e *MetalExecutor) waitForHealthy(port int, timeout time.Duration) error {
 			}
 		}
 	}
+}
+
+// buildLlamaServerArgs constructs the command-line argument vector for the
+// llama-server child process. It is split out from StartProcess so it can be
+// unit tested without spawning a real process and so the Apple-Silicon-specific
+// optimizations are inspectable in one place.
+func buildLlamaServerArgs(modelPath string, port int, config ExecutorConfig) []string {
+	gpuLayers := config.GPULayers
+	if gpuLayers == 0 {
+		gpuLayers = 99
+	}
+
+	args := []string{
+		"--model", modelPath,
+		"--host", "0.0.0.0",
+		"--port", fmt.Sprintf("%d", port),
+		"--n-gpu-layers", fmt.Sprintf("%d", gpuLayers),
+		"--ctx-size", fmt.Sprintf("%d", config.ContextSize),
+		"--metrics",
+	}
+
+	if config.FlashAttention {
+		args = append(args, "--flash-attn", "on")
+	}
+
+	if config.Mlock {
+		args = append(args, "--mlock")
+	}
+
+	threads := config.Threads
+	if threads == 0 {
+		threads = detectPerfCoreCount()
+	}
+	if threads > 0 {
+		args = append(args, "--threads", fmt.Sprintf("%d", threads))
+	}
+
+	batchSize := config.BatchSize
+	if batchSize == 0 {
+		batchSize = 2048
+	}
+	args = append(args, "--batch-size", fmt.Sprintf("%d", batchSize))
+
+	if config.UBatchSize > 0 {
+		args = append(args, "--ubatch-size", fmt.Sprintf("%d", config.UBatchSize))
+	}
+
+	if config.Jinja {
+		args = append(args, "--jinja")
+	}
+
+	return args
 }
 
 // allocatePort asks the kernel for an unused TCP port by binding to

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -107,6 +107,100 @@ func TestEnsureModel_DownloadFails(t *testing.T) {
 	}
 }
 
+func TestBuildLlamaServerArgs_Defaults(t *testing.T) {
+	args := buildLlamaServerArgs("/models/test.gguf", 8080, ExecutorConfig{
+		ContextSize: 32768,
+	})
+
+	want := map[string]string{
+		"--model":        "/models/test.gguf",
+		"--host":         "0.0.0.0",
+		"--port":         "8080",
+		"--n-gpu-layers": "99",
+		"--ctx-size":     "32768",
+		"--batch-size":   "2048",
+	}
+	for flag, expected := range want {
+		if got := flagValue(args, flag); got != expected {
+			t.Errorf("%s = %q, want %q (full args: %v)", flag, got, expected, args)
+		}
+	}
+
+	if hasFlag(args, "--metrics") != true {
+		t.Error("--metrics flag must always be present")
+	}
+
+	// FlashAttention/Mlock/Jinja default to false at the buildArgs boundary;
+	// the agent layer is what defaults them to true.
+	for _, unwanted := range []string{"--flash-attn", "--mlock", "--jinja", "--ubatch-size"} {
+		if hasFlag(args, unwanted) {
+			t.Errorf("unexpected flag %q in default args: %v", unwanted, args)
+		}
+	}
+}
+
+func TestBuildLlamaServerArgs_AppleSiliconOptimized(t *testing.T) {
+	args := buildLlamaServerArgs("/models/test.gguf", 9000, ExecutorConfig{
+		ContextSize:    65536,
+		FlashAttention: true,
+		Mlock:          true,
+		Threads:        12,
+		BatchSize:      4096,
+		UBatchSize:     512,
+		Jinja:          true,
+	})
+
+	if got := flagValue(args, "--flash-attn"); got != "on" {
+		t.Errorf("--flash-attn = %q, want %q", got, "on")
+	}
+	if !hasFlag(args, "--mlock") {
+		t.Error("--mlock missing")
+	}
+	if got := flagValue(args, "--threads"); got != "12" {
+		t.Errorf("--threads = %q, want %q", got, "12")
+	}
+	if got := flagValue(args, "--batch-size"); got != "4096" {
+		t.Errorf("--batch-size = %q, want %q", got, "4096")
+	}
+	if got := flagValue(args, "--ubatch-size"); got != "512" {
+		t.Errorf("--ubatch-size = %q, want %q", got, "512")
+	}
+	if !hasFlag(args, "--jinja") {
+		t.Error("--jinja missing")
+	}
+}
+
+func TestBuildLlamaServerArgs_GPULayersOverride(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize: 4096,
+		GPULayers:   42,
+	})
+	if got := flagValue(args, "--n-gpu-layers"); got != "42" {
+		t.Errorf("--n-gpu-layers = %q, want %q", got, "42")
+	}
+}
+
+// hasFlag reports whether a bare flag (no value following) is present.
+func hasFlag(args []string, name string) bool {
+	for _, a := range args {
+		if a == name {
+			return true
+		}
+	}
+	return false
+}
+
+// flagValue returns the argument immediately following the named flag, or ""
+// if the flag is absent or appears as the last element.
+func flagValue(args []string, name string) string {
+	for i, a := range args {
+		if a == name && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
 func TestStopProcess_InvalidPID(t *testing.T) {
 	executor := NewMetalExecutor("/bin/llama-server", "/models", newNopLogger())
 


### PR DESCRIPTION
Closes #279.

## Summary

The Metal executor was emitting only the bare-minimum llama-server flags (`--model`, `--host`, `--port`, `--n-gpu-layers`, `--ctx-size`, `--metrics`, optional `--jinja`). Three load-bearing optimizations were dropped on the floor at the agent → executor boundary, even though two of them already existed as `InferenceServiceSpec` fields plumbed through the controller path.

This PR plumbs them through and turns on safe Apple-Silicon defaults.

## What changed

- **`--flash-attn on`** when `spec.flashAttention` is unset or true. Per #279's M4 Max bench data on Qwen3.5-27B Q5_K_M, this eliminates a ~25% decode-rate degradation at 4K+ context. On NVIDIA the field already defaulted to nil-as-disabled; on Metal we flip the default to nil-as-enabled because the wired-collector + flash-attn pairing is the entire reason agentic coding works at long context on these chips.
- **`--mlock`** unconditionally on. Pins weights + KV cache against macOS's wired collector, which can silently evict Metal GPU buffers under memory pressure. There is no CRD opt-out because preventing eviction is core to what the Metal agent is for.
- **`--threads N`** pinned to the performance core count via `sysctl hw.perflevel0.physicalcpu`. Avoids E-core scheduling penalties on the inference hot path. New ` cpu_darwin.go` does the detection; ` cpu_other.go` returns 0 so the package still compiles in CI on Linux.
- **`--batch-size`** defaults to 2048 (M-series prompt-processing sweet spot per the #279 benchmark notes); honored from `spec.batchSize` when set.
- **`--ubatch-size`** honored from `spec.uBatchSize` when set; omitted otherwise so llama-server picks its own default.

`buildLlamaServerArgs()` is extracted so the flag matrix is unit-testable without spawning a real process. Three new tests cover the default shape, the all-flags-on shape, and the GPU layer override.

## Why now

Pre-flight prep for M5 Max 128 GB benchmarks. Without these flags, every llama-server number we publish would be benchmarking degraded performance.

## Test plan

- [x] `go test ./pkg/agent/...` — all green including the three new ` TestBuildLlamaServerArgs_*` cases
- [x] `go vet ./...` and full `go build ./...` clean
- [ ] Manual smoke on M5 Max once landed: deploy a Model + InferenceService, verify `ps aux | grep llama-server` shows the new flags and that long-context decode does not degrade

## Asymmetric default explained

The `FlashAttention` doc comment is updated to call out the asymmetry: nil-as-disabled on the CUDA path (preserves existing behavior), nil-as-enabled on the Metal path (new default). Explicit `false` is respected on both paths.