### PR TITLE
feat(agent): expose Apple Silicon power gauges via powermetrics

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -63,6 +63,9 @@ type AgentConfig struct {
 	MaxWatchFailures          int
 	LlamaServerStartupTimeout time.Duration
 	OMLXStartupTimeout        time.Duration
+	ApplePowerEnabled         bool
+	ApplePowerInterval        time.Duration
+	PowermetricsBin           string
 }
 
 func parseLogLevel(level string) zapcore.Level {
@@ -174,6 +177,15 @@ func main() {
 		agent.DefaultOMLXStartupTimeout,
 		"How long to wait for the oMLX daemon to become healthy after launching it. "+
 			"First model loads on M-series take 30-90s; default 120s.")
+	flag.BoolVar(&cfg.ApplePowerEnabled, "apple-power-enabled", false,
+		"Enable the macOS powermetrics sampler that publishes apple_power_*_watts gauges "+
+			"for InferCost. Requires a NOPASSWD sudoers entry for /usr/bin/powermetrics; "+
+			"see deployment/macos/sudoers.d/llmkube-powermetrics. Darwin only.")
+	flag.DurationVar(&cfg.ApplePowerInterval, "apple-power-interval",
+		agent.DefaultApplePowerInterval,
+		"powermetrics sampling cadence. Only meaningful with --apple-power-enabled.")
+	flag.StringVar(&cfg.PowermetricsBin, "powermetrics-bin", agent.DefaultPowermetricsBin,
+		"Path to the macOS powermetrics binary. Only used with --apple-power-enabled.")
 	showVersion := flag.Bool("version", false, "Show version information")
 	flag.Parse()
 
@@ -312,6 +324,9 @@ func main() {
 		MaxWatchFailures:          cfg.MaxWatchFailures,
 		LlamaServerStartupTimeout: cfg.LlamaServerStartupTimeout,
 		OMLXStartupTimeout:        cfg.OMLXStartupTimeout,
+		ApplePowerEnabled:         cfg.ApplePowerEnabled,
+		ApplePowerInterval:        cfg.ApplePowerInterval,
+		PowermetricsBin:           cfg.PowermetricsBin,
 	}
 	if cfg.WatchdogInterval > 0 {
 		agentCfg.WatchdogConfig = &agent.MemoryWatchdogConfig{

--- a/deployment/macos/README.md
+++ b/deployment/macos/README.md
@@ -177,14 +177,31 @@ The Metal Agent can publish real-time CPU / GPU / ANE / Combined power gauges so
 
 ### Enable
 
-1. Install the NOPASSWD sudoers fragment so the agent can call `powermetrics` without a password:
+1. Install the NOPASSWD sudoers fragment so the agent can call `powermetrics` without a password. **The shipped fragment pins both the binary path and its argument vector** so the grant is `powermetrics --samplers cpu_power,gpu_power -i <numeric-interval>` only — not `powermetrics --output-file=/wherever`.
 
    ```bash
-   # Replace USERNAME with the user the agent runs as
-   sed "s/USERNAME/$(whoami)/" deployment/macos/sudoers.d/llmkube-powermetrics \
-     | sudo tee /etc/sudoers.d/llmkube-powermetrics > /dev/null
-   sudo chmod 0440 /etc/sudoers.d/llmkube-powermetrics
-   sudo visudo -c -f /etc/sudoers.d/llmkube-powermetrics
+   # Render the placeholder, validate syntax in a tempfile, then atomically
+   # install. visudo -cf will refuse to install a malformed file rather than
+   # leaving sudo broken.
+   TMP=$(mktemp)
+   sed "s/__LLMKUBE_USER__/$(whoami)/" deployment/macos/sudoers.d/llmkube-powermetrics > "$TMP"
+   sudo visudo -cf "$TMP"
+   sudo install -m 0440 -o root -g wheel "$TMP" /etc/sudoers.d/llmkube-powermetrics
+   rm "$TMP"
+   ```
+
+   Verify the grant is scoped as you expect:
+
+   ```bash
+   sudo -ln | grep powermetrics
+   # User <you> may run the following commands on this host:
+   #     (root) NOPASSWD: /usr/bin/powermetrics --samplers cpu_power\,gpu_power -i [0-9]*
+   ```
+
+   To **uninstall**, simply:
+
+   ```bash
+   sudo rm /etc/sudoers.d/llmkube-powermetrics
    ```
 
 2. Add `--apple-power-enabled` to the agent's `ProgramArguments` and reload launchd:

--- a/deployment/macos/README.md
+++ b/deployment/macos/README.md
@@ -171,6 +171,59 @@ To set this in the launchd plist:
     <string>0.75</string>                 <!-- 75% of system memory -->
 ```
 
+## Apple Silicon Power Metrics (for InferCost)
+
+The Metal Agent can publish real-time CPU / GPU / ANE / Combined power gauges sourced from macOS `powermetrics`. These gauges are designed to be scraped by [InferCost](https://github.com/defilantech/infercost) for per-token cost attribution on Apple Silicon (where DCGM doesn't exist). The feature is **disabled by default** because `powermetrics` requires root.
+
+### Enable
+
+1. Install the NOPASSWD sudoers fragment so the agent can call `powermetrics` without a password:
+
+   ```bash
+   # Replace USERNAME with the user the agent runs as
+   sed "s/USERNAME/$(whoami)/" deployment/macos/sudoers.d/llmkube-powermetrics \
+     | sudo tee /etc/sudoers.d/llmkube-powermetrics > /dev/null
+   sudo chmod 0440 /etc/sudoers.d/llmkube-powermetrics
+   sudo visudo -c -f /etc/sudoers.d/llmkube-powermetrics
+   ```
+
+2. Add `--apple-power-enabled` to the agent's `ProgramArguments` and reload launchd:
+
+   ```xml
+       <string>--apple-power-enabled</string>
+   ```
+
+   Then:
+
+   ```bash
+   launchctl unload ~/Library/LaunchAgents/com.llmkube.metal-agent.plist
+   launchctl load ~/Library/LaunchAgents/com.llmkube.metal-agent.plist
+   ```
+
+3. Verify the gauges are populated:
+
+   ```bash
+   curl -s http://localhost:9090/metrics | grep apple_power
+   ```
+
+   With no inference running you'll see ~1-3 W combined; running a model under load drives it to 35-50 W on M-series.
+
+### Gauges exposed
+
+| Metric | Description |
+|--------|-------------|
+| `llmkube_metal_agent_apple_power_combined_watts` | CPU + GPU + ANE package power |
+| `llmkube_metal_agent_apple_power_gpu_watts` | GPU subsystem power |
+| `llmkube_metal_agent_apple_power_cpu_watts` | CPU subsystem power |
+| `llmkube_metal_agent_apple_power_ane_watts` | Apple Neural Engine power (typically 0 for llama.cpp / MLX inference, which uses GPU compute) |
+
+All four gauges read 0 unless `--apple-power-enabled` is set.
+
+### Tuning
+
+- `--apple-power-interval=1s` — sampling cadence; tighter values don't add fidelity because `powermetrics` rounds to whole milliseconds.
+- `--powermetrics-bin=/usr/bin/powermetrics` — override only if you've installed `powermetrics` somewhere non-standard.
+
 ## Health Checks & Monitoring
 
 The Metal Agent exposes an HTTP server on `127.0.0.1:9090` (configurable via `--port`) with health check and Prometheus metrics endpoints. The server binds to localhost only; to expose it for remote Prometheus scraping, use a reverse proxy or SSH tunnel.
@@ -193,6 +246,10 @@ The Metal Agent exposes an HTTP server on `127.0.0.1:9090` (configurable via `--
 | `llmkube_metal_agent_health_check_duration_seconds` | Histogram | Duration of health check probes. Labels: `name`, `namespace` |
 | `llmkube_metal_agent_memory_budget_bytes` | Gauge | Total memory budget for model serving |
 | `llmkube_metal_agent_memory_estimated_bytes` | Gauge | Estimated memory per process. Labels: `name`, `namespace` |
+| `llmkube_metal_agent_apple_power_combined_watts` | Gauge | Combined CPU + GPU + ANE package power. Zero unless `--apple-power-enabled`. |
+| `llmkube_metal_agent_apple_power_gpu_watts` | Gauge | GPU subsystem power. Zero unless `--apple-power-enabled`. |
+| `llmkube_metal_agent_apple_power_cpu_watts` | Gauge | CPU subsystem power. Zero unless `--apple-power-enabled`. |
+| `llmkube_metal_agent_apple_power_ane_watts` | Gauge | Apple Neural Engine power. Zero unless `--apple-power-enabled`. |
 
 Standard Go runtime and process metrics (`go_*`, `process_*`) are also available.
 

--- a/deployment/macos/sudoers.d/llmkube-powermetrics
+++ b/deployment/macos/sudoers.d/llmkube-powermetrics
@@ -1,0 +1,18 @@
+# LLMKube Metal Agent — NOPASSWD sudoers entry for /usr/bin/powermetrics.
+#
+# powermetrics requires root, but the Metal Agent runs as a regular user
+# under launchd. This fragment grants the *minimum* privilege needed: the
+# named user can run only /usr/bin/powermetrics without a password, and
+# nothing else.
+#
+# Install:
+#   sudo cp llmkube-powermetrics /etc/sudoers.d/llmkube-powermetrics
+#   sudo chmod 0440 /etc/sudoers.d/llmkube-powermetrics
+#   sudo visudo -c -f /etc/sudoers.d/llmkube-powermetrics   # syntax check
+#
+# Replace USERNAME below with the user the metal-agent runs as (typically
+# the result of `whoami`). Leaving the placeholder will make sudo refuse
+# the agent's powermetrics calls — the gauges will read zero and the agent
+# will log "powermetrics: failed to start ..." on startup.
+
+USERNAME ALL = (root) NOPASSWD: /usr/bin/powermetrics

--- a/deployment/macos/sudoers.d/llmkube-powermetrics
+++ b/deployment/macos/sudoers.d/llmkube-powermetrics
@@ -2,17 +2,41 @@
 #
 # powermetrics requires root, but the Metal Agent runs as a regular user
 # under launchd. This fragment grants the *minimum* privilege needed: the
-# named user can run only /usr/bin/powermetrics without a password, and
-# nothing else.
+# named user can run /usr/bin/powermetrics with EXACTLY the argument vector
+# the agent uses, and nothing else.
 #
-# Install:
-#   sudo cp llmkube-powermetrics /etc/sudoers.d/llmkube-powermetrics
-#   sudo chmod 0440 /etc/sudoers.d/llmkube-powermetrics
+# SECURITY — argv is pinned, not just the binary
+# ===============================================
+# A common mistake is to grant `NOPASSWD: /usr/bin/powermetrics` (any args).
+# That's a one-line root escalation: powermetrics has --output-file and other
+# flags that, combined with root, give an attacker a write-anywhere primitive
+# (`sudo powermetrics --output-file=/etc/passwd …`). The pinned-argv form
+# below restricts the user to *only* the cpu_power+gpu_power sampler invocation
+# the agent actually needs, with a numeric sampling interval.
+#
+# If you upgrade the agent and powermetrics stops returning data, it likely
+# means the agent's argv changed and this file is now a no-match. Re-install
+# from the latest release.
+#
+# Install
+# -------
+#   sudo install -m 0440 -o root -g wheel \
+#     llmkube-powermetrics /etc/sudoers.d/llmkube-powermetrics
 #   sudo visudo -c -f /etc/sudoers.d/llmkube-powermetrics   # syntax check
 #
-# Replace USERNAME below with the user the metal-agent runs as (typically
-# the result of `whoami`). Leaving the placeholder will make sudo refuse
-# the agent's powermetrics calls — the gauges will read zero and the agent
-# will log "powermetrics: failed to start ..." on startup.
+# Replace __LLMKUBE_USER__ below with the user the metal-agent runs as
+# (typically the result of `whoami` from the user's shell, NOT from a sudo
+# session). Leaving the placeholder will make sudo refuse the agent's
+# powermetrics calls — the gauges will read zero and the agent will log
+# "powermetrics: failed to start ..." on startup.
+#
+# Uninstall
+# ---------
+#   sudo rm /etc/sudoers.d/llmkube-powermetrics
+#
+# Why a separate file under sudoers.d
+# -----------------------------------
+# Keeps the grant out of the main /etc/sudoers and makes uninstall a single
+# `rm`. Owner must be root:wheel and mode 0440 or sudo will refuse the file.
 
-USERNAME ALL = (root) NOPASSWD: /usr/bin/powermetrics
+__LLMKUBE_USER__ ALL = (root) NOPASSWD: /usr/bin/powermetrics --samplers cpu_power\,gpu_power -i [0-9]*

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -256,14 +256,7 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 	// to powermetrics under sudo and publishes the apple_power_*_watts gauges
 	// for InferCost to scrape. Disabled by default because it requires a
 	// NOPASSWD sudoers entry the operator must install explicitly.
-	if a.config.ApplePowerEnabled {
-		sampler := NewApplePowerSampler(
-			a.config.PowermetricsBin,
-			a.config.ApplePowerInterval,
-			a.logger.With("subsystem", "apple-power"),
-		)
-		go sampler.Run(ctx)
-	}
+	a.maybeStartApplePowerSampler(ctx)
 
 	// Start memory watchdog (if configured)
 	if a.config.WatchdogConfig != nil {
@@ -642,6 +635,46 @@ func (a *MetalAgent) reportHealthServerExit(
 	case fatalErrChan <- fmt.Errorf("health server exited unexpectedly: %w", runErr):
 	default:
 	}
+}
+
+// applePowerRunner is the slice of ApplePowerSampler the agent depends on.
+// Defining it as an interface lets tests inject a fake whose Run() is a
+// guaranteed no-op without having to construct a darwin-only struct from a
+// Linux test binary.
+type applePowerRunner interface {
+	Run(ctx context.Context)
+}
+
+// maybeStartApplePowerSampler launches the powermetrics-driven Apple power
+// sampler in a goroutine if the feature is enabled in the agent config. It
+// returns the runner (or nil) so tests can verify wiring without poking into
+// goroutine state. The factory is overridable in tests via
+// applePowerSamplerFactory; in production it's NewApplePowerSampler.
+//
+// Extracted from Start so the conditional + wiring is unit-testable without
+// having to spin up the full agent loop.
+func (a *MetalAgent) maybeStartApplePowerSampler(ctx context.Context) applePowerRunner {
+	if !a.config.ApplePowerEnabled {
+		return nil
+	}
+	sampler := applePowerSamplerFactory(
+		a.config.PowermetricsBin,
+		a.config.ApplePowerInterval,
+		a.logger.With("subsystem", "apple-power"),
+	)
+	go sampler.Run(ctx)
+	return sampler
+}
+
+// applePowerSamplerFactory builds the runner. Defined as a package variable
+// (rather than a direct call to NewApplePowerSampler) so tests can swap in a
+// fake whose Run() is deterministic. Production code never reassigns it. The
+// declared return type is the interface; the production constructor returns
+// *ApplePowerSampler which satisfies it on every platform.
+var applePowerSamplerFactory func(string, time.Duration, *zap.SugaredLogger) applePowerRunner = func(
+	bin string, interval time.Duration, logger *zap.SugaredLogger,
+) applePowerRunner {
+	return NewApplePowerSampler(bin, interval, logger)
 }
 
 func (a *MetalAgent) scheduleRestart(ctx context.Context, name, namespace string) {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -77,6 +77,23 @@ type MetalAgentConfig struct {
 	// (DefaultOMLXStartupTimeout). The original 30s constant was too short
 	// for real M-series hardware.
 	OMLXStartupTimeout time.Duration
+
+	// ApplePowerEnabled launches the powermetrics-driven sampler that
+	// publishes apple_power_*_watts gauges. Defaults false because
+	// powermetrics requires sudo, which the agent reaches via a NOPASSWD
+	// sudoers entry the operator must install explicitly. The gauges feed
+	// InferCost's Apple Silicon per-token cost attribution. Darwin only.
+	ApplePowerEnabled bool
+
+	// ApplePowerInterval is the powermetrics sampling cadence. Zero means
+	// use DefaultApplePowerInterval (1s). Only meaningful when
+	// ApplePowerEnabled is true.
+	ApplePowerInterval time.Duration
+
+	// PowermetricsBin is the path to the macOS powermetrics binary. Empty
+	// means use DefaultPowermetricsBin (/usr/bin/powermetrics). Only used
+	// when ApplePowerEnabled is true.
+	PowermetricsBin string
 }
 
 // MetalAgent watches Kubernetes InferenceService resources and manages
@@ -234,6 +251,19 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		a.logger.With("subsystem", "health-monitor"),
 	)
 	go monitor.Run(ctx)
+
+	// Start Apple Silicon power sampler (if enabled). The sampler shells out
+	// to powermetrics under sudo and publishes the apple_power_*_watts gauges
+	// for InferCost to scrape. Disabled by default because it requires a
+	// NOPASSWD sudoers entry the operator must install explicitly.
+	if a.config.ApplePowerEnabled {
+		sampler := NewApplePowerSampler(
+			a.config.PowermetricsBin,
+			a.config.ApplePowerInterval,
+			a.logger.With("subsystem", "apple-power"),
+		)
+		go sampler.Run(ctx)
+	}
 
 	// Start memory watchdog (if configured)
 	if a.config.WatchdogConfig != nil {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -248,6 +248,95 @@ func TestReportHealthServerExit(t *testing.T) {
 	})
 }
 
+func TestMaybeStartApplePowerSampler_DisabledByDefault(t *testing.T) {
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	a := NewMetalAgent(MetalAgentConfig{
+		K8sClient: k8sClient,
+		Logger:    newNopLogger(),
+		// ApplePowerEnabled defaults false
+	})
+
+	got := a.maybeStartApplePowerSampler(context.Background())
+	if got != nil {
+		t.Errorf("expected nil sampler when ApplePowerEnabled=false, got %#v", got)
+	}
+}
+
+func TestMaybeStartApplePowerSampler_Enabled_LaunchesViaFactory(t *testing.T) {
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Swap the factory for a stub that records its construction arguments and
+	// returns a sampler whose Run() signals it executed. The whole point of
+	// the helper is the wiring between MetalAgentConfig and NewApplePowerSampler;
+	// we exercise that wiring deterministically without forking powermetrics.
+	origFactory := applePowerSamplerFactory
+	t.Cleanup(func() { applePowerSamplerFactory = origFactory })
+
+	type call struct {
+		bin      string
+		interval time.Duration
+	}
+	var got call
+	ranCh := make(chan struct{}, 1)
+	stub := &fakeApplePowerRunner{onRun: func(context.Context) {
+		select {
+		case ranCh <- struct{}{}:
+		default:
+		}
+	}}
+	applePowerSamplerFactory = func(bin string, interval time.Duration, _ *zap.SugaredLogger) applePowerRunner {
+		got = call{bin: bin, interval: interval}
+		return stub
+	}
+
+	a := NewMetalAgent(MetalAgentConfig{
+		K8sClient:          k8sClient,
+		Logger:             newNopLogger(),
+		ApplePowerEnabled:  true,
+		ApplePowerInterval: 2 * time.Second,
+		PowermetricsBin:    "/usr/bin/powermetrics",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	returned := a.maybeStartApplePowerSampler(ctx)
+
+	if returned != stub {
+		t.Errorf("expected helper to return the constructed sampler, got %#v", returned)
+	}
+	if got.bin != "/usr/bin/powermetrics" {
+		t.Errorf("factory bin = %q, want %q", got.bin, "/usr/bin/powermetrics")
+	}
+	if got.interval != 2*time.Second {
+		t.Errorf("factory interval = %v, want %v", got.interval, 2*time.Second)
+	}
+
+	// Also verify Run was actually invoked by the goroutine — without this
+	// check the helper could silently regress to building the sampler but
+	// never starting it, and the missing power data would only surface in
+	// production.
+	select {
+	case <-ranCh:
+	case <-time.After(time.Second):
+		t.Error("sampler.Run was never invoked")
+	}
+}
+
+// fakeApplePowerRunner is a deterministic stand-in for ApplePowerSampler in
+// tests. The real sampler shells out to sudo and would fail or hang in CI; the
+// fake just records that Run was called.
+type fakeApplePowerRunner struct {
+	onRun func(context.Context)
+}
+
+func (f *fakeApplePowerRunner) Run(ctx context.Context) {
+	if f.onRun != nil {
+		f.onRun(ctx)
+	}
+}
+
 func TestRunWatcherLoop_StalledPushesFatal(t *testing.T) {
 	// Build a watcher whose Watch will return ErrWatchStalled on the first
 	// poll cycle. The scriptedListClient pattern from watcher_test.go is

--- a/pkg/agent/agentmetrics.go
+++ b/pkg/agent/agentmetrics.go
@@ -129,6 +129,42 @@ var (
 		},
 		[]string{"subsystem"},
 	)
+
+	// Apple Silicon power gauges. Populated by the powermetrics sampler when
+	// the agent is run with --apple-power-enabled. Zero otherwise. Designed
+	// to be scraped by InferCost's Metal collector for $/MTok cost
+	// attribution on macOS, where DCGM (NVIDIA-only) doesn't exist.
+	// See infercost issue #46 for the cross-repo design.
+	applePowerCombinedWatts = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "llmkube_metal_agent_apple_power_combined_watts",
+			Help: "Combined CPU + GPU + ANE package power in watts from macOS powermetrics. " +
+				"Zero unless the agent is run with --apple-power-enabled and a " +
+				"NOPASSWD sudoers entry for /usr/bin/powermetrics is installed.",
+		},
+	)
+	applePowerGPUWatts = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "llmkube_metal_agent_apple_power_gpu_watts",
+			Help: "GPU subsystem power in watts from macOS powermetrics. " +
+				"Zero unless --apple-power-enabled.",
+		},
+	)
+	applePowerCPUWatts = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "llmkube_metal_agent_apple_power_cpu_watts",
+			Help: "CPU subsystem power in watts from macOS powermetrics. " +
+				"Zero unless --apple-power-enabled.",
+		},
+	)
+	applePowerANEWatts = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "llmkube_metal_agent_apple_power_ane_watts",
+			Help: "Apple Neural Engine power in watts from macOS powermetrics. " +
+				"Zero unless --apple-power-enabled. ANE is typically idle for " +
+				"llama.cpp / Metal LLM inference (which uses GPU compute, not ANE).",
+		},
+	)
 )
 
 func init() {
@@ -148,5 +184,9 @@ func init() {
 		evictionsTotal,
 		watchConsecutiveFailures,
 		fatalExitsTotal,
+		applePowerCombinedWatts,
+		applePowerGPUWatts,
+		applePowerCPUWatts,
+		applePowerANEWatts,
 	)
 }

