### PR TITLE
feat: Helm packaging, sample manifest, and concept doc for ModelRouter

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -240,6 +240,46 @@ jobs:
           fi
           echo "✅ Custom alert thresholds work correctly"
 
+      - name: Test ModelRouter image flag flows from values.yaml to controller args
+        run: |
+          # Default values: --router-proxy-image should be present and resolve
+          # to the default repository at the chart-shipped tag.
+          helm template llmkube charts/llmkube \
+            --namespace llmkube-system \
+            > /tmp/default-routerproxy.yaml
+
+          if ! grep -q "router-proxy-image=ghcr.io/defilantech/llmkube-router-proxy:" /tmp/default-routerproxy.yaml; then
+            echo "❌ --router-proxy-image flag missing from controller args under default values"
+            exit 1
+          fi
+          echo "✅ default router-proxy image flag renders correctly"
+
+          # User override: setting routerProxy.repository and .tag should
+          # flow through end-to-end into the controller --router-proxy-image flag.
+          helm template llmkube charts/llmkube \
+            --namespace llmkube-system \
+            --set controllerManager.routerProxy.repository=registry.internal/router-proxy \
+            --set controllerManager.routerProxy.tag=v1.2.3 \
+            > /tmp/override-routerproxy.yaml
+
+          if ! grep -q "router-proxy-image=registry.internal/router-proxy:v1.2.3" /tmp/override-routerproxy.yaml; then
+            echo "❌ routerProxy.repository / .tag override did not propagate to controller flag"
+            exit 1
+          fi
+          echo "✅ router-proxy image override renders correctly"
+
+          # Digest override: digest takes precedence over tag.
+          helm template llmkube charts/llmkube \
+            --namespace llmkube-system \
+            --set controllerManager.routerProxy.digest=sha256:abcdef1234567890 \
+            > /tmp/digest-routerproxy.yaml
+
+          if ! grep -q "router-proxy-image=ghcr.io/defilantech/llmkube-router-proxy@sha256:abcdef1234567890" /tmp/digest-routerproxy.yaml; then
+            echo "❌ routerProxy.digest override did not propagate to controller flag"
+            exit 1
+          fi
+          echo "✅ router-proxy digest override renders correctly"
+
   network-policy:
     name: Test NetworkPolicy
     runs-on: ubuntu-latest

--- a/charts/llmkube/templates/_helpers.tpl
+++ b/charts/llmkube/templates/_helpers.tpl
@@ -90,6 +90,24 @@ Supports optional registry prefix.
 {{- end }}
 
 {{/*
+Create the router-proxy image used as the default for ModelRouter-managed
+proxy pods. Per-ModelRouter spec.proxy.image overrides this. Same digest /
+tag resolution rules as the controller image.
+*/}}
+{{- define "llmkube.routerProxyImage" -}}
+{{- $repo := .Values.controllerManager.routerProxy.repository -}}
+{{- if .Values.controllerManager.routerProxy.registry -}}
+{{- $repo = printf "%s/%s" .Values.controllerManager.routerProxy.registry .Values.controllerManager.routerProxy.repository -}}
+{{- end -}}
+{{- if .Values.controllerManager.routerProxy.digest -}}
+{{- printf "%s@%s" $repo .Values.controllerManager.routerProxy.digest -}}
+{{- else -}}
+{{- $tag := .Values.controllerManager.routerProxy.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the namespace
 */}}
 {{- define "llmkube.namespace" -}}

--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
         # re-replace the OpenShift preset's deliberate 0 with 102 and break
         # SCC compatibility. Schema in values.schema.json enforces integer >= 0.
         - --default-fsgroup={{ .Values.controllerManager.initContainer.defaultFSGroup }}
+        - --router-proxy-image={{ include "llmkube.routerProxyImage" . }}
         ports:
         - name: health
           containerPort: 8081

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -108,6 +108,21 @@
             },
             "additionalProperties": true
           }
+        },
+        "routerProxy": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Default container image for ModelRouter-managed router-proxy pods. Per-ModelRouter spec.proxy.image overrides this.",
+          "properties": {
+            "registry": { "type": "string" },
+            "repository": { "type": "string", "minLength": 1 },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            },
+            "tag": { "type": "string" },
+            "digest": { "type": "string" }
+          }
         }
       }
     },

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -93,6 +93,41 @@ controllerManager:
   # Additional environment variables
   env: []
 
