### PR TITLE
feat(agent): eviction safety floor + evictionProtection opt-out + late-spawn condition fix (#186)

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -311,6 +311,19 @@ type InferenceServiceSpec struct {
 	// +optional
 	Priority string `json:"priority,omitempty"`
 
+	// EvictionProtection marks this service as ineligible for memory-pressure
+	// eviction by the metal-agent watchdog. Use this for production workloads
+	// that should never be silently stopped under memory pressure, even when
+	// they are the lowest-priority option. The agent's per-process pickEvictionTarget
+	// excludes protected processes from the eviction-candidate set; the
+	// MemoryPressure status condition is still patched on protected services
+	// for operator visibility.
+	//
+	// Has no effect when --eviction-enabled is unset on the metal-agent or
+	// for non-llama-server runtimes (oMLX, Ollama). Defaults to false.
+	// +optional
+	EvictionProtection *bool `json:"evictionProtection,omitempty"`
+
 	// PriorityClassName allows specifying a custom Kubernetes PriorityClass.
 	// Takes precedence over the Priority field if set.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -400,6 +400,11 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.EvictionProtection != nil {
+		in, out := &in.EvictionProtection, &out.EvictionProtection
+		*out = new(bool)
+		**out = **in
+	}
 	if in.PodSecurityContext != nil {
 		in, out := &in.PodSecurityContext, &out.PodSecurityContext
 		*out = new(v1.PodSecurityContext)

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -403,6 +403,19 @@ spec:
                   - name
                   type: object
                 type: array
+              evictionProtection:
+                description: |-
+                  EvictionProtection marks this service as ineligible for memory-pressure
+                  eviction by the metal-agent watchdog. Use this for production workloads
+                  that should never be silently stopped under memory pressure, even when
+                  they are the lowest-priority option. The agent's per-process pickEvictionTarget
+                  excludes protected processes from the eviction-candidate set; the
+                  MemoryPressure status condition is still patched on protected services
+                  for operator visibility.
+
+                  Has no effect when --eviction-enabled is unset on the metal-agent or
+                  for non-llama-server runtimes (oMLX, Ollama). Defaults to false.
+                type: boolean
               extraArgs:
                 description: |-
                   ExtraArgs provides additional command-line arguments passed directly to the

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -399,6 +399,19 @@ spec:
                   - name
                   type: object
                 type: array
+              evictionProtection:
+                description: |-
+                  EvictionProtection marks this service as ineligible for memory-pressure
+                  eviction by the metal-agent watchdog. Use this for production workloads
+                  that should never be silently stopped under memory pressure, even when
+                  they are the lowest-priority option. The agent's per-process pickEvictionTarget
+                  excludes protected processes from the eviction-candidate set; the
+                  MemoryPressure status condition is still patched on protected services
+                  for operator visibility.
+
+                  Has no effect when --eviction-enabled is unset on the metal-agent or
+                  for non-llama-server runtimes (oMLX, Ollama). Defaults to false.
+                type: boolean
               extraArgs:
                 description: |-
                   ExtraArgs provides additional command-line arguments passed directly to the

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -134,6 +134,12 @@ type MetalAgent struct {
 	// watchdog. Used to gate respawn (above) and to detect transitions for
 	// status condition updates.
 	lastPressureLevel MemoryPressureLevel
+	// pressureObserved records the pressure level at which each managed
+	// process key has already received a MemoryPressure condition patch.
+	// Lets handleMemoryPressure patch new (late-spawned) processes at the
+	// current level without re-patching ones already observed at it.
+	// Reset on every level transition.
+	pressureObserved map[string]MemoryPressureLevel
 }
 
 // ManagedProcess represents a running inference process (llama-server, oMLX, or Ollama model).
@@ -157,6 +163,13 @@ type ManagedProcess struct {
 	// memory-pressure eviction selector to pick the lowest-priority running
 	// process when system memory is critical. Empty defaults to "normal".
 	Priority string
+
+	// EvictionProtection mirrors InferenceService.Spec.EvictionProtection
+	// at spawn time. When true, the memory-pressure eviction selector
+	// excludes this process from its candidate set. The MemoryPressure
+	// status condition is still patched on protected services so operators
+	// can see system pressure even when their workload is shielded from it.
+	EvictionProtection bool
 }
 
 // NewMetalAgent creates a new Metal agent instance
@@ -185,12 +198,13 @@ func NewMetalAgent(config MetalAgentConfig) *MetalAgent {
 	}
 
 	return &MetalAgent{
-		config:          config,
-		processes:       make(map[string]*ManagedProcess),
-		logger:          logger.With("component", "metal-agent"),
-		memoryProvider:  provider,
-		memoryFraction:  fraction,
-		pressureBlocked: make(map[string]bool),
+		config:           config,
+		processes:        make(map[string]*ManagedProcess),
+		logger:           logger.With("component", "metal-agent"),
+		memoryProvider:   provider,
+		memoryFraction:   fraction,
+		pressureBlocked:  make(map[string]bool),
+		pressureObserved: make(map[string]MemoryPressureLevel),
 	}
 }
 
@@ -657,6 +671,11 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 	// Capture the workload's priority enum at spawn time so the eviction
 	// selector can rank running processes without re-reading the CRD.
 	process.Priority = isvc.Spec.Priority
+	// Capture eviction protection so the selector can filter the candidate
+	// set without round-tripping to the apiserver under memory pressure.
+	if isvc.Spec.EvictionProtection != nil {
+		process.EvictionProtection = *isvc.Spec.EvictionProtection
+	}
 
 	// Store process and update metrics
 	a.mu.Lock()

--- a/pkg/agent/agentmetrics.go
+++ b/pkg/agent/agentmetrics.go
@@ -110,6 +110,18 @@ var (
 		},
 	)
 
