### PR TITLE
feat: reconcile router-proxy Deployment, Service, and ConfigMap

### DIFF
--- a/charts/llmkube/templates/clusterrole.yaml
+++ b/charts/llmkube/templates/clusterrole.yaml
@@ -9,8 +9,22 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   - pods
+  - secrets
   verbs:
   - get
   - list
@@ -21,18 +35,6 @@ rules:
   - persistentvolumeclaims
   verbs:
   - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
   - get
   - list
   - patch

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -107,6 +107,7 @@ func main() {
 	var caCertConfigMap string
 	var initContainerImage string
 	var defaultFSGroup int64
+	var routerProxyImage string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -125,6 +126,10 @@ func main() {
 			"write to a freshly-provisioned PVC. Set to 0 to disable on OpenShift, "+
 			"where the restricted-v2 SCC injects fsGroup from the namespace's allocated "+
 			"range and rejects pods with explicit values outside that range.")
+	flag.StringVar(&routerProxyImage, "router-proxy-image", "",
+		"Default container image for ModelRouter-managed router-proxy pods. "+
+			"Empty falls back to the controller's compiled-in default. "+
+			"Per-ModelRouter spec.proxy.image overrides this.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -264,8 +269,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.ModelRouterReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		RouterProxyImage: routerProxyImage,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ModelRouter")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,8 +7,22 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   - pods
+  - secrets
   verbs:
   - get
   - list
@@ -26,18 +40,6 @@ rules:
   - persistentvolumeclaims
   verbs:
   - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
   - get
   - list
   - patch

--- a/internal/controller/modelrouter_controller.go
+++ b/internal/controller/modelrouter_controller.go
@@ -15,6 +15,8 @@ import (
 	"math"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,29 +39,45 @@ import (
 const (
 	ModelRouterPhasePending      = "Pending"
 	ModelRouterPhaseProvisioning = "Provisioning"
+	ModelRouterPhaseDegraded     = "Degraded"
 
 	ModelRouterConditionValidated     = "Validated"
 	ModelRouterConditionBackendsReady = "BackendsReady"
 
-	ModelRouterReasonSpecValid   = "SpecValid"
-	ModelRouterReasonSpecInvalid = "SpecInvalid"
+	ModelRouterReasonSpecValid          = "SpecValid"
+	ModelRouterReasonSpecInvalid        = "SpecInvalid"
+	ModelRouterReasonCompileFailed      = "CompileFailed"
+	ModelRouterReasonReconcileFailed    = "ReconcileFailed"
+	ModelRouterReasonBackendsResolved   = "BackendsResolved"
+	ModelRouterReasonBackendsUnresolved = "BackendsUnresolved"
+	ModelRouterReasonDeploymentReady    = "DeploymentReady"
+	ModelRouterReasonDeploymentNotReady = "DeploymentNotReady"
+	ModelRouterReasonDeploymentDegraded = "DeploymentDegraded"
 
 	modelRouterControllerName = "modelrouter"
 )
 
-// ModelRouterReconciler reconciles the ModelRouter CRD. In Phase 1 (this
-// commit) the reconciler validates the spec and writes a Validated
-// condition. No data plane is managed yet; the proxy Deployment, Service,
-// and ConfigMap land in #428.
+// ModelRouterReconciler reconciles the ModelRouter CRD. It validates the
+// spec, compiles the routing config, and creates / updates the ConfigMap,
+// Deployment, and Service that constitute the data plane.
 type ModelRouterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	// RouterProxyImage is the default container image for the
+	// router-proxy. Per-ModelRouter overrides in spec.proxy.image take
+	// precedence. Wired in cmd/main.go from --router-proxy-image.
+	RouterProxyImage string
 }
 
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=modelrouters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=modelrouters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=modelrouters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=inferenceservices,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 func (r *ModelRouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reconcileStart := time.Now()
@@ -80,53 +98,233 @@ func (r *ModelRouterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	valErrors := validateModelRouter(mr)
-	if err := r.updateStatus(ctx, mr, valErrors); err != nil {
-		return ctrl.Result{}, err
+	if len(valErrors) > 0 {
+		return ctrl.Result{}, r.recordValidationFailure(ctx, mr, valErrors)
 	}
-	return ctrl.Result{}, nil
+
+	compiled, err := r.compileRouterConfig(ctx, mr)
+	if err != nil {
+		return ctrl.Result{}, r.recordCompileFailure(ctx, mr, err)
+	}
+
+	if err := r.reconcileRouterConfigMap(ctx, mr, compiled); err != nil {
+		return ctrl.Result{}, r.recordReconcileFailure(ctx, mr, compiled, "ConfigMap", err)
+	}
+	if err := r.reconcileRouterDeployment(ctx, mr, compiled.Hash); err != nil {
+		return ctrl.Result{}, r.recordReconcileFailure(ctx, mr, compiled, "Deployment", err)
+	}
+	if err := r.reconcileRouterService(ctx, mr); err != nil {
+		return ctrl.Result{}, r.recordReconcileFailure(ctx, mr, compiled, "Service", err)
+	}
+
+	deployReady, deployMessage, err := r.fetchDeploymentReadiness(ctx, mr)
+	if err != nil {
+		return ctrl.Result{}, r.recordReconcileFailure(ctx, mr, compiled, "DeploymentReadiness", err)
+	}
+
+	return ctrl.Result{}, r.recordSuccess(ctx, mr, compiled, deployReady, deployMessage)
 }
 
-// updateStatus patches the ModelRouter status with the Validated condition
-// and an appropriate phase. Other conditions (BackendsReady, Available,
-// Degraded) will be set by the data-plane reconciler in #428.
-func (r *ModelRouterReconciler) updateStatus(
+// recordValidationFailure writes the validated=false branch of the
+// status. Used when validateModelRouter rejects the spec.
+func (r *ModelRouterReconciler) recordValidationFailure(
 	ctx context.Context,
 	mr *inferencev1alpha1.ModelRouter,
 	valErrors []ModelRouterValidationError,
 ) error {
-	logger := log.FromContext(ctx)
-
 	desired := mr.DeepCopy()
 	now := metav1.Now()
 	desired.Status.LastUpdated = &now
+	apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+		Type:    ModelRouterConditionValidated,
+		Status:  metav1.ConditionFalse,
+		Reason:  ModelRouterReasonSpecInvalid,
+		Message: formatValidationErrors(valErrors),
+	})
+	desired.Status.Phase = PhaseFailed
+	desired.Status.ActiveRules = 0
+	desired.Status.Backends = nil
+	return r.patchStatus(ctx, mr, desired)
+}
 
-	if len(valErrors) == 0 {
-		apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
-			Type:    ModelRouterConditionValidated,
-			Status:  metav1.ConditionTrue,
-			Reason:  ModelRouterReasonSpecValid,
-			Message: "spec passed static validation",
-		})
-		// Phase 1: no data plane yet, so a valid spec stays Pending.
-		// #428 will advance this to Provisioning / Ready / Degraded.
-		desired.Status.Phase = ModelRouterPhasePending
-		desired.Status.ActiveRules = safeInt32(len(desired.Spec.Rules))
-	} else {
-		apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
-			Type:    ModelRouterConditionValidated,
-			Status:  metav1.ConditionFalse,
-			Reason:  ModelRouterReasonSpecInvalid,
-			Message: formatValidationErrors(valErrors),
-		})
-		desired.Status.Phase = PhaseFailed
-		desired.Status.ActiveRules = 0
+// recordCompileFailure writes the configmap-compile-failed branch.
+func (r *ModelRouterReconciler) recordCompileFailure(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+	err error,
+) error {
+	desired := mr.DeepCopy()
+	now := metav1.Now()
+	desired.Status.LastUpdated = &now
+	apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+		Type:    ModelRouterConditionValidated,
+		Status:  metav1.ConditionTrue,
+		Reason:  ModelRouterReasonSpecValid,
+		Message: "spec passed static validation",
+	})
+	apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+		Type:    ConditionAvailable,
+		Status:  metav1.ConditionFalse,
+		Reason:  ModelRouterReasonCompileFailed,
+		Message: err.Error(),
+	})
+	desired.Status.Phase = PhaseFailed
+	return r.patchStatus(ctx, mr, desired)
+}
+
+// recordReconcileFailure writes the data-plane-reconcile-failed branch.
+// We keep Validated=True (spec was good) but flip Available=False with a
+// message identifying which child resource broke.
+func (r *ModelRouterReconciler) recordReconcileFailure(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+	compiled *compiledConfig,
+	resourceKind string,
+	err error,
+) error {
+	desired := mr.DeepCopy()
+	now := metav1.Now()
+	desired.Status.LastUpdated = &now
+	apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+		Type:    ModelRouterConditionValidated,
+		Status:  metav1.ConditionTrue,
+		Reason:  ModelRouterReasonSpecValid,
+		Message: "spec passed static validation",
+	})
+	apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+		Type:    ConditionAvailable,
+		Status:  metav1.ConditionFalse,
+		Reason:  ModelRouterReasonReconcileFailed,
+		Message: resourceKind + ": " + err.Error(),
+	})
+	if compiled != nil {
+		desired.Status.Backends = compiled.Backends
 	}
