### PR TITLE
fix(foreman/executor): route reviewer-role GO through modelDecidedResult

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -300,7 +300,18 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 
 	// 9. Non-GO verdicts: no commit, no push, just record the model's
 	// stated outcome and return.
-	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+	//
+	// Reviewer-role Agents take this same path on GO. A reviewer's
+	// "GO" means APPROVE, not "commit this diff." Reviewers are
+	// read-only by design (tool whitelist excludes write_file and
+	// str_replace), so HasChanges would always be false and the
+	// model's structured findings in submit_result.extra would get
+	// dropped by the noChangesResult fallback. Route through
+	// modelDecidedResult so extra.modelExtra (the full review
+	// payload: reviewOutcome, findings, issueAsk, etc.) surfaces in
+	// status.result.
+	if verdict != foremanv1alpha1.AgenticTaskVerdictGo ||
+		agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer {
 		return e.modelDecidedResult(start, transcriptRef, loopRes, verdict), nil
 	}
 

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -514,6 +514,150 @@ func TestNativeExecutor_ModelEmitsNoGo(t *testing.T) {
 	}
 }
 
+// --- Reviewer-role Agent: GO means APPROVE, not commit + push ------------
+
+// reviewerTaskAndAgent builds a reviewer-role Agent and a freeform
+// AgenticTask pointing at it. Distinct from taskAndAgent because the
+// role bit is exactly what this test exercises.
+func reviewerTaskAndAgent(name string) (*foremanv1alpha1.Agent, *foremanv1alpha1.AgenticTask) {
+	a := &foremanv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "reviewer-" + name, Namespace: "default"},
+		Spec: foremanv1alpha1.AgentSpec{
+			Role:                foremanv1alpha1.AgentRoleReviewer,
+			Model:               "test-model",
+			InferenceServiceRef: corev1.LocalObjectReference{Name: "test-svc"},
+			SystemPrompt:        "you are a test reviewer",
+			// Read-only tool whitelist: no write_file, no str_replace.
+			Tools:    []string{"read_file", "grep", "bash", "submit_result"},
+			MaxTurns: 5,
+		},
+	}
+	t := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "default", UID: types.UID("test-uid-" + name),
+		},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindFreeform,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Issue:  9999,
+				Prompt: "review the branch",
+			},
+			AgentRef: &corev1.LocalObjectReference{Name: a.Name},
+		},
+	}
+	return a, t
+}
+
+// TestNativeExecutor_ReviewerGoIsApproveNotCommit checks that when a
+// reviewer-role Agent emits verdict=GO with no workspace changes (the
+// expected reviewer shape, since reviewers don't have write tools),
+// the executor takes the modelDecidedResult path and preserves the
+// model's structured extra (reviewOutcome, findings, issueAsk, etc.)
+// in status.result, instead of downgrading to NO-GO via noChangesResult.
+//
+// Regression test for defilantech/LLMKube#543.
+func TestNativeExecutor_ReviewerGoIsApproveNotCommit(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+
+	agent, task := reviewerTaskAndAgent("approves-clean")
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+
+	// fakeRegistry returns a submit_result envelope that mimics the
+	// shape the M5-lite reviewer Agent produces in production: GO
+	// verdict, APPROVE outcome, three findings, an issueAsk quote,
+	// and the touched-files list. The reviewer never edits the
+	// workspace, so HasChanges would be false; this test asserts the
+	// no-commit reviewer path keeps that envelope intact.
+	reviewExtra := map[string]any{
+		"reviewOutcome": "APPROVE",
+		"issueAsk": "Update the existing release workflow so every tagged release " +
+			"builds the router-proxy image for amd64+arm64.",
+		"findings": []any{
+			map[string]any{
+				"severity": "info",
+				"area":     "scope-alignment",
+				"message": "Diff hits .goreleaser.yaml, values.yaml, and " +
+					"docs/site/concepts/model-router.md as the issue body names.",
+			},
+			map[string]any{
+				"severity": "info",
+				"area":     "style-consistency",
+				"message":  "New goreleaser entries mirror the existing controller + foreman-operator patterns.",
+			},
+		},
+		"filesTouched": []any{".goreleaser.yaml", "charts/llmkube/values.yaml", "docs/site/concepts/model-router.md"},
+		"riskLevel":    "low",
+		"testsAdded":   0,
+	}
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true,
+				Verdict:  "GO",
+				Summary:  "APPROVE: diff matches the issue ask, minimal scope, idiomatic.",
+				Extra:    reviewExtra,
+			},
+		},
+	}
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Bot", Email: "b@x"},
+		CommitCommitter:          repo.Identity{Name: "Bot", Email: "b@x"},
+		RegistryFactory: func(_ string, _ *foremanv1alpha1.Agent) (foremanagent.ToolRegistry, error) {
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Verdict stays GO (not downgraded to NO-GO by noChangesResult).
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("verdict: want GO got %s; full result=%+v", res.Verdict, res)
+	}
+	// Outcome is MODEL-DECIDED (the no-commit reviewer path), not
+	// NO-CHANGES (the wrong path that drops modelExtra).
+	if got := res.Extra["outcome"]; got != "MODEL-DECIDED" {
+		t.Errorf("outcome: want MODEL-DECIDED got %v", got)
+	}
+	// modelExtra survives intact and carries the structured review.
+	mx, ok := res.Extra["modelExtra"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelExtra: missing or wrong type; res.Extra=%+v", res.Extra)
+	}
+	if got := mx["reviewOutcome"]; got != "APPROVE" {
+		t.Errorf("modelExtra.reviewOutcome: want APPROVE got %v", got)
+	}
+	if findings, ok := mx["findings"].([]any); !ok || len(findings) != 2 {
+		t.Errorf("modelExtra.findings: want 2-element slice got %T %v", mx["findings"], mx["findings"])
+	}
+	if got := mx["issueAsk"]; got == nil {
+		t.Errorf("modelExtra.issueAsk: missing; the verbatim issue quote should survive")
+	}
+
+	// No branch should have landed on the remote: reviewers do not push.
+	out, _ := exec.Command("git", "-C", bare, "branch", "--list", "foreman/issue-9999").CombinedOutput()
+	if strings.Contains(string(out), "foreman/issue-9999") {
+		t.Errorf("reviewer path should not push; bare repo has branch: %s", out)
+	}
+
+	// Transcript still written.
+	cmKey := types.NamespacedName{Namespace: task.Namespace, Name: "foreman-transcript-" + task.Name}
+	var cm corev1.ConfigMap
+	if err := c.Get(context.Background(), cmKey, &cm); err != nil {
+		t.Errorf("transcript should exist on reviewer path: %v", err)
+	}
+}
+
 // --- Deterministic Agent path (M4): no LLM, single tool dispatch ----------
 
 func TestNativeExecutor_DeterministicGateAgent(t *testing.T) {


### PR DESCRIPTION
## What

Routes reviewer-role Agents' `verdict=GO` through `modelDecidedResult` instead of the `HasChanges` → `Commit` → `Push` flow that coder Agents take.

## Why

Fixes #543

Reviewer Agents are read-only by design (`Agent.spec.tools` excludes `write_file` and `str_replace`), so they never produce workspace changes. When such an Agent submits `verdict="GO"` meaning APPROVE, the existing executor's GO branch hit `HasChanges == false` and fell through to `noChangesResult`, which downgraded the verdict to NO-GO with summary `"model emitted GO but produced no diff"` and dropped the model's `submit_result.extra` payload (`reviewOutcome`, `findings`, `issueAsk`, `filesTouched`, etc.) on the floor. The structured review survived only in the transcript ConfigMap.

Surfaced cleanly by the M5-lite reviewer demo on 2026-05-25: `review-449`, `review-506`, `review-510` all emitted GO/APPROVE with 3-5 structured findings each, all got recorded as NO-GO no-diff at the AgenticTask level. Reviewer model behavior was correct; executor was discarding the output.

## How

One-line change in `pkg/foreman/agent/executor_native.go` at the verdict-handling branch in `runLLMPath`: condition now reads "non-GO verdict OR reviewer-role Agent" and routes both to `modelDecidedResult`. The non-reviewer GO path (coder commit + push) is untouched.

```go
if verdict != foremanv1alpha1.AgenticTaskVerdictGo ||
    agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer {
    return e.modelDecidedResult(start, transcriptRef, loopRes, verdict), nil
}
```

Strict role check (not "Agent's tools lack write_file") so the contract is explicit in the CR and obvious to users modeling pipelines. Future Agent roles get their own path if they need one; this PR doesn't make assumptions about them.

Adds a regression test `TestNativeExecutor_ReviewerGoIsApproveNotCommit` that constructs a reviewer-role Agent with a read-only tool whitelist, has the fake loop submit GO with realistic structured extra (mirroring the v5 reviewer payload: `reviewOutcome=APPROVE`, two findings, `issueAsk` verbatim quote, `filesTouched`), and asserts:

- `res.Verdict == GO` (not downgraded)
- `res.Extra["outcome"] == "MODEL-DECIDED"` (not "NO-CHANGES")
- `res.Extra["modelExtra"]` round-trips with `reviewOutcome`, `findings`, `issueAsk` intact
- No branch is pushed to the bare remote (reviewers never push)
- Transcript ConfigMap still gets written

## Checklist

- [x] Tests added/updated (regression test for #543)
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (n/a, internal behavior change)
