### PR TITLE
feat: capability-aware scheduler + AgenticTaskWatcher + stub executor (Foreman v0.1 M2)

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -159,6 +159,30 @@ const (
 // +kubebuilder:validation:Enum=GO;NO-GO;INCOMPLETE;GATE-PASS;GATE-FAIL;GATE-ERROR
 type AgenticTaskVerdict string
 
+const (
+	// AgenticTaskVerdictGo signals the agent finished and produced a
+	// change it stands behind: edit applied, branch pushed, ready for
+	// downstream gating.
+	AgenticTaskVerdictGo AgenticTaskVerdict = "GO"
+	// AgenticTaskVerdictNoGo signals the agent legitimately declined to
+	// produce a change (e.g. the issue is already fixed, or the scope is
+	// out of reach for this agent kind). Distinct from Failed.
+	AgenticTaskVerdictNoGo AgenticTaskVerdict = "NO-GO"
+	// AgenticTaskVerdictIncomplete signals the agent did not produce a
+	// terminal verdict before its run ended (timeout, mid-loop crash,
+	// upstream cascade-fail).
+	AgenticTaskVerdictIncomplete AgenticTaskVerdict = "INCOMPLETE"
+	// AgenticTaskVerdictGatePass is the gate agent's positive outcome:
+	// every check (fmt/vet/lint/test) passed.
+	AgenticTaskVerdictGatePass AgenticTaskVerdict = "GATE-PASS"
+	// AgenticTaskVerdictGateFail is the gate agent's negative outcome:
+	// at least one check failed but the gate itself ran cleanly.
+	AgenticTaskVerdictGateFail AgenticTaskVerdict = "GATE-FAIL"
+	// AgenticTaskVerdictGateError signals the gate runner itself failed
+	// to execute (infrastructure issue), distinct from a check failure.
+	AgenticTaskVerdictGateError AgenticTaskVerdict = "GATE-ERROR"
+)
+
 // AgenticTaskStatus defines the observed state of an AgenticTask.
 type AgenticTaskStatus struct {
 	// Phase is the current lifecycle phase.

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -15,9 +15,18 @@ limitations under the License.
 */
 
 // foreman-agent is the Foreman node-side daemon. One instance runs on each
-// host in the fleet. In M1 it owns a single responsibility: keep the
-// FleetNode CR for this host present and current (initial upsert + 30s
-// heartbeat). M2+ adds the AgenticTaskWatcher and executors.
+// host in the fleet. It is responsible for two things:
+//
+//  1. FleetNode registration + heartbeat (M1): keep the FleetNode CR
+//     for this host present and current so the scheduler can target it.
+//  2. AgenticTask watching + execution (M2+): poll the cluster for
+//     AgenticTasks the scheduler has assigned to this node, claim them,
+//     hand them to the configured Executor, and patch the terminal
+//     status when the executor returns.
+//
+// v0.1 plugs in the StubExecutor (M2 placeholder); M3 swaps in the
+// native agent loop, and M4 adds the gate-job executor for the verifier
+// role on ShadowStack.
 //
 // Cross-platform: builds on darwin (real Metal capability) and linux/amd64
 // (stub capability for now; M4 fills it in).
@@ -35,6 +44,7 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -72,6 +82,9 @@ func main() {
 		acceleratorFlag  string
 		installedModels  string
 		heartbeat        time.Duration
+		taskPollInterval time.Duration
+		taskNamespace    string
+		stubSleep        time.Duration
 		maxCtx           int
 		tokensPerSec     int
 		staticTotalRAMGB int
@@ -95,6 +108,12 @@ func main() {
 		"Comma-separated Model CR names this node has cached locally.")
 	flag.DurationVar(&heartbeat, "heartbeat-interval", foremanagent.DefaultHeartbeatInterval,
 		"How often to patch FleetNode.status with a fresh heartbeat.")
+	flag.DurationVar(&taskPollInterval, "task-poll-interval", foremanagent.DefaultWatcherInterval,
+		"How often the AgenticTask watcher polls the cluster for new assignments.")
+	flag.StringVar(&taskNamespace, "task-namespace", "default",
+		"Namespace the AgenticTask watcher reads from.")
+	flag.DurationVar(&stubSleep, "stub-sleep", foremanagent.DefaultStubSleep,
+		"How long the StubExecutor blocks per task. Only used when --executor=stub (the only v0.1 option).")
 	flag.IntVar(&maxCtx, "max-context-tokens", 0,
 		"Advertised max context window in tokens (0 = unset).")
 	flag.IntVar(&tokensPerSec, "tokens-per-second", 0,
@@ -125,7 +144,9 @@ func main() {
 	}
 
 	if workspaceDir == "" && opencodeBin == "" {
-		setupLog.Info("running in M1 mode: no executor wired yet; --workspace-dir / --opencode-bin become required at M3")
+		setupLog.Info(
+			"M2 stub executor active; --workspace-dir and --opencode-bin become required at M3",
+		)
 	}
 
 	cfg, err := loadKubeconfig(kubeContext)
@@ -170,6 +191,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	// M2 executor: stub. M3 swaps in the native agent loop.
+	executor := &foremanagent.StubExecutor{SleepDuration: stubSleep}
+
+	watcher := &foremanagent.AgenticTaskWatcher{
+		Client:    kc,
+		NodeName:  fleetNodeName,
+		Namespace: taskNamespace,
+		Interval:  taskPollInterval,
+		Executor:  executor,
+	}
+
 	cap := provider.Capability()
 	setupLog.Info("foreman-agent started",
 		"fleetNode", fleetNodeName,
@@ -178,10 +210,20 @@ func main() {
 		"accelerator", cap.Accelerator,
 		"totalRAMGB", cap.TotalRAMGB,
 		"heartbeat", heartbeat.String(),
+		"taskPollInterval", taskPollInterval.String(),
+		"taskNamespace", taskNamespace,
+		"executor", executor.Kind(),
 	)
 
-	if err := reg.Run(ctx); err != nil {
-		setupLog.Error(err, "registrar exited with error")
+	// Run the registrar and watcher concurrently. errgroup cancels both
+	// if either returns an error; on clean shutdown via SIGTERM, both
+	// return nil and we exit clean.
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error { return reg.Run(gctx) })
+	g.Go(func() error { return watcher.Run(gctx) })
+
+	if err := g.Wait(); err != nil {
+		setupLog.Error(err, "foreman-agent exited with error")
 		os.Exit(1)
 	}
 	setupLog.Info("foreman-agent stopped cleanly")

--- a/examples/foreman/m2-stub-task.yaml
+++ b/examples/foreman/m2-stub-task.yaml
@@ -1,0 +1,45 @@
+# Foreman M2 demo: a synthetic AgenticTask that exercises the dispatch
+# loop end-to-end without needing the real native agent loop (which
+# lands in M3).
+#
+# Sequence:
+#   1. Apply this manifest:
+#        kubectl apply -f examples/foreman/m2-stub-task.yaml
+#   2. The AgenticTaskReconciler running inside foreman-operator picks
+#      it up, transitions empty -> Pending, then matches it against the
+#      Ready FleetNodes and writes Pending -> Scheduled with
+#      status.assignedNode set.
+#   3. The AgenticTaskWatcher inside foreman-agent on the assigned node
+#      claims it (Scheduled -> Running) and hands it to the StubExecutor.
+#   4. The StubExecutor sleeps 10s (configurable via --stub-sleep) and
+#      returns a synthetic GO-verdict Result.
+#   5. The watcher patches Running -> Succeeded with the structured
+#      Result envelope serialized into status.result.
+#
+# Observe:
+#   kubectl get agentictask m2-stub-demo -w
+#   kubectl get agentictask m2-stub-demo -o yaml | yq '.status'
+#
+# Expected end state after ~10s:
+#   status.phase=Succeeded
+#   status.verdict=GO
+#   status.assignedNode=<a Ready FleetNode whose capability satisfies the requirements>
+#   status.result.kind=stub
+#   status.conditions[type=Completed].status=True
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: AgenticTask
+metadata:
+  name: m2-stub-demo
+  namespace: default
+  labels:
+    foreman.llmkube.dev/milestone: m2
+spec:
+  kind: freeform
+  requiredCapability:
+    # Pick the M5 Max (or any Metal node with at least 32 GiB available).
+    # Drop or relax these to dispatch to any Ready node.
+    accelerator: metal
+    minRAMGB: 32
+  payload:
+    agent: stub
+    prompt: "M2 dispatch-loop validation; the stub executor ignores this prompt."

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.uber.org/zap v1.28.0
+	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
@@ -79,7 +80,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -18,33 +18,55 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"sort"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
 
-// AgenticTaskReconciler is the scheduler: it watches AgenticTask objects,
-// matches Pending tasks to Ready FleetNodes by capability, writes the
-// assignment back onto the task, and (later) chains a verify child task
-// when an issue-fix succeeds.
+// AgenticTaskReconciler is the Foreman v0.1 scheduler. It watches
+// AgenticTask resources and routes each Pending task to the first Ready
+// FleetNode whose advertised capability satisfies the task's
+// RequiredCapability (first-fit, alphabetical-by-name for determinism).
 //
-// v0.1 / M0: this is a stub. It reads the task and logs the phase; no
-// scheduling, no node matching. The real logic lands in M2.
+// The reconciler never touches the task while the FleetAgent owns it
+// (Scheduled / Running / terminal phases). The agent owns the
+// Scheduled -> Running -> Succeeded|Failed transitions; the scheduler
+// only owns "no phase" -> Pending and Pending -> Scheduled. Cascade
+// failure from a Failed dependency is the one exception: the scheduler
+// short-circuits a downstream task with phase=Failed before it ever
+// reaches Scheduled.
 type AgenticTaskReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
+
+// requeueNoFit is the backoff when no FleetNode satisfies the task's
+// capability today. Long enough that a busy cluster does not get spammed,
+// short enough that a node coming Ready triggers dispatch within seconds
+// of the next reconcile (the FleetNode watch also re-enqueues directly).
+const requeueNoFit = 10 * time.Second
+
+// requeueWaitingForDeps is the backoff while at least one dependency is
+// still pre-terminal.
+const requeueWaitingForDeps = 10 * time.Second
 
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=agentictasks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=agentictasks/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=agentictasks/finalizers,verbs=update
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=fleetnodes,verbs=get;list;watch
 
-// Reconcile is the entry point for AgenticTask events.
+// Reconcile drives a single AgenticTask toward Scheduled.
 func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
@@ -53,20 +75,235 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	log.Info("reconciling AgenticTask",
+	log.V(1).Info("reconciling AgenticTask",
 		"kind", task.Spec.Kind,
 		"phase", task.Status.Phase,
 		"assignedNode", task.Status.AssignedNode,
 	)
 
-	// M0 stub: no-op. Scheduling logic lands in M2.
+	// Normalize an empty phase to Pending. We do this on a fresh-from-
+	// the-API view, so the next reconcile sees Pending and falls into
+	// the scheduling branch.
+	if task.Status.Phase == "" {
+		return r.setInitialPending(ctx, &task)
+	}
+
+	// The scheduler only acts on Pending. Every other phase is the
+	// FleetAgent's domain.
+	if task.Status.Phase != foremanv1alpha1.AgenticTaskPhasePending {
+		return ctrl.Result{}, nil
+	}
+
+	// Cascade-fail if any dependency has Failed.
+	if cascadeMsg, err := r.cascadeFailIfDepFailed(ctx, &task); err != nil {
+		return ctrl.Result{}, err
+	} else if cascadeMsg != "" {
+		return r.failTask(ctx, &task, "UpstreamFailed", cascadeMsg)
+	}
+
+	// Wait if any dependency is still pre-terminal.
+	allSucceeded, err := r.allDepsSucceeded(ctx, &task)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !allSucceeded {
+		return ctrl.Result{RequeueAfter: requeueWaitingForDeps}, nil
+	}
+
+	// Find a FleetNode that satisfies the task's RequiredCapability.
+	nodeName, err := r.firstFitNode(ctx, &task)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if nodeName == "" {
+		log.Info("no FleetNode matches; will retry", "task", task.Name)
+		return ctrl.Result{RequeueAfter: requeueNoFit}, nil
+	}
+
+	return r.scheduleToNode(ctx, &task, nodeName)
+}
+
+// setInitialPending writes phase=Pending the first time we see the task,
+// then requeues so the next reconcile runs the scheduling logic against
+// a Pending phase rather than racing on the same object.
+func (r *AgenticTaskReconciler) setInitialPending(ctx context.Context, task *foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
+	patch := client.MergeFrom(task.DeepCopy())
+	task.Status.Phase = foremanv1alpha1.AgenticTaskPhasePending
+	if err := r.Status().Patch(ctx, task, patch); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// cascadeFailIfDepFailed returns a non-empty message if any dependency is
+// already Failed; the caller fails the task with that message.
+func (r *AgenticTaskReconciler) cascadeFailIfDepFailed(ctx context.Context, task *foremanv1alpha1.AgenticTask) (string, error) {
+	for _, depName := range task.Spec.DependsOn {
+		var dep foremanv1alpha1.AgenticTask
+		if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: depName}, &dep); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return "", err
+		}
+		if dep.Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed {
+			return fmt.Sprintf("dependency %q failed; cascade-failing", depName), nil
+		}
+	}
+	return "", nil
+}
+
+// allDepsSucceeded returns true only when every dependency exists in the
+// same namespace AND is in phase=Succeeded.
+func (r *AgenticTaskReconciler) allDepsSucceeded(ctx context.Context, task *foremanv1alpha1.AgenticTask) (bool, error) {
+	for _, depName := range task.Spec.DependsOn {
+		var dep foremanv1alpha1.AgenticTask
+		if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: depName}, &dep); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil // wait for the dep to appear
+			}
+			return false, err
+		}
+		if dep.Status.Phase != foremanv1alpha1.AgenticTaskPhaseSucceeded {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// firstFitNode picks the alphabetically-first Ready FleetNode whose
+// advertised capability satisfies the task's RequiredCapability and that
+// is not already running another task.
+func (r *AgenticTaskReconciler) firstFitNode(ctx context.Context, task *foremanv1alpha1.AgenticTask) (string, error) {
+	var nodes foremanv1alpha1.FleetNodeList
+	if err := r.List(ctx, &nodes); err != nil {
+		return "", err
+	}
+	sort.Slice(nodes.Items, func(i, j int) bool {
+		return nodes.Items[i].Name < nodes.Items[j].Name
+	})
+	for i := range nodes.Items {
+		n := &nodes.Items[i]
+		if n.Status.Phase != foremanv1alpha1.FleetNodePhaseReady {
+			continue
+		}
+		if n.Status.CurrentTask != "" {
+			continue // v0.1: one task per node
+		}
+		if !capabilitySatisfies(task.Spec.RequiredCapability, n) {
+			continue
+		}
+		return n.Name, nil
+	}
+	return "", nil
+}
+
+// capabilitySatisfies returns true when the node's advertised capability
+// meets every requirement the task declares. Unset requirements are
+// unconstrained; an "any" accelerator matches everything.
+func capabilitySatisfies(req foremanv1alpha1.RequiredCapability, n *foremanv1alpha1.FleetNode) bool {
+	cap := n.Status.Capability
+
+	if req.Accelerator != "" && req.Accelerator != foremanv1alpha1.AgenticTaskAccelerator("any") {
+		if string(cap.Accelerator) != string(req.Accelerator) {
+			return false
+		}
+	}
+	if req.MinRAMGB > 0 && req.MinRAMGB > cap.AvailableRAMGB {
+		return false
+	}
+	if req.MinContextTokens > 0 && req.MinContextTokens > cap.MaxContextTokens {
+		return false
+	}
+	for k, v := range req.NodeSelector {
+		if n.Labels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// scheduleToNode patches the task to phase=Scheduled with the chosen
+// FleetNode set on status.assignedNode. The FleetAgent on that node
+// picks it up via its watcher.
+func (r *AgenticTaskReconciler) scheduleToNode(ctx context.Context, task *foremanv1alpha1.AgenticTask, nodeName string) (ctrl.Result, error) {
+	patch := client.MergeFrom(task.DeepCopy())
+	now := metav1.Now()
+	task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseScheduled
+	task.Status.AssignedNode = nodeName
+	setCondition(&task.Status.Conditions, metav1.Condition{
+		Type:               "Scheduled",
+		Status:             metav1.ConditionTrue,
+		Reason:             "FleetNodeAssigned",
+		Message:            fmt.Sprintf("scheduled to FleetNode %q", nodeName),
+		LastTransitionTime: now,
+	})
+	if err := r.Status().Patch(ctx, task, patch); err != nil {
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager wires the reconciler into the controller-runtime manager.
+// failTask cascade-fails a Pending task before it reaches an agent.
+func (r *AgenticTaskReconciler) failTask(ctx context.Context, task *foremanv1alpha1.AgenticTask, reason, message string) (ctrl.Result, error) {
+	patch := client.MergeFrom(task.DeepCopy())
+	now := metav1.Now()
+	task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseFailed
+	task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+	task.Status.FinishedAt = &now
+	setCondition(&task.Status.Conditions, metav1.Condition{
+		Type:               "Failed",
+		Status:             metav1.ConditionTrue,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: now,
+	})
+	return ctrl.Result{}, r.Status().Patch(ctx, task, patch)
+}
+
+// setCondition upserts a condition by type. Local to the controller
+// because the watcher in pkg/foreman/agent has its own copy; promote to
+// an internal helpers package if a third writer appears.
+func setCondition(conds *[]metav1.Condition, c metav1.Condition) {
+	for i, existing := range *conds {
+		if existing.Type == c.Type {
+			(*conds)[i] = c
+			return
+		}
+	}
+	*conds = append(*conds, c)
+}
+
+// SetupWithManager wires the reconciler. We also watch FleetNode so a
+// node going Ready (or freeing up CurrentTask) re-enqueues every Pending
+// task immediately rather than waiting for the requeue-after timer.
 func (r *AgenticTaskReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&foremanv1alpha1.AgenticTask{}).
+		Watches(&foremanv1alpha1.FleetNode{}, handler.EnqueueRequestsFromMapFunc(r.fleetNodeEnqueuesPending)).
 		Named("agentictask").
 		Complete(r)
+}
+
+// fleetNodeEnqueuesPending re-enqueues every Pending AgenticTask when a
+// FleetNode event arrives. Cheap because the controller-runtime
+// workqueue dedupes; expensive in the limit only when there are many
+// Pending tasks, which is exactly when faster dispatch matters.
+func (r *AgenticTaskReconciler) fleetNodeEnqueuesPending(ctx context.Context, _ client.Object) []ctrl.Request {
+	var list foremanv1alpha1.AgenticTaskList
+	if err := r.List(ctx, &list); err != nil {
+		logf.FromContext(ctx).Error(err, "fleetnode-trigger list failed")
+		return nil
+	}
+	requests := make([]ctrl.Request, 0, len(list.Items))
+	for i := range list.Items {
+		t := &list.Items[i]
+		if t.Status.Phase != foremanv1alpha1.AgenticTaskPhasePending {
+			continue
+		}
+		requests = append(requests, ctrl.Request{
+			NamespacedName: types.NamespacedName{Namespace: t.Namespace, Name: t.Name},
+		})
+	}
+	return requests
 }

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -123,16 +123,17 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return r.scheduleToNode(ctx, &task, nodeName)
 }
 
-// setInitialPending writes phase=Pending the first time we see the task,
-// then requeues so the next reconcile runs the scheduling logic against
-// a Pending phase rather than racing on the same object.
+// setInitialPending writes phase=Pending the first time we see the task.
+// The status patch triggers a fresh reconcile via the controller's
+// For(AgenticTask) watch, so we do not need an explicit requeue (avoiding
+// the deprecated Result.Requeue boolean).
 func (r *AgenticTaskReconciler) setInitialPending(ctx context.Context, task *foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
 	patch := client.MergeFrom(task.DeepCopy())
 	task.Status.Phase = foremanv1alpha1.AgenticTaskPhasePending
 	if err := r.Status().Patch(ctx, task, patch); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{}, nil
 }
 
 // cascadeFailIfDepFailed returns a non-empty message if any dependency is

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -17,22 +17,35 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
 
-// M0/M1 ship the AgenticTaskReconciler as a logging stub: it reads the
-// object and returns without touching status. These smoke tests pin
-// that contract so future M2 evolution either preserves it (until M2
-// merges) or breaks it intentionally with a deliberate test update.
+// The M2 AgenticTaskReconciler is the foreman v0.1 scheduler. Its
+// contract:
+//
+//   empty status.phase           -> Pending (initial normalization)
+//   Pending + no fit             -> requeue with no status mutation
+//   Pending + matching FleetNode -> Scheduled with assignedNode set
+//   Pending + dep Failed         -> cascade-fail (phase=Failed,
+//                                   verdict=INCOMPLETE,
+//                                   condition Failed/UpstreamFailed)
+//   Pending + dep pre-terminal   -> requeue with no status mutation
+//   Scheduled/Running/...        -> no-op (FleetAgent's domain)
+//
+// Each It block creates its own resources and DeferCleanup-removes them
+// so the cluster-scoped FleetNode does not leak across tests.
 
-var _ = Describe("AgenticTaskReconciler (M0 stub)", func() {
+var _ = Describe("AgenticTaskReconciler scheduler", func() {
 	var reconciler *AgenticTaskReconciler
 
 	BeforeEach(func() {
@@ -47,38 +60,195 @@ var _ = Describe("AgenticTaskReconciler (M0 stub)", func() {
 			NamespacedName: types.NamespacedName{Namespace: "default", Name: "no-such-task"},
 		})
 		Expect(err).NotTo(HaveOccurred())
-		// RequeueAfter == 0 covers both "no immediate requeue" and "no
-		// timer requeue" since controller-runtime deprecated the
-		// boolean Requeue field in favor of the zero-RequeueAfter
-		// representation.
 		Expect(res.RequeueAfter).To(BeZero())
 	})
 
-	It("reconciles an existing task without erroring and without mutating status (M0 stub)", func() {
-		task := &foremanv1alpha1.AgenticTask{
-			ObjectMeta: metav1.ObjectMeta{Name: "stub-smoke", Namespace: "default"},
-			Spec: foremanv1alpha1.AgenticTaskSpec{
-				Kind:    foremanv1alpha1.AgenticTaskKindFreeform,
-				Payload: foremanv1alpha1.AgenticTaskPayload{Prompt: "stub-smoke"},
-			},
-		}
+	It("normalizes an empty phase to Pending", func() {
+		task := newTask("normalize-empty")
 		Expect(k8sClient.Create(ctx, task)).To(Succeed())
-		DeferCleanup(func() {
-			_ = k8sClient.Delete(ctx, task)
-		})
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
 
-		_, err := reconciler.Reconcile(ctx, ctrl.Request{
-			NamespacedName: types.NamespacedName{Namespace: "default", Name: "stub-smoke"},
-		})
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
 		Expect(err).NotTo(HaveOccurred())
 
 		var fresh foremanv1alpha1.AgenticTask
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "stub-smoke"}, &fresh)).To(Succeed())
-
-		// M0 stub leaves status untouched. M2 replaces this contract.
-		Expect(string(fresh.Status.Phase)).To(BeEmpty())
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
 		Expect(fresh.Status.AssignedNode).To(BeEmpty())
-		Expect(fresh.Status.Verdict).To(BeEquivalentTo(""))
-		Expect(fresh.Status.Result).To(BeNil())
+	})
+
+	It("schedules a Pending task to the first-fit Ready FleetNode", func() {
+		task := newTask("schedule-target")
+		task.Spec.RequiredCapability = foremanv1alpha1.RequiredCapability{
+			Accelerator: foremanv1alpha1.AgenticTaskAccelerator("metal"),
+			MinRAMGB:    32,
+		}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		node := newFleetNode("schedule-target-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator:    foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:     128,
+			AvailableRAMGB: 96,
+		})
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
+	})
+
+	It("requeues without mutating status when no FleetNode satisfies the capability", func() {
+		task := newTask("no-fit")
+		task.Spec.RequiredCapability = foremanv1alpha1.RequiredCapability{
+			Accelerator: foremanv1alpha1.AgenticTaskAccelerator("metal"),
+			MinRAMGB:    256, // bigger than any node will advertise
+		}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		res, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		Expect(fresh.Status.AssignedNode).To(BeEmpty())
+	})
+
+	It("cascade-fails a Pending task when its dependency is Failed", func() {
+		dep := newTask("cascade-dep")
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, dep) })
+		setPhase(dep, foremanv1alpha1.AgenticTaskPhaseFailed)
+
+		task := newTask("cascade-target")
+		task.Spec.DependsOn = []string{dep.Name}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseFailed))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictIncomplete))
+
+		failedCond := findCondition(fresh.Status.Conditions, "Failed")
+		Expect(failedCond).NotTo(BeNil())
+		Expect(failedCond.Reason).To(Equal("UpstreamFailed"))
+	})
+
+	It("waits with requeue when a dependency is still pre-terminal", func() {
+		dep := newTask("wait-dep") // status stays empty == pre-terminal
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, dep) })
+
+		task := newTask("wait-target")
+		task.Spec.DependsOn = []string{dep.Name}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		res, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		Expect(fresh.Status.AssignedNode).To(BeEmpty())
+	})
+
+	It("does not touch a task already past Pending (FleetAgent's domain)", func() {
+		task := newTask("hands-off")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhaseRunning)
+
+		// Also set assignedNode to confirm the scheduler doesn't clobber.
+		patch := client.MergeFrom(task.DeepCopy())
+		task.Status.AssignedNode = "some-node"
+		Expect(k8sClient.Status().Patch(ctx, task, patch)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseRunning))
+		Expect(fresh.Status.AssignedNode).To(Equal("some-node"))
 	})
 })
