### PR TITLE
feat(make): one-command install-powermetrics-sudo + uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,29 @@ uninstall-metal-agent: ## Uninstall Metal agent and launchd service.
 	rm -f ~/Library/LaunchAgents/com.llmkube.metal-agent.plist
 	@echo "✅ Metal agent uninstalled"
 
+.PHONY: install-powermetrics-sudo
+install-powermetrics-sudo: ## Install NOPASSWD sudoers entry for /usr/bin/powermetrics (required for --apple-power-enabled).
+	@echo "Installing sudoers entry for the Apple power sampler..."
+	@echo "This grants the current user ($(shell whoami)) NOPASSWD access to"
+	@echo "/usr/bin/powermetrics with the EXACT argv the agent uses, and nothing else."
+	@echo ""
+	@TMP=$$(mktemp); \
+		sed "s/__LLMKUBE_USER__/$(shell whoami)/" deployment/macos/sudoers.d/llmkube-powermetrics > "$$TMP"; \
+		sudo visudo -cf "$$TMP" || (echo "❌ sudoers syntax check failed; aborting"; rm -f "$$TMP"; exit 1); \
+		sudo install -m 0440 -o root -g wheel "$$TMP" /etc/sudoers.d/llmkube-powermetrics; \
+		rm -f "$$TMP"
+	@echo ""
+	@echo "✅ Sudoers entry installed. Granted command:"
+	@sudo -ln 2>/dev/null | grep powermetrics || echo "  (run 'sudo -ln | grep powermetrics' to verify)"
+	@echo ""
+	@echo "Now restart the Metal agent with --apple-power-enabled to publish the gauges."
+
+.PHONY: uninstall-powermetrics-sudo
+uninstall-powermetrics-sudo: ## Remove the NOPASSWD sudoers entry installed by install-powermetrics-sudo.
+	@echo "Removing /etc/sudoers.d/llmkube-powermetrics..."
+	sudo rm -f /etc/sudoers.d/llmkube-powermetrics
+	@echo "✅ Sudoers entry removed. Apple power gauges will now read 0 if the agent is run with --apple-power-enabled."
+
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go $(ARGS)

--- a/deployment/macos/README.md
+++ b/deployment/macos/README.md
@@ -177,31 +177,30 @@ The Metal Agent can publish real-time CPU / GPU / ANE / Combined power gauges so
 
 ### Enable
 
-1. Install the NOPASSWD sudoers fragment so the agent can call `powermetrics` without a password. **The shipped fragment pins both the binary path and its argument vector** so the grant is `powermetrics --samplers cpu_power,gpu_power -i <numeric-interval>` only — not `powermetrics --output-file=/wherever`.
+1. Install the NOPASSWD sudoers fragment so the agent can call `powermetrics` without a password. **The shipped fragment pins both the binary path and its argument vector** so the grant is `powermetrics --samplers cpu_power,gpu_power -i <numeric-interval>` only, not `powermetrics --output-file=/wherever`.
+
+   The easy way (one command, sudo prompts you):
 
    ```bash
-   # Render the placeholder, validate syntax in a tempfile, then atomically
-   # install. visudo -cf will refuse to install a malformed file rather than
-   # leaving sudo broken.
+   make install-powermetrics-sudo
+   ```
+
+   This renders the placeholder for the current user, syntax-checks with `visudo -cf`, and atomically installs to `/etc/sudoers.d/llmkube-powermetrics` with `0440 root:wheel` ownership. The grant is read back to your terminal so you can see exactly what was just authorized.
+
+   To **uninstall**:
+
+   ```bash
+   make uninstall-powermetrics-sudo
+   ```
+
+   The fully manual equivalent (if you want to inspect every step):
+
+   ```bash
    TMP=$(mktemp)
    sed "s/__LLMKUBE_USER__/$(whoami)/" deployment/macos/sudoers.d/llmkube-powermetrics > "$TMP"
    sudo visudo -cf "$TMP"
    sudo install -m 0440 -o root -g wheel "$TMP" /etc/sudoers.d/llmkube-powermetrics
    rm "$TMP"
-   ```
-
-   Verify the grant is scoped as you expect:
-
-   ```bash
-   sudo -ln | grep powermetrics
-   # User <you> may run the following commands on this host:
-   #     (root) NOPASSWD: /usr/bin/powermetrics --samplers cpu_power\,gpu_power -i [0-9]*
-   ```
-
-   To **uninstall**, simply:
-
-   ```bash
-   sudo rm /etc/sudoers.d/llmkube-powermetrics
    ```
 
 2. Add `--apple-power-enabled` to the agent's `ProgramArguments` and reload launchd:


### PR DESCRIPTION
## Summary

Adds two Makefile targets so the NOPASSWD sudoers install for \`--apple-power-enabled\` is a one-liner instead of a 5-line shell incantation:

- \`make install-powermetrics-sudo\`
- \`make uninstall-powermetrics-sudo\`

## Why

[PR #334](https://github.com/defilantech/LLMKube/pull/334) shipped the Apple power gauges and a security-audited sudoers fragment, but the README install steps were:

\`\`\`bash
TMP=\$(mktemp)
sed \"s/__LLMKUBE_USER__/\$(whoami)/\" deployment/macos/sudoers.d/llmkube-powermetrics > \"\$TMP\"
sudo visudo -cf \"\$TMP\"
sudo install -m 0440 -o root -g wheel \"\$TMP\" /etc/sudoers.d/llmkube-powermetrics
rm \"\$TMP\"
\`\`\`

That's a friction wall for a feature most users will only ever opt into to feed InferCost. Make targets reduce it to one command without hiding anything: sudo still prompts (consent visible), the granted command is read back via \`sudo -ln | grep powermetrics\` so the operator can verify scope, and the README still documents the fully manual install for inspection.

## What's in it

- New \`install-powermetrics-sudo\` target. Renders the \`__LLMKUBE_USER__\` placeholder for \`whoami\`, syntax-checks via \`visudo -cf\` (refuses to install malformed files rather than break sudo), atomically installs to \`/etc/sudoers.d/llmkube-powermetrics\` with \`0440 root:wheel\`, then echoes the granted command back so the operator can verify exactly what was authorized.
- New \`uninstall-powermetrics-sudo\` target. Single \`sudo rm\` plus a one-line note about what the agent will see going forward.
- README updated to lead with the make targets, with the manual install retained below for operators who want to inspect each step.

## Privilege model

**Unchanged.** Pinned argv (\`/usr/bin/powermetrics --samplers cpu_power,gpu_power -i [0-9]*\` only), single binary, opt-in via \`--apple-power-enabled\` flag. The make target collapses keystrokes; it does not change what's granted.

## Test plan

- [x] \`make help\` shows both new targets in the Metal Agent section
- [x] \`make install-powermetrics-sudo\` on a fresh M5 Max with no prior sudoers entry: prompts for password, validates syntax, installs file with correct mode/owner, echoes back the granted command
- [x] \`sudo -ln | grep powermetrics\` shows the pinned-argv grant
- [x] \`make uninstall-powermetrics-sudo\` removes the file cleanly
- [ ] Reviewers: run on your own Mac if you have one