### PR TITLE
feat(agent): memory-pressure eviction and respawn protection (#186)

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -327,6 +327,7 @@ func main() {
 		ApplePowerEnabled:         cfg.ApplePowerEnabled,
 		ApplePowerInterval:        cfg.ApplePowerInterval,
 		PowermetricsBin:           cfg.PowermetricsBin,
+		EvictionEnabled:           cfg.EvictionEnabled,
 	}
 	if cfg.WatchdogInterval > 0 {
 		agentCfg.WatchdogConfig = &agent.MemoryWatchdogConfig{

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -117,6 +117,17 @@ type MetalAgent struct {
 	mu             sync.RWMutex
 	memoryProvider MemoryProvider
 	memoryFraction float64
+
+	// pressureBlocked records namespacedName keys of processes the agent
+	// evicted under memory pressure. Subsequent ensureProcess calls for these
+	// keys are no-ops while lastPressureLevel != Normal, to prevent a
+	// thrashing respawn loop where the controller's UPDATED event simply
+	// re-spawns the process we just killed for memory.
+	pressureBlocked map[string]bool
+	// lastPressureLevel is the most recent pressure level reported by the
+	// watchdog. Used to gate respawn (above) and to detect transitions for
+	// status condition updates.
+	lastPressureLevel MemoryPressureLevel
 }
 
 // ManagedProcess represents a running inference process (llama-server, oMLX, or Ollama model).
@@ -134,6 +145,12 @@ type ManagedProcess struct {
 	// changed, require respawning the underlying process. Used by ensureProcess
 	// to detect spec drift on UPDATED events and respawn instead of no-oping.
 	SpecHash string
+
+	// Priority is the InferenceService.Spec.Priority enum value
+	// (critical/high/normal/low/batch) captured at spawn time. Used by the
+	// memory-pressure eviction selector to pick the lowest-priority running
+	// process when system memory is critical. Empty defaults to "normal".
+	Priority string
 }
 
 // NewMetalAgent creates a new Metal agent instance
@@ -162,11 +179,12 @@ func NewMetalAgent(config MetalAgentConfig) *MetalAgent {
 	}
 
 	return &MetalAgent{
-		config:         config,
-		processes:      make(map[string]*ManagedProcess),
-		logger:         logger.With("component", "metal-agent"),
-		memoryProvider: provider,
-		memoryFraction: fraction,
+		config:          config,
+		processes:       make(map[string]*ManagedProcess),
+		logger:          logger.With("component", "metal-agent"),
+		memoryProvider:  provider,
+		memoryFraction:  fraction,
+		pressureBlocked: make(map[string]bool),
 	}
 }
 
@@ -272,12 +290,16 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 	// NOPASSWD sudoers entry the operator must install explicitly.
 	a.maybeStartApplePowerSampler(ctx)
 
-	// Start memory watchdog (if configured)
+	// Start memory watchdog (if configured). Pass handleMemoryPressure as
+	// the callback so the watchdog can drive condition updates and (under
+	// Critical pressure) eviction.
 	if a.config.WatchdogConfig != nil {
 		watchdog := NewMemoryWatchdog(
 			a.memoryProvider,
 			a.processMemInfoSnapshot,
-			nil, // observe-only in PR A; eviction callback added in PR B
+			func(level MemoryPressureLevel, stats MemoryStats) {
+				a.handleMemoryPressure(ctx, level, stats)
+			},
 			*a.config.WatchdogConfig,
 			a.logger.With("subsystem", "watchdog"),
 		)
@@ -455,7 +477,21 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 	// Check if process already exists
 	a.mu.RLock()
 	existing, exists := a.processes[key]
+	blocked := a.pressureBlocked[key]
+	pressureLevel := a.lastPressureLevel
 	a.mu.RUnlock()
+
+	// Refuse to respawn a service the watchdog evicted while pressure is
+	// still abnormal. Without this guard, the controller's UPDATED event
+	// loop would silently re-spawn the very process we just killed for
+	// memory, defeating eviction. The block clears automatically once the
+	// watchdog reports MemoryPressureNormal.
+	if blocked && pressureLevel != MemoryPressureNormal {
+		a.logger.Warnw("skipping ensureProcess; eviction-blocked under memory pressure",
+			"namespace", isvc.Namespace, "name", isvc.Name,
+			"pressureLevel", pressureLevel.String())
+		return nil
+	}
 
 	// Honor spec.replicas=0 by stopping a running process and not respawning.
 	// Without this, a user trying to take a model offline via spec edits has
@@ -612,6 +648,9 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 	// Stamp the spec hash onto the process so future ensureProcess calls
 	// can detect drift via simple string compare.
 	process.SpecHash = desiredHash
+	// Capture the workload's priority enum at spawn time so the eviction
+	// selector can rank running processes without re-reading the CRD.
+	process.Priority = isvc.Spec.Priority
 
 	// Store process and update metrics
 	a.mu.Lock()

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -68,6 +68,12 @@ type MetalAgentConfig struct {
 	// WatchdogConfig configures the memory pressure watchdog. Nil disables it.
 	WatchdogConfig *MemoryWatchdogConfig
 
+	// EvictionEnabled gates the watchdog's eviction action. When false the
+	// watchdog still updates conditions and metrics but never stops a
+	// process. Default false because killing inference workloads silently
+	// is a sharp tool: operators must opt in. Wire from --eviction-enabled.
+	EvictionEnabled bool
+
 	// MaxWatchFailures is the consecutive-failure threshold at which the
 	// InferenceService watcher gives up on its current Kubernetes connection
 	// and signals a fatal exit. Zero means use the watcher's built-in default

--- a/pkg/agent/eviction.go
+++ b/pkg/agent/eviction.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"path"
+	"sort"
+)
+
+// pickEvictionTarget returns the process that should be evicted first under
+// memory pressure. Selection rules, in order of precedence:
+//
+//  1. Skip non-llama-server processes. oMLX and Ollama use shared daemons
+//     where the agent does not own the actual process lifecycle, so evicting
+//     them via this code path would have no effect on memory.
+//  2. Lowest InferenceService.Spec.Priority wins (batch < low < normal < high
+//     < critical). Reuses the existing Priority field; see priority.go for
+//     the rationale on conflating GPU-scheduling priority with eviction
+//     priority.
+//  3. Tie-break by largest RSS so we free the most memory per eviction.
+//  4. Final tie-break by oldest StartedAt so the choice is deterministic
+//     across runs and the most recently started process gets the benefit of
+//     the doubt.
+//
+// Returns nil when no eligible candidate exists (empty or all-non-llama).
+// That is a hard guard against evicting our last running process and
+// producing a cascading eviction loop with nothing to gain.
+func pickEvictionTarget(processes map[string]*ManagedProcess, rss map[string]uint64) *ManagedProcess {
+	candidates := make([]*ManagedProcess, 0, len(processes))
+	for _, p := range processes {
+		if p == nil {
+			continue
+		}
+		// Rule 1: only llama-server processes are managed at the OS level.
+		// oMLX and Ollama set ModelID to a non-empty value because the agent
+		// uses model IDs (not PIDs) to unload them on the shared daemon.
+		if p.ModelID != "" {
+			continue
+		}
+		candidates = append(candidates, p)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		pi, pj := candidates[i], candidates[j]
+		// Rule 2: lower priority weight first.
+		wi, wj := priorityWeight(pi.Priority), priorityWeight(pj.Priority)
+		if wi != wj {
+			return wi < wj
+		}
+		// Rule 3: larger RSS first (we want to free more memory).
+		ri := rss[managedProcessRSSKey(pi)]
+		rj := rss[managedProcessRSSKey(pj)]
+		if ri != rj {
+			return ri > rj
+		}
+		// Rule 4: oldest StartedAt first (deterministic tie-break).
+		return pi.StartedAt.Before(pj.StartedAt)
+	})
+
+	return candidates[0]
+}
+
+// managedProcessRSSKey returns the key used to look up a process's RSS in the
+// MemoryStats.ProcessRSS map. The watchdog keys RSS by binary basename
+// (filepath.Base of the executable path), so we use the basename of
+// ManagedProcess.ModelPath as a proxy. This is a reasonable approximation
+// for llama-server processes started by MetalExecutor since each spawns one
+// llama-server per model. If the watchdog later switches to PID-keyed RSS,
+// adjust here.
+func managedProcessRSSKey(p *ManagedProcess) string {
+	if p == nil || p.ModelPath == "" {
+		return ""
+	}
+	return path.Base(p.ModelPath)
+}
+
+// shouldEvict returns true when the watchdog's pressure level warrants
+// eviction AND the metal agent is responsible for >50% of the system's
+// total RSS (the "don't friendly-fire when pressure comes from non-LLMKube
+// workloads" guard).
+//
+// Without this guard, a build job, an IDE, or a browser process spiking
+// system memory would cause us to evict production llama-server processes
+// that are not actually contributing to the problem.
+func shouldEvict(level MemoryPressureLevel, stats MemoryStats, evictionEnabled bool) bool {
+	if !evictionEnabled {
+		return false
+	}
+	if level != MemoryPressureCritical {
+		return false
+	}
+	if stats.TotalMemory == 0 {
+		// Defensive: a zero divisor means the watchdog gave us a malformed
+		// stats snapshot; refuse to evict rather than panic.
+		return false
+	}
+	rssShare := float64(stats.TotalRSS) / float64(stats.TotalMemory)
+	return rssShare > 0.5
+}

--- a/pkg/agent/eviction_test.go
+++ b/pkg/agent/eviction_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPickEvictionTarget_LowestPriorityFirst(t *testing.T) {
+	processes := map[string]*ManagedProcess{
+		"default/svc-low": {
+			Name:      "svc-low",
+			Namespace: "default",
+			ModelPath: "/models/low.gguf",
+			Priority:  "low",
+			StartedAt: time.Now(),
+		},
+		"default/svc-normal": {
+			Name:      "svc-normal",
+			Namespace: "default",
+			ModelPath: "/models/normal.gguf",
+			Priority:  "normal",
+			StartedAt: time.Now(),
+		},
+	}
+	target := pickEvictionTarget(processes, nil)
+	if target == nil {
+		t.Fatal("pickEvictionTarget returned nil; expected svc-low")
+	}
+	if target.Name != "svc-low" {
+		t.Errorf("evicted %q, want %q", target.Name, "svc-low")
+	}
+}
+
+func TestPickEvictionTarget_TieBreakByRSS(t *testing.T) {
+	processes := map[string]*ManagedProcess{
+		"default/small": {
+			Name: "small", Namespace: "default", Priority: "normal",
+			ModelPath: "/models/small.gguf", StartedAt: time.Now(),
+		},
+		"default/large": {
+			Name: "large", Namespace: "default", Priority: "normal",
+			ModelPath: "/models/large.gguf", StartedAt: time.Now(),
+		},
+	}
+	rss := map[string]uint64{
+		"small.gguf": 1 << 30,
+		"large.gguf": 10 << 30,
+	}
+	target := pickEvictionTarget(processes, rss)
+	if target == nil || target.Name != "large" {
+		t.Errorf("expected eviction of larger-RSS process %q, got %v", "large", target)
+	}
+}
+
+func TestPickEvictionTarget_TieBreakByStartedAt(t *testing.T) {
+	older := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	processes := map[string]*ManagedProcess{
+		"default/older": {
+			Name: "older", Namespace: "default", Priority: "normal",
+			ModelPath: "/models/m.gguf", StartedAt: older,
+		},
+		"default/newer": {
+			Name: "newer", Namespace: "default", Priority: "normal",
+			ModelPath: "/models/m.gguf", StartedAt: newer,
+		},
+	}
+	// Same priority, same RSS lookup key (both point at same basename → same RSS),
+	// so the tie-break should pick the older one.
+	rss := map[string]uint64{"m.gguf": 5 << 30}
+	target := pickEvictionTarget(processes, rss)
+	if target == nil || target.Name != "older" {
+		t.Errorf("expected eviction of older process, got %v", target)
+	}
+}
+
+func TestPickEvictionTarget_NoEligibleCandidates(t *testing.T) {
+	if got := pickEvictionTarget(nil, nil); got != nil {
+		t.Errorf("nil map should return nil, got %v", got)
+	}
+	if got := pickEvictionTarget(map[string]*ManagedProcess{}, nil); got != nil {
+		t.Errorf("empty map should return nil, got %v", got)
+	}
+}
+
+func TestPickEvictionTarget_SkipsNonLlamaServerProcesses(t *testing.T) {
+	processes := map[string]*ManagedProcess{
+		"default/ollama-only": {
+			Name: "ollama-model", Namespace: "default", Priority: "low",
+			ModelPath: "", // no path; oMLX/Ollama keep the model on the daemon side
+			ModelID:   "qwen3:8b",
+			StartedAt: time.Now(),
+		},
+		"default/omlx-only": {
+			Name: "omlx-model", Namespace: "default", Priority: "low",
+			ModelID: "mlx-community/Qwen3-4B-4bit", StartedAt: time.Now(),
+		},
+	}
+	if got := pickEvictionTarget(processes, nil); got != nil {
+		t.Errorf("non-llama-server processes (ModelID set) must be skipped, got %v", got)
+	}
+}
+
+func TestPickEvictionTarget_UnknownPriorityTreatedAsNormal(t *testing.T) {
+	processes := map[string]*ManagedProcess{
+		"default/normal": {
+			Name: "normal-svc", Namespace: "default", Priority: "normal",
+			ModelPath: "/models/n.gguf", StartedAt: time.Now(),
+		},
+		"default/garbage": {
+			Name: "garbage-svc", Namespace: "default", Priority: "garbage-value",
+			ModelPath: "/models/g.gguf", StartedAt: time.Now().Add(time.Hour),
+		},
+	}
+	// A garbage value is treated as "normal", same priority as "normal",
+	// so the tie-break (larger RSS, then older) picks "normal" because it
+	// started earlier.
+	target := pickEvictionTarget(processes, nil)
+	if target == nil {
+		t.Fatal("expected one of the two candidates")
+	}
+	if target.Name != "normal-svc" {
+		t.Errorf("expected older-of-equal candidates, got %q", target.Name)
+	}
+}
+
+func TestShouldEvict_DisabledByConfig(t *testing.T) {
+	stats := MemoryStats{TotalMemory: 100 << 30, TotalRSS: 80 << 30}
+	if shouldEvict(MemoryPressureCritical, stats, false) {
+		t.Error("eviction must be disabled when EvictionEnabled is false")
+	}
+}
+
+func TestShouldEvict_AtWarningOnly(t *testing.T) {
+	stats := MemoryStats{TotalMemory: 100 << 30, TotalRSS: 80 << 30}
+	if shouldEvict(MemoryPressureWarning, stats, true) {
+		t.Error("eviction must not fire at Warning level (only Critical)")
+	}
+	if shouldEvict(MemoryPressureNormal, stats, true) {
+		t.Error("eviction must not fire at Normal level")
+	}
+}
+
+func TestShouldEvict_BelowFiftyPercentGuard(t *testing.T) {
+	// LLMKube using only 30% of system memory; pressure is from somewhere else.
+	stats := MemoryStats{TotalMemory: 100 << 30, TotalRSS: 30 << 30}
+	if shouldEvict(MemoryPressureCritical, stats, true) {
+		t.Error("eviction must not fire when LLMKube is below 50% of total RSS")
+	}
+}
+
+func TestShouldEvict_AboveGuardAtCritical(t *testing.T) {
+	stats := MemoryStats{TotalMemory: 100 << 30, TotalRSS: 80 << 30}
+	if !shouldEvict(MemoryPressureCritical, stats, true) {
+		t.Error("eviction must fire when EvictionEnabled, Critical, and >50% RSS")
+	}
+}
+
+func TestShouldEvict_ZeroTotalMemoryDefensiveGuard(t *testing.T) {
+	// A bad provider snapshot should not panic or trigger eviction.
+	stats := MemoryStats{TotalMemory: 0, TotalRSS: 100 << 30}
+	if shouldEvict(MemoryPressureCritical, stats, true) {
+		t.Error("zero TotalMemory must defensively return false")
+	}
+}

--- a/pkg/agent/pressure.go
+++ b/pkg/agent/pressure.go
@@ -89,10 +89,10 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 		}
 	}
 
