### PR TITLE
fix(e2e): unblock MicroShift SCC diagnostics + bump bootstrap timeout

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -116,6 +116,21 @@ var _ = Describe("Manager", Ordered, func() {
 	AfterEach(func() {
 		specReport := CurrentSpecReport()
 		if specReport.Failed() {
+			// Resolve the controller pod lazily by label selector when the
+			// Manager Context's BeforeAll didn't run (e.g. when a CI lane
+			// focuses on a single Context with -ginkgo.focus). Without
+			// this, AfterEach issues `kubectl logs  -n ...` with an empty
+			// pod name and the diagnostic is lost — that's what masked
+			// the OpenShift SCC admission test failure.
+			if controllerPodName == "" {
+				lookup := exec.Command("kubectl", "get", "pods",
+					"-n", namespace,
+					"-l", "control-plane=controller-manager",
+					"-o", "jsonpath={.items[0].metadata.name}")
+				if name, err := utils.Run(lookup); err == nil {
+					controllerPodName = strings.TrimSpace(name)
+				}
+			}
 			By("Fetching controller manager pod logs")
 			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
 			controllerLogs, err := utils.Run(cmd)
@@ -2081,6 +2096,45 @@ spec:
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Capture richer diagnostics if anything below fails. The
+			// outer AfterEach only knows about the controller namespace;
+			// this nested deferred dump pulls the per-test namespace
+			// state (Model / InferenceService / PVC / pods / events)
+			// which is where the SCC admission story actually lives.
+			defer func() {
+				if !CurrentSpecReport().Failed() {
+					return
+				}
+				for _, args := range [][]string{
+					{"get", "model,inferenceservice,pvc,pods", "-n", sccTestNs, "-o", "wide"},
+					{"describe", "model", "scc-test-model", "-n", sccTestNs},
+					{"describe", "inferenceservice", "scc-test-inference", "-n", sccTestNs},
+					{"describe", "pvc", "-n", sccTestNs},
+					{"get", "events", "-n", sccTestNs, "--sort-by=.lastTimestamp"},
+				} {
+					out, _ := utils.Run(exec.Command("kubectl", args...))
+					_, _ = fmt.Fprintf(GinkgoWriter, "\n--- kubectl %s ---\n%s\n", strings.Join(args, " "), out)
+				}
+			}()
+
+			// MicroShift-via-MINC bootstrap is slower than kind, and the
+			// Model controller's runtime-resolved path still needs the
+			// per-namespace cache PVC to be created before
+			// reconcileDeployment runs. Five minutes matches the
+			// timeout the workflow uses elsewhere (helm install --wait).
+			openshiftEventuallyTimeout := 5 * time.Minute
+
+			By("waiting for the Model to reach Ready (focused signal: the issue isn't admission yet)")
+			verifyModelReady := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "model", "scc-test-model",
+					"-n", sccTestNs, "-o", "jsonpath={.status.phase}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("Ready"),
+					"Model.status.phase must reach Ready before the InferenceService progresses; got %q", output)
+			}
+			Eventually(verifyModelReady, openshiftEventuallyTimeout).Should(Succeed())
+
 			By("waiting for the InferenceService Deployment to exist (admission succeeded)")
 			verifyDeploymentExists := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "deployment", "scc-test-inference",
@@ -2089,7 +2143,7 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("scc-test-inference"))
 			}
-			Eventually(verifyDeploymentExists, 2*time.Minute).Should(Succeed())
+			Eventually(verifyDeploymentExists, openshiftEventuallyTimeout).Should(Succeed())
 
 			By("verifying SCC injected an fsGroup in the rendered pod spec")
 			var podFSGroup int64
@@ -2110,7 +2164,7 @@ spec:
 					"injected fsGroup %d must be <= namespace range max %d", fsGroup, rangeMax)
 				podFSGroup = fsGroup
 			}
-			Eventually(verifyPodFSGroupInRange, 2*time.Minute).Should(Succeed())
+			Eventually(verifyPodFSGroupInRange, openshiftEventuallyTimeout).Should(Succeed())
 
 			_, _ = fmt.Fprintf(GinkgoWriter,
 				"SCC injected fsGroup=%d (namespace range %d-%d) on InferenceService pod\n",


### PR DESCRIPTION
## What

The OpenShift SCC admission e2e Context has been flaking on multiple PRs (most recently #464) with no diagnostic signal: it times out at `e2e_test.go:2092` waiting for the InferenceService Deployment to be created, but the failure dump shows `kubectl logs  -n llmkube-system` (empty pod name) instead of controller logs.

This PR:
- Resolves the controller pod lazily in `AfterEach` by label selector when `controllerPodName` is empty (so focused CI runs still produce logs).
- Splits the single 120s Eventually into `Model→Ready` and `Deployment→exists` checkpoints so the next failure tells us *which* step stalled.
- Bumps the OpenShift Eventually budget to 5 minutes (matches the workflow's `helm install --wait` budget; MicroShift-on-MINC is materially slower than kind).
- Captures per-test namespace state on failure (Model/InferenceService/PVC/Pod listing + `describe` + events). The outer AfterEach only sees `llmkube-system`, so the namespace where the SCC story actually plays out was invisible.

## Why

The MicroShift / MINC lane was failing closed: red CI signal with no actionable evidence. Either we ship without OpenShift coverage at all, or we improve the diagnostic posture so the next failure is debuggable. This is the latter.

The job is still `continue-on-error: true` while it stabilizes, so this is not a behavior change. It is an observability fix. No controller / production code is touched.

Fixes ongoing MicroShift e2e flake observed across recent PRs (#464 most recently).

## How

- `controllerPodName` resolution: when empty, do `kubectl get pods -n llmkube-system -l control-plane=controller-manager -o jsonpath={.items[0].metadata.name}` and use the result. Adds ~one kubectl call to the failure path only.
- Per-test diagnostic dump: a `defer` inside the It block runs after the Eventually fails but before the spec returns. Dumps `get`/`describe` on Model, InferenceService, PVC, pods, and events in the test namespace.
- Timeout bump: introduces a local `openshiftEventuallyTimeout = 5 * time.Minute` so the three Eventuallys in this Context share one knob. Was 2 minutes each, now 5 minutes each.
- Intermediate `Model→Ready` check: HTTP-source Models reach Ready quickly (the controller's `reconcileRuntimeResolvedSource` marks Ready immediately and defers actual fetch to the InferenceService init container). If this Eventually fails, the bug is in Model reconcile; if Model reaches Ready but Deployment doesn't appear, the bug is in `ensureModelCachePVC` or `reconcileDeployment`.

## Checklist

- [x] Tests added/updated (the test itself is what's changing)
- [x] `make test` passes locally (e2e package builds with `-tags=e2e`; unit-test path not exercised by this change)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated (not user-facing; test-only change)