### PR TITLE
fix(foreman/oai): always emit content on non-assistant messages

### DIFF
--- a/pkg/foreman/agent/oai/types.go
+++ b/pkg/foreman/agent/oai/types.go
@@ -60,6 +60,46 @@ type Message struct {
 	Name       string     `json:"name,omitempty"`
 }
 
+// MarshalJSON serializes a Message such that non-assistant roles always
+// carry a content field (even when the content is the empty string),
+// while assistant messages keep the existing omitempty semantics so
+// {"role":"assistant","tool_calls":[...]} stays valid (no awkward
+// "content":"" alongside tool_calls).
+//
+// The OpenAI v1 chat-completions spec requires content on system,
+// user, and tool roles. llama.cpp's OAI surface accepts the field
+// either missing or empty; that's why this never bit Foreman against
+// Carnice or other Qwen-family backends. Stricter implementations
+// (Devstral / Mistral / DeepSeek and the OpenAI API itself) reject
+// HTTP 400 with `"All non-assistant messages must contain 'content'"`
+// when the field is absent. Fixes #556.
+func (m Message) MarshalJSON() ([]byte, error) {
+	if m.Role == RoleAssistant {
+		// Assistant: content may legitimately be omitted when the
+		// message is purely tool_calls. Fall back to the default
+		// omitempty behavior by serializing through a type alias
+		// (the alias drops MarshalJSON so json.Marshal uses the
+		// struct tags directly).
+		type assistantMessage Message
+		return json.Marshal(assistantMessage(m))
+	}
+	// system / user / tool: always emit content, even when empty.
+	out := struct {
+		Role       Role       `json:"role"`
+		Content    string     `json:"content"`
+		ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+		ToolCallID string     `json:"tool_call_id,omitempty"`
+		Name       string     `json:"name,omitempty"`
+	}{
+		Role:       m.Role,
+		Content:    m.Content,
+		ToolCalls:  m.ToolCalls,
+		ToolCallID: m.ToolCallID,
+		Name:       m.Name,
+	}
+	return json.Marshal(out)
+}
+
 // ToolCall is what the model emits when it wants a tool to run. The
 // Arguments field is a JSON-encoded object that the tool itself parses;
 // the OAI spec wraps it in a string rather than nesting it as JSON so

