### PR TITLE
feat(api): add cacheTypeCustomK/V for non-enum llama.cpp KV cache types

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -116,15 +116,34 @@ type InferenceServiceSpec struct {
 	// CacheTypeK sets the KV cache quantization type for keys.
 	// Supported values depend on the llama.cpp build version.
 	// Maps to llama.cpp --cache-type-k flag. Default: f16 (llama.cpp default).
+	// For custom build types not in the enum (e.g. TurboQuant turbo3, tbqp3), use
+	// CacheTypeCustomK instead.
 	// +kubebuilder:validation:Enum=f16;f32;q8_0;q4_0;q4_1;q5_0;q5_1;iq4_nl
 	// +optional
 	CacheTypeK string `json:"cacheTypeK,omitempty"`
 
 	// CacheTypeV sets the KV cache quantization type for values.
 	// Maps to llama.cpp --cache-type-v flag. Default: f16 (llama.cpp default).
+	// For custom build types not in the enum (e.g. TurboQuant turbo3, tbqp3), use
+	// CacheTypeCustomV instead.
 	// +kubebuilder:validation:Enum=f16;f32;q8_0;q4_0;q4_1;q5_0;q5_1;iq4_nl
 	// +optional
 	CacheTypeV string `json:"cacheTypeV,omitempty"`
+
+	// CacheTypeCustomK sets a custom KV cache type for keys that is not in the
+	// standard enum. Used for llama.cpp forks with additional cache formats such
+	// as TurboQuant (turbo3, turbo4, tbqp3, etc.). Maps to llama.cpp
+	// --cache-type-k. The runtime binary must understand the value or llama-server
+	// will fail to start; LLMKube does not validate the string.
+	// Takes precedence over CacheTypeK when both are set.
+	// +optional
+	CacheTypeCustomK string `json:"cacheTypeCustomK,omitempty"`
+
+	// CacheTypeCustomV sets a custom KV cache type for values that is not in the
+	// standard enum. See CacheTypeCustomK for usage notes. Takes precedence over
+	// CacheTypeV when both are set.
+	// +optional
+	CacheTypeCustomV string `json:"cacheTypeCustomV,omitempty"`
 
 	// MoeCPUOffload offloads all MoE expert layers to CPU for reduced VRAM usage.
 	// Enables running large MoE models (e.g., Qwen3-30B, Mixtral) on VRAM-constrained

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -141,11 +141,28 @@ spec:
                 maximum: 16384
                 minimum: 1
                 type: integer
+              cacheTypeCustomK:
+                description: |-
+                  CacheTypeCustomK sets a custom KV cache type for keys that is not in the
+                  standard enum. Used for llama.cpp forks with additional cache formats such
+                  as TurboQuant (turbo3, turbo4, tbqp3, etc.). Maps to llama.cpp
+                  --cache-type-k. The runtime binary must understand the value or llama-server
+                  will fail to start; LLMKube does not validate the string.
+                  Takes precedence over CacheTypeK when both are set.
+                type: string
+              cacheTypeCustomV:
+                description: |-
+                  CacheTypeCustomV sets a custom KV cache type for values that is not in the
+                  standard enum. See CacheTypeCustomK for usage notes. Takes precedence over
+                  CacheTypeV when both are set.
+                type: string
               cacheTypeK:
                 description: |-
                   CacheTypeK sets the KV cache quantization type for keys.
                   Supported values depend on the llama.cpp build version.
                   Maps to llama.cpp --cache-type-k flag. Default: f16 (llama.cpp default).
+                  For custom build types not in the enum (e.g. TurboQuant turbo3, tbqp3), use
+                  CacheTypeCustomK instead.
                 enum:
                 - f16
                 - f32
@@ -160,6 +177,8 @@ spec:
                 description: |-
                   CacheTypeV sets the KV cache quantization type for values.
                   Maps to llama.cpp --cache-type-v flag. Default: f16 (llama.cpp default).
+                  For custom build types not in the enum (e.g. TurboQuant turbo3, tbqp3), use
+                  CacheTypeCustomV instead.
                 enum:
                 - f16
                 - f32
@@ -392,9 +411,14 @@ spec:
                 type: array
               flashAttention:
                 description: |-
-                  FlashAttention enables flash attention for faster prompt processing and reduced
-                  VRAM usage. Requires a GPU with flash attention support (NVIDIA Ampere or newer).
-                  Maps to llama.cpp --flash-attn flag. Only applied when GPU is configured.
+                  FlashAttention enables flash attention for faster prompt processing and
+                  reduced KV cache memory. Maps to llama.cpp --flash-attn flag.
+
+                  On NVIDIA GPUs requires Ampere or newer (compute capability 8.0+).
+                  On Apple Silicon (Metal agent path) the default is true when this field
+                  is unset, because the wired-collector + flash-attn combination prevents
+                  the ~25% decode degradation observed at long context on Qwen-class
+                  models running on M-series chips.
                 type: boolean
               image:
                 description: |-

--- a/config/samples/inferenceservice_turboquant.yaml
+++ b/config/samples/inferenceservice_turboquant.yaml
@@ -1,0 +1,33 @@
+# InferenceService sample using TurboQuant KV cache compression for extended
+# context on memory-constrained hardware. Requires a llama-server binary built
+# from a TurboQuant-enabled fork (see docs/turboquant.md). The cacheTypeCustomK
+# / cacheTypeCustomV fields skip CRD enum validation so non-standard cache
+# types pass through to llama-server without LLMKube needing per-type updates.
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen35-30b-a3b-turboquant
+spec:
+  source: https://huggingface.co/unsloth/Qwen3.5-30B-A3B-GGUF/resolve/main/Qwen3.5-30B-A3B-Q8_0.gguf
+  format: gguf
+  quantization: Q8_0
+  hardware:
+    accelerator: metal
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen35-30b-a3b-turboquant
+spec:
+  modelRef: qwen35-30b-a3b-turboquant
+  runtime: llamacpp
+  replicas: 1
+  contextSize: 262144
+  flashAttention: true
+  jinja: true
+  parallelSlots: 2
+  # turbo3 = ~3.25 bits/value, ~4.9x compression vs fp16. At 256K context this
+  # is roughly ~13 GB of KV cache vs ~64 GB at fp16. Requires a TurboQuant-
+  # enabled llama.cpp build; LLMKube does not validate the string.
+  cacheTypeCustomK: turbo3
+  cacheTypeCustomV: turbo3

--- a/docs/turboquant.md
+++ b/docs/turboquant.md
@@ -1,0 +1,65 @@
+# TurboQuant KV cache types
+
+LLMKube's `cacheTypeK` and `cacheTypeV` fields on `InferenceService` validate against an enum of standard llama.cpp cache types: `f16`, `f32`, `q8_0`, `q4_0`, `q4_1`, `q5_0`, `q5_1`, `iq4_nl`. Custom llama.cpp builds add types beyond this set — most notably **TurboQuant** ([Google Research, ICLR 2026](https://research.google/blog/turboquant-redefining-ai-efficiency-with-extreme-compression/)) which adds `turbo2`, `turbo3`, `turbo4`, and several community variants (`tbq3`, `tbqp3`, etc.).
+
+To use a non-enum cache type without expanding the CRD enum every time a new one appears upstream, set the **`cacheTypeCustomK`** / **`cacheTypeCustomV`** fields:
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen35-256k
+spec:
+  modelRef: qwen3-5-30b-a3b
+  runtime: llamacpp
+  contextSize: 262144
+  flashAttention: true
+  cacheTypeCustomK: turbo3
+  cacheTypeCustomV: turbo3
+```
+
+LLMKube does not validate the string. The runtime binary must understand the value or `llama-server` will fail to start with a clear error.
+
+## Precedence
+
+When both `cacheTypeK` and `cacheTypeCustomK` are set on the same spec, **`cacheTypeCustomK` wins**. Same for V. This lets a manifest declare a standard type as a fallback while opting into a fork-specific type when one is available.
+
+## When to use which field
+
+| Field | Use when |
+|---|---|
+| `cacheTypeK` / `cacheTypeV` | The cache type is in the standard llama.cpp enum (q8_0, iq4_nl, etc.). Gives you API-server-side validation that catches typos. |
+| `cacheTypeCustomK` / `cacheTypeCustomV` | The cache type is from a fork (TurboQuant turbo3, AmesianX tbqp3, etc.). No CRD validation, but lets you use any future cache format without an LLMKube release. |
+
+## Required runtime
+
+For TurboQuant types specifically, the `llama-server` binary must be built from a fork that ships the kernels:
+
+| Backend | Fork | Branch |
+|---|---|---|
+| Metal (Apple Silicon) | [TheTom/llama-cpp-turboquant](https://github.com/TheTom/llama-cpp-turboquant) | `feature/turboquant-kv-cache` |
+| CUDA (RTX 30/40/50-series) | [spiritbuun/llama-cpp-turboquant-cuda](https://github.com/spiritbuun/llama-cpp-turboquant-cuda) | upstream-tracking |
+| Vulkan (AMD/Intel) | jesusmb1995's fork (see discussion below) | mixed K/V types |
+
+For Mac, point the metal-agent at the fork via the `--llama-server` flag in your launchd plist.
+
+## Memory savings
+
+Approximate KV cache size per token at 35B-class models, fp16 reference = `~256 KB/token`:
+
+| Cache type | bits/value | Compression | KV size at 256K context |
+|---|---|---|---|
+| `f16` (default) | 16 | 1.0× | ~64 GB |
+| `q8_0` | 8 | 2.0× | ~32 GB |
+| `turbo4` | 4.25 | 3.8× | ~17 GB |
+| `turbo3` | 3.25 | 4.9× | ~13 GB |
+| `turbo2` | 2.5 | ~6.4× | ~10 GB |
+
+Perplexity penalty for `turbo3` is around +1% on Qwen 3.5-class models per the upstream community discussion.
+
+## References
+
+- llama.cpp community discussion: <https://github.com/ggml-org/llama.cpp/discussions/20969>
+- TurboQuant paper: <https://arxiv.org/abs/2504.19874>
+- LLMKube tracking issue: [#308](https://github.com/defilantech/LLMKube/issues/308)
+- The CRD field decision: [#282](https://github.com/defilantech/LLMKube/issues/282)

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -1372,6 +1372,105 @@ var _ = Describe("Context Size Configuration", func() {
 			Expect(args).NotTo(ContainElement("--cache-type-k"))
 			Expect(args).NotTo(ContainElement("--cache-type-v"))
 		})
+
+		It("should pass through cacheTypeCustomK to --cache-type-k for fork-specific types", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cache-custom-k-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:         "cache-type-model",
+					Replicas:         &replicas,
+					Image:            "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					CacheTypeCustomK: "turbo3",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--cache-type-k", "turbo3"))
+		})
+
+		It("should prefer cacheTypeCustomK over cacheTypeK when both are set", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cache-precedence-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:         "cache-type-model",
+					Replicas:         &replicas,
+					Image:            "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					CacheTypeK:       "q8_0",
+					CacheTypeCustomK: "turbo3",
+					CacheTypeV:       "q8_0",
+					CacheTypeCustomV: "tbqp3",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--cache-type-k", "turbo3"))
+			Expect(args).To(ContainElements("--cache-type-v", "tbqp3"))
+			Expect(args).NotTo(ContainElement("q8_0"))
+		})
+
+		It("should fall back to cacheTypeK when cacheTypeCustomK is empty", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cache-fallback-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:         "cache-type-model",
+					Replicas:         &replicas,
+					Image:            "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					CacheTypeK:       "q5_1",
+					CacheTypeCustomK: "",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--cache-type-k", "q5_1"))
+		})
+
+		It("should pass through cacheTypeCustomV to --cache-type-v independently of K", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cache-custom-v-only-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:         "cache-type-model",
+					Replicas:         &replicas,
+					Image:            "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					CacheTypeCustomV: "turbo4",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--cache-type-k"))
+			Expect(args).To(ContainElements("--cache-type-v", "turbo4"))
+		})
 	})
 
 	Context("when moeCPUOffload is configured", func() {

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -65,7 +65,7 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 	args = appendParallelSlotsArgs(args, isvc.Spec.ParallelSlots)
 	args = appendFlashAttentionArgs(args, isvc.Spec.FlashAttention, gpuCount)
 	args = appendJinjaArgs(args, isvc.Spec.Jinja)
-	args = appendCacheTypeArgs(args, isvc.Spec.CacheTypeK, isvc.Spec.CacheTypeV)
+	args = appendCacheTypeArgs(args, resolveCacheType(isvc.Spec.CacheTypeCustomK, isvc.Spec.CacheTypeK), resolveCacheType(isvc.Spec.CacheTypeCustomV, isvc.Spec.CacheTypeV))
 	args = appendMoeCPUOffloadArgs(args, isvc.Spec.MoeCPUOffload)
 	args = appendMoeCPULayersArgs(args, isvc.Spec.MoeCPULayers)
 	args = appendNoKvOffloadArgs(args, isvc.Spec.NoKvOffload)

--- a/internal/controller/runtime_llamacpp_args.go
+++ b/internal/controller/runtime_llamacpp_args.go
@@ -78,6 +78,17 @@ func appendCacheTypeArgs(args []string, cacheTypeK, cacheTypeV string) []string 
 	return args
 }
 
+// resolveCacheType returns the custom cache type when set, otherwise the
+// enum-validated standard value. Lets users opt into fork-specific cache types
+// (TurboQuant turbo3/turbo4, etc.) without expanding the CRD enum, while
+// keeping the standard fields discoverable for the common case.
+func resolveCacheType(custom, standard string) string {
+	if custom != "" {
+		return custom
+	}
+	return standard
+}
+
 func appendMoeCPUOffloadArgs(args []string, moeCPUOffload *bool) []string {
 	if moeCPUOffload != nil && *moeCPUOffload {
 		return append(args, "--cpu-moe")


### PR DESCRIPTION
## Summary

- Adds `cacheTypeCustomK` / `cacheTypeCustomV` to `InferenceServiceSpec` — string fields without enum validation, used when the standard `cacheTypeK` / `cacheTypeV` fields can't express a fork-specific cache type (TurboQuant turbo3/turbo4, AmesianX tbqp3, etc.).
- When both standard and custom are set on the same field, **custom wins**. Lets a manifest declare a standard fallback while opting into a fork type when one is available.
- Runtime args path (`appendCacheTypeArgs` via new `resolveCacheType` helper) is unchanged in shape — still passes through to `--cache-type-k` / `--cache-type-v`. No validation; the runtime binary catches typos by failing to start.
- Adds `docs/turboquant.md` explainer (which fields to use, which fork to build, memory savings table) and `config/samples/inferenceservice_turboquant.yaml` ready-to-apply sample at 256K context.

Closes #282. Refs #308.

## Why

[#282](https://github.com/defilantech/LLMKube/issues/282) called out the gap directly. While validating TheTom's [llama-cpp-turboquant fork](https://github.com/TheTom/llama-cpp-turboquant) on M5 Max this evening I hit it concretely:

```
$ kubectl patch isvc qwen36-35b-a3b --type merge -p '{"spec":{"cacheTypeK":"turbo3"}}'
The InferenceService is invalid:
* spec.cacheTypeK: Unsupported value: "turbo3":
  supported values: "f16", "f32", "q8_0", "q4_0", "q4_1", "q5_0", "q5_1", "iq4_nl"
```

The existing CUDA-side TurboQuant benchmarks in `llmkube-internal/benchmarks/turboquant/` had to use `extraArgs: ["--cache-type-k", "tbqp3", ...]` for the same reason. With this PR they could use the structured field.

## Approach

The original #282 description proposed `cacheTypeCustomK` / `cacheTypeCustomV` and that's what this PR implements. Alternative considered:

| Option | Issue |
|---|---|
| Extend the standard enum (`f16;…;iq4_nl;turbo3;turbo4`) | Couples the CRD to specific forks; needs a release per new type |
| Drop enum validation entirely | Loses the safety net for common typos |
| **Add custom-string field (this PR)** | Keeps enum for discoverability + zero-CRD-update path for any future type |

## Test plan

- [x] `go test ./internal/controller/... -count=1` — full suite passes (302+ specs)
- [x] Four new Ginkgo specs covering:
  - `cacheTypeCustomK: turbo3` produces `--cache-type-k turbo3`
  - both `cacheTypeK` and `cacheTypeCustomK` set → custom wins (verified for both K and V)
  - `cacheTypeCustomK: ""` falls back to `cacheTypeK`
  - `cacheTypeCustomV` without `cacheTypeCustomK` produces only `--cache-type-v` (independence)
- [x] `make manifests generate fmt vet` clean
- [x] CRD YAML regenerated; the new fields appear without enum constraints
- [x] Manual: `kubectl apply -f config/samples/inferenceservice_turboquant.yaml` succeeds against the regenerated CRDs

## Note for reviewers

Two **separate** bugs surfaced while validating this on the metal-runtime path tonight, both filed as their own issues — they're orthogonal to this PR but block end-to-end TurboQuant on Mac:

- [#349](https://github.com/defilantech/LLMKube/issues/349) — metal-agent's `ExecutorConfig` drops `cacheTypeK/V`, `extraArgs`, `parallelSlots`, MoE flags, etc. (drops most ISVC spec fields, not just the new ones)
- [#350](https://github.com/defilantech/LLMKube/issues/350) — metal-agent ignores spec UPDATED events (early-returns when process is healthy without diffing spec)

This PR is correct and complete on its own — it's the operator-side surface area. The metal-agent fixes will land in follow-up PRs.