### PR TITLE
fix(foreman): drop chart-level subchart dep on llmkube (unblock v0.7.11 chart-releaser)

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -708,30 +708,18 @@ jobs:
           version: v3.13.0
 
       - name: Lint foreman chart
-        # Lint before wiring the subchart. helm lint will surface a
-        # "missing dependency: llmkube" warning we accept (the chart
-        # publishes via the gh-pages repo, not this checkout), but
-        # actual lint errors in the foreman templates still fail.
         run: |
           helm lint charts/foreman
           echo "✅ foreman lint passed"
 
-      - name: Wire local llmkube subchart for foreman
-        # foreman depends on llmkube; this CI does not publish a chart
-        # repo, so we satisfy the dependency by symlinking the in-tree
-        # llmkube chart into foreman/charts/. Same trick `helm dep
-        # build` would do under the hood when published.
-        run: |
-          mkdir -p charts/foreman/charts
-          ln -sf ../../llmkube charts/foreman/charts/llmkube
-
-      - name: Template foreman with defaults (no llmkube subchart)
-        # llmkube.enabled=false skips rendering the subchart so this
-        # job stays focused on the foreman templates.
+      - name: Template foreman with defaults
+        # foreman is a sibling chart to llmkube (no Helm subchart
+        # relationship), so no helm-repo wiring is required to render
+        # it. Anything that would have lived in a subchart belongs to
+        # llmkube's chart and is installed separately.
         run: |
           helm template foreman charts/foreman \
             --namespace foreman-system \
-            --set llmkube.enabled=false \
             > foreman-default.yaml
 
           for kind in "Deployment" "ClusterRole" "ClusterRoleBinding" "ServiceAccount" "PersistentVolumeClaim" "CustomResourceDefinition"; do
@@ -749,7 +737,6 @@ jobs:
         run: |
           helm template foreman charts/foreman \
             --namespace foreman-system \
-            --set llmkube.enabled=false \
             --set agent.mode=native \
             --set 'agent.roles={worker,verifier}' \
             --set agent.githubToken.secretName=foreman-github \

--- a/charts/foreman/Chart.yaml
+++ b/charts/foreman/Chart.yaml
@@ -3,8 +3,12 @@ name: foreman
 description: |
   Foreman is an opt-in add-on for LLMKube that schedules agentic workloads
   (Workload, AgenticTask) across a fleet of nodes (FleetNode). Installing
-  LLMKube alone does not install or require Foreman. Install Foreman after
-  llmkube; foreman-operator runs alongside llmkube-operator.
+  LLMKube alone does not install or require Foreman. Foreman is a SIBLING
+  chart to llmkube, not a subchart: install llmkube first (helm install
+  llmkube defilantech/llmkube), then install foreman alongside it. They
+  share no Helm relationship at packaging or install time; the only
+  coupling is that the foreman-operator's RBAC reads inference.llmkube.dev
+  CRDs that llmkube installs.
 type: application
 version: 0.7.10
 appVersion: 0.7.10
@@ -17,8 +21,3 @@ keywords:
 home: https://github.com/defilantech/LLMKube
 sources:
   - https://github.com/defilantech/LLMKube
-dependencies:
-  - name: llmkube
-    version: '>=0.7.10'
-    repository: https://defilantech.github.io/llmkube
-    condition: llmkube.enabled

--- a/docs/foreman/install-verifier-node.md
+++ b/docs/foreman/install-verifier-node.md
@@ -84,15 +84,14 @@ cd /path/to/LLMKube
 helm upgrade --install foreman \
   charts/foreman \
   --namespace foreman-system --create-namespace \
