### PR TITLE
feat(agent): cache-type-aware memory estimator + TurboQuant docs

### DIFF
--- a/config/samples/inferenceservice_turboquant.yaml
+++ b/config/samples/inferenceservice_turboquant.yaml
@@ -29,5 +29,10 @@ spec:
   # turbo3 = ~3.25 bits/value, ~4.9x compression vs fp16. At 256K context this
   # is roughly ~13 GB of KV cache vs ~64 GB at fp16. Requires a TurboQuant-
   # enabled llama.cpp build; LLMKube does not validate the string.
+  #
+  # The Metal agent's pre-flight memory check is cache-type-aware, so a
+  # turbo3-equipped 256K context that would be rejected under f16 (default)
+  # will pass the budget gate. See docs/turboquant.md for the bytes-per-element
+  # table the estimator uses.
   cacheTypeCustomK: turbo3
   cacheTypeCustomV: turbo3

--- a/docs/turboquant.md
+++ b/docs/turboquant.md
@@ -55,11 +55,20 @@ Approximate KV cache size per token at 35B-class models, fp16 reference = `~256 
 | `turbo3` | 3.25 | 4.9× | ~13 GB |
 | `turbo2` | 2.5 | ~6.4× | ~10 GB |
 
-Perplexity penalty for `turbo3` is around +1% on Qwen 3.5-class models per the upstream community discussion.
+Perplexity penalty for `turbo3` is around +1% on Qwen 3.6-class models per the upstream community discussion.
+
+## Pre-flight memory check
+
+The Metal agent's pre-flight memory check uses the configured `cacheTypeK` and `cacheTypeV` (or their `Custom` variants) when estimating per-process memory. Without this, the check would always assume `f16` and reject TurboQuant configs that actually fit. The bytes-per-element table for each cache type lives next to the estimator at `pkg/agent/memory.go` (`cacheTypeBytesPerElement`); add a new entry there if you ship a fork with additional types. Unknown types fall back to `f16` so the estimate over-allocates rather than under, which is the safer default for a pre-flight gate.
+
+## Asymmetric K and V
+
+`cacheTypeCustomK` and `cacheTypeCustomV` are independent. Setting only one is supported; mixing is too. Community guidance (see [renjithvr11.medium.com on this](https://renjithvr11.medium.com/)) suggests `q8_0` for K and `turbo4` for V on agentic workloads, on the theory that the K side is more sensitive to quantization than V. We have not run this in our own benchmarks yet — the M5 Max numbers below are all symmetric K=V.
 
 ## References
 
 - llama.cpp community discussion: <https://github.com/ggml-org/llama.cpp/discussions/20969>
 - TurboQuant paper: <https://arxiv.org/abs/2504.19874>
+- M5 Max benchmark across f16/q8_0/turbo3/turbo4 from 0 to 1M context: <https://llmkube.com/blog/turboquant-m5-max-long-context>
 - LLMKube tracking issue: [#308](https://github.com/defilantech/LLMKube/issues/308)
 - The CRD field decision: [#282](https://github.com/defilantech/LLMKube/issues/282)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -337,6 +337,23 @@ type executorBaseConfig struct {
 	UBatchSize     int
 }
 
+// resolveCacheTypes picks the effective llama.cpp KV cache types from the
+// InferenceService spec. Custom types (TurboQuant turbo3/turbo4 and any other
+// fork-specific value) win over the enum-validated standard fields. Mirrors
+// internal/controller's resolveCacheType so the metal-agent and the K8s
+// runtime emit identical flags for the same spec.
+func resolveCacheTypes(isvc *inferencev1alpha1.InferenceService) (k, v string) {
+	k = isvc.Spec.CacheTypeK
+	if isvc.Spec.CacheTypeCustomK != "" {
+		k = isvc.Spec.CacheTypeCustomK
+	}
+	v = isvc.Spec.CacheTypeV
+	if isvc.Spec.CacheTypeCustomV != "" {
+		v = isvc.Spec.CacheTypeCustomV
+	}
+	return k, v
+}
+
 // buildExecutorConfig collects every flag-relevant InferenceService field into
 // an ExecutorConfig that buildLlamaServerArgs can consume. Pointer fields are
 // dereferenced here so the executor sees plain values; cache types are resolved
@@ -346,14 +363,7 @@ func buildExecutorConfig(
 	model *inferencev1alpha1.Model,
 	base executorBaseConfig,
 ) ExecutorConfig {
-	cacheTypeK := isvc.Spec.CacheTypeK
-	if isvc.Spec.CacheTypeCustomK != "" {
-		cacheTypeK = isvc.Spec.CacheTypeCustomK
-	}
-	cacheTypeV := isvc.Spec.CacheTypeV
-	if isvc.Spec.CacheTypeCustomV != "" {
-		cacheTypeV = isvc.Spec.CacheTypeCustomV
-	}
+	cacheTypeK, cacheTypeV := resolveCacheTypes(isvc)
 
 	return ExecutorConfig{
 		Name:                   isvc.Name,
@@ -499,8 +509,14 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 		contextSize = int(*isvc.Spec.ContextSize)
 	}
 
+	// Resolve KV cache types now (custom > standard) so the memory check and
+	// the executor config see the same values; otherwise the pre-flight check
+	// would always assume f16 and reject configs that fit thanks to TurboQuant
+	// or q8_0 KV.
+	cacheTypeK, cacheTypeV := resolveCacheTypes(isvc)
+
 	// Pre-flight memory check
-	if estimate, err := a.estimateModelMemory(model, contextSize); err != nil {
+	if estimate, err := a.estimateModelMemory(model, contextSize, cacheTypeK, cacheTypeV); err != nil {
 		a.logger.Warnw("memory estimation failed, proceeding without check", "error", err)
 	} else {
 		memoryEstimatedBytes.WithLabelValues(isvc.Name, isvc.Namespace).Set(float64(estimate.TotalBytes))
@@ -883,7 +899,13 @@ func (a *MetalAgent) HealthCheck() map[string]bool {
 
 // estimateModelMemory builds a MemoryEstimate for a model using the file on disk
 // (preferred) or the Status.Size string, plus GGUF metadata when available.
-func (a *MetalAgent) estimateModelMemory(model *inferencev1alpha1.Model, contextSize int) (MemoryEstimate, error) {
+// Cache types are passed through so quantized KV caches (q8_0, turbo3, turbo4)
+// produce a realistic estimate instead of always assuming f16.
+func (a *MetalAgent) estimateModelMemory(
+	model *inferencev1alpha1.Model,
+	contextSize int,
+	cacheTypeK, cacheTypeV string,
+) (MemoryEstimate, error) {
 	var fileSizeBytes uint64
 
 	// Try to stat the model file on disk
@@ -914,7 +936,10 @@ func (a *MetalAgent) estimateModelMemory(model *inferencev1alpha1.Model, context
 		embeddingSize = model.Status.GGUF.EmbeddingSize
 	}
 
-	return EstimateModelMemory(fileSizeBytes, layerCount, embeddingSize, contextSize), nil
+	return EstimateModelMemoryWithOptions(fileSizeBytes, layerCount, embeddingSize, contextSize, EstimateOptions{
+		CacheTypeK: cacheTypeK,
+		CacheTypeV: cacheTypeV,
+	}), nil
 }
 
 // computeSpecHash returns a stable hash of the InferenceServiceSpec fields that,

--- a/pkg/agent/memory.go
+++ b/pkg/agent/memory.go
@@ -74,40 +74,115 @@ type MemoryBudget struct {
 
 const overheadBytes = 512 * 1024 * 1024 // 512 MiB constant overhead
 
-// EstimateModelMemory estimates total memory needed to serve a model.
-// When GGUF metadata is available (layerCount > 0 and embeddingSize > 0),
-// it computes KV cache as 2 * layerCount * embeddingSize * contextSize * 2 (FP16 K+V).
-// Otherwise it falls back to fileSize * 1.2 + overhead.
+// EstimateOptions tweaks EstimateModelMemoryWithOptions's KV-cache calculation.
+// Empty values reproduce the historical defaults (f16 K and V).
+type EstimateOptions struct {
+	// CacheTypeK is the llama.cpp --cache-type-k value (e.g. "q8_0", "turbo3").
+	// Empty means f16. Unknown values fall back to f16 so the estimate
+	// over-allocates rather than under, which is the safer default for a
+	// pre-flight check.
+	CacheTypeK string
+
+	// CacheTypeV mirrors CacheTypeK for --cache-type-v.
+	CacheTypeV string
+}
+
+// cacheTypeBytesPerElement returns the per-element byte cost of a llama.cpp
+// KV cache type. Quantized types include their per-block fp16 scale (and
+// fp16 min for q*_1) overhead, so this approximates real disk/memory cost
+// rather than the bare bit width. TurboQuant turbo3/turbo4 values come from
+// TheTom's spec (https://github.com/ggml-org/llama.cpp/discussions/20969).
+// The case labels are exactly the strings llama.cpp recognizes for
+// --cache-type-k / --cache-type-v; promoting them to named constants would
+// not improve safety since any typo would just move into the constant decl.
+//
+//nolint:goconst
+func cacheTypeBytesPerElement(t string) float64 {
+	switch t {
+	case "", "f16":
+		return 2.0
+	case "f32":
+		return 4.0
+	case "q8_0":
+		// 32 weights * 8 bits + fp16 scale = 272 bits / 32 = 8.5 bits = 1.0625 bytes
+		return 1.0625
+	case "q5_0":
+		// 32 * 5 + 16 = 176 / 32 = 5.5 bits
+		return 0.6875
+	case "q5_1":
+		// 32 * 5 + 32 (scale + min) = 192 / 32 = 6.0 bits
+		return 0.75
+	case "q4_0", "iq4_nl":
+		// 32 * 4 + 16 = 144 / 32 = 4.5 bits
+		return 0.5625
+	case "q4_1":
+		// 32 * 4 + 32 = 160 / 32 = 5.0 bits
+		return 0.625
+	case "turbo3":
+		// 3.25 bits/element per TurboQuant spec
+		return 0.40625
+	case "turbo4":
+		// 4.25 bits/element per TurboQuant spec
+		return 0.53125
+	default:
+		// Unknown type: assume f16 to over-estimate; safer for pre-flight check.
+		return 2.0
+	}
+}
+
+// EstimateModelMemory estimates total memory needed to serve a model with
+// llama.cpp's default f16 KV cache. Kept for backward compatibility with the
+// historical signature; new call sites should prefer EstimateModelMemoryWithOptions
+// so they can pass the actual configured cache types and get an accurate
+// estimate when TurboQuant or any quantized cache is in use.
 func EstimateModelMemory(fileSizeBytes uint64, layerCount, embeddingSize uint64, contextSize int) MemoryEstimate {
-	if layerCount > 0 && embeddingSize > 0 {
-		// KV cache: 4 * layers * embedding * context (FP16 K+V)
-		// Guard against overflow in the multiplication chain.
-		layerEmbed := layerCount * embeddingSize
-		if layerEmbed/layerCount != embeddingSize {
-			return fallbackEstimate(fileSizeBytes)
-		}
-		ctx := uint64(contextSize) //nolint:gosec // G115: contextSize is CRD-validated ≥128 upstream
-		product := layerEmbed * ctx
-		if ctx != 0 && product/ctx != layerEmbed {
-			return fallbackEstimate(fileSizeBytes)
-		}
-		kvCache := product * 4
-		if kvCache/4 != product {
-			return fallbackEstimate(fileSizeBytes)
-		}
-		total := fileSizeBytes + kvCache + uint64(overheadBytes)
-		if total < fileSizeBytes { // addition overflow
-			return fallbackEstimate(fileSizeBytes)
-		}
-		return MemoryEstimate{
-			WeightsBytes:  fileSizeBytes,
-			KVCacheBytes:  kvCache,
-			OverheadBytes: uint64(overheadBytes),
-			TotalBytes:    total,
-		}
+	return EstimateModelMemoryWithOptions(fileSizeBytes, layerCount, embeddingSize, contextSize, EstimateOptions{})
+}
+
+// EstimateModelMemoryWithOptions is EstimateModelMemory parameterized on the
+// configured KV cache types. The KV-cache term becomes
+// layers * embedding * context * (bytesPerK + bytesPerV) where bytesPerK / V
+// come from cacheTypeBytesPerElement. With f16/f16 (the empty-string default)
+// it produces the same result as EstimateModelMemory.
+func EstimateModelMemoryWithOptions(
+	fileSizeBytes uint64,
+	layerCount, embeddingSize uint64,
+	contextSize int,
+	opts EstimateOptions,
+) MemoryEstimate {
+	if layerCount == 0 || embeddingSize == 0 {
+		return fallbackEstimate(fileSizeBytes)
 	}
 
-	return fallbackEstimate(fileSizeBytes)
+	// Guard against overflow in the multiplication chain. The integer math
+	// here mirrors the historical behavior; the fractional bytes-per-element
+	// multiplication happens once at the end via float64.
+	layerEmbed := layerCount * embeddingSize
+	if layerEmbed/layerCount != embeddingSize {
+		return fallbackEstimate(fileSizeBytes)
+	}
+	ctx := uint64(contextSize) //nolint:gosec // G115: contextSize is CRD-validated ≥128 upstream
+	product := layerEmbed * ctx
+	if ctx != 0 && product/ctx != layerEmbed {
+		return fallbackEstimate(fileSizeBytes)
+	}
+
+	bytesPerKV := cacheTypeBytesPerElement(opts.CacheTypeK) + cacheTypeBytesPerElement(opts.CacheTypeV)
+	// product is at most ~10^15 for absurd configs (1M ctx, 200B model);
+	// float64 represents integers up to 2^53 ≈ 9e15 exactly, so the conversion
+	// is lossless for any realistic input.
+	kvCache := uint64(math.Ceil(float64(product) * bytesPerKV))
+
+	total := fileSizeBytes + kvCache + uint64(overheadBytes)
+	if total < fileSizeBytes { // addition overflow
+		return fallbackEstimate(fileSizeBytes)
+	}
+	return MemoryEstimate{
+		WeightsBytes:  fileSizeBytes,
+		KVCacheBytes:  kvCache,
+		OverheadBytes: uint64(overheadBytes),
+		TotalBytes:    total,
+	}
 }
 
 // fallbackEstimate uses a heuristic (fileSize * 1.2 + overhead) when GGUF

--- a/pkg/agent/memory_test.go
+++ b/pkg/agent/memory_test.go
@@ -119,6 +119,96 @@ func TestEstimateModelMemory_LargeContext(t *testing.T) {
 	}
 }
 
+// TestEstimateModelMemory_F16DefaultMatchesLegacyFormula proves the new
+// EstimateModelMemoryWithOptions path is bit-for-bit identical to the legacy
+// integer-math formula when called with the historical f16/f16 default.
+// Critical regression guard for any future call site relying on the old shape.
+func TestEstimateModelMemory_F16DefaultMatchesLegacyFormula(t *testing.T) {
+	fileSize := uint64(4831838208)
+	got := EstimateModelMemoryWithOptions(fileSize, 32, 4096, 65536, EstimateOptions{})
+	// Legacy formula: 4 * layers * embed * ctx (2 bytes/element * K + V).
+	want := uint64(4 * 32 * 4096 * 65536)
+	if got.KVCacheBytes != want {
+		t.Errorf("default-options KV = %d, want legacy %d", got.KVCacheBytes, want)
+	}
+}
+
+// TestEstimateModelMemory_Q8KVHalvesCache: q8_0 K + V should be roughly half
+// of f16 K + V for the same model and context. (Exactly 1.0625/2.0 ≈ 0.531
+// thanks to the 16-bit per-block scale.)
+func TestEstimateModelMemory_Q8KVHalvesCache(t *testing.T) {
+	fileSize := uint64(4831838208)
+	f16 := EstimateModelMemoryWithOptions(fileSize, 32, 4096, 65536, EstimateOptions{})
+	q8 := EstimateModelMemoryWithOptions(fileSize, 32, 4096, 65536, EstimateOptions{
+		CacheTypeK: "q8_0",
+		CacheTypeV: "q8_0",
+	})
+	ratio := float64(q8.KVCacheBytes) / float64(f16.KVCacheBytes)
+	if ratio < 0.50 || ratio > 0.55 {
+		t.Errorf("q8_0/f16 KV ratio = %.3f, want ~0.531", ratio)
+	}
+}
+
+// TestEstimateModelMemory_Turbo3CompressesKV asserts the architecture-independent
+// invariant: turbo3 K + V (3.25 + 3.25 bits/element) should produce a KV cache
+// roughly 1/5 the size of f16 K + V (16 + 16 bits/element). 0.8125 / 4.0 ≈ 0.203,
+// so the ratio must land between 0.18 and 0.23.
+//
+// This is the user-visible behavior change that motivated wiring cache types
+// into the estimator: a 256K context with TurboQuant cache that previously got
+// rejected as OOM (f16 estimate) now passes the pre-flight check.
+func TestEstimateModelMemory_Turbo3CompressesKV(t *testing.T) {
+	const fileSize = uint64(35) * 1024 * 1024 * 1024
+	const layers, embed = uint64(64), uint64(5120)
+	const context = 262144 // 256K
+
+	f16 := EstimateModelMemoryWithOptions(fileSize, layers, embed, context, EstimateOptions{})
+	turbo3 := EstimateModelMemoryWithOptions(fileSize, layers, embed, context, EstimateOptions{
+		CacheTypeK: "turbo3",
+		CacheTypeV: "turbo3",
+	})
+
+	ratio := float64(turbo3.KVCacheBytes) / float64(f16.KVCacheBytes)
+	if ratio < 0.18 || ratio > 0.23 {
+		t.Errorf("turbo3/f16 KV ratio = %.3f, want ~0.203 (0.8125/4.0)", ratio)
+	}
+	if turbo3.TotalBytes >= f16.TotalBytes {
+		t.Errorf("turbo3 total should be lower than f16 total: turbo3=%d, f16=%d",
+			turbo3.TotalBytes, f16.TotalBytes)
+	}
+}
+
+func TestEstimateModelMemory_AsymmetricCacheTypes(t *testing.T) {
+	// Renjith's recommendation: -ctk q8_0 -ctv turbo4. The estimate should
+	// reflect this without forcing the user into symmetric K/V.
+	fileSize := uint64(4831838208)
+	got := EstimateModelMemoryWithOptions(fileSize, 32, 4096, 65536, EstimateOptions{
+		CacheTypeK: "q8_0",
+		CacheTypeV: "turbo4",
+	})
+	// q8_0 (1.0625) + turbo4 (0.53125) = 1.59375 bytes/element.
+	const product = uint64(32) * 4096 * 65536
+	want := uint64(float64(product) * 1.59375)
+	// Allow a single-byte rounding tolerance from math.Ceil. Compare via
+	// uint64 to dodge the int64 conversion lint.
+	if got.KVCacheBytes < want || got.KVCacheBytes > want+1 {
+		t.Errorf("asymmetric q8_0/turbo4 KV = %d, want %d or %d", got.KVCacheBytes, want, want+1)
+	}
+}
+
+func TestEstimateModelMemory_UnknownCacheTypeFallsBackToF16(t *testing.T) {
+	fileSize := uint64(4831838208)
+	unknown := EstimateModelMemoryWithOptions(fileSize, 32, 4096, 65536, EstimateOptions{
+		CacheTypeK: "future-cache-format",
+		CacheTypeV: "future-cache-format",
+	})
+	f16 := EstimateModelMemoryWithOptions(fileSize, 32, 4096, 65536, EstimateOptions{})
+	if unknown.KVCacheBytes != f16.KVCacheBytes {
+		t.Errorf("unknown cache type should fall back to f16: got %d, want %d",
+			unknown.KVCacheBytes, f16.KVCacheBytes)
+	}
+}
+
 func TestDefaultMemoryFraction_Small(t *testing.T) {
 	total := uint64(16 * 1024 * 1024 * 1024) // 16 GiB
 	f := DefaultMemoryFraction(total)


### PR DESCRIPTION
## Summary

Closes the loop on the metal-agent TurboQuant story by making the pre-flight memory check honor the configured KV cache type. Builds on #353 (now merged).

## Why

The Metal agent's pre-flight memory check used a hard-coded f16 KV assumption. A user setting `cacheTypeCustomK: turbo3` with `contextSize: 262144` on a 128 GiB Mac would get rejected as OOM, even though the actual KV cache at turbo3 is roughly 1/5 the f16 size and the model fits comfortably. The only workaround was to set `resources.memory` manually or skip the check entirely.

## Changes

- **`pkg/agent/memory.go`**: new `EstimateOptions` struct + `EstimateModelMemoryWithOptions` that scales the KV term by per-element byte cost. `cacheTypeBytesPerElement` covers `f16`, `f32`, `q8_0`, `q5_0`, `q5_1`, `q4_0`, `q4_1`, `iq4_nl`, `turbo3`, `turbo4`. Unknown types fall back to f16 so the estimate over-allocates rather than under.
- **`pkg/agent/memory.go`**: legacy `EstimateModelMemory(file, layers, embed, ctx)` is preserved as a thin wrapper over the new function with empty options. No existing call site needs to change.
- **`pkg/agent/agent.go`**: `(a *MetalAgent).estimateModelMemory` now accepts cache types and threads them through. `ensureProcess` resolves them once via `resolveCacheTypes` (extracted as a free function) and passes the same values to both the estimator and `buildExecutorConfig`.
- **`docs/turboquant.md`**: new "Pre-flight memory check" section describing the estimator's cache-aware behavior; new "Asymmetric K and V" section noting community guidance on `q8_0` K + `turbo4` V; reference to the M5 Max bench post.
- **`config/samples/inferenceservice_turboquant.yaml`**: explanatory comment about the now-cache-type-aware budget gate.

## Test plan

- [x] `go test ./pkg/... ./internal/... -count=1` — all green
- [x] `golangci-lint run ./pkg/agent/...` — clean (only pre-existing G118 in health.go, unrelated)
- New unit tests:
  - `TestEstimateModelMemory_F16DefaultMatchesLegacyFormula` — bit-for-bit identical to historical formula when called with default options (regression guard)
  - `TestEstimateModelMemory_Q8KVHalvesCache` — q8_0 K+V is ~0.531x f16 K+V
  - `TestEstimateModelMemory_Turbo3CompressesKV` — turbo3/f16 ratio lands in the 0.18-0.23 window (architecture-independent invariant)
  - `TestEstimateModelMemory_AsymmetricCacheTypes` — q8_0 K + turbo4 V produces the expected combined byte cost
  - `TestEstimateModelMemory_UnknownCacheTypeFallsBackToF16` — defensive default

## Behavior change

A user who previously had to set `resources.memory` manually to bypass the f16-assuming gate can now drop that workaround for TurboQuant configs. Existing manifests with explicit memory budgets continue to work unchanged.