### PR TITLE
feat(controller): pin vLLM default image to v0.20.0

### DIFF
--- a/config/samples/inferenceservice_qwen3_coder_30b_fp8_agentic.yaml
+++ b/config/samples/inferenceservice_qwen3_coder_30b_fp8_agentic.yaml
@@ -62,7 +62,7 @@ metadata:
 spec:
   modelRef: qwen3-coder-30b-fp8
   runtime: vllm
-  image: vllm/vllm-openai:latest
+  image: vllm/vllm-openai:v0.20.0
   skipModelInit: true
   replicas: 1
   vllmConfig:

--- a/docs/vllm-default-image.md
+++ b/docs/vllm-default-image.md
@@ -1,0 +1,40 @@
+# vLLM default image
+
+LLMKube pins the default vLLM container image to a specific version rather than `:latest`. The current default is **`vllm/vllm-openai:v0.20.0`**.
+
+## Why pin
+
+`:latest` is reproducibility-hostile. A user who applies the same `InferenceService` manifest on two different days can land on two different vLLM versions with different defaults, different supported flags, and different model compatibility. Pinning gives the operator a deterministic baseline that we test against, document, and ship release notes for.
+
+## Override
+
+The default only applies when an `InferenceService` does not set `spec.image`. To run a different vLLM version, set the field explicitly:
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: my-vllm
+spec:
+  runtime: vllm
+  image: vllm/vllm-openai:v0.21.0   # any tag the runtime image registry serves
+```
+
+User-set images bypass the default entirely. There is no version compatibility check at the operator level — if a tag exists in the registry, LLMKube will pull it. Whether the resulting pod boots is between you and vLLM.
+
+## Bump cadence
+
+We bump `DefaultImage()` per vLLM minor release (e.g., v0.20 → v0.21), once a smoke test on representative hardware confirms the new image deploys cleanly via the operator. The bump lands as a PR titled `chore(controller): pin vLLM default image to vX.Y.0` and goes into the next LLMKube minor or patch release.
+
+The pin lives at [`internal/controller/runtime_vllm.go`](../internal/controller/runtime_vllm.go) on the `DefaultImage()` method. A change here is one line plus a test fixture update at [`internal/controller/inferenceservice_controller_test.go`](../internal/controller/inferenceservice_controller_test.go) that asserts the literal string.
+
+## What changes between vLLM versions
+
+vLLM minor releases routinely change CLI flag defaults, deprecate flags, add new model-architecture support, and shift the default CUDA / PyTorch / transformers versions. The LLMKube operator absorbs these where they intersect with the structured spec (e.g., `vllmConfig.kvCacheDtype`, `vllmConfig.attentionBackend`); user-provided `extraArgs` are passed through untouched.
+
+When a vLLM bump introduces a deprecation that affects `BuildArgs` (see #357 for the v0.20 `--model` example), it lands as a separate PR ahead of the default-image bump so users on the old image are not forced to upgrade simultaneously.
+
+## References
+
+- [vLLM v0.20.0 release notes](https://github.com/vllm-project/vllm/releases/tag/v0.20.0)
+- [LLMKube issue #354](https://github.com/defilantech/LLMKube/issues/354) — the v0.20.0 integration thread

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -5053,7 +5053,7 @@ var _ = Describe("RuntimeBackend interface", func() {
 
 		It("should return correct defaults", func() {
 			Expect(backend.ContainerName()).To(Equal("vllm"))
-			Expect(backend.DefaultImage()).To(Equal("vllm/vllm-openai:latest"))
+			Expect(backend.DefaultImage()).To(Equal("vllm/vllm-openai:v0.20.0"))
 			Expect(backend.DefaultPort()).To(Equal(int32(8000)))
 			Expect(backend.NeedsModelInit()).To(BeTrue())
 			Expect(backend.DefaultHPAMetric()).To(Equal("vllm:num_requests_running"))

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -32,7 +32,7 @@ const (
 type VLLMBackend struct{}
 
 func (b *VLLMBackend) ContainerName() string    { return "vllm" }
-func (b *VLLMBackend) DefaultImage() string     { return "vllm/vllm-openai:latest" }
+func (b *VLLMBackend) DefaultImage() string     { return "vllm/vllm-openai:v0.20.0" }
 func (b *VLLMBackend) DefaultPort() int32       { return 8000 }
 func (b *VLLMBackend) NeedsModelInit() bool     { return true }
 func (b *VLLMBackend) DefaultHPAMetric() string { return "vllm:num_requests_running" }


### PR DESCRIPTION
## Summary

Pin `VLLMBackend.DefaultImage()` from `vllm/vllm-openai:latest` to `vllm/vllm-openai:v0.20.0`. This is the final phase of the staged vLLM v0.20.0 integration work tracked in #354.

Closes #354.

## Why

`:latest` is reproducibility-hostile — the same manifest can land on two different vLLM versions on two different days, with different CLI flag defaults, different supported models, and different CUDA / PyTorch / transformers baselines. Pinning gives the operator a deterministic baseline that we test against and ship release notes for.

v0.20.0 has been operationally validated on ShadowStack via the smoke deploy in #356 (Apply → Ready in 3m41s, `/v1/models` and `/v1/completions` both returning HTTP 200, zero ERROR/CRITICAL/FATAL/Traceback in pod logs). The two surfaced operational issues from that validation already landed: #360 (positional model argument) and #361 (`enableServiceLinks: false`). We're shipping the pin against an operator that already absorbs v0.20's deprecations.

## Changes

| File | Change |
|---|---|
| `internal/controller/runtime_vllm.go` | `DefaultImage()` returns `vllm/vllm-openai:v0.20.0` (was `:latest`) |
| `internal/controller/inferenceservice_controller_test.go` | Test fixture asserts the new pin |
| `config/samples/inferenceservice_qwen3_coder_30b_fp8_agentic.yaml` | Bump from `:latest` to `:v0.20.0` for consistency |
| `docs/vllm-default-image.md` | NEW — explains the pinning rationale, override path (`spec.image`), and our bump cadence (per vLLM minor) |

## Behavior

- Existing `InferenceService` manifests that set `spec.image` explicitly are unaffected (user-set image always wins).
- Manifests that omit `spec.image` get `v0.20.0` instead of whatever `:latest` was on a given day.
- No CRD changes. No spec changes. Pure operator-default tweak.

## Test plan

- [x] `go test ./internal/controller/... -count=1 -timeout 300s` — all green (302 ginkgo specs + units)
- [x] `golangci-lint run ./internal/controller/...` — 0 issues
- [x] `make manifests generate` — clean (no CRD changes)
- [x] DefaultImage assertion test fixture matches new pin
- [x] Validated end-to-end via #356's smoke deploy: ShadowStack apply → Ready → completions all healthy on v0.20.0

## Refs

- vLLM v0.20.0 release: https://github.com/vllm-project/vllm/releases/tag/v0.20.0
- v0.20-driven deprecation/API fixes that landed alongside this work: #360, #361, #359
- Sample manifest pin from earlier in the series: #356
- v0.20-exclusive feature validation (TurboQuant cache types via #359 escape hatch): 12-cell matrix run end-to-end on ShadowStack (4 TurboQuant cache types × 3 contexts, Qwen2.5-1.5B-Instruct, in-cluster Job), 0 failures, all cells reach Ready and serve completions cleanly. Confirms the v0.20 image pinned here can drive cache types that only exist in v0.20+ via the operator's existing escape hatch.
