### PR TITLE
docs: bump broken bartowski phi-4-mini URL to renamed repo

### DIFF
--- a/docs/site/guides/macos-metal.md
+++ b/docs/site/guides/macos-metal.md
@@ -138,7 +138,7 @@ apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata: { name: phi-4-mini }
 spec:
-  source: https://huggingface.co/bartowski/phi-4-mini-instruct-GGUF/resolve/main/phi-4-mini-instruct-Q4_K_M.gguf
+  source: https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF/resolve/main/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf
   format: gguf
   hardware:
     accelerator: metal

--- a/docs/site/guides/openshift-install.md
+++ b/docs/site/guides/openshift-install.md
@@ -146,7 +146,7 @@ apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata: { name: phi-4-mini }
 spec:
-  source: https://huggingface.co/bartowski/phi-4-mini-instruct-GGUF/resolve/main/phi-4-mini-instruct-Q4_K_M.gguf
+  source: https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF/resolve/main/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf
   format: gguf
 ---
 apiVersion: inference.llmkube.dev/v1alpha1


### PR DESCRIPTION
## What

Bumps the broken HuggingFace URL in two install guides from
`bartowski/phi-4-mini-instruct-GGUF` (returns 401; repo renamed) to
`bartowski/microsoft_Phi-4-mini-instruct-GGUF` (returns 200; same
author, same model, includes imatrix quants). The file inside the new
repo also gained the `microsoft_` prefix, so both the repo path and
the file name change.

Two-line diff:

- `docs/site/guides/macos-metal.md:141`
- `docs/site/guides/openshift-install.md:149`

## Why

Fixes #511

Anyone walking either install guide today hits this at Step 5:
metal-agent (or the in-cluster downloader) tries to fetch the URL,
HuggingFace returns 401, llama-server never starts, and the next
verification step has nothing listening on port 8080. The diagnostic
chain isn't obvious from the surface error -- a tester reported
`Failed to connect to localhost port 8080` from the next-step curl,
which traces back here.

## How

bartowski still publishes a Phi-4-mini-instruct GGUF -- they renamed
the repo during a naming-convention overhaul so the URL the docs
captured no longer resolves. Smallest possible fix: bump to the
renamed repo by the same author.

Confirmed live before committing:

```sh
$ curl -sLI -o /dev/null -w '%{http_code}\n' \
    https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF/resolve/main/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf
200
```

Two alternative publishers were also verified live as fallbacks in
case bartowski moves again, listed in #511's body for the record:

- `unsloth/Phi-4-mini-instruct-GGUF` (34K downloads, 101 likes)
- `MaziyarPanahi/Phi-4-mini-instruct-GGUF` (113K downloads)

Kept bartowski because (a) smallest doc diff, (b) same author the
docs already trust, (c) imatrix quants match the docs' implicit
assumption.

## Checklist

- [x] Tests added/updated -- N/A; docs-only change.
- [x] `make test` passes locally -- N/A; no code touched.
- [x] `make lint` passes locally -- N/A; no code touched.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/).
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/).
- [x] Documentation updated -- this PR *is* the documentation update.