+  # Default container image for ModelRouter-managed router-proxy pods.
+  # Per-ModelRouter spec.proxy.image overrides this for individual routers.
+  # The router-proxy is a lightweight HTTP server that fronts
+  # InferenceServices and external provider backends, speaks
+  # OpenAI chat completions, and enforces policy routing.
+  #
+  # IMPORTANT (Phase 1 alpha): the release pipeline does not yet build
+  # and push the router-proxy image alongside the controller image.
+  # The default tag below is "dev" rather than the chart appVersion so
+  # users who never create a ModelRouter resource are unaffected, and
+  # users who do create one know they need to either:
+  #
+  #   1. Build the image locally (`make docker-build-router-proxy`)
+  #      and push it to a registry their cluster can reach, then
+  #      override repository / tag here.
+  #   2. Override `spec.proxy.image` per ModelRouter with their own
+  #      build.
+  #
+  # See https://github.com/defilantech/LLMKube/issues/449 for the
+  # tracking issue on integrating the router-proxy image into the
+  # release flow.
+  routerProxy:
+    # Registry prefix for the router-proxy image (mirrors controller image).
+    # Useful for air-gapped or enterprise proxy registries.
+    registry: ""
+    repository: ghcr.io/defilantech/llmkube-router-proxy
+    pullPolicy: IfNotPresent
+    # Default tag. "dev" is intentional until the release pipeline
+    # ships versioned router-proxy images alongside the controller.
+    tag: "dev"
+    # Image digest (sha256:...) - takes precedence over tag when set.
+    # Use digests for production deployments once the release pipeline
+    # publishes them.
+    digest: ""
+
 # Service account configuration
 serviceAccount:
   # Specifies whether a service account should be created

--- a/config/samples/inference_v1alpha1_modelrouter.yaml
+++ b/config/samples/inference_v1alpha1_modelrouter.yaml
@@ -1,0 +1,113 @@
+# Sample ModelRouter that exposes a single OpenAI-compatible endpoint
+# fronting a local InferenceService and an external Anthropic backend.
+#
+# This sample shows the three things that make ModelRouter useful for
+# regulated-industry enterprise adopters:
+#
+#   1. Per-rule routing by data classification, task complexity, and
+#      capabilities.
+#   2. The fail-closed gate: sensitive-data requests can only ever
+#      reach local backends, regardless of upstream availability.
+#   3. Composition with LiteLLM-style cloud-provider abstraction via a
+#      single Secret per credential.
+#
+# Apply order:
+#   1. Create the InferenceService that local-qwen references.
+#   2. Create the Secret with your Anthropic API key.
+#   3. kubectl apply -f this file.
+#
+# Verify:
+#   kubectl describe modelrouter coding-router
+#   kubectl get configmap coding-router-router-proxy -o yaml
+#   curl -X POST http://coding-router-router-proxy.<ns>.svc.cluster.local:8080/v1/chat/completions \
+#     -H 'Content-Type: application/json' \
+#     -d '{"model":"any","messages":[{"role":"user","content":"hello"}]}'
+---
+# Stub Secret. Replace the placeholder with a real ANTHROPIC_API_KEY before
+# applying, or omit the cloud-opus backend entirely until you have one.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: anthropic-key
+type: Opaque
+stringData:
+  ANTHROPIC_API_KEY: "REPLACE_WITH_YOUR_ANTHROPIC_API_KEY"
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata:
+  name: coding-router
+spec:
+  backends:
+    # Local InferenceService. The controller resolves this to its
+    # cluster URL automatically. The named InferenceService must exist
+    # in the same namespace.
+    - name: local-qwen
+      tier: local
+      inferenceServiceRef:
+        name: qwen3-coder
+      capabilities:
+        - code
+        - tools
+
+    # External Anthropic backend. The controller looks up the named
+    # Secret and injects ANTHROPIC_API_KEY into the router-proxy pod;
+    # the proxy reads it at request time and adds the right
+    # provider-specific auth header (x-api-key + anthropic-version for
+    # Anthropic).
+    - name: cloud-opus
+      tier: cloud
+      external:
+        provider: anthropic
+        model: claude-opus-4-7
+        url: https://api.anthropic.com
+        credentialsSecretRef:
+          name: anthropic-key
+      capabilities:
+        - code
+        - vision
+        - long-context
+
+  rules:
+    # The regulated-data gate. Any request carrying
+    # x-llmkube-classification: pii (or x-llmkube-classification: phi)
+    # routes ONLY to the local backend, with failClosed=true. If the
+    # local backend is unhealthy or scaled to zero, the router returns
+    # HTTP 503 rather than falling through. Sensitive data never
+    # leaves the cluster.
+    - name: pii-stays-local
+      match:
+        dataClassification: ["pii", "phi"]
+      route:
+        backends: ["local-qwen"]
+      failClosed: true
+
+    # Hard problems get the cloud model first, with the local backend
+    # as fallback. Header: x-llmkube-task-complexity: complex
+    - name: complex-to-cloud
+      match:
+        taskComplexity: complex
+      route:
+        backends: ["cloud-opus", "local-qwen"]
+        strategy: primary-fallback
+
+  # Catch-all when no rule fires. Most traffic should land here.
+  defaultRoute: local-qwen
+
+  policy:
+    classification:
+      # MVP supports header-only mode. The bundled detector (regex +
+      # optional NER) lands with the classifier feature.
+      mode: header-only
+      headerKey: x-llmkube-classification
+      # Override the default sensitive set ({pii, phi}) if your
+      # organization classifies data differently.
+      sensitiveClassifications: ["pii", "phi"]
+    auditLog:
+      sink: stdout
+
+  # Optional: per-ModelRouter overrides for the managed proxy
+  # Deployment. Omit the block entirely to use the controller defaults.
+  proxy:
+    replicas: 1
+    # image: registry.internal/llmkube-router-proxy:v0.8.0

