### PR TITLE
feat(foreman/v0.2): WorkloadSpec.reviewerAgentRefs (plural) + third pipeline stage

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -24,7 +24,7 @@ import (
 
 // AgenticTaskKind is the unit of work the task performs. Each kind has a
 // payload shape, scheduler routing, and lifecycle.
-// +kubebuilder:validation:Enum=issue-fix;verify;freeform
+// +kubebuilder:validation:Enum=issue-fix;verify;review;freeform
 type AgenticTaskKind string
 
 const (
@@ -35,6 +35,14 @@ const (
 	// codegen sync) against a pushed branch. Typically scheduled by the
 	// controller as a child of a Succeeded issue-fix task.
 	AgenticTaskKindVerify AgenticTaskKind = "verify"
+	// AgenticTaskKindReview runs a reviewer Agent against the diff that a
+	// Succeeded issue-fix produced. v0.2 emits one review task per entry
+	// in WorkloadSpec.ReviewerAgentRefs, all parallel, all depending on
+	// the upstream verify task reaching GATE-PASS. The rollup from #548
+	// treats verdict=NO-GO as "Succeeded but incomplete," so any reviewer
+	// NO-GO marks the parent Workload review-failed; Day 4 escalates that
+	// case to a hybrid cloud reviewer Agent.
+	AgenticTaskKindReview AgenticTaskKind = "review"
 	// AgenticTaskKindFreeform passes an arbitrary prompt to a named agent.
 	AgenticTaskKindFreeform AgenticTaskKind = "freeform"
 )

--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -45,7 +45,9 @@ const (
 //     for full control over a hand-authored pipeline.
 //  2. Issue-batch shortcut (Issues non-empty + CoderAgentRef +
 //     VerifierAgentRef set): emit one code+verify pair per issue. The
-//     most common shape for v0.1.
+//     most common shape for v0.1. When ReviewerAgentRefs is also set
+//     (v0.2), each issue additionally fans out one parallel review
+//     task per listed reviewer Agent, depending on the verify task.
 //  3. LLM-planner (Intent only, no Pipeline, no Issues): deferred to v0.2.
 //     v0.1 marks the Workload Failed with reason NoPlannerOrPipeline.
 type WorkloadSpec struct {
@@ -105,6 +107,28 @@ type WorkloadSpec struct {
 	// Pipeline mode.
 	// +optional
 	VerifierAgentRef *corev1.LocalObjectReference `json:"verifierAgentRef,omitempty"`
+
+	// ReviewerAgentRefs is the optional v0.2 third pipeline stage: each
+	// listed Agent runs a review task against the diff the coder
+	// produced, in parallel, all depending on the upstream verify task
+	// reaching GATE-PASS. The rendered task names are
+	// "<workload>-review-<N>-<i>" where N is the issue number and i is
+	// the index into this slice; the index keeps DNS-1123 lengths
+	// bounded across long agent names.
+	//
+	// Aggregation: any reviewer emitting verdict=NO-GO leaves that task
+	// Phase=Succeeded but not "succeeded on target," so the Workload
+	// rollup from #548 marks it under IncompleteTasks and the Workload
+	// reaches Phase=Failed with reason ChildrenIncomplete. Day 4
+	// extends this with a hybrid cloud reviewer Agent that the rollup
+	// can escalate to when the local fleet says NO-GO.
+	//
+	// Leave empty to keep the v0.1 two-step (code + verify) pipeline.
+	// Multi-strategy reviewing (validator / falsification / thinking-
+	// mode) is achieved by listing three Agent CRs with different
+	// system prompts and (optionally) the same underlying model.
+	// +optional
+	ReviewerAgentRefs []corev1.LocalObjectReference `json:"reviewerAgentRefs,omitempty"`
 }
 
 // PipelineStep is one step in an explicit Workload pipeline. Each step

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -93,6 +93,7 @@ spec:
                 enum:
                 - issue-fix
                 - verify
+                - review
                 - freeform
                 type: string
               modelRef:

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -156,6 +156,7 @@ spec:
                       enum:
                       - issue-fix
                       - verify
+                      - review
                       - freeform
                       type: string
                     name:
@@ -232,6 +233,44 @@ spec:
                   generated AgenticTask in issue-batch mode. Ignored in explicit
                   Pipeline mode (each step carries its own Payload.Repo).
                 type: string
+              reviewerAgentRefs:
+                description: |-
+                  ReviewerAgentRefs is the optional v0.2 third pipeline stage: each
+                  listed Agent runs a review task against the diff the coder
+                  produced, in parallel, all depending on the upstream verify task
+                  reaching GATE-PASS. The rendered task names are
+                  "<workload>-review-<N>-<i>" where N is the issue number and i is
+                  the index into this slice; the index keeps DNS-1123 lengths
+                  bounded across long agent names.
+
+                  Aggregation: any reviewer emitting verdict=NO-GO leaves that task
+                  Phase=Succeeded but not "succeeded on target," so the Workload
+                  rollup from #548 marks it under IncompleteTasks and the Workload
+                  reaches Phase=Failed with reason ChildrenIncomplete. Day 4
+                  extends this with a hybrid cloud reviewer Agent that the rollup
+                  can escalate to when the local fleet says NO-GO.
+
+                  Leave empty to keep the v0.1 two-step (code + verify) pipeline.
+                  Multi-strategy reviewing (validator / falsification / thinking-
+                  mode) is achieved by listing three Agent CRs with different
+                  system prompts and (optionally) the same underlying model.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               verifierAgentRef:
                 description: |-
                   VerifierAgentRef is required when Issues is set: names the same-

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -93,6 +93,7 @@ spec:
                 enum:
                 - issue-fix
                 - verify
+                - review
                 - freeform
                 type: string
               modelRef:

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -156,6 +156,7 @@ spec:
                       enum:
                       - issue-fix
                       - verify
+                      - review
                       - freeform
                       type: string
                     name:
@@ -232,6 +233,44 @@ spec:
                   generated AgenticTask in issue-batch mode. Ignored in explicit
                   Pipeline mode (each step carries its own Payload.Repo).
                 type: string
+              reviewerAgentRefs:
+                description: |-
+                  ReviewerAgentRefs is the optional v0.2 third pipeline stage: each
+                  listed Agent runs a review task against the diff the coder
+                  produced, in parallel, all depending on the upstream verify task
+                  reaching GATE-PASS. The rendered task names are
+                  "<workload>-review-<N>-<i>" where N is the issue number and i is
+                  the index into this slice; the index keeps DNS-1123 lengths
+                  bounded across long agent names.
+
+                  Aggregation: any reviewer emitting verdict=NO-GO leaves that task
+                  Phase=Succeeded but not "succeeded on target," so the Workload
+                  rollup from #548 marks it under IncompleteTasks and the Workload
+                  reaches Phase=Failed with reason ChildrenIncomplete. Day 4
+                  extends this with a hybrid cloud reviewer Agent that the rollup
+                  can escalate to when the local fleet says NO-GO.
+
+                  Leave empty to keep the v0.1 two-step (code + verify) pipeline.
+                  Multi-strategy reviewing (validator / falsification / thinking-
+                  mode) is achieved by listing three Agent CRs with different
+                  system prompts and (optionally) the same underlying model.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               verifierAgentRef:
                 description: |-
                   VerifierAgentRef is required when Issues is set: names the same-

--- a/examples/foreman/workload-with-reviewers.yaml
+++ b/examples/foreman/workload-with-reviewers.yaml
@@ -1,0 +1,73 @@
+# Foreman v0.2: three-stage pipeline (code + verify + parallel reviewers).
+#
+# Extends the workload-fix-small-bugs.yaml shortcut with the v0.2
+# ReviewerAgentRefs slice. For each issue N the WorkloadReconciler
+# now emits:
+#
+#   code-<N>       (coder Agent, on a metal FleetNode)
+#       |
+#       v
+#   verify-<N>     (deterministic gate Job, on a verifier FleetNode)
+#       |
+#       +-----> review-<N>-0  (reviewer Agent 0, parallel)
+#       +-----> review-<N>-1  (reviewer Agent 1, parallel)
+#       +-----> review-<N>-2  (reviewer Agent 2, parallel)
+#
+# All reviewers depend on verify-<N>, run in parallel, and the
+# cascade-on-verdict rollup from #548 propagates failure exactly the
+# way you'd expect:
+#
+#   - If verify-<N> lands GATE-FAIL or GATE-ERROR, every review-<N>-*
+#     short-circuits to verdict=INCOMPLETE (the gate-failed cascade)
+#     and never runs the reviewer loop. No wasted reviewer turns on a
+#     branch the gate already rejected.
+#   - If verify-<N> lands GATE-PASS but ANY reviewer emits NO-GO,
+#     that reviewer task lands Phase=Succeeded + verdict=NO-GO. The
+#     Workload rollup counts it under IncompleteTasks, drives the
+#     Workload to Phase=Failed with reason=ChildrenIncomplete, and
+#     surfaces "the gate passed, but at least one reviewer caught
+#     something the gate cannot."
+#   - Day 4 will extend this with a hybrid cloud reviewer Agent the
+#     rollup can escalate to when the local fleet says NO-GO; the
+#     local ensemble is the air-gap-friendly path, the cloud
+#     reviewer is the optional second opinion.
+#
+# Multi-strategy reviewing (the v0.2 thesis): list three reviewer
+# Agent CRs with DIFFERENT system prompts and (optionally) the same
+# underlying model. The empirical 2026-05-25 run showed that local
+# 24-26B-class models share priors with the coder when they share
+# a model family, so the strategy variants are how we get diversity
+# without buying a second GPU. Suggested starting strategies:
+#
+#   - "validator":     general scope/quality review (the v0.1 prompt)
+#   - "falsification": "try to break this diff; assume it's wrong"
+#   - "thinking":      step-by-step reasoning before verdict
+#
+# The example below references one shared Agent CR three times for
+# brevity; flesh out three distinct Agent CRs with strategy-varied
+# system prompts when you're ready to run the multi-strategy demo.
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Workload
+metadata:
+  name: small-bugs-batch-with-reviewers
+  namespace: default
+  labels:
+    app.kubernetes.io/part-of: foreman
+    foreman.llmkube.dev/milestone: v0.2
+spec:
+  intent: "Fix small open issues and pass a 3-reviewer panel"
+  repo: defilantech/LLMKube
+  maxTasks: 32
+  issues:
+    - 531   # .dockerignore re-include
+  coderAgentRef:
+    name: qwen36-35b-carnice-mtp-coder
+  verifierAgentRef:
+    name: gate
+  # v0.2: parallel reviewer ensemble per issue. Any NO-GO blocks the
+  # Workload from reaching Completed. List as many Agent CRs as your
+  # reviewer-side fleet capacity supports.
+  reviewerAgentRefs:
+    - name: qwen36-35b-a3b-reviewer
+    # - name: qwen36-35b-a3b-reviewer-falsification  # v0.2.x
+    # - name: qwen36-35b-a3b-reviewer-thinking       # v0.2.x

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -153,17 +153,24 @@ func (r *WorkloadReconciler) chooseSteps(w *foremanv1alpha1.Workload) (steps []f
 }
 
 // synthesizeIssueBatch turns Workload.spec.Issues into a flat PipelineStep
-// slice of code + verify pairs. Each issue N produces:
+// slice. Each issue N produces:
 //
 //   - step "code-<N>" (kind issue-fix, agentRef = CoderAgentRef)
 //   - step "verify-<N>" (kind verify, agentRef = VerifierAgentRef,
 //     dependsOn [code-<N>])
+//   - for each i in 0..len(ReviewerAgentRefs)-1:
+//     step "review-<N>-<i>" (kind review, agentRef = ReviewerAgentRefs[i],
+//     dependsOn [verify-<N>]). Parallel across i; the cascade-on-verdict
+//     logic from #548 short-circuits these to Incomplete if verify-<N>
+//     lands GATE-FAIL or GATE-ERROR rather than running the reviewer
+//     loop against a branch the gate already rejected.
 //
-// Payload.Branch is "foreman/issue-<N>" in both halves so the gate clones
-// the branch the coder produced (the cloneURL passthrough from #528 makes
-// the gate hit the fork, not upstream).
+// Payload.Branch is "foreman/issue-<N>" in all stages so each task
+// clones the branch the coder produced (the cloneURL passthrough from
+// #528 makes the gate hit the fork, not upstream).
 func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.PipelineStep {
-	steps := make([]foremanv1alpha1.PipelineStep, 0, len(w.Spec.Issues)*2)
+	tasksPerIssue := 2 + len(w.Spec.ReviewerAgentRefs)
+	steps := make([]foremanv1alpha1.PipelineStep, 0, len(w.Spec.Issues)*tasksPerIssue)
 	for _, n := range w.Spec.Issues {
 		codeName := fmt.Sprintf("code-%d", n)
 		verifyName := fmt.Sprintf("verify-%d", n)
@@ -191,6 +198,19 @@ func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.Pipelin
 				},
 			},
 		)
+		for i, reviewerRef := range w.Spec.ReviewerAgentRefs {
+			steps = append(steps, foremanv1alpha1.PipelineStep{
+				Name:      fmt.Sprintf("review-%d-%d", n, i),
+				Kind:      foremanv1alpha1.AgenticTaskKindReview,
+				AgentRef:  reviewerRef,
+				DependsOn: []string{verifyName},
+				Payload: foremanv1alpha1.AgenticTaskPayload{
+					Repo:   w.Spec.Repo,
+					Issue:  n,
+					Branch: branch,
+				},
+			})
+		}
 	}
 	return steps
 }

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -155,6 +155,64 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		Expect(verify531.Spec.AgentRef.Name).To(Equal("gate"))
 	})
 
