### PR TITLE
chore: repo cleanup (sanitize docs, drop dead metrics, scaffold comments)

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -21,9 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // InferenceServiceSpec defines the desired state of InferenceService
 type InferenceServiceSpec struct {
 	// ModelRef references the Model CR that contains the model to serve

--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -20,9 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // ModelSpec defines the desired state of Model
 type ModelSpec struct {
 	// Source defines where to obtain the model.

--- a/docs/air-gapped-quickstart.md
+++ b/docs/air-gapped-quickstart.md
@@ -374,7 +374,7 @@ kubectl get model my-model -o jsonpath='{.status.sha256}'
 1. **Model Integrity**: Use the `sha256` field to verify model checksums automatically
 2. **File Permissions**: Restrict model file access to necessary users/groups
 3. **Network Segmentation**: Ensure internal model servers are properly firewalled
-4. **Audit Logging**: Track model deployments and access (see [SOC2 compliance](/docs/compliance.md))
+4. **Audit Logging**: Track model deployments and access events through the controller's structured logs and Prometheus metrics. For SOC 2 / HIPAA / FedRAMP environments, forward operator logs to your SIEM via Vector, Fluent Bit, or your existing logging stack.
 
 ## Next Steps
 

--- a/docs/gpu-setup-guide.md
+++ b/docs/gpu-setup-guide.md
@@ -87,21 +87,21 @@ kubectl delete pod gpu-test
 The controller now includes GPU scheduling logic. Rebuild and deploy:
 
 ```bash
-# From project root
-cd /Users/defilan/stuffy/code/ai/llmkube
+# From the llmkube repo root:
+export VERSION=v0.7.5  # or whatever you tag your build
 
-# Regenerate CRDs with new GPU fields
+# Regenerate CRDs with the latest GPU fields
 make generate
 make manifests
 
 # Install updated CRDs
 make install
 
-# Build and push new controller image
-make docker-build docker-push IMG=ghcr.io/defilan/llmkube-controller:v0.2.0
+# Build and push your controller image
+make docker-build docker-push IMG=ghcr.io/defilan/llmkube-controller:${VERSION}
 
-# Deploy updated controller
-make deploy IMG=ghcr.io/defilan/llmkube-controller:v0.2.0
+# Deploy the updated controller
+make deploy IMG=ghcr.io/defilan/llmkube-controller:${VERSION}
 
 # Verify controller is running
 kubectl get pods -n llmkube-system
@@ -294,10 +294,10 @@ kubectl scale deployment -n kube-system --replicas=0 $(kubectl get deploy -n kub
 
 ## Next Steps
 
-1. **Set up monitoring** (Phase 2-3): Prometheus + Grafana for GPU metrics
-2. **CLI support** (Phase 2): Add `llmkube deploy --gpu 1` flag
-3. **Multi-GPU** (Phase 4-5): Test 13B models on 2x T4 GPUs
-4. **Optimize costs**: Implement auto-scaling based on traffic
+1. **Set up monitoring**: Prometheus, Grafana, and DCGM exporter for GPU metrics. See the [observability docs](../README.md#observability).
+2. **Use the CLI**: `llmkube deploy <model> --gpu 1` provisions a GPU-backed InferenceService in one command.
+3. **Try multi-GPU**: shard 13B-70B+ models across multiple GPUs on a single node. See [MULTI-GPU-DEPLOYMENT.md](./MULTI-GPU-DEPLOYMENT.md).
+4. **Optimize costs**: spot instances, scale-to-zero, and per-model GPU queues are all configurable on the InferenceService CRD.
 
 ## Troubleshooting
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -94,22 +94,6 @@ var (
 		},
 		[]string{"controller"},
 	)
-
-	// Aggregate gauges
-
-	ActiveModelsTotal = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "llmkube_active_models_total",
-			Help: "Total number of models in Ready/Cached phase.",
-		},
-	)
-
-	ActiveInferenceServicesTotal = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "llmkube_active_inferenceservices_total",
-			Help: "Total number of inference services in Ready phase.",
-		},
-	)
 )
 
 func init() {
@@ -122,7 +106,5 @@ func init() {
 		GPUQueueWaitDuration,
 		ReconcileTotal,
 		ReconcileDuration,
-		ActiveModelsTotal,
-		ActiveInferenceServicesTotal,
 	)
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -54,8 +54,6 @@ func TestMetricsRegistered(t *testing.T) {
 		{"llmkube_gpu_queue_wait_duration_seconds", GPUQueueWaitDuration},
 		{"llmkube_reconcile_total", ReconcileTotal},
 		{"llmkube_reconcile_duration_seconds", ReconcileDuration},
-		{"llmkube_active_models_total", ActiveModelsTotal},
-		{"llmkube_active_inferenceservices_total", ActiveInferenceServicesTotal},
 	}
 
 	for _, c := range collectors {
@@ -178,25 +176,6 @@ func TestReconcileDuration(t *testing.T) {
 	}
 }
 
-func TestActiveGauges(t *testing.T) {
-	ActiveModelsTotal.Set(5)
-	ActiveInferenceServicesTotal.Set(3)
-
-	var m dto.Metric
-	if err := ActiveModelsTotal.Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
-	}
-	if m.GetGauge().GetValue() != 5 {
-		t.Errorf("expected 5 active models, got %f", m.GetGauge().GetValue())
-	}
-
-	if err := ActiveInferenceServicesTotal.Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
-	}
-	if m.GetGauge().GetValue() != 3 {
-		t.Errorf("expected 3 active inference services, got %f", m.GetGauge().GetValue())
-	}
-}
 
 func TestHistogramBuckets(t *testing.T) {
 	tests := []struct {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -176,7 +176,6 @@ func TestReconcileDuration(t *testing.T) {
 	}
 }
 
-
 func TestHistogramBuckets(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

Hygiene sweep across docs, metrics, and API types. Found while doing an audit pass on the repo.

### Docs

- `docs/gpu-setup-guide.md`: removed a hardcoded developer path (`/Users/defilan/stuffy/code/ai/llmkube`) from the rebuild example, replaced with a `VERSION` env var so the example works for any reader from the repo root. Updated stale `v0.2.0` image tag references to use the same env var so the doc stops drifting on every release. Rewrote the "Next Steps" section to drop internal "Phase 2 / Phase 4-5" markers for features that have all shipped (CLI, monitoring, multi-GPU); replaced with current usage pointers.
- `docs/air-gapped-quickstart.md`: replaced a dead link to `/docs/compliance.md` (file does not exist) with concrete audit-logging guidance about forwarding operator logs to a SIEM via Vector / Fluent Bit. This is what regulated-industry users actually want to know.

### Metrics

- Removed the `ActiveModelsTotal` and `ActiveInferenceServicesTotal` aggregate gauges from `internal/metrics/metrics.go`. They were declared and registered but never written to, so they always reported zero. Permanently-zero gauges are worse than not exposing them.
- The same information is derivable from the per-resource `llmkube_model_status` and `llmkube_inferenceservice_phase` gauges via `count()` in PromQL, so removing these does not lose any signal.
- Removed the corresponding `TestActiveGauges` test and the registration entries in the test collector list.

### API types

- Removed the Kubebuilder scaffold comments (`// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!`) from `api/v1alpha1/model_types.go` and `api/v1alpha1/inferenceservice_types.go`. Both files have been owned and heavily extended for many releases.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/metrics/...` passes
- [x] DCO sign-off
- [x] Net delete of 45 lines, no functionality removed (the dead metrics carried zero info)