### PR TITLE
feat: ModelRouterReconciler skeleton with spec validation

### DIFF
--- a/charts/llmkube/templates/clusterrole.yaml
+++ b/charts/llmkube/templates/clusterrole.yaml
@@ -66,6 +66,7 @@ rules:
   - inference.llmkube.dev
   resources:
   - inferenceservices
+  - modelrouters
   - models
   verbs:
   - create
@@ -79,6 +80,7 @@ rules:
   - inference.llmkube.dev
   resources:
   - inferenceservices/finalizers
+  - modelrouters/finalizers
   - models/finalizers
   verbs:
   - update
@@ -86,6 +88,7 @@ rules:
   - inference.llmkube.dev
   resources:
   - inferenceservices/status
+  - modelrouters/status
   - models/status
   verbs:
   - get

--- a/charts/llmkube/templates/crds/modelrouters.yaml
+++ b/charts/llmkube/templates/crds/modelrouters.yaml
@@ -1,0 +1,779 @@
+{{- if .Values.crds.install }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
+  name: modelrouters.inference.llmkube.dev
+spec:
+  group: inference.llmkube.dev
+  names:
+    kind: ModelRouter
+    listKind: ModelRouterList
+    plural: modelrouters
+    shortNames:
+    - mr
+    singular: modelrouter
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.activeRules
+      name: Rules
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ModelRouter is the Schema for the modelrouters API. It exposes a single
+          OpenAI-compatible HTTP endpoint that dispatches requests across multiple
+          InferenceService backends and external providers per declarative routing
+          rules. See docs/site/concepts/model-router.md (Phase 1) for usage.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of ModelRouter
+            properties:
+              backends:
+                description: |-
+                  Backends are the candidate destinations the router can dispatch to.
+                  Order is not significant; selection is rule-driven. At least one
+                  backend must be declared.
+                items:
+                  description: |-
+                    RouterBackend is one candidate destination for routed requests.
+                    Exactly one of InferenceServiceRef or External must be set.
+                  properties:
+                    capabilities:
+                      description: |-
+                        Capabilities advertised by this backend. Rules can require
+                        capabilities (e.g. ["tools", "vision", "long-context"]) to filter
+                        candidates.
+                      items:
+                        type: string
+                      type: array
+                    costPerMillionTokens:
+                      description: |-
+                        CostPerMillionTokens is informational. Used for cost-aware routing
+                        metrics and audit-log enrichment. Values are USD.
+                      properties:
+                        completionUSD:
+                          description: |-
+                            CompletionUSD is the cost per million completion (output) tokens,
+                            in USD.
+                          pattern: ^[0-9]+(\.[0-9]+)?$
+                          type: string
+                        promptUSD:
+                          description: PromptUSD is the cost per million prompt (input)
+                            tokens, in USD.
+                          pattern: ^[0-9]+(\.[0-9]+)?$
+                          type: string
+                      type: object
+                    external:
+                      description: |-
+                        External describes an out-of-cluster provider (Anthropic, OpenAI,
+                        or a LiteLLM proxy). Mutually exclusive with InferenceServiceRef.
+                      properties:
+                        credentialsSecretRef:
+                          description: |-
+                            CredentialsSecretRef points to a Kubernetes Secret containing the
+                            provider credentials. Conventional keys: ANTHROPIC_API_KEY,
+                            OPENAI_API_KEY, LITELLM_MASTER_KEY. The router-proxy reads these as
+                            environment variables.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        model:
+                          description: |-
+                            Model is the upstream model identifier passed through to the
+                            provider (e.g. "claude-opus-4-7", "gpt-5", a LiteLLM model alias).
+                          type: string
+                        provider:
+                          description: |-
+                            Provider identifies the upstream API surface. For "litellm", URL must
+                            point at a running LiteLLM proxy speaking OpenAI-compatible API.
+                            For first-party providers, URL is optional (provider defaults apply).
+                          enum:
+                          - anthropic
+                          - openai
+                          - bedrock
+                          - vertex_ai
+                          - litellm
+                          type: string
+                        url:
+                          description: |-
+                            URL is the base URL for the provider. Required for "litellm";
+                            optional for first-party providers, which use their published default.
+                          type: string
+                      required:
+                      - model
+                      - provider
+                      type: object
+                    healthCheck:
+                      description: |-
+                        HealthCheck overrides the default health probe applied to this
+                        backend by the router-proxy.
+                      properties:
+                        intervalSeconds:
+                          default: 10
+                          description: IntervalSeconds is how often the router-proxy
+                            probes the backend.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        path:
+                          description: |-
+                            Path is the HTTP path probed for health. Defaults to "/health" for
+                            local backends and to the provider's documented health route for
+                            external providers.
+                          type: string
+                        timeoutSeconds:
+                          default: 2
+                          description: TimeoutSeconds is the maximum time a single
+                            probe may take.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                      type: object
+                    inferenceServiceRef:
+                      description: |-
+                        InferenceServiceRef references an in-cluster InferenceService.
+                        Mutually exclusive with External.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    name:
+                      description: |-
+                        Name is the stable identifier used by rules and observability labels.
+                        Must be lowercase alphanumeric or '-'.
+                      pattern: ^[a-z0-9][a-z0-9-]{0,62}$
+                      type: string
+                    tier:
+                      default: local
+                      description: |-
+                        Tier classifies the backend for rule matching. "local" backends are
+                        served from inside the cluster; "cloud" backends egress the cluster
+                        boundary. Fail-closed rules can only route to local-tier backends.
+                      enum:
+                      - local
+                      - cloud
+                      type: string
+                    weight:
+                      description: |-
+                        Weight is used for the "weighted" routing strategy. Higher values
+                        receive proportionally more traffic. Ignored for other strategies.
+                        Default 1 when unset.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                minItems: 1
+                type: array
+              defaultRoute:
+                description: |-
+                  DefaultRoute names a backend used when no rule matches.
+                  Must reference the Name of an entry in Backends.
+                type: string
+              endpoint:
+                description: |-
+                  Endpoint defines the Kubernetes Service the router-proxy is exposed
+                  through. Mirrors the shape used by InferenceService.
+                properties:
+                  path:
+                    default: /v1/chat/completions
+                    description: Path is the HTTP path for the inference endpoint
+                    type: string
+                  port:
+                    default: 8080
+                    description: Port is the service port
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  type:
+                    default: ClusterIP
+                    description: Type is the Kubernetes service type (ClusterIP, NodePort,
+                      LoadBalancer)
+                    enum:
+                    - ClusterIP
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                type: object
+              mcpServer:
+                description: |-
+                  MCPServer optionally exposes this router as a Model Context Protocol
+                  endpoint. Inactive until the Phase 3 MCP feature lands; the field is
+                  reserved in the schema for forward compatibility.
+                properties:
+                  enabled:
+                    description: |-
+                      Enabled toggles MCP exposure. Default false. When true (after Phase
+                      3 lands), the router-proxy serves an MCP endpoint at /mcp using
+                      Streamable HTTP transport and OAuth 2.1.
+                    type: boolean
+                type: object
+              policy:
+                description: Policy holds cross-cutting controls (budgets, classification,
+                  audit).
+                properties:
+                  auditLog:
+                    description: |-
+                      AuditLog controls structured audit emission. Auditing is always on;
+                      this field tunes the destination and verbosity.
+                    properties:
+                      filePath:
+                        description: |-
+                          FilePath is the destination when Sink=file. Must be writable inside
+                          the router-proxy container. Defaults to "/var/log/mlx-router/audit.log".
+                        type: string
+                      includeRequestBody:
+                        description: |-
+                          IncludeRequestBody, when true, includes the OpenAI request body in
+                          every audit entry. Disabled by default for size and privacy.
+                        type: boolean
+                      sink:
+                        default: stdout
+                        description: |-
+                          Sink selects the audit-log destination.
+                          "stdout" (default) emits one JSON object per line to the proxy
+                            container stdout, where it can be collected by the cluster log
+                            stack.
+                          "file" writes to FilePath inside the proxy container.
+                          "otlp" forwards entries to an OTel collector as log records.
+                        enum:
+                        - stdout
+                        - file
+                        - otlp
+                        type: string
+                    type: object
+                  budgets:
+                    description: |-
+                      Budgets caps token and dollar consumption per scope over a rolling
+                      window. Empty list means no budget enforcement.
+                    items:
+                      description: BudgetSpec defines a token or dollar cap over a
+                        rolling window.
+                      properties:
+                        headerKey:
+                          description: |-
+                            HeaderKey is the request header carrying the team identifier when
+                            Scope=team. Defaults to "x-llmkube-team".
+                          type: string
+                        maxTokens:
+                          description: |-
+                            MaxTokens caps total tokens (prompt + completion) over the window.
+                            Either MaxTokens or MaxUSD (or both) must be set.
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        maxUSD:
+                          description: |-
+                            MaxUSD caps total estimated cost in USD over the window. Cost is
+                            computed from RouterBackend.CostPerMillionTokens.
+                          pattern: ^[0-9]+(\.[0-9]+)?$
+                          type: string
+                        name:
+                          description: Name identifies this budget for metrics, status,
+                            and audit logs.
+                          pattern: ^[a-z0-9][a-z0-9-]{0,62}$
+                          type: string
+                        ruleName:
+                          description: RuleName is required when Scope=rule. References
+                            a RouterRule.Name.
+                          type: string
+                        scope:
+                          description: |-
+                            Scope determines what the budget applies to.
+                            "router" caps all traffic through this ModelRouter.
+                            "rule" caps traffic matching a single named rule (see RuleName).
+                            "team" caps traffic identified by a request header (see HeaderKey).
+                          enum:
+                          - router
+                          - rule
+                          - team
+                          type: string
+                        windowSeconds:
+                          default: 3600
+                          description: WindowSeconds is the rolling window over which
+                            the cap is evaluated.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                      required:
+                      - name
+                      - scope
+                      type: object
+                    type: array
+                  classification:
+                    description: |-
+                      Classification configures how the router determines the data
+                      classification of an inbound request.
+                    properties:
+                      headerKey:
+                        description: |-
+                          HeaderKey is the request header carrying the classification.
+                          Defaults to "x-llmkube-classification".
+                        type: string
+                      mode:
+                        default: header-only
+                        description: |-
+                          Mode determines how the router determines a request's
+                          classification.
+                          "header-only" (default) trusts the request header
+                            (HeaderKey, defaults to x-llmkube-classification).
+                          "detector" runs the bundled in-proxy detector.
+                          "hybrid" prefers the header, falling back to the detector when no
+                            header is present.
+                        enum:
+                        - header-only
+                        - detector
+                        - hybrid
+                        type: string
+                      sensitiveClassifications:
+                        description: |-
+                          SensitiveClassifications are the classification values that trigger
+                          fail-closed validation: any rule matching one of these values must
+                          have FailClosed=true and reference only local-tier backends.
+                          Defaults to ["pii", "phi"].
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              proxy:
+                description: |-
+                  Proxy configures the managed router-proxy Deployment (replicas,
+                  image override for air-gapped sites, resources). Sensible defaults
+                  apply when omitted.
+                properties:
+                  image:
+                    description: |-
+                      Image overrides the default router-proxy container image. Useful
+                      for air-gapped clusters that pin to an internal registry digest.
+                    type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets are passed through to the router-proxy
+                      pod spec.
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  replicas:
+                    description: |-
+                      Replicas is the desired number of router-proxy pods. Defaults to 1.
+                      The proxy is stateless for routing decisions; budget and SLO
+                      counters live in memory and reset on pod restart until the
+                      persistence feature lands.
+                    format: int32
+                    maximum: 10
+                    minimum: 1
+                    type: integer
+                  resources:
+                    description: Resources sets the pod's compute resource requests
+                      and limits.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              rules:
+                description: |-
+                  Rules are evaluated in declaration order. The first matching rule wins.
+                  If no rule matches, DefaultRoute is used. If neither a matching rule
+                  nor DefaultRoute is set, the request is rejected with HTTP 503.
+                items:
+                  description: RouterRule pairs a match expression with a routing
+                    action.
+                  properties:
+                    failClosed:
+                      description: |-
+                        FailClosed: when true, if no backend in Route.Backends is healthy
+                        or otherwise eligible, the router rejects the request with HTTP 503
+                        rather than falling through to DefaultRoute or subsequent rules.
+                        This is the regulated-data gate: a fail-closed rule guarantees that
+                        matched requests are never served by any other route.
+                      type: boolean
+                    match:
+                      description: |-
+                        Match groups all match conditions. All declared conditions must be
+                        true for the rule to fire (AND semantics). If Match is omitted the
+                        rule always matches (useful as a catch-all before DefaultRoute).
+                      properties:
+                        dataClassification:
+                          description: |-
+                            DataClassification matches if the inbound request carries any of
+                            these classifications. The classification source depends on
+                            Policy.Classification.Mode: a request header
+                            (x-llmkube-classification by default), the bundled detector, or
+                            both. Common values: "public", "internal", "confidential", "pii",
+                            "phi".
+                          items:
+                            type: string
+                          type: array
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Headers performs exact-match equality on inbound HTTP headers
+                            (case-insensitive header name comparison).
+                          type: object
+                        latencySLOMs:
+                          description: |-
+                            LatencySLOMs is a P95 first-token-latency target in milliseconds.
+                            When set, if the rolling P95 for the primary backend exceeds this
+                            value the rule promotes its declared fallback. Honored only by the
+                            "primary-fallback" strategy.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        models:
+                          description: |-
+                            Models matches against the OpenAI-style "model" field in the
+                            request body. Glob patterns are supported (e.g. "qwen3-*").
+                          items:
+                            type: string
+                          type: array
+                        requiredCapabilities:
+                          description: |-
+                            RequiredCapabilities filters backends. The rule only matches if at
+                            least one backend in Route.Backends advertises every listed
+                            capability.
+                          items:
+                            type: string
+                          type: array
+                        taskComplexity:
+                          description: |-
+                            TaskComplexity matches the inbound complexity hint (header
+                            x-llmkube-task-complexity).
+                          enum:
+                          - simple
+                          - moderate
+                          - complex
+                          type: string
+                      type: object
+                    name:
+                      description: Name is used in audit logs and metrics labels.
+                      pattern: ^[a-z0-9][a-z0-9-]{0,62}$
+                      type: string
+                    route:
+                      description: Route is the action taken when this rule matches.
+                      properties:
+                        backends:
+                          description: |-
+                            Backends is an ordered list of RouterBackend.Name values. For the
+                            "primary-fallback" strategy, the first entry is the primary and
+                            subsequent entries are tried in order on failure. For "weighted",
+                            traffic is distributed across all entries by Backend.Weight. For
+                            "shadow", the first entry serves the response and subsequent entries
+                            receive mirrored requests for evaluation only.
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                        strategy:
+                          default: primary-fallback
+                          description: Strategy selects how multiple backends are
+                            used.
+                          enum:
+                          - primary-fallback
+                          - weighted
+                          - shadow
+                          type: string
+                      required:
+                      - backends
+                      type: object
+                  required:
+                  - name
+                  - route
+                  type: object
+                type: array
+            required:
+            - backends
+            type: object
+          status:
+            description: status defines the observed state of ModelRouter
+            properties:
+              activeRules:
+                description: |-
+                  ActiveRules is the count of rules that successfully validated
+                  against current backend state.
+                format: int32
+                type: integer
+              backends:
+                description: |-
+                  Backends reports the resolved address and current health of every
+                  declared backend.
+                items:
+                  description: BackendStatus reports the runtime state of one declared
+                    backend.
+                  properties:
+                    address:
+                      description: |-
+                        Address is the resolved upstream URL the router-proxy dispatches to.
+                        For local backends this is the InferenceService's cluster URL; for
+                        external backends it is the provider's base URL.
+                      type: string
+                    healthy:
+                      description: Healthy reflects the most recent probe result.
+                      type: boolean
+                    lastProbeTime:
+                      description: |-
+                        LastProbeTime is when the proxy last completed a health probe for
+                        this backend.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message provides extra context, especially when Healthy is false
+                        (e.g. "InferenceService not Ready", "Secret missing key
+                        ANTHROPIC_API_KEY").
+                      type: string
+                    name:
+                      description: Name matches RouterBackend.Name.
+                      type: string
+                    tier:
+                      description: Tier mirrors RouterBackend.Tier for convenience.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              budgetUtilization:
+                description: BudgetUtilization summarises current budget consumption.
+                items:
+                  description: BudgetStatus reports current consumption against a
+                    declared budget.
+                  properties:
+                    name:
+                      description: Name matches BudgetSpec.Name.
+                      type: string
+                    tokensUsed:
+                      description: TokensUsed is the rolling-window token count.
+                      format: int64
+                      type: integer
+                    usdUsed:
+                      description: USDUsed is the rolling-window estimated cost in
+                        USD.
+                      type: string
+                    utilization:
+                      description: |-
+                        Utilization is the fraction of the budget consumed, 0.0 to 1.0.
+                        When both MaxTokens and MaxUSD are set this is the maximum of the
+                        two utilizations.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              conditions:
+                description: |-
+                  conditions represent the current state of the ModelRouter resource.
+
+                  Standard condition types:
+                  - "Validated":     the spec passed static validation
+                  - "BackendsReady": all referenced backends are reachable and healthy
+                  - "Available":     the router-proxy is serving traffic
+                  - "Degraded":      at least one backend is unhealthy but the router
+                                     can still serve other routes
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              endpoint:
+                description: |-
+                  Endpoint is the in-cluster URL clients should hit. Populated once
+                  the router-proxy Service is ready.
+                type: string
+              lastUpdated:
+                description: LastUpdated is the timestamp of the last status reconciliation.
+                format: date-time
+                type: string
+              phase:
+                description: |-
+                  Phase is a coarse summary of the router's state.
+                  Possible values: Pending, Provisioning, Ready, Degraded, Failed.
+                enum:
+                - Pending
+                - Provisioning
+                - Ready
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -263,6 +263,13 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "InferenceService")
 		os.Exit(1)
 	}
