### PR TITLE
docs(site): drop stale "fifteen lines" claim in openshift-install Reference

### DIFF
--- a/docs/site/guides/openshift-install.md
+++ b/docs/site/guides/openshift-install.md
@@ -293,6 +293,6 @@ and that's the same SCC shape you get on real MicroShift hosts.
 
 ## Reference
 
-- [`charts/llmkube/values-openshift.yaml`](https://github.com/defilantech/LLMKube/blob/main/charts/llmkube/values-openshift.yaml) — the preset itself, fifteen lines
+- [`charts/llmkube/values-openshift.yaml`](https://github.com/defilantech/LLMKube/blob/main/charts/llmkube/values-openshift.yaml) — the preset itself
 - [CRD reference](../concepts/crds) — `Model`, `InferenceService`, `ModelRouter`
 - OpenShift docs: [restricted-v2 SCC](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html)


### PR DESCRIPTION
## What

One-line fix: PR #465's fact-check pass updated the body of `docs/site/guides/openshift-install.md` to say "a handful of lines" instead of "fifteen lines" (the file is 24 lines, mostly comments), but the same wording in the Reference section at the bottom was missed.

## Why

Caught during a Playwright check of the live llmkube.com docs: both phrases were rendering on the same page. The exact count never mattered to a reader, so just drop it.

## How

Removes the trailing `, fifteen lines` from the bullet in the Reference section. The bullet still links to the file; readers can count for themselves if they care.

## Checklist

- [x] Tests added/updated (n/a, docs-only)
- [x] `make test` passes locally (n/a, docs-only)
- [x] `make lint` passes locally (n/a, docs-only)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (this is the doc update)