### PR TITLE
[WIP] feat: build and push llmkube-router-proxy image alongside the controller

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -108,6 +108,21 @@ builds:
     env:
       - CGO_ENABLED=0
 
+  - id: llmkube-router-proxy
+    main: ./cmd/router-proxy
+    binary: router-proxy
+
+    # Linux containers only (the router-proxy runs in-cluster).
+    goos:
+      - linux
+
+    goarch:
+      - amd64
+      - arm64
+
+    env:
+      - CGO_ENABLED=0
+
 archives:
   - id: llmkube-cli
     builds:
@@ -249,6 +264,40 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
 
+  - id: router-proxy-amd64
+    goos: linux
+    goarch: amd64
+    ids:
+      - llmkube-router-proxy
+    image_templates:
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-amd64"
+    dockerfile: Dockerfile.router-proxy
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
+  - id: router-proxy-arm64
+    goos: linux
+    goarch: arm64
+    ids:
+      - llmkube-router-proxy
+    image_templates:
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-arm64"
+    dockerfile: Dockerfile.router-proxy
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
 docker_manifests:
   - name_template: "ghcr.io/defilantech/llmkube-controller:{{ .Version }}"
     image_templates:
@@ -264,6 +313,11 @@ docker_manifests:
     image_templates:
       - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-amd64"
       - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-amd64"
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-arm64"
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -98,34 +98,17 @@ controllerManager:
   # The router-proxy is a lightweight HTTP server that fronts
   # InferenceServices and external provider backends, speaks
   # OpenAI chat completions, and enforces policy routing.
-  #
-  # IMPORTANT (Phase 1 alpha): the release pipeline does not yet build
-  # and push the router-proxy image alongside the controller image.
-  # The default tag below is "dev" rather than the chart appVersion so
-  # users who never create a ModelRouter resource are unaffected, and
-  # users who do create one know they need to either:
-  #
-  #   1. Build the image locally (`make docker-build-router-proxy`)
-  #      and push it to a registry their cluster can reach, then
-  #      override repository / tag here.
-  #   2. Override `spec.proxy.image` per ModelRouter with their own
-  #      build.
-  #
-  # See https://github.com/defilantech/LLMKube/issues/449 for the
-  # tracking issue on integrating the router-proxy image into the
-  # release flow.
   routerProxy:
     # Registry prefix for the router-proxy image (mirrors controller image).
     # Useful for air-gapped or enterprise proxy registries.
     registry: ""
     repository: ghcr.io/defilantech/llmkube-router-proxy
     pullPolicy: IfNotPresent
-    # Default tag. "dev" is intentional until the release pipeline
-    # ships versioned router-proxy images alongside the controller.
-    tag: "dev"
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
     # Image digest (sha256:...) - takes precedence over tag when set.
-    # Use digests for production deployments once the release pipeline
-    # publishes them.
+    # Use digests for production deployments to ensure immutable, verifiable images.
+    # Example: sha256:abc123def456...
     digest: ""
 
     # Cluster-wide default URL for ModelRouter External backends whose

