### PR TITLE
fix(agent): make executor startup timeouts configurable; raise defaults to 120s

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -45,22 +45,24 @@ var (
 )
 
 type AgentConfig struct {
-	Namespace              string
-	ModelStorePath         string
-	LlamaServerBin         string
-	Runtime                string
-	OMLXBin                string
-	OMLXPort               int
-	OllamaPort             int
-	Port                   int
-	LogLevel               string
-	HostIP                 string
-	MemoryFraction         float64
-	WatchdogInterval       time.Duration
-	MemoryPressureWarning  float64
-	MemoryPressureCritical float64
-	EvictionEnabled        bool
-	MaxWatchFailures       int
+	Namespace                 string
+	ModelStorePath            string
+	LlamaServerBin            string
+	Runtime                   string
+	OMLXBin                   string
+	OMLXPort                  int
+	OllamaPort                int
+	Port                      int
+	LogLevel                  string
+	HostIP                    string
+	MemoryFraction            float64
+	WatchdogInterval          time.Duration
+	MemoryPressureWarning     float64
+	MemoryPressureCritical    float64
+	EvictionEnabled           bool
+	MaxWatchFailures          int
+	LlamaServerStartupTimeout time.Duration
+	OMLXStartupTimeout        time.Duration
 }
 
 func parseLogLevel(level string) zapcore.Level {
@@ -164,6 +166,14 @@ func main() {
 	flag.IntVar(&cfg.MaxWatchFailures, "max-watch-failures", agent.DefaultMaxConsecutiveFailures,
 		"Consecutive Kubernetes list failures from the InferenceService watcher before the agent "+
 			"gives up and exits for supervisor restart. Set to 0 to use the agent default.")
+	flag.DurationVar(&cfg.LlamaServerStartupTimeout, "llama-server-startup-timeout",
+		agent.DefaultLlamaServerStartupTimeout,
+		"How long to wait for a freshly-spawned llama-server to respond on /health. "+
+			"Bump for very large models (mlock + warmup grow with model size).")
+	flag.DurationVar(&cfg.OMLXStartupTimeout, "omlx-startup-timeout",
+		agent.DefaultOMLXStartupTimeout,
+		"How long to wait for the oMLX daemon to become healthy after launching it. "+
+			"First model loads on M-series take 30-90s; default 120s.")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.Parse()
 
@@ -287,19 +297,21 @@ func main() {
 	// Create agent
 	logger.Infow("creating Metal agent")
 	agentCfg := agent.MetalAgentConfig{
-		K8sClient:        k8sClient,
-		Namespace:        cfg.Namespace,
-		ModelStorePath:   cfg.ModelStorePath,
-		LlamaServerBin:   cfg.LlamaServerBin,
-		Runtime:          cfg.Runtime,
-		OMLXBin:          cfg.OMLXBin,
-		OMLXPort:         cfg.OMLXPort,
-		OllamaPort:       cfg.OllamaPort,
-		Port:             cfg.Port,
-		HostIP:           cfg.HostIP,
-		Logger:           logger,
-		MemoryFraction:   cfg.MemoryFraction,
-		MaxWatchFailures: cfg.MaxWatchFailures,
+		K8sClient:                 k8sClient,
+		Namespace:                 cfg.Namespace,
+		ModelStorePath:            cfg.ModelStorePath,
+		LlamaServerBin:            cfg.LlamaServerBin,
+		Runtime:                   cfg.Runtime,
+		OMLXBin:                   cfg.OMLXBin,
+		OMLXPort:                  cfg.OMLXPort,
+		OllamaPort:                cfg.OllamaPort,
+		Port:                      cfg.Port,
+		HostIP:                    cfg.HostIP,
+		Logger:                    logger,
+		MemoryFraction:            cfg.MemoryFraction,
+		MaxWatchFailures:          cfg.MaxWatchFailures,
+		LlamaServerStartupTimeout: cfg.LlamaServerStartupTimeout,
+		OMLXStartupTimeout:        cfg.OMLXStartupTimeout,
 	}
 	if cfg.WatchdogInterval > 0 {
 		agentCfg.WatchdogConfig = &agent.MemoryWatchdogConfig{

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -64,6 +64,19 @@ type MetalAgentConfig struct {
 	// and signals a fatal exit. Zero means use the watcher's built-in default
 	// (DefaultMaxConsecutiveFailures).
 	MaxWatchFailures int
+
+	// LlamaServerStartupTimeout is how long the Metal executor waits for a
+	// freshly-spawned llama-server to respond on /health before giving up.
+	// Zero means use the executor default (DefaultLlamaServerStartupTimeout).
+	// Bump this when serving very large models — mlock + warmup grow with
+	// model size and the default may be too aggressive for 80+ GB models.
+	LlamaServerStartupTimeout time.Duration
+
+	// OMLXStartupTimeout is how long the agent waits for the oMLX daemon to
+	// become healthy after launching it. Zero means use the executor default
+	// (DefaultOMLXStartupTimeout). The original 30s constant was too short
+	// for real M-series hardware.
+	OMLXStartupTimeout time.Duration
 }
 
 // MetalAgent watches Kubernetes InferenceService resources and manages
@@ -158,12 +171,16 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		if port == 0 {
 			port = 8000
 		}
-		a.executor = NewOMLXExecutor(
+		omlxExec := NewOMLXExecutor(
 			a.config.OMLXBin,
 			a.config.ModelStorePath,
 			port,
 			a.logger.With("subsystem", "executor"),
 		)
+		if a.config.OMLXStartupTimeout > 0 {
+			omlxExec.SetStartupTimeout(a.config.OMLXStartupTimeout)
+		}
+		a.executor = omlxExec
 	case "ollama":
 		port := a.config.OllamaPort
 		if port == 0 {
@@ -174,11 +191,15 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 			a.logger.With("subsystem", "executor"),
 		)
 	default:
-		a.executor = NewMetalExecutor(
+		metalExec := NewMetalExecutor(
 			a.config.LlamaServerBin,
 			a.config.ModelStorePath,
 			a.logger.With("subsystem", "executor"),
 		)
+		if a.config.LlamaServerStartupTimeout > 0 {
+			metalExec.SetStartupTimeout(a.config.LlamaServerStartupTimeout)
+		}
+		a.executor = metalExec
 	}
 
 	a.registry = NewServiceRegistry(a.config.K8sClient, a.config.HostIP, a.logger.With("subsystem", "registry"))

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -71,10 +71,21 @@ type ProcessExecutor interface {
 	StopProcess(pid int) error
 }
 
+// DefaultLlamaServerStartupTimeout is how long the agent waits for a freshly
+// spawned llama-server to respond on /health. Was 30s historically; that's
+// fine for sub-30 GB models but breaks for anything larger because llama.cpp's
+// mlock pass + warmup grows roughly linearly with model size. Empirically an
+// 84 GB model (MiniMax M2.7 IQ3_S on M5 Max) takes ~30+ seconds just for
+// mlock; the original timeout would kill the process just before it would
+// have been ready. 120s gives generous headroom for the largest models that
+// fit in 128 GB unified memory while still failing fast on real breakage.
+const DefaultLlamaServerStartupTimeout = 120 * time.Second
+
 type MetalExecutor struct {
 	llamaServerBin string
 	modelStorePath string
 	logger         *zap.SugaredLogger
+	startupTimeout time.Duration
 }
 
 func NewMetalExecutor(llamaServerBin, modelStorePath string, logger *zap.SugaredLogger) *MetalExecutor {
@@ -82,7 +93,17 @@ func NewMetalExecutor(llamaServerBin, modelStorePath string, logger *zap.Sugared
 		llamaServerBin: llamaServerBin,
 		modelStorePath: modelStorePath,
 		logger:         logger,
+		startupTimeout: DefaultLlamaServerStartupTimeout,
 	}
+}
+
+// SetStartupTimeout overrides the default llama-server startup timeout.
+// Values <= 0 are coerced back to DefaultLlamaServerStartupTimeout.
+func (e *MetalExecutor) SetStartupTimeout(d time.Duration) {
+	if d <= 0 {
+		d = DefaultLlamaServerStartupTimeout
+	}
+	e.startupTimeout = d
 }
 
 func (e *MetalExecutor) StartProcess(ctx context.Context, config ExecutorConfig) (*ManagedProcess, error) {
@@ -119,12 +140,12 @@ func (e *MetalExecutor) StartProcess(ctx context.Context, config ExecutorConfig)
 		Healthy:   false,
 	}
 
-	if err := e.waitForHealthy(port, 30*time.Second); err != nil {
+	if err := e.waitForHealthy(port, e.startupTimeout); err != nil {
 		if stopErr := e.StopProcess(process.PID); stopErr != nil {
 			e.logger.Warnw("failed to stop unhealthy process after health check failure",
 				"pid", process.PID, "port", port, "error", stopErr)
 		}
-		return nil, fmt.Errorf("process failed health check: %w", err)
+		return nil, fmt.Errorf("process failed health check after %s: %w", e.startupTimeout, err)
 	}
 
 	process.Healthy = true

--- a/pkg/agent/executor_omlx.go
+++ b/pkg/agent/executor_omlx.go
@@ -30,17 +30,27 @@ import (
 	"go.uber.org/zap"
 )
 
+// DefaultOMLXStartupTimeout is how long the agent waits for the oMLX daemon
+// to become healthy after launching it. The original default was 30s, which
+// is too short on real hardware: Apple Silicon spinup for the oMLX daemon
+// includes scanning the model directory, sizing the engine pool, and loading
+// the MLX framework — empirically ~35s on M5 Max even with no models pinned.
+// 120s gives generous headroom for the slow-first-load case while still
+// failing fast if oMLX is genuinely broken.
+const DefaultOMLXStartupTimeout = 120 * time.Second
+
 // OMLXExecutor manages the shared oMLX daemon and individual model lifecycles.
 // Unlike MetalExecutor (one process per model), oMLX runs a single daemon that
 // serves all models from a shared model directory.
 type OMLXExecutor struct {
-	omlxBin    string
-	modelDir   string
-	port       int
-	process    *os.Process
-	mu         sync.Mutex
-	logger     *zap.SugaredLogger
-	httpClient *http.Client
+	omlxBin        string
+	modelDir       string
+	port           int
+	process        *os.Process
+	mu             sync.Mutex
+	logger         *zap.SugaredLogger
+	httpClient     *http.Client
+	startupTimeout time.Duration
 }
 
 // NewOMLXExecutor creates an executor that manages models via the oMLX daemon.
@@ -53,7 +63,17 @@ func NewOMLXExecutor(omlxBin, modelDir string, port int, logger *zap.SugaredLogg
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
+		startupTimeout: DefaultOMLXStartupTimeout,
 	}
+}
+
+// SetStartupTimeout overrides the default oMLX-daemon startup timeout.
+// Values <= 0 are coerced back to DefaultOMLXStartupTimeout.
+func (e *OMLXExecutor) SetStartupTimeout(d time.Duration) {
+	if d <= 0 {
+		d = DefaultOMLXStartupTimeout
+	}
+	e.startupTimeout = d
 }
 
 // omlxModelsStatusResponse is the response from GET /v1/models/status.
@@ -199,12 +219,14 @@ func (e *OMLXExecutor) ensureOMLXRunning(ctx context.Context) error {
 	e.process = cmd.Process
 	e.logger.Infow("oMLX daemon started", "pid", cmd.Process.Pid)
 
-	// Wait for oMLX to become healthy
-	if err := e.waitForHealthy(ctx, 30*time.Second); err != nil {
+	// Wait for oMLX to become healthy. On real hardware the first model load
+	// can take 30+ seconds — see DefaultOMLXStartupTimeout for the rationale.
+	if err := e.waitForHealthy(ctx, e.startupTimeout); err != nil {
 		// Best-effort kill if startup failed
 		_ = cmd.Process.Kill()
 		e.process = nil
-		return fmt.Errorf("oMLX daemon failed to become healthy: %w", err)
+		return fmt.Errorf("oMLX daemon failed to become healthy after %s: %w",
+			e.startupTimeout, err)
 	}
 
 	return nil

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestNewMetalExecutor(t *testing.T) {
@@ -199,6 +200,52 @@ func flagValue(args []string, name string) string {
 		}
 	}
 	return ""
+}
+
+func TestSetStartupTimeout(t *testing.T) {
+	executor := NewMetalExecutor("/bin/llama-server", "/models", newNopLogger())
+
+	if executor.startupTimeout != DefaultLlamaServerStartupTimeout {
+		t.Errorf("default startupTimeout = %v, want %v",
+			executor.startupTimeout, DefaultLlamaServerStartupTimeout)
+	}
+
+	executor.SetStartupTimeout(45 * time.Second)
+	if executor.startupTimeout != 45*time.Second {
+		t.Errorf("after Set(45s) = %v, want 45s", executor.startupTimeout)
+	}
+
+	// Non-positive should coerce back to default.
+	executor.SetStartupTimeout(0)
+	if executor.startupTimeout != DefaultLlamaServerStartupTimeout {
+		t.Errorf("after Set(0) = %v, want default %v",
+			executor.startupTimeout, DefaultLlamaServerStartupTimeout)
+	}
+	executor.SetStartupTimeout(-5 * time.Second)
+	if executor.startupTimeout != DefaultLlamaServerStartupTimeout {
+		t.Errorf("after Set(-5s) = %v, want default %v",
+			executor.startupTimeout, DefaultLlamaServerStartupTimeout)
+	}
+}
+
+func TestOMLXSetStartupTimeout(t *testing.T) {
+	executor := NewOMLXExecutor("/bin/omlx", "/models", 8000, newNopLogger())
+
+	if executor.startupTimeout != DefaultOMLXStartupTimeout {
+		t.Errorf("default startupTimeout = %v, want %v",
+			executor.startupTimeout, DefaultOMLXStartupTimeout)
+	}
+
+	executor.SetStartupTimeout(180 * time.Second)
+	if executor.startupTimeout != 180*time.Second {
+		t.Errorf("after Set(180s) = %v, want 180s", executor.startupTimeout)
+	}
+
+	executor.SetStartupTimeout(0)
+	if executor.startupTimeout != DefaultOMLXStartupTimeout {
+		t.Errorf("after Set(0) = %v, want default %v",
+			executor.startupTimeout, DefaultOMLXStartupTimeout)
+	}
 }
 
 func TestStopProcess_InvalidPID(t *testing.T) {


### PR DESCRIPTION
Closes #329.

## Summary

Both the Metal executor (`llama-server`) and the oMLX executor hard-coded a 30-second timeout for the spawned process to respond on `/health`. On real hardware that's too short for the cases LLMKube most cares about — surfaced *twice* during this weekend's M5 Max benchmark session:

1. **oMLX daemon startup on M5 Max takes ~35 seconds** before the first request is served (model directory scan, engine pool sizing, MLX framework load). The 30s timeout killed the daemon ~5 seconds before it would have been ready. This is the bug originally reported in #329.
2. **`llama-server` mlock + warmup of an 84 GB model (MiniMax M2.7 IQ3_S) takes well past 30s** on the same M5 Max. Discovered when trying to deploy MiniMax M2.7 alongside Qwen3.6-35B-A3B. The agent killed `llama-server` just before it would have been ready and refused to retry, blocking the whole InferenceService.

Same root cause in both places: a default-too-aggressive constant that worked fine for small-model demos but not for the model classes the M5 Max tier actually exists to serve. (Pattern is identical to #279's `--flash-attn`/`--mlock`/`--threads` plumbing — defaults that were OK in dev, wrong in production.)

## What changed

- **`OMLXExecutor`**: new `startupTimeout` field, `SetStartupTimeout(d)` setter, `DefaultOMLXStartupTimeout = 120 * time.Second`. Used in `ensureOMLXRunning`'s `waitForHealthy` call.
- **`MetalExecutor`**: same — new field, setter, `DefaultLlamaServerStartupTimeout = 120 * time.Second`. Used in `StartProcess`'s `waitForHealthy`.
- **Error messages updated**: both now include the actual timeout value (e.g. `"failed to become healthy after 120s"`) so operators can tell at a glance which knob to turn when a startup genuinely fails.
- **`MetalAgentConfig`** grows two fields plumbed end-to-end:
  - `LlamaServerStartupTimeout time.Duration`
  - `OMLXStartupTimeout time.Duration`
- **`cmd/metal-agent`** adds two CLI flags, both defaulting to 120s:
  - `--llama-server-startup-timeout`
  - `--omlx-startup-timeout`
- **Unit tests** for both setters covering default, override, and non-positive coercion (same pattern as #328's `SetPollInterval` and `SetMaxConsecutiveFailures`).

## Why bundled

Both bugs are the same architectural mistake (default-too-aggressive constant for spawned-process health check) and would have been one mental commit anyway. Reviewing them together is faster than splitting into two PRs.

## Test plan

- [x] `go test ./pkg/agent/... ./cmd/metal-agent/...` — all green including two new `TestSetStartupTimeout` and `TestOMLXSetStartupTimeout` cases
- [x] `go vet ./...` and full `go build ./...` clean
- [ ] Manual smoke on M5 Max: redeploy MiniMax M2.7 IQ3_S via the agent (now should succeed without manual `llama-server` start) — confirms the Metal executor side
- [ ] Manual smoke: redeploy Qwen3.6-27B MLX 8-bit via the oMLX runtime (which originally surfaced #329) — confirms the oMLX side

## Why now

This weekend's bench session (documented in `llmkube-internal/benchmarks/m5-max-llama-vs-mlx-2026-04-25.md`) hit both timeouts in the same afternoon. We worked around them with manual `llama-server`/`omlx serve` invocations to capture the data, but the operator should be able to manage 80+ GB models without manual intervention — that's the entire point.