### PR TITLE
feat(metal-agent): emit Kubernetes events for memory-pressure transitions, evictions, skips, and respawn blocks (closes #390)

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -28,7 +28,11 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -352,10 +356,29 @@ func main() {
 	}
 	logger.Infow("connected to Kubernetes cluster")
 
+	// EventRecorder feeds operator-facing Kubernetes events on managed
+	// InferenceService objects (memory-pressure transitions, evictions,
+	// respawn blocks). The controller-runtime client doesn't expose an
+	// EventSink, so we build a typed clientset just for the events API and
+	// wire it through a shared broadcaster. Closes #390.
+	clientset, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		logger.Errorw("failed to create kubernetes clientset for events", "error", err)
+		os.Exit(1)
+	}
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{
+		Interface: clientset.CoreV1().Events(""),
+	})
+	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme,
+		corev1.EventSource{Component: "llmkube-metal-agent"})
+	defer eventBroadcaster.Shutdown()
+
 	// Create agent
 	logger.Infow("creating Metal agent")
 	agentCfg := agent.MetalAgentConfig{
 		K8sClient:                 k8sClient,
+		EventRecorder:             eventRecorder,
 		Namespace:                 cfg.Namespace,
 		ModelStorePath:            cfg.ModelStorePath,
 		LlamaServerBin:            cfg.LlamaServerBin,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -29,7 +29,9 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -59,6 +61,14 @@ type MetalAgentConfig struct {
 	Port           int
 	HostIP         string // explicit IP to register in K8s endpoints; empty = auto-detect
 	Logger         *zap.SugaredLogger
+
+	// EventRecorder publishes Kubernetes events on managed InferenceService
+	// objects so operators can triage memory pressure / eviction / respawn
+	// behavior via `kubectl describe` (and any tool that surfaces K8s events:
+	// k9s, Lens, ArgoCD). Nil disables event emission; the agent still
+	// updates conditions and metrics. Tests can pass a record.FakeRecorder
+	// to assert on the event stream. Closes #390.
+	EventRecorder record.EventRecorder
 
 	// Runtime selects the inference backend: "llama-server" (default), "omlx", or "ollama".
 	Runtime string
@@ -544,6 +554,15 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 		a.logger.Warnw("skipping ensureProcess; eviction-blocked under memory pressure",
 			"namespace", isvc.Namespace, "name", isvc.Name,
 			"pressureLevel", pressureLevel.String())
+		// Surface the block as a Kubernetes event so an operator who
+		// `kubectl describe`s a service that "won't start" can see why.
+		// Synthesize a ManagedProcess shell with just the IS coordinates;
+		// emitInferenceEvent re-fetches the live IS for the event target.
+		a.emitInferenceEvent(ctx, &ManagedProcess{Namespace: isvc.Namespace, Name: isvc.Name},
+			corev1.EventTypeWarning, EventReasonRespawnBlocked,
+			"Respawn blocked: previous process was evicted and host memory pressure is %s",
+			pressureLevel.String(),
+		)
 		return nil
 	}
 

--- a/pkg/agent/pressure.go
+++ b/pkg/agent/pressure.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +43,42 @@ const (
 	ReasonMemoryCritical = "Critical"
 	ReasonEvicted        = "Evicted"
 )
+
+// Kubernetes event reasons emitted by the watchdog. Kept short and
+// UpperCamelCase per the corev1.Event convention so they show up cleanly in
+// `kubectl describe inferenceservice` and in tools like k9s/Lens.
+const (
+	EventReasonMemoryPressureLevelChanged = "MemoryPressureLevelChanged"
+	EventReasonEvicted                    = "Evicted"
+	EventReasonEvictionSkipped            = "EvictionSkipped"
+	EventReasonRespawnBlocked             = "RespawnBlocked"
+)
+
+// emitInferenceEvent publishes a Kubernetes event on the InferenceService
+// identified by p (namespace+name). It re-fetches the IS so the event lands
+// on the up-to-date object metadata; failures are logged and ignored, since
+// observability must never block the watchdog. No-op when EventRecorder is
+// nil, which keeps tests that wire only K8sClient working unchanged.
+func (a *MetalAgent) emitInferenceEvent(ctx context.Context, p *ManagedProcess, eventType, reason, messageFmt string, args ...interface{}) {
+	if a.config.EventRecorder == nil || p == nil {
+		return
+	}
+	if a.config.K8sClient == nil {
+		// Without a client we cannot fetch the involved object; the recorder
+		// requires a real runtime.Object to set the involvedObjectReference.
+		return
+	}
+	isvc := &inferencev1alpha1.InferenceService{}
+	key := types.NamespacedName{Namespace: p.Namespace, Name: p.Name}
+	if err := a.config.K8sClient.Get(ctx, key, isvc); err != nil {
+		if !apierrors.IsNotFound(err) {
+			a.logger.Debugw("emitInferenceEvent: get IS failed",
+				"key", key.String(), "reason", reason, "error", err)
+		}
+		return
+	}
+	a.config.EventRecorder.Eventf(isvc, eventType, reason, messageFmt, args...)
+}
 
 // handleMemoryPressure is the watchdog callback. It runs on the watchdog
 // goroutine, so it must not block on long operations: K8s status writes are
@@ -108,6 +145,25 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 		}
 	}
 
