### PR TITLE
feat(foreman): post-M4 stability follow-ups for v5-batch readiness

### DIFF
--- a/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
+++ b/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
@@ -37,7 +37,12 @@ spec:
   temperature: "0.2"
   maxTurns: 80
   maxRetries: 3
-  requestTimeoutSeconds: 600
+  # 30 min per HTTP request to llama-server. With the tool-output caps
+  # in pkg/foreman/agent/tools (read_file at 16 KiB default + ranged reads,
+  # bash at 16 KiB per stream) this is well above the natural per-turn
+  # ceiling but gives headroom for issues that legitimately need long
+  # bash invocations (e.g. `make test` on a cold gate-cache).
+  requestTimeoutSeconds: 1800
   bashTimeoutSeconds: 60
   tools:
     - read_file
@@ -71,7 +76,12 @@ spec:
 
     ## Tools available
 
-    - `read_file(path)` -- read a workspace file.
+    - `read_file(path, offset?, limit?)` -- read a workspace file. Output is
+      capped at 16 KiB; the result includes `total_lines` so you can tell
+      when there is more. For long files (CHANGELOG.md, generated CRDs,
+      large source files) pass `offset` (1-based line number) and `limit`
+      (number of lines) to read a window. Reading a large file in one
+      shot pollutes every later turn's prompt-eval; prefer ranged reads.
     - `write_file(path, content)` -- overwrite or create a workspace file.
     - `str_replace(path, old_string, new_string, expected_replacements?)`
       -- exact-text replacement; old_string must occur the expected number

--- a/config/foreman/system-prompts/coder.md
+++ b/config/foreman/system-prompts/coder.md
@@ -36,7 +36,12 @@ when you call the terminal `submit_result` tool.
 
 ## Tools available
 
-- `read_file(path)` — read a workspace file.
+- `read_file(path, offset?, limit?)` — read a workspace file. Output is
+  capped at 16 KiB; the result includes `total_lines` so you can tell
+  when there is more. For long files (CHANGELOG.md, generated CRDs,
+  large source files) pass `offset` (1-based line number) and `limit`
+  (number of lines) to read a window. Reading a large file in one shot
+  pollutes every later turn's prompt-eval; prefer ranged reads.
 - `write_file(path, content)` — overwrite or create a workspace file.
 - `str_replace(path, old_string, new_string, expected_replacements?)`
   — exact-text replacement; old_string must occur the expected number

--- a/examples/foreman/workload-memorial-day-v5.yaml
+++ b/examples/foreman/workload-memorial-day-v5.yaml
@@ -1,0 +1,45 @@
+# Foreman v0.1 — Memorial Day v5 batch.
+#
+# Six curated open LLMKube issues, fanned out into six code+verify pairs
+# by the M6 stub planner. Coder runs on the M5 Max (Apple Silicon),
+# gate Job runs on ShadowStack. Substrate underneath the coder Agent
+# is the regular (non-Carnice) Qwen 3.6 35B-A3B Q8_0 GGUF served by
+# llama-server from TheTom's TurboQuant fork, with turbo4 V-cache and
+# hybrid-thinking disabled server-side via --reasoning off +
+# --chat-template-kwargs '{"enable_thinking":false}'.
+#
+# Issues:
+#   531  .dockerignore re-include for the embedded gate-job YAML  (foreman dogfood)
+#   510  AGENTS.md / CONTRIBUTING.md: mention make lint-all       (doc)
+#   526  metal-agent --host-ip auto-detect picks unreachable vlan (bug)
+#   506  metal-agent does not reconcile pre-existing zero-replica (bug)
+#   449  release: also build/push llmkube-router-proxy image      (ci)
+#   379  Helm vs kustomize RBAC sync check                        (test/CI)
+#
+# Apply with:
+#   kubectl --context shadowstack apply -f examples/foreman/workload-memorial-day-v5.yaml
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Workload
+metadata:
+  name: memorial-day-v5
+  namespace: default
+  labels:
+    app.kubernetes.io/part-of: foreman
+    foreman.llmkube.dev/milestone: m6
+    foreman.llmkube.dev/run: memorial-day-v5
+spec:
+  intent: "Fix six curated open LLMKube issues across docs, bugs, and CI"
+  repo: defilantech/LLMKube
+  # 6 pairs = 12 tasks; matches the curated set exactly.
+  maxTasks: 12
+  issues:
+    - 531
+    - 510
+    - 526
+    - 506
+    - 449
+    - 379
+  coderAgentRef:
+    name: qwen36-35b-carnice-mtp-coder
+  verifierAgentRef:
+    name: gate

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -95,7 +95,9 @@ func initBareWithSeed(t *testing.T, root string) string {
 
 // scriptedOAI returns canned chat-completions bodies in order. After
 // the script runs out, every subsequent request returns the final body
-// (lets the loop hit MaxTurns on stuck-tools tests).
+// (lets the loop hit MaxTurns on stuck-tools tests). Fixtures stay in
+// the readable ChatResponse JSON form; the helper converts them to the
+// SSE wire format the streaming client expects.
 func scriptedOAI(t *testing.T, bodies []string) *httptest.Server {
 	t.Helper()
 	var i atomic.Int64
@@ -104,11 +106,56 @@ func scriptedOAI(t *testing.T, bodies []string) *httptest.Server {
 		if k >= len(bodies) {
 			k = len(bodies) - 1
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(bodies[k]))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(chatJSONBodyToSSE(t, bodies[k])))
 	}))
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+// chatJSONBodyToSSE wraps a readable ChatResponse JSON fixture into the
+// SSE event stream the streaming client reads. Local to this test file
+// to keep tests isolated from the oai package's internals.
+func chatJSONBodyToSSE(t *testing.T, body string) string {
+	t.Helper()
+	var parsed oai.ChatResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("chatJSONBodyToSSE: fixture is not a ChatResponse JSON: %v\nbody=%q", err, body)
+	}
+	var sb strings.Builder
+	for _, ch := range parsed.Choices {
+		chunk := oai.ChatChunk{
+			ID:     parsed.ID,
+			Object: "chat.completion.chunk",
+			Choices: []oai.ChoiceDelta{
+				{
+					Index: ch.Index,
+					Delta: oai.MessageDelta{
+						Role:    ch.Message.Role,
+						Content: ch.Message.Content,
+					},
+					FinishReason: ch.FinishReason,
+				},
+			},
+		}
+		for j, tc := range ch.Message.ToolCalls {
+			chunk.Choices[0].Delta.ToolCalls = append(
+				chunk.Choices[0].Delta.ToolCalls,
+				oai.ToolCallDelta{
+					Index:    j,
+					ID:       tc.ID,
+					Type:     tc.Type,
+					Function: oai.ToolCallFunctionDelta{Name: tc.Function.Name, Arguments: tc.Function.Arguments},
+				},
+			)
+		}
+		out, _ := json.Marshal(chunk)
+		sb.WriteString("data: ")
+		sb.Write(out)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("data: [DONE]\n\n")
+	return sb.String()
 }
 
 // fakeRegistry implements foremanagent.ToolRegistry for the executor

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -32,7 +33,9 @@ import (
 
 // scriptedOAIServer returns canned chat-completions responses in
 // sequence. Helpful for driving the loop through multi-turn flows
-// without standing up a real model.
+// without standing up a real model. The canned bodies are kept in the
+// readable ChatResponse JSON form; this helper converts each to the
+// SSE wire format the streaming client expects.
 func scriptedOAIServer(t *testing.T, bodies []string) (*httptest.Server, *atomic.Int64) {
 	t.Helper()
 	var calls atomic.Int64
@@ -43,11 +46,60 @@ func scriptedOAIServer(t *testing.T, bodies []string) (*httptest.Server, *atomic
 			http.Error(w, "script exhausted", http.StatusInternalServerError)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(bodies[i]))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(chatJSONToSSE(t, bodies[i])))
 	}))
 	t.Cleanup(srv.Close)
 	return srv, &calls
