### PR TITLE
feat(foreman/tools): distinguish whitelist-excluded from unknown tool calls

### DIFF
--- a/pkg/foreman/agent/tools/registry.go
+++ b/pkg/foreman/agent/tools/registry.go
@@ -24,12 +24,29 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 
 	"github.com/defilantech/llmkube/pkg/foreman/agent"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
 )
+
+// ErrToolNotInWhitelist is returned by Dispatch when the model calls
+// a tool that exists in the broader system but was excluded by the
+// Agent's spec.tools whitelist (the Filter step). Distinct from a
+// truly-unknown tool name so the failure taxonomy (v0.3 #559) can map
+// this to ConstraintViolated instead of the typo-flavored
+// ModelMisunderstood.
+//
+// Practical example: a reviewer-role Agent has
+// tools=[read_file, grep, bash, submit_result]. If the model calls
+// write_file (which exists in the broader system but is not on the
+// reviewer's whitelist), Dispatch returns this sentinel. The loop
+// surfaces it as a tool message whose content tells the model the
+// call was blocked by role -- and the structured error lets the
+// failure-taxonomy work split this from a typo. Closes #561.
+var ErrToolNotInWhitelist = errors.New("tools: tool excluded by Agent.spec.tools whitelist")
 
 // Tool is one callable function the model can invoke. Each tool
 // advertises its OAI schema and runs the work via Execute. Tools are
