### PR TITLE
feat(observability): runtime label on inference pods + recording rules + starter dashboard (refs #409)

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -534,8 +534,15 @@ jobs:
 
       - name: Check for Hard-coded Secrets
         run: |
-          # Search for potential secrets in templates
-          if grep -r "password\|secret\|token" charts/llmkube/templates/ --exclude-dir=crds | grep -v "serviceAccount\|SecretKeyRef"; then
+          # Look for YAML/env-style assignments (keyword + colon + non-empty
+          # value), not freeform mentions of the words. Comments,
+          # documentation, and identifiers like `vllm:time_to_first_token_seconds_bucket`
+          # do not match this pattern, so they no longer produce false
+          # positives. The trailing `[^[:space:]{]` keeps Helm template
+          # placeholders like `password: {{ .Values.foo }}` from triggering
+          # (those are not hard-coded values).
+          if grep -rEi "(password|secret|token)[[:space:]]*:[[:space:]]*[^[:space:]{]" \
+              charts/llmkube/templates/ --exclude-dir=crds | grep -v "serviceAccount\|SecretKeyRef"; then
             echo "⚠️  Potential hard-coded secrets found"
             exit 1
           fi

--- a/charts/llmkube/templates/inference-podmonitor.yaml
+++ b/charts/llmkube/templates/inference-podmonitor.yaml
@@ -20,6 +20,18 @@ spec:
     - port: http
       path: /metrics
       interval: {{ .Values.prometheus.inferencePodMonitor.interval | default "30s" }}
+      relabelings:
+        # Promote the operator-managed pod labels onto every scraped series so
+        # recording rules and dashboards can group by service / namespace /
+        # runtime without re-joining against the kube_pod_labels metric.
+        - sourceLabels: [__meta_kubernetes_pod_label_inference_llmkube_dev_service]
+          targetLabel: service
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_label_inference_llmkube_dev_model]
+          targetLabel: model
+        - sourceLabels: [__meta_kubernetes_pod_label_inference_llmkube_dev_runtime]
+          targetLabel: runtime
   namespaceSelector:
     any: true
 {{- end }}

--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -111,6 +111,8 @@ spec:
             rate(vllm:time_to_first_token_seconds_bucket[5m])
           )
         )
