### PR TITLE
feat(api): expose runtimeClassName on InferenceServiceSpec (closes #375)

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -75,6 +75,19 @@ type InferenceServiceSpec struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// RuntimeClassName selects a Kubernetes RuntimeClass for the inference Pod.
+	// Most commonly set to "nvidia" on clusters where the NVIDIA Container
+	// Runtime is not configured as the cluster default. Without it, GPU pods
+	// schedule onto the GPU node but never get the device files bind-mounted,
+	// and the container fails at runtime with "no CUDA-capable device is
+	// detected". Maps directly to PodSpec.RuntimeClassName.
+	//
+	// Most clusters running the NVIDIA GPU Operator with the default toolkit
+	// env do not need this set; it is a safety hatch for clusters where the
+	// runtime configuration is non-default.
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
+
 	// ContextSize sets the context window size for the llama.cpp server (-c flag).
 	// Larger values allow processing longer inputs but require more memory.
 	// If not specified, llama.cpp uses its default (typically 512 or 2048).

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -259,6 +259,11 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.RuntimeClassName != nil {
+		in, out := &in.RuntimeClassName, &out.RuntimeClassName
+		*out = new(string)
+		**out = **in
+	}
 	if in.ContextSize != nil {
 		in, out := &in.ContextSize, &out.ContextSize
 		*out = new(int32)

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -1335,6 +1335,19 @@ spec:
                 - tgi
                 - generic
                 type: string
+              runtimeClassName:
+                description: |-
+                  RuntimeClassName selects a Kubernetes RuntimeClass for the inference Pod.
+                  Most commonly set to "nvidia" on clusters where the NVIDIA Container
+                  Runtime is not configured as the cluster default. Without it, GPU pods
+                  schedule onto the GPU node but never get the device files bind-mounted,
+                  and the container fails at runtime with "no CUDA-capable device is
+                  detected". Maps directly to PodSpec.RuntimeClassName.
+
+                  Most clusters running the NVIDIA GPU Operator with the default toolkit
+                  env do not need this set; it is a safety hatch for clusters where the
+                  runtime configuration is non-default.
+                type: string
               securityContext:
                 description: SecurityContext defines container-level security attributes
                   for the inference container.

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1331,6 +1331,19 @@ spec:
                 - tgi
                 - generic
                 type: string
+              runtimeClassName:
+                description: |-
+                  RuntimeClassName selects a Kubernetes RuntimeClass for the inference Pod.
+                  Most commonly set to "nvidia" on clusters where the NVIDIA Container
+                  Runtime is not configured as the cluster default. Without it, GPU pods
+                  schedule onto the GPU node but never get the device files bind-mounted,
+                  and the container fails at runtime with "no CUDA-capable device is
+                  detected". Maps directly to PodSpec.RuntimeClassName.
+
+                  Most clusters running the NVIDIA GPU Operator with the default toolkit
+                  env do not need this set; it is a safety hatch for clusters where the
+                  runtime configuration is non-default.
+                type: string
               securityContext:
                 description: SecurityContext defines container-level security attributes
                   for the inference container.

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -205,6 +205,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 					Containers:         []corev1.Container{container},
 					Volumes:            storageConfig.volumes,
 					PriorityClassName:  r.resolvePriorityClassName(isvc),
+					RuntimeClassName:   isvc.Spec.RuntimeClassName,
 					ImagePullSecrets:   isvc.Spec.ImagePullSecrets,
 					EnableServiceLinks: resolveEnableServiceLinks(backend),
 				},

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -2540,6 +2540,86 @@ var _ = Describe("Context Size Configuration", func() {
 			Expect(args).NotTo(ContainElement("--batch-size"))
 		})
 	})
