### PR TITLE
fix: derive metal InferenceService phase from Endpoints, not desiredReplicas (closes #374)

### DIFF
--- a/charts/llmkube/templates/clusterrole.yaml
+++ b/charts/llmkube/templates/clusterrole.yaml
@@ -9,6 +9,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
   - pods
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -21,14 +30,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - ""

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -299,6 +299,13 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 // shares the sanitized name of the metal stub Service (see reconcileService's
 // metal branch). Missing-or-unpopulated Endpoints return 0, which is the
 // correct readyReplicas value while we wait on the agent.
+//
+// We read core/v1 Endpoints (deprecated in k8s v1.33+) rather than
+// discovery/v1 EndpointSlice because pkg/agent/registry.go still creates
+// Endpoints. Migrating both producer and consumer to EndpointSlice is tracked
+// as a follow-up; doing it in this PR would balloon scope.
+//
+//nolint:staticcheck // SA1019: see comment above; agent and controller migrate together
 func (r *InferenceServiceReconciler) metalReadyEndpoints(ctx context.Context, isvc *inferencev1alpha1.InferenceService) int32 {
 	log := logf.FromContext(ctx)
 	endpoints := &corev1.Endpoints{}
@@ -312,7 +319,15 @@ func (r *InferenceServiceReconciler) metalReadyEndpoints(ctx context.Context, is
 	}
 	var ready int32
 	for _, subset := range endpoints.Subsets {
-		ready += int32(len(subset.Addresses))
+		// In a kind/k8s cluster the agent typically registers a small handful
+		// of addresses (one per host-mode replica). Cap the per-subset count
+		// well below int32 max so the conversion is guaranteed safe even if a
+		// pathological Endpoints object lands in the cache.
+		n := len(subset.Addresses)
+		if n > 1<<20 {
+			n = 1 << 20
+		}
+		ready += int32(n) //nolint:gosec // bounded above
 	}
 	return ready
 }

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -90,6 +90,7 @@ func initContainerSecurityContext(isvc *inferencev1alpha1.InferenceService) *cor
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=get;list;watch
@@ -203,8 +204,15 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	log := logf.FromContext(ctx)
 
 	if isMetal {
-		log.Info("Metal accelerator detected, skipping Deployment creation")
-		return nil, desiredReplicas, nil, nil
+		// No Deployment for metal: the host metal-agent runs llama-server natively
+		// and registers the InferenceService's Endpoints once the model is fetched
+		// and the server is healthy. Derive readyReplicas from the Endpoints rather
+		// than blindly returning desiredReplicas, otherwise Phase reports Ready
+		// before the agent has done anything (issue #374).
+		readyReplicas := r.metalReadyEndpoints(ctx, isvc)
+		log.Info("Metal accelerator detected, skipping Deployment creation",
+			"readyEndpoints", readyReplicas, "desiredReplicas", desiredReplicas)
+		return nil, readyReplicas, nil, nil
 	}
 
 	// Surface non-fatal vLLM spec problems as a status condition before we
@@ -283,6 +291,30 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 	}
 
 	return service, nil, nil