+	if err := (&controller.ModelRouterReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ModelRouter")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -4,6 +4,7 @@
 resources:
 - bases/inference.llmkube.dev_models.yaml
 - bases/inference.llmkube.dev_inferenceservices.yaml
+- bases/inference.llmkube.dev_modelrouters.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -71,6 +71,7 @@ rules:
   - inference.llmkube.dev
   resources:
   - inferenceservices
+  - modelrouters
   - models
   verbs:
   - create
@@ -84,6 +85,7 @@ rules:
   - inference.llmkube.dev
   resources:
   - inferenceservices/finalizers
+  - modelrouters/finalizers
   - models/finalizers
   verbs:
   - update
@@ -91,6 +93,7 @@ rules:
   - inference.llmkube.dev
   resources:
   - inferenceservices/status
+  - modelrouters/status
   - models/status
   verbs:
   - get

--- a/internal/controller/modelrouter_controller.go
+++ b/internal/controller/modelrouter_controller.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
+)
+
+// Phase and condition constants specific to ModelRouter. Names that collide
+// with model_controller.go (PhaseReady, PhaseFailed, ConditionAvailable,
+// ConditionDegraded) are reused from there; only the new ones are declared
+// here.
+const (
+	ModelRouterPhasePending      = "Pending"
+	ModelRouterPhaseProvisioning = "Provisioning"
+
+	ModelRouterConditionValidated     = "Validated"
+	ModelRouterConditionBackendsReady = "BackendsReady"
+
+	ModelRouterReasonSpecValid   = "SpecValid"
+	ModelRouterReasonSpecInvalid = "SpecInvalid"
+
+	modelRouterControllerName = "modelrouter"
+)
+
+// ModelRouterReconciler reconciles the ModelRouter CRD. In Phase 1 (this
+// commit) the reconciler validates the spec and writes a Validated
+// condition. No data plane is managed yet; the proxy Deployment, Service,
+// and ConfigMap land in #428.
+type ModelRouterReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=inference.llmkube.dev,resources=modelrouters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=inference.llmkube.dev,resources=modelrouters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=inference.llmkube.dev,resources=modelrouters/finalizers,verbs=update
+// +kubebuilder:rbac:groups=inference.llmkube.dev,resources=inferenceservices,verbs=get;list;watch
+
+func (r *ModelRouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	reconcileStart := time.Now()
+	defer func() {
+		llmkubemetrics.ReconcileDuration.WithLabelValues(modelRouterControllerName).Observe(time.Since(reconcileStart).Seconds())
+	}()
+
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling ModelRouter", "name", req.Name, "namespace", req.Namespace)
+
+	mr := &inferencev1alpha1.ModelRouter{}
+	if err := r.Get(ctx, req.NamespacedName, mr); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "failed to get ModelRouter")
+		return ctrl.Result{}, err
+	}
+
+	valErrors := validateModelRouter(mr)
+	if err := r.updateStatus(ctx, mr, valErrors); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// updateStatus patches the ModelRouter status with the Validated condition
+// and an appropriate phase. Other conditions (BackendsReady, Available,
+// Degraded) will be set by the data-plane reconciler in #428.
+func (r *ModelRouterReconciler) updateStatus(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+	valErrors []ModelRouterValidationError,
+) error {
+	logger := log.FromContext(ctx)
+
+	desired := mr.DeepCopy()
+	now := metav1.Now()
+	desired.Status.LastUpdated = &now
+
+	if len(valErrors) == 0 {
+		apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+			Type:    ModelRouterConditionValidated,
+			Status:  metav1.ConditionTrue,
+			Reason:  ModelRouterReasonSpecValid,
+			Message: "spec passed static validation",
+		})
+		// Phase 1: no data plane yet, so a valid spec stays Pending.
+		// #428 will advance this to Provisioning / Ready / Degraded.
+		desired.Status.Phase = ModelRouterPhasePending
+		desired.Status.ActiveRules = safeInt32(len(desired.Spec.Rules))
+	} else {
+		apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+			Type:    ModelRouterConditionValidated,
+			Status:  metav1.ConditionFalse,
+			Reason:  ModelRouterReasonSpecInvalid,
+			Message: formatValidationErrors(valErrors),
+		})
+		desired.Status.Phase = PhaseFailed
+		desired.Status.ActiveRules = 0
+	}
+
+	if err := r.Status().Patch(ctx, desired, client.MergeFrom(mr)); err != nil {
+		logger.Error(err, "failed to update ModelRouter status")
+		return err
+	}
+	return nil
+}
+
+// safeInt32 narrows an int to int32, clamping at math.MaxInt32 when needed,
+// for populating Status fields whose CRD type is int32. The bounds check
+// above the conversion makes the narrow safe; gosec G115 cannot see across
+// the branch so we suppress on that single line.
+func safeInt32(n int) int32 {
+	if n > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(n) //nolint:gosec // bounds-checked above
+}
+
+// SetupWithManager wires up the ModelRouter primary watch plus a secondary
+// watch on InferenceService so a router whose backend turns Ready (or goes
+// away) is re-reconciled and re-validated.
+func (r *ModelRouterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&inferencev1alpha1.ModelRouter{}).
+		Watches(
+			&inferencev1alpha1.InferenceService{},
+			handler.EnqueueRequestsFromMapFunc(r.findModelRoutersForInferenceService),
+		).
+		Named(modelRouterControllerName).
+		Complete(r)
+}
+
+// findModelRoutersForInferenceService returns reconcile requests for every
+// ModelRouter in the same namespace that references the given
+// InferenceService by name. Mirrors the pattern used by
+// InferenceServiceReconciler.findInferenceServicesForModel.
+func (r *ModelRouterReconciler) findModelRoutersForInferenceService(ctx context.Context, obj client.Object) []reconcile.Request {
+	isvc, ok := obj.(*inferencev1alpha1.InferenceService)
+	if !ok {
+		return nil
+	}
+
+	routerList := &inferencev1alpha1.ModelRouterList{}
+	if err := r.List(ctx, routerList, client.InNamespace(isvc.Namespace)); err != nil {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for _, mr := range routerList.Items {
+		if routerReferencesInferenceService(&mr, isvc.Name) {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      mr.Name,
+					Namespace: mr.Namespace,
+				},
+			})
+		}
+	}
+	return requests
+}
+
+// routerReferencesInferenceService reports whether the router has a backend
+// whose InferenceServiceRef names the given service. Pulled out as a free
+// function so it's trivially unit-testable.
+func routerReferencesInferenceService(mr *inferencev1alpha1.ModelRouter, isvcName string) bool {
+	for _, b := range mr.Spec.Backends {
+		if b.InferenceServiceRef != nil && b.InferenceServiceRef.Name == isvcName {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/modelrouter_controller_test.go
+++ b/internal/controller/modelrouter_controller_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// TestRouterReferencesInferenceService covers the small pure helper that
+// powers the watch re-enqueue logic. The watch itself is exercised via
+// envtest in a separate suite once the data plane lands; this verifies the
+// matching predicate in isolation.
+func TestRouterReferencesInferenceService(t *testing.T) {
+	cases := []struct {
+		name     string
+		mr       *inferencev1alpha1.ModelRouter
+		isvcName string
+		want     bool
+	}{
+		{
+			name: "single matching local backend",
+			mr: &inferencev1alpha1.ModelRouter{
+				Spec: inferencev1alpha1.ModelRouterSpec{
+					Backends: []inferencev1alpha1.RouterBackend{
+						{Name: "a", InferenceServiceRef: &corev1.LocalObjectReference{Name: "qwen"}},
+					},
+				},
+			},
+			isvcName: "qwen",
+			want:     true,
+		},
+		{
+			name: "non-matching name",
+			mr: &inferencev1alpha1.ModelRouter{
+				Spec: inferencev1alpha1.ModelRouterSpec{
+					Backends: []inferencev1alpha1.RouterBackend{
+						{Name: "a", InferenceServiceRef: &corev1.LocalObjectReference{Name: "qwen"}},
+					},
+				},
+			},
+			isvcName: "llama",
+			want:     false,
+		},
+		{
+			name: "external-only backends are skipped",
+			mr: &inferencev1alpha1.ModelRouter{
+				Spec: inferencev1alpha1.ModelRouterSpec{
+					Backends: []inferencev1alpha1.RouterBackend{
+						{Name: "a", External: &inferencev1alpha1.ExternalProvider{Provider: "anthropic", Model: "x"}},
+					},
+				},
+			},
+			isvcName: "qwen",
+			want:     false,
+		},
+		{
+			name: "match among several backends",
+			mr: &inferencev1alpha1.ModelRouter{
+				Spec: inferencev1alpha1.ModelRouterSpec{
+					Backends: []inferencev1alpha1.RouterBackend{
+						{Name: "a", External: &inferencev1alpha1.ExternalProvider{Provider: "anthropic", Model: "x"}},
+						{Name: "b", InferenceServiceRef: &corev1.LocalObjectReference{Name: "qwen"}},
+						{Name: "c", InferenceServiceRef: &corev1.LocalObjectReference{Name: "llama"}},
+					},
+				},
+			},
+			isvcName: "llama",
+			want:     true,
+		},
+		{
+			name:     "no backends",
+			mr:       &inferencev1alpha1.ModelRouter{Spec: inferencev1alpha1.ModelRouterSpec{}},
+			isvcName: "qwen",
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := routerReferencesInferenceService(tc.mr, tc.isvcName)
+			if got != tc.want {
+				t.Errorf("routerReferencesInferenceService(%q) = %v; want %v",
+					tc.isvcName, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/modelrouter_validation.go
+++ b/internal/controller/modelrouter_validation.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// ModelRouterValidationError describes a single static-validation failure on
+// a ModelRouter spec. The Field is a dotted JSONPath-style locator so users
+// can match it to their manifest; Message is a human-readable explanation.
+type ModelRouterValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e ModelRouterValidationError) String() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// validateModelRouter performs static validation of a ModelRouter spec.
+// It checks invariants that the kubebuilder OpenAPI schema cannot express:
+//
+//   - Each backend must declare exactly one of inferenceServiceRef or external.
+//   - Backend tier must be consistent with its kind (local for
+//     inferenceServiceRef, cloud-or-omitted for external).
+//   - Backend names must be unique.
+//   - DefaultRoute, if set, names an existing backend.
+//   - Every rule's route.backends entries reference existing backends.
+//   - Rules matching sensitive classifications (pii/phi by default, or
+//     whatever policy.classification.sensitiveClassifications says) must
+//     have failClosed=true AND route only to local-tier backends. This is
+//     the regulated-data gate that prevents sensitive data from egressing.
+//   - Budget specs are well-formed (rule scope references a real rule;
+//     at least one of maxTokens or maxUSD is set).
+//
+// The function is pure: no K8s API access. The caller transforms the
+// returned errors into a Validated condition on the ModelRouter status.
+func validateModelRouter(mr *inferencev1alpha1.ModelRouter) []ModelRouterValidationError {
+	spec := &mr.Spec
+	var errs []ModelRouterValidationError
+
+	nameSet, backendsByName, backendErrs := validateBackends(spec)
+	errs = append(errs, backendErrs...)
+
+	if spec.DefaultRoute != "" && !nameSet[spec.DefaultRoute] {
+		errs = append(errs, ModelRouterValidationError{
+			Field:   "spec.defaultRoute",
+			Message: fmt.Sprintf("references undefined backend %q", spec.DefaultRoute),
+		})
+	}
+
+	ruleNames, ruleErrs := validateRules(spec, nameSet, backendsByName)
+	errs = append(errs, ruleErrs...)
+	errs = append(errs, validateBudgets(spec, ruleNames)...)
+
+	return errs
+}
+
+// validateBackends checks each RouterBackend in spec.backends and returns
+// the resolved name set, a name-to-backend lookup map, and any errors.
+func validateBackends(spec *inferencev1alpha1.ModelRouterSpec) (
+	map[string]bool,
+	map[string]*inferencev1alpha1.RouterBackend,
+	[]ModelRouterValidationError,
+) {
+	nameSet := make(map[string]bool, len(spec.Backends))
+	byName := make(map[string]*inferencev1alpha1.RouterBackend, len(spec.Backends))
+	var errs []ModelRouterValidationError
+
+	for i := range spec.Backends {
+		b := &spec.Backends[i]
+		path := fmt.Sprintf("spec.backends[%d]", i)
+		errs = append(errs, validateBackendKindExclusivity(b, path)...)
+
+		// Tier consistency: an InferenceServiceRef backend is by definition
+		// local. Allowing cloud tier here would let users bypass the
+		// fail-closed gate by mislabelling a local backend.
+		if b.InferenceServiceRef != nil && b.Tier == "cloud" {
+			errs = append(errs, ModelRouterValidationError{
+				Field:   path + ".tier",
+				Message: "tier=cloud is invalid for a backend with inferenceServiceRef (use tier=local)",
+			})
+		}
+
+		if b.Name == "" {
+			errs = append(errs, ModelRouterValidationError{
+				Field:   path + ".name",
+				Message: "name is required",
+			})
+		} else if nameSet[b.Name] {
+			errs = append(errs, ModelRouterValidationError{
+				Field:   path + ".name",
+				Message: fmt.Sprintf("duplicate backend name %q", b.Name),
+			})
+		}
+		nameSet[b.Name] = true
+		byName[b.Name] = b
+	}
+	return nameSet, byName, errs
+}
+
+// validateBackendKindExclusivity enforces exactly-one-of(inferenceServiceRef,
+// external) on a single backend.
+func validateBackendKindExclusivity(b *inferencev1alpha1.RouterBackend, path string) []ModelRouterValidationError {
+	hasLocal := b.InferenceServiceRef != nil
+	hasExt := b.External != nil
+	switch {
+	case hasLocal && hasExt:
+		return []ModelRouterValidationError{{
+			Field:   path,
+			Message: "exactly one of inferenceServiceRef or external must be set, not both",
+		}}
+	case !hasLocal && !hasExt:
+		return []ModelRouterValidationError{{
+			Field:   path,
+			Message: "exactly one of inferenceServiceRef or external must be set",
+		}}
+	}
+	return nil
+}
+
+// validateRules checks each RouterRule and returns the set of rule names
+// (for budget cross-references) plus any errors.
+func validateRules(
+	spec *inferencev1alpha1.ModelRouterSpec,
+	nameSet map[string]bool,
+	byName map[string]*inferencev1alpha1.RouterBackend,
+) (map[string]bool, []ModelRouterValidationError) {
+	sensitiveSet := sensitiveClassificationSet(spec.Policy)
+	ruleNames := make(map[string]bool, len(spec.Rules))
+	errs := make([]ModelRouterValidationError, 0, len(spec.Rules))
+
+	for i := range spec.Rules {
+		rule := &spec.Rules[i]
+		path := fmt.Sprintf("spec.rules[%d]", i)
+
+		if rule.Name != "" {
+			ruleNames[rule.Name] = true
+		}
+		errs = append(errs, validateRuleRoute(rule, path, nameSet)...)
+		errs = append(errs, validateRuleSensitiveData(rule, path, sensitiveSet, byName)...)
+	}
+	return ruleNames, errs
+}
+
+// validateRuleRoute checks that rule.route.backends references real backends.
+func validateRuleRoute(
+	rule *inferencev1alpha1.RouterRule,
+	path string,
+	nameSet map[string]bool,
+) []ModelRouterValidationError {
+	var errs []ModelRouterValidationError
+	if len(rule.Route.Backends) == 0 {
+		errs = append(errs, ModelRouterValidationError{
+			Field:   path + ".route.backends",
+			Message: "must reference at least one backend",
+		})
+	}
+	for j, name := range rule.Route.Backends {
+		if !nameSet[name] {
+			errs = append(errs, ModelRouterValidationError{
+				Field:   fmt.Sprintf("%s.route.backends[%d]", path, j),
+				Message: fmt.Sprintf("references undefined backend %q", name),
+			})
+		}
+	}
+	return errs
+}
+
+// validateRuleSensitiveData enforces the fail-closed gate: rules matching
+// sensitive classifications must have failClosed=true and may only reference
+// local-tier backends.
+func validateRuleSensitiveData(
+	rule *inferencev1alpha1.RouterRule,
+	path string,
+	sensitiveSet map[string]bool,
+	byName map[string]*inferencev1alpha1.RouterBackend,
+) []ModelRouterValidationError {
+	if rule.Match == nil {
+		return nil
+	}
+
+	var matched []string
+	for _, cls := range rule.Match.DataClassification {
+		if sensitiveSet[cls] {
+			matched = append(matched, cls)
+		}
+	}
+	if len(matched) == 0 {
+		return nil
+	}
+
+	var errs []ModelRouterValidationError
+	if !rule.FailClosed {
+		errs = append(errs, ModelRouterValidationError{
+			Field: path + ".failClosed",
+			Message: fmt.Sprintf(
+				"rule matches sensitive classifications %v and must set failClosed=true",
+				matched),
+		})
+	}
+	for _, name := range rule.Route.Backends {
+		b, ok := byName[name]
+		if !ok {
+			// Already reported in validateRuleRoute.
+			continue
+		}
+		if b.Tier == "cloud" {
+			errs = append(errs, ModelRouterValidationError{
+				Field: path + ".route.backends",
+				Message: fmt.Sprintf(
+					"sensitive-data rule cannot route to cloud-tier backend %q (matched classifications: %v)",
+					name, matched),
+			})
+		}
+	}
+	return errs
+}
+
+// validateBudgets covers the BudgetSpec invariants: rule-scoped budgets
+// must reference a real rule, and every budget must set at least one of
+// maxTokens / maxUSD.
+func validateBudgets(
+	spec *inferencev1alpha1.ModelRouterSpec,
+	ruleNames map[string]bool,
+) []ModelRouterValidationError {
+	if spec.Policy == nil {
+		return nil
+	}
+	var errs []ModelRouterValidationError
+	for i, b := range spec.Policy.Budgets {
+		path := fmt.Sprintf("spec.policy.budgets[%d]", i)
+		if b.Scope == "rule" {
+			switch {
+			case b.RuleName == "":
+				errs = append(errs, ModelRouterValidationError{
+					Field:   path + ".ruleName",
+					Message: "ruleName is required when scope=rule",
+				})
+			case !ruleNames[b.RuleName]:
+				errs = append(errs, ModelRouterValidationError{
+					Field:   path + ".ruleName",
+					Message: fmt.Sprintf("references undefined rule %q", b.RuleName),
+				})
+			}
+		}
+		if b.MaxTokens == nil && strings.TrimSpace(b.MaxUSD) == "" {
+			errs = append(errs, ModelRouterValidationError{
+				Field:   path,
+				Message: "must set at least one of maxTokens or maxUSD",
+			})
+		}
+	}
+	return errs
+}
+
+// sensitiveClassificationSet returns the set of classification values that
+// trigger fail-closed validation. When the policy explicitly lists
+// SensitiveClassifications, those are used as-is; otherwise the default of
+// {"pii", "phi"} applies. Documented in the ModelRouter concept page so
+// operators can predict the gate's behavior.
+func sensitiveClassificationSet(policy *inferencev1alpha1.RouterPolicy) map[string]bool {
+	out := make(map[string]bool, 2)
+	if policy != nil && policy.Classification != nil && len(policy.Classification.SensitiveClassifications) > 0 {
+		for _, s := range policy.Classification.SensitiveClassifications {
+			out[s] = true
+		}
+		return out
+	}
+	out["pii"] = true
+	out["phi"] = true
+	return out
+}
+
+// formatValidationErrors joins validation errors into a single status
+// message. Joined by "; " so each entry stays scannable in `kubectl describe`.
+func formatValidationErrors(errs []ModelRouterValidationError) string {
+	if len(errs) == 0 {
+		return ""
+	}
+	parts := make([]string, len(errs))
+	for i, e := range errs {
+		parts[i] = e.String()
+	}
+	return strings.Join(parts, "; ")
+}

--- a/internal/controller/modelrouter_validation_test.go
+++ b/internal/controller/modelrouter_validation_test.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+const (
+	testRouterLocalBackend = "local-qwen"
+	testRouterCloudBackend = "cloud-opus"
+	testRouterISName       = "qwen3-coder"
+	testRouterTierCloud    = "cloud"
+)
+
+func ptrInt64Local(v int64) *int64 { return &v }
+
+// validRouter returns a baseline ModelRouter that passes every validation
+// check. Subtests mutate it to exercise specific failure modes.
+func validRouter() *inferencev1alpha1.ModelRouter {
+	return &inferencev1alpha1.ModelRouter{
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{
+					Name:                testRouterLocalBackend,
+					InferenceServiceRef: &corev1.LocalObjectReference{Name: testRouterISName},
+					Tier:                "local",
+				},
+				{
+					Name: testRouterCloudBackend,
+					External: &inferencev1alpha1.ExternalProvider{
+						Provider: "anthropic",
+						Model:    "claude-opus-4-7",
+					},
+					Tier: testRouterTierCloud,
+				},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name: "pii-stays-local",
+					Match: &inferencev1alpha1.RuleMatch{
+						DataClassification: []string{"pii"},
+					},
+					Route: inferencev1alpha1.RuleRoute{
+						Backends: []string{testRouterLocalBackend},
+					},
+					FailClosed: true,
+				},
+				{
+					Name: "complex-to-cloud",
+					Match: &inferencev1alpha1.RuleMatch{
+						TaskComplexity: "complex",
+					},
+					Route: inferencev1alpha1.RuleRoute{
+						Backends: []string{testRouterCloudBackend, testRouterLocalBackend},
+					},
+				},
+			},
+			DefaultRoute: testRouterLocalBackend,
+		},
+	}
+}
+
+// TestValidateModelRouterValid ensures the canonical fixture passes cleanly.
+func TestValidateModelRouterValid(t *testing.T) {
+	errs := validateModelRouter(validRouter())
+	if len(errs) != 0 {
+		t.Fatalf("expected no validation errors, got: %s", formatValidationErrors(errs))
+	}
+}
+
+// TestValidateModelRouterBackendExclusivity covers the mutual-exclusion rule
+// for inferenceServiceRef vs external on a RouterBackend.
+func TestValidateModelRouterBackendExclusivity(t *testing.T) {
+	cases := []struct {
+		name       string
+		mutate     func(*inferencev1alpha1.ModelRouter)
+		wantSubstr string
+	}{
+		{
+			name: "both set",
+			mutate: func(mr *inferencev1alpha1.ModelRouter) {
+				mr.Spec.Backends[0].External = &inferencev1alpha1.ExternalProvider{
+					Provider: "anthropic", Model: "x",
+				}
+			},
+			wantSubstr: "not both",
+		},
+		{
+			name: "neither set",
+			mutate: func(mr *inferencev1alpha1.ModelRouter) {
+				mr.Spec.Backends[0].InferenceServiceRef = nil
+			},
+			wantSubstr: "must be set",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := validRouter()
+			tc.mutate(mr)
+			errs := validateModelRouter(mr)
+			if !errsContain(errs, tc.wantSubstr) {
+				t.Errorf("expected error containing %q, got: %s",
+					tc.wantSubstr, formatValidationErrors(errs))
+			}
+		})
+	}
+}
+
+// TestValidateModelRouterTierConsistency confirms an inferenceServiceRef
+// backend cannot be labelled tier=cloud. Allowing that would let users sneak
+// a local backend past the fail-closed gate.
+func TestValidateModelRouterTierConsistency(t *testing.T) {
+	mr := validRouter()
+	mr.Spec.Backends[0].Tier = testRouterTierCloud
+	errs := validateModelRouter(mr)
+	if !errsContain(errs, "tier=cloud is invalid") {
+		t.Errorf("expected tier consistency error, got: %s", formatValidationErrors(errs))
+	}
+}
+
+// TestValidateModelRouterDuplicateBackendNames ensures repeated names are
+// flagged. Downstream resolution uses backend name as a map key so dupes
+// would silently shadow each other.
+func TestValidateModelRouterDuplicateBackendNames(t *testing.T) {
+	mr := validRouter()
+	mr.Spec.Backends = append(mr.Spec.Backends, inferencev1alpha1.RouterBackend{
+		Name:                testRouterLocalBackend,
+		InferenceServiceRef: &corev1.LocalObjectReference{Name: "other"},
+		Tier:                "local",
+	})
+	errs := validateModelRouter(mr)
+	if !errsContain(errs, "duplicate backend name") {
+		t.Errorf("expected duplicate backend name error, got: %s", formatValidationErrors(errs))
+	}
+}
+
+// TestValidateModelRouterDefaultRouteRef ensures defaultRoute must point at
+// a real backend.
+func TestValidateModelRouterDefaultRouteRef(t *testing.T) {
+	mr := validRouter()
+	mr.Spec.DefaultRoute = "does-not-exist"
+	errs := validateModelRouter(mr)
+	if !errsContain(errs, "references undefined backend") {
+		t.Errorf("expected undefined-backend error, got: %s", formatValidationErrors(errs))
+	}
+}
+
+// TestValidateModelRouterRuleBackendRef ensures rule.route.backends entries
+// must point at real backends.
+func TestValidateModelRouterRuleBackendRef(t *testing.T) {
+	mr := validRouter()
+	mr.Spec.Rules[1].Route.Backends = []string{"ghost"}
+	errs := validateModelRouter(mr)
+	if !errsContain(errs, `references undefined backend "ghost"`) {
+		t.Errorf("expected undefined backend error, got: %s", formatValidationErrors(errs))
+	}
+}
+
+// TestValidateModelRouterRuleEmptyBackends ensures rule.route.backends must
+// be non-empty (kubebuilder MinItems is enforced at admission, but we
+// double-check defensively in case of CRD bypass).
+func TestValidateModelRouterRuleEmptyBackends(t *testing.T) {
+	mr := validRouter()
+	mr.Spec.Rules[0].Route.Backends = nil
+	errs := validateModelRouter(mr)
+	if !errsContain(errs, "must reference at least one backend") {
+		t.Errorf("expected empty-backends error, got: %s", formatValidationErrors(errs))
+	}
+}
+
+// TestValidateModelRouterSensitiveDataRequiresFailClosed is the headline
+// gate: any rule matching pii/phi must have failClosed=true.
+func TestValidateModelRouterSensitiveDataRequiresFailClosed(t *testing.T) {
+	mr := validRouter()
+	mr.Spec.Rules[0].FailClosed = false
+	errs := validateModelRouter(mr)
+	if !errsContain(errs, "must set failClosed=true") {
+		t.Errorf("expected failClosed error, got: %s", formatValidationErrors(errs))
+	}
+}
+
+// TestValidateModelRouterSensitiveDataCannotRouteCloud is the other half of
+// the fail-closed gate: even with failClosed=true, a sensitive rule cannot
+// reference cloud-tier backends. Otherwise "fail-closed" would mean "egress
+// once, then refuse on retry," which defeats the purpose.
+func TestValidateModelRouterSensitiveDataCannotRouteCloud(t *testing.T) {
+	mr := validRouter()
+	mr.Spec.Rules[0].Route.Backends = []string{testRouterCloudBackend}
+	errs := validateModelRouter(mr)
+	if !errsContain(errs, "cannot route to cloud-tier backend") {
+		t.Errorf("expected sensitive-to-cloud error, got: %s", formatValidationErrors(errs))
+	}
+}
+
+// TestValidateModelRouterCustomSensitiveClassifications confirms the
+// per-router override of the sensitive-classification set works: a router
+// that adds "secret" to the set should reject a "secret"-matching rule that
+// routes to cloud.
+func TestValidateModelRouterCustomSensitiveClassifications(t *testing.T) {
+	mr := validRouter()
+	mr.Spec.Policy = &inferencev1alpha1.RouterPolicy{
+		Classification: &inferencev1alpha1.ClassificationPolicy{
+			SensitiveClassifications: []string{"secret", "internal-only"},
+		},
+	}
+	// Add a rule matching "secret" that routes to cloud. Should be rejected.
+	mr.Spec.Rules = append(mr.Spec.Rules, inferencev1alpha1.RouterRule{
+		Name: "secret-leak",
+		Match: &inferencev1alpha1.RuleMatch{
+			DataClassification: []string{"secret"},
+		},
+		Route: inferencev1alpha1.RuleRoute{
+			Backends: []string{testRouterCloudBackend},
+		},
+		FailClosed: true,
+	})
+	errs := validateModelRouter(mr)
+	if !errsContain(errs, "cannot route to cloud-tier backend") {
+		t.Errorf("expected sensitive-to-cloud error for custom classification, got: %s",
+			formatValidationErrors(errs))
+	}
+
+	// Also confirm that the *default* sensitive classifications no longer
+	// apply when an override is set: a "pii"-matching rule under this
+	// override would no longer trigger fail-closed (since pii is not in the
+	// override list). Drop the pii rule's failClosed and verify no error.
+	mr2 := validRouter()
+	mr2.Spec.Policy = &inferencev1alpha1.RouterPolicy{
+		Classification: &inferencev1alpha1.ClassificationPolicy{
+			SensitiveClassifications: []string{"secret"},
+		},
+	}
+	mr2.Spec.Rules[0].FailClosed = false
+	errs = validateModelRouter(mr2)
+	if errsContain(errs, "must set failClosed=true") {
+		t.Errorf("override should disable the default pii gate, got: %s", formatValidationErrors(errs))
+	}
+}
+
+// TestValidateModelRouterBudget covers BudgetSpec validation:
+// rule-scoped budgets must reference a real rule, and every budget must set
+// at least one of maxTokens / maxUSD.
+func TestValidateModelRouterBudget(t *testing.T) {
+	cases := []struct {
+		name       string
+		budget     inferencev1alpha1.BudgetSpec
+		wantSubstr string
+	}{
+		{
+			name: "rule scope without ruleName",
+			budget: inferencev1alpha1.BudgetSpec{
+				Name:      "b",
+				Scope:     "rule",
+				MaxTokens: ptrInt64Local(1000),
+			},
+			wantSubstr: "ruleName is required",
+		},
+		{
+			name: "rule scope referencing unknown rule",
+			budget: inferencev1alpha1.BudgetSpec{
+				Name:      "b",
+				Scope:     "rule",
+				RuleName:  "ghost",
+				MaxTokens: ptrInt64Local(1000),
+			},
+			wantSubstr: `references undefined rule "ghost"`,
+		},
+		{
+			name: "neither maxTokens nor maxUSD",
+			budget: inferencev1alpha1.BudgetSpec{
+				Name:  "b",
+				Scope: "router",
+			},
+			wantSubstr: "must set at least one of maxTokens or maxUSD",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := validRouter()
+			mr.Spec.Policy = &inferencev1alpha1.RouterPolicy{
+				Budgets: []inferencev1alpha1.BudgetSpec{tc.budget},
+			}
+			errs := validateModelRouter(mr)
+			if !errsContain(errs, tc.wantSubstr) {
+				t.Errorf("expected error containing %q, got: %s",
+					tc.wantSubstr, formatValidationErrors(errs))
+			}
+		})
+	}
+}
+
+// errsContain reports whether any validation error's serialized form
+// contains the given substring. Helper to keep the tests above readable.
+func errsContain(errs []ModelRouterValidationError, substr string) bool {
+	for _, e := range errs {
+		if strings.Contains(e.String(), substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -654,6 +654,170 @@ spec:
 		})
 	})
 
+	Context("ModelRouter Reconciliation", func() {
+		const mrTestNs = "e2e-modelrouter-test"
+
+		BeforeAll(func() {
+			By("creating ModelRouter test namespace")
+			cmd := exec.Command("kubectl", "create", "ns", mrTestNs)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create test namespace")
+		})
+
+		AfterAll(func() {
+			By("cleaning up ModelRouter test namespace")
+			cmd := exec.Command("kubectl", "delete", "ns", mrTestNs, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		// ModelRouter validation does not require referenced InferenceServices
+		// to actually exist in the cluster; it only enforces self-consistency
+		// of the spec (exactly-one-of, name uniqueness, fail-closed gate,
+		// budget invariants). The data plane lands in #428, at which point
+		// E2E coverage will broaden to actual request dispatch.
+
+		It("should report Validated=True for a well-formed ModelRouter", func() {
+			By("applying a ModelRouter with a valid spec")
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata:
+  name: e2e-good-router
+  namespace: %s
+spec:
+  backends:
+    - name: local-stub
+      inferenceServiceRef:
+        name: stub-isvc
+      tier: local
+    - name: cloud-stub
+      external:
+        provider: anthropic
+        model: claude-opus-4-7
+      tier: cloud
+  rules:
+    - name: pii-stays-local
+      match:
+        dataClassification: ["pii"]
+      route:
+        backends: ["local-stub"]
+      failClosed: true
+    - name: complex-to-cloud
+      match:
+        taskComplexity: complex
+      route:
+        backends: ["cloud-stub"]
+  defaultRoute: local-stub
+`, mrTestNs))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to apply ModelRouter CR")
+
+			By("waiting for ModelRouter status.phase=Pending and Validated=True")
+			verifyValidated := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "modelrouter", "e2e-good-router",
+					"-n", mrTestNs, "-o", "jsonpath={.status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Pending"))
+
+				cmd = exec.Command("kubectl", "get", "modelrouter", "e2e-good-router",
+					"-n", mrTestNs, "-o",
+					`jsonpath={.status.conditions[?(@.type=="Validated")].status}`)
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"))
+
+				cmd = exec.Command("kubectl", "get", "modelrouter", "e2e-good-router",
+					"-n", mrTestNs, "-o", "jsonpath={.status.activeRules}")
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("2"))
+			}
+			Eventually(verifyValidated, 1*time.Minute).Should(Succeed())
+		})
+
+		It("should report Validated=False for a sensitive-data rule routing to cloud", func() {
+			By("applying a ModelRouter whose fail-closed PII rule points at a cloud backend")
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata:
+  name: e2e-bad-router
+  namespace: %s
+spec:
+  backends:
+    - name: local-stub
+      inferenceServiceRef:
+        name: stub-isvc
+      tier: local
+    - name: cloud-stub
+      external:
+        provider: anthropic
+        model: claude-opus-4-7
+      tier: cloud
+  rules:
+    - name: pii-leak
+      match:
+        dataClassification: ["pii"]
+      route:
+        backends: ["cloud-stub"]
+      failClosed: true
+  defaultRoute: local-stub
+`, mrTestNs))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to apply invalid ModelRouter CR")
+
+			By("waiting for ModelRouter status.phase=Failed and Validated=False with SpecInvalid reason")
+			verifyInvalid := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "modelrouter", "e2e-bad-router",
+					"-n", mrTestNs, "-o", "jsonpath={.status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Failed"))
+
+				cmd = exec.Command("kubectl", "get", "modelrouter", "e2e-bad-router",
+					"-n", mrTestNs, "-o",
+					`jsonpath={.status.conditions[?(@.type=="Validated")].status}`)
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("False"))
+
+				cmd = exec.Command("kubectl", "get", "modelrouter", "e2e-bad-router",
+					"-n", mrTestNs, "-o",
+					`jsonpath={.status.conditions[?(@.type=="Validated")].reason}`)
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("SpecInvalid"))
+
+				cmd = exec.Command("kubectl", "get", "modelrouter", "e2e-bad-router",
+					"-n", mrTestNs, "-o",
+					`jsonpath={.status.conditions[?(@.type=="Validated")].message}`)
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("cannot route to cloud-tier backend"))
+			}
+			Eventually(verifyInvalid, 1*time.Minute).Should(Succeed())
+		})
+
+		It("should clean up ModelRouter resources on deletion", func() {
+			By("deleting both test ModelRouters")
+			cmd := exec.Command("kubectl", "delete", "modelrouter", "e2e-good-router", "e2e-bad-router",
+				"-n", mrTestNs, "--ignore-not-found")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to delete ModelRouters")
+
+			By("verifying both ModelRouters are gone")
+			verifyGone := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "modelrouters", "-n", mrTestNs,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(BeEmpty())
+			}
+			Eventually(verifyGone, 30*time.Second).Should(Succeed())
+		})
+	})
+
 	Context("License Check", func() {
 		const licenseTestNs = "e2e-license-test"
 		const testLicenseModelServerURL = "http://test-model-server.e2e-license-test.svc.cluster.local/test-model.gguf"


### PR DESCRIPTION
## Summary

Adds the `ModelRouterReconciler` with static spec validation and the headline regulated-data fail-closed gate. The reconciler validates the ModelRouter spec on every change, writes a `Validated` condition, and watches `InferenceService` so a router whose backend turns Ready (or goes away) is re-reconciled.

No data plane yet. The router-proxy Deployment, Service, and ConfigMap land in #428. Phase stays `Pending` on valid spec, `Failed` on invalid.

Closes #426.

## What's validated

Each invariant below corresponds to a focused validation function and its own unit-test subtree:

| Invariant | Failure mode caught |
|---|---|
| Each backend declares exactly one of `inferenceServiceRef` / `external` | Misconfigured CRDs that the OpenAPI schema can't catch |
| `tier=cloud` is rejected on `inferenceServiceRef` backends | Users can't mislabel a local backend to slip past the fail-closed gate |
| Backend names are unique | Downstream resolution uses name as a map key; dupes would silently shadow |
| `defaultRoute` references a real backend | Dangling reference at apply time |
| `rule.route.backends` entries reference real backends | Dangling reference at apply time |
| **Fail-closed gate (1/2)**: rules matching sensitive classifications must have `failClosed: true` | PII/PHI rules without fail-closed could fall through to less-restrictive routes |
| **Fail-closed gate (2/2)**: sensitive-data rules may only route to `tier: local` backends | Even with fail-closed, a sensitive rule cannot egress |
| Budget specs require at least one of `maxTokens` / `maxUSD` | No-op budget configurations |
| `scope: rule` budgets reference a real rule | Dangling reference at apply time |

The default sensitive-classification set is `{pii, phi}`. Operators can override via `spec.policy.classification.sensitiveClassifications` (and tests confirm the override fully replaces the defaults, so `pii` is only enforced if it's in the override list).

## Files

**Added:**
- `internal/controller/modelrouter_controller.go` (reconciler, watch wiring, `safeInt32` helper for status int32 fields)
- `internal/controller/modelrouter_validation.go` (pure validation pipeline, split into `validateBackends` / `validateRules` / `validateBudgets` so each stays under gocyclo's limit)
- `internal/controller/modelrouter_validation_test.go` (16 tests across 11 test functions)
- `internal/controller/modelrouter_controller_test.go` (5 subtests for the watch helper)

**Modified:**
- `cmd/main.go`: register `ModelRouterReconciler` alongside Model and InferenceService reconcilers
- `config/rbac/role.yaml`: regenerated by `make manifests`; adds `modelrouters` verbs + status + finalizers
- `charts/llmkube/templates/clusterrole.yaml`: matching Helm RBAC update so `helm upgrade` users don't get RBAC denials on the new resource

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go fmt ./...` clean
- [x] `golangci-lint run ./internal/controller/... ./cmd/...` clean on new code (two pre-existing `staticcheck` warnings in `runtime_vllm_test.go` are unrelated)
- [x] Validation tests pass (16 tests, all under 1s)
- [x] Watch helper tests pass (5 subtests)
- [ ] envtest integration test for the controller (deferred to follow-up; see issue body)
- [ ] On a real cluster: apply a valid ModelRouter, observe `Validated=True` and `Phase=Pending`; apply an invalid one (e.g. fail-closed rule routing to cloud), observe `Validated=False` with the offending path in the message

## What's intentionally out of scope

- **envtest integration test.** The controller is wired and validation is exhaustively unit-tested. An envtest harness that creates ModelRouter + InferenceService resources and exercises the watch end-to-end will land alongside #428 (data plane) where the surface to test is meaningfully larger.
- **Helm chart packaging of the CRD.** This PR adds the RBAC verbs for the new resource (so the controller won't fail with permission errors), but `charts/llmkube/crds/inference.llmkube.dev_modelrouters.yaml` and the user-facing concept page land in #439.
- **Data plane.** No Deployment, Service, or ConfigMap is reconciled here. Applying a valid ModelRouter today produces a `Validated=True` status and `Phase=Pending`; no traffic is served. That's correct for this phase.