### PR TITLE
fix: point metal-agent mlx-server install hint at the Homebrew formula

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -157,7 +157,9 @@ func resolveVLLMSwiftBin(override string) (string, error) {
 		defaultVLLMSwiftPaths)
 }
 
-// defaultMLXServerPaths is the list of paths to search for the mlx-server binary.
+// defaultMLXServerPaths is the list of paths to search for the mlx-server
+// binary. These are the Homebrew prefixes; `brew install
+// defilantech/tap/mlx-server` installs the shim into one of them.
 var defaultMLXServerPaths = []string{
 	"/opt/homebrew/bin/mlx-server",
 	"/usr/local/bin/mlx-server",
@@ -177,7 +179,8 @@ func resolveMLXServerBin(override string) (string, error) {
 	}
 	return "", fmt.Errorf(
 		"mlx-server binary not found in default paths (%v); "+
-			"pass --mlx-server-bin=/path/to/mlx-server",
+			"install with: brew install defilantech/tap/mlx-server, "+
+			"or pass --mlx-server-bin=/path/to/mlx-server",
 		defaultMLXServerPaths)
 }
 
@@ -312,7 +315,8 @@ func main() {
 		if err != nil {
 			logger.Errorw("mlx-server binary not found",
 				"searchPaths", defaultMLXServerPaths,
-				"installHint", "pass --mlx-server-bin=/path/to/mlx-server",
+				"installHint", "brew install defilantech/tap/mlx-server, "+
+					"or pass --mlx-server-bin=/path/to/mlx-server",
 				"error", err,
 			)
 			os.Exit(1)

--- a/pkg/agent/executor_mlx_server.go
+++ b/pkg/agent/executor_mlx_server.go
@@ -37,7 +37,7 @@ import (
 const DefaultMLXServerStartupTimeout = 120 * time.Second
 
 // MLXServerExecutor manages a single mlx-server process for the agent's
-// InferenceService. mlx-server (github.com/Defilan/mlx-server) is a native
+// InferenceService. mlx-server (github.com/defilantech/mlx-server) is a native
 // OpenAI-compatible MLX inference server. Unlike the vllm-swift executor's
 // per-spawn ephemeral port, this executor binds a fixed port so clients
 // (e.g. opencode) keep a stable base URL across respawns.


### PR DESCRIPTION
## What

Updates the metal-agent's `mlx-server` "binary not found" guidance to lead with `brew install defilantech/tap/mlx-server`, and refreshes the `MLXServerExecutor` doc comment for the repo's org move.

## Why

When the `mlx-server` runtime landed (#471), `defaultMLXServerPaths` was set to the Homebrew prefixes anticipating a formula that did not exist yet. The "not found" error and log hint therefore told users only to pass `--mlx-server-bin` by hand, with no install path.

`mlx-server` now ships a Homebrew formula (`defilantech/homebrew-tap`), and the repo has moved to the `defilantech` org. The agent's guidance should reflect both.

## How

- `resolveMLXServerBin` error and the `mlx-server binary not found` log hint now lead with `brew install defilantech/tap/mlx-server`, then fall back to `--mlx-server-bin`, mirroring the existing `vllm-swift` hint.
- `defaultMLXServerPaths` comment notes the paths are the Homebrew prefixes. The paths themselves are unchanged, since they were already correct.
- `MLXServerExecutor` doc comment updated to `github.com/defilantech/mlx-server` (the repo moved orgs; the old URL still redirects).

No behavior change beyond the user-facing strings. `go build ./cmd/metal-agent/` passes; no tests assert on these messages.

Follow-up to #471.

## Checklist

- [x] `make build` passes locally (metal-agent builds)
- [ ] Tests added/updated: not applicable, user-facing string and comment changes only
- [x] Commit messages follow conventional commits
- [x] All commits signed off (`git commit -s`) per DCO
- [ ] Documentation updated: not applicable