### PR TITLE
fix: close cloud-tier conns + drop local idle timeout (closes #459)

### DIFF
--- a/internal/router/backend.go
+++ b/internal/router/backend.go
@@ -32,6 +32,17 @@ import (
 // intervention.
 const defaultQuarantineDuration = 15 * time.Second
 
+// defaultIdleConnTimeout caps how long the shared transport keeps
+// idle keep-alive connections to upstreams in its pool. The 10s value
+// is short enough that local llama-server / vLLM connections expire
+// before the upstream's own idle reaper closes them server-side
+// (which is what causes the "silent 30s stall on a healthy backend"
+// failure mode), but long enough to amortize the TCP handshake across
+// burst traffic in a typical agentic workload. Cloud-tier backends
+// bypass the pool entirely by setting `Connection: close` per request
+// in Dispatch; see the cloud-tier branch there for why.
+const defaultIdleConnTimeout = 10 * time.Second
+
 // backendHealth is the dispatcher's per-backend state. It implements
 // the half-open part of a circuit breaker: when MarkUnhealthy fires,
 // the backend is skipped until quarantineUntil; the first request
@@ -96,7 +107,7 @@ func NewDispatcher(cfg *Config, opts ...DispatcherOption) *Dispatcher {
 			Transport: &http.Transport{
 				MaxIdleConns:          100,
 				MaxIdleConnsPerHost:   10,
-				IdleConnTimeout:       90 * time.Second,
+				IdleConnTimeout:       defaultIdleConnTimeout,
 				ResponseHeaderTimeout: 30 * time.Second,
 			},
 		},
@@ -186,6 +197,23 @@ func (d *Dispatcher) Dispatch(
 	d.copyForwardedHeaders(headers, req.Header)
 	if err := d.applyCredentials(backend, req); err != nil {
 		return nil, err
+	}
+
+	// Cloud-tier backends commonly sit behind load balancers (AWS NLB,
+	// Cloudflare, Anthropic / OpenAI global LB) that aggressively
+	// recycle idle TCP connections without telling the client. Setting
+	// Connection: close on every outbound request opts that backend
+	// out of the shared keep-alive pool entirely: Go's http.Transport
+	// honors the header and closes the conn after this exchange
+	// regardless of pool capacity. The per-request handshake cost is
+	// negligible compared to typical cloud upstream latency, and we
+	// trade it for never seeing a "stale conn -> 30s silent stall"
+	// fingerprint. Local-tier backends keep the pool; their
+	// IdleConnTimeout (defaultIdleConnTimeout, 10s) is short enough
+	// that we don't see the same stale-conn failure mode.
+	if strings.EqualFold(backend.Tier, "cloud") {
+		req.Header.Set("Connection", "close")
+		req.Close = true
 	}
 
 	resp, err := d.client.Do(req)

--- a/internal/router/backend_test.go
+++ b/internal/router/backend_test.go
@@ -11,6 +11,11 @@ You may obtain a copy of the License at
 package router
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
 	"testing"
 	"time"
 )
@@ -106,5 +111,148 @@ func TestDispatcherUnknownBackendIsUnhealthy(t *testing.T) {
 	disp := NewDispatcher(&Config{})
 	if disp.IsHealthy("does-not-exist") {
 		t.Error("unknown backend should be reported unhealthy")
+	}
+}
+
+// TestDispatchCloudTierClosesConnection covers the cloud-tier
+// branch added for #459. Cloud backends sit behind LBs that recycle
+// idle conns silently; the proxy opts out of keep-alive on every
+// outbound cloud request via Connection: close + req.Close=true so
+// the next request always opens a fresh TCP conn rather than
+// risking a stale-pool 30s stall.
+func TestDispatchCloudTierClosesConnection(t *testing.T) {
+	var seenConnHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenConnHeader = r.Header.Get("Connection")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cfg := &Config{Backends: []Backend{{
+		Name: "cloud-anthropic", Tier: "cloud", Address: srv.URL,
+	}}}
+	disp := NewDispatcher(cfg)
+
+	resp, err := disp.Dispatch(context.Background(),
+		&cfg.Backends[0], http.MethodPost, "/v1/chat/completions",
+		http.Header{}, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// Go's http.Request.Close=true causes the transport to send
+	// Connection: close to the upstream. The server sees the literal
+	// header value.
+	if seenConnHeader != "close" {
+		t.Errorf("cloud-tier dispatch should carry Connection: close; server saw %q", seenConnHeader)
+	}
+}
+
+// TestDispatchLocalTierKeepsAlive is the inverse: local-tier backends
+// stay in the keep-alive pool to amortize the handshake. The proxy
+// must NOT send Connection: close on local dispatches.
+func TestDispatchLocalTierKeepsAlive(t *testing.T) {
+	var seenConnHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenConnHeader = r.Header.Get("Connection")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cfg := &Config{Backends: []Backend{{
+		Name: "local-qwen", Tier: "local", Address: srv.URL,
+	}}}
+	disp := NewDispatcher(cfg)
+
+	resp, err := disp.Dispatch(context.Background(),
+		&cfg.Backends[0], http.MethodPost, "/v1/chat/completions",
+		http.Header{}, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if seenConnHeader == "close" {
+		t.Errorf("local-tier dispatch should reuse keep-alive; got Connection: close")
+	}
+}
+
+// TestDispatchCloudTierOpensFreshConnPerRequest verifies the
+// end-to-end pool-bypass: two back-to-back dispatches to the same
+// cloud backend establish two separate TCP connections, while two
+// to a local backend reuse one. This is the observable property
+// that closes out the "stale conn -> 30s stall" failure mode at
+// the protocol level.
+func TestDispatchCloudTierOpensFreshConnPerRequest(t *testing.T) {
+	cases := []struct {
+		tier         string
+		wantDistinct int // we expect this many *distinct* local addrs
+	}{
+		{"cloud", 2},
+		{"local", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tier, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer srv.Close()
+
+			cfg := &Config{Backends: []Backend{{
+				Name: "b", Tier: tc.tier, Address: srv.URL,
+			}}}
+			disp := NewDispatcher(cfg)
+
+			localAddrs := map[string]struct{}{}
+			trace := &httptrace.ClientTrace{
+				GotConn: func(info httptrace.GotConnInfo) {
+					localAddrs[info.Conn.LocalAddr().String()] = struct{}{}
+				},
+			}
+			for i := 0; i < 2; i++ {
+				ctx := httptrace.WithClientTrace(context.Background(), trace)
+				resp, err := disp.Dispatch(ctx,
+					&cfg.Backends[0], http.MethodPost, "/x",
+					http.Header{}, []byte(`{}`))
+				if err != nil {
+					t.Fatalf("Dispatch %d: %v", i, err)
+				}
+				// Drain the body before close so Go's transport
+				// can hand the conn back to the pool. Without
+				// this the local-tier case shows two conns even
+				// though keep-alive is allowed, because the
+				// transport can't reuse a half-read body.
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+			}
+
+			if got := len(localAddrs); got != tc.wantDistinct {
+				t.Errorf("tier=%s: distinct local addrs = %d, want %d (%v)",
+					tc.tier, got, tc.wantDistinct, localAddrs)
+			}
+		})
+	}
+}
+
+// TestDispatcherUsesShortIdleConnTimeout pins the package-level
+// constant the transport uses so the "expire stale-from-upstream
+// conns before they wedge a request" behavior is observable from
+// outside the dispatcher.
+func TestDispatcherUsesShortIdleConnTimeout(t *testing.T) {
+	disp := NewDispatcher(&Config{})
+	tr, ok := disp.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", disp.client.Transport)
+	}
+	if tr.IdleConnTimeout != defaultIdleConnTimeout {
+		t.Errorf("IdleConnTimeout = %v, want %v", tr.IdleConnTimeout, defaultIdleConnTimeout)
+	}
+	if defaultIdleConnTimeout > 15*time.Second {
+		t.Errorf("defaultIdleConnTimeout = %v; should stay tight (<= 15s) to expire stale upstream conns",
+			defaultIdleConnTimeout)
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1229,6 +1229,40 @@ spec:
 					"expected controller to populate the Anthropic default URL")
 			}, 1*time.Minute, time.Second).Should(Succeed())
 		})
