### PR TITLE
fix(controller): drop model label from Deployment selector to make modelRef mutable (closes #301)

### DIFF
--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -72,6 +72,25 @@ func inferContainerSecurityContext(isvc *inferencev1alpha1.InferenceService) *co
 	}
 }
 
+// deploymentSelectorLabels returns the immutable subset of operator-managed
+// labels used for Deployment.Spec.Selector.MatchLabels. Kubernetes treats
+// the selector as immutable after creation, so any label that can change
+// over the InferenceService's lifetime (notably model.Name when the user
+// edits spec.modelRef) must NOT appear here. The model label still ships
+// on the Pod template + Deployment metadata for kubectl filtering; only
+// the selector is restricted.
+//
+// See #301 for the silent-update bug this avoids: putting modelRef into
+// the selector made the field effectively immutable, with no error
+// surfaced to the user, just an apiserver "field is immutable" error
+// looping in the controller logs.
+func deploymentSelectorLabels(isvc *inferencev1alpha1.InferenceService) map[string]string {
+	return map[string]string{
+		"app":                           isvc.Name,
+		"inference.llmkube.dev/service": isvc.Name,
+	}
+}
+
 // mergePodLabels combines operator-managed labels with the user's
 // spec.podLabels for use on the Pod template metadata. Operator-managed keys
 // always win on collision so the Deployment selector (which uses the
@@ -223,7 +242,10 @@ func (r *InferenceServiceReconciler) constructDeployment(
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				// Selector uses the immutable subset only; the model label
+				// is allowed to change when the user edits spec.modelRef
+				// and must not be matched on. See #301.
+				MatchLabels: deploymentSelectorLabels(isvc),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -4280,6 +4280,74 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			By("verifying selector matches pod labels")
 			Expect(deployment.Spec.Selector.MatchLabels["app"]).To(Equal("label-svc"))
 		})
+
+		// Regression for #301: putting modelRef into the Deployment selector
+		// made spec.modelRef silently immutable. Kubernetes rejects selector
+		// changes after creation, so a user patching modelRef saw "the CR
+		// updates but my pod never rolls" with no surfaced error. The fix
+		// drops inference.llmkube.dev/model from selector.matchLabels while
+		// keeping it on the Deployment metadata + Pod template (kubectl
+		// label filtering still works). These tests lock in the new shape.
+		It("must not include inference.llmkube.dev/model in the Deployment selector (#301)", func() {
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "label-model", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "hf://meta-llama/Llama-3-8B",
+					Format:   "gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cuda"},
+				},
+			}
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "label-svc", Namespace: "default"},
+				Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "label-model"},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 1)
+
+			selector := deployment.Spec.Selector.MatchLabels
+			Expect(selector).NotTo(HaveKey("inference.llmkube.dev/model"),
+				"selector must not match on the model label; modelRef must remain mutable")
+			Expect(selector).To(HaveKeyWithValue("app", "label-svc"))
+			Expect(selector).To(HaveKeyWithValue("inference.llmkube.dev/service", "label-svc"))
+		})
+
+		It("changing modelRef must produce a Deployment whose selector still matches the previous one (#301)", func() {
+			before := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "model-q4", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "hf://org/repo-q4",
+					Format:   "gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cuda"},
+				},
+			}
+			after := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "model-q5", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "hf://org/repo-q5",
+					Format:   "gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cuda"},
+				},
+			}
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "swap-svc", Namespace: "default"},
+				Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "model-q4"},
+			}
+
+			deploymentBefore := reconciler.constructDeployment(isvc, before, 1)
+
+			// User edits spec.modelRef to swap quantizations.
+			isvc.Spec.ModelRef = "model-q5"
+			deploymentAfter := reconciler.constructDeployment(isvc, after, 1)
+
+			// The selector must be byte-identical so an apiserver Update on
+			// the Deployment does not trip the "field is immutable" check.
+			Expect(deploymentAfter.Spec.Selector.MatchLabels).To(Equal(deploymentBefore.Spec.Selector.MatchLabels))
+
+			// And the new model label must be on the Pod template so
+			// kubectl get pods -l inference.llmkube.dev/model=model-q5 still works.
+			Expect(deploymentAfter.Spec.Template.Labels).To(
+				HaveKeyWithValue("inference.llmkube.dev/model", "model-q5"))
+		})
 	})
 })
 


### PR DESCRIPTION
Closes #301.

## Bug

`Deployment.Spec.Selector.MatchLabels` included `inference.llmkube.dev/model: <modelRef-value>`. Kubernetes treats Deployment selectors as immutable after creation, so editing `spec.modelRef` on a running InferenceService:

1. Accepted the CR change (kubectl returned success)
2. Every subsequent reconcile failed at the apiserver with \`field is immutable\`
3. The Pod kept running the old model with **no error surfaced to the user** (the failures only showed up in controller logs)

This blocked common workflows like swapping a quant level or rolling to a different upstream fork.

## Fix

Split the label set:

- **`deploymentSelectorLabels`** (new helper): `app` + `inference.llmkube.dev/service`. Both are derived from `isvc.Name` and never change over the InferenceService's lifetime, so the selector is byte-stable across reconciles and the apiserver \`Update\` succeeds.
- **Full label map** (including the model label) still ships on `Deployment.ObjectMeta.Labels` and Pod template labels, so \`kubectl get pods -l inference.llmkube.dev/model=<name>\` keeps working as a filter.

When the user now edits `modelRef`, the selector stays identical, the controller updates the Pod template (new model label, new init container args, new model path), and Kubernetes does a standard rolling update.

## Test plan

- [x] Two regression tests in \`inferenceservice_deployment_test.go\`:
  - selector must NOT contain \`inference.llmkube.dev/model\`
  - swapping \`modelRef\` on the same InferenceService produces Deployments whose selectors are deeply equal (this IS the apiserver immutability constraint, asserted at the source)
- [x] \`go test ./internal/controller/... -count=1\` passes
- [x] \`golangci-lint run ./internal/controller/...\` clean (0 issues)
- [x] No CRD changes; no chart changes
