### PR TITLE
feat(foreman/api): structured AgenticTaskFailureReason taxonomy

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -47,6 +47,108 @@ const (
 	AgenticTaskKindFreeform AgenticTaskKind = "freeform"
 )
 
+// AgenticTaskFailureReason categorizes WHY a task did not reach a
+// "succeeded-on-target" outcome. Distinct from AgenticTaskVerdict
+// (which carries the externally-meaningful WHAT: GO / NO-GO /
+// GATE-PASS / GATE-FAIL / INCOMPLETE / GATE-ERROR). Together they let
+// downstream consumers route differently on different failure modes:
+// retry the recoverable ones in place, escalate the role-discipline
+// ones, alert on infrastructure ones.
+//
+// Reason coexists with Verdict: a task can be Phase=Succeeded +
+// Verdict=GATE-FAIL + FailureReason=GateFailed, or Phase=Failed +
+// FailureReason=InfrastructureError. Empty reason on a successful
+// task is normal.
+//
+// v0.3 #559 introduces the enum + emission; per-reason retry policy
+// on AgenticTaskSpec and retry-with-correction in the loop are
+// follow-up work that consumes this signal.
+// +kubebuilder:validation:Enum=AgentNotFound;InferenceServiceUnavailable;AuthUnavailable;GitRemoteNotConfigured;CloneFailed;ModelMisunderstood;ToolFailed;MaxTurnsExhausted;ConstraintViolated;Timeout;InfrastructureError;GateFailed;GateError
+type AgenticTaskFailureReason string
+
+const (
+	// Pre-loop executor failures (the task never reached the model loop):
+
+	// FailureAgentNotFound: the Agent referenced by spec.agentRef was
+	// not present in the task's namespace at executor time. Usually a
+	// race between scheduling and execution; not retryable in place.
+	FailureAgentNotFound AgenticTaskFailureReason = "AgentNotFound"
+
+	// FailureInferenceServiceUnavailable: the Agent's InferenceServiceRef
+	// could not be resolved to a usable endpoint. The metal-agent may
+	// not have spawned llama-server yet, or the host-override port
+	// lookup failed. Retryable; #540's live-Endpoints path catches
+	// most transient cases automatically.
+	FailureInferenceServiceUnavailable AgenticTaskFailureReason = "InferenceServiceUnavailable"
+
+	// FailureAuthUnavailable: GitHub auth could not be built (no
+	// GITHUB_TOKEN, no ~/.config/foreman/github-token). Operator
+	// config error; not retryable.
+	FailureAuthUnavailable AgenticTaskFailureReason = "AuthUnavailable"
+
+	// FailureGitRemoteNotConfigured: foreman-agent was started without
+	// --git-remote-url and a coder-shaped task arrived. Operator
+	// config error; not retryable.
+	FailureGitRemoteNotConfigured AgenticTaskFailureReason = "GitRemoteNotConfigured"
+
+	// FailureCloneFailed: git clone of the workspace failed. Often
+	// network or auth; sometimes a missing branch. Retryable for
+	// transient cases.
+	FailureCloneFailed AgenticTaskFailureReason = "CloneFailed"
+
+	// In-loop failures (the model loop ran but did not reach
+	// submit_result with a successful verdict):
+
+	// FailureModelMisunderstood: model emitted a syntactically valid
+	// turn that the loop could not act on. Examples: assistant message
+	// with no tool_calls; tool call referencing a tool name unknown to
+	// the system (typo / hallucinated tool). Often recoverable with a
+	// corrective system message + retry (deferred to v0.3 follow-up).
+	FailureModelMisunderstood AgenticTaskFailureReason = "ModelMisunderstood"
+
+	// FailureToolFailed: a tool dispatch returned a structured error
+	// (str_replace context not found, bash non-zero exit, etc.). The
+	// loop surfaces these as tool messages today; this reason fires
+	// when a tool error escalates to terminal (every available retry
+	// exhausted in a future loop revision).
+	FailureToolFailed AgenticTaskFailureReason = "ToolFailed"
+
+	// FailureMaxTurnsExhausted: the loop hit Agent.spec.MaxTurns
+	// without the model calling submit_result. The model effectively
+	// gave up. Not retryable without intervention (different
+	// MaxTurns or different prompt).
+	FailureMaxTurnsExhausted AgenticTaskFailureReason = "MaxTurnsExhausted"
+
+	// FailureConstraintViolated: the model called a tool excluded by
+	// the Agent's spec.tools whitelist (#561's
+	// tools.ErrToolNotInWhitelist). Indicates a role-discipline
+	// violation. Should escalate rather than retry blindly.
+	FailureConstraintViolated AgenticTaskFailureReason = "ConstraintViolated"
+
+	// FailureTimeout: wall-clock budget exceeded. The task's
+	// spec.timeoutSeconds elapsed, or the per-turn
+	// requestTimeoutSeconds fired and no retry recovered.
+	FailureTimeout AgenticTaskFailureReason = "Timeout"
+
+	// FailureInfrastructureError: a non-model failure: apiserver
+	// unreachable, llama-server crashed, the OAI client got a 5xx,
+	// transcript ConfigMap write failed. Typically retryable.
+	FailureInfrastructureError AgenticTaskFailureReason = "InfrastructureError"
+
+	// Gate-specific failures (deterministic verify path):
+
+	// FailureGateFailed: the gate Job ran cleanly but at least one
+	// check (fmt / vet / lint / test / codegen-sync) failed. The
+	// coder's diff didn't meet quality bar; cascade-on-verdict from
+	// #548 short-circuits the downstream reviewer task.
+	FailureGateFailed AgenticTaskFailureReason = "GateFailed"
+
+	// FailureGateError: the gate Job itself failed to execute
+	// (image pull error, PVC issue, timeout before any check ran).
+	// Infrastructure rather than diff-quality; retryable.
+	FailureGateError AgenticTaskFailureReason = "GateError"
+)
+
 // AgenticTaskAccelerator pins which accelerator family a task needs from the
 // node that runs it. "any" lets the scheduler pick from any Ready FleetNode.
 // +kubebuilder:validation:Enum=metal;cuda;any
