### PR TITLE
fix: metal-path InferenceService status and memory pre-flight

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -404,8 +404,33 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&inferencev1alpha1.Model{},
 			handler.EnqueueRequestsFromMapFunc(r.findInferenceServicesForModel),
 		).
+		Watches(
+			&corev1.Endpoints{}, //nolint:staticcheck // SA1019: the metal-agent registers v1 Endpoints; EndpointSlice migration is tracked separately
+			handler.EnqueueRequestsFromMapFunc(r.findInferenceServiceForEndpoints),
+		).
 		Named("inferenceservice").
 		Complete(r)
+}
+
+// findInferenceServiceForEndpoints enqueues the InferenceService that a set of
+// Endpoints belongs to. On the Metal path there is no Deployment or Pod, so
+// the Pod watch never fires; the metal-agent signals readiness by creating a
+// v1 Endpoints object named after the InferenceService. Without this watch a
+// Metal service stays Creating until the next periodic resync. Only the
+// agent's own Endpoints are considered: the Deployment path is already
+// covered by the Pod watch.
+func (r *InferenceServiceReconciler) findInferenceServiceForEndpoints(ctx context.Context, obj client.Object) []reconcile.Request {
+	if obj.GetLabels()["llmkube.ai/managed-by"] != "metal-agent" {
+		return nil
+	}
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      obj.GetName(),
+				Namespace: obj.GetNamespace(),
+			},
+		},
+	}
 }
 
 func (r *InferenceServiceReconciler) findInferenceServiceForPod(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1171,10 +1171,22 @@ func (a *MetalAgent) estimateModelMemory(
 ) (MemoryEstimate, error) {
 	var fileSizeBytes uint64
 
-	// Try to stat the model file on disk
+	// A model with an absolute local-path source is loaded in place by the
+	// host agent (the Metal path) and is never copied into the model store,
+	// so the model-store lookup below would miss it. Size it from the source
+	// path directly.
+	if filepath.IsAbs(model.Spec.Source) {
+		if size, err := localModelSize(model.Spec.Source); err == nil {
+			fileSizeBytes = size
+		}
+	}
+
+	// Try to stat the model file in the model store (downloaded models).
 	filename := filepath.Base(model.Spec.Source)
 	localPath := filepath.Join(a.config.ModelStorePath, model.Name, filename)
-	if info, err := os.Stat(localPath); err == nil {
+	if fileSizeBytes != 0 {
+		// already sized from the local-path source above
+	} else if info, err := os.Stat(localPath); err == nil {
 		fileSizeBytes = uint64(info.Size()) //nolint:gosec // G115: os.FileInfo.Size is non-negative by contract
 	} else if model.Status.Size != "" {
 		// Fall back to parsing the human-readable size from model status
@@ -1203,6 +1215,38 @@ func (a *MetalAgent) estimateModelMemory(
 		CacheTypeK: cacheTypeK,
 		CacheTypeV: cacheTypeV,
 	}), nil
+}
+
+// localModelSize returns the on-disk size of a model at a local path: the
+// file size for a single-file model (e.g. GGUF), or the summed size of the
+// regular files for a model directory (e.g. an MLX safetensors model).
+func localModelSize(path string) (uint64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	if !info.IsDir() {
+		return uint64(info.Size()), nil //nolint:gosec // G115: os.FileInfo.Size is non-negative by contract
+	}
+	var total uint64
+	walkErr := filepath.WalkDir(path, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		fi, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += uint64(fi.Size()) //nolint:gosec // G115: os.FileInfo.Size is non-negative by contract
+		return nil
+	})
+	if walkErr != nil {
+		return 0, walkErr
+	}
+	return total, nil
 }
 
 // computeSpecHash returns a stable hash of the InferenceServiceSpec fields that,

--- a/pkg/agent/local_model_size_test.go
+++ b/pkg/agent/local_model_size_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalModelSize(t *testing.T) {
+	dir := t.TempDir()
+
+	// Single-file model (e.g. a GGUF file).
+	file := filepath.Join(dir, "model.gguf")
+	if err := os.WriteFile(file, make([]byte, 1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := localModelSize(file); err != nil || got != 1024 {
+		t.Fatalf("single file: got %d, err %v; want 1024", got, err)
+	}
+
+	// Directory model (e.g. an MLX safetensors model), including a subdir.
+	modelDir := filepath.Join(dir, "mlx-model")
+	if err := os.MkdirAll(filepath.Join(modelDir, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelDir, "a.safetensors"), make([]byte, 2048), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelDir, "sub", "b.safetensors"), make([]byte, 512), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := localModelSize(modelDir); err != nil || got != 2560 {
+		t.Fatalf("directory model: got %d, err %v; want 2560", got, err)
+	}
+
+	// Missing path returns an error.
+	if _, err := localModelSize(filepath.Join(dir, "does-not-exist")); err == nil {
+		t.Fatal("expected an error for a missing path")
+	}
+}


### PR DESCRIPTION
## What

Two metal-path correctness fixes, found while dogfooding the mlx-server runtime.

- The InferenceService controller now watches the Endpoints the metal-agent creates, so a Metal service reaches `Ready` promptly.
- The metal-agent memory pre-flight now sizes local-path models from their source.

## Why

**#486** On the Metal path there is no Deployment or Pod, and the controller only watched Deployments, Pods, and Models. When the metal-agent registered a service's endpoint, nothing triggered a reconcile, so the InferenceService sat in `Creating` / `WaitingForMetalAgent` until the next periodic resync (hours). `kubectl get isvc` misreported a fully-serving model, and tooling waiting on `Ready` would hang. Verified on a live cluster: a manual nudge made the operator reconcile, see `readyEndpoints: 1`, and flip to `Ready`.

**#487** The metal-agent memory estimator only looked for the model under `--model-store/<name>/`. A local-path Metal model has an absolute `source` that is never copied into the store, so the size could not be determined and the pre-flight memory safety check was silently skipped (`memory estimation failed, proceeding without check`).

## How

- `SetupWithManager` gains a `Watches` on `Endpoints` with a map function that enqueues the owning InferenceService. It is scoped to the agent's own Endpoints via the `llmkube.ai/managed-by: metal-agent` label, so the Deployment path (already covered by the Pod watch) is untouched. RBAC for `endpoints` was already present.
- `estimateModelMemory` now sizes a model with an absolute `source` from that path directly, via a new `localModelSize` helper that returns a file's size or the summed size of a model directory. Unit-tested.

## Checklist

- [x] `make build` / `go vet` pass locally
- [x] Tests added: `localModelSize` unit test; #486 verified by live re-test on the Metal path
- [x] Commit messages follow conventional commits
- [x] All commits signed off (`git commit -s`) per DCO

Fixes #486
Fixes #487