--- a/docs/site/concepts/model-router.md
+++ b/docs/site/concepts/model-router.md
@@ -20,19 +20,6 @@ ModelRouter is **alpha** as of LLMKube 0.8. The CRD lives in `inference.llmkube.
 
 </DocCallout>
 
-<DocCallout variant="warn" title="Router-proxy image not yet in the release pipeline">
-
-The release pipeline currently builds and publishes the controller image (`ghcr.io/defilantech/llmkube-controller`) on every release. The router-proxy image (`ghcr.io/defilantech/llmkube-router-proxy`) is not yet built by CI: see [issue #449](https://github.com/defilantech/LLMKube/issues/449).
-
-The Helm chart's default for `controllerManager.routerProxy.tag` is `"dev"` until that lands. Users who want to deploy a ModelRouter today have two options:
-
-1. **Build locally and push.** Run `make docker-build-router-proxy ROUTER_PROXY_IMG=<your-registry>/llmkube-router-proxy:dev`, push it, then `--set controllerManager.routerProxy.repository=<your-registry>/llmkube-router-proxy` on the Helm install.
-2. **Override per ModelRouter.** Set `spec.proxy.image` on each ModelRouter to an image your cluster can pull.
-
-Users who never create a ModelRouter resource are unaffected.
-
-</DocCallout>
-
 ## Why this exists
 
 LLMs are increasingly composed: an agent does some work on a fast local model, hands off a hard step to a frontier cloud model, then comes back. Every team building this hits the same three problems:


### PR DESCRIPTION
> **🤖 Foreman-authored PR.** This branch was produced by a Foreman pipeline run on 2026-05-25: a coder Agent (Qwen 3.6 35B-A3B on llama.cpp + TurboQuant on Apple Silicon) wrote the diff, the gate Job validated it (`make fmt vet lint test manifests chart-crds foreman-chart-crds` clean), and an M5-lite reviewer Agent issued the review summarized below. Marked `[WIP]` so a human maintainer can read and decide; no auto-merge.

## What

Adds the `llmkube-router-proxy` image to the goreleaser release pipeline (linux/amd64 + linux/arm64 build + docker + manifest entries), flips the chart's default `controllerManager.routerProxy.tag` from `"dev"` back to `""` (falls back to chart `appVersion`), and removes the interim warning callout from `docs/site/concepts/model-router.md`.

## Why

Fixes #449

The router-proxy image has been built ad-hoc against `:dev`; the release workflow only published the controller image. Every tagged release should also build + push router-proxy for both architectures so the chart's default tag actually resolves to a real image.

## How

- `.goreleaser.yaml`: new `llmkube-router-proxy` build entry, two docker entries (one per arch), one docker_manifests entry that produces a multi-arch manifest. Mirrors the existing controller + foreman-agent shape (same buildx usage, OCI labels, platform flags).
- `charts/llmkube/values.yaml`: `tag: ""` (so `_helpers.tpl`'s `default .Chart.AppVersion` kicks in).
- `docs/site/concepts/model-router.md`: the `<DocCallout variant="warn">` block (which warned the image was `:dev`-only) is removed.

## M5-lite reviewer summary

**Verdict: APPROVE.** riskLevel: low. testsAdded: 0 (release-pipeline change, not code).

Quoted issue ask: *"Update the existing release workflow so that every tagged release also builds Dockerfile.router-proxy for the same linux/amd64,linux/arm64 matrix the controller uses."*

Findings (all `info`):
- **scope-alignment**: diff hits the exact files + behaviors the issue asks for. Three quotes from issue body all match diff content.
- **cosign-signing**: issue mentions "Signs the image with cosign if the controller is signed (verify which is true today)" as a success criterion. Reviewer flagged: not configured anywhere in current `.goreleaser.yaml` or `.github/workflows`. Issue marks this as "(ideally)" — future enhancement, not blocking.
- **style-consistency**: new router-proxy entries mirror the existing controller / foreman-agent patterns (same buildx usage, same OCI labels, same platform flags).

## Checklist

- [x] Tests added/updated (n/a, release-config change)
- [x] `make test` passes locally (verified by Foreman gate Job)
- [x] `make lint` passes locally (verified by Foreman gate Job)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (warning callout removed)

## Provenance

- Pipeline: Foreman v0.1 Workload `memorial-day-v5` on shadowstack (2026-05-25)
- Coder: `qwen36-35b-carnice-mtp-coder` Agent on `m5max-coder` FleetNode (3m 4s wall, GO verdict)
- Gate: `gate` Agent on shadowstack (Job-based, GATE-PASS)
- Reviewer: `qwen36-35b-a3b-reviewer` Agent (M5-lite, 39s wall, APPROVE verdict)
