### PR TITLE
refactor(controller): move runtime shared test helpers to a dedicated file

### DIFF
--- a/internal/controller/runtime.go
+++ b/internal/controller/runtime.go
@@ -74,3 +74,14 @@ func resolveBackend(isvc *inferencev1alpha1.InferenceService) RuntimeBackend {
 		return &LlamaCppBackend{}
 	}
 }
+
+// resolveGPUCount determines the GPU count from Model spec or InferenceService spec.
+func resolveGPUCount(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) int32 {
+	if model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil && model.Spec.Hardware.GPU.Count > 0 {
+		return model.Spec.Hardware.GPU.Count
+	}
+	if isvc.Spec.Resources != nil && isvc.Spec.Resources.GPU > 0 {
+		return isvc.Spec.Resources.GPU
+	}
+	return 0
+}

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -138,14 +138,3 @@ func (b *LlamaCppBackend) BuildProbes(port int32) (startup, liveness, readiness 
 
 	return startup, liveness, readiness
 }
-
-// resolveGPUCount determines the GPU count from Model spec or InferenceService spec.
-func resolveGPUCount(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) int32 {
-	if model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil && model.Spec.Hardware.GPU.Count > 0 {
-		return model.Spec.Hardware.GPU.Count
-	}
-	if isvc.Spec.Resources != nil && isvc.Spec.Resources.GPU > 0 {
-		return isvc.Spec.Resources.GPU
-	}
-	return 0
-}

--- a/internal/controller/runtime_llamacpp_test.go
+++ b/internal/controller/runtime_llamacpp_test.go
@@ -37,22 +37,10 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 	const modelPath = "/models/test"
 	const port = int32(8000)
 
-	// contains is a slice of flag/value pairs ("" value means "flag must be
-	// present as a bare toggle"). notContains is just a list of flags that
-	// must NOT appear anywhere in args.
-	type flagCheck struct {
-		flag  string
-		value string
-	}
-
-	cases := []struct {
-		name        string
-		spec        *inferencev1alpha1.InferenceServiceSpec
-		contains    []flagCheck
-		notContains []string
-	}{
+	cases := []RuntimeBuildArgsTestCase{
 		{
-			name: "empty config emits only base flags",
+			model: model,
+			name:  "empty config emits only base flags",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -60,16 +48,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--ctx-size", "--parallel", "--flash-attn", "--jinja", "--cache-type-k", "--cpu-moe", "--n-cpu-moe", "--no-kv-offload", "--override-tensor", "--override-kv", "--batch-size", "--ubatch-size", "--no-warmup", "--reasoning-budget", "--reasoning-budget-message"},
 		},
 		{
-			name: "contextSize set emits flag",
+			model: model,
+			name:  "contextSize set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:     "llama",
 				ModelRef:    "test-model",
 				ContextSize: ptrInt32(8192),
 			},
-			contains: []flagCheck{{"--ctx-size", "8192"}},
+			contains: []FlagCheck{{"--ctx-size", "8192"}},
 		},
 		{
-			name: "contextSize nil does not emit flag",
+			model: model,
+			name:  "contextSize nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -77,16 +67,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--ctx-size"},
 		},
 		{
-			name: "parallelSlots set emits flag (without extraArgs precedence)",
+			model: model,
+			name:  "parallelSlots set emits flag (without extraArgs precedence)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:       "llama",
 				ModelRef:      "test-model",
 				ParallelSlots: ptrInt32(8192),
 			},
-			contains: []flagCheck{{"--parallel", "8192"}},
+			contains: []FlagCheck{{"--parallel", "8192"}},
 		},
 		{
-			name: "parallelSlots set emits flag (with extraArgs precedence)",
+			model: model,
+			name:  "parallelSlots set emits flag (with extraArgs precedence)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:       "llama",
 				ModelRef:      "test-model",
@@ -97,10 +89,11 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			// and containsArgs helper function always validate first occurrence, having
 			// --parallel 8 case true mean that no duplicate due to parallelSlots was
 			// found along the way.
-			contains: []flagCheck{{"--parallel", "8"}},
+			contains: []FlagCheck{{"--parallel", "8"}},
 		},
 		{
-			name: "parallelSlots set emits flag (with extraArgs inline precedence)",
+			model: model,
+			name:  "parallelSlots set emits flag (with extraArgs inline precedence)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:       "llama",
 				ModelRef:      "test-model",
@@ -111,10 +104,11 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			// and containsArgs helper function always validate first occurrence, having
 			// --parallel 8 case true mean that no duplicate due to parallelSlots was
 			// found along the way.
-			contains: []flagCheck{{"--parallel=8", ""}},
+			contains: []FlagCheck{{"--parallel=8", ""}},
 		},
 		{
-			name: "parallelSlots nil does not emit flag (without extraArgs precedence)",
+			model: model,
+			name:  "parallelSlots nil does not emit flag (without extraArgs precedence)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -122,16 +116,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--parallel"},
 		},
 		{
-			name: "batchSize set emits flag",
+			model: model,
+			name:  "batchSize set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:   "llama",
 				ModelRef:  "test-model",
 				BatchSize: ptrInt32(8192),
 			},
