### PR TITLE
fix(agent): respawn on InferenceService spec drift, honor replicas=0, and plumb full spec to llama-server flags

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -18,6 +18,9 @@ package agent
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -120,6 +123,11 @@ type ManagedProcess struct {
 	ModelID   string // oMLX/Ollama model identifier used for unload; empty for llama-server
 	StartedAt time.Time
 	Healthy   bool
+
+	// SpecHash captures the hash of InferenceServiceSpec fields that, if
+	// changed, require respawning the underlying process. Used by ensureProcess
+	// to detect spec drift on UPDATED events and respawn instead of no-oping.
+	SpecHash string
 }
 
 // NewMetalAgent creates a new Metal agent instance
@@ -311,21 +319,47 @@ func (a *MetalAgent) handleEvent(ctx context.Context, event InferenceServiceEven
 	return nil
 }
 
-// ensureProcess ensures a llama-server process is running for the InferenceService
+// ensureProcess ensures a llama-server process is running for the InferenceService.
+// On UPDATED events, the spec is diffed against the running process's stored
+// hash; if it changed, the existing process is stopped before a fresh one is
+// spawned so the new flags actually take effect. Replicas=0 stops the process
+// without restarting.
 func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.InferenceService) error {
 	key := types.NamespacedName{
 		Namespace: isvc.Namespace,
 		Name:      isvc.Name,
 	}.String()
 
+	desiredHash := computeSpecHash(isvc)
+
 	// Check if process already exists
 	a.mu.RLock()
 	existing, exists := a.processes[key]
 	a.mu.RUnlock()
 
-	if exists && existing.Healthy {
-		a.logger.Debugw("inference service already has a healthy process", "key", key)
+	// Honor spec.replicas=0 by stopping a running process and not respawning.
+	// Without this, a user trying to take a model offline via spec edits has
+	// to fully reload the metal-agent to evict it.
+	if isvc.Spec.Replicas != nil && *isvc.Spec.Replicas == 0 {
+		if exists {
+			a.logger.Infow("replicas=0; stopping process",
+				"namespace", isvc.Namespace, "name", isvc.Name)
+			return a.deleteProcess(ctx, key)
+		}
 		return nil
+	}
+
+	if exists && existing.Healthy {
+		if existing.SpecHash == desiredHash {
+			a.logger.Debugw("inference service already has a healthy process with matching spec", "key", key)
+			return nil
+		}
+		a.logger.Infow("spec changed; restarting process to pick up new flags",
+			"namespace", isvc.Namespace, "name", isvc.Name,
+			"oldSpecHash", existing.SpecHash, "newSpecHash", desiredHash)
+		if err := a.deleteProcess(ctx, key); err != nil {
+			return fmt.Errorf("failed to stop process before respawn: %w", err)
+		}
 	}
 
 	a.logger.Infow("starting inference service", "namespace", isvc.Namespace, "name", isvc.Name)
@@ -476,6 +510,10 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 	if err != nil {
 		return fmt.Errorf("failed to start process: %w", err)
 	}
+
+	// Stamp the spec hash onto the process so future ensureProcess calls
+	// can detect drift via simple string compare.
+	process.SpecHash = desiredHash
 
 	// Store process and update metrics
 	a.mu.Lock()
@@ -795,4 +833,74 @@ func (a *MetalAgent) estimateModelMemory(model *inferencev1alpha1.Model, context
 	}
 
 	return EstimateModelMemory(fileSizeBytes, layerCount, embeddingSize, contextSize), nil
+}
+
+// computeSpecHash returns a stable hash of the InferenceServiceSpec fields that,
+// if changed, require respawning the underlying llama-server process. Listing
+// fields explicitly (rather than hashing the full Spec) keeps the hash stable
+// across CRD additions that don't affect process invocation — adding a new
+// status-only or controller-only field won't trigger a spurious respawn.
+func computeSpecHash(isvc *inferencev1alpha1.InferenceService) string {
+	if isvc == nil {
+		return ""
+	}
+	// Fields included MUST match what the executor actually consumes (or what
+	// it will consume once #349 closes the ExecutorConfig gap). When adding a
+	// new spec field that affects llama-server args, add it here too.
+	relevant := struct {
+		ModelRef               string
+		ContextSize            *int32
+		BatchSize              *int32
+		UBatchSize             *int32
+		ParallelSlots          *int32
+		FlashAttention         *bool
+		Jinja                  *bool
+		NoKvOffload            *bool
+		NoWarmup               *bool
+		MoeCPUOffload          *bool
+		MoeCPULayers           *int32
+		CacheTypeK             string
+		CacheTypeV             string
+		CacheTypeCustomK       string
+		CacheTypeCustomV       string
+		TensorOverrides        []string
+		MetadataOverrides      []string
+		ExtraArgs              []string
+		ReasoningBudget        *int32
+		ReasoningBudgetMessage string
+		Replicas               *int32
+		Runtime                string
+	}{
+		ModelRef:               isvc.Spec.ModelRef,
+		ContextSize:            isvc.Spec.ContextSize,
+		BatchSize:              isvc.Spec.BatchSize,
+		UBatchSize:             isvc.Spec.UBatchSize,
+		ParallelSlots:          isvc.Spec.ParallelSlots,
+		FlashAttention:         isvc.Spec.FlashAttention,
+		Jinja:                  isvc.Spec.Jinja,
+		NoKvOffload:            isvc.Spec.NoKvOffload,
+		NoWarmup:               isvc.Spec.NoWarmup,
+		MoeCPUOffload:          isvc.Spec.MoeCPUOffload,
+		MoeCPULayers:           isvc.Spec.MoeCPULayers,
+		CacheTypeK:             isvc.Spec.CacheTypeK,
+		CacheTypeV:             isvc.Spec.CacheTypeV,
+		CacheTypeCustomK:       isvc.Spec.CacheTypeCustomK,
+		CacheTypeCustomV:       isvc.Spec.CacheTypeCustomV,
+		TensorOverrides:        isvc.Spec.TensorOverrides,
+		MetadataOverrides:      isvc.Spec.MetadataOverrides,
+		ExtraArgs:              isvc.Spec.ExtraArgs,
+		ReasoningBudget:        isvc.Spec.ReasoningBudget,
+		ReasoningBudgetMessage: isvc.Spec.ReasoningBudgetMessage,
+		Replicas:               isvc.Spec.Replicas,
+		Runtime:                isvc.Spec.Runtime,
+	}
+	b, err := json.Marshal(relevant)
+	if err != nil {
+		// json.Marshal on this struct shape is effectively infallible; if it
+		// somehow fails we fall back to the zero hash, which forces a respawn
+		// — safer than skipping the diff entirely.
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -325,6 +325,77 @@ func (a *MetalAgent) handleEvent(ctx context.Context, event InferenceServiceEven
 	return nil
 }
 
+// executorBaseConfig holds the values ensureProcess derives from sources
+// outside isvc.Spec (memory check, defaults, perf-core detection). Passing
+// these alongside the isvc into buildExecutorConfig lets the helper own all
+// the spec → flag mapping in one place.
+type executorBaseConfig struct {
+	GPULayers      int32
+	ContextSize    int
+	FlashAttention bool
+	BatchSize      int
+	UBatchSize     int
+}
+
+// buildExecutorConfig collects every flag-relevant InferenceService field into
+// an ExecutorConfig that buildLlamaServerArgs can consume. Pointer fields are
+// dereferenced here so the executor sees plain values; cache types are resolved
+// (custom > standard) to mirror the controller's runtime_llamacpp arg builder.
+func buildExecutorConfig(
+	isvc *inferencev1alpha1.InferenceService,
+	model *inferencev1alpha1.Model,
+	base executorBaseConfig,
+) ExecutorConfig {
+	cacheTypeK := isvc.Spec.CacheTypeK
+	if isvc.Spec.CacheTypeCustomK != "" {
+		cacheTypeK = isvc.Spec.CacheTypeCustomK
+	}
+	cacheTypeV := isvc.Spec.CacheTypeV
+	if isvc.Spec.CacheTypeCustomV != "" {
+		cacheTypeV = isvc.Spec.CacheTypeCustomV
+	}
+
+	return ExecutorConfig{
+		Name:                   isvc.Name,
+		Namespace:              isvc.Namespace,
+		ModelSource:            model.Spec.Source,
+		ModelName:              model.Name,
+		GPULayers:              base.GPULayers,
+		ContextSize:            base.ContextSize,
+		Jinja:                  derefBool(isvc.Spec.Jinja),
+		FlashAttention:         base.FlashAttention,
+		Mlock:                  true,
+		BatchSize:              base.BatchSize,
+		UBatchSize:             base.UBatchSize,
+		ParallelSlots:          derefInt32(isvc.Spec.ParallelSlots),
+		CacheTypeK:             cacheTypeK,
+		CacheTypeV:             cacheTypeV,
+		MoeCPUOffload:          derefBool(isvc.Spec.MoeCPUOffload),
+		MoeCPULayers:           derefInt32(isvc.Spec.MoeCPULayers),
+		NoKvOffload:            derefBool(isvc.Spec.NoKvOffload),
+		TensorOverrides:        isvc.Spec.TensorOverrides,
+		MetadataOverrides:      isvc.Spec.MetadataOverrides,
+		NoWarmup:               derefBool(isvc.Spec.NoWarmup),
+		ReasoningBudget:        derefInt32(isvc.Spec.ReasoningBudget),
+		ReasoningBudgetMessage: isvc.Spec.ReasoningBudgetMessage,
+		ExtraArgs:              isvc.Spec.ExtraArgs,
+	}
+}
+
+func derefBool(p *bool) bool {
+	if p == nil {
+		return false
+	}
+	return *p
+}
+
+func derefInt32(p *int32) int {
+	if p == nil {
+		return 0
+	}
+	return int(*p)
+}
+
 // validateRuntimeFormat returns an error if the model's format is incompatible
 // with the agent's configured runtime. Empty format defaults to "gguf".
 func (a *MetalAgent) validateRuntimeFormat(model *inferencev1alpha1.Model) error {
@@ -508,20 +579,16 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 		uBatchSize = int(*isvc.Spec.UBatchSize)
 	}
 
-	// Start the process
-	process, err := a.executor.StartProcess(ctx, ExecutorConfig{
-		Name:           isvc.Name,
-		Namespace:      isvc.Namespace,
-		ModelSource:    model.Spec.Source,
-		ModelName:      model.Name,
+	cfg := buildExecutorConfig(isvc, model, executorBaseConfig{
 		GPULayers:      gpuLayers,
 		ContextSize:    contextSize,
-		Jinja:          isvc.Spec.Jinja != nil && *isvc.Spec.Jinja,
 		FlashAttention: flashAttn,
-		Mlock:          true,
 		BatchSize:      batchSize,
 		UBatchSize:     uBatchSize,
 	})
+
+	// Start the process
+	process, err := a.executor.StartProcess(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to start process: %w", err)
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -35,6 +35,12 @@ import (
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
 
+// Inference runtime identifiers used by MetalAgentConfig.Runtime.
+const (
+	runtimeOMLX   = "omlx"
+	runtimeOllama = "ollama"
+)
+
 // MetalAgentConfig contains configuration for the Metal agent
 type MetalAgentConfig struct {
 	K8sClient      client.Client
@@ -191,7 +197,7 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 	}
 
 	switch a.config.Runtime {
-	case "omlx":
+	case runtimeOMLX:
 		port := a.config.OMLXPort
 		if port == 0 {
 			port = 8000
@@ -206,7 +212,7 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 			omlxExec.SetStartupTimeout(a.config.OMLXStartupTimeout)
 		}
 		a.executor = omlxExec
-	case "ollama":
+	case runtimeOllama:
 		port := a.config.OllamaPort
 		if port == 0 {
 			port = 11434
@@ -319,6 +325,39 @@ func (a *MetalAgent) handleEvent(ctx context.Context, event InferenceServiceEven
 	return nil
 }
 
+// validateRuntimeFormat returns an error if the model's format is incompatible
+// with the agent's configured runtime. Empty format defaults to "gguf".
+func (a *MetalAgent) validateRuntimeFormat(model *inferencev1alpha1.Model) error {
+	modelFormat := model.Spec.Format
+	if modelFormat == "" {
+		modelFormat = "gguf"
+	}
+
+	var bad bool
+	var runtimeLabel string
+	switch a.config.Runtime {
+	case runtimeOMLX:
+		bad = modelFormat == "gguf"
+		runtimeLabel = runtimeOMLX
+	case runtimeOllama:
+		bad = modelFormat == "mlx"
+		runtimeLabel = runtimeOllama
+	default:
+		bad = modelFormat == "mlx"
+		runtimeLabel = "llama-server"
+	}
+	if !bad {
+		return nil
+	}
+
+	a.logger.Warnw("skipping incompatible model format for runtime",
+		"model", model.Name, "format", modelFormat, "runtime", a.config.Runtime)
+	return fmt.Errorf(
+		"model %s has format %q which is incompatible with %s runtime",
+		model.Name, modelFormat, runtimeLabel,
+	)
+}
+
 // ensureProcess ensures a llama-server process is running for the InferenceService.
 // On UPDATED events, the spec is diffed against the running process's stored
 // hash; if it changed, the existing process is stopped before a fresh one is
@@ -373,32 +412,8 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 		return fmt.Errorf("failed to get model %s: %w", isvc.Spec.ModelRef, err)
 	}
 
-	// Check for runtime/format mismatch
-	modelFormat := model.Spec.Format
-	if modelFormat == "" {
-		modelFormat = "gguf" // default
-	}
-	switch a.config.Runtime {
-	case "omlx":
-		if modelFormat == "gguf" {
-			a.logger.Warnw("skipping GGUF model on oMLX runtime",
-				"model", model.Name, "format", modelFormat, "runtime", a.config.Runtime)
-			return fmt.Errorf("model %s has format %q which is incompatible with omlx runtime", model.Name, modelFormat)
-		}
-	case "ollama":
-		if modelFormat == "mlx" {
-			a.logger.Warnw("skipping MLX model on Ollama runtime",
-				"model", model.Name, "format", modelFormat, "runtime", a.config.Runtime)
-			return fmt.Errorf(
-				"model %s has format %q which is incompatible with ollama runtime",
-				model.Name, modelFormat)
-		}
-	default:
-		if modelFormat == "mlx" {
-			a.logger.Warnw("skipping MLX model on llama-server runtime",
-				"model", model.Name, "format", modelFormat, "runtime", a.config.Runtime)
-			return fmt.Errorf("model %s has format %q which is incompatible with llama-server runtime", model.Name, modelFormat)
-		}
+	if err := a.validateRuntimeFormat(model); err != nil {
+		return err
 	}
 
 	// Get GPU layers if specified

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -496,8 +496,12 @@ func TestComputeSpecHash_StableForSameSpec(t *testing.T) {
 func TestComputeSpecHash_ChangesWithContextSize(t *testing.T) {
 	ctx1 := int32(65536)
 	ctx2 := int32(131072)
-	a := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", ContextSize: &ctx1}}
-	b := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", ContextSize: &ctx2}}
+	a := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", ContextSize: &ctx1},
+	}
+	b := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", ContextSize: &ctx2},
+	}
 	if computeSpecHash(a) == computeSpecHash(b) {
 		t.Error("hash should differ when contextSize changes")
 	}
@@ -505,15 +509,22 @@ func TestComputeSpecHash_ChangesWithContextSize(t *testing.T) {
 
 func TestComputeSpecHash_ChangesWithCacheTypeCustom(t *testing.T) {
 	a := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m"}}
-	b := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", CacheTypeCustomK: "turbo3"}}
+	b := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", CacheTypeCustomK: "turbo3"},
+	}
 	if computeSpecHash(a) == computeSpecHash(b) {
-		t.Error("hash should differ when cacheTypeCustomK is set; this is the field added in #351 and the runtime arg builder uses it")
+		t.Error("hash should differ when cacheTypeCustomK is set (added in #351, used by runtime arg builder)")
 	}
 }
 
 func TestComputeSpecHash_ChangesWithExtraArgs(t *testing.T) {
 	a := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m"}}
-	b := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", ExtraArgs: []string{"--cache-type-k", "turbo3"}}}
+	b := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef:  "m",
+			ExtraArgs: []string{"--cache-type-k", "turbo3"},
+		},
+	}
 	if computeSpecHash(a) == computeSpecHash(b) {
 		t.Error("hash should differ when extraArgs is set")
 	}
@@ -525,13 +536,25 @@ func TestComputeSpecHash_NilIsvc(t *testing.T) {
 	}
 }
 
-func TestEnsureProcess_ReplicasZeroStopsExistingProcess(t *testing.T) {
+// runEnsureProcessExpectingMapEviction sets up a metal-agent with a pre-seeded
+// healthy process at default/<name>, runs ensureProcess against the given isvc,
+// and asserts the process map entry has been removed. Pre-seeded PID -99999
+// makes StopProcess error out so the function returns an error, but the
+// deletion branch has already run by then; that is the invariant we check
+// (mirrors TestDeleteProcess_StopFailureStillUnregistersEndpoint). Used by the
+// replicas=0 and spec-drift tests, which share this exact setup.
+func runEnsureProcessExpectingMapEviction(
+	t *testing.T,
+	name string,
+	isvc *inferencev1alpha1.InferenceService,
+) {
+	t.Helper()
 	scheme := newTestScheme()
 	_ = corev1.AddToScheme(scheme)
 
-	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "scale-down-isvc", Namespace: "default"}}
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
 	//nolint:staticcheck // SA1019: Endpoints API matches production code under test
-	endpoints := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "scale-down-isvc", Namespace: "default"}}
+	endpoints := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -541,14 +564,24 @@ func TestEnsureProcess_ReplicasZeroStopsExistingProcess(t *testing.T) {
 	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
 	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
 	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
-	agent.processes["default/scale-down-isvc"] = &ManagedProcess{
-		Name:      "scale-down-isvc",
+
+	key := "default/" + name
+	agent.processes[key] = &ManagedProcess{
+		Name:      name,
 		Namespace: "default",
 		PID:       -99999,
 		Healthy:   true,
 		SpecHash:  "old-hash",
 	}
 
+	_ = agent.ensureProcess(context.Background(), isvc)
+
+	if _, exists := agent.processes[key]; exists {
+		t.Errorf("process entry %q should be removed", key)
+	}
+}
+
+func TestEnsureProcess_ReplicasZeroStopsExistingProcess(t *testing.T) {
 	zeroReplicas := int32(0)
 	isvc := &inferencev1alpha1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{Name: "scale-down-isvc", Namespace: "default"},
@@ -557,16 +590,7 @@ func TestEnsureProcess_ReplicasZeroStopsExistingProcess(t *testing.T) {
 			Replicas: &zeroReplicas,
 		},
 	}
-
-	// ensureProcess with replicas=0 + existing process must call deleteProcess.
-	// We expect an error because StopProcess(-99999) fails on the fake PID,
-	// but the process map entry should still be removed (deleteProcess
-	// removes-then-stops, mirroring TestDeleteProcess_StopFailureStillUnregistersEndpoint).
-	_ = agent.ensureProcess(context.Background(), isvc)
-
-	if _, exists := agent.processes["default/scale-down-isvc"]; exists {
-		t.Error("process entry should be removed when replicas=0")
-	}
+	runEnsureProcessExpectingMapEviction(t, "scale-down-isvc", isvc)
 }
 
 func TestEnsureProcess_ReplicasZeroNoOpWhenNoProcess(t *testing.T) {
@@ -628,31 +652,6 @@ func TestEnsureProcess_HealthyAndSpecMatchesIsNoOp(t *testing.T) {
 }
 
 func TestEnsureProcess_SpecDriftCallsDeleteBeforeRespawn(t *testing.T) {
-	scheme := newTestScheme()
-	_ = corev1.AddToScheme(scheme)
-
-	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "drift-isvc", Namespace: "default"}}
-	//nolint:staticcheck // SA1019: Endpoints API matches production code under test
-	endpoints := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "drift-isvc", Namespace: "default"}}
-
-	k8sClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRuntimeObjects(svc, endpoints).
-		Build()
-
-	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
-	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
-	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
-
-	// Existing process recorded with a stale spec hash.
-	agent.processes["default/drift-isvc"] = &ManagedProcess{
-		Name:      "drift-isvc",
-		Namespace: "default",
-		PID:       -99999, // forces StopProcess error so respawn path won't run further
-		Healthy:   true,
-		SpecHash:  "stale-hash-from-old-spec",
-	}
-
 	ctx := int32(131072)
 	isvc := &inferencev1alpha1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{Name: "drift-isvc", Namespace: "default"},
@@ -661,13 +660,5 @@ func TestEnsureProcess_SpecDriftCallsDeleteBeforeRespawn(t *testing.T) {
 			ContextSize: &ctx,
 		},
 	}
-
-	// We expect an error because deleteProcess returns one (StopProcess of
-	// fake PID fails). What matters is the process map entry is gone — proves
-	// the drift-detection branch ran the delete before the failed respawn.
-	_ = agent.ensureProcess(context.Background(), isvc)
-
-	if _, exists := agent.processes["default/drift-isvc"]; exists {
-		t.Error("process entry should be removed during spec-drift respawn flow")
-	}
+	runEnsureProcessExpectingMapEviction(t, "drift-isvc", isvc)
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -536,6 +536,129 @@ func TestComputeSpecHash_NilIsvc(t *testing.T) {
 	}
 }
 
+// TestBuildExecutorConfig_PassesAllSpecFieldsThrough is the regression guard
+// for issue #349: every flag-relevant InferenceServiceSpec field must reach
+// the executor. If a future field gets added to the spec but the agent
+// forgets to plumb it, this test fails loudly.
+func TestBuildExecutorConfig_PassesAllSpecFieldsThrough(t *testing.T) {
+	parallel := int32(4)
+	moeLayers := int32(8)
+	reasoning := int32(2048)
+	jinja := true
+	moeOff := true
+	noKv := true
+	noWarm := true
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "all-fields", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef:               "any-model",
+			ParallelSlots:          &parallel,
+			Jinja:                  &jinja,
+			CacheTypeK:             "q8_0",
+			CacheTypeV:             "q8_0",
+			CacheTypeCustomK:       "turbo3", // wins over CacheTypeK
+			CacheTypeCustomV:       "turbo4", // wins over CacheTypeV
+			MoeCPUOffload:          &moeOff,
+			MoeCPULayers:           &moeLayers,
+			NoKvOffload:            &noKv,
+			TensorOverrides:        []string{"exps=CPU"},
+			MetadataOverrides:      []string{"general.architecture=qwen3"},
+			NoWarmup:               &noWarm,
+			ReasoningBudget:        &reasoning,
+			ReasoningBudgetMessage: "wrap up",
+			ExtraArgs:              []string{"--rope-scale", "4"},
+		},
+	}
+	model := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "any-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.ModelSpec{Source: "https://example.test/m.gguf"},
+	}
+
+	cfg := buildExecutorConfig(isvc, model, executorBaseConfig{
+		GPULayers:      99,
+		ContextSize:    65536,
+		FlashAttention: true,
+		BatchSize:      2048,
+		UBatchSize:     512,
+	})
+
+	checks := map[string]struct {
+		got, want any
+	}{
+		"Name":                   {cfg.Name, "all-fields"},
+		"Namespace":              {cfg.Namespace, "default"},
+		"ModelSource":            {cfg.ModelSource, "https://example.test/m.gguf"},
+		"ModelName":              {cfg.ModelName, "any-model"},
+		"GPULayers":              {cfg.GPULayers, int32(99)},
+		"ContextSize":            {cfg.ContextSize, 65536},
+		"Jinja":                  {cfg.Jinja, true},
+		"FlashAttention":         {cfg.FlashAttention, true},
+		"Mlock":                  {cfg.Mlock, true},
+		"BatchSize":              {cfg.BatchSize, 2048},
+		"UBatchSize":             {cfg.UBatchSize, 512},
+		"ParallelSlots":          {cfg.ParallelSlots, 4},
+		"CacheTypeK":             {cfg.CacheTypeK, "turbo3"},
+		"CacheTypeV":             {cfg.CacheTypeV, "turbo4"},
+		"MoeCPUOffload":          {cfg.MoeCPUOffload, true},
+		"MoeCPULayers":           {cfg.MoeCPULayers, 8},
+		"NoKvOffload":            {cfg.NoKvOffload, true},
+		"NoWarmup":               {cfg.NoWarmup, true},
+		"ReasoningBudget":        {cfg.ReasoningBudget, 2048},
+		"ReasoningBudgetMessage": {cfg.ReasoningBudgetMessage, "wrap up"},
+	}
+	for field, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", field, c.got, c.want)
+		}
+	}
+	if len(cfg.TensorOverrides) != 1 || cfg.TensorOverrides[0] != "exps=CPU" {
+		t.Errorf("TensorOverrides = %v, want [exps=CPU]", cfg.TensorOverrides)
+	}
+	if len(cfg.MetadataOverrides) != 1 || cfg.MetadataOverrides[0] != "general.architecture=qwen3" {
+		t.Errorf("MetadataOverrides = %v, want [general.architecture=qwen3]", cfg.MetadataOverrides)
+	}
+	if len(cfg.ExtraArgs) != 2 || cfg.ExtraArgs[0] != "--rope-scale" || cfg.ExtraArgs[1] != "4" {
+		t.Errorf("ExtraArgs = %v, want [--rope-scale 4]", cfg.ExtraArgs)
+	}
+}
+
+// TestBuildExecutorConfig_StandardCacheTypeWhenCustomEmpty confirms that the
+// standard cacheTypeK/V is used when the custom field is empty (the common
+// case for clusters not running a TurboQuant-enabled fork).
+func TestBuildExecutorConfig_StandardCacheTypeWhenCustomEmpty(t *testing.T) {
+	isvc := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef:   "m",
+			CacheTypeK: "q8_0",
+			CacheTypeV: "q8_0",
+		},
+	}
+	model := &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Source: "x"}}
+	cfg := buildExecutorConfig(isvc, model, executorBaseConfig{})
+	if cfg.CacheTypeK != "q8_0" {
+		t.Errorf("CacheTypeK = %q, want %q", cfg.CacheTypeK, "q8_0")
+	}
+	if cfg.CacheTypeV != "q8_0" {
+		t.Errorf("CacheTypeV = %q, want %q", cfg.CacheTypeV, "q8_0")
+	}
+}
+
+// TestBuildExecutorConfig_NilPointersAreSafe confirms that an InferenceService
+// with mostly-nil pointer fields produces a zero-valued ExecutorConfig (no
+// panics, no spurious flag values).
+func TestBuildExecutorConfig_NilPointersAreSafe(t *testing.T) {
+	isvc := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m"},
+	}
+	model := &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Source: "x"}}
+	cfg := buildExecutorConfig(isvc, model, executorBaseConfig{})
+	if cfg.ParallelSlots != 0 || cfg.MoeCPUOffload || cfg.MoeCPULayers != 0 ||
+		cfg.NoKvOffload || cfg.NoWarmup || cfg.ReasoningBudget != 0 || cfg.Jinja {
+		t.Errorf("nil pointers must produce zero-valued config, got: %+v", cfg)
+	}
+}
+
 // runEnsureProcessExpectingMapEviction sets up a metal-agent with a pre-seeded
 // healthy process at default/<name>, runs ensureProcess against the given isvc,
 // and asserts the process map entry has been removed. Pre-seeded PID -99999

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -474,3 +474,200 @@ func TestDeleteProcess_StopFailureStillUnregistersEndpoint(t *testing.T) {
 		t.Fatal("endpoints should be deleted even when StopProcess fails")
 	}
 }
