### PR TITLE
fix(vllm): set enableServiceLinks=false on vLLM Pod spec

### DIFF
--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -35,6 +35,20 @@ import (
 // init-container security context stays in the controller file with its
 // storage-builder callers.
 
+// resolveEnableServiceLinks returns the value to set on PodSpec.EnableServiceLinks
+// for a given backend. Backends that implement ServiceLinksOptOut and return
+// true get an explicit `false`; everyone else gets nil (Kubernetes default,
+// which is true). This keeps the legacy service-link env-var injection on for
+// llama.cpp / generic / personaplex / tgi where it is harmless, and disables
+// it for vLLM where the v0.20+ env-var validator turns it into log noise.
+func resolveEnableServiceLinks(backend RuntimeBackend) *bool {
+	if d, ok := backend.(ServiceLinksOptOut); ok && d.DisableServiceLinks() {
+		f := false
+		return &f
+	}
+	return nil
+}
+
 func inferPodSecurityContext(isvc *inferencev1alpha1.InferenceService) *corev1.PodSecurityContext {
 	if isvc.Spec.PodSecurityContext != nil {
 		return isvc.Spec.PodSecurityContext
@@ -186,12 +200,13 @@ func (r *InferenceServiceReconciler) constructDeployment(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					SecurityContext:   inferPodSecurityContext(isvc),
-					InitContainers:    storageConfig.initContainers,
-					Containers:        []corev1.Container{container},
-					Volumes:           storageConfig.volumes,
-					PriorityClassName: r.resolvePriorityClassName(isvc),
-					ImagePullSecrets:  isvc.Spec.ImagePullSecrets,
+					SecurityContext:    inferPodSecurityContext(isvc),
+					InitContainers:     storageConfig.initContainers,
+					Containers:         []corev1.Container{container},
+					Volumes:            storageConfig.volumes,
+					PriorityClassName:  r.resolvePriorityClassName(isvc),
+					ImagePullSecrets:   isvc.Spec.ImagePullSecrets,
+					EnableServiceLinks: resolveEnableServiceLinks(backend),
 				},
 			},
 		},

--- a/internal/controller/runtime.go
+++ b/internal/controller/runtime.go
@@ -47,6 +47,18 @@ type HPAMetricProvider interface {
 	DefaultHPAMetric() string
 }
 
+// ServiceLinksOptOut is optionally implemented by backends that should run with
+// the legacy Kubernetes service-link env-var injection disabled. Returning true
+// sets `enableServiceLinks: false` on the Pod spec, which suppresses the
+// `<UPPER_SERVICE_NAME>_*` env vars Kubernetes auto-injects for every Service
+// in the namespace. vLLM v0.20+ implements a strict env-var validator that
+// flags any `VLLM_*` env var as unknown — meaning every other vLLM Service in
+// the namespace produces a warning per env var per pod. DNS-based service
+// discovery is unaffected.
+type ServiceLinksOptOut interface {
+	DisableServiceLinks() bool
+}
+
 // resolveBackend returns the RuntimeBackend for the given InferenceService.
 func resolveBackend(isvc *inferencev1alpha1.InferenceService) RuntimeBackend {
 	switch isvc.Spec.Runtime {

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -37,6 +37,13 @@ func (b *VLLMBackend) DefaultPort() int32       { return 8000 }
 func (b *VLLMBackend) NeedsModelInit() bool     { return true }
 func (b *VLLMBackend) DefaultHPAMetric() string { return "vllm:num_requests_running" }
 
+// DisableServiceLinks returns true so the operator emits Pods with
+// `enableServiceLinks: false`. vLLM v0.20+ logs a warning for every K8s
+// service-link env var that matches the `VLLM_*` prefix; in a namespace with
+// multiple vLLM Services that's per-pod per-other-service noise. DNS-based
+// service discovery is unaffected — the env vars were a legacy mechanism.
+func (b *VLLMBackend) DisableServiceLinks() bool { return true }
+
 // BuildArgs generates the vLLM server CLI arguments. Arguments are emitted in a
 // deterministic order so snapshot-style tests and diff reviews stay stable:
 //

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -294,6 +294,64 @@ func TestVLLMBuildArgsDeterministic(t *testing.T) {
 	}
 }
 
+// TestVLLMDisableServiceLinks asserts the VLLMBackend opts out of the legacy
+// K8s service-link env-var injection. vLLM v0.20+ flags every K8s-injected
+// VLLM_<svcname>_* env var as unknown; disabling service links suppresses the
+// noise without affecting DNS service discovery.
+func TestVLLMDisableServiceLinks(t *testing.T) {
+	backend := &VLLMBackend{}
+	if !backend.DisableServiceLinks() {
+		t.Error("VLLMBackend.DisableServiceLinks() = false, want true (vLLM v0.20+ env validator noise)")
+	}
+}
+
+// TestResolveEnableServiceLinks covers the wiring between ServiceLinksOptOut
+// and the *bool the deployment builder writes to Pod.Spec.EnableServiceLinks.
+// nil = K8s default (links on); explicit *false = links off.
+func TestResolveEnableServiceLinks(t *testing.T) {
+	cases := []struct {
+		name       string
+		backend    RuntimeBackend
+		wantNil    bool
+		wantValue  bool
+		hasOptOut  bool
+		expectFlag string
+	}{
+		{
+			name:    "VLLMBackend opts out -> *false",
+			backend: &VLLMBackend{},
+			wantNil: false, wantValue: false,
+		},
+		{
+			name:    "LlamaCppBackend does not implement opt-out -> nil (default)",
+			backend: &LlamaCppBackend{},
+			wantNil: true,
+		},
+		{
+			name:    "GenericBackend does not implement opt-out -> nil (default)",
+			backend: &GenericBackend{},
+			wantNil: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveEnableServiceLinks(tc.backend)
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("got %v, want nil (default service links)", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("got nil, want non-nil (explicit opt-out)")
+			}
+			if *got != tc.wantValue {
+				t.Errorf("got *%v, want *%v", *got, tc.wantValue)
+			}
+		})
+	}
+}
+
 // TestResolveKVCacheDtype covers the precedence rules for the custom-vs-standard
 // KV cache type field. Direct unit tests on the resolver are easier to debug
 // than going through BuildArgs and arg-list scanning.


### PR DESCRIPTION
## Summary

vLLM v0.20.0 added a strict env-var validator that flags every K8s-injected service-link env var as "Unknown vLLM environment variable detected" because they happen to start with `VLLM_<SERVICE_NAME>_*`. Disable the legacy service-link injection on vLLM pods.

Closes #358.

## Why

Kubernetes auto-injects `<UPPER_SERVICE_NAME>_*` env vars into every container for every Service in the namespace (the legacy "service links" feature, predating DNS service discovery). A Service named `vllm-foo` produces `VLLM_FOO_PORT`, `VLLM_FOO_SERVICE_HOST`, etc. in every other vLLM pod. vLLM v0.20+ scans them, sees the `VLLM_` prefix, and logs a warning per variable.

For our smoke test we saw 8 such warnings just for one service (`VLLM_V020_SMOKE_*`). In a cluster with 5 vLLM ISVCs, every pod would log ~32 warnings on startup.

## Approach

Add an optional interface alongside the existing `CommandBuilder` / `EnvBuilder` / `HPAMetricProvider` pattern:

```go
type ServiceLinksOptOut interface {
    DisableServiceLinks() bool
}
```

`VLLMBackend` implements it (returns `true`). `LlamaCppBackend`, `GenericBackend`, etc. don't, so they keep K8s default behavior. The deployment builder calls `resolveEnableServiceLinks(backend)` and sets `PodSpec.EnableServiceLinks` to `*false` when the backend opts out, `nil` otherwise.

DNS-based service discovery is unaffected. The env vars were a legacy mechanism that K8s docs themselves nudge people away from.

## Changes

| File | Change |
|---|---|
| `internal/controller/runtime.go` | New `ServiceLinksOptOut` optional interface |
| `internal/controller/runtime_vllm.go` | `VLLMBackend.DisableServiceLinks() bool { return true }` |
| `internal/controller/deployment_builder.go` | New `resolveEnableServiceLinks(backend)` helper; wire it into `PodSpec.EnableServiceLinks` |
| `internal/controller/runtime_vllm_test.go` | `TestVLLMDisableServiceLinks` + `TestResolveEnableServiceLinks` (3-case table covering vLLM / llama.cpp / generic) |

## Test plan

- [x] `go test ./internal/controller/... -count=1 -timeout 300s` — all green (302 ginkgo specs + new units)
- [x] `golangci-lint run ./internal/controller/...` — 0 issues
- [x] New unit tests asserting the opt-in pattern (vLLM only) and the resolver's nil/explicit-false behavior

## Refs

- Surfaced from #354 (vLLM v0.20.0 integration validation)
- Validation source: `llmkube-internal/benchmarks/vllm-v0.20/shadowstack-validation-2026-04-28.md`
- K8s docs on enableServiceLinks: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#environment-variables