### PR TITLE
feat(agent): vllm-swift runtime + TurboQuant passthrough (#391)

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -52,6 +52,7 @@ type AgentConfig struct {
 	OMLXBin                   string
 	OMLXPort                  int
 	OllamaPort                int
+	VLLMSwiftBin              string
 	Port                      int
 	LogLevel                  string
 	HostIP                    string
@@ -63,6 +64,7 @@ type AgentConfig struct {
 	MaxWatchFailures          int
 	LlamaServerStartupTimeout time.Duration
 	OMLXStartupTimeout        time.Duration
+	VLLMSwiftStartupTimeout   time.Duration
 	ApplePowerEnabled         bool
 	ApplePowerInterval        time.Duration
 	PowermetricsBin           string
@@ -124,6 +126,30 @@ var defaultOMLXPaths = []string{
 	"/usr/local/bin/omlx",
 }
 
+// defaultVLLMSwiftPaths is the list of paths to search for the vllm-swift binary.
+var defaultVLLMSwiftPaths = []string{
+	"/opt/homebrew/bin/vllm-swift",
+	"/usr/local/bin/vllm-swift",
+}
+
+// resolveVLLMSwiftBin returns the vllm-swift binary path. If override is
+// non-empty it is returned as-is. Otherwise the function searches
+// defaultVLLMSwiftPaths.
+func resolveVLLMSwiftBin(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	for _, p := range defaultVLLMSwiftPaths {
+		if _, err := statFunc(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"vllm-swift binary not found in default paths (%v); "+
+			"install with: brew tap TheTom/tap && brew install vllm-swift, or pass --vllm-swift-bin=/path/to/binary",
+		defaultVLLMSwiftPaths)
+}
+
 // resolveOMLXBin returns the omlx binary path. If override is non-empty it is
 // returned as-is. Otherwise the function searches defaultOMLXPaths.
 func resolveOMLXBin(override string) (string, error) {
@@ -149,10 +175,11 @@ func main() {
 	flag.StringVar(&cfg.Namespace, "namespace", "default", "Kubernetes namespace to watch")
 	flag.StringVar(&cfg.ModelStorePath, "model-store", "/tmp/llmkube-models", "Path to store downloaded models")
 	flag.StringVar(&llamaServerFlag, "llama-server", "", "Path to llama-server binary (auto-detected if not set)")
-	flag.StringVar(&cfg.Runtime, "runtime", "llama-server", "Inference runtime: llama-server, omlx, or ollama")
+	flag.StringVar(&cfg.Runtime, "runtime", "llama-server", "Inference runtime: llama-server, omlx, ollama, or vllm-swift")
 	flag.StringVar(&cfg.OMLXBin, "omlx-bin", "", "Path to omlx binary (auto-detected if not set)")
 	flag.IntVar(&cfg.OMLXPort, "omlx-port", 8000, "Port for oMLX server")
 	flag.IntVar(&cfg.OllamaPort, "ollama-port", 11434, "Port for Ollama server")
+	flag.StringVar(&cfg.VLLMSwiftBin, "vllm-swift-bin", "", "Path to vllm-swift binary (auto-detected if not set)")
 	flag.IntVar(&cfg.Port, "port", 9090, "Agent metrics/health port")
 	flag.StringVar(&cfg.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	flag.StringVar(&cfg.HostIP, "host-ip", "", "IP address to register in Kubernetes endpoints (auto-detected if empty)")
@@ -177,6 +204,11 @@ func main() {
 		agent.DefaultOMLXStartupTimeout,
 		"How long to wait for the oMLX daemon to become healthy after launching it. "+
 			"First model loads on M-series take 30-90s; default 120s.")
+	flag.DurationVar(&cfg.VLLMSwiftStartupTimeout, "vllm-swift-startup-timeout",
+		agent.DefaultVLLMSwiftStartupTimeout,
+		"How long to wait for vllm-swift to respond on /health. vLLM init plus "+
+			"Swift bridge load plus weight load grow with model size; default 120s "+
+			"works for 30B-class models on M5 Max. Bump for larger models.")
 	flag.BoolVar(&cfg.ApplePowerEnabled, "apple-power-enabled", false,
 		"Enable the macOS powermetrics sampler that publishes apple_power_*_watts gauges "+
 			"for InferCost. Requires a NOPASSWD sudoers entry for /usr/bin/powermetrics; "+
@@ -226,6 +258,17 @@ func main() {
 		// Ollama manages itself — no binary resolution needed.
 		// The agent will check if Ollama is running at startup via health check.
 		logger.Infow("using Ollama runtime", "port", cfg.OllamaPort)
+	case "vllm-swift":
+		resolvedBin, err := resolveVLLMSwiftBin(cfg.VLLMSwiftBin)
+		if err != nil {
+			logger.Errorw("vllm-swift binary not found",
+				"searchPaths", defaultVLLMSwiftPaths,
+				"installHint", "brew tap TheTom/tap && brew install vllm-swift",
+				"error", err,
+			)
+			os.Exit(1)
+		}
+		cfg.VLLMSwiftBin = resolvedBin
 	default:
 		cfg.Runtime = "llama-server"
 		resolvedBin, err := resolveLlamaServerBin(llamaServerFlag)
@@ -251,6 +294,7 @@ func main() {
 		"runtime", cfg.Runtime,
 		"llamaServerBin", cfg.LlamaServerBin,
 		"omlxBin", cfg.OMLXBin,
+		"vllmSwiftBin", cfg.VLLMSwiftBin,
 		"agentPort", cfg.Port,
 		"hostIP", hostIP,
 		"logLevel", cfg.LogLevel,
@@ -281,6 +325,8 @@ func main() {
 		logger.Infow("omlx binary found", "path", cfg.OMLXBin)
 	case "ollama":
 		logger.Infow("using Ollama daemon", "port", cfg.OllamaPort)
+	case "vllm-swift":
+		logger.Infow("vllm-swift binary found", "path", cfg.VLLMSwiftBin)
 	default:
 		logger.Infow("llama-server binary found", "path", cfg.LlamaServerBin)
 	}
@@ -317,6 +363,7 @@ func main() {
 		OMLXBin:                   cfg.OMLXBin,
 		OMLXPort:                  cfg.OMLXPort,
 		OllamaPort:                cfg.OllamaPort,
+		VLLMSwiftBin:              cfg.VLLMSwiftBin,
 		Port:                      cfg.Port,
 		HostIP:                    cfg.HostIP,
 		Logger:                    logger,
@@ -324,6 +371,7 @@ func main() {
 		MaxWatchFailures:          cfg.MaxWatchFailures,
 		LlamaServerStartupTimeout: cfg.LlamaServerStartupTimeout,
 		OMLXStartupTimeout:        cfg.OMLXStartupTimeout,
+		VLLMSwiftStartupTimeout:   cfg.VLLMSwiftStartupTimeout,
 		ApplePowerEnabled:         cfg.ApplePowerEnabled,
 		ApplePowerInterval:        cfg.ApplePowerInterval,
 		PowermetricsBin:           cfg.PowermetricsBin,

--- a/config/samples/inferenceservice_qwen3_4b_vllm_swift_turboquant.yaml
+++ b/config/samples/inferenceservice_qwen3_4b_vllm_swift_turboquant.yaml
@@ -1,0 +1,38 @@
+# InferenceService served by vllm-swift on the metal-agent path with
+# TurboQuant KV cache compression. Requires the metal-agent to be running
+# with `--runtime vllm-swift` against this cluster.
+#
+# Reference: TheTom/vllm-swift v0.3.1+ (the bf16 TurboFlash + dim=512 kernel
+# work that landed in v0.3.0 enables Gemma 4 31B too once vllm-swift gains a
+# matching loader; today this manifest targets Qwen3-4B which the README ships
+# as the recommended TurboQuant demo).
+#
+# The `cacheTypeCustomK`/`cacheTypeCustomV` strings are passed through to
+# vllm-swift as `--additional-config '{"kv_scheme":"<value>","kv_bits":<n>}'`.
+# Recognized schemes: turbo4v2 (recommended), turbo3, turbo4, turbo2.
+# Unrecognized strings cause the executor to omit --additional-config so
+# vllm-swift falls back to its built-in fp16 KV cache.
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-4b-tq
+spec:
+  source: mlx-community/Qwen3-4B-4bit
+  format: mlx
+  hardware:
+    accelerator: metal
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen-tq
+spec:
+  modelRef: qwen3-4b-tq
+  replicas: 1
+  contextSize: 8192
+  parallelSlots: 4
+  # turbo4v2 = ~3x KV cache compression vs fp16 with quality preserved
+  # (TheTom's recommended scheme for the quality/compression sweet spot).
+  # Use turbo3 for ~4.6x compression at a small PPL cost on long context.
+  cacheTypeCustomK: turbo4v2
+  cacheTypeCustomV: turbo4v2

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -42,6 +42,14 @@ const (
 	runtimeVLLMSwift = "vllm-swift"
 )
 
+// Model format identifiers (Model.Spec.Format) the agent recognizes for
+// runtime-compatibility checks. Defined here so validateRuntimeFormat can
+// switch on them without scattering literals (goconst).
+const (
+	formatGGUF = "gguf"
+	formatMLX  = "mlx"
+)
+
 // MetalAgentConfig contains configuration for the Metal agent
 type MetalAgentConfig struct {
 	K8sClient      client.Client
@@ -473,26 +481,26 @@ func derefInt32(p *int32) int {
 func (a *MetalAgent) validateRuntimeFormat(model *inferencev1alpha1.Model) error {
 	modelFormat := model.Spec.Format
 	if modelFormat == "" {
-		modelFormat = "gguf"
+		modelFormat = formatGGUF
 	}
 
 	var bad bool
 	var runtimeLabel string
 	switch a.config.Runtime {
 	case runtimeOMLX:
-		bad = modelFormat == "gguf"
+		bad = modelFormat == formatGGUF
 		runtimeLabel = runtimeOMLX
 	case runtimeOllama:
-		bad = modelFormat == "mlx"
+		bad = modelFormat == formatMLX
 		runtimeLabel = runtimeOllama
 	case runtimeVLLMSwift:
 		// vllm-swift accepts MLX directories AND HuggingFace safetensors
 		// directories (the SwiftInferenceEngine reads both). gguf is the
 		// only incompatible format.
-		bad = modelFormat == "gguf"
+		bad = modelFormat == formatGGUF
 		runtimeLabel = runtimeVLLMSwift
 	default:
-		bad = modelFormat == "mlx"
+		bad = modelFormat == formatMLX
 		runtimeLabel = "llama-server"
 	}
 	if !bad {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -37,8 +37,9 @@ import (
 
 // Inference runtime identifiers used by MetalAgentConfig.Runtime.
 const (
-	runtimeOMLX   = "omlx"
-	runtimeOllama = "ollama"
+	runtimeOMLX      = "omlx"
+	runtimeOllama    = "ollama"
+	runtimeVLLMSwift = "vllm-swift"
 )
 
 // MetalAgentConfig contains configuration for the Metal agent
@@ -59,6 +60,9 @@ type MetalAgentConfig struct {
 	OMLXPort int
 	// OllamaPort is the port the Ollama daemon listens on (default 11434).
 	OllamaPort int
+	// VLLMSwiftBin is the path to the vllm-swift binary. Only used when
+	// Runtime is "vllm-swift". Empty means auto-detect via $PATH.
+	VLLMSwiftBin string
 
 	// MemoryProvider supplies system memory info. Nil defaults to DarwinMemoryProvider.
 	MemoryProvider MemoryProvider
@@ -92,6 +96,12 @@ type MetalAgentConfig struct {
 	// (DefaultOMLXStartupTimeout). The original 30s constant was too short
 	// for real M-series hardware.
 	OMLXStartupTimeout time.Duration
+
+	// VLLMSwiftStartupTimeout is how long the agent waits for vllm-swift to
+	// respond on /health. Zero means use the executor default
+	// (DefaultVLLMSwiftStartupTimeout). vLLM init + Swift bridge load + weight
+	// load grow with model size; 120s default works for ~30B models on M5 Max.
+	VLLMSwiftStartupTimeout time.Duration
 
 	// ApplePowerEnabled launches the powermetrics-driven sampler that
 	// publishes apple_power_*_watts gauges. Defaults false because
@@ -259,6 +269,16 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 			port,
 			a.logger.With("subsystem", "executor"),
 		)
+	case runtimeVLLMSwift:
+		vllmSwiftExec := NewVLLMSwiftExecutor(
+			a.config.VLLMSwiftBin,
+			a.config.ModelStorePath,
+			a.logger.With("subsystem", "executor"),
+		)
+		if a.config.VLLMSwiftStartupTimeout > 0 {
+			vllmSwiftExec.SetStartupTimeout(a.config.VLLMSwiftStartupTimeout)
+		}
+		a.executor = vllmSwiftExec
 	default:
 		metalExec := NewMetalExecutor(
 			a.config.LlamaServerBin,
@@ -465,6 +485,12 @@ func (a *MetalAgent) validateRuntimeFormat(model *inferencev1alpha1.Model) error
 	case runtimeOllama:
 		bad = modelFormat == "mlx"
 		runtimeLabel = runtimeOllama
+	case runtimeVLLMSwift:
+		// vllm-swift accepts MLX directories AND HuggingFace safetensors
+		// directories (the SwiftInferenceEngine reads both). gguf is the
+		// only incompatible format.
+		bad = modelFormat == "gguf"
+		runtimeLabel = runtimeVLLMSwift
 	default:
 		bad = modelFormat == "mlx"
 		runtimeLabel = "llama-server"

--- a/pkg/agent/executor_vllm_swift.go
+++ b/pkg/agent/executor_vllm_swift.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// DefaultVLLMSwiftStartupTimeout is how long the agent waits for a freshly
+// spawned vllm-swift process to respond on /health. vllm-swift is a thin
+// wrapper around vLLM's OpenAI api_server, so startup involves vLLM init,
+// the Swift/Metal bridge load, and (for big models) the weight load. On
+// real hardware that's 30-90s for a 30B model on M5 Max. 120s gives
+// generous headroom while still failing fast on real breakage.
+const DefaultVLLMSwiftStartupTimeout = 120 * time.Second
+
+// VLLMSwiftExecutor manages individual vllm-swift processes, one per
+// InferenceService. Unlike OMLXExecutor (single shared daemon serving N
+// models), each ISvc gets its own vllm-swift process bound to its own port.
+// This matches the MetalExecutor (llama-server) lifecycle.
+type VLLMSwiftExecutor struct {
+	bin            string
+	modelStorePath string
+	logger         *zap.SugaredLogger
+	startupTimeout time.Duration
+}
+
+// NewVLLMSwiftExecutor creates an executor that spawns one vllm-swift
+// process per InferenceService.
+func NewVLLMSwiftExecutor(bin, modelStorePath string, logger *zap.SugaredLogger) *VLLMSwiftExecutor {
+	return &VLLMSwiftExecutor{
+		bin:            bin,
+		modelStorePath: modelStorePath,
+		logger:         logger,
+		startupTimeout: DefaultVLLMSwiftStartupTimeout,
+	}
+}
+
+// SetStartupTimeout overrides the default vllm-swift startup timeout.
+// Values <= 0 are coerced back to DefaultVLLMSwiftStartupTimeout.
+func (e *VLLMSwiftExecutor) SetStartupTimeout(d time.Duration) {
+	if d <= 0 {
+		d = DefaultVLLMSwiftStartupTimeout
+	}
+	e.startupTimeout = d
+}
+
+// StartProcess resolves the model directory, allocates a port, and spawns
+// vllm-swift. It blocks until /health returns 200 or startupTimeout fires.
+func (e *VLLMSwiftExecutor) StartProcess(ctx context.Context, config ExecutorConfig) (*ManagedProcess, error) {
+	modelPath := e.resolveModelPath(config)
+	if _, err := os.Stat(modelPath); err != nil {
+		return nil, fmt.Errorf(
+			"vllm-swift model directory not found at %s: %w (the host metal-agent does not download MLX/HF model directories; pre-download with `vllm-swift download <hf-id>`)",
+			modelPath, err)
+	}
+
+	port, err := e.allocatePort()
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate port: %w", err)
+	}
+
+	args := buildVLLMSwiftArgs(modelPath, port, config)
+
+	e.logger.Infow("starting vllm-swift",
+		"bin", e.bin, "modelPath", modelPath, "port", port, "ctx", config.ContextSize)
+
+	cmd := exec.Command(e.bin, args...)
+	cmd.Env = os.Environ()
+
+	// Capture child stdout/stderr to a per-process log file. Without this,
+	// Go's exec.Command discards both, which means a vllm-swift import
+	// failure or model load error becomes a silent crashloop with no
+	// trail. The log path is stable per (namespace, name) so operators
+	// can `tail -f` it during demos and post-mortem after bad rollouts.
+	logPath := e.processLogPath(config.Namespace, config.Name)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open vllm-swift log file %s: %w", logPath, err)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return nil, fmt.Errorf("failed to start vllm-swift: %w", err)
+	}
+	// The child holds the fd; we can close our handle. The OS keeps the
+	// inode alive until the child closes (or exits, which closes its fds).
+	_ = logFile.Close()
+
+	process := &ManagedProcess{
+		Name:      config.Name,
+		Namespace: config.Namespace,
+		PID:       cmd.Process.Pid,
+		Port:      port,
+		ModelPath: modelPath,
+		ModelID:   filepath.Base(modelPath),
+		StartedAt: time.Now(),
+		Healthy:   false,
+	}
+
+	if err := e.waitForHealthy(port, e.startupTimeout); err != nil {
+		if killErr := cmd.Process.Kill(); killErr != nil {
+			e.logger.Warnw("failed to kill unhealthy vllm-swift process",
+				"pid", cmd.Process.Pid, "error", killErr)
+		}
+		return nil, fmt.Errorf("vllm-swift failed health check after %s: %w",
+			e.startupTimeout, err)
+	}
+
+	process.Healthy = true
+	e.logger.Infow("vllm-swift ready", "pid", process.PID, "port", port, "modelID", process.ModelID)
+	return process, nil
+}
+
+// StopProcess sends SIGTERM with a 10s grace period before SIGKILL.
+// vllm-swift's underlying Python api_server respects SIGTERM and shuts down
+// the engine cleanly.
+func (e *VLLMSwiftExecutor) StopProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("failed to find process %d: %w", pid, err)
+	}
+
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("failed to send SIGTERM to process %d: %w", pid, err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := process.Wait()
+		done <- err
+	}()
+
+	select {
+	case <-time.After(10 * time.Second):
+		_ = process.Kill()
+		return fmt.Errorf("process %d did not exit gracefully, killed", pid)
+	case err := <-done:
+		return err
+	}
+}
+
+// processLogPath returns the per-process log file path for vllm-swift's
+// stdout/stderr capture. We anchor under modelStorePath so log files live
+// alongside the model artifacts the agent is already managing. The
+// (namespace, name) pair is stable per InferenceService so operators can
+// `tail -f` it across restarts.
+func (e *VLLMSwiftExecutor) processLogPath(namespace, name string) string {
+	return filepath.Join(e.modelStorePath, fmt.Sprintf("vllm-swift-%s-%s.log", namespace, name))
+}
+
+// resolveModelPath returns the on-disk path to the model directory.
+// vllm-swift takes a directory containing config.json + safetensors/MLX
+// weights, NOT a single file. If ModelSource is an absolute path or
+// directory-shaped string, use it as-is; otherwise treat it as relative to
+// modelStorePath.
+//
+// We resolve symlinks aggressively: vllm-swift's Swift-side architecture
+// detection has a known issue where loading through a symlinked path
+// reports "Unsupported model type: qwen3" (and similar for other archs)
+// even when the same model loads cleanly via the resolved target. Passing
+// the canonical path to the child sidesteps this entirely. EvalSymlinks
+// returns the original path on failure so a missing dir still produces
+// the friendly "model directory not found" error from StartProcess.
+func (e *VLLMSwiftExecutor) resolveModelPath(config ExecutorConfig) string {
+	candidate := config.ModelSource
+	if candidate == "" {
+		candidate = filepath.Join(e.modelStorePath, config.ModelName)
+	} else if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(e.modelStorePath, candidate)
+	}
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return candidate
+	}
+	return resolved
+}
+
+// allocatePort asks the kernel for an unused TCP port. Same TOCTOU
+// behavior as MetalExecutor.allocatePort (microsecond window before the
+// child binds). Reused via a free function to avoid coupling executors.
+func (e *VLLMSwiftExecutor) allocatePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = ln.Close() }()
+	return ln.Addr().(*net.TCPAddr).Port, nil
+}
+
+// waitForHealthy polls /health on the allocated port until 200 or timeout.
+func (e *VLLMSwiftExecutor) waitForHealthy(port int, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	healthURL := fmt.Sprintf("http://localhost:%d/health", port)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for vllm-swift /health")
+		case <-ticker.C:
+			resp, err := http.Get(healthURL)
+			if err == nil && resp.StatusCode == http.StatusOK {
+				_ = resp.Body.Close()
+				return nil
+			}
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+		}
+	}
+}
+
+// buildVLLMSwiftArgs constructs the command-line argument vector for the
+// vllm-swift child process. Split out from StartProcess so the mapping
+// from CRD fields to vLLM flags is unit-testable without spawning a real
+// process.
+//
+// vllm-swift is a thin wrapper around `python -m vllm.entrypoints.openai.api_server`
+// that auto-detects and injects the right --tool-call-parser based on the
+// model architecture (see TheTom/vllm-swift detect_tool_parser.py). The
+// metal-agent therefore does NOT inject --tool-call-parser explicitly; we
+// let the wrapper do its job. Users who need to override pass the flag
+// through ExtraArgs (which appends last so it wins).
+func buildVLLMSwiftArgs(modelPath string, port int, config ExecutorConfig) []string {
+	args := []string{
+		"serve", modelPath,
+		"--port", fmt.Sprintf("%d", port),
+		"--host", "0.0.0.0",
+		"--max-model-len", fmt.Sprintf("%d", config.ContextSize),
+	}
+
+	if config.ParallelSlots > 1 {
+		args = append(args, "--max-num-seqs", fmt.Sprintf("%d", config.ParallelSlots))
+	}
+
+	// TurboQuant KV cache compression. CacheTypeK is the resolved cache-type
+	// at the executor boundary: the agent layer (resolveCacheTypes) flattens
+	// the CRD's CacheTypeK + CacheTypeCustomK pair so executors only see one
+	// string. vllm-swift uses a single kv_scheme/kv_bits pair for both K and
+	// V, so we only consult the K side.
+	if scheme, bits := turboQuantConfig(config.CacheTypeK); scheme != "" {
+		blob, _ := json.Marshal(map[string]any{
+			"kv_scheme": scheme,
+			"kv_bits":   bits,
+		})
+		args = append(args, "--additional-config", string(blob))
+	}
+
+	// ExtraArgs comes last so user-provided overrides actually override
+	// any flag we set above (vLLM uses last-wins for repeated flags).
+	if len(config.ExtraArgs) > 0 {
+		args = append(args, config.ExtraArgs...)
+	}
+
+	return args
+}
+
+// turboQuantConfig maps a CacheTypeCustomK string to (kv_scheme, kv_bits)
+// for vllm-swift's --additional-config JSON. Only the documented turbo*
+// schemes are recognized; anything else (including empty) returns ("", 0)
+// so the caller knows to omit --additional-config entirely.
+//
+// Reference: TheTom/vllm-swift README + worker.py:123-126 which reads
+// kv_scheme/kv_bits from vllm_config.additional_config.
+func turboQuantConfig(cacheType string) (scheme string, bits int) {
+	switch cacheType {
+	case "turbo4v2", "turbo4":
+		return cacheType, 4
+	case "turbo3":
+		return cacheType, 3
+	case "turbo2":
+		return cacheType, 2
+	default:
+		return "", 0
+	}
+}

--- a/pkg/agent/executor_vllm_swift.go
+++ b/pkg/agent/executor_vllm_swift.go
@@ -76,7 +76,9 @@ func (e *VLLMSwiftExecutor) StartProcess(ctx context.Context, config ExecutorCon
 	modelPath := e.resolveModelPath(config)
 	if _, err := os.Stat(modelPath); err != nil {
 		return nil, fmt.Errorf(
-			"vllm-swift model directory not found at %s: %w (the host metal-agent does not download MLX/HF model directories; pre-download with `vllm-swift download <hf-id>`)",
+			"vllm-swift model directory not found at %s: %w "+
+				"(the host metal-agent does not download MLX/HF model directories; "+
+				"pre-download with `vllm-swift download <hf-id>`)",
 			modelPath, err)
 	}
 
@@ -99,7 +101,7 @@ func (e *VLLMSwiftExecutor) StartProcess(ctx context.Context, config ExecutorCon
 	// trail. The log path is stable per (namespace, name) so operators
 	// can `tail -f` it during demos and post-mortem after bad rollouts.
 	logPath := e.processLogPath(config.Namespace, config.Name)
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open vllm-swift log file %s: %w", logPath, err)
 	}
@@ -287,6 +289,16 @@ func buildVLLMSwiftArgs(modelPath string, port int, config ExecutorConfig) []str
 	return args
 }
 
+// TurboQuant KV scheme identifiers passed to vllm-swift via additional_config.
+// Defined as exported constants so callers (CLI samples, future callers) can
+// reference the canonical strings without typos and so goconst is happy.
+const (
+	turboQuantScheme4v2 = "turbo4v2"
+	turboQuantScheme4   = "turbo4"
+	turboQuantScheme3   = "turbo3"
+	turboQuantScheme2   = "turbo2"
+)
+
 // turboQuantConfig maps a CacheTypeCustomK string to (kv_scheme, kv_bits)
 // for vllm-swift's --additional-config JSON. Only the documented turbo*
 // schemes are recognized; anything else (including empty) returns ("", 0)
@@ -296,11 +308,11 @@ func buildVLLMSwiftArgs(modelPath string, port int, config ExecutorConfig) []str
 // kv_scheme/kv_bits from vllm_config.additional_config.
 func turboQuantConfig(cacheType string) (scheme string, bits int) {
 	switch cacheType {
-	case "turbo4v2", "turbo4":
+	case turboQuantScheme4v2, turboQuantScheme4:
 		return cacheType, 4
-	case "turbo3":
+	case turboQuantScheme3:
 		return cacheType, 3
-	case "turbo2":
+	case turboQuantScheme2:
 		return cacheType, 2
 	default:
 		return "", 0

--- a/pkg/agent/executor_vllm_swift_test.go
+++ b/pkg/agent/executor_vllm_swift_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestNewVLLMSwiftExecutor(t *testing.T) {
+	executor := NewVLLMSwiftExecutor("/opt/homebrew/bin/vllm-swift", "/models", newNopLogger())
+
+	if executor.bin != "/opt/homebrew/bin/vllm-swift" {
+		t.Errorf("bin = %q, want %q", executor.bin, "/opt/homebrew/bin/vllm-swift")
+	}
+	if executor.modelStorePath != "/models" {
+		t.Errorf("modelStorePath = %q, want %q", executor.modelStorePath, "/models")
+	}
+	if executor.startupTimeout != DefaultVLLMSwiftStartupTimeout {
+		t.Errorf("default startupTimeout = %v, want %v",
+			executor.startupTimeout, DefaultVLLMSwiftStartupTimeout)
+	}
+}
+
+func TestVLLMSwiftSetStartupTimeout(t *testing.T) {
+	executor := NewVLLMSwiftExecutor("/bin/vllm-swift", "/models", newNopLogger())
+
+	executor.SetStartupTimeout(180 * time.Second)
+	if executor.startupTimeout != 180*time.Second {
+		t.Errorf("after Set(180s) = %v, want 180s", executor.startupTimeout)
+	}
+
+	// Non-positive values coerce back to default.
+	executor.SetStartupTimeout(0)
+	if executor.startupTimeout != DefaultVLLMSwiftStartupTimeout {
+		t.Errorf("after Set(0) = %v, want default %v",
+			executor.startupTimeout, DefaultVLLMSwiftStartupTimeout)
+	}
+	executor.SetStartupTimeout(-5 * time.Second)
+	if executor.startupTimeout != DefaultVLLMSwiftStartupTimeout {
+		t.Errorf("after Set(-5s) = %v, want default %v",
+			executor.startupTimeout, DefaultVLLMSwiftStartupTimeout)
+	}
+}
+
+func TestVLLMSwiftStopProcess_InvalidPID(t *testing.T) {
+	executor := NewVLLMSwiftExecutor("/bin/vllm-swift", "/models", newNopLogger())
+
+	err := executor.StopProcess(-99999)
+	if err == nil {
+		t.Error("StopProcess with invalid PID should return error")
+	}
+}
+
+func TestTurboQuantConfig(t *testing.T) {
+	tests := []struct {
+		cacheType  string
+		wantScheme string
+		wantBits   int
+	}{
+		{"turbo4v2", "turbo4v2", 4},
+		{"turbo4", "turbo4", 4},
+		{"turbo3", "turbo3", 3},
+		{"turbo2", "turbo2", 2},
+		{"", "", 0},
+		{"f16", "", 0},
+		{"q8_0", "", 0},
+		{"iq4_nl", "", 0},
+		{"TURBO4V2", "", 0}, // case-sensitive, upstream uses lowercase
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.cacheType, func(t *testing.T) {
+			scheme, bits := turboQuantConfig(tc.cacheType)
+			if scheme != tc.wantScheme {
+				t.Errorf("scheme = %q, want %q", scheme, tc.wantScheme)
+			}
+			if bits != tc.wantBits {
+				t.Errorf("bits = %d, want %d", bits, tc.wantBits)
+			}
+		})
+	}
+}
+
+func TestBuildVLLMSwiftArgs_Defaults(t *testing.T) {
+	args := buildVLLMSwiftArgs("/models/Qwen3-4B-4bit", 8080, ExecutorConfig{
+		ContextSize: 32768,
+	})
+
+	// Positional model path comes after "serve" subcommand.
+	if len(args) < 2 || args[0] != "serve" {
+		t.Fatalf("first arg must be \"serve\" subcommand, got: %v", args)
+	}
+	if args[1] != "/models/Qwen3-4B-4bit" {
+		t.Errorf("model path = %q, want %q (full args: %v)",
+			args[1], "/models/Qwen3-4B-4bit", args)
+	}
+
+	want := map[string]string{
+		"--port":          "8080",
+		"--max-model-len": "32768",
+	}
+	for flag, expected := range want {
+		if got := flagValue(args, flag); got != expected {
+			t.Errorf("%s = %q, want %q (full args: %v)", flag, got, expected, args)
+		}
+	}
+
+	// Defaults must NOT inject TurboQuant or seq concurrency.
+	for _, unwanted := range []string{
+		"--additional-config", "--max-num-seqs", "--gpu-memory-utilization",
+	} {
+		if hasFlag(args, unwanted) {
+			t.Errorf("unexpected flag %q in default args: %v", unwanted, args)
+		}
+	}
+}
+
+func TestBuildVLLMSwiftArgs_ParallelSlots(t *testing.T) {
+	args := buildVLLMSwiftArgs("/m", 8080, ExecutorConfig{
+		ContextSize:   4096,
+		ParallelSlots: 8,
+	})
+	if got := flagValue(args, "--max-num-seqs"); got != "8" {
+		t.Errorf("--max-num-seqs = %q, want %q (full args: %v)", got, "8", args)
+	}
+}
+
+func TestBuildVLLMSwiftArgs_ParallelSlotsOneOrZeroOmits(t *testing.T) {
+	for _, n := range []int{0, 1} {
+		args := buildVLLMSwiftArgs("/m", 8080, ExecutorConfig{
+			ContextSize:   4096,
+			ParallelSlots: n,
+		})
+		if hasFlag(args, "--max-num-seqs") {
+			t.Errorf("--max-num-seqs must be omitted for ParallelSlots=%d (full args: %v)",
+				n, args)
+		}
+	}
+}
+
+func TestBuildVLLMSwiftArgs_TurboQuant(t *testing.T) {
+	tests := []struct {
+		name       string
+		cacheTypeK string
+		wantScheme string
+		wantBits   int
+	}{
+		{"turbo4v2_recommended", "turbo4v2", "turbo4v2", 4},
+		{"turbo3_max_compression", "turbo3", "turbo3", 3},
+		{"turbo4_legacy", "turbo4", "turbo4", 4},
+		{"turbo2_aggressive", "turbo2", "turbo2", 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildVLLMSwiftArgs("/m", 8080, ExecutorConfig{
+				ContextSize: 131072,
+				CacheTypeK:  tc.cacheTypeK,
+			})
+			raw := flagValue(args, "--additional-config")
+			if raw == "" {
+				t.Fatalf("--additional-config missing for %s (full args: %v)", tc.cacheTypeK, args)
+			}
+			var got map[string]any
+			if err := json.Unmarshal([]byte(raw), &got); err != nil {
+				t.Fatalf("--additional-config value is not valid JSON: %q (err %v)", raw, err)
+			}
+			if got["kv_scheme"] != tc.wantScheme {
+				t.Errorf("kv_scheme = %v, want %q", got["kv_scheme"], tc.wantScheme)
+			}
+			// JSON numbers decode to float64.
+			if int(got["kv_bits"].(float64)) != tc.wantBits {
+				t.Errorf("kv_bits = %v, want %d", got["kv_bits"], tc.wantBits)
+			}
+		})
+	}
+}
+
+func TestBuildVLLMSwiftArgs_TurboQuantOmittedForNonTurboCacheTypes(t *testing.T) {
+	for _, ct := range []string{"", "f16", "q8_0", "iq4_nl"} {
+		args := buildVLLMSwiftArgs("/m", 8080, ExecutorConfig{
+			ContextSize: 4096,
+			CacheTypeK:  ct,
+		})
+		if hasFlag(args, "--additional-config") {
+			t.Errorf("--additional-config must be omitted for non-turbo CacheTypeK=%q (full args: %v)",
+				ct, args)
+		}
+	}
+}
+
+func TestBuildVLLMSwiftArgs_ExtraArgsAppendedLast(t *testing.T) {
+	args := buildVLLMSwiftArgs("/m", 8080, ExecutorConfig{
+		ContextSize: 4096,
+		ExtraArgs:   []string{"--enable-reasoning", "--reasoning-parser", "deepseek_r1"},
+	})
+	if len(args) < 3 {
+		t.Fatalf("args too short: %v", args)
+	}
+	tail := args[len(args)-3:]
+	want := []string{"--enable-reasoning", "--reasoning-parser", "deepseek_r1"}
+	for i, w := range want {
+		if tail[i] != w {
+			t.Errorf("tail[%d] = %q, want %q (full args: %v)", i, tail[i], w, args)
+		}
+	}
+}
+
+func TestBuildVLLMSwiftArgs_TurboQuantPlusParallelSlots(t *testing.T) {
+	// Real-world coding-model invocation: TurboQuant for long context PLUS
+	// parallel slots for concurrent agent requests. Both must be present.
+	args := buildVLLMSwiftArgs("/models/qwen", 8080, ExecutorConfig{
+		ContextSize:   131072,
+		ParallelSlots: 4,
+		CacheTypeK:    "turbo4v2",
+	})
+	if got := flagValue(args, "--max-num-seqs"); got != "4" {
+		t.Errorf("--max-num-seqs = %q, want %q", got, "4")
+	}
+	if !hasFlag(args, "--additional-config") {
+		t.Errorf("--additional-config missing in combined invocation: %v", args)
+	}
+}

--- a/pkg/agent/executor_vllm_swift_test.go
+++ b/pkg/agent/executor_vllm_swift_test.go
@@ -18,6 +18,16 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -236,4 +246,189 @@ func TestBuildVLLMSwiftArgs_TurboQuantPlusParallelSlots(t *testing.T) {
 	if !hasFlag(args, "--additional-config") {
 		t.Errorf("--additional-config missing in combined invocation: %v", args)
 	}
+}
+
+func TestVLLMSwiftProcessLogPath(t *testing.T) {
+	executor := NewVLLMSwiftExecutor("/bin/vllm-swift", "/var/lib/llmkube", newNopLogger())
+
+	got := executor.processLogPath("default", "qwen-coder")
+	want := filepath.Join("/var/lib/llmkube", "vllm-swift-default-qwen-coder.log")
+	if got != want {
+		t.Errorf("processLogPath = %q, want %q", got, want)
+	}
+
+	// Different namespace + name yields a distinct path.
+	other := executor.processLogPath("prod", "qwen-coder")
+	if other == got {
+		t.Errorf("processLogPath collided across namespaces: %q == %q", other, got)
+	}
+}
+
+func TestVLLMSwiftResolveModelPath(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Build a real on-disk layout that exercises the symlink path:
+	//   <tmp>/models/Qwen3-4B-4bit/        (the actual model dir)
+	//   <tmp>/models/mlx-community/Qwen3-4B-4bit -> ../Qwen3-4B-4bit
+	modelStore := filepath.Join(tmp, "models")
+	realDir := filepath.Join(modelStore, "Qwen3-4B-4bit")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	hfDir := filepath.Join(modelStore, "mlx-community")
+	if err := os.MkdirAll(hfDir, 0o755); err != nil {
+		t.Fatalf("mkdir hf: %v", err)
+	}
+	symlink := filepath.Join(hfDir, "Qwen3-4B-4bit")
+	if err := os.Symlink(realDir, symlink); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	executor := NewVLLMSwiftExecutor("/bin/vllm-swift", modelStore, newNopLogger())
+
+	tests := []struct {
+		name   string
+		config ExecutorConfig
+		want   string
+	}{
+		{
+			name:   "absolute path passes through and resolves symlinks",
+			config: ExecutorConfig{ModelSource: symlink},
+			want:   realDir,
+		},
+		{
+			name:   "relative HF-shorthand resolves under modelStorePath then through symlink",
+			config: ExecutorConfig{ModelSource: "mlx-community/Qwen3-4B-4bit"},
+			want:   realDir,
+		},
+		{
+			name:   "absolute non-symlinked path stays as-is",
+			config: ExecutorConfig{ModelSource: realDir},
+			want:   realDir,
+		},
+		{
+			name:   "empty source falls back to <modelStore>/<name>",
+			config: ExecutorConfig{ModelName: "Qwen3-4B-4bit"},
+			want:   realDir,
+		},
+		{
+			name:   "non-existent path returns the candidate unchanged",
+			config: ExecutorConfig{ModelSource: "/nope/does-not-exist"},
+			want:   "/nope/does-not-exist",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// On macOS /tmp resolves to /private/tmp; resolve the want side
+			// the same way so the comparison is symlink-agnostic.
+			wantResolved, err := filepath.EvalSymlinks(tc.want)
+			if err != nil {
+				wantResolved = tc.want
+			}
+			got := executor.resolveModelPath(tc.config)
+			if got != wantResolved && got != tc.want {
+				t.Errorf("resolveModelPath = %q, want %q (or %q before EvalSymlinks)",
+					got, wantResolved, tc.want)
+			}
+		})
+	}
+}
+
+func TestVLLMSwiftAllocatePort(t *testing.T) {
+	executor := NewVLLMSwiftExecutor("/bin/vllm-swift", "/models", newNopLogger())
+
+	port, err := executor.allocatePort()
+	if err != nil {
+		t.Fatalf("allocatePort: %v", err)
+	}
+	if port < 1 || port > 65535 {
+		t.Errorf("allocatePort returned port %d outside valid range", port)
+	}
+
+	// The returned port must be immediately bindable (we want a fresh
+	// non-collided port back, not one stuck in TIME_WAIT or similar).
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("port %d not bindable after allocate: %v", port, err)
+	}
+	_ = ln.Close()
+}
+
+func TestVLLMSwiftWaitForHealthy_OK(t *testing.T) {
+	// Mock health server that responds 200 immediately.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := mustExtractPort(t, srv.URL)
+	executor := NewVLLMSwiftExecutor("/bin/vllm-swift", "/models", newNopLogger())
+
+	if err := executor.waitForHealthy(port, 5*time.Second); err != nil {
+		t.Errorf("waitForHealthy returned error against healthy server: %v", err)
+	}
+}
+
+func TestVLLMSwiftWaitForHealthy_Timeout(t *testing.T) {
+	// Server that returns 503 forever — waitForHealthy should give up after
+	// the deadline rather than hanging or false-positive-ing.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	port := mustExtractPort(t, srv.URL)
+	executor := NewVLLMSwiftExecutor("/bin/vllm-swift", "/models", newNopLogger())
+
+	start := time.Now()
+	err := executor.waitForHealthy(port, 1500*time.Millisecond)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("waitForHealthy must return error when server is never healthy")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("error must mention timeout, got: %v", err)
+	}
+	if elapsed < 1400*time.Millisecond || elapsed > 3*time.Second {
+		t.Errorf("waitForHealthy elapsed = %v, want roughly 1.5s", elapsed)
+	}
+}
+
+func TestVLLMSwiftStopProcess_HappyPath(t *testing.T) {
+	// Spawn a `sleep` child the executor doesn't manage, then ask
+	// StopProcess to send it SIGTERM. The default SIGTERM handler exits the
+	// child cleanly, which Wait() observes. This validates the SIGTERM path
+	// without needing a real vllm-swift child.
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("could not spawn sleep: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	executor := NewVLLMSwiftExecutor("/bin/vllm-swift", "/models", newNopLogger())
+	if err := executor.StopProcess(cmd.Process.Pid); err != nil {
+		t.Errorf("StopProcess returned error on graceful SIGTERM exit: %v", err)
+	}
+}
+
+// mustExtractPort pulls the numeric port out of an httptest.Server URL.
+func mustExtractPort(t *testing.T, raw string) int {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse server URL %q: %v", raw, err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse port from %q: %v", u.Port(), err)
+	}
+	return port
 }


### PR DESCRIPTION
Closes #391.

Adds vllm-swift as a fourth metal-agent runtime alongside `llama-server` / `omlx` / `ollama`. Mirrors the `MetalExecutor` lifecycle: one process per InferenceService, dynamic port allocation, `/health` probe before marking Ready.

## What's in

- New `runtime: vllm-swift` selectable via `--runtime vllm-swift` (auto-detects `vllm-swift` on PATH).
- New `--vllm-swift-bin` and `--vllm-swift-startup-timeout` flags.
- TurboQuant KV cache compression via the existing `cacheTypeCustomK` / `cacheTypeCustomV` CRD fields. Maps onto vllm-swift's `--additional-config '{"kv_scheme":"<X>","kv_bits":<N>}'` (verified empirically and against TheTom's `worker.py:123-126`).
- Per-process child stdout/stderr capture under `<model-store>/vllm-swift-<namespace>-<name>.log`. Without this, a vllm-swift import failure or weight-load error becomes a silent crashloop.
- `filepath.EvalSymlinks` on the model path before spawn. vllm-swift's Swift backend has a known issue where loading through a symlinked path reports `Unsupported model type` even when the underlying target loads cleanly.
- Sample manifest: `config/samples/inferenceservice_qwen3_4b_vllm_swift_turboquant.yaml`.

## TurboQuant scheme mapping

| `cacheTypeCustomK` | `kv_scheme` | `kv_bits` | Compression |
| --- | --- | --- | --- |
| `turbo4v2` | turbo4v2 | 4 | ~3x (recommended, quality preserved) |
| `turbo4`   | turbo4   | 4 | ~3.7x |
| `turbo3`   | turbo3   | 3 | ~4.6x |
| `turbo2`   | turbo2   | 2 | ~7x (aggressive) |
| anything else | (omitted) | (omitted) | fp16 fallback |

## Tests

14 new test cases covering:

- `TestNewVLLMSwiftExecutor` / `TestVLLMSwiftSetStartupTimeout` / `TestVLLMSwiftStopProcess_InvalidPID`
- `TestTurboQuantConfig` (9 sub-cases: turbo4v2/4/3/2 mappings, standard cache types must omit, case sensitivity)
- `TestBuildVLLMSwiftArgs_Defaults` / `...ParallelSlots` / `...ParallelSlotsOneOrZeroOmits` / `...TurboQuant` (4 sub-cases) / `...TurboQuantOmittedForNonTurboCacheTypes` / `...ExtraArgsAppendedLast` / `...TurboQuantPlusParallelSlots`

```
$ go test ./pkg/agent/ ./cmd/metal-agent/ -count=1
ok  github.com/defilantech/llmkube/pkg/agent
ok  github.com/defilantech/llmkube/cmd/metal-agent
```

## Smoke evidence (M5 Max, vllm-swift v0.3.1)

Manifest:

```yaml
apiVersion: inference.llmkube.dev/v1alpha1
kind: Model
metadata:
  name: qwen3-4b-tq
spec:
  source: mlx-community/Qwen3-4B-4bit
  format: mlx
  hardware:
    accelerator: metal
---
apiVersion: inference.llmkube.dev/v1alpha1
kind: InferenceService
metadata:
  name: qwen-tq-smoke
spec:
  modelRef: qwen3-4b-tq
  contextSize: 8192
  parallelSlots: 4
  cacheTypeCustomK: turbo4v2
  cacheTypeCustomV: turbo4v2
```

Metal-agent log:

```
starting vllm-swift  bin=/opt/homebrew/bin/vllm-swift port=58941 ctx=8192
vllm-swift ready     pid=71079 port=58941 modelID=Qwen3-4B-4bit
registered endpoint  hostIP=192.168.1.47 port=58941
```

vllm-swift child log (shows the args our builder produced reaching vLLM):

```
non-default args: {'enable_auto_tool_choice': True, 'tool_call_parser': 'hermes',
                   'host': '0.0.0.0', 'port': 58941,
                   'model': '/Users/defilan/models/Qwen3-4B-4bit',
                   'max_model_len': 8192, 'max_num_seqs': 4,
                   'additional_config': {'kv_bits': 4, 'kv_scheme': 'turbo4v2'}}
Application startup complete.
```

Time from "starting inference service" to "vllm-swift ready": **~7s** for Qwen3-4B-4bit.

```
$ kubectl get isvc,svc,endpoints -n default
inferenceservice/qwen-tq-smoke   qwen3-4b-tq   1   http://qwen-tq-smoke.default.svc.cluster.local:8080/v1/chat/completions
service/qwen-tq-smoke            ClusterIP    10.96.239.239   <none>   8080/TCP
endpoints/qwen-tq-smoke          192.168.1.47:58941
```

```
$ curl -s http://localhost:58941/v1/chat/completions ...
"reply: <think>"...   # Qwen's thinking-tag opener, truncated at max_tokens=15
```

## Test plan

- [x] `go test ./pkg/agent/ ./cmd/metal-agent/` clean
- [x] `make build-metal-agent` clean
- [x] `golangci-lint run ./pkg/agent/... ./cmd/metal-agent/...` clean (after the lint-fix follow-up commit)
- [x] `go vet` / `go fmt` clean
- [x] Manual smoke on M5 Max with vllm-swift v0.3.1 + Qwen3-4B-4bit + turbo4v2
- [x] Verify K8s Service + Endpoints register correctly via the existing ServiceRegistry
- [x] Verify `/v1/chat/completions` returns tokens through the registered endpoint

## Out of scope (follow-ups)

- **Per-runtime model-format compatibility check.** vllm-swift v0.3.1's Swift backend doesn't yet load every architecture (Qwen3.6-35B-A3B uses GatedDeltaNet kernels that aren't compiled in; some Gemma 4 variants need the dim=512 kernel + a config tweak). The metal-agent will spawn vllm-swift regardless and surface the failure via the existing health-check timeout path. A follow-up could pre-validate against a known-supported list.
- **Memory pre-flight estimator support for vllm-swift.** Currently the estimator is sized for `llama-server` / `omlx`. vllm-swift's working-set is similar but the prefill workspace differs. The existing memory-estimation-failed warning already gates correctly (warns + proceeds); a proper estimator is a separate enhancement.
- **TurboQuant scheme + bits validation against vllm-swift's actual support.** Today we trust the user; any string starting with `turbo` passes through. vllm-swift's Swift loader is the validation layer. Could be tightened to a known-good enum if we want CRD-side rejection.

## Related

- #391 (this issue)
- #392 (controller-side local-path-with-metal-accelerator gap; the `EvalSymlinks` resolution here helps the symlink-workaround documented in that issue)
- TheTom/vllm-swift v0.3.1 ([release notes](https://github.com/TheTom/vllm-swift/releases/tag/v0.3.0))