--- a/pkg/agent/agentmetrics_test.go
+++ b/pkg/agent/agentmetrics_test.go
@@ -39,6 +39,10 @@ func TestAgentMetricsRegistered(t *testing.T) {
 		{"llmkube_metal_agent_process_rss_bytes", processRSSBytes},
 		{"llmkube_metal_agent_memory_pressure_level", memoryPressureLevelGauge},
 		{"llmkube_metal_agent_evictions_total", evictionsTotal},
+		{"llmkube_metal_agent_apple_power_combined_watts", applePowerCombinedWatts},
+		{"llmkube_metal_agent_apple_power_gpu_watts", applePowerGPUWatts},
+		{"llmkube_metal_agent_apple_power_cpu_watts", applePowerCPUWatts},
+		{"llmkube_metal_agent_apple_power_ane_watts", applePowerANEWatts},
 	}
 
 	for _, c := range collectors {

--- a/pkg/agent/power_darwin.go
+++ b/pkg/agent/power_darwin.go
@@ -1,0 +1,280 @@
+//go:build darwin
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// DefaultPowermetricsBin is the canonical macOS powermetrics binary path. It
+// requires root, which the agent reaches via a NOPASSWD sudoers entry rather
+// than by running as root itself. See deployment/macos/sudoers.d/llmkube-powermetrics.
+const DefaultPowermetricsBin = "/usr/bin/powermetrics"
+
+// DefaultApplePowerInterval is the powermetrics sampling cadence. 1s matches
+// the granularity needed for InferCost to attribute decode-vs-idle power on
+// short bursts; tighter intervals don't add value because powermetrics already
+// rounds to whole milliseconds.
+const DefaultApplePowerInterval = time.Second
+
+// powermetrics emits "<label>: <integer> mW" lines after each sample header.
+// Within one sample the cpu_power section emits CPU/GPU/ANE/Combined and the
+// gpu_power section then emits GPU again — we only update gauges on the
+// *first* occurrence of each label between sample boundaries so the duplicate
+// GPU line in the gpu_power section is ignored.
+var (
+	powerSampleHeaderRE = regexp.MustCompile(`^\*\*\* Sampled system activity`)
+	powerLineRE         = regexp.MustCompile(
+		`^(CPU Power|GPU Power|ANE Power|Combined Power[^:]*): (\d+) mW`,
+	)
+)
+
+// applePowerSample is one parsed powermetrics window. Watts are floats because
+// powermetrics reports milliwatts as integers and we divide by 1000.
+type applePowerSample struct {
+	CPUWatts      float64
+	GPUWatts      float64
+	ANEWatts      float64
+	CombinedWatts float64
+}
+
+// ApplePowerSampler runs `sudo powermetrics --samplers cpu_power,gpu_power -i
+// <interval>` as a long-lived child process and updates the apple_power_*
+// Prometheus gauges from each emitted sample. Cancel ctx in Run to stop the
+// child cleanly.
+type ApplePowerSampler struct {
+	bin      string
+	interval time.Duration
+	logger   *zap.SugaredLogger
+
+	// commandFactory builds the exec.Cmd. Overridden in tests so the parser
+	// can be exercised without spawning powermetrics.
+	commandFactory func(ctx context.Context, bin string, interval time.Duration) *exec.Cmd
+}
+
+// NewApplePowerSampler constructs a sampler. Empty bin or zero interval fall
+// back to DefaultPowermetricsBin / DefaultApplePowerInterval.
+func NewApplePowerSampler(bin string, interval time.Duration, logger *zap.SugaredLogger) *ApplePowerSampler {
+	if bin == "" {
+		bin = DefaultPowermetricsBin
+	}
+	if interval <= 0 {
+		interval = DefaultApplePowerInterval
+	}
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+	return &ApplePowerSampler{
+		bin:            bin,
+		interval:       interval,
+		logger:         logger,
+		commandFactory: defaultPowermetricsCommand,
+	}
+}
+
+// Run launches powermetrics under sudo and parses its stdout until ctx is
+// cancelled or the child exits. It logs and returns on terminal errors but
+// does not panic the agent — Apple power data is purely additive.
+func (s *ApplePowerSampler) Run(ctx context.Context) {
+	cmd := s.commandFactory(ctx, s.bin, s.interval)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		s.logger.Warnw("apple-power: stdout pipe failed", "error", err)
+		return
+	}
+	stderrBuf := &strings.Builder{}
+	cmd.Stderr = stderrCapture{w: stderrBuf, max: 4096}
+
+	if err := cmd.Start(); err != nil {
+		s.logger.Warnw("apple-power: failed to start powermetrics — "+
+			"is the NOPASSWD sudoers entry installed?",
+			"bin", s.bin, "error", err)
+		return
+	}
+	s.logger.Infow("apple-power: sampling started",
+		"bin", s.bin, "interval", s.interval, "pid", cmd.Process.Pid)
+
+	parseDone := make(chan struct{})
+	go func() {
+		defer close(parseDone)
+		if perr := parsePowermetricsStream(stdout, applyPowerSample); perr != nil {
+			s.logger.Warnw("apple-power: parser error", "error", perr)
+		}
+	}()
+
+	// Wait for either ctx cancellation or the powermetrics child to exit on
+	// its own. On cancellation we send SIGTERM to give powermetrics a chance
+	// to flush its sampler before the parent reaps it.
+	select {
+	case <-ctx.Done():
+		if cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+		}
+	case <-parseDone:
+	}
+
+	waitErr := cmd.Wait()
+	<-parseDone
+	if waitErr != nil && ctx.Err() == nil {
+		s.logger.Warnw("apple-power: powermetrics exited unexpectedly",
+			"error", waitErr, "stderr", strings.TrimSpace(stderrBuf.String()))
+	} else {
+		s.logger.Infow("apple-power: sampling stopped")
+	}
+}
+
+// applyPowerSample writes a parsed sample into the Prometheus gauges. Split
+// out so parsePowermetricsStream is testable without touching real metrics.
+func applyPowerSample(s applePowerSample) {
+	applePowerCPUWatts.Set(s.CPUWatts)
+	applePowerGPUWatts.Set(s.GPUWatts)
+	applePowerANEWatts.Set(s.ANEWatts)
+	applePowerCombinedWatts.Set(s.CombinedWatts)
+}
+
+// parsePowermetricsStream reads powermetrics text output line by line, builds
+// one applePowerSample per sample-header boundary, and invokes emit when the
+// sample's Combined Power line is seen. It returns when r reaches EOF or
+// errors. Designed to be driven from a goroutine; never panics on malformed
+// input.
+func parsePowermetricsStream(r io.Reader, emit func(applePowerSample)) error {
+	scanner := bufio.NewScanner(r)
+	// powermetrics emits very long CPU-frequency lines (~2-4 KB). Bump the
+	// buffer past the bufio default so we don't truncate mid-sample.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		current  applePowerSample
+		seenCPU  bool
+		seenGPU  bool
+		seenANE  bool
+		seenComb bool
+		inSample bool
+	)
+
+	resetSample := func() {
+		current = applePowerSample{}
+		seenCPU, seenGPU, seenANE, seenComb = false, false, false, false
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if powerSampleHeaderRE.MatchString(line) {
+			// New sample boundary. Emit the previous sample only if we got
+			// the Combined Power reading — anything less is a partial parse
+			// and would publish stale zeros.
+			if inSample && seenComb {
+				emit(current)
+			}
+			resetSample()
+			inSample = true
+			continue
+		}
+		if !inSample {
+			continue
+		}
+		m := powerLineRE.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		mw, err := strconv.Atoi(m[2])
+		if err != nil {
+			continue
+		}
+		watts := float64(mw) / 1000.0
+		switch {
+		case strings.HasPrefix(m[1], "CPU Power"):
+			if !seenCPU {
+				current.CPUWatts = watts
+				seenCPU = true
+			}
+		case strings.HasPrefix(m[1], "GPU Power"):
+			if !seenGPU {
+				current.GPUWatts = watts
+				seenGPU = true
+			}
+		case strings.HasPrefix(m[1], "ANE Power"):
+			if !seenANE {
+				current.ANEWatts = watts
+				seenANE = true
+			}
+		case strings.HasPrefix(m[1], "Combined Power"):
+			if !seenComb {
+				current.CombinedWatts = watts
+				seenComb = true
+			}
+		}
+	}
+
+	// Flush final sample on EOF.
+	if inSample && seenComb {
+		emit(current)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("powermetrics scanner: %w", err)
+	}
+	return nil
+}
+
+// defaultPowermetricsCommand builds the actual sudo invocation. Split out so
+// tests can swap in a fixture-replay command.
+func defaultPowermetricsCommand(ctx context.Context, bin string, interval time.Duration) *exec.Cmd {
+	intervalMS := int(interval / time.Millisecond)
+	if intervalMS < 100 {
+		intervalMS = 100
+	}
+	return exec.CommandContext(ctx,
+		"sudo", "-n", bin,
+		"--samplers", "cpu_power,gpu_power",
+		"-i", strconv.Itoa(intervalMS),
+	)
+}
+
+// stderrCapture is an io.Writer that retains at most max bytes of stderr,
+// useful for surfacing the actual sudo/powermetrics failure reason in logs
+// without unbounded memory growth.
+type stderrCapture struct {
+	w   *strings.Builder
+	max int
+}
+
+func (c stderrCapture) Write(p []byte) (int, error) {
+	remaining := c.max - c.w.Len()
+	if remaining <= 0 {
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		c.w.Write(p[:remaining])
+	} else {
+		c.w.Write(p)
+	}
+	return len(p), nil
+}

