### PR TITLE
fix(agent): reconcile orphaned Service+Endpoints on agent startup

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -183,6 +183,17 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 
 	a.registry = NewServiceRegistry(a.config.K8sClient, a.config.HostIP, a.logger.With("subsystem", "registry"))
 
+	// Reconcile orphaned Service+Endpoints from prior agent sessions. The
+	// watcher's `seen` map starts fresh each Watch() call, so InferenceServices
+	// deleted while the agent was down don't trigger the cleanup path. This
+	// pass closes that gap by treating the agent-managed-by label as the
+	// authoritative inventory and cross-checking each Service against the API.
+	if cleaned, err := a.registry.ReconcileOrphanEndpoints(ctx, a.config.Namespace); err != nil {
+		a.logger.Warnw("orphan endpoint reconciliation failed", "error", err)
+	} else if cleaned > 0 {
+		a.logger.Infow("cleaned up orphaned endpoints from prior sessions", "count", cleaned)
+	}
+
 	// Start health server. An unexpected exit here (port binding lost,
 	// listener crashed) is fatal — the management plane is how operators
 	// observe and recover the agent, so running blind is worse than

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -193,6 +194,92 @@ func (r *ServiceRegistry) UnregisterEndpoint(ctx context.Context, namespace, nam
 	}
 
 	return nil
+}
+
+// ReconcileOrphanEndpoints scans all Service objects labeled as managed by
+// this agent and removes any whose corresponding InferenceService no longer
+// exists. Intended to be called once at agent startup to clean up state left
+// behind when the agent was down at the time an InferenceService was deleted.
+//
+// Why this is needed: the InferenceServiceWatcher only emits DELETED events
+// for resources it observed in its *current* session — its `seen` map is
+// reinitialized on each Watch() call. If a user deletes an InferenceService
+// between agent restarts, the new agent session has no record of the prior
+// resource and never invokes the cleanup path, so the K8s Service+Endpoints
+// stay around forever. This reconciler closes that gap by treating the
+// agent-managed-by label as the authoritative inventory of "things this
+// agent created" and cross-checking each one against the live API.
+//
+// Returns the number of orphan endpoints actually cleaned. Errors looking up
+// any individual InferenceService are logged and skipped so one transient
+// failure doesn't block cleanup of unrelated orphans.
+func (r *ServiceRegistry) ReconcileOrphanEndpoints(ctx context.Context, namespace string) (int, error) {
+	services := &corev1.ServiceList{}
+	opts := []client.ListOption{
+		client.MatchingLabels{"llmkube.ai/managed-by": "metal-agent"},
+	}
+	if namespace != "" {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	if err := r.client.List(ctx, services, opts...); err != nil {
+		return 0, fmt.Errorf("list managed services: %w", err)
+	}
+
+	cleaned := 0
+	for i := range services.Items {
+		svc := &services.Items[i]
+		isvcName := svc.Labels["llmkube.ai/inference-service"]
+		if isvcName == "" {
+			// Service is labeled managed-by us but missing the
+			// inference-service label — should never happen given how
+			// RegisterEndpoint stamps both, but skip rather than
+			// guess at an owner.
+			r.logger.Warnw(
+				"managed service missing inference-service label, skipping reconcile",
+				"namespace", svc.Namespace,
+				"service", svc.Name,
+			)
+			continue
+		}
+
+		isvc := &inferencev1alpha1.InferenceService{}
+		err := r.client.Get(ctx, types.NamespacedName{
+			Namespace: svc.Namespace,
+			Name:      isvcName,
+		}, isvc)
+		if err == nil {
+			// InferenceService still exists — leave the Service+Endpoints alone.
+			continue
+		}
+		if !apierrors.IsNotFound(err) {
+			// Something else went wrong looking up the InferenceService;
+			// log and move on. We'd rather leak a Service than delete one
+			// whose owner-status we couldn't verify.
+			r.logger.Warnw("failed to look up InferenceService for managed Service",
+				"namespace", svc.Namespace,
+				"service", svc.Name,
+				"isvc", isvcName,
+				"error", err,
+			)
+			continue
+		}
+
+		r.logger.Infow("cleaning up orphaned managed endpoint",
+			"namespace", svc.Namespace,
+			"service", svc.Name,
+			"isvc", isvcName,
+		)
+		if err := r.UnregisterEndpoint(ctx, svc.Namespace, isvcName); err != nil {
+			r.logger.Warnw("failed to unregister orphan endpoint",
+				"namespace", svc.Namespace,
+				"service", svc.Name,
+				"error", err,
+			)
+			continue
+		}
+		cleaned++
+	}
+	return cleaned, nil
 }
 
 // sanitizeServiceName converts a name to be DNS-1035 compliant

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -299,6 +299,121 @@ func TestUnregisterEndpoint_Idempotent(t *testing.T) {
 	}
 }
 