--- a/docs/site/_meta/nav.yaml
+++ b/docs/site/_meta/nav.yaml
@@ -43,6 +43,9 @@ sections:
         slug: concepts/runtime-backends
         file: concepts/runtime-backends.md
         status: stub
+      - label: Model Router
+        slug: concepts/model-router
+        file: concepts/model-router.md
       - label: How LLMKube compares
         slug: concepts/comparison
         file: concepts/comparison.md

--- a/docs/site/concepts/comparison.md
+++ b/docs/site/concepts/comparison.md
@@ -1,12 +1,12 @@
 ---
 title: How LLMKube compares
 description: Honest comparison of LLMKube against KubeAI, llm-d, Ollama, and NVIDIA NIM. Where each one fits and where they don't.
-updated: 2026-05-12
+updated: 2026-05-03
 ---
 
 # How LLMKube compares
 
-LLMKube is the only Kubernetes operator we've found that combines two things: native Apple Silicon processes alongside Linux GPU pods (with per-process memory-pressure protection built in), and a [policy-aware hybrid routing layer](/docs/concepts/model-router) that lets agents transparently hand off between local and cloud models under fail-closed compliance controls. For everything else listed below, another project on this page is the better choice.
+LLMKube is the only Kubernetes operator we've found that runs native Apple Silicon processes alongside Linux GPU pods, with per-process memory-pressure protection built in. For everything else listed below, another project on this page is the better choice.
 
 <DocCallout variant="note" title="Read this first">
 
@@ -24,13 +24,13 @@ Honest comparison, not a sales pitch. We use vLLM, llama.cpp, and TGI as runtime
 
 ## Capability matrix
 
