### PR TITLE
fix: don't quarantine backends on per-attempt context deadline (closes #462)

### DIFF
--- a/internal/router/backend.go
+++ b/internal/router/backend.go
@@ -13,6 +13,7 @@ package router
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -255,7 +256,20 @@ func (d *Dispatcher) Dispatch(
 
 	resp, err := d.client.Do(req)
 	if err != nil {
-		d.MarkUnhealthy(backend.Name)
+		// A per-attempt context deadline (caller's
+		// context.WithTimeout, eg the rule.timeout path from #461)
+		// is a rule-level policy decision, not a backend-health
+		// signal. The upstream may still be perfectly healthy and
+		// capable of serving other rules with longer budgets. Same
+		// for context.Canceled, which fires when an inbound client
+		// disconnects mid-dispatch. Reserve quarantine for genuine
+		// connectivity / 5xx failures so a tight rule's timeout
+		// doesn't poison a lenient sibling rule targeting the same
+		// backend. Closes #462.
+		if !errors.Is(err, context.DeadlineExceeded) &&
+			!errors.Is(err, context.Canceled) {
+			d.MarkUnhealthy(backend.Name)
+		}
 		return nil, fmt.Errorf("upstream request: %w", err)
 	}
 	if resp.StatusCode >= 500 {

--- a/internal/router/backend_test.go
+++ b/internal/router/backend_test.go
@@ -12,6 +12,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -288,5 +289,141 @@ func TestDispatcherResponseHeaderTimeoutOverride(t *testing.T) {
 	tr, _ := disp.client.Transport.(*http.Transport)
 	if tr.ResponseHeaderTimeout != 7*time.Second {
 		t.Errorf("transport ResponseHeaderTimeout = %v, want 7s", tr.ResponseHeaderTimeout)
+	}
+}
+
+// TestDispatchContextDeadlineDoesNotQuarantine covers the #462
+// regression: a per-attempt context deadline is a rule-level policy
+// decision, not a backend-health signal. The dispatcher must NOT
+// MarkUnhealthy on context.DeadlineExceeded so a strict rule's
+// timeout doesn't poison a lenient sibling rule targeting the same
+// backend.
+func TestDispatchContextDeadlineDoesNotQuarantine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Sleep longer than any caller's deadline. The dispatcher
+		// should give up via context.WithTimeout but leave us alive.
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cfg := &Config{Backends: []Backend{{
+		Name: "slow-but-alive", Tier: "local", Address: srv.URL,
+	}}}
+	disp := NewDispatcher(cfg)
+
+	// Tight deadline forces context.DeadlineExceeded.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	resp, err := disp.Dispatch(ctx, &cfg.Backends[0],
+		http.MethodPost, "/x", http.Header{}, []byte(`{}`))
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("Dispatch should have returned the deadline error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %v, want context.DeadlineExceeded chain", err)
+	}
+
+	// The backend must still be reported healthy: another rule with
+	// a generous budget should be free to dispatch right now.
+	if !disp.IsHealthy("slow-but-alive") {
+		t.Error("backend marked unhealthy on deadline-exceeded; sibling rules will starve until quarantine expires")
+	}
+}
+
+// TestDispatchContextCanceledDoesNotQuarantine pins the same
+// invariant for the context.Canceled case (inbound client
+// disconnects mid-dispatch). Same reasoning: the backend didn't
+// fail, the upstream caller went away.
+func TestDispatchContextCanceledDoesNotQuarantine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := &Config{Backends: []Backend{{
+		Name: "cancellable", Tier: "local", Address: srv.URL,
+	}}}
+	disp := NewDispatcher(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel the moment we send the request.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	resp, err := disp.Dispatch(ctx, &cfg.Backends[0],
+		http.MethodPost, "/x", http.Header{}, []byte(`{}`))
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("Dispatch should have returned the cancel error")
+	}
+
+	if !disp.IsHealthy("cancellable") {
+		t.Error("backend marked unhealthy on context.Canceled; client disconnect is not a backend signal")
+	}
+}
+
+// TestDispatchConnectionFailureStillQuarantines confirms the
+// dispatcher still treats genuine connection failures (closed
+// server, unreachable host) as a backend-health signal and
+// quarantines. Distinguishes the deadline-exception change above
+// from a blanket "never mark unhealthy" regression.
+func TestDispatchConnectionFailureStillQuarantines(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	addr := srv.URL
+	srv.Close() // shut it down so the next dial fails
+
+	cfg := &Config{Backends: []Backend{{
+		Name: "dead", Tier: "local", Address: addr,
+	}}}
+	disp := NewDispatcher(cfg)
+
+	resp, err := disp.Dispatch(context.Background(), &cfg.Backends[0],
+		http.MethodPost, "/x", http.Header{}, []byte(`{}`))
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("Dispatch should have failed against a closed server")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("unexpected deadline error; want a real connect/dial error")
+	}
+	if disp.IsHealthy("dead") {
+		t.Error("backend should be marked unhealthy after a connect failure")
+	}
+}
+
+// TestDispatchUpstream5xxStillQuarantines is the third corner of the
+// triangle: 5xx response must still trigger MarkUnhealthy (was the
+// only quarantine path before the half-open work; still true today).
+func TestDispatchUpstream5xxStillQuarantines(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := &Config{Backends: []Backend{{
+		Name: "broken", Tier: "local", Address: srv.URL,
+	}}}
+	disp := NewDispatcher(cfg)
+
+	resp, err := disp.Dispatch(context.Background(), &cfg.Backends[0],
+		http.MethodPost, "/x", http.Header{}, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Dispatch returned an error on 5xx: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if disp.IsHealthy("broken") {
+		t.Error("backend should be marked unhealthy after a 5xx response")
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1361,6 +1361,23 @@ spec:
 				g.Expect(out).To(ContainSubstring(`"rule":"tight-budget"`))
 				g.Expect(out).To(ContainSubstring(`"timeoutMs":200`))
 			}, 30*time.Second, time.Second).Should(Succeed())
+
+			By("immediately POSTing through the SAME backend with no header (lenient implicit rule) and expecting 200")
+			// Regression test for #462. Before the deadline-doesn't-
+			// quarantine fix, the tight rule's timeout above flipped
+			// the slow-local backend to unhealthy for 15 seconds,
+			// so this very next call (which would otherwise succeed
+			// — the stub's 800ms delay fits inside the proxy's 120s
+			// default for the implicit defaultRoute rule) failed
+			// with `backend "slow-local" marked unhealthy`. After
+			// the fix the backend stays healthy and dispatch
+			// succeeds.
+			_, status, err = runCurlInCluster(mrcTestNs, timeoutURL, "POST",
+				nil, // no x-llmkube-task header -> defaultRoute path
+				`{"model":"stub","stream":false,"messages":[{"role":"user","content":"hi"}]}`)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(200),
+				"lenient dispatch must not be poisoned by the strict rule's prior deadline; got %d", status)
 		})
 	})
 