-			contains: []flagCheck{{"--batch-size", "8192"}},
+			contains: []FlagCheck{{"--batch-size", "8192"}},
 		},
 		{
-			name: "batchSize nil does not emit flag",
+			model: model,
+			name:  "batchSize nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -139,16 +135,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--batch-size"},
 		},
 		{
-			name: "uBatchSize set emits flag",
+			model: model,
+			name:  "uBatchSize set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "llama",
 				ModelRef:   "test-model",
 				UBatchSize: ptrInt32(8192),
 			},
-			contains: []flagCheck{{"--ubatch-size", "8192"}},
+			contains: []FlagCheck{{"--ubatch-size", "8192"}},
 		},
 		{
-			name: "uBatchSize nil does not emit flag",
+			model: model,
+			name:  "uBatchSize nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -156,16 +154,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--ubatch-size"},
 		},
 		{
-			name: "moeCPULayers set emits flag",
+			model: model,
+			name:  "moeCPULayers set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:      "llama",
 				ModelRef:     "test-model",
 				MoeCPULayers: ptrInt32(8192),
 			},
-			contains: []flagCheck{{"--n-cpu-moe", "8192"}},
+			contains: []FlagCheck{{"--n-cpu-moe", "8192"}},
 		},
 		{
-			name: "moeCPULayers nil does not emit flag",
+			model: model,
+			name:  "moeCPULayers nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -173,7 +173,8 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--n-cpu-moe"},
 		},
 		{
-			name: "flashAttention=true does not emit flag without GPU",
+			model: model,
+			name:  "flashAttention=true does not emit flag without GPU",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:        "llama",
 				ModelRef:       "test-model",
@@ -182,7 +183,8 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--flash-attn"},
 		},
 		{
-			name: "flashAttention=false does not emit flag",
+			model: model,
+			name:  "flashAttention=false does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:        "llama",
 				ModelRef:       "test-model",
@@ -191,16 +193,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--flash-attn"},
 		},
 		{
-			name: "jinja=true emits flag",
+			model: model,
+			name:  "jinja=true emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
 				Jinja:    ptrBool(true),
 			},
-			contains: []flagCheck{{"--jinja", ""}},
+			contains: []FlagCheck{{"--jinja", ""}},
 		},
 		{
-			name: "jinja=false does not emit flag",
+			model: model,
+			name:  "jinja=false does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -209,16 +213,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--jinja"},
 		},
 		{
-			name: "moeCPUOffload=true emits flag",
+			model: model,
+			name:  "moeCPUOffload=true emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:       "llama",
 				ModelRef:      "test-model",
 				MoeCPUOffload: ptrBool(true),
 			},
-			contains: []flagCheck{{"--cpu-moe", ""}},
+			contains: []FlagCheck{{"--cpu-moe", ""}},
 		},
 		{
-			name: "moeCPUOffload=false does not emit flag",
+			model: model,
+			name:  "moeCPUOffload=false does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:       "llama",
 				ModelRef:      "test-model",
@@ -227,16 +233,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--cpu-moe"},
 		},
 		{
-			name: "noKVOffload=true emits flag",
+			model: model,
+			name:  "noKVOffload=true emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:     "llama",
 				ModelRef:    "test-model",
 				NoKvOffload: ptrBool(true),
 			},
-			contains: []flagCheck{{"--no-kv-offload", ""}},
+			contains: []FlagCheck{{"--no-kv-offload", ""}},
 		},
 		{
-			name: "noKVOffload=false does not emit flag",
+			model: model,
+			name:  "noKVOffload=false does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:     "llama",
 				ModelRef:    "test-model",
@@ -245,16 +253,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--no-kv-offload"},
 		},
 		{
-			name: "noWarmup=true emits flag",
+			model: model,
+			name:  "noWarmup=true emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
 				NoWarmup: ptrBool(true),
 			},