+
+	// Issue #375: spec.runtimeClassName threads through to PodSpec.RuntimeClassName
+	// so users on clusters where the NVIDIA Container Runtime is not the cluster
+	// default can opt their inference Pods into the right RuntimeClass without
+	// resorting to mutating-webhook hacks.
+	Context("when runtimeClassName is configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rcn-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{Count: 1, Layers: 64},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "rcn-cache-key",
+					Path:     "/tmp/llmkube/models/rcn-model.gguf",
+				},
+			}
+		})
+
+		It("should set PodSpec.RuntimeClassName when spec.runtimeClassName is set", func() {
+			replicas := int32(1)
+			rcn := "nvidia"
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rcn-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:         "rcn-model",
+					Replicas:         &replicas,
+					Image:            "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					RuntimeClassName: &rcn,
+					Resources:        &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			rcnGot := deployment.Spec.Template.Spec.RuntimeClassName
+			Expect(rcnGot).NotTo(BeNil())
+			Expect(*rcnGot).To(Equal("nvidia"))
+		})
+
+		It("should leave PodSpec.RuntimeClassName nil when spec.runtimeClassName is unset", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-rcn-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:  "rcn-model",
+					Replicas:  &replicas,
+					Image:     "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			Expect(deployment.Spec.Template.Spec.RuntimeClassName).To(BeNil())
+		})
+	})
 })
 
 var _ = Describe("constructDeployment additional cases", func() {


### PR DESCRIPTION
Closes #375.

## Summary

Adds `RuntimeClassName *string` to `InferenceServiceSpec`. The deployment builder forwards it to `PodSpec.RuntimeClassName`. Most commonly set to `"nvidia"` on clusters where the NVIDIA Container Runtime is not configured as the cluster default.

Originally surfaced via a Discord question yesterday: a community member's GPU pods were scheduling onto the GPU node but never getting the device files bind-mounted. They needed to set `runtimeClassName: nvidia` on the Pod, and there was no way to plumb that through `InferenceServiceSpec`. The available workarounds were either reconfiguring containerd globally or running a Kyverno mutating webhook against the inference label selector. Both clunkier than just having the field on the CRD.

## Changes

| File | Change |
|---|---|
| `api/v1alpha1/inferenceservice_types.go` | Add `RuntimeClassName *string \`json:"runtimeClassName,omitempty"\`` field with usage docs |
| `api/v1alpha1/zz_generated.deepcopy.go` | `make generate` |
| `config/crd/bases/...` | `make manifests` |
| `charts/llmkube/templates/crds/inferenceservices.yaml` | `make chart-crds` |
| `internal/controller/deployment_builder.go` | One-line `RuntimeClassName: isvc.Spec.RuntimeClassName` in PodSpec construction |
| `internal/controller/inferenceservice_deployment_test.go` | Two unit tests: set path asserts `*PodSpec.RuntimeClassName == "nvidia"`, unset path asserts `PodSpec.RuntimeClassName == nil` |

Net: +125 lines, no deletions. Field is optional and nil-safe; existing clusters see no behavior change.

## Why now

Tagged for the 0.7.6 release window (the same window that closed #374 via PR #376). It's a small, isolated, user-visible feature that closes a real Discord-reported gap. Doesn't overlap with any other open PR (#340 lives in `runtime_*.go`; this lives in `deployment_builder.go`).

## Out of scope (deferred to follow-ups if needed)

- Validating that the named RuntimeClass actually exists in the cluster — Kubernetes returns a clear error at pod admission, no need to duplicate
- Auto-detecting the cluster's GPU runtime configuration — users should know their cluster
- A `runtimeClass` example in the README — happy to add as a one-paragraph follow-up if the team wants it

## Test plan

- [x] `make manifests generate fmt vet` clean
- [x] `make chart-crds` synced (no drift)
- [x] `go test ./internal/controller/... ./pkg/agent/...` passes (new tests included)
- [x] `golangci-lint v2.4.0` reports 0 issues
- [ ] Manual verification on a kind cluster: deploy with and without `runtimeClassName: nvidia`, confirm `kubectl get pod -o yaml` shows the expected `runtimeClassName` value

## Related

- Issue #375 (the request)
- PR #376 (sibling RuntimeClass-adjacent fix on the metal-accelerator path; merged earlier today)
- Discord origin (the community member who reported it)