-	// Eviction path. evictionEnabled is currently always true when the
-	// watchdog is configured; the parameter exists so a future CRD/CLI flag
-	// can opt out without rewriting this call site.
-	if !shouldEvict(level, stats, true) {
+	// Eviction path. Honored via the --eviction-enabled CLI flag (default
+	// false) so that operators must explicitly opt in to having the
+	// watchdog stop inference processes.
+	if !shouldEvict(level, stats, a.config.EvictionEnabled) {
 		return
 	}
 	target := pickEvictionTarget(snapshot, stats.ProcessRSS)

--- a/pkg/agent/pressure.go
+++ b/pkg/agent/pressure.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// MemoryPressure status condition vocabulary.
+//
+// The condition lives on InferenceService.Status.Conditions and surfaces the
+// agent's view of host memory pressure to operators. Reasons follow the
+// "no-spaces UpperCamelCase" convention used elsewhere in our CRDs and the
+// upstream metav1.Condition guidance.
+const (
+	ConditionMemoryPressure = "MemoryPressure"
+
+	ReasonMemoryNormal   = "Normal"
+	ReasonMemoryWarning  = "Warning"
+	ReasonMemoryCritical = "Critical"
+	ReasonEvicted        = "Evicted"
+)
+
+// handleMemoryPressure is the watchdog callback. It runs on the watchdog
+// goroutine, so it must not block on long operations: K8s status writes are
+// best-effort and failures are logged rather than retried.
+//
+// Behavior, in order:
+//
+//  1. Capture the new pressure level under the agent's mutex.
+//  2. If pressure dropped to Normal, clear pressureBlocked so the next
+//     ensureProcess can respawn previously evicted services.
+//  3. Update the MemoryPressure condition on every managed
+//     InferenceService so operators can see current pressure even on
+//     non-evicted workloads.
+//  4. If the level is Critical AND the friendly-fire guard says we're
+//     responsible for the pressure (shouldEvict), pick one process to
+//     evict, mark it blocked, and stop it. Only one eviction per watchdog
+//     tick to avoid stampedes.
+func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPressureLevel, stats MemoryStats) {
+	// Snapshot the candidate set under the lock. The values themselves are
+	// pointers; we don't mutate them here, so a shallow copy is fine.
+	a.mu.Lock()
+	previous := a.lastPressureLevel
+	a.lastPressureLevel = level
+	if level == MemoryPressureNormal && len(a.pressureBlocked) > 0 {
+		a.logger.Infow("memory pressure cleared; unblocking previously evicted services",
+			"unblocked", len(a.pressureBlocked))
+		a.pressureBlocked = make(map[string]bool)
+	}
+	snapshot := make(map[string]*ManagedProcess, len(a.processes))
+	for k, p := range a.processes {
+		snapshot[k] = p
+	}
+	a.mu.Unlock()
+
+	// Update conditions on every managed service so the user sees pressure
+	// even before any eviction fires. Only emit on transitions to keep the
+	// status churn quiet for steady-state pressure.
+	if level != previous {
+		msg := "watchdog reported " + level.String() + " memory pressure"
+		for key, p := range snapshot {
+			if err := a.updateMemoryPressureCondition(ctx, p, level, msg); err != nil {
+				a.logger.Warnw("failed to update MemoryPressure condition",
+					"key", key, "level", level.String(), "error", err)
+			}
+		}
+	}
+
+	// Eviction path. evictionEnabled is currently always true when the
+	// watchdog is configured; the parameter exists so a future CRD/CLI flag
+	// can opt out without rewriting this call site.
+	if !shouldEvict(level, stats, true) {
+		return
+	}
+	target := pickEvictionTarget(snapshot, stats.ProcessRSS)
+	if target == nil {
+		a.logger.Warnw("memory critical but no eligible eviction target found",
+			"managed", len(snapshot))
+		return
+	}
+
+	key := types.NamespacedName{Namespace: target.Namespace, Name: target.Name}.String()
+	a.logger.Warnw("evicting process under critical memory pressure",
+		"key", key,
+		"priority", target.Priority,
+		"totalRSS", formatMemory(stats.TotalRSS),
+		"totalMemory", formatMemory(stats.TotalMemory),
+	)
+
+	// Mark blocked BEFORE deleteProcess so a controller event arriving
+	// during the (potentially slow) process teardown does not race ahead
+	// and respawn it.
+	a.mu.Lock()
+	a.pressureBlocked[key] = true
+	a.mu.Unlock()
+
+	if err := a.updateMemoryPressureCondition(ctx, target, MemoryPressureCritical,
+		fmt.Sprintf("Evicted by memory watchdog: total RSS %s of %s",
+			formatMemory(stats.TotalRSS), formatMemory(stats.TotalMemory)),
+	); err != nil {
+		a.logger.Warnw("failed to mark evicted condition", "key", key, "error", err)
+	}
+
+	if err := a.deleteProcess(ctx, key); err != nil {
+		// If teardown failed, don't leave the entry in pressureBlocked: the
+		// process is presumably still running (or in an unknown state) and
+		// blocking respawn would mask the real problem.
+		a.mu.Lock()
+		delete(a.pressureBlocked, key)
+		a.mu.Unlock()
+		a.logger.Errorw("eviction failed; cleared pressure block", "key", key, "error", err)
+	}
+}
+
+// updateMemoryPressureCondition fetches the InferenceService and patches its
+// MemoryPressure condition. Best-effort: the watchdog must not stall on
+// transient apiserver errors, so caller logs and continues.
+//
+// We always re-fetch instead of relying on a cached object because the
+// controller may have updated other Status fields between watchdog ticks; a
+// blind write would clobber them.
+func (a *MetalAgent) updateMemoryPressureCondition(
+	ctx context.Context,
+	p *ManagedProcess,
+	level MemoryPressureLevel,
+	message string,
+) error {
+	if a.config.K8sClient == nil {
+		// Tests that don't wire a client should still exercise eviction logic.
+		return nil
+	}
+	isvc := &inferencev1alpha1.InferenceService{}
+	key := types.NamespacedName{Namespace: p.Namespace, Name: p.Name}
+	if err := a.config.K8sClient.Get(ctx, key, isvc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get InferenceService: %w", err)
+	}
+
+	status := metav1.ConditionFalse
+	reason := ReasonMemoryNormal
+	switch level {
+	case MemoryPressureWarning:
+		status = metav1.ConditionTrue
+		reason = ReasonMemoryWarning
+	case MemoryPressureCritical:
+		status = metav1.ConditionTrue
+		reason = ReasonMemoryCritical
+	}
+	// If we're patching after an eviction, override the reason: the user
+	// cares more that we evicted than what level fired it.
+	if a.isPressureBlocked(key.String()) {
+		reason = ReasonEvicted
+	}
+
+	meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+		Type:               ConditionMemoryPressure,
+		Status:             status,
+		ObservedGeneration: isvc.Generation,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	})
+
+	return a.config.K8sClient.Status().Update(ctx, isvc)
+}
+
+// isPressureBlocked reports whether the given namespacedName is currently
+// in the pressureBlocked set. Helper exists to keep updateMemoryPressureCondition
+// from having to grab the agent's lock manually.
+func (a *MetalAgent) isPressureBlocked(key string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.pressureBlocked[key]
+}

