### PR TITLE
fix(foreman/loop): force-terminate returns clean Terminal envelope (#544 follow-up)

### DIFF
--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -151,13 +151,15 @@ type LoopResult struct {
 // runtime failed): the loop ran cleanly, the model just gave up.
 var ErrMaxTurnsExhausted = errors.New("loop: max turns exhausted")
 
-// ErrStuckLoopDetected is the marker returned from Loop.Run when the
-// progress monitor force-terminated. LoopResult.Terminal is also set
-// to a synthetic submit_result envelope with verdict=INCOMPLETE and
-// extra.outcome=STUCK-LOOP-DETECTED so callers that key on Terminal
-// see the normal terminal shape; this error gives callers that key
-// on err the same signal.
-var ErrStuckLoopDetected = errors.New("loop: stuck-loop detector force-terminated")
+// StuckLoopOutcome is the value the progress monitor sets in
+// LoopResult.Terminal.Extra["outcome"] when it force-terminates a run.
+// Callers that want to distinguish a model-emitted terminal from a
+// detector-synthesized one check this marker (or read the Signal
+// field) rather than keying on a sentinel error. The loop returns a
+// nil error with a populated Terminal envelope so the executor's
+// normal terminal-handling path runs and the synthesized verdict
+// surfaces in AgenticTask.status.result.
+const StuckLoopOutcome = "STUCK-LOOP-DETECTED"
 
 // ErrAssistantNoToolCalls is returned when the model replies with text
 // only and no tool_calls. The loop has no way to make forward progress
@@ -248,9 +250,16 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 			// transcript is left intact so the executor can persist
 			// the trajectory for review; res.Terminal carries the
 			// synthesized envelope so downstream consumers see a
-			// normal terminal shape.
+			// normal terminal shape. We return a NIL error here on
+			// purpose: a force-terminate is a clean structural outcome
+			// (not an infrastructure failure) and the executor's
+			// terminal-handling path needs to run so the synthesized
+			// verdict + Extra.outcome propagate to AgenticTask status.
+			// Callers can distinguish this case from a model-emitted
+			// terminal by checking Terminal.Extra["outcome"] for
+			// StuckLoopOutcome (see ForceTerminateEnvelope).
 			res.Terminal = ForceTerminateEnvelope(decision, turn)
-			return res, ErrStuckLoopDetected
+			return res, nil
 		}
 	}
 	return res, ErrMaxTurnsExhausted

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -351,8 +351,12 @@ func TestLoop_StuckLoopDetectorForceTerminates(t *testing.T) {
 		MaxTurns: 10,
 		Progress: ProgressConfig{RepeatedToolThreshold: 3},
 	})
-	if !errors.Is(err, ErrStuckLoopDetected) {
-		t.Fatalf("expected ErrStuckLoopDetected; got %v", err)
+	// The loop returns nil error on a clean force-terminate: it's a
+	// structural outcome (the model is stuck, harness intervened), not
+	// an infrastructure failure. Callers distinguish this from a model-
+	// emitted terminal by inspecting Terminal.Extra["outcome"].
+	if err != nil {
+		t.Fatalf("expected nil error on clean force-terminate; got %v", err)
 	}
 	if res.Terminal == nil {
 		t.Fatal("expected synthesized Terminal envelope")
@@ -360,8 +364,8 @@ func TestLoop_StuckLoopDetectorForceTerminates(t *testing.T) {
 	if res.Terminal.Verdict != "INCOMPLETE" {
 		t.Errorf("synthesized verdict: want INCOMPLETE; got %q", res.Terminal.Verdict)
 	}
-	if got := res.Terminal.Extra["outcome"]; got != "STUCK-LOOP-DETECTED" {
-		t.Errorf("Extra.outcome: want STUCK-LOOP-DETECTED; got %v", got)
+	if got := res.Terminal.Extra["outcome"]; got != StuckLoopOutcome {
+		t.Errorf("Extra.outcome: want %q; got %v", StuckLoopOutcome, got)
 	}
 	if got := res.Terminal.Extra["signal"]; got != "RepeatedToolCall" {
 		t.Errorf("Extra.signal: want RepeatedToolCall; got %v", got)


### PR DESCRIPTION
## What

One-line fix to the stuck-loop detector's force-terminate path. Return `nil` error from `Loop.Run` when synthesizing a terminal envelope, so the executor's terminal-handling path runs instead of the infrastructure-error path.

## Why

The v0.3 validation batch's rerun-3b (2026-05-27) ran the freshly-rolled `v0.3-stuck-loop-2172ece` binaries. The detector fired correctly — all six code tasks terminated in 22-41s instead of 90-120s, the wall-time reduction matching the PR #569 prediction. **But every task wrote `phase=Failed` with empty `status.extra`** instead of the documented `phase=Succeeded` + `verdict=INCOMPLETE` + `extra.outcome=STUCK-LOOP-DETECTED`.

The reason: `Loop.Run` was returning `ErrStuckLoopDetected` alongside the populated `res.Terminal`. The executor's `loopErr` switch (`executor_native.go` lines 344-364) only matches `ErrMaxTurnsExhausted`, `ErrAssistantNoToolCalls`, and context errors; the `default` branch treats anything else as an infrastructure failure and returns `nil, loopErr` without consulting `res.Terminal`. The synthesized envelope went into the void.

A force-terminate is structural, not infrastructural — same shape as a model-emitted `submit_result(verdict=INCOMPLETE)`, just authored by the harness. It deserves the normal terminal-handling path.

## How

Two changes:

1. **`pkg/foreman/agent/loop.go`** — the force-terminate case returns `nil` error. The synthesized `Terminal` envelope carries `Extra["outcome"] = StuckLoopOutcome` so callers that want to distinguish detector-synthesized from model-emitted terminals can check the marker.
2. **`pkg/foreman/agent/loop.go`** — drop the unused `ErrStuckLoopDetected` sentinel; replace with a public `StuckLoopOutcome` constant. Less of a sentinel pattern, more of a documented value.
3. **`pkg/foreman/agent/loop_test.go`** — `TestLoop_StuckLoopDetectorForceTerminates` asserts `err == nil` + `Terminal.Extra["outcome"] == StuckLoopOutcome`. The other detector tests in `progress_test.go` are unchanged (they test the monitor, not the loop integration).

After this lands:

- Force-terminated tasks: `phase=Succeeded`, `verdict=INCOMPLETE`, `extra.outcome=STUCK-LOOP-DETECTED`, `extra.signal` populated, `extra.detail` populated.
- Cascade-on-verdict (#541) handles the verify-step skip naturally (verdict != GO).
- Workload rollup counters surface stuck-loop-terminated tasks the same way they surface any other non-GO outcome.

## Tests

- Updated `TestLoop_StuckLoopDetectorForceTerminates`: expects `err == nil`, `Terminal.Verdict == "INCOMPLETE"`, `Terminal.Extra["outcome"] == StuckLoopOutcome`.
- All 12 `progress_test.go` unit tests still pass (monitor logic unchanged).
- `TestLoop_ProgressMonitorDisabledByDefault` unchanged (the disabled path was already returning `ErrMaxTurnsExhausted`).

## Checklist

- [x] `make lint test` clean (both arches)
- [x] No CRD changes
- [x] No Agent CR changes
- [x] Empirically motivated: rerun-3b transcripts on shadowstack show the routing bug
- [x] DCO sign-off

Fixes the integration bug in #544 / PR #569 spotted in the rerun-3b empirical run.
