### PR TITLE
fix(foreman): cascade + Workload rollup gate on phase AND verdict, not phase alone

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -201,6 +201,34 @@ const (
 	AgenticTaskVerdictGateError AgenticTaskVerdict = "GATE-ERROR"
 )
 
+// SucceededOnTarget reports whether the task is in a terminal Succeeded
+// phase AND its verdict is a positive outcome that produced usable
+// downstream artifacts (GO for LLM-driven Agents, GATE-PASS for the
+// deterministic gate Agent).
+//
+// This is the correct gate for downstream behavior. A task can end with
+// Phase=Succeeded + Verdict=INCOMPLETE (e.g. MaxTurnsExhausted,
+// LoopContractViolation, AssistantHallucinatedFinish) when the executor
+// reached terminal state cleanly but the agent loop did not produce a
+// usable result. The dependents of such a task must NOT proceed against
+// nonexistent output (a verify task that tries to clone a branch the
+// coder never pushed crashes on GATE-FAIL for the wrong reason), and
+// the Workload status rollup must NOT count it as a win.
+//
+// Fixes defilantech/LLMKube#541: cascadeFailIfDepFailed and the Workload
+// rollup previously gated on Phase alone, leaking INCOMPLETE coder
+// tasks through.
+func (t *AgenticTask) SucceededOnTarget() bool {
+	if t == nil || t.Status.Phase != AgenticTaskPhaseSucceeded {
+		return false
+	}
+	switch t.Status.Verdict {
+	case AgenticTaskVerdictGo, AgenticTaskVerdictGatePass:
+		return true
+	}
+	return false
+}
+
 // AgenticTaskStatus defines the observed state of an AgenticTask.
 type AgenticTaskStatus struct {
 	// Phase is the current lifecycle phase.

--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -166,13 +166,25 @@ type WorkloadStatus struct {
 	// +optional
 	Tasks []corev1.ObjectReference `json:"tasks,omitempty"`
 
-	// SucceededTasks counts child tasks in phase Succeeded.
+	// SucceededTasks counts child tasks that reached a positive terminal
+	// outcome (Phase=Succeeded AND verdict in {GO, GATE-PASS}). A child
+	// in Phase=Succeeded with verdict INCOMPLETE / NO-GO / GATE-FAIL /
+	// GATE-ERROR is NOT counted here; it lands in IncompleteTasks.
 	// +optional
 	SucceededTasks int32 `json:"succeededTasks,omitempty"`
 
 	// FailedTasks counts child tasks in phase Failed.
 	// +optional
 	FailedTasks int32 `json:"failedTasks,omitempty"`
+
+	// IncompleteTasks counts child tasks that reached Phase=Succeeded
+	// but did not produce a usable artifact (verdict in {INCOMPLETE,
+	// NO-GO, GATE-FAIL, GATE-ERROR}). These are surfaced separately
+	// from FailedTasks so callers can distinguish "the runtime errored"
+	// from "the agent legitimately gave up or the gate Job said the
+	// branch didn't pass the checks."
+	// +optional
+	IncompleteTasks int32 `json:"incompleteTasks,omitempty"`
 
 	// PlannerModel records which frontier model the planner actually used
 	// for this workload. Set after the planner runs.

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -320,6 +320,16 @@ spec:
                 description: FailedTasks counts child tasks in phase Failed.
                 format: int32
                 type: integer
+              incompleteTasks:
+                description: |-
+                  IncompleteTasks counts child tasks that reached Phase=Succeeded
+                  but did not produce a usable artifact (verdict in {INCOMPLETE,
+                  NO-GO, GATE-FAIL, GATE-ERROR}). These are surfaced separately
+                  from FailedTasks so callers can distinguish "the runtime errored"
+                  from "the agent legitimately gave up or the gate Job said the
+                  branch didn't pass the checks."
+                format: int32
+                type: integer
               phase:
                 description: Phase is the lifecycle state.
                 enum:
@@ -335,7 +345,11 @@ spec:
                   for this workload. Set after the planner runs.
                 type: string
               succeededTasks:
-                description: SucceededTasks counts child tasks in phase Succeeded.
+                description: |-
+                  SucceededTasks counts child tasks that reached a positive terminal
+                  outcome (Phase=Succeeded AND verdict in {GO, GATE-PASS}). A child
+                  in Phase=Succeeded with verdict INCOMPLETE / NO-GO / GATE-FAIL /
+                  GATE-ERROR is NOT counted here; it lands in IncompleteTasks.
                 format: int32
                 type: integer
               tasks:

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -320,6 +320,16 @@ spec:
                 description: FailedTasks counts child tasks in phase Failed.
                 format: int32
                 type: integer
+              incompleteTasks:
+                description: |-
+                  IncompleteTasks counts child tasks that reached Phase=Succeeded
+                  but did not produce a usable artifact (verdict in {INCOMPLETE,
+                  NO-GO, GATE-FAIL, GATE-ERROR}). These are surfaced separately
+                  from FailedTasks so callers can distinguish "the runtime errored"
+                  from "the agent legitimately gave up or the gate Job said the
+                  branch didn't pass the checks."
+                format: int32
+                type: integer
               phase:
                 description: Phase is the lifecycle state.
                 enum:
@@ -335,7 +345,11 @@ spec:
                   for this workload. Set after the planner runs.
                 type: string
               succeededTasks:
-                description: SucceededTasks counts child tasks in phase Succeeded.
+                description: |-
+                  SucceededTasks counts child tasks that reached a positive terminal
+                  outcome (Phase=Succeeded AND verdict in {GO, GATE-PASS}). A child
+                  in Phase=Succeeded with verdict INCOMPLETE / NO-GO / GATE-FAIL /
+                  GATE-ERROR is NOT counted here; it lands in IncompleteTasks.
                 format: int32
                 type: integer
               tasks:

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -166,8 +166,22 @@ func (r *AgenticTaskReconciler) setInitialPending(ctx context.Context, task *for
 	return ctrl.Result{}, nil
 }
 
-// cascadeFailIfDepFailed returns a non-empty message if any dependency is
-// already Failed; the caller fails the task with that message.
+// cascadeFailIfDepFailed returns a non-empty message if any dependency
+// is terminal-without-success; the caller fails the task with that
+// message.
+//
+// "Terminal without success" means either:
+//   - Phase=Failed (executor errored out), OR
+//   - Phase=Succeeded but verdict in {INCOMPLETE, NO-GO, GATE-FAIL,
+//     GATE-ERROR}. The dep is done, but it did not produce a usable
+//     artifact. A downstream verify task should not run against a
+//     branch the coder never pushed; a downstream review task should
+//     not run against a coder verdict that already declined.
+//
+// Previously this gated on Phase=Failed only, which leaked INCOMPLETE
+// coder tasks through to their downstream verifiers and made the
+// downstream task fail GATE-FAIL on a clone-of-nonexistent-branch
+// (the wrong reason). Fixes defilantech/LLMKube#541.
 func (r *AgenticTaskReconciler) cascadeFailIfDepFailed(ctx context.Context, task *foremanv1alpha1.AgenticTask) (string, error) {
 	for _, depName := range task.Spec.DependsOn {
 		var dep foremanv1alpha1.AgenticTask
@@ -180,12 +194,23 @@ func (r *AgenticTaskReconciler) cascadeFailIfDepFailed(ctx context.Context, task
 		if dep.Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed {
 			return fmt.Sprintf("dependency %q failed; cascade-failing", depName), nil
 		}
+		// Phase=Succeeded but verdict not on-target = terminal without
+		// usable output. Cascade-fail so dependents don't run against
+		// a nonexistent artifact.
+		if dep.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded && !dep.SucceededOnTarget() {
+			return fmt.Sprintf("dependency %q ended with verdict=%s (not on-target); cascade-failing",
+				depName, dep.Status.Verdict), nil
+		}
 	}
 	return "", nil
 }
 
-// allDepsSucceeded returns true only when every dependency exists in the
-// same namespace AND is in phase=Succeeded.
+// allDepsSucceeded returns true only when every dependency exists in
+// the same namespace AND is on-target (Phase=Succeeded AND verdict in
+// {GO, GATE-PASS}).
+//
+// Previously gated on Phase=Succeeded alone, allowing INCOMPLETE /
+// GATE-FAIL deps to unblock dependents. Fixes defilantech/LLMKube#541.
 func (r *AgenticTaskReconciler) allDepsSucceeded(ctx context.Context, task *foremanv1alpha1.AgenticTask) (bool, error) {
 	for _, depName := range task.Spec.DependsOn {
 		var dep foremanv1alpha1.AgenticTask
@@ -195,7 +220,7 @@ func (r *AgenticTaskReconciler) allDepsSucceeded(ctx context.Context, task *fore
 			}
 			return false, err
 		}
-		if dep.Status.Phase != foremanv1alpha1.AgenticTaskPhaseSucceeded {
+		if !dep.SucceededOnTarget() {
 			return false, nil
 		}
 	}

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -284,45 +284,71 @@ func (r *WorkloadReconciler) listChildren(ctx context.Context, w *foremanv1alpha
 }
 
 // rollup computes the Workload's terminal-or-in-flight state from its
-// children's phases and patches status. Triggered on every child phase
-// change via the Owns() watch.
+// children's phases AND verdicts and patches status. Triggered on every
+// child phase change via the Owns() watch.
+//
+// Counts children in four buckets:
+//   - succeeded: SucceededOnTarget() (Phase=Succeeded AND verdict in
+//     {GO, GATE-PASS}) — produced a usable artifact
+//   - incomplete: Phase=Succeeded but verdict in {INCOMPLETE, NO-GO,
+//     GATE-FAIL, GATE-ERROR} — terminal without usable output
+//   - failed: Phase=Failed
+//   - inFlight: everything else (Pending / Scheduled / Running)
+//
+// Previous rollup counted Phase=Succeeded as a win regardless of
+// verdict, which misreported the Memorial Day v5 batch as "12/12
+// Succeeded" when 2 of those 12 ended INCOMPLETE and 2 ended GATE-FAIL.
+// Fixes defilantech/LLMKube#541.
 func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
 	var (
-		succeeded, failed, inFlight int32
+		succeeded, incomplete, failed, inFlight int32
 	)
 	for i := range children {
-		switch children[i].Status.Phase {
-		case foremanv1alpha1.AgenticTaskPhaseSucceeded:
+		switch {
+		case children[i].SucceededOnTarget():
 			succeeded++
-		case foremanv1alpha1.AgenticTaskPhaseFailed:
+		case children[i].Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded:
+			// Terminal Phase=Succeeded but verdict isn't on-target.
+			incomplete++
+		case children[i].Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed:
 			failed++
 		default:
 			inFlight++
 		}
 	}
 
+	total := succeeded + incomplete + failed + inFlight
 	patch := client.MergeFrom(w.DeepCopy())
 	now := metav1.Now()
 	w.Status.SucceededTasks = succeeded
 	w.Status.FailedTasks = failed
+	w.Status.IncompleteTasks = incomplete
 
 	switch {
-	case inFlight == 0 && failed == 0:
+	case inFlight == 0 && failed == 0 && incomplete == 0:
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseCompleted
 		setCondition(&w.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeCompleted,
 			Status:             metav1.ConditionTrue,
 			Reason:             "AllChildrenSucceeded",
-			Message:            fmt.Sprintf("%d/%d child tasks Succeeded", succeeded, succeeded),
+			Message:            fmt.Sprintf("%d/%d child tasks on-target Succeeded", succeeded, total),
 			LastTransitionTime: now,
 		})
-	case inFlight == 0 && failed > 0:
+	case inFlight == 0 && (failed > 0 || incomplete > 0):
+		// Any incomplete OR failed child rolls the Workload to Failed
+		// terminal state. The condition message breaks out both counts
+		// so the operator can distinguish "agent gave up" (incomplete)
+		// from "executor errored" (failed).
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseFailed
+		reason := "ChildrenFailed"
+		if failed == 0 {
+			reason = "ChildrenIncomplete"
+		}
 		setCondition(&w.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeCompleted,
 			Status:             metav1.ConditionFalse,
-			Reason:             "ChildrenFailed",
-			Message:            fmt.Sprintf("%d child task(s) Failed", failed),
+			Reason:             reason,
+			Message:            fmt.Sprintf("%d on-target, %d incomplete, %d failed (of %d)", succeeded, incomplete, failed, total),
 			LastTransitionTime: now,
 		})
 	default:
@@ -331,7 +357,7 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Type:               "Dispatched",
 			Status:             metav1.ConditionTrue,
 			Reason:             "ChildrenInFlight",
-			Message:            fmt.Sprintf("%d in-flight, %d Succeeded, %d Failed", inFlight, succeeded, failed),
+			Message:            fmt.Sprintf("%d in-flight, %d on-target, %d incomplete, %d failed", inFlight, succeeded, incomplete, failed),
 			LastTransitionTime: now,
 		})
 	}

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -199,12 +199,24 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Force both children Succeeded via status patch.
-		for _, name := range []string{"rollup-test-code-42", "rollup-test-verify-42"} {
+		// Force both children Succeeded via status patch. As of #541
+		// the rollup distinguishes on-target Succeeded (verdict in
+		// {GO, GATE-PASS}) from terminal-without-output Succeeded;
+		// the coder gets verdict=GO and the verifier verdict=GATE-PASS
+		// so SucceededOnTarget() returns true for both.
+		on := []struct {
+			name    string
+			verdict foremanv1alpha1.AgenticTaskVerdict
+		}{
+			{"rollup-test-code-42", foremanv1alpha1.AgenticTaskVerdictGo},
+			{"rollup-test-verify-42", foremanv1alpha1.AgenticTaskVerdictGatePass},
+		}
+		for _, e := range on {
 			var t foremanv1alpha1.AgenticTask
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: name}, &t)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: e.name}, &t)).To(Succeed())
 			patch := client.MergeFrom(t.DeepCopy())
 			t.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+			t.Status.Verdict = e.verdict
 			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
 		}
 