+
+		It("should send Connection: close on cloud-tier dispatch (no keep-alive pool)", func() {
+			// Regression test for #459. Cloud-tier backends bypass
+			// the proxy's keep-alive pool so a stale-from-upstream
+			// conn can never wedge a 30s wait at the dispatcher's
+			// ResponseHeaderTimeout. The stub-upstream's
+			// /__introspect__ endpoint reports every header it
+			// received per request; we POST twice and verify both
+			// requests arrived with Connection: close.
+			By("resetting cloud stub recordings")
+			resetStubs(mrcTestNs, cloudStubSvc)
+
+			By("POSTing twice via the complex-to-cloud rule")
+			for i := 0; i < 2; i++ {
+				out := chatCompletion(mrcTestNs, routerName,
+					map[string]string{"x-llmkube-task-complexity": "complex"},
+					`{"model":"claude-opus-4-7","stream":false,"messages":[{"role":"user","content":"hi"}]}`)
+				Expect(out).To(ContainSubstring("stub-response-from-"+cloudStubSvc),
+					"cloud stub should have served request %d", i)
+			}
+
+			By("verifying every cloud-tier dispatch carried Connection: close")
+			Eventually(func(g Gomega) {
+				snap := stubSnapshot(g, mrcTestNs, cloudStubSvc)
+				g.Expect(snap.Requests).To(HaveLen(2),
+					"cloud stub should have recorded both requests")
+				for i, req := range snap.Requests {
+					// Header canonicalization in Go's net/http
+					// normalizes to "Connection" (title case).
+					g.Expect(req.Headers["Connection"]).To(ContainElement("close"),
+						"request %d arrived without Connection: close", i)
+				}
+			}, 30*time.Second, time.Second).Should(Succeed())
+		})
 	})
 
 	Context("License Check", func() {


### PR DESCRIPTION
## Summary

Closes #459. The router-proxy's shared keep-alive pool held idle TCP
connections for 90s without probing them on reuse. Cloud LBs (NLB,
Cloudflare, the Anthropic / OpenAI public endpoints) aggressively
recycle idle conns server-side without telling the client. The next
request after an idle gap wrote to a dead-from-the-other-side socket;
TCP write succeeded locally but no response came, the dispatcher sat
until the 30s \`ResponseHeaderTimeout\`, and the audit log surfaced a
\`latencyMs=30003\` fail-closed.

This was the dominant flake in the two-model demo
(\`hack/demo-modelrouter.sh\` test 4) and a real production risk for
anyone fronting Anthropic / OpenAI / a LiteLLM proxy through the
ModelRouter.

## Approach

Header-only, no transport restructuring:

- **Cloud-tier backends**: \`Dispatch()\` sets \`req.Close = true\` and
  \`Connection: close\` when \`backend.Tier == \"cloud\"\`. Go's
  transport honors both and bypasses the pool. Per-request handshake
  cost is dwarfed by cloud upstream latency.
- **Local-tier**: shared transport's \`IdleConnTimeout\` drops from
  90s to 10s. Amortizes the handshake across burst traffic but
  expires conns before they go stale.

## Test plan

- [x] \`TestDispatchCloudTierClosesConnection\` — server-side
      asserts \`Connection: close\` arrived on cloud-tier dispatch.
- [x] \`TestDispatchLocalTierKeepsAlive\` — inverse.
- [x] \`TestDispatchCloudTierOpensFreshConnPerRequest\` — httptrace
      counts distinct local addrs; cloud=2, local=1.
- [x] \`TestDispatcherUsesShortIdleConnTimeout\` — pins the constant.
- [x] All existing router + controller tests stay green.
- [x] \`golangci-lint run ./...\` adds zero issues vs main.
- [ ] New e2e spec under \`ModelRouter Cluster\`: complex-to-cloud
      route, two POSTs, assert every recorded cloud-stub request
      carried \`Connection: close\`. Verified end-to-end on the kind
      merge gate.

## Non-breaking

CRD shape unchanged. Helm values unchanged. The behavior change is
internal to the proxy's dispatcher; any operator who was relying on
the 90s idle pool was already paying for the stale-conn failure mode
silently.