### PR TITLE
fix(controller): defer HTTP(S) Model downloads to the workload init container

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -140,9 +140,9 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			"CPU/KV offloading is enabled but resources.memory/hostMemory is not set; hybrid pods consume significant host RAM")
 	}
 
-	if r.Recorder != nil && model.Status.Phase == PhaseReady && model.Status.Path == "" && !needsSkipModelInit(inferenceService) {
+	if r.Recorder != nil && shouldWarnMissingSkipModelInit(model, inferenceService) {
 		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "MissingSkipModelInit", "Reconcile",
-			"Model source is runtime-resolved but spec.skipModelInit is not set; init container will fail")
+			"Model source is a HuggingFace repo ID (resolved by the runtime at startup); set spec.skipModelInit=true so the init container does not run")
 	}
 
 	deployment, readyReplicas, result, err := r.reconcileDeployment(ctx, inferenceService, model, desiredReplicas, modelReady, isMetal)
@@ -287,6 +287,32 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 
 func needsSkipModelInit(isvc *inferencev1alpha1.InferenceService) bool {
 	return isvc.Spec.SkipModelInit != nil && *isvc.Spec.SkipModelInit
+}
+
+// shouldWarnMissingSkipModelInit reports whether the InferenceService should
+// receive a `MissingSkipModelInit` warning event. The warning fires when:
+//
+//   - The Model is Ready (so we know its source type matters), AND
+//   - The Model's source is resolved entirely by the runtime — currently
+//     only HuggingFace repo IDs, which vLLM/llama.cpp fetch directly via
+//     HF_TOKEN at workload startup, AND
+//   - The InferenceService still has the init container enabled
+//     (skipModelInit is unset or false).
+//
+// In that combination the init container has nothing to fetch and the Pod
+// will fail to start. HTTP(S) sources also have Status.Path == "" after
+// issue #363 — the controller defers their fetch to the workload init
+// container — but those DO need the init container (it is exactly how the
+// per-namespace cache PVC gets populated), so the warning must NOT fire for
+// them.
+func shouldWarnMissingSkipModelInit(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService) bool {
+	if model.Status.Phase != PhaseReady {
+		return false
+	}
+	if !isHFRepoSource(model.Spec.Source) {
+		return false
+	}
+	return !needsSkipModelInit(isvc)
 }
 
 func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/inferenceservice_controller_test.go
+++ b/internal/controller/inferenceservice_controller_test.go
@@ -6036,3 +6036,52 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 		})
 	})
 })
+
+// Regression coverage for the false-fire that landed alongside issue #363's
+// initial fix: extending the deferred-fetch path to HTTP(S) sources made
+// Status.Path == "" for those Models, and the existing
+// MissingSkipModelInit-warning heuristic was using `Status.Path == ""` as a
+// proxy for "runtime-internal source" — so it started warning on HTTP(S)
+// InferenceServices, which do need the init container. The fix narrows the
+// warning to HuggingFace repo IDs (the only source type that's truly
+// runtime-resolved). Below: the warning's full truth table so the heuristic
+// can't drift again.
+var _ = Describe("shouldWarnMissingSkipModelInit", func() {
+	tt := func(modelPhase, source string, skipInit *bool) bool {
+		model := &inferencev1alpha1.Model{
+			Spec:   inferencev1alpha1.ModelSpec{Source: source},
+			Status: inferencev1alpha1.ModelStatus{Phase: modelPhase},
+		}
+		isvc := &inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{SkipModelInit: skipInit},
+		}
+		return shouldWarnMissingSkipModelInit(model, isvc)
+	}
+	pTrue := func() *bool { v := true; return &v }
+	pFalse := func() *bool { v := false; return &v }
+
+	It("warns: HuggingFace repo ID + Ready Model + skipModelInit unset", func() {
+		Expect(tt(PhaseReady, "Qwen/Qwen3.6-35B-A3B", nil)).To(BeTrue())
+	})
+	It("warns: HuggingFace repo ID + Ready Model + skipModelInit explicitly false", func() {
+		Expect(tt(PhaseReady, "Qwen/Qwen3.6-35B-A3B", pFalse())).To(BeTrue())
+	})
+	It("does not warn: HuggingFace repo ID + skipModelInit=true (correctly configured)", func() {
+		Expect(tt(PhaseReady, "Qwen/Qwen3.6-35B-A3B", pTrue())).To(BeFalse())
+	})
+	It("does not warn: HTTPS source — init container is required to populate the per-namespace cache PVC (issue #363)", func() {
+		Expect(tt(PhaseReady, "https://huggingface.co/example/repo/resolve/main/m.gguf", nil)).To(BeFalse())
+	})
+	It("does not warn: HTTP source — same as HTTPS", func() {
+		Expect(tt(PhaseReady, "http://example.com/m.gguf", nil)).To(BeFalse())
+	})
+	It("does not warn: file:// source — controller copies in-process and Status.Path is populated", func() {
+		Expect(tt(PhaseReady, "file:///mnt/models/m.gguf", nil)).To(BeFalse())
+	})
+	It("does not warn: pvc:// source — model is mounted directly, no init container needed", func() {
+		Expect(tt(PhaseReady, "pvc://my-claim/path/m.gguf", nil)).To(BeFalse())
+	})
+	It("does not warn: Model not yet Ready (irrelevant — warning waits until Status is settled)", func() {
+		Expect(tt("Downloading", "Qwen/Qwen3.6-35B-A3B", nil)).To(BeFalse())
+	})
+})

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -96,7 +96,19 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// runtime container at startup, not by the Model controller. The controller
 	// marks the model Ready immediately so referencing InferenceServices can proceed.
 	if isHFRepoSource(model.Spec.Source) {
-		return ctrl.Result{}, r.reconcileRuntimeResolvedSource(ctx, model)
+		return ctrl.Result{}, r.reconcileRuntimeResolvedSource(ctx, model, "")
+	}
+
+	// Remote HTTP(S) sources are downloaded by the InferenceService Pod's
+	// init container into the per-namespace model cache PVC, not by the
+	// Model controller. The controller pod's storage path lives on the
+	// operator-namespace PVC (e.g. llmkube-system/llmkube-model-cache) and
+	// PVCs cannot be cross-namespace mounted, so a controller-side download
+	// is invisible to inference Pods. Defer the fetch to the workload and
+	// populate CacheKey so the init container can land the file at the
+	// canonical /models/<cacheKey>/<basename> path the runtime expects.
+	if isRemoteHTTPSource(model.Spec.Source) {
+		return ctrl.Result{}, r.reconcileRuntimeResolvedSource(ctx, model, computeCacheKey(model.Spec.Source))
 	}
 
 	cacheKey := computeCacheKey(model.Spec.Source)
