### PR TITLE
feat: add make lint-all target for cross-arch linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,13 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
+.PHONY: lint-all
+lint-all: golangci-lint ## Lint under all supported GOOS settings (slower; run before pushing).
+	@echo "==> Lint GOOS=darwin"
+	GOOS=darwin $(GOLANGCI_LINT) run ./...
+	@echo "==> Lint GOOS=linux"
+	GOOS=linux $(GOLANGCI_LINT) run ./...
+
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix


### PR DESCRIPTION
## What

Adds a new `make lint-all` Makefile target that runs `golangci-lint` under both
`GOOS=darwin` and `GOOS=linux`, intended as an opt-in pre-push gate. The default
`make lint` is unchanged (still single-arch, fast for the inner loop).

Net diff: 7 lines added to `Makefile`, no other files touched. Matches the
snippet in the issue body verbatim, except for matching the file's existing
`$(GOLANGCI_LINT)` variable name (which is what was suggested).

## Why

Fixes #503

Quoting the issue: files guarded by `//go:build !darwin` (or any tag the host
doesn't satisfy) don't compile under the default `GOOS`, so `golangci-lint`
silently skips them. CI on Ubuntu catches these at the worst possible time:
after the contributor has already pushed. The pattern surfaced twice on PR #501
in quick succession (`94c8ef8` and `09db359`); same concern compounds when M4's
gate Agent introduces another linux/amd64-only code path on top of the existing
darwin Metal one.

## How

Implemented by the Foreman M3 native agent loop (`feat/foreman-m3` branch,
local on the M5 Max). Provenance is recorded in transparent fashion because
this is the v0.1 demo run that proved the loop end-to-end:

- **Model:** `Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-I-Balanced` (3B active
  params), served by llama.cpp Metal via metal-agent at 256K context.
- **Agent role:** `coder`, system prompt = the autofix `issue-fixer.md` port
  to the OpenAI function-calling shape (`config/foreman/system-prompts/coder.md`
  on `feat/foreman-m3`).
- **Wall-clock:** 76 seconds, 16 turns, no retries.
- **Tool sequence:** `bash ls` -> `read_file Makefile` ->
  `grep //go:build` -> `read_file pkg/foreman/agent/capability_other.go` (the
  exact file the issue cited) -> `read_file .golangci.yml` ->
  `str_replace Makefile` -> `make lint-all` (exit 0) -> `make fmt` (exit 0) ->
  `git status --porcelain` -> `submit_result(verdict="GO")`.

The model read the issue body, verified the premise by opening a real build-
tagged file in the repo, made the edit at the right insertion point in the
Makefile (between `lint` and `lint-fix`), and ran the new target to confirm
it works before submitting.

The commit message above is the model's, used by the executor verbatim
(M3 contract: model authors the message including the `Fixes #N` trailer; the
executor only adds the DCO sign-off via `git commit -s`).

## Checklist

- [x] Tests added/updated -- N/A; this is a Makefile addition, no production
      code changes.
- [x] `make test` passes locally -- N/A; no Go code changed. The model ran
      `make fmt` and `make lint-all` (the new target) inside its workspace as
      verification.
- [x] `make lint` passes locally -- the new target itself was exercised
      (`make lint-all`, both GOOS=darwin and GOOS=linux, exit 0).
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated -- the issue suggested adding an `AGENTS.md` /
      `CONTRIBUTING.md` line pointing at `lint-all` for pre-push. Deferring
      that to a separate small PR so this one stays a single-file change.
