### PR TITLE
feat: router-proxy cluster e2e + runtime fail-closed 503 (closes #430)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,6 +10,13 @@ jobs:
   test-e2e:
     name: Run on Ubuntu (kind, default storage)
     runs-on: ubuntu-latest
+    env:
+      # Tag the router-proxy and stub-upstream images deterministically
+      # so the BeforeSuite can both load them into kind and reference
+      # them by name when patching the operator deploy + spinning up
+      # the fake upstreams.
+      ROUTER_PROXY_IMG: ghcr.io/defilantech/llmkube-router-proxy:dev
+      STUB_UPSTREAM_IMG: localhost/llmkube-stub-upstream:e2e
     steps:
       - name: Clone the code
         uses: actions/checkout@v6
@@ -29,6 +36,13 @@ jobs:
         run: kind version
 
       - name: Running Test e2e
+        env:
+          # Opts the suite into the ModelRouter cluster Context. When
+          # set, BeforeSuite builds and side-loads router-proxy + stub
+          # upstream images into kind in addition to the controller
+          # image. Without this flag the cluster Context is skipped so
+          # the existing kind-only runs stay fast.
+          LLMKUBE_E2E_ROUTER_CLUSTER: "true"
         run: |
           go mod tidy
           make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,14 @@ docker-push-router-proxy: ## Push the router-proxy image.
 build-router-proxy: fmt vet ## Build router-proxy binary into bin/.
 	go build -o bin/router-proxy ./cmd/router-proxy
 
+# Stub upstream used by the ModelRouter cluster e2e tests to play both
+# the "local InferenceService" and "cloud provider" roles. Image is only
+# built into the kind cluster during the e2e job; not published.
+STUB_UPSTREAM_IMG ?= localhost/llmkube-stub-upstream:e2e
+.PHONY: docker-build-stub-upstream
+docker-build-stub-upstream: ## Build docker image for the e2e stub upstream.
+	$(CONTAINER_TOOL) build -f test/e2e/stubupstream/Dockerfile -t ${STUB_UPSTREAM_IMG} .
+
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
 # - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/

--- a/internal/controller/router_builders_test.go
+++ b/internal/controller/router_builders_test.go
@@ -188,6 +188,55 @@ func TestCompileRouterConfigMissingSecretKey(t *testing.T) {
 	}
 }
 
+// TestCompileRouterConfigExternalNoSecretSkipsCredentials covers the
+// "auth-less external backend" path (e.g. an in-cluster OpenAI-shape
+// mock, a LiteLLM proxy that handles auth on its own side, a non-
+// LLMKube vLLM): when no credentialsSecretRef is provided, the
+// controller must NOT inject a well-known credentials env name into
+// the compiled config, or the proxy would refuse to dispatch with
+// "credentials env X is unset" even though the backend never needed
+// auth.
+func TestCompileRouterConfigExternalNoSecretSkipsCredentials(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-auth-router",
+			Namespace: testBuilderNs,
+		},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{
+					Name: "local-mock",
+					External: &inferencev1alpha1.ExternalProvider{
+						Provider: "openai",
+						Model:    "stub",
+						URL:      "http://mock.example.svc.cluster.local:8080",
+					},
+					Tier: "local",
+				},
+			},
+			DefaultRoute: "local-mock",
+		},
+	}
+	r := newRouterReconcilerForTest(t, mr)
+
+	compiled, err := r.compileRouterConfig(context.Background(), mr)
+	if err != nil {
+		t.Fatalf("compileRouterConfig: %v", err)
+	}
+
+	var cfg router.Config
+	if err := json.Unmarshal(compiled.JSON, &cfg); err != nil {
+		t.Fatalf("unmarshal compiled JSON: %v", err)
+	}
+	if got := cfg.Backends[0].CredentialsEnv; got != "" {
+		t.Errorf("external backend without secret got CredentialsEnv = %q, want empty", got)
+	}
+	if !compiled.Backends[0].Healthy {
+		t.Errorf("backend should be Healthy=true when no secret is required, Message=%q",
+			compiled.Backends[0].Message)
+	}
+}
+
 // TestRouterDeploymentBuilder pins the deployment shape this PR
 // contracts on for downstream callers (CI smoke tests, future
 // production users).

