### PR TITLE
fix(foreman/build): include gate_job_template.yaml in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,9 @@
 # Re-include Go module files
 !go.mod
 !go.sum
+
+# Re-include the gate-job YAML template the foreman-agent embeds via
+# //go:embed in pkg/foreman/agent/tools/run_gate_job.go. The Docker
+# build fails at the go-build step without this; goreleaser builds
+# embed before docker-build so they're unaffected. Fixes #531.
+!pkg/foreman/agent/tools/gate_job_template.yaml


### PR DESCRIPTION
## What

Re-include `pkg/foreman/agent/tools/gate_job_template.yaml` in the Docker build context so the foreman-agent image build at the Dockerfile path succeeds.

## Why

The repo `.dockerignore` is an opt-in allowlist (`**` then explicit `!` re-includes). It re-included `.go` files and Go module files only, so the YAML the agent embeds via `//go:embed` was filtered out. The go-build step in `Dockerfile.foreman-agent` failed with:

```
pkg/foreman/agent/tools/run_gate_job.go:44:12: pattern gate_job_template.yaml: no matching files found
```

Goreleaser builds were unaffected (they embed before docker-build runs), so only the Dockerfile path bit. Hit live tonight while building the v0.2 Day 4 foreman-agent image for shadowstack deploy.

## How

One-line re-include in `.dockerignore`:

```
!pkg/foreman/agent/tools/gate_job_template.yaml
```

Narrow path rather than `!**/*.yaml` so we don't accidentally pick up other test/CI YAML in the context.

## Checklist

- [x] Local Docker build now succeeds: `docker buildx build --platform linux/amd64 -f Dockerfile.foreman-agent .`
- [x] DCO sign-off (`git commit -s`)
- [x] Fixes #531