@@ -239,19 +251,22 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
 		Expect(err).NotTo(HaveOccurred())
 
-		// One child Succeeded, the other Failed -> terminal Failed rollup.
+		// One child on-target Succeeded (GO), the other Failed.
+		// Terminal Failed rollup.
 		updates := []struct {
-			name  string
-			phase foremanv1alpha1.AgenticTaskPhase
+			name    string
+			phase   foremanv1alpha1.AgenticTaskPhase
+			verdict foremanv1alpha1.AgenticTaskVerdict
 		}{
-			{"rollup-fail-code-99", foremanv1alpha1.AgenticTaskPhaseSucceeded},
-			{"rollup-fail-verify-99", foremanv1alpha1.AgenticTaskPhaseFailed},
+			{"rollup-fail-code-99", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGo},
+			{"rollup-fail-verify-99", foremanv1alpha1.AgenticTaskPhaseFailed, ""},
 		}
 		for _, u := range updates {
 			var t foremanv1alpha1.AgenticTask
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: u.name}, &t)).To(Succeed())
 			patch := client.MergeFrom(t.DeepCopy())
 			t.Status.Phase = u.phase
+			t.Status.Verdict = u.verdict
 			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
 		}
 
@@ -266,6 +281,68 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		completed := findCondition(fresh.Status.Conditions, conditionTypeCompleted)
 		Expect(completed).NotTo(BeNil())
 		Expect(completed.Reason).To(Equal("ChildrenFailed"))