+	desired.Status.Phase = PhaseFailed
+	return r.patchStatus(ctx, mr, desired)
+}
 
-	if err := r.Status().Patch(ctx, desired, client.MergeFrom(mr)); err != nil {
-		logger.Error(err, "failed to update ModelRouter status")
+// recordSuccess writes the happy-path status when the data plane is at
+// least provisioning correctly. Phase ranges over Provisioning / Ready
+// / Degraded depending on backend health and deployment readiness.
+func (r *ModelRouterReconciler) recordSuccess(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+	compiled *compiledConfig,
+	deployReady bool,
+	deployMessage string,
+) error {
+	desired := mr.DeepCopy()
+	now := metav1.Now()
+	desired.Status.LastUpdated = &now
+	desired.Status.Endpoint = routerProxyEndpoint(mr)
+	desired.Status.ActiveRules = safeInt32(len(mr.Spec.Rules))
+	desired.Status.Backends = compiled.Backends
+
+	apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+		Type:    ModelRouterConditionValidated,
+		Status:  metav1.ConditionTrue,
+		Reason:  ModelRouterReasonSpecValid,
+		Message: "spec passed static validation",
+	})
+
+	backendsReady, backendsMessage := summarizeBackends(compiled.Backends)
+	apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+		Type:    ModelRouterConditionBackendsReady,
+		Status:  conditionBool(backendsReady),
+		Reason:  conditionPick(backendsReady, ModelRouterReasonBackendsResolved, ModelRouterReasonBackendsUnresolved),
+		Message: backendsMessage,
+	})
+
+	apimeta.SetStatusCondition(&desired.Status.Conditions, metav1.Condition{
+		Type:    ConditionAvailable,
+		Status:  conditionBool(deployReady),
+		Reason:  conditionPick(deployReady, ModelRouterReasonDeploymentReady, ModelRouterReasonDeploymentNotReady),
+		Message: deployMessage,
+	})
+
+	switch {
+	case deployReady && backendsReady:
+		desired.Status.Phase = PhaseReady
+	case deployReady && !backendsReady:
+		desired.Status.Phase = ModelRouterPhaseDegraded
+	default:
+		desired.Status.Phase = ModelRouterPhaseProvisioning
+	}
+	return r.patchStatus(ctx, mr, desired)
+}
+
+func (r *ModelRouterReconciler) patchStatus(
+	ctx context.Context,
+	original, desired *inferencev1alpha1.ModelRouter,
+) error {
+	if err := r.Status().Patch(ctx, desired, client.MergeFrom(original)); err != nil {
+		log.FromContext(ctx).Error(err, "failed to update ModelRouter status")
 		return err
 	}
 	return nil
+}
+
+// fetchDeploymentReadiness reads the proxy Deployment's current replica
+// status and returns a (ready, message, err) triple. Returns (false,
+// "Deployment not yet created", nil) when the Deployment does not exist
+// (the create just queued and we'll re-reconcile when the cache observes
+// it).
+func (r *ModelRouterReconciler) fetchDeploymentReadiness(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+) (bool, string, error) {
+	dep := &appsv1.Deployment{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      routerProxyResourceName(mr.Name),
+		Namespace: mr.Namespace,
+	}, dep)
+	switch {
+	case errors.IsNotFound(err):
+		return false, "Deployment not yet observed", nil
+	case err != nil:
+		return false, "", err
+	}
+	desired := int32(1)
+	if dep.Spec.Replicas != nil {
+		desired = *dep.Spec.Replicas
+	}
+	if dep.Status.ReadyReplicas >= desired && desired > 0 {
+		return true, "Deployment is fully Ready", nil
+	}
+	return false, "Waiting for proxy pods to become Ready", nil
+}
+
+// summarizeBackends returns (allHealthy, message) for the per-backend
+// statuses produced by compileRouterConfig.
+func summarizeBackends(backends []inferencev1alpha1.BackendStatus) (bool, string) {
+	if len(backends) == 0 {
+		return false, "no backends declared"
+	}
+	healthy := 0
+	for _, b := range backends {
+		if b.Healthy {
+			healthy++
+		}
+	}
+	if healthy == len(backends) {
+		return true, "all backends resolved"
+	}
+	return false, "some backends unresolved (see status.backends for details)"
+}
+
+func conditionBool(ok bool) metav1.ConditionStatus {
+	if ok {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
+}
+
+func conditionPick(ok bool, whenTrue, whenFalse string) string {
+	if ok {
+		return whenTrue
+	}
+	return whenFalse
 }
 
 // safeInt32 narrows an int to int32, clamping at math.MaxInt32 when needed,
@@ -140,12 +338,16 @@ func safeInt32(n int) int32 {
 	return int32(n) //nolint:gosec // bounds-checked above
 }
 
-// SetupWithManager wires up the ModelRouter primary watch plus a secondary
-// watch on InferenceService so a router whose backend turns Ready (or goes
-// away) is re-reconciled and re-validated.
+// SetupWithManager wires up the ModelRouter primary watch, the owned
+// child resources (Deployment, Service, ConfigMap), and the secondary
+// watch on InferenceService so a router whose backend turns Ready (or
+// goes away) is re-reconciled.
 func (r *ModelRouterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&inferencev1alpha1.ModelRouter{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
 		Watches(
 			&inferencev1alpha1.InferenceService{},
 			handler.EnqueueRequestsFromMapFunc(r.findModelRoutersForInferenceService),

--- a/internal/controller/modelrouter_validation.go
+++ b/internal/controller/modelrouter_validation.go
@@ -87,7 +87,7 @@ func validateBackends(spec *inferencev1alpha1.ModelRouterSpec) (
 		// Tier consistency: an InferenceServiceRef backend is by definition
 		// local. Allowing cloud tier here would let users bypass the
 		// fail-closed gate by mislabelling a local backend.
-		if b.InferenceServiceRef != nil && b.Tier == "cloud" {
+		if b.InferenceServiceRef != nil && b.Tier == backendTierCloud {
 			errs = append(errs, ModelRouterValidationError{
 				Field:   path + ".tier",
 				Message: "tier=cloud is invalid for a backend with inferenceServiceRef (use tier=local)",
@@ -217,7 +217,7 @@ func validateRuleSensitiveData(
 			// Already reported in validateRuleRoute.
 			continue
 		}
-		if b.Tier == "cloud" {
+		if b.Tier == backendTierCloud {
 			errs = append(errs, ModelRouterValidationError{
 				Field: path + ".route.backends",
 				Message: fmt.Sprintf(

--- a/internal/controller/router_builders_test.go
+++ b/internal/controller/router_builders_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/internal/router"
+)
+
+const testBuilderNs = "router-builder-test"
+
+func ptrInt32B(v int32) *int32 { return &v }
+
+func builderTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add v1alpha1: %v", err)
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	return s
+}
+
+// canonicalModelRouter is the "real-world shape" router builder tests
+// validate against: one local backend referencing an InferenceService,
+// one external backend with credentials, plus the pii fail-closed rule
+// and a complex-to-cloud rule.
+func canonicalModelRouter() *inferencev1alpha1.ModelRouter {
+	return &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "coding-router",
+			Namespace: testBuilderNs,
+		},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{
+					Name:                "local-qwen",
+					InferenceServiceRef: &corev1.LocalObjectReference{Name: "qwen3-coder"},
+					Tier:                "local",
+					Capabilities:        []string{"code", "tools"},
+				},
+				{
+					Name: "cloud-opus",
+					External: &inferencev1alpha1.ExternalProvider{
+						Provider:             "anthropic",
+						Model:                "claude-opus-4-7",
+						URL:                  "https://api.anthropic.com",
+						CredentialsSecretRef: &corev1.LocalObjectReference{Name: "anthropic-key"},
+					},
+					Tier:         "cloud",
+					Capabilities: []string{"vision"},
+				},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:       "pii-stays-local",
+					Match:      &inferencev1alpha1.RuleMatch{DataClassification: []string{"pii"}},
+					Route:      inferencev1alpha1.RuleRoute{Backends: []string{"local-qwen"}},
+					FailClosed: true,
+				},
+				{
+					Name:  "complex-to-cloud",
+					Match: &inferencev1alpha1.RuleMatch{TaskComplexity: "complex"},
+					Route: inferencev1alpha1.RuleRoute{Backends: []string{"cloud-opus", "local-qwen"}},
+				},
+			},
+			DefaultRoute: "local-qwen",
+			Policy: &inferencev1alpha1.RouterPolicy{
+				Classification: &inferencev1alpha1.ClassificationPolicy{Mode: "header-only"},
+				AuditLog:       &inferencev1alpha1.AuditLogPolicy{Sink: "stdout"},
+			},
+		},
+	}
+}
+
+func newRouterReconcilerForTest(t *testing.T, mr *inferencev1alpha1.ModelRouter, seeds ...client.Object) *ModelRouterReconciler {
+	t.Helper()
+	scheme := builderTestScheme(t)
+	objs := append([]client.Object{mr}, seeds...)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &ModelRouterReconciler{
+		Client: c,
+		Scheme: scheme,
+	}
+}
+
+// TestCompileRouterConfigResolvesLocalBackend verifies that a local
+// InferenceServiceRef resolves to the expected in-cluster URL.
+func TestCompileRouterConfigResolvesLocalBackend(t *testing.T) {
+	mr := canonicalModelRouter()
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "qwen3-coder", Namespace: testBuilderNs},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "qwen3-coder"},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "anthropic-key", Namespace: testBuilderNs},
+		Data:       map[string][]byte{"ANTHROPIC_API_KEY": []byte("test")},
+	}
+	r := newRouterReconcilerForTest(t, mr, isvc, secret)
+
+	compiled, err := r.compileRouterConfig(context.Background(), mr)
+	if err != nil {
+		t.Fatalf("compileRouterConfig: %v", err)
+	}
+
+	var cfg router.Config
+	if err := json.Unmarshal(compiled.JSON, &cfg); err != nil {
+		t.Fatalf("unmarshal compiled JSON: %v", err)
+	}
+	if len(cfg.Backends) != 2 {
+		t.Fatalf("got %d backends, want 2", len(cfg.Backends))
+	}
+	wantPrefix := "http://qwen3-coder." + testBuilderNs + ".svc.cluster.local:"
+	if !strings.HasPrefix(cfg.Backends[0].Address, wantPrefix) {
+		t.Errorf("local backend address = %q, want prefix %q", cfg.Backends[0].Address, wantPrefix)
+	}
+	if cfg.Backends[1].CredentialsEnv != "ANTHROPIC_API_KEY" {
+		t.Errorf("cloud backend credentials env = %q, want ANTHROPIC_API_KEY", cfg.Backends[1].CredentialsEnv)
+	}
+	for _, b := range compiled.Backends {
+		if !b.Healthy {
+			t.Errorf("backend %s should be healthy after resolution, Message=%q", b.Name, b.Message)
+		}
+	}
+}
+
+// TestCompileRouterConfigMissingInferenceService confirms that a missing
+// local InferenceService produces an unhealthy backend status. The
+// proxy's Validate() rejects empty addresses, so the overall compile
+// errors out; callers patch the failure into the Available condition.
+func TestCompileRouterConfigMissingInferenceService(t *testing.T) {
+	mr := canonicalModelRouter()
+	r := newRouterReconcilerForTest(t, mr) // no InferenceService or Secret seeded
+	_, err := r.compileRouterConfig(context.Background(), mr)
+	if err == nil {
+		t.Fatal("expected validation error when InferenceService is missing")
+	}
+}
+
+// TestCompileRouterConfigMissingSecretKey surfaces a Secret-missing-key
+// as a per-backend Healthy=false status. The local backend still
+// resolves cleanly so the wire shape passes validation.
+func TestCompileRouterConfigMissingSecretKey(t *testing.T) {
+	mr := canonicalModelRouter()
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "qwen3-coder", Namespace: testBuilderNs},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "anthropic-key", Namespace: testBuilderNs},
+		Data:       map[string][]byte{"WRONG_KEY": []byte("ignored")},
+	}
+	r := newRouterReconcilerForTest(t, mr, isvc, secret)
+
+	compiled, err := r.compileRouterConfig(context.Background(), mr)
+	if err != nil {
+		t.Fatalf("compileRouterConfig: %v", err)
+	}
+	cloud := compiled.Backends[1]
+	if cloud.Name != "cloud-opus" {
+		t.Fatalf("unexpected ordering: %+v", compiled.Backends)
+	}
+	if cloud.Healthy {
+		t.Error("cloud backend should be unhealthy when credentials key is missing")
+	}
+	if !strings.Contains(cloud.Message, "missing key") {
+		t.Errorf("cloud backend Message = %q, want missing-key error", cloud.Message)
+	}
+}
+
+// TestRouterDeploymentBuilder pins the deployment shape this PR
+// contracts on for downstream callers (CI smoke tests, future
+// production users).
+func TestRouterDeploymentBuilder(t *testing.T) {
+	mr := canonicalModelRouter()
+	r := &ModelRouterReconciler{RouterProxyImage: "ghcr.io/test/router-proxy:v1"}
+	dep := r.newRouterDeployment(mr, "deadbeef")
+
+	if got := dep.Name; got != "coding-router-router-proxy" {
+		t.Errorf("Deployment name = %q", got)
+	}
+	if *dep.Spec.Replicas != 1 {
+		t.Errorf("default replicas = %d, want 1", *dep.Spec.Replicas)
+	}
+
+	pod := dep.Spec.Template
+	if pod.Annotations[routerProxyConfigHashAnnotation] != "deadbeef" {
+		t.Errorf("config hash annotation = %q", pod.Annotations[routerProxyConfigHashAnnotation])
+	}
+	if len(pod.Spec.Containers) != 1 {
+		t.Fatalf("got %d containers, want 1", len(pod.Spec.Containers))
+	}
+	c := pod.Spec.Containers[0]
+	if c.Image != "ghcr.io/test/router-proxy:v1" {
+		t.Errorf("image = %q, want flag-provided override", c.Image)
+	}
+	if !strings.Contains(strings.Join(c.Args, " "), routerProxyConfigMountPath+"/"+routerProxyConfigKey) {
+		t.Errorf("--config arg missing; args=%v", c.Args)
+	}
+	if c.SecurityContext == nil || c.SecurityContext.RunAsNonRoot == nil || !*c.SecurityContext.RunAsNonRoot {
+		t.Error("container SecurityContext must set RunAsNonRoot=true")
+	}
+	if c.SecurityContext == nil || c.SecurityContext.ReadOnlyRootFilesystem == nil || !*c.SecurityContext.ReadOnlyRootFilesystem {
+		t.Error("container SecurityContext must set ReadOnlyRootFilesystem=true")
+	}
+	if !hasConfigVolume(pod.Spec.Volumes) {
+		t.Error("pod spec must mount router-config volume")
+	}
+	if !hasEnvFromSecret(c.EnvFrom, "anthropic-key") {
+		t.Errorf("container envFrom must reference anthropic-key; got %+v", c.EnvFrom)
+	}
+}
+
+// TestRouterDeploymentBuilderRespectsOverrides validates that
+// spec.proxy.{replicas,image} take precedence over the controller's
+// flag defaults.
+func TestRouterDeploymentBuilderRespectsOverrides(t *testing.T) {
+	mr := canonicalModelRouter()
+	mr.Spec.Proxy = &inferencev1alpha1.RouterProxySpec{
+		Replicas: ptrInt32B(3),
+		Image:    "registry.internal/router-proxy:custom",
+	}
+	r := &ModelRouterReconciler{RouterProxyImage: "should-be-overridden"}
+	dep := r.newRouterDeployment(mr, "hash")
+	if *dep.Spec.Replicas != 3 {
+		t.Errorf("replicas override = %d, want 3", *dep.Spec.Replicas)
+	}
+	if got := dep.Spec.Template.Spec.Containers[0].Image; got != "registry.internal/router-proxy:custom" {
+		t.Errorf("image = %q, want spec.proxy.image override", got)
+	}
+}
+
+// TestRouterServiceBuilder confirms ClusterIP default and the
+// canonical selector label.
+func TestRouterServiceBuilder(t *testing.T) {
+	mr := canonicalModelRouter()
+	svc := newRouterService(mr)
+	if svc.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Errorf("default type = %v, want ClusterIP", svc.Spec.Type)
+	}
+	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 8080 {
+		t.Errorf("ports = %+v", svc.Spec.Ports)
+	}
+	if got := svc.Spec.Selector["inference.llmkube.dev/model-router"]; got != mr.Name {
+		t.Errorf("selector label = %q, want %q", got, mr.Name)
+	}
+}
+
+func TestRouterServiceBuilderUpgradesType(t *testing.T) {
+	mr := canonicalModelRouter()
+	mr.Spec.Endpoint = &inferencev1alpha1.EndpointSpec{Type: "LoadBalancer"}
+	svc := newRouterService(mr)
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		t.Errorf("Type = %v, want LoadBalancer", svc.Spec.Type)
+	}
+}
+
+func TestRouterProxyEndpointURL(t *testing.T) {
+	mr := canonicalModelRouter()
+	want := "http://coding-router-router-proxy." + testBuilderNs + ".svc.cluster.local:8080/v1/chat/completions"
+	if got := routerProxyEndpoint(mr); got != want {
+		t.Errorf("endpoint = %q, want %q", got, want)
+	}
+	mr.Spec.Endpoint = &inferencev1alpha1.EndpointSpec{Port: 9090, Path: "/v1/completions"}
+	if got := routerProxyEndpoint(mr); !strings.HasSuffix(got, ":9090/v1/completions") {
+		t.Errorf("override endpoint = %q", got)
+	}
+}
+
+func TestSummarizeBackends(t *testing.T) {
+	cases := []struct {
+		name      string
+		backends  []inferencev1alpha1.BackendStatus
+		wantReady bool
+	}{
+		{name: "empty", wantReady: false},
+		{
+			name: "all healthy",
+			backends: []inferencev1alpha1.BackendStatus{
+				{Name: "a", Healthy: true},
+				{Name: "b", Healthy: true},
+			},
+			wantReady: true,
+		},
+		{
+			name: "one unhealthy",
+			backends: []inferencev1alpha1.BackendStatus{
+				{Name: "a", Healthy: true},
+				{Name: "b", Healthy: false, Message: "secret missing"},
+			},
+			wantReady: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ready, _ := summarizeBackends(tc.backends)
+			if ready != tc.wantReady {
+				t.Errorf("ready = %v, want %v", ready, tc.wantReady)
+			}
+		})
+	}
+}
+
+func hasConfigVolume(vols []corev1.Volume) bool {
+	for _, v := range vols {
+		if v.Name == "router-config" && v.ConfigMap != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEnvFromSecret(envFrom []corev1.EnvFromSource, name string) bool {
+	for _, e := range envFrom {
+		if e.SecretRef != nil && e.SecretRef.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/router_common.go
+++ b/internal/controller/router_common.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Names, labels, and annotations shared across the three router-proxy
+// builders (config, deployment, service). Pulled into a single file so
+// the wire-shape contract is in one place.
+const (
+	// Backend tier strings shared between controller and proxy.
+	backendTierLocal = "local"
+	backendTierCloud = "cloud"
+
+	// routerProxyComponent is the value of the standard k8s
+	// app.kubernetes.io/component label applied to every owned object.
+	routerProxyComponent = "router-proxy"
+
+	// routerProxyContainerName is the container name inside the proxy
+	// Deployment. Matched by ServiceMonitor selectors later.
+	routerProxyContainerName = "router-proxy"
+
+	// routerProxyConfigMountPath is where the controller mounts the
+	// ConfigMap inside the proxy pod. Must match the binary's
+	// --config default (see cmd/router-proxy/main.go).
+	routerProxyConfigMountPath = "/etc/llmkube/router"
+
+	// routerProxyConfigHashAnnotation is set on the Deployment pod
+	// template so a ConfigMap content change triggers a rollout.
+	routerProxyConfigHashAnnotation = "inference.llmkube.dev/router-config-hash"
+
+	// routerProxyPort is the HTTP port the proxy listens on.
+	routerProxyPort int32 = 8080
+)
+
+// routerProxyResourceName is the canonical name used for every K8s
+// object owned by a ModelRouter (Deployment, Service, ConfigMap). One
+// helper keeps the naming consistent and the test fixtures predictable.
+func routerProxyResourceName(modelRouterName string) string {
+	return sanitizeDNSName(modelRouterName) + "-router-proxy"
+}
+
+// routerProxyLabels are the standard k8s app labels applied to every
+// owned object. The selectorLabels subset is used as the Deployment
+// selector and Service selector and is immutable for the lifetime of
+// the ModelRouter.
+func routerProxyLabels(mr *inferencev1alpha1.ModelRouter) map[string]string {
+	l := routerProxySelectorLabels(mr)
+	l["app.kubernetes.io/name"] = "llmkube"
+	l["app.kubernetes.io/component"] = routerProxyComponent
+	l["app.kubernetes.io/managed-by"] = "llmkube-controller"
+	return l
+}
+
+// routerProxySelectorLabels is the immutable label set used as both the
+// Deployment podSelector and the Service selector. Keep it small and
+// stable; downstream tooling depends on it.
+func routerProxySelectorLabels(mr *inferencev1alpha1.ModelRouter) map[string]string {
+	return map[string]string{
+		"app":                                routerProxyResourceName(mr.Name),
+		"inference.llmkube.dev/model-router": mr.Name,
+	}
+}

--- a/internal/controller/router_config_builder.go
+++ b/internal/controller/router_config_builder.go
@@ -1,0 +1,351 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/internal/router"
+)
+
+// routerProxyConfigKey is the file name inside the controller-managed
+// ConfigMap. The router-proxy mounts the ConfigMap at
+// routerProxyConfigMountPath and reads <mount>/config.json.
+const routerProxyConfigKey = "config.json"
+
+// compiledConfig captures everything the controller needs after
+// translating a ModelRouter spec into the proxy wire shape: the raw
+// JSON bytes, a content hash that drives pod rollout, and per-backend
+// status the reconciler propagates into Status.Backends.
+type compiledConfig struct {
+	JSON     []byte
+	Hash     string
+	Backends []inferencev1alpha1.BackendStatus
+	Warnings []string
+}
+
+// compileRouterConfig resolves every backend in the ModelRouter spec
+// (InferenceService lookups for local backends, secret-key checks for
+// external ones), translates the spec into the proxy wire shape, and
+// returns the JSON + content hash plus the BackendStatus list the
+// reconciler writes back.
+//
+// Unresolvable backends are reported as Healthy=false with a Message
+// rather than failing the whole compile; the proxy treats them as
+// unhealthy and skips them at request time. This matches the existing
+// model_controller convention of degraded-but-running over fail-stop.
+func (r *ModelRouterReconciler) compileRouterConfig(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+) (*compiledConfig, error) {
+	out := &router.Config{
+		DefaultRoute: mr.Spec.DefaultRoute,
+		Backends:     make([]router.Backend, 0, len(mr.Spec.Backends)),
+		Rules:        make([]router.Rule, 0, len(mr.Spec.Rules)),
+	}
+	statuses := make([]inferencev1alpha1.BackendStatus, 0, len(mr.Spec.Backends))
+	var warnings []string
+
+	for i := range mr.Spec.Backends {
+		b := &mr.Spec.Backends[i]
+		wire, status := r.resolveBackend(ctx, mr, b)
+		if status.Message != "" {
+			warnings = append(warnings, fmt.Sprintf("backend %q: %s", b.Name, status.Message))
+		}
+		out.Backends = append(out.Backends, wire)
+		statuses = append(statuses, status)
+	}
+
+	for i := range mr.Spec.Rules {
+		out.Rules = append(out.Rules, translateRule(&mr.Spec.Rules[i]))
+	}
+	out.Policy = translatePolicy(mr.Spec.Policy)
+
+	if err := out.Validate(); err != nil {
+		return nil, fmt.Errorf("compiled router config failed validation: %w", err)
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal router config: %w", err)
+	}
+	sum := sha256.Sum256(data)
+
+	return &compiledConfig{
+		JSON:     data,
+		Hash:     hex.EncodeToString(sum[:]),
+		Backends: statuses,
+		Warnings: warnings,
+	}, nil
+}
+
+// resolveBackend turns one ModelRouter backend into its proxy wire
+// representation plus the BackendStatus the reconciler reports.
+func (r *ModelRouterReconciler) resolveBackend(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+	b *inferencev1alpha1.RouterBackend,
+) (router.Backend, inferencev1alpha1.BackendStatus) {
+	now := metav1.Now()
+	status := inferencev1alpha1.BackendStatus{
+		Name:          b.Name,
+		Tier:          b.Tier,
+		LastProbeTime: &now,
+	}
+	wire := router.Backend{
+		Name:         b.Name,
+		Tier:         b.Tier,
+		Capabilities: append([]string(nil), b.Capabilities...),
+	}
+	if b.Weight != nil {
+		wire.Weight = int(*b.Weight)
+	}
+
+	switch {
+	case b.InferenceServiceRef != nil:
+		if wire.Tier == "" {
+			wire.Tier = backendTierLocal
+			status.Tier = backendTierLocal
+		}
+		addr, msg := r.resolveInferenceServiceAddress(ctx, mr.Namespace, b.InferenceServiceRef.Name)
+		wire.Address = addr
+		status.Address = addr
+		status.Healthy = addr != ""
+		status.Message = msg
+	case b.External != nil:
+		if wire.Tier == "" {
+			wire.Tier = backendTierCloud
+			status.Tier = backendTierCloud
+		}
+		wire.Provider = b.External.Provider
+		wire.Model = b.External.Model
+		wire.Address = b.External.URL
+		status.Address = b.External.URL
+		wire.CredentialsEnv = wellKnownCredEnv(b.External.Provider)
+		if b.External.CredentialsSecretRef != nil {
+			if err := r.assertCredentialsSecretExists(ctx, mr.Namespace,
+				b.External.CredentialsSecretRef.Name, wire.CredentialsEnv); err != nil {
+				status.Healthy = false
+				status.Message = err.Error()
+			} else {
+				status.Healthy = true
+			}
+		} else {
+			// LiteLLM-style external backends sometimes handle auth
+			// themselves; allow no secret.
+			status.Healthy = true
+		}
+	default:
+		status.Healthy = false
+		status.Message = "no inferenceServiceRef or external provider declared"
+	}
+	return wire, status
+}
+
+// resolveInferenceServiceAddress builds the cluster URL the router-proxy
+// will POST to for a local backend. Returns ("", message) when the
+// InferenceService doesn't exist; the caller surfaces that on
+// Status.Backends.
+func (r *ModelRouterReconciler) resolveInferenceServiceAddress(
+	ctx context.Context,
+	namespace, name string,
+) (string, string) {
+	isvc := &inferencev1alpha1.InferenceService{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, isvc); err != nil {
+		if errors.IsNotFound(err) {
+			return "", fmt.Sprintf("InferenceService %q not found in namespace %q", name, namespace)
+		}
+		return "", fmt.Sprintf("InferenceService %q lookup failed: %v", name, err)
+	}
+	port := int32(8080)
+	if isvc.Spec.Endpoint != nil && isvc.Spec.Endpoint.Port > 0 {
+		port = isvc.Spec.Endpoint.Port
+	}
+	svcName := sanitizeDNSName(isvc.Name)
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", svcName, isvc.Namespace, port), ""
+}
+
+// assertCredentialsSecretExists verifies the referenced Secret is present
+// and contains the expected key. Catches the misconfigured-secret case
+// at reconcile time rather than at first request.
+func (r *ModelRouterReconciler) assertCredentialsSecretExists(
+	ctx context.Context,
+	namespace, name, expectedKey string,
+) error {
+	sec := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, sec); err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("credentials Secret %q not found", name)
+		}
+		return fmt.Errorf("credentials Secret %q lookup failed: %w", name, err)
+	}
+	if expectedKey == "" {
+		return nil
+	}
+	if _, ok := sec.Data[expectedKey]; !ok {
+		return fmt.Errorf("credentials Secret %q missing key %q", name, expectedKey)
+	}
+	return nil
+}
+
+// wellKnownCredEnv maps a provider name to the conventional environment
+// variable the router-proxy expects to read. Mirrors the proxy's
+// applyCredentials switch in internal/router/backend.go.
+func wellKnownCredEnv(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "ANTHROPIC_API_KEY"
+	case "openai":
+		return "OPENAI_API_KEY"
+	case "litellm":
+		return "LITELLM_MASTER_KEY"
+	case "bedrock":
+		return "AWS_ACCESS_KEY_ID"
+	case "vertex_ai":
+		return "GOOGLE_APPLICATION_CREDENTIALS"
+	default:
+		return ""
+	}
+}
+
+// translateRule maps a ModelRouter spec rule to the proxy wire shape.
+// Pure transformation; no I/O.
+func translateRule(in *inferencev1alpha1.RouterRule) router.Rule {
+	out := router.Rule{
+		Name:       in.Name,
+		FailClosed: in.FailClosed,
+		Route: router.RuleRoute{
+			Backends: append([]string(nil), in.Route.Backends...),
+			Strategy: in.Route.Strategy,
+		},
+	}
+	if in.Match != nil {
+		out.Match = router.RuleMatch{
+			DataClassification:   append([]string(nil), in.Match.DataClassification...),
+			TaskComplexity:       in.Match.TaskComplexity,
+			RequiredCapabilities: append([]string(nil), in.Match.RequiredCapabilities...),
+			Headers:              copyStringMap(in.Match.Headers),
+			Models:               append([]string(nil), in.Match.Models...),
+		}
+	}
+	return out
+}
+
+// translatePolicy maps the ModelRouter policy block to the proxy shape.
+// A nil input policy yields a defaulted-but-valid wire policy.
+func translatePolicy(p *inferencev1alpha1.RouterPolicy) router.Policy {
+	out := router.Policy{
+		Classification: router.ClassificationPolicy{Mode: "header-only"},
+		AuditLog:       router.AuditLogPolicy{Sink: "stdout"},
+	}
+	if p == nil {
+		return out
+	}
+	if p.Classification != nil {
+		out.Classification = router.ClassificationPolicy{
+			Mode:      p.Classification.Mode,
+			HeaderKey: p.Classification.HeaderKey,
+			Sensitive: append([]string(nil), p.Classification.SensitiveClassifications...),
+		}
+		if out.Classification.Mode == "" {
+			out.Classification.Mode = "header-only"
+		}
+	}
+	if p.AuditLog != nil {
+		out.AuditLog = router.AuditLogPolicy{
+			Sink:               p.AuditLog.Sink,
+			FilePath:           p.AuditLog.FilePath,
+			IncludeRequestBody: p.AuditLog.IncludeRequestBody,
+		}
+		if out.AuditLog.Sink == "" {
+			out.AuditLog.Sink = "stdout"
+		}
+	}
+	return out
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// reconcileRouterConfigMap creates or updates the ConfigMap that backs
+// the router-proxy. The ConfigMap is owner-referenced to the ModelRouter
+// so deleting the parent garbage-collects the config.
+func (r *ModelRouterReconciler) reconcileRouterConfigMap(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+	compiled *compiledConfig,
+) error {
+	desired := newRouterConfigMap(mr, compiled)
+	if err := controllerutil.SetControllerReference(mr, desired, r.Scheme); err != nil {
+		return fmt.Errorf("set owner ref on router ConfigMap: %w", err)
+	}
+
+	existing := &corev1.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	switch {
+	case errors.IsNotFound(err):
+		return r.Create(ctx, desired)
+	case err != nil:
+		return err
+	}
+
+	if existing.Data[routerProxyConfigKey] == desired.Data[routerProxyConfigKey] &&
+		existing.Annotations[routerProxyConfigHashAnnotation] == compiled.Hash {
+		return nil
+	}
+	existing.Data = desired.Data
+	if existing.Annotations == nil {
+		existing.Annotations = map[string]string{}
+	}
+	existing.Annotations[routerProxyConfigHashAnnotation] = compiled.Hash
+	existing.Labels = desired.Labels
+	if err := controllerutil.SetControllerReference(mr, existing, r.Scheme); err != nil {
+		return fmt.Errorf("set owner ref on existing router ConfigMap: %w", err)
+	}
+	return r.Update(ctx, existing)
+}
+
+// newRouterConfigMap is the in-memory blueprint of the ConfigMap. Kept
+// separate from reconcileRouterConfigMap so unit tests can call it
+// without a fake client.
+func newRouterConfigMap(mr *inferencev1alpha1.ModelRouter, compiled *compiledConfig) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routerProxyResourceName(mr.Name),
+			Namespace: mr.Namespace,
+			Labels:    routerProxyLabels(mr),
+			Annotations: map[string]string{
+				routerProxyConfigHashAnnotation: compiled.Hash,
+			},
+		},
+		Data: map[string]string{
+			routerProxyConfigKey: string(compiled.JSON),
+		},
+	}
+}