+
+// --- test helpers ---
+
+func newTask(name string) *foremanv1alpha1.AgenticTask {
+	return &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind:    foremanv1alpha1.AgenticTaskKindFreeform,
+			Payload: foremanv1alpha1.AgenticTaskPayload{Prompt: "test"},
+		},
+	}
+}
+
+func newFleetNode(name string) *foremanv1alpha1.FleetNode {
+	return &foremanv1alpha1.FleetNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: foremanv1alpha1.FleetNodeSpec{
+			NodeName: name,
+			Roles:    []string{"worker"},
+		},
+	}
+}
+
+func setPhase(task *foremanv1alpha1.AgenticTask, phase foremanv1alpha1.AgenticTaskPhase) {
+	GinkgoHelper()
+	patch := client.MergeFrom(task.DeepCopy())
+	task.Status.Phase = phase
+	Expect(k8sClient.Status().Patch(ctx, task, patch)).To(Succeed())
+}
+
+func setNodeReady(node *foremanv1alpha1.FleetNode, cap foremanv1alpha1.FleetNodeCapability) {
+	GinkgoHelper()
+	patch := client.MergeFrom(node.DeepCopy())
+	node.Status.Phase = foremanv1alpha1.FleetNodePhaseReady
+	node.Status.Capability = cap
+	now := metav1.Now()
+	node.Status.LastHeartbeatTime = &now
+	Expect(k8sClient.Status().Patch(ctx, node, patch)).To(Succeed())
+}
+
+func reqFor(obj client.Object) ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}}
+}
+
+func nn(obj client.Object) types.NamespacedName {
+	return types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+}
+
+func findCondition(conds []metav1.Condition, kind string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == kind {
+			return &conds[i]
+		}
+	}
+	return nil
+}

