### PR TITLE
feat(metal-agent): InferenceService name allowlist for multi-Mac fleets

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -69,6 +69,7 @@ type AgentConfig struct {
 	MemoryPressureCritical    float64
 	EvictionEnabled           bool
 	MaxWatchFailures          int
+	InferenceServiceAllowlist string
 	LlamaServerStartupTimeout time.Duration
 	OMLXStartupTimeout        time.Duration
 	VLLMSwiftStartupTimeout   time.Duration
@@ -76,6 +77,27 @@ type AgentConfig struct {
 	ApplePowerEnabled         bool
 	ApplePowerInterval        time.Duration
 	PowermetricsBin           string
+}
+
+// splitCSV parses a comma-separated string into a trimmed []string,
+// dropping empties. Returns nil for an empty input so callers can
+// `if len(...) > 0` cleanly.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func parseLogLevel(level string) zapcore.Level {
@@ -238,6 +260,11 @@ func main() {
 	flag.IntVar(&cfg.MaxWatchFailures, "max-watch-failures", agent.DefaultMaxConsecutiveFailures,
 		"Consecutive Kubernetes list failures from the InferenceService watcher before the agent "+
 			"gives up and exits for supervisor restart. Set to 0 to use the agent default.")
+	flag.StringVar(&cfg.InferenceServiceAllowlist, "inference-service-allowlist", "",
+		"Comma-separated list of InferenceService names this agent is permitted to claim. "+
+			"Empty (default) claims every metal-accelerator InferenceService in --namespace "+
+			"(v0.1 behavior). Set on multi-Mac fleets that share one Kubernetes cluster so "+
+			"each node claims only its own InferenceServices instead of racing with peers (#524).")
 	flag.DurationVar(&cfg.LlamaServerStartupTimeout, "llama-server-startup-timeout",
 		agent.DefaultLlamaServerStartupTimeout,
 		"How long to wait for a freshly-spawned llama-server to respond on /health. "+
@@ -451,6 +478,7 @@ func main() {
 		Logger:                    logger,
 		MemoryFraction:            cfg.MemoryFraction,
 		MaxWatchFailures:          cfg.MaxWatchFailures,
+		InferenceServiceAllowlist: splitCSV(cfg.InferenceServiceAllowlist),
 		LlamaServerStartupTimeout: cfg.LlamaServerStartupTimeout,
 		OMLXStartupTimeout:        cfg.OMLXStartupTimeout,
 		VLLMSwiftStartupTimeout:   cfg.VLLMSwiftStartupTimeout,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -115,6 +115,14 @@ type MetalAgentConfig struct {
 	// (DefaultMaxConsecutiveFailures).
 	MaxWatchFailures int
 
+	// InferenceServiceAllowlist optionally restricts which
+	// InferenceServices this agent claims by name. Empty / nil claims
+	// every metal-accelerator InferenceService in the namespace (v0.1
+	// behavior); non-empty surfaces only the named ones to the
+	// runtime executor. v0.2 (#524): lets multi-Mac fleets share a
+	// cluster without racing for each other's InferenceServices.
+	InferenceServiceAllowlist []string
+
 	// LlamaServerStartupTimeout is how long the Metal executor waits for a
 	// freshly-spawned llama-server to respond on /health before giving up.
 	// Zero means use the executor default (DefaultLlamaServerStartupTimeout).
@@ -289,6 +297,13 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 	a.watcher = NewInferenceServiceWatcher(a.config.K8sClient, a.config.Namespace, a.logger.With("subsystem", "watcher"))
 	if a.config.MaxWatchFailures > 0 {
 		a.watcher.SetMaxConsecutiveFailures(a.config.MaxWatchFailures)
+	}
+	if len(a.config.InferenceServiceAllowlist) > 0 {
+		a.watcher.SetNameAllowlist(a.config.InferenceServiceAllowlist)
+		a.logger.Infow(
+			"InferenceService name allowlist active (#524 multi-Mac partition)",
+			"allowed", a.config.InferenceServiceAllowlist,
+		)
 	}
 
 	switch a.config.Runtime {

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -72,6 +73,14 @@ type InferenceServiceWatcher struct {
 	logger                 *zap.SugaredLogger
 	maxConsecutiveFailures int
 	pollInterval           time.Duration
+	// nameAllowlist optionally restricts which InferenceServices the
+	// watcher claims by name. When nil or empty the watcher claims
+	// every metal-accelerator InferenceService in its namespace
+	// (v0.1 behavior); when non-empty only InferenceServices whose
+	// name is a member are surfaced as events. Set via
+	// SetNameAllowlist; v0.2 #524 (per-node partition for multi-Mac
+	// fleets sharing one cluster).
+	nameAllowlist map[string]struct{}
 }
 
 // NewInferenceServiceWatcher creates a new watcher with the default failure
@@ -108,6 +117,36 @@ func (w *InferenceServiceWatcher) SetPollInterval(d time.Duration) {
 		return
 	}
 	w.pollInterval = d
+}
+
+// SetNameAllowlist restricts which InferenceServices the watcher
+// surfaces, by name. Empty / nil disables the filter (v0.1 behavior:
+// every metal-accelerator InferenceService in the namespace is
+// claimed). When set, only InferenceServices whose name is a member
+// produce events; everything else is silently skipped at the
+// shouldWatch gate.
+//
+// Use this on multi-Mac fleets sharing one cluster so each node
+// claims only its own InferenceServices instead of racing with peers
+// for every metal ISvc in the namespace (#524).
+func (w *InferenceServiceWatcher) SetNameAllowlist(names []string) {
+	if len(names) == 0 {
+		w.nameAllowlist = nil
+		return
+	}
+	allow := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		allow[n] = struct{}{}
+	}
+	if len(allow) == 0 {
+		w.nameAllowlist = nil
+		return
+	}
+	w.nameAllowlist = allow
 }
 
 // Watch starts watching for InferenceService changes. It returns nil on clean
@@ -270,10 +309,26 @@ func (w *InferenceServiceWatcher) poll(
 }
 
 // shouldWatch determines if this InferenceService should be watched by the Metal Agent.
-// It looks up the referenced Model and only returns true if the Model's accelerator is "metal".
+// It applies (in order):
+//  1. nameAllowlist filter -- cheap; skips the API call below if the
+//     InferenceService isn't on this node's list. v0.2 #524: lets
+//     multi-Mac fleets partition without colliding.
+//  2. Model.spec.hardware.accelerator check -- looks up the referenced
+//     Model and returns true only when its accelerator is "metal".
 func (w *InferenceServiceWatcher) shouldWatch(ctx context.Context, isvc *inferencev1alpha1.InferenceService) bool {
 	if isvc.Spec.ModelRef == "" {
 		return false
+	}
+
+	if w.nameAllowlist != nil {
+		if _, ok := w.nameAllowlist[isvc.Name]; !ok {
+			w.logger.Debugw(
+				"skipping inference service: not in this agent's name allowlist (#524)",
+				"namespace", isvc.Namespace,
+				"inferenceService", isvc.Name,
+			)
+			return false
+		}
 	}
 
 	model := &inferencev1alpha1.Model{}

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -177,6 +177,100 @@ func TestShouldWatch(t *testing.T) {
 	}
 }
 
+// TestSetNameAllowlist_FiltersInShouldWatch pins #524 partition behavior:
+// when an allowlist is set, only InferenceServices whose name is on the
+// list pass shouldWatch, regardless of accelerator. Empty / nil allowlist
+// preserves the v0.1 behavior of accepting every metal-accelerator
+// InferenceService.
+func TestSetNameAllowlist_FiltersInShouldWatch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	metalModel := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "metal-model", Namespace: "default"},
+		Spec: inferencev1alpha1.ModelSpec{
+			Source:   "https://example.com/model.gguf",
+			Format:   "gguf",
+			Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(metalModel).Build()
+
+	mkISvc := func(name string) *inferencev1alpha1.InferenceService {
+		return &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "metal-model"},
+		}
+	}
+
+	t.Run("no allowlist: every metal ISvc passes (v0.1 behavior)", func(t *testing.T) {
+		w := NewInferenceServiceWatcher(k8sClient, "default", newNopLogger())
+		for _, name := range []string{"qwen36-35b-a3b", "devstral-24b", "anything-else"} {
+			if !w.shouldWatch(context.Background(), mkISvc(name)) {
+				t.Errorf("%q: want true, got false", name)
+			}
+		}
+	})
+
+	t.Run("allowlist set: only listed names pass", func(t *testing.T) {
+		w := NewInferenceServiceWatcher(k8sClient, "default", newNopLogger())
+		w.SetNameAllowlist([]string{"qwen36-35b-a3b"})
+		if !w.shouldWatch(context.Background(), mkISvc("qwen36-35b-a3b")) {
+			t.Error("qwen36-35b-a3b: want true (on allowlist), got false")
+		}
+		if w.shouldWatch(context.Background(), mkISvc("devstral-24b")) {
+			t.Error("devstral-24b: want false (not on allowlist), got true")
+		}
+	})
+
+	t.Run("allowlist with multiple names", func(t *testing.T) {
+		w := NewInferenceServiceWatcher(k8sClient, "default", newNopLogger())
+		w.SetNameAllowlist([]string{"qwen36-35b-a3b", "devstral-24b"})
+		for _, name := range []string{"qwen36-35b-a3b", "devstral-24b"} {
+			if !w.shouldWatch(context.Background(), mkISvc(name)) {
+				t.Errorf("%q: want true (on allowlist), got false", name)
+			}
+		}
+		if w.shouldWatch(context.Background(), mkISvc("third-model")) {
+			t.Error("third-model: want false (not on allowlist), got true")
+		}
+	})
+
+	t.Run("allowlist with empty/whitespace entries gets normalized", func(t *testing.T) {
+		w := NewInferenceServiceWatcher(k8sClient, "default", newNopLogger())
+		w.SetNameAllowlist([]string{"", "  qwen36-35b-a3b  ", ""})
+		if !w.shouldWatch(context.Background(), mkISvc("qwen36-35b-a3b")) {
+			t.Error("qwen36-35b-a3b: want true after whitespace trim, got false")
+		}
+		if w.shouldWatch(context.Background(), mkISvc("other")) {
+			t.Error("other: want false (not on allowlist), got true")
+		}
+	})
+
+	t.Run("re-clearing allowlist with empty slice restores v0.1 behavior", func(t *testing.T) {
+		w := NewInferenceServiceWatcher(k8sClient, "default", newNopLogger())
+		w.SetNameAllowlist([]string{"qwen36-35b-a3b"})
+		w.SetNameAllowlist(nil)
+		if !w.shouldWatch(context.Background(), mkISvc("devstral-24b")) {
+			t.Error("devstral-24b: want true after allowlist cleared, got false")
+		}
+	})
+
+	t.Run("allowlist skips ISvc before the (more expensive) Model lookup", func(t *testing.T) {
+		// Watcher with NO model in the fake client; if the allowlist
+		// skip didn't short-circuit, shouldWatch would try (and fail)
+		// to Get the Model. Confirms ordering: allowlist filter runs
+		// before the API call.
+		emptyClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		w := NewInferenceServiceWatcher(emptyClient, "default", newNopLogger())
+		w.SetNameAllowlist([]string{"yes"})
+		if w.shouldWatch(context.Background(), mkISvc("no")) {
+			t.Error("non-allowlisted name should return false without hitting the API")
+		}
+	})
+}
+
 func TestParseKey(t *testing.T) {
 	tests := []struct {
 		input         string


### PR DESCRIPTION
## What

Add `--inference-service-allowlist` (CSV) to `metal-agent` so each node in a multi-Mac fleet claims only the InferenceServices it's explicitly named for:

```bash
# M5 Max
llmkube-metal-agent --namespace default --inference-service-allowlist=qwen36-35b-a3b

# Mac Studio
llmkube-metal-agent --namespace default --inference-service-allowlist=devstral-24b
```

Empty / unset preserves v0.1 behavior (claim every metal-accelerator InferenceService in the namespace).

## Why

The metal-agent has only `--namespace` as a filter, so multiple Macs sharing one Kubernetes cluster race for every metal-accelerator InferenceService. Today the race resolves OK by accident — only one node has the model file on disk, the others fail the memory pre-flight or local-path lookup and log warnings — but at scale the noise and non-determinism grow linearly with fleet size.

Hit live tonight bringing up a Mac Studio metal-agent alongside the M5 Max for v0.2 M5 Proper: the Studio claimed `qwen36-35b-a3b` (which lives on M5 Max only) and spammed download failures.

## How

**Implementation**:
- `InferenceServiceWatcher` gains a `nameAllowlist map[string]struct{}` + `SetNameAllowlist([]string)` setter
- `shouldWatch` applies the allowlist BEFORE the Model lookup so non-allowlisted ISvcs are skipped without an API call
- New `--inference-service-allowlist` CSV flag on the metal-agent CLI
- New `splitCSV` helper to normalize the flag value

**Alternative considered**: per-node namespaces (#524's original proposal). Rejected for v0.2 because it would force every Foreman Agent CR to live in a per-node namespace and break the `Agent.spec.InferenceServiceRef` (LocalObjectReference) shape. The allowlist solves the immediate race without API-shape changes.

**Alternative considered**: label-selector. More k8s-idiomatic but requires labeling every InferenceService. For fleets of <10 nodes the allowlist is simpler. The two approaches compose if needed later (v0.3 follow-up).

## Tests

`TestSetNameAllowlist_FiltersInShouldWatch` — 6-case whitebox table:
- No allowlist: every metal ISvc passes (v0.1 behavior preserved)
- Single-name allow: only that ISvc passes
- Multi-name allow: each listed name passes; non-listed skip
- Whitespace normalization: `"  name  "` and empty entries handled
- Re-clear with nil: v0.1 behavior restored
- Short-circuit ordering: allowlist filter runs BEFORE the Model API call (validated by giving an empty fake client and confirming no Get error)

## Checklist

- [x] `make fmt vet lint test` clean (Mac)
- [x] `GOOS=linux ./bin/golangci-lint run ./...` clean
- [x] Backward compatible: empty / unset allowlist preserves v0.1 single-node behavior
- [x] DCO sign-off (`git commit -s`)
- [x] Fixes #524