+
+func TestComputeSpecHash_StableForSameSpec(t *testing.T) {
+	ctx := int32(65536)
+	isvc := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef:    "test-model",
+			ContextSize: &ctx,
+		},
+	}
+	h1 := computeSpecHash(isvc)
+	h2 := computeSpecHash(isvc)
+	if h1 != h2 {
+		t.Errorf("hash should be stable across calls with same input: %s vs %s", h1, h2)
+	}
+	if h1 == "" {
+		t.Error("hash should not be empty for valid spec")
+	}
+}
+
+func TestComputeSpecHash_ChangesWithContextSize(t *testing.T) {
+	ctx1 := int32(65536)
+	ctx2 := int32(131072)
+	a := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", ContextSize: &ctx1}}
+	b := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", ContextSize: &ctx2}}
+	if computeSpecHash(a) == computeSpecHash(b) {
+		t.Error("hash should differ when contextSize changes")
+	}
+}
+
+func TestComputeSpecHash_ChangesWithCacheTypeCustom(t *testing.T) {
+	a := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m"}}
+	b := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", CacheTypeCustomK: "turbo3"}}
+	if computeSpecHash(a) == computeSpecHash(b) {
+		t.Error("hash should differ when cacheTypeCustomK is set; this is the field added in #351 and the runtime arg builder uses it")
+	}
+}
+
+func TestComputeSpecHash_ChangesWithExtraArgs(t *testing.T) {
+	a := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m"}}
+	b := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", ExtraArgs: []string{"--cache-type-k", "turbo3"}}}
+	if computeSpecHash(a) == computeSpecHash(b) {
+		t.Error("hash should differ when extraArgs is set")
+	}
+}
+
+func TestComputeSpecHash_NilIsvc(t *testing.T) {
+	if computeSpecHash(nil) != "" {
+		t.Error("nil isvc should produce empty hash, not panic")
+	}
+}
+
+func TestEnsureProcess_ReplicasZeroStopsExistingProcess(t *testing.T) {
+	scheme := newTestScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "scale-down-isvc", Namespace: "default"}}
+	//nolint:staticcheck // SA1019: Endpoints API matches production code under test
+	endpoints := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "scale-down-isvc", Namespace: "default"}}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(svc, endpoints).
+		Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
+	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+	agent.processes["default/scale-down-isvc"] = &ManagedProcess{
+		Name:      "scale-down-isvc",
+		Namespace: "default",
+		PID:       -99999,
+		Healthy:   true,
+		SpecHash:  "old-hash",
+	}
+
+	zeroReplicas := int32(0)
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "scale-down-isvc", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "any-model",
+			Replicas: &zeroReplicas,
+		},
+	}
+
+	// ensureProcess with replicas=0 + existing process must call deleteProcess.
+	// We expect an error because StopProcess(-99999) fails on the fake PID,
+	// but the process map entry should still be removed (deleteProcess
+	// removes-then-stops, mirroring TestDeleteProcess_StopFailureStillUnregistersEndpoint).
+	_ = agent.ensureProcess(context.Background(), isvc)
+
+	if _, exists := agent.processes["default/scale-down-isvc"]; exists {
+		t.Error("process entry should be removed when replicas=0")
+	}
+}
+
+func TestEnsureProcess_ReplicasZeroNoOpWhenNoProcess(t *testing.T) {
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
+	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	zeroReplicas := int32(0)
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "never-existed", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "any-model",
+			Replicas: &zeroReplicas,
+		},
+	}
+
+	if err := agent.ensureProcess(context.Background(), isvc); err != nil {
+		t.Errorf("replicas=0 with no existing process should be a no-op (no error), got: %v", err)
+	}
+}
+
+func TestEnsureProcess_HealthyAndSpecMatchesIsNoOp(t *testing.T) {
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
+	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	ctx := int32(65536)
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "noop-isvc", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef:    "any-model",
+			ContextSize: &ctx,
+		},
+	}
+
+	// Pre-seed a healthy process whose SpecHash matches the incoming spec.
+	// ensureProcess should fast-path return nil without consulting K8s for
+	// the Model — proving the no-op happens before the model lookup that
+	// would otherwise fail (no Model in the fake client).
+	agent.processes["default/noop-isvc"] = &ManagedProcess{
+		Name:      "noop-isvc",
+		Namespace: "default",
+		Healthy:   true,
+		SpecHash:  computeSpecHash(isvc),
+	}
+
+	if err := agent.ensureProcess(context.Background(), isvc); err != nil {
+		t.Errorf("healthy + matching specHash should no-op without error, got: %v", err)
+	}
+	if _, exists := agent.processes["default/noop-isvc"]; !exists {
+		t.Error("process entry should remain when no-op fast path triggers")
+	}
+}
+
+func TestEnsureProcess_SpecDriftCallsDeleteBeforeRespawn(t *testing.T) {
+	scheme := newTestScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "drift-isvc", Namespace: "default"}}
+	//nolint:staticcheck // SA1019: Endpoints API matches production code under test
+	endpoints := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "drift-isvc", Namespace: "default"}}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(svc, endpoints).
+		Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
+	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	// Existing process recorded with a stale spec hash.
+	agent.processes["default/drift-isvc"] = &ManagedProcess{
+		Name:      "drift-isvc",
+		Namespace: "default",
+		PID:       -99999, // forces StopProcess error so respawn path won't run further
+		Healthy:   true,
+		SpecHash:  "stale-hash-from-old-spec",
+	}
+
+	ctx := int32(131072)
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "drift-isvc", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef:    "any-model",
+			ContextSize: &ctx,
+		},
+	}
+
+	// We expect an error because deleteProcess returns one (StopProcess of
+	// fake PID fails). What matters is the process map entry is gone — proves
+	// the drift-detection branch ran the delete before the failed respawn.
+	_ = agent.ensureProcess(context.Background(), isvc)
+
+	if _, exists := agent.processes["default/drift-isvc"]; exists {
+		t.Error("process entry should be removed during spec-drift respawn flow")
+	}
+}

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -62,6 +62,47 @@ type ExecutorConfig struct {
 	// UBatchSize sets --ubatch-size. Zero omits the flag (use llama-server's
 	// own default).
 	UBatchSize int
+
+	// ParallelSlots maps to --parallel. Values <= 1 omit the flag (one slot
+	// is the llama-server default and adding the flag is just noise).
+	ParallelSlots int
+
+	// CacheTypeK / CacheTypeV are the resolved llama.cpp KV cache types,
+	// already passed through CRD custom-vs-standard resolution at the agent
+	// boundary. Empty omits the corresponding flag.
+	CacheTypeK string
+	CacheTypeV string
+
+	// MoeCPUOffload maps to --cpu-moe (offload all MoE expert layers to CPU).
+	MoeCPUOffload bool
+
+	// MoeCPULayers maps to --n-cpu-moe (offload first N MoE layers to CPU).
+	// Zero omits the flag.
+	MoeCPULayers int
+
+	// NoKvOffload maps to --no-kv-offload (keep KV cache on host RAM).
+	NoKvOffload bool
+
+	// TensorOverrides become repeated --override-tensor flags.
+	TensorOverrides []string
+
+	// MetadataOverrides become repeated --override-kv flags.
+	MetadataOverrides []string
+
+	// NoWarmup maps to --no-warmup (skip the prompt-processing warmup pass).
+	NoWarmup bool
+
+	// ReasoningBudget maps to --reasoning-budget. Zero omits both this and
+	// ReasoningBudgetMessage.
+	ReasoningBudget int
+
+	// ReasoningBudgetMessage maps to --reasoning-budget-message. Ignored
+	// unless ReasoningBudget > 0.
+	ReasoningBudgetMessage string
+
+	// ExtraArgs are appended to the command line as-is, last, so they can
+	// override any earlier flag llama-server emitted (last-wins).
+	ExtraArgs []string
 }
 
 // ProcessExecutor is the interface that both llama-server and oMLX executors
