### PR TITLE
docs(macos-metal): derive curl port from Endpoints (follow-up to #513)

### DIFF
--- a/docs/site/guides/macos-metal.md
+++ b/docs/site/guides/macos-metal.md
@@ -164,14 +164,43 @@ The agent's log should show:
 "msg":"started inference service","name":"phi-4-mini","pid":<llama-server-pid>
 ```
 
-Query the model from this Mac (`llama-server` is already running
-natively on this host via metal-agent, so no port-forward is needed
-when you are on the same machine):
+### Find the endpoint
+
+The metal-agent picks the port `llama-server` listens on at spawn
+time and registers it as the Service's Endpoint. Unless you started
+the agent with `--llama-server-port <N>`, the port is not 8080 — it
+is allocated from the ephemeral range and changes across restarts.
+Always read the endpoint from the cluster rather than assuming a port:
 
 ```bash
-curl -sS http://localhost:8080/v1/chat/completions \
+kubectl get endpoints phi-4-mini \
+  -o jsonpath='{.subsets[0].addresses[0].ip}:{.subsets[0].ports[0].port}{"\n"}'
+# example: 192.168.1.50:63344
+```
+
+The IP is your Mac's reachable address (LAN, Tailscale, etc., set via
+`--host-ip` in Step 4). The port is whatever the agent allocated. The
+two together are how every client — including pods inside the cluster
+— reaches the model.
+
+### Query the model
+
+From the Mac that runs metal-agent, `localhost` works because
+`llama-server` is bound to `0.0.0.0` on the host. Read the port from
+the cluster and curl it:
+
+```bash
+PORT=$(kubectl get endpoints phi-4-mini -o jsonpath='{.subsets[0].ports[0].port}')
+curl -sS "http://localhost:${PORT}/v1/chat/completions" \
   -H 'content-type: application/json' \
   -d '{"model":"phi-4-mini","messages":[{"role":"user","content":"hi"}]}'
+```
+
+If your shell or paste medium strips backslash line-continuations,
+the equivalent one-liner is safer to copy:
+
+```bash
+curl -sS "http://localhost:${PORT}/v1/chat/completions" -H 'content-type: application/json' -d '{"model":"phi-4-mini","messages":[{"role":"user","content":"hi"}]}'
 ```
 
 ### Reaching the service from elsewhere
@@ -181,16 +210,25 @@ design: the metal-agent registers the host as the Endpoint, so the
 Service has no Pods to target. That means
 `kubectl port-forward svc/phi-4-mini ...` returns
 `error: cannot attach to *v1.Service: ... Service is defined without
-a selector` and cannot be used here. Two supported ways to expose
-this Service to clients on other machines:
+a selector` and cannot be used here. Two supported ways to reach the
+service from a machine that is not the Mac:
 
-1. **Set `spec.endpoint.type: NodePort` on the InferenceService.**
-   Then `curl http://<host-ip>:<node-port>/v1/...` from anywhere that
-   can route to the host.
-2. **Hit the host directly.** metal-agent binds `llama-server` to
-   `0.0.0.0` and registers `<host-ip>:<port>` as the Endpoint, so
-   `curl http://<host-ip>:8080/v1/...` works from any client on the
-   same network.
+1. **Hit the host directly.** Use the address `kubectl get endpoints`
+   printed above. From any client on the same network:
+
+   ```bash
+   curl -sS "http://192.168.1.50:63344/v1/chat/completions" \
+     -H 'content-type: application/json' \
+     -d '{"model":"phi-4-mini","messages":[{"role":"user","content":"hi"}]}'
+   ```
+
+   Substitute your own IP and port. This is the same address that
+   in-cluster pods route to via the Service's ClusterIP, so a NodePort
+   is not required for LAN clients.
+2. **Pin the agent's port + set `spec.endpoint.type: NodePort`** if
+   you want a stable, externally-advertised port that survives agent
+   restarts. Start metal-agent with `--llama-server-port 8080` (or any
+   fixed value you choose) and set the NodePort on the InferenceService.
 
 ## Memory budgets
 


### PR DESCRIPTION
## What

Follow-up to #513. Derives the curl port from
`kubectl get endpoints` instead of hardcoding `:8080`, and adds a
one-liner curl alongside the multi-line form to survive paste
mediums that strip backslash line-continuations.

Single file: `docs/site/guides/macos-metal.md`, +52 / -14 lines.

This change was originally a second commit on the #513 branch
(`8626b18`) but did not land in the merge -- only the first commit
made it to `main`. Resurrecting it here on a clean branch off the
new `main`.

## Why

After #513 merged, a tester walking the guide hit
`Failed to connect to localhost port 8080 after 0 ms: Couldn't
connect to server`, even though their `InferenceService` was
`Ready` and the model had downloaded successfully. Diagnosis:

```sh
$ kubectl get endpoints phi-4-mini -o jsonpath='{.subsets[0].addresses[0].ip}:{.subsets[0].ports[0].port}{"\n"}'
192.168.65.254:63344
```

metal-agent only binds llama-server to port 8080 when started with
`--llama-server-port 8080`. Without that flag, it allocates from
the ephemeral port range and the Endpoint reflects whatever it got
(here, `63344`). The merged doc hardcodes `:8080`, which is wrong
for any default install.

## How

- New "Find the endpoint" subsection that reads the actual IP:port
  via `kubectl get endpoints` before curling. Example output
  explicitly shows a non-8080 port so the reader sees it varies.
- "Query the model" uses `PORT=$(kubectl get endpoints ...)` to
  derive the port. Works regardless of whether the agent was
  started with `--llama-server-port` or not.
- Single-line curl form added below the multi-line for anyone
  copying through a paste medium that strips trailing backslashes.
- "Reaching the service from elsewhere" reordered: "hit the host
  directly" moved to #1 with a concrete example reusing the
  address kubectl already printed. NodePort moved to #2 with
  guidance to pair it with `--llama-server-port` for a stable port
  across restarts.

Verified live on an M5 Max running a metal-served InferenceService
(`qwen36-35b-carnice-mtp`): `PORT=$(kubectl get endpoints ...)`
returned `8080` (since metal-agent on this host uses the flag);
both multi-line and one-line curl returned `HTTP 200` at ~119
tok/s. For the tester's setup the same snippet would derive
`63344` and would have worked.

## Checklist

- [x] Tests added/updated -- N/A; docs-only change.
- [x] `make test` passes locally -- N/A; no code touched.
- [x] `make lint` passes locally -- N/A; no code touched.
- [x] Commit messages follow conventional commits.
- [x] All commits are signed off (`git commit -s`) per DCO.
- [x] Documentation updated -- this PR *is* the documentation update.
