### PR TITLE
feat: router-proxy binary with OpenAI streaming passthrough

### DIFF
--- a/Dockerfile.router-proxy
+++ b/Dockerfile.router-proxy
@@ -1,0 +1,34 @@
+# Build stage: full Go toolchain on a small base.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+
+# Dependency layer cache: copy module files first so source-only changes
+# don't bust the module download cache.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY api/ api/
+COPY cmd/ cmd/
+COPY internal/ internal/
+
+# Static build so the resulting binary runs on the distroless static
+# image (no libc). -s -w strips DWARF and symbol table for size.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o router-proxy ./cmd/router-proxy
+
+# Runtime stage: distroless, non-root, no shell.
+FROM gcr.io/distroless/static:nonroot
+
+WORKDIR /
+COPY --from=builder /workspace/router-proxy /usr/local/bin/router-proxy
+
+# Expose the default HTTP port; the binary's --listen flag overrides.
+EXPOSE 8080
+
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/router-proxy"]

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,19 @@ docker-build: ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
 
+ROUTER_PROXY_IMG ?= ghcr.io/defilantech/llmkube-router-proxy:dev
+.PHONY: docker-build-router-proxy
+docker-build-router-proxy: ## Build docker image for the router-proxy data plane.
+	$(CONTAINER_TOOL) build -f Dockerfile.router-proxy -t ${ROUTER_PROXY_IMG} .
+
+.PHONY: docker-push-router-proxy
+docker-push-router-proxy: ## Push the router-proxy image.
+	$(CONTAINER_TOOL) push ${ROUTER_PROXY_IMG}
+
+.PHONY: build-router-proxy
+build-router-proxy: fmt vet ## Build router-proxy binary into bin/.
+	go build -o bin/router-proxy ./cmd/router-proxy
+
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
 # - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/

