### PR TITLE
docs: add MAINTAINERS file and recommend private vulnerability reporting

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,29 @@
+# Maintainers
+
+This file lists the maintainers of LLMKube.
+
+## Current Maintainers
+
+| Maintainer  | GitHub                                 | Areas                          |
+| ----------- | -------------------------------------- | ------------------------------ |
+| Chris Maher | [@Defilan](https://github.com/Defilan) | All: operator, CLI, Helm, docs |
+
+LLMKube is currently maintained by a single person. The maintainer reviews
+and merges pull requests, triages issues, cuts releases, and sets technical
+direction.
+
+## Becoming a Maintainer
+
+As the contributor community grows, this document will describe the path to
+becoming a maintainer: a track record of quality contributions, issue triage,
+and review participation, followed by an invitation from the existing
+maintainers.
+
+If you would like to get more involved, the best starting points are opening
+focused pull requests, helping triage issues, and joining discussions. See
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Security
+
+Security reports follow the process in [SECURITY.md](SECURITY.md). Please do
+not send vulnerability reports to individual maintainers.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,9 +16,9 @@ We take security seriously. If you discover a security vulnerability in LLMKube,
 
 ### How to Report
 
-1. **Do NOT open a public GitHub issue** for security vulnerabilities
-2. Email security concerns to: **contact@defilan.com** (or open a private security advisory)
-3. Use GitHub's [private vulnerability reporting](https://github.com/defilantech/LLMKube/security/advisories/new)
+1. **Do NOT open a public GitHub issue** for security vulnerabilities.
+2. **Preferred:** use GitHub's [private vulnerability reporting](https://github.com/defilantech/LLMKube/security/advisories/new). Reports stay private, are tracked in one place, and let us publish an advisory once a fix ships.
+3. **Alternative:** email **contact@defilan.com**.
 
 ### What to Include
 


### PR DESCRIPTION
## What

- Adds `MAINTAINERS.md`.
- Updates `SECURITY.md` to lead with GitHub private vulnerability reporting as the preferred channel.

## Why

LLMKube had a `SECURITY.md` but no `MAINTAINERS.md`, so the governance side of the project was undocumented: who maintains it and how that opens up over time.

`SECURITY.md` already linked to GitHub private vulnerability reporting, but that repo feature was disabled, so the link did not lead anywhere useful. Private vulnerability reporting has now been enabled on the repository. Email was listed as the primary channel; private reporting is the better default (the report stays private, is tracked, and can become a published advisory).

## How

- `MAINTAINERS.md`: documents the current single-maintainer model honestly, points contributors at `CONTRIBUTING.md`, and routes security reports through `SECURITY.md` rather than to individuals.
- `SECURITY.md`: the "How to Report" steps now mark private vulnerability reporting as preferred and email as the alternative. No other content changed.

Repository setting: private vulnerability reporting enabled (done outside this PR, since it is a setting, not a file).

## Checklist

- [x] Documentation updated
- [ ] Tests added/updated: not applicable, documentation only
- [x] Commit messages follow conventional commits
- [x] All commits signed off (`git commit -s`) per DCO