+	})
+
+	// Regression for defilantech/LLMKube#541. Phase=Succeeded with a
+	// non-positive verdict (INCOMPLETE, NO-GO, GATE-FAIL, GATE-ERROR)
+	// must NOT count as a win in the rollup. The Memorial Day v5 batch
+	// reported "12/12 child tasks Succeeded" + Phase=Completed when
+	// 2 children were INCOMPLETE and 2 were GATE-FAIL; the new
+	// IncompleteTasks counter + Failed-on-incomplete phase logic
+	// makes that report honest.
+	It("rolls up Phase=Succeeded + verdict=INCOMPLETE into incompleteTasks and Failed phase (#541)", func() {
+		wl := newWorkload("rollup-incomplete", foremanv1alpha1.WorkloadSpec{
+			Intent:           "rollup-incomplete",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{1234},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Coder Succeeded but INCOMPLETE (MaxTurnsExhausted shape);
+		// verifier Succeeded with GATE-FAIL (it ran but the gate's
+		// `make` checks did not pass — also a terminal-without-output).
+		updates := []struct {
+			name    string
+			phase   foremanv1alpha1.AgenticTaskPhase
+			verdict foremanv1alpha1.AgenticTaskVerdict
+		}{
+			{"rollup-incomplete-code-1234", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictIncomplete},
+			{"rollup-incomplete-verify-1234", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGateFail},
+		}
+		for _, u := range updates {
+			var t foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: u.name}, &t)).To(Succeed())
+			patch := client.MergeFrom(t.DeepCopy())
+			t.Status.Phase = u.phase
+			t.Status.Verdict = u.verdict
+			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
+		}
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		// Previously: Phase=Completed, SucceededTasks=2, FailedTasks=0.
+		// Now: Phase=Failed, SucceededTasks=0, FailedTasks=0,
+		//      IncompleteTasks=2, reason=ChildrenIncomplete.
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseFailed),
+			"workload with all-incomplete children must NOT roll to Completed")
+		Expect(fresh.Status.SucceededTasks).To(Equal(int32(0)))
+		Expect(fresh.Status.FailedTasks).To(Equal(int32(0)))
+		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(2)))
+		completed := findCondition(fresh.Status.Conditions, conditionTypeCompleted)
+		Expect(completed).NotTo(BeNil())
+		Expect(completed.Reason).To(Equal("ChildrenIncomplete"))
 	})
 })
 