@@ -276,12 +317,39 @@ func buildLlamaServerArgs(modelPath string, port int, config ExecutorConfig) []s
 		"--metrics",
 	}
 
+	if config.ParallelSlots > 1 {
+		args = append(args, "--parallel", fmt.Sprintf("%d", config.ParallelSlots))
+	}
+
 	if config.FlashAttention {
 		args = append(args, "--flash-attn", "on")
 	}
 
 	if config.Mlock {
 		args = append(args, "--mlock")
+	}
+
+	if config.CacheTypeK != "" {
+		args = append(args, "--cache-type-k", config.CacheTypeK)
+	}
+	if config.CacheTypeV != "" {
+		args = append(args, "--cache-type-v", config.CacheTypeV)
+	}
+
+	if config.MoeCPUOffload {
+		args = append(args, "--cpu-moe")
+	}
+	if config.MoeCPULayers > 0 {
+		args = append(args, "--n-cpu-moe", fmt.Sprintf("%d", config.MoeCPULayers))
+	}
+	if config.NoKvOffload {
+		args = append(args, "--no-kv-offload")
+	}
+	for _, override := range config.TensorOverrides {
+		args = append(args, "--override-tensor", override)
+	}
+	for _, override := range config.MetadataOverrides {
+		args = append(args, "--override-kv", override)
 	}
 
 	threads := config.Threads