@@ -262,6 +364,18 @@ type AgenticTaskStatus struct {
 	// Verdict is the final outcome category.
 	// +optional
 	Verdict AgenticTaskVerdict `json:"verdict,omitempty"`
+
+	// FailureReason categorizes WHY a task did not reach a "succeeded
+	// on target" outcome. Distinct from Verdict (which carries the
+	// externally-meaningful WHAT). Empty on a successful task. See
+	// AgenticTaskFailureReason for the full enum + per-reason semantics.
+	//
+	// v0.3 #559: introduces the structured reason so downstream
+	// consumers (the Workload reconciler's rollup, future retry
+	// policy, batch-level metrics) can route on a typed value rather
+	// than mining the Result.Extra map.
+	// +optional
+	FailureReason AgenticTaskFailureReason `json:"failureReason,omitempty"`
 
 	// Result is the structured JSON the agent emitted, validated against the
 	// foreman.v1 schema. Opaque to the API server.

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -277,6 +277,32 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              failureReason:
+                description: |-
+                  FailureReason categorizes WHY a task did not reach a "succeeded
+                  on target" outcome. Distinct from Verdict (which carries the
+                  externally-meaningful WHAT). Empty on a successful task. See
+                  AgenticTaskFailureReason for the full enum + per-reason semantics.
+
+                  v0.3 #559: introduces the structured reason so downstream
+                  consumers (the Workload reconciler's rollup, future retry
+                  policy, batch-level metrics) can route on a typed value rather
+                  than mining the Result.Extra map.
+                enum:
+                - AgentNotFound
+                - InferenceServiceUnavailable
+                - AuthUnavailable
+                - GitRemoteNotConfigured
+                - CloneFailed
+                - ModelMisunderstood
+                - ToolFailed
+                - MaxTurnsExhausted
+                - ConstraintViolated
+                - Timeout
+                - InfrastructureError
+                - GateFailed
+                - GateError
+                type: string
               finishedAt:
                 description: FinishedAt is when the executor produced a verdict (success
                   or fail).

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -277,6 +277,32 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              failureReason:
+                description: |-
+                  FailureReason categorizes WHY a task did not reach a "succeeded
+                  on target" outcome. Distinct from Verdict (which carries the
+                  externally-meaningful WHAT). Empty on a successful task. See
+                  AgenticTaskFailureReason for the full enum + per-reason semantics.
+
+                  v0.3 #559: introduces the structured reason so downstream
+                  consumers (the Workload reconciler's rollup, future retry
+                  policy, batch-level metrics) can route on a typed value rather
+                  than mining the Result.Extra map.
+                enum:
+                - AgentNotFound
+                - InferenceServiceUnavailable
+                - AuthUnavailable
+                - GitRemoteNotConfigured
+                - CloneFailed
+                - ModelMisunderstood
+                - ToolFailed
+                - MaxTurnsExhausted
+                - ConstraintViolated
+                - Timeout
+                - InfrastructureError
+                - GateFailed
+                - GateError
+                type: string
               finishedAt:
                 description: FinishedAt is when the executor produced a verdict (success
                   or fail).

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -152,7 +152,7 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 		if apierrors.IsNotFound(err) {
 			// Scheduler should have caught this; if we got here the
 			// Agent was deleted between scheduling and execution.
-			return e.failResult(start, "AgentNotFound",
+			return e.failResult(start, foremanv1alpha1.FailureAgentNotFound,
 				fmt.Sprintf("Agent %q not found in namespace %q", agentKey.Name, agentKey.Namespace)), nil
 		}
 		return nil, fmt.Errorf("resolve agent: %w", err)
@@ -176,7 +176,7 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 		var err error
 		endpoint, err = e.resolveProviderEndpoint(ctx, task.Namespace, &agent)
 		if err != nil {
-			return e.failResult(start, "InferenceServiceUnavailable", err.Error()), nil
+			return e.failResult(start, foremanv1alpha1.FailureInferenceServiceUnavailable, err.Error()), nil
 		}
 	}
 