@@ -318,11 +330,20 @@ func (r *ModelReconciler) reconcilePVCSource(ctx context.Context, model *inferen
 	return ctrl.Result{}, nil
 }
 
-// reconcileRuntimeResolvedSource handles runtime-resolved model sources such as
-// HuggingFace repo IDs. The runtime container (e.g., vLLM) will fetch the model
-// at startup using its own mechanism (e.g., HF_TOKEN). The controller marks the
-// model Ready immediately without downloading anything.
-func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, model *inferencev1alpha1.Model) error {
+// reconcileRuntimeResolvedSource handles model sources whose actual fetch is
+// performed outside the Model controller — either by the runtime container
+// itself (HuggingFace repo IDs resolved by vLLM/llama.cpp at startup) or by
+// the InferenceService Pod's init container (remote HTTP(S) URLs downloaded
+// into the per-namespace model cache PVC). In both cases the controller
+// marks the model Ready immediately so referencing InferenceServices can
+// proceed.
+//
+// cacheKey is populated for sources that flow through the per-namespace cache
+// PVC (HTTP(S) URLs). It is empty for runtime-internal sources like HF repo
+// IDs where the runtime resolves and stores the model on its own. A non-empty
+// cacheKey lets InferenceService.spec build the canonical
+// /models/<cacheKey>/<basename> path that the init container will populate.
+func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, model *inferencev1alpha1.Model, cacheKey string) error {
 	logger := log.FromContext(ctx)
 
 	// Early exit if already Ready
@@ -332,18 +353,24 @@ func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, mo
 		return nil
 	}
 
-	logger.Info("Source is runtime-resolved, skipping download", "source", model.Spec.Source)
+	reason := "RuntimeResolved"
+	message := "Source is runtime-resolved (e.g., HuggingFace repo ID); runtime will fetch at startup"
+	if cacheKey != "" {
+		reason = "WorkloadResolved"
+		message = "Source is a remote URL; the InferenceService Pod's init container will fetch the model into the per-namespace model cache PVC at startup"
+	}
+
+	logger.Info("Source is runtime-resolved, skipping controller-side download", "source", model.Spec.Source, "cacheKey", cacheKey)
 
 	model.Status.Phase = PhaseReady
 	model.Status.Path = ""
-	model.Status.CacheKey = ""
+	model.Status.CacheKey = cacheKey
 	model.Status.Size = "0"
 	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(model.Spec.Hardware)
 	now := metav1.Now()
 	model.Status.LastUpdated = &now
 
