### PR TITLE
[WIP] fix(metal-agent): reconcile pre-existing InferenceService status on startup

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -367,6 +367,15 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		a.logger.Infow("cleaned up orphaned endpoints from prior sessions", "count", cleaned)
 	}
 
+	// Startup reconcile: sweep all InferenceServices in the watched namespace
+	// and converge their status against observed reality. The watcher only
+	// fires on CHANGES, so pre-existing zero-replica state from a previous
+	// agent run would otherwise keep stale readyReplicas / phase indefinitely.
+	// See https://github.com/defilantech/LLMKube/issues/506.
+	if err := a.reconcileOnStartup(ctx); err != nil {
+		a.logger.Warnw("startup reconcile failed", "error", err)
+	}
+
 	// Start health server. An unexpected exit here (port binding lost,
 	// listener crashed) is fatal — the management plane is how operators
 	// observe and recover the agent, so running blind is worse than
@@ -967,6 +976,28 @@ func (a *MetalAgent) markStopped(ctx context.Context, isvc *inferencev1alpha1.In
 // scheduleRestart increments the restart counter and re-runs ensureProcess
 // for the named InferenceService. It is called by HealthMonitor when a process
 // becomes unhealthy.
+
+// reconcileOnStartup lists all InferenceServices in the watched namespace and
+// calls ensureProcess for each one. This converges their status against
+// observed reality on agent boot, because the watcher only fires on CHANGES
+// and pre-existing zero-replica state from a previous agent run would
+// otherwise keep stale readyReplicas / phase indefinitely.
+// See https://github.com/defilantech/LLMKube/issues/506.
+func (a *MetalAgent) reconcileOnStartup(ctx context.Context) error {
+	var list inferencev1alpha1.InferenceServiceList
+	if err := a.config.K8sClient.List(ctx, &list, client.InNamespace(a.config.Namespace)); err != nil {
+		return fmt.Errorf("list InferenceServices for startup reconcile: %w", err)
+	}
+	for i := range list.Items {
+		svc := &list.Items[i]
+		if err := a.ensureProcess(ctx, svc); err != nil {
+			a.logger.Warnw("startup reconcile failed for InferenceService",
+				"namespace", svc.Namespace, "name", svc.Name, "error", err)
+		}
+	}
+	return nil
+}
+
 // runWatcherLoop drives a.watcher.Watch in a loop, retrying transient errors
 // with exponential backoff (handles the "CRDs not installed yet" startup
 // race) but bubbling ErrWatchStalled up via fatalErrChan immediately.

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1061,3 +1061,98 @@ func TestEnsureProcess_InFlightGuard(t *testing.T) {
 		t.Errorf("starting map not cleared after spawn, has %d entries", leftover)
 	}
 }
+
+// TestReconcileOnStartup_CorrectsStaleStatus verifies that reconcileOnStartup
+// patches the status of InferenceServices whose spec.replicas=0 but whose
+// status still shows ReadyReplicas > 0 from a prior agent run. See #506.
+func TestReconcileOnStartup_CorrectsStaleStatus(t *testing.T) {
+	scheme := newTestScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	zero := int32(0)
+	stale := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "stale-service",
+			Namespace:  "default",
+			Generation: 5,
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "any-model",
+			Replicas: &zero,
+		},
+		Status: inferencev1alpha1.InferenceServiceStatus{
+			Phase:           "Ready",
+			ReadyReplicas:   1,
+			DesiredReplicas: 1,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&inferencev1alpha1.InferenceService{}).
+		WithRuntimeObjects(stale).
+		Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
+	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	if err := agent.reconcileOnStartup(context.Background()); err != nil {
+		t.Fatalf("reconcileOnStartup returned unexpected error: %v", err)
+	}
+
+	got := &inferencev1alpha1.InferenceService{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "stale-service", Namespace: "default"}, got); err != nil {
+		t.Fatalf("fetch InferenceService back: %v", err)
+	}
+
+	if got.Status.Phase != "Stopped" {
+		t.Errorf("status.phase = %q, want Stopped", got.Status.Phase)
+	}
+	if got.Status.ReadyReplicas != 0 {
+		t.Errorf("status.readyReplicas = %d, want 0", got.Status.ReadyReplicas)
+	}
+	if got.Status.DesiredReplicas != 0 {
+		t.Errorf("status.desiredReplicas = %d, want 0", got.Status.DesiredReplicas)
+	}
+}
+
+// TestReconcileOnStartup_SkipsNonZeroReplicas verifies that the startup
+// reconcile does not block on InferenceServices with replicas > 0 that have
+// no running process (they would fail to start without a model, which is
+// expected — the watcher will handle them when the model is ready). Errors
+// are logged but do not abort the sweep.
+func TestReconcileOnStartup_SkipsNonZeroReplicas(t *testing.T) {
+	scheme := newTestScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	one := int32(1)
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "non-zero-replicas",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "missing-model",
+			Replicas: &one,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&inferencev1alpha1.InferenceService{}).
+		WithRuntimeObjects(isvc).
+		Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
+	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	// reconcileOnStartup should not return an error even when a service
+	// fails to reconcile (errors are logged and the sweep continues).
+	err := agent.reconcileOnStartup(context.Background())
+	if err != nil {
+		t.Errorf("reconcileOnStartup returned error %v, want nil (errors are logged, not returned)", err)
+	}
+}