+	// Emit a single Kubernetes event per managed process on level transitions
+	// (not on every same-level tick, otherwise sustained pressure floods the
+	// event stream). Type Warning for non-Normal levels so tools like k9s
+	// surface them with the appropriate icon. Closes #390.
+	if level != previous {
+		eventType := corev1.EventTypeNormal
+		if level != MemoryPressureNormal {
+			eventType = corev1.EventTypeWarning
+		}
+		eventMsg := fmt.Sprintf("MemoryPressure transitioned from %s to %s (totalRSS=%s of %s)",
+			previous.String(), level.String(),
+			formatMemory(stats.TotalRSS), formatMemory(stats.TotalMemory),
+		)
+		for _, p := range snapshot {
+			a.emitInferenceEvent(ctx, p, eventType,
+				EventReasonMemoryPressureLevelChanged, "%s", eventMsg)
+		}
+	}
+
 	// Eviction path. Honored via the --eviction-enabled CLI flag (default
 	// false) so that operators must explicitly opt in to having the
 	// watchdog stop inference processes.
@@ -117,6 +173,8 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 		// every Warning tick and obscure the signal operators care about.
 		if level == MemoryPressureCritical {
 			evictionsSkippedTotal.WithLabelValues("disabled").Inc()
+			a.emitEvictionSkippedAcrossManaged(ctx, snapshot, "disabled",
+				"watchdog at Critical but eviction disabled (set --eviction-enabled to opt in)")
 		}
 		return
 	}
@@ -126,6 +184,9 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 		// is the watchdog's normal observation, not a refusal.
 		if level == MemoryPressureCritical {
 			evictionsSkippedTotal.WithLabelValues("below_guard").Inc()
+			a.emitEvictionSkippedAcrossManaged(ctx, snapshot, "below_guard",
+				fmt.Sprintf("watchdog at Critical but managed processes hold less than 50%% of system RSS (totalRSS=%s of %s); refusing friendly fire",
+					formatMemory(stats.TotalRSS), formatMemory(stats.TotalMemory)))
 		}
 		return
 	}
@@ -134,6 +195,10 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 		evictionsSkippedTotal.WithLabelValues(skipReason).Inc()
 		a.logger.Warnw("memory critical but no eligible eviction target found",
 			"managed", len(snapshot), "reason", skipReason)
+		a.emitEvictionSkippedAcrossManaged(ctx, snapshot, skipReason,
+			fmt.Sprintf("eviction skipped: reason=%s (managed=%d, totalRSS=%s of %s)",
+				skipReason, len(snapshot),
+				formatMemory(stats.TotalRSS), formatMemory(stats.TotalMemory)))
 		return
 	}
 
@@ -167,6 +232,28 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 		delete(a.pressureBlocked, key)
 		a.mu.Unlock()
 		a.logger.Errorw("eviction failed; cleared pressure block", "key", key, "error", err)