--- a/internal/controller/router_deployment_builder.go
+++ b/internal/controller/router_deployment_builder.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// defaultRouterProxyImage is the image used when neither the controller
+// flag nor the ModelRouter.spec.proxy.image override sets one. Real
+// deployments override this in production; the default is a development
+// tag for local kind clusters.
+const defaultRouterProxyImage = "ghcr.io/defilantech/llmkube-router-proxy:dev"
+
+// reconcileRouterDeployment creates or updates the Deployment that runs
+// the router-proxy. The Deployment is owner-referenced to the
+// ModelRouter; deleting the parent garbage-collects the pods.
+func (r *ModelRouterReconciler) reconcileRouterDeployment(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+	configHash string,
+) error {
+	desired := r.newRouterDeployment(mr, configHash)
+	if err := controllerutil.SetControllerReference(mr, desired, r.Scheme); err != nil {
+		return fmt.Errorf("set owner ref on router Deployment: %w", err)
+	}
+
+	existing := &appsv1.Deployment{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	switch {
+	case errors.IsNotFound(err):
+		return r.Create(ctx, desired)
+	case err != nil:
+		return err
+	}
+
+	// PodTemplate selector is immutable; copy only mutable surface. We
+	// keep the existing ObjectMeta UID/Generation but refresh Spec.
+	existing.Spec.Replicas = desired.Spec.Replicas
+	existing.Spec.Template = desired.Spec.Template
+	existing.Labels = desired.Labels
+	if err := controllerutil.SetControllerReference(mr, existing, r.Scheme); err != nil {
+		return fmt.Errorf("set owner ref on existing router Deployment: %w", err)
+	}
+	return r.Update(ctx, existing)
+}
+
+// newRouterDeployment is the in-memory blueprint of the proxy
+// Deployment. Pulls overrides from spec.proxy if set, otherwise falls
+// back to sensible defaults that work on most kind / vanilla K8s
+// clusters and don't violate the restricted PodSecurityStandard.
+func (r *ModelRouterReconciler) newRouterDeployment(
+	mr *inferencev1alpha1.ModelRouter,
+	configHash string,
+) *appsv1.Deployment {
+	replicas := int32(1)
+	image := r.routerProxyImage()
+	var resources corev1.ResourceRequirements
+	var imagePullSecrets []corev1.LocalObjectReference
+
+	if mr.Spec.Proxy != nil {
+		if mr.Spec.Proxy.Replicas != nil {
+			replicas = *mr.Spec.Proxy.Replicas
+		}
+		if mr.Spec.Proxy.Image != "" {
+			image = mr.Spec.Proxy.Image
+		}
+		if mr.Spec.Proxy.Resources != nil {
+			resources = *mr.Spec.Proxy.Resources
+		}
+		imagePullSecrets = mr.Spec.Proxy.ImagePullSecrets
+	}
+	if resources.Requests == nil && resources.Limits == nil {
+		resources = defaultRouterProxyResources()
+	}
+
+	envFrom := credentialsEnvFrom(mr)
+
+	podLabels := routerProxySelectorLabels(mr)
+	podAnnotations := map[string]string{
+		// Re-roll pods automatically when the ConfigMap content
+		// changes. controller-runtime's CreateOrUpdate doesn't trigger
+		// a rollout on its own; the hash annotation does.
+		routerProxyConfigHashAnnotation: configHash,
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routerProxyResourceName(mr.Name),
+			Namespace: mr.Namespace,
+			Labels:    routerProxyLabels(mr),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      podLabels,
+					Annotations: podAnnotations,
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext:  routerProxyPodSecurityContext(),
+					ImagePullSecrets: imagePullSecrets,
+					Containers: []corev1.Container{
+						{
+							Name:            routerProxyContainerName,
+							Image:           image,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args: []string{
+								"--config", routerProxyConfigMountPath + "/" + routerProxyConfigKey,
+								"--listen", fmt.Sprintf(":%d", routerProxyPort),
+								"--log-format", "json",
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "http",
+									ContainerPort: routerProxyPort,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							EnvFrom: envFrom,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "router-config",
+									MountPath: routerProxyConfigMountPath,
+									ReadOnly:  true,
+								},
+							},
+							Resources:       resources,
+							SecurityContext: routerProxyContainerSecurityContext(),
+							LivenessProbe:   routerProxyProbe(20, 10),
+							ReadinessProbe:  routerProxyProbe(5, 5),
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "router-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: routerProxyResourceName(mr.Name),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// credentialsEnvFrom builds the envFrom list that injects every cloud
+// backend's credentials into the proxy pod. We use secretRef so the
+// proxy reads the values via os.Getenv at request time. Optional=true
+// keeps the pod schedulable even when a referenced Secret hasn't been
+// created yet; the proxy reports the backend unhealthy until it is.
+func credentialsEnvFrom(mr *inferencev1alpha1.ModelRouter) []corev1.EnvFromSource {
+	seen := make(map[string]bool)
+	var out []corev1.EnvFromSource
+	for i := range mr.Spec.Backends {
+		b := &mr.Spec.Backends[i]
+		if b.External == nil || b.External.CredentialsSecretRef == nil {
+			continue
+		}
+		name := b.External.CredentialsSecretRef.Name
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		optional := true
+		out = append(out, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: name},
+				Optional:             &optional,
+			},
+		})
+	}
+	return out
+}
+
+func defaultRouterProxyResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+}
+
+// routerProxyPodSecurityContext is the minimum-privilege pod-level
+// security context that satisfies the restricted PodSecurityStandard.
+// Matches what the InferenceServiceReconciler does for inference pods.
+func routerProxyPodSecurityContext() *corev1.PodSecurityContext {
+	uid := int64(65532)
+	return &corev1.PodSecurityContext{
+		RunAsNonRoot: boolPtr(true),
+		RunAsUser:    &uid,
+		FSGroup:      &uid,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// routerProxyContainerSecurityContext is the container-level security
+// context. ReadOnlyRootFilesystem is safe here because the proxy never
+// writes to disk (config is mounted ro, logs go to stdout).
+func routerProxyContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: boolPtr(false),
+		ReadOnlyRootFilesystem:   boolPtr(true),
+		RunAsNonRoot:             boolPtr(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+}
+
+func routerProxyProbe(initialDelay, periodSeconds int32) *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/health",
+				Port: intstr.FromInt(int(routerProxyPort)),
+			},
+		},
+		InitialDelaySeconds: initialDelay,
+		PeriodSeconds:       periodSeconds,
+		TimeoutSeconds:      2,
+		FailureThreshold:    3,
+	}
+}
+
+// routerProxyImage returns the image the reconciler will set on the
+// router-proxy container. The reconciler holds the flag-derived
+// default; per-ModelRouter overrides come from spec.proxy.image and
+// are applied in newRouterDeployment.
+func (r *ModelRouterReconciler) routerProxyImage() string {
+	if r.RouterProxyImage != "" {
+		return r.RouterProxyImage
+	}
+	return defaultRouterProxyImage
+}

