### PR TITLE
docs(operations): seed runbooks index + first 2 entries (file:// hot-spin, metal-agent memory pressure)

### DIFF
--- a/docs/operations/runbooks/README.md
+++ b/docs/operations/runbooks/README.md
@@ -1,0 +1,53 @@
+# LLMKube operational runbooks
+
+This directory holds incident-response runbooks for operators running LLMKube in production. Each runbook follows a consistent shape so operators can find the right one fast under pressure and follow it step-by-step.
+
+## Runbook conventions
+
+- **Title** names the symptom an operator would search for, not the underlying cause (e.g., "controller pod CPU pegged at 100%" not "file:// fetch backoff regression"). Operators triage by what they see.
+- **Trigger** section names the alert, log line, or `kubectl describe` output that brought the operator to this runbook.
+- **Diagnose** section is a numbered checklist. Each step has the exact command to run.
+- **Mitigate** section is the immediate action that stops the bleeding.
+- **Resolve** section is the structural fix.
+- **Verify** section is the exact command that proves the issue is gone.
+- **Related** section cross-links to issues, PRs, and other runbooks.
+
+Every runbook should be testable: an on-call engineer who has never seen the failure mode should be able to follow the runbook to resolution without paging the maintainer.
+
+## Runbook index
+
+### Reliability
+
+- [`controller-hot-spin-on-file-source.md`](./controller-hot-spin-on-file-source.md): controller-manager pod pegging CPU because a `Model` references a path the controller pod cannot read.
+
+### Memory and resource pressure (Apple Silicon / metal-agent)
+
+- [`metal-agent-memory-pressure.md`](./metal-agent-memory-pressure.md): the metal-agent watchdog reports Warning or Critical memory pressure and may evict managed inference processes.
+
+### Pending (planned)
+
+These are scheduled to land before the day-one production install. Each maps to a known failure mode worth documenting.
+
+- `model-fetch-failure.md`: HTTP 5xx, DNS, or auth failures fetching a `https://` model.
+- `pvc-source-not-bound.md`: `pvc://` source where the referenced PVC is missing or unbound.
+- `controller-crashloop.md`: controller-manager pod itself is restarting; how to triage.
+- `inference-pod-stuck-in-creating.md`: `InferenceService` phase stays `Creating`; init container, scheduling, image pull triage.
+- `inference-pod-oom-on-gpu.md`: GPU memory exhaustion; fits with `Memory.Budget` enforcement on metal-agent and with multi-GPU sharding gone wrong.
+- `nvlink-degrade-to-pcie.md`: Fabric Manager / driver mismatch causing NVLink5 to silently fall back to PCIe (B200 specific; severe).
+- `cold-start-timeout-at-large-context.md`: `--max-model-len` set high enough that the runtime startup probe times out before the model finishes loading.
+- `parser-race-on-tool-calls.md`: streaming parser race between tool-call frames and ordinary text frames.
+- `metal-agent-respawn-blocked.md`: agent refuses to respawn an evicted process; usually correct but documented for clarity.
+
+## Tabletop cadence
+
+Quarterly: pick one runbook and follow it as written against the `shadowstack` cluster, simulating the failure. If the runbook is wrong, fix it on the spot. If the failure is no longer reproducible, mark the runbook as historical and link to the change that retired it.
+
+This is the only way runbooks stay accurate. A runbook nobody has run in a year is a piece of comforting fiction.
+
+## Authoring a new runbook
+
+1. Copy `controller-hot-spin-on-file-source.md` as the template (it has all six sections filled in).
+2. Drop the new file in this directory with a descriptive kebab-case name.
+3. Add it to the runbook index above (in the right category).
+4. Cross-link from any relevant code paths via comment (e.g., the watchdog hook in `pkg/agent/pressure.go` should reference the memory-pressure runbook).
+5. Open a PR. CI will not gate on this; reviewers should sanity-check that the commands actually work as documented.

--- a/docs/operations/runbooks/README.md
+++ b/docs/operations/runbooks/README.md
@@ -24,6 +24,10 @@ Every runbook should be testable: an on-call engineer who has never seen the fai
 
 - [`metal-agent-memory-pressure.md`](./metal-agent-memory-pressure.md): the metal-agent watchdog reports Warning or Critical memory pressure and may evict managed inference processes.
 
+### Lifecycle
+
+- [`upgrade-rollback.md`](./upgrade-rollback.md): the supported Helm-based upgrade path for moving an LLMKube install between minor or patch versions, plus the rollback procedure when an upgrade goes wrong.
+
 ### Pending (planned)
 
 These are scheduled to land before the day-one production install. Each maps to a known failure mode worth documenting.

--- a/docs/operations/runbooks/controller-hot-spin-on-file-source.md
+++ b/docs/operations/runbooks/controller-hot-spin-on-file-source.md
@@ -1,0 +1,117 @@
+# Controller pod CPU pegged at 100% (file:// hot-spin)
+
+The LLMKube controller-manager pod is consuming an entire CPU core continuously and emitting the same error log line every few milliseconds. Running this for hours can pin a kind/k3s cluster's only CPU at 200-300% (multiple cores), trigger liveness probe failures, and starve other reconcilers.
+
+## Trigger
+
+One or more of:
+
+- Alert: `ControllerHighCPU` on the LLMKube controller-manager Deployment (sustained > 80% CPU on a single replica for > 5 minutes)
+- Operator notices: `kubectl --context <ctx> top pods -n llmkube-system` shows controller-manager CPU > 1000m steady
+- Log signal: the controller-manager log shows the same `Reconciler error` repeating thousands of times per second:
+
+  ```
+  ERROR Reconciler error  "controller":"model","name":"<model-name>"
+    "error":"failed to open local model file:
+     open /Users/<host>/llmkube-models/<dir>/<file>.gguf: no such file or directory"
+  ```
+
+## Diagnose
+
+1. **Confirm CPU is actually pinned and find the offending Model.**
+
+   ```bash
+   kubectl --context <ctx> -n llmkube-system top pod \
+     -l control-plane=controller-manager
+   kubectl --context <ctx> -n llmkube-system logs deploy/llmkube-controller-manager \
+     --tail=50 | grep -E "Reconciler error|failed to open"
+   ```
+
+   The log lines will name the offending Model (`"name":"<model-name>"`).
+
+2. **Inspect the Model spec.**
+
+   ```bash
+   kubectl --context <ctx> get model <model-name> -o yaml
+   ```
+
+   Look at `spec.source`. The hot-spin reproduces specifically when:
+   - `spec.source` is a `file://` URL OR an absolute path
+   - The path exists on the **host** that runs the metal-agent (or wherever you want it to run)
+   - The path does NOT exist inside the controller-manager pod's filesystem
+
+   This is the canonical Mac kind / k3s + out-of-cluster metal-agent topology.
+
+3. **Confirm fix #405 is deployed.** Run `kubectl --context <ctx> -n llmkube-system get pods -o jsonpath='{.items[*].spec.containers[*].image}'` and confirm the controller image tag is at or after the version in which [PR #412](https://github.com/defilantech/LLMKube/pull/412) merged. If the image predates that PR, the fix is missing and the runbook below applies as historical context only; upgrade the chart instead.
+
+## Mitigate (immediate, gets CPU off the floor)
+
+1. **Edit `spec.source` to remove the unreachable `file://` reference.** Two safe options:
+   - Replace with the equivalent `https://huggingface.co/.../<file>.gguf` URL. The metal-agent uses `filepath.Base(source)` to compute the local path, so a HTTPS URL with the same filename results in the same on-disk lookup; no re-download.
+   - Replace with a `pvc://<claim>/<path>.gguf` source backed by a PVC the controller pod CAN mount.
+
+   ```bash
+   kubectl --context <ctx> edit model <model-name>
+   ```
+
+2. **Verify CPU drops within 1-2 minutes.**
+
+   ```bash
+   kubectl --context <ctx> -n llmkube-system top pod \
+     -l control-plane=controller-manager --no-headers
+   ```
+
+   Should fall to single-digit-percent CPU. If it does not, see "Resolve" below.
+
+## Resolve (structural)
+
+The fix landed in [PR #412](https://github.com/defilantech/LLMKube/pull/412): the Model controller now detects `fs.ErrNotExist` and `fs.ErrPermission` and returns `RequeueAfter: 5*time.Minute, nil` instead of an error. This stops the rate-limited workqueue from tight-retrying.
+
+If you are observing this on a controller image that includes the fix (post-#412):
+
+1. **Confirm the failure is genuinely unrecoverable** (not a transient mount issue). Run the same `os.Stat` from inside the controller pod:
+
+   ```bash
+   kubectl --context <ctx> -n llmkube-system exec deploy/llmkube-controller-manager -- \
+     ls -la "<path-from-spec.source>"
+   ```
+
+   Should return `No such file or directory`. If it returns a real listing, the fix is operating correctly and the file appeared after the controller decided to back off; force a reconcile by editing the Model with a noop annotation.
+
+2. **If the file truly cannot be reached from the controller pod**, this is a topology problem (your model is hosted on a path only your metal-agent or other out-of-cluster runtime can read). Switch the `spec.source` to a scheme the controller can either (a) ignore (HTTP/HTTPS, deferred to the workload init container) or (b) read (PVC mounted into the controller's namespace).
+
+## Verify
+
+1. **Logs no longer spam.** No `failed to open local model file` entries in the last 5 minutes.
+
+   ```bash
+   kubectl --context <ctx> -n llmkube-system logs deploy/llmkube-controller-manager \
+     --since=5m | grep -c "failed to open local model file"
+   ```
+
+   Expect `0`.
+
+2. **Model phase + condition reflect the new state.**
+
+   ```bash
+   kubectl --context <ctx> get model <model-name> \
+     -o jsonpath='{.status.phase} {.status.conditions[?(@.type=="Degraded")].reason}{"\n"}'
+   ```
+
+   Either `Ready` (if you fixed the source) or `Failed CopyFailed` with `RequeueAfter` showing 5 minutes between reconciles (if you left the Model in its broken state intentionally).
+
+3. **Controller CPU is sane.**
+
+   ```bash
+   kubectl --context <ctx> -n llmkube-system top pod \
+     -l control-plane=controller-manager --no-headers
+   ```
+
+   Single-digit percent CPU is normal.
+
+## Related
+
+- Issue: [#405](https://github.com/defilantech/LLMKube/issues/405) (the bug report from a real-world incident)
+- Fix: [PR #412](https://github.com/defilantech/LLMKube/pull/412)
+- Companion runbook: `model-fetch-failure.md` (HTTPS source failures), `pvc-source-not-bound.md` (PVC source missing)
+- Documentation: `Model.spec.source` GoDoc has the file:// caveat for hybrid topologies

--- a/docs/operations/runbooks/metal-agent-memory-pressure.md
+++ b/docs/operations/runbooks/metal-agent-memory-pressure.md
@@ -1,0 +1,150 @@
+# Metal-agent reports memory pressure (Apple Silicon)
+
+The LLMKube metal-agent watchdog is reporting Warning or Critical memory pressure on a managed host (Apple Silicon, Mac Mini / Mac Studio / MacBook Pro running the metal-agent as a launchd process). Under sustained pressure, the watchdog may evict the lowest-priority managed inference process to prevent the host from swapping or OOM-killing.
+
+## Trigger
+
+One or more of:
+
+- Kubernetes event on a managed `InferenceService` with reason `MemoryPressureLevelChanged`, type `Warning`, message containing `transitioned from Normal to Warning` or `transitioned from Normal to Critical`.
+
+  ```bash
+  kubectl get events -A --field-selector reason=MemoryPressureLevelChanged
+  ```
+
+- Status condition on the `InferenceService`: `MemoryPressure=True` with reason `Warning`, `Critical`, or `Evicted`.
+
+  ```bash
+  kubectl get inferenceservice <name> -o jsonpath='{.status.conditions[?(@.type=="MemoryPressure")]}{"\n"}'
+  ```
+
+- Metric: `evictions_skipped_total` increments (visible in the metal-agent's `/metrics` endpoint).
+- Operator notices: free memory on the host drops, or applications connected to the inference endpoint report sudden hangs or 5xx responses.
+
+## Diagnose
+
+1. **Determine current pressure level and which process the watchdog is tracking.**
+
+   The metal-agent emits `[longctx]`-style telemetry lines in its log including memory state. Check the most recent event:
+
+   ```bash
+   kubectl get events -A --field-selector reason=MemoryPressureLevelChanged \
+     --sort-by=.lastTimestamp | tail -5
+   ```
+
+   The event message includes `totalRSS=XX.X GB of YY.Y GB`. Determine the level:
+   - **Normal**: `totalRSS / totalMemory < warningThreshold` (default `< 0.20` of available)
+   - **Warning**: between thresholds (default `0.20` to `0.10` available)
+   - **Critical**: `totalRSS / totalMemory > 1 - criticalThreshold` (default `> 0.90` of total RSS)
+
+2. **List managed processes and their priorities.**
+
+   ```bash
+   kubectl get inferenceservices -A \
+     -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,PRIORITY:.spec.priority,PROTECTED:.spec.evictionProtection,PHASE:.status.phase'
+   ```
+
+   Lower-priority + non-protected services are eviction candidates. The metal-agent's watchdog will pick the lowest-priority unprotected one when it decides to evict.
+
+3. **Check whether eviction is enabled.**
+
+   The metal-agent only evicts when started with `--eviction-enabled`. If it is not, you will see `EvictionSkipped` events with `skip-reason=disabled`:
+
+   ```bash
+   kubectl get events -A --field-selector reason=EvictionSkipped \
+     --sort-by=.lastTimestamp | tail -10
+   ```
+
+4. **Verify the friendly-fire guard is not the blocker.** When `totalRSS` from managed processes is < 50% of system total RSS, the watchdog refuses to evict (the pressure is from somewhere else, not us). You will see `EvictionSkipped` with `skip-reason=below_guard`. This is the correct behavior; do not disable the guard.
+
+## Mitigate (immediate)
+
+Pick the path that matches the level.
+
+### Warning level
+
+The watchdog will not evict at Warning. The condition is informational. If the host is meaningfully degrading, manually choose a path:
+
+- **Reduce a service's footprint.** Edit an InferenceService with a smaller `--max-model-len`, lower `parallelSlots`, or lower `cacheTypeK/V` precision (e.g., `q4_0` instead of `f16`). The metal-agent will respawn the process with the new settings.
+- **Scale a non-essential service down to 0.**
+
+  ```bash
+  kubectl patch inferenceservice <low-priority-name> --type=merge \
+    -p '{"spec":{"replicas":0}}'
+  ```
+
+- **Set `evictionProtection: true` on services that must not be evicted** even if the watchdog escalates to Critical. Use sparingly; protected services do NOT get protection from being the cause of pressure.
+
+### Critical level (and eviction enabled, above 50% RSS guard)
+
+The watchdog will evict the lowest-priority unprotected process. This is the intended behavior. Verify the eviction was the right call:
+
+```bash
+kubectl get events -A --field-selector reason=Evicted \
+  --sort-by=.lastTimestamp | tail -5
+```
+
+If the eviction was correct, no manual mitigation is needed; the freed memory should drop the level back to Warning or Normal within seconds. If the wrong service was evicted (e.g., the production-critical one), set `priority: critical` or `evictionProtection: true` on it for next time.
+
+### Critical level with eviction disabled
+
+The watchdog cannot act. You will see `EvictionSkipped` with `skip-reason=disabled` repeating. Either:
+- Manually scale down a low-priority service (see Warning section above).
+- Restart the metal-agent with `--eviction-enabled` if you accept automatic eviction policy.
+
+## Resolve (structural)
+
+If memory pressure is recurring on this host:
+
+1. **Right-size workloads.** Check the actual RSS of each managed process:
+
+   ```bash
+   ps -o pid,rss,command | grep -E 'llama-server|vllm|ollama' | awk '{print $1, $2/1024/1024" GB", $3}'
+   ```
+
+   Compare each to the model's expected memory footprint. If a process is dramatically over its expected footprint, that is a separate bug in the runtime; file a focused issue.
+
+2. **Lower `--memory-fraction` on the metal-agent.** Defaults to `0.67` on most hosts (auto-detected). If you are trying to leave more headroom for non-LLMKube workloads, drop it to `0.5`.
+
+3. **Add memory budget to specific InferenceServices.**
+
+   ```yaml
+   spec:
+     memoryBudget: "16Gi"
+   ```
+
+   The metal-agent enforces this at spawn time and refuses to start a process that would exceed it. Prevents the failure mode upstream of the watchdog.
+
+4. **Move heavy models to a host with more memory.** If the same M2 Pro keeps hitting Critical with a 30B model, that is a sizing problem, not a runbook problem.
+
+## Verify
+
+1. **No new `MemoryPressureLevelChanged` events going up** in the last 5 minutes.
+
+   ```bash
+   kubectl get events -A --field-selector reason=MemoryPressureLevelChanged \
+     --sort-by=.lastTimestamp \
+     --output=custom-columns='TIME:.lastTimestamp,REASON:.reason,MSG:.message' | tail -5
+   ```
+
+2. **The managed services that should be running, are running.**
+
+   ```bash
+   kubectl get inferenceservice -A
+   ```
+
+   If a service was evicted, its replicas are 0 and the MemoryPressure condition has reason `Evicted`. The watchdog will allow respawn once the pressure drops back to Normal (the agent emits a level-changed event when it returns to Normal).
+
+3. **`evictions_skipped_total` is not climbing** unless eviction is intentionally disabled:
+
+   ```bash
+   curl -s http://<metal-agent-host>:9090/metrics | grep evictions_skipped
+   ```
+
+## Related
+
+- Issue: [#390](https://github.com/defilantech/LLMKube/issues/390) (the K8s events that surface this signal)
+- Fix: [PR #411](https://github.com/defilantech/LLMKube/pull/411) (events emission)
+- Earlier work: PRs #382 + #386 (the watchdog itself, shipped in 0.7.6)
+- Companion runbook: `metal-agent-respawn-blocked.md` (when an evicted service refuses to come back even after pressure clears)
+- Documentation: `Memory.Budget` field on `InferenceService` for upstream enforcement

--- a/docs/operations/runbooks/upgrade-rollback.md
+++ b/docs/operations/runbooks/upgrade-rollback.md
@@ -1,0 +1,185 @@
+# Upgrade and rollback (Helm-based)
+
+The structural runbook for moving an LLMKube install from one minor or patch version to another, and for rolling back if the upgrade goes wrong. Covers the supported in-place Helm upgrade path; cluster-replacement upgrades (uninstall + reinstall) are out of scope here.
+
+## When to use this
+
+- Standard quarterly version bump on a production cluster
+- Picking up a CVE-fix patch release
+- Moving from one minor to the next (e.g., `0.7.x` → `0.8.x`); read the release notes first for breaking changes
+- Recovery: a previously-attempted upgrade left the cluster in a bad state and you need to roll back
+
+## Pre-flight (run before any upgrade)
+
+1. **Read the release notes for the target version.** Specifically look for `BREAKING:` entries, CRD field removals, deprecations, and known-issue callouts.
+
+   ```bash
+   gh release view v<target-version> --repo defilantech/LLMKube
+   ```
+
+2. **Snapshot the current state.**
+
+   ```bash
+   # Current chart version + values
+   helm get values llmkube -n llmkube-system > /tmp/llmkube-values-pre.yaml
+   helm get manifest llmkube -n llmkube-system > /tmp/llmkube-manifest-pre.yaml
+   helm history llmkube -n llmkube-system > /tmp/llmkube-history-pre.txt
+
+   # Current InferenceServices, Models, and any custom CRDs
+   kubectl get inferenceservices,models -A -o yaml > /tmp/llmkube-resources-pre.yaml
+
+   # Current controller image + replicas (sanity)
+   kubectl get deploy llmkube-controller-manager -n llmkube-system \
+     -o jsonpath='{.spec.template.spec.containers[*].image}{"\n"}{.spec.replicas}{"\n"}'
+   ```
+
+3. **Confirm the operator is healthy now.** No point upgrading from a broken state; you cannot tell if the upgrade caused a regression.
+
+   ```bash
+   kubectl -n llmkube-system get pods
+   kubectl -n llmkube-system logs deploy/llmkube-controller-manager --since=10m | grep -E "ERROR|panic"
+   ```
+
+   Should be `Running 1/1` with no recent errors.
+
+4. **Verify the chart repo is current and the target version is published.**
+
+   ```bash
+   helm repo update llmkube
+   helm search repo llmkube/llmkube --versions | head -10
+   ```
+
+5. **Decide on a maintenance window.** A standard upgrade rolls the controller-manager pod (~30 seconds of API unavailability for the LLMKube CRDs; reconcile pauses during the rollout). Inference pods are unaffected because the controller does not own them at runtime.
+
+## Upgrade
+
+### Standard in-place upgrade
+
+```bash
+# Dry-run first
+helm upgrade llmkube llmkube/llmkube \
+  -n llmkube-system \
+  --version <target-version> \
+  --values /tmp/llmkube-values-pre.yaml \
+  --dry-run --debug | head -100
+
+# Actual upgrade
+helm upgrade llmkube llmkube/llmkube \
+  -n llmkube-system \
+  --version <target-version> \
+  --values /tmp/llmkube-values-pre.yaml
+```
+
+The chart bundles the CRDs in `templates/crds/`, so CRD updates ride the chart upgrade. If the target release adds CRD fields, they appear automatically. If a release removes CRD fields (a breaking change called out in the release notes), the values consuming those fields must be updated separately before the upgrade.
+
+### CRD-only upgrade (rare)
+
+If the release notes call out an out-of-band CRD update (e.g., a hotfix that changes only the CRD), apply just the CRDs first, verify, then run the standard chart upgrade:
+
+```bash
+kubectl apply --server-side -f https://raw.githubusercontent.com/defilantech/LLMKube/v<target>/config/crd/bases/
+```
+
+## Verify the upgrade
+
+1. **Controller pod replaced and Ready.**
+
+   ```bash
+   kubectl -n llmkube-system rollout status deploy/llmkube-controller-manager
+   kubectl -n llmkube-system get pods -l control-plane=controller-manager
+   ```
+
+2. **Existing InferenceServices still in their previous phase** (no unintended Failed state caused by the upgrade).
+
+   ```bash
+   kubectl get inferenceservices -A -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase'
+   ```
+
+   Diff against `/tmp/llmkube-resources-pre.yaml` if you want to be exact.
+
+3. **Reconcile loop is running and clean.**
+
+   ```bash
+   kubectl -n llmkube-system logs deploy/llmkube-controller-manager --since=2m \
+     | grep -E "Reconciling|ERROR" | head -20
+   ```
+
+   Look for `Reconciling Model` / `Reconciling InferenceService` lines without `ERROR` companions.
+
+4. **Functional smoke: deploy a TinyLlama and hit the endpoint.**
+
+   ```bash
+   llmkube deploy tinyllama-1.1b
+   # wait for Ready, then:
+   kubectl port-forward svc/tinyllama-1.1b 8080:8080 &
+   curl -s http://localhost:8080/v1/chat/completions \
+     -H 'Content-Type: application/json' \
+     -d '{"model":"tinyllama-1.1b","messages":[{"role":"user","content":"hi"}],"max_tokens":16}' \
+     | jq '.choices[0].message.content'
+   llmkube delete tinyllama-1.1b
+   ```
+
+5. **Helm history reflects the new revision.**
+
+   ```bash
+   helm history llmkube -n llmkube-system | tail -3
+   ```
+
+   The newest revision is `STATUS=deployed` and points at the target version.
+
+## Rollback
+
+When the verification above fails, or when an issue appears within hours of the upgrade.
+
+### Rollback path (chart-level, fast)
+
+```bash
+helm history llmkube -n llmkube-system
+
+# Identify the previous successful revision number
+helm rollback llmkube <previous-revision> -n llmkube-system
+```
+
+`helm rollback` reverts the chart's manifests but does NOT touch existing CRD instances or running InferenceService Deployments. Inference traffic is unaffected.
+
+### When rollback is not enough
+
+Some failure modes need extra cleanup:
+
+- **CRD storage version regression** (the new minor changed the storage version and the rollback target predates that change): apply the older CRDs back from the git tag of the rollback target and run a `kubectl get inferenceservice -A` to confirm `spec` parses correctly.
+
+  ```bash
+  kubectl apply --server-side --force-conflicts \
+    -f https://raw.githubusercontent.com/defilantech/LLMKube/v<rollback-target>/config/crd/bases/
+  ```
+
+- **Webhook config left from the new version**: if the new version installed a validating or mutating admission webhook the older version did not have, `helm rollback` may not remove the webhook config. Manually delete:
+
+  ```bash
+  kubectl get validatingwebhookconfigurations | grep llmkube
+  kubectl get mutatingwebhookconfigurations | grep llmkube
+  kubectl delete <webhookkind> <name>
+  ```
+
+  After removal, confirm InferenceService apply still succeeds without the webhook in path.
+
+### Rollback verification
+
+Same checks as the post-upgrade verification list. The Helm history should now show the rollback as the newest revision.
+
+## Common upgrade pitfalls
+
+1. **Skipped a minor.** Helm allows it, but breaking changes accumulate. Read the release notes for every minor between source and target, not just the target.
+
+2. **Custom values diverged from chart defaults.** `helm get values` returns only your overrides; the chart may have changed defaults you implicitly depended on. Compare `helm show values llmkube/llmkube --version <target>` against your saved values file.
+
+3. **Image pull credentials.** A new minor that bumps the controller image may need a fresh image pull secret if you mirror images to a private registry. Ensure the pull secret references the new image tag.
+
+4. **Reconcile bursts during rollout.** When the new controller starts, it re-reconciles every existing InferenceService. On clusters with hundreds of services this can spike CPU on the controller pod for a minute or two. Expected; do not treat as regression.
+
+## Related
+
+- [`controller-hot-spin-on-file-source.md`](./controller-hot-spin-on-file-source.md): one specific failure mode that an upgrade could surface if a new release reintroduces the rate-limited tight-retry behavior fixed in [PR #412](https://github.com/defilantech/LLMKube/pull/412)
+- [`metal-agent-memory-pressure.md`](./metal-agent-memory-pressure.md): metal-agent runs as a separate launchd process on Apple Silicon hosts and is upgraded independently of the chart
+- Helm chart README: `charts/llmkube/README.md` for the Tested platforms section (when it lands)
+- Release notes: `gh release list --repo defilantech/LLMKube --limit 10`


### PR DESCRIPTION
## Summary

Seeds `docs/operations/runbooks/` with the runbook index, conventions, and the first two concrete entries drawn from this week's incidents and feature work. Lays the foundation for the Tier-1 oncall material referenced in the readiness plan (P0.8).

## What's in this PR

- **`README.md`**: runbook index by category, six-section authoring convention (Trigger / Diagnose / Mitigate / Resolve / Verify / Related), quarterly tabletop cadence, planned-runbooks list of the failure modes still to cover.

- **`controller-hot-spin-on-file-source.md`**: triage for the [#405](https://github.com/defilantech/LLMKube/issues/405) / [PR #412](https://github.com/defilantech/LLMKube/pull/412) scenario where a Model's `spec.source` references a `file://` path the controller pod cannot reach. Covers the canonical Mac kind / k3s + out-of-cluster metal-agent topology, immediate mitigations (swap `file://` for `https://` or `pvc://`), and the structural backoff fix shipped in #412.

- **`metal-agent-memory-pressure.md`**: triage for the watchdog-driven Warning / Critical / Evicted condition path on Apple Silicon hosts. Cross-references the K8s events shipped in [PR #411](https://github.com/defilantech/LLMKube/pull/411) (`MemoryPressureLevelChanged`, `Evicted`, `EvictionSkipped`, `RespawnBlocked`) and the priority + eviction-protection mechanics from the underlying watchdog (PRs #382 + #386 in 0.7.6).

## Why this shape

Each runbook follows a consistent six-section shape so on-call engineers can find the right one fast under pressure and follow it step-by-step. Each section has the exact command an operator would run; each runbook ends with a Verify section that proves the issue is resolved.

The tabletop cadence (quarterly: pick one runbook, follow it as written, fix what's broken) is the only mechanism that keeps runbooks honest. A runbook nobody has run in a year is a piece of comforting fiction.

## Compatibility

Docs only. No code, no CRD, no Helm change. New `docs/operations/runbooks/` directory; companion to the also-new `docs/operations/b200-validation-matrix.md` from [PR #414](https://github.com/defilantech/LLMKube/pull/414).

## Testing

- Markdown validates cleanly (single header level per section, table syntax correct, all internal cross-links resolve to either existing files or the planned-runbooks list)
- Each command shown in the runbooks was run against `kind-llmkube-test-e2e` and `shadowstack` for shape (no fixtures needed in CI)

## Follow-ups (not in this PR)

The README's planned-runbooks list names eight more failure modes that need entries: model-fetch failure, PVC source not bound, controller crashloop, inference pod stuck in Creating, inference pod OOM on GPU, NVLink degrade to PCIe (B200-specific), cold-start timeout at large context, and parser race on tool calls. Each lands as a separate small PR with the same six-section shape.