+		return
+	}
+
+	a.emitInferenceEvent(ctx, target, corev1.EventTypeWarning, EventReasonEvicted,
+		"Process evicted to relieve memory pressure (priority=%s, totalRSS=%s of %s)",
+		target.Priority,
+		formatMemory(stats.TotalRSS), formatMemory(stats.TotalMemory),
+	)
+}
+
+// emitEvictionSkippedAcrossManaged broadcasts an EvictionSkipped event to
+// every currently-managed process. Used when the watchdog would have evicted
+// but couldn't (eviction disabled, below-guard, or no candidate found): no
+// single InferenceService is the "subject" of the skip, but operators on any
+// of the managed services should be able to see why their host stayed under
+// pressure without action. Type Normal because the agent is behaving as
+// designed; the higher-severity signal is the underlying MemoryPressure
+// condition + level-changed event.
+func (a *MetalAgent) emitEvictionSkippedAcrossManaged(ctx context.Context, snapshot map[string]*ManagedProcess, reason, message string) {
+	for _, p := range snapshot {
+		a.emitInferenceEvent(ctx, p, corev1.EventTypeNormal,
+			EventReasonEvictionSkipped, "%s (skip-reason=%s)", message, reason)
 	}
 }
 

--- a/pkg/agent/pressure.go
+++ b/pkg/agent/pressure.go
@@ -59,6 +59,13 @@ const (
 // on the up-to-date object metadata; failures are logged and ignored, since
 // observability must never block the watchdog. No-op when EventRecorder is
 // nil, which keeps tests that wire only K8sClient working unchanged.
+//
+// Lock safety: this helper performs apiserver I/O (a Get + an event write)
+// and MUST NOT be called while holding a.mu. Callers in pressure.go drop
+// the lock before invoking it; the existing call sites all live in the
+// post-Unlock section of handleMemoryPressure and the no-lock path in
+// ensureProcess. Future callers must preserve that property or risk
+// stalling the watchdog goroutine on a slow apiserver round-trip.
 func (a *MetalAgent) emitInferenceEvent(
 	ctx context.Context, p *ManagedProcess,
 	eventType, reason, messageFmt string, args ...interface{},
@@ -255,6 +262,13 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 // pressure without action. Type Normal because the agent is behaving as
 // designed; the higher-severity signal is the underlying MemoryPressure
 // condition + level-changed event.
+//
+// Follow-up (#390 review): under sustained Critical+disabled (or below-guard)
+// pressure this fans out N events per watchdog tick across N managed
+// processes. If that ever drowns out level-changed events in operator
+// tooling, gate via a per-IS `lastSkipReason` map (analogous to
+// pressureObserved) so we only emit when the reason changes. Not done in
+// the initial PR because the actual on-cluster volume is still unknown.
 func (a *MetalAgent) emitEvictionSkippedAcrossManaged(
 	ctx context.Context, snapshot map[string]*ManagedProcess,
 	reason, message string,

--- a/pkg/agent/pressure.go
+++ b/pkg/agent/pressure.go
@@ -59,7 +59,10 @@ const (
 // on the up-to-date object metadata; failures are logged and ignored, since
 // observability must never block the watchdog. No-op when EventRecorder is
 // nil, which keeps tests that wire only K8sClient working unchanged.
-func (a *MetalAgent) emitInferenceEvent(ctx context.Context, p *ManagedProcess, eventType, reason, messageFmt string, args ...interface{}) {
+func (a *MetalAgent) emitInferenceEvent(
+	ctx context.Context, p *ManagedProcess,
+	eventType, reason, messageFmt string, args ...interface{},
+) {
 	if a.config.EventRecorder == nil || p == nil {
 		return
 	}
@@ -185,7 +188,9 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 		if level == MemoryPressureCritical {
 			evictionsSkippedTotal.WithLabelValues("below_guard").Inc()
 			a.emitEvictionSkippedAcrossManaged(ctx, snapshot, "below_guard",
-				fmt.Sprintf("watchdog at Critical but managed processes hold less than 50%% of system RSS (totalRSS=%s of %s); refusing friendly fire",
+				fmt.Sprintf(
+					"watchdog at Critical but managed processes hold less than 50%% of system RSS "+
+						"(totalRSS=%s of %s); refusing friendly fire",
 					formatMemory(stats.TotalRSS), formatMemory(stats.TotalMemory)))
 		}
 		return
@@ -250,7 +255,10 @@ func (a *MetalAgent) handleMemoryPressure(ctx context.Context, level MemoryPress
 // pressure without action. Type Normal because the agent is behaving as
 // designed; the higher-severity signal is the underlying MemoryPressure
 // condition + level-changed event.
-func (a *MetalAgent) emitEvictionSkippedAcrossManaged(ctx context.Context, snapshot map[string]*ManagedProcess, reason, message string) {
+func (a *MetalAgent) emitEvictionSkippedAcrossManaged(
+	ctx context.Context, snapshot map[string]*ManagedProcess,
+	reason, message string,
+) {
 	for _, p := range snapshot {
 		a.emitInferenceEvent(ctx, p, corev1.EventTypeNormal,
 			EventReasonEvictionSkipped, "%s (skip-reason=%s)", message, reason)

--- a/pkg/agent/pressure_test.go
+++ b/pkg/agent/pressure_test.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -477,4 +479,199 @@ func TestHandleMemoryPressure_NormalClearsBlockedSet(t *testing.T) {
 	if a.lastPressureLevel != MemoryPressureNormal {
 		t.Errorf("lastPressureLevel = %v, want Normal", a.lastPressureLevel)
 	}
+}
+
+// drainEvents reads everything currently buffered in a record.FakeRecorder
+// channel and returns it. The FakeRecorder's channel buffer is configured by
+// the test author; we drain non-blocking so an empty channel returns nil.
+func drainEvents(rec *record.FakeRecorder) []string {
+	var out []string
+	for {
+		select {
+		case e := <-rec.Events:
+			out = append(out, e)
+		default:
+			return out
+		}
+	}
+}
+
+// TestHandleMemoryPressure_EmitsLevelChangedEvent verifies that a level
+// transition publishes one MemoryPressureLevelChanged event per managed
+// process. Type Warning when leaving Normal, Type Normal when returning.
+// Closes #390 for the level-changed reason.
+func TestHandleMemoryPressure_EmitsLevelChangedEvent(t *testing.T) {
+	isvc := newPressureTestISvc("svc-a", "normal")
+	a := newPressureTestAgent(t, isvc)
+	rec := record.NewFakeRecorder(32)
+	a.config.EventRecorder = rec
+
+	a.processes["default/svc-a"] = &ManagedProcess{
+		Name: "svc-a", Namespace: "default", ModelPath: "/m.gguf",
+		Priority: "normal", StartedAt: time.Now(),
+	}
+
+	// Normal -> Warning transition
+	a.handleMemoryPressure(context.Background(), MemoryPressureWarning, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 25 << 30,
+	})
+
+	events := drainEvents(rec)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 event on transition, got %d: %v", len(events), events)
+	}
+	if !strings.Contains(events[0], EventReasonMemoryPressureLevelChanged) {
+		t.Errorf("event missing reason %q: %s", EventReasonMemoryPressureLevelChanged, events[0])
+	}
+	if !strings.Contains(events[0], corev1.EventTypeWarning) {
+		t.Errorf("non-Normal level should emit type Warning, got: %s", events[0])
+	}
+	if !strings.Contains(events[0], "normal to warning") {
+		t.Errorf("event message should describe the transition, got: %s", events[0])
+	}
+
+	// Same-level tick: no new event (we only fire on transitions, not every
+	// watchdog tick, otherwise sustained pressure floods event history).
+	a.handleMemoryPressure(context.Background(), MemoryPressureWarning, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 25 << 30,
+	})
+	if len(drainEvents(rec)) != 0 {
+		t.Error("same-level ticks must not emit a level-changed event")
+	}
+}
+
+// TestHandleMemoryPressure_EmitsEvictedEvent verifies that a successful
+// eviction emits an Evicted event of Type Warning on the target service. The
+// event message must include the priority (so operators can reason about the
+// eviction selector) and the system memory state at decision time.
+func TestHandleMemoryPressure_EmitsEvictedEvent(t *testing.T) {
+	low := newPressureTestISvc("svc-low", "low")
+	high := newPressureTestISvc("svc-high", "high")
+	a := newPressureTestAgent(t, low, high)
+	a.config.EvictionEnabled = true
+	a.executor = stubExecutor{}
+	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+	rec := record.NewFakeRecorder(32)
+	a.config.EventRecorder = rec
+
+	a.processes["default/svc-low"] = &ManagedProcess{
+		Name: "svc-low", Namespace: "default", Priority: "low",
+		ModelPath: "/m.gguf", PID: 999990, StartedAt: time.Now(),
+	}
+	a.processes["default/svc-high"] = &ManagedProcess{
+		Name: "svc-high", Namespace: "default", Priority: "high",
+		ModelPath: "/m.gguf", PID: 999991, StartedAt: time.Now(),
+	}
+
+	a.handleMemoryPressure(context.Background(), MemoryPressureCritical, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 80 << 30,
+	})
+
+	events := drainEvents(rec)
+	var evicted string
+	for _, e := range events {
+		if strings.Contains(e, EventReasonEvicted) {
+			evicted = e
+			break
+		}
+	}
+	if evicted == "" {
+		t.Fatalf("expected an Evicted event in the stream, got: %v", events)
+	}
+	if !strings.Contains(evicted, corev1.EventTypeWarning) {
+		t.Errorf("Evicted must be Type Warning, got: %s", evicted)
+	}
+	if !strings.Contains(evicted, "priority=low") {
+		t.Errorf("Evicted message should record priority of victim, got: %s", evicted)
+	}
+}
+
+// TestHandleMemoryPressure_EmitsEvictionSkippedWhenDisabled covers the
+// "watchdog wanted to act, refused" path: critical pressure with eviction
+// disabled emits an EvictionSkipped event so operators understand why their
+// host stayed pressured without action.
+func TestHandleMemoryPressure_EmitsEvictionSkippedWhenDisabled(t *testing.T) {
+	isvc := newPressureTestISvc("svc-low", "low")
+	a := newPressureTestAgent(t, isvc)
+	a.config.EvictionEnabled = false
+	a.executor = stubExecutor{}
+	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+	rec := record.NewFakeRecorder(32)
+	a.config.EventRecorder = rec
+
+	a.processes["default/svc-low"] = &ManagedProcess{
+		Name: "svc-low", Namespace: "default", Priority: "low",
+		ModelPath: "/m.gguf", PID: 999990, StartedAt: time.Now(),
+	}
+
+	a.handleMemoryPressure(context.Background(), MemoryPressureCritical, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 80 << 30,
+	})
+
+	events := drainEvents(rec)
+	var skipped string
+	for _, e := range events {
+		if strings.Contains(e, EventReasonEvictionSkipped) {
+			skipped = e
+			break
+		}
+	}
+	if skipped == "" {
+		t.Fatalf("expected EvictionSkipped event when eviction disabled, got: %v", events)
+	}
+	if !strings.Contains(skipped, "skip-reason=disabled") {
+		t.Errorf("EvictionSkipped should record skip-reason, got: %s", skipped)
+	}
+}
+
+// TestEnsureProcess_EmitsRespawnBlockedEvent verifies the back-pressure
+// guard surfaces as a Kubernetes event so an operator who runs
+// `kubectl describe inferenceservice <svc>` after a "won't start" complaint
+// sees the agent's reason rather than just empty status.
+func TestEnsureProcess_EmitsRespawnBlockedEvent(t *testing.T) {
+	isvc := newPressureTestISvc("svc-a", "low")
+	a := newPressureTestAgent(t, isvc)
+	a.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	rec := record.NewFakeRecorder(32)
+	a.config.EventRecorder = rec
+
+	a.pressureBlocked["default/svc-a"] = true
+	a.lastPressureLevel = MemoryPressureCritical
+
+	if err := a.ensureProcess(context.Background(), isvc); err != nil {
+		t.Fatalf("ensureProcess returned error, expected silent skip: %v", err)
+	}
+
+	events := drainEvents(rec)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 RespawnBlocked event, got %d: %v", len(events), events)
+	}
+	if !strings.Contains(events[0], EventReasonRespawnBlocked) {
+		t.Errorf("event missing reason %q: %s", EventReasonRespawnBlocked, events[0])
+	}
+	if !strings.Contains(events[0], corev1.EventTypeWarning) {
+		t.Errorf("RespawnBlocked must be Type Warning, got: %s", events[0])
+	}
+	if !strings.Contains(events[0], MemoryPressureCritical.String()) {
+		t.Errorf("RespawnBlocked should mention current pressure level, got: %s", events[0])
+	}
+}
+
+// TestEmitInferenceEvent_NilRecorderIsNoop verifies the agent stays
+// functional when the operator runs without an EventRecorder configured
+// (today's default in tests; the metal-agent main.go always wires one in
+// production). No panic, no crash, no event.
+func TestEmitInferenceEvent_NilRecorderIsNoop(t *testing.T) {
+	isvc := newPressureTestISvc("svc-a", "normal")
+	a := newPressureTestAgent(t, isvc)
+	// EventRecorder intentionally nil
+
+	a.processes["default/svc-a"] = &ManagedProcess{
+		Name: "svc-a", Namespace: "default", ModelPath: "/m.gguf",
+		Priority: "normal", StartedAt: time.Now(),
+	}
+
+	a.handleMemoryPressure(context.Background(), MemoryPressureWarning, MemoryStats{
+		TotalMemory: 100 << 30, TotalRSS: 25 << 30,
+	})
 }


### PR DESCRIPTION
## Summary

Closes #390. Wires `record.EventRecorder` into the metal-agent so the watchdog publishes Kubernetes events on managed `InferenceService` objects. Today the watchdog patches the `MemoryPressure` status condition and increments the `evictions_skipped_total` counter, but operators triaging "why did my model disappear" or "why is the watchdog Critical and nothing happened" only have the condition (point-in-time, no history), Prometheus counters (requires Prometheus + scraping), and agent logs. After this PR, `kubectl describe inferenceservice <name>` and any tool that surfaces K8s events (k9s, Lens, ArgoCD) shows what happened.

## Reasons emitted

| Reason | Type | When |
|---|---|---|
| `MemoryPressureLevelChanged` | Warning | Watchdog level transitions out of Normal (Normal -> Warning, Normal -> Critical, Warning -> Critical) |
| `MemoryPressureLevelChanged` | Normal | Watchdog level returns to Normal |
| `Evicted` | Warning | Process killed by watchdog under Critical pressure |
| `EvictionSkipped` | Normal | Watchdog wanted to evict but didn't (3 reasons: `disabled`, `below_guard`, no-target reasons from `pickEvictionTarget`) |
| `RespawnBlocked` | Warning | `ensureProcess` hit the eviction back-pressure guard |

Level-changed events fire on transition only, not every same-level watchdog tick: sustained pressure would otherwise flood event history. EvictionSkipped fans out to every managed process when no single IS is the subject of the skip, so an operator on any of them can see why their host stayed pressured without action.

## Implementation

- `MetalAgentConfig.EventRecorder` is a new `record.EventRecorder` field. Nil-safe: tests that don't wire one stay green; `emitInferenceEvent` no-ops on nil. Production `cmd/metal-agent/main.go` always wires one.
- `cmd/metal-agent/main.go` builds a `record.NewBroadcaster()` against a typed `kubernetes.Interface` clientset (the controller-runtime client doesn't expose an event sink) and calls `Shutdown()` on agent stop.
- `emitInferenceEvent` re-fetches the involved `InferenceService` so the event lands on the up-to-date object metadata. Failures are logged at debug and ignored: observability must never block the watchdog.

No CRD changes. No breaking API changes. The K8sClient + watchdog code paths are unchanged outside the event-emission additions.

## Testing

`record.FakeRecorder` makes the event payload assertable by reading from a buffered channel.

- `TestHandleMemoryPressure_EmitsLevelChangedEvent`: transition emits exactly one event per managed process; same-level tick is a no-op (regression guard against future "fire every tick" mistakes)
- `TestHandleMemoryPressure_EmitsEvictedEvent`: priority + RSS captured in the message
- `TestHandleMemoryPressure_EmitsEvictionSkippedWhenDisabled`: skip-reason captured in message tail
- `TestEnsureProcess_EmitsRespawnBlockedEvent`: Type Warning + current pressure level in message
- `TestEmitInferenceEvent_NilRecorderIsNoop`: no panic / crash / event when EventRecorder is nil

Full `go test ./...` green. `helm lint charts/llmkube` clean.

## Manual smoke (planned)

- Deploy on this M4 Max with the recorder wired, induce memory pressure (load a 35B model), confirm `kubectl get events -n default --watch` shows the events with the right Type and message.

Closes #390