+	It("fans out one review task per ReviewerAgentRef, each depending on the verify task (v0.2)", func() {
+		wl := newWorkload("batch-with-reviewers", foremanv1alpha1.WorkloadSpec{
+			Intent:           "batch + reviewers",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{510, 531},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "reviewer-validator"},
+				{Name: "reviewer-falsification"},
+				{Name: "reviewer-thinking"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhasePlanned))
+		// 2 issues * (code + verify + 3 reviewers) = 10 tasks total.
+		Expect(fresh.Status.Tasks).To(HaveLen(10))
+
+		// review-510-1 (the second reviewer of the first issue): kind +
+		// agentRef + dependsOn must all line up.
+		var review5101 foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: "default", Name: "batch-with-reviewers-review-510-1",
+		}, &review5101)).To(Succeed())
+		Expect(review5101.Spec.Kind).To(Equal(foremanv1alpha1.AgenticTaskKindReview))
+		Expect(review5101.Spec.AgentRef.Name).To(Equal("reviewer-falsification"))
+		Expect(review5101.Spec.DependsOn).To(ConsistOf("batch-with-reviewers-verify-510"))
+		Expect(review5101.Spec.Payload.Issue).To(Equal(int32(510)))
+		Expect(review5101.Spec.Payload.Branch).To(Equal("foreman/issue-510"))
+
+		// review-531-2: the third reviewer of the second issue. Confirms
+		// the cross-product expansion (per-issue x per-reviewer).
+		var review5312 foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: "default", Name: "batch-with-reviewers-review-531-2",
+		}, &review5312)).To(Succeed())
+		Expect(review5312.Spec.AgentRef.Name).To(Equal("reviewer-thinking"))
+		Expect(review5312.Spec.DependsOn).To(ConsistOf("batch-with-reviewers-verify-531"))
+
+		// review-510-0 must NOT depend on review-510-1 or any other
+		// reviewer: parallel-after-gate is the whole point.
+		var review5100 foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: "default", Name: "batch-with-reviewers-review-510-0",
+		}, &review5100)).To(Succeed())
+		Expect(review5100.Spec.DependsOn).To(ConsistOf("batch-with-reviewers-verify-510"))
+	})
+
 	It("clips with MaxTasks and sets the Truncated condition", func() {
 		wl := newWorkload("max-tasks-clip", foremanv1alpha1.WorkloadSpec{
 			Intent:           "clipped",


### PR DESCRIPTION
## What

Add the v0.2 reviewer-ensemble surface: a plural `ReviewerAgentRefs` field on `WorkloadSpec`, a new `AgenticTaskKind=review` enum value, and a third pipeline stage where each listed reviewer Agent runs in parallel against the diff the coder produced.

```
code-N → verify-N → ┬─→ review-N-0   (reviewer Agent 0, parallel)
                    ├─→ review-N-1   (reviewer Agent 1, parallel)
                    └─→ review-N-2   (reviewer Agent 2, parallel)
```

Per-issue task count goes from 2 to `2 + len(ReviewerAgentRefs)`. Empty slice preserves the v0.1 two-step pipeline.

## Why

The empirical run on 2026-05-25 showed local 24-26B-class reviewers rubber-stamp same-model coder branches at 0/3 catch rate on structural bugs (validator-style prompts alone). A cross-prompt ensemble (validator + falsification + thinking-mode) is the air-gap-friendly answer for orgs that can't or won't route review through a cloud frontier model. Day 4 will add the hybrid cloud reviewer Agent the rollup can escalate to; Day 3 (this PR) lands the local plumbing.

## How

**Cascade integration**: the cascade-on-verdict logic from #548 short-circuits `review-N-*` to `verdict=INCOMPLETE` when `verify-N` lands `GATE-FAIL` or `GATE-ERROR`, so reviewers never burn turns on a branch the gate already rejected.

**Aggregation**: any reviewer emitting `verdict=NO-GO` lands `Phase=Succeeded` but is not "succeeded on target." The Workload rollup from #548 counts these under `IncompleteTasks` and drives the Workload to `Phase=Failed` with `reason=ChildrenIncomplete`. This implements the "any NO-GO blocks" semantic without any new rollup machinery.

**Test coverage**: new Ginkgo case in the WorkloadReconciler suite: 2 issues × (code + verify + 3 reviewers) = 10 tasks; per-task `agentRef`, `Kind`, `payload`, and `DependsOn` all pinned. Parallel-after-gate is asserted explicitly (no reviewer depends on another reviewer of the same issue).

## Checklist

- [x] `make fmt vet lint test` clean (Mac)
- [x] `GOOS=linux ./bin/golangci-lint run ./...` clean
- [x] `make manifests chart-crds foreman-chart-crds` synced
- [x] No breaking change: existing Workloads without `reviewerAgentRefs` keep the v0.1 two-step pipeline
- [x] Example manifest in `examples/foreman/workload-with-reviewers.yaml` documents the new shape
- [x] DCO sign-off (`git commit -s`)