+}
+
+// metalReadyEndpoints returns the count of ready addresses on the Endpoints
+// object that the metal-agent is expected to populate when its host-side
+// llama-server has fetched the model and become healthy. The Endpoints object
+// shares the sanitized name of the metal stub Service (see reconcileService's
+// metal branch). Missing-or-unpopulated Endpoints return 0, which is the
+// correct readyReplicas value while we wait on the agent.
+func (r *InferenceServiceReconciler) metalReadyEndpoints(ctx context.Context, isvc *inferencev1alpha1.InferenceService) int32 {
+	log := logf.FromContext(ctx)
+	endpoints := &corev1.Endpoints{}
+	name := sanitizeDNSName(isvc.Name)
+	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: isvc.Namespace}, endpoints)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "Failed to get Endpoints for metal accelerator", "name", name)
+		}
+		return 0
+	}
+	var ready int32
+	for _, subset := range endpoints.Subsets {
+		ready += int32(len(subset.Addresses))
+	}
+	return ready
 }
 
 func needsSkipModelInit(isvc *inferencev1alpha1.InferenceService) bool {

--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -536,10 +536,70 @@ var _ = Describe("Reconcile lifecycle", func() {
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc)
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 
-			By("verifying status is Ready (Metal returns desiredReplicas as ready)")
+			By("verifying status is Creating (no Endpoints yet from the metal-agent; issue #374)")
+			updated := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal("Creating"))
+		})
+
+		It("should be Ready once the metal-agent registers Endpoints (issue #374)", func() {
+			modelName := "metal-model-with-ep"
+			isvcName := "isvc-metal-with-ep"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, model)
+			}()
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, isvc)
+			}()
+
+			// Simulate the metal-agent registering Endpoints once llama-server is healthy.
+			endpoints := &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "192.0.2.10"}},
+					Ports:     []corev1.EndpointPort{{Port: 8080, Protocol: corev1.ProtocolTCP}},
+				}},
+			}
+			Expect(k8sClient.Create(ctx, endpoints)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, endpoints)
+			}()
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
 			updated := &inferencev1alpha1.InferenceService{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
 			Expect(updated.Status.Phase).To(Equal("Ready"))
+			Expect(updated.Status.ReadyReplicas).To(Equal(int32(1)))
 		})
 
 		It("should set correct endpoint URL for Metal InferenceService", func() {

--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -573,10 +573,13 @@ var _ = Describe("Reconcile lifecycle", func() {
 				_ = k8sClient.Delete(ctx, isvc)
 			}()
 
-			// Simulate the metal-agent registering Endpoints once llama-server is healthy.
-			endpoints := &corev1.Endpoints{
+			// Simulate the metal-agent registering Endpoints once llama-server
+			// is healthy. core/v1 Endpoints is deprecated in k8s v1.33+, but
+			// pkg/agent/registry.go still uses it; migration to EndpointSlice
+			// is tracked as a follow-up to this PR.
+			endpoints := &corev1.Endpoints{ //nolint:staticcheck // SA1019: agent + controller migrate together
 				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
-				Subsets: []corev1.EndpointSubset{{
+				Subsets: []corev1.EndpointSubset{{ //nolint:staticcheck // SA1019: same
 					Addresses: []corev1.EndpointAddress{{IP: "192.0.2.10"}},
 					Ports:     []corev1.EndpointPort{{Port: 8080, Protocol: corev1.ProtocolTCP}},
 				}},

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -353,11 +353,20 @@ func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, mo
 		return nil
 	}
 
+	isMetal := model.Spec.Hardware != nil && model.Spec.Hardware.Accelerator == "metal"
+
 	reason := "RuntimeResolved"
 	message := "Source is runtime-resolved (e.g., HuggingFace repo ID); runtime will fetch at startup"
 	if cacheKey != "" {
 		reason = "WorkloadResolved"
-		message = "Source is a remote URL; the InferenceService Pod's init container will fetch the model into the per-namespace model cache PVC at startup"
+		if isMetal {
+			// On the metal accelerator path there is no Pod and no init container.
+			// The host metal-agent fetches the file into its model store when it
+			// reconciles the InferenceService that references this Model.
+			message = "Source is a remote URL; the host metal-agent will fetch the model into its model store when the InferenceService is reconciled"
+		} else {
+			message = "Source is a remote URL; the InferenceService Pod's init container will fetch the model into the per-namespace model cache PVC at startup"
+		}
 	}
 
 	logger.Info("Source is runtime-resolved, skipping controller-side download", "source", model.Spec.Source, "cacheKey", cacheKey)

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -48,9 +48,13 @@ const (
 	PhaseReady            = "Ready"
 	PhaseFailed           = "Failed"
 	PhaseCached           = "Cached"
+	PhaseCreating         = "Creating"
 	DefaultModelCachePath = "/models"
 
-	ConditionDegraded = "Degraded"
+	ConditionAvailable = "Available"
+	ConditionDegraded  = "Degraded"
+
+	ReasonWorkloadResolved = "WorkloadResolved"
 )
 
 type ModelReconciler struct {
@@ -358,7 +362,7 @@ func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, mo
 	reason := "RuntimeResolved"
 	message := "Source is runtime-resolved (e.g., HuggingFace repo ID); runtime will fetch at startup"
 	if cacheKey != "" {
-		reason = "WorkloadResolved"
+		reason = ReasonWorkloadResolved
 		if isMetal {
 			// On the metal accelerator path there is no Pod and no init container.
 			// The host metal-agent fetches the file into its model store when it

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Model Controller Reconcile", func() {
 		// HTTP fetches.
 		var hasWorkloadResolved bool
 		for _, cond := range updated.Status.Conditions {
-			if cond.Type == "Available" && cond.Reason == "WorkloadResolved" {
+			if cond.Type == ConditionAvailable && cond.Reason == "WorkloadResolved" {
 				hasWorkloadResolved = true
 			}
 		}
@@ -311,7 +311,7 @@ var _ = Describe("Model Controller Reconcile", func() {
 
 		var foundCondition bool
 		for _, cond := range updated.Status.Conditions {
-			if cond.Type == "Available" && cond.Reason == "WorkloadResolved" {
+			if cond.Type == ConditionAvailable && cond.Reason == "WorkloadResolved" {
 				foundCondition = true
 				Expect(cond.Message).To(ContainSubstring("metal-agent"),
 					"metal-accelerator message should describe the host agent fetch path, not the init container")
@@ -1085,7 +1085,7 @@ var _ = Describe("Runtime-Resolved Source Reconcile", func() {
 		// Verify Available condition with RuntimeResolved reason
 		var hasRuntimeResolved bool
 		for _, cond := range updated.Status.Conditions {
-			if cond.Type == "Available" && cond.Reason == "RuntimeResolved" {
+			if cond.Type == ConditionAvailable && cond.Reason == "RuntimeResolved" {
 				hasRuntimeResolved = true
 			}
 		}

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -275,6 +275,53 @@ var _ = Describe("Model Controller Reconcile", func() {
 		Expect(hasWorkloadResolved).To(BeTrue(), "expected Available/WorkloadResolved condition")
 	})
 
+	// On the metal accelerator path the host metal-agent fetches the model;
+	// there is no Pod and no init container. The Available condition's message
+	// should describe the agent fetch path rather than the init-container path
+	// users see for CUDA/CPU deployments (issue #374).
+	It("should describe the metal-agent fetch path for HTTPS source on metal accelerator", func() {
+		modelName := "metal-model-https"
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		source := "https://example.com/metal-model.gguf"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   source,
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+
+		var foundCondition bool
+		for _, cond := range updated.Status.Conditions {
+			if cond.Type == "Available" && cond.Reason == "WorkloadResolved" {
+				foundCondition = true
+				Expect(cond.Message).To(ContainSubstring("metal-agent"),
+					"metal-accelerator message should describe the host agent fetch path, not the init container")
+				Expect(cond.Message).NotTo(ContainSubstring("init container"),
+					"metal-accelerator path has no Pod and no init container")
+			}
+		}
+		Expect(foundCondition).To(BeTrue(), "expected Available/WorkloadResolved condition")
+	})
+
 	It("should copy local model file and set Ready", func() {
 		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -82,12 +82,12 @@ func (r *InferenceServiceReconciler) determinePhase(ctx context.Context, isvc *i
 		}
 	}
 	if isMetal {
-		return "Creating", &SchedulingInfo{
+		return PhaseCreating, &SchedulingInfo{
 			Status:  "WaitingForMetalAgent",
 			Message: "Waiting for the host metal-agent to fetch the model and register Endpoints",
 		}
 	}
-	return "Creating", nil
+	return PhaseCreating, nil
 }
 
 func (r *InferenceServiceReconciler) getPodSchedulingInfo(ctx context.Context, isvc *inferencev1alpha1.InferenceService) (*SchedulingInfo, error) {

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -81,6 +81,12 @@ func (r *InferenceServiceReconciler) determinePhase(ctx context.Context, isvc *i
 			return PhaseWaitingForGPU, schedulingInfo
 		}
 	}
+	if isMetal {
+		return "Creating", &SchedulingInfo{
+			Status:  "WaitingForMetalAgent",
+			Message: "Waiting for the host metal-agent to fetch the model and register Endpoints",
+		}
+	}
 	return "Creating", nil
 }
 


### PR DESCRIPTION
Closes #374.

## Summary

Two related defects in the metal accelerator code path caused `InferenceService` and `Model` resources to be marked `Ready` immediately, before the host metal-agent had actually fetched or loaded the model. The user-visible symptom was `llmkube deploy <model> --accelerator metal` reporting "Deployment Ready" within seconds, with no download in flight, no `llama-server` running, and a status message that pointed at an init container that never gets created on this path.

## Defects fixed

### 1. Phase short-circuit on metal

`internal/controller/inferenceservice_controller.go` `reconcileDeployment`'s metal branch returned `desiredReplicas` as the second return value, which the caller treats as `readyReplicas`. `determinePhase` then evaluated `readyReplicas == desiredReplicas && readyReplicas > 0` and reported `PhaseReady` immediately, fully decoupled from anything the metal-agent had done.

The agent registers an `Endpoints` resource pointing at the host IP and serve port once llama-server is healthy. The fix queries that resource and counts ready addresses:

```go
if isMetal {
    readyReplicas := r.metalReadyEndpoints(ctx, isvc)
    return nil, readyReplicas, nil, nil
}
```

`metalReadyEndpoints` looks up the same sanitized name as the metal stub Service and returns the count of `Subsets[].Addresses`. No Endpoints registered means readyReplicas=0, and `determinePhase` falls through to `Creating` with a new `SchedulingInfo{Status: "WaitingForMetalAgent"}` so users get a clear status message instead of an empty one.

### 2. Misleading status message on metal+HTTPS Models

`internal/controller/model_controller.go` `reconcileRuntimeResolvedSource` wrote `"the InferenceService Pod's init container will fetch the model into the per-namespace model cache PVC at startup"` regardless of accelerator. Metal deployments have no Pod and no init container; the agent fetches via `pkg/agent/executor.go`'s `MetalExecutor.ensureModel`. The fix branches the message on accelerator:

```
metal:    "the host metal-agent will fetch the model into its model store when the InferenceService is reconciled"
non-metal: "the InferenceService Pod's init container will fetch the model into the per-namespace model cache PVC at startup"
```

`Model.Status.Phase=Ready` semantics for HTTPS sources are unchanged on both paths. "Ready" continues to mean "controller-side reconciliation is done, the runtime/agent fetches at workload start," which matches the long-standing CUDA/CPU behavior. A richer fetch-state feedback channel from the agent is a separate, larger change.

## RBAC

Added `core/endpoints` `get;list;watch` to the manager ClusterRole. Regenerated `config/rbac/role.yaml` via `make manifests`. Helm chart CRDs are unchanged (no CRD field additions).

## Tests

Three test changes:

- **Updated** `should skip Deployment for Metal accelerator` (`inferenceservice_reconcile_test.go`): now expects `Phase=Creating` when no Endpoints are present, replacing the old assertion that effectively encoded the bug.
- **New** `should be Ready once the metal-agent registers Endpoints` (`inferenceservice_reconcile_test.go`): pre-creates an Endpoints with one ready address, asserts `Phase=Ready` and `ReadyReplicas=1`.
- **New** `should describe the metal-agent fetch path for HTTPS source on metal accelerator` (`model_controller_test.go`): asserts the WorkloadResolved condition message contains `"metal-agent"` and not `"init container"` for metal Models with HTTPS sources.

`go test ./internal/...` is green; full controller suite runs in ~7s.

## Test plan

- [x] `make manifests generate fmt vet`
- [x] `go test ./internal/...`
- [x] `make chart-crds` (no drift)
- [ ] Manual smoke on a kind cluster with the metal-agent attached: deploy a remote-URL model with `--accelerator metal`, verify Phase stays in Creating until the agent reports an Endpoint, then transitions to Ready
- [ ] Verify the status message on `kubectl describe model <metal-model>` reads "metal-agent" rather than "init container"

## Out of scope

- A `ModelLoadStatus` subresource the metal-agent updates as it downloads → loads → serves. Mentioned in the original issue under "Suggested Fix #3" as a longer-term piece. Tracking in a follow-up.
- Auto-discovering whether the cluster has the metal-agent installed.

## Related

- Issue #374 (filed earlier today during a metal smoke test on the work laptop)
- The agent-side fetch path: `pkg/agent/executor.go:222` `MetalExecutor.ensureModel` (unchanged)