### PR TITLE
docs(readme): HN-launch readiness fixes (broken link, Apple Silicon CTA, quickstart memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ flowchart TB
     AGENT -- "registers Endpoints" --> CLUSTER
 ```
 
-Same operator manages Linux/GPU pods and Apple Silicon hosts; both surface as `InferenceService` objects to `kubectl`. Full breakdown with reconciliation flow and the CRD reference: **[docs.llmkube.com/concepts/architecture](https://llmkube.com/docs/concepts/architecture)**.
+Same operator manages Linux/GPU pods and Apple Silicon hosts; both surface as `InferenceService` objects to `kubectl`.
+
+Setup guide for the metal-agent on Apple Silicon: [`deployment/macos/README.md`](deployment/macos/README.md).
 
 ---
 
@@ -106,8 +108,8 @@ brew install defilantech/tap/llmkube
 helm repo add llmkube https://defilantech.github.io/LLMKube
 helm install llmkube llmkube/llmkube --namespace llmkube-system --create-namespace
 
-# Deploy a model (one command)
-llmkube deploy phi-4-mini --cpu 500m --memory 1Gi
+# Deploy a model (one command, uses catalog-tested defaults)
+llmkube deploy phi-4-mini
 
 # Query it (OpenAI-compatible)
 kubectl port-forward svc/phi-4-mini 8080:8080 &


### PR DESCRIPTION
## Summary

Three small README fixes ahead of the Show HN launch tomorrow morning. Goal: nothing on the README's first-impression path is broken or stale.

1. **Drop the broken \`docs.llmkube.com/concepts/architecture\` link** — the docs site page is currently a stub pointing back at GitHub markdown (the \`docs/site/\` migration in #396 is still open on a separate branch). The architecture explanation already lives in this README, so the dangling outbound just erodes trust on first impression.
2. **Surface the Apple Silicon install path** — the metal-agent setup guide at \`deployment/macos/README.md\` is a real 22 KB doc, but the main README never linked to it. Curious readers had no obvious next step after the architecture section.
3. **Fix the quickstart deploy command** — \`--memory 1Gi\` predates the v0.7.6 catalog tightening (#386 / #387). With the now-default 8192 context for \`phi-4-mini\` the model OOMs at 1 Gi. Dropping the override lets the catalog's tested defaults (\`cpu=2, memory=4Gi, context=8192\`) apply.

## Verification done before this PR

Quickstart block validated against current state:
- ✓ brew tap \`defilantech/homebrew-tap\` exposes \`llmkube.rb\`
- ✓ helm index at \`defilantech.github.io/LLMKube\` lists 0.7.6 as latest chart
- ✓ \`phi-4-mini\` is in \`pkg/cli/catalog.yaml\` line 38 with post-#386 sane defaults

## Test plan

- [x] CI passes (DCO, govulncheck, build matrix)
- [ ] Reviewer clicks the new \`deployment/macos/README.md\` link and confirms it lands on a real guide
- [ ] Reviewer confirms the \`docs.llmkube.com\` link is gone