### PR TITLE
fix(vllm): use positional model argument instead of deprecated --model

### DIFF
--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -5074,7 +5074,10 @@ var _ = Describe("RuntimeBackend interface", func() {
 			}
 			model := &inferencev1alpha1.Model{}
 			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
-			Expect(args).To(ContainElements("--model", "/models/llama3"))
+			// vLLM v0.20+ uses model as a positional argument (args[0]); the
+			// deprecated --model flag must not appear.
+			Expect(args[0]).To(Equal("/models/llama3"))
+			Expect(args).NotTo(ContainElement("--model"))
 			Expect(args).To(ContainElements("--tensor-parallel-size", "2"))
 			Expect(args).To(ContainElements("--max-model-len", "4096"))
 			Expect(args).To(ContainElements("--quantization", "awq"))
@@ -5106,11 +5109,14 @@ var _ = Describe("RuntimeBackend interface", func() {
 			}
 			model := &inferencev1alpha1.Model{}
 			args := backend.BuildArgs(isvc, model, "/models/llama3", 8000)
-			Expect(args).To(ContainElements("--model", "/models/llama3"))
+			// Model path is positional (args[0]) per vLLM v0.20+; --model is
+			// deprecated and intentionally omitted.
+			Expect(args[0]).To(Equal("/models/llama3"))
+			Expect(args).NotTo(ContainElement("--model"))
 			Expect(args).To(ContainElements("--host", "0.0.0.0"))
 			Expect(args).To(ContainElements("--port", "8000"))
-			// No additional flags beyond defaults
-			Expect(args).To(HaveLen(6))
+			// Five elements: <model> --host 0.0.0.0 --port 8000.
+			Expect(args).To(HaveLen(5))
 		})
 
 		It("should append extraArgs after typed flags", func() {

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -54,8 +54,12 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 	if source == "" {
 		source = model.Spec.Source
 	}
+	// vLLM v0.20 deprecated --model in favor of a positional argument; --model
+	// will be removed in a future minor. The positional form is supported by
+	// every vLLM release we run against, so this works on both v0.19 (silent
+	// accept) and v0.20+ (no deprecation warning).
 	args := []string{
-		"--model", source,
+		source,
 		"--host", "0.0.0.0",
 		"--port", fmt.Sprintf("%d", port),
 	}

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -76,10 +76,12 @@ func TestVLLMBuildArgs(t *testing.T) {
 		notContains []string
 	}{
 		{
-			name:        "nil config emits only base flags",
-			cfg:         nil,
-			contains:    []flagCheck{{"--model", modelPath}, {"--host", "0.0.0.0"}, {"--port", "8000"}},
-			notContains: []string{"--kv-cache-dtype", "--enable-prefix-caching", "--enable-chunked-prefill", "--max-num-batched-tokens", "--attention-backend", "--speculative-model", "--enable-expert-parallel"},
+			name: "nil config emits only base flags (model as positional)",
+			cfg:  nil,
+			// vLLM v0.20+ deprecated --model in favor of a positional argument.
+			// The bare model path appears as args[0]; --model itself must NOT appear.
+			contains:    []flagCheck{{"--host", "0.0.0.0"}, {"--port", "8000"}},
+			notContains: []string{"--model", "--kv-cache-dtype", "--enable-prefix-caching", "--enable-chunked-prefill", "--max-num-batched-tokens", "--attention-backend", "--speculative-model", "--enable-expert-parallel"},
 		},
 		{
 			name:        "empty config emits only base flags",


### PR DESCRIPTION
## Summary

vLLM v0.20.0 deprecated the `--model` CLI flag in favor of a positional argument. Switch `VLLMBackend.BuildArgs` to emit the model path as the first arg.

Closes #357.

## Why

Visible during the v0.20.0 ShadowStack validation:

```
WARNING [argparse_utils.py:257] With \`vllm serve\`, you should provide
the model as a positional argument or in a config file instead of via
the \`--model\` option. The \`--model\` option will be removed in a future
version.
```

Today this is a warning, not an error — vLLM still accepts `--model`. But it will break on a future vLLM minor and the operator should track the supported API surface.

## Backward compatibility

The positional form is supported by every vLLM release we run against. The deprecation is new in v0.20; the positional form has been accepted for much longer. So this works on v0.19.x and v0.20+ identically.

## Changes

| File | Change |
|---|---|
| `internal/controller/runtime_vllm.go` | `args := []string{"--model", source, ...}` → `args := []string{source, ...}` |
| `internal/controller/runtime_vllm_test.go` | nil-config base-flags case: `--model` moved from `contains` to `notContains`; positional path covered by other cases |
| `internal/controller/inferenceservice_controller_test.go` | two ginkgo specs assert `args[0]==path`, `--model` not present; "no extraArgs" length expectation 6→5 |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/controller/... -count=1 -timeout 300s` — all 302 ginkgo specs pass plus the targeted vLLM unit tests
- [x] `golangci-lint run ./internal/controller/...` — 0 issues

## Refs

- Surfaced from #354 (vLLM v0.20.0 integration validation)
- Validation source: `llmkube-internal/benchmarks/vllm-v0.20/shadowstack-validation-2026-04-28.md`