-	if err := r.updateStatus(ctx, model, "Available", metav1.ConditionTrue, "RuntimeResolved",
-		"Source is runtime-resolved (e.g., HuggingFace repo ID); runtime will fetch at startup"); err != nil {
+	if err := r.updateStatus(ctx, model, "Available", metav1.ConditionTrue, reason, message); err != nil {
 		return err
 	}
 

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -79,9 +79,8 @@ var _ = Describe("Model Controller", func() {
 			By("Cleanup the specific resource instance Model")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
-		It("should successfully reconcile the resource", func() {
+		It("should defer HTTPS sources to the workload init container without downloading", func() {
 			By("Reconciling the created resource")
-			// Create a temp directory for model cache
 			tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 			Expect(err).NotTo(HaveOccurred())
 			defer func() { _ = os.RemoveAll(tempDir) }()
@@ -92,15 +91,24 @@ var _ = Describe("Model Controller", func() {
 				StoragePath: tempDir,
 			}
 
-			// Note: This will attempt to download the model, which will fail for test URL
-			// In a real scenario, you'd mock the download or use a valid test model
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+			// HTTPS sources are downloaded by the InferenceService Pod's init
+			// container into the per-namespace model cache PVC, not by the
+			// controller (whose StoragePath lives on the operator-namespace PVC).
+			// The controller marks the model Ready immediately so the workload
+			// can proceed to download.
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			// We expect an error because the test URL doesn't exist
-			// This test validates the controller handles the error gracefully
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("bad status"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			updated := &inferencev1alpha1.Model{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(PhaseReady))
+			Expect(updated.Status.CacheKey).To(HaveLen(16))
+			// Controller did not write to its filesystem.
+			entries, _ := os.ReadDir(tempDir)
+			Expect(entries).To(BeEmpty(), "controller must not write under StoragePath for HTTPS sources")
 		})
 	})
 })
@@ -152,7 +160,15 @@ var _ = Describe("Model Controller Reconcile", func() {
 
 	It("should set Ready when model file already exists in cache", func() {
 		modelName := "model-cached"
-		source := "https://example.com/cached-model.gguf"
+		// Use a file:// source so the test exercises the controller's cache-hit
+		// path. HTTPS sources are deferred to the workload init container and
+		// don't go through the in-process cache logic.
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src-model.gguf")
+		Expect(os.WriteFile(srcFile, []byte("fake-model-data"), 0644)).To(Succeed())
+		source := fmt.Sprintf("file://%s", srcFile)
 
 		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 		Expect(err).NotTo(HaveOccurred())
@@ -195,29 +211,28 @@ var _ = Describe("Model Controller Reconcile", func() {
 		Expect(updated.Status.LastUpdated).NotTo(BeNil())
 	})
 
-	It("should download model from HTTP server and set Ready", func() {
-		modelContent := []byte("fake-gguf-model-content-for-test")
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(modelContent)
-		}))
-		defer server.Close()
-
-		modelName := "model-download-test"
+	// HTTPS sources deferred to the workload init container — see issue #363.
+	// The controller does NOT download HTTP(S) sources because its filesystem
+	// (StoragePath) lives on the operator-namespace cache PVC, which Pods in
+	// user namespaces cannot mount. Downloading there means the workload's
+	// init container would still re-fetch the model from scratch. The
+	// equivalent "controller fetches a non-PVC source and lands at the
+	// expected cache path" coverage for sources that DO go through the
+	// in-process path lives at "should copy local model file and set Ready"
+	// below (file:// sources).
+	It("should defer HTTPS source to the InferenceService init container", func() {
+		modelName := "model-https-deferred"
 		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
+		source := "https://example.com/some-model.gguf"
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
-			Spec: inferencev1alpha1.ModelSpec{
-				Source: fmt.Sprintf("%s/model.gguf", server.URL),
-			},
+			Spec:       inferencev1alpha1.ModelSpec{Source: source},
 		}
 		Expect(k8sClient.Create(ctx, model)).To(Succeed())
-		defer func() {
-			_ = k8sClient.Delete(ctx, model)
-		}()
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
 			Client:      k8sClient,
@@ -233,47 +248,31 @@ var _ = Describe("Model Controller Reconcile", func() {
 		updated := &inferencev1alpha1.Model{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
 		Expect(updated.Status.Phase).To(Equal(PhaseReady))
-		Expect(updated.Status.Size).NotTo(BeEmpty())
-		Expect(updated.Status.CacheKey).To(HaveLen(16))
-	})
+		// CacheKey populated so the InferenceService init container can build
+		// the canonical /models/<cacheKey>/<basename> path.
+		Expect(updated.Status.CacheKey).To(Equal(computeCacheKey(source)))
+		// Controller-side fields stay empty: the workload populates these when
+		// it actually downloads the model.
+		Expect(updated.Status.Path).To(BeEmpty())
+		Expect(updated.Status.SHA256).To(BeEmpty())
 
-	It("should set Failed and requeue on download failure", func() {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-		}))
-		defer server.Close()
+		// Critical regression check (issue #363): the controller must not
+		// write anything under its own StoragePath for HTTP(S) sources, since
+		// that storage is invisible to inference Pods in other namespaces.
+		entries, readErr := os.ReadDir(tempDir)
+		Expect(readErr).NotTo(HaveOccurred())
+		Expect(entries).To(BeEmpty(), "controller must not write under StoragePath for HTTPS sources (issue #363)")
 
-		modelName := "model-download-fail"
-		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
-		Expect(err).NotTo(HaveOccurred())
-		defer func() { _ = os.RemoveAll(tempDir) }()
-
-		model := &inferencev1alpha1.Model{
-			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
-			Spec: inferencev1alpha1.ModelSpec{
-				Source: fmt.Sprintf("%s/model.gguf", server.URL),
-			},
+		// Condition is Available with the WorkloadResolved reason so users can
+		// distinguish runtime-internal HF resolution from init-container
+		// HTTP fetches.
+		var hasWorkloadResolved bool
+		for _, cond := range updated.Status.Conditions {
+			if cond.Type == "Available" && cond.Reason == "WorkloadResolved" {
+				hasWorkloadResolved = true
+			}
 		}
-		Expect(k8sClient.Create(ctx, model)).To(Succeed())
-		defer func() {
-			_ = k8sClient.Delete(ctx, model)
-		}()
-
-		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
-		}
-		result, err := reconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
-		})
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("bad status"))
-		Expect(result.RequeueAfter).To(Equal(5 * time.Minute))
-
-		updated := &inferencev1alpha1.Model{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
-		Expect(updated.Status.Phase).To(Equal(PhaseFailed))
+		Expect(hasWorkloadResolved).To(BeTrue(), "expected Available/WorkloadResolved condition")
 	})
 
 	It("should copy local model file and set Ready", func() {
@@ -366,7 +365,14 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
-		source := "https://example.com/already-ready-model.gguf"
+		// file:// source so the test exercises the controller's in-process
+		// cache + migration path. HTTPS sources are deferred to the workload.
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src.gguf")
+		Expect(os.WriteFile(srcFile, []byte("cached-model-data"), 0644)).To(Succeed())
+		source := fmt.Sprintf("file://%s", srcFile)
 		cacheKey := computeCacheKey(source)
 		modelDir := filepath.Join(tempDir, cacheKey)
 		legacyPath := filepath.Join(modelDir, "model.gguf")
@@ -421,19 +427,21 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		Expect(afterSecond.Status.LastUpdated.Equal(lastUpdated)).To(BeTrue())
 	})
 
-	It("should re-download when model is Ready but file is missing", func() {
+	It("should re-fetch when model is Ready but file is missing", func() {
 		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
-		modelContent := []byte("re-downloaded-model-content")
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(modelContent)
-		}))
-		defer server.Close()
+		// Use a file:// source so the test exercises the controller's
+		// re-fetch behavior on stale status. HTTPS is deferred to the
+		// workload init container.
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src.gguf")
+		Expect(os.WriteFile(srcFile, []byte("re-fetched-model-content"), 0644)).To(Succeed())
 
-		source := fmt.Sprintf("%s/model.gguf", server.URL)
+		source := fmt.Sprintf("file://%s", srcFile)
 		cacheKey := computeCacheKey(source)
 		stalePath := filepath.Join(tempDir, cacheKey, "model.gguf")
 
@@ -473,17 +481,16 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should not leave partial file at final path on download failure", func() {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		}))
-		defer server.Close()
-
+	It("should not leave partial file at final path on fetch failure", func() {
 		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
-		source := fmt.Sprintf("%s/model.gguf", server.URL)
+		// Point at a file:// source whose target does not exist. This
+		// exercises the controller's atomic-rename guarantee for non-PVC,
+		// non-HTTP sources (HTTP sources are deferred to the workload init
+		// container, see issue #363).
+		source := "file:///nonexistent/path/to/source-model.gguf"
 		cacheKey := computeCacheKey(source)
 		modelDir := filepath.Join(tempDir, cacheKey)
 		modelPath := filepath.Join(modelDir, "model.gguf")
@@ -508,7 +515,7 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 
 		// Final model path must NOT exist
 		_, err = os.Stat(modelPath)
-		Expect(os.IsNotExist(err)).To(BeTrue(), "final model path should not exist after failed download")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "final model path should not exist after failed fetch")
 
 		// No temp files should remain in the cache directory
 		if entries, dirErr := os.ReadDir(modelDir); dirErr == nil {
@@ -756,20 +763,24 @@ var _ = Describe("PVC Source Reconcile", func() {
 var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 	ctx := context.Background()
 
-	It("renames downloaded model to GGUF metadata name", func() {
+	It("renames fetched model to GGUF metadata name", func() {
+		// HTTPS sources defer to the workload init container; the controller's
+		// canonical-name migration runs only for in-process source types like
+		// file://. The init container performs its own naming on the
+		// per-namespace cache PVC.
 		ggufBytes := buildMinimalGGUF("Gemma-4-E4B-It")
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(ggufBytes)
-		}))
-		defer server.Close()
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src.gguf")
+		Expect(os.WriteFile(srcFile, ggufBytes, 0644)).To(Succeed())
 
 		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		modelName := "gemma-test"
-		source := fmt.Sprintf("%s/model.gguf", server.URL)
+		source := fmt.Sprintf("file://%s", srcFile)
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
 			Spec:       inferencev1alpha1.ModelSpec{Source: source},
@@ -806,17 +817,18 @@ var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 
 	It("sanitizes unsafe characters from GGUF metadata name", func() {
 		ggufBytes := buildMinimalGGUF("Llama 3.1/Instruct")
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write(ggufBytes)
-		}))
-		defer server.Close()
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src.gguf")
+		Expect(os.WriteFile(srcFile, ggufBytes, 0644)).To(Succeed())
 
 		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		modelName := "llama-test"
-		source := fmt.Sprintf("%s/model.gguf", server.URL)
+		source := fmt.Sprintf("file://%s", srcFile)
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
 			Spec:       inferencev1alpha1.ModelSpec{Source: source},
@@ -889,19 +901,23 @@ var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 	})
 
 	It("falls back to Model.Name when GGUF metadata name is missing", func() {
-		// Valid GGUF with no general.name key.
+		// Valid GGUF with no general.name key, served via a file:// source.
+		// HTTP(S) sources are deferred to the workload init container, so the
+		// controller's GGUF parsing + canonical-name migration only runs for
+		// in-process source types (file://, etc.).
 		ggufBytes := buildMinimalGGUF("")
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write(ggufBytes)
-		}))
-		defer server.Close()
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src.gguf")
+		Expect(os.WriteFile(srcFile, ggufBytes, 0644)).To(Succeed())
 
 		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		modelName := "fallback-by-cr-name"
-		source := fmt.Sprintf("%s/model.gguf", server.URL)
+		source := fmt.Sprintf("file://%s", srcFile)
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
 			Spec:       inferencev1alpha1.ModelSpec{Source: source},
@@ -931,9 +947,16 @@ var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
-		// Pre-stage a real GGUF file at the legacy path.
+		// Pre-stage a real GGUF file at the legacy path. file:// source so the
+		// controller's migration path runs (HTTP(S) is deferred to the
+		// workload init container).
 		ggufBytes := buildMinimalGGUF("Legacy-Cached-Model")
-		source := "https://example.com/legacy.gguf"
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src.gguf")
+		Expect(os.WriteFile(srcFile, ggufBytes, 0644)).To(Succeed())
+		source := fmt.Sprintf("file://%s", srcFile)
 		cacheKey := computeCacheKey(source)
 		modelDir := filepath.Join(tempDir, cacheKey)
 		legacyPath := filepath.Join(modelDir, "model.gguf")
@@ -1102,13 +1125,17 @@ var _ = Describe("Runtime-Resolved Source Reconcile", func() {
 var _ = Describe("SHA256 Verification", func() {
 	ctx := context.Background()
 
-	It("should pass when spec SHA256 matches downloaded file", func() {
+	It("should pass when spec SHA256 matches the fetched file", func() {
+		// HTTP(S) sources are deferred to the workload init container, so the
+		// controller's SHA256 verification path runs only for in-process
+		// sources (file://, etc.). Workload-side SHA verification is the
+		// responsibility of the runtime / init container.
 		modelContent := []byte("sha256-test-model-content")
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(modelContent)
-		}))
-		defer server.Close()
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src.gguf")
+		Expect(os.WriteFile(srcFile, modelContent, 0644)).To(Succeed())
 
 		tempDir, err := os.MkdirTemp("", "llmkube-sha-*")
 		Expect(err).NotTo(HaveOccurred())
@@ -1125,7 +1152,7 @@ var _ = Describe("SHA256 Verification", func() {
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
 			Spec: inferencev1alpha1.ModelSpec{
-				Source: fmt.Sprintf("%s/model.gguf", server.URL),
+				Source: fmt.Sprintf("file://%s", srcFile),
 				SHA256: expectedHash,
 			},
 		}
@@ -1149,13 +1176,13 @@ var _ = Describe("SHA256 Verification", func() {
 		Expect(updated.Status.SHA256).To(Equal(expectedHash))
 	})
 
-	It("should fail when spec SHA256 does not match downloaded file", func() {
+	It("should fail when spec SHA256 does not match the fetched file", func() {
 		modelContent := []byte("sha256-mismatch-content")
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(modelContent)
-		}))
-		defer server.Close()
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src.gguf")
+		Expect(os.WriteFile(srcFile, modelContent, 0644)).To(Succeed())
 
 		tempDir, err := os.MkdirTemp("", "llmkube-sha-*")
 		Expect(err).NotTo(HaveOccurred())
@@ -1165,7 +1192,7 @@ var _ = Describe("SHA256 Verification", func() {
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
 			Spec: inferencev1alpha1.ModelSpec{
-				Source: fmt.Sprintf("%s/model.gguf", server.URL),
+				Source: fmt.Sprintf("file://%s", srcFile),
 				SHA256: "0000000000000000000000000000000000000000000000000000000000000000",
 			},
 		}
@@ -1205,11 +1232,11 @@ var _ = Describe("SHA256 Verification", func() {
 
 	It("should compute and store SHA256 even when not specified in spec", func() {
 		modelContent := []byte("sha256-auto-compute-content")
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(modelContent)
-		}))
-		defer server.Close()
+		srcDir, err := os.MkdirTemp("", "llmkube-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "src.gguf")
+		Expect(os.WriteFile(srcFile, modelContent, 0644)).To(Succeed())
 
 		tempDir, err := os.MkdirTemp("", "llmkube-sha-*")
 		Expect(err).NotTo(HaveOccurred())
@@ -1219,7 +1246,7 @@ var _ = Describe("SHA256 Verification", func() {
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
 			Spec: inferencev1alpha1.ModelSpec{
-				Source: fmt.Sprintf("%s/model.gguf", server.URL),
+				Source: fmt.Sprintf("file://%s", srcFile),
 				// SHA256 intentionally not set
 			},
 		}
@@ -1262,5 +1289,142 @@ var _ = Describe("computeFileSHA256", func() {
 	It("should return error for nonexistent file", func() {
 		_, err := computeFileSHA256("/nonexistent/file.gguf")
 		Expect(err).To(HaveOccurred())
+	})
+})
+
+// Regression coverage for issue #363 — "Model cache PVC created in
+// llmkube-system instead of the Model CR's namespace".
+//
+// The original disconnect: the Model controller downloaded HTTPS sources
+// in-process to its own pod's filesystem (operator-namespace cache PVC),
+// while the InferenceService init container read from a per-namespace cache
+// PVC. Because PVCs cannot be cross-namespace mounted, the controller's
+// download was invisible to the inference Pod, which silently re-fetched
+// from source on every fresh InferenceService.
+//
+// These tests assert the architectural invariants that prevent that
+// disconnect from coming back:
+//  1. For HTTP(S) sources, the controller writes nothing under StoragePath.
+//  2. The Model.Status.CacheKey produced by Reconcile() is the same key the
+//     InferenceService Pod's storage config uses to build the init
+//     container's MODEL_PATH. If those ever desync, the inference Pod's
+//     "skip download if file exists" cache check fails silently and
+//     every Pod re-downloads.
+//  3. CacheKey is populated only for source types that flow through the
+//     per-namespace cache PVC (HTTP(S)), not for runtime-internal sources
+//     (HF repo IDs that vLLM resolves itself).
+var _ = Describe("Issue #363 regression — controller / workload cache disconnect", func() {
+	ctx := context.Background()
+
+	It("does not write under StoragePath for HTTPS sources", func() {
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "issue-363-no-fs-write"
+		source := "https://huggingface.co/example-org/example-repo/resolve/main/m.gguf"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: source},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The controller must not have created any directory or file under
+		// its StoragePath. Any write here would land on the operator-
+		// namespace PVC, which Pods in user namespaces cannot mount.
+		entries, readErr := os.ReadDir(tempDir)
+		Expect(readErr).NotTo(HaveOccurred())
+		Expect(entries).To(BeEmpty(), "operator-namespace cache PVC must stay untouched for HTTPS sources")
+	})
+
+	It("emits a CacheKey that matches the InferenceService init container's MODEL_PATH for HTTPS sources", func() {
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "issue-363-cachekey-roundtrip"
+		source := "https://huggingface.co/example-org/example-repo/resolve/main/m.gguf"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: source},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.CacheKey).NotTo(BeEmpty(), "HTTPS source must populate CacheKey so the init container can build /models/<cacheKey>/<basename>")
+
+		// Build the InferenceService Pod's storage config from this Model and
+		// assert the init container's MODEL_PATH lines up with the Model's
+		// CacheKey. The init container's `if [ ! -f "$MODEL_PATH" ]` check
+		// only works when both sides agree on the path.
+		config := buildCachedStorageConfig(updated, nil, "", "curl:8.18.0")
+		expectedPrefix := "/models/" + updated.Status.CacheKey + "/"
+		Expect(config.modelPath).To(HavePrefix(expectedPrefix),
+			"init container MODEL_PATH must live under /models/<Status.CacheKey>/")
+
+		var modelPathEnv string
+		for _, e := range config.initContainers[0].Env {
+			if e.Name == "MODEL_PATH" {
+				modelPathEnv = e.Value
+			}
+		}
+		Expect(modelPathEnv).To(Equal(config.modelPath))
+		Expect(modelPathEnv).To(HavePrefix(expectedPrefix),
+			"MODEL_PATH env on the init container must use Status.CacheKey from Reconcile()")
+	})
+
+	It("leaves CacheKey empty for HuggingFace repo IDs (runtime-internal resolution)", func() {
+		// HF repo IDs are resolved by vLLM/llama.cpp at runtime, not by the
+		// init container. CacheKey is irrelevant in that path; this test
+		// guards against accidentally populating it (which would cause the
+		// init container to try to materialize a file at a synthetic path).
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "issue-363-hf-no-cachekey"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: "Qwen/Qwen3.6-35B-A3B"},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.CacheKey).To(BeEmpty(), "HF repo IDs must not populate CacheKey — runtime resolves them internally")
 	})
 })

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -71,6 +71,16 @@ func getLocalPath(source string) string {
 	return source
 }
 
+// isRemoteHTTPSource reports whether source is an http:// or https:// URL.
+// These sources are downloaded by the inference Pod's init container into the
+// per-namespace model cache PVC, not by the Model controller. Downloading in
+// the controller's pod writes to the operator-namespace PVC, which is not
+// visible to Pods in user namespaces (PVCs cannot be cross-namespace mounted),
+// so the controller defers the actual fetch to the workload.
+func isRemoteHTTPSource(source string) bool {
+	return strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://")
+}
+
 // isHFRepoSource reports whether source looks like a HuggingFace repo ID
 // (e.g., "TinyLlama/TinyLlama-1.1B-Chat-v1.0", "Qwen/Qwen3.6-35B-A3B").
 // These sources are downloaded by the runtime (vLLM) at startup, not by

--- a/internal/controller/source_test.go
+++ b/internal/controller/source_test.go
@@ -153,3 +153,67 @@ var _ = Describe("isHFRepoSource (source.go)", func() {
 		Expect(isHFRepoSource("multi/part/path/thing")).To(BeTrue())
 	})
 })
+
+var _ = Describe("isRemoteHTTPSource (source.go)", func() {
+	// Regression coverage for issue #363: the controller defers HTTP(S)
+	// sources to the workload init container so the per-namespace cache PVC
+	// is populated. If a future change widens or narrows what this matcher
+	// considers HTTP(S), the dispatch in Reconcile() flips silently, so this
+	// matcher needs explicit, exhaustive cases.
+	It("should return true for https URL", func() {
+		Expect(isRemoteHTTPSource("https://huggingface.co/org/repo/resolve/main/model.gguf")).To(BeTrue())
+	})
+	It("should return true for http URL", func() {
+		Expect(isRemoteHTTPSource("http://example.com/model.gguf")).To(BeTrue())
+	})
+	It("should return true for https URL with port and query", func() {
+		Expect(isRemoteHTTPSource("https://my-mirror.local:8443/m.gguf?token=abc")).To(BeTrue())
+	})
+	It("should return false for HuggingFace repo ID", func() {
+		Expect(isRemoteHTTPSource("Qwen/Qwen3.6-35B-A3B")).To(BeFalse())
+	})
+	It("should return false for file:// URL", func() {
+		Expect(isRemoteHTTPSource("file:///mnt/models/local.gguf")).To(BeFalse())
+	})
+	It("should return false for absolute path", func() {
+		Expect(isRemoteHTTPSource("/mnt/models/local.gguf")).To(BeFalse())
+	})
+	It("should return false for pvc:// source", func() {
+		Expect(isRemoteHTTPSource("pvc://my-claim/path/model.gguf")).To(BeFalse())
+	})
+	It("should return false for empty string", func() {
+		Expect(isRemoteHTTPSource("")).To(BeFalse())
+	})
+	It("should return false for ftp:// URL (out of scope for the workload init container)", func() {
+		Expect(isRemoteHTTPSource("ftp://example.com/model.gguf")).To(BeFalse())
+	})
+	It("source-type matchers must be mutually exclusive", func() {
+		// Architectural invariant: every reachable source falls into exactly
+		// one category. If this regresses, Reconcile()'s dispatch order
+		// becomes load-bearing and silent bugs creep in.
+		cases := []string{
+			"https://huggingface.co/org/repo/resolve/main/m.gguf",
+			"http://mirror.local/m.gguf",
+			"Qwen/Qwen3.6-35B-A3B",
+			"file:///mnt/models/m.gguf",
+			"/mnt/models/m.gguf",
+			"pvc://my-claim/path/m.gguf",
+		}
+		for _, src := range cases {
+			matchCount := 0
+			if isPVCSource(src) {
+				matchCount++
+			}
+			if isHFRepoSource(src) {
+				matchCount++
+			}
+			if isRemoteHTTPSource(src) {
+				matchCount++
+			}
+			if isLocalSource(src) {
+				matchCount++
+			}
+			Expect(matchCount).To(Equal(1), "source %q must match exactly one category, got %d", src, matchCount)
+		}
+	})
+})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -390,9 +390,22 @@ spec:
 			Expect(output).To(Equal("True"))
 		})
 
-		It("should recover a cached model to Ready after controller restart", func() {
+		It("should keep an HTTP-sourced Model Ready across a controller restart", func() {
+			// HTTP(S) sources are deferred to the InferenceService Pod's init
+			// container (issue #363) — the Model controller doesn't manage
+			// the cache for these sources, so a controller restart should
+			// not trigger a re-download and Status.CacheKey should persist
+			// across the restart.
+			By("recording Status.CacheKey before the restart")
+			cmd := exec.Command("kubectl", "get", "model", "test-model",
+				"-n", crTestNs, "-o", "jsonpath={.status.cacheKey}")
+			cacheKeyBefore, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cacheKeyBefore).To(MatchRegexp(`^[0-9a-f]{16}$`),
+				"HTTP(S) Models must have a CacheKey populated so the InferenceService init container can build /models/<cacheKey>/<basename>")
+
 			By("recording the current controller pod name")
-			cmd := exec.Command("kubectl", "get", "pods",
+			cmd = exec.Command("kubectl", "get", "pods",
 				"-l", "control-plane=controller-manager",
 				"-n", namespace,
 				"-o", "jsonpath={.items[0].metadata.name}")
@@ -433,31 +446,32 @@ spec:
 			// Update controllerPodName so AfterEach logs the right pod on failure
 			controllerPodName = newPod
 
-			By("waiting for the Model to return to Ready after restart")
-			// The Kind cluster uses emptyDir so the cached file is lost on restart.
-			// The controller detects this ("Model marked Ready but file missing")
-			// and re-downloads cleanly. Verify it returns to Ready.
+			By("verifying the Model stays Ready and CacheKey is preserved")
 			Eventually(func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "model", "test-model",
 					"-n", crTestNs, "-o", "jsonpath={.status.phase}")
-				output, err := utils.Run(cmd)
+				phase, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("Ready"))
+				g.Expect(phase).To(Equal("Ready"))
+
+				cmd = exec.Command("kubectl", "get", "model", "test-model",
+					"-n", crTestNs, "-o", "jsonpath={.status.cacheKey}")
+				cacheKeyAfter, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cacheKeyAfter).To(Equal(cacheKeyBefore), "CacheKey must survive controller restart")
 			}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
-			By("verifying the new controller detected the missing cache and recovered")
-			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "logs", newPod, "-n", namespace)
-				logs, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(logs).To(ContainSubstring("Model marked Ready but file missing, will re-download"))
-			}, 1*time.Minute, 2*time.Second).Should(Succeed())
-
-			By("confirming the model was re-downloaded successfully")
+			By("verifying the new controller did NOT attempt a controller-side download (issue #363)")
+			// Regression guard: prior to issue #363's fix the controller
+			// downloaded HTTP(S) sources in-process to its own filesystem,
+			// which lived on a different PVC than the inference Pod read
+			// from. Asserting absence of "Downloading model" guarantees the
+			// new controller takes the workload-deferred path on restart.
 			cmd = exec.Command("kubectl", "logs", newPod, "-n", namespace)
 			logs, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(logs).To(ContainSubstring("Downloading model"))
+			Expect(logs).NotTo(ContainSubstring("Downloading model"),
+				"controller must not perform an in-process download for HTTP(S) sources after restart")
 		})
 
 		It("should create Deployment and Service for InferenceService", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -582,8 +582,15 @@ spec:
 			Eventually(verifyServiceGone, 1*time.Minute).Should(Succeed())
 		})
 
-		It("should report Failed for Model with unreachable source", func() {
-			By("applying a Model CR with a URL that returns 404")
+		It("should report Failed for Model with unreachable file:// source", func() {
+			// HTTP(S) sources are validated by the InferenceService Pod's init
+			// container, not by the Model controller (issue #363), so a 404
+			// HTTP source no longer surfaces a Failed Model phase. file://
+			// sources still flow through the controller's in-process path
+			// and surface broken sources as Model.status.phase=Failed with
+			// reason=CopyFailed, which is the controller-side failure
+			// surface we want to keep covered here.
+			By("applying a Model CR with a file:// path that does not exist on the controller pod")
 			cmd := exec.Command("kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
@@ -591,7 +598,7 @@ metadata:
   name: test-model-bad-source
   namespace: %s
 spec:
-  source: "http://test-model-server.e2e-cr-test.svc.cluster.local/nonexistent.gguf"
+  source: "file:///nonexistent/path/to/missing-model.gguf"
 `, crTestNs))
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to apply Model CR")
@@ -606,13 +613,13 @@ spec:
 			}
 			Eventually(verifyModelFailed, 2*time.Minute).Should(Succeed())
 
-			By("verifying Degraded condition with DownloadFailed reason")
+			By("verifying Degraded condition with CopyFailed reason")
 			cmd = exec.Command("kubectl", "get", "model", "test-model-bad-source",
 				"-n", crTestNs, "-o",
 				`jsonpath={.status.conditions[?(@.type=="Degraded")].reason}`)
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(Equal("DownloadFailed"))
+			Expect(output).To(Equal("CopyFailed"))
 		})
 	})
 


### PR DESCRIPTION
## Summary

Fixes #363 — the Model controller was downloading HTTP(S) sources into the operator's namespace cache PVC, while the InferenceService Pod's init container reads from a per-namespace PVC. Because PVCs cannot be cross-namespace mounted, the controller's download was invisible to the inference Pod, which silently re-fetched on every fresh InferenceService.

## Why

The disconnect was introduced 5 months ago in c3cb891 (first shipped in `llmkube-0.4.4`) when per-namespace cache PVCs landed without updating the Model controller's in-process download path. Users who happen to deploy in the operator's namespace (where both PVCs collapse to one) or who use HuggingFace repo IDs (resolved by vLLM at runtime) or `pvc://` sources never hit it. The "default namespace + HTTPS source" combination — the kind-cluster default — does, which is what the bug reporter tripped on.

The two PVCs visible in the bug report:

```
NAMESPACE        NAME                  CAPACITY   STATUS
default          llmkube-model-cache   100Gi      Bound   <- inference Pod reads this
llmkube-system   llmkube-model-cache   100Gi      Bound   <- controller wrote here
```

The controller's download lived in `llmkube-system/llmkube-model-cache`, the inference Pod's init container looked at `default/llmkube-model-cache` and found nothing, so it re-fetched.

## Fix

Extend the existing `reconcileRuntimeResolvedSource` shortcut (already used for HuggingFace repo IDs) to HTTP and HTTPS URLs. The Model is marked `Ready` immediately with `Status.CacheKey` populated; the InferenceService Pod's init container performs the actual fetch into the per-namespace PVC at startup, and subsequent InferenceServices in the same namespace get cache hits via the existing `if [ ! -f \"\$MODEL_PATH\" ]` check.

The new `WorkloadResolved` condition reason distinguishes init-container HTTP fetches from HF runtime-internal resolution. `CacheKey` is populated for HTTP(S) so the init container can build the canonical `/models/<cacheKey>/<basename>` path; for HF repo IDs `CacheKey` stays empty since vLLM resolves the model itself.

## Behavior change for users

For HTTP(S)-sourced Models:

- Status moves to `Ready` immediately. Phase no longer transitions through `Downloading` in the controller.
- `Status.GGUF`, `Status.Path`, `Status.Size`, `Status.SHA256` are now empty on the Model — the runtime/init container populates the equivalents at workload startup. Same surface as HF repo sources today.
- The first InferenceService referencing the Model triggers the actual download into the per-namespace cache PVC. Subsequent InferenceServices in the same namespace cache-hit.
- The Model controller no longer writes to its own filesystem (operator-namespace PVC) for HTTP(S) sources. That PVC is now used only by `file://` sources and the controller's own scratch space; a follow-up can deprecate it entirely once `file://` sources move to the workload path too.

For PVC sources, HF repo sources, and `file://` sources: no change.

## Out of scope (deferred to follow-up)

`file://` sources still flow through the in-process copy path. They have the same architectural disconnect (the controller's copy lands on the operator PVC; the init container reads from the per-namespace PVC + a HostPath mount on the Pod's node) but the workaround is more involved and the use case is rarer. Tracking separately.

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt` clean
- [x] `go test ./internal/controller/...` — 318 specs pass (was 305; net +13 tests)
- [x] Existing 13 httptest-server-driven tests for the in-process HTTPS path: 8 converted to `file://` sources where the test was about cache mechanics, 2 redundant ones replaced with a single new `should defer HTTPS source to the InferenceService init container` test that asserts the new behavior, 3 left in place because they exercise `downloadModel` directly at the unit level
- [x] New regression test pack `Issue #363 regression — controller / workload cache disconnect` with three assertions:
  - controller does not write under `StoragePath` for HTTP(S) sources
  - `Reconcile()`'s `Status.CacheKey` matches the init container's `MODEL_PATH` produced by `buildCachedStorageConfig` (literal disconnect this PR fixes)
  - HF repo IDs leave `CacheKey` empty (preserves runtime-resolved semantics)
- [x] New `isRemoteHTTPSource` matcher tests with a mutual-exclusivity invariant against `isPVCSource` / `isHFRepoSource` / `isLocalSource` so future source-type additions can't silently break dispatch
- [x] DCO sign-off

## Refs

- Issue: #363
- Commit that introduced the disconnect: c3cb891 ("feat: Support per-namespace model cache PVCs", 2025-11-26)
- First affected release: llmkube-0.4.4

Closes #363