### PR TITLE
feat: external provider URL defaults + cluster-wide LiteLLM URL (closes #438)

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
         # SCC compatibility. Schema in values.schema.json enforces integer >= 0.
         - --default-fsgroup={{ .Values.controllerManager.initContainer.defaultFSGroup }}
         - --router-proxy-image={{ include "llmkube.routerProxyImage" . }}
+        {{- with .Values.controllerManager.routerProxy.defaultLiteLLMURL }}
+        - --default-litellm-url={{ . }}
+        {{- end }}
         ports:
         - name: health
           containerPort: 8081

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -121,7 +121,8 @@
               "enum": ["Always", "IfNotPresent", "Never"]
             },
             "tag": { "type": "string" },
-            "digest": { "type": "string" }
+            "digest": { "type": "string" },
+            "defaultLiteLLMURL": { "type": "string" }
           }
         }
       }

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -128,6 +128,17 @@ controllerManager:
     # publishes them.
     digest: ""
 
+    # Cluster-wide default URL for ModelRouter External backends whose
+    # provider=litellm and url is unspecified. Lets platform teams
+    # centralize the LiteLLM proxy endpoint so application teams can
+    # declare `external: {provider: litellm, model: ...}` without
+    # repeating the LiteLLM Service URL on every ModelRouter. Empty
+    # means application teams must include url explicitly.
+    #
+    # Example (in-cluster LiteLLM at the standard port):
+    #   defaultLiteLLMURL: "http://litellm.litellm.svc.cluster.local:4000"
+    defaultLiteLLMURL: ""
+
 # Service account configuration
 serviceAccount:
   # Specifies whether a service account should be created

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,6 +108,7 @@ func main() {
 	var initContainerImage string
 	var defaultFSGroup int64
 	var routerProxyImage string
+	var defaultLiteLLMURL string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -130,6 +131,12 @@ func main() {
 		"Default container image for ModelRouter-managed router-proxy pods. "+
 			"Empty falls back to the controller's compiled-in default. "+
 			"Per-ModelRouter spec.proxy.image overrides this.")
+	flag.StringVar(&defaultLiteLLMURL, "default-litellm-url", "",
+		"Cluster-wide default URL for External backends with provider=litellm "+
+			"that omit url. Lets operators centralize the LiteLLM proxy "+
+			"endpoint so application teams can declare external backends "+
+			"without repeating the URL on every ModelRouter. Empty means "+
+			"users must specify url explicitly.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -269,9 +276,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.ModelRouterReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		RouterProxyImage: routerProxyImage,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		RouterProxyImage:  routerProxyImage,
+		DefaultLiteLLMURL: defaultLiteLLMURL,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ModelRouter")
 		os.Exit(1)

--- a/docs/site/concepts/model-router.md
+++ b/docs/site/concepts/model-router.md
@@ -150,6 +150,33 @@ LLMKube does not replace [LiteLLM](https://github.com/BerriAI/litellm). For orga
 
 LiteLLM handles provider auth, retries, and cost tracking. ModelRouter adds K8s-native policy, fail-closed enforcement, and audit logs.
 
+### Cluster-wide LiteLLM default
+
+Platform teams can centralize the LiteLLM URL via a controller flag so application teams don't have to repeat it on every `ModelRouter`:
+
+```yaml
+# Helm values
+controllerManager:
+  routerProxy:
+    defaultLiteLLMURL: http://litellm.litellm.svc.cluster.local:4000
+```
+
+With that set, application teams can declare LiteLLM-backed routers without `url`:
+
+```yaml
+external:
+  provider: litellm
+  model: openrouter/anthropic/claude-opus-4-7
+```
+
+A per-backend `url` always wins over the cluster default.
+
+## Shape compatibility
+
+The router-proxy forwards the inbound OpenAI chat-completion request body to upstream backends verbatim. For backends that already speak OpenAI (local `InferenceService` pods, LiteLLM, an in-cluster vLLM or oMLX), this is correct. For first-party providers whose native API does not match (Anthropic's `/v1/messages`, Bedrock's per-region shapes, Vertex AI's structured Content payloads), put a LiteLLM proxy in front and reference it via `provider: litellm` — LiteLLM handles the per-provider translation.
+
+When you specify `provider: anthropic` or `provider: openai` without `url`, the controller fills in the published default (`https://api.anthropic.com`, `https://api.openai.com`). This works as-is for OpenAI (which already speaks the OpenAI shape) and for any Anthropic-compatible endpoint that accepts OpenAI requests. Direct calls against `api.anthropic.com` itself require LiteLLM in front; native Anthropic-Messages translation is on the roadmap, not in Phase 1.
+
 ## What's in scope, what isn't
 
 **In scope:**

--- a/internal/controller/modelrouter_controller.go
+++ b/internal/controller/modelrouter_controller.go
@@ -68,6 +68,15 @@ type ModelRouterReconciler struct {
 	// router-proxy. Per-ModelRouter overrides in spec.proxy.image take
 	// precedence. Wired in cmd/main.go from --router-proxy-image.
 	RouterProxyImage string
+
+	// DefaultLiteLLMURL is the cluster-wide default LiteLLM proxy URL
+	// the reconciler injects into External backends whose
+	// provider=litellm and URL is empty. Operators set this once via
+	// --default-litellm-url so application teams can declare
+	// `external: {provider: litellm, model: ...}` without repeating
+	// the LiteLLM Service URL on every ModelRouter. Empty string
+	// means "no default — the user must specify URL explicitly".
+	DefaultLiteLLMURL string
 }
 
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=modelrouters,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/router_builders_test.go
+++ b/internal/controller/router_builders_test.go
@@ -237,6 +237,154 @@ func TestCompileRouterConfigExternalNoSecretSkipsCredentials(t *testing.T) {
 	}
 }
 
+// TestResolveExternalURLProviderDefaults covers the URL-defaulting
+// matrix added for issue #438: first-party providers get their
+// published endpoint when url is omitted, litellm gets the operator-
+// configured cluster default (or a clear error when neither is set),
+// and providers without a built-in default require an explicit url.
+func TestResolveExternalURLProviderDefaults(t *testing.T) {
+	cases := []struct {
+		name       string
+		provider   string
+		url        string
+		litellmDef string
+		wantAddr   string
+		wantMsg    string
+	}{
+		{
+			name:     "explicit url always wins",
+			provider: "anthropic",
+			url:      "https://eu.api.anthropic.com",
+			wantAddr: "https://eu.api.anthropic.com",
+		},
+		{
+			name:     "anthropic default",
+			provider: "anthropic",
+			wantAddr: "https://api.anthropic.com",
+		},
+		{
+			name:     "openai default",
+			provider: "openai",
+			wantAddr: "https://api.openai.com",
+		},
+		{
+			name:       "litellm with operator default",
+			provider:   "litellm",
+			litellmDef: "http://litellm.litellm.svc.cluster.local:4000",
+			wantAddr:   "http://litellm.litellm.svc.cluster.local:4000",
+		},
+		{
+			name:     "litellm without default returns error",
+			provider: "litellm",
+			wantMsg:  "default-litellm-url",
+		},
+		{
+			name:     "bedrock requires explicit url",
+			provider: "bedrock",
+			wantMsg:  "no built-in default",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &ModelRouterReconciler{DefaultLiteLLMURL: tc.litellmDef}
+			gotAddr, gotMsg := r.resolveExternalURL(&inferencev1alpha1.ExternalProvider{
+				Provider: tc.provider,
+				URL:      tc.url,
+			})
+			if gotAddr != tc.wantAddr {
+				t.Errorf("address = %q, want %q", gotAddr, tc.wantAddr)
+			}
+			if tc.wantMsg == "" {
+				if gotMsg != "" {
+					t.Errorf("unexpected message: %q", gotMsg)
+				}
+			} else if !strings.Contains(gotMsg, tc.wantMsg) {
+				t.Errorf("message = %q, want substring %q", gotMsg, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// TestCompileRouterConfigDefaultsAnthropicURL exercises the full
+// compile path with an Anthropic backend missing url: the wire config
+// and BackendStatus.Address must both pick up https://api.anthropic.com.
+func TestCompileRouterConfigDefaultsAnthropicURL(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-url-router",
+			Namespace: testBuilderNs,
+		},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{
+					Name: "cloud-anthropic",
+					External: &inferencev1alpha1.ExternalProvider{
+						Provider: "anthropic",
+						Model:    "claude-opus-4-7",
+					},
+					Tier: "cloud",
+				},
+			},
+			DefaultRoute: "cloud-anthropic",
+		},
+	}
+	r := newRouterReconcilerForTest(t, mr)
+
+	compiled, err := r.compileRouterConfig(context.Background(), mr)
+	if err != nil {
+		t.Fatalf("compileRouterConfig: %v", err)
+	}
+	var cfg router.Config
+	if err := json.Unmarshal(compiled.JSON, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := cfg.Backends[0].Address; got != "https://api.anthropic.com" {
+		t.Errorf("wire Address = %q, want https://api.anthropic.com", got)
+	}
+	if got := compiled.Backends[0].Address; got != "https://api.anthropic.com" {
+		t.Errorf("status Address = %q, want https://api.anthropic.com", got)
+	}
+	if !compiled.Backends[0].Healthy {
+		t.Errorf("backend should be Healthy, Message=%q", compiled.Backends[0].Message)
+	}
+}
+
+// TestCompileRouterConfigLiteLLMMissingURLFails confirms a litellm
+// backend without url AND no operator default surfaces a clear
+// Healthy=false status; the controller doesn't silently emit an empty
+// Address that the proxy would later reject with a worse error.
+func TestCompileRouterConfigLiteLLMMissingURLFails(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "litellm-missing-router",
+			Namespace: testBuilderNs,
+		},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{
+					Name: "cloud-litellm",
+					External: &inferencev1alpha1.ExternalProvider{
+						Provider: "litellm",
+						Model:    "claude-opus-4-7",
+					},
+					Tier: "cloud",
+				},
+			},
+			DefaultRoute: "cloud-litellm",
+		},
+	}
+	r := newRouterReconcilerForTest(t, mr) // no DefaultLiteLLMURL set
+
+	_, err := r.compileRouterConfig(context.Background(), mr)
+	if err == nil {
+		t.Fatal("expected validation error for empty address")
+	}
+	if !strings.Contains(err.Error(), "address") &&
+		!strings.Contains(err.Error(), "url") {
+		t.Errorf("error %q should mention address/url shape", err.Error())
+	}
+}
+
 // TestRouterDeploymentBuilder pins the deployment shape this PR
 // contracts on for downstream callers (CI smoke tests, future
 // production users).

--- a/internal/controller/router_config_builder.go
+++ b/internal/controller/router_config_builder.go
@@ -32,6 +32,13 @@ import (
 // routerProxyConfigMountPath and reads <mount>/config.json.
 const routerProxyConfigKey = "config.json"
 
+// Built-in URL defaults for first-party providers. Used by
+// resolveExternalURL when External.URL is empty.
+const (
+	defaultAnthropicURL = "https://api.anthropic.com"
+	defaultOpenAIURL    = "https://api.openai.com"
+)
+
 // compiledConfig captures everything the controller needs after
 // translating a ModelRouter spec into the proxy wire shape: the raw
 // JSON bytes, a content hash that drives pod rollout, and per-backend
@@ -137,8 +144,14 @@ func (r *ModelRouterReconciler) resolveBackend(
 		}
 		wire.Provider = b.External.Provider
 		wire.Model = b.External.Model
-		wire.Address = b.External.URL
-		status.Address = b.External.URL
+		addr, urlMsg := r.resolveExternalURL(b.External)
+		wire.Address = addr
+		status.Address = addr
+		if addr == "" {
+			status.Healthy = false
+			status.Message = urlMsg
+			return wire, status
+		}
 		if b.External.CredentialsSecretRef != nil {
 			// Resolving the well-known env var only when the user
 			// declared a Secret keeps backends like LiteLLM (which
@@ -163,6 +176,35 @@ func (r *ModelRouterReconciler) resolveBackend(
 		status.Message = "no inferenceServiceRef or external provider declared"
 	}
 	return wire, status
+}
+
+// resolveExternalURL applies the per-provider URL default when the user
+// did not specify one. First-party providers have a single published
+// endpoint we can hardcode; LiteLLM has no universal default but
+// operators can configure a cluster-wide one via --default-litellm-url.
+// Returns ("", msg) when no URL is available so the caller can surface
+// the misconfiguration in BackendStatus.Message instead of writing an
+// empty Address into the compiled config (which the proxy would later
+// reject at dispatch time with a less actionable error).
+func (r *ModelRouterReconciler) resolveExternalURL(p *inferencev1alpha1.ExternalProvider) (string, string) {
+	if p.URL != "" {
+		return p.URL, ""
+	}
+	switch p.Provider {
+	case "anthropic":
+		return defaultAnthropicURL, ""
+	case "openai":
+		return defaultOpenAIURL, ""
+	case "litellm":
+		if r.DefaultLiteLLMURL != "" {
+			return r.DefaultLiteLLMURL, ""
+		}
+		return "", "external backend with provider=litellm requires url " +
+			"(or operator-configured --default-litellm-url)"
+	default:
+		return "", fmt.Sprintf("external backend with provider=%q requires url "+
+			"(no built-in default for this provider)", p.Provider)
+	}
 }
 
 // resolveInferenceServiceAddress builds the cluster URL the router-proxy

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1141,6 +1141,54 @@ spec:
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "local stub failed to come back")
 		})
