### PR TITLE
fix(controller): use GGUF metadata name for downloaded model file basename

### DIFF
--- a/internal/controller/filename.go
+++ b/internal/controller/filename.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// modelFileExt is the on-disk extension used for downloaded model files.
+const modelFileExt = ".gguf"
+
+// legacyModelFilename is the basename historical versions of the controller
+// wrote downloaded files as. New downloads prefer a metadata-derived name;
+// legacy files are migrated in place on next reconcile.
+const legacyModelFilename = "model" + modelFileExt
+
+// fallbackModelFilename is the slug used when neither GGUF metadata nor
+// Model.metadata.name yields a non-empty sanitized name.
+const fallbackModelFilename = "model"
+
+// sanitizeModelFilename converts an arbitrary string into a slug safe to use
+// as a filename basename. The rule set:
+//   - Characters outside [A-Za-z0-9._-] are replaced with '-'
+//   - Runs of '-' are collapsed
+//   - Leading and trailing '-', '.', and '_' are trimmed (no path-traversal)
+//   - Returns "" if the input is empty after sanitization
+func sanitizeModelFilename(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '-' || r == '_':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := b.String()
+	out = strings.Trim(out, "-._")
+	// Collapse any remaining double-dash runs that survived the trim.
+	for strings.Contains(out, "--") {
+		out = strings.ReplaceAll(out, "--", "-")
+	}
+	return out
+}
+
+// canonicalModelBasename returns the desired GGUF filename basename (without
+// directory) for a Model, in priority order:
+//  1. sanitized Model.Status.GGUF.ModelName
+//  2. sanitized Model.Name
+//  3. fallbackModelFilename
+//
+// Always includes the .gguf extension.
+func canonicalModelBasename(model *inferencev1alpha1.Model) string {
+	var name string
+	if model.Status.GGUF != nil {
+		name = sanitizeModelFilename(model.Status.GGUF.ModelName)
+	}
+	if name == "" {
+		name = sanitizeModelFilename(model.Name)
+	}
+	if name == "" {
+		name = fallbackModelFilename
+	}
+	return name + modelFileExt
+}
+
+// canonicalModelPath joins the model cache directory with the canonical
+// basename for a Model.
+func canonicalModelPath(modelDir string, model *inferencev1alpha1.Model) string {
+	return filepath.Join(modelDir, canonicalModelBasename(model))
+}
+
+// findCachedModelFile looks for a single .gguf file in modelDir and returns
+// (path, fileInfo, true) if found. If the canonical filename and the legacy
+// "model.gguf" both exist, it prefers the canonical one. If multiple .gguf
+// files exist for any other reason, it returns the lexicographically first.
+func findCachedModelFile(modelDir string) (string, os.FileInfo, bool) {
+	matches, err := filepath.Glob(filepath.Join(modelDir, "*"+modelFileExt))
+	if err != nil || len(matches) == 0 {
+		return "", nil, false
+	}
+	sort.Strings(matches)
+	pick := matches[0]
+	for _, m := range matches {
+		if filepath.Base(m) != legacyModelFilename {
+			pick = m
+			break
+		}
+	}
+	info, err := os.Stat(pick)
+	if err != nil {
+		return "", nil, false
+	}
+	return pick, info, true
+}
+
+// migrateModelFilename renames currentPath to the canonical path for the given
+// model, returning the path the file resides at after the operation. If the
+// file is already at the canonical path, currentPath is returned unchanged.
+// Caller should populate model.Status.GGUF before calling so the metadata-
+// derived name is preferred. If the canonical path already exists alongside
+// currentPath (shouldn't happen, but be safe), currentPath is returned and a
+// warning is logged.
+func (r *ModelReconciler) migrateModelFilename(currentPath, modelDir string, model *inferencev1alpha1.Model) (string, error) {
+	logger := log.FromContext(context.Background())
+	desired := canonicalModelPath(modelDir, model)
+	if currentPath == desired {
+		return currentPath, nil
+	}
+	if _, err := os.Stat(desired); err == nil {
+		logger.Info("Canonical model path already exists; not overwriting", "current", currentPath, "canonical", desired)
+		return currentPath, nil
+	}
+	if err := os.Rename(currentPath, desired); err != nil {
+		return currentPath, fmt.Errorf("rename %s -> %s: %w", currentPath, desired, err)
+	}
+	logger.Info("Migrated model file to canonical filename", "from", currentPath, "to", desired)
+	return desired, nil
+}

