### PR TITLE
fix(catalog): default phi-4-mini context to 8K (closes #386)

### DIFF
--- a/catalog/catalog.yaml
+++ b/catalog/catalog.yaml
@@ -41,7 +41,12 @@ models:
     size: "3.8B"
     quantization: "Q5_K_M"
     source: "https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF/resolve/main/microsoft_Phi-4-mini-instruct-Q5_K_M.gguf"
-    context_size: 128000
+    # Default context kept at 8192 even though Phi-4 supports 128K. Reason:
+    # the KV cache for 128K context on a 3.8B model exceeds the catalog's
+    # recommended 4Gi memory request, OOMing on first deploy. Users who need
+    # the full 128K can override via spec.contextSize on InferenceService or
+    # --context on the CLI. See #386.
+    context_size: 8192
     gpu_layers: 32
     use_cases:
       - "reasoning"

--- a/pkg/cli/catalog.yaml
+++ b/pkg/cli/catalog.yaml
@@ -41,7 +41,12 @@ models:
     size: "3.8B"
     quantization: "Q5_K_M"
     source: "https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF/resolve/main/microsoft_Phi-4-mini-instruct-Q5_K_M.gguf"
-    context_size: 128000
+    # Default context kept at 8192 even though Phi-4 supports 128K. Reason:
+    # the KV cache for 128K context on a 3.8B model exceeds the catalog's
+    # recommended 4Gi memory request, OOMing on first deploy. Users who need
+    # the full 128K can override via spec.contextSize on InferenceService or
+    # --context on the CLI. See #386.
+    context_size: 8192
     gpu_layers: 32
     use_cases:
       - "reasoning"


### PR DESCRIPTION
Closes #386.

## The bug

\`catalog/catalog.yaml\` shipped \`phi-4-mini\` with \`context_size: 128000\` paired with a \`memory: 4Gi\` request. KV cache for 128K context on a 3.8B model exceeds 4Gi during model load. Pod lands in \`CrashLoopBackOff\` with repeated \`SystemOOM\` events.

This is the first model the quickstart docs recommend deploying. A copy-paste \`llmkube deploy phi-4-mini\` from the catalog defaults breaks on minute one of a new user's session. HN-killer for the launch window.

## The fix

Drop the catalog default to \`context_size: 8192\`. Phi-4 still supports 128K when users explicitly set \`spec.contextSize\` on InferenceService or pass \`--context 128000\` on the CLI. Other catalog small-models (3B–7B class) already default to 8192–32768; phi-4-mini was the outlier.

## Test plan

- [x] \`llmkube catalog info phi-4-mini\` reports \`Context Size: 8,192 tokens\`
- [x] \`llmkube deploy phi-4-mini\` on a fresh kind cluster reaches Ready in 13s (verified locally)
- [x] OpenAI-compatible API request returns 200 OK after deploy
- [x] \`go test ./pkg/cli/... -run Catalog\` passes
- [x] \`go vet\` clean

## Note on the duplicate catalog files

This repo currently maintains two copies of \`catalog.yaml\`: one at the repo root (\`catalog/catalog.yaml\`) and one embedded into the CLI binary (\`pkg/cli/catalog.yaml\` via \`go:embed\`). Both are updated in this PR so the next binary build picks up the fix.

The duplication is asking for drift. Worth a follow-up issue to consolidate to a single source of truth (probably \`catalog/catalog.yaml\` as canonical with a build-time copy / symlink to \`pkg/cli/\`). Out of scope for this PR.