--- a/pkg/foreman/agent/oai/types_test.go
+++ b/pkg/foreman/agent/oai/types_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oai
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestMessageMarshalJSON_NonAssistantAlwaysIncludesContent pins the
+// #556 fix: non-assistant messages (system / user / tool) MUST carry a
+// `content` field on the wire even when the value is empty, otherwise
+// strict-schema backends (Devstral / Mistral / DeepSeek / OpenAI API)
+// reject with HTTP 400. Carnice and other lenient llama.cpp backends
+// tolerate the omission, which is why this never surfaced until live
+// against Devstral.
+func TestMessageMarshalJSON_NonAssistantAlwaysIncludesContent(t *testing.T) {
+	cases := []struct {
+		name        string
+		msg         Message
+		wantHasKey  bool   // wire payload must contain `"content":`
+		wantContent string // expected value of content key (only checked when wantHasKey)
+	}{
+		{
+			name:        "system role with non-empty content emits content",
+			msg:         Message{Role: RoleSystem, Content: "you are a coder"},
+			wantHasKey:  true,
+			wantContent: "you are a coder",
+		},
+		{
+			name:        "system role with empty content STILL emits content (#556)",
+			msg:         Message{Role: RoleSystem, Content: ""},
+			wantHasKey:  true,
+			wantContent: "",
+		},
+		{
+			name:        "user role with empty content STILL emits content (#556)",
+			msg:         Message{Role: RoleUser, Content: ""},
+			wantHasKey:  true,
+			wantContent: "",
+		},
+		{
+			name: "tool role with empty content STILL emits content (the original Devstral repro)",
+			msg: Message{
+				Role:       RoleTool,
+				Content:    "",
+				ToolCallID: "call_abc123",
+			},
+			wantHasKey:  true,
+			wantContent: "",
+		},
+		{
+			name: "tool role with non-empty content emits the result verbatim",
+			msg: Message{
+				Role:       RoleTool,
+				Content:    `{"exit_code":0,"stdout":"ok"}`,
+				ToolCallID: "call_abc123",
+			},
+			wantHasKey:  true,
+			wantContent: `{"exit_code":0,"stdout":"ok"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.msg)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if tc.wantHasKey && !strings.Contains(string(raw), `"content":`) {
+				t.Errorf("payload missing required content key: %s", raw)
+			}
+			// Round-trip parse to confirm the content value is exactly
+			// what we expected (catches any escape-encoding regressions).
+			var decoded map[string]any
+			if err := json.Unmarshal(raw, &decoded); err != nil {
+				t.Fatalf("round-trip decode: %v", err)
+			}
+			if got, ok := decoded["content"]; !ok {
+				t.Errorf("decoded map missing content key: %v", decoded)
+			} else if got != tc.wantContent {
+				t.Errorf("content: want %q got %v", tc.wantContent, got)
+			}
+		})
+	}
+}
+
+// TestMessageMarshalJSON_AssistantOmitsContentWhenEmpty pins the
+// counter-case: assistant messages with no text content (only
+// tool_calls) MUST NOT emit `"content":""`. Some servers reject the
+// combination of empty content + tool_calls; the OpenAI spec allows
+// content to be absent on assistant turns. Keep the existing
+// omitempty semantics for this role.
+func TestMessageMarshalJSON_AssistantOmitsContentWhenEmpty(t *testing.T) {
+	cases := []struct {
+		name       string
+		msg        Message
+		wantHasKey bool
+	}{
+		{
+			name: "assistant with empty content + tool_calls omits content",
+			msg: Message{
+				Role: RoleAssistant,
+				ToolCalls: []ToolCall{
+					{ID: "call_1", Type: "function", Function: ToolCallFunction{Name: "read_file", Arguments: `{"path":"foo.go"}`}},
+				},
+			},
+			wantHasKey: false,
+		},
+		{
+			name: "assistant with non-empty content emits content",
+			msg: Message{
+				Role:    RoleAssistant,
+				Content: "thinking through this...",
+			},
+			wantHasKey: true,
+		},
+		{
+			name:       "assistant with empty content AND no tool_calls still omits content (edge case)",
+			msg:        Message{Role: RoleAssistant},
+			wantHasKey: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.msg)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			hasKey := strings.Contains(string(raw), `"content":`)
+			if hasKey != tc.wantHasKey {
+				t.Errorf("content key presence: want %v got %v (payload=%s)", tc.wantHasKey, hasKey, raw)
+			}
+		})
+	}
+}
+
+// TestMessageMarshalJSON_RoleAlwaysEmitted is a belt-and-suspenders
+// guard: regardless of which marshal branch a message goes through,
+// the role field must always be on the wire (it's the primary
+// dispatch key for the server). A bug in either branch that dropped
+// the role would surface here.
+func TestMessageMarshalJSON_RoleAlwaysEmitted(t *testing.T) {
+	for _, role := range []Role{RoleSystem, RoleUser, RoleAssistant, RoleTool} {
+		raw, err := json.Marshal(Message{Role: role})
+		if err != nil {
+			t.Fatalf("marshal %q: %v", role, err)
+		}
+		want := `"role":"` + string(role) + `"`
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("role %q missing from payload %s", role, raw)
+		}
+	}
+}


### PR DESCRIPTION
## What

Foreman's OAI client serialized `Message` with `json:"content,omitempty"`, which drops empty strings from the wire entirely. Carnice and other permissive llama.cpp backends tolerated the missing key, so the bug stayed invisible until 2026-05-26 when the Day 5 M5 Proper smoke test put a Devstral 24B reviewer in the pipeline and turn 1 came back HTTP 400:

```
{"error":{"code":400,"message":"All non-assistant messages must contain 'content'","type":"invalid_request_error"}}
```

Add a custom `MarshalJSON` on `Message` that keeps the existing `omitempty` semantics for the assistant role (where empty content alongside `tool_calls` is normal per the OpenAI spec) but always emits content on system / user / tool roles, even as an empty string.

## Why (Fixes #556)

This is the unlock for cross-model reviewer-diversity work. Without it Foreman only works against llama.cpp-permissive backends (Qwen, MiniMax, Carnice variants); Mistral / Mixtral / DeepSeek / much of the Hugging Face top-50 will reject just like Devstral did. The whole v0.2 reviewer-diversity story (and the v6 empirical validation batch in Day 6) requires this fix.

## How

Wire-side only; no API breakage for callers. Two code paths in `MarshalJSON`:

- **Assistant role**: existing `omitempty` semantics preserved via type alias (assistant + tool_calls cleanly serializes without `"content":""`).
- **All other roles**: inline anonymous struct without the `omitempty` tag on `Content`, so the field always emits.

## Test coverage

`TestMessageMarshalJSON_*` (9 cases across 3 tests):
- **NonAssistantAlwaysIncludesContent** (5 cases): system / user / tool with both empty and non-empty content always emit `"content":` on the wire
- **AssistantOmitsContentWhenEmpty** (3 cases): assistant + tool_calls omits the content key; assistant with non-empty content emits it; assistant with neither still omits
- **RoleAlwaysEmitted** (4 cases): role field is on the wire for every role regardless of which marshal branch runs

## Checklist

- [x] `make fmt vet lint test` clean (Mac)
- [x] `GOOS=linux ./bin/golangci-lint run ./...` clean
- [x] Full foreman test suite green
- [x] No CRD / chart changes (wire-shape fix only)
- [x] No backward incompatibility (Carnice still works; Devstral now works too)
- [x] DCO sign-off (`git commit -s`)
- [x] Fixes #556