+func TestReconcileOrphanEndpoints(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	// Live InferenceService whose Service+Endpoints should NOT be cleaned up.
+	liveISVC := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "live-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "live-model"},
+	}
+	liveSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "live-model",
+			Namespace: "default",
+			Labels: map[string]string{
+				"llmkube.ai/managed-by":        "metal-agent",
+				"llmkube.ai/inference-service": "live-model",
+			},
+		},
+	}
+
+	// Orphan: Service exists but no matching InferenceService.
+	orphanSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "orphan-model",
+			Namespace: "default",
+			Labels: map[string]string{
+				"llmkube.ai/managed-by":        "metal-agent",
+				"llmkube.ai/inference-service": "orphan-model",
+			},
+		},
+	}
+	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	orphanEndpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "orphan-model",
+			Namespace: "default",
+			Labels: map[string]string{
+				"llmkube.ai/managed-by":        "metal-agent",
+				"llmkube.ai/inference-service": "orphan-model",
+			},
+		},
+	}
+
+	// Foreign Service that we don't own — must be ignored entirely.
+	foreignSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreign-svc",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "something-else"},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(liveISVC, liveSvc, orphanSvc, orphanEndpoints, foreignSvc).
+		Build()
+
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	cleaned, err := registry.ReconcileOrphanEndpoints(context.Background(), "default")
+	if err != nil {
+		t.Fatalf("ReconcileOrphanEndpoints returned error: %v", err)
+	}
+	if cleaned != 1 {
+		t.Errorf("cleaned = %d, want 1 (only orphan-model should be cleaned)", cleaned)
+	}
+
+	// Live InferenceService's Service must still exist.
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "live-model", Namespace: "default"},
+		&corev1.Service{}); err != nil {
+		t.Errorf("live Service was wrongly deleted: %v", err)
+	}
+
+	// Orphan Service must be gone.
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "orphan-model", Namespace: "default"},
+		&corev1.Service{}); err == nil {
+		t.Error("orphan Service should have been deleted")
+	}
+
+	// Orphan Endpoints must also be gone.
+	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "orphan-model", Namespace: "default"},
+		&corev1.Endpoints{}); err == nil {
+		t.Error("orphan Endpoints should have been deleted")
+	}
+
+	// Foreign Service (not labeled managed-by us) must be untouched.
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "foreign-svc", Namespace: "default"},
+		&corev1.Service{}); err != nil {
+		t.Errorf("foreign Service was wrongly deleted: %v", err)
+	}
+}
+
+func TestReconcileOrphanEndpoints_EmptyCluster(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	cleaned, err := registry.ReconcileOrphanEndpoints(context.Background(), "default")
+	if err != nil {
+		t.Fatalf("ReconcileOrphanEndpoints on empty cluster returned error: %v", err)
+	}
+	if cleaned != 0 {
+		t.Errorf("cleaned = %d, want 0 on empty cluster", cleaned)
+	}
+}
+
 func TestGetHostIP(t *testing.T) {
 	// getHostIP should return a non-empty string regardless of environment
 	ip := getHostIP()


### PR DESCRIPTION
Closes #331.

## Summary

The InferenceServiceWatcher only emits \`DELETED\` events for resources it observed in its **current session** — its \`seen\` map is reinitialized on each \`Watch()\` call. If an InferenceService is deleted while the agent is down, the new agent session never sees the deletion event and the registered Service+Endpoints leak forever.

Caught during this weekend's M5 Max bench session — stale endpoints \`qwen36-27b\` and \`qwen36-27b-mlx\` were still in the cluster hours after their owning InferenceServices were deleted, breaking the \`qwen-local\` helper script that resolves the current llama-server port from the K8s endpoint registration.

## What changed

- **New method \`ServiceRegistry.ReconcileOrphanEndpoints(ctx, namespace)\`**: lists all Services labeled \`llmkube.ai/managed-by=metal-agent\` in the watched namespace, looks up each one's corresponding InferenceService (by the \`llmkube.ai/inference-service\` label which already holds the InferenceService name), and calls the existing \`UnregisterEndpoint\` path for any whose InferenceService no longer exists. Returns the count cleaned for logging.
- **Called once from \`MetalAgent.Start\`** after the registry is initialized but before the watcher takes over. Errors looking up individual InferenceServices are logged and skipped — we'd rather leak a Service than wrongly delete one whose owner-status we couldn't verify.
- **Two new unit tests**:
  - \`TestReconcileOrphanEndpoints\` exercises the full path with one live InferenceService (must not be deleted), one orphan (must be deleted), and one foreign Service we don't own (must be ignored).
  - \`TestReconcileOrphanEndpoints_EmptyCluster\` verifies the no-op case is clean.

This is a standard K8s controller-style reconciliation pattern — treat the agent's own labels as the authoritative inventory of "things this agent created" and reconcile against live API state. Same shape of fix as the watcher hardening from #328.

## Why now

This is the 4th real bug the M5 Max bench week has surfaced (after #279, #328, #329) — every one was \"shipped operator + real workload immediately surfaced X\". Worth landing all four before the Sunday post drops, so the post can credibly cite them as production-discovered rather than CI-discovered.

## Test plan

- [x] \`go test ./pkg/agent/... ./cmd/metal-agent/...\` — all green including the two new \`TestReconcileOrphan*\` cases
- [x] \`go vet ./...\` and full \`go build ./...\` clean
- [ ] Manual smoke on M5 Max after merge: deploy an InferenceService, stop the agent, delete the InferenceService, restart the agent, verify the Service+Endpoints get cleaned up at startup with an \`info\` log line.