### PR TITLE
feat: add scale sub resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,11 @@ spec:
 
 ```bash
 kubectl apply -f model.yaml
+
+# Scale replicas at any time — InferenceService supports the standard Kubernetes scale subresource
+kubectl scale inferenceservice/tinyllama --replicas=3
 ```
+
 </details>
 
 **Full setup guides:** [Minikube Quickstart](docs/minikube-quickstart.md) | [GKE with GPUs](docs/gpu-setup-guide.md) | [Air-Gapped Deployment](docs/air-gapped-quickstart.md) | [OpenShift](#troubleshooting)
@@ -314,7 +318,7 @@ Consistent ~53 tok/s across 3-8B models with automatic layer sharding. See [v0.4
 - Automatic model download from HuggingFace, HTTP, or PVC (S3 planned)
 - Persistent model cache, download once, deploy instantly ([guide](docs/MODEL-CACHE.md))
 - OpenAI-compatible `/v1/chat/completions` API
-- Multi-replica horizontal scaling
+- Multi-replica horizontal scaling with scale subresource support (`kubectl scale`, KEDA)
 - License compliance scanning for GGUF models
 
 **Routing & policy ([ModelRouter](#composition-modelrouter)):**

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ spec:
 ```bash
 kubectl apply -f model.yaml
 ```
-
 </details>
 
 **Full setup guides:** [Minikube Quickstart](docs/minikube-quickstart.md) | [GKE with GPUs](docs/gpu-setup-guide.md) | [Air-Gapped Deployment](docs/air-gapped-quickstart.md) | [OpenShift](#troubleshooting)

--- a/README.md
+++ b/README.md
@@ -154,9 +154,6 @@ spec:
 
 ```bash
 kubectl apply -f model.yaml
-
-# Scale replicas at any time — InferenceService supports the standard Kubernetes scale subresource
-kubectl scale inferenceservice/tinyllama --replicas=3
 ```
 
 </details>

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -650,7 +650,7 @@ type InferenceServiceStatus struct {
 	// +optional
 	DesiredReplicas int32 `json:"desiredReplicas,omitempty"`
 
-	// Replicas is the current number of running inference pods, exposed via the scale subresource.
+	// Replicas is the current number of running inference pods
 	// +optional
 	Replicas int32 `json:"replicas,omitempty"`
 

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -650,6 +650,10 @@ type InferenceServiceStatus struct {
 	// +optional
 	DesiredReplicas int32 `json:"desiredReplicas,omitempty"`
 
+	// Replicas is the current number of running inference pods, exposed via the scale subresource.
+	// +optional
+	Replicas int32 `json:"replicas,omitempty"`
+
 	// Endpoint is the service URL where inference requests can be sent
 	// +optional
 	Endpoint string `json:"endpoint,omitempty"`
@@ -699,6 +703,7 @@ type InferenceServiceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:shortName=isvc
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Model",type=string,JSONPath=`.spec.modelRef`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -1998,6 +1998,11 @@ spec:
                 description: Replicas tracks the number of ready vs desired pods
                 format: int32
                 type: integer
+              replicas:
+                description: Replicas is the current number of running inference pods,
+                  exposed via the scale subresource.
+                format: int32
+                type: integer
               schedulingMessage:
                 description: SchedulingMessage provides details about scheduling issues
                 type: string
@@ -2016,5 +2021,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}
 {{- end }}

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -1999,8 +1999,7 @@ spec:
                 format: int32
                 type: integer
               replicas:
-                description: Replicas is the current number of running inference pods,
-                  exposed via the scale subresource.
+                description: Replicas is the current number of running inference pods
                 format: int32
                 type: integer
               schedulingMessage:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1994,6 +1994,11 @@ spec:
                 description: Replicas tracks the number of ready vs desired pods
                 format: int32
                 type: integer
+              replicas:
+                description: Replicas is the current number of running inference pods,
+                  exposed via the scale subresource.
+                format: int32
+                type: integer
               schedulingMessage:
                 description: SchedulingMessage provides details about scheduling issues
                 type: string
@@ -2012,4 +2017,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1995,8 +1995,7 @@ spec:
                 format: int32
                 type: integer
               replicas:
-                description: Replicas is the current number of running inference pods,
-                  exposed via the scale subresource.
+                description: Replicas is the current number of running inference pods
                 format: int32
                 type: integer
               schedulingMessage:

--- a/config/samples/inferenceservice_scale_subresource.yaml
+++ b/config/samples/inferenceservice_scale_subresource.yaml
@@ -1,0 +1,31 @@
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: tinyllama-scalable
+  namespace: default
+spec:
+  modelRef: tinyllama
+  replicas: 0
+  image: ghcr.io/ggml-org/llama.cpp:server
+  resources:
+    cpu: "2"
+    memory: "4Gi"
+
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: tinyllama-scalable
+spec:
+  scaleTargetRef:
+    apiVersion: inference.llmkube.dev/v1alpha1
+    kind: InferenceService
+    name: tinyllama-scalable
+  minReplicaCount: 0
+  maxReplicaCount: 4
+  triggers:
+    - type: external
+      metadata:
+        scalerAddress: keda-add-ons-http-external-scaler.kube-system.svc:9090
+        host: tinyllama-scalable.default.svc.cluster.local
+        targetPendingRequests: "1"

--- a/config/samples/inferenceservice_scale_subresource.yaml
+++ b/config/samples/inferenceservice_scale_subresource.yaml
@@ -1,31 +1,77 @@
+# !IMPORTANT!
+# This approach of using external scalers such as KEDA is mutually exclusive with `spec.autoscaling`
+# You should use either one or the other, but not both at the same time.
+# If both are specified, the two controllers will fight each other, leading to undesired behavior.
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: gemma-4
+  namespace: default
+spec:
+  source: https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-UD-Q6_K_XL.gguf
+  format: gguf
+  quantization: Q6_K_XL
+  # ... other model fields ...
+
+---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
-  name: tinyllama-scalable
+  name: gemma-4-scale-to-zero
   namespace: default
 spec:
-  modelRef: tinyllama
+  # The modelRef field links this InferenceService to the Model defined above.
+  modelRef: gemma-4
+
+  # Set replicas to 0 to enable scale-to-zero.
+  # KEDA will scale up the replicas based on the defined triggers.
   replicas: 0
-  image: ghcr.io/ggml-org/llama.cpp:server
-  resources:
-    cpu: "2"
-    memory: "4Gi"
+
+  # ... other inference service fields ...
 
 ---
-apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
+apiVersion: v1
+kind: Service
 metadata:
-  name: tinyllama-scalable
+  name: gemma-4-proxy
+  namespace: default
 spec:
+  type: ExternalName
+  ports: [{port: 8080}]
+
+  # This ExternalName service points to the KEDA HTTP interceptor,
+  # which will route traffic to the InferenceService when it's scaled up.
+  # This example assumes the interceptor is deployed in the kube-system namespace with this name.
+  externalName: keda-add-ons-http-interceptor-proxy.kube-system.svc.cluster.local
+
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: gemma-4
+  namespace: default
+spec:
+  # The FQDN of the service to monitor for scaling.
+  # This should match the ExternalName service defined above.
+  hosts: ["gemma-4-proxy.default.svc.cluster.local"]
+
+  # The scaleTargetRef defines which InferenceService this scaler is associated with.
   scaleTargetRef:
     apiVersion: inference.llmkube.dev/v1alpha1
     kind: InferenceService
-    name: tinyllama-scalable
-  minReplicaCount: 0
-  maxReplicaCount: 4
-  triggers:
-    - type: external
-      metadata:
-        scalerAddress: keda-add-ons-http-external-scaler.kube-system.svc:9090
-        host: tinyllama-scalable.default.svc.cluster.local
-        targetPendingRequests: "1"
+    name: gemma-4
+    service: gemma-4
+    port: 8080
+
+  # Define the scaling behavior based on HTTP traffic.
+  # This example scales up to 1 replica when there is at least 1 request per second.
+  # Adjust the target value and type as needed for your workload.
+  # The intended use case here is to have the model scaled down to zero when idle,
+  # and automatically scale up when traffic arrives.
+  # The first request may experience cold start latency, but subsequent requests will be
+  # served with low latency as long as the model remains scaled up.
+  # Cold start times may be improved by using the local PVC cache.
+  replicas:
+    min: 0
+    max: 1

--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -810,6 +810,68 @@ var _ = Describe("Reconcile lifecycle", func() {
 			Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
 		})
 
+		It("should populate status.Replicas for the scale subresource", func() {
+			modelName := "model-scale-subresource"
+			isvcName := "isvc-scale-subresource"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, model)
+			}()
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(2)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, isvc)
+			}()
+
+			// Simulate the metal-agent registering 2 ready endpoints
+			endpoints := &corev1.Endpoints{ //nolint:staticcheck // SA1019: agent + controller migrate together
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Subsets: []corev1.EndpointSubset{{ //nolint:staticcheck
+					Addresses: []corev1.EndpointAddress{{IP: "192.0.2.10"}, {IP: "192.0.2.11"}},
+					Ports:     []corev1.EndpointPort{{Port: 8080, Protocol: corev1.ProtocolTCP}},
+				}},
+			}
+			Expect(k8sClient.Create(ctx, endpoints)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, endpoints)
+			}()
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+
+			By("verifying status.Replicas mirrors ReadyReplicas so kubectl scale and KEDA can read it")
+			Expect(updated.Status.ReadyReplicas).To(Equal(int32(2)))
+			Expect(updated.Status.Replicas).To(Equal(updated.Status.ReadyReplicas))
+		})
+
 		It("should create PVC when model has CacheKey and ModelCachePath is set", func() {
 			modelName := "model-with-cache"
 			isvcName := fmt.Sprintf("isvc-pvc-test-%d", GinkgoRandomSeed())

--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -810,7 +812,7 @@ var _ = Describe("Reconcile lifecycle", func() {
 			Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
 		})
 
-		It("should populate status.Replicas for the scale subresource", func() {
+		It("should expose and accept writes via the /scale subresource", func() {
 			modelName := "model-scale-subresource"
 			isvcName := "isvc-scale-subresource"
 
@@ -822,9 +824,7 @@ var _ = Describe("Reconcile lifecycle", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, model)).To(Succeed())
-			defer func() {
-				_ = k8sClient.Delete(ctx, model)
-			}()
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
 			model.Status.Phase = PhaseReady
 			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
 
@@ -837,9 +837,7 @@ var _ = Describe("Reconcile lifecycle", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
-			defer func() {
-				_ = k8sClient.Delete(ctx, isvc)
-			}()
+			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
 
 			// Simulate the metal-agent registering 2 ready endpoints
 			endpoints := &corev1.Endpoints{ //nolint:staticcheck // SA1019: agent + controller migrate together
@@ -850,9 +848,7 @@ var _ = Describe("Reconcile lifecycle", func() {
 				}},
 			}
 			Expect(k8sClient.Create(ctx, endpoints)).To(Succeed())
-			defer func() {
-				_ = k8sClient.Delete(ctx, endpoints)
-			}()
+			defer func() { _ = k8sClient.Delete(ctx, endpoints) }()
 
 			reconciler := &InferenceServiceReconciler{
 				Client:             k8sClient,
@@ -864,12 +860,89 @@ var _ = Describe("Reconcile lifecycle", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
+			By("reading status.replicas via the /scale subresource after reconcile")
+			scale := &autoscalingv1.Scale{}
+			Expect(k8sClient.SubResource("scale").Get(ctx, isvc, scale)).To(Succeed())
+			Expect(scale.Spec.Replicas).To(Equal(int32(2)))
+			Expect(scale.Status.Replicas).To(Equal(int32(2)))
+
+			By("writing a new replica count via the /scale subresource")
+			scale.Spec.Replicas = 3
+			Expect(k8sClient.SubResource("scale").Update(ctx, isvc, client.WithSubResourceBody(scale))).To(Succeed())
+
+			By("verifying the write propagated to spec.replicas")
 			updated := &inferencev1alpha1.InferenceService{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+			Expect(*updated.Spec.Replicas).To(Equal(int32(3)))
+		})
 
-			By("verifying status.Replicas mirrors ReadyReplicas so kubectl scale and KEDA can read it")
-			Expect(updated.Status.ReadyReplicas).To(Equal(int32(2)))
-			Expect(updated.Status.Replicas).To(Equal(updated.Status.ReadyReplicas))
+		It("should support scale-to-zero via the /scale subresource", func() {
+			modelName := "model-scale-to-zero"
+			isvcName := "isvc-scale-to-zero"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+			endpoints := &corev1.Endpoints{ //nolint:staticcheck
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Subsets: []corev1.EndpointSubset{{ //nolint:staticcheck
+					Addresses: []corev1.EndpointAddress{{IP: "192.0.2.20"}},
+					Ports:     []corev1.EndpointPort{{Port: 8080, Protocol: corev1.ProtocolTCP}},
+				}},
+			}
+			Expect(k8sClient.Create(ctx, endpoints)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, endpoints) }()
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("scaling to zero via the /scale subresource")
+			scale := &autoscalingv1.Scale{}
+			Expect(k8sClient.SubResource("scale").Get(ctx, isvc, scale)).To(Succeed())
+			scale.Spec.Replicas = 0
+			Expect(k8sClient.SubResource("scale").Update(ctx, isvc, client.WithSubResourceBody(scale))).To(Succeed())
+
+			By("verifying spec.replicas is now 0")
+			updated := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+			Expect(*updated.Spec.Replicas).To(Equal(int32(0)))
+
+			By("verifying status.replicas is 0 after reconcile with no endpoints")
+			Expect(k8sClient.Delete(ctx, endpoints)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+			Expect(updated.Status.Replicas).To(Equal(int32(0)))
 		})
 
 		It("should create PVC when model has CacheKey and ModelCachePath is set", func() {

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -111,7 +111,7 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 	isvc.Status.Phase = phase
 	isvc.Status.ModelReady = modelReady
 	isvc.Status.ReadyReplicas = readyReplicas
-	isvc.Status.Replicas = readyReplicas
+	isvc.Status.Replicas = desiredReplicas
 	isvc.Status.DesiredReplicas = desiredReplicas
 	isvc.Status.Endpoint = endpoint
 	isvc.Status.LastUpdated = &now

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -111,6 +111,7 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 	isvc.Status.Phase = phase
 	isvc.Status.ModelReady = modelReady
 	isvc.Status.ReadyReplicas = readyReplicas
+	isvc.Status.Replicas = readyReplicas
 	isvc.Status.DesiredReplicas = desiredReplicas
 	isvc.Status.Endpoint = endpoint
 	isvc.Status.LastUpdated = &now


### PR DESCRIPTION
## What

Scale-to-zero support: keep InferenceService.spec.replicas: 0 at idle, use a KEDA ScaledObject (HTTP or external trigger) to scale to 1 on demand, and scale back to 0 after a cooldown period. Essentially allowing me to hot swap models on limited hardware.

## Why

This feature allows InferenceServices to be scaled up/down on-demand via `kubectl scale` or via external scalers such as KEDA. This also allows scale to zero to work.

Fixes #473 

## How

Added scale sub-resource.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change)