--- a/internal/controller/filename_test.go
+++ b/internal/controller/filename_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func TestSanitizeModelFilename(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"already safe", "Gemma-4-E4B-It", "Gemma-4-E4B-It"},
+		{"spaces", "Llama 3.1 Instruct", "Llama-3.1-Instruct"},
+		{"slash", "Llama 3.1/Instruct", "Llama-3.1-Instruct"},
+		{"colon", "Qwen3:30B", "Qwen3-30B"},
+		{"underscore preserved", "model_v2", "model_v2"},
+		{"dot preserved", "model.v2.gguf", "model.v2.gguf"},
+		{"unicode replaced", "café", "caf"},
+		{"all separators", "///", ""},
+		{"all dots", "...", ""},
+		{"path traversal", "..", ""},
+		{"leading dot", ".hidden", "hidden"},
+		{"trailing dash", "name-", "name"},
+		{"runs of separators", "a   b", "a-b"},
+		{"runs of dashes from mixed", "a / b", "a-b"},
+		{"only dashes", "----", ""},
+		{"long mixed", "Q4_K_M / Llama-3.1 (8B)", "Q4_K_M-Llama-3.1-8B"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeModelFilename(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeModelFilename(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalModelBasename(t *testing.T) {
+	cases := []struct {
+		name      string
+		modelName string
+		gguf      *inferencev1alpha1.GGUFMetadata
+		want      string
+	}{
+		{
+			name:      "uses GGUF metadata name when available",
+			modelName: "gemma",
+			gguf:      &inferencev1alpha1.GGUFMetadata{ModelName: "Gemma-4-E4B-It"},
+			want:      "Gemma-4-E4B-It.gguf",
+		},
+		{
+			name:      "falls back to Model.Name when GGUF status is nil",
+			modelName: "gemma-4-e4b",
+			gguf:      nil,
+			want:      "gemma-4-e4b.gguf",
+		},
+		{
+			name:      "falls back to Model.Name when GGUF name is empty",
+			modelName: "gemma-4-e4b",
+			gguf:      &inferencev1alpha1.GGUFMetadata{ModelName: ""},
+			want:      "gemma-4-e4b.gguf",
+		},
+		{
+			name:      "sanitizes GGUF name with unsafe characters",
+			modelName: "fallback",
+			gguf:      &inferencev1alpha1.GGUFMetadata{ModelName: "Llama 3.1/Instruct"},
+			want:      "Llama-3.1-Instruct.gguf",
+		},
+		{
+			name:      "falls back to Model.Name when GGUF name sanitizes to empty",
+			modelName: "fallback",
+			gguf:      &inferencev1alpha1.GGUFMetadata{ModelName: "///"},
+			want:      "fallback.gguf",
+		},
+		{
+			name:      "falls back to literal model when both empty",
+			modelName: "",
+			gguf:      &inferencev1alpha1.GGUFMetadata{ModelName: ""},
+			want:      "model.gguf",
+		},
+		{
+			name:      "rejects path traversal in GGUF name",
+			modelName: "safe",
+			gguf:      &inferencev1alpha1.GGUFMetadata{ModelName: ".."},
+			want:      "safe.gguf",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: tc.modelName},
+			}
+			model.Status.GGUF = tc.gguf
+			got := canonicalModelBasename(model)
+			if got != tc.want {
+				t.Errorf("canonicalModelBasename(modelName=%q, gguf=%+v) = %q, want %q",
+					tc.modelName, tc.gguf, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalModelBasenameNoGGUFStatus(t *testing.T) {
+	model := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-model"},
+	}
+	if got, want := canonicalModelBasename(model), "my-model.gguf"; got != want {
+		t.Errorf("canonicalModelBasename = %q, want %q", got, want)
+	}
+}

--- a/internal/controller/filename_test.go
+++ b/internal/controller/filename_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +49,10 @@ func TestSanitizeModelFilename(t *testing.T) {
 		{"runs of dashes from mixed", "a / b", "a-b"},
 		{"only dashes", "----", ""},
 		{"long mixed", "Q4_K_M / Llama-3.1 (8B)", "Q4_K_M-Llama-3.1-8B"},
+		// "/-/" forces the main loop to emit "---" because the literal "-"
+		// is in the allowed set and clears the prevDash flag, which the
+		// post-trim collapse loop must then reduce back to a single dash.
+		{"collapses post-trim double dash", "a/-/b", "a-b"},
 	}
 
 	for _, tc := range cases {
@@ -131,5 +137,111 @@ func TestCanonicalModelBasenameNoGGUFStatus(t *testing.T) {
 	}
 	if got, want := canonicalModelBasename(model), "my-model.gguf"; got != want {
 		t.Errorf("canonicalModelBasename = %q, want %q", got, want)
+	}
+}
+
+// TestFindCachedModelFilePrefersCanonical exercises the inner-loop branch in
+// findCachedModelFile: when both `model.gguf` (legacy) and a non-legacy GGUF
+// exist in the same directory, the non-legacy one wins regardless of sort
+// order. The non-legacy filename here ("qwen.gguf") sorts AFTER "model.gguf",
+// so the helper must walk past the legacy match.
+func TestFindCachedModelFilePrefersCanonical(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, "model.gguf")
+	canonical := filepath.Join(dir, "qwen.gguf")
+	if err := os.WriteFile(legacy, []byte("legacy"), 0o644); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+	if err := os.WriteFile(canonical, []byte("canonical"), 0o644); err != nil {
+		t.Fatalf("write canonical: %v", err)
+	}
+
+	got, info, ok := findCachedModelFile(dir)
+	if !ok {
+		t.Fatal("findCachedModelFile reported no match")
+	}
+	if got != canonical {
+		t.Errorf("got %q, want %q (non-legacy preference)", got, canonical)
+	}
+	if info == nil || info.Size() == 0 {
+		t.Errorf("expected non-nil FileInfo with size > 0, got %+v", info)
+	}
+}
+
+func TestFindCachedModelFileNoMatches(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, ok := findCachedModelFile(dir); ok {
+		t.Fatal("expected no match for empty directory")
+	}
+}
+
+func TestMigrateModelFilenameNoOpWhenAlreadyCanonical(t *testing.T) {
+	dir := t.TempDir()
+	model := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "noop"}}
+	current := filepath.Join(dir, canonicalModelBasename(model))
+	if err := os.WriteFile(current, []byte("data"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	r := &ModelReconciler{}
+	got, err := r.migrateModelFilename(current, dir, model)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != current {
+		t.Errorf("got %q, want %q (no-op)", got, current)
+	}
+	if _, err := os.Stat(current); err != nil {
+		t.Errorf("file should still exist at original path: %v", err)
+	}
+}
+
+// TestMigrateModelFilenameSkipsWhenCanonicalExists covers the defensive
+// collision branch: if both the source and the canonical destination exist
+// (shouldn't happen during a normal reconcile, but possible under crash-recovery),
+// we keep the source path unchanged and never overwrite the destination.
+func TestMigrateModelFilenameSkipsWhenCanonicalExists(t *testing.T) {
+	dir := t.TempDir()
+	model := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "collide"}}
+
+	current := filepath.Join(dir, "model.gguf")
+	canonical := filepath.Join(dir, canonicalModelBasename(model))
+	if err := os.WriteFile(current, []byte("legacy"), 0o644); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+	if err := os.WriteFile(canonical, []byte("preexisting"), 0o644); err != nil {
+		t.Fatalf("seed canonical: %v", err)
+	}
+
+	r := &ModelReconciler{}
+	got, err := r.migrateModelFilename(current, dir, model)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != current {
+		t.Errorf("got %q, want %q (no overwrite)", got, current)
+	}
+	// Both files should still exist, untouched.
+	if data, _ := os.ReadFile(canonical); string(data) != "preexisting" {
+		t.Errorf("canonical was overwritten: got %q, want %q", data, "preexisting")
+	}
+	if data, _ := os.ReadFile(current); string(data) != "legacy" {
+		t.Errorf("current was modified: got %q, want %q", data, "legacy")
+	}
+}
+
+func TestMigrateModelFilenameRenameError(t *testing.T) {
+	dir := t.TempDir()
+	model := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "rename-fail"}}
+	// Source does not exist on disk → os.Rename returns ENOENT.
+	current := filepath.Join(dir, "model.gguf")
+
+	r := &ModelReconciler{}
+	got, err := r.migrateModelFilename(current, dir, model)
+	if err == nil {
+		t.Fatal("expected rename error, got nil")
+	}
+	if got != current {
+		t.Errorf("got %q, want %q (caller falls back to current on error)", got, current)
 	}
 }

