### PR TITLE
chore(samples): pin vLLM samples to v0.20.0 + add smoke manifest

### DIFF
--- a/config/samples/vllm-tinyllama.yaml
+++ b/config/samples/vllm-tinyllama.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   modelRef: tinyllama-1b
   runtime: vllm
-  image: vllm/vllm-openai:cu130-nightly
+  image: vllm/vllm-openai:v0.20.0
   skipModelInit: true
   vllmConfig:
     maxModelLen: 2048

--- a/config/samples/vllm-v0.20-smoke.yaml
+++ b/config/samples/vllm-v0.20-smoke.yaml
@@ -1,0 +1,59 @@
+# Smoke-test manifest for vLLM v0.20.0 on a CUDA cluster. Pinned image so this
+# stays a deterministic operational gate even after :latest moves on. Designed
+# for a small enough model that it runs on a single 16 GB consumer GPU
+# (RTX 5060 Ti, RTX 4060 Ti, T4 with FP16, etc.) and exercises the full
+# operator path: model registration, init container, vLLM server startup,
+# probes, service registration, OpenAI-compatible endpoints.
+#
+# Apply:
+#   kubectl apply -f config/samples/vllm-v0.20-smoke.yaml
+#
+# Verify:
+#   kubectl get isvc vllm-v020-smoke -w
+#   kubectl port-forward svc/vllm-v020-smoke 8000:8000
+#   curl localhost:8000/v1/models
+#   curl localhost:8000/v1/completions \
+#     -H 'Content-Type: application/json' \
+#     -d '{"model":"Qwen/Qwen2.5-0.5B-Instruct","prompt":"hello","max_tokens":16}'
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen25-0-5b-instruct
+  namespace: default
+spec:
+  # HF-resolved source: vLLM downloads weights at pod startup, no init download.
+  source: "Qwen/Qwen2.5-0.5B-Instruct"
+  format: safetensors
+  hardware:
+    accelerator: cuda
+    gpu:
+      enabled: true
+      count: 1
+      vendor: nvidia
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: vllm-v020-smoke
+  namespace: default
+spec:
+  modelRef: qwen25-0-5b-instruct
+  runtime: vllm
+  image: vllm/vllm-openai:v0.20.0
+  skipModelInit: true
+  vllmConfig:
+    maxModelLen: 4096
+    dtype: float16
+    # Default kvCacheDtype: auto. Smoke test exercises the default path; the
+    # turbo2 / fp8 variants live in benchmarks/turboquant/manifests/.
+    hfTokenSecretRef:
+      name: hf-token
+      key: HF_TOKEN
+  endpoint:
+    port: 8000
+    type: ClusterIP
+  resources:
+    gpu: 1
+    cpu: "2"
+    memory: "8Gi"


### PR DESCRIPTION
## Summary

Operational gate for vLLM v0.20.0 integration on ShadowStack (#354). No operator code touched. PR1 of a staged series:
- **PR1 (this)**: pin sample manifests to v0.20.0 + ship a small smoke manifest
- **PR2 (#359, open)**: kvCacheCustomDtype escape hatch on the CRD (mirrors #351's CacheTypeCustomK/V)
- **PR3 (after bench)**: pin VLLMBackend.DefaultImage to v0.20.0

## Why pin samples now

The tinyllama sample was on `vllm/vllm-openai:cu130-nightly`, a tag that's no longer the right reference. v0.20.0 shipped 2026-04-27 with TurboQuant 2-bit KV, FlashAttention 4 as the MLA prefill default, DeepSeek V4 support, and a CUDA 13.0 / PyTorch 2.11 baseline. Pinning gives reviewers a deterministic version to apply; the smoke manifest gives anyone with a single 16 GB consumer GPU a deployable end-to-end test of the operator's vLLM path.

## Changes

| File | Change |
|---|---|
| `config/samples/vllm-tinyllama.yaml` | image: `cu130-nightly` → `v0.20.0` |
| `config/samples/vllm-v0.20-smoke.yaml` | NEW — Qwen2.5-0.5B-Instruct, default flags, ClusterIP, 1 GPU |

## ShadowStack readiness (Phase 0 of the parent plan)

| Check | Result |
|---|---|
| Driver | 590.48.01 (CUDA 13 ready, well above 575 floor) |
| GPU allocatable | 2× RTX 5060 Ti |
| Ephemeral storage | ~912 GiB |
| GPU operator | All pods Running |
| Last CUDA validator | Successful |

## Test plan

Full results in https://github.com/defilantech/LLMKube/pull/356#issuecomment-4339695947 — every item executed against ShadowStack.

- [x] `kubectl apply --dry-run=client -f config/samples/vllm-v0.20-smoke.yaml` — accepted
- [x] `kubectl apply --dry-run=client -f config/samples/vllm-tinyllama.yaml` — accepted
- [x] `kubectl apply --dry-run=server` on both — admission accepted
- [x] Apply smoke manifest to ShadowStack → Ready in **3m41s** (warm) / 3m50s (cold), both well under 5 min
- [x] `/v1/models` returns HTTP 200 with the model id and matching `max_model_len`
- [x] `/v1/completions` returns generated tokens for `"The capital of France is"`
- [x] Zero ERROR / CRITICAL / FATAL / Traceback lines in pod logs
- [x] WARNINGS characterized: 8× K8s service-link env-var noise (#358), 1× `--model` deprecation (#357), 2× informational
- [x] Findings captured in `llmkube-internal/benchmarks/vllm-v0.20/shadowstack-validation-2026-04-28.md`

## Refs

- Issue #354 — Validate + integrate vLLM v0.20.0
- Surfaced follow-ups: #357 (BuildArgs deprecation), #358 (enableServiceLinks)
- vLLM v0.20.0 release: https://github.com/vllm-project/vllm/releases/tag/v0.20.0