### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# AGENTS.md
+
+LLMKube is a Kubernetes operator that deploys and manages local LLM inference
+workloads. Go 1.25, built with controller-runtime / Kubebuilder. This file tells
+coding agents how to work in this repo. Humans: see `CONTRIBUTING.md`.
+
+## Setup
+
+- Go 1.25+ (pinned in `go.mod`).
+- `make test` downloads envtest binaries on first run; no cluster needed for unit tests.
+- `make test-e2e` requires Docker and Kind.
+
+## Commands
+
+| Task                              | Command          |
+|-----------------------------------|------------------|
+| Build the controller              | `make build`     |
+| Build the `llmkube` CLI           | `make build-cli` |
+| Unit tests (envtest)              | `make test`      |
+| E2E tests (needs Kind)            | `make test-e2e`  |
+| Format                            | `make fmt`       |
+| Vet                               | `make vet`       |
+| Lint (golangci-lint)              | `make lint`      |
+| Regenerate CRDs / RBAC / webhooks | `make manifests` |
+| Regenerate DeepCopy methods       | `make generate`  |
+
+## Before you commit
+
+A change is not done until all of these pass:
+
+1. `make fmt`
+2. `make vet`
+3. `make lint`
+4. `make test`
+
+If you edited CRD types in `api/v1alpha1/`, also run:
+
+5. `make generate` — DeepCopy methods
+6. `make chart-crds` — regenerates CRDs and syncs them into the Helm chart
+7. `git status` must be clean afterward. Uncommitted generated files mean a
+   step was skipped, and the CI CRD sync check will fail.
+
+## Code style
+
+- Match the surrounding code: naming, error handling, comment density, layout.
+  Do not introduce a different style for new code.
+- Idiomatic Go: `gofmt`, wrapped errors (`fmt.Errorf("...: %w", err)`), table-driven tests.
+- Comments explain *why*, not *what*. Do not add docstrings or decorative
+  comments to hit a quota.
+- Controller code follows controller-runtime conventions: reconcilers are
+  idempotent, garbage collection uses owner references, state is surfaced
+  through status conditions.
+
+## Testing
+
+- Every behavior change needs a test. A bug fix gets a regression test that
+  fails before the fix and passes after.
+- Unit tests use `envtest` (controller-runtime); they run with `make test` and
+  need no live cluster.
+- Assert observable behavior, not internal implementation detail.
+- Do not weaken or delete a test to make a change pass. If a test is genuinely
+  wrong, fix it and say why.
+
+## Commits
+
+This repo uses conventional commit prefixes so `release-please` can generate
+changelogs and version bumps. Every commit needs one:
+
+| Prefix      | Use for                                   | Version bump |
+|-------------|-------------------------------------------|--------------|
+| `feat:`     | New feature, CRD field, CLI command       | minor        |
+| `fix:`      | Bug fix, correctness improvement          | patch        |
+| `perf:`     | Performance improvement                   | patch        |
+| `docs:`     | Documentation only                        | patch        |
+| `chore:`    | Deps, CI, tooling (hidden from changelog) | none         |
+| `test:`     | Test-only change (hidden)                 | none         |
+| `refactor:` | Refactor, no behavior change (hidden)     | none         |
+
+Use `feat!:` / `fix!:` for breaking changes.
+
+- Sign off every commit: `git commit -s` (DCO is enforced by CI).
+- Subject says *what* changed; body says *why*. No implementation play-by-play.
+- Do not add `Co-Authored-By` trailers or AI/tool attribution to commit messages.
+- One logical change per commit.
+
+## Branches and pull requests
+
+- Contributions go through fork-based PRs. Branch from an up-to-date `main`.
+- Branch names: `feat/<slug>`, `fix/<slug>`, `chore/<slug>`.
+- PRs follow `.github/PULL_REQUEST_TEMPLATE.md` (What / Why / How / Checklist)
+  and reference the issue with `Fixes #N`.
+- Do not push to `main`. Do not force-push shared branches.
+
+## Project layout
+
+| Path                   | Contents                                        |
+|------------------------|-------------------------------------------------|
+| `cmd/`                 | Entry points (controller, metal-agent)          |
+| `internal/controller/` | Model + InferenceService reconcilers            |
+| `internal/metrics/`    | Prometheus metrics                              |
+| `pkg/cli/`             | Cobra CLI commands                              |
+| `api/v1alpha1/`        | CRD type definitions (regenerate after editing) |
+| `charts/llmkube/`      | Helm chart (CRDs synced via `make chart-crds`)  |
+| `config/`              | Kustomize bases                                 |
+
+The two CRDs are **Model** (a model spec) and **InferenceService** (a
+deployment config).
+
+## Do not
+
+- Do not hand-edit generated files (`zz_generated.*`, CRD YAML under `config/`
+  and `charts/`). Change the source and regenerate.
+- Do not commit secrets, kubeconfigs, or `.env` files.
+- Do not skip the pre-commit checks or the CRD sync step.


### PR DESCRIPTION
## What

Add a root `AGENTS.md`: a concise, tool-agnostic guide for AI coding agents (and a quick reference for humans) covering build/test commands, code style, testing requirements, commit conventions, and project layout.

## Why

Coding agents and new contributors currently reverse-engineer the project's conventions from the Makefile, CI workflows, and prior commits. `AGENTS.md` is the emerging cross-tool standard for putting that context in one predictable place. A single source of truth for "how to work in this repo" cuts down malformed commits, skipped CRD-sync steps, and missing tests.

No linked issue; this is a documentation addition.

## How

- New `AGENTS.md` at the repo root. Every command is verified against the current `Makefile`.
- Sections: setup, commands, a pre-commit checklist (including the `make chart-crds` step the CI CRD sync check depends on), code style, testing requirements, the conventional-commit prefix table, fork-based PR flow, and project layout.
- Complements `CONTRIBUTING.md` (process detail) rather than duplicating it.

## Checklist

- [ ] Tests added/updated — n/a, documentation only
- [ ] `make test` passes locally — n/a, no code change
- [ ] `make lint` passes locally — n/a, no code change
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated