### PR TITLE
fix(foreman/m4): gate Job honors payload.branch + clones from --git-remote-url

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -373,9 +373,13 @@ func (e *NativeAgentLoopExecutor) executeDeterministic(
 	}
 
 	// The task payload becomes the tool's arguments. For the gate
-	// Agent's run_gate_job tool, this means {repo, branch, checks}
-	// surface from spec.payload via well-known fields.
-	args := buildDeterministicArgs(task, branch)
+	// Agent's run_gate_job tool, this means {repo, branch, checks,
+	// cloneURL} surface from spec.payload via well-known fields. The
+	// cloneURL override carries the executor's --git-remote-url so the
+	// gate Job clones from the fork the upstream coder pushed to,
+	// rather than the upstream payload.repo where the branch does not
+	// yet exist.
+	args := buildDeterministicArgs(task, branch, e.GitRemoteURL)
 
 	result, dispatchErr := registry.Dispatch(ctx, toolName, args)
 	if dispatchErr != nil {
@@ -424,15 +428,24 @@ func pickDeterministicTool(tools []string) string {
 
 // buildDeterministicArgs synthesizes a JSON args blob the deterministic
 // tool receives. The gate Agent's run_gate_job tool will read
-// {repo, branch} from this; other deterministic tools can extend the
-// shape as needed.
-func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch string) json.RawMessage {
+// {repo, branch, cloneURL} from this; other deterministic tools can
+// extend the shape as needed.
+//
+// cloneURL is the executor's --git-remote-url passed through verbatim.
+// When set, the gate Job clones from this URL instead of constructing
+// one from CloneURLBase + payload.repo. v0.1 needs this because the
+// upstream coder task pushes to a fork (the foreman-agent's
+// --git-remote-url) and the gate must verify that branch on the fork,
+// not on the upstream payload.repo where the branch does not yet
+// exist. Empty cloneURL preserves the M4 default (upstream + repo).
+func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL string) json.RawMessage {
 	args := map[string]any{
-		"repo":    task.Spec.Payload.Repo,
-		"branch":  branch,
-		"issue":   task.Spec.Payload.Issue,
-		"prompt":  task.Spec.Payload.Prompt,
-		"taskRef": map[string]string{"namespace": task.Namespace, "name": task.Name},
+		"repo":     task.Spec.Payload.Repo,
+		"branch":   branch,
+		"cloneURL": cloneURL,
+		"issue":    task.Spec.Payload.Issue,
+		"prompt":   task.Spec.Payload.Prompt,
+		"taskRef":  map[string]string{"namespace": task.Namespace, "name": task.Name},
 	}
 	out, _ := json.Marshal(args)
 	return out
@@ -602,11 +615,21 @@ func objRefAsMap(ref corev1.ObjectReference) map[string]any {
 
 // --- helpers --------------------------------------------------------------
 
-// branchNameForTask picks a branch name for the push. issue-fix tasks
-// get foreman/issue-<N>; other kinds get foreman/<task-name>. v0.1
-// keeps slugs minimal; v0.2 may take an explicit IssueTitle field on
-// AgenticTaskPayload and slug it for the branch.
+// branchNameForTask picks a branch name for the task. Precedence:
+//
+//  1. Explicit task.Spec.Payload.Branch wins. This is the documented
+//     hand-off for verify tasks (which gate a branch the upstream coder
+//     task already produced) and the escape hatch for any task that
+//     wants to pin the branch name from the caller.
+//  2. issue-fix with Payload.Issue > 0 derives foreman/issue-<N>.
+//  3. Everything else falls back to foreman/<task-name>.
+//
+// v0.1 keeps slugs minimal; v0.2 may take an explicit IssueTitle field
+// on AgenticTaskPayload and slug it for the branch.
 func branchNameForTask(task *foremanv1alpha1.AgenticTask) string {
+	if task.Spec.Payload.Branch != "" {
+		return task.Spec.Payload.Branch
+	}
 	if task.Spec.Kind == foremanv1alpha1.AgenticTaskKindIssueFix && task.Spec.Payload.Issue > 0 {
 		return fmt.Sprintf("%s/issue-%d", repo.BranchPrefix, task.Spec.Payload.Issue)
 	}

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+// Whitebox tests for the unexported helpers in executor_native.go.
+// The blackbox tests in executor_native_test.go drive end-to-end
+// behavior through the public Executor; this file pins the helper
+// semantics individually so a regression surfaces with a precise
+// failure rather than as a cascading executor flake.
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// TestBranchNameForTask covers the precedence rule between explicit
+// payload.branch (set on verify tasks per the v0.1 hand-off, and as an
+// escape hatch on any task) and the issue-fix / task-name derivation.
+// Regression for #528 part 1.
+func TestBranchNameForTask(t *testing.T) {
+	cases := []struct {
+		name string
+		task *foremanv1alpha1.AgenticTask
+		want string
+	}{
+		{
+			name: "payload.branch wins over issue-fix derivation",
+			task: &foremanv1alpha1.AgenticTask{
+				ObjectMeta: metav1.ObjectMeta{Name: "code-510"},
+				Spec: foremanv1alpha1.AgenticTaskSpec{
+					Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+					Payload: foremanv1alpha1.AgenticTaskPayload{
+						Issue:  510,
+						Branch: "release-1.2-cherry-pick-of-510",
+					},
+				},
+			},
+			want: "release-1.2-cherry-pick-of-510",
+		},
+		{
+			name: "payload.branch on verify (the gate hand-off shape)",
+			task: &foremanv1alpha1.AgenticTask{
+				ObjectMeta: metav1.ObjectMeta{Name: "gate-510"},
+				Spec: foremanv1alpha1.AgenticTaskSpec{
+					Kind: foremanv1alpha1.AgenticTaskKindVerify,
+					Payload: foremanv1alpha1.AgenticTaskPayload{
+						Issue:  510,
+						Branch: "foreman/issue-510",
+					},
+				},
+			},
+			want: "foreman/issue-510",
+		},
+		{
+			name: "issue-fix without payload.branch falls back to issue derivation",
+			task: &foremanv1alpha1.AgenticTask{
+				ObjectMeta: metav1.ObjectMeta{Name: "code-503"},
+				Spec: foremanv1alpha1.AgenticTaskSpec{
+					Kind:    foremanv1alpha1.AgenticTaskKindIssueFix,
+					Payload: foremanv1alpha1.AgenticTaskPayload{Issue: 503},
+				},
+			},
+			want: "foreman/issue-503",
+		},
+		{
+			name: "non-issue-fix without payload.branch falls back to task name",
+			task: &foremanv1alpha1.AgenticTask{
+				ObjectMeta: metav1.ObjectMeta{Name: "verify-only"},
+				Spec: foremanv1alpha1.AgenticTaskSpec{
+					Kind: foremanv1alpha1.AgenticTaskKindVerify,
+				},
+			},
+			want: "foreman/verify-only",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := branchNameForTask(tc.task); got != tc.want {
+				t.Errorf("want %q got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestBuildDeterministicArgs pins the JSON shape buildDeterministicArgs
+// produces, including the cloneURL passthrough the v0.1 gate path
+// needs (#528 part 2). The tool layer asserts on these fields; this
+// test catches drift between the executor's argument synthesis and
+// run_gate_job's runGateJobArgs decoding.
+func TestBuildDeterministicArgs(t *testing.T) {
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "gate-510", Namespace: "default"},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindVerify,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Issue:  510,
+				Branch: "foreman/issue-510",
+			},
+		},
+	}
+
+	t.Run("cloneURL set", func(t *testing.T) {
+		raw := buildDeterministicArgs(task, "foreman/issue-510", "https://github.com/Defilan/LLMKube.git")
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("decode args: %v", err)
+		}
+		if got["branch"] != "foreman/issue-510" {
+			t.Errorf("branch: want foreman/issue-510 got %v", got["branch"])
+		}
+		if got["repo"] != "defilantech/LLMKube" {
+			t.Errorf("repo: want defilantech/LLMKube got %v", got["repo"])
+		}
+		if got["cloneURL"] != "https://github.com/Defilan/LLMKube.git" {
+			t.Errorf("cloneURL: want fork URL got %v", got["cloneURL"])
+		}
+		ref, ok := got["taskRef"].(map[string]any)
+		if !ok {
+			t.Fatalf("taskRef missing or wrong shape: %v", got["taskRef"])
+		}
+		if ref["namespace"] != "default" || ref["name"] != "gate-510" {
+			t.Errorf("taskRef: want default/gate-510 got %v/%v", ref["namespace"], ref["name"])
+		}
+	})
+
+	t.Run("cloneURL empty preserves M4 default", func(t *testing.T) {
+		raw := buildDeterministicArgs(task, "foreman/issue-510", "")
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("decode args: %v", err)
+		}
+		if got["cloneURL"] != "" {
+			t.Errorf("cloneURL: want empty (so tool falls back to CloneURLBase+Repo) got %v", got["cloneURL"])
+		}
+	})
+}

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -122,14 +122,23 @@ type fakeRegistry struct {
 	// workspace is captured at construction so touch knows where to
 	// write changes for tests that want the commit path to succeed.
 	workspace string
+	// lastName + lastArgs record the most recent Dispatch call so a
+	// test can assert that the executor passed the expected args (e.g.
+	// branch + cloneURL) into the tool layer.
+	lastName string
+	lastArgs json.RawMessage
 }
 
 func (r *fakeRegistry) Schemas() []oai.Tool { return nil }
 
-func (r *fakeRegistry) Dispatch(_ context.Context, name string, _ json.RawMessage) (*foremanagent.ToolResult, error) {
+func (r *fakeRegistry) Dispatch(
+	_ context.Context, name string, args json.RawMessage,
+) (*foremanagent.ToolResult, error) {
 	if r.touch != nil {
 		r.touch(name, r.workspace)
 	}
+	r.lastName = name
+	r.lastArgs = args
 	res, ok := r.results[name]
 	if !ok {
 		return nil, errors.New("fake registry: unknown tool " + name)
@@ -544,5 +553,24 @@ func TestNativeExecutor_DeterministicGateAgent(t *testing.T) {
 		t.Errorf("transcript ConfigMap should NOT exist on deterministic runs, but it does")
 	} else if !apierrors.IsNotFound(getErr) {
 		t.Errorf("expected NotFound for transcript cm; got %v", getErr)
+	}
+
+	// Args the registry actually saw must carry the payload's branch
+	// (not a task-name-derived one) and the executor's GitRemoteURL as
+	// cloneURL. Both are required for the gate Job to clone the right
+	// branch from the right remote in v0.1. Regression coverage for
+	// #528.
+	var got map[string]any
+	if err := json.Unmarshal(reg.lastArgs, &got); err != nil {
+		t.Fatalf("decode dispatched args: %v", err)
+	}
+	if got["branch"] != "foreman/issue-9999" {
+		t.Errorf("dispatched branch: want foreman/issue-9999 got %v", got["branch"])
+	}
+	if got["cloneURL"] != bare {
+		t.Errorf("dispatched cloneURL: want %q got %v", bare, got["cloneURL"])
+	}
+	if got["repo"] != "defilantech/LLMKube" {
+		t.Errorf("dispatched repo: want defilantech/LLMKube got %v", got["repo"])
 	}
 }

--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -19,6 +19,12 @@
 #   .CPURequest / .CPULimit / .MemRequest / .MemLimit
 #   .CloneURLBase   -- "https://github.com" (override for fork-style
 #                      hosts; the default matches autofix)
+#   .CloneURL       -- optional. When non-empty, the Job clones this
+#                      URL verbatim and ignores .CloneURLBase / .Repo
+#                      for the clone command (the log line still names
+#                      .Repo for operator readability). Used by the v0.1
+#                      gate to clone from the foreman-agent's --git-
+#                      remote-url (the fork) rather than upstream.
 #   .TaskNamespace / .TaskName -- the AgenticTask that owns this Job;
 #                                 surfaced as labels for observability.
 apiVersion: batch/v1
@@ -52,7 +58,7 @@ spec:
               set -uo pipefail
               echo "=== clone {{ .Repo }} @ {{ .Branch }} ==="
               git clone --depth 1 --branch "{{ .Branch }}" \
-                "{{ .CloneURLBase }}/{{ .Repo }}.git" /work || { echo "GATE FAIL: clone"; exit 1; }
+                "{{ if .CloneURL }}{{ .CloneURL }}{{ else }}{{ .CloneURLBase }}/{{ .Repo }}.git{{ end }}" /work || { echo "GATE FAIL: clone"; exit 1; }
               cd /work
               rc=0
               {{- range .Checks }}

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -148,11 +148,19 @@ type RunGateJobTool struct {
 // `taskRef` is auto-populated by executor_native.go's
 // buildDeterministicArgs and lets the tool stamp owner-ref-style
 // labels on the Job for observability.
+//
+// `cloneURL` is optional. When non-empty, the gate Job clones it
+// verbatim instead of constructing a URL from CloneURLBase + Repo. It
+// exists because v0.1 coders push to a fork (the foreman-agent's
+// --git-remote-url) while payload.repo names the upstream the fix is
+// for; the gate must verify the branch on the fork where it actually
+// lives. Empty preserves the historical CloneURLBase + Repo behavior.
 type runGateJobArgs struct {
-	Repo    string   `json:"repo"`
-	Branch  string   `json:"branch"`
-	Checks  []string `json:"checks,omitempty"`
-	TaskRef struct {
+	Repo     string   `json:"repo"`
+	Branch   string   `json:"branch"`
+	CloneURL string   `json:"cloneURL,omitempty"`
+	Checks   []string `json:"checks,omitempty"`
+	TaskRef  struct {
 		Namespace string `json:"namespace"`
 		Name      string `json:"name"`
 	} `json:"taskRef"`
@@ -231,6 +239,7 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 		MemRequest:              cfg.MemRequest,
 		MemLimit:                cfg.MemLimit,
 		CloneURLBase:            cfg.CloneURLBase,
+		CloneURL:                a.CloneURL,
 		TaskNamespace:           a.TaskRef.Namespace,
 		TaskName:                a.TaskRef.Name,
 	})
@@ -351,6 +360,12 @@ func (t *RunGateJobTool) errorResult(jobName, msg string) *agent.ToolResult {
 // rendererInput is the struct text/template binds against. Keeping it
 // here (rather than reusing the public Config + args structs) keeps the
 // template stable across signature changes upstream.
+//
+// CloneURL, when non-empty, replaces the default `CloneURLBase/Repo.git`
+// clone target. The template renders one or the other; Repo is still
+// used in the human-readable log line either way ("=== clone <repo>
+// @ <branch> ===") so an operator scanning Pod logs sees what was
+// being verified, regardless of where the branch physically lives.
 type rendererInput struct {
 	Name                    string
 	Namespace               string
@@ -366,6 +381,7 @@ type rendererInput struct {
 	MemRequest              string
 	MemLimit                string
 	CloneURLBase            string
+	CloneURL                string
 	TaskNamespace           string
 	TaskName                string
 }

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -390,3 +390,76 @@ func TestRenderGateJob_RendersChecksAndPVCMount(t *testing.T) {
 		t.Errorf("task-name label: %q", got)
 	}
 }
+
+// TestRenderGateJob_CloneURLOverride asserts the template branches
+// correctly on the CloneURL field: when set, the git clone target is
+// the override URL verbatim; when empty, the historical
+// CloneURLBase + Repo + .git is preserved. The human-readable log
+// line ("=== clone <repo> @ <branch> ===") always names Repo so an
+// operator sees what was being verified regardless of where the
+// branch physically lives. Regression for #528 part 2.
+func TestRenderGateJob_CloneURLOverride(t *testing.T) {
+	cases := []struct {
+		name        string
+		cloneURL    string
+		mustHave    []string
+		mustNotHave []string
+	}{
+		{
+			name:     "override wins",
+			cloneURL: "https://github.com/Defilan/LLMKube.git",
+			mustHave: []string{
+				`"https://github.com/Defilan/LLMKube.git"`,
+				"=== clone defilantech/LLMKube @ foreman/issue-510 ===",
+			},
+			mustNotHave: []string{
+				`"https://github.com/defilantech/LLMKube.git"`,
+			},
+		},
+		{
+			name:     "empty falls back to CloneURLBase + Repo",
+			cloneURL: "",
+			mustHave: []string{
+				`"https://github.com/defilantech/LLMKube.git"`,
+				"=== clone defilantech/LLMKube @ foreman/issue-510 ===",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			job, err := renderGateJob(rendererInput{
+				Name:                    "foreman-gate-x",
+				Namespace:               "foreman-system",
+				Image:                   "golang:1.26",
+				Repo:                    "defilantech/LLMKube",
+				Branch:                  "foreman/issue-510",
+				Checks:                  []string{"fmt"},
+				PVCName:                 "foreman-gate-cache",
+				ActiveDeadlineSeconds:   1800,
+				TTLSecondsAfterFinished: 86400,
+				CPURequest:              "2",
+				CPULimit:                "4",
+				MemRequest:              "4Gi",
+				MemLimit:                "8Gi",
+				CloneURLBase:            "https://github.com",
+				CloneURL:                tc.cloneURL,
+				TaskNamespace:           "default",
+				TaskName:                "gate-510",
+			})
+			if err != nil {
+				t.Fatalf("renderGateJob: %v", err)
+			}
+			args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
+			for _, sub := range tc.mustHave {
+				if !strings.Contains(args, sub) {
+					t.Errorf("missing %q in rendered args:\n%s", sub, args)
+				}
+			}
+			for _, sub := range tc.mustNotHave {
+				if strings.Contains(args, sub) {
+					t.Errorf("unwanted %q present in rendered args:\n%s", sub, args)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fix the v0.1 two-step pipeline's gate step so the Job clones the branch
the upstream coder actually produced. Two narrow changes:

1. `branchNameForTask` honors `task.spec.payload.branch` when set; falls
   back to the existing issue-fix / task-name derivation otherwise.
2. `buildDeterministicArgs` threads the foreman-agent's
   `--git-remote-url` into the deterministic tool args as `cloneURL`.
   The `run_gate_job` template uses it for the git clone target when
   non-empty; otherwise it preserves the historical `CloneURLBase + Repo`
   behavior.

## Why

Fixes #528

V3 demo against LLMKube #510 last night succeeded at the coder step
(`foreman/issue-510` on `Defilan/LLMKube` @ `cea26a81`) but the gate
Job tried to clone:

```
defilantech/LLMKube @ foreman/gate-510   →   GATE FAIL: clone
```

Two distinct mistakes in one path:

- **branch**: derived from the task name (`gate-510`) instead of the
  task's `payload.branch` (`foreman/issue-510`). The
  `AgenticTaskPayload.Branch` schema doc already says "Required for
  verify"; the executor just was not reading it.
- **repo**: the Job cloned upstream (`defilantech/LLMKube`) but the
  coder pushed the branch to the fork the foreman-agent was started
  with via `--git-remote-url` (`Defilan/LLMKube`). The branch only
  exists on the fork.

Both broke every M4+ gate run; this is the V3 acceptance blocker.

## How

### branchNameForTask precedence (executor_native.go)

```go
if task.Spec.Payload.Branch != "" {
    return task.Spec.Payload.Branch
}
if task.Spec.Kind == AgenticTaskKindIssueFix && task.Spec.Payload.Issue > 0 {
    return fmt.Sprintf("%s/issue-%d", repo.BranchPrefix, task.Spec.Payload.Issue)
}
return fmt.Sprintf("%s/%s", repo.BranchPrefix, task.Name)
```

The coder path (M3) is unchanged when callers leave `payload.branch`
empty (the M3 demo + integration tests). The gate path (M4) now uses
the branch the demo manifest already documented as required.

### cloneURL passthrough (executor_native.go + run_gate_job.go + gate_job_template.yaml)

`NativeAgentLoopExecutor.GitRemoteURL` is the foreman-agent's
`--git-remote-url`. `buildDeterministicArgs` now includes it under the
`cloneURL` key; `runGateJobArgs` decodes it; `rendererInput` carries
it; the template renders:

```bash
git clone --depth 1 --branch "{{ .Branch }}" \
  "{{ if .CloneURL }}{{ .CloneURL }}{{ else }}{{ .CloneURLBase }}/{{ .Repo }}.git{{ end }}" /work
```

The human-readable log line still names `.Repo`, so operators see
"clone defilantech/LLMKube @ foreman/issue-510" in the Pod log
regardless of where the branch physically lives. The override is
opt-in: a foreman-agent installed without `--git-remote-url` (the M4
default) renders the upstream form exactly as today.

### Tests

- `pkg/foreman/agent/executor_native_internal_test.go` (new whitebox
  file in `package agent`):
  - `TestBranchNameForTask`: four-way precedence table
    (`payload.branch` wins, issue-fix derivation, task-name fallback,
    verify with explicit branch).
  - `TestBuildDeterministicArgs`: pins the JSON shape, including
    `cloneURL` on / off.
- `pkg/foreman/agent/executor_native_test.go`:
  `TestNativeExecutor_DeterministicGateAgent` extended to assert the
  dispatched args carry `payload.branch` and the executor's
  `GitRemoteURL`. `fakeRegistry` now records the last-dispatch args.
- `pkg/foreman/agent/tools/run_gate_job_test.go`:
  `TestRenderGateJob_CloneURLOverride` table-test asserts override
  rendering when set + fallback preservation when empty.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (incl. `GOOS=linux ./bin/golangci-lint run ./...`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (template + struct doc comments)