-| Project | K8s-native | Apple Silicon | Memory-pressure protection | Engines | Multi-GPU | Hybrid routing | License |
-|---|---|---|---|---|---|---|---|
-| **LLMKube** | ✓ operator + Model, InferenceService, ModelRouter CRDs | ✓ native via the metal-agent (no containers) | ✓ watchdog, priority-based eviction, per-service opt-out | llama.cpp, vLLM, TGI, oMLX, Ollama | Layer-based sharding across GPUs on a node | ✓ [ModelRouter](/docs/concepts/model-router): local + cloud handoff with fail-closed for regulated data | Apache 2.0 |
-| **KubeAI** | ✓ operator + Model CRD | — Linux containers only | — | vLLM, Ollama, Faster-Whisper, Infinity (embeddings) | Multi-GPU pods via `resourceProfile`, tensor-parallel args passed to vLLM | — local intra-cluster only via Model Proxy | Apache 2.0 |
-| **llm-d** | ✓ Helm + Gateway API + `InferencePool` | — datacenter accelerators only (NVIDIA, AMD, Intel, TPU) | — | vLLM (primary), SGLang | Wide expert parallelism + disaggregated multi-node serving | — vLLM-focused, single-engine | Apache 2.0 |
-| **Ollama** | — single binary on a host | ✓ native (its sweet spot) | — | Forked llama.cpp (GGUF), MLX engine (Safetensors, macOS) | Automatic spreading across GPUs on one node | — single-node | MIT |
-| **NVIDIA NIM Operator** | ✓ CRDs + Helm + KServe integration | — | — | TensorRT-LLM (primary), vLLM (select models), Triton serving | Tensor parallelism via TRT-LLM, multi-node via the Operator | — | Operator: Apache 2.0. Runtime: NVIDIA AI Enterprise (free cloud tier on build.nvidia.com) |
+| Project | K8s-native | Apple Silicon | Memory-pressure protection | Engines | Multi-GPU | License |
+|---|---|---|---|---|---|---|
+| **LLMKube** | ✓ operator + Model and InferenceService CRDs | ✓ native via the metal-agent (no containers) | ✓ watchdog, priority-based eviction, per-service opt-out | llama.cpp, vLLM, TGI, oMLX, Ollama | Layer-based sharding across GPUs on a node | Apache 2.0 |
+| **KubeAI** | ✓ operator + Model CRD | — Linux containers only | — | vLLM, Ollama, Faster-Whisper, Infinity (embeddings) | Multi-GPU pods via `resourceProfile`, tensor-parallel args passed to vLLM | Apache 2.0 |
+| **llm-d** | ✓ Helm + Gateway API + `InferencePool` | — datacenter accelerators only (NVIDIA, AMD, Intel, TPU) | — | vLLM (primary), SGLang | Wide expert parallelism + disaggregated multi-node serving | Apache 2.0 |
+| **Ollama** | — single binary on a host | ✓ native (its sweet spot) | — | Forked llama.cpp (GGUF), MLX engine (Safetensors, macOS) | Automatic spreading across GPUs on one node | MIT |
+| **NVIDIA NIM Operator** | ✓ CRDs + Helm + KServe integration | — | — | TensorRT-LLM (primary), vLLM (select models), Triton serving | Tensor parallelism via TRT-LLM, multi-node via the Operator | Operator: Apache 2.0. Runtime: NVIDIA AI Enterprise (free cloud tier on build.nvidia.com) |
 
 Verified against project repos and official docs. If you spot anything inaccurate, please [open an issue](https://github.com/defilantech/LLMKube/issues/new?title=Comparison+page+correction).
 

--- a/docs/site/concepts/comparison.md
+++ b/docs/site/concepts/comparison.md
@@ -1,12 +1,12 @@
 ---
 title: How LLMKube compares
 description: Honest comparison of LLMKube against KubeAI, llm-d, Ollama, and NVIDIA NIM. Where each one fits and where they don't.
-updated: 2026-05-03
+updated: 2026-05-12
 ---
 
 # How LLMKube compares
 
-LLMKube is the only Kubernetes operator we've found that runs native Apple Silicon processes alongside Linux GPU pods, with per-process memory-pressure protection built in. For everything else listed below, another project on this page is the better choice.
+LLMKube is the only Kubernetes operator we've found that combines two things: native Apple Silicon processes alongside Linux GPU pods (with per-process memory-pressure protection built in), and a [policy-aware hybrid routing layer](/docs/concepts/model-router) that lets agents transparently hand off between local and cloud models under fail-closed compliance controls. For everything else listed below, another project on this page is the better choice.
 
 <DocCallout variant="note" title="Read this first">
 
@@ -24,13 +24,13 @@ Honest comparison, not a sales pitch. We use vLLM, llama.cpp, and TGI as runtime
 
 ## Capability matrix
 
-| Project | K8s-native | Apple Silicon | Memory-pressure protection | Engines | Multi-GPU | License |
-|---|---|---|---|---|---|---|
-| **LLMKube** | ✓ operator + Model and InferenceService CRDs | ✓ native via the metal-agent (no containers) | ✓ watchdog, priority-based eviction, per-service opt-out | llama.cpp, vLLM, TGI, oMLX, Ollama | Layer-based sharding across GPUs on a node | Apache 2.0 |
-| **KubeAI** | ✓ operator + Model CRD | — Linux containers only | — | vLLM, Ollama, Faster-Whisper, Infinity (embeddings) | Multi-GPU pods via `resourceProfile`, tensor-parallel args passed to vLLM | Apache 2.0 |
-| **llm-d** | ✓ Helm + Gateway API + `InferencePool` | — datacenter accelerators only (NVIDIA, AMD, Intel, TPU) | — | vLLM (primary), SGLang | Wide expert parallelism + disaggregated multi-node serving | Apache 2.0 |
-| **Ollama** | — single binary on a host | ✓ native (its sweet spot) | — | Forked llama.cpp (GGUF), MLX engine (Safetensors, macOS) | Automatic spreading across GPUs on one node | MIT |
-| **NVIDIA NIM Operator** | ✓ CRDs + Helm + KServe integration | — | — | TensorRT-LLM (primary), vLLM (select models), Triton serving | Tensor parallelism via TRT-LLM, multi-node via the Operator | Operator: Apache 2.0. Runtime: NVIDIA AI Enterprise (free cloud tier on build.nvidia.com) |
+| Project | K8s-native | Apple Silicon | Memory-pressure protection | Engines | Multi-GPU | Hybrid routing | License |
+|---|---|---|---|---|---|---|---|
+| **LLMKube** | ✓ operator + Model, InferenceService, ModelRouter CRDs | ✓ native via the metal-agent (no containers) | ✓ watchdog, priority-based eviction, per-service opt-out | llama.cpp, vLLM, TGI, oMLX, Ollama | Layer-based sharding across GPUs on a node | ✓ [ModelRouter](/docs/concepts/model-router): local + cloud handoff with fail-closed for regulated data | Apache 2.0 |
+| **KubeAI** | ✓ operator + Model CRD | — Linux containers only | — | vLLM, Ollama, Faster-Whisper, Infinity (embeddings) | Multi-GPU pods via `resourceProfile`, tensor-parallel args passed to vLLM | — local intra-cluster only via Model Proxy | Apache 2.0 |
+| **llm-d** | ✓ Helm + Gateway API + `InferencePool` | — datacenter accelerators only (NVIDIA, AMD, Intel, TPU) | — | vLLM (primary), SGLang | Wide expert parallelism + disaggregated multi-node serving | — vLLM-focused, single-engine | Apache 2.0 |
+| **Ollama** | — single binary on a host | ✓ native (its sweet spot) | — | Forked llama.cpp (GGUF), MLX engine (Safetensors, macOS) | Automatic spreading across GPUs on one node | — single-node | MIT |
+| **NVIDIA NIM Operator** | ✓ CRDs + Helm + KServe integration | — | — | TensorRT-LLM (primary), vLLM (select models), Triton serving | Tensor parallelism via TRT-LLM, multi-node via the Operator | — | Operator: Apache 2.0. Runtime: NVIDIA AI Enterprise (free cloud tier on build.nvidia.com) |
 
 Verified against project repos and official docs. If you spot anything inaccurate, please [open an issue](https://github.com/defilantech/LLMKube/issues/new?title=Comparison+page+correction).
 

--- a/docs/site/concepts/model-router.md
+++ b/docs/site/concepts/model-router.md
@@ -20,7 +20,7 @@ ModelRouter is **alpha** as of LLMKube 0.8. The CRD lives in `inference.llmkube.
 
 </DocCallout>
 
-<DocCallout variant="warning" title="Router-proxy image not yet in the release pipeline">
+<DocCallout variant="warn" title="Router-proxy image not yet in the release pipeline">
 
 The release pipeline currently builds and publishes the controller image (`ghcr.io/defilantech/llmkube-controller`) on every release. The router-proxy image (`ghcr.io/defilantech/llmkube-router-proxy`) is not yet built by CI: see [issue #449](https://github.com/defilantech/LLMKube/issues/449).
 

--- a/docs/site/concepts/model-router.md
+++ b/docs/site/concepts/model-router.md
@@ -1,0 +1,219 @@
+---
+title: Model Router
+description: A single OpenAI-compatible endpoint that routes across local InferenceServices and external providers (Anthropic, OpenAI, LiteLLM) with policy-driven handoff, fail-closed semantics for regulated data, and audit log per request.
+updated: 2026-05-12
+---
+
+# Model Router
+
+The `ModelRouter` CRD exposes a single OpenAI-compatible HTTP endpoint that dispatches requests across multiple backends:
+
+- Local `InferenceService` instances managed by LLMKube
+- External providers (Anthropic, OpenAI) called directly
+- A LiteLLM proxy that aggregates many providers behind one URL
+
+It is the **cross-engine handoff layer** for agentic chains: an agent running against a local model can transparently call out to a cloud model for specific steps, governed by declarative policy that enforces data classification, cost, and capability constraints.
+
+<DocCallout variant="note" title="Status">
+
+ModelRouter is **alpha** as of LLMKube 0.8. The CRD lives in `inference.llmkube.dev/v1alpha1`. The wire shape may evolve before v1beta1.
+
+</DocCallout>
+
+<DocCallout variant="warning" title="Router-proxy image not yet in the release pipeline">
+
+The release pipeline currently builds and publishes the controller image (`ghcr.io/defilantech/llmkube-controller`) on every release. The router-proxy image (`ghcr.io/defilantech/llmkube-router-proxy`) is not yet built by CI: see [issue #449](https://github.com/defilantech/LLMKube/issues/449).
+
+The Helm chart's default for `controllerManager.routerProxy.tag` is `"dev"` until that lands. Users who want to deploy a ModelRouter today have two options:
+
+1. **Build locally and push.** Run `make docker-build-router-proxy ROUTER_PROXY_IMG=<your-registry>/llmkube-router-proxy:dev`, push it, then `--set controllerManager.routerProxy.repository=<your-registry>/llmkube-router-proxy` on the Helm install.
+2. **Override per ModelRouter.** Set `spec.proxy.image` on each ModelRouter to an image your cluster can pull.
+
+Users who never create a ModelRouter resource are unaffected.
+
+</DocCallout>
+
+## Why this exists
+
+LLMs are increasingly composed: an agent does some work on a fast local model, hands off a hard step to a frontier cloud model, then comes back. Every team building this hits the same three problems:
+
+1. **The agent code wants one endpoint**, not a dispatch tree. Agent runtimes (LangGraph, CrewAI, OpenAI Agents SDK, Anthropic Agent SDK) all consume a single OpenAI-compatible URL.
+2. **Routing policy belongs in the platform**, not the agent. Compliance teams need to know that PII can't egress; finance teams need cost caps; SRE teams need fallback on local outage. None of that should live in Python at the agent level.
+3. **The choice between local and cloud changes**. Today's local model handles 80% of requests; tomorrow's handles 95%. The agent shouldn't have to change.
+
+`ModelRouter` solves all three by sitting in the data path as a small managed HTTP proxy with declarative routing rules.
+
+## Architecture
+
+```
+   +-------------+
+   | Agent / App |
+   +------+------+
+          |  OpenAI-compatible API
+          v
+   +----------------------------------------------------+
+   |  router-proxy Deployment (controller-managed)      |
+   |  - reads compiled config from a mounted ConfigMap  |
+   |  - matches each request against ordered rules      |
+   |  - enforces the fail-closed gate                   |
+   |  - streams responses (SSE / chunked) with no buffer|
+   |  - emits one audit-log line per request            |
+   +-----+----------------------+-----------------------+
+         |                      |
+         v                      v
+   +-----------+         +-------------------------+
+   | local     |         | external provider       |
+   | Inference |         | (Anthropic / OpenAI /   |
+   | Service   |         |  LiteLLM passthrough)   |
+   +-----------+         +-------------------------+
+```
+
+The controller compiles `ModelRouter.spec` into a JSON config, writes it to a `ConfigMap`, and reconciles a `Deployment` plus `Service` that mounts the ConfigMap and runs the [router-proxy binary](https://github.com/defilantech/LLMKube/blob/main/cmd/router-proxy). The ConfigMap content is hashed and the hash lands on the pod template annotation, so any spec change triggers a clean rollout.
+
+## The fail-closed gate
+
+The headline differentiator. A rule that matches sensitive classifications (default: `pii`, `phi`) and is marked `failClosed: true` has two guarantees:
+
+1. **Cannot reference cloud-tier backends.** The controller rejects the manifest at `kubectl apply` if it tries to. This is the static half of the gate.
+2. **Refuses rather than falls through.** At request time, if every backend in the route is unhealthy, the proxy returns HTTP 503 and emits an audit-log denial. It does **not** fall through to other rules or to `defaultRoute`. Sensitive data never leaves the cluster, even on outage.
+
+This is the property regulated industries (healthcare, finance, defense, manufacturing) need to adopt local LLM inference at all.
+
+## Minimal example
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata:
+  name: coding-router
+spec:
+  backends:
+    - name: local-qwen
+      tier: local
+      inferenceServiceRef:
+        name: qwen3-coder
+    - name: cloud-opus
+      tier: cloud
+      external:
+        provider: anthropic
+        model: claude-opus-4-7
+        url: https://api.anthropic.com
+        credentialsSecretRef:
+          name: anthropic-key
+
+  rules:
+    - name: pii-stays-local
+      match:
+        dataClassification: ["pii", "phi"]
+      route:
+        backends: ["local-qwen"]
+      failClosed: true
+
+    - name: complex-to-cloud
+      match:
+        taskComplexity: complex
+      route:
+        backends: ["cloud-opus", "local-qwen"]
+        strategy: primary-fallback
+
+  defaultRoute: local-qwen
+```
+
+After `kubectl apply`:
+
+- `kubectl describe modelrouter coding-router` shows the status conditions and per-backend health.
+- `kubectl get configmap coding-router-router-proxy` contains the compiled JSON config.
+- The endpoint is `http://coding-router-router-proxy.<namespace>.svc.cluster.local:8080/v1/chat/completions`.
+
+Point any OpenAI-compatible client at that URL and it just works. Headers that change routing:
+
+| Header | Effect |
+|---|---|
+| `x-llmkube-classification: pii` | Matches `pii-stays-local` rule; local-only, fail-closed. |
+| `x-llmkube-task-complexity: complex` | Matches `complex-to-cloud` rule; tries Opus first, falls back to Qwen on 5xx. |
+| (no headers) | Falls through to `defaultRoute: local-qwen`. |
+
+## Composition with LiteLLM
+
+LLMKube does not replace [LiteLLM](https://github.com/BerriAI/litellm). For organizations already running a LiteLLM proxy as their cloud-provider abstraction, point a `ModelRouter` external backend at it:
+
+```yaml
+- name: anything-via-litellm
+  tier: cloud
+  external:
+    provider: litellm
+    url: http://foundation-router.gateway.svc.cluster.local:4000
+    model: openrouter/anthropic/claude-opus-4-7
+    credentialsSecretRef:
+      name: litellm-master-key
+```
+
+LiteLLM handles provider auth, retries, and cost tracking. ModelRouter adds K8s-native policy, fail-closed enforcement, and audit logs.
+
+## What's in scope, what isn't
+
+**In scope:**
+
+- Routing rules: data classification, task complexity, required capabilities, model glob, header match
+- Strategies: primary-fallback (MVP), weighted and shadow (roadmap)
+- Fail-closed gate, both static (apply-time) and runtime
+- OpenAI-compatible request / response, including streaming SSE
+- Structured audit log to stdout (other sinks roadmap)
+- Per-route budget caps (roadmap)
+- MCP server endpoint (roadmap)
+
+**Out of scope:**
+
+- The agent runtime itself. ModelRouter is consumed *by* LangGraph, CrewAI, OpenAI Agents SDK, Anthropic Agent SDK, Cline, OpenCode, Aider, and any other framework that speaks the OpenAI API. We don't reinvent that layer.
+- Inference engines. `InferenceService` already wraps llama.cpp, vLLM, TGI, oMLX. ModelRouter sits *above* them.
+- General-purpose K8s gateway. ModelRouter is scoped specifically to LLM traffic with policy.
+
+## Comparison to alternatives
+
+| | ModelRouter | LiteLLM proxy | KubeAI Model Proxy | llm-d Inference Gateway |
+|---|---|---|---|---|
+| **K8s-native CRD** | ✓ | — (Helm chart, no CRD) | ✓ (limited) | ✓ (Gateway API extension) |
+| **Cross-engine handoff (local + cloud)** | ✓ | ✓ (cloud only) | — (local intra-cluster only) | — (vLLM-focused) |
+| **Fail-closed for sensitive data** | ✓ (static + runtime) | — | — | — |
+| **Audit log per request** | ✓ | partial | — | partial |
+| **Composes with LiteLLM** | ✓ (as a backend) | n/a | — | — |
+
+The three peers all solve adjacent but different problems. ModelRouter's specific niche is **policy-aware hybrid routing for regulated-industry adoption**: the place where "I run my own AI" meets "I sometimes need to call Opus" meets "compliance must be enforceable."
+
+## Status surface
+
+After a successful reconcile, `status` on a ModelRouter looks like:
+
+```yaml
+status:
+  phase: Provisioning   # or Ready / Degraded / Failed
+  endpoint: http://coding-router-router-proxy.default.svc.cluster.local:8080/v1/chat/completions
+  activeRules: 2
+  backends:
+    - name: local-qwen
+      tier: local
+      address: http://qwen3-coder.default.svc.cluster.local:8080
+      healthy: true
+    - name: cloud-opus
+      tier: cloud
+      address: https://api.anthropic.com
+      healthy: true
+  conditions:
+    - type: Validated
+      status: "True"
+      reason: SpecValid
+    - type: BackendsReady
+      status: "True"
+      reason: BackendsResolved
+    - type: Available
+      status: "True"
+      reason: DeploymentReady
+```
+
+`phase` is the coarse summary; the conditions tell the full story.
+
+## Next steps
+
+- Read the [CRD reference](/docs/concepts/crds) for the full spec.
+- See [Multi-GPU sharding](/docs/guides/multi-gpu) for backing the local InferenceService with sharded GPU pods.
+- Read the [comparison page](/docs/concepts/comparison) to understand how ModelRouter fits relative to other K8s LLM operators.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -881,8 +881,10 @@ spec:
 			// testing those resolutions, just that the YAML passes server-side
 			// admission against the live CRD schema.
 			By("server-side dry-run apply of the sample ModelRouter manifest")
+			// utils.Run rewrites cmd.Dir to the project root, so the path
+			// is repo-relative, not relative to test/e2e.
 			cmd := exec.Command("kubectl", "apply",
-				"-f", "../../config/samples/inference_v1alpha1_modelrouter.yaml",
+				"-f", "config/samples/inference_v1alpha1_modelrouter.yaml",
 				"-n", mrTestNs,
 				"--dry-run=server",
 				"--validate=true")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -872,6 +872,25 @@ spec:
 			Eventually(verifyInvalid, 1*time.Minute).Should(Succeed())
 		})
 
+		It("should accept the shipped sample manifest under server-side validation", func() {
+			// Dogfood the user-facing sample at config/samples/inference_v1alpha1_modelrouter.yaml.
+			// Catches drift between the sample and the actual CRD schema (a recurring
+			// failure mode when CRD fields evolve and samples don't get updated).
+			// We use --dry-run=server because the sample references a Secret and an
+			// InferenceService that this test namespace doesn't contain; we're not
+			// testing those resolutions, just that the YAML passes server-side
+			// admission against the live CRD schema.
+			By("server-side dry-run apply of the sample ModelRouter manifest")
+			cmd := exec.Command("kubectl", "apply",
+				"-f", "../../config/samples/inference_v1alpha1_modelrouter.yaml",
+				"-n", mrTestNs,
+				"--dry-run=server",
+				"--validate=true")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "sample manifest failed server-side validation: %s", output)
+			Expect(output).To(ContainSubstring("modelrouter.inference.llmkube.dev/coding-router"))
+		})
+
 		It("should clean up ModelRouter resources and child resources on deletion", func() {
 			By("deleting both test ModelRouters")
 			cmd := exec.Command("kubectl", "delete", "modelrouter", "e2e-good-router", "e2e-bad-router",


### PR DESCRIPTION
## Summary

Adds the user-facing surface that makes ModelRouter shippable: Helm chart wiring for the proxy image, a worked sample manifest, a full concept page, plus CI assertions and an e2e step that dogfoods the sample. Closes #439.

Phase 1 of [the ModelRouter epic (#437)](https://github.com/defilantech/LLMKube/issues/437) is now feature-complete in code; the remaining e2e validation (#430 runtime fail-closed in a real cluster, #438 external-provider passthrough with a stub LiteLLM) is consolidated into a single follow-up PR.

## What's in

**Helm chart:**

- `controllerManager.routerProxy` block in `values.yaml`. Same `registry / repository / pullPolicy / tag / digest` shape as the existing `image` and `initContainer` blocks. **Default tag pinned to `"dev"`** rather than the chart appVersion, because the release pipeline does not yet publish a versioned router-proxy image (see [Known limitation](#known-limitation-router-proxy-image-not-in-release-pipeline) below).
- `llmkube.routerProxyImage` helper in `_helpers.tpl` with the same tag/digest resolution rules as `llmkube.controllerImage`.
- `--router-proxy-image=<resolved-image>` wired into the controller-manager Deployment template. The controller flag from #447 now flows through Helm.
- `values.schema.json` entry validates the new block at install / upgrade time.

**Sample manifest** (`config/samples/inference_v1alpha1_modelrouter.yaml`): full worked example, namespace-agnostic, with stub Secret, local + external backends, PII fail-closed rule, complex-to-cloud handoff, default route, and policy block. Inline comments explain each block.

**Concept doc** (`docs/site/concepts/model-router.md`): why ModelRouter exists, ASCII architecture diagram, fail-closed gate in plain language, minimal worked example, composition with LiteLLM, scope boundaries, comparison vs LiteLLM proxy / KubeAI Model Proxy / llm-d Inference Gateway, status surface anatomy, plus the "release pipeline" warning callout.

**Comparison page + nav** updated.

## CI and e2e coverage for the new wire-shape

**`.github/workflows/helm-chart.yml`** gets a new step in the Prometheus-integration job that asserts three things:
1. Default values render `--router-proxy-image=ghcr.io/defilantech/llmkube-router-proxy:<tag>` in the controller Deployment.
2. Setting `routerProxy.repository` + `routerProxy.tag` propagates end-to-end into the controller flag.
3. Setting `routerProxy.digest` takes precedence over `.tag`.

Catches future drift between `values.yaml`, the helper template, and the Deployment template.

**`test/e2e/e2e_test.go`** gets a new `It` block under "ModelRouter Reconciliation" that runs `kubectl apply --dry-run=server` against `config/samples/inference_v1alpha1_modelrouter.yaml`. This dogfoods the shipped sample against the live CRD schema and catches drift between sample and CRD (a recurring failure mode when fields evolve and samples don't get updated).

## Known limitation: router-proxy image not in release pipeline

The release pipeline currently publishes `ghcr.io/defilantech/llmkube-controller:<version>` on every tag but does not yet build the corresponding `llmkube-router-proxy:<version>`. To avoid users hitting `ImagePullBackOff` on the proxy pods, this PR pins the chart default for `controllerManager.routerProxy.tag` to `"dev"` (which lines up with `make docker-build-router-proxy` locally) rather than tracking chart appVersion.

Users have two paths until the pipeline lands:
1. `make docker-build-router-proxy ROUTER_PROXY_IMG=<your-registry>/...:dev`, push, then `--set controllerManager.routerProxy.repository=<your-registry>/...` on Helm install.
2. Override `spec.proxy.image` per ModelRouter.

**Tracking issue: [#449](https://github.com/defilantech/LLMKube/issues/449)**, with the cleanup steps (flip default back to `""`, remove the warning callout) once it ships.

## Verification

- `helm template charts/llmkube/ --set crds.install=true` renders `--router-proxy-image=ghcr.io/defilantech/llmkube-router-proxy:dev`
- `helm template ... --set controllerManager.routerProxy.tag=v1.2.3` renders the v1.2.3 tag
- `helm template ... --set controllerManager.routerProxy.digest=sha256:...` renders the digest with `@` separator
- `helm lint charts/llmkube/` clean
- `go build`, `go vet`, `go test ./...`, `golangci-lint` all clean on my changes
- e2e build clean with `-tags e2e`

## What's still missing for full Phase 1

| Issue | Remaining work |
|---|---|
| #430 fail-closed enforcement | Cluster-level e2e (static check + runtime check are both shipped) |
| #438 external providers via LiteLLM | E2E with a stub LiteLLM container in CI (controller wiring and proxy logic shipped) |
| #449 release-pipeline router-proxy build | Needs goreleaser config update |

#430 and #438 share infra (side-loaded router-proxy images in kind) and will be combined in a single follow-up PR. #449 is a separate workflow change.

## Test plan

- [x] `helm template` renders the new flag with the pinned `dev` tag by default
- [x] Override propagation tests pass in the Helm CI workflow
- [x] `helm lint` clean
- [x] Sample manifest is namespace-agnostic and `--dry-run=server` will pass in e2e
- [x] Concept page markdown lints (no em dashes, no broken anchors)
- [x] Nav entry slots under Concepts
- [x] CI runs all template-validation jobs and the new e2e step successfully
- [ ] Docs site preview renders the new page (verify in llmkube-web before merge)