### PR TITLE
fix: report Stopped phase when InferenceService.spec.replicas=0 on Metal path

### DIFF
--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -296,6 +296,24 @@ var _ = Describe("determinePhase", func() {
 		phase, _ := reconciler.determinePhase(context.Background(), isvc, 0, 1, true, nil)
 		Expect(phase).To(Equal("Creating"))
 	})
+
+	It("should return Stopped when replicas=0 on generic path", func() {
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		}
+		phase, info := reconciler.determinePhase(context.Background(), isvc, 0, 0, false, &appsv1.Deployment{})
+		Expect(phase).To(Equal(PhaseStopped))
+		Expect(info).To(BeNil())
+	})
+
+	It("should return Stopped when replicas=0 on Metal path", func() {
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		}
+		phase, info := reconciler.determinePhase(context.Background(), isvc, 0, 0, true, nil)
+		Expect(phase).To(Equal(PhaseStopped))
+		Expect(info).To(BeNil())
+	})
 })
 
 var _ = Describe("findInferenceServiceForPod", func() {

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -49,6 +49,7 @@ const (
 	PhaseFailed   = "Failed"
 	PhaseCached   = "Cached"
 	PhaseCreating = "Creating"
+	PhaseStopped  = "Stopped"
 	// acceleratorMetal is the Model.Spec.Hardware.Accelerator value for the
 	// host metal-agent path.
 	acceleratorMetal      = "metal"

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -72,6 +72,9 @@ func (r *InferenceServiceReconciler) determinePhase(ctx context.Context, isvc *i
 	if readyReplicas > 0 {
 		return "Progressing", nil
 	}
+	if desiredReplicas == 0 && readyReplicas == 0 {
+		return PhaseStopped, nil
+	}
 	if !isMetal && deployment != nil {
 		schedulingInfo, err := r.getPodSchedulingInfo(ctx, isvc)
 		if err != nil {


### PR DESCRIPTION
## What

Report the `Stopped` phase on an InferenceService scaled to `spec.replicas=0`, instead of `Creating`.

## Why

Fixes #489

When a Metal InferenceService is scaled to `spec.replicas=0`, the metal-agent correctly tears down the runtime process, but the operator kept reporting `Creating`. `determinePhase` had no `replicas==0` branch, so a deliberately-stopped service was indistinguishable from one still coming up.

## How

- `determinePhase` (`scheduling.go`): add an early return — when `desiredReplicas == 0 && readyReplicas == 0`, return `Stopped`. It sits after the `readyReplicas > 0 -> Progressing` check and before the Metal/generic branches, so it covers both paths.
- `model_controller.go`: add the `PhaseStopped` constant alongside the existing phase constants.
- `Stopped` is already in the `phase` field's kubebuilder enum (`inferenceservice_types.go`), so no CRD regeneration is needed.
- Two regression tests in `inferenceservice_reconcile_test.go` cover the generic and Metal code paths.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated — n/a, no user-facing doc change