-			contains: []flagCheck{{"--no-warmup", ""}},
+			contains: []FlagCheck{{"--no-warmup", ""}},
 		},
 		{
-			name: "noWarmup=false does not emit flag",
+			model: model,
+			name:  "noWarmup=false does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -263,38 +273,42 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--no-warmup"},
 		},
 		{
-			name: "reasoningBudget set emits flag (without message)",
+			model: model,
+			name:  "reasoningBudget set emits flag (without message)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:         "llama",
 				ModelRef:        "test-model",
 				ReasoningBudget: ptrInt32(8192),
 			},
-			contains: []flagCheck{{"--reasoning-budget", "8192"}},
+			contains: []FlagCheck{{"--reasoning-budget", "8192"}},
 		},
 		{
-			name: "reasoningBudget set emits flag (with message)",
+			model: model,
+			name:  "reasoningBudget set emits flag (with message)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:                "llama",
 				ModelRef:               "test-model",
 				ReasoningBudget:        ptrInt32(8192),
 				ReasoningBudgetMessage: "message",
 			},
-			contains: []flagCheck{
+			contains: []FlagCheck{
 				{"--reasoning-budget", "8192"},
 				{"--reasoning-budget-message", "message"},
 			},
 		},
 		{
-			name: "cacheTypeK set emits flag",
+			model: model,
+			name:  "cacheTypeK set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "llama",
 				ModelRef:   "test-model",
 				CacheTypeK: "key",
 			},
-			contains: []flagCheck{{"--cache-type-k", "key"}},
+			contains: []FlagCheck{{"--cache-type-k", "key"}},
 		},
 		{
-			name: "cacheTypeK nil does not emit flag",
+			model: model,
+			name:  "cacheTypeK nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -302,16 +316,18 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--cache-type-k"},
 		},
 		{
-			name: "cacheTypeV set emits flag",
+			model: model,
+			name:  "cacheTypeV set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "llama",
 				ModelRef:   "test-model",
 				CacheTypeV: "value",
 			},
-			contains: []flagCheck{{"--cache-type-v", "value"}},
+			contains: []FlagCheck{{"--cache-type-v", "value"}},
 		},
 		{
-			name: "cacheTypeV nil does not emit flag",
+			model: model,
+			name:  "cacheTypeV nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -319,19 +335,21 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--cache-type-v"},
 		},
 		{
-			name: "tensorOverride set emits flag",
+			model: model,
+			name:  "tensorOverride set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:         "llama",
 				ModelRef:        "test-model",
 				TensorOverrides: []string{"value1", "value2"},
 			},
-			contains: []flagCheck{
+			contains: []FlagCheck{
 				{"--override-tensor", "value1"},
 				{"--override-tensor", "value2"},
 			},
 		},
 		{
-			name: "tensorOverrides nil does not emit flag",
+			model: model,
+			name:  "tensorOverrides nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -339,19 +357,21 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--override-tensor"},
 		},
 		{
-			name: "metadataOverride set emits flag",
+			model: model,
+			name:  "metadataOverride set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:           "llama",
 				ModelRef:          "test-model",
 				MetadataOverrides: []string{"value1", "value2"},
 			},
-			contains: []flagCheck{
+			contains: []FlagCheck{
 				{"--override-kv", "value1"},
 				{"--override-kv", "value2"},
 			},
 		},
 		{
-			name: "metadataOverride nil does not emits flag",
+			model: model,
+			name:  "metadataOverride nil does not emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -359,7 +379,8 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--override-kv"},
 		},
 		{
-			name: "full agentic config emits all flags together",
+			model: model,
+			name:  "full agentic config emits all flags together",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:                "llama",
 				ModelRef:               "test-model",
@@ -380,7 +401,7 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 				TensorOverrides:        []string{"value1", "value2"},
 				UBatchSize:             ptrInt32(2),
 			},
-			contains: []flagCheck{
+			contains: []FlagCheck{
 				{"--batch-size", "2"},
 				{"--cache-type-k", "key"},
 				{"--cache-type-v", "value"},
@@ -409,7 +430,7 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "isvc-" + strings.ReplaceAll(tc.name, " ", "-"), Namespace: "default"},
 				Spec:       *tc.spec,
 			}
