### PR TITLE
fix: clear stale conditions when a model reaches Ready without a download

### DIFF
--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -54,8 +54,9 @@ const (
 	acceleratorMetal      = "metal"
 	DefaultModelCachePath = "/models"
 
-	ConditionAvailable = "Available"
-	ConditionDegraded  = "Degraded"
+	ConditionAvailable   = "Available"
+	ConditionDegraded    = "Degraded"
+	ConditionProgressing = "Progressing"
 
 	ReasonWorkloadResolved = "WorkloadResolved"
 )
@@ -181,7 +182,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if model.Status.Phase != progressPhase {
 		model.Status.Phase = progressPhase
 		model.Status.CacheKey = cacheKey
-		if err := r.updateStatus(ctx, model, "Progressing", metav1.ConditionTrue, progressReason, progressMessage); err != nil {
+		if err := r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionTrue, progressReason, progressMessage); err != nil {
 			return ctrl.Result{}, err
 		}
 		logger.Info(progressMessage, "source", model.Spec.Source, "cacheKey", cacheKey)
@@ -314,7 +315,7 @@ func (r *ModelReconciler) reconcilePVCSource(ctx context.Context, model *inferen
 		logger.Info("PVC not yet bound", "pvc", claimName, "phase", pvc.Status.Phase)
 		model.Status.Phase = "Pending"
 		msg := fmt.Sprintf("PVC %q is %s, waiting for it to be Bound", claimName, pvc.Status.Phase)
-		if statusErr := r.updateStatus(ctx, model, "Progressing", metav1.ConditionTrue, "PVCNotBound", msg); statusErr != nil {
+		if statusErr := r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionTrue, "PVCNotBound", msg); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
 		}
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
@@ -440,6 +441,12 @@ func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, mo
 	now := metav1.Now()
 	model.Status.LastUpdated = &now
 
+	// A model reaching Ready through this no-download path may still carry
+	// Progressing/Degraded conditions from an earlier copy or download
+	// attempt; clear them so a Ready model is not also reported Degraded.
+	if err := r.clearProgressConditions(ctx, model); err != nil {
+		return err
+	}
 	if err := r.updateStatus(ctx, model, "Available", metav1.ConditionTrue, reason, message); err != nil {
 		return err
 	}
@@ -577,7 +584,27 @@ func (r *ModelReconciler) downloadModel(ctx context.Context, source, dest string
 	return size, nil
 }
 
-//nolint:unparam
+// clearProgressConditions flips any Progressing or Degraded conditions on the
+// model to False. A model that reaches Ready through a no-download path can
+// still carry Progressing/Degraded conditions written by an earlier copy or
+// download attempt (for example a Metal local-path model wedged in Copying
+// under an operator version that predates the no-download path). Leaving them
+// set reports a Ready model as also Degraded, which is contradictory.
+func (r *ModelReconciler) clearProgressConditions(ctx context.Context, model *inferencev1alpha1.Model) error {
+	for _, condType := range []string{ConditionProgressing, ConditionDegraded} {
+		for _, c := range model.Status.Conditions {
+			if c.Type == condType && c.Status != metav1.ConditionFalse {
+				if err := r.updateStatus(ctx, model, condType, metav1.ConditionFalse,
+					"Superseded", "Model reached Ready without a controller-side download"); err != nil {
+					return err
+				}
+				break
+			}
+		}
+	}
+	return nil
+}
+
 func (r *ModelReconciler) updateStatus(ctx context.Context, model *inferencev1alpha1.Model, condType string, status metav1.ConditionStatus, reason, message string) error {
 	condition := metav1.Condition{
 		Type:               condType,

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -369,6 +369,64 @@ var _ = Describe("Model Controller Reconcile", func() {
 		Expect(foundCondition).To(BeTrue(), "expected Available/MetalAgentManaged condition")
 	})
 
+	// Regression for #475: a Metal local-path model that wedged in the copy
+	// path under an older operator keeps stale Degraded/Progressing conditions
+	// after the no-download path marks it Ready. They must be cleared so a
+	// Ready model is not simultaneously reported as Degraded.
+	It("should clear stale Degraded/Progressing conditions on a metal local-path model", func() {
+		modelName := "metal-model-stale-conds"
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "/models/on/the/metal/node/Qwen3.6-35B-A3B-8bit",
+				Format:   "safetensors",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		// Simulate a prior reconcile under an older operator that wedged the
+		// model in the copy path: stale Degraded + Progressing conditions.
+		model.Status.Conditions = []metav1.Condition{
+			{
+				Type: ConditionDegraded, Status: metav1.ConditionTrue, Reason: "CopyFailed",
+				Message: "failed to open local model file", LastTransitionTime: metav1.Now(),
+			},
+			{
+				Type: ConditionProgressing, Status: metav1.ConditionTrue, Reason: "CopyStarted",
+				Message: "Started copying local model", LastTransitionTime: metav1.Now(),
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseReady))
+
+		conds := map[string]metav1.ConditionStatus{}
+		for _, c := range updated.Status.Conditions {
+			conds[c.Type] = c.Status
+		}
+		Expect(conds[ConditionAvailable]).To(Equal(metav1.ConditionTrue))
+		Expect(conds[ConditionDegraded]).To(Equal(metav1.ConditionFalse), "stale Degraded must be cleared")
+		Expect(conds[ConditionProgressing]).To(Equal(metav1.ConditionFalse), "stale Progressing must be cleared")
+	})
+
 	It("should copy local model file and set Ready", func() {
 		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## What

Clear lingering `Progressing` / `Degraded` conditions when a Model reaches `Ready` through the no-download path, so a `Ready` Model is not also reported `Degraded`.

## Why

Fixes #475.

A Model that reaches `Ready` via `reconcileRuntimeResolvedSource` (PVC, HuggingFace repo, remote HTTP, or Metal local-path source) kept any `Progressing`/`Degraded` conditions written by an earlier copy or download attempt. `updateStatus` sets a single condition by type and never clears the others.

Most visible case: a Metal local-path Model wedged in `Copying` under an operator version before #472, then upgraded to a build with #472. It correctly transitions to `Ready` / `Available=True`, but `kubectl describe` still shows `Degraded=True (CopyFailed)` and `Progressing=True`. `kubectl get` looks fine while `describe` is contradictory. A Model created fresh under #472 never hits the copy path, so this is an upgrade-in-place artifact.

## How

Add `clearProgressConditions`, which flips any lingering `Progressing` / `Degraded` conditions to `False` (through `updateStatus`) before the no-download path marks the Model `Available`. The `Progressing` condition type also becomes a named constant (`ConditionProgressing`) alongside `ConditionAvailable` / `ConditionDegraded`.

## Checklist

- [x] Tests added/updated: controller test seeding stale `Degraded`/`Progressing` conditions on a Metal local-path Model and asserting they are cleared on reconcile
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change): n/a, status-reporting fix