@@ -47,6 +64,14 @@ type Tool interface {
 // Agent.spec.tools whitelist names.
 type Registry struct {
 	tools map[string]Tool
+	// filteredOut tracks tool names that exist in the broader system
+	// (the pre-Filter registry) but were excluded by the whitelist.
+	// Dispatch distinguishes these from truly-unknown names so the
+	// failure-taxonomy work (v0.3 #559) can route ConstraintViolated
+	// separately from ModelMisunderstood. Empty when the Registry was
+	// constructed without Filter, in which case every dispatch failure
+	// is "unknown tool" as before.
+	filteredOut map[string]bool
 }
 
 // New constructs a Registry holding the given tools. Each tool's Name()
@@ -66,14 +91,30 @@ func New(tools ...Tool) (*Registry, error) {
 // Filter returns a new Registry containing only the tools whose names
 // appear in whitelist. Unknown names return an error so a typo in an
 // Agent CR fails loud rather than silently disabling a tool.
+//
+// The returned Registry remembers the names that existed in the source
+// Registry but were excluded by the whitelist; Dispatch uses this to
+// emit ErrToolNotInWhitelist (distinct from "unknown tool") when the
+// model calls one of those excluded names. The reviewer-role hardening
+// in #561 relies on this distinction.
 func (r *Registry) Filter(whitelist []string) (*Registry, error) {
-	out := &Registry{tools: make(map[string]Tool, len(whitelist))}
+	out := &Registry{
+		tools:       make(map[string]Tool, len(whitelist)),
+		filteredOut: make(map[string]bool, len(r.tools)),
+	}
+	allowed := make(map[string]bool, len(whitelist))
 	for _, name := range whitelist {
 		t, ok := r.tools[name]
 		if !ok {
 			return nil, fmt.Errorf("tools.Filter: unknown tool %q", name)
 		}
 		out.tools[name] = t
+		allowed[name] = true
+	}
+	for name := range r.tools {
+		if !allowed[name] {
+			out.filteredOut[name] = true
+		}
 	}
 	return out, nil
 }
@@ -103,13 +144,24 @@ func (r *Registry) Schemas() []oai.Tool {
 	return out
 }
 
-// Dispatch executes one tool call. Unknown tool names return an error
-// that the loop turns into a tool message so the model can recover on
-// the next turn.
+// Dispatch executes one tool call. Three failure modes:
+//
+//  1. Name is in the registry (whitelist): execute and return.
+//  2. Name is in the source registry but excluded by the Filter
+//     whitelist: return a wrapped ErrToolNotInWhitelist. The loop
+//     turns this into a tool message that tells the model the call
+//     was blocked by role. v0.3 #559 will map this to
+//     ConstraintViolated in the failure taxonomy.
+//  3. Name is unknown to the system entirely (typo, hallucinated
+//     tool): return a generic "unknown tool" error. The loop also
+//     turns this into a tool message; the model usually self-corrects
+//     on the next turn.
 func (r *Registry) Dispatch(ctx context.Context, name string, args json.RawMessage) (*agent.ToolResult, error) {
-	t, ok := r.tools[name]
-	if !ok {
-		return nil, fmt.Errorf("tools: unknown tool %q", name)
+	if t, ok := r.tools[name]; ok {
+		return t.Execute(ctx, args)
 	}
-	return t.Execute(ctx, args)
+	if r.filteredOut[name] {
+		return nil, fmt.Errorf("%w: %q", ErrToolNotInWhitelist, name)
+	}
+	return nil, fmt.Errorf("tools: unknown tool %q", name)
 }

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -82,6 +82,83 @@ func TestRegistry_Schemas_SortedAndDispatchUnknown(t *testing.T) {
 	}
 }
 
+// TestRegistry_Dispatch_FilteredToolReturnsWhitelistSentinel pins
+// the v0.3 #561 fix: when an Agent's whitelist excludes a tool that
+// exists in the broader registry, Dispatch returns the structured
+// ErrToolNotInWhitelist sentinel rather than the generic "unknown
+// tool" error. This distinction lets the future failure taxonomy
+// (#559) route the two failure modes to ConstraintViolated vs
+// ModelMisunderstood.
+func TestRegistry_Dispatch_FilteredToolReturnsWhitelistSentinel(t *testing.T) {
+	ws := makeWorkspace(t)
+	r, err := New(&ReadFileTool{Workspace: ws}, &WriteFileTool{Workspace: ws}, &GrepTool{Workspace: ws})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Reviewer-style whitelist: read_file + grep only. write_file is
+	// known to the system but excluded.
+	reviewer, err := r.Filter([]string{"read_file", "grep"})
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+
+	// Whitelisted tool dispatches successfully (sanity).
+	if _, err := reviewer.Dispatch(context.Background(), "read_file",
+		json.RawMessage(`{"path":"nope-but-the-arg-error-is-fine.txt"}`)); err == nil {
+		// We don't care about success here; we care that we got past
+		// the registry layer into the tool itself (which will fail on
+		// the missing file but that's a tool-level error, not a
+		// dispatch error). Either way, no whitelist error.
+		_ = err
+	}
+
+	// write_file is filtered out: expect ErrToolNotInWhitelist.
+	_, err = reviewer.Dispatch(context.Background(), "write_file", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected ErrToolNotInWhitelist, got nil")
+	}
+	if !errors.Is(err, ErrToolNotInWhitelist) {
+		t.Errorf("err: want errors.Is(ErrToolNotInWhitelist), got %v", err)
+	}
+	// The error should also name the offending tool for diagnosability.
+	if !strings.Contains(err.Error(), "write_file") {
+		t.Errorf("err message should name the tool, got: %v", err)
+	}
+
+	// A truly unknown tool name returns a DIFFERENT error (not the
+	// whitelist sentinel). Confirms the two paths are distinguishable.
+	_, err = reviewer.Dispatch(context.Background(), "completely_made_up", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected unknown-tool error, got nil")
+	}
+	if errors.Is(err, ErrToolNotInWhitelist) {
+		t.Errorf("unknown-tool error should NOT be ErrToolNotInWhitelist, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "unknown tool") {
+		t.Errorf("err message should say 'unknown tool', got: %v", err)
+	}
+}
+
+// TestRegistry_Dispatch_UnfilteredRegistryNoFalsePositives pins
+// back-compat: a Registry built with New() (no Filter step) never
+// emits ErrToolNotInWhitelist. The sentinel only fires for filtered
+// registries; un-Filter'd ones treat every unknown name as
+// "unknown tool" exactly like before.
+func TestRegistry_Dispatch_UnfilteredRegistryNoFalsePositives(t *testing.T) {
+	ws := makeWorkspace(t)
+	r, err := New(&ReadFileTool{Workspace: ws})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = r.Dispatch(context.Background(), "write_file", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for non-registered tool")
+	}
+	if errors.Is(err, ErrToolNotInWhitelist) {
+		t.Errorf("un-Filter'd Registry should not emit ErrToolNotInWhitelist, got: %v", err)
+	}
+}
+
 // --- workspace ------------------------------------------------------------
 
 func TestResolveInside_Cases(t *testing.T) {


### PR DESCRIPTION
## What

Add an `ErrToolNotInWhitelist` sentinel returned by `Registry.Dispatch` when the model calls a tool that exists in the source Registry but was excluded by the `Filter()` whitelist. Today both failure modes (typo vs. whitelist-excluded) collapse into the same generic `"unknown tool"` error.

## Why (Fixes #561)

The v0.3 failure-taxonomy work (#559) needs to distinguish:

- **`ModelMisunderstood`** — model emitted a typo'd / hallucinated tool name. Retry-with-correction often recovers.
- **`ConstraintViolated`** — model called a real tool the Agent's role isn't allowed to use (e.g. a reviewer calling `write_file`). Should escalate, not retry blindly.

Today the loop sees identical strings for both and can't route them differently. This PR adds the distinction at the structured-error layer; #559 will consume the sentinel.

## How

Three Dispatch paths:

1. **Whitelisted tool**: execute and return. (unchanged)
2. **Tool in source registry but excluded by whitelist**: return wrapped `ErrToolNotInWhitelist`. Detectable via `errors.Is(err, tools.ErrToolNotInWhitelist)`.
3. **Tool unknown to the system entirely**: generic `"unknown tool"` error. (unchanged)

The `Filter()` function now tracks the names that exist in the source registry but didn't make the whitelist, in a new `filteredOut` set on the Registry. A Registry built with `New()` (no `Filter` step) leaves `filteredOut` empty and never emits the sentinel, so v0.1 back-compat is preserved.

## Test coverage

`TestRegistry_Dispatch_FilteredToolReturnsWhitelistSentinel`:
- A reviewer-shape Registry (`read_file + grep`) returns `ErrToolNotInWhitelist` when the model calls `write_file`. Error message names the offending tool.
- The same registry returns the generic `"unknown tool"` error for a name like `completely_made_up`. Confirms the two paths are distinguishable via `errors.Is`.

`TestRegistry_Dispatch_UnfilteredRegistryNoFalsePositives`:
- A Registry built directly with `New()` (no `Filter` step) never emits the sentinel — back-compat guard.

## Checklist

- [x] `make fmt vet lint test` clean (Mac)
- [x] `GOOS=linux ./bin/golangci-lint run ./...` clean
- [x] Full foreman test suite green
- [x] No CRD / chart changes (Go-only)
- [x] Backward compatible: `Registry.New()` users see no behavior change; only `Filter()`'d registries emit the new sentinel
- [x] DCO sign-off
- [x] Fixes #561

## Part of

v0.3 "harness-tightening" release. Pairs with #559 (failure taxonomy + retry-with-correction) which will consume `ErrToolNotInWhitelist` to map to a structured `ConstraintViolated` failure reason.