-			args := backend.BuildArgs(isvc, model, modelPath, port)
+			args := backend.BuildArgs(isvc, tc.model, modelPath, port)
 			for _, fc := range tc.contains {
 				if !containsArg(args, fc.flag, fc.value) {
 					t.Errorf("expected %q %q in args, got: %v", fc.flag, fc.value, args)

--- a/internal/controller/runtime_llamacpp_test.go
+++ b/internal/controller/runtime_llamacpp_test.go
@@ -37,7 +37,16 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 	const modelPath = "/models/test"
 	const port = int32(8000)
 
-	cases := []RuntimeBuildArgsTestCase{
+	cases := []struct {
+		// contains is a slice of flag/value pairs ("" value means "flag must be
+		// present as a bare toggle").
+		contains []FlagCheck
+		// notContains is just a list of flags that must NOT appear anywhere in args.
+		notContains []string
+		model       *inferencev1alpha1.Model
+		name        string
+		spec        *inferencev1alpha1.InferenceServiceSpec
+	}{
 		{
 			model: model,
 			name:  "empty config emits only base flags",

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -1,0 +1,26 @@
+package controller
+
+// containsArg reports whether args contains the given flag. When value is
+// non-empty, it also requires the immediately following entry to equal value
+// (i.e. `--flag value` as separate slice elements, which is how BuildArgs
+// emits everything).
+func containsArg(args []string, flag, value string) bool {
+	for i, a := range args {
+		if a != flag {
+			continue
+		}
+		if value == "" {
+			return true
+		}
+		if i+1 < len(args) && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// ptrString, ptrBool, ptrInt32 are local helpers so tests read naturally.
+func ptrBool(b bool) *bool          { return &b }
+func ptrFloat64(f float64) *float64 { return &f }
+func ptrInt32(i int32) *int32       { return &i }
+func ptrString(s string) *string    { return &s }

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -1,5 +1,7 @@
 package controller
 
+import inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+
 // containsArg reports whether args contains the given flag. When value is
 // non-empty, it also requires the immediately following entry to equal value
 // (i.e. `--flag value` as separate slice elements, which is how BuildArgs
@@ -24,3 +26,19 @@ func ptrBool(b bool) *bool          { return &b }
 func ptrFloat64(f float64) *float64 { return &f }
 func ptrInt32(i int32) *int32       { return &i }
 func ptrString(s string) *string    { return &s }
+
+type FlagCheck struct {
+	flag  string
+	value string
+}
+
+type RuntimeBuildArgsTestCase struct {
+	// contains is a slice of flag/value pairs ("" value means "flag must be
+	// present as a bare toggle").
+	contains []FlagCheck
+	// notContains is just a list of flags that must NOT appear anywhere in args.
+	notContains []string
+	model       *inferencev1alpha1.Model
+	name        string
+	spec        *inferencev1alpha1.InferenceServiceSpec
+}

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -1,6 +1,10 @@
 package controller
 
-import inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+import (
+	"testing"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
 
 // containsArg reports whether args contains the given flag. When value is
 // non-empty, it also requires the immediately following entry to equal value
@@ -41,4 +45,74 @@ type RuntimeBuildArgsTestCase struct {
 	model       *inferencev1alpha1.Model
 	name        string
 	spec        *inferencev1alpha1.InferenceServiceSpec
+}
+
+func TestResolveGPUCount(t *testing.T) {
+	cases := []struct {
+		expected int32
+		isvc     *inferencev1alpha1.InferenceService
+		model    *inferencev1alpha1.Model
+		name     string
+	}{
+		{
+			expected: 1,
+			isvc:     &inferencev1alpha1.InferenceService{},
+			model: &inferencev1alpha1.Model{
+				Spec: inferencev1alpha1.ModelSpec{
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count: 1,
+						},
+					},
+				},
+			},
+			name: "model.Spec.Hardware.GPU.Count set resolve GPU count",
+		},
+		{
+			expected: 1,
+			isvc: &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 1,
+					},
+				},
+			},
+			model: &inferencev1alpha1.Model{},
+			name:  "isvc.Spec.Resources.GPU set resolve GPU count",
+		},
+		{
+			expected: 1,
+			isvc: &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					Resources: &inferencev1alpha1.InferenceResourceRequirements{
+						GPU: 2,
+					},
+				},
+			},
+			model: &inferencev1alpha1.Model{
+				Spec: inferencev1alpha1.ModelSpec{
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{
+							Count: 1,
+						},
+					},
+				},
+			},
+			name: "model.Spec.Hardware.GPU.Count have precedence over isvc.Spec.Resources.GPU",
+		},
+		{
+			expected: 0,
+			isvc:     &inferencev1alpha1.InferenceService{},
+			model:    &inferencev1alpha1.Model{},
+			name:     "no GPU set resolve to 0",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := resolveGPUCount(tc.isvc, tc.model)
+			if actual != tc.expected {
+				t.Errorf("expected %d GPU count, got: %d", tc.expected, actual)
+			}
+		})
+	}
 }

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -36,17 +36,6 @@ type FlagCheck struct {
 	value string
 }
 
