### PR TITLE
fix: inference PodMonitor selector matched no pods

### DIFF
--- a/charts/llmkube/templates/inference-podmonitor.yaml
+++ b/charts/llmkube/templates/inference-podmonitor.yaml
@@ -11,8 +11,9 @@ metadata:
     {{- end }}
 spec:
   selector:
-    matchLabels:
-      inference.llmkube.dev/service: ""
+    # Match every pod carrying the operator-managed service label. A
+    # matchLabels entry with an empty value would be ANDed in and match
+    # nothing, so the Exists expression is the whole selector.
     matchExpressions:
       - key: inference.llmkube.dev/service
         operator: Exists


### PR DESCRIPTION
## What

Fixes the inference `PodMonitor` selector in the Helm chart so it actually scrapes inference pods.

## Why

`charts/llmkube/templates/inference-podmonitor.yaml` had:

```yaml
selector:
  matchLabels:
    inference.llmkube.dev/service: ""
  matchExpressions:
    - key: inference.llmkube.dev/service
      operator: Exists
```

`matchLabels` and `matchExpressions` are ANDed. The `matchLabels` entry requires the `inference.llmkube.dev/service` label to equal the empty string; real inference pods carry the service name as the value, so the combined selector matched **no pods**.

Consequence: llama.cpp `--metrics` data never reached Prometheus. That starved inference dashboards, recording rules, and the `spec.autoscaling` HPA, which scales on `llamacpp:requests_processing`, a metric that was never scraped. Verified on a live cluster: no scrape target for the inference pods, no `llamacpp:*` series.

## How

Drop the `matchLabels` block. `matchExpressions` with `operator: Exists` already selects every pod carrying the label, which is the intent. Confirmed on the cluster: after correcting the selector, the inference pods become scrape targets and `llamacpp:requests_processing` appears in Prometheus.

## Checklist

- [x] Bug fix verified on a live cluster
- [ ] Tests added/updated: not applicable, Helm template selector fix
- [x] Commit messages follow conventional commits
- [x] All commits signed off (`git commit -s`) per DCO

Fixes #480