### PR TITLE
docs: README polish (llama.cpp credit, vLLM, KubeAI/llm-d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ Works over LAN, Tailscale, WireGuard, or any routable network. **[Full Metal Age
 
 **LLMKube is for teams that want Kubernetes-managed LLM inference across heterogeneous hardware.** If you just need to run a model on one machine, Ollama is simpler. If you need maximum throughput on NVIDIA-only clusters, vLLM is faster. LLMKube occupies the space where Kubernetes orchestration, multi-hardware support, and operational simplicity intersect.
 
+**Versus newer adjacent projects:**
+- **KubeAI**: similar Kubernetes-operator scope. KubeAI focuses on autoscaling vLLM/Ollama on NVIDIA. LLMKube adds first-class Apple Silicon Metal support, GGUF + HF runtime mixing, and a model catalog CLI.
+- **llm-d**: distributed inference for very large models on NVIDIA fleets. Different problem space. LLMKube targets heterogeneous on-prem clusters (laptops, edge nodes, single GPUs) where llm-d's distributed-NVIDIA-first design is overkill.
+
 ---
 
 ## Performance
@@ -219,11 +223,11 @@ Consistent ~53 tok/s across 3-8B models with automatic layer sharding. See [v0.4
 
 **Inference:**
 - Kubernetes-native CRDs (`Model` + `InferenceService`)
+- Multiple runtimes: llama.cpp (GGUF), vLLM (HuggingFace + safetensors), TGI, Ollama
 - Automatic model download from HuggingFace, HTTP, or PVC (S3 planned)
-- Persistent model cache — download once, deploy instantly ([guide](docs/MODEL-CACHE.md))
+- Persistent model cache, download once, deploy instantly ([guide](docs/MODEL-CACHE.md))
 - OpenAI-compatible `/v1/chat/completions` API
 - Multi-replica horizontal scaling
-- GGUF format with quantization support
 - License compliance scanning for GGUF models
 
 **GPU:**
@@ -382,7 +386,7 @@ We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full gu
 
 ## Acknowledgments
 
-Built on [Kubebuilder](https://kubebuilder.io), [llama.cpp](https://github.com/ggerganov/llama.cpp), [Prometheus](https://prometheus.io), and [Helm](https://helm.sh).
+Built on [Kubebuilder](https://kubebuilder.io), [llama.cpp](https://github.com/ggml-org/llama.cpp), [Prometheus](https://prometheus.io), and [Helm](https://helm.sh).
 
 ## License
 

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -10,7 +10,7 @@ This guide walks you through deploying your first LLM inference service with LLM
   - **GKE/EKS/AKS**: Any managed Kubernetes
 - `kubectl` configured and connected
 - At least 2GB free memory on your nodes
-- Go 1.24+ (if running controller locally)
+- Go 1.25+ (if running controller locally)
 
 ## What You'll Deploy
 
@@ -32,7 +32,7 @@ cd LLMKube
 # Install CRDs
 make install
 
-# Run controller locally (requires Go 1.24+)
+# Run controller locally (requires Go 1.25+)
 make run
 ```
 
@@ -414,7 +414,7 @@ kubectl delete crd inferenceservices.inference.llmkube.dev
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/Defilan/LLMKube/issues)
+- **Issues**: [GitHub Issues](https://github.com/defilantech/llmkube/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/defilantech/LLMKube/discussions)
 
 ---


### PR DESCRIPTION
## Summary

Follow-up to #369. README hygiene sweep.

- `README.md` acknowledgments: link llama.cpp at `ggml-org/llama.cpp` (current canonical repo) instead of the old `ggerganov/llama.cpp` URL.
- `README.md` features list: surface multiple-runtime support (llama.cpp, vLLM, TGI, Ollama) on the headline Inference bullet. vLLM has been shipping for several releases but was invisible in the README features.
- `README.md` "How Is This Different?" section: add a short paragraph explicitly naming KubeAI and llm-d. Both get name-dropped on every K8s+LLM thread, and pre-empting "why not X" is the highest-ROI comparison move.
- `examples/quickstart/README.md`: bump Go 1.24+ to Go 1.25+ in two places (matches `go.mod`) and fix the `Defilan/LLMKube` issues link to `defilantech/llmkube`.

## Test plan

- [x] DCO sign-off
- [x] No em-dashes in the diff
- [x] Acknowledgment URL `https://github.com/ggml-org/llama.cpp` resolves