### PR TITLE
fix(foreman/tools): cmd.WaitDelay + process-group kill so BashTool can't deadlock on grandchild-held pipes

### DIFF
--- a/pkg/foreman/agent/tools/bash.go
+++ b/pkg/foreman/agent/tools/bash.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/defilantech/llmkube/pkg/foreman/agent"
@@ -44,6 +45,20 @@ import (
 const (
 	defaultBashTimeout   = 30 * time.Second
 	defaultBashOutputCap = 16 * 1024 // 16 KiB per stream
+
+	// defaultBashWaitDelay caps the time Cmd.Wait blocks waiting for
+	// io.Copy goroutines on stdout/stderr to see EOF after the
+	// process itself exits. Without this, an LLM-issued bash command
+	// that backgrounds a grandchild (e.g. `find / -name foo &`,
+	// `docker run -d`, anything that detaches) leaves the grandchild
+	// holding the inherited stdout/stderr pipes, and Cmd.Wait blocks
+	// indefinitely in awaitGoroutines. Empirically observed in the
+	// 2026-05-25 v5 batch where `find / -maxdepth 5 -name AGENTS.md`
+	// pinned a coder run for 36+ minutes (defilantech/LLMKube#539).
+	//
+	// 5 s is generous: with the process group killed by Cancel below,
+	// kernel-level pipe drainage usually completes in <100 ms.
+	defaultBashWaitDelay = 5 * time.Second
 )
 
 // BashTool runs a shell command in the workspace under "sh -c" with a
@@ -106,6 +121,33 @@ func (t *BashTool) Execute(ctx context.Context, args json.RawMessage) (*agent.To
 	cmd := exec.CommandContext(runCtx, "sh", "-c", a.Command) //nolint:gosec // G204: bash by design
 	cmd.Dir = t.Workspace
 	cmd.Env = t.scrubbedEnv()
+
+	// Run the shell in its own process group so we can kill the entire
+	// subtree (grandchildren too) when the deadline fires. Setpgid on
+	// Unix; harmless no-op on platforms that ignore it. Without this,
+	// a backgrounded grandchild (`sleep 60 &`, `docker run -d`, etc.)
+	// outlives the shell and keeps the inherited stdout/stderr pipes
+	// open, blocking Cmd.Wait forever. See defaultBashWaitDelay for
+	// the empirical case that motivated the fix.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// Cancel runs when runCtx fires (i.e. the BashTool deadline). The
+	// os/exec default SIGKILLs the leader; we SIGKILL the whole process
+	// group so grandchildren die with the shell. Required for WaitDelay
+	// below to be useful: if the grandchildren stay alive, the pipes
+	// stay open and io.Copy never sees EOF regardless of WaitDelay.
+	cmd.Cancel = func() error {
+		return killProcessGroup(cmd.Process)
+	}
+
+	// WaitDelay caps the time Cmd.Wait will block on stdio drainage
+	// after the process exits (or is killed by Cancel). The pipes
+	// should close almost immediately once the process group is dead;
+	// the cap is paranoid insurance against edge cases (e.g. a child
+	// that detaches into its own session via setsid). After WaitDelay
+	// elapses, the kernel-level pipe handles are force-closed and the
+	// io.Copy goroutines unblock with an io.ErrClosedPipe.
+	cmd.WaitDelay = defaultBashWaitDelay
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -188,6 +230,33 @@ func (t *BashTool) scrubbedEnv() []string {
 		}
 	}
 	return out
+}
+
+// killProcessGroup sends SIGKILL to the entire process group leader-ed
+// by p. Required because Cmd.Wait blocks on `awaitGoroutines` until
+// io.Copy sees EOF on the inherited stdout/stderr pipes, and those
+// pipes do not close until every descendant holding them exits. A
+// backgrounded grandchild (sleep, docker daemon, kubectl proxy, find
+// /, etc.) inherits the shell's pipes; killing only the shell leaves
+// the pipes open. Negative pid in syscall.Kill addresses the process
+// group, which (combined with Setpgid: true on the shell) catches the
+// whole subtree.
+//
+// nil p means the process never started; nothing to kill.
+//
+// Any error is ignored at the call site -- this runs from Cmd.Cancel
+// on context expiry, where the goal is best-effort cleanup. If
+// signaling the group fails (ESRCH because the leader already exited
+// cleanly, EPERM in some sandboxed containers), the WaitDelay timeout
+// will still force pipe closure as a fallback.
+func killProcessGroup(p *os.Process) error {
+	if p == nil {
+		return nil
+	}
+	// Negative pid in syscall.Kill targets the process group with that
+	// pgid. Combined with SysProcAttr.Setpgid: true on the leader,
+	// pgid == leader's pid.
+	return syscall.Kill(-p.Pid, syscall.SIGKILL)
 }
 
 // truncateBytes returns b as a string, capped at maxBytes with a

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -519,6 +520,61 @@ func TestBash_TimeoutFlag(t *testing.T) {
 	out := res.Output.(map[string]any)
 	if !out["timed_out"].(bool) {
 		t.Errorf("expected timed_out=true; output=%v", out)
+	}
+}
+
+// TestBash_GrandchildPipeDoesNotDeadlock is the regression test for
+// defilantech/LLMKube#539. Without WaitDelay + process-group kill on
+// Cancel, a bash command that backgrounds a long-lived grandchild
+// causes Cmd.Wait to block until the grandchild exits (because the
+// grandchild inherited the shell's stdout/stderr pipes and Cmd.Wait
+// blocks in awaitGoroutines waiting for io.Copy to see EOF).
+//
+// The command `(sleep 60 &) ; echo started ; sleep 0.1`:
+//   - the subshell `(...)` runs `sleep 60 &` and exits immediately
+//   - `sleep 60` is left running in the background, holding the
+//     parent shell's pipes via inheritance
+//   - the parent echoes "started", sleeps 0.1s, and exits
+//   - without the fix, Cmd.Wait blocks for 60s waiting for the
+//     orphaned `sleep 60` to finish
+//   - with the fix, the 200ms timeout fires Cancel, which kills the
+//     entire process group (including sleep), pipes close, Wait
+//     returns within timeout + WaitDelay (200ms + 5s).
+func TestBash_GrandchildPipeDoesNotDeadlock(t *testing.T) {
+	b := &BashTool{
+		Workspace: makeWorkspace(t),
+		// Short Timeout so we hit the cancel-then-WaitDelay path
+		// quickly. The fix bounds total wall at Timeout + WaitDelay.
+		Timeout: 200 * time.Millisecond,
+	}
+	const cmd = `(sleep 60 &) ; echo started ; sleep 0.1`
+	argsJSON := json.RawMessage(`{"command":` + strconv.Quote(cmd) + `}`)
+
+	start := time.Now()
+	res, err := b.Execute(context.Background(), argsJSON)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	// Without the fix this blocks for ~60s. With it, Timeout (200ms)
+	// plus WaitDelay (5s) caps wall at ~5.2s plus a little OS slack.
+	// 15s is a generous upper bound; anything above 30s is the bug.
+	if elapsed > 15*time.Second {
+		t.Errorf("BashTool blocked for %v on a backgrounded-grandchild "+
+			"command; expected <15s; #539 regression. cmd=%q", elapsed, cmd)
+	}
+	out := res.Output.(map[string]any)
+	stdout, _ := out["stdout"].(string)
+	// The shell printed "started" before the 0.1s sleep at the end,
+	// so we should see it captured. (The 0.1s tail makes the parent
+	// shell hit the 200ms Timeout reliably even on slow CI.)
+	if !strings.Contains(stdout, "started") {
+		t.Errorf("expected 'started' in stdout; got: %q", stdout)
+	}
+	if !out["timed_out"].(bool) {
+		t.Errorf("expected timed_out=true (200ms < 0.1s sleep should "+
+			"miss, but in practice the +0.1s sleep is enough); out=%v", out)
 	}
 }
 


