### PR TITLE
feat(api): add podAnnotations and podLabels passthrough (closes #326)

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -75,6 +75,23 @@ type InferenceServiceSpec struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// PodAnnotations are merged into the inference Pod's metadata.annotations.
+	// Use this to tag Pods for downstream tooling (cost attribution, service
+	// mesh routing, custom admission controllers) without those tools needing
+	// to know about LLMKube's CRD schema. Pure passthrough; the operator
+	// itself does not set any annotations on inference Pods today.
+	// +optional
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
+	// PodLabels are merged into the inference Pod's metadata.labels alongside
+	// the operator-managed labels (`app`, `inference.llmkube.dev/model`,
+	// `inference.llmkube.dev/service`). Operator-managed keys take precedence
+	// on collision so the Deployment selector stays in sync with the Pods it
+	// owns. The Deployment selector itself uses only the operator-managed
+	// labels and is immutable, so changing PodLabels later is safe.
+	// +optional
+	PodLabels map[string]string `json:"podLabels,omitempty"`
+
 	// RuntimeClassName selects a Kubernetes RuntimeClass for the inference Pod.
 	// Most commonly set to "nvidia" on clusters where the NVIDIA Container
 	// Runtime is not configured as the cluster default. Without it, GPU pods

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -259,6 +259,20 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.PodLabels != nil {
+		in, out := &in.PodLabels, &out.PodLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.RuntimeClassName != nil {
 		in, out := &in.RuntimeClassName, &out.RuntimeClassName
 		*out = new(string)

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -553,6 +553,27 @@ spec:
                       Requires the bitsandbytes package in the container image.
                     type: boolean
                 type: object
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PodAnnotations are merged into the inference Pod's metadata.annotations.
+                  Use this to tag Pods for downstream tooling (cost attribution, service
+                  mesh routing, custom admission controllers) without those tools needing
+                  to know about LLMKube's CRD schema. Pure passthrough; the operator
+                  itself does not set any annotations on inference Pods today.
+                type: object
+              podLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PodLabels are merged into the inference Pod's metadata.labels alongside
+                  the operator-managed labels (`app`, `inference.llmkube.dev/model`,
+                  `inference.llmkube.dev/service`). Operator-managed keys take precedence
+                  on collision so the Deployment selector stays in sync with the Pods it
+                  owns. The Deployment selector itself uses only the operator-managed
+                  labels and is immutable, so changing PodLabels later is safe.
+                type: object
               podSecurityContext:
                 description: |-
                   PodSecurityContext defines pod-level security attributes for inference pods.

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -549,6 +549,27 @@ spec:
                       Requires the bitsandbytes package in the container image.
                     type: boolean
                 type: object
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PodAnnotations are merged into the inference Pod's metadata.annotations.
+                  Use this to tag Pods for downstream tooling (cost attribution, service
+                  mesh routing, custom admission controllers) without those tools needing
+                  to know about LLMKube's CRD schema. Pure passthrough; the operator
+                  itself does not set any annotations on inference Pods today.
+                type: object
+              podLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PodLabels are merged into the inference Pod's metadata.labels alongside
+                  the operator-managed labels (`app`, `inference.llmkube.dev/model`,
+                  `inference.llmkube.dev/service`). Operator-managed keys take precedence
+                  on collision so the Deployment selector stays in sync with the Pods it
+                  owns. The Deployment selector itself uses only the operator-managed
+                  labels and is immutable, so changing PodLabels later is safe.
+                type: object
               podSecurityContext:
                 description: |-
                   PodSecurityContext defines pod-level security attributes for inference pods.

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -72,6 +72,36 @@ func inferContainerSecurityContext(isvc *inferencev1alpha1.InferenceService) *co
 	}
 }
 
+// mergePodLabels combines operator-managed labels with the user's
+// spec.podLabels for use on the Pod template metadata. Operator-managed keys
+// always win on collision so the Deployment selector (which uses the
+// operator-only set, not this merged result) keeps matching the Pods it owns.
+// Returns a fresh map; callers may safely mutate either input afterwards.
+func mergePodLabels(operator, user map[string]string) map[string]string {
+	merged := make(map[string]string, len(operator)+len(user))
+	for k, v := range user {
+		merged[k] = v
+	}
+	for k, v := range operator {
+		merged[k] = v // operator wins on collision
+	}
+	return merged
+}
+
+// copyMap returns a fresh shallow copy of m, or nil when m is empty. Used to
+// pass spec.podAnnotations through to PodTemplateSpec.ObjectMeta.Annotations
+// without sharing storage with the user's spec.
+func copyMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func (r *InferenceServiceReconciler) constructDeployment(
 	isvc *inferencev1alpha1.InferenceService,
 	model *inferencev1alpha1.Model,
@@ -197,7 +227,8 @@ func (r *InferenceServiceReconciler) constructDeployment(
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      mergePodLabels(labels, isvc.Spec.PodLabels),
+					Annotations: copyMap(isvc.Spec.PodAnnotations),
 				},
 				Spec: corev1.PodSpec{
 					SecurityContext:    inferPodSecurityContext(isvc),

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -2620,6 +2620,176 @@ var _ = Describe("Context Size Configuration", func() {
 			Expect(deployment.Spec.Template.Spec.RuntimeClassName).To(BeNil())
 		})
 	})
+
+	// Issue #326: PodAnnotations and PodLabels passthrough lets users tag
+	// Pods for downstream tooling (cost attribution, service mesh routing,
+	// admission controllers) without requiring those tools to know about
+	// LLMKube's CRD schema. Operator-managed labels win on collision so the
+	// Deployment selector keeps matching the Pods it owns.
+	Context("when podAnnotations and podLabels are configured", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				ModelCachePath:     "/tmp/llmkube/models",
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-meta-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{Count: 1, Layers: 64},
+					},
+				},
+				Status: inferencev1alpha1.ModelStatus{
+					Phase:    "Ready",
+					CacheKey: "pod-meta-cache-key",
+					Path:     "/tmp/llmkube/models/pod-meta-model.gguf",
+				},
+			}
+		})
+
+		It("should propagate user annotations to the Pod template", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "annotated-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "pod-meta-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					PodAnnotations: map[string]string{
+						"infercost.ai/backend": "vllm",
+						"linkerd.io/inject":    "enabled",
+					},
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			ann := deployment.Spec.Template.Annotations
+			Expect(ann).To(HaveKeyWithValue("infercost.ai/backend", "vllm"))
+			Expect(ann).To(HaveKeyWithValue("linkerd.io/inject", "enabled"))
+		})
+
+		It("should propagate user labels to the Pod template alongside operator labels", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "labeled-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "pod-meta-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					PodLabels: map[string]string{
+						"team":      "platform",
+						"cost-tier": "premium",
+					},
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			podLabels := deployment.Spec.Template.Labels
+			Expect(podLabels).To(HaveKeyWithValue("team", "platform"))
+			Expect(podLabels).To(HaveKeyWithValue("cost-tier", "premium"))
+			// Operator-managed labels still present
+			Expect(podLabels).To(HaveKeyWithValue("app", "labeled-service"))
+			Expect(podLabels).To(HaveKeyWithValue("inference.llmkube.dev/service", "labeled-service"))
+			Expect(podLabels).To(HaveKeyWithValue("inference.llmkube.dev/model", "pod-meta-model"))
+		})
+
+		It("should let operator labels win on collision with user labels", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "collision-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "pod-meta-model",
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					PodLabels: map[string]string{
+						"app":                           "user-supplied-app",
+						"inference.llmkube.dev/service": "user-supplied-svc",
+					},
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			podLabels := deployment.Spec.Template.Labels
+			Expect(podLabels).To(HaveKeyWithValue("app", "collision-service"))
+			Expect(podLabels).To(HaveKeyWithValue("inference.llmkube.dev/service", "collision-service"))
+		})
+
+		It("should keep the Deployment selector unaffected by user labels", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "selector-stability-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:  "pod-meta-model",
+					Replicas:  &replicas,
+					Image:     "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					PodLabels: map[string]string{"team": "platform"},
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			selector := deployment.Spec.Selector.MatchLabels
+			// User labels MUST NOT bleed into the selector (selector is immutable
+			// post-creation; a future PodLabels change would orphan running Pods).
+			Expect(selector).NotTo(HaveKey("team"))
+			Expect(selector).To(HaveKeyWithValue("app", "selector-stability-service"))
+			Expect(selector).To(HaveKeyWithValue("inference.llmkube.dev/service", "selector-stability-service"))
+		})
+
+		It("should leave annotations nil and pod labels operator-only when both fields are unset", func() {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bare-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:  "pod-meta-model",
+					Replicas:  &replicas,
+					Image:     "ghcr.io/ggml-org/llama.cpp:server-cuda13",
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			Expect(deployment.Spec.Template.Annotations).To(BeNil())
+			podLabels := deployment.Spec.Template.Labels
+			Expect(podLabels).To(HaveLen(3))
+			Expect(podLabels).To(HaveKey("app"))
+			Expect(podLabels).To(HaveKey("inference.llmkube.dev/model"))
+			Expect(podLabels).To(HaveKey("inference.llmkube.dev/service"))
+		})
+	})
 })
 
 var _ = Describe("constructDeployment additional cases", func() {


### PR DESCRIPTION
Closes #326.

## Summary

Adds `PodAnnotations` and `PodLabels` to `InferenceServiceSpec`, mirroring the standard Kubernetes operator pattern. Pods created by the controller now carry user-supplied annotations and labels (with operator-managed labels winning on collision so the Deployment selector stays stable).

Originally surfaced running InferCost alongside LLMKube. InferCost's scraper keys off an `infercost.ai/backend` annotation on the Pod to know which metrics format to scrape; without it, it defaults to llama.cpp and silently reports zero tokens for vLLM workloads. This unblocks that integration without LLMKube needing to know about InferCost (or any other downstream tool that uses Pod metadata for discovery).

## Design

- **`PodAnnotations`**: pure passthrough. The operator sets no annotations on inference Pods today, so nothing to merge.
- **`PodLabels`**: merged into the Pod's labels alongside the operator-managed labels (`app`, `inference.llmkube.dev/model`, `inference.llmkube.dev/service`). Operator-managed keys win on collision.
- **Selector unaffected**: the Deployment selector continues to use only the operator-managed label set. The selector is immutable post-creation; if user labels bled into it, a future `PodLabels` change would orphan running Pods. Tested explicitly.

Two helpers in `deployment_builder.go`: `mergePodLabels` (operator wins) and `copyMap` (defensive shallow copy so the rendered Pod template never aliases the user's spec map).

## Changes

| File | Change |
|---|---|
| `api/v1alpha1/inferenceservice_types.go` | Two new optional fields with godoc explaining the operator-wins-on-collision and selector-immutability rules |
| `api/v1alpha1/zz_generated.deepcopy.go` | `make generate` |
| `config/crd/bases/...`, `charts/llmkube/templates/crds/...` | `make manifests && make chart-crds` |
| `internal/controller/deployment_builder.go` | `mergePodLabels` and `copyMap` helpers; PodTemplateSpec ObjectMeta uses them |
| `internal/controller/inferenceservice_deployment_test.go` | **5 new unit tests**: annotation propagation, label propagation alongside operator labels, operator-wins-on-collision, selector-immutability under user labels, unset/nil case |

Net: +275 / -1 lines across 6 files.

## Test plan

- [x] `make manifests generate fmt vet` clean
- [x] `make chart-crds` synced
- [x] `go test ./internal/controller/... ./pkg/agent/...` passes (5 new tests included)
- [x] `golangci-lint v2.4.0` reports 0 issues
- [ ] Manual smoke: deploy an ISVC with `podAnnotations: {infercost.ai/backend: vllm}` and `podLabels: {team: platform}`, verify both appear on the Pod via `kubectl get pod -o yaml`

## Notes for whoever reviews

- The selector-stability test is the load-bearing one. The first failure mode if someone edits this later is "user changes podLabels, Deployment orphans Pods, downtime." The test guards exactly that.
- Operator-wins-on-collision is the second load-bearing piece. Without it, a user could inadvertently break the operator's own Pod-discovery pattern by setting `app: my-thing`.
- No effect on existing clusters: both fields are optional and nil-safe; existing InferenceServices render the same Pod spec they did before.

## Out of scope (deferred)

- E2E test (the issue listed it; the unit tests cover the spec contract end-to-end via `constructDeployment`. Real envtest is in the controller integration tests already)
- Doc snippet (will follow up in a docs-only PR if the team wants the InferCost example written out)

## Conflict check

- No overlap with PR #340 (Faylixe's parallelSlots PR; lives in `runtime_*.go`)
- No overlap with PR #370 (release-please; lives in version files)