### PR DESCRIPTION
## What

The router-proxy's dispatcher quarantined a backend on
`context.DeadlineExceeded` (a per-rule budget refusal), conflating
it with a backend-health signal. The half-open circuit breaker
then poisoned the backend for 15s — including for sibling rules
on the same router with much more generous timeouts. This PR
treats deadline/canceled as rule-level signals and reserves
quarantine for real connect failures / 5xx.

## Why

Fixes #462.

The bug emerged from the strict/relaxed PII policy pattern in the
demo script: same backend, two rules, two different budgets. A
tight rule's deadline poisoned the lenient sibling's access for
the full quarantine window. Audit log signature:

```
{...,"rule":"pii-strict","outcome":"fail_closed_runtime",
 "latencyMs":4001,"timeoutMs":4000}
{...,"rule":"pii-relaxed","outcome":"fail_closed_runtime",
 "latencyMs":0,"timeoutMs":30000}
```

`latencyMs=0` is the smoking gun — dispatch was gated by
`IsHealthy` before reaching the upstream.

This pattern (mixed-budget rules on the same router) is the
common shape for production users after #461 shipped per-rule
timeouts, and is exactly what the latency-SLO design in #437
targets.

## How

In `internal/router/backend.go:Dispatch()`, gate `MarkUnhealthy`
on the error class:

```go
if !errors.Is(err, context.DeadlineExceeded) &&
    !errors.Is(err, context.Canceled) {
    d.MarkUnhealthy(backend.Name)
}
```

Genuine connect failures (DNS, refused, reset) and 5xx responses
still flip the backend to unhealthy and trigger the circuit
breaker — that path is unchanged.

## Checklist

- [x] Tests added/updated — four new dispatcher tests cover all
      three corners (deadline, canceled, conn-fail, 5xx)
- [x] `make test` passes locally
- [x] `make lint` passes locally (lint adds zero new issues vs main)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated — no user-facing surface change, audit
      log shape unchanged. Operators who previously saw spurious
      "backend marked unhealthy" after a deadline now see correct
      dispatch behavior.