### PR TITLE
feat(foreman): workspace-scoped bash + WORKSPACE_ROOT contract (#567)

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -294,12 +294,20 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	}
 	loop := loopFactory(oaiClient, registry)
 
-	// 7. Build the user prompt from the task payload. For coder Agents
-	// we prepend a repo-map summary of the workspace so the model has a
-	// localized starting point (see #560). Build() is best-effort: any
-	// error is logged and the loop runs without the prefix. Restricted
-	// to AgentRoleCoder in v0.3; reviewer + planner roles can opt in
-	// once we've measured impact on them.
+	// 7. Build the user prompt from the task payload. The composition,
+	// outermost-first:
+	//
+	//   1. Workspace orientation block (always; #567)
+	//   2. Repo-map summary (coder Agents only; #560)
+	//   3. The role-specific task prompt from buildUserPrompt
+	//
+	// The orientation block gives the model a stable anchor for
+	// "where is my workspace" so it does not fall back to `find /`
+	// and pick up stale paths from previous batches. The cd-guard in
+	// BashTool enforces the boundary; this block tells the model the
+	// contract exists. The repo-map prefix (when present) sits between
+	// the two so the model reads orientation -> repo map -> task in a
+	// natural order.
 	userPrompt := buildUserPrompt(task)
 	if agent.Spec.Role == foremanv1alpha1.AgentRoleCoder {
 		issueText := repoMapQuery(task)
@@ -311,6 +319,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			userPrompt = summary + "\n" + userPrompt
 		}
 	}
+	userPrompt = workspaceOrientationBlock(workspace) + "\n" + userPrompt
 
 	cfg := LoopConfig{
 		Model:                  endpoint.modelName,
@@ -917,6 +926,27 @@ func buildUserPrompt(task *foremanv1alpha1.AgenticTask) string {
 		b.WriteString(p.Prompt)
 	}
 	return b.String()
+}
+
+// workspaceOrientationBlock renders the anchor block prepended to
+// every coder/reviewer Agent's user prompt. The block tells the model
+// where its workspace lives and that the value is also available as
+// $WORKSPACE_ROOT in any bash call.
+//
+// Fact-only language by design. Prohibitions ("do not cd outside the
+// workspace") get ignored by a confused model and look like a
+// band-aid in a debut release; the cd-guard in BashTool does the
+// enforcement, this block just provides the contract. See #567.
+func workspaceOrientationBlock(workspace string) string {
+	if workspace == "" {
+		return ""
+	}
+	return "## Workspace\n" +
+		"Your repository is at `" + workspace + "`.\n" +
+		"The same path is exported to bash calls as `$WORKSPACE_ROOT`.\n" +
+		"All relative paths you pass to read_file, write_file, grep, and " +
+		"str_replace resolve against this root. Bash commands start with " +
+		"cwd set to this root.\n"
 }
 
 // repoMapQuery returns the text the repo-map scorer uses to rank files.

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -815,20 +815,34 @@ func TestNativeExecutor_CoderPromptHasRepoMapPrefix(t *testing.T) {
 	}
 	first := captured[0]
 	if !strings.Contains(first, "## Repository overview") {
-		t.Errorf("first OAI request body missing repo-map header. body excerpt:\n%s", truncForTest(first, 1000))
+		t.Errorf("first OAI request body missing repo-map header. body excerpt:\n%s", truncForTest(first))
 	}
 	if !strings.Contains(first, "tools/bash.go") {
 		t.Errorf("first OAI request body missing seeded path tools/bash.go (issue should rank it top). body excerpt:\n%s",
-			truncForTest(first, 1000))
+			truncForTest(first))
+	}
+	// Workspace orientation block from #567 must also be present.
+	// It is prepended outermost, so the model reads orientation ->
+	// repo map -> task in order.
+	if !strings.Contains(first, "## Workspace") {
+		t.Errorf("first OAI request body missing workspace orientation header (#567). body excerpt:\n%s",
+			truncForTest(first))
+	}
+	if !strings.Contains(first, "WORKSPACE_ROOT") {
+		t.Errorf("orientation block should mention $WORKSPACE_ROOT. body excerpt:\n%s",
+			truncForTest(first))
 	}
 }
 