@@ -302,8 +370,24 @@ func buildLlamaServerArgs(modelPath string, port int, config ExecutorConfig) []s
 		args = append(args, "--ubatch-size", fmt.Sprintf("%d", config.UBatchSize))
 	}
 
+	if config.NoWarmup {
+		args = append(args, "--no-warmup")
+	}
+
+	if config.ReasoningBudget > 0 {
+		args = append(args, "--reasoning-budget", fmt.Sprintf("%d", config.ReasoningBudget))
+		if config.ReasoningBudgetMessage != "" {
+			args = append(args, "--reasoning-budget-message", config.ReasoningBudgetMessage)
+		}
+	}
+
 	if config.Jinja {
 		args = append(args, "--jinja")
+	}
+
+	// ExtraArgs comes last so user-provided overrides actually override.
+	if len(config.ExtraArgs) > 0 {
+		args = append(args, config.ExtraArgs...)
 	}
 
 	return args

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -181,6 +181,150 @@ func TestBuildLlamaServerArgs_GPULayersOverride(t *testing.T) {
 	}
 }
 
+func TestBuildLlamaServerArgs_CacheTypes(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize: 4096,
+		CacheTypeK:  "turbo3",
+		CacheTypeV:  "turbo4",
+	})
+	if got := flagValue(args, "--cache-type-k"); got != "turbo3" {
+		t.Errorf("--cache-type-k = %q, want %q (full args: %v)", got, "turbo3", args)
+	}
+	if got := flagValue(args, "--cache-type-v"); got != "turbo4" {
+		t.Errorf("--cache-type-v = %q, want %q (full args: %v)", got, "turbo4", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_CacheTypesEmptyOmits(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{ContextSize: 4096})
+	if hasFlag(args, "--cache-type-k") {
+		t.Errorf("--cache-type-k must be omitted when CacheTypeK is empty (full args: %v)", args)
+	}
+	if hasFlag(args, "--cache-type-v") {
+		t.Errorf("--cache-type-v must be omitted when CacheTypeV is empty (full args: %v)", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_ParallelSlots(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize:   4096,
+		ParallelSlots: 4,
+	})
+	if got := flagValue(args, "--parallel"); got != "4" {
+		t.Errorf("--parallel = %q, want %q (full args: %v)", got, "4", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_ParallelSlotsOneOrZeroOmits(t *testing.T) {
+	for _, n := range []int{0, 1} {
+		args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+			ContextSize:   4096,
+			ParallelSlots: n,
+		})
+		if hasFlag(args, "--parallel") {
+			t.Errorf("--parallel must be omitted for ParallelSlots=%d (full args: %v)", n, args)
+		}
+	}
+}
+
+func TestBuildLlamaServerArgs_MoeOffloadFlags(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize:   4096,
+		MoeCPUOffload: true,
+		MoeCPULayers:  6,
+		NoKvOffload:   true,
+	})
+	if !hasFlag(args, "--cpu-moe") {
+		t.Errorf("--cpu-moe missing when MoeCPUOffload=true (full args: %v)", args)
+	}
+	if got := flagValue(args, "--n-cpu-moe"); got != "6" {
+		t.Errorf("--n-cpu-moe = %q, want %q", got, "6")
+	}
+	if !hasFlag(args, "--no-kv-offload") {
+		t.Errorf("--no-kv-offload missing when NoKvOffload=true")
+	}
+}
+
+func TestBuildLlamaServerArgs_TensorAndMetadataOverrides(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize:       4096,
+		TensorOverrides:   []string{"exps=CPU", "attn=GPU"},
+		MetadataOverrides: []string{"general.architecture=qwen3", "qwen3.context_length=u32:262144"},
+	})
+	tensorCount := 0
+	kvCount := 0
+	for i, a := range args {
+		if a == "--override-tensor" && i+1 < len(args) {
+			tensorCount++
+		}
+		if a == "--override-kv" && i+1 < len(args) {
+			kvCount++
+		}
+	}
+	if tensorCount != 2 {
+		t.Errorf("--override-tensor count = %d, want 2 (full args: %v)", tensorCount, args)
+	}
+	if kvCount != 2 {
+		t.Errorf("--override-kv count = %d, want 2 (full args: %v)", kvCount, args)
+	}
+}
+
+func TestBuildLlamaServerArgs_NoWarmup(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize: 4096,
+		NoWarmup:    true,
+	})
+	if !hasFlag(args, "--no-warmup") {
+		t.Errorf("--no-warmup missing when NoWarmup=true (full args: %v)", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_ReasoningBudget(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize:            4096,
+		ReasoningBudget:        2048,
+		ReasoningBudgetMessage: "wrap it up",
+	})
+	if got := flagValue(args, "--reasoning-budget"); got != "2048" {
+		t.Errorf("--reasoning-budget = %q, want %q", got, "2048")
+	}
+	if got := flagValue(args, "--reasoning-budget-message"); got != "wrap it up" {
+		t.Errorf("--reasoning-budget-message = %q, want %q", got, "wrap it up")
+	}
+}
+
+func TestBuildLlamaServerArgs_ReasoningBudgetMessageRequiresBudget(t *testing.T) {
+	// Message without a budget is meaningless and must not produce a stray flag.
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize:            4096,
+		ReasoningBudgetMessage: "wrap it up",
+	})
+	if hasFlag(args, "--reasoning-budget") {
+		t.Errorf("--reasoning-budget must be omitted when ReasoningBudget=0")
+	}
+	if hasFlag(args, "--reasoning-budget-message") {
+		t.Errorf("--reasoning-budget-message must be omitted when ReasoningBudget=0 (full args: %v)", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_ExtraArgsAppendedLast(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize: 4096,
+		ExtraArgs:   []string{"--rope-scaling", "yarn", "--rope-scale", "4"},
+	})
+	// All four ExtraArgs tokens must appear in order at the very end.
+	if len(args) < 4 {
+		t.Fatalf("args too short: %v", args)
+	}
+	tail := args[len(args)-4:]
+	want := []string{"--rope-scaling", "yarn", "--rope-scale", "4"}
+	for i, w := range want {
+		if tail[i] != w {
+			t.Errorf("tail[%d] = %q, want %q (full args: %v)", i, tail[i], w, args)
+		}
+	}
+}
+
 // hasFlag reports whether a bare flag (no value following) is present.
 func hasFlag(args []string, name string) bool {
 	for _, a := range args {


### PR DESCRIPTION
## Summary

Closes #349 and #350. Two complementary metal-agent fixes — either alone leaves the user with a half-working spec patch.

### #350 — respawn on spec drift; honor replicas=0
- `ensureProcess` now diffs the running process's stored spec hash against the incoming ISVC; on drift it stops the old process and spawns a fresh one.
- `spec.replicas: 0` with an existing process now stops the process (was previously ignored).
- `ManagedProcess` gains a `SpecHash` field, populated at spawn time.
- New `computeSpecHash` helper hashes an explicit allowlist of spec fields that affect llama-server invocation.

### #349 — plumb full spec through to the executor
- `ExecutorConfig` was missing every field the controller adds to the llama-server command line: cacheTypeK/V (and the custom variants from #351), parallelSlots, MoE offload knobs, KV/tensor overrides, reasoning budget, noWarmup, extraArgs.
- Mirror `internal/controller`'s `runtime_llamacpp_args.go` ordering so the metal-agent emits the same flags as the Linux/CUDA path for a given InferenceService spec.
- New `buildExecutorConfig` helper centralizes the spec-to-config translation; it also drops `ensureProcess`'s cyclomatic complexity below the lint threshold.

Without both fixes the user experience is broken: #350 alone notices spec drift but the new spawn uses identical flags because the executor never received the new fields. #349 alone makes the executor capable of using the new flags, but the agent never restarts the process to pick them up.

## Why

I hit this concretely while validating TheTom's TurboQuant fork on M5 Max:

```
$ kubectl patch isvc qwen36-35b-a3b --type merge -p '{"spec":{"contextSize":262144}}'
inferenceservice.inference.llmkube.dev/qwen36-35b-a3b patched

$ kubectl get isvc qwen36-35b-a3b -o jsonpath='{.spec.contextSize}'
262144

$ ps aux | grep llama-server | grep ctx-size
... --ctx-size 65536 ...   # still the old value
```

Same story with `cacheTypeCustomK: turbo3` after #351 — patched fine, ignored entirely.

## Test plan

- [x] `go test ./pkg/... ./internal/... -count=1` — all green
- [x] `golangci-lint run ./pkg/agent/...` — clean (only pre-existing G118 in health.go)
- New tests:
  - 5 `computeSpecHash` tests covering stability, drift detection, and nil safety
  - 4 `ensureProcess` tests covering replicas=0 (existing + nonexistent process), healthy fast-path, and spec-drift respawn
  - 13 `buildLlamaServerArgs` tests covering each new flag and its omit-on-default case
  - 3 `buildExecutorConfig` tests including the regression guard `TestBuildExecutorConfig_PassesAllSpecFieldsThrough`
- Tested live: `kubectl patch isvc ... --type merge -p '{"spec":{"contextSize":262144,"cacheTypeCustomK":"turbo3"}}'` triggers a respawn within ~10s, new llama-server has the new flags.

## Note for reviewers

This is a behavior change visible to users. Before this PR, `kubectl patch` on a running ISVC would silently keep the old behavior. After this PR, the change takes effect on the next reconcile (typically <30s).

`replicas: 0` was previously a foot-gun (you'd patch it expecting to take a model offline, then notice it was still running). Now it works.