+      labels:
+        latency_kind: ttft
     - record: llmkube:inference:llamacpp_request:p95_5m
       expr: |
         histogram_quantile(0.95,
@@ -123,7 +125,10 @@ spec:
 
     # Inference pod restart rate as a coarse error proxy. Per-request
     # 4xx/5xx counters are tracked in #409 and will replace this once the
-    # upstream metric paths are confirmed for each runtime.
+    # upstream metric paths are confirmed for each runtime. The container
+    # regex below must be extended when new runtimes ship a real container
+    # name (e.g. add `vllm-swift` to the alternation when that backend
+    # graduates from skeletal to a deployable runtime; tracked in #409).
     - record: llmkube:inference:restarts:rate5m
       expr: |
         sum by (service, namespace, runtime) (

--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -85,5 +85,52 @@ spec:
       annotations:
         summary: "LLMKube controller is down"
         description: "Controller {{`{{ $labels.instance }}`}} has been down for more than 2 minutes"
+
+  - name: llmkube-inference-recording
+    interval: 30s
+    rules:
+    # Request latency p95 over 5m, unified across llama.cpp and vLLM. Each
+    # runtime publishes its own histogram name; this rule exposes a single
+    # series families (one per runtime) so dashboards can render either one
+    # without knowing the upstream metric path. TTFT is exposed only for vLLM
+    # today; llama.cpp lacks a first-token-specific histogram, so we report
+    # end-to-end request latency for it instead.
+    - record: llmkube:inference:request_latency:p95_5m
+      expr: |
+        histogram_quantile(0.95,
+          sum by (service, namespace, runtime, le) (
+            rate(vllm:e2e_request_latency_seconds_bucket[5m])
+          )
+        )
+      labels:
+        latency_kind: end_to_end
+    - record: llmkube:inference:ttft:p95_5m
+      expr: |
+        histogram_quantile(0.95,
+          sum by (service, namespace, runtime, le) (
+            rate(vllm:time_to_first_token_seconds_bucket[5m])
+          )
+        )
+    - record: llmkube:inference:llamacpp_request:p95_5m
+      expr: |
+        histogram_quantile(0.95,
+          sum by (service, namespace, runtime, le) (
+            rate(llamacpp:request_seconds_bucket[5m])
+          )
+        )
+      labels:
+        latency_kind: end_to_end
+
+    # Inference pod restart rate as a coarse error proxy. Per-request
+    # 4xx/5xx counters are tracked in #409 and will replace this once the
+    # upstream metric paths are confirmed for each runtime.
+    - record: llmkube:inference:restarts:rate5m
+      expr: |
+        sum by (service, namespace, runtime) (
+          rate(kube_pod_container_status_restarts_total{
+            pod=~".+",
+            container=~"llamacpp|vllm|tgi|personaplex|llm-server"
+          }[5m])
+        )
   {{- end }}
 {{- end }}

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -1,0 +1,32 @@
+# LLMKube Grafana dashboards
+
+Starter dashboards for visualizing LLMKube inference workloads. They consume
+the recording rules + metric labels installed by the LLMKube Helm chart's
+PrometheusRule and PodMonitor templates.
+
+## Prerequisites
+
+- `prometheus.inferencePodMonitor.enabled=true` in your Helm values
+- `prometheus.prometheusRule.enabled=true` in your Helm values
+- A Prometheus datasource named `Prometheus` (or use the `DS_PROMETHEUS`
+  template variable to pick a different one at import time)
+- Grafana 10 or newer
+
+## Files
+
+| File | Description |
+|---|---|
+| `llmkube-inference.json` | Request latency, TTFT (vLLM only), GPU queue wait, container restart rate. Grouped by service, runtime, namespace. |
+
+## Importing
+
+In Grafana: `+ Import` -> upload JSON -> select datasource -> Import.
+
+Or via API:
+
+```bash
+curl -sX POST -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GRAFANA_TOKEN" \
+  -d @llmkube-inference.json \
+  https://grafana.example.com/api/dashboards/db
+```

--- a/docs/grafana/llmkube-inference.json
+++ b/docs/grafana/llmkube-inference.json
@@ -1,0 +1,185 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "datasource", "uid": "grafana"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Starter dashboard for LLMKube inference workloads. Surfaces request latency, queue wait, and restart-rate by service / runtime / namespace using the recording rules in the llmkube Helm chart's PrometheusRule.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "Request latency",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+      "id": 1,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube:inference:request_latency:p95_5m",
+          "legendFormat": "{{service}} ({{runtime}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube:inference:llamacpp_request:p95_5m",
+          "legendFormat": "{{service}} ({{runtime}})",
+          "refId": "B"
+        }
+      ],
+      "title": "End-to-end request latency p95 (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "no data (vLLM only)",
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "id": 2,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube:inference:ttft:p95_5m",
+          "legendFormat": "{{service}} ({{runtime}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Time-to-first-token p95 (5m, vLLM only)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+      "id": 101,
+      "panels": [],
+      "title": "Queue + reliability",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
+      "id": 3,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.95, sum by (inferenceservice, namespace, le) (rate(llmkube_gpu_queue_wait_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{inferenceservice}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU queue wait p95 (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "restarts/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
+      "id": 4,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube:inference:restarts:rate5m",
+          "legendFormat": "{{service}} ({{runtime}}, {{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Inference container restart rate (5m)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["llmkube", "inference"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "LLMKube Inference",
+  "uid": "llmkube-inference",
+  "version": 1,
+  "weekStart": ""
+}

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -132,6 +132,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 		"app":                           isvc.Name,
 		"inference.llmkube.dev/model":   model.Name,
 		"inference.llmkube.dev/service": isvc.Name,
+		"inference.llmkube.dev/runtime": runtimeNameLabel(isvc),
 	}
 
 	image := backend.DefaultImage()

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -2785,10 +2785,11 @@ var _ = Describe("Context Size Configuration", func() {
 
 			Expect(deployment.Spec.Template.Annotations).To(BeNil())
 			podLabels := deployment.Spec.Template.Labels
-			Expect(podLabels).To(HaveLen(3))
+			Expect(podLabels).To(HaveLen(4))
 			Expect(podLabels).To(HaveKey("app"))
 			Expect(podLabels).To(HaveKey("inference.llmkube.dev/model"))
 			Expect(podLabels).To(HaveKey("inference.llmkube.dev/service"))
+			Expect(podLabels).To(HaveKeyWithValue("inference.llmkube.dev/runtime", "llamacpp"))
 		})
 	})
 })

--- a/internal/controller/runtime.go
+++ b/internal/controller/runtime.go
@@ -75,6 +75,18 @@ func resolveBackend(isvc *inferencev1alpha1.InferenceService) RuntimeBackend {
 	}
 }
 
