### PR TITLE
fix(foreman/executor): resolve InferenceService port from live Endpoints, not stale install-time override

### DIFF
--- a/charts/foreman/templates/agent-rbac.yaml
+++ b/charts/foreman/templates/agent-rbac.yaml
@@ -42,6 +42,16 @@ rules:
     resources: ["inferenceservices"]
     verbs: ["get", "list", "watch"]
 
+  # When --inference-base-url-host-override is set (off-cluster,
+  # same-host installs), the native executor reads the live llama-
+  # server port from the v1 Endpoints object the metal-agent maintains
+  # for each InferenceService. The controller-runtime cache backs this
+  # with a watch so a respawn-driven port roll is picked up on the
+  # next task dispatch (#540).
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch"]
+
   # Native executor writes the per-task transcript ConfigMap, owner-
   # ref'd to the AgenticTask.
   - apiGroups: [""]

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -98,9 +98,10 @@ func main() {
 		staticTotalRAMGB int
 
 		// M3 executor flags
-		agentMode            string
-		gitRemoteURL         string
-		inferenceURLOverride string
+		agentMode                string
+		gitRemoteURL             string
+		inferenceURLOverride     string
+		inferenceURLHostOverride string
 
 		// M4 gate-tool flags
 		foremanNamespace  string
@@ -149,9 +150,18 @@ func main() {
 	flag.StringVar(&gitRemoteURL, "git-remote-url", "",
 		"git URL to clone from and push branches to. v0.1 uses the fork for both. Required when --agent-mode=native.")
 	flag.StringVar(&inferenceURLOverride, "inference-base-url-override", "",
-		"Override the inference URL the OAI client dispatches to (e.g. http://localhost:8080/v1). "+
-			"Required when foreman-agent runs outside the cluster; the in-cluster "+
-			"path resolves from InferenceService.status.endpoint.")
+		"Replace the resolved InferenceService URL entirely (e.g. http://localhost:8080/v1). "+
+			"Use for tests and stub OAI servers; for off-cluster, same-host installs prefer "+
+			"--inference-base-url-host-override so the live port flows through on every "+
+			"llama-server respawn (#540).")
+	flag.StringVar(&inferenceURLHostOverride, "inference-base-url-host-override", "",
+		"Rewrite the host of the resolved InferenceService URL to this value (e.g. 127.0.0.1) "+
+			"and substitute the live port from the v1 Endpoints object the metal-agent "+
+			"maintains for the InferenceService. Use for off-cluster, same-host installs "+
+			"(foreman-agent on the same Mac as the metal-agent) where cluster DNS does not "+
+			"resolve but the local llama-server's port rolls on every respawn. The "+
+			"controller-runtime cache re-reads the current port on each task dispatch, so "+
+			"this stays current without restart.")
 	flag.StringVar(&commitAuthorName, "commit-author-name", "Foreman Bot",
 		"git author + committer name for branches produced by the native loop.")
 	flag.StringVar(&commitAuthorEmail, "commit-author-email", "",
@@ -266,10 +276,11 @@ func main() {
 		executor = &foremanagent.StubExecutor{SleepDuration: stubSleep}
 	case "native":
 		executor = &foremanagent.NativeAgentLoopExecutor{
-			Client:                   kc,
-			WorkspaceRoot:            workspaceDir,
-			GitRemoteURL:             gitRemoteURL,
-			InferenceBaseURLOverride: inferenceURLOverride,
+			Client:                       kc,
+			WorkspaceRoot:                workspaceDir,
+			GitRemoteURL:                 gitRemoteURL,
+			InferenceBaseURLOverride:     inferenceURLOverride,
+			InferenceBaseURLHostOverride: inferenceURLHostOverride,
 			CommitAuthor: repo.Identity{
 				Name: commitAuthorName, Email: commitAuthorEmail,
 			},

--- a/docs/foreman/runbook-m3.md
+++ b/docs/foreman/runbook-m3.md
@@ -90,7 +90,7 @@ pkill -f 'llmkube-foreman-agent --agent-mode=stub' || true
   --task-namespace=default \
   --workspace-dir=$HOME/foreman-workspaces \
   --git-remote-url=https://github.com/Defilan/LLMKube.git \
-  --inference-base-url-override=http://localhost:8080/v1 \
+  --inference-base-url-host-override=127.0.0.1 \
   --commit-author-name="Foreman Bot" \
   --commit-author-email="foreman@$(hostname -s).local" \
   --installed-models=qwen36-35b-carnice-mtp \
@@ -102,11 +102,16 @@ Why each native-mode flag:
 
 - `--git-remote-url`: v0.1 clones from and pushes to the same URL (the
   fork). v0.2 will split clone-from-upstream from push-to-fork.
-- `--inference-base-url-override`: required when foreman-agent runs
-  on the host (where `*.svc.cluster.local` does not resolve);
-  bypasses InferenceService endpoint resolution. The path here must
-  match the actual llama.cpp port (`localhost:8080/v1` on the M5
-  Max default).
+- `--inference-base-url-host-override`: required when foreman-agent
+  runs on the host (where `*.svc.cluster.local` does not resolve).
+  The executor still reads `InferenceService.status.endpoint` for the
+  scheme and path; it substitutes this host and re-reads the live
+  port from the v1 Endpoints object the metal-agent rewrites on every
+  llama-server respawn. Set to `127.0.0.1` for the launchd-on-M5-Max
+  case. (`--inference-base-url-override` is still available for tests
+  and stub OAI servers as a full-URL replacement, but it locks the
+  port at install time and breaks on every metal-agent respawn,
+  which is exactly the bug #540 fixes.)
 - `--commit-author-email`: required; the executor refuses to start
   without it because DCO sign-off needs a real email.
 - `--installed-models`, `--max-context-tokens`, `--tokens-per-second`:

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -66,12 +67,28 @@ type NativeAgentLoopExecutor struct {
 	// push-to-fork.
 	GitRemoteURL string
 
-	// InferenceBaseURLOverride bypasses InferenceService resolution and
-	// dispatches OAI requests to this URL instead. Required when the
-	// foreman-agent runs outside the cluster (e.g. on the M5 Max host
-	// where in-cluster DNS does not resolve). Must include the /v1
-	// suffix; the OAI client appends /chat/completions.
+	// InferenceBaseURLOverride bypasses InferenceService resolution
+	// entirely and dispatches OAI requests to this URL. Use for tests
+	// and stub OAI servers; for off-cluster, same-host installs (e.g.
+	// foreman-agent on the M5 Max) prefer InferenceBaseURLHostOverride
+	// instead so the live port from the metal-agent's Endpoints object
+	// flows through on every llama-server respawn. Must include the
+	// /v1 suffix; the OAI client appends /chat/completions.
 	InferenceBaseURLOverride string
+
+	// InferenceBaseURLHostOverride, when non-empty, rewrites the host
+	// of the resolved InferenceService URL to this value (e.g.
+	// "127.0.0.1") and substitutes the live port from the v1 Endpoints
+	// object the metal-agent maintains for the InferenceService. The
+	// scheme and path are kept from InferenceService.status.endpoint.
+	//
+	// This is the K8s-native answer for off-cluster, same-host installs:
+	// the metal-agent rewrites Endpoints on every llama-server respawn,
+	// so each task dispatch re-reads the current port through the
+	// controller-runtime cache. Compare to InferenceBaseURLOverride,
+	// which locks the port at install time and breaks on respawn
+	// (#540).
+	InferenceBaseURLHostOverride string
 
 	// CommitAuthor and CommitCommitter are the git identities the
 	// resulting commit carries. v0.1 sets both to the same Identity.
@@ -463,9 +480,18 @@ func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL 
 }
 
 // resolveInferenceBaseURL turns Agent.spec.inferenceServiceRef into a
-// base URL the OAI client can hit. Override wins for the v0.1 path
-// where foreman-agent runs outside the cluster; otherwise we read
-// InferenceService.status.endpoint and trim the chat-completions suffix.
+// base URL the OAI client can hit. Three modes, in precedence order:
+//
+//  1. InferenceBaseURLOverride: full URL replacement. Used by tests
+//     and stub OAI servers.
+//  2. InferenceBaseURLHostOverride: read InferenceService.status.endpoint
+//     for scheme + path, read the v1 Endpoints object the metal-agent
+//     maintains for the live port, substitute the override host. Used
+//     by off-cluster, same-host installs (foreman-agent on the M5 Max
+//     where cluster DNS does not resolve but the metal-agent rewrites
+//     Endpoints on every llama-server respawn).
+//  3. Default: trust status.endpoint as the cluster-DNS form, used by
+//     in-cluster foreman-agents.
 func (e *NativeAgentLoopExecutor) resolveInferenceBaseURL(
 	ctx context.Context,
 	namespace string,
@@ -489,7 +515,66 @@ func (e *NativeAgentLoopExecutor) resolveInferenceBaseURL(
 	// status.endpoint is the chat-completions URL; the OAI client
 	// expects the /v1 base.
 	endpoint = strings.TrimSuffix(endpoint, "/chat/completions")
-	return strings.TrimRight(endpoint, "/"), nil
+	endpoint = strings.TrimRight(endpoint, "/")
+
+	if e.InferenceBaseURLHostOverride != "" {
+		return e.rewriteHostFromEndpoints(ctx, namespace, isvc.Name, endpoint)
+	}
+	return endpoint, nil
+}
+
+// rewriteHostFromEndpoints replaces the host of baseURL with the
+// configured InferenceBaseURLHostOverride and the live port from the
+// InferenceService's v1 Endpoints object. The Endpoints name mirrors
+// the operator's sanitizeDNSName (dots become hyphens; see
+// internal/controller/inferenceservice_controller.go).
+//
+// EndpointSlice migration is tracked separately and producer + consumer
+// move together.
+//
+//nolint:staticcheck // SA1019: the metal-agent registers v1 Endpoints;
+func (e *NativeAgentLoopExecutor) rewriteHostFromEndpoints(
+	ctx context.Context, namespace, isvcName, baseURL string,
+) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse status.endpoint %q: %w", baseURL, err)
+	}
+	var eps corev1.Endpoints
+	epsName := strings.ReplaceAll(isvcName, ".", "-")
+	key := types.NamespacedName{Namespace: namespace, Name: epsName}
+	if err := e.Client.Get(ctx, key, &eps); err != nil {
+		return "", fmt.Errorf("get Endpoints %s for host-override resolution: %w", key, err)
+	}
+	port, err := firstReadyPort(eps)
+	if err != nil {
+		return "", fmt.Errorf("Endpoints %s: %w", key, err)
+	}
+	u.Host = fmt.Sprintf("%s:%d", e.InferenceBaseURLHostOverride, port)
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+// firstReadyPort returns the first port advertised on a subset that
+// has at least one ready address. metal-agent registers one address +
+// one port per InferenceService today; a future multi-replica metal
+// path would need a smarter selector, but for the v0.2 same-host case
+// "the only port" is the right port.
+//
+//nolint:staticcheck // SA1019: see rewriteHostFromEndpoints note.
+func firstReadyPort(eps corev1.Endpoints) (int32, error) {
+	for _, subset := range eps.Subsets {
+		if len(subset.Addresses) == 0 {
+			continue
+		}
+		for _, p := range subset.Ports {
+			if p.Port > 0 {
+				return p.Port, nil
+			}
+		}
+	}
+	// metal-agent has not registered llama-server yet, or just
+	// respawned and is between unregister + register.
+	return 0, errors.New("no ready address with a port on the Endpoints object")
 }
 
 // buildAuth resolves credentials via the configured AuthFactory or

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -23,12 +23,18 @@ package agent
 // failure rather than as a cascading executor flake.
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
 
 // TestBranchNameForTask covers the precedence rule between explicit
@@ -152,4 +158,216 @@ func TestBuildDeterministicArgs(t *testing.T) {
 			t.Errorf("cloneURL: want empty (so tool falls back to CloneURLBase+Repo) got %v", got["cloneURL"])
 		}
 	})
+}
+
+// resolveSchemeForTests builds a runtime scheme with the API types the
+// resolveInferenceBaseURL tests touch. corev1 covers Endpoints,
+// inferencev1alpha1 covers InferenceService, foreman covers the
+// Agent CR field types referenced incidentally.
+func resolveSchemeForTests(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("corev1: %v", err)
+	}
+	if err := inferencev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("inferencev1alpha1: %v", err)
+	}
+	if err := foremanv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("foreman: %v", err)
+	}
+	return s
+}
+
+// TestResolveInferenceBaseURL pins the precedence rules among the
+// three resolution modes (full override, host override + Endpoints,
+// status.endpoint default) and the error shapes the caller sees when
+// any prerequisite is missing. Regression for #540: the static
+// override locked the port at install time, so every metal-agent
+// respawn broke every subsequent task; the host-override path re-reads
+// the live port from Endpoints on each call.
+func TestResolveInferenceBaseURL(t *testing.T) {
+	// Helpers that build the canned cluster objects each case may want
+	// the fake client seeded with.
+	mkAgent := func(isvcName string) *foremanv1alpha1.Agent {
+		return &foremanv1alpha1.Agent{
+			ObjectMeta: metav1.ObjectMeta{Name: "coder", Namespace: "default"},
+			Spec: foremanv1alpha1.AgentSpec{
+				InferenceServiceRef: foremanv1alpha1Local(isvcName),
+			},
+		}
+	}
+	mkISvc := func(name, endpoint string) *inferencev1alpha1.InferenceService {
+		return &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Status:     inferencev1alpha1.InferenceServiceStatus{Endpoint: endpoint},
+		}
+	}
+	//nolint:staticcheck // SA1019: matches production code path.
+	mkEndpoints := func(name string, port int32, withAddress bool) *corev1.Endpoints {
+		eps := &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Subsets:    []corev1.EndpointSubset{{Ports: []corev1.EndpointPort{{Port: port}}}},
+		}
+		if withAddress {
+			eps.Subsets[0].Addresses = []corev1.EndpointAddress{{IP: "10.42.0.5"}}
+		}
+		return eps
+	}
+
+	cases := []struct {
+		name        string
+		executor    NativeAgentLoopExecutor
+		seedObjects []any
+		want        string
+		wantErrFrag string
+	}{
+		{
+			name: "full override wins over everything else",
+			executor: NativeAgentLoopExecutor{
+				InferenceBaseURLOverride:     "http://stub:7777/v1/",
+				InferenceBaseURLHostOverride: "127.0.0.1", // ignored when full override set
+			},
+			want: "http://stub:7777/v1",
+		},
+		{
+			name:     "default: status.endpoint cluster-DNS form, chat suffix stripped",
+			executor: NativeAgentLoopExecutor{},
+			seedObjects: []any{
+				mkISvc("test-svc", "http://test-svc.default.svc.cluster.local:80/v1/chat/completions"),
+			},
+			want: "http://test-svc.default.svc.cluster.local:80/v1",
+		},
+		{
+			name: "host override rewrites host + uses live port from Endpoints",
+			executor: NativeAgentLoopExecutor{
+				InferenceBaseURLHostOverride: "127.0.0.1",
+			},
+			seedObjects: []any{
+				mkISvc("test-svc", "http://test-svc.default.svc.cluster.local:80/v1/chat/completions"),
+				mkEndpoints("test-svc", 60177, true),
+			},
+			want: "http://127.0.0.1:60177/v1",
+		},
+		{
+			name: "host override: live port flows through after a respawn (different port)",
+			executor: NativeAgentLoopExecutor{
+				InferenceBaseURLHostOverride: "127.0.0.1",
+			},
+			seedObjects: []any{
+				mkISvc("test-svc", "http://test-svc.default.svc.cluster.local:80/v1/chat/completions"),
+				mkEndpoints("test-svc", 49931, true), // metal-agent rolled it to a new port
+			},
+			want: "http://127.0.0.1:49931/v1",
+		},
+		{
+			name: "host override: dotted InferenceService name maps to hyphenated Endpoints",
+			executor: NativeAgentLoopExecutor{
+				InferenceBaseURLHostOverride: "127.0.0.1",
+			},
+			seedObjects: []any{
+				// Agent references the dotted name; the operator
+				// sanitizes dots to hyphens when naming the Endpoints
+				// object the metal-agent registers.
+				func() *foremanv1alpha1.Agent { return mkAgent("inf.svc.dotted") }(),
+				mkISvc("inf.svc.dotted", "http://inf-svc-dotted.default.svc.cluster.local:80/v1/chat/completions"),
+				mkEndpoints("inf-svc-dotted", 60177, true),
+			},
+			want: "http://127.0.0.1:60177/v1",
+		},
+		{
+			name: "host override: missing Endpoints surfaces a clear error (not connect-refused later)",
+			executor: NativeAgentLoopExecutor{
+				InferenceBaseURLHostOverride: "127.0.0.1",
+			},
+			seedObjects: []any{
+				mkISvc("test-svc", "http://test-svc.default.svc.cluster.local:80/v1/chat/completions"),
+				// no Endpoints object
+			},
+			wantErrFrag: "get Endpoints",
+		},
+		{
+			name: "host override: Endpoints exists but has no ready address",
+			executor: NativeAgentLoopExecutor{
+				InferenceBaseURLHostOverride: "127.0.0.1",
+			},
+			seedObjects: []any{
+				mkISvc("test-svc", "http://test-svc.default.svc.cluster.local:80/v1/chat/completions"),
+				mkEndpoints("test-svc", 60177, false), // port present, no addresses
+			},
+			wantErrFrag: "no ready address with a port",
+		},
+		{
+			name:        "default: InferenceService not found",
+			executor:    NativeAgentLoopExecutor{},
+			seedObjects: nil,
+			wantErrFrag: "get InferenceService",
+		},
+		{
+			name:     "default: status.endpoint empty (operator has not populated it yet)",
+			executor: NativeAgentLoopExecutor{},
+			seedObjects: []any{
+				mkISvc("test-svc", ""),
+			},
+			wantErrFrag: "empty status.endpoint",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := fake.NewClientBuilder().WithScheme(resolveSchemeForTests(t))
+			// Build the agent for this case: the dotted-name case
+			// supplies its own; everything else uses the standard
+			// "test-svc" agent.
+			var agent *foremanv1alpha1.Agent
+			for _, obj := range tc.seedObjects {
+				switch v := obj.(type) {
+				case *foremanv1alpha1.Agent:
+					agent = v
+					b = b.WithObjects(v)
+				case *inferencev1alpha1.InferenceService:
+					b = b.WithObjects(v)
+				//nolint:staticcheck // SA1019: mirrors the production
+				// resolveInferenceBaseURL path; producer + consumer
+				// migrate from v1 Endpoints to discoveryv1 EndpointSlice
+				// together.
+				case *corev1.Endpoints:
+					b = b.WithObjects(v)
+				default:
+					t.Fatalf("unhandled seed object type %T", obj)
+				}
+			}
+			if agent == nil {
+				agent = mkAgent("test-svc")
+			}
+			e := tc.executor
+			e.Client = b.Build()
+
+			got, err := e.resolveInferenceBaseURL(context.Background(), "default", agent)
+			if tc.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil (result=%q)", tc.wantErrFrag, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrFrag) {
+					t.Errorf("error fragment: want %q, got %v", tc.wantErrFrag, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveInferenceBaseURL: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("URL: want %q got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// foremanv1alpha1Local is a tiny test-side helper to avoid importing
+// corev1 directly in the test fixture builder. The Agent CR uses
+// corev1.LocalObjectReference for InferenceServiceRef, which the
+// production code already depends on; this function names the import
+// boundary so the test reads cleanly.
+func foremanv1alpha1Local(name string) corev1.LocalObjectReference {
+	return corev1.LocalObjectReference{Name: name}
 }


### PR DESCRIPTION
## What

Replace the static `--inference-base-url-override` resolution path with a K8s-native dynamic lookup for off-cluster, same-host foreman-agent installs:

- New `--inference-base-url-host-override` flag (e.g. `127.0.0.1`). When set, the native executor reads `InferenceService.status.endpoint` for the scheme + path, reads the v1 Endpoints object the metal-agent maintains for the InferenceService to get the live port, and substitutes the override host.
- `--inference-base-url-override` retained for tests + stub OAI servers (full-URL replacement).
- New `endpoints: get/list/watch` rule on the foreman-agent ClusterRole.
- M3 runbook updated to recommend the new flag.
- 8-case whitebox table test pins precedence among the three resolution modes plus the error shapes when Endpoints is missing or has no ready addresses.

## Why (Fixes #540)

The foreman-agent launchd plist on Apple Silicon worker installs hardcodes `--inference-base-url-override=http://127.0.0.1:<PORT>/v1`. Every metal-agent respawn rolls llama-server onto a fresh dynamic port, but the static override never updates: the next coder task dials the dead port and fails turn-1 with `connect: connection refused`.

Hit live during the v5 batch on 2026-05-25: 12/12 tasks failed within ~30s because the install-time override pointed at port 49931 while llama-server had moved to 60177. Manually patching the plist + `launchctl bootout`/`bootstrap` recovered it.

## How

K8s-native pattern: the metal-agent's `RegisterEndpoint` rewrites a v1 Endpoints object on every llama-server respawn (the operator already watches this in #486). The foreman-agent now reads through the controller-runtime informer cache on each task dispatch, so a respawn-driven port roll flows through to the next task without restarting foreman-agent.

Why this shape over a metal-agent reverse-proxy (the issue's option 2):
- Treats K8s as the registry of record (no parallel registry in metal-agent).
- No new long-lived TCP listener to manage.
- Generalizes off-host (a foreman-agent on a different machine works the same way, without the host override).
- Matches what `kube-proxy` does conceptually: watch Endpoints, route to the live backend.

## Checklist

- [x] `make fmt vet lint test` clean (Mac)
- [x] `GOOS=linux ./bin/golangci-lint run ./...` clean
- [x] No CRD changes; `make manifests chart-crds` confirms clean
- [x] New RBAC rule renders correctly under `helm template charts/foreman`
- [x] DCO sign-off (`git commit -s`)
- [x] Runbook updated alongside the flag rename