--- a/internal/controller/router_deployment_builder.go
+++ b/internal/controller/router_deployment_builder.go
@@ -177,7 +177,7 @@ func (r *ModelRouterReconciler) newRouterDeployment(
 // created yet; the proxy reports the backend unhealthy until it is.
 func credentialsEnvFrom(mr *inferencev1alpha1.ModelRouter) []corev1.EnvFromSource {
 	seen := make(map[string]bool)
-	var out []corev1.EnvFromSource
+	out := make([]corev1.EnvFromSource, 0, len(mr.Spec.Backends))
 	for i := range mr.Spec.Backends {
 		b := &mr.Spec.Backends[i]
 		if b.External == nil || b.External.CredentialsSecretRef == nil {

--- a/internal/controller/router_service_builder.go
+++ b/internal/controller/router_service_builder.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// reconcileRouterService creates or updates the K8s Service in front of
+// the router-proxy pods. ClusterIP by default; spec.endpoint.type can
+// upgrade to NodePort / LoadBalancer to expose the router beyond the
+// cluster (most users won't, but enterprise admins occasionally do for
+// per-router edge-of-cluster ingress).
+func (r *ModelRouterReconciler) reconcileRouterService(
+	ctx context.Context,
+	mr *inferencev1alpha1.ModelRouter,
+) error {
+	desired := newRouterService(mr)
+	if err := controllerutil.SetControllerReference(mr, desired, r.Scheme); err != nil {
+		return fmt.Errorf("set owner ref on router Service: %w", err)
+	}
+
+	existing := &corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	switch {
+	case errors.IsNotFound(err):
+		return r.Create(ctx, desired)
+	case err != nil:
+		return err
+	}
+
+	// The selector is immutable in the K8s API; we set it once at
+	// creation and never mutate it. The port and service-type are the
+	// only mutable bits worth syncing here.
+	existing.Spec.Type = desired.Spec.Type
+	existing.Spec.Ports = desired.Spec.Ports
+	existing.Labels = desired.Labels
+	if err := controllerutil.SetControllerReference(mr, existing, r.Scheme); err != nil {
+		return fmt.Errorf("set owner ref on existing router Service: %w", err)
+	}
+	return r.Update(ctx, existing)
+}
+
+// newRouterService is the in-memory blueprint of the Service. Pure
+// function for testability.
+func newRouterService(mr *inferencev1alpha1.ModelRouter) *corev1.Service {
+	port := routerProxyPort
+	serviceType := corev1.ServiceTypeClusterIP
+	if mr.Spec.Endpoint != nil {
+		if mr.Spec.Endpoint.Port > 0 {
+			port = mr.Spec.Endpoint.Port
+		}
+		switch mr.Spec.Endpoint.Type {
+		case "NodePort":
+			serviceType = corev1.ServiceTypeNodePort
+		case "LoadBalancer":
+			serviceType = corev1.ServiceTypeLoadBalancer
+		}
+	}
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routerProxyResourceName(mr.Name),
+			Namespace: mr.Namespace,
+			Labels:    routerProxyLabels(mr),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     serviceType,
+			Selector: routerProxySelectorLabels(mr),
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       port,
+					TargetPort: intstr.FromInt(int(port)),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+}
+
+// routerProxyEndpoint constructs the in-cluster URL that the
+// ModelRouter publishes on status.endpoint. Mirrors the shape used by
+// InferenceService.
+func routerProxyEndpoint(mr *inferencev1alpha1.ModelRouter) string {
+	port := routerProxyPort
+	path := "/v1/chat/completions"
+	if mr.Spec.Endpoint != nil {
+		if mr.Spec.Endpoint.Port > 0 {
+			port = mr.Spec.Endpoint.Port
+		}
+		if mr.Spec.Endpoint.Path != "" {
+			path = mr.Spec.Endpoint.Path
+		}
+	}
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s",
+		routerProxyResourceName(mr.Name), mr.Namespace, port, path)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -662,6 +662,39 @@ spec:
 			cmd := exec.Command("kubectl", "create", "ns", mrTestNs)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create test namespace")
+
+			By("seeding a stub InferenceService for backend resolution")
+			// The controller resolves InferenceServiceRef to a cluster URL
+			// when compiling the router config. The referenced
+			// InferenceService doesn't need to be Ready (its pods would
+			// require a real model image which the kind e2e doesn't
+			// side-load), only present so resolution succeeds.
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: stub-model
+  namespace: %s
+spec:
+  source: file:///tmp/stub.gguf
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: stub-isvc
+  namespace: %s
+spec:
+  modelRef: stub-model
+`, mrTestNs, mrTestNs))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to seed stub InferenceService")
+
+			By("seeding a stub Secret for the cloud backend credentials")
+			cmd = exec.Command("kubectl", "create", "secret", "generic", "anthropic-key",
+				"-n", mrTestNs,
+				"--from-literal=ANTHROPIC_API_KEY=stub-key-for-e2e")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create stub credentials Secret")
 		})
 
 		AfterAll(func() {
@@ -670,13 +703,7 @@ spec:
 			_, _ = utils.Run(cmd)
 		})
 
-		// ModelRouter validation does not require referenced InferenceServices
-		// to actually exist in the cluster; it only enforces self-consistency
-		// of the spec (exactly-one-of, name uniqueness, fail-closed gate,
-		// budget invariants). The data plane lands in #428, at which point
-		// E2E coverage will broaden to actual request dispatch.
-
-		It("should report Validated=True for a well-formed ModelRouter", func() {
+		It("should reconcile a ModelRouter to a populated endpoint and child resources", func() {
 			By("applying a ModelRouter with a valid spec")
 			cmd := exec.Command("kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
@@ -694,6 +721,9 @@ spec:
       external:
         provider: anthropic
         model: claude-opus-4-7
+        url: https://api.anthropic.com
+        credentialsSecretRef:
+          name: anthropic-key
       tier: cloud
   rules:
     - name: pii-stays-local
@@ -712,20 +742,22 @@ spec:
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to apply ModelRouter CR")
 
-			By("waiting for ModelRouter status.phase=Pending and Validated=True")
-			verifyValidated := func(g Gomega) {
+			By("waiting for ModelRouter Validated=True and status.endpoint to be populated")
+			verifyStatus := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "modelrouter", "e2e-good-router",
-					"-n", mrTestNs, "-o", "jsonpath={.status.phase}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("Pending"))
-
-				cmd = exec.Command("kubectl", "get", "modelrouter", "e2e-good-router",
 					"-n", mrTestNs, "-o",
 					`jsonpath={.status.conditions[?(@.type=="Validated")].status}`)
-				output, err = utils.Run(cmd)
+				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("True"))
+
+				cmd = exec.Command("kubectl", "get", "modelrouter", "e2e-good-router",
+					"-n", mrTestNs, "-o", "jsonpath={.status.endpoint}")
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				// Endpoint convention: http://<name>-router-proxy.<ns>.svc.cluster.local:8080/v1/chat/completions
+				g.Expect(output).To(ContainSubstring("e2e-good-router-router-proxy." + mrTestNs))
+				g.Expect(output).To(ContainSubstring(":8080/v1/chat/completions"))
 
 				cmd = exec.Command("kubectl", "get", "modelrouter", "e2e-good-router",
 					"-n", mrTestNs, "-o", "jsonpath={.status.activeRules}")
@@ -733,7 +765,48 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("2"))
 			}
-			Eventually(verifyValidated, 1*time.Minute).Should(Succeed())
+			Eventually(verifyStatus, 1*time.Minute).Should(Succeed())
+
+			By("verifying the proxy ConfigMap exists with the compiled config")
+			verifyConfigMap := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "configmap", "e2e-good-router-router-proxy",
+					"-n", mrTestNs, "-o", "jsonpath={.data.config\\.json}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("local-stub"))
+				g.Expect(output).To(ContainSubstring("cloud-stub"))
+				g.Expect(output).To(ContainSubstring("pii-stays-local"))
+			}
+			Eventually(verifyConfigMap, 1*time.Minute).Should(Succeed())
+
+			By("verifying the proxy Service exists on the expected port")
+			verifyService := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "service", "e2e-good-router-router-proxy",
+					"-n", mrTestNs, "-o", "jsonpath={.spec.ports[0].port}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("8080"))
+			}
+			Eventually(verifyService, 1*time.Minute).Should(Succeed())
+
+			By("verifying the proxy Deployment exists with the config hash annotation")
+			verifyDeployment := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "deployment", "e2e-good-router-router-proxy",
+					"-n", mrTestNs, "-o",
+					`jsonpath={.spec.template.metadata.annotations.inference\.llmkube\.dev/router-config-hash}`)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(),
+					"Deployment must carry the config hash annotation that triggers rollout")
+
+				cmd = exec.Command("kubectl", "get", "deployment", "e2e-good-router-router-proxy",
+					"-n", mrTestNs, "-o",
+					`jsonpath={.spec.template.spec.containers[0].image}`)
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "Deployment container must have an image set")
+			}
+			Eventually(verifyDeployment, 1*time.Minute).Should(Succeed())
 		})
 
 		It("should report Validated=False for a sensitive-data rule routing to cloud", func() {
@@ -799,7 +872,7 @@ spec:
 			Eventually(verifyInvalid, 1*time.Minute).Should(Succeed())
 		})
 
-		It("should clean up ModelRouter resources on deletion", func() {
+		It("should clean up ModelRouter resources and child resources on deletion", func() {
 			By("deleting both test ModelRouters")
 			cmd := exec.Command("kubectl", "delete", "modelrouter", "e2e-good-router", "e2e-bad-router",
 				"-n", mrTestNs, "--ignore-not-found")
@@ -807,14 +880,28 @@ spec:
 			Expect(err).NotTo(HaveOccurred(), "Failed to delete ModelRouters")
 
 			By("verifying both ModelRouters are gone")
-			verifyGone := func(g Gomega) {
+			verifyMRGone := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "modelrouters", "-n", mrTestNs,
 					"-o", "jsonpath={.items[*].metadata.name}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(BeEmpty())
 			}
-			Eventually(verifyGone, 30*time.Second).Should(Succeed())
+			Eventually(verifyMRGone, 30*time.Second).Should(Succeed())
+
+			By("verifying owner-ref GC removed the child Deployment, Service, and ConfigMap")
+			verifyChildrenGone := func(g Gomega) {
+				for _, kind := range []string{"deployment", "service", "configmap"} {
+					cmd := exec.Command("kubectl", "get", kind, "e2e-good-router-router-proxy",
+						"-n", mrTestNs, "--ignore-not-found",
+						"-o", "jsonpath={.metadata.name}")
+					output, err := utils.Run(cmd)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(output).To(BeEmpty(),
+						"child %s should be garbage-collected after ModelRouter deletion", kind)
+				}
+			}
+			Eventually(verifyChildrenGone, 1*time.Minute).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
## Summary

Wires the `ModelRouterReconciler` to produce a complete data plane. Applying a `ModelRouter` now produces an owner-referenced `ConfigMap` (compiled routing config), `Deployment` (running the router-proxy from #427), and `Service` (in front of the proxy pods). Status surfaces the endpoint URL, per-backend health, and phase transitions across Provisioning / Ready / Degraded / Failed.

Closes #428.

## Reconcile flow

```
                         +-- Validated=False  -> Phase=Failed
validateModelRouter -----+
                         +-> compileRouterConfig
                              |
                              +-- compile error -> Phase=Failed (Available=False, Reason=CompileFailed)
                              |
                              +-> reconcileRouterConfigMap
                                  reconcileRouterDeployment
                                  reconcileRouterService
                                  |
                                  +-- any child error -> Phase=Failed (Reason=ReconcileFailed)
                                  |
                                  +-> fetchDeploymentReadiness
                                       |
                                       +-- ready + all backends healthy -> Phase=Ready
                                       +-- ready + some backends unhealthy -> Phase=Degraded
                                       +-- not yet ready -> Phase=Provisioning
```

## What's in the config

`compileRouterConfig` resolves every spec backend into the proxy's wire shape:
- **Local backends** (`inferenceServiceRef`): look up the InferenceService and build `http://<name>.<ns>.svc.cluster.local:<port>`.
- **External backends**: pass through `URL`, `Provider`, `Model`. Map provider to a well-known credentials env var name (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `LITELLM_MASTER_KEY`, `AWS_ACCESS_KEY_ID`, `GOOGLE_APPLICATION_CREDENTIALS`).
- **Per-backend errors** (missing InferenceService, missing Secret key) surface as `Status.Backends[*].Healthy=false` with a message, rather than failing the whole compile. The proxy treats unhealthy backends as skip-during-dispatch.

The compiled JSON is content-hashed; the hash lands on the Deployment pod template annotation `inference.llmkube.dev/router-config-hash`, which triggers a rollout whenever the ConfigMap content changes.

## Deployment shape

- Image: `--router-proxy-image` flag, overridable per ModelRouter via `spec.proxy.image`.
- Args: `--config /etc/llmkube/router/config.json --listen :8080 --log-format json`
- Security context: non-root (UID 65532), read-only rootfs, drop ALL caps, RuntimeDefault seccomp.
- envFrom: every cloud-backend `credentialsSecretRef` is mounted (optional=true so the pod schedules even when a referenced Secret is missing; the proxy reports the backend unhealthy until the Secret is created).
- Liveness / readiness probes against `/health`.

## Service shape

ClusterIP by default with selector label `inference.llmkube.dev/model-router=<name>`. `spec.endpoint.type` upgrades to NodePort or LoadBalancer.

## RBAC

| Path | Change |
|---|---|
| `config/rbac/role.yaml` | Regenerated by `make manifests`. Adds `configmaps` (full verbs), `secrets` (read-only). |
| `charts/llmkube/templates/clusterrole.yaml` | Hand-mirrored so `helm upgrade` users get the same verbs (the #445 fix carried forward). |

## Tests

**Unit (`internal/controller/router_builders_test.go`, 11 tests):**

- `TestCompileRouterConfigResolvesLocalBackend`: end-to-end resolve happy path with seeded InferenceService and Secret.
- `TestCompileRouterConfigMissingInferenceService`: surfaces the missing-backend case as a Healthy=false BackendStatus.
- `TestCompileRouterConfigMissingSecretKey`: cloud backend with wrong key in Secret reports Healthy=false; local backend still resolves cleanly.
- `TestRouterDeploymentBuilder`: pins the Deployment contract (image, config-hash annotation, mount path, security context, envFrom).
- `TestRouterDeploymentBuilderRespectsOverrides`: `spec.proxy.replicas` and `spec.proxy.image` win over flag defaults.
- `TestRouterServiceBuilder` + `TestRouterServiceBuilderUpgradesType`: ClusterIP default and LoadBalancer override.
- `TestRouterProxyEndpointURL`: canonical endpoint shape and override.
- `TestSummarizeBackends` (3 subtests): condition message generation for `BackendsReady`.

**E2E (`test/e2e/e2e_test.go`, expanded ModelRouter Reconciliation context):**

- `BeforeAll` seeds a stub `Model` + `InferenceService` and an `anthropic-key` Secret so backend resolution succeeds in the kind cluster.
- New `It("should reconcile a ModelRouter to a populated endpoint and child resources")` asserts:
  - `status.conditions[type=Validated].status == True`
  - `status.endpoint` matches the canonical URL shape
  - `ConfigMap` exists with compiled `config.json` containing all backend / rule names
  - `Service` exists with port 8080
  - `Deployment` exists with the config-hash annotation and a non-empty image
- Cleanup test extended to verify owner-ref GC removes the child Deployment, Service, and ConfigMap when the ModelRouter is deleted.
- The fail-closed validation case from #445 is preserved unchanged.

## What CI exercises

The kind e2e cluster doesn't side-load the router-proxy image, so proxy pods will be in `ImagePullBackOff`. The assertions are deliberately Pod-readiness-independent: they verify the controller produces correct shapes (ConfigMap content, Deployment annotations, Service ports, owner refs), not that proxy traffic actually flows. End-to-end traffic through the proxy lands later:

- #429 wires external providers fully through the controller
- #432 adds weighted / shadow routing strategies that make the in-cluster proxy traffic test meaningful
- #441 layers MCP and the inline classifier

Until then, the **binary smoke test in `cmd/router-proxy/main_integration_test.go`** (added in #446) verifies the proxy itself works against a fake upstream, and these e2e tests verify the controller emits the right shape into the cluster. Together they cover both ends of the wire contract.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/controller/...` clean (pre-existing runtime_vllm_test.go warnings unrelated)
- [x] All 38 controller + 27 router unit tests pass locally
- [x] E2E builds clean with `go build -tags e2e ./test/e2e/...`
- [x] Kind e2e in CI exercises the new assertions

## Out of scope

- External provider request flow end-to-end (proxy already handles it; needs real credentials and live upstreams to verify, deferred to #429).
- Weighted / shadow routing strategies in the data path: **#432**
- Prometheus metrics + OTel spans for the controller: **#433**
- Budgets + audit-log sinks beyond stdout: **#434**
- Helm chart packaging of the router-proxy image, sample manifest, concept doc: **#439**