### PR DESCRIPTION
## What

Three places in the Foreman reconcilers gated on `Phase=Succeeded` without checking the verdict, leaking `INCOMPLETE` / `NO-GO` / `GATE-FAIL` children through as if they were wins:

- `AgenticTaskReconciler.cascadeFailIfDepFailed` cascaded only on `Phase=Failed`
- `AgenticTaskReconciler.allDepsSucceeded` returned true for any `Phase=Succeeded` dep
- `WorkloadReconciler.rollup` counted any `Phase=Succeeded` child as a success in `SucceededTasks`

Adds an `AgenticTask.SucceededOnTarget() bool` helper (true iff `Phase=Succeeded` AND verdict in `{GO, GATE-PASS}`) and routes all three sites through it. Adds a `WorkloadStatus.IncompleteTasks int32` field so the rollup can surface terminal-without-output children separately from failed ones.

## Why

Fixes #541

Memorial Day v5 batch made this concrete: a Workload with 2 INCOMPLETE coder children and 2 GATE-FAIL verifier children rolled up to `Phase=Completed` with `succeededTasks=12, failedTasks=0`. The actual outcome was 4 PR-ready branches + 2 INCOMPLETE coder runs (no branch pushed) + 2 GATE-FAIL verifier runs (cascade-clone-failure on the missing branches). The Workload status misreported this as 12 wins.