@@ -208,13 +208,13 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 
 	auth, err := e.buildAuth()
 	if err != nil {
-		return e.failResult(start, "AuthUnavailable", err.Error()), nil
+		return e.failResult(start, foremanv1alpha1.FailureAuthUnavailable, err.Error()), nil
 	}
 	defer func() { _ = auth.Close() }()
 
 	cloneURL := e.GitRemoteURL
 	if cloneURL == "" {
-		return e.failResult(start, "GitRemoteURLNotConfigured",
+		return e.failResult(start, foremanv1alpha1.FailureGitRemoteNotConfigured,
 			"foreman-agent was not started with --git-remote-url; cannot clone"), nil
 	}
 	if err := repo.Clone(ctx, repo.CloneOptions{
@@ -222,20 +222,26 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 		Dest:      workspace,
 		Auth:      auth,
 	}); err != nil {
-		return e.failResult(start, "CloneFailed", err.Error()), nil
+		return e.failResult(start, foremanv1alpha1.FailureCloneFailed, err.Error()), nil
 	}
 
 	// 4. Branch off main.
 	branch := branchNameForTask(task)
 	if err := repo.CreateAndCheckoutBranch(ctx, workspace, branch); err != nil {
-		return e.failResult(start, "BranchCheckoutFailed", err.Error()), nil
+		// Branch checkout is part of workspace prep; bucket with
+		// CloneFailed so downstream retry policy treats them the same.
+		return e.failResult(start, foremanv1alpha1.FailureCloneFailed, err.Error()), nil
 	}
 
 	// 5. Build tool registry pinned to this workspace + filtered by the
 	// Agent's tool whitelist.
 	registry, err := e.RegistryFactory(workspace, &agent)
 	if err != nil {
-		return e.failResult(start, "ToolRegistryBuildFailed", err.Error()), nil
+		// Registry build failure is an operator config issue (bad
+		// whitelist name, duplicate tool); not a runtime model
+		// failure. Bucket as infrastructure so it surfaces distinctly
+		// from in-loop tool errors.
+		return e.failResult(start, foremanv1alpha1.FailureInfrastructureError, err.Error()), nil
 	}
 
 	// 5b. Deterministic Agent path: no LLM loop. Dispatch the agent's
@@ -313,13 +319,21 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		switch {
 		case errors.Is(loopErr, ErrMaxTurnsExhausted):
 			return e.incompleteResult(start, transcriptRef, loopRes,
-				"MaxTurnsExhausted", "model did not call submit_result within max_turns"), nil
+				foremanv1alpha1.FailureMaxTurnsExhausted,
+				"model did not call submit_result within max_turns"), nil
 		case errors.Is(loopErr, ErrAssistantNoToolCalls):
 			return e.incompleteResult(start, transcriptRef, loopRes,
-				"AssistantHallucinatedFinish", "model returned text without tool_calls; loop cannot make progress"), nil
+				foremanv1alpha1.FailureModelMisunderstood,
+				"model returned text without tool_calls; loop cannot make progress"), nil
+		case errors.Is(loopErr, context.Canceled), errors.Is(loopErr, context.DeadlineExceeded):
+			return e.incompleteResult(start, transcriptRef, loopRes,
+				foremanv1alpha1.FailureTimeout,
+				loopErr.Error()), nil
 		default:
 			// Anything else is a system / transport failure: bubble up