+	evictionsSkippedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llmkube_metal_agent_evictions_skipped_total",
+			Help: "Total number of times the watchdog wanted to evict but did not. " +
+				"Reasons: 'disabled' (eviction CLI flag off), 'below_guard' (LLMKube " +
+				"not responsible for >50% of system RSS), 'floor' (would have left " +
+				"zero managed processes), 'all_protected' (every candidate has " +
+				"EvictionProtection=true), 'empty' (no managed processes).",
+		},
+		[]string{"reason"},
+	)
+
 	watchConsecutiveFailures = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "llmkube_metal_agent_watch_consecutive_failures",
@@ -182,6 +194,7 @@ func init() {
 		processRSSBytes,
 		memoryPressureLevelGauge,
 		evictionsTotal,
+		evictionsSkippedTotal,
 		watchConsecutiveFailures,
 		fatalExitsTotal,
 		applePowerCombinedWatts,

--- a/pkg/agent/eviction.go
+++ b/pkg/agent/eviction.go
@@ -21,60 +21,116 @@ import (
 	"sort"
 )
 
-// pickEvictionTarget returns the process that should be evicted first under
-// memory pressure. Selection rules, in order of precedence:
+// Skip reasons returned alongside a nil eviction target. Surfaced to the
+// evictions_skipped_total counter so operators can debug "watchdog went
+// Critical but nothing was evicted" without trawling logs.
 //
-//  1. Skip non-llama-server processes. oMLX and Ollama use shared daemons
+// These are distinct rather than collapsed into one because they imply
+// different operator actions: floor means "this is single-tenant by
+// design," all_protected means "review your evictionProtection settings,"
+// runtime_ineligible means "no llama-server workloads on this agent."
+// no managed processes at all
+const SkipReasonEmpty = "empty"
+
+// safety floor: refused to evict the last managed process
+const SkipReasonFloor = "floor"
+
+// at least one llama-server process exists, but every one has
+// EvictionProtection=true so none are eligible
+const SkipReasonAllProtected = "all_protected"
+
+// every managed process is on a shared daemon (oMLX/Ollama) the agent
+// does not own at the OS level, so killing them via this code path would
+// have no effect on memory
+const SkipReasonRuntimeIneligible = "runtime_ineligible"
+
+// pickEvictionTarget returns the process that should be evicted first under
+// memory pressure, or (nil, reason) when nothing is eligible. Selection
+// rules, in order of precedence:
+//
+//  1. Safety floor: if there is at most one managed process total, return
+//     (nil, "floor"). Killing the last workload helps no one and would
+//     surprise a single-tenant operator who installed LLMKube to run one
+//     big model. The floor counts ALL managed processes (including
+//     protected and non-llama-server entries) on purpose so the rule is
+//     simple and predictable.
+//  2. Skip non-llama-server processes. oMLX and Ollama use shared daemons
 //     where the agent does not own the actual process lifecycle, so evicting
 //     them via this code path would have no effect on memory.
-//  2. Lowest InferenceService.Spec.Priority wins (batch < low < normal < high
-//     < critical). Reuses the existing Priority field; see priority.go for
-//     the rationale on conflating GPU-scheduling priority with eviction
+//  3. Skip processes with EvictionProtection=true so users can opt
+//     individual workloads out of eviction.
+//  4. Lowest InferenceService.Spec.Priority wins (batch < low < normal <
+//     high < critical). Reuses the existing Priority field; see priority.go
+//     for the rationale on conflating GPU-scheduling priority with eviction
 //     priority.
-//  3. Tie-break by largest RSS so we free the most memory per eviction.
-//  4. Final tie-break by oldest StartedAt so the choice is deterministic
+//  5. Tie-break by largest RSS so we free the most memory per eviction.
+//  6. Final tie-break by oldest StartedAt so the choice is deterministic
 //     across runs and the most recently started process gets the benefit of
 //     the doubt.
 //
-// Returns nil when no eligible candidate exists (empty or all-non-llama).
-// That is a hard guard against evicting our last running process and
-// producing a cascading eviction loop with nothing to gain.
-func pickEvictionTarget(processes map[string]*ManagedProcess, rss map[string]uint64) *ManagedProcess {
-	candidates := make([]*ManagedProcess, 0, len(processes))
+// Returns (nil, "all_protected") when every managed process is either
+// non-llama-server or has EvictionProtection=true. Returns (nil, "empty")
+// when the input map is empty or nil.
+func pickEvictionTarget(processes map[string]*ManagedProcess, rss map[string]uint64) (*ManagedProcess, string) {
+	if len(processes) == 0 {
+		return nil, SkipReasonEmpty
+	}
+	// Rule 1: safety floor. Counted on the FULL processes map (not on the
+	// filtered candidate set) so the rule is simple to reason about: "only
+	// one workload? leave it alone."
+	if len(processes) <= 1 {
+		return nil, SkipReasonFloor
+	}
+
+	// Two-pass filter so we can distinguish "no llama-server workloads"
+	// from "all workloads opted out": the first surfaces a runtime/config
+	// problem, the second surfaces a settings problem the operator can fix.
+	llamaServer := make([]*ManagedProcess, 0, len(processes))
 	for _, p := range processes {
 		if p == nil {
 			continue
 		}
-		// Rule 1: only llama-server processes are managed at the OS level.
+		// Rule 2: only llama-server processes are managed at the OS level.
 		// oMLX and Ollama set ModelID to a non-empty value because the agent
 		// uses model IDs (not PIDs) to unload them on the shared daemon.
-		if p.ModelID != "" {
+		if p.ModelID == "" {
+			llamaServer = append(llamaServer, p)
+		}
+	}
+	if len(llamaServer) == 0 {
+		return nil, SkipReasonRuntimeIneligible
+	}
+
+	candidates := make([]*ManagedProcess, 0, len(llamaServer))
+	for _, p := range llamaServer {
+		// Rule 3: respect per-workload opt-out.
+		if p.EvictionProtection {
 			continue
 		}
 		candidates = append(candidates, p)
 	}
 	if len(candidates) == 0 {
-		return nil
+		return nil, SkipReasonAllProtected
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
 		pi, pj := candidates[i], candidates[j]
-		// Rule 2: lower priority weight first.
+		// Rule 4: lower priority weight first.
 		wi, wj := priorityWeight(pi.Priority), priorityWeight(pj.Priority)
 		if wi != wj {
 			return wi < wj
 		}
-		// Rule 3: larger RSS first (we want to free more memory).
+		// Rule 5: larger RSS first (we want to free more memory).
 		ri := rss[managedProcessRSSKey(pi)]
 		rj := rss[managedProcessRSSKey(pj)]
 		if ri != rj {
 			return ri > rj
 		}
-		// Rule 4: oldest StartedAt first (deterministic tie-break).
+		// Rule 6: oldest StartedAt first (deterministic tie-break).
 		return pi.StartedAt.Before(pj.StartedAt)
 	})
 
-	return candidates[0]
+	return candidates[0], ""
 }
 
 // managedProcessRSSKey returns the key used to look up a process's RSS in the

--- a/pkg/agent/eviction_test.go
+++ b/pkg/agent/eviction_test.go
@@ -38,12 +38,15 @@ func TestPickEvictionTarget_LowestPriorityFirst(t *testing.T) {
 			StartedAt: time.Now(),
 		},
 	}
-	target := pickEvictionTarget(processes, nil)
+	target, reason := pickEvictionTarget(processes, nil)
 	if target == nil {
-		t.Fatal("pickEvictionTarget returned nil; expected svc-low")
+		t.Fatalf("pickEvictionTarget returned nil (reason=%q); expected svc-low", reason)
 	}
 	if target.Name != "svc-low" {
 		t.Errorf("evicted %q, want %q", target.Name, "svc-low")
+	}
+	if reason != "" {
+		t.Errorf("reason should be empty when target returned, got %q", reason)
 	}
 }
 