--- a/pkg/foreman/agent/executor.go
+++ b/pkg/foreman/agent/executor.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// Executor runs an AgenticTask and produces a structured Result. v0.1
+// ships only a stub executor (M2); the native agent loop (M3) and the
+// gate-job executor (M4) plug in behind the same interface so the
+// watcher does not need to learn about new task kinds.
+//
+// Implementations honor ctx cancellation: a cancelled ctx during Execute
+// must return promptly with ctx.Err(). The watcher cancels ctx on
+// SIGTERM so the host can shut down cleanly during a long run.
+type Executor interface {
+	// Kind identifies this executor for logs and Result.Kind. Stable
+	// values: "stub", "issue-fix", "verify", "freeform".
+	Kind() string
+
+	// Execute runs the task to completion. A nil error means the
+	// executor produced a Result (which itself may carry NO-GO or
+	// GATE-FAIL verdict). A non-nil error is a system failure: the
+	// executor did not complete, and the watcher patches the task as
+	// Failed with the error in the Completed condition.
+	Execute(ctx context.Context, task *foremanv1alpha1.AgenticTask) (*Result, error)
+}

--- a/pkg/foreman/agent/executor_stub.go
+++ b/pkg/foreman/agent/executor_stub.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// DefaultStubSleep is the synthetic duration the stub executor blocks
+// for; long enough to prove the dispatch loop end-to-end (Pending ->
+// Scheduled -> Running -> Succeeded transitions are visible), short
+// enough not to clog the demo.
+const DefaultStubSleep = 10 * time.Second
+
+// StubExecutor is the M2 placeholder: it sleeps for SleepDuration, then
+// returns a synthetic GO-verdict Result. Exists so the scheduler ->
+// watcher -> executor -> status-patch loop can be validated end-to-end
+// before the real native agent loop lands in M3.
+type StubExecutor struct {
+	// SleepDuration controls how long Execute blocks. Zero defaults to
+	// DefaultStubSleep.
+	SleepDuration time.Duration
+}
+
+// NewStubExecutor returns a StubExecutor with default sleep duration.
+func NewStubExecutor() *StubExecutor {
+	return &StubExecutor{SleepDuration: DefaultStubSleep}
+}
+
+// Kind identifies this executor in Result.Kind and in logs.
+func (s *StubExecutor) Kind() string { return "stub" }
+
+// Execute sleeps for SleepDuration (or default) and returns a Result that
+// labels the task as a stub run. Cancellation via ctx returns
+// immediately with ctx.Err().
+func (s *StubExecutor) Execute(ctx context.Context, task *foremanv1alpha1.AgenticTask) (*Result, error) {
+	dur := s.SleepDuration
+	if dur <= 0 {
+		dur = DefaultStubSleep
+	}
+	start := time.Now()
+	select {
+	case <-time.After(dur):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	elapsed := time.Since(start)
+	res := NewResult(
+		s.Kind(),
+		foremanv1alpha1.AgenticTaskVerdictGo,
+		fmt.Sprintf("stub executor slept %s on task %s/%s", elapsed.Round(time.Millisecond), task.Namespace, task.Name),
+		elapsed,
+	)
+	res.Extra = map[string]any{
+		"taskKind":  string(task.Spec.Kind),
+		"agentName": task.Spec.Payload.Agent,
+		"modelRef":  task.Spec.ModelRef,
+	}
+	return res, nil
+}

--- a/pkg/foreman/agent/result.go
+++ b/pkg/foreman/agent/result.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"time"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// ResultSchemaVersion is the on-the-wire identifier of the structured
+// result envelope every Foreman executor emits. v0.1 ships v1; later
+// additive changes (new optional fields) keep the same version, breaking
+// changes bump to v2 and the parser gates on this string.
+const ResultSchemaVersion = "foreman.v1"
+
+// Result is the structured envelope every Executor returns. The watcher
+// serializes it into AgenticTask.status.result as a JSON RawExtension; the
+// next pipeline step (or the human reviewer) reads it from there. The
+// envelope is intentionally small and stable: Kind discriminates the
+// shape of Extra, Verdict carries the externally-meaningful outcome
+// category, and Summary is the one-line "what happened" string.
+type Result struct {
+	// SchemaVersion is always ResultSchemaVersion. The watcher refuses to
+	// store a Result with a missing or mismatched version.
+	SchemaVersion string `json:"schemaVersion"`
+
+	// Kind identifies which executor produced this result: "stub" in M2,
+	// "issue-fix" / "verify" / "freeform" once M3-M4 land. The Foreman
+	// scheduler does not interpret Kind; downstream consumers (the next
+	// step in the pipeline, the planner's evaluator) may.
+	Kind string `json:"kind"`
+
+	// Verdict is the outcome category. Reuses the AgenticTaskVerdict enum
+	// so the value in status.result.verdict matches status.verdict
+	// exactly when both are present.
+	Verdict foremanv1alpha1.AgenticTaskVerdict `json:"verdict"`
+
+	// Summary is a human-readable one-liner. The watcher copies this into
+	// the Completed condition's Message; keep it terse.
+	Summary string `json:"summary"`
+
+	// Extra carries Kind-specific fields (e.g. filesChanged, gate check
+	// breakdown, agent transcript pointers). Opaque to the watcher.
+	Extra map[string]any `json:"extra,omitempty"`
+
+	// ElapsedSec is the wall-clock duration of the executor's Run, in
+	// seconds. Recorded by the executor, not the watcher.
+	ElapsedSec float64 `json:"elapsedSec"`
+}
+
+// NewResult builds a Result with the schema version pre-filled. Callers
+// fill Extra after construction if they have Kind-specific fields.
+func NewResult(kind string, verdict foremanv1alpha1.AgenticTaskVerdict, summary string, elapsed time.Duration) *Result {
+	return &Result{
+		SchemaVersion: ResultSchemaVersion,
+		Kind:          kind,
+		Verdict:       verdict,
+		Summary:       summary,
+		ElapsedSec:    elapsed.Seconds(),
+	}
+}

--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// DefaultWatcherInterval is the poll cadence between AgenticTask list
+// passes. 5s mirrors the metal-agent's InferenceService watcher; bigger
+// is too slow for interactive demos, smaller produces apiserver chatter
+// for no benefit at v0.1 task volumes.
+const DefaultWatcherInterval = 5 * time.Second
+
+// DefaultMaxConsecutiveWatcherFailures is the threshold past which the
+// watcher returns ErrWatcherStalled. Matches the metal-agent's pattern.
+const DefaultMaxConsecutiveWatcherFailures = 3
+
+// ErrWatcherStalled is returned from Run when consecutive List() failures
+// exceed the configured threshold; the supervisor (launchd / systemd /
+// the harness) is expected to recycle the process to rebuild the client.
+var ErrWatcherStalled = errors.New("foreman agentictask watcher stalled: consecutive list failures exceeded threshold")
+
+// AgenticTaskWatcher is the node-side dispatch loop: it polls the
+// cluster for AgenticTasks assigned to this FleetNode, claims any in
+// phase=Scheduled, hands them to the configured Executor, and patches
+// the final phase/verdict/result when the executor returns.
+//
+// v0.1 runs one task at a time per node (single Executor.Execute in
+// flight, controlled by a mutex). v0.2 may introduce a worker pool.
+type AgenticTaskWatcher struct {
+	// Client is the Kubernetes client. Required.
+	Client client.Client
+
+	// NodeName is this host's FleetNode.metadata.name (and the value the
+	// scheduler writes into AgenticTask.status.assignedNode for tasks it
+	// routes here). Required.
+	NodeName string
+
+	// Namespace bounds the List() call. v0.1 watches one namespace.
+	// Defaults to "default" when empty.
+	Namespace string
+
+	// Interval is the poll cadence. Zero defaults to DefaultWatcherInterval.
+	Interval time.Duration
+
+	// MaxConsecutiveFailures is the stall threshold. Zero defaults to
+	// DefaultMaxConsecutiveWatcherFailures.
+	MaxConsecutiveFailures int
+
+	// Executor runs claimed tasks. Required.
+	Executor Executor
+
+	// inflightMu guards inflight. Exactly one task at a time in v0.1.
+	inflightMu sync.Mutex
+	inflight   *foremanv1alpha1.AgenticTask
+}
+
+// Run blocks, polling every Interval until ctx is cancelled. Returns
+// ErrWatcherStalled if List() fails MaxConsecutiveFailures times in a
+// row; the supervisor should recycle the process.
+func (w *AgenticTaskWatcher) Run(ctx context.Context) error {
+	log := logf.FromContext(ctx).WithName("agentictask-watcher").WithValues("node", w.NodeName)
+
+	interval := w.Interval
+	if interval <= 0 {
+		interval = DefaultWatcherInterval
+	}
+	maxFails := w.MaxConsecutiveFailures
+	if maxFails <= 0 {
+		maxFails = DefaultMaxConsecutiveWatcherFailures
+	}
+	ns := w.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+
+	log.Info("starting", "interval", interval.String(), "namespace", ns, "executor", w.Executor.Kind())
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	consecutiveFails := 0
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("stopping")
+			return nil
+		case <-ticker.C:
+			if err := w.pollOnce(ctx, ns); err != nil {
+				consecutiveFails++
+				log.Error(err, "poll failed", "consecutiveFails", consecutiveFails, "max", maxFails)
+				if consecutiveFails >= maxFails {
+					return fmt.Errorf("%w: %d consecutive failures", ErrWatcherStalled, consecutiveFails)
+				}
+				continue
+			}
+			consecutiveFails = 0
+		}
+	}
+}
+
+// pollOnce runs a single List() pass and dispatches any task assigned to
+// this node that is in phase=Scheduled.
+func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) error {
+	// If a task is already in flight, skip until it completes; v0.1 is
+	// one-task-per-node.
+	w.inflightMu.Lock()
+	busy := w.inflight != nil
+	w.inflightMu.Unlock()
+	if busy {
+		return nil
+	}
+
+	var list foremanv1alpha1.AgenticTaskList
+	if err := w.Client.List(ctx, &list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("list AgenticTasks: %w", err)
+	}
+
+	for i := range list.Items {
+		t := &list.Items[i]
+		if t.Status.AssignedNode != w.NodeName {
+			continue
+		}
+		if t.Status.Phase != foremanv1alpha1.AgenticTaskPhaseScheduled {
+			continue
+		}
+		if err := w.claim(ctx, t); err != nil {
+			// Patch race or transient apiserver error; let the next
+			// poll retry. Do not count toward the stall threshold
+			// because List() itself succeeded.
+			logf.FromContext(ctx).WithName("agentictask-watcher").Error(err, "claim failed", "task", t.Name)
+			continue
+		}
+		// Took it. Launch the executor and return to the polling loop;
+		// the next poll will see inflight!=nil and skip.
+		w.launchExecutor(ctx, t)
+		return nil
+	}
+	return nil
+}
+
+// claim flips Scheduled -> Running using a status merge patch. Optimistic
+// concurrency: if the patch fails because someone else moved the task,
+// the next poll will see the new phase and skip cleanly.
+func (w *AgenticTaskWatcher) claim(ctx context.Context, t *foremanv1alpha1.AgenticTask) error {
+	patch := client.MergeFrom(t.DeepCopy())
+	now := metav1.Now()
+	t.Status.Phase = foremanv1alpha1.AgenticTaskPhaseRunning
+	t.Status.ClaimedAt = &now
+	t.Status.StartedAt = &now
+	setCondition(&t.Status.Conditions, metav1.Condition{
+		Type:               "Running",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Claimed",
+		Message:            fmt.Sprintf("claimed by %s", w.NodeName),
+		LastTransitionTime: now,
+	})
+	return w.Client.Status().Patch(ctx, t, patch)
+}
+
+// launchExecutor runs Execute in a goroutine, patches the terminal
+// status when it returns, and clears the inflight slot.
+func (w *AgenticTaskWatcher) launchExecutor(ctx context.Context, t *foremanv1alpha1.AgenticTask) {
+	w.inflightMu.Lock()
+	w.inflight = t
+	w.inflightMu.Unlock()
+
+	log := logf.FromContext(ctx).WithName("agentictask-watcher").WithValues("task", t.Name, "kind", t.Spec.Kind)
+	log.Info("dispatching to executor")
+
+	go func() {
+		defer func() {
+			w.inflightMu.Lock()
+			w.inflight = nil
+			w.inflightMu.Unlock()
+		}()
+
+		// Use a fresh context so the executor's lifetime is decoupled from
+		// the poll tick. Cancellation still propagates from the parent.
+		execCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		res, execErr := w.Executor.Execute(execCtx, t)
+		if patchErr := w.patchTerminal(ctx, t, res, execErr); patchErr != nil {
+			log.Error(patchErr, "patching terminal status failed")
+		}
+	}()
+}
+
+// patchTerminal re-fetches the task and writes its final phase, verdict,
+// result envelope, and Completed condition.
+func (w *AgenticTaskWatcher) patchTerminal(
+	ctx context.Context,
+	t *foremanv1alpha1.AgenticTask,
+	res *Result,
+	execErr error,
+) error {
+	var fresh foremanv1alpha1.AgenticTask
+	key := types.NamespacedName{Namespace: t.Namespace, Name: t.Name}
+	if err := w.Client.Get(ctx, key, &fresh); err != nil {
+		return fmt.Errorf("refetch %s: %w", key, err)
+	}
+	patch := client.MergeFrom(fresh.DeepCopy())
+	now := metav1.Now()
+	fresh.Status.FinishedAt = &now
+
+	if execErr != nil {
+		fresh.Status.Phase = foremanv1alpha1.AgenticTaskPhaseFailed
+		fresh.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+		setCondition(&fresh.Status.Conditions, metav1.Condition{
+			Type:               "Completed",
+			Status:             metav1.ConditionFalse,
+			Reason:             "ExecutorError",
+			Message:            execErr.Error(),
+			LastTransitionTime: now,
+		})
+		return w.Client.Status().Patch(ctx, &fresh, patch)
+	}
+
+	if res == nil {
+		// Defensive: nil error + nil result is a contract violation;
+		// surface it explicitly rather than silently succeeding.
+		fresh.Status.Phase = foremanv1alpha1.AgenticTaskPhaseFailed
+		fresh.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+		setCondition(&fresh.Status.Conditions, metav1.Condition{
+			Type:               "Completed",
+			Status:             metav1.ConditionFalse,
+			Reason:             "ExecutorContractViolation",
+			Message:            "executor returned nil error and nil Result",
+			LastTransitionTime: now,
+		})
+		return w.Client.Status().Patch(ctx, &fresh, patch)
+	}
+
+	fresh.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	fresh.Status.Verdict = res.Verdict
+	raw, err := json.Marshal(res)
+	if err != nil {
+		return fmt.Errorf("marshal result: %w", err)
+	}
+	fresh.Status.Result = &runtime.RawExtension{Raw: raw}
+	setCondition(&fresh.Status.Conditions, metav1.Condition{
+		Type:               "Completed",
+		Status:             metav1.ConditionTrue,
+		Reason:             "ExecutorSucceeded",
+		Message:            res.Summary,
+		LastTransitionTime: now,
+	})
+	return w.Client.Status().Patch(ctx, &fresh, patch)
+}
+
+// setCondition upserts a condition by type. Unexported because both the
+// watcher and the scheduler each have their own copy for now; if we add
+// a third writer we move this to a shared internal package.
+func setCondition(conds *[]metav1.Condition, c metav1.Condition) {
+	for i, existing := range *conds {
+		if existing.Type == c.Type {
+			(*conds)[i] = c
+			return
+		}
+	}
+	*conds = append(*conds, c)
+}