+
+		It("should default external provider URL for first-party providers", func() {
+			// Apply a sibling ModelRouter that omits url on an Anthropic
+			// external backend. The controller's resolveExternalURL must
+			// fill in https://api.anthropic.com so application teams can
+			// declare provider+model without repeating the upstream URL
+			// on every ModelRouter. Dispatch isn't exercised here (the
+			// test cluster cannot reach the real Anthropic API); the
+			// assertion is that the status surface carries the resolved
+			// address. The matching unit test
+			// (TestCompileRouterConfigDefaultsAnthropicURL) pins the
+			// behavior at the unit boundary; this spec proves the
+			// reconciler actually writes it through to the live cluster.
+			By("applying a ModelRouter with provider=anthropic and no URL")
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata:
+  name: e2e-default-url-router
+  namespace: %s
+spec:
+  backends:
+    - name: cloud-anthropic
+      external:
+        provider: anthropic
+        model: claude-opus-4-7
+      tier: cloud
+  defaultRoute: cloud-anthropic
+`, mrcTestNs))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to apply default-URL ModelRouter")
+
+			defer func() {
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "modelrouter",
+					"e2e-default-url-router", "-n", mrcTestNs, "--ignore-not-found"))
+			}()
+
+			By("waiting for status.backends[*].address to be populated with the provider default")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "modelrouter", "e2e-default-url-router",
+					"-n", mrcTestNs, "-o",
+					"jsonpath={.status.backends[0].address}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("https://api.anthropic.com"),
+					"expected controller to populate the Anthropic default URL")
+			}, 1*time.Minute, time.Second).Should(Succeed())
+		})
 	})
 
 	Context("License Check", func() {


### PR DESCRIPTION
## Summary

Closes #438 (last Phase 1 ModelRouter item).

Today, an external backend with `provider: anthropic` and no `url` silently
produces an empty wire Address. The controller writes `""` into the
compiled config, the proxy then rejects every dispatch with a generic
connection error, and the user gets no hint about the misconfiguration.

This PR tightens that path:

- **First-party provider defaults**: `anthropic` -> `https://api.anthropic.com`,
  `openai` -> `https://api.openai.com`. Application teams can now declare
  external backends with just `provider` + `model`.
- **Cluster-wide LiteLLM URL**: new ` --default-litellm-url` controller
  flag (Helm: `controllerManager.routerProxy.defaultLiteLLMURL`) sets a
  cluster default so platform teams centralize the LiteLLM Service URL.
- **Clear failure surface**: when no default applies (Bedrock / Vertex AI,
  or LiteLLM with no operator flag set), the backend goes `Healthy=false`
  with a clear ` .status.backends[*].message` rather than silently
  shipping a broken config.

Doc update explains the OpenAI-shape boundary: the proxy forwards chat
completion requests verbatim, so non-OpenAI providers (native Anthropic
Messages, Bedrock, Vertex) still need LiteLLM in front for shape
translation. That work is roadmap, not Phase 1.

## Test plan

- [x] `TestResolveExternalURLProviderDefaults` table-driven matrix covers
      every provider including operator-default and the bedrock
      negative case.
- [x] `TestCompileRouterConfigDefaultsAnthropicURL` pins the full
      compile path writing the default into both wire and status.
- [x] `TestCompileRouterConfigLiteLLMMissingURLFails` covers the
      unhealthy-no-default path.
- [x] Existing controller tests stay green.
- [x] golangci-lint adds zero new issues vs main.
- [ ] New ` ModelRouter Cluster` e2e spec applies an Anthropic backend
      with no url and verifies the status.backends[0].address is the
      Anthropic default. Verified end-to-end on the kind merge gate.
- [ ] Helm value documented in ` values.yaml` + schema; ` helm template`
      renders the flag correctly when set and omits it when empty.