### PR TITLE
fix: scale llama.cpp on requests_deferred, not requests_processing

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -408,7 +408,8 @@ type AutoscalingSpec struct {
 	MaxReplicas int32 `json:"maxReplicas"`
 
 	// Metrics defines the scaling metrics and target values.
-	// If empty, defaults to llamacpp:requests_processing with target average value of 2.
+	// If empty, defaults to the runtime's default metric with a target
+	// average value of 2 (llama.cpp: llamacpp:requests_deferred).
 	// +optional
 	Metrics []MetricSpec `json:"metrics,omitempty"`
 }

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -98,7 +98,8 @@ spec:
                   metrics:
                     description: |-
                       Metrics defines the scaling metrics and target values.
-                      If empty, defaults to llamacpp:requests_processing with target average value of 2.
+                      If empty, defaults to the runtime's default metric with a target
+                      average value of 2 (llama.cpp: llamacpp:requests_deferred).
                     items:
                       description: MetricSpec defines a single metric for HPA scaling.
                       properties:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -94,7 +94,8 @@ spec:
                   metrics:
                     description: |-
                       Metrics defines the scaling metrics and target values.
-                      If empty, defaults to llamacpp:requests_processing with target average value of 2.
+                      If empty, defaults to the runtime's default metric with a target
+                      average value of 2 (llama.cpp: llamacpp:requests_deferred).
                     items:
                       description: MetricSpec defines a single metric for HPA scaling.
                       properties:

--- a/internal/controller/inferenceservice_scheduling_test.go
+++ b/internal/controller/inferenceservice_scheduling_test.go
@@ -139,7 +139,7 @@ var _ = Describe("HPA Autoscaling", func() {
 				Equal(autoscalingv2.PodsMetricSourceType),
 			)
 			Expect(hpa.Spec.Metrics[0].Pods.Metric.Name).To(
-				Equal("llamacpp:requests_processing"),
+				Equal("llamacpp:requests_deferred"),
 			)
 			Expect(hpa.Spec.Metrics[0].Pods.Target.AverageValue.String()).To(
 				Equal("2"),

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -29,8 +29,13 @@ func (b *LlamaCppBackend) DefaultPort() int32 {
 	return 8080
 }
 
-func (b *LlamaCppBackend) NeedsModelInit() bool     { return true }
-func (b *LlamaCppBackend) DefaultHPAMetric() string { return "llamacpp:requests_processing" }
+func (b *LlamaCppBackend) NeedsModelInit() bool { return true }
+
+// DefaultHPAMetric scales on queue depth rather than requests_processing.
+// requests_processing is bounded by the server slot count (1 by default),
+// so it cannot reach a target above 1; requests_deferred is the unbounded
+// count of requests waiting for a slot and is the honest overload signal.
+func (b *LlamaCppBackend) DefaultHPAMetric() string { return "llamacpp:requests_deferred" }
 
 func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, modelPath string, port int32) []string {
 	args := []string{


### PR DESCRIPTION
## What

Changes the llama.cpp backend's default HPA metric from `llamacpp:requests_processing` to `llamacpp:requests_deferred`.

## Why

When `spec.autoscaling` is set with no explicit metrics, the operator generates an HPA on the runtime's `DefaultHPAMetric()` with a target `AverageValue` of `2`. For llama.cpp that metric was `llamacpp:requests_processing`.

`requests_processing` is a gauge bounded by the llama-server slot count, and llama-server runs a single slot by default (no `--parallel`). So the metric is capped at 1 per pod and can never reach the target of 2. With default settings, `spec.autoscaling` never scaled a llama.cpp service up. Verified on a live cluster: under sustained concurrent load the HPA stayed at minReplicas while requests piled into the queue.

## How

`requests_deferred` is the gauge of requests waiting for a slot. It is unbounded, directly signals "this service is out of capacity," and works at any slot count. Switching the default to it makes `spec.autoscaling` autoscale out of the box.

The HPA test that asserted the default metric name is updated.

## Checklist

- [x] Bug reproduced and fix verified on a live cluster
- [x] Tests updated (`constructHPA` default-metric assertion)
- [x] `make build` / `go vet` pass locally
- [x] Commit messages follow conventional commits
- [x] All commits signed off (`git commit -s`) per DCO

Fixes #482