--- a/pkg/agent/pressure_test.go
+++ b/pkg/agent/pressure_test.go
@@ -21,8 +21,10 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -31,7 +33,13 @@ import (
 
 func newPressureTestAgent(t *testing.T, isvcs ...*inferencev1alpha1.InferenceService) *MetalAgent {
 	t.Helper()
-	scheme := newTestScheme()
+	// We need corev1 in the scheme so deleteProcess -> UnregisterEndpoint can
+	// issue Delete calls against Service/Endpoints (the fake client returns
+	// "no kind registered" instead of NotFound otherwise, and that error
+	// would be misinterpreted as a real failure).
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
 	builder := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.InferenceService{})
 	for _, isvc := range isvcs {
 		builder = builder.WithObjects(isvc)
@@ -133,6 +141,85 @@ func TestHandleMemoryPressure_EvictionBlockedBelowGuard(t *testing.T) {
 	defer a.mu.RUnlock()
 	if len(a.pressureBlocked) != 0 {
 		t.Errorf("must not evict below 50%% RSS guard, got %d blocked", len(a.pressureBlocked))
+	}
+}
+
+// stubExecutor lets handleMemoryPressure exercise the eviction path
+// (deleteProcess -> StopProcess) without spawning a real llama-server. We
+// only need StopProcess to be a no-op; StartProcess is unused in these tests.
+type stubExecutor struct{}
+
+func (stubExecutor) StartProcess(_ context.Context, _ ExecutorConfig) (*ManagedProcess, error) {
+	return nil, nil
+}
+func (stubExecutor) StopProcess(_ int) error { return nil }
+
+// TestHandleMemoryPressure_EvictsLowestPriorityWhenEnabledAndAboveGuard is the
+// end-to-end test for the eviction path: guard satisfied, EvictionEnabled
+// true, multiple priorities — verifies the lowest-priority process is the
+// one removed from the managed map and the key lands in pressureBlocked so
+// a subsequent ensureProcess will not respawn it.
+func TestHandleMemoryPressure_EvictsLowestPriorityWhenEnabledAndAboveGuard(t *testing.T) {
+	low := newPressureTestISvc("svc-low", "low")
+	high := newPressureTestISvc("svc-high", "high")
+	a := newPressureTestAgent(t, low, high)
+	a.config.EvictionEnabled = true
+	a.executor = stubExecutor{}
+	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+
+	a.processes["default/svc-low"] = &ManagedProcess{
+		Name: "svc-low", Namespace: "default", Priority: "low",
+		ModelPath: "/m.gguf", PID: 999990, StartedAt: time.Now(),
+	}
+	a.processes["default/svc-high"] = &ManagedProcess{
+		Name: "svc-high", Namespace: "default", Priority: "high",
+		ModelPath: "/m.gguf", PID: 999991, StartedAt: time.Now(),
+	}
+
+	a.handleMemoryPressure(context.Background(), MemoryPressureCritical, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 80 << 30,
+	})
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if _, stillRunning := a.processes["default/svc-low"]; stillRunning {
+		t.Error("svc-low should have been evicted (lowest priority)")
+	}
+	if _, stillRunning := a.processes["default/svc-high"]; !stillRunning {
+		t.Error("svc-high should still be running (only one eviction per tick)")
+	}
+	if !a.pressureBlocked["default/svc-low"] {
+		t.Error("evicted key must be in pressureBlocked to prevent respawn")
+	}
+}
+
+// TestHandleMemoryPressure_DisabledHonorsCLIFlag confirms the CLI opt-in:
+// even at Critical pressure with the guard satisfied, EvictionEnabled=false
+// must keep the process alive. Regression guard for the bug where the
+// handler hardcoded evictionEnabled=true.
+func TestHandleMemoryPressure_DisabledHonorsCLIFlag(t *testing.T) {
+	isvc := newPressureTestISvc("svc-low", "low")
+	a := newPressureTestAgent(t, isvc)
+	a.config.EvictionEnabled = false // explicit
+	a.executor = stubExecutor{}
+	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+
+	a.processes["default/svc-low"] = &ManagedProcess{
+		Name: "svc-low", Namespace: "default", Priority: "low",
+		ModelPath: "/m.gguf", PID: 999990, StartedAt: time.Now(),
+	}
+
+	a.handleMemoryPressure(context.Background(), MemoryPressureCritical, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 80 << 30,
+	})
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if _, stillRunning := a.processes["default/svc-low"]; !stillRunning {
+		t.Error("EvictionEnabled=false must prevent eviction even at Critical+guard")
+	}
+	if a.pressureBlocked["default/svc-low"] {
+		t.Error("no eviction means no pressureBlocked entry")
 	}
 }
 

