### PR TITLE
fix: preserve external annotations on reconciler Deployment updates

### DIFF
--- a/docs/site/concepts/model-router.md
+++ b/docs/site/concepts/model-router.md
@@ -195,6 +195,48 @@ When you specify `provider: anthropic` or `provider: openai` without `url`, the 
 - Inference engines. `InferenceService` already wraps llama.cpp, vLLM, TGI, oMLX. ModelRouter sits *above* them.
 - General-purpose K8s gateway. ModelRouter is scoped specifically to LLM traffic with policy.
 
+## Phase 1 limitations (v1alpha1)
+
+The Phase 1 router-proxy ships with three concrete gaps that show up
+on agentic-coding workloads. They are intentional scope for v1alpha1
+and tracked for Phase 2; calling them out so you can plan around them
+rather than discovering them mid-incident.
+
+### 1. Timeouts cap TTFT, not stream duration
+
+`rule.timeout` and `backend.timeout` apply to the **time-to-first-byte**
+(first response header from the upstream), not the total duration of
+the stream. Once the upstream starts sending SSE chunks, the proxy
+will pipe them to your client for as long as the upstream keeps
+producing, with no aggregate cap.
+
+For agentic-coding workloads this is usually what you want (large
+refactors generate 5-10 minute SSE streams that you don't want the
+proxy interrupting), but it means a *hung* stream where the upstream
+goes silent mid-response is bounded only by kernel TCP keepalive or
+your client's read deadline. **Set a client-side timeout in your
+agent runtime as the safety net for hung streams.** A stream-duration
+cap field is planned for Phase 2.
+
+### 2. Audit log is coarse
+
+The per-request audit-log line records `latencyMs`, `status`,
+`outcome`, and `timeoutMs`, but not streamed bytes, token count, or
+stream-duration breakdown. "Why did this 8-minute agent loop run
+slow?" needs upstream metrics, not the proxy log.
+
+Per-request token/byte accounting and a proxy-emitted Prometheus
+histogram are planned for Phase 2 (issue [#433](https://github.com/defilantech/LLMKube/issues/433)).
+
+### 3. Inbound request bodies are buffered
+
+Outbound responses stream chunk-by-chunk; **inbound requests are
+fully buffered** before routing (up to a 32 MiB cap, enough for
+~128K-token prompts). For 50 concurrent long-context requests that
+is around 25 MB of resident memory in the proxy pod, comfortable on
+a default 256 MiB pod but not zero. True request-side streaming is
+planned for Phase 2.
+
 ## Comparison to alternatives
 
 | | ModelRouter | LiteLLM proxy | KubeAI Model Proxy | llm-d Inference Gateway |

--- a/internal/controller/hpa_reconciler.go
+++ b/internal/controller/hpa_reconciler.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -71,7 +70,7 @@ func (r *InferenceServiceReconciler) reconcileHPA(
 
 	hpa := r.constructHPA(isvc, deploymentName)
 
-	if err := controllerutil.SetControllerReference(
+	if err := setControllerReferenceUnblocked(
 		isvc, hpa, r.Scheme,
 	); err != nil {
 		return fmt.Errorf(

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -256,16 +256,16 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	// sync labels survive operator reconciles. Operator-owned keys
 	// still win on collision. Same fix as the router-proxy reconciler
 	// in router_deployment_builder.go; see #456.
-	existingTemplateLabels := existingDeployment.Spec.Template.ObjectMeta.Labels
-	existingTemplateAnnotations := existingDeployment.Spec.Template.ObjectMeta.Annotations
+	existingTemplateLabels := existingDeployment.Spec.Template.Labels
+	existingTemplateAnnotations := existingDeployment.Spec.Template.Annotations
 	existingDeployment.Spec = deployment.Spec
-	existingDeployment.Spec.Template.ObjectMeta.Labels = mergePreservingExternal(
+	existingDeployment.Spec.Template.Labels = mergePreservingExternal(
 		existingTemplateLabels,
-		deployment.Spec.Template.ObjectMeta.Labels,
+		deployment.Spec.Template.Labels,
 	)
-	existingDeployment.Spec.Template.ObjectMeta.Annotations = mergePreservingExternal(
+	existingDeployment.Spec.Template.Annotations = mergePreservingExternal(
 		existingTemplateAnnotations,
-		deployment.Spec.Template.ObjectMeta.Annotations,
+		deployment.Spec.Template.Annotations,
 	)
 	// When autoscaling is enabled, let the HPA manage replicas
 	if isvc.Spec.Autoscaling != nil {

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -250,7 +250,23 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 		return nil, 0, nil, err
 	}
 
+	// Snapshot externally-set template metadata before the wholesale
+	// Spec replace; restore it afterward so sidecar-injector
+	// annotations, `kubectl rollout restart`'s restartedAt, and GitOps
+	// sync labels survive operator reconciles. Operator-owned keys
+	// still win on collision. Same fix as the router-proxy reconciler
+	// in router_deployment_builder.go; see #456.
+	existingTemplateLabels := existingDeployment.Spec.Template.ObjectMeta.Labels
+	existingTemplateAnnotations := existingDeployment.Spec.Template.ObjectMeta.Annotations
 	existingDeployment.Spec = deployment.Spec
+	existingDeployment.Spec.Template.ObjectMeta.Labels = mergePreservingExternal(
+		existingTemplateLabels,
+		deployment.Spec.Template.ObjectMeta.Labels,
+	)
+	existingDeployment.Spec.Template.ObjectMeta.Annotations = mergePreservingExternal(
+		existingTemplateAnnotations,
+		deployment.Spec.Template.ObjectMeta.Annotations,
+	)
 	// When autoscaling is enabled, let the HPA manage replicas
 	if isvc.Spec.Autoscaling != nil {
 		existingDeployment.Spec.Replicas = nil

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -230,7 +229,7 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	r.reconcileVLLMSpecCondition(isvc)
 
 	deployment := r.constructDeployment(isvc, model, desiredReplicas)
-	if err := controllerutil.SetControllerReference(isvc, deployment, r.Scheme); err != nil {
+	if err := setControllerReferenceUnblocked(isvc, deployment, r.Scheme); err != nil {
 		log.Error(err, "Failed to set controller reference for Deployment")
 		return nil, 0, nil, err
 	}
@@ -295,7 +294,7 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 	}
 
 	service := r.constructService(isvc)
-	if err := controllerutil.SetControllerReference(isvc, service, r.Scheme); err != nil {
+	if err := setControllerReferenceUnblocked(isvc, service, r.Scheme); err != nil {
 		log.Error(err, "Failed to set controller reference for Service")
 		return nil, nil, err
 	}

--- a/internal/controller/merge.go
+++ b/internal/controller/merge.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+// mergePreservingExternal returns a fresh map containing every key from
+// existing that is not also present in desired, plus every key from
+// desired. Desired wins on collision. Use this whenever an operator
+// reconciler wants to assert the keys it owns while leaving foreign
+// keys (sidecar-injector annotations, kubectl rollout-restart's
+// restartedAt, GitOps-tool sync labels) untouched.
+//
+// Without this, reconcilers that do a wholesale assignment of
+// metadata.labels or pod template annotations strip external keys on
+// every reconcile, which manifests as flapping ReplicaSets and
+// truncated in-flight requests when paired with `kubectl rollout
+// restart` or any sidecar injector. See #456.
+//
+// Returns nil only when both inputs are empty; otherwise a non-nil
+// map (the empty case matters because Kubernetes treats an empty map
+// the same as nil on Patch, but Go's reflect comparisons don't).
+func mergePreservingExternal(existing, desired map[string]string) map[string]string {
+	if len(existing) == 0 && len(desired) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(existing)+len(desired))
+	for k, v := range existing {
+		out[k] = v
+	}
+	for k, v := range desired {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/controller/merge_test.go
+++ b/internal/controller/merge_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergePreservingExternal(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing map[string]string
+		desired  map[string]string
+		want     map[string]string
+	}{
+		{
+			name:     "both nil returns nil so we don't churn objects with empty maps",
+			existing: nil,
+			desired:  nil,
+			want:     nil,
+		},
+		{
+			name:     "desired only",
+			existing: nil,
+			desired:  map[string]string{"a": "1"},
+			want:     map[string]string{"a": "1"},
+		},
+		{
+			name:     "external only is preserved",
+			existing: map[string]string{"sidecar.istio.io/inject": "true"},
+			desired:  nil,
+			want:     map[string]string{"sidecar.istio.io/inject": "true"},
+		},
+		{
+			name: "desired wins on collision, external pass-through",
+			existing: map[string]string{
+				"inference.llmkube.dev/router-config-hash": "oldhash",
+				"sidecar.istio.io/inject":                  "true",
+				"kubectl.kubernetes.io/restartedAt":        "2026-05-13T20:00:00Z",
+			},
+			desired: map[string]string{
+				"inference.llmkube.dev/router-config-hash": "newhash",
+			},
+			want: map[string]string{
+				"inference.llmkube.dev/router-config-hash": "newhash",
+				"sidecar.istio.io/inject":                  "true",
+				"kubectl.kubernetes.io/restartedAt":        "2026-05-13T20:00:00Z",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergePreservingExternal(tc.existing, tc.desired)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got=%v want=%v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/ownerref.go
+++ b/internal/controller/ownerref.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// setControllerReferenceUnblocked sets controlled's owner reference to
+// owner (Controller=true) but explicitly clears BlockOwnerDeletion.
+//
+// Why: controller-runtime's SetControllerReference sets
+// BlockOwnerDeletion=true by default. The kube-apiserver
+// GarbageCollector admission plugin validates that by looking up the
+// owner Kind in its RESTMapper to check the caller's `update`
+// permission on the owner's `finalizers` subresource. If the API
+// server's discovery cache hasn't populated for a freshly-registered
+// CRD yet, the lookup fails and Create is rejected with:
+//
+//	deployments.apps "foo" is forbidden: cannot set blockOwnerDeletion
+//	in this case because cannot find RESTMapping for APIVersion ...
+//	Kind InferenceService: no matches for kind "InferenceService"
+//
+// On kind that race window is microseconds and we never see it. On
+// MicroShift-in-MINC the in-container apiserver populates discovery
+// lazily on first request and the window is wide enough to trip every
+// first-reconcile Create. The same race could in principle hit any
+// fresh-install path; bundling the fix here means it won't.
+//
+// We don't actually need BlockOwnerDeletion. Cascading delete still
+// cleans up operator-managed children when their parent CR is
+// deleted; the "block" semantics only matter for finalizer-based
+// cleanup workflows LLMKube does not use today. Trade: cleaner
+// bootstrap for slightly looser cascade ordering guarantees we
+// weren't relying on.
+func setControllerReferenceUnblocked(
+	owner, controlled metav1.Object,
+	scheme *runtime.Scheme,
+) error {
+	if err := controllerutil.SetControllerReference(owner, controlled, scheme); err != nil {
+		return err
+	}
+	refs := controlled.GetOwnerReferences()
+	for i := range refs {
+		if refs[i].UID == owner.GetUID() {
+			falseVal := false
+			refs[i].BlockOwnerDeletion = &falseVal
+		}
+	}
+	controlled.SetOwnerReferences(refs)
+	return nil
+}

--- a/internal/controller/ownerref_test.go
+++ b/internal/controller/ownerref_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// TestSetControllerReferenceUnblocked verifies that the helper sets a
+// controller owner reference but clears BlockOwnerDeletion. Without
+// BlockOwnerDeletion cleared, the API server's GarbageCollector
+// admission plugin tries to look up the owner Kind via RESTMapper to
+// validate the caller's permission on the owner's `finalizers`
+// subresource. That lookup races against fresh-CRD discovery on
+// MicroShift and rejects every first-reconcile Create until the
+// API server's discovery cache catches up.
+func TestSetControllerReferenceUnblocked(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1alpha1: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1: %v", err)
+	}
+
+	owner := &inferencev1alpha1.InferenceService{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "inference.llmkube.dev/v1alpha1",
+			Kind:       "InferenceService",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owner-isvc",
+			Namespace: "ns",
+			UID:       types.UID("owner-uid-1234"),
+		},
+	}
+	controlled := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "owned-deploy", Namespace: "ns"},
+	}
+
+	if err := setControllerReferenceUnblocked(owner, controlled, scheme); err != nil {
+		t.Fatalf("setControllerReferenceUnblocked: %v", err)
+	}
+
+	refs := controlled.GetOwnerReferences()
+	if len(refs) != 1 {
+		t.Fatalf("want 1 owner ref, got %d: %+v", len(refs), refs)
+	}
+	ref := refs[0]
+	if ref.UID != owner.UID {
+		t.Errorf("owner UID = %q, want %q", ref.UID, owner.UID)
+	}
+	if ref.Controller == nil || !*ref.Controller {
+		t.Errorf("Controller = %v, want true", ref.Controller)
+	}
+	if ref.BlockOwnerDeletion == nil {
+		t.Error("BlockOwnerDeletion is nil; want explicitly *false")
+	} else if *ref.BlockOwnerDeletion {
+		t.Errorf("BlockOwnerDeletion = true, want false (avoids MicroShift RESTMapper bootstrap race)")
+	}
+}

--- a/internal/controller/router_builders_test.go
+++ b/internal/controller/router_builders_test.go
@@ -703,12 +703,13 @@ func TestReconcileRouterDeploymentPreservesExternalAnnotations(t *testing.T) {
 	// Build the initial Deployment the way an earlier reconcile would
 	// have, then layer external metadata on top to simulate sidecar
 	// injection / kubectl rollout-restart / GitOps annotations.
+	const gitopsInstance = "coding-router-fleet"
 	r := &ModelRouterReconciler{RouterProxyImage: "ghcr.io/test/router-proxy:v1"}
 	initial := r.newRouterDeployment(mr, "oldhash")
-	initial.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"] = "true"
-	initial.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = "2026-05-13T20:00:00Z"
-	initial.Spec.Template.ObjectMeta.Labels["external-team-label"] = "ml-platform"
-	initial.Labels["argocd.argoproj.io/instance"] = "llmkube"
+	initial.Spec.Template.Annotations["sidecar.istio.io/inject"] = "true"
+	initial.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = "2026-05-13T20:00:00Z"
+	initial.Spec.Template.Labels["external-team-label"] = "ml-platform"
+	initial.Labels["argocd.argoproj.io/instance"] = gitopsInstance
 
 	scheme := builderTestScheme(t)
 	c := fake.NewClientBuilder().
@@ -736,27 +737,27 @@ func TestReconcileRouterDeploymentPreservesExternalAnnotations(t *testing.T) {
 	}
 
 	// 1. Operator-owned annotation reflects the new hash.
-	gotHash := updated.Spec.Template.ObjectMeta.Annotations[routerProxyConfigHashAnnotation]
+	gotHash := updated.Spec.Template.Annotations[routerProxyConfigHashAnnotation]
 	if gotHash != "newhash" {
 		t.Errorf("config hash annotation = %q, want newhash", gotHash)
 	}
 
 	// 2. External pod-template annotations survive.
-	if got := updated.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"]; got != "true" {
+	if got := updated.Spec.Template.Annotations["sidecar.istio.io/inject"]; got != "true" {
 		t.Errorf("sidecar.istio.io/inject = %q, want true (sidecar injector annotation must survive reconcile)", got)
 	}
-	if got := updated.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"]; got != "2026-05-13T20:00:00Z" {
+	if got := updated.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]; got != "2026-05-13T20:00:00Z" {
 		t.Errorf("kubectl.kubernetes.io/restartedAt = %q, want preserved value (kubectl rollout restart must survive reconcile)", got)
 	}
 
 	// 3. External pod-template label survives.
-	if got := updated.Spec.Template.ObjectMeta.Labels["external-team-label"]; got != "ml-platform" {
+	if got := updated.Spec.Template.Labels["external-team-label"]; got != "ml-platform" {
 		t.Errorf("external-team-label = %q, want ml-platform (foreign template labels must pass through)", got)
 	}
 
 	// 4. External top-level Deployment label survives.
-	if got := updated.Labels["argocd.argoproj.io/instance"]; got != "llmkube" {
-		t.Errorf("argocd instance label = %q, want llmkube (GitOps labels must pass through)", got)
+	if got := updated.Labels["argocd.argoproj.io/instance"]; got != gitopsInstance {
+		t.Errorf("argocd instance label = %q, want %q (GitOps labels must pass through)", got, gitopsInstance)
 	}
 
 	// 5. Operator-owned selector labels remain intact (regression
@@ -764,7 +765,7 @@ func TestReconcileRouterDeploymentPreservesExternalAnnotations(t *testing.T) {
 	// template).
 	wantSelector := routerProxySelectorLabels(mr)
 	for k, v := range wantSelector {
-		if got := updated.Spec.Template.ObjectMeta.Labels[k]; got != v {
+		if got := updated.Spec.Template.Labels[k]; got != v {
 			t.Errorf("selector label %q = %q, want %q", k, got, v)
 		}
 	}

--- a/internal/controller/router_builders_test.go
+++ b/internal/controller/router_builders_test.go
@@ -17,9 +17,11 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -39,6 +41,9 @@ func builderTestScheme(t *testing.T) *runtime.Scheme {
 	}
 	if err := corev1.AddToScheme(s); err != nil {
 		t.Fatalf("add corev1: %v", err)
+	}
+	if err := appsv1.AddToScheme(s); err != nil {
+		t.Fatalf("add appsv1: %v", err)
 	}
 	return s
 }
@@ -679,4 +684,88 @@ func hasEnvFromSecret(envFrom []corev1.EnvFromSource, name string) bool {
 		}
 	}
 	return false
+}
+
+// TestReconcileRouterDeploymentPreservesExternalAnnotations exercises the
+// #456 fix end to end through the fake client: seed a router-proxy
+// Deployment with both operator-owned and externally-set annotations,
+// run reconcileRouterDeployment, and assert the externally-set keys
+// survive the update.
+//
+// Without the fix the reconciler does `existing.Spec.Template =
+// desired.Spec.Template`, which strips every external annotation
+// (sidecar injectors, `kubectl rollout restart`'s restartedAt,
+// GitOps tool sync labels) on every reconcile. That manifests as
+// flapping ReplicaSets and truncated in-flight requests.
+func TestReconcileRouterDeploymentPreservesExternalAnnotations(t *testing.T) {
+	mr := canonicalModelRouter()
+
+	// Build the initial Deployment the way an earlier reconcile would
+	// have, then layer external metadata on top to simulate sidecar
+	// injection / kubectl rollout-restart / GitOps annotations.
+	r := &ModelRouterReconciler{RouterProxyImage: "ghcr.io/test/router-proxy:v1"}
+	initial := r.newRouterDeployment(mr, "oldhash")
+	initial.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"] = "true"
+	initial.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = "2026-05-13T20:00:00Z"
+	initial.Spec.Template.ObjectMeta.Labels["external-team-label"] = "ml-platform"
+	initial.Labels["argocd.argoproj.io/instance"] = "llmkube"
+
+	scheme := builderTestScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mr, initial).
+		Build()
+	rec := &ModelRouterReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		RouterProxyImage: "ghcr.io/test/router-proxy:v1",
+	}
+
+	// Reconcile with a NEW config hash so the operator's owned
+	// annotation needs to change.
+	if err := rec.reconcileRouterDeployment(context.Background(), mr, "newhash"); err != nil {
+		t.Fatalf("reconcileRouterDeployment: %v", err)
+	}
+
+	updated := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Name:      routerProxyResourceName(mr.Name),
+		Namespace: mr.Namespace,
+	}, updated); err != nil {
+		t.Fatalf("Get updated Deployment: %v", err)
+	}
+
+	// 1. Operator-owned annotation reflects the new hash.
+	gotHash := updated.Spec.Template.ObjectMeta.Annotations[routerProxyConfigHashAnnotation]
+	if gotHash != "newhash" {
+		t.Errorf("config hash annotation = %q, want newhash", gotHash)
+	}
+
+	// 2. External pod-template annotations survive.
+	if got := updated.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"]; got != "true" {
+		t.Errorf("sidecar.istio.io/inject = %q, want true (sidecar injector annotation must survive reconcile)", got)
+	}
+	if got := updated.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"]; got != "2026-05-13T20:00:00Z" {
+		t.Errorf("kubectl.kubernetes.io/restartedAt = %q, want preserved value (kubectl rollout restart must survive reconcile)", got)
+	}
+
+	// 3. External pod-template label survives.
+	if got := updated.Spec.Template.ObjectMeta.Labels["external-team-label"]; got != "ml-platform" {
+		t.Errorf("external-team-label = %q, want ml-platform (foreign template labels must pass through)", got)
+	}
+
+	// 4. External top-level Deployment label survives.
+	if got := updated.Labels["argocd.argoproj.io/instance"]; got != "llmkube" {
+		t.Errorf("argocd instance label = %q, want llmkube (GitOps labels must pass through)", got)
+	}
+
+	// 5. Operator-owned selector labels remain intact (regression
+	// guard against the selector going out of sync with the
+	// template).
+	wantSelector := routerProxySelectorLabels(mr)
+	for k, v := range wantSelector {
+		if got := updated.Spec.Template.ObjectMeta.Labels[k]; got != v {
+			t.Errorf("selector label %q = %q, want %q", k, got, v)
+		}
+	}
 }

--- a/internal/controller/router_config_builder.go
+++ b/internal/controller/router_config_builder.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	"github.com/defilantech/llmkube/internal/router"
@@ -355,7 +354,7 @@ func (r *ModelRouterReconciler) reconcileRouterConfigMap(
 	compiled *compiledConfig,
 ) error {
 	desired := newRouterConfigMap(mr, compiled)
-	if err := controllerutil.SetControllerReference(mr, desired, r.Scheme); err != nil {
+	if err := setControllerReferenceUnblocked(mr, desired, r.Scheme); err != nil {
 		return fmt.Errorf("set owner ref on router ConfigMap: %w", err)
 	}
 
@@ -378,7 +377,7 @@ func (r *ModelRouterReconciler) reconcileRouterConfigMap(
 	}
 	existing.Annotations[routerProxyConfigHashAnnotation] = compiled.Hash
 	existing.Labels = desired.Labels
-	if err := controllerutil.SetControllerReference(mr, existing, r.Scheme); err != nil {
+	if err := setControllerReferenceUnblocked(mr, existing, r.Scheme); err != nil {
 		return fmt.Errorf("set owner ref on existing router ConfigMap: %w", err)
 	}
 	return r.Update(ctx, existing)

--- a/internal/controller/router_deployment_builder.go
+++ b/internal/controller/router_deployment_builder.go
@@ -61,13 +61,13 @@ func (r *ModelRouterReconciler) reconcileRouterDeployment(
 	// pass through. Fixes #456.
 	existing.Spec.Replicas = desired.Spec.Replicas
 	existing.Spec.Template.Spec = desired.Spec.Template.Spec
-	existing.Spec.Template.ObjectMeta.Labels = mergePreservingExternal(
-		existing.Spec.Template.ObjectMeta.Labels,
-		desired.Spec.Template.ObjectMeta.Labels,
+	existing.Spec.Template.Labels = mergePreservingExternal(
+		existing.Spec.Template.Labels,
+		desired.Spec.Template.Labels,
 	)
-	existing.Spec.Template.ObjectMeta.Annotations = mergePreservingExternal(
-		existing.Spec.Template.ObjectMeta.Annotations,
-		desired.Spec.Template.ObjectMeta.Annotations,
+	existing.Spec.Template.Annotations = mergePreservingExternal(
+		existing.Spec.Template.Annotations,
+		desired.Spec.Template.Annotations,
 	)
 	existing.Labels = mergePreservingExternal(existing.Labels, desired.Labels)
 	if err := controllerutil.SetControllerReference(mr, existing, r.Scheme); err != nil {

--- a/internal/controller/router_deployment_builder.go
+++ b/internal/controller/router_deployment_builder.go
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -41,7 +40,7 @@ func (r *ModelRouterReconciler) reconcileRouterDeployment(
 	configHash string,
 ) error {
 	desired := r.newRouterDeployment(mr, configHash)
-	if err := controllerutil.SetControllerReference(mr, desired, r.Scheme); err != nil {
+	if err := setControllerReferenceUnblocked(mr, desired, r.Scheme); err != nil {
 		return fmt.Errorf("set owner ref on router Deployment: %w", err)
 	}
 
@@ -70,7 +69,7 @@ func (r *ModelRouterReconciler) reconcileRouterDeployment(
 		desired.Spec.Template.Annotations,
 	)
 	existing.Labels = mergePreservingExternal(existing.Labels, desired.Labels)
-	if err := controllerutil.SetControllerReference(mr, existing, r.Scheme); err != nil {
+	if err := setControllerReferenceUnblocked(mr, existing, r.Scheme); err != nil {
 		return fmt.Errorf("set owner ref on existing router Deployment: %w", err)
 	}
 	return r.Update(ctx, existing)

--- a/internal/controller/router_deployment_builder.go
+++ b/internal/controller/router_deployment_builder.go
@@ -54,11 +54,22 @@ func (r *ModelRouterReconciler) reconcileRouterDeployment(
 		return err
 	}
 
-	// PodTemplate selector is immutable; copy only mutable surface. We
-	// keep the existing ObjectMeta UID/Generation but refresh Spec.
+	// PodTemplate selector is immutable; copy mutable surface while
+	// preserving externally-set annotations and labels (sidecar
+	// injectors, `kubectl rollout restart`'s restartedAt, GitOps sync
+	// labels). Operator-owned keys win on collision; foreign keys
+	// pass through. Fixes #456.
 	existing.Spec.Replicas = desired.Spec.Replicas
-	existing.Spec.Template = desired.Spec.Template
-	existing.Labels = desired.Labels
+	existing.Spec.Template.Spec = desired.Spec.Template.Spec
+	existing.Spec.Template.ObjectMeta.Labels = mergePreservingExternal(
+		existing.Spec.Template.ObjectMeta.Labels,
+		desired.Spec.Template.ObjectMeta.Labels,
+	)
+	existing.Spec.Template.ObjectMeta.Annotations = mergePreservingExternal(
+		existing.Spec.Template.ObjectMeta.Annotations,
+		desired.Spec.Template.ObjectMeta.Annotations,
+	)
+	existing.Labels = mergePreservingExternal(existing.Labels, desired.Labels)
 	if err := controllerutil.SetControllerReference(mr, existing, r.Scheme); err != nil {
 		return fmt.Errorf("set owner ref on existing router Deployment: %w", err)
 	}

--- a/internal/controller/router_service_builder.go
+++ b/internal/controller/router_service_builder.go
@@ -19,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -34,7 +33,7 @@ func (r *ModelRouterReconciler) reconcileRouterService(
 	mr *inferencev1alpha1.ModelRouter,
 ) error {
 	desired := newRouterService(mr)
-	if err := controllerutil.SetControllerReference(mr, desired, r.Scheme); err != nil {
+	if err := setControllerReferenceUnblocked(mr, desired, r.Scheme); err != nil {
 		return fmt.Errorf("set owner ref on router Service: %w", err)
 	}
 
@@ -53,7 +52,7 @@ func (r *ModelRouterReconciler) reconcileRouterService(
 	existing.Spec.Type = desired.Spec.Type
 	existing.Spec.Ports = desired.Spec.Ports
 	existing.Labels = desired.Labels
-	if err := controllerutil.SetControllerReference(mr, existing, r.Scheme); err != nil {
+	if err := setControllerReferenceUnblocked(mr, existing, r.Scheme); err != nil {
 		return fmt.Errorf("set owner ref on existing router Service: %w", err)
 	}
 	return r.Update(ctx, existing)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -830,6 +830,112 @@ spec:
 			Eventually(verifyDeployment, 1*time.Minute).Should(Succeed())
 		})
 
+		It("should preserve external pod-template annotations across reconciles (#456)", func() {
+			// Regression test for #456: the prior reconciler did a
+			// wholesale `existing.Spec.Template = desired.Spec.Template`,
+			// which stripped every external annotation (sidecar
+			// injectors, `kubectl rollout restart`'s restartedAt,
+			// GitOps tool sync labels) on the very next reconcile.
+			// Visible symptom: ReplicaSets flap, in-flight requests
+			// get truncated.
+			//
+			// This test reuses the `e2e-good-router` proxy Deployment
+			// created by the preceding test, patches its pod template
+			// with two external annotations, forces a reconcile by
+			// bumping the ModelRouter's proxy replicas, and asserts
+			// the external annotations survive.
+
+			const (
+				istioAnnotation     = "sidecar.istio.io/inject"
+				rolloutAnnotation   = "kubectl.kubernetes.io/restartedAt"
+				rolloutAnnotationVS = "2026-05-14T00:00:00Z"
+				proxyDeploymentName = "e2e-good-router-router-proxy"
+			)
+
+			By("verifying the proxy Deployment from the previous test still exists")
+			verifyDeploymentReady := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "deployment", proxyDeploymentName,
+					"-n", mrTestNs, "-o", "jsonpath={.metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal(proxyDeploymentName))
+			}
+			Eventually(verifyDeploymentReady, 30*time.Second).Should(Succeed())
+
+			By("patching the proxy Deployment's pod template with external annotations")
+			// Simulates an Istio sidecar injector + a kubectl rollout
+			// restart adding annotations the operator does not own.
+			patch := fmt.Sprintf(
+				`{"spec":{"template":{"metadata":{"annotations":{%q:%q,%q:%q}}}}}`,
+				istioAnnotation, "true",
+				rolloutAnnotation, rolloutAnnotationVS,
+			)
+			cmd := exec.Command("kubectl", "patch", "deployment", proxyDeploymentName,
+				"-n", mrTestNs, "--type=merge", "-p", patch)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to patch external annotations onto proxy Deployment")
+
+			By("forcing a controller reconcile by bumping ModelRouter spec.proxy.replicas")
+			// The controller watches ModelRouter; updating its spec
+			// guarantees a reconcile cycle that walks through
+			// reconcileRouterDeployment. Without the #456 fix, that
+			// reconcile would strip the annotations we just set.
+			cmd = exec.Command("kubectl", "patch", "modelrouter", "e2e-good-router",
+				"-n", mrTestNs, "--type=merge",
+				"-p", `{"spec":{"proxy":{"replicas":2}}}`)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to bump ModelRouter spec.proxy.replicas")
+
+			By("waiting for the controller to reconcile the replica bump (proves reconcile ran)")
+			verifyReplicasReconciled := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "deployment", proxyDeploymentName,
+					"-n", mrTestNs, "-o", "jsonpath={.spec.replicas}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("2"),
+					"controller must have reconciled the replica bump; spec.replicas = %q", output)
+			}
+			Eventually(verifyReplicasReconciled, 1*time.Minute).Should(Succeed())
+
+			By("verifying the external annotations survived the reconcile")
+			// One Eventually wrapping all assertions: in the rare
+			// case the reconciler observed the spec bump before
+			// observing the Deployment patch, we want to give it a
+			// second pass. The fix is correct either way; this just
+			// avoids flakiness if the test happens to race.
+			verifyAnnotationsSurvived := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "deployment", proxyDeploymentName,
+					"-n", mrTestNs, "-o",
+					fmt.Sprintf(`jsonpath={.spec.template.metadata.annotations.%s}`,
+						strings.ReplaceAll(istioAnnotation, ".", `\.`)))
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("true"),
+					"sidecar injector annotation %q must survive reconcile (fix #456)", istioAnnotation)
+
+				cmd = exec.Command("kubectl", "get", "deployment", proxyDeploymentName,
+					"-n", mrTestNs, "-o",
+					fmt.Sprintf(`jsonpath={.spec.template.metadata.annotations.%s}`,
+						strings.ReplaceAll(rolloutAnnotation, ".", `\.`)))
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal(rolloutAnnotationVS),
+					"kubectl rollout-restart annotation must survive reconcile (fix #456)")
+
+				// Sanity: operator-owned config-hash annotation is
+				// still present. Confirms we didn't accidentally
+				// preserve external keys at the cost of operator keys.
+				cmd = exec.Command("kubectl", "get", "deployment", proxyDeploymentName,
+					"-n", mrTestNs, "-o",
+					`jsonpath={.spec.template.metadata.annotations.inference\.llmkube\.dev/router-config-hash}`)
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(),
+					"operator-owned config-hash annotation must still be present after reconcile")
+			}
+			Eventually(verifyAnnotationsSurvived, 30*time.Second).Should(Succeed())
+		})
+
 		It("should report Validated=False for a sensitive-data rule routing to cloud", func() {
 			By("applying a ModelRouter whose fail-closed PII rule points at a cloud backend")
 			cmd := exec.Command("kubectl", "apply", "-f", "-")


### PR DESCRIPTION
## What

Two related fixes that together make 0.7.8 ship-ready for the audience watching Marcel's video.

### Fix 1: preserve external pod-template annotations on reconcile (closes #456)

Both the ModelRouter and the InferenceService reconcilers were replacing the pod template wholesale:

```go
existing.Spec.Template = desired.Spec.Template  // router_deployment_builder.go
existingDeployment.Spec = deployment.Spec       // inferenceservice_controller.go
```

That stripped every annotation an external actor set on the pod template: sidecar injectors (Istio, Linkerd), `kubectl rollout restart`'s `kubectl.kubernetes.io/restartedAt`, GitOps tool sync labels. The visible symptom was a `kubectl rollout restart` spinning two ReplicaSets that flap against each other while the controller's reconcile fought kubectl's annotation, and in-flight requests got truncated.

Fixed by adding a `mergePreservingExternal(existing, desired)` helper. Operator-owned keys win on collision; foreign keys pass through. Spec replacement otherwise stays wholesale so the existing config-hash rollout mechanism keeps working.

### Fix 2: drop BlockOwnerDeletion on operator-managed children

While running the MicroShift / MINC lane, PR #466's improved diagnostics surfaced a real flake:

```
deployments.apps "scc-test-inference" is forbidden:
  cannot set blockOwnerDeletion in this case because cannot find
  RESTMapping for APIVersion inference.llmkube.dev/v1alpha1
  Kind InferenceService: no matches for kind "InferenceService"
```

controller-runtime's `SetControllerReference` sets `BlockOwnerDeletion=true` by default. The kube-apiserver `GarbageCollector` admission plugin validates that flag by RESTMapping the owner Kind to check the caller's `update` permission on the owner's `finalizers` subresource. On kind the API server's discovery cache is warm by the time the controller starts. On MicroShift-in-MINC, the in-container apiserver populates discovery lazily on first request and the controller's first reconcile races it and loses.

LLMKube doesn't need `BlockOwnerDeletion`. Cascading delete still cleans up operator-managed children when their parent CR is deleted; the "block" semantics only matter for finalizer-based cleanup workflows we don't use. Trade-off: cleaner bootstrap for slightly looser cascade ordering guarantees we weren't relying on.

Fixed by a new `setControllerReferenceUnblocked` helper that wraps `controllerutil.SetControllerReference` and clears `BlockOwnerDeletion` on the owner reference. Applied to all 9 call sites: router Deployment/Service/ConfigMap reconcilers, InferenceService Deployment/Service reconcilers, and the HPA reconciler.

## Why

`#456` is filed today and is a real ergonomic / correctness problem for any cluster running a service mesh, ArgoCD, or kubectl rollout-restart. The MicroShift flake has been blocking CI signal across multiple recent PRs (#464, #466, this one). Marcel Dempers' YouTube video is driving traffic right now; the operator needs to behave predictably for first-time users on real clusters before we cut 0.7.8.

Fixes #456.

## How

**Annotation preservation:**
- New helper `mergePreservingExternal` in `internal/controller/merge.go`
- Both reconcilers now call it on the pod-template labels + annotations, plus the router-proxy's top-level Deployment labels
- Spec replacement is otherwise unchanged so the existing config-hash rollout mechanism keeps working

**BlockOwnerDeletion:**
- New helper `setControllerReferenceUnblocked` in `internal/controller/ownerref.go`
- Wraps `controllerutil.SetControllerReference`, then walks the resulting owner refs and clears `BlockOwnerDeletion` on the one we just installed
- All 9 controller call sites switched over

**Coverage:**
- `TestMergePreservingExternal` — helper unit test (4 cases)
- `TestSetControllerReferenceUnblocked` — verifies the resulting owner ref has `Controller=true` and `BlockOwnerDeletion=false`
- `TestReconcileRouterDeploymentPreservesExternalAnnotations` — full fake-client integration test for the annotation fix
- **New e2e step**: `should preserve external pod-template annotations across reconciles (#456)` in the `ModelRouter Reconciliation` Context patches the proxy Deployment with sidecar/kubectl-rollout-restart annotations, bumps `spec.proxy.replicas` to force reconcile, then Eventually-asserts the external annotations survive AND the operator-owned config-hash annotation is also still present
- Local: `make lint`, `make test`, `go vet -tags=e2e ./test/e2e/...` all clean

## Checklist

- [x] Tests added (merge_test.go, ownerref_test.go, router_builders_test.go integration test, new e2e step)
- [x] `go test ./internal/controller/...` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits (4 commits: `fix:`, `docs(site):`, `fix(lint):`, `test(e2e):`, `fix:` for BlockOwnerDeletion)
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (Phase 1 limitations callout in `concepts/model-router.md`)