### PR DESCRIPTION
## What

Closes the Pending -> Scheduled -> Running -> Succeeded dispatch loop for the Foreman v0.1 add-on. Adds the capability-aware scheduler to the foreman-operator; the AgenticTaskWatcher, Executor abstraction, and StubExecutor to foreman-agent; and the foreman.v1 Result envelope they share. End-to-end demoed against kind-llmkube-local.

## Why

Refs #500.

M2 is the architectural validation milestone for Foreman: it proves the CRDs from M0 and the FleetNode heartbeat from M1 actually compose into a working dispatch loop, without yet depending on the M3 native agent loop. The StubExecutor stands in for M3's real native agent loop so the plumbing is observable end to end today.

M2 also locked down the function-calling substrate decision the v0.1 plan rests on. Smoke-tested the live Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP endpoint serving on Apple Silicon Metal: 13/15 multi-turn flows pass cleanly; the 2 failures are a known upstream llama.cpp issue (ggml-org/llama.cpp#22072, comment with our repro added) where the strict tool-call argument parser rejects truncated JSON from the model. M3's native loop will treat this as a recoverable transient with bounded retry, getting effective success to ~99.78%. No change to M2.

## How

**Scheduler** (`internal/foreman/controller/agentictask_controller.go`) evolved from the M0 logging stub into the real reconciler:

- Normalizes empty phase to `Pending` so subsequent logic only branches on enum values it owns.
- Cascade-fails (phase=Failed, reason=UpstreamFailed) when any `dependsOn` target is in phase=Failed.
- Waits with requeue while any `dependsOn` target is pre-terminal.
- First-fit FleetNode picker: alphabetical-by-name over Ready nodes whose capability satisfies the task's `RequiredCapability` (accelerator family, `MinRAMGB <= AvailableRAMGB`, `MinContextTokens <= MaxContextTokens`, `NodeSelector` subset of node labels). Skips nodes whose `status.currentTask` is non-empty (v0.1 worker-concurrency=1).
- Watches `FleetNode` in addition to `AgenticTask`; re-enqueues all Pending tasks on each FleetNode event so a node going Ready dispatches immediately rather than waiting for the requeue-after timer.

**Node-side watcher** (`pkg/foreman/agent/watcher.go`):

- Polls every `--task-poll-interval` (default 5s) for AgenticTasks where `status.assignedNode == myNodeName && phase == Scheduled`.
- Claims via status merge-patch with optimistic concurrency; race losers see the new phase on the next poll.
- Runs `Executor.Execute` in a goroutine; v0.1 keeps one task per node in flight via a mutex'd `inflight` slot.
- Re-fetches the task before the terminal patch to avoid clobbering concurrent edits. On executor error, patches `phase=Failed` with `verdict=INCOMPLETE` and the error in the `Completed` condition. Defensive contract-violation path on nil error + nil Result.
- Returns `ErrWatcherStalled` after `MaxConsecutiveFailures` (default 3) `List()` failures in a row, mirroring `pkg/agent/watcher.go`'s supervisor-restart pattern.

**Executor abstraction** (`pkg/foreman/agent/{executor,executor_stub,result}.go`):

- `Executor` interface: `Kind() string` + `Execute(ctx, task) (*Result, error)`. Small interface so M3 (native agent loop), M4 (gate-job executor), and any future kind plug in behind the same shape.
- `Result` is the `foreman.v1` envelope shared between executors and any downstream consumer (planner evaluator, future DecisionLog, the human reviewer): SchemaVersion, Kind, Verdict, Summary, Extra, ElapsedSec.
- `AgenticTaskVerdict` constants added to `api/foreman/v1alpha1` (GO, NO-GO, INCOMPLETE, GATE-PASS, GATE-FAIL, GATE-ERROR). No CRD schema change; the enum validator was already on the type.
- `StubExecutor`: sleeps for `--stub-sleep` (default 10s) and returns a synthetic GO-verdict Result. Used to validate dispatch end-to-end today; M3 swaps in the native agent loop behind the same interface.

**Binary wiring** (`cmd/foreman-agent/main.go`):

- New flags: `--task-poll-interval`, `--task-namespace`, `--stub-sleep`.
- Runs the registrar (M1) and the watcher (M2) concurrently via `errgroup`. On clean shutdown via SIGTERM both return nil; binary exits cleanly.

**Tests:** the M0 stub-smoke test in `agentictask_controller_test.go` is rewritten to exercise the M2 contract (Pending → Scheduled with capability matching, cascade-fail, dependency waits, busy-node skip). Existing M0+M1 tests untouched. Envtest harness from #501 carries forward.

## Verification

Live demo on `kind-llmkube-local` with `foreman-operator` + `foreman-agent` (`--heartbeat-interval=3s --task-poll-interval=2s --stub-sleep=8s`) + apply of `examples/foreman/m2-stub-task.yaml`. Observed the full conditions trail in order:

```
Scheduled  True  FleetNodeAssigned   scheduled to FleetNode "m5-max"
Running    True  Claimed              claimed by m5-max
Completed  True  ExecutorSucceeded    stub executor slept 8.001s ...
```

Final `status.result`:

```json
{
  "schemaVersion": "foreman.v1",
  "kind":          "stub",
  "verdict":       "GO",
  "elapsedSec":    8.001,
  "extra":         { "taskKind": "freeform", "agentName": "stub", "modelRef": "" },
  "summary":       "stub executor slept 8.001s on task default/m2-stub-demo"
}
```

`make test` passes on both arches. `make lint` 0 issues on darwin and on `GOOS=linux` (addresses the cross-arch gap captured in #503). No regressions in the LLMKube core inference flow.

## Checklist

- [x] Tests added/updated (M0 stub test rewritten as M2 scheduler test)
- [x] `make test` passes locally (both arches)
- [x] `make lint` passes locally (both arches)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated — README + chart README land alongside M6

## What's next

M3 (#500): build the native agent loop in Go using OpenAI function calling, land the Agent CRD, ship the `minimax-coder` Agent. The retry policy for the upstream llama.cpp tools-strict-parse 500 (#22072) is the only architectural decision M3 takes on top of what M2 already proves works.