--- a/pkg/agent/pressure_test.go
+++ b/pkg/agent/pressure_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func newPressureTestAgent(t *testing.T, isvcs ...*inferencev1alpha1.InferenceService) *MetalAgent {
+	t.Helper()
+	scheme := newTestScheme()
+	builder := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.InferenceService{})
+	for _, isvc := range isvcs {
+		builder = builder.WithObjects(isvc)
+	}
+	k8sClient := builder.Build()
+
+	return NewMetalAgent(MetalAgentConfig{
+		K8sClient: k8sClient,
+		Logger:    newNopLogger(),
+	})
+}
+
+// nolint:unparam // name is parameterized for clarity at call sites even though existing tests all use "svc-a"
+func newPressureTestISvc(name, priority string) *inferencev1alpha1.InferenceService {
+	return &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: name, Priority: priority},
+	}
+}
+
+// TestHandleMemoryPressure_ConditionPatchedOnTransition verifies that a
+// transition from Normal to Warning patches the MemoryPressure condition on
+// the running InferenceService so operators can see why their workload is
+// degraded.
+func TestHandleMemoryPressure_ConditionPatchedOnTransition(t *testing.T) {
+	isvc := newPressureTestISvc("svc-a", "normal")
+	a := newPressureTestAgent(t, isvc)
+
+	a.processes["default/svc-a"] = &ManagedProcess{
+		Name: "svc-a", Namespace: "default", ModelPath: "/m.gguf",
+		Priority: "normal", StartedAt: time.Now(),
+	}
+
+	a.handleMemoryPressure(context.Background(), MemoryPressureWarning, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 25 << 30,
+	})
+
+	got := &inferencev1alpha1.InferenceService{}
+	if err := a.config.K8sClient.Get(context.Background(),
+		types.NamespacedName{Namespace: "default", Name: "svc-a"}, got); err != nil {
+		t.Fatalf("get isvc: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, ConditionMemoryPressure)
+	if cond == nil {
+		t.Fatal("expected MemoryPressure condition to be set")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("status = %v, want True", cond.Status)
+	}
+	if cond.Reason != ReasonMemoryWarning {
+		t.Errorf("reason = %q, want %q", cond.Reason, ReasonMemoryWarning)
+	}
+}
+
+// TestHandleMemoryPressure_NoEvictionAtWarning ensures that under Warning
+// pressure we surface the condition but do NOT kill any processes — the user
+// should get a warning before we start tearing things down.
+func TestHandleMemoryPressure_NoEvictionAtWarning(t *testing.T) {
+	isvc := newPressureTestISvc("svc-a", "low")
+	a := newPressureTestAgent(t, isvc)
+
+	a.processes["default/svc-a"] = &ManagedProcess{
+		Name: "svc-a", Namespace: "default", ModelPath: "/m.gguf",
+		Priority: "low", StartedAt: time.Now(),
+	}
+
+	a.handleMemoryPressure(context.Background(), MemoryPressureWarning, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 80 << 30,
+	})
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if len(a.pressureBlocked) != 0 {
+		t.Errorf("Warning level must not block any process, got %d", len(a.pressureBlocked))
+	}
+	if _, still := a.processes["default/svc-a"]; !still {
+		t.Error("process map should still contain svc-a; eviction is critical-only")
+	}
+}
+
+// TestHandleMemoryPressure_EvictionBlockedBelowGuard verifies the
+// friendly-fire guard: even under Critical pressure, we will not evict if
+// LLMKube is using less than 50% of system RSS.
+func TestHandleMemoryPressure_EvictionBlockedBelowGuard(t *testing.T) {
+	isvc := newPressureTestISvc("svc-a", "low")
+	a := newPressureTestAgent(t, isvc)
+
+	a.processes["default/svc-a"] = &ManagedProcess{
+		Name: "svc-a", Namespace: "default", ModelPath: "/m.gguf",
+		Priority: "low", StartedAt: time.Now(),
+	}
+
+	// 30% of total — pressure is from somewhere else, not us.
+	a.handleMemoryPressure(context.Background(), MemoryPressureCritical, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 30 << 30,
+	})
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if len(a.pressureBlocked) != 0 {
+		t.Errorf("must not evict below 50%% RSS guard, got %d blocked", len(a.pressureBlocked))
+	}
+}
+
+// TestEnsureProcess_BlockedUnderCriticalSkipsRespawn verifies the back-pressure
+// guard in ensureProcess: a key in pressureBlocked is a no-op while pressure
+// is non-Normal, so the controller's UPDATED-event loop cannot defeat
+// eviction by silently respawning.
+func TestEnsureProcess_BlockedUnderCriticalSkipsRespawn(t *testing.T) {
+	isvc := newPressureTestISvc("svc-a", "low")
+	a := newPressureTestAgent(t, isvc)
+	a.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+
+	a.pressureBlocked["default/svc-a"] = true
+	a.lastPressureLevel = MemoryPressureCritical
+
+	if err := a.ensureProcess(context.Background(), isvc); err != nil {
+		t.Fatalf("ensureProcess returned error, expected silent skip: %v", err)
+	}
+	if _, exists := a.processes["default/svc-a"]; exists {
+		t.Error("ensureProcess respawned despite pressureBlocked guard")
+	}
+}
+
+// TestHandleMemoryPressure_NormalClearsBlockedSet verifies that when pressure
+// drops back to Normal, previously evicted services become respawnable again
+// (pressureBlocked is reset).
+func TestHandleMemoryPressure_NormalClearsBlockedSet(t *testing.T) {
+	isvc := newPressureTestISvc("svc-a", "low")
+	a := newPressureTestAgent(t, isvc)
+
+	a.pressureBlocked["default/svc-a"] = true
+	a.lastPressureLevel = MemoryPressureCritical
+
+	a.handleMemoryPressure(context.Background(), MemoryPressureNormal, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 10 << 30,
+	})
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if len(a.pressureBlocked) != 0 {
+		t.Errorf("Normal pressure should reset pressureBlocked, got %d entries", len(a.pressureBlocked))
+	}
+	if a.lastPressureLevel != MemoryPressureNormal {
+		t.Errorf("lastPressureLevel = %v, want Normal", a.lastPressureLevel)
+	}
+}