-type RuntimeBuildArgsTestCase struct {
-	// contains is a slice of flag/value pairs ("" value means "flag must be
-	// present as a bare toggle").
-	contains []FlagCheck
-	// notContains is just a list of flags that must NOT appear anywhere in args.
-	notContains []string
-	model       *inferencev1alpha1.Model
-	name        string
-	spec        *inferencev1alpha1.InferenceServiceSpec
-}
-
 func TestResolveGPUCount(t *testing.T) {
 	cases := []struct {
 		expected int32

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -48,7 +48,16 @@ func TestVLLMBuildArgs(t *testing.T) {
 	const modelPath = "/models/test"
 	const port = int32(8000)
 
-	cases := []RuntimeBuildArgsTestCase{
+	cases := []struct {
+		// contains is a slice of flag/value pairs ("" value means "flag must be
+		// present as a bare toggle").
+		contains []FlagCheck
+		// notContains is just a list of flags that must NOT appear anywhere in args.
+		notContains []string
+		model       *inferencev1alpha1.Model
+		name        string
+		spec        *inferencev1alpha1.InferenceServiceSpec
+	}{
 		{
 			model: model,
 			name:  "nil config emits only base flags (model as positional)",

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -48,22 +48,10 @@ func TestVLLMBuildArgs(t *testing.T) {
 	const modelPath = "/models/test"
 	const port = int32(8000)
 
-	// contains is a slice of flag/value pairs ("" value means "flag must be
-	// present as a bare toggle"). notContains is just a list of flags that
-	// must NOT appear anywhere in args.
-	type flagCheck struct {
-		flag  string
-		value string
-	}
-
-	cases := []struct {
-		name        string
-		spec        *inferencev1alpha1.InferenceServiceSpec
-		contains    []flagCheck
-		notContains []string
-	}{
+	cases := []RuntimeBuildArgsTestCase{
 		{
-			name: "nil config emits only base flags (model as positional)",
+			model: model,
+			name:  "nil config emits only base flags (model as positional)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -71,7 +59,7 @@ func TestVLLMBuildArgs(t *testing.T) {
 			},
 			// vLLM v0.20+ deprecated --model in favor of a positional argument.
 			// The bare model path appears as args[0]; --model itself must NOT appear.
-			contains: []flagCheck{{"--host", "0.0.0.0"}, {"--port", "8000"}},
+			contains: []FlagCheck{{"--host", "0.0.0.0"}, {"--port", "8000"}},
 			notContains: []string{
 				"--attention-backend",
 				"--cpu-offload-gb",
@@ -86,7 +74,8 @@ func TestVLLMBuildArgs(t *testing.T) {
 			},
 		},
 		{
-			name: "empty config emits only base flags",
+			model: model,
+			name:  "empty config emits only base flags",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -104,16 +93,18 @@ func TestVLLMBuildArgs(t *testing.T) {
 			},
 		},
 		{
-			name: "cpuOffloadGB set emits flag if gpu is enabled",
+			model: modelWithGpu,
+			name:  "cpuOffloadGB set emits flag if gpu is enabled",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model-gpu",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{CPUOffloadGB: ptrInt32(4)},
 			},
-			contains: []flagCheck{{"--cpu-offload-gb", "4"}},
+			contains: []FlagCheck{{"--cpu-offload-gb", "4"}},
 		},
 		{
-			name: "cpuOffloadGB set does not emit flag if gpu is not enabled",
+			model: model,
+			name:  "cpuOffloadGB set does not emit flag if gpu is not enabled",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -122,7 +113,8 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--cpu-offload-gb"},
 		},
 		{
-			name: "cpuOffloadGB nil does not emit flag",
+			model: model,
+			name:  "cpuOffloadGB nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -131,16 +123,18 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--cpu-offload-gb"},
 		},
 		{
-			name: "gpuMemoryUtilization set emits flag if gpu is enabled",
+			model: modelWithGpu,
+			name:  "gpuMemoryUtilization set emits flag if gpu is enabled",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model-gpu",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{GPUMemoryUtilization: ptrFloat64(0.80)},
 			},
-			contains: []flagCheck{{"--gpu-memory-utilization", "0.8"}},
+			contains: []FlagCheck{{"--gpu-memory-utilization", "0.8"}},
 		},
 		{
-			name: "gpuMemoryUtilization does not emit flag if gpu is not enabled",
+			model: model,
+			name:  "gpuMemoryUtilization does not emit flag if gpu is not enabled",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -149,7 +143,8 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--gpu-memory-utilization"},
 		},
 		{
-			name: "gpuMemoryUtilization nil does not emit flag",
+			model: model,
+			name:  "gpuMemoryUtilization nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -158,7 +153,8 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--gpu-memory-utilization"},
 		},
 		{
-			name: "kvCacheDtype=auto does not emit flag (vLLM default)",
+			model: model,
+			name:  "kvCacheDtype=auto does not emit flag (vLLM default)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -167,34 +163,38 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--kv-cache-dtype"},
 		},
 		{
-			name: "kvCacheDtype=fp8_e5m2 emits flag",
+			model: model,
+			name:  "kvCacheDtype=fp8_e5m2 emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{KVCacheDtype: ptrString("fp8_e5m2")},
 			},
-			contains: []flagCheck{{"--kv-cache-dtype", "fp8_e5m2"}},
+			contains: []FlagCheck{{"--kv-cache-dtype", "fp8_e5m2"}},
 		},
 		{
-			name: "kvCacheDtype=fp8_e4m3 emits flag",
+			model: model,
+			name:  "kvCacheDtype=fp8_e4m3 emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{KVCacheDtype: ptrString("fp8_e4m3")},
 			},
-			contains: []flagCheck{{"--kv-cache-dtype", "fp8_e4m3"}},
+			contains: []FlagCheck{{"--kv-cache-dtype", "fp8_e4m3"}},
 		},
 		{
-			name: "kvCacheCustomDtype=turbo2 emits flag (vLLM v0.20+ TurboQuant 2-bit)",
+			model: model,
+			name:  "kvCacheCustomDtype=turbo2 emits flag (vLLM v0.20+ TurboQuant 2-bit)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{KVCacheCustomDtype: "turbo2"},
 			},
-			contains: []flagCheck{{"--kv-cache-dtype", "turbo2"}},
+			contains: []FlagCheck{{"--kv-cache-dtype", "turbo2"}},
 		},
 		{
-			name: "kvCacheCustomDtype wins over standard kvCacheDtype when both set",
+			model: model,
+			name:  "kvCacheCustomDtype wins over standard kvCacheDtype when both set",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "vllm",
 				ModelRef: "test-model",
@@ -203,11 +203,12 @@ func TestVLLMBuildArgs(t *testing.T) {
 					KVCacheCustomDtype: "turbo2",
 				},
 			},
-			contains:    []flagCheck{{"--kv-cache-dtype", "turbo2"}},
+			contains:    []FlagCheck{{"--kv-cache-dtype", "turbo2"}},
 			notContains: []string{"fp8_e4m3"},
 		},
 		{
-			name: "kvCacheCustomDtype empty falls back to standard kvCacheDtype",
+			model: model,
+			name:  "kvCacheCustomDtype empty falls back to standard kvCacheDtype",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "vllm",
 				ModelRef: "test-model",
@@ -216,19 +217,21 @@ func TestVLLMBuildArgs(t *testing.T) {
 					KVCacheCustomDtype: "",
 				},
 			},