--- a/pkg/agent/power_darwin.go
+++ b/pkg/agent/power_darwin.go
@@ -74,6 +74,11 @@ type ApplePowerSampler struct {
 	interval time.Duration
 	logger   *zap.SugaredLogger
 
+	// disabled is true when NewApplePowerSampler refused to construct a real
+	// sampler (e.g. because --powermetrics-bin was overridden). Run becomes a
+	// no-op so the agent keeps running without power data rather than crashing.
+	disabled bool
+
 	// commandFactory builds the exec.Cmd. Overridden in tests so the parser
 	// can be exercised without spawning powermetrics.
 	commandFactory func(ctx context.Context, bin string, interval time.Duration) *exec.Cmd
@@ -81,15 +86,30 @@ type ApplePowerSampler struct {
 
 // NewApplePowerSampler constructs a sampler. Empty bin or zero interval fall
 // back to DefaultPowermetricsBin / DefaultApplePowerInterval.
+//
+// SECURITY: bin is locked to DefaultPowermetricsBin. The shipped sudoers entry
+// grants NOPASSWD only for that exact path; allowing an arbitrary --powermetrics-bin
+// would let an operator point the agent at a binary the sudoers spec doesn't
+// match (silently broken, no power data) — or worse, line up a path that
+// happens to match a future, looser sudoers rule. We refuse to construct a
+// real sampler when bin diverges and return a no-op instead so the agent keeps
+// running without power data rather than failing closed.
 func NewApplePowerSampler(bin string, interval time.Duration, logger *zap.SugaredLogger) *ApplePowerSampler {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
 	if bin == "" {
 		bin = DefaultPowermetricsBin
 	}
+	if bin != DefaultPowermetricsBin {
+		logger.Warnw("apple-power: refusing to launch with non-default powermetrics bin — "+
+			"the shipped sudoers entry is pinned to "+DefaultPowermetricsBin+
+			"; remove --powermetrics-bin or rebuild from source if you really need a different path",
+			"requestedBin", bin, "expectedBin", DefaultPowermetricsBin)
+		return &ApplePowerSampler{disabled: true, logger: logger}
+	}
 	if interval <= 0 {
 		interval = DefaultApplePowerInterval
-	}
-	if logger == nil {
-		logger = zap.NewNop().Sugar()
 	}
 	return &ApplePowerSampler{
 		bin:            bin,
@@ -103,6 +123,10 @@ func NewApplePowerSampler(bin string, interval time.Duration, logger *zap.Sugare
 // cancelled or the child exits. It logs and returns on terminal errors but
 // does not panic the agent — Apple power data is purely additive.
 func (s *ApplePowerSampler) Run(ctx context.Context) {
+	if s.disabled {
+		s.logger.Infow("apple-power: sampler disabled (see prior warning); skipping")
+		return
+	}
 	cmd := s.commandFactory(ctx, s.bin, s.interval)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -244,15 +268,26 @@ func parsePowermetricsStream(r io.Reader, emit func(applePowerSample)) error {
 	return nil
 }
 
+// defaultSudoBin is the absolute path to sudo. Hard-coded so a $PATH attacker
+// can't substitute their own sudo wrapper to capture the (root) NOPASSWD
+// invocation. macOS ships sudo at /usr/bin/sudo and SIP keeps it there.
+const defaultSudoBin = "/usr/bin/sudo"
+
 // defaultPowermetricsCommand builds the actual sudo invocation. Split out so
 // tests can swap in a fixture-replay command.
+//
+// SECURITY: the argv emitted here is what the shipped sudoers fragment is
+// pinned to. If you change flags, update deployment/macos/sudoers.d/llmkube-powermetrics
+// in lockstep — and the regression test in power_darwin_test.go that asserts
+// the two stay in sync — or the agent will silently lose power data after
+// upgrade because sudoers will no longer match the new argv.
 func defaultPowermetricsCommand(ctx context.Context, bin string, interval time.Duration) *exec.Cmd {
 	intervalMS := int(interval / time.Millisecond)
 	if intervalMS < 100 {
 		intervalMS = 100
 	}
 	return exec.CommandContext(ctx,
-		"sudo", "-n", bin,
+		defaultSudoBin, "-n", bin,
 		"--samplers", "cpu_power,gpu_power",
 		"-i", strconv.Itoa(intervalMS),
 	)

--- a/pkg/agent/power_darwin_test.go
+++ b/pkg/agent/power_darwin_test.go
@@ -1,0 +1,150 @@
+//go:build darwin
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParsePowermetricsStream_Fixture(t *testing.T) {
+	f, err := os.Open("testdata/powermetrics_sample.txt")
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var samples []applePowerSample
+	if err := parsePowermetricsStream(f, func(s applePowerSample) {
+		samples = append(samples, s)
+	}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if len(samples) == 0 {
+		t.Fatal("expected at least one sample, got 0")
+	}
+
+	for i, s := range samples {
+		if s.CombinedWatts <= 0 {
+			t.Errorf("sample %d: CombinedWatts %.3f, want >0", i, s.CombinedWatts)
+		}
+		// Combined Power = CPU + GPU + ANE per powermetrics docs. Allow 50 mW
+		// rounding slop because powermetrics rounds each component to whole
+		// milliwatts independently.
+		sum := s.CPUWatts + s.GPUWatts + s.ANEWatts
+		if diff := s.CombinedWatts - sum; diff > 0.05 || diff < -0.05 {
+			t.Errorf("sample %d: combined %.3f != cpu+gpu+ane %.3f", i, s.CombinedWatts, sum)
+		}
+		if s.CPUWatts < 0 || s.GPUWatts < 0 || s.ANEWatts < 0 {
+			t.Errorf("sample %d: negative component: cpu=%.3f gpu=%.3f ane=%.3f",
+				i, s.CPUWatts, s.GPUWatts, s.ANEWatts)
+		}
+	}
+}
+
+// TestParsePowermetricsStream_DuplicateGPULineIgnored guards the behaviour
+// described in power_darwin.go: powermetrics emits "GPU Power: <n> mW" twice
+// per sample (once in cpu_power, once in gpu_power) and the parser must take
+// the first occurrence so the value matches what was summed into Combined.
+func TestParsePowermetricsStream_DuplicateGPULineIgnored(t *testing.T) {
+	input := strings.Join([]string{
+		"*** Sampled system activity (header)",
+		"CPU Power: 100 mW",
+		"GPU Power: 50 mW",
+		"ANE Power: 0 mW",
+		"Combined Power (CPU + GPU + ANE): 150 mW",
+		"GPU Power: 9999 mW", // duplicate from the gpu_power section
+		"",
+	}, "\n")
+
+	var got []applePowerSample
+	if err := parsePowermetricsStream(strings.NewReader(input), func(s applePowerSample) {
+		got = append(got, s)
+	}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("want 1 sample, got %d", len(got))
+	}
+	if got[0].GPUWatts != 0.05 {
+		t.Errorf("want GPUWatts 0.05 (first occurrence), got %.3f", got[0].GPUWatts)
+	}
+	if got[0].CombinedWatts != 0.15 {
+		t.Errorf("want CombinedWatts 0.15, got %.3f", got[0].CombinedWatts)
+	}
+}
+
+// TestParsePowermetricsStream_PartialSampleNotEmitted ensures that a sample
+// missing its Combined Power line never emits — partial parses would publish
+// stale-zero gauges and corrupt InferCost's per-token math.
+func TestParsePowermetricsStream_PartialSampleNotEmitted(t *testing.T) {
+	input := strings.Join([]string{
+		"*** Sampled system activity (header 1)",
+		"CPU Power: 100 mW",
+		"GPU Power: 50 mW",
+		// no ANE, no Combined — process killed mid-write
+		"*** Sampled system activity (header 2)",
+		"CPU Power: 200 mW",
+		"GPU Power: 80 mW",
+		"ANE Power: 0 mW",
+		"Combined Power (CPU + GPU + ANE): 280 mW",
+		"",
+	}, "\n")
+
+	var got []applePowerSample
+	if err := parsePowermetricsStream(strings.NewReader(input), func(s applePowerSample) {
+		got = append(got, s)
+	}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("want 1 sample (only the complete one), got %d", len(got))
+	}
+	if got[0].CombinedWatts != 0.28 {
+		t.Errorf("want CombinedWatts 0.28, got %.3f", got[0].CombinedWatts)
+	}
+}
+
+func TestStderrCapture_TruncatesAtMax(t *testing.T) {
+	var sb strings.Builder
+	c := stderrCapture{w: &sb, max: 10}
+	n, err := c.Write([]byte("12345"))
+	if err != nil || n != 5 {
+		t.Fatalf("first write: n=%d err=%v", n, err)
+	}
+	n, err = c.Write([]byte("67890ABCDE"))
+	if err != nil || n != 10 {
+		t.Fatalf("second write: n=%d err=%v", n, err)
+	}
+	if got := sb.String(); got != "1234567890" {
+		t.Errorf("captured %q, want %q", got, "1234567890")
+	}
+	// Further writes are silently swallowed.
+	n, err = c.Write([]byte("XYZ"))
+	if err != nil || n != 3 {
+		t.Fatalf("post-cap write: n=%d err=%v", n, err)
+	}
+	if got := sb.String(); got != "1234567890" {
+		t.Errorf("after overflow %q, want %q", got, "1234567890")
+	}
+}

--- a/pkg/agent/power_darwin_test.go
+++ b/pkg/agent/power_darwin_test.go
@@ -19,9 +19,15 @@ limitations under the License.
 package agent
 
 import (
+	"bufio"
+	"context"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
+
+	"go.uber.org/zap"
 )
 
 func TestParsePowermetricsStream_Fixture(t *testing.T) {
@@ -123,6 +129,106 @@ func TestParsePowermetricsStream_PartialSampleNotEmitted(t *testing.T) {
 	if got[0].CombinedWatts != 0.28 {
 		t.Errorf("want CombinedWatts 0.28, got %.3f", got[0].CombinedWatts)
 	}
+}
+
+// TestDefaultPowermetricsCommand_MatchesSudoersSpec is the regression guard
+// that keeps the agent's argv aligned with the shipped sudoers fragment.
+// If you change defaultPowermetricsCommand without updating
+// deployment/macos/sudoers.d/llmkube-powermetrics, this test will fail —
+// preventing a release where the gauges silently stop publishing because
+// sudo refuses the new argv.
+func TestDefaultPowermetricsCommand_MatchesSudoersSpec(t *testing.T) {
+	cmd := defaultPowermetricsCommand(context.Background(), DefaultPowermetricsBin, time.Second)
+
+	// argv[0] must be absolute /usr/bin/sudo so a $PATH attacker can't
+	// substitute their own sudo wrapper to capture our (root) NOPASSWD call.
+	if cmd.Path != defaultSudoBin {
+		t.Errorf("sudo path = %q, want %q", cmd.Path, defaultSudoBin)
+	}
+	wantArgs := []string{
+		defaultSudoBin, "-n",
+		DefaultPowermetricsBin,
+		"--samplers", "cpu_power,gpu_power",
+		"-i", "1000",
+	}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("argv = %v (len %d), want %v (len %d)",
+			cmd.Args, len(cmd.Args), wantArgs, len(wantArgs))
+	}
+	for i, want := range wantArgs {
+		if cmd.Args[i] != want {
+			t.Errorf("argv[%d] = %q, want %q", i, cmd.Args[i], want)
+		}
+	}
+
+	// Cross-check against the actual sudoers fragment we ship. Strip the
+	// `User Host = (root) NOPASSWD:` prefix and what's left must match the
+	// post-binary portion of our argv with the dynamic interval rendered.
+	specPattern := readShippedSudoersSpec(t)
+	postBinary := strings.Join(cmd.Args[3:], " ") // drop sudo, -n, /usr/bin/powermetrics
+	// sudoers escapes the comma in cpu_power\,gpu_power; strip the backslash
+	// before matching against the rendered argv.
+	specPattern = strings.ReplaceAll(specPattern, `\,`, ",")
+	// "[0-9]*" in the sudoers spec is shell-glob, not regex. Translate.
+	regexPattern := "^" + strings.ReplaceAll(regexp.QuoteMeta(specPattern), `\[0-9\]\*`, `[0-9]+`) + "$"
+	if !regexp.MustCompile(regexPattern).MatchString(postBinary) {
+		t.Errorf("agent argv %q does not satisfy shipped sudoers spec %q (regex %q)",
+			postBinary, specPattern, regexPattern)
+	}
+}
+
+// TestNewApplePowerSampler_RejectsNonDefaultBin guards H-2 from the security
+// audit: the --powermetrics-bin override flag must not produce a working
+// sampler against a path the shipped sudoers entry doesn't match.
+func TestNewApplePowerSampler_RejectsNonDefaultBin(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	s := NewApplePowerSampler("/tmp/not-the-real-powermetrics", time.Second, logger)
+	if !s.disabled {
+		t.Fatal("expected sampler to be disabled when bin diverges from default")
+	}
+	// Run must be a fast no-op — if the disable check is missed it would try
+	// to fork sudo, which we definitely don't want in unit tests.
+	done := make(chan struct{})
+	go func() {
+		s.Run(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("disabled sampler Run did not return promptly")
+	}
+}
+
+// readShippedSudoersSpec extracts the actual command-spec from the file we
+// ship at deployment/macos/sudoers.d/llmkube-powermetrics. Skipping comments
+// and the user/host preamble, we keep just what comes after `NOPASSWD:`.
+func readShippedSudoersSpec(t *testing.T) string {
+	t.Helper()
+	const path = "../../deployment/macos/sudoers.d/llmkube-powermetrics"
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open shipped sudoers fragment %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.Index(line, "NOPASSWD:")
+		if idx < 0 {
+			continue
+		}
+		spec := strings.TrimSpace(line[idx+len("NOPASSWD:"):])
+		// Drop the binary path itself; we only need the arg portion.
+		spec = strings.TrimPrefix(spec, DefaultPowermetricsBin+" ")
+		return spec
+	}
+	t.Fatalf("no NOPASSWD line found in %s", path)
+	return ""
 }
 
 func TestStderrCapture_TruncatesAtMax(t *testing.T) {

--- a/pkg/agent/power_other.go
+++ b/pkg/agent/power_other.go
@@ -1,0 +1,49 @@
+//go:build !darwin
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// DefaultPowermetricsBin keeps the symbol available cross-platform so cmd/
+// can reference it in flag defaults without build tags. It has no meaning on
+// non-Darwin systems.
+const DefaultPowermetricsBin = "/usr/bin/powermetrics"
+
+// DefaultApplePowerInterval mirrors the Darwin constant for cross-platform
+// flag defaults. powermetrics doesn't exist outside macOS.
+const DefaultApplePowerInterval = time.Second
+
+// ApplePowerSampler is a no-op stub for non-Darwin builds. The Metal agent
+// only runs in production on macOS, but the package compiles cross-platform
+// so unit tests can run in CI on Linux.
+type ApplePowerSampler struct{}
+
+// NewApplePowerSampler returns a no-op sampler on non-Darwin.
+func NewApplePowerSampler(_ string, _ time.Duration, _ *zap.SugaredLogger) *ApplePowerSampler {
+	return &ApplePowerSampler{}
+}
+
+// Run returns immediately on non-Darwin builds. Apple power data is only
+// available via macOS powermetrics.
+func (s *ApplePowerSampler) Run(_ context.Context) {}

--- a/pkg/agent/power_other_test.go
+++ b/pkg/agent/power_other_test.go
@@ -1,0 +1,50 @@
+//go:build !darwin
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TestApplePowerSampler_OtherIsNoOp guards the cross-platform contract: on
+// non-Darwin builds the sampler must construct cleanly, satisfy the runner
+// interface, and exit Run promptly without doing any work. CI runs on Linux
+// and would silently lose the build-tag gate if power_other.go were ever
+// removed or changed to call into Darwin-only code.
+func TestApplePowerSampler_OtherIsNoOp(t *testing.T) {
+	s := NewApplePowerSampler("/anything/at/all", 5*time.Second, zap.NewNop().Sugar())
+	if s == nil {
+		t.Fatal("NewApplePowerSampler returned nil on non-darwin")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.Run(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return promptly on non-darwin (should be a no-op)")
+	}
+}

--- a/pkg/agent/testdata/powermetrics_sample.txt
+++ b/pkg/agent/testdata/powermetrics_sample.txt
@@ -1,0 +1,800 @@
+Machine model: Mac17,6
+OS version: 25E253
+Boot arguments: 
+Boot time: Fri Apr 24 11:07:27 2026
+
+
+
+*** Sampled system activity (Sat Apr 25 10:34:37 2026 -0700) (1018.73ms elapsed) ***
+
+
+**** Processor usage ****
+
+P0-Cluster HW active frequency: 1472 MHz
+P0-Cluster HW active residency:  30.36% (1344 MHz:  25% 1644 MHz: .94% 1992 MHz: 1.8% 2304 MHz: 1.9% 2652 MHz: .18% 2964 MHz:   0% 3240 MHz: .17% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P0-Cluster idle residency:  69.64%
+P0-Cluster down residency:   0.00%
+CPU 0 frequency: 1519 MHz
+CPU 0 active residency:  14.79% (1344 MHz:  11% 1644 MHz: .50% 1992 MHz: 1.2% 2304 MHz: 1.5% 2652 MHz: .07% 2964 MHz:   0% 3240 MHz: .06% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 0 idle residency:  85.21%
+CPU 0 down residency:   0.00%
+CPU 1 frequency: 1460 MHz
+CPU 1 active residency:   9.70% (1344 MHz: 8.3% 1644 MHz: .22% 1992 MHz: .60% 2304 MHz: .44% 2652 MHz: .14% 2964 MHz:   0% 3240 MHz: .04% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 1 idle residency:  90.30%
+CPU 1 down residency:   0.00%
+CPU 2 frequency: 1480 MHz
+CPU 2 active residency:   6.34% (1344 MHz: 5.3% 1644 MHz: .10% 1992 MHz: .45% 2304 MHz: .41% 2652 MHz: .04% 2964 MHz:   0% 3240 MHz: .05% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 2 idle residency:  93.66%
+CPU 2 down residency:   0.00%
+CPU 3 frequency: 1484 MHz
+CPU 3 active residency:   6.40% (1344 MHz: 5.1% 1644 MHz: .44% 1992 MHz: .41% 2304 MHz: .39% 2652 MHz: .02% 2964 MHz:   0% 3240 MHz: .05% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 3 idle residency:  93.60%
+CPU 3 down residency:   0.00%
+CPU 4 frequency: 1490 MHz
+CPU 4 active residency:   3.89% (1344 MHz: 3.2% 1644 MHz: .11% 1992 MHz: .32% 2304 MHz: .19% 2652 MHz: .02% 2964 MHz:   0% 3240 MHz: .06% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 4 idle residency:  96.11%
+CPU 4 down residency:   0.00%
+CPU 5 frequency: 1496 MHz
+CPU 5 active residency:   3.55% (1344 MHz: 2.9% 1644 MHz: .03% 1992 MHz: .39% 2304 MHz: .24% 2652 MHz: .03% 2964 MHz:   0% 3240 MHz: .00% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 5 idle residency:  96.45%
+CPU 5 down residency:   0.00%
+
+P1-Cluster HW active frequency: 0 MHz
+P1-Cluster HW active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P1-Cluster idle residency:   0.00%
+P1-Cluster down residency: 100.00%
+CPU 6 frequency: 0 MHz
+CPU 6 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 6 idle residency:   0.00%
+CPU 6 down residency: 100.00%
+CPU 7 frequency: 0 MHz
+CPU 7 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 7 idle residency:   0.00%
+CPU 7 down residency: 100.00%
+CPU 8 frequency: 0 MHz
+CPU 8 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 8 idle residency:   0.00%
+CPU 8 down residency: 100.00%
+CPU 9 frequency: 0 MHz
+CPU 9 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 9 idle residency:   0.00%
+CPU 9 down residency: 100.00%
+CPU 10 frequency: 0 MHz
+CPU 10 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 10 idle residency:   0.00%
+CPU 10 down residency: 100.00%
+CPU 11 frequency: 0 MHz
+CPU 11 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 11 idle residency:   0.00%
+CPU 11 down residency: 100.00%
+
+S-Cluster HW active frequency: 2421 MHz
+S-Cluster HW active residency:   5.18% (1308 MHz: 2.6% 1620 MHz:   0% 1980 MHz: .56% 2292 MHz: .39% 2580 MHz: .09% 2880 MHz: .05% 3180 MHz: .01% 3432 MHz: .05% 3648 MHz: .02% 3828 MHz: .03% 3984 MHz: .01% 4104 MHz: .01% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz: .00% 4308 MHz: .00% 4332 MHz:   0% 4428 MHz: .01% 4512 MHz: .01% 4608 MHz: 1.3%)
+S-Cluster idle residency:  21.18%
+S-Cluster down residency:  73.64%
+CPU 12 frequency: 1828 MHz
+CPU 12 active residency:   0.99% (1308 MHz: .45% 1620 MHz:   0% 1980 MHz: .23% 2292 MHz: .26% 2580 MHz: .03% 2880 MHz: .00% 3180 MHz: .00% 3432 MHz: .00% 3648 MHz: .01% 3828 MHz: .01% 3984 MHz: .00% 4104 MHz: .00% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz: .00% 4512 MHz:   0% 4608 MHz: .01%)
+CPU 12 idle residency:  25.38%
+CPU 12 down residency:  73.63%
+CPU 13 frequency: 1822 MHz
+CPU 13 active residency:   0.52% (1308 MHz: .24% 1620 MHz:   0% 1980 MHz: .15% 2292 MHz: .08% 2580 MHz: .02% 2880 MHz: .00% 3180 MHz: .00% 3432 MHz: .01% 3648 MHz: .00% 3828 MHz: .01% 3984 MHz: .00% 4104 MHz: .00% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz: .00%)
+CPU 13 idle residency:  25.86%
+CPU 13 down residency:  73.63%
+CPU 14 frequency: 1520 MHz
+CPU 14 active residency:   0.29% (1308 MHz: .21% 1620 MHz:   0% 1980 MHz: .07% 2292 MHz: .01% 2580 MHz: .00% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz: .00% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 14 idle residency:  26.08%
+CPU 14 down residency:  73.63%
+CPU 15 frequency: 1341 MHz
+CPU 15 active residency:   0.20% (1308 MHz: .20% 1620 MHz:   0% 1980 MHz:   0% 2292 MHz:   0% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz: .00% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 15 idle residency:  26.17%
+CPU 15 down residency:  73.63%
+CPU 16 frequency: 3639 MHz
+CPU 16 active residency:   0.68% (1308 MHz: .20% 1620 MHz:   0% 1980 MHz:   0% 2292 MHz: .01% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz: .48%)
+CPU 16 idle residency:  25.69%
+CPU 16 down residency:  73.63%
+CPU 17 frequency: 4000 MHz
+CPU 17 active residency:   1.04% (1308 MHz: .19% 1620 MHz:   0% 1980 MHz:   0% 2292 MHz:   0% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz: .84%)
+CPU 17 idle residency:  25.34%
+CPU 17 down residency:  73.63%
+
+CPU Power: 164 mW
+GPU Power: 7 mW
+ANE Power: 0 mW
+Combined Power (CPU + GPU + ANE): 171 mW
+
+**** GPU usage ****
+
+GPU HW active frequency: 338 MHz
+GPU HW active residency:   1.03% (338 MHz: 1.0% 486 MHz:   0% 636 MHz:   0% 796 MHz:   0% 888 MHz:   0% 988 MHz:   0% 1084 MHz:   0% 1182 MHz:   0% 1278 MHz:   0% 1374 MHz:   0% 1470 MHz:   0% 1578 MHz:   0% 1620 MHz:   0%)
+GPU SW requested state: (P1 : 100% P2 :   0% P3 :   0% P4 :   0% P5 :   0% P6 :   0% P7 :   0% P8 :   0% P9 :   0% P10 :   0% P11 :   0% P12 :   0% P13 :   0%)
+GPU idle residency:  98.97%
+GPU Power: 7 mW
+
+
+
+*** Sampled system activity (Sat Apr 25 10:34:38 2026 -0700) (1026.88ms elapsed) ***
+
+
+**** Processor usage ****
+
+P0-Cluster HW active frequency: 1630 MHz
+P0-Cluster HW active residency:  55.69% (1344 MHz:  35% 1644 MHz: 4.7% 1992 MHz: 5.3% 2304 MHz: 8.5% 2652 MHz: 1.6% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .26%)
+P0-Cluster idle residency:  44.31%
+P0-Cluster down residency:   0.00%
+CPU 0 frequency: 1660 MHz
+CPU 0 active residency:  26.06% (1344 MHz:  16% 1644 MHz: 2.3% 1992 MHz: 2.4% 2304 MHz: 4.9% 2652 MHz: .94% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .02%)
+CPU 0 idle residency:  73.94%
+CPU 0 down residency:   0.00%
+CPU 1 frequency: 1620 MHz
+CPU 1 active residency:  21.15% (1344 MHz:  13% 1644 MHz: 1.9% 1992 MHz: 1.8% 2304 MHz: 3.5% 2652 MHz: .47% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .04%)
+CPU 1 idle residency:  78.85%
+CPU 1 down residency:   0.00%
+CPU 2 frequency: 1618 MHz
+CPU 2 active residency:  17.21% (1344 MHz:  11% 1644 MHz: 1.8% 1992 MHz: 1.7% 2304 MHz: 2.9% 2652 MHz: .27% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .00%)
+CPU 2 idle residency:  82.79%
+CPU 2 down residency:   0.00%
+CPU 3 frequency: 1628 MHz
+CPU 3 active residency:  15.54% (1344 MHz: 9.9% 1644 MHz: 1.2% 1992 MHz: 1.3% 2304 MHz: 2.6% 2652 MHz: .56% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .00%)
+CPU 3 idle residency:  84.46%
+CPU 3 down residency:   0.00%
+CPU 4 frequency: 1651 MHz
+CPU 4 active residency:  13.60% (1344 MHz: 8.6% 1644 MHz: 1.0% 1992 MHz: 1.3% 2304 MHz: 2.2% 2652 MHz: .38% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .14%)
+CPU 4 idle residency:  86.40%
+CPU 4 down residency:   0.00%
+CPU 5 frequency: 1673 MHz
+CPU 5 active residency:   9.53% (1344 MHz: 5.3% 1644 MHz: .96% 1992 MHz: 1.1% 2304 MHz: 2.0% 2652 MHz: .15% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .00%)
+CPU 5 idle residency:  90.47%
+CPU 5 down residency:   0.00%
+
+P1-Cluster HW active frequency: 0 MHz
+P1-Cluster HW active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P1-Cluster idle residency:   0.00%
+P1-Cluster down residency: 100.00%
+CPU 6 frequency: 0 MHz
+CPU 6 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 6 idle residency:   0.00%
+CPU 6 down residency: 100.00%
+CPU 7 frequency: 0 MHz
+CPU 7 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 7 idle residency:   0.00%
+CPU 7 down residency: 100.00%
+CPU 8 frequency: 0 MHz
+CPU 8 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 8 idle residency:   0.00%
+CPU 8 down residency: 100.00%
+CPU 9 frequency: 0 MHz
+CPU 9 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 9 idle residency:   0.00%
+CPU 9 down residency: 100.00%
+CPU 10 frequency: 0 MHz
+CPU 10 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 10 idle residency:   0.00%
+CPU 10 down residency: 100.00%
+CPU 11 frequency: 0 MHz
+CPU 11 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 11 idle residency:   0.00%
+CPU 11 down residency: 100.00%
+
+S-Cluster HW active frequency: 1963 MHz
+S-Cluster HW active residency:   8.31% (1308 MHz: 4.0% 1620 MHz:   0% 1980 MHz: 2.3% 2292 MHz: .79% 2580 MHz: .41% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz: .01% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz: .05% 4608 MHz: .72%)
+S-Cluster idle residency:  20.82%
+S-Cluster down residency:  70.87%
+CPU 12 frequency: 2046 MHz
+CPU 12 active residency:   0.91% (1308 MHz: .03% 1620 MHz:   0% 1980 MHz: .64% 2292 MHz: .25% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 12 idle residency:  25.70%
+CPU 12 down residency:  73.39%
+CPU 13 frequency: 2111 MHz
+CPU 13 active residency:   0.16% (1308 MHz: .02% 1620 MHz:   0% 1980 MHz: .03% 2292 MHz: .11% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 13 idle residency:  27.62%
+CPU 13 down residency:  72.22%
+CPU 14 frequency: 1594 MHz
+CPU 14 active residency:   0.04% (1308 MHz: .03% 1620 MHz:   0% 1980 MHz: .01% 2292 MHz: .01% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 14 idle residency:  28.16%
+CPU 14 down residency:  71.80%
+CPU 15 frequency: 1308 MHz
+CPU 15 active residency:   0.02% (1308 MHz: .02% 1620 MHz:   0% 1980 MHz:   0% 2292 MHz:   0% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 15 idle residency:  28.26%
+CPU 15 down residency:  71.72%
+CPU 16 frequency: 1308 MHz
+CPU 16 active residency:   0.02% (1308 MHz: .02% 1620 MHz:   0% 1980 MHz:   0% 2292 MHz:   0% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 16 idle residency:  28.27%
+CPU 16 down residency:  71.71%
+CPU 17 frequency: 1308 MHz
+CPU 17 active residency:   0.02% (1308 MHz: .02% 1620 MHz:   0% 1980 MHz:   0% 2292 MHz:   0% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 17 idle residency:  28.27%
+CPU 17 down residency:  71.71%
+
+CPU Power: 406 mW
+GPU Power: 21 mW
+ANE Power: 0 mW
+Combined Power (CPU + GPU + ANE): 428 mW
+
+**** GPU usage ****
+
+GPU HW active frequency: 338 MHz
+GPU HW active residency:   3.67% (338 MHz: 3.7% 486 MHz:   0% 636 MHz:   0% 796 MHz:   0% 888 MHz:   0% 988 MHz:   0% 1084 MHz:   0% 1182 MHz:   0% 1278 MHz:   0% 1374 MHz:   0% 1470 MHz:   0% 1578 MHz:   0% 1620 MHz:   0%)
+GPU SW requested state: (P1 : 100% P2 :   0% P3 :   0% P4 :   0% P5 :   0% P6 :   0% P7 :   0% P8 :   0% P9 :   0% P10 :   0% P11 :   0% P12 :   0% P13 :   0%)
+GPU idle residency:  96.33%
+GPU Power: 21 mW
+
+
+
+*** Sampled system activity (Sat Apr 25 10:34:39 2026 -0700) (1027.05ms elapsed) ***
+
+
+**** Processor usage ****
+
+P0-Cluster HW active frequency: 1784 MHz
+P0-Cluster HW active residency:  41.12% (1344 MHz:  21% 1644 MHz: 2.5% 1992 MHz: 4.7% 2304 MHz: 6.6% 2652 MHz: 6.1% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P0-Cluster idle residency:  58.88%
+P0-Cluster down residency:   0.00%
+CPU 0 frequency: 1832 MHz
+CPU 0 active residency:  19.57% (1344 MHz: 9.0% 1644 MHz: 1.6% 1992 MHz: 2.1% 2304 MHz: 3.9% 2652 MHz: 3.1% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 0 idle residency:  80.43%
+CPU 0 down residency:   0.00%
+CPU 1 frequency: 1817 MHz
+CPU 1 active residency:  14.51% (1344 MHz: 6.9% 1644 MHz: .80% 1992 MHz: 2.2% 2304 MHz: 2.4% 2652 MHz: 2.2% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 1 idle residency:  85.49%
+CPU 1 down residency:   0.00%
+CPU 2 frequency: 1796 MHz
+CPU 2 active residency:  12.57% (1344 MHz: 6.3% 1644 MHz: .70% 1992 MHz: 1.7% 2304 MHz: 2.0% 2652 MHz: 1.8% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 2 idle residency:  87.43%
+CPU 2 down residency:   0.00%
+CPU 3 frequency: 1836 MHz
+CPU 3 active residency:   9.28% (1344 MHz: 4.2% 1644 MHz: .44% 1992 MHz: 1.7% 2304 MHz: 1.5% 2652 MHz: 1.5% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 3 idle residency:  90.72%
+CPU 3 down residency:   0.00%
+CPU 4 frequency: 1840 MHz
+CPU 4 active residency:   7.32% (1344 MHz: 3.2% 1644 MHz: .30% 1992 MHz: 1.4% 2304 MHz: 1.7% 2652 MHz: .80% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 4 idle residency:  92.68%
+CPU 4 down residency:   0.00%
+CPU 5 frequency: 1885 MHz
+CPU 5 active residency:   6.36% (1344 MHz: 2.7% 1644 MHz: .25% 1992 MHz: 1.0% 2304 MHz: 1.4% 2652 MHz: 1.0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 5 idle residency:  93.64%
+CPU 5 down residency:   0.00%
+
+P1-Cluster HW active frequency: 1344 MHz
+P1-Cluster HW active residency:   0.87% (1344 MHz: .87% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P1-Cluster idle residency:   2.00%
+P1-Cluster down residency:  97.13%
+CPU 6 frequency: 0 MHz
+CPU 6 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 6 idle residency:   2.70%
+CPU 6 down residency:  97.30%
+CPU 7 frequency: 0 MHz
+CPU 7 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 7 idle residency:   2.72%
+CPU 7 down residency:  97.28%
+CPU 8 frequency: 0 MHz
+CPU 8 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 8 idle residency:   2.72%
+CPU 8 down residency:  97.28%
+CPU 9 frequency: 0 MHz
+CPU 9 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 9 idle residency:   2.72%
+CPU 9 down residency:  97.28%
+CPU 10 frequency: 0 MHz
+CPU 10 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 10 idle residency:   2.72%
+CPU 10 down residency:  97.28%
+CPU 11 frequency: 0 MHz
+CPU 11 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 11 idle residency:   2.72%
+CPU 11 down residency:  97.28%
+
+S-Cluster HW active frequency: 2076 MHz
+S-Cluster HW active residency:  14.47% (1308 MHz: 4.3% 1620 MHz:   0% 1980 MHz: 4.0% 2292 MHz: 1.8% 2580 MHz: 1.8% 2880 MHz: 1.7% 3180 MHz: .93% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+S-Cluster idle residency:  22.51%
+S-Cluster down residency:  63.02%
+CPU 12 frequency: 2304 MHz
+CPU 12 active residency:   4.44% (1308 MHz: 1.2% 1620 MHz:   0% 1980 MHz: 1.4% 2292 MHz: .87% 2580 MHz: .32% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz: .68%)
+CPU 12 idle residency:  30.68%
+CPU 12 down residency:  64.89%
+CPU 13 frequency: 1704 MHz
+CPU 13 active residency:   1.86% (1308 MHz: 1.1% 1620 MHz:   0% 1980 MHz: .55% 2292 MHz: .05% 2580 MHz: .05% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz: .08%)
+CPU 13 idle residency:  33.83%
+CPU 13 down residency:  64.31%
+CPU 14 frequency: 1396 MHz
+CPU 14 active residency:   1.21% (1308 MHz: 1.1% 1620 MHz:   0% 1980 MHz: .12% 2292 MHz: .00% 2580 MHz: .00% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz: .00%)
+CPU 14 idle residency:  34.53%
+CPU 14 down residency:  64.27%
+CPU 15 frequency: 1317 MHz
+CPU 15 active residency:   1.07% (1308 MHz: 1.1% 1620 MHz:   0% 1980 MHz: .01% 2292 MHz:   0% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz: .00%)
+CPU 15 idle residency:  35.52%
+CPU 15 down residency:  63.41%
+CPU 16 frequency: 1311 MHz
+CPU 16 active residency:   1.06% (1308 MHz: 1.1% 1620 MHz:   0% 1980 MHz: .00% 2292 MHz:   0% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz: .00%)
+CPU 16 idle residency:  35.64%
+CPU 16 down residency:  63.30%
+CPU 17 frequency: 1308 MHz
+CPU 17 active residency:   1.05% (1308 MHz: 1.1% 1620 MHz:   0% 1980 MHz: .00% 2292 MHz:   0% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 17 idle residency:  35.89%
+CPU 17 down residency:  63.06%
+
+CPU Power: 432 mW
+GPU Power: 25 mW
+ANE Power: 0 mW
+Combined Power (CPU + GPU + ANE): 458 mW
+
+**** GPU usage ****
+
+GPU HW active frequency: 338 MHz
+GPU HW active residency:   3.91% (338 MHz: 3.9% 486 MHz:   0% 636 MHz:   0% 796 MHz:   0% 888 MHz:   0% 988 MHz:   0% 1084 MHz:   0% 1182 MHz:   0% 1278 MHz:   0% 1374 MHz:   0% 1470 MHz:   0% 1578 MHz:   0% 1620 MHz:   0%)
+GPU SW requested state: (P1 : 100% P2 :   0% P3 :   0% P4 :   0% P5 :   0% P6 :   0% P7 :   0% P8 :   0% P9 :   0% P10 :   0% P11 :   0% P12 :   0% P13 :   0%)
+GPU idle residency:  96.09%
+GPU Power: 26 mW
+
+
+
+*** Sampled system activity (Sat Apr 25 10:34:40 2026 -0700) (1027.74ms elapsed) ***
+
+
+**** Processor usage ****
+
+P0-Cluster HW active frequency: 1551 MHz
+P0-Cluster HW active residency:  47.13% (1344 MHz:  36% 1644 MHz: 3.2% 1992 MHz: 1.3% 2304 MHz: 3.9% 2652 MHz: 3.2% 2964 MHz: .05% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P0-Cluster idle residency:  52.87%
+P0-Cluster down residency:   0.00%
+CPU 0 frequency: 1557 MHz
+CPU 0 active residency:  16.12% (1344 MHz:  12% 1644 MHz: .91% 1992 MHz: .51% 2304 MHz: 1.4% 2652 MHz: 1.1% 2964 MHz: .03% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 0 idle residency:  83.88%
+CPU 0 down residency:   0.00%
+CPU 1 frequency: 1491 MHz
+CPU 1 active residency:  15.28% (1344 MHz:  12% 1644 MHz: .75% 1992 MHz: .48% 2304 MHz: 1.1% 2652 MHz: .49% 2964 MHz: .01% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 1 idle residency:  84.72%
+CPU 1 down residency:   0.00%
+CPU 2 frequency: 1569 MHz
+CPU 2 active residency:  14.65% (1344 MHz: 9.6% 1644 MHz: 2.5% 1992 MHz: .42% 2304 MHz: 1.4% 2652 MHz: .71% 2964 MHz: .01% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 2 idle residency:  85.35%
+CPU 2 down residency:   0.00%
+CPU 3 frequency: 1609 MHz
+CPU 3 active residency:  19.38% (1344 MHz:  14% 1644 MHz: .78% 1992 MHz: 1.0% 2304 MHz: 2.2% 2652 MHz: 1.6% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 3 idle residency:  80.62%
+CPU 3 down residency:   0.00%
+CPU 4 frequency: 1539 MHz
+CPU 4 active residency:   5.86% (1344 MHz: 4.4% 1644 MHz: .35% 1992 MHz: .18% 2304 MHz: .72% 2652 MHz: .18% 2964 MHz: .00% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 4 idle residency:  94.14%
+CPU 4 down residency:   0.00%
+CPU 5 frequency: 1630 MHz
+CPU 5 active residency:   5.68% (1344 MHz: 4.0% 1644 MHz: .21% 1992 MHz: .17% 2304 MHz: .76% 2652 MHz: .54% 2964 MHz: .01% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 5 idle residency:  94.32%
+CPU 5 down residency:   0.00%
+
+P1-Cluster HW active frequency: 1344 MHz
+P1-Cluster HW active residency:   0.11% (1344 MHz: .11% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P1-Cluster idle residency:   0.66%
+P1-Cluster down residency:  99.23%
+CPU 6 frequency: 0 MHz
+CPU 6 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 6 idle residency:   0.74%
+CPU 6 down residency:  99.26%
+CPU 7 frequency: 0 MHz
+CPU 7 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 7 idle residency:   0.74%
+CPU 7 down residency:  99.26%
+CPU 8 frequency: 0 MHz
+CPU 8 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 8 idle residency:   0.74%
+CPU 8 down residency:  99.26%
+CPU 9 frequency: 0 MHz
+CPU 9 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 9 idle residency:   0.74%
+CPU 9 down residency:  99.26%
+CPU 10 frequency: 0 MHz
+CPU 10 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 10 idle residency:   0.74%
+CPU 10 down residency:  99.26%
+CPU 11 frequency: 0 MHz
+CPU 11 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 11 idle residency:   0.74%
+CPU 11 down residency:  99.26%
+
+S-Cluster HW active frequency: 1889 MHz
+S-Cluster HW active residency:  12.19% (1308 MHz: 3.2% 1620 MHz:   0% 1980 MHz: 6.3% 2292 MHz: 2.3% 2580 MHz: .47% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+S-Cluster idle residency:  21.72%
+S-Cluster down residency:  66.09%
+CPU 12 frequency: 2141 MHz
+CPU 12 active residency:  11.18% (1308 MHz: 1.3% 1620 MHz:   0% 1980 MHz: 5.2% 2292 MHz: 2.1% 2580 MHz: 1.6% 2880 MHz: .63% 3180 MHz: .40% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 12 idle residency:  26.48%
+CPU 12 down residency:  62.34%
+CPU 13 frequency: 2064 MHz
+CPU 13 active residency:   6.13% (1308 MHz: 1.2% 1620 MHz:   0% 1980 MHz: 3.1% 2292 MHz: .71% 2580 MHz: .31% 2880 MHz: .34% 3180 MHz: .50% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 13 idle residency:  30.07%
+CPU 13 down residency:  63.81%
+CPU 14 frequency: 2118 MHz
+CPU 14 active residency:   5.54% (1308 MHz: 1.0% 1620 MHz:   0% 1980 MHz: 2.6% 2292 MHz: .55% 2580 MHz: .19% 2880 MHz: .83% 3180 MHz: .35% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 14 idle residency:  30.26%
+CPU 14 down residency:  64.20%
+CPU 15 frequency: 1824 MHz
+CPU 15 active residency:   2.34% (1308 MHz: 1.1% 1620 MHz:   0% 1980 MHz: .85% 2292 MHz: .09% 2580 MHz: .05% 2880 MHz: .10% 3180 MHz: .18% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 15 idle residency:  32.55%
+CPU 15 down residency:  65.10%
+CPU 16 frequency: 1741 MHz
+CPU 16 active residency:   1.62% (1308 MHz: 1.0% 1620 MHz:   0% 1980 MHz: .28% 2292 MHz: .02% 2580 MHz: .16% 2880 MHz: .09% 3180 MHz: .09% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 16 idle residency:  33.16%
+CPU 16 down residency:  65.22%
+CPU 17 frequency: 1490 MHz
+CPU 17 active residency:   1.22% (1308 MHz: 1.0% 1620 MHz:   0% 1980 MHz: .11% 2292 MHz:   0% 2580 MHz: .00% 2880 MHz: .03% 3180 MHz: .05% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 17 idle residency:  33.30%
+CPU 17 down residency:  65.48%
+
+CPU Power: 318 mW
+GPU Power: 38 mW
+ANE Power: 0 mW
+Combined Power (CPU + GPU + ANE): 356 mW
+
+**** GPU usage ****
+
+GPU HW active frequency: 338 MHz
+GPU HW active residency:   4.43% (338 MHz: 4.4% 486 MHz:   0% 636 MHz:   0% 796 MHz:   0% 888 MHz:   0% 988 MHz:   0% 1084 MHz:   0% 1182 MHz:   0% 1278 MHz:   0% 1374 MHz:   0% 1470 MHz:   0% 1578 MHz:   0% 1620 MHz:   0%)
+GPU SW requested state: (P1 : 100% P2 :   0% P3 :   0% P4 :   0% P5 :   0% P6 :   0% P7 :   0% P8 :   0% P9 :   0% P10 :   0% P11 :   0% P12 :   0% P13 :   0%)
+GPU idle residency:  95.57%
+GPU Power: 37 mW
+
+
+
+*** Sampled system activity (Sat Apr 25 10:34:41 2026 -0700) (1024.87ms elapsed) ***
+
+
+**** Processor usage ****
+
+P0-Cluster HW active frequency: 1763 MHz
+P0-Cluster HW active residency:  47.73% (1344 MHz:  21% 1644 MHz: 5.0% 1992 MHz:  12% 2304 MHz: 6.0% 2652 MHz: 3.6% 2964 MHz: .08% 3240 MHz: .00% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P0-Cluster idle residency:  52.27%
+P0-Cluster down residency:   0.00%
+CPU 0 frequency: 1756 MHz
+CPU 0 active residency:  19.70% (1344 MHz: 8.6% 1644 MHz: 1.8% 1992 MHz: 5.3% 2304 MHz: 2.9% 2652 MHz: 1.0% 2964 MHz: .01% 3240 MHz: .00% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 0 idle residency:  80.30%
+CPU 0 down residency:   0.00%
+CPU 1 frequency: 1772 MHz
+CPU 1 active residency:  17.73% (1344 MHz: 7.1% 1644 MHz: 2.3% 1992 MHz: 4.9% 2304 MHz: 2.3% 2652 MHz: 1.2% 2964 MHz: .01% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 1 idle residency:  82.27%
+CPU 1 down residency:   0.00%
+CPU 2 frequency: 1733 MHz
+CPU 2 active residency:  12.64% (1344 MHz: 5.8% 1644 MHz: 1.1% 1992 MHz: 3.6% 2304 MHz: 1.4% 2652 MHz: .68% 2964 MHz: .01% 3240 MHz: .00% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 2 idle residency:  87.36%
+CPU 2 down residency:   0.00%
+CPU 3 frequency: 1850 MHz
+CPU 3 active residency:  11.56% (1344 MHz: 4.2% 1644 MHz: .92% 1992 MHz: 3.4% 2304 MHz: 1.9% 2652 MHz: 1.2% 2964 MHz: .00% 3240 MHz: .00% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 3 idle residency:  88.44%
+CPU 3 down residency:   0.00%
+CPU 4 frequency: 1740 MHz
+CPU 4 active residency:   7.66% (1344 MHz: 3.3% 1644 MHz: 1.1% 1992 MHz: 2.0% 2304 MHz: .95% 2652 MHz: .36% 2964 MHz: .01% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 4 idle residency:  92.34%
+CPU 4 down residency:   0.00%
+CPU 5 frequency: 1751 MHz
+CPU 5 active residency:   6.06% (1344 MHz: 2.8% 1644 MHz: .42% 1992 MHz: 1.7% 2304 MHz: .59% 2652 MHz: .49% 2964 MHz: .01% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 5 idle residency:  93.94%
+CPU 5 down residency:   0.00%
+
+P1-Cluster HW active frequency: 0 MHz
+P1-Cluster HW active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P1-Cluster idle residency:   0.00%
+P1-Cluster down residency: 100.00%
+CPU 6 frequency: 0 MHz
+CPU 6 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 6 idle residency:   0.00%
+CPU 6 down residency: 100.00%
+CPU 7 frequency: 0 MHz
+CPU 7 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 7 idle residency:   0.00%
+CPU 7 down residency: 100.00%
+CPU 8 frequency: 0 MHz
+CPU 8 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 8 idle residency:   0.00%
+CPU 8 down residency: 100.00%
+CPU 9 frequency: 0 MHz
+CPU 9 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 9 idle residency:   0.00%
+CPU 9 down residency: 100.00%
+CPU 10 frequency: 0 MHz
+CPU 10 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 10 idle residency:   0.00%
+CPU 10 down residency: 100.00%
+CPU 11 frequency: 0 MHz
+CPU 11 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 11 idle residency:   0.00%
+CPU 11 down residency: 100.00%
+
+S-Cluster HW active frequency: 1984 MHz
+S-Cluster HW active residency:  26.77% (1308 MHz: 6.6% 1620 MHz:   0% 1980 MHz:  11% 2292 MHz: 4.6% 2580 MHz: 3.0% 2880 MHz: 1.4% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+S-Cluster idle residency:  37.76%
+S-Cluster down residency:  35.46%
+CPU 12 frequency: 2116 MHz
+CPU 12 active residency:  13.15% (1308 MHz: .80% 1620 MHz:   0% 1980 MHz: 7.2% 2292 MHz: 3.0% 2580 MHz: 1.8% 2880 MHz: .37% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 12 idle residency:  51.36%
+CPU 12 down residency:  35.50%
+CPU 13 frequency: 2268 MHz
+CPU 13 active residency:   7.87% (1308 MHz: .55% 1620 MHz:   0% 1980 MHz: 2.3% 2292 MHz: 2.1% 2580 MHz: 2.1% 2880 MHz: .80% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 13 idle residency:  56.64%
+CPU 13 down residency:  35.50%
+CPU 14 frequency: 2161 MHz
+CPU 14 active residency:   6.64% (1308 MHz: .51% 1620 MHz:   0% 1980 MHz: 3.2% 2292 MHz: 1.2% 2580 MHz: 1.5% 2880 MHz: .34% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 14 idle residency:  57.86%
+CPU 14 down residency:  35.50%
+CPU 15 frequency: 1960 MHz
+CPU 15 active residency:   2.06% (1308 MHz: .49% 1620 MHz:   0% 1980 MHz: .97% 2292 MHz: .29% 2580 MHz: .25% 2880 MHz: .06% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 15 idle residency:  62.45%
+CPU 15 down residency:  35.49%
+CPU 16 frequency: 1688 MHz
+CPU 16 active residency:   1.05% (1308 MHz: .67% 1620 MHz:   0% 1980 MHz: .06% 2292 MHz: .19% 2580 MHz: .10% 2880 MHz: .03% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 16 idle residency:  63.45%
+CPU 16 down residency:  35.50%
+CPU 17 frequency: 1349 MHz
+CPU 17 active residency:   0.51% (1308 MHz: .49% 1620 MHz:   0% 1980 MHz: .01% 2292 MHz: .00% 2580 MHz: .00% 2880 MHz: .01% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 17 idle residency:  63.99%
+CPU 17 down residency:  35.50%
+
+CPU Power: 608 mW
+GPU Power: 71 mW
+ANE Power: 0 mW
+Combined Power (CPU + GPU + ANE): 679 mW
+
+**** GPU usage ****
+
+GPU HW active frequency: 338 MHz
+GPU HW active residency:   7.96% (338 MHz: 8.0% 486 MHz:   0% 636 MHz:   0% 796 MHz:   0% 888 MHz:   0% 988 MHz:   0% 1084 MHz:   0% 1182 MHz:   0% 1278 MHz:   0% 1374 MHz:   0% 1470 MHz:   0% 1578 MHz:   0% 1620 MHz:   0%)
+GPU SW requested state: (P1 : 100% P2 :   0% P3 :   0% P4 :   0% P5 :   0% P6 :   0% P7 :   0% P8 :   0% P9 :   0% P10 :   0% P11 :   0% P12 :   0% P13 :   0%)
+GPU idle residency:  92.04%
+GPU Power: 71 mW
+
+
+
+*** Sampled system activity (Sat Apr 25 10:34:43 2026 -0700) (1024.70ms elapsed) ***
+
+
+**** Processor usage ****
+
+P0-Cluster HW active frequency: 1847 MHz
+P0-Cluster HW active residency:  48.09% (1344 MHz:  20% 1644 MHz: 3.2% 1992 MHz: 9.0% 2304 MHz: 9.8% 2652 MHz: 4.7% 2964 MHz:   0% 3240 MHz: .36% 3504 MHz: .22% 3696 MHz:   0% 3876 MHz: .05% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz: .00% 4380 MHz: .16%)
+P0-Cluster idle residency:  51.91%
+P0-Cluster down residency:   0.00%
+CPU 0 frequency: 1865 MHz
+CPU 0 active residency:  20.04% (1344 MHz: 8.2% 1644 MHz: 1.6% 1992 MHz: 3.6% 2304 MHz: 4.1% 2652 MHz: 2.1% 2964 MHz:   0% 3240 MHz: .20% 3504 MHz: .14% 3696 MHz:   0% 3876 MHz: .01% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .08%)
+CPU 0 idle residency:  79.96%
+CPU 0 down residency:   0.00%
+CPU 1 frequency: 1832 MHz
+CPU 1 active residency:  14.58% (1344 MHz: 6.5% 1644 MHz: 1.0% 1992 MHz: 2.6% 2304 MHz: 2.6% 2652 MHz: 1.7% 2964 MHz:   0% 3240 MHz: .03% 3504 MHz: .12% 3696 MHz:   0% 3876 MHz: .00% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .04%)
+CPU 1 idle residency:  85.42%
+CPU 1 down residency:   0.00%
+CPU 2 frequency: 1903 MHz
+CPU 2 active residency:  12.16% (1344 MHz: 4.6% 1644 MHz: .75% 1992 MHz: 2.5% 2304 MHz: 2.6% 2652 MHz: 1.5% 2964 MHz:   0% 3240 MHz: .05% 3504 MHz: .13% 3696 MHz:   0% 3876 MHz: .01% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .03%)
+CPU 2 idle residency:  87.84%
+CPU 2 down residency:   0.00%
+CPU 3 frequency: 1928 MHz
+CPU 3 active residency:   9.10% (1344 MHz: 3.4% 1644 MHz: .58% 1992 MHz: 1.7% 2304 MHz: 2.0% 2652 MHz: 1.3% 2964 MHz:   0% 3240 MHz: .09% 3504 MHz: .10% 3696 MHz:   0% 3876 MHz: .00% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .03%)
+CPU 3 idle residency:  90.90%
+CPU 3 down residency:   0.00%
+CPU 4 frequency: 1889 MHz
+CPU 4 active residency:   8.09% (1344 MHz: 3.3% 1644 MHz: .53% 1992 MHz: 1.3% 2304 MHz: 1.7% 2652 MHz: 1.1% 2964 MHz:   0% 3240 MHz: .00% 3504 MHz: .10% 3696 MHz:   0% 3876 MHz: .00% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .02%)
+CPU 4 idle residency:  91.91%
+CPU 4 down residency:   0.00%
+CPU 5 frequency: 1848 MHz
+CPU 5 active residency:   5.59% (1344 MHz: 2.5% 1644 MHz: .32% 1992 MHz: .78% 2304 MHz: 1.3% 2652 MHz: .56% 2964 MHz:   0% 3240 MHz: .01% 3504 MHz: .08% 3696 MHz:   0% 3876 MHz: .00% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz: .01%)
+CPU 5 idle residency:  94.41%
+CPU 5 down residency:   0.00%
+
+P1-Cluster HW active frequency: 1844 MHz
+P1-Cluster HW active residency:   1.08% (1344 MHz: .85% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz: .02% 3696 MHz: .14% 3876 MHz: .06% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P1-Cluster idle residency:   3.44%
+P1-Cluster down residency:  95.48%
+CPU 6 frequency: 0 MHz
+CPU 6 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 6 idle residency:   4.20%
+CPU 6 down residency:  95.80%
+CPU 7 frequency: 0 MHz
+CPU 7 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 7 idle residency:   4.22%
+CPU 7 down residency:  95.78%
+CPU 8 frequency: 0 MHz
+CPU 8 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 8 idle residency:   4.23%
+CPU 8 down residency:  95.77%
+CPU 9 frequency: 0 MHz
+CPU 9 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 9 idle residency:   4.25%
+CPU 9 down residency:  95.75%
+CPU 10 frequency: 0 MHz
+CPU 10 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 10 idle residency:   4.25%
+CPU 10 down residency:  95.75%
+CPU 11 frequency: 0 MHz
+CPU 11 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 11 idle residency:   4.24%
+CPU 11 down residency:  95.76%
+
+S-Cluster HW active frequency: 2174 MHz
+S-Cluster HW active residency:  28.13% (1308 MHz: 7.8% 1620 MHz:   0% 1980 MHz: 6.9% 2292 MHz: 4.6% 2580 MHz: 2.7% 2880 MHz: 2.1% 3180 MHz: 1.6% 3432 MHz: 1.1% 3648 MHz: 1.3% 3828 MHz: .07% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+S-Cluster idle residency:  39.94%
+S-Cluster down residency:  31.93%
+CPU 12 frequency: 2490 MHz
+CPU 12 active residency:  15.20% (1308 MHz: 1.1% 1620 MHz:   0% 1980 MHz: 4.1% 2292 MHz: 2.9% 2580 MHz: 2.1% 2880 MHz: 1.5% 3180 MHz: 1.3% 3432 MHz: 1.0% 3648 MHz: 1.1% 3828 MHz: .06% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 12 idle residency:  52.83%
+CPU 12 down residency:  31.97%
+CPU 13 frequency: 2288 MHz
+CPU 13 active residency:   5.85% (1308 MHz: .84% 1620 MHz:   0% 1980 MHz: 1.9% 2292 MHz: 1.1% 2580 MHz: .72% 2880 MHz: .51% 3180 MHz: .33% 3432 MHz: .17% 3648 MHz: .28% 3828 MHz: .01% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 13 idle residency:  62.19%
+CPU 13 down residency:  31.97%
+CPU 14 frequency: 2214 MHz
+CPU 14 active residency:   3.34% (1308 MHz: .61% 1620 MHz:   0% 1980 MHz: .91% 2292 MHz: .82% 2580 MHz: .49% 2880 MHz: .23% 3180 MHz: .05% 3432 MHz: .06% 3648 MHz: .17% 3828 MHz: .00% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 14 idle residency:  64.69%
+CPU 14 down residency:  31.97%
+CPU 15 frequency: 2219 MHz
+CPU 15 active residency:   2.59% (1308 MHz: .62% 1620 MHz:   0% 1980 MHz: .39% 2292 MHz: .62% 2580 MHz: .49% 2880 MHz: .26% 3180 MHz: .04% 3432 MHz: .05% 3648 MHz: .12% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 15 idle residency:  65.44%
+CPU 15 down residency:  31.97%
+CPU 16 frequency: 2086 MHz
+CPU 16 active residency:   1.57% (1308 MHz: .59% 1620 MHz:   0% 1980 MHz: .08% 2292 MHz: .33% 2580 MHz: .32% 2880 MHz: .17% 3180 MHz: .02% 3432 MHz: .02% 3648 MHz: .03% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 16 idle residency:  66.47%
+CPU 16 down residency:  31.97%
+CPU 17 frequency: 1920 MHz
+CPU 17 active residency:   1.22% (1308 MHz: .57% 1620 MHz:   0% 1980 MHz: .03% 2292 MHz: .40% 2580 MHz: .16% 2880 MHz: .00% 3180 MHz: .00% 3432 MHz: .02% 3648 MHz: .03% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 17 idle residency:  66.81%
+CPU 17 down residency:  31.97%
+
+CPU Power: 676 mW
+GPU Power: 58 mW
+ANE Power: 0 mW
+Combined Power (CPU + GPU + ANE): 734 mW
+
+**** GPU usage ****
+
+GPU HW active frequency: 338 MHz
+GPU HW active residency:   7.27% (338 MHz: 7.3% 486 MHz:   0% 636 MHz:   0% 796 MHz:   0% 888 MHz:   0% 988 MHz:   0% 1084 MHz:   0% 1182 MHz:   0% 1278 MHz:   0% 1374 MHz:   0% 1470 MHz:   0% 1578 MHz:   0% 1620 MHz:   0%)
+GPU SW requested state: (P1 : 100% P2 :   0% P3 :   0% P4 :   0% P5 :   0% P6 :   0% P7 :   0% P8 :   0% P9 :   0% P10 :   0% P11 :   0% P12 :   0% P13 :   0%)
+GPU idle residency:  92.73%
+GPU Power: 58 mW
+
+
+
+*** Sampled system activity (Sat Apr 25 10:34:44 2026 -0700) (1025.67ms elapsed) ***
+
+
+**** Processor usage ****
+
+P0-Cluster HW active frequency: 1814 MHz
+P0-Cluster HW active residency:  44.46% (1344 MHz:  20% 1644 MHz: .98% 1992 MHz:  12% 2304 MHz: 6.5% 2652 MHz: 5.2% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P0-Cluster idle residency:  55.54%
+P0-Cluster down residency:   0.00%
+CPU 0 frequency: 1804 MHz
+CPU 0 active residency:  18.89% (1344 MHz: 8.8% 1644 MHz: .16% 1992 MHz: 5.1% 2304 MHz: 2.7% 2652 MHz: 2.1% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 0 idle residency:  81.11%
+CPU 0 down residency:   0.00%
+CPU 1 frequency: 1890 MHz
+CPU 1 active residency:  17.22% (1344 MHz: 6.6% 1644 MHz: .44% 1992 MHz: 4.6% 2304 MHz: 2.9% 2652 MHz: 2.7% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 1 idle residency:  82.78%
+CPU 1 down residency:   0.00%
+CPU 2 frequency: 1847 MHz
+CPU 2 active residency:  12.34% (1344 MHz: 5.0% 1644 MHz: .29% 1992 MHz: 3.4% 2304 MHz: 2.5% 2652 MHz: 1.2% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 2 idle residency:  87.66%
+CPU 2 down residency:   0.00%
+CPU 3 frequency: 1881 MHz
+CPU 3 active residency:  10.66% (1344 MHz: 4.4% 1644 MHz: .24% 1992 MHz: 2.2% 2304 MHz: 2.2% 2652 MHz: 1.7% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 3 idle residency:  89.34%
+CPU 3 down residency:   0.00%
+CPU 4 frequency: 1903 MHz
+CPU 4 active residency:   7.24% (1344 MHz: 2.9% 1644 MHz: .02% 1992 MHz: 1.9% 2304 MHz: 1.2% 2652 MHz: 1.3% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 4 idle residency:  92.76%
+CPU 4 down residency:   0.00%
+CPU 5 frequency: 1937 MHz
+CPU 5 active residency:   6.52% (1344 MHz: 2.4% 1644 MHz: .02% 1992 MHz: 1.6% 2304 MHz: 1.4% 2652 MHz: 1.1% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 5 idle residency:  93.48%
+CPU 5 down residency:   0.00%
+
+P1-Cluster HW active frequency: 1390 MHz
+P1-Cluster HW active residency:   0.62% (1344 MHz: .58% 1644 MHz:   0% 1992 MHz: .04% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P1-Cluster idle residency:   1.49%
+P1-Cluster down residency:  97.88%
+CPU 6 frequency: 0 MHz
+CPU 6 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 6 idle residency:   1.94%
+CPU 6 down residency:  98.06%
+CPU 7 frequency: 0 MHz
+CPU 7 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 7 idle residency:   1.97%
+CPU 7 down residency:  98.03%
+CPU 8 frequency: 0 MHz
+CPU 8 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 8 idle residency:   1.97%
+CPU 8 down residency:  98.03%
+CPU 9 frequency: 0 MHz
+CPU 9 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 9 idle residency:   1.97%
+CPU 9 down residency:  98.03%
+CPU 10 frequency: 0 MHz
+CPU 10 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 10 idle residency:   1.98%
+CPU 10 down residency:  98.02%
+CPU 11 frequency: 0 MHz
+CPU 11 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 11 idle residency:   1.98%
+CPU 11 down residency:  98.02%
+
+S-Cluster HW active frequency: 1857 MHz
+S-Cluster HW active residency:  16.66% (1308 MHz: 5.5% 1620 MHz:   0% 1980 MHz: 7.2% 2292 MHz: 2.7% 2580 MHz: .92% 2880 MHz: .29% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+S-Cluster idle residency:  28.85%
+S-Cluster down residency:  54.49%
+CPU 12 frequency: 2034 MHz
+CPU 12 active residency:   6.72% (1308 MHz: .90% 1620 MHz:   0% 1980 MHz: 3.8% 2292 MHz: 1.2% 2580 MHz: .66% 2880 MHz: .23% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 12 idle residency:  38.74%
+CPU 12 down residency:  54.54%
+CPU 13 frequency: 1995 MHz
+CPU 13 active residency:   4.20% (1308 MHz: .75% 1620 MHz:   0% 1980 MHz: 2.1% 2292 MHz: .83% 2580 MHz: .50% 2880 MHz: .01% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 13 idle residency:  41.27%
+CPU 13 down residency:  54.54%
+CPU 14 frequency: 1913 MHz
+CPU 14 active residency:   3.27% (1308 MHz: .83% 1620 MHz:   0% 1980 MHz: 1.6% 2292 MHz: .69% 2580 MHz: .16% 2880 MHz: .03% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 14 idle residency:  42.19%
+CPU 14 down residency:  54.54%
+CPU 15 frequency: 1812 MHz
+CPU 15 active residency:   1.47% (1308 MHz: .64% 1620 MHz:   0% 1980 MHz: .52% 2292 MHz: .08% 2580 MHz: .15% 2880 MHz: .08% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 15 idle residency:  43.99%
+CPU 15 down residency:  54.54%
+CPU 16 frequency: 1566 MHz
+CPU 16 active residency:   1.09% (1308 MHz: .67% 1620 MHz:   0% 1980 MHz: .42% 2292 MHz: .00% 2580 MHz: .00% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 16 idle residency:  44.37%
+CPU 16 down residency:  54.54%
+CPU 17 frequency: 1474 MHz
+CPU 17 active residency:   0.84% (1308 MHz: .63% 1620 MHz:   0% 1980 MHz: .21% 2292 MHz:   0% 2580 MHz:   0% 2880 MHz:   0% 3180 MHz:   0% 3432 MHz:   0% 3648 MHz:   0% 3828 MHz:   0% 3984 MHz:   0% 4104 MHz:   0% 4188 MHz:   0% 4236 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4332 MHz:   0% 4428 MHz:   0% 4512 MHz:   0% 4608 MHz:   0%)
+CPU 17 idle residency:  44.63%
+CPU 17 down residency:  54.54%
+
+CPU Power: 438 mW
+GPU Power: 52 mW
+ANE Power: 0 mW
+Combined Power (CPU + GPU + ANE): 489 mW
+
+**** GPU usage ****
+
+GPU HW active frequency: 338 MHz
+GPU HW active residency:   5.36% (338 MHz: 5.4% 486 MHz:   0% 636 MHz:   0% 796 MHz:   0% 888 MHz:   0% 988 MHz:   0% 1084 MHz:   0% 1182 MHz:   0% 1278 MHz:   0% 1374 MHz:   0% 1470 MHz:   0% 1578 MHz:   0% 1620 MHz:   0%)
+GPU SW requested state: (P1 : 100% P2 :   0% P3 :   0% P4 :   0% P5 :   0% P6 :   0% P7 :   0% P8 :   0% P9 :   0% P10 :   0% P11 :   0% P12 :   0% P13 :   0%)
+GPU idle residency:  94.64%
+GPU Power: 54 mW
+
+
+
+*** Sampled system activity (Sat Apr 25 10:34:45 2026 -0700) (1027.30ms elapsed) ***
+
+
+**** Processor usage ****
+
+P0-Cluster HW active frequency: 1973 MHz
+P0-Cluster HW active residency:  49.55% (1344 MHz:  15% 1644 MHz: .65% 1992 MHz:  14% 2304 MHz:  10% 2652 MHz: 9.1% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P0-Cluster idle residency:  50.45%
+P0-Cluster down residency:   0.00%
+CPU 0 frequency: 1922 MHz
+CPU 0 active residency:  21.32% (1344 MHz: 7.1% 1644 MHz: .26% 1992 MHz: 6.9% 2304 MHz: 4.1% 2652 MHz: 2.9% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 0 idle residency:  78.68%
+CPU 0 down residency:   0.00%
+CPU 1 frequency: 2032 MHz
+CPU 1 active residency:  16.41% (1344 MHz: 4.3% 1644 MHz: .05% 1992 MHz: 4.6% 2304 MHz: 4.1% 2652 MHz: 3.3% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 1 idle residency:  83.59%
+CPU 1 down residency:   0.00%
+CPU 2 frequency: 2055 MHz
+CPU 2 active residency:  12.88% (1344 MHz: 3.4% 1644 MHz: .26% 1992 MHz: 2.8% 2304 MHz: 3.3% 2652 MHz: 3.1% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 2 idle residency:  87.12%
+CPU 2 down residency:   0.00%
+CPU 3 frequency: 1981 MHz
+CPU 3 active residency:   9.30% (1344 MHz: 2.8% 1644 MHz: .10% 1992 MHz: 2.5% 2304 MHz: 2.5% 2652 MHz: 1.4% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 3 idle residency:  90.70%
+CPU 3 down residency:   0.00%
+CPU 4 frequency: 1989 MHz
+CPU 4 active residency:   6.23% (1344 MHz: 2.1% 1644 MHz: .01% 1992 MHz: 1.3% 2304 MHz: 1.4% 2652 MHz: 1.4% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 4 idle residency:  93.77%
+CPU 4 down residency:   0.00%
+CPU 5 frequency: 2059 MHz
+CPU 5 active residency:   4.84% (1344 MHz: 1.2% 1644 MHz: .01% 1992 MHz: 1.4% 2304 MHz: 1.1% 2652 MHz: 1.1% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 5 idle residency:  95.16%
+CPU 5 down residency:   0.00%
+
+P1-Cluster HW active frequency: 1344 MHz
+P1-Cluster HW active residency:   0.09% (1344 MHz: .09% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+P1-Cluster idle residency:   0.61%
+P1-Cluster down residency:  99.30%
+CPU 6 frequency: 0 MHz
+CPU 6 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)
+CPU 6 idle residency:   0.66%
+CPU 6 down residency:  99.34%
+CPU 7 frequency: 0 MHz
+CPU 7 active residency:   0.00% (1344 MHz:   0% 1644 MHz:   0% 1992 MHz:   0% 2304 MHz:   0% 2652 MHz:   0% 2964 MHz:   0% 3240 MHz:   0% 3504 MHz:   0% 3696 MHz:   0% 3876 MHz:   0% 4044 MHz:   0% 4176 MHz:   0% 4284 MHz:   0% 4308 MHz:   0% 4380 MHz:   0%)


### PR DESCRIPTION
## Summary

Adds a darwin-only powermetrics sampler that publishes four new Prometheus gauges on the Metal agent's existing `AgentRegistry`:

- `llmkube_metal_agent_apple_power_combined_watts`
- `llmkube_metal_agent_apple_power_gpu_watts`
- `llmkube_metal_agent_apple_power_cpu_watts`
- `llmkube_metal_agent_apple_power_ane_watts`

Designed to be scraped by [InferCost](https://github.com/defilantech/infercost)'s upcoming Metal collector for per-token cost attribution on Apple Silicon, where DCGM (NVIDIA-only) doesn't exist. See [InferCost #46](https://github.com/defilantech/infercost/issues/46) for the cross-repo design.

## Why

Today the Apple sample CostProfile in InferCost says: *"Apple Silicon has no DCGM exporter; InferCost falls back to TDP-based power estimation. Real-time power metrics will require a Metal-aware exporter (tracked on the roadmap)."* This PR is the LLMKube half of closing that gap.

This weekend's M5 Max bench session ran 2.06 tok/s/W of inference and computed \$0.015/M tokens marginal cost manually from `powermetrics`, but InferCost itself couldn't see any of it. After this PR + the matching InferCost PR, the same flow works end-to-end without manual math.

## What changed

| File | Change |
|------|--------|
| `pkg/agent/agentmetrics.go` | Add 4 `apple_power_*_watts` gauges; register in `init()` |
| `pkg/agent/power_darwin.go` (new) | `ApplePowerSampler` — spawns `sudo powermetrics --samplers cpu_power,gpu_power -i <interval>`, parses output, updates gauges |
| `pkg/agent/power_other.go` (new) | No-op stub for non-Darwin builds (CI on Linux still compiles) |
| `pkg/agent/power_darwin_test.go` (new) | Parser tests against captured fixture, duplicate-GPU-line handling, partial-sample guard, stderr capture |
| `pkg/agent/testdata/powermetrics_sample.txt` (new) | 7-sample captured fixture from real M5 Max output |
| `pkg/agent/agentmetrics_test.go` | Register the 4 new gauges in the existing init-coverage test |
| `pkg/agent/agent.go` | Add `ApplePowerEnabled`/`ApplePowerInterval`/`PowermetricsBin` to `MetalAgentConfig`; conditionally launch sampler goroutine in `Start()` |
| `cmd/metal-agent/main.go` | Add `--apple-power-enabled`, `--apple-power-interval`, `--powermetrics-bin` flags |
| `deployment/macos/sudoers.d/llmkube-powermetrics` (new) | Sample NOPASSWD sudoers fragment |
| `deployment/macos/README.md` | Document the enable steps and the 4 new gauges |

## Privilege handling

`powermetrics` requires root, but the agent runs as a regular user under launchd. Three options were considered: (1) NOPASSWD sudoers entry for `/usr/bin/powermetrics` only, (2) run the entire metal-agent as root, (3) external launchd job + tail a shared file.

Picked (1) because it's the smallest privilege grant — `powermetrics`-only, not full root for the agent — and is well-understood by macOS admins. The flag defaults to **disabled** so users opt into the sudoers requirement explicitly. Without `--apple-power-enabled`, behavior is unchanged from today.

## Parser quirk handled

`powermetrics` emits two `GPU Power: <n> mW` lines per sample — one in the cpu_power section, one in the gpu_power section. Only the first occurrence per sample is published, so the gauge value matches what was actually summed into `Combined Power`. Test `TestParsePowermetricsStream_DuplicateGPULineIgnored` guards this.

A second guard (`TestParsePowermetricsStream_PartialSampleNotEmitted`) ensures samples missing their `Combined Power` line never emit, so InferCost's per-token math doesn't see stale-zero gauges if powermetrics is killed mid-write.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `golangci-lint run ./pkg/agent/... ./cmd/metal-agent/...` — only the preexisting `health.go` G118 finding (unrelated)
- [x] `go vet ./...` clean
- [x] `gofmt -w` clean
- [x] Parser tests pass against captured fixture from real M5 Max powermetrics output
- [x] Manual on M5 Max: install sudoers fragment, restart agent with `--apple-power-enabled`, `curl /metrics | grep apple_power`, run inference, watch gauge rise; stop, watch fall to ~1 W idle baseline

## Follow-up

Phase 2 (separate PR in defilantech/infercost) will add a `metal` collector type to InferCost that scrapes these gauges. See plan link above.

Closes #335