Downstream of cascadeFailIfDepFailed there's a second bug from the same root cause: when a coder task ends `Phase=Succeeded + verdict=INCOMPLETE`, its dependent `verify-N` task was getting dispatched anyway. The verifier then tried to clone a branch the coder never pushed and crashed `GATE-FAIL` on the missing-branch error. That's a GATE-FAIL for the wrong reason and a wasted gate-Job run.

## How

### `AgenticTask.SucceededOnTarget()`

```go
func (t *AgenticTask) SucceededOnTarget() bool {
    if t == nil || t.Status.Phase != AgenticTaskPhaseSucceeded {
        return false
    }
    switch t.Status.Verdict {
    case AgenticTaskVerdictGo, AgenticTaskVerdictGatePass:
        return true
    }
    return false
}
```

Centralizes the "is this a usable terminal outcome" check so both reconcilers + the rollup share one definition.

### `cascadeFailIfDepFailed` now cascades on terminal-without-success

```go
if dep.Status.Phase == AgenticTaskPhaseFailed {
    return cascadeMessage("dep failed")
}
if dep.Status.Phase == AgenticTaskPhaseSucceeded && !dep.SucceededOnTarget() {
    return cascadeMessage("dep ended with verdict=X (not on-target); cascade-failing")
}
```

### `allDepsSucceeded` requires every dep to be on-target