-			contains: []flagCheck{{"--kv-cache-dtype", "fp8_e5m2"}},
+			contains: []FlagCheck{{"--kv-cache-dtype", "fp8_e5m2"}},
 		},
 		{
-			name: "enablePrefixCaching=true emits flag",
+			model: model,
+			name:  "enablePrefixCaching=true emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{EnablePrefixCaching: ptrBool(true)},
 			},
-			contains: []flagCheck{{"--enable-prefix-caching", ""}},
+			contains: []FlagCheck{{"--enable-prefix-caching", ""}},
 		},
 		{
-			name: "enablePrefixCaching=false does not emit flag (lets vLLM default)",
+			model: model,
+			name:  "enablePrefixCaching=false does not emit flag (lets vLLM default)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -237,16 +240,18 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--enable-prefix-caching"},
 		},
 		{
-			name: "enableChunkedPrefill=true emits flag",
+			model: model,
+			name:  "enableChunkedPrefill=true emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{EnableChunkedPrefill: ptrBool(true)},
 			},
-			contains: []flagCheck{{"--enable-chunked-prefill", ""}},
+			contains: []FlagCheck{{"--enable-chunked-prefill", ""}},
 		},
 		{
-			name: "enableChunkedPrefill=false does not emit flag",
+			model: model,
+			name:  "enableChunkedPrefill=false does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -255,16 +260,18 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--enable-chunked-prefill"},
 		},
 		{
-			name: "maxNumBatchedTokens set emits flag",
+			model: model,
+			name:  "maxNumBatchedTokens set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{MaxNumBatchedTokens: ptrInt32(8192)},
 			},
