### PR TITLE
fix(foreman): chart wires --workspace-dir + tightens docs for native-mode required values

### DIFF
--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -54,6 +54,7 @@ spec:
             {{- if .Values.agent.inferenceBaseURLOverride }}
             - --inference-base-url-override={{ .Values.agent.inferenceBaseURLOverride }}
             {{- end }}
+            - --workspace-dir={{ .Values.agent.workspaceDir }}
             {{- if .Values.agent.gitRemoteURL }}
             - --git-remote-url={{ .Values.agent.gitRemoteURL }}
             {{- end }}

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -123,17 +123,39 @@ agent:
   # agent runs outside the cluster against a port-forwarded service.
   inferenceBaseURLOverride: ""
 
-  # Git remote the coder-role native executor clones from and pushes
-  # branches to. Required for coder-role nodes (e.g. M5 Max running
-  # the Carnice Agent); leave empty on deterministic-only nodes (e.g.
-  # the verifier-tagged node running the M4 gate Agent) -- coder tasks scheduled
-  # to such a node fail with GitRemoteURLNotConfigured, deterministic
-  # Agents run fine.
+  # Where the native + deterministic executors clone working copies
+  # of a repo for the duration of a task. The /workspace path is
+  # mounted as an emptyDir below; override here if you want a PVC-
+  # backed workspace (e.g. to keep go-build caches warm across runs)
+  # or a different in-Pod path. The default /workspace is the right
+  # answer on the published distroless image because the binary's
+  # home dir (/home/nonroot) is on the read-only rootfs and breaks
+  # the deterministic gate Agent's workspace prep step.
+  workspaceDir: /workspace
+
+  # Git remote the executor (both native LLM-driven coder and the
+  # deterministic gate, which clones the upstream coder's branch from
+  # the fork) reads from and pushes branches to. Required for ALL
+  # native-mode nodes including verifier-only nodes:
+  #
+  #   - coder-role nodes (M5 Max running the Carnice Agent) need it to
+  #     push the resulting branch.
+  #   - verifier-role nodes (ShadowStack running the M4 gate Agent)
+  #     need it because run_gate_job clones the branch the coder pushed
+  #     to the fork, not the upstream repo where the branch does not
+  #     yet exist.
+  #
+  # Leaving this empty puts the agent into "deterministic-only-without-
+  # network-git" mode: the M4 V3 two-step pipeline fails at the gate's
+  # clone step with "foreman-agent was not started with --git-remote-url;
+  # cannot clone". Stub-mode agents do not need it.
   gitRemoteURL: ""
 
   # Git author + committer identity stamped onto commits the coder-
-  # role executor produces. Same gate-only-node guidance applies: a
-  # deterministic-only node can leave these empty.
+  # role executor produces. Required when agent.mode=native AND the
+  # agent's roles include "worker" (i.e. it can host the coder Agent).
+  # Verifier-only nodes can leave these empty -- the gate path does not
+  # commit anything.
   commitAuthorName: ""    # defaults to "Foreman Bot" inside the binary
   commitAuthorEmail: ""
 


### PR DESCRIPTION
## What

Wire `--workspace-dir` into the chart-rendered Deployment + tighten the
values.yaml docs so a fresh `helm install foreman defilantech/foreman`
actually works for the documented use cases (coder-only, verifier-only,
combined).

## Why

Fixes #527

A fresh chart install with `agent.mode=native` shipped without three
flags the agent's executor paths need:

- `--workspace-dir` was never rendered. The default points at
  `~/foreman-workspaces` which on the published distroless image is
  `/home/nonroot` (read-only). The first task — coder or gate — fails
  with `mkdir workspace parent: /home/nonroot/foreman-workspaces:
  read-only file system` before any real work begins.
- `--git-remote-url` and `--commit-author-email` were documented as
  coder-only, but the M4 V3 pipeline made them required for
  **verifier-only nodes too**: `run_gate_job` clones the branch the
  upstream coder pushed to the fork (per the #528 fix), so the gate
  Job needs the fork URL.

The ShadowStack foreman-agent Deployment was hot-patched on 2026-05-24
with all three flags to unblock the M4 V3 demo (which then produced
the clean GATE-PASS in [PR #533](https://github.com/defilantech/LLMKube/pull/533)'s
demo). This PR makes that hot-patch permanent in the chart.

## How

`charts/foreman/values.yaml`:

- New unconditional `agent.workspaceDir: /workspace` value. /workspace
  is the existing emptyDir mount in agent-deployment.yaml, so the
  default just works on the distroless rootfs. Operators wanting a
  PVC-backed workspace can override.
- Tightened comments on `gitRemoteURL`, `commitAuthorName`, and
  `commitAuthorEmail` to spell out exactly which roles need them and
  what error message a missing value produces. No more "leave empty
  on deterministic-only nodes" -- the gate Agent now uses the
  remote URL too.

`charts/foreman/templates/agent-deployment.yaml`:

- Render `--workspace-dir={{ .Values.agent.workspaceDir }}`
  unconditionally between the existing `--inference-base-url-override`
  and `--git-remote-url` flag blocks. The other two stay conditional
  because verifier-only stub-mode installs may legitimately omit them.

## Verification

```
$ helm lint charts/foreman/
1 chart(s) linted, 0 chart(s) failed

# Combined coder+verifier
$ helm template foreman charts/foreman/ \
    --set agent.mode=native \
    --set agent.gitRemoteURL=https://example.com/fork.git \
    --set agent.commitAuthorEmail=bot@example.com \
    --set 'agent.roles={worker,verifier}' | grep -A 6 args:
          args:
            - --agent-mode=native
            - --roles=worker,verifier
            - --workspace-dir=/workspace
            - --git-remote-url=https://example.com/fork.git
            - --commit-author-email=bot@example.com

# Verifier-only minimal
$ helm template foreman charts/foreman/ \
    --set agent.mode=native --set 'agent.roles={verifier}' \
    | grep -E 'workspace-dir|git-remote-url|commit-author'
            - --workspace-dir=/workspace
```

## Checklist

- [x] `helm lint` passes
- [x] `helm template` renders cleanly across all documented role combos
- [x] No CRD changes; pure chart values + template edit
- [x] Conventional commit + DCO sign-off
- [x] Documentation updated (values.yaml comments)