--- a/internal/controller/gguf_fixture_test.go
+++ b/internal/controller/gguf_fixture_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// buildMinimalGGUF constructs the bytes of a minimal-but-valid GGUF v3 file
+// with a single string metadata entry "general.name" set to the supplied name
+// (or no metadata at all when name is empty). Tensor count is zero. Used by
+// tests that exercise the controller's GGUF metadata extraction path without
+// pulling in a real model file.
+//
+// Layout reference: pkg/gguf/parser.go (ggufMagic, parseHeader, readValue).
+func buildMinimalGGUF(name string) []byte {
+	buf := &bytes.Buffer{}
+	mustWriteLE(buf, uint32(0x46554747)) // magic
+	mustWriteLE(buf, uint32(3))          // version
+	mustWriteLE(buf, uint64(0))          // tensor_count
+
+	if name == "" {
+		mustWriteLE(buf, uint64(0)) // metadata_kv_count
+		return buf.Bytes()
+	}
+
+	mustWriteLE(buf, uint64(1)) // metadata_kv_count
+
+	// Key: "general.name" (length-prefixed string)
+	key := "general.name"
+	mustWriteLE(buf, uint64(len(key)))
+	buf.WriteString(key)
+
+	// Value: type tag 8 (STRING), then length-prefixed string.
+	mustWriteLE(buf, uint32(8))
+	mustWriteLE(buf, uint64(len(name)))
+	buf.WriteString(name)
+
+	return buf.Bytes()
+}
+
+func mustWriteLE(buf *bytes.Buffer, data interface{}) {
+	if err := binary.Write(buf, binary.LittleEndian, data); err != nil {
+		panic(err)
+	}
+}

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -101,40 +101,55 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	cacheKey := computeCacheKey(model.Spec.Source)
 	modelDir := filepath.Join(r.StoragePath, cacheKey)
