### PR TITLE
docs(site): air-gapped, OpenShift, macOS Metal guides + architecture refresh (Tier 1)

### DIFF
--- a/docs/site/_meta/nav.yaml
+++ b/docs/site/_meta/nav.yaml
@@ -58,7 +58,12 @@ sections:
       - label: Air-gapped install
         slug: guides/air-gapped
         file: guides/air-gapped.md
-        status: stub
+      - label: OpenShift / OKD / MicroShift install
+        slug: guides/openshift-install
+        file: guides/openshift-install.md
+      - label: macOS Metal Agent
+        slug: guides/macos-metal
+        file: guides/macos-metal.md
       - label: Multi-GPU sharding
         slug: guides/multi-gpu
         file: guides/multi-gpu.md

--- a/docs/site/concepts/architecture.md
+++ b/docs/site/concepts/architecture.md
@@ -1,0 +1,196 @@
+---
+title: Architecture
+description: How LLMKube's controller, runtime pods, metal-agent, and router-proxy work together. Two cooperating control planes (in-cluster controller plus optional host-native metal-agent) and one data plane (the runtime pods and, when ModelRouter is in use, the router-proxy).
+---
+
+# Architecture
+
+LLMKube's architecture is shaped around a single guiding decision:
+the *control plane* lives in Kubernetes, but the *workload* can
+live wherever the GPU lives. That lets the same operator manage
+NVIDIA pods running inside the cluster, Apple Silicon Macs running
+native processes alongside the cluster, and external cloud
+providers routed through `ModelRouter` — all surfaced as the same
+CRDs to `kubectl`.
+
+This page is the map of how those pieces fit together.
+
+## The three custom resources
+
+All three live in `inference.llmkube.dev/v1alpha1`.
+
+- **`Model`** declares a model artifact: where the GGUF / HF
+  weights come from (URL, PVC, file path, HuggingFace repo ID),
+  what runtime can consume it, and any hardware preferences
+  (Metal vs CUDA, multi-GPU sharding hints).
+- **`InferenceService`** declares a serving deployment: a
+  reference to a `Model`, a runtime (`llamacpp`, `vllm`, `tgi`,
+  `ollama`), replicas, resources, an OpenAI-compatible endpoint.
+  Two `InferenceService` objects can share a `Model`.
+- **`ModelRouter`** declares a policy-aware HTTP router in front
+  of one or more `InferenceService` and / or external
+  provider backends. Optional; only needed when you want
+  classification-aware routing, fail-closed semantics, or
+  per-rule timeout budgets.
+
+See the [`CRD reference`](./crds) for every field, and the
+[`Model Router`](./model-router) concept doc for the full policy
+model.
+
+## The two control planes
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Kubernetes cluster                          │
+│                                                                 │
+│   ┌──────────────────────────────────────────────────────┐      │
+│   │ LLMKube controller (in-cluster)                      │      │
+│   │   • Reconciles Model / InferenceService / ModelRouter│      │
+│   │   • Schedules runtime pods (NVIDIA path)             │      │
+│   │   • Schedules router-proxy Deployment                │      │
+│   │   • Owns CRD status, conditions, audit events        │      │
+│   └──────────────────────────────────────────────────────┘      │
+│                                                                 │
+│   Runtime pods (NVIDIA / CPU)         router-proxy Deployment   │
+│   ┌─────────────────┐                  ┌─────────────────┐      │
+│   │ llama.cpp / vLLM│  ◄──policy──     │  ModelRouter    │      │
+│   │ TGI / Ollama    │                  │  data plane     │      │
+│   └─────────────────┘                  └─────────────────┘      │
+└─────────────────────────────────────────────────────────────────┘
+                                          ▲
+                                          │ policy decisions per request
+                                          │
+                                  ┌─────────────────┐
+                                  │ external models │
+                                  │ (Anthropic /    │
+                                  │  OpenAI /       │
+                                  │  LiteLLM)       │
+                                  └─────────────────┘
+
+       ┌────────────────────────────────────────────────────┐
+       │ Apple Silicon host (optional, on the LAN/VPN)      │
+       │                                                    │
+       │   metal-agent ──supervises──▶ llama-server          │
+       │      (native macOS daemon)    (Metal GPU access)   │
+       │                                                    │
+       │   metal-agent ──registers──▶ Kubernetes Endpoints  │
+       │       (host IP + allocated port)                   │
+       └────────────────────────────────────────────────────┘
+```
+
+**The in-cluster controller** is the source of truth for desired
+state. It watches the CRDs, schedules runtime pods (for NVIDIA /
+CPU workloads), creates the `Service` / `ConfigMap` / `Deployment`
+for `ModelRouter` data planes, and writes back status.
+
+**The metal-agent** is a native macOS daemon that runs *outside*
+the cluster on Apple Silicon hosts. It also watches the
+Kubernetes API for `InferenceService` resources with
+`accelerator: metal`, but instead of scheduling a Pod it spawns
+`llama-server` natively on the Mac with full Metal GPU access,
+then registers a Kubernetes `Endpoints` object pointing at the
+Mac's host IP. Any pod in the cluster can route to the Mac via
+the resulting `Service` URL.
+
+The two cooperate without overlap: the in-cluster controller
+manages everything *inside* Kubernetes (CRD status, container
+pods, Services, ConfigMaps); the metal-agent manages everything
+*outside* (native processes, Metal context, host memory
+pressure). The CRD is the protocol between them.
+
+See [`macOS Metal Agent`](../guides/macos-metal) for the
+agent's install and tuning.
+
+## The data plane
+
+There are two data planes a request can hit, depending on whether
+`ModelRouter` is in use:
+
+1. **Direct InferenceService**: a client (your application, an
+   agent runtime) talks straight to the `InferenceService`'s
+   `Service` URL. That URL is OpenAI-compatible and points at
+   either a Pod (NVIDIA / CPU) or a metal-agent-registered
+   Endpoint (Apple Silicon). No policy layer.
+
+2. **Through ModelRouter**: the client talks to the
+   `ModelRouter`'s `Service` URL. The router-proxy pod
+   resolves the request's classification, task complexity,
+   capabilities, and headers against the router's rules, picks a
+   backend, and dispatches to either an in-cluster
+   `InferenceService` *or* an external provider (Anthropic /
+   OpenAI / LiteLLM / Bedrock / Vertex). Streaming SSE
+   passthrough; fail-closed semantics enforced at the proxy
+   for regulated-data rules.
+
+Pick (1) when an agent or app just needs one model. Pick (2) when
+you have multiple models, mixed local + external providers, or
+data classifications that require policy enforcement. The two
+shapes compose: you can have direct clients hitting some
+InferenceServices and policy-routed clients hitting the same
+InferenceServices through a ModelRouter.
+
+## Streaming, classification, and audit
+
+The proxy emits a structured audit log entry per request:
+
+```json
+{
+  "msg": "router.dispatch",
+  "rule": "pii-stays-local",
+  "backend": "local-coder",
+  "backendTier": "local",
+  "status": 200,
+  "outcome": "ok",
+  "latencyMs": 4271,
+  "timeoutMs": 8000
+}
+```
+
+Every routing decision is recoverable from the log. Compliance
+audits, "why did this 503", and per-rule budget verification all
+trace back to those records. Pair with Prometheus metrics
+(planned in the next observability pass) and the OTel tracing the
+controller already emits to Tempo for full visibility.
+
+## Why this shape
+
+A few decisions worth being explicit about:
+
+- **The control plane is inside the cluster, not on a Mac.**
+  Apple Silicon serves traffic; it doesn't manage state.
+  Restarting your Mac doesn't lose any CRD or controller state.
+- **The router-proxy is a managed Deployment, not a service-mesh
+  Filter.** It runs as a normal pod the controller owns. No
+  service-mesh dependency, air-gap-friendly, and policy stays in
+  Go where we control it.
+- **Cross-engine routing is a separate CRD, not a flag on
+  `InferenceService`.** That keeps the simple case simple (just
+  declare a model, get a serving endpoint) and lets the policy
+  case grow without overloading the inference surface.
+- **The data classification is read from a request header, not
+  inferred.** Operators can opt in to classifier sidecars later;
+  the v1alpha1 contract is "the caller asserts the
+  classification" so the proxy never has to be the source of
+  truth for what data is sensitive.
+
+## Where things live in the repo
+
+| Component | Source |
+|---|---|
+| Controller binary | `cmd/main.go`, `internal/controller/**` |
+| CRD types | `api/v1alpha1/*.go` |
+| metal-agent binary | `cmd/metal-agent/main.go`, `pkg/agent/**` |
+| router-proxy binary | `cmd/router-proxy/main.go`, `internal/router/**` |
+| Helm chart | `charts/llmkube/` |
+| CRD manifests (generated) | `config/crd/bases/`, `charts/llmkube/templates/crds/` |
+| Sample CRs | `config/samples/` |
+
+## Next steps
+
+- [`CRD reference`](./crds) for every field on every resource
+- [`Model Router`](./model-router) for the policy / fail-closed
+  semantics covered briefly above
+- [`How LLMKube compares`](./comparison) versus vLLM, Ollama,
+  KServe, LocalAI, KubeAI, llm-d, LiteLLM
+- [`Install in 5 minutes`](../getting-started) to provision a
+  cluster and try this end-to-end

--- a/docs/site/guides/air-gapped.md
+++ b/docs/site/guides/air-gapped.md
@@ -1,0 +1,383 @@
+---
+title: Air-gapped install
+description: Deploy LLMKube and its models in clusters with no internet access. Covers offline operator install, private container registries, custom CA certificates, model storage strategies, and using ModelRouter without external providers.
+---
+
+# Air-gapped install
+
+LLMKube ships designed to install and operate in clusters with no
+internet access. Government / defense, HIPAA-regulated healthcare,
+financial trading floors, remote-edge sites, and any corporate
+network with restrictive egress all fit the same shape: get the
+operator image, the runtime image, the model weights, and a CA
+bundle to the cluster once, then never reach the public internet
+again.
+
+This guide covers each piece end to end against the current `v0.7.8`
+release.
+
+## Prerequisites
+
+- A Kubernetes cluster (v1.30+) without public-internet egress
+- A workstation with cluster access (`kubectl`, `helm`, optionally
+  the `llmkube` CLI)
+- A "sneakernet path": some way to copy a few tens of GB of files
+  from a connected machine into the air-gapped environment
+- One of: pre-downloaded GGUF model files, a private container
+  registry the cluster can reach, or a `ReadOnlyMany` PVC seeded
+  with model weights
+
+## Architecture overview
+
+Three workloads need to land inside the air gap:
+
+1. **The operator** (`ghcr.io/defilantech/llmkube-controller:v0.7.8`)
+   reconciles `Model`, `InferenceService`, and `ModelRouter` custom
+   resources.
+2. **The runtime images** (`ghcr.io/ggml-org/llama.cpp:server-cuda13`
+   for llama.cpp; equivalents for vLLM, TGI, Ollama). The operator
+   only schedules pods using these; it doesn't pull weights into
+   them.
+3. **The router-proxy** (`ghcr.io/defilantech/llmkube-router-proxy:dev`)
+   if you use `ModelRouter`. Only needed when you want the
+   policy-aware routing layer.
+
+Plus the model weights themselves, which the operator either copies
+from a local source or mounts from a PVC. There is no model-weight
+download from the operator's runtime pods at request time.
+
+## Step 1: Stage the container images
+
+On a connected machine, save the four images you need:
+
+```bash
+docker pull ghcr.io/defilantech/llmkube-controller:v0.7.8
+docker pull ghcr.io/defilantech/llmkube-router-proxy:v0.7.8
+docker pull ghcr.io/ggml-org/llama.cpp:server-cuda13
+docker pull docker.io/curlimages/curl:8.18.0   # init container
+
+docker save \
+  ghcr.io/defilantech/llmkube-controller:v0.7.8 \
+  ghcr.io/defilantech/llmkube-router-proxy:v0.7.8 \
+  ghcr.io/ggml-org/llama.cpp:server-cuda13 \
+  docker.io/curlimages/curl:8.18.0 \
+  > llmkube-bundle.tar
+```
+
+Transfer the bundle, then on the air-gapped side push to your
+private registry:
+
+```bash
+docker load < llmkube-bundle.tar
+for img in \
+  ghcr.io/defilantech/llmkube-controller:v0.7.8 \
+  ghcr.io/defilantech/llmkube-router-proxy:v0.7.8 \
+  ghcr.io/ggml-org/llama.cpp:server-cuda13 \
+  docker.io/curlimages/curl:8.18.0
+do
+  newtag="registry.internal.corp/${img#*/}"
+  docker tag "$img" "$newtag"
+  docker push "$newtag"
+done
+```
+
+## Step 2: Install the operator from your private registry
+
+Pull the Helm chart on the connected side:
+
+```bash
+helm repo add llmkube https://defilantech.github.io/LLMKube
+helm pull llmkube/llmkube --untar
+```
+
+Transfer the chart directory into the air gap, then install with
+overrides pointing at your registry:
+
+```bash
+helm install llmkube ./llmkube \
+  --namespace llmkube-system --create-namespace \
+  --set controllerManager.image.repository=registry.internal.corp/defilantech/llmkube-controller \
+  --set controllerManager.image.tag=v0.7.8 \
+  --set controllerManager.routerProxy.repository=registry.internal.corp/defilantech/llmkube-router-proxy \
+  --set controllerManager.routerProxy.tag=v0.7.8 \
+  --set controllerManager.initContainer.image=registry.internal.corp/curlimages/curl:8.18.0
+```
+
+The `initContainer.image` override matters: by default the
+operator's `Model` reconciler schedules an init container that pulls
+model weights via HTTP(S). In an air-gapped environment that
+container still runs (even when reading from a `pvc://` or local
+file source — it sets up the on-disk layout). If your registry
+mirror requires a different image (your own distroless curl, for
+example), point it here.
+
+### OpenShift / OKD / MicroShift
+
+Use the bundled preset, which is air-gap-safe on top of being
+SCC-compliant:
+
+```bash
+helm install llmkube ./llmkube \
+  -f ./llmkube/values-openshift.yaml \
+  --namespace llmkube-system --create-namespace \
+  --set controllerManager.image.repository=registry.internal.corp/defilantech/llmkube-controller \
+  --set controllerManager.image.tag=v0.7.8 \
+  --set controllerManager.initContainer.image=registry.internal.corp/curlimages/curl:8.18.0
+```
+
+See [`OpenShift install`](./openshift-install) for the full
+restricted-v2 SCC walkthrough.
+
+## Step 3: Custom CA certificates
+
+Most air-gapped corporate networks intercept TLS with an internal
+CA. The operator's init container needs that CA in its trust store
+to clone the model file over HTTPS from your internal model server.
+
+1. Create a `ConfigMap` in the operator's namespace with one
+   `ca.crt` key:
+
+   ```bash
+   kubectl -n llmkube-system create configmap corporate-ca \
+     --from-file=ca.crt=/path/to/corporate-root-ca.pem
+   ```
+
+2. Point the operator at it via the Helm value:
+
+   ```bash
+   helm upgrade llmkube ./llmkube \
+     -n llmkube-system \
+     --reuse-values \
+     --set controllerManager.caCertConfigMap=corporate-ca
+   ```
+
+3. The operator now mounts that ConfigMap into every init container
+   it spawns, so model downloads from `https://model-server.internal`
+   succeed without skipping verification. The CA is also picked up
+   by the controller itself for any reconcile-time HTTP calls.
+
+## Step 4: Get model weights into the cluster
+
+Pick one of four shapes. The PVC option is the most operationally
+predictable for air-gapped fleets.
+
+### Option A: `pvc://` (recommended)
+
+Seed a `ReadOnlyMany` PVC once with the weights, then reference it
+from every `Model`:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+  namespace: default
+spec:
+  accessModes: [ReadOnlyMany]
+  resources: { requests: { storage: 100Gi } }
+  storageClassName: nfs  # or whatever your air-gapped cluster has
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata: { name: llama-3-8b, namespace: default }
+spec:
+  source: pvc://model-cache/llama-3.1-8b-q4_k_m.gguf
+  format: gguf
+```
+
+The controller validates the PVC exists and is Bound, marks the
+`Model` Ready immediately, and the `InferenceService` mounts the
+PVC read-only into the runtime pod. No init-container download, no
+HTTP traffic.
+
+### Option B: Internal HTTP server
+
+If you already run a model server (NGINX serving GGUFs, an S3-
+compatible internal bucket, an artifact registry):
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata: { name: llama-3-8b }
+spec:
+  source: https://model-server.internal.corp/llama-3.1-8b-q4_k_m.gguf
+  format: gguf
+  sha256: "a1b2c3d4e5f6...64-char-hex-string..."  # strongly recommended
+```
+
+The `sha256` field is the audit trail air-gapped operators need:
+the controller computes the hash after copy and rejects the model
+if it doesn't match. The computed value is written to
+`status.sha256` either way.
+
+### Option C: File path on the node
+
+Lowest-ceremony option for single-node or DaemonSet shapes:
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+spec:
+  source: file:///mnt/models/llama-3.1-8b-q4_k_m.gguf
+  format: gguf
+```
+
+Pin the workload to nodes that have the file (via Deployment node
+selector, taint/toleration, or affinity). The operator does not
+distribute the file across nodes; that's the operator's
+responsibility.
+
+### Option D: HuggingFace repo ID (Ollama / vLLM only)
+
+vLLM and Ollama runtimes can resolve HF repo IDs at runtime from a
+mirror. Point your runtime image's `HF_ENDPOINT` environment
+variable at your internal mirror (e.g. an Artifactory or Sonatype
+Nexus repository) and use:
+
+```yaml
+spec:
+  source: meta-llama/Meta-Llama-3.1-8B-Instruct
+  format: hf-repo
+```
+
+## Step 5: Verify
+
+```bash
+kubectl -n default get models,inferenceservices
+# expect: PHASE=Ready on the Model and on the InferenceService
+
+kubectl -n default port-forward svc/llama-3-8b 8080:8080 &
+curl -sS http://localhost:8080/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"llama-3-8b","messages":[{"role":"user","content":"hi"}]}'
+```
+
+If the call returns a token stream, the air-gap install is complete.
+
+## ModelRouter in air-gapped clusters
+
+The `ModelRouter` CRD enables policy-aware routing across multiple
+backends. In an air-gapped cluster, "external provider" backends
+target an internal LiteLLM proxy or a private-cloud inference
+endpoint, not the public Anthropic / OpenAI APIs.
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata: { name: secure-router, namespace: default }
+spec:
+  backends:
+    - name: local-llama
+      inferenceServiceRef: { name: llama-3-8b }
+      tier: local
+    - name: internal-litellm
+      external:
+        provider: litellm
+        url: http://litellm.gateway.internal.corp:4000
+        model: internal-claude-clone
+        credentialsSecretRef: { name: litellm-key }
+      tier: cloud   # tier name is internal; doesn't imply public internet
+  rules:
+    - name: pii-stays-local
+      match: { dataClassification: [pii] }
+      route: { backends: [local-llama] }
+      failClosed: true
+      timeout: 8s
+  defaultRoute: local-llama
+```
+
+Two air-gap-relevant properties:
+
+- **`failClosed: true`** on a rule rejects the request rather than
+  falling through. In a regulated environment this is the
+  enforcement boundary: PII can never spill onto a cloud-tier
+  backend even if one is configured, because the controller
+  validates that at apply time *and* the proxy enforces it at
+  request time.
+- **`provider: litellm`** with a private URL: LLMKube does not
+  reach `api.litellm.ai`. The `provider` value selects the request-
+  shape adapter; the `url` is the only thing dialed. Routes through
+  your internal LiteLLM proxy, which then handles any further
+  internal-cloud calls. See the
+  [`ModelRouter concept doc`](../concepts/model-router) for the
+  full policy model.
+
+## Storage strategy
+
+| Shape | Best for | Trade-off |
+|---|---|---|
+| `pvc://` with `ReadOnlyMany` NFS | Multi-node clusters, mixed read traffic | Requires shared storage |
+| `pvc://` with `ReadWriteOnce` local SSD | Single-node, fastest cold-start | One pod at a time per PVC |
+| Internal HTTPS server + SHA256 | Multi-cluster fleets that already have an artifact server | Controller computes hash on every download |
+| Node-local `file://` | Single-node demos, DaemonSet shape | Requires pinning workload to nodes that have the file |
+
+For ModelRouter installations the proxy is stateless and doesn't
+need its own storage. Only the runtime pods need model weight
+access.
+
+## Troubleshooting
+
+**Model stuck in `Pending` with `init container exit 23`**
+The init container couldn't reach the source URL. Check the
+`controllerManager.caCertConfigMap` is set if your URL uses
+internal TLS. View the init log:
+`kubectl logs <pod> -c model-downloader`.
+
+**Model stuck in `Pending` with `dial tcp ... no route to host`**
+The cluster's egress policy is blocking the connection. Confirm
+your `NetworkPolicy` permits the runtime namespace to reach
+`model-server.internal.corp` on port 443.
+
+**`pvc://` source reports `PVC <name> not Bound`**
+The PVC exists but no PV satisfies it. Check
+`kubectl describe pvc <name>` for binding failures; storage class
+mismatches are the most common cause in fresh air-gapped clusters.
+
+**Operator pod `ImagePullBackOff`**
+`controllerManager.image.repository` is wrong or the registry needs
+auth. Add `imagePullSecrets` in the Helm values:
+
+```bash
+helm upgrade llmkube ./llmkube \
+  -n llmkube-system --reuse-values \
+  --set 'controllerManager.imagePullSecrets[0].name=internal-registry-creds'
+```
+
+## SHA256 audit and integrity
+
+Every `Model` whose source is `https://` or `file://` gets a
+`status.sha256` written by the controller after the download
+completes. Pair this with the optional `spec.sha256` field for
+fail-closed integrity verification:
+
+```yaml
+spec:
+  source: https://model-server.internal.corp/model.gguf
+  sha256: a1b2c3d4...
+```
+
+If the computed hash does not match `spec.sha256`, the controller
+marks the `Model` `Failed` with the mismatch message in
+`status.conditions[type=Ready].message`. The init container never
+hands the bad file to a runtime pod.
+
+`pvc://` sources don't get a `status.sha256` because the controller
+doesn't mount PVCs at reconcile time. Compute the hash externally
+when seeding the PVC if you need provenance.
+
+## Next steps
+
+- [`OpenShift install`](./openshift-install) for restricted-v2 SCC
+  clusters
+- [`Multi-GPU sharding`](./multi-gpu) for 70B+ models across two
+  or more GPUs
+- [`Model cache`](./model-cache) for the persistent PVC cache
+  pattern that complements pvc:// sources
+- [`Model Router`](../concepts/model-router) for the policy /
+  fail-closed semantics summarized above
+
+## Reference
+
+- [Helm chart values](../reference/helm-values)
+- [CRD reference](../concepts/crds)
+- [Architecture overview](../concepts/architecture)