--- a/cmd/router-proxy/main.go
+++ b/cmd/router-proxy/main.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// Command router-proxy serves the LLMKube ModelRouter HTTP data plane.
+//
+// The binary is intentionally small: it reads a compiled routing config
+// from a file (the controller writes that file via a ConfigMap mount),
+// listens for OpenAI-compatible chat completion requests, and dispatches
+// them to backends according to the rules. The controller does the heavy
+// lifting (validation, secrets, owner references); the proxy does only
+// inference-path work.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/defilantech/llmkube/internal/router"
+)
+
+func main() {
+	configPath := flag.String("config", "/etc/llmkube/router/config.json",
+		"Path to the compiled router config file (mounted from the controller-managed ConfigMap).")
+	listen := flag.String("listen", ":8080",
+		"Address the HTTP server binds to (host:port).")
+	logFormat := flag.String("log-format", "json",
+		"Structured log format: json or text.")
+	shutdownTimeout := flag.Duration("shutdown-timeout", 30*time.Second,
+		"How long to wait for in-flight requests on SIGTERM before forcing a close.")
+	flag.Parse()
+
+	logger := newLogger(*logFormat)
+	slog.SetDefault(logger)
+
+	cfg, err := router.LoadConfig(*configPath)
+	if err != nil {
+		logger.Error("load router config", "error", err, "path", *configPath)
+		os.Exit(1)
+	}
+	logger.Info("router config loaded",
+		"backends", len(cfg.Backends),
+		"rules", len(cfg.Rules),
+		"defaultRoute", cfg.DefaultRoute,
+	)
+
+	proxy := router.NewProxy(cfg, logger)
+	mux := http.NewServeMux()
+	proxy.Mount(mux)
+
+	srv := &http.Server{
+		Addr:              *listen,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		// No write timeout: streaming chat completions can be long-lived.
+		// Per-request context handles the real deadline.
+	}
+
+	// Run the server in a goroutine so the main goroutine can wait on
+	// SIGTERM and trigger graceful shutdown.
+	serverErr := make(chan error, 1)
+	go func() {
+		logger.Info("router-proxy listening", "address", *listen)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+		}
+		close(serverErr)
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case <-stop:
+		logger.Info("shutdown signal received; draining in-flight requests")
+		ctx, cancel := context.WithTimeout(context.Background(), *shutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			logger.Error("graceful shutdown failed", "error", err)
+			os.Exit(1)
+		}
+		logger.Info("router-proxy stopped cleanly")
+	case err := <-serverErr:
+		if err != nil {
+			logger.Error("server failed", "error", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func newLogger(format string) *slog.Logger {
+	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	switch strings.ToLower(format) {
+	case "text":
+		return slog.New(slog.NewTextHandler(os.Stdout, opts))
+	default:
+		return slog.New(slog.NewJSONHandler(os.Stdout, opts))
+	}
+}

--- a/cmd/router-proxy/main_integration_test.go
+++ b/cmd/router-proxy/main_integration_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestRouterProxyBinarySmoke compiles the router-proxy binary, starts it
+// with a real config file and fake upstream backend, sends an HTTP
+// request, and SIGTERM's the process. This is the per-PR check that the
+// binary actually works end-to-end as a subprocess (something the
+// in-process router unit tests can't verify).
+//
+// Cluster-level e2e arrives with #428, where the controller deploys the
+// proxy from a ModelRouter CRD. This integration test is the
+// pre-cluster gate.
+func TestRouterProxyBinarySmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration smoke in -short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("signal handling is POSIX-specific")
+	}
+
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "router-proxy")
+
+	// Build the binary from source. Uses the same module the test runs
+	// under, so any compile error in router-proxy fails this test.
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+	build := exec.Command("go", "build", "-o", binPath, "./cmd/router-proxy")
+	build.Dir = repoRoot
+	build.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+
+	// Stand up a fake upstream backend that the proxy will dispatch to.
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"smoke ok"}}]}`)
+	}))
+	defer upstream.Close()
+
+	// Write a minimal router config pointing at the fake upstream.
+	configPath := filepath.Join(dir, "config.json")
+	config := map[string]any{
+		"backends": []map[string]any{
+			{"name": "local", "tier": "local", "address": upstream.URL},
+		},
+		"defaultRoute": "local",
+		"policy": map[string]any{
+			"classification": map[string]any{"mode": "header-only"},
+			"auditLog":       map[string]any{"sink": "stdout"},
+		},
+	}
+	cfgBytes, _ := json.MarshalIndent(config, "", "  ")
+	if err := os.WriteFile(configPath, cfgBytes, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	port := pickFreePort(t)
+	listen := fmt.Sprintf("127.0.0.1:%d", port)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binPath,
+		"--config", configPath,
+		"--listen", listen,
+		"--log-format", "text",
+	)
+	// Capture stdout/stderr in case the test fails so we get logs.
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start router-proxy: %v", err)
+	}
+	t.Cleanup(func() {
+		// Force-kill in case the test fails before SIGTERM.
+		_ = cmd.Process.Kill()
+		out, _ := io.ReadAll(stdout)
+		errOut, _ := io.ReadAll(stderr)
+		if len(out)+len(errOut) > 0 {
+			t.Logf("router-proxy stdout:\n%s", out)
+			t.Logf("router-proxy stderr:\n%s", errOut)
+		}
+	})
+
+	if err := waitForReady("http://"+listen+"/health", 10*time.Second); err != nil {
+		t.Fatalf("router-proxy never became ready: %v", err)
+	}
+
+	// Exercise a real chat completion through the binary.
+	resp, err := http.Post(
+		"http://"+listen+"/v1/chat/completions",
+		"application/json",
+		strings.NewReader(`{"model":"any"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST /v1/chat/completions: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "smoke ok") {
+		t.Errorf("response missing upstream payload: %s", body)
+	}
+	if upstreamHits != 1 {
+		t.Errorf("upstream hits = %d, want 1", upstreamHits)
+	}
+
+	// Verify /v1/models also works.
+	modelsResp, err := http.Get("http://" + listen + "/v1/models")
+	if err != nil {
+		t.Fatalf("GET /v1/models: %v", err)
+	}
+	defer func() { _ = modelsResp.Body.Close() }()
+	if modelsResp.StatusCode != http.StatusOK {
+		t.Errorf("models status = %d, want 200", modelsResp.StatusCode)
+	}
+
+	// SIGTERM and confirm clean exit within the shutdown budget.
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && !exitErr.Success() && exitErr.ExitCode() != 0 {
+				t.Errorf("router-proxy exited non-zero after SIGTERM: %v", err)
+			}
+		}
+	case <-time.After(15 * time.Second):
+		t.Error("router-proxy did not shut down within 15s of SIGTERM")
+	}
+}
+
+// waitForReady polls the given URL until it returns 2xx or the timeout
+// expires.
+func waitForReady(url string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url) //nolint:gosec // URL is constructed locally in test
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode < 300 {
+				return nil
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for %s", url)
+}
+
+// pickFreePort returns an OS-assigned free TCP port. There is an
+// inherent race between picking and using the port, but for a
+// single-test subprocess it's reliable enough.
+func pickFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("pick free port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
+}
+
+// findRepoRoot walks up from this test file's location until it finds a
+// go.mod, returning the directory containing it. Lets the test invoke
+// `go build ./cmd/router-proxy` regardless of where `go test` is run.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found in any parent of %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/internal/router/backend.go
+++ b/internal/router/backend.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package router
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Dispatcher knows how to forward an inbound request to a chosen backend.
+// One Dispatcher instance is shared across all requests; it owns the
+// per-backend http.Client pool and health bookkeeping.
+type Dispatcher struct {
+	cfg     *Config
+	client  *http.Client
+	healthy sync.Map // backendName -> *atomic.Bool
+
+	// nowFn is overridable in tests.
+	nowFn func() time.Time
+}
+
+// NewDispatcher returns a Dispatcher bound to the given Config. All
+// backends start in a healthy state; the proxy flips them unhealthy on
+// failed requests and back to healthy on the next successful request.
+// More sophisticated health probing (separate goroutine pinging /health)
+// lands with the production-hardening phase.
+func NewDispatcher(cfg *Config) *Dispatcher {
+	d := &Dispatcher{
+		cfg: cfg,
+		client: &http.Client{
+			// Streaming requests can be long-lived. The per-request
+			// context is the real deadline; this caps idle and connect
+			// phases to prevent leaking goroutines on dead backends.
+			Timeout: 0,
+			Transport: &http.Transport{
+				MaxIdleConns:          100,
+				MaxIdleConnsPerHost:   10,
+				IdleConnTimeout:       90 * time.Second,
+				ResponseHeaderTimeout: 30 * time.Second,
+			},
+		},
+		nowFn: time.Now,
+	}
+	for _, b := range cfg.Backends {
+		var h atomic.Bool
+		h.Store(true)
+		d.healthy.Store(b.Name, &h)
+	}
+	return d
+}
+
+// IsHealthy reports the dispatcher's current view of backend health.
+// Unknown backend names report unhealthy.
+func (d *Dispatcher) IsHealthy(name string) bool {
+	v, ok := d.healthy.Load(name)
+	if !ok {
+		return false
+	}
+	return v.(*atomic.Bool).Load()
+}
+
+// MarkHealthy flips the backend to healthy. Called on every successful
+// dispatch; cheap when already healthy.
+func (d *Dispatcher) MarkHealthy(name string) {
+	if v, ok := d.healthy.Load(name); ok {
+		v.(*atomic.Bool).Store(true)
+	}
+}
+
+// MarkUnhealthy flips the backend to unhealthy. The proxy calls this on
+// 5xx / network errors. Subsequent requests skip this backend during
+// primary-fallback strategy until the next successful dispatch flips it
+// back to healthy.
+func (d *Dispatcher) MarkUnhealthy(name string) {
+	if v, ok := d.healthy.Load(name); ok {
+		v.(*atomic.Bool).Store(false)
+	}
+}
+
+// Dispatch forwards the request to the named backend and returns the
+// upstream response. Caller is responsible for streaming the body to
+// the inbound client and closing it. On error the response is nil.
+//
+// requestBody is the already-buffered inbound body. The proxy reads the
+// body once (it needs to parse the "model" field) and reuses the bytes
+// across fallback attempts.
+func (d *Dispatcher) Dispatch(
+	ctx context.Context,
+	backend *Backend,
+	method, path string,
+	headers http.Header,
+	requestBody []byte,
+) (*http.Response, error) {
+	if backend == nil {
+		return nil, fmt.Errorf("dispatch: backend is nil")
+	}
+	url := joinURL(backend.Address, path)
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(requestBody))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	d.copyForwardedHeaders(headers, req.Header)
+	if err := d.applyCredentials(backend, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		d.MarkUnhealthy(backend.Name)
+		return nil, fmt.Errorf("upstream request: %w", err)
+	}
+	if resp.StatusCode >= 500 {
+		// Don't flip on 4xx: those are client errors, not backend
+		// problems. 5xx however means the backend itself misbehaved.
+		d.MarkUnhealthy(backend.Name)
+	} else {
+		d.MarkHealthy(backend.Name)
+	}
+	return resp, nil
+}
+
+// copyForwardedHeaders copies inbound headers to the outbound request,
+// dropping hop-by-hop headers per RFC 7230 section 6.1 plus a small
+// set of headers we explicitly do not want to forward upstream
+// (authorization is replaced by the backend's own credentials; content-
+// length is recomputed by the http client).
+func (d *Dispatcher) copyForwardedHeaders(in, out http.Header) {
+	for k, vals := range in {
+		if hopByHop[strings.ToLower(k)] {
+			continue
+		}
+		for _, v := range vals {
+			out.Add(k, v)
+		}
+	}
+}
+
+// applyCredentials injects the backend's credentials into the outbound
+// request. Local backends typically have no credentials; cloud backends
+// reference an env var by name in CredentialsEnv. The provider value
+// controls header shape (Authorization: Bearer for OpenAI / LiteLLM,
+// x-api-key for Anthropic, etc.).
+func (d *Dispatcher) applyCredentials(b *Backend, req *http.Request) error {
+	if b.CredentialsEnv == "" {
+		return nil
+	}
+	val := os.Getenv(b.CredentialsEnv)
+	if val == "" {
+		return fmt.Errorf("backend %s: credentials env %s is unset", b.Name, b.CredentialsEnv)
+	}
+	switch strings.ToLower(b.Provider) {
+	case "anthropic":
+		req.Header.Set("x-api-key", val)
+		req.Header.Set("anthropic-version", "2023-06-01")
+	case "openai", "litellm", "":
+		req.Header.Set("Authorization", "Bearer "+val)
+	default:
+		req.Header.Set("Authorization", "Bearer "+val)
+	}
+	return nil
+}
+
+func joinURL(base, p string) string {
+	if base == "" {
+		return p
+	}
+	if p == "" {
+		return base
+	}
+	if strings.HasSuffix(base, "/") && strings.HasPrefix(p, "/") {
+		return base + p[1:]
+	}
+	if !strings.HasSuffix(base, "/") && !strings.HasPrefix(p, "/") {
+		return base + "/" + p
+	}
+	return base + p
+}
+
+// Hop-by-hop headers per RFC 7230 section 6.1. We also drop authorization
+// because the backend supplies its own credentials.
+var hopByHop = map[string]bool{
+	"connection":          true,
+	"keep-alive":          true,
+	"proxy-authenticate":  true,
+	"proxy-authorization": true,
+	"te":                  true,
+	"trailer":             true,
+	"transfer-encoding":   true,
+	"upgrade":             true,
+	"authorization":       true,
+	"content-length":      true,
+	"host":                true,
+}
+
+// PipeBody copies the upstream response body to the client writer,
+// flushing after every read so SSE chunks are delivered immediately.
+// http.ResponseWriter must implement http.Flusher for streaming to work;
+// the standard library's net/http server does, but tests using
+// httptest.ResponseRecorder do not, so callers handle that fallback.
+func PipeBody(dst io.Writer, src io.Reader, flush func()) (int64, error) {
+	buf := make([]byte, 8*1024) // 8 KiB matches net/http's internal default
+	var total int64
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			written, werr := dst.Write(buf[:n])
+			total += int64(written)
+			if werr != nil {
+				return total, werr
+			}
+			if flush != nil {
+				flush()
+			}
+		}
+		if err == io.EOF {
+			return total, nil
+		}
+		if err != nil {
+			return total, err
+		}
+	}
+}