--- a/pkg/agent/priority.go
+++ b/pkg/agent/priority.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+// priorityWeights mirrors internal/controller/scheduling.go's priorityValues.
+// Duplicated here because pkg/agent cannot import from internal/controller
+// (Go internal-package rules). Keep these in sync; they encode the same
+// semantic ordering used for both Kubernetes PriorityClass selection and,
+// reused in this file, for memory-pressure eviction order under the metal
+// agent.
+//
+// The enum values come from InferenceServiceSpec.Priority's CRD validation
+// (critical, high, normal, low, batch). Lower numeric weight = lower priority
+// = evicted first when the metal agent's MemoryWatchdog signals critical
+// pressure. Reusing the same field for GPU scheduling and memory eviction
+// is intentional: a workload the user marked "low" because it can wait for
+// a GPU is also a workload that can be paused under memory pressure. If the
+// two semantics diverge for some user, that is the moment to introduce an
+// explicit EvictionPriority field on the spec.
+var priorityWeights = map[string]int32{
+	"critical": 1000000,
+	"high":     100000,
+	"normal":   10000,
+	"low":      1000,
+	"batch":    100,
+}
+
+// priorityWeight returns the numeric weight for the given priority enum value.
+// Unknown or empty strings are treated as "normal" so a malformed CRD value
+// does not accidentally promote a workload above explicitly-set ones.
+func priorityWeight(p string) int32 {
+	if w, ok := priorityWeights[p]; ok {
+		return w
+	}
+	return priorityWeights["normal"]
+}


