### PR TITLE
feat(api): add kvCacheCustomDtype for non-enum vLLM KV cache types

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -452,10 +452,22 @@ type VLLMConfig struct {
 	// KV cache memory roughly in half versus auto (which follows dtype), which
 	// is what unlocks 128K+ context on consumer VRAM for agentic workloads.
 	// Maps to vLLM --kv-cache-dtype flag.
+	// For custom build types not in the enum (e.g. TurboQuant turbo2 from
+	// vLLM v0.20+), use KVCacheCustomDtype instead.
 	// +kubebuilder:validation:Enum=auto;fp8_e5m2;fp8_e4m3
 	// +kubebuilder:default=auto
 	// +optional
 	KVCacheDtype *string `json:"kvCacheDtype,omitempty"`
+
+	// KVCacheCustomDtype sets a custom vLLM KV cache element type that is not
+	// in the standard enum. Used for vLLM versions with additional cache
+	// formats such as TurboQuant 2-bit (turbo2, shipped in v0.20.0). Maps to
+	// vLLM --kv-cache-dtype. The runtime image must understand the value or
+	// vLLM will fail to start; LLMKube does not validate the string. Mirrors
+	// the llama.cpp-side CacheTypeCustomK/V escape hatch.
+	// Takes precedence over KVCacheDtype when both are set.
+	// +optional
+	KVCacheCustomDtype string `json:"kvCacheCustomDtype,omitempty"`
 
 	// EnablePrefixCaching turns on vLLM's automatic prefix caching for repeated prompts.
 	// Significantly reduces time-to-first-token for conversational and agentic workloads

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1717,6 +1717,16 @@ spec:
                     - key
                     type: object
                     x-kubernetes-map-type: atomic
+                  kvCacheCustomDtype:
+                    description: |-
+                      KVCacheCustomDtype sets a custom vLLM KV cache element type that is not
+                      in the standard enum. Used for vLLM versions with additional cache
+                      formats such as TurboQuant 2-bit (turbo2, shipped in v0.20.0). Maps to
+                      vLLM --kv-cache-dtype. The runtime image must understand the value or
+                      vLLM will fail to start; LLMKube does not validate the string. Mirrors
+                      the llama.cpp-side CacheTypeCustomK/V escape hatch.
+                      Takes precedence over KVCacheDtype when both are set.
+                    type: string
                   kvCacheDtype:
                     default: auto
                     description: |-
@@ -1724,6 +1734,8 @@ spec:
                       KV cache memory roughly in half versus auto (which follows dtype), which
                       is what unlocks 128K+ context on consumer VRAM for agentic workloads.
                       Maps to vLLM --kv-cache-dtype flag.
+                      For custom build types not in the enum (e.g. TurboQuant turbo2 from
+                      vLLM v0.20+), use KVCacheCustomDtype instead.
                     enum:
                     - auto
                     - fp8_e5m2

--- a/config/samples/vllm-v0.20-qwen32b-turbo2.yaml
+++ b/config/samples/vllm-v0.20-qwen32b-turbo2.yaml
@@ -1,0 +1,62 @@
+# Reference manifest for vLLM v0.20.0 + TurboQuant 2-bit KV cache (turbo2).
+# turbo2 ships in vllm/vllm-openai:v0.20.0 (vLLM PRs #38479, #40092). Earlier
+# images do NOT understand the turbo2 cache type and will fail to start.
+# LLMKube does not validate the kvCacheCustomDtype string.
+#
+# Why this manifest exists: turbo2 is not in the standard kvCacheDtype enum
+# (auto/fp8_e5m2/fp8_e4m3). The kvCacheCustomDtype escape hatch passes the
+# value straight through to vLLM's --kv-cache-dtype flag without LLMKube CRD
+# validation. Mirrors the llama.cpp-side cacheTypeCustomK/V pattern.
+#
+# Apply:
+#   kubectl apply -f config/samples/vllm-v0.20-qwen32b-turbo2.yaml
+#
+# Verify the spawned vLLM process picked up the flag:
+#   kubectl get pod -l app.kubernetes.io/instance=vllm-qwen32b-turbo2 \
+#     -o jsonpath='{.items[0].spec.containers[0].args}' | tr ' ' '\n' | grep -A1 cache-dtype
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen32b-instruct
+  namespace: default
+spec:
+  source: "Qwen/Qwen2.5-32B-Instruct"
+  format: safetensors
+  hardware:
+    accelerator: cuda
+    gpu:
+      enabled: true
+      count: 2
+      vendor: nvidia
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: vllm-qwen32b-turbo2
+  namespace: default
+spec:
+  modelRef: qwen32b-instruct
+  runtime: vllm
+  image: vllm/vllm-openai:v0.20.0
+  skipModelInit: true
+  vllmConfig:
+    tensorParallelSize: 2
+    maxModelLen: 131072
+    dtype: bfloat16
+    # turbo2 = TurboQuant 2-bit KV cache (vLLM v0.20+, PRs #38479 + #40092).
+    # ~6.4x compression vs f16. Compare with llama.cpp's turbo3/turbo4 on the
+    # Metal side (see docs/turboquant.md for cross-runtime context).
+    kvCacheCustomDtype: turbo2
+    enablePrefixCaching: true
+    enableChunkedPrefill: true
+    hfTokenSecretRef:
+      name: hf-token
+      key: HF_TOKEN
+  endpoint:
+    port: 8000
+    type: ClusterIP
+  resources:
+    gpu: 2
+    cpu: "4"
+    memory: "16Gi"

--- a/docs/kv-cache-dtype.md
+++ b/docs/kv-cache-dtype.md
@@ -1,0 +1,95 @@
+# KV cache types across runtimes
+
+LLMKube exposes KV cache quantization for both supported runtimes via different fields, because the runtimes themselves expose different sets of cache types and use different flag conventions. This page is the single reference for picking a value.
+
+## Why KV cache type matters
+
+Long-context inference is bandwidth-bound on the KV cache, not the weights. At fp16 (the default), a 30B-class model's KV cache at 256K context is ~64 GB — over budget for most consumer GPUs and well over the M5 Max's effective per-process memory ceiling. Quantized cache types trade a small perplexity penalty for a large memory and bandwidth win, which directly translates into either higher concurrency at the same context or longer context at the same hardware.
+
+| Backend | Cache type | bits/value | KV @ 128K (30B-class) | Use when |
+|---|---|---|---|---|
+| llama.cpp | f16 (default) | 16 | ~32 GB | Reference / baseline |
+| llama.cpp | q8_0 | 8.5 | ~17 GB | Conservative quant, broadly supported |
+| llama.cpp | iq4_nl | 4.5 | ~9 GB | Aggressive but still standard |
+| llama.cpp | turbo4 (fork) | 4.25 | ~8.5 GB | Decode-heavy agentic workloads on Metal |
+| llama.cpp | turbo3 (fork) | 3.25 | ~6.5 GB | Long-context prefill on Metal |
+| vLLM | auto (default) | follows dtype | varies | Reference / baseline |
+| vLLM | fp8_e4m3 | 8 | ~16 GB | Production agentic on H100/L4 |
+| vLLM | fp8_e5m2 | 8 | ~16 GB | Same scale, different exponent bias |
+| vLLM | turbo2 (v0.20+) | 2 | ~4 GB | Maximum context per VRAM |
+
+## Two runtimes, two fields each
+
+Each runtime has both a standard enum-validated field and a custom-string escape hatch. The custom field always wins when both are set.
+
+### llama.cpp
+
+```yaml
+spec:
+  cacheTypeK: q8_0     # enum-validated: f16, f32, q8_0, q4_0, q4_1, q5_0, q5_1, iq4_nl
+  cacheTypeV: q8_0     # same enum
+
+  # Or the custom escape hatch (TurboQuant turbo3/turbo4, AmesianX tbqp3, etc.)
+  cacheTypeCustomK: turbo3
+  cacheTypeCustomV: turbo3
+```
+
+K and V are independent. Asymmetric `cacheTypeK: q8_0` + `cacheTypeCustomV: turbo4` is supported and is the recommended config from community benchmarks for some agentic workloads.
+
+### vLLM
+
+```yaml
+spec:
+  vllmConfig:
+    kvCacheDtype: fp8_e4m3        # enum: auto, fp8_e5m2, fp8_e4m3
+    # Or the custom escape hatch (turbo2 from vLLM v0.20+, future variants)
+    kvCacheCustomDtype: turbo2
+```
+
+vLLM does not split K and V into separate flags — `--kv-cache-dtype` controls both.
+
+## When to use which field
+
+| You're using | Use |
+|---|---|
+| A standard llama.cpp cache type (q8_0, iq4_nl, etc.) | `cacheTypeK` / `cacheTypeV` (enum-validated, catches typos at API-server admission) |
+| TurboQuant turbo3/turbo4 on Metal or AmesianX tbqp3 on CUDA | `cacheTypeCustomK` / `cacheTypeCustomV` |
+| Standard vLLM auto/fp8 | `kvCacheDtype` (enum-validated) |
+| TurboQuant turbo2 on vLLM v0.20+, or any future cache format | `kvCacheCustomDtype` |
+
+The custom fields skip CRD enum validation. The runtime image / binary must understand the value or the underlying server fails to start with a clear error. LLMKube does not pre-validate the strings so it can support any fork-specific value without an LLMKube release.
+
+## Cross-runtime memory comparison
+
+These numbers are approximate. Real measurements depend on the model's attention pattern (DeltaNet, GQA ratio, head count) and the runtime's framing overhead.
+
+| Runtime | Backend | Cache | Ratio vs f16 (lower = more compression) |
+|---|---|---|---|
+| llama.cpp | Metal (M5 Max) | f16 | 1.000 |
+| llama.cpp | Metal (M5 Max) | q8_0 | 0.531 |
+| llama.cpp | Metal (M5 Max) | turbo4 | 0.266 |
+| llama.cpp | Metal (M5 Max) | turbo3 | 0.203 |
+| vLLM | CUDA (RTX 5060 Ti) | fp8_e4m3 | 0.500 |
+| vLLM | CUDA (RTX 5060 Ti) | turbo2 | 0.125 |
+
+The Metal-side numbers come from the [TurboQuant on M5 Max bench](https://llmkube.com/blog/turboquant-m5-max-long-context). The vLLM-side `turbo2` row will be backed by the ShadowStack bench tracked under issue #354.
+
+## Required runtime images
+
+For non-enum types, the runtime image must include the implementation:
+
+| Backend | Cache type | Image / branch |
+|---|---|---|
+| Metal (Apple Silicon) | turbo3, turbo4 | [TheTom/llama-cpp-turboquant](https://github.com/TheTom/llama-cpp-turboquant) `feature/turboquant-kv-cache` |
+| CUDA (NVIDIA) | tbqp3 | [spiritbuun/llama-cpp-turboquant-cuda](https://github.com/spiritbuun/llama-cpp-turboquant-cuda) |
+| vLLM | turbo2 | `vllm/vllm-openai:v0.20.0` and later |
+
+For Metal, point the metal-agent at the fork via the `--llama-server` flag in your launchd plist (see `docs/turboquant.md`).
+
+## References
+
+- llama.cpp KV cache discussion: <https://github.com/ggml-org/llama.cpp/discussions/20969>
+- vLLM TurboQuant 2-bit PR: <https://github.com/vllm-project/vllm/pull/38479>
+- vLLM v0.20.0 release notes: <https://github.com/vllm-project/vllm/releases/tag/v0.20.0>
+- Llama.cpp-side details: [docs/turboquant.md](./turboquant.md)
+- Cross-architecture bench: <https://llmkube.com/blog/turboquant-m5-max-long-context>

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -75,8 +75,10 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 			args = append(args, "--dtype", cfg.Dtype)
 		}
 		// KV cache dtype: emit unless unset or explicitly "auto" (vLLM's default).
-		if cfg.KVCacheDtype != nil && *cfg.KVCacheDtype != "" && *cfg.KVCacheDtype != "auto" {
-			args = append(args, "--kv-cache-dtype", *cfg.KVCacheDtype)
+		// Custom value (e.g. TurboQuant turbo2 from vLLM v0.20+) wins over the
+		// enum-validated standard field, mirroring llama.cpp's resolveCacheType.
+		if resolved := resolveKVCacheDtype(cfg.KVCacheCustomDtype, cfg.KVCacheDtype); resolved != "" && resolved != "auto" {
+			args = append(args, "--kv-cache-dtype", resolved)
 		}
 		// Prefix caching: only emit when user explicitly opted in (true).
 		// vLLM's own default handles the nil/false case.
@@ -126,6 +128,22 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 	}
 
 	return args
+}
+
+// resolveKVCacheDtype returns the custom vLLM KV cache type when set,
+// otherwise the enum-validated standard value (dereferenced; nil → ""). Lets
+// users opt into vLLM image-specific cache formats (TurboQuant turbo2 from
+// v0.20+, future variants) without expanding the CRD enum on every release,
+// while keeping the standard field discoverable for the common case. Mirrors
+// resolveCacheType on the llama.cpp side.
+func resolveKVCacheDtype(custom string, standard *string) string {
+	if custom != "" {
+		return custom
+	}
+	if standard == nil {
+		return ""
+	}
+	return *standard
 }
 
 // ValidateVLLMConfig checks the VLLMConfig for structurally invalid

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -102,6 +102,28 @@ func TestVLLMBuildArgs(t *testing.T) {
 			contains: []flagCheck{{"--kv-cache-dtype", "fp8_e4m3"}},
 		},
 		{
+			name:     "kvCacheCustomDtype=turbo2 emits flag (vLLM v0.20+ TurboQuant 2-bit)",
+			cfg:      &inferencev1alpha1.VLLMConfig{KVCacheCustomDtype: "turbo2"},
+			contains: []flagCheck{{"--kv-cache-dtype", "turbo2"}},
+		},
+		{
+			name: "kvCacheCustomDtype wins over standard kvCacheDtype when both set",
+			cfg: &inferencev1alpha1.VLLMConfig{
+				KVCacheDtype:       ptrString("fp8_e4m3"),
+				KVCacheCustomDtype: "turbo2",
+			},
+			contains:    []flagCheck{{"--kv-cache-dtype", "turbo2"}},
+			notContains: []string{"fp8_e4m3"},
+		},
+		{
+			name: "kvCacheCustomDtype empty falls back to standard kvCacheDtype",
+			cfg: &inferencev1alpha1.VLLMConfig{
+				KVCacheDtype:       ptrString("fp8_e5m2"),
+				KVCacheCustomDtype: "",
+			},
+			contains: []flagCheck{{"--kv-cache-dtype", "fp8_e5m2"}},
+		},
+		{
 			name:     "enablePrefixCaching=true emits flag",
 			cfg:      &inferencev1alpha1.VLLMConfig{EnablePrefixCaching: ptrBool(true)},
 			contains: []flagCheck{{"--enable-prefix-caching", ""}},
@@ -269,6 +291,34 @@ func TestVLLMBuildArgsDeterministic(t *testing.T) {
 				t.Fatalf("iteration %d pos %d: %q != %q", i, j, got[j], first[j])
 			}
 		}
+	}
+}
+
+// TestResolveKVCacheDtype covers the precedence rules for the custom-vs-standard
+// KV cache type field. Direct unit tests on the resolver are easier to debug
+// than going through BuildArgs and arg-list scanning.
+func TestResolveKVCacheDtype(t *testing.T) {
+	cases := []struct {
+		name     string
+		custom   string
+		standard *string
+		want     string
+	}{
+		{name: "both unset returns empty", custom: "", standard: nil, want: ""},
+		{name: "standard nil and custom empty returns empty", custom: "", standard: nil, want: ""},
+		{name: "standard set, custom empty returns standard", custom: "", standard: ptrString("fp8_e4m3"), want: "fp8_e4m3"},
+		{name: "standard auto, custom empty returns auto", custom: "", standard: ptrString("auto"), want: "auto"},
+		{name: "custom set, standard nil returns custom", custom: "turbo2", standard: nil, want: "turbo2"},
+		{name: "custom set, standard set returns custom (custom wins)", custom: "turbo2", standard: ptrString("fp8_e5m2"), want: "turbo2"},
+		{name: "custom set, standard auto returns custom", custom: "turbo2", standard: ptrString("auto"), want: "turbo2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveKVCacheDtype(tc.custom, tc.standard)
+			if got != tc.want {
+				t.Errorf("resolveKVCacheDtype(%q, %v) = %q, want %q", tc.custom, tc.standard, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

vLLM v0.20.0 shipped TurboQuant 2-bit KV cache (`turbo2`). The CRD's existing `kvCacheDtype` field is enum-validated against `auto;fp8_e5m2;fp8_e4m3` — that excludes `turbo2` and any future fork or upstream variant. Until now the only escape was `extraArgs`, which sidesteps the operator's understanding of the spec entirely.

Add `KVCacheCustomDtype` as a string field with no enum validation, plus a `resolveKVCacheDtype` helper that picks custom > standard. The runtime image must understand the value or vLLM fails to start; LLMKube does not pre-validate. **Mirrors the llama.cpp-side `CacheTypeCustomK/V` escape hatch shipped in #351.**

This is **PR2 of the staged #354 integration**. PR1 (#356, sample-manifest pin) is still open. PR3 (DefaultImage pin) lands after Phase 2 bench data confirms v0.20.0 is healthy.

## Changes

| File | What |
|---|---|
| `api/v1alpha1/inferenceservice_types.go` | New `KVCacheCustomDtype string` field on `VLLMConfig`, doc comment cross-references the standard field and the llama.cpp-side mirror |
| `internal/controller/runtime_vllm.go` | `BuildArgs` calls new `resolveKVCacheDtype(custom, standard)` helper instead of dereferencing the standard field directly. Helper sits next to `BuildArgs`, mirrors `resolveCacheType` from PR #353 |
| `internal/controller/runtime_vllm_test.go` | 4 new `TestVLLMBuildArgs` table cases + a dedicated `TestResolveKVCacheDtype` covering the precedence rules across 7 custom/standard combinations |
| `config/crd/bases/inference.llmkube.dev_inferenceservices.yaml` | Auto-regenerated by `make manifests` |
| `config/samples/vllm-v0.20-qwen32b-turbo2.yaml` | NEW reference manifest pinned to v0.20.0 |
| `docs/kv-cache-dtype.md` | NEW cross-runtime page covering both llama.cpp and vLLM enums + escape hatches, with a memory-compression comparison table |

## Behavior

```yaml
# Before this PR — turbo2 only via extraArgs:
spec:
  vllmConfig:
    kvCacheDtype: auto    # accepted but ignored once we override
  extraArgs:
    - --kv-cache-dtype
    - turbo2

# After this PR — structured field:
spec:
  vllmConfig:
    kvCacheCustomDtype: turbo2   # wins over kvCacheDtype if both are set
```

Existing `kvCacheDtype` users see no change. `kvCacheCustomDtype` is opt-in.

## Test plan

- [x] `go test ./internal/controller/... ./api/... ./pkg/... -count=1` — all green
- [x] `golangci-lint run ./internal/controller/... ./api/...` — 0 issues
- [x] `make manifests generate` — clean regeneration, custom field appears in CRD schema
- [x] 4 new BuildArgs cases (turbo2 emission, custom-wins, custom-empty-falls-back-to-standard, etc.)
- [x] `TestResolveKVCacheDtype` with 7 explicit precedence cases (both unset, custom-only, standard-only, both set, etc.)
- [ ] Apply the new sample manifest to ShadowStack — covered separately by Phase 2 bench

## Refs

- Issue #354 — Validate + integrate vLLM v0.20.0
- vLLM TurboQuant 2-bit PR: https://github.com/vllm-project/vllm/pull/38479
- vLLM v0.20.0 release: https://github.com/vllm-project/vllm/releases/tag/v0.20.0
- Pattern reuse: PR #351 (`CacheTypeCustomK/V`) on the llama.cpp side