--- a/internal/controller/router_config_builder.go
+++ b/internal/controller/router_config_builder.go
@@ -139,8 +139,15 @@ func (r *ModelRouterReconciler) resolveBackend(
 		wire.Model = b.External.Model
 		wire.Address = b.External.URL
 		status.Address = b.External.URL
-		wire.CredentialsEnv = wellKnownCredEnv(b.External.Provider)
 		if b.External.CredentialsSecretRef != nil {
+			// Resolving the well-known env var only when the user
+			// declared a Secret keeps backends like LiteLLM (which
+			// proxy auth themselves) and in-cluster sidecars (a
+			// non-LLMKube vLLM, an OpenAI-shape mock) able to opt out
+			// of credential injection. Without this gate the proxy
+			// would refuse to dispatch with "credentials env X is
+			// unset" even though the backend never needed auth.
+			wire.CredentialsEnv = wellKnownCredEnv(b.External.Provider)
 			if err := r.assertCredentialsSecretExists(ctx, mr.Namespace,
 				b.External.CredentialsSecretRef.Name, wire.CredentialsEnv); err != nil {
 				status.Healthy = false
@@ -149,8 +156,6 @@ func (r *ModelRouterReconciler) resolveBackend(
 				status.Healthy = true
 			}
 		} else {
-			// LiteLLM-style external backends sometimes handle auth
-			// themselves; allow no secret.
 			status.Healthy = true
 		}
 	default:

--- a/internal/router/proxy.go
+++ b/internal/router/proxy.go
@@ -119,6 +119,22 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	chosen, resp, err := p.dispatchWithFallback(r.Context(), &decision, r.Header, body, "/v1/chat/completions")
 	elapsed := time.Since(start)
 	if err != nil {
+		// Runtime fail-closed: when every backend in a fail-closed
+		// rule's pool is unreachable, return 503 with a clear reason
+		// rather than 502. This is the runtime counterpart to the
+		// controller's static fail-closed validation: we refuse the
+		// request instead of letting it spill onto an unmatched
+		// backend (which dispatchWithFallback never does anyway, but
+		// the status code communicates intent — sensitive data did
+		// not egress because policy said so, not because of a generic
+		// upstream outage).
+		if decision.FailClosed {
+			writeError(w, http.StatusServiceUnavailable,
+				"fail-closed: all rule backends unhealthy: "+err.Error())
+			p.audit(features, decision, nil, http.StatusServiceUnavailable,
+				"fail_closed_runtime", elapsed)
+			return
+		}
 		writeError(w, http.StatusBadGateway, "all backends failed: "+err.Error())
 		p.audit(features, decision, nil, http.StatusBadGateway, "all_backends_failed", elapsed)
 		return

--- a/internal/router/proxy_test.go
+++ b/internal/router/proxy_test.go
@@ -241,7 +241,8 @@ func TestProxyFallsThroughToDefault(t *testing.T) {
 
 // TestProxyFailClosedOnLocalDown is the regulated-data gate verified at
 // runtime: when the only local backend is unhealthy, a PII request is
-// refused with 503 rather than falling through to the cloud backend.
+// refused with 503 (fail-closed runtime) and the cloud backend is
+// never touched.
 func TestProxyFailClosedOnLocalDown(t *testing.T) {
 	h := newProxyHarness(t)
 	h.proxy.disp.MarkUnhealthy("local-qwen")
@@ -250,11 +251,30 @@ func TestProxyFailClosedOnLocalDown(t *testing.T) {
 		"x-llmkube-classification": "pii",
 	})
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusBadGateway && resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 502/503", resp.StatusCode)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 fail-closed runtime", resp.StatusCode)
 	}
 	if h.cloudBack.calls.Load() != 0 {
 		t.Errorf("cloud must not receive pii request; calls = %d", h.cloudBack.calls.Load())
+	}
+}
+
+// TestProxyNonFailClosedReturns502OnAllBackendsDown documents the
+// negative case: a non-fail-closed rule with all backends unreachable
+// returns 502 (BadGateway), not 503. This is what distinguishes a
+// generic upstream outage from a policy-level refusal.
+func TestProxyNonFailClosedReturns502OnAllBackendsDown(t *testing.T) {
+	h := newProxyHarness(t)
+	// Disable both backends so the default-route fallback fails too.
+	h.proxy.disp.MarkUnhealthy("local-qwen")
+	h.proxy.disp.MarkUnhealthy("cloud-opus")
+
+	// No classification, no complexity: hits the default route, which
+	// the harness configures with FailClosed=false.
+	resp := h.post(t, map[string]any{"model": "any"}, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 (non-fail-closed upstream outage)", resp.StatusCode)
 	}
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -43,6 +43,19 @@ var (
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
 	projectImage = "example.com/llmkube:v0.0.1"
+
+	// routerProxyImage matches the default image the operator's
+	// ModelRouterReconciler hard-codes (internal/controller/router_deployment_builder.go).
+	// Side-loading exactly this tag means the controller can dispatch
+	// new ModelRouter resources without a per-deploy --router-proxy-image
+	// flag rewrite. Override with the LLMKUBE_E2E_ROUTER_PROXY_IMG env
+	// var when running locally against a different registry/tag.
+	routerProxyImage = "ghcr.io/defilantech/llmkube-router-proxy:dev"
+
+	// stubUpstreamImage is the fake llama.cpp / cloud-provider used in
+	// the ModelRouter cluster Context. Only side-loaded when
+	// LLMKUBE_E2E_ROUTER_CLUSTER=true so unrelated jobs stay fast.
+	stubUpstreamImage = "localhost/llmkube-stub-upstream:e2e"
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -74,6 +87,32 @@ var _ = BeforeSuite(func() {
 		By("loading the manager(Operator) image on Kind")
 		err = utils.LoadImageToKindClusterWithName(projectImage)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
+
+		if os.Getenv("LLMKUBE_E2E_ROUTER_CLUSTER") == "true" {
+			By("building the router-proxy image")
+			cmd = exec.Command("make", "docker-build-router-proxy",
+				fmt.Sprintf("ROUTER_PROXY_IMG=%s", routerProxyImage))
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+				"Failed to build the router-proxy image")
+
+			By("loading the router-proxy image on Kind")
+			err = utils.LoadImageToKindClusterWithName(routerProxyImage)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+				"Failed to load the router-proxy image into Kind")
+
+			By("building the stub-upstream image")
+			cmd = exec.Command("make", "docker-build-stub-upstream",
+				fmt.Sprintf("STUB_UPSTREAM_IMG=%s", stubUpstreamImage))
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+				"Failed to build the stub-upstream image")
+
+			By("loading the stub-upstream image on Kind")
+			err = utils.LoadImageToKindClusterWithName(stubUpstreamImage)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+				"Failed to load the stub-upstream image into Kind")
+		}
 	}
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -530,19 +530,25 @@ spec:
 			}
 			Eventually(verifyDeploymentExists, 2*time.Minute).Should(Succeed())
 