-	modelPath := filepath.Join(modelDir, "model.gguf")
+	// downloadPath is the path used during/after download. After GGUF metadata
+	// parsing, the file is migrated to canonicalModelPath(modelDir, model).
+	downloadPath := filepath.Join(modelDir, legacyModelFilename)
 
-	// Early exit: if status already shows Ready and the file exists on disk,
-	// skip the entire reconcile to avoid status updates that trigger re-reconciles.
+	// Early exit: if status is Ready, file exists on disk, AND it is already at
+	// the canonical filename, skip the entire reconcile. Otherwise we fall through
+	// so legacy "model.gguf" files get migrated to a metadata-derived basename.
 	if model.Status.Phase == PhaseReady && model.Status.Path != "" {
 		if _, err := os.Stat(model.Status.Path); err == nil {
-			logger.Info("Model already Ready and cached, skipping reconcile", "path", model.Status.Path)
-			llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
-			return ctrl.Result{}, nil
+			canonical := canonicalModelPath(filepath.Dir(model.Status.Path), model)
+			if model.Status.Path == canonical {
+				logger.Info("Model already Ready and cached at canonical path, skipping reconcile", "path", model.Status.Path)
+				llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
+				return ctrl.Result{}, nil
+			}
+			logger.Info("Model needs filename migration", "currentPath", model.Status.Path, "canonicalPath", canonical)
+		} else {
+			logger.Info("Model marked Ready but file missing, will re-download", "path", model.Status.Path)
 		}
-		logger.Info("Model marked Ready but file missing, will re-download", "path", model.Status.Path)
 	}
 
-	logger.Info("Using cache key for model", "cacheKey", cacheKey, "path", modelPath)
+	logger.Info("Using cache key for model", "cacheKey", cacheKey, "dir", modelDir)
 
