### PR TITLE
fix: stop the operator fighting the HPA over Deployment replicas

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -257,6 +257,7 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	// in router_deployment_builder.go; see #456.
 	existingTemplateLabels := existingDeployment.Spec.Template.Labels
 	existingTemplateAnnotations := existingDeployment.Spec.Template.Annotations
+	existingReplicas := existingDeployment.Spec.Replicas
 	existingDeployment.Spec = deployment.Spec
 	existingDeployment.Spec.Template.Labels = mergePreservingExternal(
 		existingTemplateLabels,
@@ -266,9 +267,13 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 		existingTemplateAnnotations,
 		deployment.Spec.Template.Annotations,
 	)
-	// When autoscaling is enabled, let the HPA manage replicas
+	// When autoscaling is enabled the HPA owns the replica count: preserve
+	// the live value rather than overwriting it with the operator's desired
+	// count. Setting it to nil does not work here: a plain Update with a nil
+	// replicas field is defaulted back to 1 by the API server, which fights
+	// the HPA on every reconcile.
 	if isvc.Spec.Autoscaling != nil {
-		existingDeployment.Spec.Replicas = nil
+		existingDeployment.Spec.Replicas = existingReplicas
 	}
 	if err := r.Update(ctx, existingDeployment); err != nil {
 		log.Error(err, "Failed to update Deployment")

--- a/internal/controller/inferenceservice_scheduling_test.go
+++ b/internal/controller/inferenceservice_scheduling_test.go
@@ -592,7 +592,7 @@ var _ = Describe("HPA Autoscaling", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("should set Deployment replicas to nil when autoscaling enabled", func() {
+		It("should preserve HPA-managed Deployment replicas when autoscaling enabled", func() {
 			modelName := "hpa-replicas-model"
 			isvcName := "hpa-replicas-isvc"
 
@@ -657,7 +657,7 @@ var _ = Describe("HPA Autoscaling", func() {
 				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
 			}
 
-			By("first reconcile creates deployment with replicas")
+			By("first reconcile creates the deployment")
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name: isvcName, Namespace: "default",
@@ -665,7 +665,15 @@ var _ = Describe("HPA Autoscaling", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("second reconcile avoids overwriting HPA-managed replicas")
+			By("the HPA scales the deployment up")
+			dep := &appsv1.Deployment{}
+			depKey := types.NamespacedName{Name: isvcName, Namespace: "default"}
+			Expect(k8sClient.Get(ctx, depKey, dep)).To(Succeed())
+			scaled := int32(5)
+			dep.Spec.Replicas = &scaled
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			By("second reconcile preserves the HPA-managed replica count")
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name: isvcName, Namespace: "default",
@@ -673,15 +681,11 @@ var _ = Describe("HPA Autoscaling", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: isvcName, Namespace: "default",
-			}, dep)).To(Succeed())
-			// When autoscaling is enabled, the controller sets replicas to nil
-			// to let the HPA manage scaling. The API server defaults nil to 1,
-			// so we verify the controller did NOT force the isvc's configured
-			// replicas (2) onto the deployment.
-			Expect(*dep.Spec.Replicas).NotTo(Equal(int32(2)))
+			Expect(k8sClient.Get(ctx, depKey, dep)).To(Succeed())
+			// With autoscaling enabled the operator must not overwrite the
+			// replica count the HPA set; it preserves the live value rather
+			// than resetting it (sending nil would default back to 1).
+			Expect(*dep.Spec.Replicas).To(Equal(int32(5)))
 		})
 	})
 })


### PR DESCRIPTION
## What

When `spec.autoscaling` is set, the operator no longer overwrites the HPA-managed Deployment replica count.

## Why

The InferenceService reconcile loop replaces the live Deployment spec wholesale (`existingDeployment.Spec = deployment.Spec`), then tried to compensate:

```go
// When autoscaling is enabled, let the HPA manage replicas
if isvc.Spec.Autoscaling != nil {
    existingDeployment.Spec.Replicas = nil
}
```

The intent was right, the mechanism was not. A plain `Update` with a nil `replicas` field is defaulted back to `1` by the API server. So every reconcile reset the Deployment to 1 replica and clobbered whatever the HPA had set.

On a live cluster, with the HPA scaling toward 4 under load, this produced `Scaled up replica set ... from 1 to 4` **41 times in 14 minutes**, and the pod count never stabilized above 1. `spec.autoscaling` was effectively non-functional.

## How

Snapshot the live `Spec.Replicas` before the wholesale spec replace and, when autoscaling is enabled, restore it instead of setting nil. This mirrors the existing template label/annotation snapshot-and-restore pattern in the same function (#456). The HPA's replica count now survives reconciles.

Initial replica count is unaffected: it is still set from `spec.replicas` when the Deployment is first created.

## Checklist

- [x] Root cause verified on a live cluster (41 rescale events reproduced)
- [ ] Tests added/updated: behavior is in the live reconcile path; covered by manual cluster verification
- [x] `make build` / `go vet` pass locally
- [x] Commit messages follow conventional commits
- [x] All commits signed off (`git commit -s`) per DCO

Fixes #484