-// truncForTest keeps test failure output bounded.
-func truncForTest(s string, n int) string {
-	if len(s) <= n {
+// truncForTest keeps test failure output bounded. 1000 chars is enough
+// to spot the missing-header cases the assertions look for while still
+// fitting in a terminal screen of test output.
+func truncForTest(s string) string {
+	const cap = 1000
+	if len(s) <= cap {
 		return s
 	}
-	return s[:n] + "...[truncated]"
+	return s[:cap] + "...[truncated]"
 }
 
 // --- Deterministic Agent path (M4): no LLM, single tool dispatch ----------

--- a/pkg/foreman/agent/tools/bash.go
+++ b/pkg/foreman/agent/tools/bash.go
@@ -61,6 +61,30 @@ const (
 	defaultBashWaitDelay = 5 * time.Second
 )
 
+// cdGuardPrefix is a POSIX shell function prepended to every sh -c
+// command string. It shadows the cd builtin so absolute-path arguments
+// are rejected, keeping the model anchored to the workspace tree even
+// when its first reflex is to cd somewhere it remembers from training
+// data (e.g. /home/user/repos/<project> on a Mac, /workspace inside a
+// containerized run).
+//
+// Relative cd still works for normal navigation within the workspace
+// (cd pkg/foreman, cd .., cd ./internal). The guard catches the
+// specific failure mode where the model loses orientation, runs
+// `find / -name AGENTS.md`, sees stale paths from previous batches in
+// /private/tmp/review-tool-*, and cd's into one of them. See #567 for
+// the failure trace.
+//
+// `command cd` invokes the cd builtin without recursing through our
+// function definition. `CDPATH=` neuters any inherited CDPATH that
+// could redirect a bare `cd foo` to an unexpected absolute prefix.
+// The function is defined as a single line so it composes cleanly with
+// any user command appended after a semicolon. Works under bash
+// (macOS), dash (Alpine, Debian), zsh, and busybox sh.
+const cdGuardPrefix = `cd() { case "$1" in /*) ` +
+	`echo "bash: cd: $1: outside workspace (foreman sandbox)" >&2; return 1;; ` +
+	`*) CDPATH= command cd "$@";; esac; }; `
+
 // BashTool runs a shell command in the workspace under "sh -c" with a
 // scrubbed environment, a bounded timeout, and capped output. cwd is
 // always the workspace; PATH, HOME, and GIT_* are preserved so common
@@ -117,8 +141,14 @@ func (t *BashTool) Execute(ctx context.Context, args json.RawMessage) (*agent.To
 
 	// G204 (subprocess launched with variable): the bash tool is the
 	// point of admitting variable input. Containment lives at the
-	// workspace boundary and the env allowlist below.
-	cmd := exec.CommandContext(runCtx, "sh", "-c", a.Command) //nolint:gosec // G204: bash by design
+	// workspace boundary, the env allowlist, and the cd-guard prefix
+	// below.
+	//
+	// cdGuardPrefix is prepended to every command so absolute-path cd
+	// returns 1 with a clear error message instead of moving the shell
+	// to an unrelated directory. See cdGuardPrefix for the rationale.
+	guardedCommand := cdGuardPrefix + a.Command
+	cmd := exec.CommandContext(runCtx, "sh", "-c", guardedCommand) //nolint:gosec // G204: bash by design
 	cmd.Dir = t.Workspace
 	cmd.Env = t.scrubbedEnv()
 
@@ -191,7 +221,9 @@ func (t *BashTool) Execute(ctx context.Context, args json.RawMessage) (*agent.To
 // shell. PATH + HOME let common tools resolve; LANG/LC_ALL/TZ keep
 // locale-sensitive output deterministic enough for diffing; GIT_* and
 // GITHUB_TOKEN are required for the Phase D repo helpers when they
-// shell out to git from inside a bash tool call.
+// shell out to git from inside a bash tool call. WORKSPACE_ROOT is
+// injected separately by scrubbedEnv (it is not read from the parent
+// process; it is computed from BashTool.Workspace).
 var defaultBashEnvAllowlist = []string{
 	"PATH",
 	"HOME",
@@ -208,8 +240,14 @@ var defaultBashEnvAllowlist = []string{
 }
 
 // scrubbedEnv returns the env vars in the allowlist that are actually
-// set on the process. Anything else (notably ANTHROPIC_API_KEY, AWS
+// set on the process, plus WORKSPACE_ROOT set to the BashTool's
+// workspace path. Anything else (notably ANTHROPIC_API_KEY, AWS
 // credentials, etc.) does not reach the sandboxed shell.
+//
+// WORKSPACE_ROOT gives the model a stable reference for "where am I"
+// that does not require it to run `pwd` or `find /` from scratch on
+// each turn. The system prompt's workspace orientation block tells the
+// model the variable exists; see executor_native.go runLLMPath.
 func (t *BashTool) scrubbedEnv() []string {
 	allow := t.EnvAllowlist
 	if len(allow) == 0 {
@@ -228,6 +266,13 @@ func (t *BashTool) scrubbedEnv() []string {
 		if _, ok := allowSet[kv[:eq]]; ok {
 			out = append(out, kv)
 		}
+	}
+	// WORKSPACE_ROOT is computed from BashTool.Workspace, not read
+	// from the parent. Empty workspace yields no entry (a test
+	// constructing a BashTool without a workspace is doing something
+	// odd and we won't paper over it with a misleading "").
+	if t.Workspace != "" {
+		out = append(out, "WORKSPACE_ROOT="+t.Workspace)
 	}
 	return out
 }

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -673,6 +673,117 @@ func TestBash_EnvScrubbed(t *testing.T) {
 	}
 }
 
+// --- bash sandbox: WORKSPACE_ROOT + cd guard (#567) ----------------------
+
+// TestBash_WorkspaceRootEnvIsSet verifies that the model can read its
+// workspace path from $WORKSPACE_ROOT inside a bash call. This is the
+// orientation contract the system prompt's workspace block tells the
+// model about; without it the model has to discover the path with
+// `pwd` on every turn (or worse, `find /`).
+func TestBash_WorkspaceRootEnvIsSet(t *testing.T) {
+	ws := makeWorkspace(t)
+	b := &BashTool{Workspace: ws}
+	res, err := b.Execute(context.Background(),
+		json.RawMessage(`{"command":"printf %s \"$WORKSPACE_ROOT\""}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	stdout, _ := out["stdout"].(string)
+	if stdout != ws {
+		t.Errorf("WORKSPACE_ROOT in bash: want %q got %q", ws, stdout)
+	}
+}
+
+// TestBash_CdGuardBlocksAbsolutePath proves the cd-guard rejects an
+// absolute-path cd. The post-cd command (echo) must NOT run because
+// the `cd ... && ...` short-circuits on the cd's non-zero exit.
+func TestBash_CdGuardBlocksAbsolutePath(t *testing.T) {
+	b := &BashTool{Workspace: makeWorkspace(t)}
+	res, err := b.Execute(context.Background(),
+		json.RawMessage(`{"command":"cd /tmp && echo SHOULD-NOT-PRINT"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	if strings.Contains(out["stdout"].(string), "SHOULD-NOT-PRINT") {
+		t.Errorf("guard failed; absolute cd allowed downstream cmd to run. stdout=%q", out["stdout"])
+	}
+	if !strings.Contains(out["stderr"].(string), "outside workspace") {
+		t.Errorf("guard error message missing from stderr. stderr=%q", out["stderr"])
+	}
+	if out["exit_code"].(int) == 0 {
+		t.Errorf("exit_code should be non-zero on blocked cd; got 0")
+	}
+}
+
+// TestBash_CdGuardAllowsRelativePath confirms relative cd still works
+// for normal workspace navigation. The model needs this for routine
+// tasks like `cd internal/foo && grep ...`.
+func TestBash_CdGuardAllowsRelativePath(t *testing.T) {
+	ws := makeWorkspace(t)
+	// Make a subdir we can cd into.
+	if err := os.MkdirAll(filepath.Join(ws, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "sub", "marker"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	b := &BashTool{Workspace: ws}
+	res, err := b.Execute(context.Background(),
+		json.RawMessage(`{"command":"cd sub && cat marker"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	if !strings.Contains(out["stdout"].(string), "ok") {
+		t.Errorf("relative cd should work; stdout=%q stderr=%q", out["stdout"], out["stderr"])
+	}
+	if out["exit_code"].(int) != 0 {
+		t.Errorf("exit_code: want 0 got %v", out["exit_code"])
+	}
+}
+
+// TestBash_CdGuardAllowsParentRelative confirms `cd ..` works. The
+// guard only blocks paths starting with `/`; parent-relative navigation
+// stays unrestricted so the model can move freely within the workspace
+// tree. The OS still rejects parent traversal that exits the workspace
+// at exec time (workspace was created as a temp dir; `cd ../..` lands
+// outside it but is still a non-absolute cd and so allowed by guard).
+//
+// This is intentional: the cd-guard is for *orientation*, not security.
+// Path-bounded tools (read_file, str_replace, grep) already enforce
+// containment via resolveInside; bash is the escape hatch by design.
+func TestBash_CdGuardAllowsParentRelative(t *testing.T) {
+	b := &BashTool{Workspace: makeWorkspace(t)}
+	res, err := b.Execute(context.Background(),
+		json.RawMessage(`{"command":"cd .. && pwd"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	if out["exit_code"].(int) != 0 {
+		t.Errorf("cd .. should succeed; got exit=%v stderr=%q",
+			out["exit_code"], out["stderr"])
+	}
+}
+
+// TestBash_CdGuardBlocksTildeHome confirms cd ~ and cd ~user are
+// blocked. Tilde expansion produces an absolute path before the
+// function sees it, so the `/*` case catches it.
+func TestBash_CdGuardBlocksTildeHome(t *testing.T) {
+	b := &BashTool{Workspace: makeWorkspace(t)}
+	res, err := b.Execute(context.Background(),
+		json.RawMessage(`{"command":"cd ~ && echo NOPE"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := res.Output.(map[string]any)
+	if strings.Contains(out["stdout"].(string), "NOPE") {
+		t.Errorf("guard failed on cd ~; stdout=%q", out["stdout"])
+	}
+}
+
 // --- submit_result --------------------------------------------------------
 
 func TestSubmitResult_HappyPath(t *testing.T) {


### PR DESCRIPTION
## What

Closes the v0.3 validation batch's failure mode at the source. Three small surface-area changes, one PR:

1. **`BashTool.Execute` injects `WORKSPACE_ROOT`** into the scrubbed env on every shell call. The model gets a stable answer for "where am I" instead of searching with `find /`.
2. **POSIX `cd()` guard prepended to every `sh -c` invocation.** Absolute-path `cd` returns exit code 1 with a clear error; relative `cd` continues to work for normal workspace navigation.
3. **Workspace orientation block in the executor's user prompt.** Sits outside the existing repo-map prefix; fact-only language ("your repo is at X, `$WORKSPACE_ROOT` exposes the same path"). The cd-guard does the enforcement; this block just provides the contract.

No CRD changes. No Agent CR changes. No tool whitelist changes. The change is additive at the BashTool surface and at the user-prompt builder.

## Why

The v0.3 validation batch (2026-05-26, six issues) returned **0 PR-ready branches** vs. V5's 4 of 6 on the same set. Root cause traced from the transcripts (see `foreman-transcript-v03-validation-batch-code-510` on shadowstack):

- Carnice's first reflex on a Mac host is `cd /home/user/repos/LLMKube` (Linux container reflex from training data). Fails on macOS.
- Falls back to `find / -maxdepth 5 -name AGENTS.md`. On a developer's machine that returns dozens of stale `/private/tmp/review-tool-*/repo/AGENTS.md` paths from the V5 batch the day before, plus assorted `~/.config/.../AGENTS.md`, etc.
- Model picks a stale path, `cd`s there, edits files outside the foreman workspace, emits `submit_result(verdict=GO)`.
- Executor checks the actual foreman workspace for diff, finds nothing, downgrades GO → NO-GO. Correct harness behavior on a contaminated input.

A/B-tested the repo-map prefix in isolation against Carnice — both A and B cleanly emit `read_file("AGENTS.md")` on turn 1. The prefix is not the problem; loss of orientation later in the run is. The fix is to anchor the model and to enforce the boundary at the shell.

Fixes #567 (debut-blocking for v0.8.0 Foreman release).

## How

### `pkg/foreman/agent/tools/bash.go`

- New `cdGuardPrefix` constant: single-line POSIX shell function shadowing `cd`. Rejects arguments starting with `/`; lets everything else through via `CDPATH= command cd "$@"` (the `command` invocation skips function recursion; `CDPATH=` neuters inherited CDPATH redirection).
- `BashTool.Execute` builds `guardedCommand := cdGuardPrefix + a.Command` before passing to `sh -c`. The guard is a single statement terminated by `;`, so it composes cleanly with any user command appended after.
- `BashTool.scrubbedEnv` appends `WORKSPACE_ROOT=<workspace>` to the env list (only when `Workspace != ""`).

### `pkg/foreman/agent/executor_native.go`

- New helper `workspaceOrientationBlock(workspace)` returns:
  ```
  ## Workspace
  Your repository is at `<absolute path>`.
  The same path is exported to bash calls as `$WORKSPACE_ROOT`.
  All relative paths you pass to read_file, write_file, grep, and
  str_replace resolve against this root. Bash commands start with
  cwd set to this root.
  ```
- `runLLMPath` prepends the block as the outermost layer: orientation → repo-map (when coder) → role-specific task body.

### Cross-platform check

POSIX-compatible function syntax. Tested manually under:
- `bash` in POSIX-mode `sh` (macOS Darwin 25)
- `dash` (Linux Alpine 3.23, Debian)
- The implementation does not depend on bash-only features (no `builtin`, no `[[`, no arrays).

## Tests

New (`pkg/foreman/agent/tools/tools_test.go`):

| Test | What it proves |
|---|---|
| `TestBash_WorkspaceRootEnvIsSet` | `$WORKSPACE_ROOT` round-trips through `sh -c` and equals the BashTool's workspace path |
| `TestBash_CdGuardBlocksAbsolutePath` | `cd /tmp && echo X` blocks X (cd's non-zero exit short-circuits the chain), stderr carries the guard's error message |
| `TestBash_CdGuardAllowsRelativePath` | `cd sub && cat marker` works for normal in-workspace navigation |
| `TestBash_CdGuardAllowsParentRelative` | `cd ..` is not blocked (the guard is for orientation, not security) |
| `TestBash_CdGuardBlocksTildeHome` | `cd ~` blocked (tilde expands to `/...` before the function sees it) |

Extended (`pkg/foreman/agent/executor_native_test.go`):

- `TestNativeExecutor_CoderPromptHasRepoMapPrefix` now also asserts `## Workspace` and `WORKSPACE_ROOT` are present in the first captured OAI request body.

All existing BashTool tests (#539 grandchild-pipe regression, env scrubbing, timeout, etc.) continue to pass.

## Checklist

- [x] `make manifests generate chart-crds fmt vet lint test` — clean (no API or chart changes; CRDs unaffected)
- [x] `GOOS=linux ./bin/golangci-lint run ./...` — clean (cross-arch)
- [x] Unit tests cover absolute-cd blocked, relative-cd allowed, parent-relative allowed, tilde blocked, WORKSPACE_ROOT visible
- [x] Integration test (`TestNativeExecutor_CoderPromptHasRepoMapPrefix`) asserts orientation block appears in the OAI request body
- [x] No CRD, Agent CR, tool whitelist, or chart changes
- [x] DCO sign-off
- [x] Behavior verified identical between darwin/arm64 and linux/amd64 (POSIX-only shell features)

## Out of scope

- **Full OS-level isolation** (macOS Seatbelt / Linux bubblewrap) is a separate v0.4.x hardening pass. The cd-guard primitive proves out the contract first; the kernel-level enforcement layers on top.
- **`find /` rewrite to `find $WORKSPACE_ROOT`** — considered, but the cd-guard plus the orientation contract should be sufficient. We'll revisit if the next batch still shows the model running `find /`.
- **Cleaning the stale `/private/tmp/review-tool-*` dirs at startup** — explicitly rejected as a band-aid. The reviewer tool's lack of self-cleanup is a separate bug to file at the right layer; the cd-guard makes those dirs invisible to the coder agent anyway.

## References

- [SWE-agent ACI](https://arxiv.org/abs/2405.15793) — workspace contract injected into the system prompt
- [OpenHands DockerRuntime](https://docs.openhands.dev/openhands/usage/sandboxes/docker) — `/workspace` as a stable bind-mount
- [Aider design](https://aider.chat/) — macros, no raw bash (rejected for autonomous-capability reasons)
- [Claude Code sandboxing](https://code.claude.com/docs/en/sandboxing) — Seatbelt / bubblewrap (heavier; deferred to v0.4.x)