-	if fileInfo, err := os.Stat(modelPath); err == nil {
-		logger.Info("Model found in cache, skipping download", "path", modelPath, "size", fileInfo.Size())
+	if existingPath, fileInfo, ok := findCachedModelFile(modelDir); ok {
+		logger.Info("Model found in cache, skipping download", "path", existingPath, "size", fileInfo.Size())
 
-		model.Status.Phase = PhaseReady
-		model.Status.Path = modelPath
-		model.Status.Size = formatBytes(fileInfo.Size())
-		model.Status.CacheKey = cacheKey
-		model.Status.AcceleratorReady = r.checkAcceleratorAvailability(model.Spec.Hardware)
-		now := metav1.Now()
-		model.Status.LastUpdated = &now
-
-		// Parse GGUF metadata (non-fatal, skip if already populated)
+		// Parse GGUF metadata first (non-fatal) so we have the metadata-derived
+		// name available for the rename below.
 		if model.Status.GGUF == nil {
-			if ggufMeta, err := r.parseGGUFMetadata(modelPath); err != nil {
+			if ggufMeta, err := r.parseGGUFMetadata(existingPath); err != nil {
 				logger.Info("Failed to parse GGUF metadata (non-fatal)", "error", err)
 			} else {
 				model.Status.GGUF = ggufMeta
 			}
 		}
+
+		finalPath, err := r.migrateModelFilename(existingPath, modelDir, model)
+		if err != nil {
+			logger.Error(err, "Failed to migrate model filename, keeping existing")
+			finalPath = existingPath
+		}
+
+		model.Status.Phase = PhaseReady
+		model.Status.Path = finalPath
+		model.Status.Size = formatBytes(fileInfo.Size())
+		model.Status.CacheKey = cacheKey
+		model.Status.AcceleratorReady = r.checkAcceleratorAvailability(model.Spec.Hardware)
+		now := metav1.Now()
+		model.Status.LastUpdated = &now
 
 		if err := r.updateStatus(ctx, model, "Available", metav1.ConditionTrue, "ModelCached", "Model found in cache"); err != nil {
 			return ctrl.Result{}, err
@@ -176,7 +191,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if isLocal {
 		sourceType = "local"
 	}
-	size, err := r.fetchModel(ctx, model.Spec.Source, modelPath)
+	size, err := r.fetchModel(ctx, model.Spec.Source, downloadPath)
 	fetchDuration := time.Since(fetchStart).Seconds()
 	llmkubemetrics.ModelDownloadDuration.WithLabelValues(model.Name, model.Namespace, sourceType).Observe(fetchDuration)
 	if err != nil {
@@ -191,9 +206,9 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	// SHA256 integrity verification
-	if err := r.verifySHA256(ctx, model, modelPath); err != nil {
+	if err := r.verifySHA256(ctx, model, downloadPath); err != nil {
 		logger.Error(err, "SHA256 integrity check failed")
-		_ = os.Remove(modelPath)
+		_ = os.Remove(downloadPath)
 		llmkubemetrics.ReconcileTotal.WithLabelValues("model", "error").Inc()
 		llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, PhaseFailed).Set(1)
 		model.Status.Phase = PhaseFailed
@@ -203,20 +218,27 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
+	// Parse GGUF metadata (non-fatal). Done before the rename so the metadata-
+	// derived name is available to canonicalModelPath.
+	if ggufMeta, err := r.parseGGUFMetadata(downloadPath); err != nil {
+		logger.Info("Failed to parse GGUF metadata (non-fatal)", "error", err)
+	} else {
+		model.Status.GGUF = ggufMeta
+	}
+
+	finalPath, err := r.migrateModelFilename(downloadPath, modelDir, model)
+	if err != nil {
+		logger.Error(err, "Failed to rename model to canonical filename, keeping download path")
+		finalPath = downloadPath
+	}
+
 	model.Status.Phase = PhaseReady
-	model.Status.Path = modelPath
+	model.Status.Path = finalPath
 	model.Status.Size = formatBytes(size)
 	model.Status.CacheKey = cacheKey
 	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(model.Spec.Hardware)
 	now := metav1.Now()
 	model.Status.LastUpdated = &now
-
-	// Parse GGUF metadata (non-fatal)
-	if ggufMeta, err := r.parseGGUFMetadata(modelPath); err != nil {
-		logger.Info("Failed to parse GGUF metadata (non-fatal)", "error", err)
-	} else {
-		model.Status.GGUF = ggufMeta
-	}
 
 	if err := r.updateStatus(ctx, model, "Available", metav1.ConditionTrue, "ModelReady", "Model downloaded and cached"); err != nil {
 		return ctrl.Result{}, err
@@ -224,7 +246,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "Ready").Set(1)
 	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
-	logger.Info("Model ready and cached", "path", modelPath, "size", model.Status.Size, "cacheKey", cacheKey)
+	logger.Info("Model ready and cached", "path", finalPath, "size", model.Status.Size, "cacheKey", cacheKey)
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -369,9 +369,9 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		source := "https://example.com/already-ready-model.gguf"
 		cacheKey := computeCacheKey(source)
 		modelDir := filepath.Join(tempDir, cacheKey)
-		modelPath := filepath.Join(modelDir, "model.gguf")
+		legacyPath := filepath.Join(modelDir, "model.gguf")
 		Expect(os.MkdirAll(modelDir, 0755)).To(Succeed())
-		Expect(os.WriteFile(modelPath, []byte("cached-model-data"), 0644)).To(Succeed())
+		Expect(os.WriteFile(legacyPath, []byte("cached-model-data"), 0644)).To(Succeed())
 
 		modelName := "model-already-ready"
 		model := &inferencev1alpha1.Model{
@@ -381,7 +381,9 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		Expect(k8sClient.Create(ctx, model)).To(Succeed())
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
-		// First reconcile to set the model to Ready state
+		// First reconcile finds the legacy "model.gguf" in the cache, parses
+		// (fake) GGUF metadata (which fails non-fatally), and migrates the file
+		// to the canonical filename derived from Model.Name.
 		reconciler := &ModelReconciler{
 			Client:      k8sClient,
 			Scheme:      k8sClient.Scheme(),
@@ -393,11 +395,16 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(reconcile.Result{}))
 
-		// Verify model is Ready
+		// Verify model is Ready and file was migrated to the canonical name.
+		expectedPath := filepath.Join(modelDir, modelName+".gguf")
 		updated := &inferencev1alpha1.Model{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
 		Expect(updated.Status.Phase).To(Equal(PhaseReady))
-		Expect(updated.Status.Path).To(Equal(modelPath))
+		Expect(updated.Status.Path).To(Equal(expectedPath))
+		_, err = os.Stat(expectedPath)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(legacyPath)
+		Expect(os.IsNotExist(err)).To(BeTrue(), "legacy model.gguf should have been renamed away")
 		lastUpdated := updated.Status.LastUpdated.DeepCopy()
 
 		// Second reconcile should return immediately without updating status
@@ -428,7 +435,7 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 
 		source := fmt.Sprintf("%s/model.gguf", server.URL)
 		cacheKey := computeCacheKey(source)
-		modelPath := filepath.Join(tempDir, cacheKey, "model.gguf")
+		stalePath := filepath.Join(tempDir, cacheKey, "model.gguf")
 
 		modelName := "model-ready-missing-file"
 		model := &inferencev1alpha1.Model{
@@ -438,9 +445,10 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		Expect(k8sClient.Create(ctx, model)).To(Succeed())
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
-		// Manually set the status to Ready with a path that doesn't exist
+		// Manually set the status to Ready with a path that doesn't exist on
+		// disk to simulate a controller restart with stale status.
 		model.Status.Phase = PhaseReady
-		model.Status.Path = modelPath
+		model.Status.Path = stalePath
 		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
 
 		reconciler := &ModelReconciler{
@@ -454,13 +462,14 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(reconcile.Result{}))
 
-		// Verify model was re-downloaded and is Ready again
+		// Verify model was re-downloaded and landed at the canonical filename
+		// (Model.Name fallback because fake GGUF data fails parsing).
+		expectedPath := filepath.Join(tempDir, cacheKey, modelName+".gguf")
 		updated := &inferencev1alpha1.Model{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
 		Expect(updated.Status.Phase).To(Equal(PhaseReady))
-
-		// Verify the file now exists
-		_, err = os.Stat(modelPath)
+		Expect(updated.Status.Path).To(Equal(expectedPath))
+		_, err = os.Stat(expectedPath)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -741,6 +750,228 @@ var _ = Describe("PVC Source Reconcile", func() {
 			}
 		}
 		Expect(hasDegraded).To(BeTrue())
+	})
+})
+
+var _ = Describe("Model Controller - GGUF Filename Migration", func() {
+	ctx := context.Background()
+
+	It("renames downloaded model to GGUF metadata name", func() {
+		ggufBytes := buildMinimalGGUF("Gemma-4-E4B-It")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(ggufBytes)
+		}))
+		defer server.Close()
+
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "gemma-test"
+		source := fmt.Sprintf("%s/model.gguf", server.URL)
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: source},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseReady))
+		Expect(updated.Status.GGUF).NotTo(BeNil())
+		Expect(updated.Status.GGUF.ModelName).To(Equal("Gemma-4-E4B-It"))
+
+		cacheKey := computeCacheKey(source)
+		expectedPath := filepath.Join(tempDir, cacheKey, "Gemma-4-E4B-It.gguf")
+		Expect(updated.Status.Path).To(Equal(expectedPath))
+		_, err = os.Stat(expectedPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		legacyPath := filepath.Join(tempDir, cacheKey, "model.gguf")
+		_, err = os.Stat(legacyPath)
+		Expect(os.IsNotExist(err)).To(BeTrue(), "legacy model.gguf should not exist alongside canonical name")
+	})
+
+	It("sanitizes unsafe characters from GGUF metadata name", func() {
+		ggufBytes := buildMinimalGGUF("Llama 3.1/Instruct")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(ggufBytes)
+		}))
+		defer server.Close()
+
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "llama-test"
+		source := fmt.Sprintf("%s/model.gguf", server.URL)
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: source},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		cacheKey := computeCacheKey(source)
+		expectedPath := filepath.Join(tempDir, cacheKey, "Llama-3.1-Instruct.gguf")
+		Expect(updated.Status.Path).To(Equal(expectedPath))
+		_, err = os.Stat(expectedPath)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("early-exits on second reconcile after rename to canonical path", func() {
+		ggufBytes := buildMinimalGGUF("Test-Model")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(ggufBytes)
+		}))
+		defer server.Close()
+
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "test-rename-then-skip"
+		source := fmt.Sprintf("%s/model.gguf", server.URL)
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: source},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		first := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, first)).To(Succeed())
+		firstUpdated := first.Status.LastUpdated.DeepCopy()
+
+		// Second reconcile must early-exit without bumping LastUpdated.
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		second := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, second)).To(Succeed())
+		Expect(second.Status.LastUpdated.Equal(firstUpdated)).To(BeTrue())
+	})
+
+	It("falls back to Model.Name when GGUF metadata name is missing", func() {
+		// Valid GGUF with no general.name key.
+		ggufBytes := buildMinimalGGUF("")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(ggufBytes)
+		}))
+		defer server.Close()
+
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "fallback-by-cr-name"
+		source := fmt.Sprintf("%s/model.gguf", server.URL)
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: source},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		cacheKey := computeCacheKey(source)
+		expectedPath := filepath.Join(tempDir, cacheKey, modelName+".gguf")
+		Expect(updated.Status.Path).To(Equal(expectedPath))
+	})
+
+	It("migrates an existing legacy model.gguf to canonical name on next reconcile", func() {
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		// Pre-stage a real GGUF file at the legacy path.
+		ggufBytes := buildMinimalGGUF("Legacy-Cached-Model")
+		source := "https://example.com/legacy.gguf"
+		cacheKey := computeCacheKey(source)
+		modelDir := filepath.Join(tempDir, cacheKey)
+		legacyPath := filepath.Join(modelDir, "model.gguf")
+		Expect(os.MkdirAll(modelDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(legacyPath, ggufBytes, 0644)).To(Succeed())
+
+		modelName := "model-with-legacy-cache"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: source},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		// Simulate post-upgrade state: status was Ready under the legacy path.
+		model.Status.Phase = PhaseReady
+		model.Status.Path = legacyPath
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		expectedPath := filepath.Join(modelDir, "Legacy-Cached-Model.gguf")
+		Expect(updated.Status.Path).To(Equal(expectedPath))
+
+		_, err = os.Stat(expectedPath)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(legacyPath)
+		Expect(os.IsNotExist(err)).To(BeTrue(), "legacy model.gguf should have been renamed away")
 	})
 })
 

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -110,7 +111,17 @@ func buildPVCStorageConfig(model *inferencev1alpha1.Model) modelStorageConfig {
 
 func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, caCertConfigMap string, initContainerImage string) modelStorageConfig {
 	cacheDir := fmt.Sprintf("/models/%s", model.Status.CacheKey)
-	modelPath := fmt.Sprintf("%s/model.gguf", cacheDir)
+	// Match the basename the Model controller renames the file to after
+	// parsing GGUF metadata. If the controller has already populated
+	// Status.Path, use that basename verbatim so the init container's cache
+	// hit lands on the same file. Otherwise (e.g. HF repo sources where the
+	// controller does no download), use the canonical basename so the init
+	// container creates the file at the same path the controller would.
+	basename := canonicalModelBasename(model)
+	if model.Status.Path != "" {
+		basename = filepath.Base(model.Status.Path)
+	}
+	modelPath := fmt.Sprintf("%s/%s", cacheDir, basename)
 
 	initVolumeMounts := []corev1.VolumeMount{
 		{Name: "model-cache", MountPath: "/models"},


### PR DESCRIPTION
## Summary

- Renames each downloaded GGUF on disk from the literal `model.gguf` to a metadata-derived basename: `Status.GGUF.ModelName` → `Model.Name` → `"model"`, sanitized slug-style.
- Adds `findCachedModelFile` (glob `*.gguf`) and `migrateModelFilename` so legacy `model.gguf` files are renamed in place on the next reconcile after upgrade — no re-download.
- Updates the init container's `MODEL_PATH` to track `filepath.Base(model.Status.Path)` so cached-mode pods land on the same file the controller produced.

Closes #337.

## Why

@castorinop's report: every model on disk is `model.gguf`, so proxies like Olla report indistinguishable ids and multi-model namespaces collapse. The fix uses the data we already had: `Model.Status.GGUF.ModelName` is populated on the same reconcile pass and was never wired into the filename.

## Sanitization rule

Slug-style: keep `[A-Za-z0-9._-]`, replace anything else with `-`, collapse runs, and trim leading/trailing `-._` so `..` and `.hidden` reduce to safe basenames or to empty (then fall through to `Model.Name`).

## Migration

Lazy, in-place. Legacy `model.gguf` files are detected via glob, parsed for GGUF metadata, then renamed to the canonical filename on the next reconcile. Early-exit only fires when `Status.Path` already points at the canonical name, so a fleet upgrade does one rename per Model and becomes a no-op thereafter.

## Test plan

- [x] `go test ./internal/controller/... -count=1` — full controller suite (302 specs) passes
- [x] 18 sanitizer table cases (`sanitizeModelFilename`)
- [x] 7 canonical-basename cases (`canonicalModelBasename`) including path-traversal guard, GGUF-empty fallback, sanitize-to-empty fallback
- [x] 5 new envtest specs:
  - download → renamed to `Gemma-4-E4B-It.gguf` from real GGUF metadata
  - sanitization of unsafe chars (`Llama 3.1/Instruct` → `Llama-3.1-Instruct.gguf`)
  - second reconcile early-exits without bumping `LastUpdated`
  - GGUF metadata name missing → falls back to `Model.Name`
  - existing legacy `model.gguf` migrated in place on next reconcile (the upgrade path)
- [x] Two existing specs (`should skip reconcile when model is already Ready and file exists`, `should re-download when model is Ready but file is missing`) updated to reflect canonical-name behavior
- [x] `go vet ./...`, `make manifests generate` clean (no CRD schema changes)

## Notes for reviewer

- No CRD schema change — this is purely controller-internal behavior.
- The runtime-reported model id (`/v1/models`) for llama.cpp is the file basename by default. Users who set `extraArgs: ["--alias", "..."]` still win — the alias overrides the basename. The workaround @castorinop posted in the issue continues to work alongside this fix.
- For HF-repo sources where the controller does no download, the init container now uses `canonicalModelBasename(model)` (Model.Name-derived) as the deterministic basename, replacing the previous literal `model.gguf`. This is also a small correctness win for HF-repo deployments serving multiple models.