### PR TITLE
fix: prevent concurrent runtime respawn in metal-agent

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -170,6 +170,15 @@ type MetalAgent struct {
 	// current level without re-patching ones already observed at it.
 	// Reset on every level transition.
 	pressureObserved map[string]MemoryPressureLevel
+
+	// starting records namespacedName keys whose ensureProcess call is
+	// in flight. The K8s watcher (handleEvent) and the health monitor
+	// (scheduleRestart) can both call ensureProcess for the same key at the
+	// same time; the model load between the processes[] check and the store
+	// is long and unlocked, so without this guard both callers pass the
+	// stale check and each spawns a runtime process — loading the model
+	// twice, enough to exhaust host memory.
+	starting map[string]bool
 }
 
 // ManagedProcess represents a running inference process (llama-server, oMLX, or Ollama model).
@@ -235,6 +244,7 @@ func NewMetalAgent(config MetalAgentConfig) *MetalAgent {
 		memoryFraction:   fraction,
 		pressureBlocked:  make(map[string]bool),
 		pressureObserved: make(map[string]MemoryPressureLevel),
+		starting:         make(map[string]bool),
 	}
 }
 
@@ -539,6 +549,27 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 	}.String()
 
 	desiredHash := computeSpecHash(isvc)
+
+	// Serialize ensureProcess per service. The K8s watcher and the health
+	// monitor's scheduleRestart can both reach ensureProcess for this key
+	// concurrently; the spawn path between the processes[] check and the
+	// store is long and unlocked, so without this guard both callers would
+	// spawn a runtime process and load the model twice. A spec change that
+	// arrives mid-spawn is dropped here and reconciled by the next watch
+	// event — acceptable, where a double model load is not.
+	a.mu.Lock()
+	if a.starting[key] {
+		a.mu.Unlock()
+		a.logger.Debugw("ensureProcess already in flight; skipping", "key", key)
+		return nil
+	}
+	a.starting[key] = true
+	a.mu.Unlock()
+	defer func() {
+		a.mu.Lock()
+		delete(a.starting, key)
+		a.mu.Unlock()
+	}()
 
 	// Check if process already exists
 	a.mu.RLock()

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -19,6 +19,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -950,4 +951,113 @@ func TestEnsureProcess_SpecDriftCallsDeleteBeforeRespawn(t *testing.T) {
 		},
 	}
 	runEnsureProcessExpectingMapEviction(t, "drift-isvc", isvc)
+}
+
+// blockingExecutor is a ProcessExecutor whose StartProcess blocks until the
+// test releases it, recording how many times it was entered. It opens a wide,
+// deterministic race window for the in-flight guard test.
+type blockingExecutor struct {
+	calls   atomic.Int64
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingExecutor) StartProcess(_ context.Context, cfg ExecutorConfig) (*ManagedProcess, error) {
+	e.calls.Add(1)
+	e.entered <- struct{}{}
+	<-e.release
+	return &ManagedProcess{
+		Name:      cfg.Name,
+		Namespace: cfg.Namespace,
+		PID:       424242,
+		Port:      9099,
+		ModelPath: "/tmp/race-model",
+		Healthy:   true,
+		StartedAt: time.Now(),
+	}, nil
+}
+
+func (e *blockingExecutor) StopProcess(_ int) error { return nil }
+
+// TestEnsureProcess_InFlightGuard is a regression test for the respawn race:
+// while one ensureProcess call is mid-spawn (blocked in StartProcess), a
+// second call for the same InferenceService must short-circuit instead of
+// spawning a second process. In production both the K8s watcher and the
+// health monitor's scheduleRestart reached StartProcess concurrently, loading
+// the model twice and exhausting host memory.
+func TestEnsureProcess_InFlightGuard(t *testing.T) {
+	scheme := newTestScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	model := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "race-model", Namespace: "default"},
+		Spec: inferencev1alpha1.ModelSpec{
+			Source:   "/tmp/race-model.gguf",
+			Format:   "gguf",
+			Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+		},
+	}
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "race-isvc", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "race-model"},
+	}
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "race-isvc", Namespace: "default"}}
+	//nolint:staticcheck // SA1019: Endpoints API matches production code under test
+	endpoints := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "race-isvc", Namespace: "default"}}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&inferencev1alpha1.InferenceService{}).
+		WithRuntimeObjects(model, isvc, svc, endpoints).
+		Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{
+		K8sClient:      k8sClient,
+		Namespace:      "default",
+		MemoryProvider: &mockMemoryProvider{totalBytes: 128 << 30, availableBytes: 120 << 30},
+	})
+	exec := &blockingExecutor{entered: make(chan struct{}), release: make(chan struct{})}
+	agent.executor = exec
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	// First caller proceeds and blocks inside StartProcess.
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- agent.ensureProcess(context.Background(), isvc) }()
+
+	select {
+	case <-exec.entered:
+		// first call is now mid-spawn; starting[key] is set
+	case <-time.After(10 * time.Second):
+		t.Fatal("first ensureProcess never reached StartProcess")
+	}
+
+	// Second caller (the would-be racing path) must short-circuit fast.
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- agent.ensureProcess(context.Background(), isvc) }()
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Errorf("second ensureProcess returned error, want nil skip: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("second ensureProcess did not return — in-flight guard missing; it is racing the spawn")
+	}
+
+	if got := exec.calls.Load(); got != 1 {
+		t.Errorf("StartProcess called %d times during the in-flight window, want 1", got)
+	}
+
+	close(exec.release)
+	if err := <-firstDone; err != nil {
+		// Endpoint registration against the fake client may noop-error; the
+		// spawn-once invariant above is the assertion that matters.
+		t.Logf("first ensureProcess returned: %v", err)
+	}
+
+	agent.mu.Lock()
+	leftover := len(agent.starting)
+	agent.mu.Unlock()
+	if leftover != 0 {
+		t.Errorf("starting map not cleared after spawn, has %d entries", leftover)
+	}
 }


### PR DESCRIPTION
## What

Fix a check-then-act race in the metal-agent's `ensureProcess` that let two
callers spawn a second inference runtime process for the same
`InferenceService`, loading the model twice and exhausting host memory.

## Why

`ensureProcess` read `processes[key]` under `RLock`, released the lock, then ran
the long unlocked spawn path — K8s fetch, memory estimation, and
`StartProcess` (a multi-minute model load) — re-locking only to store the
result. The K8s watcher (`handleEvent`) and the health monitor
(`scheduleRestart`, fired on "process became unhealthy") both reach
`ensureProcess` for the same service; both could pass the stale `processes[]`
check and both call `StartProcess`. Observed in practice: two concurrent ~35GB
model loads OOM'd the host.

No linked issue — found while integrating a new runtime under the metal-agent.

## How

Add a per-service in-flight guard. `ensureProcess` records the namespaced key
in a new `starting` map under the existing mutex and clears it on every return
path via `defer`. A second concurrent call for the same key short-circuits
(returns `nil`). Brief lock acquisitions only — the lock is **not** held across
the slow spawn. A spec change arriving mid-spawn is dropped and reconciled by
the next watch event, which is acceptable where a double model load is not.

## Checklist

- [x] Tests added/updated — `-race` regression test driving two concurrent `ensureProcess` calls, asserting `StartProcess` runs exactly once
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change) — n/a, internal bug fix