--- a/docs/site/guides/air-gapped.md
+++ b/docs/site/guides/air-gapped.md
@@ -13,7 +13,7 @@ operator image, the runtime image, the model weights, and a CA
 bundle to the cluster once, then never reach the public internet
 again.
 
-This guide covers each piece end to end against the current `v0.7.8`
+This guide covers each piece end to end against the current `v0.7.7`
 release.
 
 ## Prerequisites
@@ -31,7 +31,7 @@ release.
 
 Three workloads need to land inside the air gap:
 
-1. **The operator** (`ghcr.io/defilantech/llmkube-controller:v0.7.8`)
+1. **The operator** (`ghcr.io/defilantech/llmkube-controller:v0.7.7`)
    reconciles `Model`, `InferenceService`, and `ModelRouter` custom
    resources.
 2. **The runtime images** (`ghcr.io/ggml-org/llama.cpp:server-cuda13`
@@ -40,7 +40,14 @@ Three workloads need to land inside the air gap:
    them.
 3. **The router-proxy** (`ghcr.io/defilantech/llmkube-router-proxy:dev`)
    if you use `ModelRouter`. Only needed when you want the
-   policy-aware routing layer.
+   policy-aware routing layer. The release pipeline does not yet
+   ship versioned router-proxy images alongside the controller, so
+   the chart default is the `dev` tag (see
+   [`#449`](https://github.com/defilantech/LLMKube/issues/449)). If
+   you need a pinned tag in an air-gapped registry, build the image
+   yourself from this commit (`make docker-build-router-proxy
+   ROUTER_PROXY_IMG=registry.internal.corp/defilantech/llmkube-router-proxy:0.7.7`)
+   and use that tag below.
 
 Plus the model weights themselves, which the operator either copies
 from a local source or mounts from a PVC. There is no model-weight
@@ -51,14 +58,14 @@ download from the operator's runtime pods at request time.
 On a connected machine, save the four images you need:
 
 ```bash
-docker pull ghcr.io/defilantech/llmkube-controller:v0.7.8
-docker pull ghcr.io/defilantech/llmkube-router-proxy:v0.7.8
+docker pull ghcr.io/defilantech/llmkube-controller:v0.7.7
+docker pull ghcr.io/defilantech/llmkube-router-proxy:dev
 docker pull ghcr.io/ggml-org/llama.cpp:server-cuda13
 docker pull docker.io/curlimages/curl:8.18.0   # init container
 
 docker save \
-  ghcr.io/defilantech/llmkube-controller:v0.7.8 \
-  ghcr.io/defilantech/llmkube-router-proxy:v0.7.8 \
+  ghcr.io/defilantech/llmkube-controller:v0.7.7 \
+  ghcr.io/defilantech/llmkube-router-proxy:dev \
   ghcr.io/ggml-org/llama.cpp:server-cuda13 \
   docker.io/curlimages/curl:8.18.0 \
   > llmkube-bundle.tar
@@ -70,8 +77,8 @@ private registry:
 ```bash
 docker load < llmkube-bundle.tar
 for img in \
-  ghcr.io/defilantech/llmkube-controller:v0.7.8 \
-  ghcr.io/defilantech/llmkube-router-proxy:v0.7.8 \
+  ghcr.io/defilantech/llmkube-controller:v0.7.7 \
+  ghcr.io/defilantech/llmkube-router-proxy:dev \
   ghcr.io/ggml-org/llama.cpp:server-cuda13 \
   docker.io/curlimages/curl:8.18.0
 do
@@ -97,19 +104,22 @@ overrides pointing at your registry:
 helm install llmkube ./llmkube \
   --namespace llmkube-system --create-namespace \
   --set controllerManager.image.repository=registry.internal.corp/defilantech/llmkube-controller \
-  --set controllerManager.image.tag=v0.7.8 \
+  --set controllerManager.image.tag=v0.7.7 \
   --set controllerManager.routerProxy.repository=registry.internal.corp/defilantech/llmkube-router-proxy \
-  --set controllerManager.routerProxy.tag=v0.7.8 \
-  --set controllerManager.initContainer.image=registry.internal.corp/curlimages/curl:8.18.0
+  --set controllerManager.routerProxy.tag=dev \
+  --set controllerManager.initContainer.repository=registry.internal.corp/curlimages/curl \
+  --set controllerManager.initContainer.tag=8.18.0
 ```
 
-The `initContainer.image` override matters: by default the
-operator's `Model` reconciler schedules an init container that pulls
-model weights via HTTP(S). In an air-gapped environment that
-container still runs (even when reading from a `pvc://` or local
-file source — it sets up the on-disk layout). If your registry
-mirror requires a different image (your own distroless curl, for
-example), point it here.
+The `initContainer.repository` / `initContainer.tag` overrides
+matter: by default the InferenceService Pod schedules an init
+container that pulls model weights via HTTP(S). In an air-gapped
+environment that container still runs (even when reading from a
+`pvc://` or local file source — it sets up the on-disk layout). If
+your registry mirror requires a different image (your own distroless
+curl, for example), point it here. The chart consumes these as two
+separate fields, not a single `image` value (see
+[`_helpers.tpl`](https://github.com/defilantech/LLMKube/blob/main/charts/llmkube/templates/_helpers.tpl)).
 
 ### OpenShift / OKD / MicroShift
 
@@ -121,8 +131,9 @@ helm install llmkube ./llmkube \
   -f ./llmkube/values-openshift.yaml \
   --namespace llmkube-system --create-namespace \
   --set controllerManager.image.repository=registry.internal.corp/defilantech/llmkube-controller \
-  --set controllerManager.image.tag=v0.7.8 \
-  --set controllerManager.initContainer.image=registry.internal.corp/curlimages/curl:8.18.0
+  --set controllerManager.image.tag=v0.7.7 \
+  --set controllerManager.initContainer.repository=registry.internal.corp/curlimages/curl \
+  --set controllerManager.initContainer.tag=8.18.0
 ```
 
 See [`OpenShift install`](./openshift-install) for the full
@@ -134,27 +145,36 @@ Most air-gapped corporate networks intercept TLS with an internal
 CA. The operator's init container needs that CA in its trust store
 to clone the model file over HTTPS from your internal model server.
 
-1. Create a `ConfigMap` in the operator's namespace with one
-   `ca.crt` key:
+The controller binary accepts a `--ca-cert-configmap` flag that
+takes the name of a ConfigMap holding a `ca.crt` key. The Helm
+chart does not yet expose this as a top-level value (tracked
+upstream as a documentation/chart-coverage gap), so you wire it in
+by editing the controller Deployment args directly after install:
+
+1. Create a `ConfigMap` in every namespace where you will deploy
+   `InferenceService` objects (the init container runs in the
+   workload's namespace, not the operator's):
 
    ```bash
-   kubectl -n llmkube-system create configmap corporate-ca \
+   kubectl -n default create configmap corporate-ca \
      --from-file=ca.crt=/path/to/corporate-root-ca.pem
    ```
 
-2. Point the operator at it via the Helm value:
+2. Patch the controller Deployment to pass the flag:
 
    ```bash
-   helm upgrade llmkube ./llmkube \
-     -n llmkube-system \
-     --reuse-values \
-     --set controllerManager.caCertConfigMap=corporate-ca
+   kubectl -n llmkube-system patch deployment llmkube-controller-manager \
+     --type=json \
+     -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--ca-cert-configmap=corporate-ca"}]'
    ```
 
 3. The operator now mounts that ConfigMap into every init container
    it spawns, so model downloads from `https://model-server.internal`
-   succeed without skipping verification. The CA is also picked up
-   by the controller itself for any reconcile-time HTTP calls.
+   succeed without skipping verification.
+
+Repeat step 1 for each application namespace; the operator looks up
+the ConfigMap in the InferenceService's own namespace at reconcile
+time.
 
 ## Step 4: Get model weights into the cluster
 
@@ -318,9 +338,10 @@ access.
 ## Troubleshooting
 
 **Model stuck in `Pending` with `init container exit 23`**
-The init container couldn't reach the source URL. Check the
-`controllerManager.caCertConfigMap` is set if your URL uses
-internal TLS. View the init log:
+The init container couldn't reach the source URL. Confirm the
+`--ca-cert-configmap` flag is set on the controller (see Step 3) if
+your URL uses internal TLS, and that the named ConfigMap exists in
+the InferenceService's namespace. View the init log:
 `kubectl logs <pod> -c model-downloader`.
 
 **Model stuck in `Pending` with `dial tcp ... no route to host`**
@@ -335,12 +356,13 @@ mismatches are the most common cause in fresh air-gapped clusters.
 
 **Operator pod `ImagePullBackOff`**
 `controllerManager.image.repository` is wrong or the registry needs
-auth. Add `imagePullSecrets` in the Helm values:
+auth. Add `imagePullSecrets` in the Helm values (the field is
+top-level, not under `controllerManager`):
 
 ```bash
 helm upgrade llmkube ./llmkube \
   -n llmkube-system --reuse-values \
-  --set 'controllerManager.imagePullSecrets[0].name=internal-registry-creds'
+  --set 'imagePullSecrets[0].name=internal-registry-creds'
 ```
 
 ## SHA256 audit and integrity

--- a/docs/site/guides/macos-metal.md
+++ b/docs/site/guides/macos-metal.md
@@ -1,0 +1,360 @@
+---
+title: macOS Metal Agent
+description: Run Metal-accelerated LLM inference on Apple Silicon Macs as a first-class Kubernetes workload. The Metal Agent is a native macOS daemon that watches the Kubernetes API and supervises llama-server processes with full Metal GPU access.
+---
+
+# macOS Metal Agent
+
+LLMKube's Metal Agent is the thing no other Kubernetes LLM tool
+does. It lets your Mac Studio, Mac mini, or any Apple Silicon
+machine serve as a first-class Kubernetes inference node — with
+the same `InferenceService` CRD you use for NVIDIA GPUs and
+without losing access to Metal because the workload is trapped in
+a container.
+
+The shape: a native macOS daemon (the agent) watches the
+Kubernetes API for `InferenceService` resources marked
+`accelerator: metal`, spawns `llama-server` processes natively
+with full Metal GPU access, and registers endpoints back into the
+cluster so any pod can route traffic to your Mac over LAN /
+Tailscale / WireGuard.
+
+This guide gets you from a fresh Apple Silicon machine to a
+running Metal-accelerated InferenceService in about ten minutes.
+
+## Prerequisites
+
+- **Apple Silicon Mac** (M1 / M2 / M3 / M4 / M5). Intel Macs with
+  Metal 2+ work but performance is materially worse.
+- **Access to a Kubernetes cluster** — either remote (recommended;
+  most production patterns put the Mac on the LAN as an inference
+  node) or local (minikube / kind on Docker Desktop).
+- **kubectl** configured against your cluster.
+- **Homebrew** (or any equivalent way to install `llama.cpp` with
+  Metal support).
+
+## Step 1: Install llama.cpp with Metal
+
+```bash
+brew install llama.cpp
+```
+
+Verify Metal is detected:
+
+```bash
+system_profiler SPDisplaysDataType | grep Metal
+# expected: Metal Support: Metal 3
+```
+
+## Step 2: Install the LLMKube operator in your cluster
+
+If you haven't already, install the operator. The Metal Agent
+relies on the operator's CRDs being installed and the controller
+running.
+
+```bash
+helm repo add llmkube https://defilantech.github.io/LLMKube
+helm install llmkube llmkube/llmkube \
+  -n llmkube-system --create-namespace
+```
+
+For OpenShift clusters, add `-f values-openshift.yaml`
+(see [`OpenShift install`](./openshift-install)).
+
+## Step 3: Install and start the Metal Agent
+
+Clone the operator repo on your Mac and run the bundled installer:
+
+```bash
+git clone https://github.com/defilantech/LLMKube.git
+cd LLMKube
+make install-metal-agent
+```
+
+This builds the agent binary, installs to
+`/usr/local/bin/llmkube-metal-agent`, drops a launchd plist into
+`~/Library/LaunchAgents/`, and starts the service. On a fresh Mac
+the whole thing takes about twenty seconds.
+
+If you need to install manually (different binary path, different
+launch system), see the
+[`deployment/macos/README.md`](https://github.com/defilantech/LLMKube/blob/main/deployment/macos/README.md)
+for the full plist and launchctl commands.
+
+### Verify the agent is running
+
+```bash
+launchctl list | grep llmkube
+# expected: <PID>   0   com.llmkube.metal-agent
+
+curl -s http://localhost:9090/healthz
+# expected: {"status":"ok"}
+
+tail -f /Users/$(whoami)/Library/Logs/llmkube-metal-agent.log
+# leave this tab open; we'll watch it pick up the first InferenceService
+```
+
+## Step 4: Remote cluster setup
+
+If your Kubernetes cluster runs on a different machine (a Linux
+server or cloud cluster, as opposed to local kind / minikube), the
+agent needs to register your Mac's reachable IP so cluster pods
+can route to `llama-server` on your Mac.
+
+```bash
+# Find your Mac's IP on the LAN
+ipconfig getifaddr en0
+# example: 192.168.1.50
+
+# Or on Tailscale / WireGuard
+tailscale status | head -2
+```
+
+Edit `~/Library/LaunchAgents/com.llmkube.metal-agent.plist` and
+add to the `ProgramArguments` array:
+
+```xml
+<string>--host-ip</string>
+<string>192.168.1.50</string>
+```
+
+Reload:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.llmkube.metal-agent.plist
+launchctl load ~/Library/LaunchAgents/com.llmkube.metal-agent.plist
+```
+
+Without `--host-ip` the agent registers `localhost` as the
+endpoint, which only works when Kubernetes lives on the same Mac
+(local minikube or Docker Desktop kind).
+
+## Step 5: Deploy a model with Metal
+
+From any machine that can talk to your cluster:
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata: { name: phi-4-mini }
+spec:
+  source: https://huggingface.co/bartowski/phi-4-mini-instruct-GGUF/resolve/main/phi-4-mini-instruct-Q4_K_M.gguf
+  format: gguf
+  hardware:
+    accelerator: metal
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata: { name: phi-4-mini }
+spec:
+  modelRef: phi-4-mini
+```
+
+```bash
+kubectl apply -f phi-4-mini.yaml
+kubectl get inferenceservice phi-4-mini -w
+# wait for PHASE=Ready
+```
+
+The agent's log should show:
+
+```
+"msg":"starting inference service","name":"phi-4-mini"
+"msg":"registered endpoint","hostIP":"192.168.1.50","port":<allocated>
+"msg":"started inference service","name":"phi-4-mini","pid":<llama-server-pid>
+```
+
+Query the model from anywhere in the cluster:
+
+```bash
+kubectl port-forward svc/phi-4-mini 8080:8080 &
+curl -sS http://localhost:8080/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"phi-4-mini","messages":[{"role":"user","content":"hi"}]}'
+```
+
+## Memory budgets
+
+The agent estimates each model's memory cost (weights + KV cache +
+overhead) before spawning `llama-server`. If the model won't fit
+in the configured budget, the agent refuses to start it and marks
+the InferenceService with `status.schedulingStatus: InsufficientMemory`.
+
+Defaults are tuned by total system RAM:
+
+| Total RAM | Default fraction | Budget |
+|---|---|---|
+| 16 GB | 67% | ~10.7 GB |
+| 36 GB | 67% | ~24.1 GB |
+| 48 GB | 75% | 36 GB |
+| 64 GB | 75% | 48 GB |
+| 128 GB | 90% | 115 GB |
+
+Override the fraction with `--memory-fraction 0.9` for a dedicated
+inference machine, or `0.5` if the Mac is also your daily-driver
+workstation. Add the flag to the launchd plist's `ProgramArguments`
+the same way as `--host-ip`.
+
+The agent also implements **memory-pressure protection**: if
+macOS reports critical memory pressure, the agent can evict the
+lowest-priority running InferenceService and refuse to spawn new
+ones until pressure normalizes. See the
+[`Memory-pressure protection`](../memory-pressure-protection)
+guide for tuning.
+
+## ModelRouter integration
+
+The Metal Agent's InferenceServices are first-class targets for
+the `ModelRouter` CRD. Reference them by name like any other
+local backend:
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata: { name: hybrid-router }
+spec:
+  backends:
+    - name: local-mac
+      inferenceServiceRef: { name: phi-4-mini }   # the InferenceService above
+      tier: local
+      capabilities: [chat]
+    - name: cloud-opus
+      external:
+        provider: anthropic
+        model: claude-opus-4-7
+        credentialsSecretRef: { name: anthropic-key }
+      tier: cloud
+  rules:
+    - name: pii-stays-on-mac
+      match: { dataClassification: [pii] }
+      route: { backends: [local-mac] }
+      failClosed: true
+  defaultRoute: local-mac
+```
+
+The router-proxy pod (which the controller schedules in the
+cluster, *not* on the Mac) dials the agent-registered endpoint
+when the rule resolves to `local-mac`. From the router's
+perspective the Mac-served backend is indistinguishable from a
+container-served one — same `InferenceServiceRef` shape, same
+fail-closed semantics, same per-rule timeout budgets.
+
+See the [`ModelRouter concept doc`](../concepts/model-router) for
+the full policy model.
+
+## Cross-cluster fleet shape
+
+Heterogeneous clusters are the strongest pattern: NVIDIA nodes in
+a cloud for heavy workloads, Mac Studios on-prem for
+low-latency / sensitive work, all managed by the same controller
+with the same CRDs. The agent makes the Mac visible to the
+controller exactly like a Linux node visible to a `Deployment`
+reconciler — just with `accelerator: metal` instead of
+`accelerator: cuda` on the `Model`.
+
+Operationally:
+
+- Put the Mac on the same VPN / Tailscale tailnet as your
+  cluster's worker nodes.
+- Set `--host-ip` to the Mac's address on that network.
+- The controller routes all `accelerator: metal` InferenceServices
+  to whatever agent is registered for that endpoint.
+
+## Optional: Apple Silicon power metrics
+
+For [InferCost](https://github.com/defilantech/infercost) (LLMKube's
+companion FinOps project) per-token cost attribution on Apple
+Silicon, the agent can publish CPU / GPU / ANE / Combined power
+gauges sourced from `powermetrics`. This is **disabled by default**
+because `powermetrics` requires root.
+
+Enable in three steps:
+
+1. Install the bundled NOPASSWD sudoers fragment, which pins both
+   the binary path and the argument vector so the grant is the
+   narrowest possible:
+
+   ```bash
+   make install-powermetrics-sudo
+   ```
+
+2. Add `--apple-power-enabled` to the launchd plist's
+   `ProgramArguments` array.
+
+3. Reload the agent.
+
+The four gauges exposed:
+`llmkube_metal_agent_apple_power_combined_watts`,
+`llmkube_metal_agent_apple_power_gpu_watts`,
+`llmkube_metal_agent_apple_power_cpu_watts`,
+`llmkube_metal_agent_apple_power_ane_watts`.
+
+See the
+[`deployment/macos/README.md`](https://github.com/defilantech/LLMKube/blob/main/deployment/macos/README.md#apple-silicon-power-metrics-for-infercost)
+for the full sudoers setup and a manual install path that lets you
+inspect each step before running it.
+
+## Troubleshooting
+
+**Agent process not running after install**
+Check `~/Library/Logs/llmkube-metal-agent.log` (or the path
+configured in your launchd plist) for the first-launch error.
+Most common cause: `llama-server` not on PATH or at the configured
+`--llama-server` path.
+
+**Pods can't reach llama-server (remote cluster)**
+The agent registered `localhost`. Confirm `--host-ip` is set in
+the plist and points at an address reachable from your cluster's
+worker nodes:
+
+```bash
+# From a worker node:
+ping <your-mac-ip>
+curl http://<your-mac-ip>:<allocated-port>/v1/models
+```
+
+If those work but routing through the cluster Service fails, check
+the registered Endpoints object:
+
+```bash
+kubectl get endpoints <inferenceservice-name>
+# expect: subsets[0].addresses[0].ip = your Mac's --host-ip
+```
+
+**InferenceService stuck in `InsufficientMemory`**
+The agent's pre-flight estimator says the model won't fit. Either
+shrink the model (use a smaller quantization), reduce the context
+size in the `InferenceService` spec, or raise
+`--memory-fraction`. If the Mac is the only Mac in the cluster and
+this is a dedicated inference machine, `0.9` is reasonable.
+
+**macOS firewall prompt on first run**
+The Metal Agent listens on `127.0.0.1:9090` for its own
+health/metrics, and `llama-server` listens on an allocated port
+for inbound inference. macOS will prompt to allow incoming
+connections on first run. Allow them.
+
+**Agent log shows `replicas=0; stopping process` unexpectedly**
+A controller-side reconcile saw `spec.replicas=0` on the
+`InferenceService`. Check whether something scaled it down
+(another operator, a Helm upgrade reverting your spec, an
+operator-managed argocd app pulling a stale value).
+
+## Uninstall
+
+```bash
+cd /path/to/LLMKube-checkout
+make uninstall-metal-agent
+```
+
+That tears down the launchd service, removes the binary from
+`/usr/local/bin`, and deletes the plist. Model weights downloaded
+into the agent's `--model-store` path stay on disk (the agent
+doesn't clean those up; remove manually if needed).
+
+## Reference
+
+- [`deployment/macos/README.md`](https://github.com/defilantech/LLMKube/blob/main/deployment/macos/README.md) — full reference including manual install, launchd plist tuning, Prometheus metrics enumeration, sudoers fragment internals
+- [`Memory-pressure protection`](../memory-pressure-protection) — eviction tuning and the InferenceService priority field
+- [`Model Router`](../concepts/model-router) — policy-aware routing layer above Metal-served InferenceServices
+- [`Air-gapped install`](./air-gapped) — combining Metal serving with offline / private-registry installs

--- a/docs/site/guides/macos-metal.md
+++ b/docs/site/guides/macos-metal.md
@@ -90,7 +90,7 @@ launchctl list | grep llmkube
 curl -s http://localhost:9090/healthz
 # expected: {"status":"ok"}
 
-tail -f /Users/$(whoami)/Library/Logs/llmkube-metal-agent.log
+tail -f /tmp/llmkube-metal-agent.log
 # leave this tab open; we'll watch it pick up the first InferenceService
 ```
 
@@ -297,10 +297,11 @@ inspect each step before running it.
 ## Troubleshooting
 
 **Agent process not running after install**
-Check `~/Library/Logs/llmkube-metal-agent.log` (or the path
-configured in your launchd plist) for the first-launch error.
-Most common cause: `llama-server` not on PATH or at the configured
-`--llama-server` path.
+Check `/tmp/llmkube-metal-agent.log` (the
+`StandardOutPath`/`StandardErrorPath` configured in the bundled
+launchd plist) for the first-launch error. Most common cause:
+`llama-server` not on PATH or at the configured `--llama-server`
+path.
 
 **Pods can't reach llama-server (remote cluster)**
 The agent registered `localhost`. Confirm `--host-ip` is set in

--- a/docs/site/guides/model-matrix.md
+++ b/docs/site/guides/model-matrix.md
@@ -16,7 +16,7 @@ A practical guide to picking a GGUF model for [LLMKube](https://llmkube.com) bas
 required memory = gguf_file_size * 1.20  +  kv_cache(ctx_length)
 ```
 
-For most chat workloads at 8K to 16K context, **add 20 to 30 percent to the file size** and you will be close. Long context windows (128K+) or fp16 KV cache push this much higher. See [KV cache headroom](#kv-cache-headroom) below and the LLMKube [KV cache types](/docs/operations/kv-cache) and [Memory-pressure protection](/docs/memory-pressure-protection) docs for the knobs.
+For most chat workloads at 8K to 16K context, **add 20 to 30 percent to the file size** and you will be close. Long context windows (128K+) or fp16 KV cache push this much higher. The KV cache headroom section below covers the math, and the LLMKube [KV cache types](/docs/operations/kv-cache) and [Memory-pressure protection](/docs/memory-pressure-protection) docs document the runtime knobs.
 
 **Quant choice.** `Q4_K_M` and `IQ4_XS` are the sweet spot for most users: good quality, smallest size that still feels like the original. `Q5_K_M` and `Q6_K` cost more memory but get closer to fp16 quality. `Q8_0` is near lossless at roughly 1 byte per parameter. The Unsloth `UD-*_XL` variants are dynamic quants that mix bit widths smartly; usually preferred when available.
 

--- a/docs/site/guides/openshift-install.md
+++ b/docs/site/guides/openshift-install.md
@@ -1,0 +1,290 @@
+---
+title: OpenShift / OKD / MicroShift install
+description: Install LLMKube on OpenShift, OKD, or MicroShift. Covers the bundled values-openshift.yaml Helm preset, restricted-v2 SCC behavior, per-InferenceService fsGroup overrides, and the MicroShift CI parity LLMKube ships with.
+---
+
+# OpenShift / OKD / MicroShift install
+
+LLMKube ships with first-class OpenShift support as of `v0.7.7`.
+Every PR exercises a real MicroShift cluster in CI against the
+`restricted-v2` SecurityContextConstraint, so the
+SCC-compatibility path is regression-tested before it reaches you.
+
+This guide covers the install for OpenShift Container Platform,
+OKD, MicroShift, and any distribution that runs the standard SCC
+admission controller with the `MustRunAs` fsGroup strategy.
+
+## TL;DR
+
+Use the bundled Helm preset:
+
+```bash
+helm repo add llmkube https://defilantech.github.io/LLMKube
+helm install llmkube llmkube/llmkube \
+  -f charts/llmkube/values-openshift.yaml \
+  -n llmkube-system --create-namespace
+```
+
+That single command produces an LLMKube install whose
+`InferenceService` pods are admitted cleanly under `restricted-v2`.
+The same preset works on OpenShift Container Platform, OKD,
+MicroShift, and standalone OpenShift Local.
+
+The rest of this page explains why the preset is needed and how to
+adapt it for less common SCC configurations.
+
+## Why the preset exists
+
+The default LLMKube install (the one you'd get with plain
+`helm install llmkube llmkube/llmkube`) sets a sensible `fsGroup`
+default of `102` on every `InferenceService` pod. That value lines
+up with the GID of the `curl_group` user in the default
+init-container image (`docker.io/curlimages/curl:8.18.0`), which is
+what lets the init container write the downloaded model into a
+freshly-provisioned PVC.
+
+On standard Kubernetes that's correct. On OpenShift's
+`restricted-v2` SCC, it's not:
+
+- `restricted-v2` enforces `MustRunAs` for `fsGroup`.
+- The namespace carries an
+  `openshift.io/sa.scc.supplemental-groups` annotation describing
+  the GID range pods in that namespace may use.
+- The SCC admission controller wants to inject an `fsGroup` from
+  that range itself.
+- If the pod spec already declares a different `fsGroup`, admission
+  fails: `unable to validate against any security context constraint:
+  fsGroup not within allowed range`.
+
+LLMKube's default `fsGroup=102` is outside any namespace's allocated
+range, so plain `helm install` produces pods that never get
+scheduled.
+
+## What the preset does
+
+`charts/llmkube/values-openshift.yaml` is fifteen lines of YAML.
+The load-bearing setting is:
+
+```yaml
+controllerManager:
+  initContainer:
+    defaultFSGroup: 0
+```
+
+`0` is a sentinel meaning "don't set fsGroup at all" — the operator
+emits InferenceService pods without an `fsGroup` in their
+`podSecurityContext`, and the SCC admission controller injects the
+right value from the namespace's allocated range.
+
+CI coverage: the `test-e2e-openshift` job in
+`.github/workflows/test-e2e.yml` runs the full operator suite
+against a MicroShift cluster via MINC on every PR. The job is
+currently best-effort (`continue-on-error: true`) while the
+MicroShift-in-CI setup is hardened, but the kind merge gate plus
+the OpenShift parity job catch the same admission regressions.
+
+## Step-by-step install
+
+### 1. Create the namespace
+
+OpenShift will compute the supplemental-groups range when the
+namespace is created. Both `oc` and `kubectl` work:
+
+```bash
+oc create namespace llmkube-system
+oc get namespace llmkube-system -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.supplemental-groups}'
+# example: 1000680000/10000
+```
+
+The range is the operator's signal that `restricted-v2` is in
+effect. If the annotation is empty you're on plain Kubernetes; use
+the standard install instead.
+
+### 2. Install LLMKube with the preset
+
+If you cloned the operator repo:
+
+```bash
+helm install llmkube ./charts/llmkube \
+  -f charts/llmkube/values-openshift.yaml \
+  -n llmkube-system
+```
+
+If you're installing from the Helm repo:
+
+```bash
+helm repo add llmkube https://defilantech.github.io/LLMKube
+helm pull llmkube/llmkube --untar
+helm install llmkube ./llmkube \
+  -f ./llmkube/values-openshift.yaml \
+  -n llmkube-system
+```
+
+### 3. Verify the controller is up
+
+```bash
+oc -n llmkube-system get pods
+# expect: llmkube-controller-manager-...   1/1   Running
+
+oc -n llmkube-system logs deployment/llmkube-controller-manager \
+  | grep "default-fsgroup"
+# expect: default-fsgroup=0  (sentinel: operator emits no fsGroup)
+```
+
+### 4. Deploy a model
+
+Apply any standard `Model` + `InferenceService`. The pod will be
+admitted by `restricted-v2` with the SCC's chosen `fsGroup`:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata: { name: phi-4-mini }
+spec:
+  source: https://huggingface.co/bartowski/phi-4-mini-instruct-GGUF/resolve/main/phi-4-mini-instruct-Q4_K_M.gguf
+  format: gguf
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata: { name: phi-4-mini }
+spec:
+  modelRef: phi-4-mini
+EOF
+```
+
+Verify the pod's effective security context shows an fsGroup that
+falls inside your namespace's allocated range:
+
+```bash
+oc -n default get pod -l app=phi-4-mini -o jsonpath='{.items[0].spec.securityContext.fsGroup}'
+# example: 1000680000  (first value from the supplemental-groups annotation)
+```
+
+## Single-tenant escape hatch
+
+If you'd rather pin `fsGroup` per workload than disable the
+operator-wide default, omit the preset and set the value directly
+on each `InferenceService`:
+
+```bash
+oc get namespace default -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.supplemental-groups}'
+# example: 1000680000/10000
+```
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata: { name: phi-4-mini }
+spec:
+  modelRef: phi-4-mini
+  podSecurityContext:
+    fsGroup: 1000680000   # first value from the command above
+```
+
+That works on a single namespace where you control every
+deployment. The operator-wide preset is preferred for multi-tenant
+or platform-team-managed clusters.
+
+## ModelRouter on OpenShift
+
+The same preset covers the router-proxy pods that the
+`ModelRouter` reconciler creates. The router-proxy already runs as
+a non-root user (UID 65532), so `restricted-v2` admits it cleanly
+once the preset is in place.
+
+The proxy has no model-weight init container; it doesn't need
+`fsGroup` at all. The preset's `defaultFSGroup: 0` flows through to
+the router-proxy pod spec the same way as InferenceService pods —
+SCC injects from the namespace range or skips fsGroup entirely if
+the pod has no writable volumes that need group ownership.
+
+If your OpenShift cluster requires `imagePullSecrets` on every
+namespace (a common pattern with private mirror registries), add
+them to the `ModelRouter` spec.proxy block as well:
+
+```yaml
+spec:
+  proxy:
+    imagePullSecrets:
+      - name: internal-registry-creds
+```
+
+## Air-gapped OpenShift
+
+For OpenShift installs without public-internet egress, combine this
+guide with the [`Air-gapped install`](./air-gapped) walkthrough.
+The Helm install line becomes:
+
+```bash
+helm install llmkube ./llmkube \
+  -f ./llmkube/values-openshift.yaml \
+  -n llmkube-system --create-namespace \
+  --set controllerManager.image.repository=registry.internal.corp/defilantech/llmkube-controller \
+  --set controllerManager.image.tag=v0.7.8 \
+  --set controllerManager.initContainer.image=registry.internal.corp/curlimages/curl:8.18.0
+```
+
+Both presets are additive: the OpenShift values handle SCC, the
+extra `--set` flags handle the private registry.
+
+## Verification
+
+End-to-end smoke test that exercises the SCC admission path:
+
+```bash
+oc create namespace e2e-scc
+oc apply -n e2e-scc -f config/samples/inference_v1alpha1_model.yaml
+oc apply -n e2e-scc -f config/samples/inference_v1alpha1_inferenceservice.yaml
+oc -n e2e-scc wait inferenceservice/sample --for=jsonpath='{.status.phase}'=Ready --timeout=5m
+
+# Confirm the SCC injected an fsGroup from the namespace range
+oc -n e2e-scc get pod -l inference.llmkube.dev/service=sample \
+  -o jsonpath='{.items[0].spec.securityContext.fsGroup}'
+```
+
+If the InferenceService reaches `Ready` and the pod's `fsGroup`
+falls inside the namespace's supplemental-groups annotation, the
+preset is working as designed.
+
+## Troubleshooting
+
+**`Pod ... is forbidden: unable to validate against any security context constraint`**
+Your install didn't pick up the preset. Confirm with
+`helm get values llmkube -n llmkube-system` that
+`controllerManager.initContainer.defaultFSGroup` is `0`. Rerun
+`helm upgrade` with `-f values-openshift.yaml --reuse-values`.
+
+**`fsGroup not within allowed range`**
+A per-InferenceService `podSecurityContext.fsGroup` is set but
+falls outside the namespace's supplemental-groups range. Either
+remove it (the SCC will inject) or set it to the first value in
+the namespace's range.
+
+**Controller pod itself won't start with `restricted-v2`**
+LLMKube's controller manager runs as UID 65532 with no
+`fsGroup` declaration, which is SCC-clean. If it's still failing,
+check whether your cluster uses a more restrictive SCC than
+`restricted-v2` (some enterprises ship custom SCCs that further
+constrain seccomp profiles). Override
+`controllerManager.podSecurityContext` in your Helm values.
+
+**MicroShift on a single-node edge box**
+Same preset. The MicroShift CI lane in this repo uses MINC
+(MicroShift in Container) with the standard `restricted-v2` SCC,
+and that's the same SCC shape you get on real MicroShift hosts.
+
+## Next steps
+
+- [Air-gapped install](./air-gapped) if you're combining OpenShift
+  with restricted-egress requirements
+- [Model Router](../concepts/model-router) for the policy-aware
+  routing layer; the same SCC preset covers its proxy pods
+- [Multi-GPU sharding](./multi-gpu) for 70B+ models on
+  OpenShift-managed NVIDIA nodes
+
+## Reference
+
+- [`charts/llmkube/values-openshift.yaml`](https://github.com/defilantech/LLMKube/blob/main/charts/llmkube/values-openshift.yaml) — the preset itself, fifteen lines
+- [CRD reference](../concepts/crds) — `Model`, `InferenceService`, `ModelRouter`
+- OpenShift docs: [restricted-v2 SCC](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html)

--- a/docs/site/guides/openshift-install.md
+++ b/docs/site/guides/openshift-install.md
@@ -62,8 +62,9 @@ scheduled.
 
 ## What the preset does
 
-`charts/llmkube/values-openshift.yaml` is fifteen lines of YAML.
-The load-bearing setting is:
+`charts/llmkube/values-openshift.yaml` is a handful of lines of
+YAML, almost all of which are explanatory comments. The
+load-bearing setting is:
 
 ```yaml
 controllerManager:
@@ -126,9 +127,12 @@ helm install llmkube ./llmkube \
 oc -n llmkube-system get pods
 # expect: llmkube-controller-manager-...   1/1   Running
 
-oc -n llmkube-system logs deployment/llmkube-controller-manager \
-  | grep "default-fsgroup"
-# expect: default-fsgroup=0  (sentinel: operator emits no fsGroup)
+# Confirm the preset took: the rendered Deployment passes
+# --default-fsgroup=0 in the manager container's args.
+oc -n llmkube-system get deployment llmkube-controller-manager \
+  -o jsonpath='{.spec.template.spec.containers[0].args}' \
+  | tr ',' '\n' | grep default-fsgroup
+# expect: "--default-fsgroup=0"
 ```
 
 ### 4. Deploy a model
@@ -221,12 +225,15 @@ helm install llmkube ./llmkube \
   -f ./llmkube/values-openshift.yaml \
   -n llmkube-system --create-namespace \
   --set controllerManager.image.repository=registry.internal.corp/defilantech/llmkube-controller \
-  --set controllerManager.image.tag=v0.7.8 \
-  --set controllerManager.initContainer.image=registry.internal.corp/curlimages/curl:8.18.0
+  --set controllerManager.image.tag=v0.7.7 \
+  --set controllerManager.initContainer.repository=registry.internal.corp/curlimages/curl \
+  --set controllerManager.initContainer.tag=8.18.0
 ```
 
 Both presets are additive: the OpenShift values handle SCC, the
-extra `--set` flags handle the private registry.
+extra `--set` flags handle the private registry. Note that the
+init container is configured via `repository` + `tag` separately,
+not a single `image` field.
 
 ## Verification
 
@@ -236,10 +243,11 @@ End-to-end smoke test that exercises the SCC admission path:
 oc create namespace e2e-scc
 oc apply -n e2e-scc -f config/samples/inference_v1alpha1_model.yaml
 oc apply -n e2e-scc -f config/samples/inference_v1alpha1_inferenceservice.yaml
-oc -n e2e-scc wait inferenceservice/sample --for=jsonpath='{.status.phase}'=Ready --timeout=5m
+oc -n e2e-scc wait inferenceservice/phi-3-inference \
+  --for=jsonpath='{.status.phase}'=Ready --timeout=5m
 
 # Confirm the SCC injected an fsGroup from the namespace range
-oc -n e2e-scc get pod -l inference.llmkube.dev/service=sample \
+oc -n e2e-scc get pod -l inference.llmkube.dev/service=phi-3-inference \
   -o jsonpath='{.items[0].spec.securityContext.fsGroup}'
 ```
 


### PR DESCRIPTION
## What

Tier 1 of the docs-site fill-in. Four pages land at \`llmkube.com/docs\`:

- \`guides/air-gapped.md\` — offline install of operator + router-proxy + runtime images via private registry, custom CA cert ConfigMap, model-weight strategies (\`pvc://\`, internal HTTPS + SHA256 audit, \`file://\`), and using \`ModelRouter\` without public-internet external providers (LiteLLM-only).
- \`guides/openshift-install.md\` — \`values-openshift.yaml\` preset walkthrough, restricted-v2 SCC behavior, per-InferenceService escape hatch, MicroShift CI parity.
- \`guides/macos-metal.md\` — port of \`deployment/macos/README.md\` (608 lines) into a tighter ~400-line install-and-go guide, with new ModelRouter integration section.
- \`concepts/architecture.md\` — refresh. The page was declared in nav.yaml but had no markdown on disk; this lands the proper concept page covering the three CRDs and two control planes.

Plus \`docs/site/_meta/nav.yaml\` drops \`status: stub\` on air-gapped and adds nav entries for openshift-install and macos-metal under Guides.

## Why

The Marcel Dempers \"Run LLMs on Kubernetes with LLMKube\" video (91K-sub channel) is driving measurable traffic to llmkube.com/docs this week. The site currently renders 12 \`status: stub\` placeholders for shipped features and has zero docs-site coverage for OpenShift / Metal-agent / air-gapped — exactly the workloads enterprise viewers will ask about first.

This is Tier 1 of the three-tier plan in \`/.claude/plans/let-s-plan-this-out-cozy-sketch.md\`. Tier 2 (observability, multi-gpu, gpu-setup, model-cache, minikube, kv-cache) and Tier 3 (generated CLI / Helm / metrics / CRD reference) follow.

No issue link — this is docs filling in shipped features.

## How

Sources reused, not rewritten, per the user-preference memory:

- \`docs/air-gapped-quickstart.md\` (pre-ModelRouter) -> ported to site, updated for 0.7.8: ModelRouter air-gap usage, custom CA cert path, init-container override, image bundle includes router-proxy.
- \`charts/llmkube/values-openshift.yaml\` -> the source of truth for the OpenShift guide's \"what does the preset actually do\" section.
- \`deployment/macos/README.md\` -> ported to site with ModelRouter integration paragraph and memory-pressure cross-link.

mdsvex frontmatter on every page (\`title\`, \`description\`). No \`DocCallout\` usage in this PR (kept the prose-only path to minimize llmkube-web component surface). No new asciinema casts.

### Drive-by

\`docs/site/guides/model-matrix.md\` had a broken self-anchor \`#kv-cache-headroom\` that blocked \`npm run build\` in llmkube-web (mdsvex doesn't auto-slug headings without \`rehype-slug\`). Rewrote as prose. Unblocks the build for this PR and Tier 2 / Tier 3.

## Checklist

- [x] Tests added/updated — N/A, docs only
- [x] \`make test\` passes locally — N/A, docs only
- [x] \`make lint\` passes locally — N/A, docs only
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (\`git commit -s\`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated — this IS the doc update

## Verification

\`\`\`
cd /Users/defilan/stuffy/code/web/llmkube-web
LLMKUBE_DOCS_LOCAL_PATH=/Users/defilan/stuffy/code/ai/llmkube npm run build
\`\`\`

Clean build, all four new pages produced under \`build/docs/<slug>.html\` with the correct titles. Sidebar renders the three new entries with no \"in progress\" stub marker.

Next time llmkube-web's Netlify pipeline syncs operator main, these pages ship to llmkube.com/docs.