--- a/internal/router/config.go
+++ b/internal/router/config.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// Package router implements the LLMKube router-proxy: a small HTTP server
+// that fronts multiple LLM backends (in-cluster InferenceServices, external
+// providers like Anthropic / OpenAI / a LiteLLM proxy) and dispatches
+// OpenAI-compatible chat completion requests across them according to
+// declarative rules.
+//
+// The router-proxy is intentionally decoupled from the ModelRouter CRD
+// types in api/v1alpha1. The ModelRouterReconciler (internal/controller)
+// compiles a ModelRouter spec into a flat JSON config shape and writes it
+// to a ConfigMap; the proxy reads that config from disk on startup. This
+// keeps the binary small (no kubebuilder/client-go in the inference hot
+// path) and makes the proxy testable in isolation.
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Config is the on-disk representation read by the router-proxy. The
+// controller produces this from a ModelRouter spec; the wire shape is a
+// stable contract between the two components.
+type Config struct {
+	// Backends is the resolved list of dispatch destinations.
+	Backends []Backend `json:"backends"`
+
+	// Rules are evaluated in declaration order on every request. The first
+	// rule whose Match expression accepts the request wins.
+	Rules []Rule `json:"rules,omitempty"`
+
+	// DefaultRoute names the backend used when no rule matches.
+	DefaultRoute string `json:"defaultRoute,omitempty"`
+
+	// Policy holds cross-cutting controls (classification, audit). Budget
+	// enforcement and persistence land in #434 / #440.
+	Policy Policy `json:"policy"`
+}
+
+// Backend is one dispatch destination. The controller resolves an
+// InferenceServiceRef to an in-cluster URL before writing the ConfigMap;
+// the proxy only ever sees resolved addresses.
+type Backend struct {
+	Name string `json:"name"`
+
+	// Tier is "local" or "cloud". Used by the fail-closed gate: sensitive-
+	// data rules cannot route to cloud-tier backends.
+	Tier string `json:"tier"`
+
+	// Address is the upstream base URL the proxy sends requests to. For
+	// local backends this is the InferenceService cluster URL (e.g.
+	// http://qwen3-coder.platform.svc.cluster.local:8080). For external
+	// providers it is the provider base URL.
+	Address string `json:"address"`
+
+	// Provider identifies the upstream API surface for external backends
+	// ("anthropic", "openai", "litellm", etc.). Empty for local backends.
+	Provider string `json:"provider,omitempty"`
+
+	// Model is the upstream model identifier passed to the provider.
+	// Empty for local backends (the request body carries the model name).
+	Model string `json:"model,omitempty"`
+
+	// Capabilities advertised by this backend (e.g. ["tools", "vision"]).
+	// Rules can require capabilities to filter candidates.
+	Capabilities []string `json:"capabilities,omitempty"`
+
+	// Weight informs the "weighted" routing strategy (#432). Currently
+	// unused; the MVP strategy is primary-fallback.
+	Weight int `json:"weight,omitempty"`
+
+	// CredentialsEnv names an environment variable holding the bearer or
+	// API key for this backend. The proxy reads the value at request time
+	// and injects it into the upstream request as Authorization or
+	// x-api-key, depending on Provider. Empty for local backends.
+	CredentialsEnv string `json:"credentialsEnv,omitempty"`
+}
+
+// Rule pairs a Match expression with a Route action.
+type Rule struct {
+	Name  string    `json:"name"`
+	Match RuleMatch `json:"match,omitempty"`
+	Route RuleRoute `json:"route"`
+
+	// FailClosed, when true, rejects the request with HTTP 503 if no
+	// backend in Route.Backends is healthy or eligible. The regulated-
+	// data gate that prevents fallback to cloud on local outage.
+	FailClosed bool `json:"failClosed,omitempty"`
+}
+
+// RuleMatch declares the conditions under which a Rule fires. All declared
+// fields are ANDed. Empty fields are not considered.
+type RuleMatch struct {
+	// DataClassification matches when the request's classification (from
+	// header, see Policy.Classification) is one of these values.
+	DataClassification []string `json:"dataClassification,omitempty"`
+
+	// TaskComplexity matches when the inbound x-llmkube-task-complexity
+	// header equals this value.
+	TaskComplexity string `json:"taskComplexity,omitempty"`
+
+	// RequiredCapabilities filters Route.Backends to those advertising
+	// every listed capability.
+	RequiredCapabilities []string `json:"requiredCapabilities,omitempty"`
+
+	// Headers performs exact-match equality on inbound headers.
+	Headers map[string]string `json:"headers,omitempty"`
+
+	// Models matches against the OpenAI "model" field in the request
+	// body. Glob patterns are supported (e.g. "qwen3-*").
+	Models []string `json:"models,omitempty"`
+}
+
+// RuleRoute names the backends a matched rule dispatches to and how.
+type RuleRoute struct {
+	Backends []string `json:"backends"`
+
+	// Strategy is "primary-fallback" (default), "weighted", or "shadow".
+	// Only primary-fallback is implemented in the MVP; the other two land
+	// in #432.
+	Strategy string `json:"strategy,omitempty"`
+}
+
+// Policy holds cross-cutting controls.
+type Policy struct {
+	Classification ClassificationPolicy `json:"classification"`
+	AuditLog       AuditLogPolicy       `json:"auditLog"`
+}
+
+// ClassificationPolicy configures how the proxy determines the
+// classification of an inbound request. Currently "header-only" is the
+// only fully-implemented mode; "detector" / "hybrid" land in #441.
+type ClassificationPolicy struct {
+	Mode      string   `json:"mode"`
+	HeaderKey string   `json:"headerKey,omitempty"`
+	Sensitive []string `json:"sensitiveClassifications,omitempty"`
+}
+
+// AuditLogPolicy configures audit log emission. The proxy always emits
+// one structured log line per routing decision; this configures the sink.
+type AuditLogPolicy struct {
+	Sink               string `json:"sink"`
+	FilePath           string `json:"filePath,omitempty"`
+	IncludeRequestBody bool   `json:"includeRequestBody,omitempty"`
+}
+
+// LoadConfig reads and parses a router-proxy config from path. The proxy
+// reads its config once at startup; hot-reload via file-watcher lands in
+// a follow-up (the controller already triggers a pod rollout when the
+// ConfigMap changes, so for the MVP a restart is sufficient).
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path comes from a flag, not user input
+	if err != nil {
+		return nil, fmt.Errorf("read router config %s: %w", path, err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse router config %s: %w", path, err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid router config %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// Validate performs runtime sanity checks beyond what the controller's
+// static validation enforces. The controller validates the CRD; this
+// catches drift between controller and proxy (e.g. a manually edited
+// ConfigMap on a debugging cluster) and protects the dispatch loop from
+// surprises.
+func (c *Config) Validate() error {
+	if len(c.Backends) == 0 {
+		return fmt.Errorf("backends must be non-empty")
+	}
+	names := make(map[string]bool, len(c.Backends))
+	for i, b := range c.Backends {
+		if b.Name == "" {
+			return fmt.Errorf("backends[%d]: name is required", i)
+		}
+		if names[b.Name] {
+			return fmt.Errorf("backends[%d]: duplicate name %q", i, b.Name)
+		}
+		names[b.Name] = true
+		if b.Tier != "local" && b.Tier != "cloud" {
+			return fmt.Errorf("backends[%d] %s: tier must be local or cloud, got %q", i, b.Name, b.Tier)
+		}
+		if b.Address == "" {
+			return fmt.Errorf("backends[%d] %s: address is required", i, b.Name)
+		}
+	}
+	if c.DefaultRoute != "" && !names[c.DefaultRoute] {
+		return fmt.Errorf("defaultRoute %q does not name an existing backend", c.DefaultRoute)
+	}
+	for i, r := range c.Rules {
+		if r.Name == "" {
+			return fmt.Errorf("rules[%d]: name is required", i)
+		}
+		if len(r.Route.Backends) == 0 {
+			return fmt.Errorf("rules[%d] %s: route.backends must be non-empty", i, r.Name)
+		}
+		for j, name := range r.Route.Backends {
+			if !names[name] {
+				return fmt.Errorf("rules[%d] %s: route.backends[%d] %q does not name an existing backend",
+					i, r.Name, j, name)
+			}
+		}
+	}
+	return nil
+}
+
+// BackendByName returns the backend with the given name, or nil. The
+// dispatch loop uses this on every request, so it does a linear scan
+// against typical config sizes (10s of backends). Switch to a map cache
+// if profiles ever show it matters.
+func (c *Config) BackendByName(name string) *Backend {
+	for i := range c.Backends {
+		if c.Backends[i].Name == name {
+			return &c.Backends[i]
+		}
+	}
+	return nil
+}
+
+// SensitiveSet returns the set of classification values that trigger the
+// fail-closed gate. Defaults to {pii, phi}; overridable via policy.
+func (c *Config) SensitiveSet() map[string]bool {
+	out := make(map[string]bool, 2)
+	if len(c.Policy.Classification.Sensitive) > 0 {
+		for _, s := range c.Policy.Classification.Sensitive {
+			out[s] = true
+		}
+		return out
+	}
+	out["pii"] = true
+	out["phi"] = true
+	return out
+}
+
+// ClassificationHeader returns the request header name carrying the
+// classification, defaulting to x-llmkube-classification.
+func (c *Config) ClassificationHeader() string {
+	if h := strings.TrimSpace(c.Policy.Classification.HeaderKey); h != "" {
+		return h
+	}
+	return "x-llmkube-classification"
+}

--- a/internal/router/config_test.go
+++ b/internal/router/config_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validConfig is the canonical "everything is fine" fixture used as the
+// starting point for subtests that mutate one field.
+func validConfig() *Config {
+	return &Config{
+		Backends: []Backend{
+			{Name: "local-qwen", Tier: "local", Address: "http://qwen.svc:8080"},
+			{
+				Name:     "cloud-opus",
+				Tier:     "cloud",
+				Address:  "https://api.anthropic.com",
+				Provider: "anthropic",
+				Model:    "claude-opus-4-7",
+			},
+		},
+		Rules: []Rule{
+			{
+				Name:       "pii-stays-local",
+				Match:      RuleMatch{DataClassification: []string{"pii"}},
+				Route:      RuleRoute{Backends: []string{"local-qwen"}},
+				FailClosed: true,
+			},
+		},
+		DefaultRoute: "local-qwen",
+		Policy: Policy{
+			Classification: ClassificationPolicy{Mode: "header-only"},
+			AuditLog:       AuditLogPolicy{Sink: "stdout"},
+		},
+	}
+}
+
+func TestConfigValidateAcceptsCanonical(t *testing.T) {
+	if err := validConfig().Validate(); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestConfigValidateRejections(t *testing.T) {
+	cases := []struct {
+		name       string
+		mutate     func(*Config)
+		wantSubstr string
+	}{
+		{
+			name:       "no backends",
+			mutate:     func(c *Config) { c.Backends = nil },
+			wantSubstr: "backends must be non-empty",
+		},
+		{
+			name: "backend missing name",
+			mutate: func(c *Config) {
+				c.Backends[0].Name = ""
+			},
+			wantSubstr: "name is required",
+		},
+		{
+			name: "duplicate backend names",
+			mutate: func(c *Config) {
+				c.Backends = append(c.Backends, Backend{
+					Name: "local-qwen", Tier: "local", Address: "http://x",
+				})
+			},
+			wantSubstr: "duplicate name",
+		},
+		{
+			name: "invalid tier",
+			mutate: func(c *Config) {
+				c.Backends[0].Tier = "edge"
+			},
+			wantSubstr: "tier must be local or cloud",
+		},
+		{
+			name: "missing address",
+			mutate: func(c *Config) {
+				c.Backends[0].Address = ""
+			},
+			wantSubstr: "address is required",
+		},
+		{
+			name: "defaultRoute references unknown backend",
+			mutate: func(c *Config) {
+				c.DefaultRoute = "ghost"
+			},
+			wantSubstr: `defaultRoute "ghost" does not name`,
+		},
+		{
+			name: "rule with empty backends",
+			mutate: func(c *Config) {
+				c.Rules[0].Route.Backends = nil
+			},
+			wantSubstr: "route.backends must be non-empty",
+		},
+		{
+			name: "rule references unknown backend",
+			mutate: func(c *Config) {
+				c.Rules[0].Route.Backends = []string{"ghost"}
+			},
+			wantSubstr: `does not name an existing backend`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validConfig()
+			tc.mutate(cfg)
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("expected error containing %q, got %v", tc.wantSubstr, err)
+			}
+		})
+	}
+}
+
+// TestLoadConfigRoundTrip confirms that what we write to disk parses
+// back to the same shape. This is the wire contract between the
+// controller's ConfigMap writer and the proxy's reader.
+func TestLoadConfigRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "router.json")
+	if err := os.WriteFile(path, []byte(canonicalJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Backends) != 2 {
+		t.Errorf("got %d backends, want 2", len(cfg.Backends))
+	}
+	if cfg.DefaultRoute != "local-qwen" {
+		t.Errorf("DefaultRoute = %q, want local-qwen", cfg.DefaultRoute)
+	}
+	if !cfg.Rules[0].FailClosed {
+		t.Error("expected FailClosed=true on pii rule")
+	}
+}
+
+func TestLoadConfigSurfacesIOErrors(t *testing.T) {
+	_, err := LoadConfig("/nonexistent/router.json")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "read router config") {
+		t.Errorf("expected wrapped read error, got %v", err)
+	}
+}
+
+func TestLoadConfigSurfacesParseErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse router config") {
+		t.Errorf("expected wrapped parse error, got %v", err)
+	}
+}
+
+func TestSensitiveSetDefaults(t *testing.T) {
+	cfg := &Config{}
+	got := cfg.SensitiveSet()
+	for _, want := range []string{"pii", "phi"} {
+		if !got[want] {
+			t.Errorf("default sensitive set missing %q", want)
+		}
+	}
+}
+
+func TestSensitiveSetOverride(t *testing.T) {
+	cfg := &Config{
+		Policy: Policy{
+			Classification: ClassificationPolicy{
+				Sensitive: []string{"secret"},
+			},
+		},
+	}
+	got := cfg.SensitiveSet()
+	if !got["secret"] {
+		t.Error("override should contain secret")
+	}
+	if got["pii"] {
+		t.Error("override should replace defaults; pii should not be sensitive")
+	}
+}
+
+func TestClassificationHeaderDefault(t *testing.T) {
+	cfg := &Config{}
+	if got := cfg.ClassificationHeader(); got != "x-llmkube-classification" {
+		t.Errorf("got %q, want default", got)
+	}
+}
+
+func TestClassificationHeaderOverride(t *testing.T) {
+	cfg := &Config{
+		Policy: Policy{
+			Classification: ClassificationPolicy{HeaderKey: "x-corp-classification"},
+		},
+	}
+	if got := cfg.ClassificationHeader(); got != "x-corp-classification" {
+		t.Errorf("got %q, want override", got)
+	}
+}
+
+const canonicalJSON = `{
+  "backends": [
+    {"name": "local-qwen", "tier": "local", "address": "http://qwen.svc:8080"},
+    {"name": "cloud-opus", "tier": "cloud", "address": "https://api.anthropic.com",
+     "provider": "anthropic", "model": "claude-opus-4-7", "credentialsEnv": "ANTHROPIC_API_KEY"}
+  ],
+  "rules": [
+    {"name": "pii-stays-local",
+     "match": {"dataClassification": ["pii"]},
+     "route": {"backends": ["local-qwen"]},
+     "failClosed": true}
+  ],
+  "defaultRoute": "local-qwen",
+  "policy": {
+    "classification": {"mode": "header-only"},
+    "auditLog": {"sink": "stdout"}
+  }
+}`