+}
+
+// chatJSONToSSE wraps a readable ChatResponse JSON fixture into the
+// SSE event stream the new streaming client reads. One chunk per
+// choice, then `data: [DONE]`. Tool calls collapse into a single
+// fragment per call.
+func chatJSONToSSE(t *testing.T, body string) string {
+	t.Helper()
+	var parsed oai.ChatResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("chatJSONToSSE: fixture is not a ChatResponse JSON: %v\nbody=%q", err, body)
+	}
+	var sb strings.Builder
+	for _, ch := range parsed.Choices {
+		chunk := oai.ChatChunk{
+			ID:     parsed.ID,
+			Object: "chat.completion.chunk",
+			Choices: []oai.ChoiceDelta{
+				{
+					Index: ch.Index,
+					Delta: oai.MessageDelta{
+						Role:    ch.Message.Role,
+						Content: ch.Message.Content,
+					},
+					FinishReason: ch.FinishReason,
+				},
+			},
+		}
+		for j, tc := range ch.Message.ToolCalls {
+			chunk.Choices[0].Delta.ToolCalls = append(
+				chunk.Choices[0].Delta.ToolCalls,
+				oai.ToolCallDelta{
+					Index:    j,
+					ID:       tc.ID,
+					Type:     tc.Type,
+					Function: oai.ToolCallFunctionDelta{Name: tc.Function.Name, Arguments: tc.Function.Arguments},
+				},
+			)
+		}
+		out, err := json.Marshal(chunk)
+		if err != nil {
+			t.Fatalf("chatJSONToSSE: marshal chunk: %v", err)
+		}
+		sb.WriteString("data: ")
+		sb.Write(out)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("data: [DONE]\n\n")
+	return sb.String()
 }
 
 // fakeRegistry records every Dispatch call and returns canned ToolResult
@@ -249,8 +301,8 @@ func TestLoop_TranscriptPreservedOnError(t *testing.T) {
 	var n atomic.Int64
 	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
 		if n.Add(1) == 1 {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(toolCallReadFile))
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte(chatJSONToSSE(t, toolCallReadFile)))
 			return
 		}
 		http.Error(w, "kaboom", http.StatusInternalServerError)

--- a/pkg/foreman/agent/oai/client.go
+++ b/pkg/foreman/agent/oai/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oai
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -25,6 +26,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -45,6 +47,10 @@ var ErrNoChoices = errors.New("oai: response contained no choices")
 // It is deliberately not the official OpenAI SDK: Foreman needs exactly
 // one HTTP shape, we want llama.cpp-specific retry semantics, and the
 // SDK pulls a large transitive cone we would rather not adopt for v0.1.
