### PR TITLE
feat: add mlx-server runtime to the metal-agent

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -57,6 +57,8 @@ type AgentConfig struct {
 	OMLXPort                  int
 	OllamaPort                int
 	VLLMSwiftBin              string
+	MLXServerBin              string
+	MLXServerPort             int
 	Port                      int
 	LogLevel                  string
 	HostIP                    string
@@ -69,6 +71,7 @@ type AgentConfig struct {
 	LlamaServerStartupTimeout time.Duration
 	OMLXStartupTimeout        time.Duration
 	VLLMSwiftStartupTimeout   time.Duration
+	MLXServerStartupTimeout   time.Duration
 	ApplePowerEnabled         bool
 	ApplePowerInterval        time.Duration
 	PowermetricsBin           string
@@ -154,6 +157,30 @@ func resolveVLLMSwiftBin(override string) (string, error) {
 		defaultVLLMSwiftPaths)
 }
 
+// defaultMLXServerPaths is the list of paths to search for the mlx-server binary.
+var defaultMLXServerPaths = []string{
+	"/opt/homebrew/bin/mlx-server",
+	"/usr/local/bin/mlx-server",
+}
+
+// resolveMLXServerBin returns the mlx-server binary path. If override is
+// non-empty it is returned as-is. Otherwise the function searches
+// defaultMLXServerPaths.
+func resolveMLXServerBin(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	for _, p := range defaultMLXServerPaths {
+		if _, err := statFunc(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"mlx-server binary not found in default paths (%v); "+
+			"pass --mlx-server-bin=/path/to/mlx-server",
+		defaultMLXServerPaths)
+}
+
 // resolveOMLXBin returns the omlx binary path. If override is non-empty it is
 // returned as-is. Otherwise the function searches defaultOMLXPaths.
 func resolveOMLXBin(override string) (string, error) {
@@ -179,11 +206,14 @@ func main() {
 	flag.StringVar(&cfg.Namespace, "namespace", "default", "Kubernetes namespace to watch")
 	flag.StringVar(&cfg.ModelStorePath, "model-store", "/tmp/llmkube-models", "Path to store downloaded models")
 	flag.StringVar(&llamaServerFlag, "llama-server", "", "Path to llama-server binary (auto-detected if not set)")
-	flag.StringVar(&cfg.Runtime, "runtime", "llama-server", "Inference runtime: llama-server, omlx, ollama, or vllm-swift")
+	flag.StringVar(&cfg.Runtime, "runtime", "llama-server",
+		"Inference runtime: llama-server, omlx, ollama, vllm-swift, or mlx-server")
 	flag.StringVar(&cfg.OMLXBin, "omlx-bin", "", "Path to omlx binary (auto-detected if not set)")
 	flag.IntVar(&cfg.OMLXPort, "omlx-port", 8000, "Port for oMLX server")
 	flag.IntVar(&cfg.OllamaPort, "ollama-port", 11434, "Port for Ollama server")
 	flag.StringVar(&cfg.VLLMSwiftBin, "vllm-swift-bin", "", "Path to vllm-swift binary (auto-detected if not set)")
+	flag.StringVar(&cfg.MLXServerBin, "mlx-server-bin", "", "Path to mlx-server binary (auto-detected if not set)")
+	flag.IntVar(&cfg.MLXServerPort, "mlx-server-port", 8080, "Fixed port for the mlx-server runtime")
 	flag.IntVar(&cfg.Port, "port", 9090, "Agent metrics/health port")
 	flag.StringVar(&cfg.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	flag.StringVar(&cfg.HostIP, "host-ip", "", "IP address to register in Kubernetes endpoints (auto-detected if empty)")
@@ -213,6 +243,10 @@ func main() {
 		"How long to wait for vllm-swift to respond on /health. vLLM init plus "+
 			"Swift bridge load plus weight load grow with model size; default 120s "+
 			"works for 30B-class models on M5 Max. Bump for larger models.")
+	flag.DurationVar(&cfg.MLXServerStartupTimeout, "mlx-server-startup-timeout",
+		agent.DefaultMLXServerStartupTimeout,
+		"How long to wait for mlx-server to respond on /health. MLX weight load "+
+			"grows with model size; default 120s works for ~35B models on M5 Max.")
 	flag.BoolVar(&cfg.ApplePowerEnabled, "apple-power-enabled", false,
 		"Enable the macOS powermetrics sampler that publishes apple_power_*_watts gauges "+
 			"for InferCost. Requires a NOPASSWD sudoers entry for /usr/bin/powermetrics; "+
@@ -273,6 +307,17 @@ func main() {
 			os.Exit(1)
 		}
 		cfg.VLLMSwiftBin = resolvedBin
+	case "mlx-server":
+		resolvedBin, err := resolveMLXServerBin(cfg.MLXServerBin)
+		if err != nil {
+			logger.Errorw("mlx-server binary not found",
+				"searchPaths", defaultMLXServerPaths,
+				"installHint", "pass --mlx-server-bin=/path/to/mlx-server",
+				"error", err,
+			)
+			os.Exit(1)
+		}
+		cfg.MLXServerBin = resolvedBin
 	default:
 		cfg.Runtime = "llama-server"
 		resolvedBin, err := resolveLlamaServerBin(llamaServerFlag)
@@ -331,6 +376,8 @@ func main() {
 		logger.Infow("using Ollama daemon", "port", cfg.OllamaPort)
 	case "vllm-swift":
 		logger.Infow("vllm-swift binary found", "path", cfg.VLLMSwiftBin)
+	case "mlx-server":
+		logger.Infow("mlx-server binary found", "path", cfg.MLXServerBin)
 	default:
 		logger.Infow("llama-server binary found", "path", cfg.LlamaServerBin)
 	}
@@ -387,6 +434,8 @@ func main() {
 		OMLXPort:                  cfg.OMLXPort,
 		OllamaPort:                cfg.OllamaPort,
 		VLLMSwiftBin:              cfg.VLLMSwiftBin,
+		MLXServerBin:              cfg.MLXServerBin,
+		MLXServerPort:             cfg.MLXServerPort,
 		Port:                      cfg.Port,
 		HostIP:                    cfg.HostIP,
 		Logger:                    logger,
@@ -395,6 +444,7 @@ func main() {
 		LlamaServerStartupTimeout: cfg.LlamaServerStartupTimeout,
 		OMLXStartupTimeout:        cfg.OMLXStartupTimeout,
 		VLLMSwiftStartupTimeout:   cfg.VLLMSwiftStartupTimeout,
+		MLXServerStartupTimeout:   cfg.MLXServerStartupTimeout,
 		ApplePowerEnabled:         cfg.ApplePowerEnabled,
 		ApplePowerInterval:        cfg.ApplePowerInterval,
 		PowermetricsBin:           cfg.PowermetricsBin,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -44,6 +44,7 @@ const (
 	runtimeOMLX      = "omlx"
 	runtimeOllama    = "ollama"
 	runtimeVLLMSwift = "vllm-swift"
+	runtimeMLXServer = "mlx-server"
 )
 
 // Model format identifiers (Model.Spec.Format) the agent recognizes for
@@ -83,6 +84,12 @@ type MetalAgentConfig struct {
 	// VLLMSwiftBin is the path to the vllm-swift binary. Only used when
 	// Runtime is "vllm-swift". Empty means auto-detect via $PATH.
 	VLLMSwiftBin string
+	// MLXServerBin is the path to the mlx-server binary. Only used when
+	// Runtime is "mlx-server".
+	MLXServerBin string
+	// MLXServerPort is the fixed port the mlx-server process binds.
+	// Only used when Runtime is "mlx-server"; zero defaults to 8080.
+	MLXServerPort int
 
 	// MemoryProvider supplies system memory info. Nil defaults to DarwinMemoryProvider.
 	MemoryProvider MemoryProvider
@@ -122,6 +129,12 @@ type MetalAgentConfig struct {
 	// (DefaultVLLMSwiftStartupTimeout). vLLM init + Swift bridge load + weight
 	// load grow with model size; 120s default works for ~30B models on M5 Max.
 	VLLMSwiftStartupTimeout time.Duration
+
+	// MLXServerStartupTimeout is how long the agent waits for mlx-server to
+	// respond on /health. Zero means use the executor default
+	// (DefaultMLXServerStartupTimeout). MLX weight load grows with model
+	// size; the 120s default works for ~35B models on M5 Max.
+	MLXServerStartupTimeout time.Duration
 
 	// ApplePowerEnabled launches the powermetrics-driven sampler that
 	// publishes apple_power_*_watts gauges. Defaults false because
@@ -309,6 +322,21 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 			vllmSwiftExec.SetStartupTimeout(a.config.VLLMSwiftStartupTimeout)
 		}
 		a.executor = vllmSwiftExec
+	case runtimeMLXServer:
+		port := a.config.MLXServerPort
+		if port == 0 {
+			port = 8080
+		}
+		mlxServerExec := NewMLXServerExecutor(
+			a.config.MLXServerBin,
+			a.config.ModelStorePath,
+			port,
+			a.logger.With("subsystem", "executor"),
+		)
+		if a.config.MLXServerStartupTimeout > 0 {
+			mlxServerExec.SetStartupTimeout(a.config.MLXServerStartupTimeout)
+		}
+		a.executor = mlxServerExec
 	default:
 		metalExec := NewMetalExecutor(
 			a.config.LlamaServerBin,
@@ -521,6 +549,11 @@ func (a *MetalAgent) validateRuntimeFormat(model *inferencev1alpha1.Model) error
 		// only incompatible format.
 		bad = modelFormat == formatGGUF
 		runtimeLabel = runtimeVLLMSwift
+	case runtimeMLXServer:
+		// mlx-server reads MLX directories and HuggingFace safetensors
+		// directories; gguf is the only incompatible format.
+		bad = modelFormat == formatGGUF
+		runtimeLabel = runtimeMLXServer
 	default:
 		bad = modelFormat == formatMLX
 		runtimeLabel = "llama-server"

--- a/pkg/agent/executor_mlx_server.go
+++ b/pkg/agent/executor_mlx_server.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// DefaultMLXServerStartupTimeout is how long the agent waits for a freshly
+// spawned mlx-server process to respond on /health. mlx-server loads MLX
+// weights on startup; a 35B-class model on an M5 Max is well under a minute
+// once cached, but a cold load is slower. 120s gives generous headroom while
+// still failing fast on real breakage.
+const DefaultMLXServerStartupTimeout = 120 * time.Second
+
+// MLXServerExecutor manages a single mlx-server process for the agent's
+// InferenceService. mlx-server (github.com/Defilan/mlx-server) is a native
+// OpenAI-compatible MLX inference server. Unlike the vllm-swift executor's
+// per-spawn ephemeral port, this executor binds a fixed port so clients
+// (e.g. opencode) keep a stable base URL across respawns.
+type MLXServerExecutor struct {
+	bin            string
+	modelStorePath string
+	port           int
+	logger         *zap.SugaredLogger
+	startupTimeout time.Duration
+}
+
+// NewMLXServerExecutor creates an executor that spawns one mlx-server
+// process on the given fixed port.
+func NewMLXServerExecutor(bin, modelStorePath string, port int, logger *zap.SugaredLogger) *MLXServerExecutor {
+	return &MLXServerExecutor{
+		bin:            bin,
+		modelStorePath: modelStorePath,
+		port:           port,
+		logger:         logger,
+		startupTimeout: DefaultMLXServerStartupTimeout,
+	}
+}
+
+// SetStartupTimeout overrides the default mlx-server startup timeout.
+// Values <= 0 are coerced back to DefaultMLXServerStartupTimeout.
+func (e *MLXServerExecutor) SetStartupTimeout(d time.Duration) {
+	if d <= 0 {
+		d = DefaultMLXServerStartupTimeout
+	}
+	e.startupTimeout = d
+}
+
+// StartProcess resolves the model directory and spawns mlx-server on the
+// executor's fixed port. It blocks until /health returns 200 or
+// startupTimeout fires.
+func (e *MLXServerExecutor) StartProcess(_ context.Context, config ExecutorConfig) (*ManagedProcess, error) {
+	modelPath := e.resolveModelPath(config)
+	if _, err := os.Stat(modelPath); err != nil {
+		return nil, fmt.Errorf(
+			"mlx-server model directory not found at %s: %w "+
+				"(the host metal-agent does not download MLX/HF model directories; "+
+				"pre-download the model directory before deploying)",
+			modelPath, err)
+	}
+
+	args := buildMLXServerArgs(modelPath, e.port, config)
+
+	e.logger.Infow("starting mlx-server",
+		"bin", e.bin, "modelPath", modelPath, "port", e.port)
+
+	cmd := exec.Command(e.bin, args...)
+	cmd.Env = os.Environ()
+
+	// Capture child stdout/stderr to a per-process log file. Without this a
+	// model-load failure becomes a silent crashloop with no trail. The path
+	// is stable per (namespace, name) so operators can tail it across restarts.
+	logPath := e.processLogPath(config.Namespace, config.Name)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open mlx-server log file %s: %w", logPath, err)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return nil, fmt.Errorf("failed to start mlx-server: %w", err)
+	}
+	// The child holds the fd; close our handle. The OS keeps the inode alive
+	// until the child exits.
+	_ = logFile.Close()
+
+	process := &ManagedProcess{
+		Name:      config.Name,
+		Namespace: config.Namespace,
+		PID:       cmd.Process.Pid,
+		Port:      e.port,
+		ModelPath: modelPath,
+		ModelID:   filepath.Base(modelPath),
+		StartedAt: time.Now(),
+		Healthy:   false,
+	}
+
+	if err := e.waitForHealthy(e.port, e.startupTimeout); err != nil {
+		if killErr := cmd.Process.Kill(); killErr != nil {
+			e.logger.Warnw("failed to kill unhealthy mlx-server process",
+				"pid", cmd.Process.Pid, "error", killErr)
+		}
+		return nil, fmt.Errorf("mlx-server failed health check after %s: %w",
+			e.startupTimeout, err)
+	}
+
+	process.Healthy = true
+	e.logger.Infow("mlx-server ready", "pid", process.PID, "port", e.port, "modelID", process.ModelID)
+	return process, nil
+}
+
+// StopProcess sends SIGTERM with a 10s grace period before SIGKILL.
+func (e *MLXServerExecutor) StopProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("failed to find process %d: %w", pid, err)
+	}
+
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("failed to send SIGTERM to process %d: %w", pid, err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := process.Wait()
+		done <- err
+	}()
+
+	select {
+	case <-time.After(10 * time.Second):
+		_ = process.Kill()
+		return fmt.Errorf("process %d did not exit gracefully, killed", pid)
+	case err := <-done:
+		return err
+	}
+}
+
+// processLogPath returns the per-process log file path for mlx-server's
+// stdout/stderr capture, anchored under modelStorePath alongside the model
+// artifacts. The (namespace, name) pair is stable across restarts.
+func (e *MLXServerExecutor) processLogPath(namespace, name string) string {
+	return filepath.Join(e.modelStorePath, fmt.Sprintf("mlx-server-%s-%s.log", namespace, name))
+}
+
+// resolveModelPath returns the on-disk path to the model directory.
+// mlx-server takes a directory containing config.json + safetensors/MLX
+// weights. If ModelSource is an absolute path use it as-is; otherwise treat
+// it as relative to modelStorePath.
+//
+// Symlinks are resolved aggressively: MLX's Swift-side architecture detection
+// has a known issue loading through a symlinked path, so the canonical path
+// is passed to the child. EvalSymlinks returns the original path on failure
+// so a missing directory still produces the friendly error from StartProcess.
+func (e *MLXServerExecutor) resolveModelPath(config ExecutorConfig) string {
+	candidate := config.ModelSource
+	if candidate == "" {
+		candidate = filepath.Join(e.modelStorePath, config.ModelName)
+	} else if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(e.modelStorePath, candidate)
+	}
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return candidate
+	}
+	return resolved
+}
+
+// waitForHealthy polls /health on the given port until 200 or timeout.
+func (e *MLXServerExecutor) waitForHealthy(port int, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	healthURL := fmt.Sprintf("http://localhost:%d/health", port)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for mlx-server /health")
+		case <-ticker.C:
+			resp, err := http.Get(healthURL)
+			if err == nil && resp.StatusCode == http.StatusOK {
+				_ = resp.Body.Close()
+				return nil
+			}
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+		}
+	}
+}
+
+// buildMLXServerArgs constructs the command-line argument vector for the
+// mlx-server child. Split out from StartProcess so the CRD-field-to-flag
+// mapping is unit-testable without spawning a process.
+//
+// mlx-server-specific flags such as --tool-call-format and --reasoning are
+// not set here; they ride through ExtraArgs (InferenceService.spec.extraArgs),
+// appended last so user-provided values win.
+func buildMLXServerArgs(modelPath string, port int, config ExecutorConfig) []string {
+	args := []string{
+		"--model", modelPath,
+		"--host", "0.0.0.0",
+		"--port", fmt.Sprintf("%d", port),
+	}
+
+	if config.ParallelSlots > 1 {
+		args = append(args, "--max-slots", fmt.Sprintf("%d", config.ParallelSlots))
+	}
+
+	// ExtraArgs comes last so user-provided overrides win.
+	if len(config.ExtraArgs) > 0 {
+		args = append(args, config.ExtraArgs...)
+	}
+
+	return args
+}

--- a/pkg/agent/executor_mlx_server_test.go
+++ b/pkg/agent/executor_mlx_server_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const mlxTestModelStore = "/models"
+
+func TestNewMLXServerExecutor(t *testing.T) {
+	executor := NewMLXServerExecutor("/opt/homebrew/bin/mlx-server", mlxTestModelStore, 8080, newNopLogger())
+
+	if executor.bin != "/opt/homebrew/bin/mlx-server" {
+		t.Errorf("bin = %q, want %q", executor.bin, "/opt/homebrew/bin/mlx-server")
+	}
+	if executor.modelStorePath != mlxTestModelStore {
+		t.Errorf("modelStorePath = %q, want %q", executor.modelStorePath, mlxTestModelStore)
+	}
+	if executor.port != 8080 {
+		t.Errorf("port = %d, want 8080", executor.port)
+	}
+	if executor.startupTimeout != DefaultMLXServerStartupTimeout {
+		t.Errorf("default startupTimeout = %v, want %v",
+			executor.startupTimeout, DefaultMLXServerStartupTimeout)
+	}
+}
+
+func TestMLXServerSetStartupTimeout(t *testing.T) {
+	executor := NewMLXServerExecutor("/bin/mlx-server", mlxTestModelStore, 8080, newNopLogger())
+
+	executor.SetStartupTimeout(200 * time.Second)
+	if executor.startupTimeout != 200*time.Second {
+		t.Errorf("after Set(200s) = %v, want 200s", executor.startupTimeout)
+	}
+
+	// Non-positive values coerce back to default.
+	for _, d := range []time.Duration{0, -5 * time.Second} {
+		executor.SetStartupTimeout(d)
+		if executor.startupTimeout != DefaultMLXServerStartupTimeout {
+			t.Errorf("after Set(%v) = %v, want default %v",
+				d, executor.startupTimeout, DefaultMLXServerStartupTimeout)
+		}
+	}
+}
+
+func TestBuildMLXServerArgs_Defaults(t *testing.T) {
+	args := buildMLXServerArgs("/models/Qwen3.6-35B-A3B-8bit", 8080, ExecutorConfig{})
+
+	want := map[string]string{
+		"--model": "/models/Qwen3.6-35B-A3B-8bit",
+		"--host":  "0.0.0.0",
+		"--port":  "8080",
+	}
+	for flag, expected := range want {
+		if got := flagValue(args, flag); got != expected {
+			t.Errorf("%s = %q, want %q (full args: %v)", flag, got, expected, args)
+		}
+	}
+
+	// Defaults must not inject slot concurrency.
+	if hasFlag(args, "--max-slots") {
+		t.Errorf("--max-slots must be omitted by default (full args: %v)", args)
+	}
+}
+
+func TestBuildMLXServerArgs_ParallelSlots(t *testing.T) {
+	args := buildMLXServerArgs("/m", 8080, ExecutorConfig{ParallelSlots: 4})
+	if got := flagValue(args, "--max-slots"); got != "4" {
+		t.Errorf("--max-slots = %q, want %q (full args: %v)", got, "4", args)
+	}
+
+	// 0 and 1 omit the flag.
+	for _, n := range []int{0, 1} {
+		a := buildMLXServerArgs("/m", 8080, ExecutorConfig{ParallelSlots: n})
+		if hasFlag(a, "--max-slots") {
+			t.Errorf("--max-slots must be omitted for ParallelSlots=%d (full args: %v)", n, a)
+		}
+	}
+}
+
+func TestBuildMLXServerArgs_ExtraArgsAppendedLast(t *testing.T) {
+	args := buildMLXServerArgs("/m", 8080, ExecutorConfig{
+		ExtraArgs: []string{"--tool-call-format", "xml_function", "--reasoning", "prefilled"},
+	})
+	if len(args) < 4 {
+		t.Fatalf("args too short: %v", args)
+	}
+	tail := args[len(args)-4:]
+	want := []string{"--tool-call-format", "xml_function", "--reasoning", "prefilled"}
+	for i, w := range want {
+		if tail[i] != w {
+			t.Errorf("tail[%d] = %q, want %q (full args: %v)", i, tail[i], w, args)
+		}
+	}
+}
+
+func TestMLXServerProcessLogPath(t *testing.T) {
+	executor := NewMLXServerExecutor("/bin/mlx-server", "/var/lib/llmkube", 8080, newNopLogger())
+
+	got := executor.processLogPath("default", "qwen36-opencode")
+	want := filepath.Join("/var/lib/llmkube", "mlx-server-default-qwen36-opencode.log")
+	if got != want {
+		t.Errorf("processLogPath = %q, want %q", got, want)
+	}
+
+	if other := executor.processLogPath("prod", "qwen36-opencode"); other == got {
+		t.Errorf("processLogPath collided across namespaces: %q == %q", other, got)
+	}
+}
+
+func TestMLXServerStopProcess_InvalidPID(t *testing.T) {
+	executor := NewMLXServerExecutor("/bin/mlx-server", mlxTestModelStore, 8080, newNopLogger())
+
+	if err := executor.StopProcess(-99999); err == nil {
+		t.Error("StopProcess with invalid PID should return error")
+	}
+}
+
+func TestMLXServerWaitForHealthy_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := mustExtractPort(t, srv.URL)
+	executor := NewMLXServerExecutor("/bin/mlx-server", mlxTestModelStore, port, newNopLogger())
+
+	if err := executor.waitForHealthy(port, 5*time.Second); err != nil {
+		t.Errorf("waitForHealthy returned error against healthy server: %v", err)
+	}
+}
+
+func TestMLXServerWaitForHealthy_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	port := mustExtractPort(t, srv.URL)
+	executor := NewMLXServerExecutor("/bin/mlx-server", mlxTestModelStore, port, newNopLogger())
+
+	err := executor.waitForHealthy(port, 1500*time.Millisecond)
+	if err == nil {
+		t.Fatal("waitForHealthy must return error when server is never healthy")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("error must mention timeout, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Add `mlx-server` as a metal-agent inference runtime, alongside `llama-server`,
`omlx`, `ollama`, and `vllm-swift`.

## Why

[mlx-server](https://github.com/Defilan/mlx-server) is a native
OpenAI-compatible MLX inference server for Apple Silicon. This lets the
metal-agent supervise it as a first-class `InferenceService` runtime — the
same lifecycle the agent already gives the other runtimes.

No linked issue.

## How

- **`MLXServerExecutor`** (`pkg/agent/executor_mlx_server.go`) implements
  `ProcessExecutor`: resolves the model directory, spawns `mlx-server`, polls
  `/health`, and stops it with SIGTERM plus a grace period. Unlike the
  vllm-swift executor's per-spawn ephemeral port it binds a **fixed port**
  (default 8080) so clients keep a stable base URL across respawns.
- `runtimeMLXServer` wired into the executor-selection switch and
  `validateRuntimeFormat` (MLX directories and HF safetensors accepted, `gguf`
  rejected — same as vllm-swift).
- `--mlx-server-bin`, `--mlx-server-port`, and `--mlx-server-startup-timeout`
  flags on the metal-agent, with binary auto-detection.
- `mlx-server`-specific flags such as `--tool-call-format` and `--reasoning`
  ride through `InferenceService.spec.extraArgs` — no new CRD fields.

## Checklist

- [x] Tests added/updated — `executor_mlx_server_test.go` covers arg construction, the fixed-port executor, health polling, and process teardown
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change) — the macOS Metal guide's runtime list is a small follow-up