-  --set llmkube.enabled=false \
   --set agent.mode=native \
   --set 'agent.roles={worker,verifier}'
 ```
 
-The `llmkube.enabled=false` flag skips the subchart resolution. The
-chart declares `llmkube >=0.7.10`; if you have LLMKube core
-installed separately at any current version, that dep is satisfied
-and the local-checkout install Just Works.
+Foreman is a sibling chart to llmkube, not a subchart: installing
+foreman never installs (or expects to install) llmkube. If you have
+not already installed llmkube core in the same cluster, do that
+first per the prerequisite section above.
 
 ## Foreman milestone status
 
@@ -122,7 +121,6 @@ nodes that will also run coder-role Agents (M3 + later), add the
 helm upgrade --install foreman \
   charts/foreman \
   --namespace foreman-system --create-namespace \
-  --set llmkube.enabled=false \
   --set agent.mode=native \
   --set 'agent.roles={worker,verifier}' \
   --set agent.gitRemoteURL=https://github.com/Defilan/LLMKube.git \


### PR DESCRIPTION
## What

Drop the chart-level subchart dependency from `charts/foreman/Chart.yaml`.
The v0.7.10 release's `release-helm` job failed packaging the foreman
chart; this PR fixes the root cause so the next release-please cut
(v0.7.11) can publish both charts cleanly.

## Why

Fixes the v0.7.10 chart-releaser failure (see logs on
[Release Please workflow run 26317970069](https://github.com/defilantech/LLMKube/actions/runs/26317970069),
job `release-helm`):

```
Packaging chart 'charts/foreman'...
Error: no cached repository for helm-manager-... found.
(try 'helm repo update'): no such file or directory
```

Root cause is a design mistake that landed in PR #518. `charts/foreman
/Chart.yaml` declared llmkube as a Helm subchart dependency. When
chart-releaser invoked `helm package`, helm tried to resolve the dep
from configured repos:

- The runner had no helm repos configured
- Even if it did, the published llmkube chart maxes at 0.7.9; foreman/
  Chart.yaml asked for `>=0.7.10`, the version chart-releaser was about
  to publish in the same run

Chicken-and-egg: the dep needed to resolve against a chart being
published in the same step that was failing.

The chart-level dep was wrong design from the start. foreman is an
opt-in add-on, not a Helm subchart of llmkube. The intended model is:
install llmkube first, then install foreman alongside it. Most K8s
add-ons (cert-manager, external-dns, ...) work the same way. The dep
was a hangover from an earlier "M3 + M4 + chart ship together" framing
that we've since deferred.

## How

- `charts/foreman/Chart.yaml`: removed the entire `dependencies:` block.
  Updated the chart description to explicitly state foreman is a
  **sibling chart** to llmkube, not a subchart, and to spell out the
  install order (llmkube first, foreman after).
- `docs/foreman/install-verifier-node.md`: removed every
  `--set llmkube.enabled=false` from helm install commands (no subchart
  to disable anymore). Tightened the explanatory text.
- `.github/workflows/helm-chart.yml` `foreman-chart` job: removed the
  "Wire local llmkube subchart for foreman" step (the symlink workaround
  we needed when packaging foreman triggered Helm dep resolution). The
  helm-template + kubeconform validation steps no longer need
  `--set llmkube.enabled=false` either.

What did NOT change:

- F3's release-please tracking of both `charts/llmkube/Chart.yaml` and
  `charts/foreman/Chart.yaml` stays in place. Both charts continue to
  bump in lockstep with every release; that is version coupling,
  separate from Helm subchart coupling. The CI assertion that catches
  "someone added a new chart but did not wire it into release-please"
  is unaffected.
- The runbook prerequisite that installs llmkube before foreman is
  unchanged: the install order is the same; the Helm relationship is
  the only thing being decoupled.

## Verification

Local:

- `helm lint charts/foreman` :: clean (just the INFO about a missing
  icon; no "missing dependency" warning anymore).
- `helm template charts/foreman` without any helm-repo wiring renders
  the same 13 resources as before.
- `helm template` with the verifier-node override path propagates
  `--agent-mode=native`, `--roles=worker,verifier`, and `GITHUB_TOKEN`.

Live (post-merge expected behavior):

- release-please opens a v0.7.11 release PR.
- After merge, chart-releaser packages foreman against a Chart.yaml
  with no `dependencies:` block. `helm package` no longer triggers
  dep resolution and succeeds.
- Both `llmkube-0.7.11.tgz` and `foreman-0.7.11.tgz` publish to gh-
  pages. Foreman becomes installable from the public chart repo for
  the first time.

The v0.7.10 release stays as-is. Binaries + container images either
succeeded or are still going via goreleaser; the helm chart was
never published at 0.7.10 and won't be retroactively. v0.7.11 is the
first usable Foreman tag at the chart repo level.

## Related

- Follows PR #518 (Foreman M4, merged)
- Refs #500 (Foreman v0.1 epic)

## Checklist

- [x] Tests added/updated (no Go code changed; chart + CI + docs only)
- [x] `make test` passes locally (unchanged from main)
- [x] `make lint` passes locally (unchanged from main)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (`install-verifier-node.md` install commands corrected)