### PR DESCRIPTION
## What

BashTool can no longer deadlock when an LLM-issued command backgrounds a long-lived grandchild process that inherits the shell's stdout/stderr pipes.

Three settings on the `os/exec.Cmd`:

```go
cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
cmd.Cancel       = func() error { return killProcessGroup(cmd.Process) }
cmd.WaitDelay    = 5 * time.Second
```

Plus a `killProcessGroup` helper that sends `SIGKILL` to the whole process group (`syscall.Kill(-pid, SIGKILL)`).

## Why

Fixes #539

Empirically observed in the 2026-05-25 v5 batch: the coder model issued `find / -maxdepth 5 -name AGENTS.md` via BashTool. `BashTimeoutSeconds = 30` killed the shell after 30 s, but the `find` it had spawned survived (PID 49284, PPID=1 after reparenting to launchd) and kept the shell's inherited stdout pipe open. `Cmd.Wait` blocked in `awaitGoroutines` for 36+ minutes because the io.Copy goroutines never saw EOF.

`BashTimeoutSeconds` doesn't help in this shape: it cancels the context, which kills the direct child shell, but the post-`Wait` pipe drain is the part that hangs, and the context cancellation doesn't reach grandchildren.

The generalized failure mode is any LLM-issued bash that spawns a long-lived grandchild process which inherits stdout/stderr: `find /`, `docker run -d`, `kubectl proxy`, `make watch`, `&`-suffixed commands, anything that detaches or daemonizes.

## How

Go's `os/exec` has had built-in support for exactly this case since Go 1.20:

- **`SysProcAttr.Setpgid: true`** makes the shell the leader of its own process group. All grandchildren inherit that pgid (until/unless they explicitly `setpgid`).
- **`cmd.Cancel`** runs when `runCtx` fires. The default os/exec behavior is `SIGKILL` on the leader only. We override to send the kill to the entire process group via `syscall.Kill(-pid, SIGKILL)`. Grandchildren die with the shell.
- **`cmd.WaitDelay`** caps the time `Wait` blocks on stdio drainage after the process is dead. After `WaitDelay`, kernel-level pipe handles are force-closed and the io.Copy goroutines unblock with `io.ErrClosedPipe`, regardless of any remaining FD holders.

The three settings interlock: `Setpgid` ensures `killProcessGroup` actually reaches everything; `Cancel` kills the group on timeout; `WaitDelay` is paranoid insurance for the edge case where a child detached into its own session via `setsid` (in which case it's outside our process group and the kill misses it).

### Regression test

`TestBash_GrandchildPipeDoesNotDeadlock` drives the exact failure shape:

```go
const cmd = `(sleep 60 &) ; echo started ; sleep 0.1`
```

With Timeout=200ms. Without the fix this blocks ~60s. With it, the call returns in ~5s (Timeout + WaitDelay). Test asserts wall <15s to allow CI slack and detects regression cleanly. Verified locally: test passes in 5.12s.

## Checklist

- [x] Tests added/updated (regression test for #539)
- [x] `make test` passes locally (`go test ./pkg/foreman/agent/tools/` clean in 5.8s)
- [x] `make lint` passes locally (0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (n/a, internal behavior fix)