--- a/internal/router/match.go
+++ b/internal/router/match.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package router
+
+import (
+	"path"
+	"strings"
+)
+
+// RequestFeatures captures everything a Rule can match against. The proxy
+// extracts this once per request and feeds it through the matcher loop.
+type RequestFeatures struct {
+	// Model is the OpenAI "model" field from the request body. Empty if
+	// the body omitted it (we still try to match other rule fields).
+	Model string
+
+	// Classification is the resolved data classification of the request.
+	// Resolved by the proxy from the configured header (header-only mode)
+	// before the matcher runs.
+	Classification string
+
+	// TaskComplexity is the inbound x-llmkube-task-complexity hint.
+	TaskComplexity string
+
+	// Headers is the inbound HTTP header map (canonicalized lower-case
+	// keys for case-insensitive matching).
+	Headers map[string]string
+}
+
+// MatchResult records the outcome of evaluating the rule set for one
+// request. If no rule matched and Config.DefaultRoute is set, the proxy
+// dispatches to the default backend with Rule == nil and Strategy ==
+// "primary-fallback" semantics.
+type MatchResult struct {
+	// Rule is the matched rule, or nil if no rule matched (in which case
+	// DefaultRoute applies).
+	Rule *Rule
+
+	// Backends is the ordered list of backend names this request may be
+	// dispatched to. Derived from the matched rule's Route.Backends, or
+	// from Config.DefaultRoute if no rule matched.
+	Backends []string
+
+	// Strategy is the dispatch strategy ("primary-fallback", "weighted",
+	// "shadow"). Defaults to "primary-fallback" when omitted.
+	Strategy string
+
+	// FailClosed is true when a matched fail-closed rule rejects the
+	// request rather than falling through if no backend is healthy.
+	FailClosed bool
+}
+
+// Matcher pre-computes lookups over a Config so the per-request hot path
+// is allocation-free. Construct once at startup, reuse across requests.
+type Matcher struct {
+	cfg            *Config
+	backendsByName map[string]*Backend
+}
+
+// NewMatcher returns a Matcher bound to the given config. The matcher
+// holds a pointer to the config and assumes it is immutable; rebuild on
+// config reload.
+func NewMatcher(cfg *Config) *Matcher {
+	byName := make(map[string]*Backend, len(cfg.Backends))
+	for i := range cfg.Backends {
+		byName[cfg.Backends[i].Name] = &cfg.Backends[i]
+	}
+	return &Matcher{cfg: cfg, backendsByName: byName}
+}
+
+// Match evaluates the rule set against the request features and returns
+// the routing decision. If no rule matches and DefaultRoute is empty,
+// returns a MatchResult with nil Backends, which the proxy translates to
+// HTTP 503.
+func (m *Matcher) Match(features *RequestFeatures) MatchResult {
+	for i := range m.cfg.Rules {
+		rule := &m.cfg.Rules[i]
+		if !m.ruleMatches(rule, features) {
+			continue
+		}
+		return MatchResult{
+			Rule:       rule,
+			Backends:   rule.Route.Backends,
+			Strategy:   strategyOrDefault(rule.Route.Strategy),
+			FailClosed: rule.FailClosed,
+		}
+	}
+
+	if m.cfg.DefaultRoute != "" {
+		return MatchResult{
+			Backends: []string{m.cfg.DefaultRoute},
+			Strategy: strategyPrimaryFallback,
+		}
+	}
+	return MatchResult{}
+}
+
+// BackendByName proxies to Config.BackendByName but uses the cached map
+// so the per-request lookup is O(1).
+func (m *Matcher) BackendByName(name string) *Backend {
+	return m.backendsByName[name]
+}
+
+const (
+	strategyPrimaryFallback = "primary-fallback"
+	strategyWeighted        = "weighted"
+	strategyShadow          = "shadow"
+)
+
+func strategyOrDefault(s string) string {
+	if s == "" {
+		return strategyPrimaryFallback
+	}
+	return s
+}
+
+// ruleMatches reports whether every declared Match field on the rule is
+// satisfied by the request features. Empty fields are not considered
+// (match-all semantics on the dimension).
+func (m *Matcher) ruleMatches(rule *Rule, f *RequestFeatures) bool {
+	mt := &rule.Match
+
+	if len(mt.DataClassification) > 0 && !contains(mt.DataClassification, f.Classification) {
+		return false
+	}
+	if mt.TaskComplexity != "" && mt.TaskComplexity != f.TaskComplexity {
+		return false
+	}
+	if !matchModels(mt.Models, f.Model) {
+		return false
+	}
+	if !matchHeaders(mt.Headers, f.Headers) {
+		return false
+	}
+	if !m.satisfiesRequiredCapabilities(mt.RequiredCapabilities, rule.Route.Backends) {
+		return false
+	}
+	return true
+}
+
+// matchModels reports whether the request model matches at least one of
+// the rule's model patterns. Empty pattern list matches anything; an
+// empty request model only matches if a pattern is "*" or empty list.
+func matchModels(patterns []string, model string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	if model == "" {
+		// An empty model can only satisfy a literal "*" wildcard.
+		for _, p := range patterns {
+			if p == "*" {
+				return true
+			}
+		}
+		return false
+	}
+	for _, p := range patterns {
+		if ok, _ := path.Match(p, model); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// matchHeaders performs case-insensitive equality on the header pairs the
+// rule declares. Missing headers fail the match.
+func matchHeaders(want, have map[string]string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	for k, wantVal := range want {
+		got, ok := have[strings.ToLower(k)]
+		if !ok || got != wantVal {
+			return false
+		}
+	}
+	return true
+}
+
+// satisfiesRequiredCapabilities returns true when at least one backend
+// named in the route advertises every required capability. This is the
+// "any candidate matches" semantic: a rule with required ["vision"] will
+// match if any of its route backends has vision, even if others don't.
+func (m *Matcher) satisfiesRequiredCapabilities(required, backendNames []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	for _, name := range backendNames {
+		b := m.backendsByName[name]
+		if b == nil {
+			continue
+		}
+		if hasAllCapabilities(b.Capabilities, required) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAllCapabilities(have, want []string) bool {
+	set := make(map[string]bool, len(have))
+	for _, c := range have {
+		set[c] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/router/match_test.go
+++ b/internal/router/match_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package router
+
+import "testing"
+
+func matcherFromValid() *Matcher {
+	return NewMatcher(validConfig())
+}
+
+func TestMatchPIIRouteWins(t *testing.T) {
+	got := matcherFromValid().Match(&RequestFeatures{Classification: "pii"})
+	if got.Rule == nil {
+		t.Fatal("expected pii rule to match, got default")
+	}
+	if got.Rule.Name != "pii-stays-local" {
+		t.Errorf("matched rule = %q, want pii-stays-local", got.Rule.Name)
+	}
+	if !got.FailClosed {
+		t.Error("matched fail-closed rule should report FailClosed=true")
+	}
+	if got.Strategy != strategyPrimaryFallback {
+		t.Errorf("default strategy = %q, want primary-fallback", got.Strategy)
+	}
+}
+
+func TestMatchFallsThroughToDefault(t *testing.T) {
+	got := matcherFromValid().Match(&RequestFeatures{Classification: "public"})
+	if got.Rule != nil {
+		t.Errorf("expected no rule match, got %q", got.Rule.Name)
+	}
+	if len(got.Backends) != 1 || got.Backends[0] != "local-qwen" {
+		t.Errorf("expected default-route fallback to local-qwen, got %v", got.Backends)
+	}
+}
+
+func TestMatchReturnsEmptyWhenNoDefaultAndNoRule(t *testing.T) {
+	cfg := validConfig()
+	cfg.Rules = nil
+	cfg.DefaultRoute = ""
+	got := NewMatcher(cfg).Match(&RequestFeatures{Classification: "public"})
+	if len(got.Backends) != 0 {
+		t.Errorf("expected no backends, got %v", got.Backends)
+	}
+}
+
+func TestMatchModelGlob(t *testing.T) {
+	cfg := validConfig()
+	cfg.Rules = []Rule{{
+		Name:  "qwen-family",
+		Match: RuleMatch{Models: []string{"qwen3-*"}},
+		Route: RuleRoute{Backends: []string{"local-qwen"}},
+	}}
+	m := NewMatcher(cfg)
+	if got := m.Match(&RequestFeatures{Model: "qwen3-coder-30b"}); got.Rule == nil {
+		t.Error("qwen3-coder-30b should match qwen3-*")
+	}
+	if got := m.Match(&RequestFeatures{Model: "llama-3"}); got.Rule != nil {
+		t.Errorf("llama-3 should not match qwen3-*, matched %q", got.Rule.Name)
+	}
+}
+
+func TestMatchHeadersCaseInsensitive(t *testing.T) {
+	cfg := validConfig()
+	cfg.Rules = []Rule{{
+		Name:  "team-rule",
+		Match: RuleMatch{Headers: map[string]string{"X-Team": "research"}},
+		Route: RuleRoute{Backends: []string{"local-qwen"}},
+	}}
+	m := NewMatcher(cfg)
+	got := m.Match(&RequestFeatures{Headers: map[string]string{"x-team": "research"}})
+	if got.Rule == nil {
+		t.Error("lowercase header should match canonical declaration")
+	}
+}
+
+func TestMatchTaskComplexity(t *testing.T) {
+	cfg := validConfig()
+	cfg.Rules = []Rule{{
+		Name:  "complex-to-cloud",
+		Match: RuleMatch{TaskComplexity: "complex"},
+		Route: RuleRoute{Backends: []string{"cloud-opus"}},
+	}}
+	m := NewMatcher(cfg)
+	if got := m.Match(&RequestFeatures{TaskComplexity: "complex"}); got.Rule == nil {
+		t.Error("complex task should match")
+	}
+	if got := m.Match(&RequestFeatures{TaskComplexity: "simple"}); got.Rule != nil {
+		t.Errorf("simple task should not match complex rule, matched %q", got.Rule.Name)
+	}
+}
+
+func TestMatchRequiredCapabilities(t *testing.T) {
+	cfg := validConfig()
+	cfg.Backends[0].Capabilities = []string{"code"}
+	cfg.Backends[1].Capabilities = []string{"vision", "long-context"}
+	cfg.Rules = []Rule{{
+		Name: "vision-rule",
+		Match: RuleMatch{
+			Models:               []string{"*"},
+			RequiredCapabilities: []string{"vision"},
+		},
+		Route: RuleRoute{Backends: []string{"local-qwen", "cloud-opus"}},
+	}}
+	m := NewMatcher(cfg)
+	// At least one route backend has vision; should match.
+	if got := m.Match(&RequestFeatures{Model: "any"}); got.Rule == nil {
+		t.Error("expected match: cloud-opus has vision")
+	}
+
+	// Remove vision from cloud-opus; now no backend in the route has it.
+	cfg.Backends[1].Capabilities = []string{"long-context"}
+	m = NewMatcher(cfg)
+	if got := m.Match(&RequestFeatures{Model: "any"}); got.Rule != nil {
+		t.Errorf("expected no match when no route backend has vision; matched %q", got.Rule.Name)
+	}
+}
+
+func TestMatchFirstRuleWins(t *testing.T) {
+	cfg := validConfig()
+	cfg.Rules = []Rule{
+		{
+			Name:  "first",
+			Match: RuleMatch{Models: []string{"*"}},
+			Route: RuleRoute{Backends: []string{"local-qwen"}},
+		},
+		{
+			Name:  "second",
+			Match: RuleMatch{Models: []string{"*"}},
+			Route: RuleRoute{Backends: []string{"cloud-opus"}},
+		},
+	}
+	got := NewMatcher(cfg).Match(&RequestFeatures{Model: "any-model"})
+	if got.Rule == nil || got.Rule.Name != "first" {
+		t.Errorf("expected first rule to win, got %v", got.Rule)
+	}
+}

--- a/internal/router/proxy.go
+++ b/internal/router/proxy.go
@@ -1,0 +1,309 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Proxy is the router-proxy HTTP application. Construct via NewProxy and
+// register handlers with Mount; the proxy is safe for concurrent use.
+type Proxy struct {
+	cfg     *Config
+	matcher *Matcher
+	disp    *Dispatcher
+	logger  *slog.Logger
+}
+
+// NewProxy constructs a Proxy from a loaded Config.
+func NewProxy(cfg *Config, logger *slog.Logger) *Proxy {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Proxy{
+		cfg:     cfg,
+		matcher: NewMatcher(cfg),
+		disp:    NewDispatcher(cfg),
+		logger:  logger,
+	}
+}
+
+// Mount wires up the OpenAI-compatible endpoints plus /health on the
+// given mux. Callers attach the mux to an http.Server.
+func (p *Proxy) Mount(mux *http.ServeMux) {
+	mux.HandleFunc("POST /v1/chat/completions", p.handleChatCompletions)
+	mux.HandleFunc("GET /v1/models", p.handleModels)
+	mux.HandleFunc("GET /health", p.handleHealth)
+	mux.HandleFunc("GET /healthz", p.handleHealth)
+}
+
+// handleHealth always returns 200. The Kubernetes liveness probe uses
+// this; the proxy is "alive" as long as its goroutine runs. Readiness
+// gating on backend health lands with #432 / #428.
+func (p *Proxy) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+// handleModels returns an OpenAI-compatible /v1/models payload listing
+// every backend in the config. Cloud backends report their upstream
+// Model field; local backends report their backend name.
+func (p *Proxy) handleModels(w http.ResponseWriter, _ *http.Request) {
+	type model struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		Created int64  `json:"created"`
+		OwnedBy string `json:"owned_by"`
+	}
+	now := time.Now().Unix()
+	models := make([]model, 0, len(p.cfg.Backends))
+	for _, b := range p.cfg.Backends {
+		id := b.Name
+		if b.Model != "" {
+			id = b.Model
+		}
+		owned := "llmkube"
+		if b.Provider != "" {
+			owned = b.Provider
+		}
+		models = append(models, model{ID: id, Object: "model", Created: now, OwnedBy: owned})
+	}
+	body, _ := json.Marshal(map[string]any{"object": "list", "data": models})
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}
+
+// handleChatCompletions is the primary routing endpoint. It buffers the
+// inbound request body (needs the "model" field for matching), evaluates
+// the rule set, dispatches to the chosen backend, and streams the
+// response back. SSE / chunked passthrough is automatic.
+func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRequestBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "request body: "+err.Error())
+		return
+	}
+
+	features, isStream := extractFeatures(body, r, p.cfg.ClassificationHeader())
+
+	decision := p.matcher.Match(&features)
+	if len(decision.Backends) == 0 {
+		writeError(w, http.StatusServiceUnavailable, "no rule matched and no defaultRoute configured")
+		p.audit(features, decision, nil, http.StatusServiceUnavailable, "no_route", 0)
+		return
+	}
+
+	if err := p.enforceFailClosed(&features, &decision); err != nil {
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+		p.audit(features, decision, nil, http.StatusServiceUnavailable, "fail_closed", 0)
+		return
+	}
+
+	start := time.Now()
+	chosen, resp, err := p.dispatchWithFallback(r.Context(), &decision, r.Header, body, "/v1/chat/completions")
+	elapsed := time.Since(start)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "all backends failed: "+err.Error())
+		p.audit(features, decision, nil, http.StatusBadGateway, "all_backends_failed", elapsed)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	streamed := streamResponse(w, resp, isStream)
+	p.audit(features, decision, chosen, resp.StatusCode, streamedReason(streamed), elapsed)
+}
+
+const maxRequestBodyBytes = 32 << 20 // 32 MiB, generous for long prompts
+
+// extractFeatures pulls the model name, stream flag, classification, and
+// task complexity out of the inbound request. The model name comes from
+// the JSON body; the rest come from headers per the MVP header-only
+// classification mode.
+func extractFeatures(body []byte, r *http.Request, classHeader string) (RequestFeatures, bool) {
+	headers := make(map[string]string, len(r.Header))
+	for k, vals := range r.Header {
+		if len(vals) > 0 {
+			headers[strings.ToLower(k)] = vals[0]
+		}
+	}
+
+	var partial struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	// Body may not be valid JSON yet at this point (the upstream may be
+	// more permissive). We extract what we can and proceed.
+	_ = json.Unmarshal(body, &partial)
+
+	return RequestFeatures{
+		Model:          partial.Model,
+		Classification: strings.ToLower(headers[strings.ToLower(classHeader)]),
+		TaskComplexity: strings.ToLower(headers["x-llmkube-task-complexity"]),
+		Headers:        headers,
+	}, partial.Stream
+}
+
+// enforceFailClosed implements the runtime half of the fail-closed gate.
+// For sensitive-data requests routing to a fail-closed rule, every
+// backend in the route must be local-tier; otherwise we refuse. The
+// static half of this check runs in the controller at apply time, but
+// repeating it here defends against drift between controller and proxy
+// config.
+func (p *Proxy) enforceFailClosed(f *RequestFeatures, dec *MatchResult) error {
+	if !dec.FailClosed {
+		return nil
+	}
+	sensitive := p.cfg.SensitiveSet()
+	if !sensitive[f.Classification] {
+		return nil
+	}
+	for _, name := range dec.Backends {
+		b := p.matcher.BackendByName(name)
+		if b == nil {
+			return fmt.Errorf("fail-closed: backend %q not configured", name)
+		}
+		if b.Tier != "local" {
+			return fmt.Errorf("fail-closed: sensitive classification %q cannot route to %s-tier backend %q",
+				f.Classification, b.Tier, name)
+		}
+	}
+	return nil
+}
+
+// dispatchWithFallback walks the backend list in declared order and
+// returns the first successful (non-5xx, non-error) response. On
+// fail-closed routes with all backends unhealthy, the last error
+// propagates back to the handler as HTTP 502.
+func (p *Proxy) dispatchWithFallback(
+	ctx context.Context,
+	dec *MatchResult,
+	headers http.Header,
+	body []byte,
+	path string,
+) (*Backend, *http.Response, error) {
+	var lastErr error
+	for _, name := range dec.Backends {
+		b := p.matcher.BackendByName(name)
+		if b == nil {
+			lastErr = fmt.Errorf("backend %q not configured", name)
+			continue
+		}
+		if !p.disp.IsHealthy(name) {
+			lastErr = fmt.Errorf("backend %q marked unhealthy", name)
+			continue
+		}
+		resp, err := p.disp.Dispatch(ctx, b, http.MethodPost, path, headers, body)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if resp.StatusCode >= 500 {
+			// Drain and close so the connection is reusable.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("%s returned %d", name, resp.StatusCode)
+			continue
+		}
+		return b, resp, nil
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no backends attempted")
+	}
+	return nil, nil, lastErr
+}
+
+// streamResponse copies the upstream response to the client. Returns
+// true if we treated the response as a stream (set SSE-friendly headers
+// and flushed after every chunk). The decision is driven by the
+// request's "stream": true flag and the upstream Content-Type.
+func streamResponse(w http.ResponseWriter, resp *http.Response, requestedStream bool) bool {
+	upstreamCT := resp.Header.Get("Content-Type")
+	isSSE := strings.HasPrefix(upstreamCT, "text/event-stream")
+	isStream := requestedStream || isSSE
+
+	// Forward upstream headers (except hop-by-hop).
+	for k, vals := range resp.Header {
+		if hopByHop[strings.ToLower(k)] {
+			continue
+		}
+		for _, v := range vals {
+			w.Header().Add(k, v)
+		}
+	}
+	if isStream && w.Header().Get("Cache-Control") == "" {
+		w.Header().Set("Cache-Control", "no-cache")
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	if !isStream {
+		_, _ = io.Copy(w, resp.Body)
+		return false
+	}
+
+	var flush func()
+	if f, ok := w.(http.Flusher); ok {
+		flush = f.Flush
+	}
+	_, _ = PipeBody(w, resp.Body, flush)
+	return true
+}
+
+// audit emits one structured log line per request. Sink configuration
+// (file, OTLP) lands with #434; for the MVP we always log to the proxy
+// stdout via slog.
+func (p *Proxy) audit(
+	f RequestFeatures,
+	dec MatchResult,
+	chosen *Backend,
+	statusCode int,
+	outcome string,
+	elapsed time.Duration,
+) {
+	attrs := []any{
+		"model", f.Model,
+		"classification", f.Classification,
+		"taskComplexity", f.TaskComplexity,
+		"status", statusCode,
+		"outcome", outcome,
+		"latencyMs", elapsed.Milliseconds(),
+	}
+	if dec.Rule != nil {
+		attrs = append(attrs, "rule", dec.Rule.Name)
+	}
+	if chosen != nil {
+		attrs = append(attrs, "backend", chosen.Name, "backendTier", chosen.Tier)
+	}
+	p.logger.Info("router.dispatch", attrs...)
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	body, _ := json.Marshal(map[string]any{
+		"error": map[string]any{"code": code, "message": msg},
+	})
+	_, _ = w.Write(body)
+}
+
+func streamedReason(streamed bool) string {
+	if streamed {
+		return "ok_stream"
+	}
+	return "ok"
+}

--- a/internal/router/proxy_test.go
+++ b/internal/router/proxy_test.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package router
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeBackend wraps an httptest.Server and a handler that the test can
+// swap per case. It also tracks call counts so tests can assert which
+// backend(s) were hit.
+type fakeBackend struct {
+	srv    *httptest.Server
+	calls  atomic.Int64
+	status atomic.Int64 // status code to return; defaults to 200
+	body   atomic.Pointer[string]
+	stream atomic.Bool
+}
+
+func newFakeBackend(t *testing.T) *fakeBackend {
+	t.Helper()
+	fb := &fakeBackend{}
+	fb.status.Store(200)
+	defaultBody := `{"choices":[{"message":{"content":"hi"}}]}`
+	fb.body.Store(&defaultBody)
+
+	fb.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fb.calls.Add(1)
+		status := int(fb.status.Load())
+		body := *fb.body.Load()
+
+		if fb.stream.Load() {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(status)
+			flusher, _ := w.(http.Flusher)
+			for _, chunk := range []string{"a", "b", "c"} {
+				_, _ = fmt.Fprintf(w, "data: {\"delta\":%q}\n\n", chunk)
+				if flusher != nil {
+					flusher.Flush()
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+			_, _ = fmt.Fprintln(w, "data: [DONE]")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(fb.srv.Close)
+	return fb
+}
+
+func (fb *fakeBackend) URL() string { return fb.srv.URL }
+
+// proxyHarness sets up a Proxy wired to two fake backends (one local,
+// one cloud) plus the standard pii rule. Returns the proxy mounted on a
+// fresh ServeMux ready to serve.
+type proxyHarness struct {
+	cfg       *Config
+	localBack *fakeBackend
+	cloudBack *fakeBackend
+	proxy     *Proxy
+	handler   http.Handler
+}
+
+func newProxyHarness(t *testing.T) *proxyHarness {
+	t.Helper()
+	local := newFakeBackend(t)
+	cloud := newFakeBackend(t)
+
+	cfg := &Config{
+		Backends: []Backend{
+			{Name: "local-qwen", Tier: "local", Address: local.URL()},
+			{Name: "cloud-opus", Tier: "cloud", Address: cloud.URL(),
+				Provider: "anthropic", Model: "claude-opus-4-7"},
+		},
+		Rules: []Rule{
+			{
+				Name:       "pii-stays-local",
+				Match:      RuleMatch{DataClassification: []string{"pii"}},
+				Route:      RuleRoute{Backends: []string{"local-qwen"}},
+				FailClosed: true,
+			},
+			{
+				Name:  "complex-to-cloud",
+				Match: RuleMatch{TaskComplexity: "complex"},
+				Route: RuleRoute{Backends: []string{"cloud-opus", "local-qwen"}},
+			},
+		},
+		DefaultRoute: "local-qwen",
+		Policy: Policy{
+			Classification: ClassificationPolicy{Mode: "header-only"},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("harness config: %v", err)
+	}
+
+	proxy := NewProxy(cfg, slog.Default())
+	mux := http.NewServeMux()
+	proxy.Mount(mux)
+	return &proxyHarness{
+		cfg:       cfg,
+		localBack: local,
+		cloudBack: cloud,
+		proxy:     proxy,
+		handler:   mux,
+	}
+}
+
+func (h *proxyHarness) post(t *testing.T, payload map[string]any, headers map[string]string) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.handler.ServeHTTP(rec, req)
+	return rec.Result()
+}
+
+// streamingPost uses a real httptest.Server so we exercise streaming via
+// a chunked response (httptest.ResponseRecorder doesn't implement
+// Flusher).
+func (h *proxyHarness) streamingPost(t *testing.T, payload map[string]any, headers map[string]string) *http.Response {
+	t.Helper()
+	srv := httptest.NewServer(h.handler)
+	t.Cleanup(srv.Close)
+	body, _ := json.Marshal(payload)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+func TestProxyHealth(t *testing.T) {
+	h := newProxyHarness(t)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	h.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("/health = %d, want 200", rec.Code)
+	}
+}
+
+func TestProxyModels(t *testing.T) {
+	h := newProxyHarness(t)
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+	h.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/v1/models = %d, want 200", rec.Code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode /v1/models: %v", err)
+	}
+	data, _ := got["data"].([]any)
+	if len(data) != 2 {
+		t.Errorf("expected 2 models, got %d", len(data))
+	}
+}
+
+func TestProxyRoutesPIIToLocal(t *testing.T) {
+	h := newProxyHarness(t)
+	resp := h.post(t, map[string]any{"model": "any"}, map[string]string{
+		"x-llmkube-classification": "pii",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if h.localBack.calls.Load() != 1 {
+		t.Errorf("local backend calls = %d, want 1", h.localBack.calls.Load())
+	}
+	if h.cloudBack.calls.Load() != 0 {
+		t.Errorf("cloud backend should not be called for pii, calls = %d", h.cloudBack.calls.Load())
+	}
+}
+
+func TestProxyRoutesComplexToCloud(t *testing.T) {
+	h := newProxyHarness(t)
+	resp := h.post(t, map[string]any{"model": "any"}, map[string]string{
+		"x-llmkube-task-complexity": "complex",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if h.cloudBack.calls.Load() != 1 {
+		t.Errorf("cloud backend calls = %d, want 1", h.cloudBack.calls.Load())
+	}
+}
+
+func TestProxyFallsThroughToDefault(t *testing.T) {
+	h := newProxyHarness(t)
+	resp := h.post(t, map[string]any{"model": "any"}, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if h.localBack.calls.Load() != 1 {
+		t.Errorf("default should hit local, calls = %d", h.localBack.calls.Load())
+	}
+}
+
+// TestProxyFailClosedOnLocalDown is the regulated-data gate verified at
+// runtime: when the only local backend is unhealthy, a PII request is
+// refused with 503 rather than falling through to the cloud backend.
+func TestProxyFailClosedOnLocalDown(t *testing.T) {
+	h := newProxyHarness(t)
+	h.proxy.disp.MarkUnhealthy("local-qwen")
+
+	resp := h.post(t, map[string]any{"model": "any"}, map[string]string{
+		"x-llmkube-classification": "pii",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway && resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 502/503", resp.StatusCode)
+	}
+	if h.cloudBack.calls.Load() != 0 {
+		t.Errorf("cloud must not receive pii request; calls = %d", h.cloudBack.calls.Load())
+	}
+}
+
+func TestProxyPrimaryFallbackOnUpstream5xx(t *testing.T) {
+	h := newProxyHarness(t)
+	// Cloud (primary for complex rule) returns 500; proxy must fall
+	// over to local (the secondary in the route).
+	h.cloudBack.status.Store(500)
+
+	resp := h.post(t, map[string]any{"model": "any"}, map[string]string{
+		"x-llmkube-task-complexity": "complex",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (fallback to local)", resp.StatusCode)
+	}
+	if h.cloudBack.calls.Load() != 1 {
+		t.Errorf("cloud should be tried once, calls = %d", h.cloudBack.calls.Load())
+	}
+	if h.localBack.calls.Load() != 1 {
+		t.Errorf("local should be tried as fallback, calls = %d", h.localBack.calls.Load())
+	}
+}
+
+func TestProxyStreamingSSE(t *testing.T) {
+	h := newProxyHarness(t)
+	h.localBack.stream.Store(true)
+
+	resp := h.streamingPost(t, map[string]any{
+		"model":  "any",
+		"stream": true,
+	}, nil)
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Errorf("Content-Type = %q, want text/event-stream", got)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{"delta", "[DONE]"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("stream output missing %q; got:\n%s", want, joined)
+		}
+	}
+}
+
+// TestProxy503WhenNoRoute confirms the explicit "no rule and no default"
+// case returns 503 rather than panicking.
+func TestProxy503WhenNoRoute(t *testing.T) {
+	cfg := &Config{
+		Backends: []Backend{{Name: "x", Tier: "local", Address: "http://nowhere.invalid"}},
+		// No rules, no default route.
+	}
+	proxy := NewProxy(cfg, slog.Default())
+	mux := http.NewServeMux()
+	proxy.Mount(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"any"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+}
+
+// TestProxyRejectsOversizedBody enforces the body-size cap; a request
+// larger than maxRequestBodyBytes is rejected with 400.
+func TestProxyRejectsOversizedBody(t *testing.T) {
+	h := newProxyHarness(t)
+	big := strings.Repeat("x", maxRequestBodyBytes+1)
+	body := `{"model":"any","padding":"` + big + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestExtractFeaturesHandlesMalformedBody ensures a non-JSON body does
+// not crash feature extraction; the matcher just sees an empty model.
+func TestExtractFeaturesHandlesMalformedBody(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not json"))
+	f, _ := extractFeatures([]byte("not json"), r, "x-llmkube-classification")
+	if f.Model != "" {
+		t.Errorf("Model = %q, want empty", f.Model)
+	}
+}
+
+// TestExtractFeaturesParsesURL is a sanity-check that the helper still
+// compiles after refactoring; importing net/url keeps build tags honest.
+func TestExtractFeaturesParsesURL(t *testing.T) {
+	u, _ := url.Parse("http://x/v1/chat/completions")
+	if u.Path != "/v1/chat/completions" {
+		t.Errorf("url parse busted: %q", u.Path)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the ModelRouter data plane as a small standalone Go binary (`cmd/router-proxy`). The binary reads a compiled routing config from disk (the controller writes that file via a mounted ConfigMap in #428) and dispatches OpenAI-compatible chat completion requests across local InferenceServices and external providers.

Closes #427.

## Architecture

The proxy is deliberately decoupled from the `api/v1alpha1` CRD types. The reconciler (which lands in #428) will compile a `ModelRouter` spec into a flat JSON config and emit it via a ConfigMap mounted into the proxy pod. This decoupling:

- Keeps the proxy small: no kubebuilder / client-go in the inference hot path.
- Keeps the wire shape stable across CRD churn.
- Makes the binary testable in isolation (no envtest needed for HTTP behavior).

```
inbound POST /v1/chat/completions
  -> parse model + stream flag from body
  -> classify (header-only mode)
  -> matcher: first rule whose Match accepts the request
  -> fail-closed gate (sensitive classification + cloud backend = 503)
  -> dispatch primary-fallback: try backend[0], on 5xx try backend[1], ...
  -> stream upstream response (SSE / chunked) with Flush after each chunk
  -> audit log line via slog
```

## What's covered

| Surface | Status |
|---|---|
| `/v1/chat/completions` (streaming + non-streaming) | yes |
| `/v1/models` | yes |
| `/health`, `/healthz` | yes |
| Primary-fallback strategy | yes (others land in #432) |
| Fail-closed gate at runtime | yes |
| Anthropic / OpenAI / LiteLLM auth injection | yes |
| Body size cap (32 MiB) | yes |
| Graceful SIGTERM/SIGINT shutdown | yes |
| Audit log per request (slog stdout) | yes |
| Prometheus metrics | no (#433) |
| Weighted / shadow strategies | no (#432) |
| Budgets / 429 | no (#434) |

## Tests

29 tests in three suites, all passing in under 2 seconds total:

- **`internal/router/config_test.go`** (10 tests): LoadConfig round-trip, Validate happy + 8 sad paths, SensitiveSet + ClassificationHeader behavior.
- **`internal/router/match_test.go`** (8 tests): rule matching, glob, case-insensitive headers, capabilities, first-match wins, default-route fallthrough.
- **`internal/router/proxy_test.go`** (10 tests): full request flow with httptest fake backends. Covers pii→local routing, complex→cloud, fail-closed gate at runtime (cloud must not be hit when local is down on a fail-closed pii rule), primary-fallback on upstream 5xx, **streaming SSE end-to-end via real `httptest.Server`** since `httptest.ResponseRecorder` doesn't implement `http.Flusher`, 503 on no route, body-size cap.
- **`cmd/router-proxy/main_integration_test.go`** (1 test, the binary smoke): builds the binary from source via `go build`, starts it as a subprocess with a real config file and fake upstream, exercises `/v1/chat/completions` and `/v1/models`, sends SIGTERM and verifies clean shutdown within 15s. **This is the pre-cluster gate for binary-level regressions** (CLI flag parsing, signal handling, config loading from disk, real net.Listen) until #428 lands the controller-managed Deployment.

## E2E coverage strategy

Cluster-level e2e for the proxy needs the controller to deploy it, which is scoped to #428. Until then the binary-level integration test in `cmd/router-proxy/main_integration_test.go` is the equivalent end-to-end gate: it compiles, runs as a subprocess, exercises real HTTP, and verifies graceful shutdown. This is what CI's `go test` step runs on every PR and catches the same regressions an in-cluster smoke would.

When #428 merges, e2e will broaden to: apply a `ModelRouter` CRD, let the controller spin up the proxy Deployment, dispatch a streaming chat completion through it, verify the response and the audit log.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go fmt ./...` clean
- [x] `golangci-lint run ./internal/router/... ./cmd/router-proxy/...` clean (0 issues)
- [x] All 28 unit/integration tests pass locally
- [x] Binary smoke test compiles, runs, serves HTTP, shuts down cleanly on SIGTERM
- [ ] Cluster e2e (deferred to #428; binary smoke is the gate until then)
- [x] Manual `make docker-build-router-proxy` (will run in CI's Package and Install Test)

## Out of scope (deferred to follow-up issues)

- Controller reconciling the router-proxy Deployment + Service + ConfigMap: **#428**
- External provider backends fully integrated via the controller (the proxy supports them today; the controller just needs to emit the right ConfigMap): **#438**
- Hot config reload via file watcher (controller-triggered rollout suffices for MVP)
- Weighted / shadow routing strategies, rolling backend health: **#432**
- Prometheus metrics and OTel spans: **#433**
- Budgets and audit log sinks beyond stdout: **#434**
- Helm chart packaging of the proxy image / Deployment: **#439**