-			contains: []flagCheck{{"--max-num-batched-tokens", "8192"}},
+			contains: []FlagCheck{{"--max-num-batched-tokens", "8192"}},
 		},
 		{
-			name: "maxNumBatchedTokens nil does not emit flag",
+			model: model,
+			name:  "maxNumBatchedTokens nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -273,17 +280,19 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--max-num-batched-tokens"},
 		},
 		{
-			name: "parallelSlots set emits flag (without extraArgs precedence)",
+			model: model,
+			name:  "parallelSlots set emits flag (without extraArgs precedence)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:       "vllm",
 				ModelRef:      "test-model",
 				ParallelSlots: ptrInt32(1),
 				VLLMConfig:    &inferencev1alpha1.VLLMConfig{},
 			},
-			contains: []flagCheck{{"--max-num-seqs", "1"}},
+			contains: []FlagCheck{{"--max-num-seqs", "1"}},
 		},
 		{
-			name: "parallelSlots set emits flag (with extraArgs precedence)",
+			model: model,
+			name:  "parallelSlots set emits flag (with extraArgs precedence)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:       "vllm",
 				ModelRef:      "test-model",
@@ -294,10 +303,11 @@ func TestVLLMBuildArgs(t *testing.T) {
 			// and containsArgs helper function always validate first occurrence, having
 			// --max-num-seqs 8 case true mean that no duplicate due to parallelSlots was
 			// found along the way.
-			contains: []flagCheck{{"--max-num-seqs", "8"}},
+			contains: []FlagCheck{{"--max-num-seqs", "8"}},
 		},
 		{
-			name: "parallelSlots set emits flag (with extraArgs inline precedence)",
+			model: model,
+			name:  "parallelSlots set emits flag (with extraArgs inline precedence)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:       "vllm",
 				ModelRef:      "test-model",
@@ -308,10 +318,11 @@ func TestVLLMBuildArgs(t *testing.T) {
 			// and containsArgs helper function always validate first occurrence, having
 			// --max-num-seqs 8 case true mean that no duplicate due to parallelSlots was
 			// found along the way.
-			contains: []flagCheck{{"--max-num-seqs=8", ""}},
+			contains: []FlagCheck{{"--max-num-seqs=8", ""}},
 		},
 		{
-			name: "parallelSlots nil does not emit flag",
+			model: model,
+			name:  "parallelSlots nil does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -320,25 +331,28 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--max-num-seqs"},
 		},
 		{
-			name: "attentionBackend=FLASHINFER emits flag (uppercase)",
+			model: model,
+			name:  "attentionBackend=FLASHINFER emits flag (uppercase)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{AttentionBackend: "FLASHINFER"},
 			},
-			contains: []flagCheck{{"--attention-backend", "FLASHINFER"}},
+			contains: []FlagCheck{{"--attention-backend", "FLASHINFER"}},
 		},
 		{
-			name: "attentionBackend=flashinfer emits flag (lowercase compat)",
+			model: model,
+			name:  "attentionBackend=flashinfer emits flag (lowercase compat)",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{AttentionBackend: "flashinfer"},
 			},
-			contains: []flagCheck{{"--attention-backend", "flashinfer"}},
+			contains: []FlagCheck{{"--attention-backend", "flashinfer"}},
 		},
 		{
-			name: "speculative enabled+model emits both flags",
+			model: model,
+			name:  "speculative enabled+model emits both flags",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "vllm",
 				ModelRef: "test-model",
@@ -350,13 +364,14 @@ func TestVLLMBuildArgs(t *testing.T) {
 					},
 				},
 			},