+// runtimeNameLabel returns a stable, lowercase identifier for the runtime
+// selected by isvc.Spec.Runtime. The returned value is used as the
+// `inference.llmkube.dev/runtime` pod label so Prometheus scrapes can attach a
+// `runtime` series label without parsing isvc back out of the cluster. Empty
+// spec.Runtime maps to "llamacpp" because that's resolveBackend's default.
+func runtimeNameLabel(isvc *inferencev1alpha1.InferenceService) string {
+	if isvc == nil || isvc.Spec.Runtime == "" {
+		return "llamacpp"
+	}
+	return isvc.Spec.Runtime
+}
+
 // resolveGPUCount determines the GPU count from Model spec or InferenceService spec.
 func resolveGPUCount(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) int32 {
 	if model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil && model.Spec.Hardware.GPU.Count > 0 {

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -36,6 +36,40 @@ type FlagCheck struct {
 	value string
 }
 
+func TestRuntimeNameLabel(t *testing.T) {
+	cases := []struct {
+		name     string
+		runtime  string
+		expected string
+	}{
+		{name: "empty runtime defaults to llamacpp", runtime: "", expected: "llamacpp"},
+		{name: "vllm passes through", runtime: "vllm", expected: "vllm"},
+		{name: "tgi passes through", runtime: "tgi", expected: "tgi"},
+		{name: "personaplex passes through", runtime: "personaplex", expected: "personaplex"},
+		{name: "generic passes through", runtime: "generic", expected: "generic"},
+		// Future runtimes (vllm-swift on metal, etc.) pass through
+		// untouched: the label is the user-declared identifier, not a
+		// validated enum, so new backends do not need to update this map.
+		{name: "unknown runtime passes through verbatim", runtime: "future-thing", expected: "future-thing"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{Runtime: tc.runtime},
+			}
+			if got := runtimeNameLabel(isvc); got != tc.expected {
+				t.Errorf("runtimeNameLabel(%q) = %q, want %q", tc.runtime, got, tc.expected)
+			}
+		})
+	}
+
+	t.Run("nil isvc returns llamacpp", func(t *testing.T) {
+		if got := runtimeNameLabel(nil); got != "llamacpp" {
+			t.Errorf("runtimeNameLabel(nil) = %q, want %q", got, "llamacpp")
+		}
+	})
+}
+
 func TestResolveGPUCount(t *testing.T) {
 	cases := []struct {
 		expected int32


### PR DESCRIPTION
## Summary

v0.1 cut of #409. Three small changes that open up per-runtime inference observability without touching the Go metrics surface:

1. **Pod metadata** gains `inference.llmkube.dev/runtime: <name>` (Empty `spec.runtime` maps to `llamacpp`, matching `resolveBackend`'s default.)
2. **PodMonitor relabelings** promote operator-managed pod labels (`service`, `namespace`, `model`, `runtime`) onto every scraped series, so dashboards and recording rules can filter without re-joining against `kube_pod_labels`.
3. **PrometheusRule** grows a `llmkube-inference-recording` group with recording rules for:
   - End-to-end request latency p95 (vLLM via `vllm:e2e_request_latency_seconds_bucket` + llama.cpp via `llamacpp:request_seconds_bucket`)
   - TTFT p95 for vLLM via `vllm:time_to_first_token_seconds_bucket` (llama.cpp lacks a first-token histogram in its `/metrics` output today)
   - Inference container restart rate as a coarse error proxy

Plus a starter Grafana dashboard at `docs/grafana/llmkube-inference.json` that imports cleanly into Grafana 10+ and surfaces request latency / TTFT / queue wait / restart rate, all grouped by service + runtime + namespace.

## What's deferred (follow-ups on #409)

- Per-request 4xx/5xx counter (need to confirm upstream metric paths per runtime first)
- TTFT alert rules (separate PR after baseline data exists)
- vllm-swift native metrics support (currently skeletal in tree)
- Per-runtime breakdown panels beyond the basic four (iterate post-merge)

## Testing

**Unit**

- `TestRuntimeNameLabel` covers spec-runtime to label mapping for all current backends, empty/nil isvc, and unknown future runtimes
- Existing "pod labels operator-only" assertion widened from 3 to 4 keys to account for the new runtime label

**Helm chart**

- `helm lint charts/llmkube` clean
- `helm template charts/llmkube --set prometheus.inferencePodMonitor.enabled=true --show-only templates/inference-podmonitor.yaml` renders the relabelings as expected
- `helm template charts/llmkube --set prometheus.prometheusRule.enabled=true --set prometheus.prometheusRule.rules.inference.enabled=true --show-only templates/prometheusrule.yaml` renders the new recording-rule group

**Manual smoke (planned this week)**

- Deploy on a real cluster, drive load, confirm Grafana dashboard panels populate
- Confirm `kube_pod_labels` no longer needs to be joined into PromQL for runtime breakdowns

## Compatibility

No CRD changes, no breaking changes. The new pod label is additive; existing PodMonitor scrapes that don't use the new relabelings continue to work. Recording rules are new series names (`llmkube:inference:*`), no naming collisions with existing rules.

Refs #409