-			// as an error so the watcher records ExecutorError.
+			// as an error so the watcher records ExecutorError. The
+			// watcher's execErr path tags this as InfrastructureError
+			// via the FailureReason mapping in patchTerminal.
 			return nil, loopErr
 		}
 	}
@@ -328,7 +342,8 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// Defensive: loop returned nil error but no terminal. Shouldn't
 		// happen given the loop's invariants; report it explicitly.
 		return e.incompleteResult(start, transcriptRef, loopRes,
-			"LoopContractViolation", "loop returned nil error but no terminal result"), nil
+			foremanv1alpha1.FailureInfrastructureError,
+			"loop returned nil error but no terminal result"), nil
 	}
 
 	verdict := foremanv1alpha1.AgenticTaskVerdict(loopRes.Terminal.Verdict)
@@ -414,7 +429,7 @@ func (e *NativeAgentLoopExecutor) executeDeterministic(
 ) *Result {
 	toolName := pickDeterministicTool(agent.Spec.Tools)
 	if toolName == "" {
-		return e.failResult(start, "NoDeterministicTool",
+		return e.failResult(start, foremanv1alpha1.FailureInfrastructureError,
 			"deterministic Agent has no non-terminal tool in spec.tools; expected exactly one (e.g. run_gate_job)")
 	}
 
@@ -429,7 +444,7 @@ func (e *NativeAgentLoopExecutor) executeDeterministic(
 
 	result, dispatchErr := registry.Dispatch(ctx, toolName, args)
 	if dispatchErr != nil {
-		return e.failResult(start, "ToolDispatchFailed",
+		return e.failResult(start, foremanv1alpha1.FailureToolFailed,
 			fmt.Sprintf("%s: %s", toolName, dispatchErr.Error()))
 	}
 
@@ -448,6 +463,17 @@ func (e *NativeAgentLoopExecutor) executeDeterministic(
 	}
 
 	r := NewResult(e.Kind(), verdict, summary, time.Since(start))
+	// v0.3 #559: surface a structured FailureReason for the gate
+	// verdicts. GATE-PASS / GO leave FailureReason empty (success);
+	// GATE-FAIL maps to GateFailed (diff didn't meet quality bar;
+	// retry is a code-side fix, not a gate-side issue); GATE-ERROR
+	// maps to GateError (gate infrastructure problem, retryable).
+	switch verdict {
+	case foremanv1alpha1.AgenticTaskVerdictGateFail:
+		r.FailureReason = foremanv1alpha1.FailureGateFailed
+	case foremanv1alpha1.AgenticTaskVerdictGateError:
+		r.FailureReason = foremanv1alpha1.FailureGateError
+	}
 	r.Extra = map[string]any{
 		"outcome":        "",
 		"deterministic":  true,
@@ -704,26 +730,32 @@ func (e *NativeAgentLoopExecutor) buildAuth() (*repo.Auth, error) {
 // --- Result builders ------------------------------------------------------
 
 // failResult builds a verdict=INCOMPLETE Result that the watcher will
-// patch as phase=Succeeded; the failure shape lives in Result.Extra.
-// Used for environment errors (Agent not found, clone failed, etc.)
-// where the executor never reached the model. We do not return an
-// error from these paths because the failure is data-shaped: the task
-// got a real, structured outcome that a downstream consumer can read.
-func (e *NativeAgentLoopExecutor) failResult(start time.Time, reason, message string) *Result {
+// patch as phase=Succeeded; the failure shape lives in Result.Extra
+// and (v0.3 #559) in the structured Result.FailureReason. Used for
+// environment errors (Agent not found, clone failed, etc.) where the
+// executor never reached the model. We do not return an error from
+// these paths because the failure is data-shaped: the task got a
+// real, structured outcome that a downstream consumer can read.
+func (e *NativeAgentLoopExecutor) failResult(
+	start time.Time, reason foremanv1alpha1.AgenticTaskFailureReason, message string,
+) *Result {
 	r := NewResult(e.Kind(), foremanv1alpha1.AgenticTaskVerdictIncomplete, message, time.Since(start))
+	r.FailureReason = reason
 	r.Extra = map[string]any{
-		"reason":  reason,
+		"reason":  string(reason), // mirror for back-compat; v0.3 #559
 		"outcome": "EXECUTOR-PRECONDITION-FAILED",
 	}
 	return r
 }
 
 func (e *NativeAgentLoopExecutor) incompleteResult(
-	start time.Time, tref corev1.ObjectReference, lr *LoopResult, reason, msg string,
+	start time.Time, tref corev1.ObjectReference, lr *LoopResult,
+	reason foremanv1alpha1.AgenticTaskFailureReason, msg string,
 ) *Result {
 	r := NewResult(e.Kind(), foremanv1alpha1.AgenticTaskVerdictIncomplete, msg, time.Since(start))
+	r.FailureReason = reason
 	r.Extra = map[string]any{
-		"reason":        reason,
+		"reason":        string(reason),
 		"outcome":       "LOOP-INCOMPLETE",
 		"transcriptRef": objRefAsMap(tref),
 		"turnCount":     lr.Turns,

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -371,6 +372,86 @@ func TestResolveInferenceBaseURL(t *testing.T) {
 // boundary so the test reads cleanly.
 func foremanv1alpha1Local(name string) corev1.LocalObjectReference {
 	return corev1.LocalObjectReference{Name: name}
+}
+
+// TestFailResult_EmitsStructuredFailureReason pins the v0.3 #559
+// invariant: the failResult helper writes the typed reason to BOTH
+// Result.FailureReason (the structured field; what the watcher writes
+// to Status.FailureReason for downstream consumers) AND
+// Result.Extra["reason"] (the back-compat mirror; v0.1 observers).
+//
+// The whitebox path keeps the surface small; the executor's many
+// failResult call sites pass typed constants, and this test pins
+// that the conversion to the wire shape is correct.
+func TestFailResult_EmitsStructuredFailureReason(t *testing.T) {
+	e := &NativeAgentLoopExecutor{}
+	cases := []struct {
+		name   string
+		reason foremanv1alpha1.AgenticTaskFailureReason
+	}{
+		{"AgentNotFound", foremanv1alpha1.FailureAgentNotFound},
+		{"InferenceServiceUnavailable", foremanv1alpha1.FailureInferenceServiceUnavailable},
+		{"AuthUnavailable", foremanv1alpha1.FailureAuthUnavailable},
+		{"GitRemoteNotConfigured", foremanv1alpha1.FailureGitRemoteNotConfigured},
+		{"CloneFailed", foremanv1alpha1.FailureCloneFailed},
+		{"InfrastructureError", foremanv1alpha1.FailureInfrastructureError},
+		{"ToolFailed", foremanv1alpha1.FailureToolFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := e.failResult(time.Time{}, tc.reason, "some message")
+			if r.FailureReason != tc.reason {
+				t.Errorf("Result.FailureReason: want %q got %q", tc.reason, r.FailureReason)
+			}
+			if got := r.Extra["reason"]; got != string(tc.reason) {
+				t.Errorf("Result.Extra[reason]: want %q got %v", string(tc.reason), got)
+			}
+			// Verdict on a failResult is always INCOMPLETE; the watcher
+			// patches Phase=Failed in this path.
+			if r.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+				t.Errorf("Verdict: want INCOMPLETE got %q", r.Verdict)
+			}
+		})
+	}
+}
+
+// TestIncompleteResult_EmitsStructuredFailureReason mirrors the
+// failResult test for the in-loop incomplete path. The incompleteResult
+// helper is called when the loop exited cleanly but without a terminal
+// (MaxTurns, AssistantNoToolCalls, ctx Timeout). Each path must emit
+// the right structured reason.
+func TestIncompleteResult_EmitsStructuredFailureReason(t *testing.T) {
+	e := &NativeAgentLoopExecutor{}
+	cases := []foremanv1alpha1.AgenticTaskFailureReason{
+		foremanv1alpha1.FailureMaxTurnsExhausted,
+		foremanv1alpha1.FailureModelMisunderstood,
+		foremanv1alpha1.FailureTimeout,
+		foremanv1alpha1.FailureInfrastructureError,
+	}
+	for _, reason := range cases {
+		t.Run(string(reason), func(t *testing.T) {
+			r := e.incompleteResult(
+				time.Time{},
+				corev1.ObjectReference{Name: "transcript"},
+				&LoopResult{Turns: 7},
+				reason,
+				"msg",
+			)
+			if r.FailureReason != reason {
+				t.Errorf("Result.FailureReason: want %q got %q", reason, r.FailureReason)
+			}
+			if got := r.Extra["reason"]; got != string(reason) {
+				t.Errorf("Result.Extra[reason]: want %q got %v", string(reason), got)
+			}
+			// turnCount + outcome carry across as before.
+			if got := r.Extra["turnCount"]; got != 7 {
+				t.Errorf("Extra[turnCount]: want 7 got %v", got)
+			}
+			if got := r.Extra["outcome"]; got != "LOOP-INCOMPLETE" {
+				t.Errorf("Extra[outcome]: want LOOP-INCOMPLETE got %v", got)
+			}
+		})
+	}
 }
 
 // TestResolveProviderEndpoint covers the v0.2 cloud-proxy resolution

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -269,7 +269,13 @@ func TestNativeExecutor_AgentNotFound(t *testing.T) {
 		t.Fatalf("expected INCOMPLETE result, got %+v", res)
 	}
 	if got := res.Extra["reason"]; got != "AgentNotFound" {
-		t.Errorf("reason: want AgentNotFound got %v", got)
+		t.Errorf("Extra[reason]: want AgentNotFound got %v", got)
+	}
+	// v0.3 #559: same value should also surface on the structured
+	// Result.FailureReason field (which the watcher writes to
+	// Status.FailureReason for downstream consumers).
+	if got := res.FailureReason; got != foremanv1alpha1.FailureAgentNotFound {
+		t.Errorf("FailureReason: want %q got %q", foremanv1alpha1.FailureAgentNotFound, got)
 	}
 }
 

--- a/pkg/foreman/agent/result.go
+++ b/pkg/foreman/agent/result.go
@@ -50,6 +50,17 @@ type Result struct {
 	// exactly when both are present.
 	Verdict foremanv1alpha1.AgenticTaskVerdict `json:"verdict"`
 
+	// FailureReason categorizes WHY a non-success Verdict landed. The
+	// watcher copies this into AgenticTaskStatus.FailureReason. Empty
+	// on a successful task (Verdict in {GO, GATE-PASS}). See
+	// AgenticTaskFailureReason for the enum.
+	//
+	// v0.3 #559: structured failure taxonomy. Result.Extra["reason"]
+	// is kept in sync for one release for back-compat with any
+	// observer that mines the JSON; new code should read this typed
+	// field instead.
+	FailureReason foremanv1alpha1.AgenticTaskFailureReason `json:"failureReason,omitempty"`
+
 	// Summary is a human-readable one-liner. The watcher copies this into
 	// the Completed condition's Message; keep it terse.
 	Summary string `json:"summary"`

--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -235,6 +235,11 @@ func (w *AgenticTaskWatcher) patchTerminal(
 	if execErr != nil {
 		fresh.Status.Phase = foremanv1alpha1.AgenticTaskPhaseFailed
 		fresh.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+		// v0.3 #559: the bubble-up path lands here. Map to
+		// InfrastructureError (the watcher has no visibility into
+		// what KIND of err this is, only that the executor wanted
+		// the supervisor to see it).
+		fresh.Status.FailureReason = foremanv1alpha1.FailureInfrastructureError
 		setCondition(&fresh.Status.Conditions, metav1.Condition{
 			Type:               "Completed",
 			Status:             metav1.ConditionFalse,
@@ -250,6 +255,7 @@ func (w *AgenticTaskWatcher) patchTerminal(
 		// surface it explicitly rather than silently succeeding.
 		fresh.Status.Phase = foremanv1alpha1.AgenticTaskPhaseFailed
 		fresh.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+		fresh.Status.FailureReason = foremanv1alpha1.FailureInfrastructureError
 		setCondition(&fresh.Status.Conditions, metav1.Condition{
 			Type:               "Completed",
 			Status:             metav1.ConditionFalse,
@@ -262,6 +268,11 @@ func (w *AgenticTaskWatcher) patchTerminal(
 
 	fresh.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 	fresh.Status.Verdict = res.Verdict
+	// v0.3 #559: lift the structured FailureReason from the Result
+	// envelope onto the status. Empty on a successful task (Verdict
+	// in {GO, GATE-PASS}); set on Phase=Succeeded + non-success
+	// Verdict (NO-GO, GATE-FAIL, INCOMPLETE).
+	fresh.Status.FailureReason = res.FailureReason
 	raw, err := json.Marshal(res)
 	if err != nil {
 		return fmt.Errorf("marshal result: %w", err)


### PR DESCRIPTION
## What

Add a structured `AgenticTaskFailureReason` enum (13 values) and surface it as a top-level field on both the Executor `Result` envelope and `AgenticTaskStatus`. Promote every existing string-typed `Result.Extra["reason"]` to a typed constant. Preserve the Extra-map mirror for one release so existing observers don't break.

## Why (Fixes #559)

Today every non-success AgenticTask end-state collapses into a stringly-typed `reason` in `Result.Extra`. The Workload reconciler's rollup, the future per-reason retry policy, batch-level reporting, and cross-task learning all need a **typed** enum they can route on. This PR is the foundational data shape; the retry consumers come in follow-ups.

## How

**13 reasons across three regions:**

| Region | Reasons |
|---|---|
| Pre-loop (executor) | `AgentNotFound`, `InferenceServiceUnavailable`, `AuthUnavailable`, `GitRemoteNotConfigured`, `CloneFailed` |
| In-loop | `ModelMisunderstood`, `ToolFailed`, `MaxTurnsExhausted`, `ConstraintViolated`*, `Timeout`, `InfrastructureError` |
| Gate-specific | `GateFailed`, `GateError` |

\* `ConstraintViolated` is declared; #561's `ErrToolNotInWhitelist` (PR #564) will wire to it in a follow-up after both PRs merge.

**Surface**:
- `Result.FailureReason` on the executor envelope
- `AgenticTaskStatus.FailureReason` on the CR
- Watcher copies `Result.FailureReason` → `Status.FailureReason` on every terminal patch
- `Result.Extra["reason"]` kept in sync for one release (back-compat mirror)

**String → typed migration**: all existing call sites now pass enum constants. Strings like `"BranchCheckoutFailed"`, `"ToolRegistryBuildFailed"`, `"NoDeterministicTool"`, `"AssistantHallucinatedFinish"` got folded into the appropriate bucket (workspace prep → `CloneFailed`; operator config → `InfrastructureError`; assistant-no-tools → `ModelMisunderstood`).

**Gate verdict mapping**: in the deterministic gate path, `GATE-FAIL` Verdict now lands `FailureReason=GateFailed` and `GATE-ERROR` lands `FailureReason=GateError`. Distinct because they imply different retry policies (gate-fail is a coder-side fix; gate-error is infrastructure).

## Scope (deliberately small)

Emission + status surface only. **Two pieces explicitly deferred** to follow-up issues:

- Per-reason retry policy on `AgenticTaskSpec` and reconciler retry/escalate logic (#559's "retry policy" half)
- Retry-with-correction in the agent loop (inject corrective system message on recoverable tool errors)

Splitting these keeps this PR focused on the foundational typed signal. The downstream consumers are independent and benefit from typed data once it exists.

## Test coverage

- `TestFailResult_EmitsStructuredFailureReason`: 7 cases pinning that every typed reason flows to both `Result.FailureReason` (structured) and `Result.Extra["reason"]` (back-compat) without drift.
- `TestIncompleteResult_EmitsStructuredFailureReason`: 4 cases for the in-loop incomplete paths.
- `TestNativeExecutor_AgentNotFound`: existing executor test extended to assert the new structured field alongside the Extra-map mirror.

## Checklist

- [x] `make fmt vet lint test` clean (Mac)
- [x] `GOOS=linux ./bin/golangci-lint run ./...` clean
- [x] `make manifests generate chart-crds foreman-chart-crds` synced
- [x] Full foreman + controller test suite green
- [x] Backward compatible: existing AgenticTasks without `status.failureReason` keep working; existing observers reading `Result.Extra["reason"]` keep working
- [x] DCO sign-off
- [x] Fixes #559

## Part of

v0.3 "harness-tightening" release. Third v0.3 issue to ship (after #558 observation masking + #561 whitelist sentinel). Together with #561's `ErrToolNotInWhitelist`, sets up the per-reason retry policy + retry-with-correction follow-up PRs.
