### PR TITLE
docs(macos-metal): replace broken port-forward step with host-localhost curl

### DIFF
--- a/docs/site/guides/macos-metal.md
+++ b/docs/site/guides/macos-metal.md
@@ -164,14 +164,33 @@ The agent's log should show:
 "msg":"started inference service","name":"phi-4-mini","pid":<llama-server-pid>
 ```
 
-Query the model from anywhere in the cluster:
+Query the model from this Mac (`llama-server` is already running
+natively on this host via metal-agent, so no port-forward is needed
+when you are on the same machine):
 
 ```bash
-kubectl port-forward svc/phi-4-mini 8080:8080 &
 curl -sS http://localhost:8080/v1/chat/completions \
   -H 'content-type: application/json' \
   -d '{"model":"phi-4-mini","messages":[{"role":"user","content":"hi"}]}'
 ```
+
+### Reaching the service from elsewhere
+
+The InferenceService Service on the metal path is selector-less by
+design: the metal-agent registers the host as the Endpoint, so the
+Service has no Pods to target. That means
+`kubectl port-forward svc/phi-4-mini ...` returns
+`error: cannot attach to *v1.Service: ... Service is defined without
+a selector` and cannot be used here. Two supported ways to expose
+this Service to clients on other machines:
+
+1. **Set `spec.endpoint.type: NodePort` on the InferenceService.**
+   Then `curl http://<host-ip>:<node-port>/v1/...` from anywhere that
+   can route to the host.
+2. **Hit the host directly.** metal-agent binds `llama-server` to
+   `0.0.0.0` and registers `<host-ip>:<port>` as the Endpoint, so
+   `curl http://<host-ip>:8080/v1/...` works from any client on the
+   same network.
 
 ## Memory budgets
 


### PR DESCRIPTION
## What

Replaces the macOS Metal quickstart's `kubectl port-forward svc/...`
instruction (which never works against a metal-served InferenceService)
with a direct `curl http://localhost:8080/...` from the same Mac, plus
a short "Reaching the service from elsewhere" subsection covering
NodePort + direct host-IP access for off-host clients.

Single-file diff: `docs/site/guides/macos-metal.md`, +21 / -2 lines.

## Why

Fixes #512

The metal path operator deliberately creates a selector-less Service
(metal-agent runs `llama-server` natively on the host and registers
the host IP as the Endpoint manually). `kubectl port-forward svc/...`
is hard-wired to require a Selector and refuses to consult the
Endpoints object, so the guide's step returns:

```
error: cannot attach to *v1.Service: invalid service 'phi-4-mini':
Service is defined without a selector
```

Every reader of the macOS Metal quickstart hits this at Step 5, and
the diagnostic is uninformative without architectural context. See
issue #512 for the full root-cause writeup + alternatives considered.

## How

- Reframed the leading sentence: the original "Query the model from
  anywhere in the cluster" was misleading (the metal path's
  ClusterIP service is reachable from in-cluster, but the
  port-forward call is bound to your laptop, so the natural reading
  is wrong twice over).
- New copy explicitly names the design (selector-less Service) so a
  reader hitting the same error via another doc path can grep and
  land here.
- Two supported off-host exposure paths documented: `NodePort`
  endpoint type, and direct `<host-ip>:<port>` access. Both work
  today; nothing needed from the operator.

## Checklist

- [x] Tests added/updated -- N/A; docs-only change.
- [x] `make test` passes locally -- N/A; no code touched. CI's
      `Documentation Validation` job exercises the doc lint surface.
- [x] `make lint` passes locally -- N/A; same reason.
- [x] Commit messages follow conventional commits.
- [x] All commits are signed off (`git commit -s`) per DCO.
- [x] Documentation updated -- this PR *is* the documentation update.