+//
+// Wire protocol is SSE (text/event-stream) only -- see ChatRequest's
+// docstring for why. Aggregation happens transparently inside Chat;
+// callers see the same ChatResponse shape regardless.
 type Client struct {
 	baseURL    string
 	httpClient *http.Client
@@ -58,6 +64,8 @@ type Client struct {
 type Option func(*Client)
 
 // WithHTTPClient overrides the default http.Client (mainly for tests).
+// Tests that drive a chunked SSE response from an httptest.Server pass
+// their own client here so the SSE parsing path is exercised end to end.
 func WithHTTPClient(c *http.Client) Option {
 	return func(cl *Client) { cl.httpClient = c }
 }
@@ -71,13 +79,25 @@ func WithBackoffs(b []time.Duration) Option {
 }
 
 // New builds a client. baseURL must include the /v1 suffix
-// ("http://localhost:8080/v1"). requestTimeout bounds a single HTTP
-// request. maxRetries bounds how many additional attempts we make on
-// ErrTruncatedToolCallArguments; pass 0 to disable retries entirely.
+// ("http://localhost:8080/v1"). requestTimeout bounds how long we wait
+// for the upstream to start sending response headers; it does not
+// bound the total streaming duration (long completions on slow models
+// would otherwise spuriously time out). The caller's context.Context
+// is the overall guard. maxRetries bounds how many additional attempts
+// we make on ErrTruncatedToolCallArguments; pass 0 to disable retries
+// entirely.
 func New(baseURL string, requestTimeout time.Duration, maxRetries int, opts ...Option) *Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = requestTimeout
 	c := &Client{
-		baseURL:    baseURL,
-		httpClient: &http.Client{Timeout: requestTimeout},
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Transport: transport,
+			// No Client.Timeout: the streaming body can legitimately
+			// take longer than the header wait (a thinking model
+			// emitting a 50K-token reasoning trace at 30 tok/s = 30
+			// min). ctx.Done is the overall guard.
+		},
 		maxRetries: maxRetries,
 		backoffs: []time.Duration{
 			50 * time.Millisecond,
@@ -91,11 +111,12 @@ func New(baseURL string, requestTimeout time.Duration, maxRetries int, opts ...O
 	return c
 }
 
-// Chat sends a single chat-completions request and returns the response.
-// On ErrTruncatedToolCallArguments the call is retried up to MaxRetries
-// times with bounded exponential backoff plus jitter. Any other error
-// (HTTP non-2xx, transport failure, JSON decode failure) is returned to
-// the caller immediately without retry.
+// Chat sends a single chat-completions request and returns the
+// aggregated streamed response. On ErrTruncatedToolCallArguments the
+// call is retried up to MaxRetries times with bounded exponential
+// backoff plus jitter. Any other error (HTTP non-2xx, transport
+// failure, SSE parse failure) is returned to the caller immediately
+// without retry.
 func (c *Client) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
 	var lastErr error
 	for attempt := 0; attempt <= c.maxRetries; attempt++ {
@@ -146,14 +167,19 @@ func (c *Client) sleepBackoff(ctx context.Context, i int) error {
 	}
 }
 
-// doOnce performs a single round trip with no retry. Returns the parsed
-// response on 2xx + clean arguments, or one of:
+// doOnce performs a single streaming round trip with no retry. The wire
+// protocol is SSE (text/event-stream): the server emits a sequence of
+// `data: {json}` lines that this method aggregates into a single
+// ChatResponse. Returns the aggregated response on 2xx + clean
+// arguments, or one of:
 //
 //   - ErrTruncatedToolCallArguments :: 2xx but tool_call.arguments not JSON
-//   - ErrNoChoices                  :: 2xx but len(Choices) == 0
+//   - ErrNoChoices                  :: 2xx but no choices arrived in the stream
 //   - a wrapped status error        :: non-2xx, body included in the message
 //   - a wrapped transport error     :: dial / TLS / read failure
 func (c *Client) doOnce(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	// Force streaming on the wire regardless of caller setting.
+	req.Stream = true
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
@@ -164,16 +190,28 @@ func (c *Client) doOnce(ctx context.Context, req ChatRequest) (*ChatResponse, er
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("dispatch request: %w", err)
 	}
 	defer func() {
-		// Drain and close so the TCP connection can be reused, capped
-		// at 64 KB to keep a chatty server from stalling shutdown.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+		// Drain so the TCP connection can be reused, but bound the
+		// drain so a server that holds the connection open after
+		// finish_reason without sending [DONE] (observed live with
+		// llama.cpp + Carnice on tool-call responses) cannot stall
+		// the caller. Cap at 64 KiB and 100ms; on hit, we close
+		// without reuse and the next call opens a fresh conn.
+		drained := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+			close(drained)
+		}()
+		select {
+		case <-drained:
+		case <-time.After(100 * time.Millisecond):
+		}
 		_ = resp.Body.Close()
 	}()
 
@@ -182,17 +220,179 @@ func (c *Client) doOnce(ctx context.Context, req ChatRequest) (*ChatResponse, er
 		return nil, fmt.Errorf("oai: status %d: %s", resp.StatusCode, string(b))
 	}
 
-	var parsed ChatResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
+	parsed, err := readSSEStream(resp.Body)
+	if err != nil {
+		return nil, err
 	}
 	if len(parsed.Choices) == 0 {
 		return nil, ErrNoChoices
 	}
-	if err := validateToolCallArguments(&parsed); err != nil {
+	if err := validateToolCallArguments(parsed); err != nil {
 		return nil, err
 	}
-	return &parsed, nil
+	return parsed, nil
+}
+
+// readSSEStream reads the SSE event stream and aggregates the streamed
+// chunks into a single ChatResponse. The OpenAI streaming format is:
+//
+//	data: {"id":"...","choices":[{"index":0,"delta":{...}, ...}]}
+//	data: {"id":"...","choices":[{"index":0,"delta":{...}, ...}]}
+//	...
+//	data: [DONE]
+//
+// Each delta carries an incremental piece of the assistant message:
+// initial chunk has the role, subsequent chunks accumulate content and
+// tool-call argument fragments. The aggregator keys tool calls by their
+// Index across deltas and concatenates Function.Arguments into the
+// final string.
+func readSSEStream(body io.Reader) (*ChatResponse, error) {
+	scanner := bufio.NewScanner(body)
+	// SSE lines can be arbitrarily long (a single chunk may carry a
+	// large content burst). Set a generous max-token size so the
+	// scanner does not fail mid-stream on a 1 MiB JSON line.
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	agg := &chatAggregator{
+		choices: map[int]*Choice{},
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		// SSE protocol: blank lines separate events; non-data: lines
+		// (e.g. `: keep-alive` comments, `event:` field) are ignored
+		// here -- we only care about the data: payload.
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" {
+			continue
+		}
+		if payload == "[DONE]" {
+			break
+		}
+		var chunk ChatChunk
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			return nil, fmt.Errorf("decode SSE chunk: %w (line=%q)", err, payload)
+		}
+		agg.absorb(chunk)
+
+		// Some llama.cpp builds + response shapes (notably thinking-trace
+		// models emitting tool calls) finish the model output but never
+		// emit `data: [DONE]\n\n` -- they just stop sending and keep the
+		// HTTP/1.1 keep-alive connection open. Reading would block forever
+		// waiting on bytes the server will not send.
+		//
+		// Use finish_reason as the authoritative termination signal: when
+		// every choice we have observed has a non-empty finish_reason, the
+		// model has declared it done. Break here; [DONE] is now optional.
+		if agg.allChoicesFinished() {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read SSE stream: %w", err)
+	}
+
+	return agg.build(), nil
+}
+
+// chatAggregator collapses a sequence of SSE chunks into a single
+// ChatResponse with one Message per choice index. It tracks per-choice
+// accumulators so multiple parallel choices (some servers stream more
+// than one) are kept independent.
+type chatAggregator struct {
+	id      string
+	choices map[int]*Choice // keyed by Choice.Index for stable ordering on build()
+}
+
+// absorb folds one streamed ChatChunk into the aggregator state.
+func (a *chatAggregator) absorb(chunk ChatChunk) {
+	if a.id == "" && chunk.ID != "" {
+		a.id = chunk.ID
+	}
+	for _, cd := range chunk.Choices {
+		ch, ok := a.choices[cd.Index]
+		if !ok {
+			ch = &Choice{Index: cd.Index}
+			a.choices[cd.Index] = ch
+		}
+		// Role arrives on the first delta; later deltas may repeat it
+		// or omit it. First non-empty wins.
+		if ch.Message.Role == "" && cd.Delta.Role != "" {
+			ch.Message.Role = cd.Delta.Role
+		}
+		ch.Message.Content += cd.Delta.Content
+
+		// Tool call fragments arrive keyed by their own per-message
+		// Index (distinct from the choice index). Aggregate into the
+		// Choice's Message.ToolCalls slice, allocating new entries on
+		// demand and concatenating Function.Arguments piece by piece.
+		for _, tcd := range cd.Delta.ToolCalls {
+			for len(ch.Message.ToolCalls) <= tcd.Index {
+				ch.Message.ToolCalls = append(ch.Message.ToolCalls, ToolCall{})
+			}
+			tc := &ch.Message.ToolCalls[tcd.Index]
+			if tcd.ID != "" {
+				tc.ID = tcd.ID
+			}
+			if tcd.Type != "" {
+				tc.Type = tcd.Type
+			}
+			if tcd.Function.Name != "" {
+				tc.Function.Name = tcd.Function.Name
+			}
+			tc.Function.Arguments += tcd.Function.Arguments
+		}
+
+		if cd.FinishReason != "" {
+			ch.FinishReason = cd.FinishReason
+		}
+	}
+}
+
+// allChoicesFinished returns true when the aggregator has seen at least
+// one choice and every observed choice has a non-empty FinishReason.
+// Callers use this to detect end-of-stream when the server omits the
+// SSE [DONE] terminator -- which llama.cpp does for some response
+// shapes (tool calls emitted by thinking-trace models).
+func (a *chatAggregator) allChoicesFinished() bool {
+	if len(a.choices) == 0 {
+		return false
+	}
+	for _, ch := range a.choices {
+		if ch.FinishReason == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// build returns the aggregated ChatResponse with choices ordered by
+// their Index so iteration is deterministic regardless of map order.
+func (a *chatAggregator) build() *ChatResponse {
+	if len(a.choices) == 0 {
+		return &ChatResponse{ID: a.id}
+	}
+	// Order by index. Most responses have one choice; a small slice
+	// makes the ordered range obvious without a sort.Slice.
+	maxIdx := -1
+	for k := range a.choices {
+		if k > maxIdx {
+			maxIdx = k
+		}
+	}
+	out := &ChatResponse{
+		ID:      a.id,
+		Choices: make([]Choice, 0, maxIdx+1),
+	}
+	for i := 0; i <= maxIdx; i++ {
+		if ch, ok := a.choices[i]; ok {
+			out.Choices = append(out.Choices, *ch)
+		}
+	}
+	return out
 }
 
 // validateToolCallArguments returns ErrTruncatedToolCallArguments if any

--- a/pkg/foreman/agent/oai/client_test.go
+++ b/pkg/foreman/agent/oai/client_test.go
@@ -32,6 +32,12 @@ import (
 // scriptedHandler returns canned responses in order. After the script
 // is exhausted, subsequent calls return the final entry (so a test that
 // expects a retry to succeed on the second try just needs two entries).
+//
+// On 2xx responses the body fixture (a complete ChatResponse JSON, kept
+// in that shape for readability) is converted on the wire into SSE
+// events so the client's streaming parser is exercised end to end. The
+// fixtures stay in the readable / authoritative form; serialization to
+// SSE is a single helper call right before WriteHeader.
 func scriptedHandler(t *testing.T, attempts *atomic.Int64, statuses []int, bodies []string) http.Handler {
 	t.Helper()
 	if len(statuses) != len(bodies) {
@@ -53,10 +59,74 @@ func scriptedHandler(t *testing.T, attempts *atomic.Int64, statuses []int, bodie
 		if err := json.Unmarshal(raw, &probe); err != nil {
 			t.Errorf("request body is not a ChatRequest: %v", err)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(statuses[i])
-		_, _ = w.Write([]byte(bodies[i]))
+		if !probe.Stream {
+			t.Errorf("client must set Stream=true on the wire")
+		}
+		status := statuses[i]
+		body := bodies[i]
+		if status >= 200 && status < 300 {
+			body = chatResponseToSSE(t, body)
+			w.Header().Set("Content-Type", "text/event-stream")
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
 	})
+}
+
+// chatResponseToSSE serializes a complete ChatResponse JSON fixture as
+// the SSE event stream a real OpenAI-compatible server would emit:
+// one `data:` line per choice's delta, then a terminal `data: [DONE]`.
+// One chunk per choice is enough for the parser tests; the multi-chunk
+// aggregation path is covered by TestReadSSEStream_Aggregation.
+func chatResponseToSSE(t *testing.T, body string) string {
+	t.Helper()
+	var parsed ChatResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("chatResponseToSSE: fixture is not a ChatResponse JSON: %v", err)
+	}
+	var sb strings.Builder
+	for _, ch := range parsed.Choices {
+		chunk := ChatChunk{
+			ID:     parsed.ID,
+			Object: "chat.completion.chunk",
+			Choices: []ChoiceDelta{
+				{
+					Index: ch.Index,
+					Delta: MessageDelta{
+						Role:    ch.Message.Role,
+						Content: ch.Message.Content,
+					},
+					FinishReason: ch.FinishReason,
+				},
+			},
+		}
+		// Tool calls collapse into one fragment per call: the model
+		// would have streamed Function.Arguments in pieces; here we
+		// emit the whole argument string in a single delta. The
+		// aggregator handles either shape identically.
+		for _, tc := range ch.Message.ToolCalls {
+			chunk.Choices[0].Delta.ToolCalls = append(
+				chunk.Choices[0].Delta.ToolCalls,
+				ToolCallDelta{
+					Index:    len(chunk.Choices[0].Delta.ToolCalls),
+					ID:       tc.ID,
+					Type:     tc.Type,
+					Function: ToolCallFunctionDelta{Name: tc.Function.Name, Arguments: tc.Function.Arguments},
+				},
+			)
+		}
+		out, err := json.Marshal(chunk)
+		if err != nil {
+			t.Fatalf("chatResponseToSSE: marshal chunk: %v", err)
+		}
+		sb.WriteString("data: ")
+		sb.Write(out)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("data: [DONE]\n\n")
+	return sb.String()
 }
 
 const okBodyOneToolCall = `{
@@ -256,5 +326,168 @@ func TestClient_Chat_ContextCancelDuringBackoff(t *testing.T) {
 	_, err := c.Chat(ctx, ChatRequest{Model: "test"})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestClient_Chat_TerminatesOnFinishReasonWithoutDONE pins the
+// finish_reason-as-end-of-stream behavior. Discovered live 2026-05-24:
+// llama.cpp builds emitting tool calls from a thinking-trace model
+// (Carnice APEX-MTP-I) send the model's finish_reason chunk but then
+// keep the HTTP/1.1 keep-alive connection open without sending the
+// terminal `data: [DONE]\n\n` marker. The client must treat
+// finish_reason set on every observed choice as authoritative
+// end-of-stream; otherwise the scanner blocks indefinitely on bytes
+// the server will not send.
+func TestClient_Chat_TerminatesOnFinishReasonWithoutDONE(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// One delta carrying a finished tool call. NO trailing
+		// `data: [DONE]` marker -- the server just stops sending.
+		// The handler returns here, the response body completes
+		// naturally, but the test specifically exercises the
+		// finish_reason-based early exit by also writing a long
+		// hang-up window: we sleep AFTER the chunk so the scanner
+		// would block if finish_reason were not consulted.
+		flusher, _ := w.(http.Flusher)
+		chunk := ChatChunk{
+			ID:     "no-done",
+			Object: "chat.completion.chunk",
+			Choices: []ChoiceDelta{
+				{
+					Index: 0,
+					Delta: MessageDelta{
+						Role: RoleAssistant,
+						ToolCalls: []ToolCallDelta{
+							{
+								Index:    0,
+								ID:       "tc-1",
+								Type:     "function",
+								Function: ToolCallFunctionDelta{Name: "noop", Arguments: "{}"},
+							},
+						},
+					},
+					FinishReason: "tool_calls",
+				},
+			},
+		}
+		out, _ := json.Marshal(chunk)
+		_, _ = w.Write([]byte("data: "))
+		_, _ = w.Write(out)
+		_, _ = w.Write([]byte("\n\n"))
+		flusher.Flush()
+		// Hold the connection open without sending more data. If the
+		// client did not honor finish_reason, the scanner would still
+		// be blocked reading when the server-side handler finally
+		// returns (which closes the body and lets the scanner see EOF).
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", time.Second, 0, WithBackoffs(noJitterBackoffs))
+	start := time.Now()
+	resp, err := c.Chat(context.Background(), ChatRequest{Model: "test"})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	// Must return well before the server's 200ms hold finishes. The
+	// caller-side drain budget is 100ms (see doOnce's defer), so we
+	// allow up to that plus a small scheduler slack. The point of
+	// the test is that we do NOT block for the full 200ms server hold.
+	if elapsed > 180*time.Millisecond {
+		t.Errorf("Chat blocked %v waiting for [DONE]; finish_reason should have terminated sooner", elapsed)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("choices: want 1 got %d", len(resp.Choices))
+	}
+	if resp.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish_reason: got %q", resp.Choices[0].FinishReason)
+	}
+	tcs := resp.Choices[0].Message.ToolCalls
+	if len(tcs) != 1 || tcs[0].Function.Name != "noop" {
+		t.Errorf("tool call shape: %+v", tcs)
+	}
+}
+
+// TestClient_Chat_AggregatesMultiChunkArguments covers the streaming
+// aggregation path the real server uses: tool-call arguments arrive in
+// fragments, often character-by-character or token-by-token. The
+// aggregator must concatenate them into the final argument string.
+func TestClient_Chat_AggregatesMultiChunkArguments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+
+		// First chunk: role + tool call id/name + empty args.
+		c1 := ChatChunk{
+			ID: "agg", Object: "chat.completion.chunk",
+			Choices: []ChoiceDelta{{
+				Index: 0,
+				Delta: MessageDelta{
+					Role: RoleAssistant,
+					ToolCalls: []ToolCallDelta{{
+						Index:    0,
+						ID:       "tc-x",
+						Type:     "function",
+						Function: ToolCallFunctionDelta{Name: "read_file", Arguments: `{"pa`},
+					}},
+				},
+			}},
+		}
+		// Subsequent chunks stream arg fragments. No id/type/name (already set).
+		c2 := ChatChunk{
+			ID: "agg", Object: "chat.completion.chunk",
+			Choices: []ChoiceDelta{{
+				Index: 0,
+				Delta: MessageDelta{
+					ToolCalls: []ToolCallDelta{{
+						Index:    0,
+						Function: ToolCallFunctionDelta{Arguments: `th":"R`},
+					}},
+				},
+			}},
+		}
+		c3 := ChatChunk{
+			ID: "agg", Object: "chat.completion.chunk",
+			Choices: []ChoiceDelta{{
+				Index: 0,
+				Delta: MessageDelta{
+					ToolCalls: []ToolCallDelta{{
+						Index:    0,
+						Function: ToolCallFunctionDelta{Arguments: `EADME.md"}`},
+					}},
+				},
+				FinishReason: "tool_calls",
+			}},
+		}
+		for _, c := range []ChatChunk{c1, c2, c3} {
+			out, _ := json.Marshal(c)
+			_, _ = w.Write([]byte("data: "))
+			_, _ = w.Write(out)
+			_, _ = w.Write([]byte("\n\n"))
+			flusher.Flush()
+		}
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", time.Second, 0, WithBackoffs(noJitterBackoffs))
+	resp, err := c.Chat(context.Background(), ChatRequest{Model: "test"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	tcs := resp.Choices[0].Message.ToolCalls
+	if len(tcs) != 1 {
+		t.Fatalf("tool_calls: want 1 got %d", len(tcs))
+	}
+	want := `{"path":"README.md"}`
+	if tcs[0].Function.Arguments != want {
+		t.Errorf("aggregated arguments: got %q want %q", tcs[0].Function.Arguments, want)
+	}
+	if tcs[0].ID != "tc-x" || tcs[0].Function.Name != "read_file" {
+		t.Errorf("metadata lost in aggregation: %+v", tcs[0])
 	}
 }

--- a/pkg/foreman/agent/oai/types.go
+++ b/pkg/foreman/agent/oai/types.go
@@ -92,18 +92,28 @@ type ToolSchemaDef struct {
 	Parameters  json.RawMessage `json:"parameters"`
 }
 
-// ChatRequest is the request body for POST /v1/chat/completions. v0.1
-// is non-streaming; the loop pulls a complete response per turn.
+// ChatRequest is the request body for POST /v1/chat/completions.
+//
+// The client always sets Stream=true on the wire: thinking-trace models
+// like Carnice generate enormous reasoning blocks before producing the
+// actual tool call, and llama.cpp buffers the entire completion before
+// sending response headers in non-streaming mode -- which makes
+// http.Client.Timeout fire on long completions even though the model
+// is doing real work. Streaming sends headers immediately and lets the
+// caller's context.Context govern the overall lifetime.
 type ChatRequest struct {
 	Model       string    `json:"model"`
 	Messages    []Message `json:"messages"`
 	Tools       []Tool    `json:"tools,omitempty"`
 	Temperature *float64  `json:"temperature,omitempty"`
-	Stream      bool      `json:"stream"`
+	// Stream is set by the client just before the wire send; callers
+	// do not need to populate it.
+	Stream bool `json:"stream"`
 }
 
-// ChatResponse is the relevant subset of the response body. We do not
-// stream so there is only one choice in v0.1; we do not track usage.
+// ChatResponse is the relevant subset of the response body. The Client
+// always reads streamed chunks off the wire and aggregates them into
+// this shape so the rest of the loop sees a single complete response.
 type ChatResponse struct {
 	ID      string   `json:"id"`
 	Choices []Choice `json:"choices"`
@@ -114,4 +124,51 @@ type Choice struct {
 	Index        int     `json:"index"`
 	Message      Message `json:"message"`
 	FinishReason string  `json:"finish_reason"`
+}
+
+// ChatChunk is a single Server-Sent Events frame on the chat-completions
+// stream. The OpenAI SSE format wraps an unwrapped JSON object per
+// `data:` line; this struct is what the line decodes into.
+type ChatChunk struct {
+	ID      string        `json:"id"`
+	Object  string        `json:"object"`
+	Choices []ChoiceDelta `json:"choices"`
+}
+
+// ChoiceDelta is the streamed-piece counterpart to Choice. The Delta
+// field carries incremental content / tool-call fragments; FinishReason
+// is empty (omitted) until the model's final chunk for this choice.
+type ChoiceDelta struct {
+	Index        int          `json:"index"`
+	Delta        MessageDelta `json:"delta"`
+	FinishReason string       `json:"finish_reason"`
+}
+
+// MessageDelta is the streamed-piece counterpart to Message. Each field
+// arrives in pieces across chunks: Role on the first chunk, Content
+// accumulating as tokens are generated, and ToolCalls arriving with
+// their Function.Arguments streamed in fragments.
+type MessageDelta struct {
+	Role      Role            `json:"role,omitempty"`
+	Content   string          `json:"content,omitempty"`
+	ToolCalls []ToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+// ToolCallDelta is the streamed-piece counterpart to ToolCall. The
+// Index field identifies which tool call this fragment belongs to
+// (the model may emit multiple parallel tool calls; aggregation keys
+// by Index). ID + Type + Function.Name arrive on the first fragment;
+// Function.Arguments arrives in pieces across subsequent fragments.
+type ToolCallDelta struct {
+	Index    int                   `json:"index"`
+	ID       string                `json:"id,omitempty"`
+	Type     string                `json:"type,omitempty"`
+	Function ToolCallFunctionDelta `json:"function"`
+}
+
+// ToolCallFunctionDelta mirrors ToolCallFunction but with all fields
+// optional / streamable.
+type ToolCallFunctionDelta struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
 }

--- a/pkg/foreman/agent/tools/bash.go
+++ b/pkg/foreman/agent/tools/bash.go
@@ -33,9 +33,17 @@ import (
 
 // Defaults are conservative enough for a hostile model and generous
 // enough for typical "go build ./..." use during a coder run.
+//
+// The output cap is per-stream (stdout and stderr each capped
+// independently), so a worst-case turn surfaces ~32 KiB total. Each
+// tool result stays in the OAI message history for every subsequent
+// turn's prompt-eval, so per-stream caps in the tens of KiB compound
+// quickly across 15+ turns. 16 KiB per stream is enough to surface
+// the tail of a `go test ./...` run or a `make lint` failure, which
+// is what the model actually needs to debug.
 const (
 	defaultBashTimeout   = 30 * time.Second
-	defaultBashOutputCap = 64 * 1024 // 64 KiB combined per stream
+	defaultBashOutputCap = 16 * 1024 // 16 KiB per stream
 )
 
 // BashTool runs a shell command in the workspace under "sh -c" with a

--- a/pkg/foreman/agent/tools/read_file.go
+++ b/pkg/foreman/agent/tools/read_file.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tools
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -29,16 +31,39 @@ import (
 
 // defaultReadMaxBytes caps a single read_file call so a confused model
 // asking for a 50 MB binary blob does not blow the transcript budget.
-const defaultReadMaxBytes = 256 * 1024 // 256 KiB
+//
+// We deliberately keep this tight (16 KiB) because each tool result
+// stays in the OAI message history for every subsequent turn's
+// prompt-eval. A 60 KiB file read on turn 4 makes every later turn's
+// prompt-eval pay for those 60 KiB again -- on Carnice MoE on Metal,
+// that compounds into multi-minute prompt-eval times by turn 20+.
+//
+// 16 KiB is enough to read a typical Go file or top-level config end
+// to end (the LLMKube + Foreman codebase has very few sources past
+// 8 KiB). For genuinely long files the model uses the offset / limit
+// args to read a window.
+const defaultReadMaxBytes = 16 * 1024 // 16 KiB
 
 // ReadFileTool reads a workspace file and returns its contents (capped).
+//
+// Two reading modes via Execute args:
+//
+//  1. Default (no offset, no limit) :: read from the start of the file
+//     up to MaxBytes; if the file is larger, set truncated=true.
+//     The content field is the raw bytes verbatim.
+//  2. Line-ranged (offset >= 1 or limit > 0) :: skip to line `offset`,
+//     read at most `limit` lines (limit=0 means "to end of file"),
+//     still bounded by MaxBytes. Line bookkeeping fields (start_line /
+//     end_line / total_lines) reflect the actual window served.
 type ReadFileTool struct {
 	Workspace string
 	MaxBytes  int // 0 falls back to defaultReadMaxBytes
 }
 
 type readFileArgs struct {
-	Path string `json:"path"`
+	Path   string `json:"path"`
+	Offset int    `json:"offset,omitempty"` // 1-based line number to start at; default 1
+	Limit  int    `json:"limit,omitempty"`  // max lines to read; default 0 = no line limit
 }
 
 // Name returns the tool name as advertised to the model.
@@ -47,21 +72,32 @@ func (t *ReadFileTool) Name() string { return "read_file" }
 // Schema returns the OAI schema advertisement.
 func (t *ReadFileTool) Schema() oai.ToolSchemaDef {
 	return oai.ToolSchemaDef{
-		Name:        "read_file",
-		Description: "Read a file from the workspace and return its contents. Paths are relative to the repository root.",
+		Name: "read_file",
+		Description: "Read a file from the workspace and return its contents. " +
+			"Output is capped at 16 KiB by default; for longer files pass offset " +
+			"and limit to read a window of the file. The result includes " +
+			"total_lines so subsequent calls can fetch the rest. Paths are " +
+			"relative to the repository root.",
 		Parameters: json.RawMessage(`{
 "type": "object",
 "properties": {
-  "path": {"type": "string", "description": "Workspace-relative path to the file."}
+  "path":   {"type": "string", "description": "Workspace-relative path to the file."},
+  "offset": {"type": "integer", "minimum": 1,
+             "description": "1-based starting line for a ranged read. Defaults to 1."},
+  "limit":  {"type": "integer", "minimum": 0,
+             "description": "Lines to return for a ranged read. 0 (default) reads to EOF or until the byte cap."}
 },
 "required": ["path"]
 }`),
 	}
 }
 
-// Execute reads the file at args.path and returns the contents capped at
-// MaxBytes. Paths are containment-checked; absolute paths and any path
-// that resolves outside the workspace return an error.
+// Execute reads the file at args.path and returns the contents capped
+// at MaxBytes. With args.offset / args.limit unset (the default mode),
+// the tool returns raw bytes verbatim. With either set, the tool
+// returns a line-aligned window. Paths are containment-checked;
+// absolute paths and paths that resolve outside the workspace return an
+// error.
 func (t *ReadFileTool) Execute(_ context.Context, args json.RawMessage) (*agent.ToolResult, error) {
 	var a readFileArgs
 	if err := json.Unmarshal(args, &a); err != nil {
@@ -70,35 +106,216 @@ func (t *ReadFileTool) Execute(_ context.Context, args json.RawMessage) (*agent.
 	if a.Path == "" {
 		return nil, fmt.Errorf("read_file: path is required")
 	}
+	if a.Offset < 0 {
+		return nil, fmt.Errorf("read_file: offset must be >= 1 (or 0/unset for start of file)")
+	}
+	if a.Limit < 0 {
+		return nil, fmt.Errorf("read_file: limit must be >= 0 (0 means no line limit)")
+	}
+
 	full, err := resolveInside(t.Workspace, a.Path)
 	if err != nil {
 		return nil, fmt.Errorf("read_file: %w", err)
 	}
-	f, err := os.Open(full) //nolint:gosec // G304: path is resolveInside-validated
+
+	cap := t.MaxBytes
+	if cap <= 0 {
+		cap = defaultReadMaxBytes
+	}
+
+	if a.Offset == 0 && a.Limit == 0 {
+		return t.readWhole(a.Path, full, cap)
+	}
+	return t.readRange(a.Path, full, cap, a.Offset, a.Limit)
+}
+
+// readWhole is the default-mode path: raw bytes from the start of the
+// file up to cap. Preserves the byte-for-byte fidelity callers expect
+// when not requesting a ranged window. Includes total_lines so the
+// model knows to switch to a ranged read on the next call when there
+// is more content beyond the cap.
+func (t *ReadFileTool) readWhole(path, full string, cap int) (*agent.ToolResult, error) {
+	f, err := os.Open(full) //nolint:gosec // G304: full is resolveInside-validated by the caller
 	if err != nil {
-		return nil, fmt.Errorf("read_file: open %q: %w", a.Path, err)
+		return nil, fmt.Errorf("read_file: open %q: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
 
-	limit := t.MaxBytes
-	if limit <= 0 {
-		limit = defaultReadMaxBytes
-	}
 	// Read one extra byte to detect truncation cleanly.
-	buf, err := io.ReadAll(io.LimitReader(f, int64(limit)+1))
+	buf, err := io.ReadAll(io.LimitReader(f, int64(cap)+1))
 	if err != nil {
-		return nil, fmt.Errorf("read_file: read %q: %w", a.Path, err)
+		return nil, fmt.Errorf("read_file: read %q: %w", path, err)
 	}
-	truncated := len(buf) > limit
+	truncated := len(buf) > cap
 	if truncated {
-		buf = buf[:limit]
+		buf = buf[:cap]
 	}
+
+	// Count lines in the returned slice. If truncated, also count the
+	// remaining lines in the rest of the file so total_lines stays
+	// accurate without buffering the whole file.
+	emittedLines := countLines(buf)
+	totalLines := emittedLines
+	if truncated {
+		remaining, err := countRemainingLines(f)
+		if err != nil {
+			return nil, fmt.Errorf("read_file: count tail %q: %w", path, err)
+		}
+		totalLines += remaining
+		// If the truncation point fell mid-line, the next line is
+		// already half-counted in emittedLines; the tail count starts
+		// from the next newline so the sum is correct.
+	}
+
+	endLine := emittedLines
+	if endLine == 0 && len(buf) > 0 {
+		endLine = 1 // file with no newlines at all is still 1 line of content
+	}
+
 	return &agent.ToolResult{
 		Output: map[string]any{
-			"path":      a.Path,
-			"content":   string(buf),
-			"truncated": truncated,
-			"bytes":     len(buf),
+			"path":        path,
+			"content":     string(buf),
+			"bytes":       len(buf),
+			"truncated":   truncated,
+			"start_line":  1,
+			"end_line":    endLine,
+			"total_lines": totalLines,
 		},
 	}, nil
+}
+
+// readRange is the line-ranged path. Skips to line `offset`, reads up
+// to `limit` lines, all bounded by cap bytes. The model uses this to
+// walk large files in windows without re-embedding the whole file in
+// every later turn.
+func (t *ReadFileTool) readRange(path, full string, cap, offset, limit int) (*agent.ToolResult, error) {
+	f, err := os.Open(full) //nolint:gosec // G304: full is resolveInside-validated by the caller
+	if err != nil {
+		return nil, fmt.Errorf("read_file: open %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	startLine := offset
+	if startLine < 1 {
+		startLine = 1
+	}
+
+	scanner := bufio.NewScanner(f)
+	// Allow long single lines (generated CRDs, minified JS, etc.).
+	// 8 MiB ceiling is far above any reasonable source file and well
+	// under runaway-memory territory.
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+
+	var (
+		out         bytes.Buffer
+		lineNum     = 0
+		emittedEnd  = 0 // last 1-based line number included in output
+		truncated   bool
+		emittedDone bool // once true, we stop accumulating but keep counting lines for total_lines
+	)
+
+	for scanner.Scan() {
+		lineNum++
+
+		// Skip until offset.
+		if lineNum < startLine {
+			continue
+		}
+
+		// Past the limit or past the byte cap: keep scanning so
+		// total_lines stays accurate, but stop accumulating output.
+		if emittedDone {
+			continue
+		}
+
+		// Stop emitting after `limit` lines (when limit > 0).
+		if limit > 0 && (lineNum-startLine) >= limit {
+			emittedDone = true
+			continue
+		}
+
+		line := scanner.Bytes()
+		needed := len(line) + 1 // include the newline we add back
+		if out.Len()+needed > cap {
+			// One more byte would push past the cap. Write what fits,
+			// mark truncated, switch to count-only mode for the rest
+			// of the file. The model can re-call with a later offset
+			// or a smaller limit.
+			remaining := cap - out.Len()
+			if remaining > 0 {
+				if remaining > len(line) {
+					out.Write(line)
+					out.WriteByte('\n')
+				} else {
+					out.Write(line[:remaining])
+				}
+			}
+			truncated = true
+			emittedDone = true
+			emittedEnd = lineNum
+			continue
+		}
+		out.Write(line)
+		out.WriteByte('\n')
+		emittedEnd = lineNum
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read_file: scan %q: %w", path, err)
+	}
+
+	if startLine > lineNum && lineNum > 0 {
+		// offset past EOF -- return empty content with truthful counts.
+		emittedEnd = startLine - 1
+	}
+
+	return &agent.ToolResult{
+		Output: map[string]any{
+			"path":        path,
+			"content":     out.String(),
+			"bytes":       out.Len(),
+			"truncated":   truncated,
+			"start_line":  startLine,
+			"end_line":    emittedEnd,
+			"total_lines": lineNum,
+		},
+	}, nil
+}
+
+// countLines returns the number of \n-terminated lines in b. A trailing
+// non-empty fragment without a final \n counts as one additional line
+// (matches the intuitive "lines in this content" expectation).
+func countLines(b []byte) int {
+	n := bytes.Count(b, []byte{'\n'})
+	if len(b) > 0 && b[len(b)-1] != '\n' {
+		n++
+	}
+	return n
+}
+
+// countRemainingLines reads f to EOF and returns the number of newlines
+// encountered. Used after a truncated read to finish counting
+// total_lines without buffering the file's tail in memory.
+func countRemainingLines(f *os.File) (int, error) {
+	buf := make([]byte, 64*1024)
+	count := 0
+	lastByte := byte(0)
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			count += bytes.Count(buf[:n], []byte{'\n'})
+			lastByte = buf[n-1] //nolint:gosec // G602: n > 0 + Read contract n <= len(buf)
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, err
+		}
+	}
+	// A final non-newline-terminated fragment of tail is its own line.
+	if lastByte != 0 && lastByte != '\n' {
+		count++
+	}
+	return count, nil
 }

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -175,6 +176,167 @@ func TestReadFile_PathRequired(t *testing.T) {
 	rf := &ReadFileTool{Workspace: makeWorkspace(t)}
 	if _, err := rf.Execute(context.Background(), json.RawMessage(`{}`)); err == nil {
 		t.Fatal("expected error for empty path")
+	}
+}
+
+// TestReadFile_WholeReadReportsLineCounts pins the default-mode contract:
+// no offset / no limit returns raw bytes (no added trailing newline) plus
+// truthful line bookkeeping fields. The line fields exist on every
+// result -- including default-mode -- so the model has the data needed
+// to decide whether to follow up with a ranged read.
+func TestReadFile_WholeReadReportsLineCounts(t *testing.T) {
+	ws := makeWorkspace(t)
+	content := "alpha\nbeta\ngamma\n"
+	if err := os.WriteFile(filepath.Join(ws, "three.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rf := &ReadFileTool{Workspace: ws, MaxBytes: 100}
+	res, err := rf.Execute(context.Background(), json.RawMessage(`{"path":"three.txt"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	if out["content"] != content {
+		t.Errorf("content: got %q want %q", out["content"], content)
+	}
+	if out["bytes"].(int) != len(content) {
+		t.Errorf("bytes: got %v want %d", out["bytes"], len(content))
+	}
+	if out["total_lines"].(int) != 3 {
+		t.Errorf("total_lines: got %v want 3", out["total_lines"])
+	}
+	if out["start_line"].(int) != 1 || out["end_line"].(int) != 3 {
+		t.Errorf("line range: got [%v..%v] want [1..3]", out["start_line"], out["end_line"])
+	}
+}
+
+// TestReadFile_DefaultModeTracksTotalLinesOnTruncate covers the
+// truncation case: when the default-mode read hits MaxBytes mid-file,
+// total_lines must still reflect the whole file so the caller can
+// follow up with a ranged read targeting the remaining lines.
+func TestReadFile_DefaultModeTracksTotalLinesOnTruncate(t *testing.T) {
+	ws := makeWorkspace(t)
+	// 20 lines of "line-NN\n"; each line ~8 bytes so 20 lines = 160 bytes.
+	content := ""
+	for i := 1; i <= 20; i++ {
+		content += fmt.Sprintf("line-%02d\n", i)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "long.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Cap below the file size so we definitely truncate.
+	rf := &ReadFileTool{Workspace: ws, MaxBytes: 40}
+	res, err := rf.Execute(context.Background(), json.RawMessage(`{"path":"long.txt"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	if !out["truncated"].(bool) {
+		t.Errorf("expected truncated=true")
+	}
+	if out["total_lines"].(int) != 20 {
+		t.Errorf("total_lines after truncate: got %v want 20", out["total_lines"])
+	}
+}
+
+// TestReadFile_RangedRead exercises the offset+limit path. The model
+// reads a window of a long file without dragging the whole thing into
+// the OAI message history (the bug that motivated this tool change --
+// a single 65 KB read of CHANGELOG.md polluted every subsequent turn).
+func TestReadFile_RangedRead(t *testing.T) {
+	ws := makeWorkspace(t)
+	// 50 lines so we can pick a clear window in the middle.
+	content := ""
+	for i := 1; i <= 50; i++ {
+		content += fmt.Sprintf("L%02d\n", i)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "fifty.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rf := &ReadFileTool{Workspace: ws, MaxBytes: 16 * 1024}
+	res, err := rf.Execute(context.Background(),
+		json.RawMessage(`{"path":"fifty.txt","offset":11,"limit":5}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	want := "L11\nL12\nL13\nL14\nL15\n"
+	if out["content"] != want {
+		t.Errorf("ranged content: got %q want %q", out["content"], want)
+	}
+	if out["start_line"].(int) != 11 || out["end_line"].(int) != 15 {
+		t.Errorf("ranged line span: got [%v..%v] want [11..15]", out["start_line"], out["end_line"])
+	}
+	if out["total_lines"].(int) != 50 {
+		t.Errorf("total_lines: got %v want 50", out["total_lines"])
+	}
+	if out["truncated"].(bool) {
+		t.Errorf("did not expect truncated=true on a within-cap range")
+	}
+}
+
+// TestReadFile_RangedRead_PastEOF documents the contract for an
+// offset past the end of the file: empty content, truthful total
+// lines, end_line < start_line.
+func TestReadFile_RangedRead_PastEOF(t *testing.T) {
+	ws := makeWorkspace(t)
+	if err := os.WriteFile(filepath.Join(ws, "short.txt"), []byte("a\nb\nc\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rf := &ReadFileTool{Workspace: ws}
+	res, err := rf.Execute(context.Background(),
+		json.RawMessage(`{"path":"short.txt","offset":100,"limit":10}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	if out["content"] != "" {
+		t.Errorf("content past EOF: got %q want empty", out["content"])
+	}
+	if out["total_lines"].(int) != 3 {
+		t.Errorf("total_lines: got %v want 3", out["total_lines"])
+	}
+}
+
+// TestReadFile_RangedRead_HitsMaxBytes ensures that even in ranged
+// mode, MaxBytes is the hard ceiling -- the model cannot ask for a
+// huge limit and bypass the cap.
+func TestReadFile_RangedRead_HitsMaxBytes(t *testing.T) {
+	ws := makeWorkspace(t)
+	content := ""
+	for i := 1; i <= 200; i++ {
+		content += fmt.Sprintf("line-%03d-padding-text\n", i)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "big.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rf := &ReadFileTool{Workspace: ws, MaxBytes: 100}
+	res, err := rf.Execute(context.Background(),
+		json.RawMessage(`{"path":"big.txt","offset":1,"limit":200}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	if !out["truncated"].(bool) {
+		t.Errorf("expected truncated=true at MaxBytes ceiling")
+	}
+	if out["bytes"].(int) > 100 {
+		t.Errorf("bytes exceeded cap: got %v", out["bytes"])
+	}
+}
+
+// TestReadFile_InvalidArgs covers the new arg validation: negative
+// offset / negative limit / bad JSON.
+func TestReadFile_InvalidArgs(t *testing.T) {
+	rf := &ReadFileTool{Workspace: makeWorkspace(t)}
+	cases := []string{
+		`{"path":"p.txt","offset":-1}`,
+		`{"path":"p.txt","limit":-5}`,
+	}
+	for _, c := range cases {
+		if _, err := rf.Execute(context.Background(), json.RawMessage(c)); err == nil {
+			t.Errorf("expected error for args %s", c)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Four follow-up commits to the M3 + M4 work that made the Memorial Day v5 batch viable. Each is independently defensible; together they're "the runtime improvements the v5 batch surfaced as necessary."

1. **SSE streaming OAI client** (`pkg/foreman/agent/oai/`) — switches the client from non-streaming JSON to SSE. The non-streaming path was timing out when llama-server buffered Qwen3 hybrid-thinking traces during long prompt-eval turns. Streaming flushes deltas as they arrive so the client never sees a silent connection.
2. **Tool output caps** (`pkg/foreman/agent/tools/`) — drops `read_file` default cap from 256 KiB to 16 KiB, adds ranged-read mode (offset + limit), drops `bash` per-stream cap from 64 KiB to 16 KiB. A 66 KB CHANGELOG.md read was bloating every subsequent turn's prompt-eval by ~17K tokens.
3. **Coder Agent CR tweaks** (`config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml`, `config/foreman/system-prompts/coder.md`) — bumps `requestTimeoutSeconds` to 1800 (headroom for long prompt-eval with streaming) and nudges the prompt to prefer ranged reads on long files.
4. **Example Workload manifest** (`examples/foreman/workload-memorial-day-v5.yaml`) — concrete 6-issue M6-stub-planner example that mirrors the existing `workload-fix-small-bugs.yaml` shape.

## Why

These are the changes that, in aggregate, took the Foreman pipeline from "single-issue demo works" to "6-issue overnight batch produces 4 PR-ready branches against real issues" in the Memorial Day v5 run. The streaming fix alone unblocks every Qwen3-class hybrid-thinking model; the tool caps alone fix context bloat that compounds across turns; the timeout bump alone gives prompt-eval enough room to land after cache pressure builds. Together they're the runtime hygiene the M3 + M4 milestones implied but did not initially deliver.

The v5 batch (12 AgenticTasks, 2h 8s total wall) surfaced these requirements under load. Diagnostics + reproducers are captured in `~/stuffy/code/ai/llmkube-internal/diagnostics/` for the goroutine-dump and orphan-find evidence.

Fixes #

## How

- **Streaming client** (`oai/client.go`, `oai/types.go`): `Stream=true` is forced on the wire regardless of caller; `http.Client.Timeout = 0`; `Transport.ResponseHeaderTimeout = requestTimeout` (header wait only); a new `readSSEStream` parses chunks and aggregates into the existing `ChatResponse` shape. Termination on `data: [DONE]` OR all-choices-finished (llama.cpp omits `[DONE]` for some tool-call shapes — verified by `TestClient_Chat_TerminatesOnFinishReasonWithoutDONE`). 100ms bounded body drain on close so the connection releases cleanly. New types: `ChatChunk`, `ChoiceDelta`, `MessageDelta`, `ToolCallDelta`, `ToolCallFunctionDelta`. Test helpers `chatJSONToSSE` + `chatResponseToSSE` let existing JSON fixtures drive the new wire format without rewrites.
- **Tool caps** (`tools/read_file.go`, `tools/bash.go`): `read_file` rewritten with two modes (`readWhole` raw bytes, `readRange` line-aligned). Output adds `bytes`, `truncated`, `start_line`, `end_line`, `total_lines`. `countRemainingLines` helper for accurate `total_lines` on truncated whole reads. Schema advertises the new `offset` and `limit` parameters. `bash` per-stream cap dropped from 64 KiB to 16 KiB. Six new table-driven tests cover whole reads with line counts, ranged reads, past-EOF, max-bytes truncation, invalid args, and default-mode line-count tracking on truncated files.
- **Coder Agent** (`qwen36-35b-carnice-mtp-coder.yaml`): `requestTimeoutSeconds: 1800`. The accompanying `coder.md` system prompt mentions ranged reads in the `read_file` description; the inline `systemPrompt` in the Agent CR is kept in sync.
- **Example Workload**: clean 6-issue manifest, no live cluster state, applies cleanly against an existing `qwen36-35b-carnice-mtp-coder` + `gate` Agent pair.

Coverage after this PR:

- `pkg/foreman/agent/oai`: 90.4%
- `pkg/foreman/agent/tools`: 82.7%
- `pkg/foreman/agent`: 54.4%

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change)