@@ -62,7 +65,7 @@ func TestPickEvictionTarget_TieBreakByRSS(t *testing.T) {
 		"small.gguf": 1 << 30,
 		"large.gguf": 10 << 30,
 	}
-	target := pickEvictionTarget(processes, rss)
+	target, _ := pickEvictionTarget(processes, rss)
 	if target == nil || target.Name != "large" {
 		t.Errorf("expected eviction of larger-RSS process %q, got %v", "large", target)
 	}
@@ -84,22 +87,119 @@ func TestPickEvictionTarget_TieBreakByStartedAt(t *testing.T) {
 	// Same priority, same RSS lookup key (both point at same basename → same RSS),
 	// so the tie-break should pick the older one.
 	rss := map[string]uint64{"m.gguf": 5 << 30}
-	target := pickEvictionTarget(processes, rss)
+	target, _ := pickEvictionTarget(processes, rss)
 	if target == nil || target.Name != "older" {
 		t.Errorf("expected eviction of older process, got %v", target)
 	}
 }
 
-func TestPickEvictionTarget_NoEligibleCandidates(t *testing.T) {
-	if got := pickEvictionTarget(nil, nil); got != nil {
-		t.Errorf("nil map should return nil, got %v", got)
+func TestPickEvictionTarget_NilAndEmptyMaps(t *testing.T) {
+	if got, reason := pickEvictionTarget(nil, nil); got != nil || reason != SkipReasonEmpty {
+		t.Errorf("nil map should return (nil, %q), got (%v, %q)", SkipReasonEmpty, got, reason)
 	}
-	if got := pickEvictionTarget(map[string]*ManagedProcess{}, nil); got != nil {
-		t.Errorf("empty map should return nil, got %v", got)
+	if got, reason := pickEvictionTarget(map[string]*ManagedProcess{}, nil); got != nil || reason != SkipReasonEmpty {
+		t.Errorf("empty map should return (nil, %q), got (%v, %q)", SkipReasonEmpty, got, reason)
 	}
 }
 
-func TestPickEvictionTarget_SkipsNonLlamaServerProcesses(t *testing.T) {
+// TestPickEvictionTarget_FloorReturnsNilForLastProcess locks down the PR-2B
+// safety net for single-tenant setups. With exactly one managed process,
+// the selector refuses to evict regardless of priority — killing the only
+// workload is never an improvement over leaving it alone.
+func TestPickEvictionTarget_FloorReturnsNilForLastProcess(t *testing.T) {
+	processes := map[string]*ManagedProcess{
+		"default/only": {
+			Name: "only-svc", Namespace: "default", Priority: "batch",
+			ModelPath: "/models/only.gguf", StartedAt: time.Now(),
+		},
+	}
+	got, reason := pickEvictionTarget(processes, nil)
+	if got != nil {
+		t.Errorf("floor must refuse to evict the last managed process, got %v", got)
+	}
+	if reason != SkipReasonFloor {
+		t.Errorf("reason = %q, want %q", reason, SkipReasonFloor)
+	}
+}
+
+// TestPickEvictionTarget_FloorAllowsEvictionAtTwoUnprotected is the regression
+// guard for the floor's exact semantics: counts the FULL processes map,
+// not the candidate set. Two unprotected processes are both eligible, and
+// the lower-priority one gets evicted as before.
+func TestPickEvictionTarget_FloorAllowsEvictionAtTwoUnprotected(t *testing.T) {
+	processes := map[string]*ManagedProcess{
+		"default/svc-low": {
+			Name: "svc-low", Namespace: "default", Priority: "low",
+			ModelPath: "/models/low.gguf", StartedAt: time.Now(),
+		},
+		"default/svc-high": {
+			Name: "svc-high", Namespace: "default", Priority: "high",
+			ModelPath: "/models/high.gguf", StartedAt: time.Now(),
+		},
+	}
+	target, reason := pickEvictionTarget(processes, nil)
+	if target == nil {
+		t.Fatalf("floor must permit eviction at len=2 (reason=%q)", reason)
+	}
+	if target.Name != "svc-low" {
+		t.Errorf("evicted %q, want %q", target.Name, "svc-low")
+	}
+}
+
+// TestPickEvictionTarget_SkipsProtectedFromCandidates locks down the
+// per-workload opt-out: a single unprotected process alongside a protected
+// one is the only eviction target, even if the protected one has lower
+// priority. (Two managed processes total → floor permits eviction.)
+func TestPickEvictionTarget_SkipsProtectedFromCandidates(t *testing.T) {
+	processes := map[string]*ManagedProcess{
+		"default/protected-low": {
+			Name: "protected-low", Namespace: "default", Priority: "batch",
+			ModelPath: "/models/p.gguf", StartedAt: time.Now(),
+			EvictionProtection: true,
+		},
+		"default/unprotected-high": {
+			Name: "unprotected-high", Namespace: "default", Priority: "high",
+			ModelPath: "/models/u.gguf", StartedAt: time.Now(),
+		},
+	}
+	target, _ := pickEvictionTarget(processes, nil)
+	if target == nil || target.Name != "unprotected-high" {
+		t.Errorf("expected eviction of the only unprotected process, got %v", target)
+	}
+}
+
+// TestPickEvictionTarget_AllProtectedReturnsAllProtectedReason verifies
+// that when every llama-server-eligible process is opted out, the selector
+// returns nil with a reason operators can act on (review their
+// evictionProtection settings). Floor passes (len=2), so this is purely
+// the protected-set check.
+func TestPickEvictionTarget_AllProtectedReturnsAllProtectedReason(t *testing.T) {
+	processes := map[string]*ManagedProcess{
+		"default/p1": {
+			Name: "p1", Namespace: "default", Priority: "low",
+			ModelPath: "/models/a.gguf", StartedAt: time.Now(),
+			EvictionProtection: true,
+		},
+		"default/p2": {
+			Name: "p2", Namespace: "default", Priority: "low",
+			ModelPath: "/models/b.gguf", StartedAt: time.Now(),
+			EvictionProtection: true,
+		},
+	}
+	got, reason := pickEvictionTarget(processes, nil)
+	if got != nil {
+		t.Errorf("all-protected must return nil, got %v", got)
+	}
+	if reason != SkipReasonAllProtected {
+		t.Errorf("reason = %q, want %q", reason, SkipReasonAllProtected)
+	}
+}
+
+// TestPickEvictionTarget_AllRuntimeIneligibleReturnsRuntimeReason is the
+// pre-existing oMLX/Ollama path. Reason renamed from the implicit catch-all
+// to runtime_ineligible so operators see "no llama-server workloads to
+// evict here" rather than thinking they have a protection-config issue.
+func TestPickEvictionTarget_AllRuntimeIneligibleReturnsRuntimeReason(t *testing.T) {
 	processes := map[string]*ManagedProcess{
 		"default/ollama-only": {
 			Name: "ollama-model", Namespace: "default", Priority: "low",
@@ -112,8 +212,12 @@ func TestPickEvictionTarget_SkipsNonLlamaServerProcesses(t *testing.T) {
 			ModelID: "mlx-community/Qwen3-4B-4bit", StartedAt: time.Now(),
 		},
 	}
-	if got := pickEvictionTarget(processes, nil); got != nil {
-		t.Errorf("non-llama-server processes (ModelID set) must be skipped, got %v", got)
+	got, reason := pickEvictionTarget(processes, nil)
+	if got != nil {
+		t.Errorf("non-llama-server processes must be skipped, got %v", got)
+	}
+	if reason != SkipReasonRuntimeIneligible {
+		t.Errorf("reason = %q, want %q", reason, SkipReasonRuntimeIneligible)
 	}
 }
 
@@ -131,7 +235,7 @@ func TestPickEvictionTarget_UnknownPriorityTreatedAsNormal(t *testing.T) {
 	// A garbage value is treated as "normal", same priority as "normal",
 	// so the tie-break (larger RSS, then older) picks "normal" because it
 	// started earlier.
-	target := pickEvictionTarget(processes, nil)
+	target, _ := pickEvictionTarget(processes, nil)
 	if target == nil {
 		t.Fatal("expected one of the two candidates")
 	}

--- a/pkg/agent/pressure.go
+++ b/pkg/agent/pressure.go
@@ -53,12 +53,15 @@ const (
 //  2. If pressure dropped to Normal, clear pressureBlocked so the next
 //     ensureProcess can respawn previously evicted services.
 //  3. Update the MemoryPressure condition on every managed
-//     InferenceService so operators can see current pressure even on
-//     non-evicted workloads.
+//     InferenceService that has not already been observed at this level
+//     (covers level transitions and late-spawned processes during
+//     sustained pressure).
 //  4. If the level is Critical AND the friendly-fire guard says we're
 //     responsible for the pressure (shouldEvict), pick one process to
 //     evict, mark it blocked, and stop it. Only one eviction per watchdog
-//     tick to avoid stampedes.
+//     tick to avoid stampedes. Skip-without-evict outcomes are recorded
+//     in the evictions_skipped_total counter so operators can debug why
+//     no eviction happened.
 func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPressureLevel, stats MemoryStats) {
 	// Snapshot the candidate set under the lock. The values themselves are
 	// pointers; we don't mutate them here, so a shallow copy is fine.
@@ -70,35 +73,67 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 			"unblocked", len(a.pressureBlocked))
 		a.pressureBlocked = make(map[string]bool)
 	}
+	// Reset observed-at-level when the level changes so each new level
+	// triggers a fresh round of condition patches.
+	if level != previous {
+		a.pressureObserved = make(map[string]MemoryPressureLevel, len(a.processes))
+	}
 	snapshot := make(map[string]*ManagedProcess, len(a.processes))
 	for k, p := range a.processes {
 		snapshot[k] = p
 	}
+	// Determine which keys still need a condition patch at this level.
+	// New keys (added since the last tick) and unchanged keys at a new
+	// level both fall through; already-observed keys are skipped to keep
+	// the status churn quiet under sustained pressure.
+	needsPatch := make(map[string]*ManagedProcess, len(snapshot))
+	for k, p := range snapshot {
+		if a.pressureObserved[k] != level {
+			needsPatch[k] = p
+		}
+	}
 	a.mu.Unlock()
 
-	// Update conditions on every managed service so the user sees pressure
-	// even before any eviction fires. Only emit on transitions to keep the
-	// status churn quiet for steady-state pressure.
-	if level != previous {
+	if len(needsPatch) > 0 {
 		msg := "watchdog reported " + level.String() + " memory pressure"
-		for key, p := range snapshot {
+		for key, p := range needsPatch {
 			if err := a.updateMemoryPressureCondition(ctx, p, level, msg); err != nil {
 				a.logger.Warnw("failed to update MemoryPressure condition",
 					"key", key, "level", level.String(), "error", err)
+				continue
 			}
+			a.mu.Lock()
+			a.pressureObserved[key] = level
+			a.mu.Unlock()
 		}
 	}
 
 	// Eviction path. Honored via the --eviction-enabled CLI flag (default
 	// false) so that operators must explicitly opt in to having the
 	// watchdog stop inference processes.
-	if !shouldEvict(level, stats, a.config.EvictionEnabled) {
+	if !a.config.EvictionEnabled {
+		// Only count this when the watchdog would otherwise have fired
+		// eviction (Critical level). Otherwise we'd inflate the counter
+		// every Warning tick and obscure the signal operators care about.
+		if level == MemoryPressureCritical {
+			evictionsSkippedTotal.WithLabelValues("disabled").Inc()
+		}
 		return
 	}
-	target := pickEvictionTarget(snapshot, stats.ProcessRSS)
+	if !shouldEvict(level, stats, a.config.EvictionEnabled) {
+		// Either not Critical or below the 50% RSS friendly-fire guard.
+		// Only the Critical+below-guard case is interesting; non-Critical
+		// is the watchdog's normal observation, not a refusal.
+		if level == MemoryPressureCritical {
+			evictionsSkippedTotal.WithLabelValues("below_guard").Inc()
+		}
+		return
+	}
+	target, skipReason := pickEvictionTarget(snapshot, stats.ProcessRSS)
 	if target == nil {
+		evictionsSkippedTotal.WithLabelValues(skipReason).Inc()
 		a.logger.Warnw("memory critical but no eligible eviction target found",
-			"managed", len(snapshot))
+			"managed", len(snapshot), "reason", skipReason)
 		return
 	}
 

--- a/pkg/agent/pressure_test.go
+++ b/pkg/agent/pressure_test.go
@@ -21,11 +21,13 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -241,6 +243,216 @@ func TestEnsureProcess_BlockedUnderCriticalSkipsRespawn(t *testing.T) {
 	if _, exists := a.processes["default/svc-a"]; exists {
 		t.Error("ensureProcess respawned despite pressureBlocked guard")
 	}
+}
+
+// TestHandleMemoryPressure_PatchesConditionForLateSpawnedProcess locks down
+// the PR-2B fix for the gap PR-2A had: a process that spawns AFTER a level
+// transition would not get a MemoryPressure condition until the next
+// transition. Now the handler patches any key not yet observed at the
+// current level, so a late-arrival sees the condition on the very next
+// watchdog tick.
+func TestHandleMemoryPressure_PatchesConditionForLateSpawnedProcess(t *testing.T) {
+	earlyISvc := newPressureTestISvc("svc-early", "normal")
+	lateISvc := newPressureTestISvc("svc-late", "normal")
+	a := newPressureTestAgent(t, earlyISvc, lateISvc)
+
+	// Simulate the agent has already observed svc-early at Critical (the
+	// transition tick fired before svc-late spawned).
+	a.processes["default/svc-early"] = &ManagedProcess{
+		Name: "svc-early", Namespace: "default", ModelPath: "/m.gguf",
+		Priority: "normal", StartedAt: time.Now(),
+	}
+	a.lastPressureLevel = MemoryPressureCritical
+	a.pressureObserved["default/svc-early"] = MemoryPressureCritical
+
+	// Now svc-late spawns mid-pressure, then the watchdog ticks again at
+	// the same level (no transition).
+	a.processes["default/svc-late"] = &ManagedProcess{
+		Name: "svc-late", Namespace: "default", ModelPath: "/m.gguf",
+		Priority: "normal", StartedAt: time.Now(),
+	}
+	a.handleMemoryPressure(context.Background(), MemoryPressureCritical, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 25 << 30,
+	})
+
+	got := &inferencev1alpha1.InferenceService{}
+	if err := a.config.K8sClient.Get(context.Background(),
+		types.NamespacedName{Namespace: "default", Name: "svc-late"}, got); err != nil {
+		t.Fatalf("get svc-late: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, ConditionMemoryPressure)
+	if cond == nil {
+		t.Fatal("late-spawned process must receive a MemoryPressure condition on the next tick")
+	}
+	if cond.Reason != ReasonMemoryCritical {
+		t.Errorf("condition reason = %q, want %q", cond.Reason, ReasonMemoryCritical)
+	}
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.pressureObserved["default/svc-late"] != MemoryPressureCritical {
+		t.Error("svc-late must be marked observed at Critical after the patch")
+	}
+}
+
+// countingClient wraps the fake client to track how many Status().Update
+// calls land on the apiserver. We use it to verify that the
+// already-observed short-circuit prevents redundant patches.
+type countingStatusClient struct {
+	client.Client
+	updates *int
+}
+
+func (c countingStatusClient) Status() client.SubResourceWriter {
+	return countingStatusWriter{SubResourceWriter: c.Client.Status(), updates: c.updates}
+}
+
+type countingStatusWriter struct {
+	client.SubResourceWriter
+	updates *int
+}
+
+func (w countingStatusWriter) Update(
+	ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption,
+) error {
+	*w.updates++
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}
+
+// TestHandleMemoryPressure_DoesNotRePatchAlreadyObserved verifies the
+// other side of the late-spawn fix: a key that has been observed at the
+// current level must not generate another Status().Update on subsequent
+// ticks at the same level. Without this, sustained Critical pressure would
+// thrash the apiserver every tick.
+func TestHandleMemoryPressure_DoesNotRePatchAlreadyObserved(t *testing.T) {
+	isvc := newPressureTestISvc("svc-a", "normal")
+	a := newPressureTestAgent(t, isvc)
+	updates := 0
+	a.config.K8sClient = countingStatusClient{Client: a.config.K8sClient, updates: &updates}
+
+	a.processes["default/svc-a"] = &ManagedProcess{
+		Name: "svc-a", Namespace: "default", ModelPath: "/m.gguf",
+		Priority: "normal", StartedAt: time.Now(),
+	}
+
+	stats := MemoryStats{TotalMemory: 100 << 30, TotalRSS: 25 << 30}
+	a.handleMemoryPressure(context.Background(), MemoryPressureCritical, stats)
+	if updates != 1 {
+		t.Errorf("first tick at Critical should patch once, got %d", updates)
+	}
+	a.handleMemoryPressure(context.Background(), MemoryPressureCritical, stats)
+	if updates != 1 {
+		t.Errorf("second tick at same Critical level must not re-patch, got %d total updates", updates)
+	}
+}
+
+// TestHandleMemoryPressure_IncrementsSkippedCounter is the table-driven
+// regression guard for the new evictions_skipped_total metric. Each
+// scenario forces a different skip path and asserts the labelled counter
+// ticks exactly once.
+func TestHandleMemoryPressure_IncrementsSkippedCounter(t *testing.T) {
+	tests := []struct {
+		name           string
+		evictionEnable bool
+		level          MemoryPressureLevel
+		processes      func(*MetalAgent)
+		stats          MemoryStats
+		wantReason     string
+	}{
+		{
+			name:           "disabled at critical",
+			evictionEnable: false,
+			level:          MemoryPressureCritical,
+			processes: func(a *MetalAgent) {
+				a.processes["default/svc-a"] = &ManagedProcess{
+					Name: "svc-a", Namespace: "default", ModelPath: "/m.gguf",
+					Priority: "low", StartedAt: time.Now(),
+				}
+			},
+			stats:      MemoryStats{TotalMemory: 100 << 30, TotalRSS: 80 << 30},
+			wantReason: "disabled",
+		},
+		{
+			name:           "enabled but below guard at critical",
+			evictionEnable: true,
+			level:          MemoryPressureCritical,
+			processes: func(a *MetalAgent) {
+				a.processes["default/svc-a"] = &ManagedProcess{
+					Name: "svc-a", Namespace: "default", ModelPath: "/m.gguf",
+					Priority: "low", StartedAt: time.Now(),
+				}
+				a.processes["default/svc-b"] = &ManagedProcess{
+					Name: "svc-b", Namespace: "default", ModelPath: "/m.gguf",
+					Priority: "low", StartedAt: time.Now(),
+				}
+			},
+			stats:      MemoryStats{TotalMemory: 100 << 30, TotalRSS: 30 << 30},
+			wantReason: "below_guard",
+		},
+		{
+			name:           "floor with one process",
+			evictionEnable: true,
+			level:          MemoryPressureCritical,
+			processes: func(a *MetalAgent) {
+				a.processes["default/svc-only"] = &ManagedProcess{
+					Name: "svc-only", Namespace: "default", ModelPath: "/m.gguf",
+					Priority: "low", StartedAt: time.Now(),
+				}
+			},
+			stats:      MemoryStats{TotalMemory: 100 << 30, TotalRSS: 80 << 30},
+			wantReason: SkipReasonFloor,
+		},
+		{
+			name:           "all protected",
+			evictionEnable: true,
+			level:          MemoryPressureCritical,
+			processes: func(a *MetalAgent) {
+				a.processes["default/p1"] = &ManagedProcess{
+					Name: "p1", Namespace: "default", ModelPath: "/m.gguf",
+					Priority: "low", StartedAt: time.Now(),
+					EvictionProtection: true,
+				}
+				a.processes["default/p2"] = &ManagedProcess{
+					Name: "p2", Namespace: "default", ModelPath: "/m.gguf",
+					Priority: "low", StartedAt: time.Now(),
+					EvictionProtection: true,
+				}
+			},
+			stats:      MemoryStats{TotalMemory: 100 << 30, TotalRSS: 80 << 30},
+			wantReason: SkipReasonAllProtected,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newPressureTestAgent(t)
+			a.config.EvictionEnabled = tc.evictionEnable
+			a.executor = stubExecutor{}
+			a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+			tc.processes(a)
+
+			before := readSkippedCounter(t, tc.wantReason)
+			a.handleMemoryPressure(context.Background(), tc.level, tc.stats)
+			after := readSkippedCounter(t, tc.wantReason)
+
+			if got := after - before; got != 1 {
+				t.Errorf("evictions_skipped_total{reason=%q} delta = %v, want 1", tc.wantReason, got)
+			}
+		})
+	}
+}
+
+// readSkippedCounter pulls the current value of evictions_skipped_total
+// for a given reason label out of the shared Prometheus registry. Skipped
+// counters survive across tests in this package because the registry is a
+// process-global; tests measure deltas instead of absolute values.
+func readSkippedCounter(t *testing.T, reason string) float64 {
+	t.Helper()
+	m := &dto.Metric{}
+	if err := evictionsSkippedTotal.WithLabelValues(reason).Write(m); err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	return m.GetCounter().GetValue()
 }
 
 // TestHandleMemoryPressure_NormalClearsBlockedSet verifies that when pressure


### PR DESCRIPTION
Follow-up to PR-2A (#382). Closes #383 and the visibility gap on-cluster smoke testing surfaced.

## What ships

**Safety floor** — `pickEvictionTarget` refuses to evict when only one managed process exists. The friendly-fire 50% RSS guard does not protect single-tenant operators (a 70 GB model on a 128 GB Mac satisfies the guard); the floor makes that case safe by construction. Counts the FULL processes map, not the candidate set, so the rule is simple: **one workload, leave it alone.**

**Per-workload opt-out** — new `InferenceService.Spec.EvictionProtection *bool` CRD field. Protected processes are excluded from the eviction-candidate set but still receive the `MemoryPressure` status condition for operator visibility. Captured onto `ManagedProcess` at spawn, mirroring `Priority`.

**Late-spawn condition fix** — PR-2A only patched conditions on level transitions, so a process that spawned AFTER a transition would not get a condition until the next transition. Added `pressureObserved map[string]MemoryPressureLevel` so `handleMemoryPressure` patches any key not yet observed at the current level. Already-observed keys short-circuit so sustained pressure does not thrash the apiserver.

**Eviction-skipped metric** — new `llmkube_metal_agent_evictions_skipped_total{reason}` counter with labels `disabled` / `below_guard` / `floor` / `all_protected` / `runtime_ineligible`. Lets operators answer \"watchdog went Critical and nothing was evicted, why?\" without trawling logs. Increments only at Critical level so non-Critical observations do not pollute it.

## API change

`pickEvictionTarget` now returns `(*ManagedProcess, string)` — second return is the skip reason (empty when a target was returned). Internal API only; no consumer outside `pkg/agent`.

## Test plan

- [x] 9 selector tests including new floor / protection / skip-reason coverage
- [x] 8 pressure-handler tests including late-spawn patch, no-repatch on sustained pressure, and table-driven skip-counter increments for all 4 actionable reasons
- [x] `go test ./pkg/agent/... -count=1` passes (25 tests total)
- [x] `golangci-lint run ./pkg/agent/... ./api/...` clean for code introduced here (preexisting `health.go:213` G118 and `agent_test.go:639` `q8_0` goconst stay; not ours)
- [x] `make generate manifests chart-crds` produces the included CRD diff with no extra noise; `crd-sync-check` will pass
- [x] **Smoke on kind cluster** with three llama-server processes (one with `evictionProtection: true`) plus a fourth applied mid-Critical pressure:
  - All three got `MemoryPressure=True reason=Critical` conditions including the protected one
  - The fourth (late-spawn) got the condition on the **next watchdog tick**, no transition required
  - `evictions_skipped_total{reason=\"below_guard\"}` incremented per Critical tick (RSS 2.4 GB / 128 GB system = 1.9% — guard correctly held)
  - Logs show `\"reason\":\"below_guard\"` on each Critical tick

## Out of scope, deferred

- K8s event emission (the agent has no `EventRecorder`; would require `record.NewBroadcaster` setup since the agent is not controller-runtime-based). The condition + counter give operators the same signal in a less invasive way.
- Documenting the failure mode in the metal-agent docs.
- Smarter friendly-fire heuristics.

Closes #383.