-			By("verifying Service exists with correct port")
-			cmd = exec.Command("kubectl", "get", "service", "test-inference",
-				"-n", crTestNs, "-o", "jsonpath={.spec.ports[0].port}")
-			output, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(Equal("8080"))
+			By("verifying Service exists with correct port and selector")
+			// The Service is reconciled separately from the Deployment, so
+			// even after the Deployment is observed it can take a beat
+			// for the Service to land. Wrap both checks in Eventually so
+			// kind runs under load (a CI runner alongside Helm install +
+			// MicroShift jobs) don't surface this as a flake.
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "service", "test-inference",
+					"-n", crTestNs, "-o", "jsonpath={.spec.ports[0].port}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("8080"))
 
-			By("verifying Service selector matches")
-			cmd = exec.Command("kubectl", "get", "service", "test-inference",
-				"-n", crTestNs, "-o", "jsonpath={.spec.selector.app}")
-			output, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(Equal("test-inference"))
+				cmd = exec.Command("kubectl", "get", "service", "test-inference",
+					"-n", crTestNs, "-o", "jsonpath={.spec.selector.app}")
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("test-inference"))
+			}, 1*time.Minute, time.Second).Should(Succeed())
 
 			By("verifying InferenceService status endpoint")
 			verifyEndpoint := func(g Gomega) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -926,6 +926,210 @@ spec:
 		})
 	})
 