-			contains: []flagCheck{
+			contains: []FlagCheck{
 				{"--speculative-model", "Qwen/Qwen3.6-4B"},
 				{"--num-speculative-tokens", "4"},
 			},
 		},
 		{
-			name: "speculative enabled without model skips both flags",
+			model: model,
+			name:  "speculative enabled without model skips both flags",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "vllm",
 				ModelRef: "test-model",
@@ -370,7 +385,8 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--speculative-model", "--num-speculative-tokens"},
 		},
 		{
-			name: "speculative disabled does not emit flags even with model set",
+			model: model,
+			name:  "speculative disabled does not emit flags even with model set",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "vllm",
 				ModelRef: "test-model",
@@ -384,16 +400,18 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--speculative-model", "--num-speculative-tokens"},
 		},
 		{
-			name: "enableExpertParallel=true emits flag",
+			model: model,
+			name:  "enableExpertParallel=true emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
 				VLLMConfig: &inferencev1alpha1.VLLMConfig{EnableExpertParallel: ptrBool(true)},
 			},
-			contains: []flagCheck{{"--enable-expert-parallel", ""}},
+			contains: []FlagCheck{{"--enable-expert-parallel", ""}},
 		},
 		{
-			name: "enableExpertParallel=false does not emit flag",
+			model: model,
+			name:  "enableExpertParallel=false does not emit flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:    "vllm",
 				ModelRef:   "test-model",
@@ -402,7 +420,8 @@ func TestVLLMBuildArgs(t *testing.T) {
 			notContains: []string{"--enable-expert-parallel"},
 		},
 		{
-			name: "full agentic config emits all flags together",
+			model: model,
+			name:  "full agentic config emits all flags together",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:       "vllm",
 				ModelRef:      "test-model",
@@ -419,7 +438,7 @@ func TestVLLMBuildArgs(t *testing.T) {
 					TensorParallelSize:   ptrInt32(2),
 				},
 			},
-			contains: []flagCheck{
+			contains: []FlagCheck{
 				{"--attention-backend", "FLASHINFER"},
 				{"--dtype", "bfloat16"},
 				{"--enable-prefix-caching", ""},
@@ -440,12 +459,7 @@ func TestVLLMBuildArgs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "isvc-" + strings.ReplaceAll(tc.name, " ", "-"), Namespace: "default"},
 				Spec:       *tc.spec,
 			}
-			var args []string
-			if tc.spec.ModelRef == "test-model-gpu" {
-				args = backend.BuildArgs(isvc, modelWithGpu, modelPath, port)
-			} else {
-				args = backend.BuildArgs(isvc, model, modelPath, port)
-			}
+			args := backend.BuildArgs(isvc, tc.model, modelPath, port)
 			for _, fc := range tc.contains {
 				if !containsArg(args, fc.flag, fc.value) {
 					t.Errorf("expected %q %q in args, got: %v", fc.flag, fc.value, args)

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -25,31 +25,6 @@ import (
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
 
-// containsArg reports whether args contains the given flag. When value is
-// non-empty, it also requires the immediately following entry to equal value
-// (i.e. `--flag value` as separate slice elements, which is how BuildArgs
-// emits everything).
-func containsArg(args []string, flag, value string) bool {
-	for i, a := range args {
-		if a != flag {
-			continue
-		}
-		if value == "" {
-			return true
-		}
-		if i+1 < len(args) && args[i+1] == value {
-			return true
-		}
-	}
-	return false
-}
-
-// ptrString, ptrBool, ptrInt32 are local helpers so tests read naturally.
-func ptrString(s string) *string    { return &s }
-func ptrBool(b bool) *bool          { return &b }
-func ptrInt32(i int32) *int32       { return &i }
-func ptrFloat64(f float64) *float64 { return &f }
-
 // TestVLLMBuildArgs is the single table-driven test that covers every new
 // agentic-coding flag and the "not emitted when unset/false" counterpart.
 // Each row asserts a set of must-contain and must-not-contain flags on the


### PR DESCRIPTION
## What

Cleanup testing and shared helpers.

## Why

As discussed in previous PR reviews, some refactoring and cleanup was needed on the runtime testing part.

## How

- Move shared helper functions for runtime testing to a dedicated file `runtime_test.go` (`containsArgs` and `ptr*`).
- Move duplicated FlagCheck structure to `runtime_test.go`.
- Move duplicated test case inline structure to `runtime_test.go.
- Add model to test case to add fixture variations based on model spec.
- Move `resolveGPUCount` from `runtime_llama.go` to `runtime.go`.
- Add test suite for `resolveGPUCount`.

## Checklist

- [X] Tests added/updated
- [X] `make test` passes locally
- [X] `make lint` passes locally
- [X] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [X] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [X] Documentation updated (if user-facing change)
