### PR TITLE
[WIP] docs: mention make lint-all in AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,18 @@ A change is not done until all of these pass:
 3. `make lint`
 4. `make test`
 
+## Before pushing a PR
+
+Run the cross-arch lint pass to catch `//go:build`-tagged files that the
+host's default `GOOS` would silently skip:
+
+```sh
+make lint-all
+```
+
+This is about 2× slower than `make lint`; it is an opt-in step so the inner
+loop stays fast.
+
 If you edited CRD types in `api/v1alpha1/`, also run:
 
 5. `make generate` — DeepCopy methods

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,6 +234,9 @@ make test-e2e
 # Lint
 make lint
 
+# Cross-arch lint (run before pushing; catches GOOS-tagged files)
+make lint-all
+
 # Verify manifests are up to date
 make manifests
 git diff --exit-code  # Should be no changes


### PR DESCRIPTION
> **🤖 Foreman-authored PR.** Branch produced by a Foreman pipeline on 2026-05-25: Qwen 3.6 35B-A3B coder + gate Job + M5-lite reviewer. Marked `[WIP]` for human review.

## What

Adds a "Before pushing a PR" section to `AGENTS.md` and a `make lint-all` line to `CONTRIBUTING.md`'s lint block, pointing contributors at the cross-arch lint target that has been silently skipped on Apple Silicon.

## Why

Fixes #510

`make lint-all` exists in the Makefile (line 114, present since PR #508) but contributors using `make lint` on a Mac silently skip `//go:build !darwin`-tagged files; PRs fail CI's cross-arch lint check downstream. The fix is to surface `make lint-all` in the docs contributors actually read.

## How

- `AGENTS.md`: 12 lines added in a new "Before pushing a PR" section under the build / test commands.
- `CONTRIBUTING.md`: 3 lines added to the lint block, mirroring the existing `make lint` instructions.

## M5-lite reviewer summary

**Verdict: APPROVE.** riskLevel: low. testsAdded: 0 (docs change).

Quoted issue ask: *"point contributors at it from AGENTS.md (and/or CONTRIBUTING.md) so they actually use it."*

Findings (all `info`):
- **scope-alignment**: both files match the issue's proposed solution verbatim. AGENTS.md gets the section the issue proposed; CONTRIBUTING.md gets the `make lint-all` line in the lint block.
- **minimal-and-idiomatic**: only 2 files touched, 15 insertions, 0 deletions. No generated files edited. Style matches surrounding markdown.
- **no-side-effects**: pure documentation change. Reviewer confirmed `make lint-all` target already exists in the Makefile (line 114, present since PR #508), so the new instructions point at something real.

## Checklist

- [x] Tests added/updated (n/a, docs change)
- [x] `make test` passes locally (verified by Foreman gate Job)
- [x] `make lint` passes locally (verified by Foreman gate Job)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (the PR IS documentation)

## Provenance

- Pipeline: Foreman v0.1 Workload `memorial-day-v5` on shadowstack (2026-05-25)
- Coder: `qwen36-35b-carnice-mtp-coder` Agent on `m5max-coder` FleetNode (48s wall, GO verdict)
- Gate: `gate` Agent on shadowstack (Job-based, GATE-PASS)
- Reviewer: `qwen36-35b-a3b-reviewer` Agent (M5-lite, 19s wall, APPROVE verdict)