+	// ModelRouter Cluster covers the runtime data plane: with the
+	// router-proxy and a stub upstream image side-loaded into kind, we
+	// stand up real proxy pods, drive chat completions through them, and
+	// assert that routing, fail-closed enforcement, and credential
+	// injection behave end-to-end. Gated on LLMKUBE_E2E_ROUTER_CLUSTER
+	// because it depends on the BeforeSuite having built and loaded
+	// router-proxy + stub-upstream images, which only the dedicated kind
+	// e2e job opts into today.
+	Context("ModelRouter Cluster", Ordered, func() {
+		const mrcTestNs = "e2e-modelrouter-cluster"
+		const routerName = "e2e-cluster-router"
+		const localStubSvc = "fake-local"
+		const cloudStubSvc = "fake-cloud"
+		// #nosec G101 -- test fixture, not a real credential
+		const stubAPIKey = "stub-cloud-key-for-e2e"
+
+		BeforeAll(func() {
+			if os.Getenv("LLMKUBE_E2E_ROUTER_CLUSTER") != "true" {
+				Skip("LLMKUBE_E2E_ROUTER_CLUSTER not set; " +
+					"cluster routing tests require the router-proxy and " +
+					"stub-upstream images side-loaded into kind")
+			}
+
+			By("creating ModelRouter cluster test namespace")
+			cmd := exec.Command("kubectl", "create", "ns", mrcTestNs)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create cluster test namespace")
+
+			By("deploying fake-local and fake-cloud stub upstreams")
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(
+				renderStubUpstream(mrcTestNs, localStubSvc) +
+					renderStubUpstream(mrcTestNs, cloudStubSvc))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to deploy stub upstreams")
+
+			By("waiting for stub upstream Deployments to become Available")
+			for _, name := range []string{localStubSvc, cloudStubSvc} {
+				cmd = exec.Command("kubectl", "rollout", "status",
+					"deployment/"+name, "-n", mrcTestNs, "--timeout=120s")
+				_, err = utils.Run(cmd)
+				Expect(err).NotTo(HaveOccurred(),
+					"stub upstream %s never reached Available", name)
+			}
+
+			By("creating cloud credentials Secret")
+			cmd = exec.Command("kubectl", "create", "secret", "generic", "fake-cloud-key",
+				"-n", mrcTestNs,
+				"--from-literal=ANTHROPIC_API_KEY="+stubAPIKey)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create cloud creds Secret")
+
+			By("applying the cluster-routing ModelRouter")
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  backends:
+    - name: local-stub
+      external:
+        provider: openai
+        model: stub-local
+        url: http://%s.%s.svc.cluster.local:8080
+      tier: local
+    - name: cloud-stub
+      external:
+        provider: anthropic
+        model: claude-opus-4-7
+        url: http://%s.%s.svc.cluster.local:8080
+        credentialsSecretRef:
+          name: fake-cloud-key
+      tier: cloud
+  rules:
+    - name: pii-stays-local
+      match:
+        dataClassification: ["pii"]
+      route:
+        backends: ["local-stub"]
+      failClosed: true
+    - name: complex-to-cloud
+      match:
+        taskComplexity: complex
+      route:
+        backends: ["cloud-stub"]
+  defaultRoute: local-stub
+`, routerName, mrcTestNs, localStubSvc, mrcTestNs, cloudStubSvc, mrcTestNs))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to apply ModelRouter")
+
+			By("waiting for the proxy Deployment to become Available")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "rollout", "status",
+					"deployment/"+routerName+"-router-proxy", "-n", mrcTestNs,
+					"--timeout=10s")
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+				"router-proxy Deployment never reached Available")
+		})
+
+		AfterAll(func() {
+			if os.Getenv("LLMKUBE_E2E_ROUTER_CLUSTER") != "true" {
+				return
+			}
+			By("cleaning up the ModelRouter cluster test namespace")
+			cmd := exec.Command("kubectl", "delete", "ns", mrcTestNs, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should route default chat completions to the local backend", func() {
+			By("resetting stub upstream recordings")
+			resetStubs(mrcTestNs, localStubSvc, cloudStubSvc)
+
+			By("POSTing a chat completion through the proxy")
+			out := chatCompletion(mrcTestNs, routerName, nil,
+				`{"model":"stub-local","stream":false,"messages":[{"role":"user","content":"hello"}]}`)
+			Expect(out).To(ContainSubstring("stub-response-from-"+localStubSvc),
+				"chat completion did not appear to flow through the local stub")
+
+			By("verifying the local stub received the request and the cloud stub did not")
+			Eventually(func(g Gomega) {
+				localCount := stubRequestCount(g, mrcTestNs, localStubSvc)
+				cloudCount := stubRequestCount(g, mrcTestNs, cloudStubSvc)
+				g.Expect(localCount).To(BeNumerically(">=", 1),
+					"expected local stub to record the request")
+				g.Expect(cloudCount).To(Equal(0),
+					"cloud stub must not see default-route traffic")
+			}, 30*time.Second, time.Second).Should(Succeed())
+		})
+
+		It("should route complex-task requests to the cloud backend with Anthropic-style auth", func() {
+			By("resetting stub upstream recordings")
+			resetStubs(mrcTestNs, localStubSvc, cloudStubSvc)
+
+			By("POSTing with task-complexity=complex")
+			out := chatCompletion(mrcTestNs, routerName,
+				map[string]string{"x-llmkube-task-complexity": "complex"},
+				`{"model":"claude-opus-4-7","stream":false,"messages":[{"role":"user","content":"design a system"}]}`)
+			Expect(out).To(ContainSubstring("stub-response-from-"+cloudStubSvc),
+				"complex-task did not flow through the cloud stub")
+
+			By("verifying the cloud stub received it with x-api-key + anthropic-version headers")
+			Eventually(func(g Gomega) {
+				snap := stubSnapshot(g, mrcTestNs, cloudStubSvc)
+				g.Expect(snap.Requests).NotTo(BeEmpty())
+				last := snap.Requests[len(snap.Requests)-1]
+				g.Expect(last.Headers["X-Api-Key"]).To(ContainElement(stubAPIKey),
+					"x-api-key not injected for Anthropic cloud backend")
+				g.Expect(last.Headers["Anthropic-Version"]).NotTo(BeEmpty(),
+					"anthropic-version not injected for Anthropic cloud backend")
+			}, 30*time.Second, time.Second).Should(Succeed())
+		})
+
+		It("should fail-closed with 503 when a PII request's local backend is unavailable", func() {
+			By("resetting stub upstream recordings")
+			resetStubs(mrcTestNs, localStubSvc, cloudStubSvc)
+
+			By("scaling the local stub Deployment to zero")
+			cmd := exec.Command("kubectl", "scale", "deployment/"+localStubSvc,
+				"-n", mrcTestNs, "--replicas=0")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to scale local stub to zero")
+
+			By("waiting for local stub endpoints to drain")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "endpoints", localStubSvc,
+					"-n", mrcTestNs, "-o",
+					"jsonpath={.subsets[*].addresses[*].ip}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(output)).To(BeEmpty(),
+					"local stub still has endpoints")
+			}, 60*time.Second, time.Second).Should(Succeed())
+
+			By("POSTing a PII-classified request and expecting HTTP 503")
+			status := chatCompletionStatus(mrcTestNs, routerName,
+				map[string]string{"x-llmkube-classification": "pii"},
+				`{"model":"stub-local","stream":false,"messages":[{"role":"user","content":"ssn 123"}]}`)
+			Expect(status).To(Equal(503),
+				"PII request with local backend down must fail-closed with 503")
+
+			By("verifying the cloud stub received no traffic (no egress on fail-closed)")
+			Consistently(func(g Gomega) {
+				cloudCount := stubRequestCount(g, mrcTestNs, cloudStubSvc)
+				g.Expect(cloudCount).To(Equal(0),
+					"fail-closed must not egress sensitive data to a cloud backend")
+			}, 10*time.Second, 2*time.Second).Should(Succeed())
+
+			By("scaling the local stub back up so subsequent specs can rely on it")
+			cmd = exec.Command("kubectl", "scale", "deployment/"+localStubSvc,
+				"-n", mrcTestNs, "--replicas=1")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to restore local stub replica")
+
+			cmd = exec.Command("kubectl", "rollout", "status",
+				"deployment/"+localStubSvc, "-n", mrcTestNs, "--timeout=60s")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "local stub failed to come back")
+		})
+	})
+
 	Context("License Check", func() {
 		const licenseTestNs = "e2e-license-test"
 		const testLicenseModelServerURL = "http://test-model-server.e2e-license-test.svc.cluster.local/test-model.gguf"
@@ -1718,4 +1922,250 @@ type tokenRequest struct {
 	Status struct {
 		Token string `json:"token"`
 	} `json:"status"`
+}
+
+// renderStubUpstream produces a Deployment+Service manifest pair for a
+// single stub upstream identified by name. Both fake-local and
+// fake-cloud are deployed from the same template with a different
+// --label so introspect responses can tell them apart. The image is
+// side-loaded into kind in BeforeSuite (LLMKUBE_E2E_ROUTER_CLUSTER=true)
+// and pulled with IfNotPresent so the test never hits a registry.
+func renderStubUpstream(ns, name string) string {
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+  labels:
+    app: %[2]s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: %[2]s
+  template:
+    metadata:
+      labels:
+        app: %[2]s
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: stub
+          image: localhost/llmkube-stub-upstream:e2e
+          imagePullPolicy: IfNotPresent
+          args: ["-label=%[2]s", "-listen=:8080"]
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+spec:
+  selector:
+    app: %[2]s
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+`, ns, name)
+}
+
+// stubIntrospectResponse mirrors the JSON returned by the stub upstream
+// /__introspect__ endpoint. Only the fields we assert on are decoded.
+type stubIntrospectResponse struct {
+	Label    string `json:"label"`
+	Requests []struct {
+		Method   string              `json:"method"`
+		Path     string              `json:"path"`
+		Headers  map[string][]string `json:"headers"`
+		Body     string              `json:"body"`
+		At       string              `json:"at"`
+		Streamed bool                `json:"streamed"`
+	} `json:"requests"`
+}
+
+// runCurlInCluster runs a one-shot curl against an in-cluster URL using
+// kubectl run + delete. Returns (stdout, status code, error). The body
+// of the HTTP response is followed by an `HTTP_STATUS=<code>` line that
+// the parser strips out. Errors here are reserved for orchestration
+// failures (pod scheduling, log fetch) – an HTTP 5xx still returns
+// (logs, code, nil) so callers can assert on the status.
+func runCurlInCluster(ns, url, method string, headers map[string]string, body string) (string, int, error) {
+	curlArgs := []string{
+		"curl", "-sS", "-o", "/tmp/body", "-w", "HTTP_STATUS=%{http_code}\n",
+		"-X", method,
+	}
+	for k, v := range headers {
+		curlArgs = append(curlArgs, "-H", fmt.Sprintf("%s: %s", k, v))
+	}
+	if body != "" {
+		curlArgs = append(curlArgs, "-H", "content-type: application/json",
+			"--data-binary", body)
+	}
+	curlArgs = append(curlArgs, url)
+
+	// The pod runs `curl ... > status_line; cat /tmp/body; status_line` so
+	// the pod logs end with the parseable HTTP_STATUS= sentinel.
+	shellCmd := strings.Join(quoteShell(curlArgs), " ") +
+		" > /tmp/status; cat /tmp/body; echo; cat /tmp/status"
+
+	// Match the curl-metrics pattern used elsewhere in this suite:
+	// kubectl run with --overrides supplying the full container spec
+	// (command/args + securityContext). The pod's logs are then
+	// fetched to retrieve the response body and the parseable
+	// HTTP_STATUS= sentinel.
+	overrides := fmt.Sprintf(`{
+		"spec": {
+			"restartPolicy": "Never",
+			"containers": [{
+				"name": "curl",
+				"image": "docker.io/curlimages/curl:8.18.0",
+				"command": ["/bin/sh", "-c"],
+				"args": [%q],
+				"securityContext": {
+					"allowPrivilegeEscalation": false,
+					"capabilities": {"drop": ["ALL"]},
+					"runAsNonRoot": true,
+					"runAsUser": 1000,
+					"seccompProfile": {"type": "RuntimeDefault"}
+				}
+			}]
+		}
+	}`, shellCmd)
+
+	podName := fmt.Sprintf("e2e-curl-%d", time.Now().UnixNano())
+	runCmd := exec.Command("kubectl", "run", podName,
+		"--restart=Never", "--namespace", ns,
+		"--image=docker.io/curlimages/curl:8.18.0",
+		"--overrides", overrides)
+	if _, err := utils.Run(runCmd); err != nil {
+		return "", 0, fmt.Errorf("kubectl run: %w", err)
+	}
+	defer func() {
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", podName,
+			"-n", ns, "--ignore-not-found", "--wait=false"))
+	}()
+
+	// Poll for terminal phase (Succeeded or Failed); kubectl wait can't
+	// express "either" cleanly so we look at .status.phase directly.
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		phaseCmd := exec.Command("kubectl", "get", "pod", podName,
+			"-n", ns, "-o", "jsonpath={.status.phase}")
+		phase, _ := utils.Run(phaseCmd)
+		if phase == "Succeeded" || phase == "Failed" {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	logs, err := utils.Run(exec.Command("kubectl", "logs", podName, "-n", ns))
+	if err != nil {
+		return "", 0, fmt.Errorf("kubectl logs: %w", err)
+	}
+	status := 0
+	for _, line := range strings.Split(logs, "\n") {
+		if strings.HasPrefix(line, "HTTP_STATUS=") {
+			status, _ = strconv.Atoi(strings.TrimPrefix(line, "HTTP_STATUS="))
+		}
+	}
+	return logs, status, nil
+}
+
+// quoteShell shell-quotes each arg so the rendered command is safe to
+// run via sh -c. POSIX single quotes block expansion; the only escaping
+// needed is for embedded single quotes.
+func quoteShell(args []string) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		out[i] = "'" + strings.ReplaceAll(a, "'", `'\''`) + "'"
+	}
+	return out
+}
+
+// chatCompletion runs a curl pod that POSTs to the router-proxy Service
+// for the given router. Returns the body of the response (best-effort,
+// shape may vary on error). Fails the test if the request couldn't be
+// dispatched at all.
+func chatCompletion(ns, router string, headers map[string]string, body string) string {
+	url := fmt.Sprintf("http://%s-router-proxy.%s.svc.cluster.local:8080/v1/chat/completions",
+		router, ns)
+	out, _, err := runCurlInCluster(ns, url, "POST", headers, body)
+	Expect(err).NotTo(HaveOccurred(), "curl dispatch failed: %s", out)
+	return out
+}
+
+// chatCompletionStatus is the same as chatCompletion but returns just
+// the HTTP status code, used for the fail-closed assertion. Does not
+// fail the test on non-2xx since the test wants to assert on 503.
+func chatCompletionStatus(ns, router string, headers map[string]string, body string) int {
+	url := fmt.Sprintf("http://%s-router-proxy.%s.svc.cluster.local:8080/v1/chat/completions",
+		router, ns)
+	_, status, err := runCurlInCluster(ns, url, "POST", headers, body)
+	Expect(err).NotTo(HaveOccurred(), "curl dispatch failed")
+	return status
+}
+
+// stubSnapshot fetches the introspection payload from a stub upstream by
+// curl-ing /__introspect__ via a transient curl pod inside the cluster.
+// Used by the routing assertions to inspect which upstream received
+// what.
+func stubSnapshot(g Gomega, ns, svc string) stubIntrospectResponse {
+	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080/__introspect__", svc, ns)
+	out, _, err := runCurlInCluster(ns, url, "GET", nil, "")
+	g.Expect(err).NotTo(HaveOccurred(), "introspect curl failed: %s", out)
+
+	// runCurlInCluster's logs include a trailing HTTP_STATUS= line; strip
+	// it and any leading non-JSON noise.
+	idx := strings.Index(out, "{")
+	if idx == -1 {
+		g.Expect(idx).NotTo(Equal(-1), "introspect output had no JSON body: %s", out)
+	}
+	end := strings.LastIndex(out, "}")
+	if end == -1 || end < idx {
+		g.Expect(end).NotTo(BeNumerically("<", idx), "introspect output malformed: %s", out)
+	}
+	var snap stubIntrospectResponse
+	g.Expect(json.Unmarshal([]byte(out[idx:end+1]), &snap)).To(Succeed(),
+		"failed to parse introspect payload: %s", out)
+	return snap
+}
+
+// stubRequestCount returns how many recorded requests the stub holds.
+func stubRequestCount(g Gomega, ns, svc string) int {
+	return len(stubSnapshot(g, ns, svc).Requests)
+}
+
+// resetStubs clears the recording buffer on both upstreams between
+// specs so assertions only see traffic from the current case.
+func resetStubs(ns string, svcs ...string) {
+	for _, svc := range svcs {
+		url := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080/__introspect__/reset", svc, ns)
+		_, _, _ = runCurlInCluster(ns, url, "POST", nil, "")
+	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1093,10 +1093,17 @@ spec:
 			Expect(err).NotTo(HaveOccurred(), "failed to scale local stub to zero")
 
 			By("waiting for local stub endpoints to drain")
+			// Query EndpointSlice (v1) rather than the legacy Endpoints
+			// object: kubectl emits a "v1 Endpoints is deprecated" warning
+			// to stderr on k8s 1.33+, and utils.Run combines stdout+stderr,
+			// so the legacy path returns the warning string instead of an
+			// empty payload. EndpointSlice is the modern source of truth
+			// for service backing pods regardless.
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "endpoints", localStubSvc,
-					"-n", mrcTestNs, "-o",
-					"jsonpath={.subsets[*].addresses[*].ip}")
+				cmd := exec.Command("kubectl", "get", "endpointslices",
+					"-n", mrcTestNs,
+					"-l", "kubernetes.io/service-name="+localStubSvc,
+					"-o", "jsonpath={.items[*].endpoints[*].addresses[*]}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(strings.TrimSpace(output)).To(BeEmpty(),

--- a/test/e2e/stubupstream/Dockerfile
+++ b/test/e2e/stubupstream/Dockerfile
@@ -1,0 +1,30 @@
+# Container image for the e2e stub upstream. Only built during the
+# ModelRouter cluster e2e job; not shipped to users. Mirrors the
+# distroless-static + non-root layout of the router-proxy image so the
+# proxy and the stub run under the same PodSecurityStandard restricted
+# constraints that we enforce in the test namespace.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY test/e2e/stubupstream/ test/e2e/stubupstream/
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o stub-upstream ./test/e2e/stubupstream
+
+FROM gcr.io/distroless/static:nonroot
+
+WORKDIR /
+COPY --from=builder /workspace/stub-upstream /usr/local/bin/stub-upstream
+
+EXPOSE 8080
+
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/stub-upstream"]

--- a/test/e2e/stubupstream/main.go
+++ b/test/e2e/stubupstream/main.go
@@ -1,0 +1,218 @@
+// Package main is a minimal HTTP server used by the ModelRouter cluster
+// e2e tests as a fake "local InferenceService" or "cloud provider"
+// upstream. The binary speaks just enough of the OpenAI chat-completions
+// shape for the router-proxy to dispatch real requests at it, plus an
+// /__introspect__ endpoint the tests use to assert which upstream
+// received which request (and with what headers).
+//
+// This is intentionally not part of the operator's public surface; it
+// lives under test/e2e/ and is only built into a container image during
+// the e2e job.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type recordedRequest struct {
+	Method   string              `json:"method"`
+	Path     string              `json:"path"`
+	Headers  map[string][]string `json:"headers"`
+	Body     string              `json:"body"`
+	At       time.Time           `json:"at"`
+	Streamed bool                `json:"streamed"`
+}
+
+type recorder struct {
+	mu      sync.Mutex
+	records []recordedRequest
+}
+
+func (r *recorder) record(req recordedRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, req)
+	if len(r.records) > 100 {
+		r.records = r.records[len(r.records)-100:]
+	}
+}
+
+func (r *recorder) snapshot() []recordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedRequest, len(r.records))
+	copy(out, r.records)
+	return out
+}
+
+func (r *recorder) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = nil
+}
+
+func main() {
+	label := flag.String("label", "stub",
+		"identifier returned in chat completion content so tests can tell upstreams apart")
+	listen := flag.String("listen", ":8080", "address to listen on")
+	flag.Parse()
+
+	rec := &recorder{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+
+	mux.HandleFunc("GET /__introspect__", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"label":    *label,
+			"requests": rec.snapshot(),
+		})
+	})
+	mux.HandleFunc("POST /__introspect__/reset", func(w http.ResponseWriter, _ *http.Request) {
+		rec.reset()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+
+		stream := false
+		var parsed map[string]any
+		if err := json.Unmarshal(body, &parsed); err == nil {
+			if v, ok := parsed["stream"].(bool); ok {
+				stream = v
+			}
+		}
+
+		rec.record(recordedRequest{
+			Method:   r.Method,
+			Path:     r.URL.Path,
+			Headers:  cloneHeader(r.Header),
+			Body:     string(body),
+			At:       time.Now().UTC(),
+			Streamed: stream,
+		})
+
+		if stream {
+			writeStreamed(w, *label)
+			return
+		}
+		writeNonStreamed(w, *label)
+	})
+
+	mux.HandleFunc("GET /v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object": "list",
+			"data": []map[string]string{
+				{"id": *label, "object": "model"},
+			},
+		})
+	})
+
+	log.Printf("stub-upstream label=%s listen=%s", *label, *listen)
+	srv := &http.Server{
+		Addr:              *listen,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func cloneHeader(h http.Header) map[string][]string {
+	out := make(map[string][]string, len(h))
+	for k, vs := range h {
+		dup := make([]string, len(vs))
+		copy(dup, vs)
+		out[k] = dup
+	}
+	return out
+}
+
+func writeNonStreamed(w http.ResponseWriter, label string) {
+	resp := map[string]any{
+		"id":      "stub-" + label + "-" + strconv.FormatInt(time.Now().UnixNano(), 10),
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   label,
+		"choices": []map[string]any{
+			{
+				"index":         0,
+				"finish_reason": "stop",
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "stub-response-from-" + label,
+				},
+			},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func writeStreamed(w http.ResponseWriter, label string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher, _ := w.(http.Flusher)
+
+	chunks := []map[string]any{
+		{
+			"id":      "stub-stream-" + label,
+			"object":  "chat.completion.chunk",
+			"created": time.Now().Unix(),
+			"model":   label,
+			"choices": []map[string]any{
+				{"index": 0, "delta": map[string]any{"role": "assistant"}},
+			},
+		},
+		{
+			"id":      "stub-stream-" + label,
+			"object":  "chat.completion.chunk",
+			"created": time.Now().Unix(),
+			"model":   label,
+			"choices": []map[string]any{
+				{"index": 0, "delta": map[string]any{"content": "stub-response-from-" + label}},
+			},
+		},
+		{
+			"id":      "stub-stream-" + label,
+			"object":  "chat.completion.chunk",
+			"created": time.Now().Unix(),
+			"model":   label,
+			"choices": []map[string]any{
+				{"index": 0, "delta": map[string]any{}, "finish_reason": "stop"},
+			},
+		},
+	}
+	for _, c := range chunks {
+		data, _ := json.Marshal(c)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	if flusher != nil {
+		flusher.Flush()
+	}
+}


### PR DESCRIPTION
## Summary

Drive real `router-proxy` pods inside the kind e2e cluster and end-to-end
prove the ModelRouter's runtime contract:

- Default chat completion routes to a local stub upstream.
- `x-llmkube-task-complexity: complex` routes to a cloud stub with
  `x-api-key` + `anthropic-version` injected from a `Secret`.
- PII header with the local backend scaled to zero returns **HTTP 503**
  (`fail_closed_runtime`) and never egresses to the cloud upstream.

To make case 3 cleanly distinguish a *policy refusal* from a *generic
upstream outage*, this PR also wires the runtime fail-closed gate in
`internal/router/proxy.go`: when every backend in a fail-closed rule's
pool is unreachable, the proxy now responds 503 instead of 502.
Non-fail-closed rules still return 502 on the same failure; the unit
test pins both branches.

Closes #430. Lays the infra for #438 (the cloud-stub already takes
external-provider traffic with credential injection).

## Infrastructure changes

- New `test/e2e/stubupstream` binary + Dockerfile: a tiny OpenAI-shaped
  HTTP server with an `/__introspect__` endpoint the suite uses to
  assert which upstream received which request.
- `Makefile` target `docker-build-stub-upstream`.
- `BeforeSuite` builds and side-loads `router-proxy` and `stub-upstream`
  images into kind when `LLMKUBE_E2E_ROUTER_CLUSTER=true`. The default
  kind job opts in; the Longhorn and OpenShift jobs are unaffected.
- `test-e2e.yml` sets the opt-in env var on the default kind job.

## Test plan

- [x] `go test ./internal/router/...` -- new and existing fail-closed
      tests pass.
- [x] `go test ./internal/controller/...` -- unaffected, still green.
- [x] `go vet ./...` clean.
- [x] `golangci-lint run ./...` adds zero new issues vs. main.
- [ ] Default kind e2e job in CI builds the router-proxy + stub-upstream
      images and runs the new ModelRouter Cluster Context end-to-end.
- [ ] PII fail-closed assertion sees HTTP 503 and a zero-traffic cloud
      stub in the kind run.