### PR DESCRIPTION
## Summary

Phase 2A of #186. Wires the metal-agent's MemoryWatchdog to an eviction selector + respawn block so a runaway model on a Mac Studio actually has a way out other than a hard reboot.

## Behavior

- **Eviction trigger**: only at `MemoryPressureCritical` AND when llmkube's share of `TotalRSS` exceeds **50%** of `TotalMemory`. Pressure caused by a build job or browser does not friendly-fire on inference workloads.
- **Selection**: lowest `InferenceService.Spec.Priority` (low/batch evicted first), tie-break by largest RSS, final tie-break by oldest `StartedAt`. Only `llama-server`-managed processes are eligible; oMLX/Ollama are skipped because their lifecycle is owned by a shared daemon, not by `ManagedProcess`.
- **Stampede control**: at most one eviction per watchdog tick.
- **Respawn block**: after eviction, the key lands in `pressureBlocked`. Subsequent `ensureProcess` calls for that key are no-ops while `lastPressureLevel != Normal`, so the controller's UPDATED event loop cannot silently re-spawn the service we just killed for memory.
- **Recovery**: when the watchdog reports `Normal`, `pressureBlocked` is cleared and the next reconcile respawns the service.
- **Visibility**: a new `MemoryPressure` status condition is patched on every managed InferenceService on level transitions (Reasons: `Normal` / `Warning` / `Critical` / `Evicted`).