### PR DESCRIPTION
> **🤖 Foreman-authored PR.** Branch produced by a Foreman pipeline on 2026-05-25: Qwen 3.6 35B-A3B coder + gate Job + M5-lite reviewer. Marked `[WIP]` for human review.

## What

Adds a `reconcileOnStartup` sweep to the metal-agent that lists all watched `InferenceService` resources at boot and calls `ensureProcess` on each, so stale `replicas=0` status from a previous metal-agent shutdown is converged against ground truth on restart.

## Why

Fixes #506

If the metal-agent shuts down while an `InferenceService` has `replicas=0` in status (because the model was being unloaded), the next boot won't trigger a reconcile until the watcher emits an event. The status drifts from reality until something else nudges it.

## How

- `pkg/agent/agent.go`: new `reconcileOnStartup` method (+31 lines). Runs synchronously in `Start()` before watcher goroutines start, so no concurrency issues with `ensureProcess`'s starting mutex.
- `pkg/agent/agent_test.go`: two new regression tests (+95 lines).
  - `TestReconcileOnStartup_CorrectsStaleStatus`: verifies stale `replicas=0` is corrected on boot.
  - `TestReconcileOnStartup_SkipsNonZeroReplicas`: verifies errors on individual services don't abort the sweep.

## M5-lite reviewer summary

**Verdict: APPROVE.** riskLevel: low. testsAdded: 2.

Quoted issue ask: *"On startup, the metal-agent should sweep all watched InferenceServices and reconcile each against ground truth."*

Findings (all `low` severity):
- **scope**: diff exactly matches the issue ask; commit message correctly references `Fixes #506`.
- **minimalism**: only 2 files touched, +31/-0 in `agent.go`, +95/-0 in `agent_test.go`. No generated files modified. Style matches surrounding code.
- **tests**: both new tests assert real behavior (stale status correction, error isolation) rather than tautological constants. All existing tests pass.
- **side-effects**: reviewer verified `reconcileOnStartup` runs synchronously in `Start()` before watcher goroutines, so no concurrency issues with `ensureProcess`'s starting mutex. Post-convergence the watcher sees updated status but won't re-trigger.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (verified by Foreman gate Job)
- [x] `make lint` passes locally (verified by Foreman gate Job)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (n/a, internal behavior)

## Provenance

- Pipeline: Foreman v0.1 Workload `memorial-day-v5` on shadowstack (2026-05-25)
- Coder: `qwen36-35b-carnice-mtp-coder` Agent on `m5max-coder` FleetNode (4m 55s wall, GO verdict)
- Gate: `gate` Agent on shadowstack (Job-based, GATE-PASS)
- Reviewer: `qwen36-35b-a3b-reviewer` Agent (M5-lite, 84s wall, APPROVE verdict)