```go
if !dep.SucceededOnTarget() { return false, nil }
```

### `WorkloadReconciler.rollup` now four buckets + IncompleteTasks field

- `succeeded` — `SucceededOnTarget()`
- `incomplete` — `Phase=Succeeded` but not on-target
- `failed` — `Phase=Failed`
- `inFlight` — everything else

Workload rolls to `Phase=Completed` only when ALL children are on-target. Any incomplete OR failed children roll to `Phase=Failed` with a `ChildrenIncomplete` or `ChildrenFailed` condition reason that distinguishes the two cases. Condition message format breaks out all counts so the operator can see at a glance: `"4 on-target, 2 incomplete, 0 failed (of 6)"`.

### Regression test

New `It("rolls up Phase=Succeeded + verdict=INCOMPLETE into incompleteTasks and Failed phase (#541)", ...)` replays the exact v5 batch shape (one INCOMPLETE coder + one GATE-FAIL verifier under a Workload) and asserts:

```go
Expect(fresh.Status.Phase).To(Equal(WorkloadPhaseFailed))
Expect(fresh.Status.SucceededTasks).To(Equal(int32(0)))
Expect(fresh.Status.FailedTasks).To(Equal(int32(0)))
Expect(fresh.Status.IncompleteTasks).To(Equal(int32(2)))
```

Previous v5 batch would have made these all 0/0/2/0/`Phase=Completed`. The new logic makes that report honest.

### Two existing tests updated

Both tests previously set `Phase=Succeeded` without `Verdict`. Under the new contract that counts as `incomplete`, so the tests are updated to set both `Phase` and `Verdict` (`GO` for coder, `GATE-PASS` for verifier).

## Checklist

- [x] Tests added/updated (1 new regression + 2 existing tests updated for the new contract)
- [x] `make test` passes locally (21/21 specs)
- [x] `make lint` passes locally (0 issues)
- [x] CRDs regenerated (`make manifests chart-crds foreman-chart-crds`); `IncompleteTasks` field present in both `config/crd/bases/foreman.llmkube.dev_workloads.yaml` and `charts/foreman/templates/crds/workloads.yaml`
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO

## Backwards compatibility note

`WorkloadStatus.IncompleteTasks` is a new optional field. Existing Workloads without the field default to 0 — which is correct, since they pre-date the new accounting. The `WorkloadStatus.SucceededTasks` semantics tightened (now requires verdict in addition to phase), so an old Workload whose children were Phase=Succeeded + verdict=empty would now read as `incomplete` rather than `succeeded`. In practice the executor always sets a verdict when transitioning to terminal, so this only affects hand-crafted test fixtures (covered in the test updates above).