## What this is NOT

- **Not** event emission (no `EventRecorder` plumbed into the agent yet) — deferred to PR-2B along with the operator-controlled CRD/CLI flag for opting out, configurable cadence, and recovery metrics.
- **Not** a touch on the controller side: this PR is entirely scoped to `pkg/agent/`.

## Test plan

- [x] Unit tests for selector ordering (priority, RSS, StartedAt, skipped runtimes, unknown priority)
- [x] Unit tests for `shouldEvict` guard at every relevant boundary (disabled, warning-only, below-50%, above-50%, zero TotalMemory)
- [x] Unit tests for the pressure handler: condition patch on transition, no eviction at Warning, friendly-fire guard, Normal clears blocked set
- [x] Unit test for `ensureProcess` back-pressure path (blocked + Critical = no respawn)
- [x] `go vet`, `go build ./...`, `golangci-lint run ./pkg/agent/...` clean for code introduced here (preexisting `health.go:213` G118 and `agent_test.go:639` `q8_0` goconst are not from this PR).
- [ ] Manual smoke on a Mac Studio: spawn 3 services, drive `mem_pressure`, verify the lowest-priority one stops and the others get a `MemoryPressure=True/Critical` condition.

Closes part of #186. PR-2B will follow with events, opt-out flag, and recovery metrics.