### PR TITLE
fix(agent): detect stalled K8s polling and exit for supervisor restart

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -60,6 +60,7 @@ type AgentConfig struct {
 	MemoryPressureWarning  float64
 	MemoryPressureCritical float64
 	EvictionEnabled        bool
+	MaxWatchFailures       int
 }
 
 func parseLogLevel(level string) zapcore.Level {
@@ -160,6 +161,8 @@ func main() {
 		"Available memory fraction below which pressure is critical")
 	flag.BoolVar(&cfg.EvictionEnabled, "eviction-enabled", false,
 		"Enable automatic process eviction under critical memory pressure")
+	flag.IntVar(&cfg.MaxWatchFailures, "max-watch-failures", agent.DefaultMaxConsecutiveFailures,
+		"Consecutive Kubernetes list failures from the InferenceService watcher before the agent gives up and exits for supervisor restart. Set to 0 to use the agent default.")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.Parse()
 
@@ -283,18 +286,19 @@ func main() {
 	// Create agent
 	logger.Infow("creating Metal agent")
 	agentCfg := agent.MetalAgentConfig{
-		K8sClient:      k8sClient,
-		Namespace:      cfg.Namespace,
-		ModelStorePath: cfg.ModelStorePath,
-		LlamaServerBin: cfg.LlamaServerBin,
-		Runtime:        cfg.Runtime,
-		OMLXBin:        cfg.OMLXBin,
-		OMLXPort:       cfg.OMLXPort,
-		OllamaPort:     cfg.OllamaPort,
-		Port:           cfg.Port,
-		HostIP:         cfg.HostIP,
-		Logger:         logger,
-		MemoryFraction: cfg.MemoryFraction,
+		K8sClient:        k8sClient,
+		Namespace:        cfg.Namespace,
+		ModelStorePath:   cfg.ModelStorePath,
+		LlamaServerBin:   cfg.LlamaServerBin,
+		Runtime:          cfg.Runtime,
+		OMLXBin:          cfg.OMLXBin,
+		OMLXPort:         cfg.OMLXPort,
+		OllamaPort:       cfg.OllamaPort,
+		Port:             cfg.Port,
+		HostIP:           cfg.HostIP,
+		Logger:           logger,
+		MemoryFraction:   cfg.MemoryFraction,
+		MaxWatchFailures: cfg.MaxWatchFailures,
 	}
 	if cfg.WatchdogInterval > 0 {
 		agentCfg.WatchdogConfig = &agent.MemoryWatchdogConfig{

--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -162,7 +162,8 @@ func main() {
 	flag.BoolVar(&cfg.EvictionEnabled, "eviction-enabled", false,
 		"Enable automatic process eviction under critical memory pressure")
 	flag.IntVar(&cfg.MaxWatchFailures, "max-watch-failures", agent.DefaultMaxConsecutiveFailures,
-		"Consecutive Kubernetes list failures from the InferenceService watcher before the agent gives up and exits for supervisor restart. Set to 0 to use the agent default.")
+		"Consecutive Kubernetes list failures from the InferenceService watcher before the agent "+
+			"gives up and exits for supervisor restart. Set to 0 to use the agent default.")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.Parse()
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -58,6 +58,12 @@ type MetalAgentConfig struct {
 
 	// WatchdogConfig configures the memory pressure watchdog. Nil disables it.
 	WatchdogConfig *MemoryWatchdogConfig
+
+	// MaxWatchFailures is the consecutive-failure threshold at which the
+	// InferenceService watcher gives up on its current Kubernetes connection
+	// and signals a fatal exit. Zero means use the watcher's built-in default
+	// (DefaultMaxConsecutiveFailures).
+	MaxWatchFailures int
 }
 
 // MetalAgent watches Kubernetes InferenceService resources and manages
@@ -135,8 +141,16 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		a.logger.Warnw("unable to query total memory", "error", err)
 	}
 
+	// fatalErrChan carries terminal failures from background subsystems
+	// (watcher, health server) up to the main select loop, so the agent can
+	// return cleanly and let the supervisor restart the process.
+	fatalErrChan := make(chan error, 2)
+
 	// Initialize components
 	a.watcher = NewInferenceServiceWatcher(a.config.K8sClient, a.config.Namespace, a.logger.With("subsystem", "watcher"))
+	if a.config.MaxWatchFailures > 0 {
+		a.watcher.SetMaxConsecutiveFailures(a.config.MaxWatchFailures)
+	}
 
 	switch a.config.Runtime {
 	case "omlx":
@@ -169,12 +183,22 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 
 	a.registry = NewServiceRegistry(a.config.K8sClient, a.config.HostIP, a.logger.With("subsystem", "registry"))
 
-	// Start health server
+	// Start health server. An unexpected exit here (port binding lost,
+	// listener crashed) is fatal — the management plane is how operators
+	// observe and recover the agent, so running blind is worse than
+	// restarting clean.
 	if a.config.Port > 0 {
 		healthSrv := NewHealthServer(a, a.config.Port, a.logger.With("subsystem", "health-server"))
 		go func() {
-			if err := healthSrv.Run(ctx); err != nil {
-				a.logger.Warnw("health server exited with error", "error", err)
+			err := healthSrv.Run(ctx)
+			if err == nil || ctx.Err() != nil {
+				return
+			}
+			a.logger.Errorw("health server exited unexpectedly, signalling fatal exit", "error", err)
+			fatalExitsTotal.WithLabelValues("health-server").Inc()
+			select {
+			case fatalErrChan <- fmt.Errorf("health server exited unexpectedly: %w", err):
+			default:
 			}
 		}()
 	}
@@ -203,6 +227,10 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 	// Start watcher with retry logic. If the CRDs are not installed when
 	// the agent starts, Watch will fail immediately. We retry with
 	// exponential backoff so the agent recovers once CRDs become available.
+	// ErrWatchStalled is the one error type we do NOT retry on — it means
+	// the watcher's Kubernetes client is wedged, which a fresh Watch on the
+	// same client cannot fix. Bubble it up via fatalErrChan so the agent
+	// returns and the supervisor restarts the process with a fresh client.
 	eventChan := make(chan InferenceServiceEvent)
 	go func() {
 		const (
@@ -217,8 +245,15 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 				// Clean exit (context cancelled) — don't retry.
 				return
 			}
-			// Check if context is done before retrying.
 			if ctx.Err() != nil {
+				return
+			}
+			if errors.Is(err, ErrWatchStalled) {
+				fatalExitsTotal.WithLabelValues("watcher").Inc()
+				select {
+				case fatalErrChan <- err:
+				default:
+				}
 				return
 			}
 			a.logger.Warnw("watcher exited with error, retrying",
@@ -240,6 +275,10 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
+		case fatalErr := <-fatalErrChan:
+			a.logger.Errorw("agent received fatal signal, exiting for supervisor restart",
+				"error", fatalErr)
+			return fatalErr
 		case event := <-eventChan:
 			if err := a.handleEvent(ctx, event); err != nil {
 				a.logger.Warnw("failed to handle event", "eventType", event.Type, "error", err)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -190,16 +190,7 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 	if a.config.Port > 0 {
 		healthSrv := NewHealthServer(a, a.config.Port, a.logger.With("subsystem", "health-server"))
 		go func() {
-			err := healthSrv.Run(ctx)
-			if err == nil || ctx.Err() != nil {
-				return
-			}
-			a.logger.Errorw("health server exited unexpectedly, signalling fatal exit", "error", err)
-			fatalExitsTotal.WithLabelValues("health-server").Inc()
-			select {
-			case fatalErrChan <- fmt.Errorf("health server exited unexpectedly: %w", err):
-			default:
-			}
+			a.reportHealthServerExit(ctx, healthSrv.Run(ctx), fatalErrChan)
 		}()
 	}
 
@@ -224,51 +215,12 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		go watchdog.Run(ctx)
 	}
 
-	// Start watcher with retry logic. If the CRDs are not installed when
-	// the agent starts, Watch will fail immediately. We retry with
-	// exponential backoff so the agent recovers once CRDs become available.
-	// ErrWatchStalled is the one error type we do NOT retry on — it means
-	// the watcher's Kubernetes client is wedged, which a fresh Watch on the
-	// same client cannot fix. Bubble it up via fatalErrChan so the agent
-	// returns and the supervisor restarts the process with a fresh client.
+	// Start watcher with retry logic. If the CRDs are not installed when the
+	// agent starts, Watch will fail immediately. The retry loop with
+	// exponential backoff makes the agent recover once the CRDs land.
+	// ErrWatchStalled bypasses the retry path — see runWatcherLoop for why.
 	eventChan := make(chan InferenceServiceEvent)
-	go func() {
-		const (
-			initialBackoff = 5 * time.Second
-			maxBackoff     = 60 * time.Second
-			backoffFactor  = 2
-		)
-		backoff := initialBackoff
-		for {
-			err := a.watcher.Watch(ctx, eventChan)
-			if err == nil {
-				// Clean exit (context cancelled) — don't retry.
-				return
-			}
-			if ctx.Err() != nil {
-				return
-			}
-			if errors.Is(err, ErrWatchStalled) {
-				fatalExitsTotal.WithLabelValues("watcher").Inc()
-				select {
-				case fatalErrChan <- err:
-				default:
-				}
-				return
-			}
-			a.logger.Warnw("watcher exited with error, retrying",
-				"error", err, "retryIn", backoff)
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(backoff):
-			}
-			backoff *= backoffFactor
-			if backoff > maxBackoff {
-				backoff = maxBackoff
-			}
-		}
-	}()
+	go a.runWatcherLoop(ctx, eventChan, fatalErrChan)
 
 	// Process events
 	for {
@@ -535,6 +487,80 @@ func (a *MetalAgent) deleteProcess(ctx context.Context, key string) error {
 // scheduleRestart increments the restart counter and re-runs ensureProcess
 // for the named InferenceService. It is called by HealthMonitor when a process
 // becomes unhealthy.
+// runWatcherLoop drives a.watcher.Watch in a loop, retrying transient errors
+// with exponential backoff (handles the "CRDs not installed yet" startup
+// race) but bubbling ErrWatchStalled up via fatalErrChan immediately.
+// Stalled means the watcher's controller-runtime client cache is wedged;
+// restarting Watch on the same client cannot fix that, so the agent has to
+// exit and let its supervisor recycle the process with a fresh client.
+//
+// Extracted from Start so the retry-vs-fatal decision is unit-testable.
+func (a *MetalAgent) runWatcherLoop(
+	ctx context.Context,
+	eventChan chan<- InferenceServiceEvent,
+	fatalErrChan chan<- error,
+) {
+	const (
+		initialBackoff = 5 * time.Second
+		maxBackoff     = 60 * time.Second
+		backoffFactor  = 2
+	)
+	backoff := initialBackoff
+	for {
+		err := a.watcher.Watch(ctx, eventChan)
+		if err == nil {
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if errors.Is(err, ErrWatchStalled) {
+			fatalExitsTotal.WithLabelValues("watcher").Inc()
+			select {
+			case fatalErrChan <- err:
+			default:
+			}
+			return
+		}
+		a.logger.Warnw("watcher exited with error, retrying",
+			"error", err, "retryIn", backoff)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff *= backoffFactor
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// reportHealthServerExit handles the post-Run state of the management HTTP
+// server. It is a no-op when the server returned cleanly or when the agent
+// itself is shutting down (ctx cancelled). Any other return is fatal and
+// pushed to fatalErrChan so the agent exits — running the agent without the
+// management plane (metrics, healthz, readyz) is exactly the failure mode
+// #276 reported.
+//
+// Extracted from the Start goroutine so the no-op-vs-fatal classification is
+// unit-testable without spinning up an HTTP server.
+func (a *MetalAgent) reportHealthServerExit(
+	ctx context.Context,
+	runErr error,
+	fatalErrChan chan<- error,
+) {
+	if runErr == nil || ctx.Err() != nil {
+		return
+	}
+	a.logger.Errorw("health server exited unexpectedly, signalling fatal exit", "error", runErr)
+	fatalExitsTotal.WithLabelValues("health-server").Inc()
+	select {
+	case fatalErrChan <- fmt.Errorf("health server exited unexpectedly: %w", runErr):
+	default:
+	}
+}
+
 func (a *MetalAgent) scheduleRestart(ctx context.Context, name, namespace string) {
 	processRestarts.WithLabelValues(name, namespace).Inc()
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -18,7 +18,9 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -183,6 +185,144 @@ func TestShutdown_NoProcesses(t *testing.T) {
 	err := agent.Shutdown(context.Background())
 	if err != nil {
 		t.Errorf("Shutdown with no processes returned error: %v", err)
+	}
+}
+
+func TestReportHealthServerExit(t *testing.T) {
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient})
+
+	t.Run("nil err is no-op", func(t *testing.T) {
+		ch := make(chan error, 1)
+		agent.reportHealthServerExit(context.Background(), nil, ch)
+		select {
+		case got := <-ch:
+			t.Errorf("unexpected fatal signal: %v", got)
+		default:
+		}
+	})
+
+	t.Run("ctx cancelled is no-op", func(t *testing.T) {
+		ch := make(chan error, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		agent.reportHealthServerExit(ctx, errors.New("listener died"), ch)
+		select {
+		case got := <-ch:
+			t.Errorf("unexpected fatal signal during shutdown: %v", got)
+		default:
+		}
+	})
+
+	t.Run("real error pushes fatal", func(t *testing.T) {
+		ch := make(chan error, 1)
+		runErr := errors.New("listener died")
+		agent.reportHealthServerExit(context.Background(), runErr, ch)
+		select {
+		case got := <-ch:
+			if !errors.Is(got, runErr) {
+				t.Errorf("fatal err = %v, want wrap of %v", got, runErr)
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Error("expected fatal signal but channel was empty")
+		}
+	})
+
+	t.Run("non-blocking when channel is full", func(t *testing.T) {
+		// fatalErrChan in production is buffered for 2; if both slots are
+		// already taken (e.g., watcher fatal already in flight) we must not
+		// block forever. The select{default} branch is what guarantees this.
+		ch := make(chan error, 1)
+		ch <- errors.New("prior fatal")
+		done := make(chan struct{})
+		go func() {
+			agent.reportHealthServerExit(context.Background(), errors.New("listener died"), ch)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(500 * time.Millisecond):
+			t.Error("reportHealthServerExit blocked when channel was full")
+		}
+	})
+}
+
+func TestRunWatcherLoop_StalledPushesFatal(t *testing.T) {
+	// Build a watcher whose Watch will return ErrWatchStalled on the first
+	// poll cycle. The scriptedListClient pattern from watcher_test.go is
+	// reused: succeed on listExisting, fail every poll, threshold=1.
+	c, _ := scriptedListClient(t, func(n int32) bool { return n > 1 })
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient})
+	agent.watcher = NewInferenceServiceWatcher(c, "default", newNopLogger())
+	agent.watcher.SetPollInterval(10 * time.Millisecond)
+	agent.watcher.SetMaxConsecutiveFailures(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	eventChan := make(chan InferenceServiceEvent, 1)
+	fatalErrChan := make(chan error, 2)
+
+	done := make(chan struct{})
+	go func() {
+		agent.runWatcherLoop(ctx, eventChan, fatalErrChan)
+		close(done)
+	}()
+
+	select {
+	case got := <-fatalErrChan:
+		if !errors.Is(got, ErrWatchStalled) {
+			t.Errorf("fatalErrChan got %v, want ErrWatchStalled", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWatcherLoop did not push to fatalErrChan within 2s")
+	}
+
+	// runWatcherLoop must also return after pushing — otherwise it would
+	// keep retrying ErrWatchStalled and double-push (or burn CPU).
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Error("runWatcherLoop did not return after pushing fatal signal")
+	}
+}
+
+func TestRunWatcherLoop_ContextCancellationExitsCleanly(t *testing.T) {
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient})
+	agent.watcher = NewInferenceServiceWatcher(k8sClient, "default", newNopLogger())
+	agent.watcher.SetPollInterval(10 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	eventChan := make(chan InferenceServiceEvent, 1)
+	fatalErrChan := make(chan error, 2)
+
+	done := make(chan struct{})
+	go func() {
+		agent.runWatcherLoop(ctx, eventChan, fatalErrChan)
+		close(done)
+	}()
+
+	// Give the loop a moment to start, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWatcherLoop did not exit on ctx cancellation")
+	}
+
+	// No fatal signal should have been pushed during clean shutdown.
+	select {
+	case got := <-fatalErrChan:
+		t.Errorf("unexpected fatal signal during clean shutdown: %v", got)
+	default:
 	}
 }
 

--- a/pkg/agent/agentmetrics.go
+++ b/pkg/agent/agentmetrics.go
@@ -113,14 +113,19 @@ var (
 	watchConsecutiveFailures = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "llmkube_metal_agent_watch_consecutive_failures",
-			Help: "Current count of consecutive Kubernetes list failures from the InferenceService watcher. Resets to 0 on a successful poll. Triggers a fatal exit when the configured threshold is reached.",
+			Help: "Current count of consecutive Kubernetes list failures from the " +
+				"InferenceService watcher. Resets to 0 on a successful poll. " +
+				"Triggers a fatal exit when the configured threshold is reached.",
 		},
 	)
 
 	fatalExitsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "llmkube_metal_agent_fatal_exits_total",
-			Help: "Total number of fatal-exit signals raised by agent subsystems (watcher, health-server). The agent process terminates after raising one; this counter is therefore typically 0 or 1 over a process lifetime, but useful when scraped by a metric pipeline that survives the restart.",
+			Help: "Total number of fatal-exit signals raised by agent subsystems " +
+				"(watcher, health-server). The agent process terminates after raising one; " +
+				"this counter is therefore typically 0 or 1 over a process lifetime, but " +
+				"useful when scraped by a metric pipeline that survives the restart.",
 		},
 		[]string{"subsystem"},
 	)

--- a/pkg/agent/agentmetrics.go
+++ b/pkg/agent/agentmetrics.go
@@ -109,6 +109,21 @@ var (
 			Help: "Total number of process eviction events triggered by memory pressure.",
 		},
 	)
+
+	watchConsecutiveFailures = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "llmkube_metal_agent_watch_consecutive_failures",
+			Help: "Current count of consecutive Kubernetes list failures from the InferenceService watcher. Resets to 0 on a successful poll. Triggers a fatal exit when the configured threshold is reached.",
+		},
+	)
+
+	fatalExitsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llmkube_metal_agent_fatal_exits_total",
+			Help: "Total number of fatal-exit signals raised by agent subsystems (watcher, health-server). The agent process terminates after raising one; this counter is therefore typically 0 or 1 over a process lifetime, but useful when scraped by a metric pipeline that survives the restart.",
+		},
+		[]string{"subsystem"},
+	)
 )
 
 func init() {
@@ -126,5 +141,7 @@ func init() {
 		processRSSBytes,
 		memoryPressureLevelGauge,
 		evictionsTotal,
+		watchConsecutiveFailures,
+		fatalExitsTotal,
 	)
 }

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -28,6 +29,21 @@ import (
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
+
+// ErrWatchStalled is returned from Watch when the polling loop has accumulated
+// more consecutive list errors than the configured threshold. The agent treats
+// this as a fatal condition and exits non-zero so the process supervisor
+// (launchd / systemd) can recycle it with a fresh Kubernetes client. This
+// recovers from situations like the underlying controller-runtime cache
+// silently serving stale data after its watch connection drops.
+var ErrWatchStalled = errors.New("watcher polling stalled: consecutive list failures exceeded threshold")
+
+// DefaultMaxConsecutiveFailures is the threshold at which the watcher gives
+// up on its current Kubernetes connection. Three failures over the 5-second
+// poll interval is 15 seconds of consecutive trouble — long enough to rule
+// out a single transient network blip and short enough that the agent does
+// not silently sit on a dead watch for hours.
+const DefaultMaxConsecutiveFailures = 3
 
 // EventType represents the type of InferenceService event
 type EventType string
@@ -44,27 +60,59 @@ type InferenceServiceEvent struct {
 	InferenceService *inferencev1alpha1.InferenceService
 }
 
+// defaultPollInterval is how often the watcher re-lists InferenceServices
+// looking for changes. Five seconds is a balance between responsiveness for
+// scaling events and load on the API server when many agents share a cluster.
+const defaultPollInterval = 5 * time.Second
+
 // InferenceServiceWatcher watches for InferenceService resources
 type InferenceServiceWatcher struct {
-	client    client.Client
-	namespace string
-	logger    *zap.SugaredLogger
+	client                 client.Client
+	namespace              string
+	logger                 *zap.SugaredLogger
+	maxConsecutiveFailures int
+	pollInterval           time.Duration
 }
 
-// NewInferenceServiceWatcher creates a new watcher
+// NewInferenceServiceWatcher creates a new watcher with the default failure
+// threshold (DefaultMaxConsecutiveFailures). Use SetMaxConsecutiveFailures to
+// override.
 func NewInferenceServiceWatcher(
 	k8sClient client.Client,
 	namespace string,
 	logger *zap.SugaredLogger,
 ) *InferenceServiceWatcher {
 	return &InferenceServiceWatcher{
-		client:    k8sClient,
-		namespace: namespace,
-		logger:    logger,
+		client:                 k8sClient,
+		namespace:              namespace,
+		logger:                 logger,
+		maxConsecutiveFailures: DefaultMaxConsecutiveFailures,
+		pollInterval:           defaultPollInterval,
 	}
 }
 
-// Watch starts watching for InferenceService changes
+// SetMaxConsecutiveFailures overrides the default failure threshold. Values
+// less than 1 are coerced to DefaultMaxConsecutiveFailures.
+func (w *InferenceServiceWatcher) SetMaxConsecutiveFailures(n int) {
+	if n < 1 {
+		n = DefaultMaxConsecutiveFailures
+	}
+	w.maxConsecutiveFailures = n
+}
+
+// SetPollInterval overrides the default 5s polling interval. Intended for
+// tests that want to drive the loop quickly; production code should leave
+// the default alone. Zero or negative values are ignored.
+func (w *InferenceServiceWatcher) SetPollInterval(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	w.pollInterval = d
+}
+
+// Watch starts watching for InferenceService changes. It returns nil on clean
+// context cancellation, ErrWatchStalled when consecutive list failures exceed
+// the configured threshold, or a wrapped error on initial-list failure.
 func (w *InferenceServiceWatcher) Watch(ctx context.Context, eventChan chan<- InferenceServiceEvent) error {
 	// List existing InferenceServices on startup
 	if err := w.listExisting(ctx, eventChan); err != nil {
@@ -72,11 +120,22 @@ func (w *InferenceServiceWatcher) Watch(ctx context.Context, eventChan chan<- In
 	}
 
 	// Watch for changes
-	ticker := time.NewTicker(5 * time.Second)
+	interval := w.pollInterval
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	// Store last seen resource versions to detect changes
 	seen := make(map[string]string)
+
+	threshold := w.maxConsecutiveFailures
+	if threshold < 1 {
+		threshold = DefaultMaxConsecutiveFailures
+	}
+	consecutiveFailures := 0
+	watchConsecutiveFailures.Set(0)
 
 	for {
 		select {
@@ -84,7 +143,28 @@ func (w *InferenceServiceWatcher) Watch(ctx context.Context, eventChan chan<- In
 			return nil
 		case <-ticker.C:
 			if err := w.poll(ctx, eventChan, seen); err != nil {
-				w.logger.Warnw("polling error", "error", err)
+				consecutiveFailures++
+				watchConsecutiveFailures.Set(float64(consecutiveFailures))
+				w.logger.Warnw("polling error",
+					"error", err,
+					"consecutiveFailures", consecutiveFailures,
+					"threshold", threshold,
+				)
+				if consecutiveFailures >= threshold {
+					w.logger.Errorw(
+						"watcher stalled — exceeded consecutive failure threshold, returning ErrWatchStalled so the agent can exit and be restarted by its supervisor",
+						"consecutiveFailures", consecutiveFailures,
+						"threshold", threshold,
+						"lastError", err,
+					)
+					return ErrWatchStalled
+				}
+				continue
+			}
+			if consecutiveFailures > 0 {
+				w.logger.Infow("polling recovered after errors", "previousFailures", consecutiveFailures)
+				consecutiveFailures = 0
+				watchConsecutiveFailures.Set(0)
 			}
 		}
 	}

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -152,7 +152,9 @@ func (w *InferenceServiceWatcher) Watch(ctx context.Context, eventChan chan<- In
 				)
 				if consecutiveFailures >= threshold {
 					w.logger.Errorw(
-						"watcher stalled — exceeded consecutive failure threshold, returning ErrWatchStalled so the agent can exit and be restarted by its supervisor",
+						"watcher stalled — exceeded consecutive failure threshold, "+
+							"returning ErrWatchStalled so the agent can exit and "+
+							"be restarted by its supervisor",
 						"consecutiveFailures", consecutiveFailures,
 						"threshold", threshold,
 						"lastError", err,

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -18,12 +18,16 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -400,6 +404,108 @@ func TestPoll_DetectsDeletedService(t *testing.T) {
 	}
 	if event.InferenceService.Name != "old-model" {
 		t.Errorf("event service name = %q, want %q", event.InferenceService.Name, "old-model")
+	}
+}
+
+func TestSetMaxConsecutiveFailures(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	w := NewInferenceServiceWatcher(k8sClient, "default", newNopLogger())
+
+	if w.maxConsecutiveFailures != DefaultMaxConsecutiveFailures {
+		t.Errorf("default = %d, want %d", w.maxConsecutiveFailures, DefaultMaxConsecutiveFailures)
+	}
+	w.SetMaxConsecutiveFailures(7)
+	if w.maxConsecutiveFailures != 7 {
+		t.Errorf("after Set(7) = %d, want 7", w.maxConsecutiveFailures)
+	}
+	// Non-positive coerces back to default.
+	w.SetMaxConsecutiveFailures(0)
+	if w.maxConsecutiveFailures != DefaultMaxConsecutiveFailures {
+		t.Errorf("after Set(0) = %d, want %d", w.maxConsecutiveFailures, DefaultMaxConsecutiveFailures)
+	}
+}
+
+func TestSetPollInterval(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	w := NewInferenceServiceWatcher(k8sClient, "default", newNopLogger())
+
+	if w.pollInterval != defaultPollInterval {
+		t.Errorf("default poll interval = %v, want %v", w.pollInterval, defaultPollInterval)
+	}
+	w.SetPollInterval(50 * time.Millisecond)
+	if w.pollInterval != 50*time.Millisecond {
+		t.Errorf("after Set(50ms) = %v", w.pollInterval)
+	}
+	// Non-positive ignored.
+	w.SetPollInterval(0)
+	if w.pollInterval != 50*time.Millisecond {
+		t.Errorf("Set(0) should be ignored, got %v", w.pollInterval)
+	}
+}
+
+// scriptedListClient wraps a fake client and lets each test prescribe a
+// failure pattern across successive List calls. failBetween reports whether
+// the n-th call (1-indexed) should fail.
+func scriptedListClient(t *testing.T, failOnCall func(n int32) bool) (client.Client, *atomic.Int32) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	var calls atomic.Int32
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, w client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			n := calls.Add(1)
+			if failOnCall(n) {
+				return errors.New("synthetic list failure")
+			}
+			return w.List(ctx, list, opts...)
+		},
+	})
+	return c, &calls
+}
+
+func TestWatch_StalledExitsAfterThreshold(t *testing.T) {
+	// Call 1 (listExisting) succeeds; calls 2+ all fail. With threshold=2 the
+	// watcher should bail out after two consecutive poll failures.
+	c, _ := scriptedListClient(t, func(n int32) bool { return n > 1 })
+	w := NewInferenceServiceWatcher(c, "default", newNopLogger())
+	w.SetPollInterval(10 * time.Millisecond)
+	w.SetMaxConsecutiveFailures(2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	eventChan := make(chan InferenceServiceEvent, 1)
+	err := w.Watch(ctx, eventChan)
+	if !errors.Is(err, ErrWatchStalled) {
+		t.Fatalf("Watch returned %v, want ErrWatchStalled", err)
+	}
+}
+
+func TestWatch_RecoversAndResetsCounter(t *testing.T) {
+	// listExisting (call 1) succeeds; polls 2 and 3 fail; everything after
+	// succeeds. Threshold of 5 means the recovery on call 4 should reset the
+	// counter and Watch should never return ErrWatchStalled — only the
+	// context timeout exits the loop.
+	c, _ := scriptedListClient(t, func(n int32) bool { return n == 2 || n == 3 })
+	w := NewInferenceServiceWatcher(c, "default", newNopLogger())
+	w.SetPollInterval(10 * time.Millisecond)
+	w.SetMaxConsecutiveFailures(5)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	eventChan := make(chan InferenceServiceEvent, 1)
+	err := w.Watch(ctx, eventChan)
+
+	if errors.Is(err, ErrWatchStalled) {
+		t.Errorf("Watch returned ErrWatchStalled despite mid-run recovery; counter did not reset")
 	}
 }
 

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -473,7 +473,7 @@ func scriptedListClient(t *testing.T, failOnCall func(n int32) bool) (client.Cli
 func TestWatch_StalledExitsAfterThreshold(t *testing.T) {
 	// Call 1 (listExisting) succeeds; calls 2+ all fail. With threshold=2 the
 	// watcher should bail out after two consecutive poll failures.
-	c, _ := scriptedListClient(t, func(n int32) bool { return n > 1 })
+	c, calls := scriptedListClient(t, func(n int32) bool { return n > 1 })
 	w := NewInferenceServiceWatcher(c, "default", newNopLogger())
 	w.SetPollInterval(10 * time.Millisecond)
 	w.SetMaxConsecutiveFailures(2)
@@ -486,6 +486,11 @@ func TestWatch_StalledExitsAfterThreshold(t *testing.T) {
 	if !errors.Is(err, ErrWatchStalled) {
 		t.Fatalf("Watch returned %v, want ErrWatchStalled", err)
 	}
+	// Sanity: 1 listExisting + 2 failed polls = exactly 3 List calls. Anything
+	// higher means we burned past the threshold without bailing out.
+	if got := calls.Load(); got != 3 {
+		t.Errorf("List call count = %d, want 3 (1 list-existing + 2 failed polls)", got)
+	}
 }
 
 func TestWatch_RecoversAndResetsCounter(t *testing.T) {
@@ -493,7 +498,7 @@ func TestWatch_RecoversAndResetsCounter(t *testing.T) {
 	// succeeds. Threshold of 5 means the recovery on call 4 should reset the
 	// counter and Watch should never return ErrWatchStalled — only the
 	// context timeout exits the loop.
-	c, _ := scriptedListClient(t, func(n int32) bool { return n == 2 || n == 3 })
+	c, calls := scriptedListClient(t, func(n int32) bool { return n == 2 || n == 3 })
 	w := NewInferenceServiceWatcher(c, "default", newNopLogger())
 	w.SetPollInterval(10 * time.Millisecond)
 	w.SetMaxConsecutiveFailures(5)
@@ -506,6 +511,11 @@ func TestWatch_RecoversAndResetsCounter(t *testing.T) {
 
 	if errors.Is(err, ErrWatchStalled) {
 		t.Errorf("Watch returned ErrWatchStalled despite mid-run recovery; counter did not reset")
+	}
+	// We should see at least 4 calls (list-existing + the two failures + at
+	// least one recovery) within the 500ms test window at a 10ms tick.
+	if got := calls.Load(); got < 4 {
+		t.Errorf("List call count = %d, want >= 4 to prove recovery exercised", got)
 	}
 }
 


### PR DESCRIPTION
Closes #276.

## Summary

The InferenceService watcher's 5-second polling loop has no give-up condition. When the underlying controller-runtime cache silently serves stale data (which #276 reports happened after 25 days of uptime on shadowstack), the agent enters a hung state: scaling events are ignored, the management HTTP server eventually becomes unreachable, and only a manual SIGKILL recovers it.

There is no in-process fix for a wedged controller-runtime client — the cache is process-level and recreating the watcher does not reset it. The correct move is to exit non-zero and let the process supervisor (launchd / systemd / k8s) restart with a fresh client. This PR wires that path.

## What changed

- **Watcher counts consecutive list failures.** When the count exceeds \`--max-watch-failures\` (new flag, default 3), \`Watch()\` returns the new sentinel \`ErrWatchStalled\`. A successful poll resets the counter and logs the recovery at info level so it shows up cleanly in the journal.
- **Agent introduces a \`fatalErrChan\`.** Watcher and health-server goroutines use it to signal terminal failures up to the main select loop. The agent's existing exponential-backoff retry around \`Watch()\` is bypassed for \`ErrWatchStalled\` specifically, because retrying with the same wedged client cannot help.
- **Health server unexpected exits also become fatal.** Previously a dead listener was logged warn and the agent kept running with no management plane — that's precisely the second symptom #276 describes.
- **Two new Prometheus metrics:**
  - \`llmkube_metal_agent_watch_consecutive_failures\` (gauge) — current count, useful for alerting before the threshold is reached
  - \`llmkube_metal_agent_fatal_exits_total\` (counter, labeled by subsystem) — typically 0 or 1 over a process lifetime, but valuable when scraped by a metric pipeline that survives the restart
- **Poll interval is now an injectable field** so tests don't need to wait 15+ seconds. Production default unchanged at 5s.
- **New CLI flag** \`--max-watch-failures\` plumbed through \`MetalAgentConfig.MaxWatchFailures\`. Set to 0 to use the package default (\`agent.DefaultMaxConsecutiveFailures = 3\`).

## Why exit instead of recover

Recreating the controller-runtime client in-process would require restructuring the agent's initialization, and it would not address related state (e.g., the health server's listener) that the bug also describes failing. A clean exit lets the supervisor return the agent to a fully-known-good state in seconds, which is the same recovery mechanism we already rely on for any other hard failure (panic, OOM, signal). The blast radius is small: the InferenceService state is in Kubernetes, llama-server child processes survive the agent's SIGTERM (no \`Pdeathsig\` on macOS), and the new agent reattaches to them on startup via the registry.

## Test plan

- [x] \`go test ./pkg/agent/... ./cmd/metal-agent/...\` — all green including five new \`TestWatch_*\` and \`TestSet*\` cases
- [x] \`go vet ./...\` and full \`go build ./...\` clean
- [ ] Manual smoke on M5 Max: deploy an InferenceService, kill the K8s API server (or simulate via iptables drop), verify agent logs the consecutive-failure escalation and exits non-zero within ~15 seconds. Confirm launchd/systemd restarts the agent and the InferenceService is reattached.

## Why now

Pre-flight prep for the M5 Max 128 GB benchmark suite. Multi-day overnight agentic runs would otherwise be at the mercy of a silent watcher stall.