### PR TITLE
feat(foreman): executor fetches GitHub issue body when payload prompt is empty (#571)

### DIFF
--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -61,6 +61,7 @@ import (
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	foremantools "github.com/defilantech/llmkube/pkg/foreman/agent/tools"
 )
@@ -289,6 +290,7 @@ func main() {
 			},
 			KeepWorkspace:   keepWorkspace,
 			RegistryFactory: makeRegistryFactory(kc, kcs, foremanNamespace),
+			IssueFetcher:    githubissue.NewClient(),
 		}
 	default:
 		setupLog.Error(nil, "unknown --agent-mode", "value", agentMode, "valid", "stub|native")

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,6 +37,7 @@ import (
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repomap"
@@ -117,6 +119,13 @@ type NativeAgentLoopExecutor struct {
 	// because the tools subpackage owns workspace containment and we
 	// do not want the executor reimplementing it.
 	RegistryFactory func(workspace string, agent *foremanv1alpha1.Agent) (ToolRegistry, error)
+
+	// IssueFetcher pulls the GitHub issue title + body so buildUserPrompt
+	// can include them. Best-effort: a nil fetcher or a failed fetch
+	// runs the loop with the empty-body behavior (pre-#571 default),
+	// preserving backward compatibility. Tests inject a fake; production
+	// wires githubissue.NewClient() in cmd/foreman-agent.
+	IssueFetcher githubissue.Fetcher
 }
 
 // Kind identifies this executor in Result.Kind and in logs.
@@ -308,6 +317,14 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// contract exists. The repo-map prefix (when present) sits between
 	// the two so the model reads orientation -> repo map -> task in a
 	// natural order.
+	//
+	// Before assembling, fetch the GitHub issue body when the task is
+	// an issue-fix with an empty payload prompt (#571). The M6 stub
+	// planner synthesizes AgenticTasks from issue numbers and leaves
+	// the prompt empty; without this fetch the model is asked to fix
+	// "#510" with no knowledge of what #510 is about. Best-effort: a
+	// failed fetch logs and the loop runs with the pre-#571 behavior.
+	fetchIssueBodyIfNeeded(ctx, e.IssueFetcher, task, auth, log)
 	userPrompt := buildUserPrompt(task)
 	if agent.Spec.Role == foremanv1alpha1.AgentRoleCoder {
 		issueText := repoMapQuery(task)
@@ -927,6 +944,85 @@ func buildUserPrompt(task *foremanv1alpha1.AgenticTask) string {
 		b.WriteString(p.Prompt)
 	}
 	return b.String()
+}
+
+// fetchIssueBodyIfNeeded populates task.Spec.Payload.Prompt from the
+// GitHub issue body when the task is an issue-fix with an empty
+// prompt. The M6 stub planner does not pull issue bodies at synthesis
+// time; this lazy fetch makes a coder Agent's first turn actually
+// useful instead of being told "fix #510" with no context (#571).
+//
+// Best-effort: no fetcher, no auth token, malformed repo, or HTTP
+// failure all yield a log line and leave the payload prompt empty,
+// preserving the pre-#571 behavior. The model can still grep the repo
+// for clues; the goal here is to give it a much better starting
+// point when GitHub is reachable.
+//
+// Truncation + title formatting happen inside the fetcher; the body
+// we paste includes the title prefix so the model sees what it is
+// being asked to do before reading the longer body.
+func fetchIssueBodyIfNeeded(
+	ctx context.Context,
+	fetcher githubissue.Fetcher,
+	task *foremanv1alpha1.AgenticTask,
+	auth *repo.Auth,
+	log logr.Logger,
+) {
+	if fetcher == nil {
+		return
+	}
+	if task.Spec.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
+		return
+	}
+	if task.Spec.Payload.Prompt != "" {
+		return
+	}
+	if task.Spec.Payload.Issue <= 0 {
+		return
+	}
+	owner, repoName, err := githubissue.ParseRepo(task.Spec.Payload.Repo)
+	if err != nil {
+		log.Info("issue fetch skipped: bad repo string", "repo", task.Spec.Payload.Repo, "err", err.Error())
+		return
+	}
+	token := ""
+	if auth != nil {
+		token = auth.Token
+	}
+	iss, err := fetcher.Fetch(ctx, owner, repoName, int(task.Spec.Payload.Issue), token)
+	if err != nil {
+		// Distinguish the common cases so the log line is actionable.
+		var herr *githubissue.HTTPError
+		switch {
+		case errors.As(err, &herr) && herr.IsNotFound():
+			log.Info("issue fetch: not found; continuing with empty body",
+				"issue", task.Spec.Payload.Issue, "repo", task.Spec.Payload.Repo)
+		case errors.As(err, &herr) && herr.IsUnauthorized():
+			log.Info("issue fetch: unauthorized; check GITHUB_TOKEN",
+				"issue", task.Spec.Payload.Issue, "repo", task.Spec.Payload.Repo)
+		default:
+			log.Info("issue fetch failed; continuing with empty body",
+				"err", err.Error(),
+				"issue", task.Spec.Payload.Issue, "repo", task.Spec.Payload.Repo)
+		}
+		return
+	}
+	// Compose title + state + labels + body. The model needs the title
+	// (often the entire ask, especially for small docs/CI issues), the
+	// state (closed -> probably already fixed -> NO-GO candidate), and
+	// the labels (helps with triage). Body is the longest part and
+	// goes last so the structured fields stay near the top.
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Issue #%d: %s\n\n", iss.Number, iss.Title)
+	fmt.Fprintf(&b, "State: %s\n", iss.State)
+	if len(iss.Labels) > 0 {
+		fmt.Fprintf(&b, "Labels: %s\n", strings.Join(iss.Labels, ", "))
+	}
+	b.WriteString("\n")
+	b.WriteString(iss.Body)
+	task.Spec.Payload.Prompt = b.String()
+	log.Info("issue body fetched",
+		"issue", iss.Number, "state", iss.State, "bodyLen", len(iss.Body))
 }
 
 // progressConfigFromAgent maps the Agent CR's stuckLoopDetection field

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -38,6 +39,7 @@ import (
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 )
@@ -843,6 +845,184 @@ func truncForTest(s string) string {
 		return s
 	}
 	return s[:cap] + "...[truncated]"
+}
+
+// fakeIssueFetcher is a deterministic Fetcher for the executor tests.
+// Returns a canned Issue for the configured number; returns an error
+// for any other number so a test mismatch fails loudly rather than
+// silently exercising the wrong path.
+type fakeIssueFetcher struct {
+	want   int
+	issue  *githubissue.Issue
+	err    error
+	calls  int
+	lastTk string
+}
+
+func (f *fakeIssueFetcher) Fetch(_ context.Context, _, _ string, n int, token string) (*githubissue.Issue, error) {
+	f.calls++
+	f.lastTk = token
+	if n != f.want {
+		return nil, fmt.Errorf("fakeIssueFetcher: unexpected issue #%d (want %d)", n, f.want)
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.issue, nil
+}
+
+// TestNativeExecutor_FetchesIssueBodyWhenPromptEmpty exercises #571:
+// when the AgenticTask payload has no prompt body, the executor pulls
+// the issue title + body from GitHub and prepends them to the user
+// prompt so the model knows what it is being asked to fix.
+func TestNativeExecutor_FetchesIssueBodyWhenPromptEmpty(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+
+	var captured []string
+	oaiSrv := recordingOAI(t, []string{submitGoBody}, &captured)
+
+	agent, task := taskAndAgent("issuefetch")
+	// taskAndAgent ships a non-empty prompt ("test issue") so other
+	// tests do not exercise the fetch path. For this test we clear it
+	// to simulate the M6 stub planner's output (issue number set,
+	// prompt empty) which is the case the fetch is meant to handle.
+	task.Spec.Payload.Prompt = ""
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true, Verdict: "GO", Summary: "ok",
+				CommitMessage: "fix: trivial\n",
+			},
+		},
+		touch: func(name string, ws string) {
+			if name == "submit_result" {
+				_ = os.WriteFile(filepath.Join(ws, "fix.txt"), []byte("x\n"), 0o644)
+			}
+		},
+	}
+
+	fetcher := &fakeIssueFetcher{
+		want: 9999,
+		issue: &githubissue.Issue{
+			Number: 9999,
+			Title:  "[BUG] Foo widget breaks on input X",
+			Body:   "The widget panics when given X. Steps to reproduce: ...",
+			State:  "open",
+			Labels: []string{"bug", "area/foreman"},
+		},
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Bot", Email: "b@x"},
+		CommitCommitter:          repo.Identity{Name: "Bot", Email: "b@x"},
+		RegistryFactory: func(ws string, _ *foremanv1alpha1.Agent) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory:  fakeAuth(t),
+		IssueFetcher: fetcher,
+	}
+
+	if _, err := e.Execute(context.Background(), task); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if fetcher.calls != 1 {
+		t.Errorf("fetcher should be called exactly once; got %d", fetcher.calls)
+	}
+	if fetcher.lastTk == "" {
+		t.Errorf("fetcher should receive the auth token from repo.Auth; got empty")
+	}
+
+	if len(captured) == 0 {
+		t.Fatal("no OAI requests captured")
+	}
+	first := captured[0]
+
+	// The issue title, state, labels, and body all need to be in the
+	// user message so the model has the full ask in front of it.
+	for _, want := range []string{
+		"# Issue #9999",
+		"Foo widget breaks on input X",
+		"State: open",
+		"Labels: bug, area/foreman",
+		"The widget panics when given X",
+	} {
+		if !strings.Contains(first, want) {
+			t.Errorf("OAI request body missing %q. excerpt:\n%s", want, truncForTest(first))
+		}
+	}
+}
+
+// TestNativeExecutor_NoFetcherFallsBackToEmptyBody confirms the
+// pre-#571 behavior is preserved when the executor has no fetcher
+// wired (nil) or when the fetcher fails. A failed fetch must not
+// abort the run; the loop runs with whatever buildUserPrompt produces
+// from the empty payload prompt.
+func TestNativeExecutor_NoFetcherFallsBackToEmptyBody(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+
+	var captured []string
+	oaiSrv := recordingOAI(t, []string{submitGoBody}, &captured)
+
+	agent, task := taskAndAgent("nofetcher")
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true, Verdict: "GO", Summary: "ok",
+				CommitMessage: "fix: trivial\n",
+			},
+		},
+		touch: func(name string, ws string) {
+			if name == "submit_result" {
+				_ = os.WriteFile(filepath.Join(ws, "fix.txt"), []byte("x\n"), 0o644)
+			}
+		},
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Bot", Email: "b@x"},
+		CommitCommitter:          repo.Identity{Name: "Bot", Email: "b@x"},
+		RegistryFactory: func(ws string, _ *foremanv1alpha1.Agent) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+		// IssueFetcher intentionally nil.
+	}
+
+	if _, err := e.Execute(context.Background(), task); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(captured) == 0 {
+		t.Fatal("no OAI requests captured")
+	}
+	first := captured[0]
+	// Expect the legacy "You are working on issue #9999" line to be
+	// present, and NO "# Issue #9999" header (since no fetch happened).
+	if !strings.Contains(first, "You are working on issue #9999") {
+		t.Errorf("legacy issue line missing. excerpt:\n%s", truncForTest(first))
+	}
+	if strings.Contains(first, "# Issue #9999") {
+		t.Errorf("issue header should NOT be present without a fetcher. excerpt:\n%s", truncForTest(first))
+	}
 }
 
 // --- Deterministic Agent path (M4): no LLM, single tool dispatch ----------

--- a/pkg/foreman/agent/githubissue/fetch.go
+++ b/pkg/foreman/agent/githubissue/fetch.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package githubissue fetches a single GitHub issue's title + body so the
+// Foreman executor can include it in the user prompt sent to a coder
+// Agent. The model needs to know WHAT it is fixing; reading the issue
+// body is the obvious way to learn that, and the harness reading it
+// for the model keeps the model's tool budget free for the actual fix.
+//
+// Trade-offs deliberately taken in v0.3.x:
+//
+//   - REST, not GraphQL: one endpoint, one JSON shape, no scopes to
+//     guess. The body cap below already addresses the "rich content"
+//     argument for GraphQL.
+//   - Title + body + labels only. Comments often clarify the ask, but
+//     they explode payload size unpredictably and the model can pull
+//     them via `bash` if it really needs them (it almost never does).
+//   - Best-effort. A failed fetch logs and the executor keeps the
+//     existing empty-body behavior; the loop runs with whatever
+//     buildUserPrompt produces from the (empty) payload prompt.
+package githubissue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultBodyCap bounds the issue body size we paste into the user
+// prompt. 16 KiB is enough for the actual feature/bug description on
+// the LLMKube tracker (median issue body ~1-2 KB, p99 ~8 KB). Larger
+// issues get truncated with a marker so the model knows there is more.
+const DefaultBodyCap = 16 * 1024
+
+// DefaultTimeout caps a single fetch. The GitHub API is fast; if the
+// network is slow we'd rather skip the fetch than hold up the loop.
+const DefaultTimeout = 10 * time.Second
+
+// Issue is the minimum subset of the GitHub issue payload the executor
+// needs. State is included so a model handed a closed issue can decide
+// to NO-GO immediately rather than re-implement a fix that already
+// shipped.
+type Issue struct {
+	Number int      `json:"number"`
+	Title  string   `json:"title"`
+	Body   string   `json:"body"`
+	State  string   `json:"state"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+// Fetcher is the seam between the executor and the GitHub API. The
+// executor takes a Fetcher in via dependency injection so unit tests
+// can substitute an httptest server. Production builds wire a Client
+// backed by net/http.
+type Fetcher interface {
+	Fetch(ctx context.Context, owner, repo string, number int, token string) (*Issue, error)
+}
+
+// Client is the production Fetcher. BaseURL is overridable so tests
+// can point at an httptest server; production leaves it empty and the
+// client uses https://api.github.com.
+type Client struct {
+	HTTPClient *http.Client
+	BaseURL    string // empty defaults to https://api.github.com
+	BodyCap    int    // 0 defaults to DefaultBodyCap
+}
+
+// NewClient constructs a Client with sensible defaults: 10s timeout,
+// GitHub's public API base URL, and the standard body cap.
+func NewClient() *Client {
+	return &Client{
+		HTTPClient: &http.Client{Timeout: DefaultTimeout},
+	}
+}
+
+// Fetch calls GET /repos/{owner}/{repo}/issues/{number}. Token is the
+// GitHub PAT (or fine-grained token) used in the Authorization header;
+// the empty string sends an unauthenticated request, which works for
+// public repos at the lower rate-limit tier (60/hr/IP).
+func (c *Client) Fetch(ctx context.Context, owner, repo string, number int, token string) (*Issue, error) {
+	if owner == "" || repo == "" {
+		return nil, fmt.Errorf("githubissue: owner+repo required")
+	}
+	if number <= 0 {
+		return nil, fmt.Errorf("githubissue: issue number must be positive")
+	}
+
+	base := c.BaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d", base, owner, repo, number)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("githubissue: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("githubissue: http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("githubissue: read body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Surface the status code so the executor's log line tells you
+		// whether the issue exists, the token is wrong, or the rate
+		// limit kicked in. Don't expose the body verbatim in the error:
+		// it's free-form HTML on auth failures and clutters logs.
+		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
+	}
+
+	// Use a raw struct because the GitHub labels field is `[{name,...}]`
+	// not `[]string` (so we can't unmarshal directly into Issue).
+	var raw struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		State  string `json:"state"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("githubissue: decode: %w", err)
+	}
+
+	out := &Issue{
+		Number: raw.Number,
+		Title:  raw.Title,
+		Body:   truncateBody(raw.Body, c.BodyCap),
+		State:  raw.State,
+	}
+	for _, l := range raw.Labels {
+		if l.Name != "" {
+			out.Labels = append(out.Labels, l.Name)
+		}
+	}
+	return out, nil
+}
+
+// HTTPError is returned when the GitHub API returns a non-200 status.
+// Callers that want to distinguish "issue not found" from "token
+// invalid" from "rate limited" can errors.As() into this and read
+// StatusCode.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+}
+
+// Error implements error.
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("githubissue: %s returned HTTP %d", e.URL, e.StatusCode)
+}
+
+// IsNotFound is true when the API returned 404; the executor uses this
+// to log a single helpful line rather than a generic "fetch failed."
+func (e *HTTPError) IsNotFound() bool { return e.StatusCode == http.StatusNotFound }
+
+// IsUnauthorized is true when the API returned 401 or 403; usually
+// means the token is wrong or the issue is in a private repo the
+// token does not see.
+func (e *HTTPError) IsUnauthorized() bool {
+	return e.StatusCode == http.StatusUnauthorized || e.StatusCode == http.StatusForbidden
+}
+
+// truncateBody bounds the body size. The marker is parseable by both
+// humans and models: a clear note that more text exists and the
+// model can pull the full issue via the GitHub UI / `gh` if needed.
+func truncateBody(body string, cap int) string {
+	if cap <= 0 {
+		cap = DefaultBodyCap
+	}
+	if len(body) <= cap {
+		return body
+	}
+	const marker = "\n\n... [issue body truncated; full text on GitHub]"
+	keep := cap - len(marker)
+	if keep < 0 {
+		keep = 0
+	}
+	return body[:keep] + marker
+}
+
+// ParseRepo splits an "owner/repo" string into its parts. Returns an
+// error if the input is malformed; the executor logs the error and
+// skips the fetch (best-effort).
+func ParseRepo(s string) (owner, repo string, err error) {
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", errors.New("githubissue: repo must be owner/repo")
+	}
+	return parts[0], parts[1], nil
+}

--- a/pkg/foreman/agent/githubissue/fetch_test.go
+++ b/pkg/foreman/agent/githubissue/fetch_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package githubissue
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseRepo(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{"defilantech/LLMKube", "defilantech", "LLMKube", false},
+		{"owner/repo", "owner", "repo", false},
+		{"", "", "", true},
+		{"single", "", "", true},
+		{"a/b/c", "", "", true},
+		{"/empty-owner", "", "", true},
+		{"empty-repo/", "", "", true},
+	}
+	for _, tc := range cases {
+		o, r, err := ParseRepo(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%q: wantErr=%v got err=%v", tc.in, tc.wantErr, err)
+		}
+		if o != tc.wantOwner || r != tc.wantRepo {
+			t.Errorf("%q: want (%q,%q) got (%q,%q)", tc.in, tc.wantOwner, tc.wantRepo, o, r)
+		}
+	}
+}
+
+// TestClient_Fetch_HappyPath wires the Client at an httptest server
+// serving the canonical GitHub issue payload. Verifies the parsed
+// fields, the Authorization header propagation, and the API headers.
+func TestClient_Fetch_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("auth header: want 'Bearer test-token' got %q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Errorf("accept header: want vnd.github+json got %q", got)
+		}
+		if got := r.URL.Path; got != "/repos/defilantech/LLMKube/issues/510" {
+			t.Errorf("path: want /repos/.../510 got %q", got)
+		}
+		_, _ = w.Write([]byte(`{
+			"number": 510,
+			"title": "[FEATURE] Mention make lint-all in AGENTS.md",
+			"body": "After PR #508 lands the make lint-all target, point contributors at it from AGENTS.md.",
+			"state": "open",
+			"labels": [
+				{"name": "documentation"},
+				{"name": "enhancement"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL}
+	iss, err := c.Fetch(context.Background(), "defilantech", "LLMKube", 510, "test-token")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if iss.Number != 510 {
+		t.Errorf("number: got %d", iss.Number)
+	}
+	if !strings.Contains(iss.Title, "Mention make lint-all") {
+		t.Errorf("title: got %q", iss.Title)
+	}
+	if !strings.Contains(iss.Body, "AGENTS.md") {
+		t.Errorf("body: got %q", iss.Body)
+	}
+	if iss.State != "open" {
+		t.Errorf("state: got %q", iss.State)
+	}
+	if len(iss.Labels) != 2 || iss.Labels[0] != "documentation" || iss.Labels[1] != "enhancement" {
+		t.Errorf("labels: got %v", iss.Labels)
+	}
+}
+
+// TestClient_Fetch_NoToken confirms an unauthenticated request omits
+// the Authorization header entirely. The empty token is the documented
+// "public repo, low rate-limit" path.
+func TestClient_Fetch_NoToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("auth header: want empty (anonymous) got %q", got)
+		}
+		_, _ = w.Write([]byte(`{"number": 1, "title": "t", "body": "b", "state": "open"}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL}
+	if _, err := c.Fetch(context.Background(), "o", "r", 1, ""); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+}
+
+// TestClient_Fetch_NotFound surfaces the 404 as an HTTPError. The
+// executor uses IsNotFound to distinguish "issue is gone" from "token
+// is wrong" and log appropriately.
+func TestClient_Fetch_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL}
+	_, err := c.Fetch(context.Background(), "o", "r", 999999, "")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	var herr *HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected *HTTPError; got %T (%v)", err, err)
+	}
+	if !herr.IsNotFound() {
+		t.Errorf("IsNotFound: got false")
+	}
+	if herr.IsUnauthorized() {
+		t.Errorf("IsUnauthorized: should be false for a 404")
+	}
+}
+
+// TestClient_Fetch_Unauthorized covers both 401 and 403; IsUnauthorized
+// returns true for either so the executor's log line can suggest a
+// token check.
+func TestClient_Fetch_Unauthorized(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(code)
+		}))
+		c := &Client{BaseURL: srv.URL}
+		_, err := c.Fetch(context.Background(), "o", "r", 1, "bad")
+		srv.Close()
+		var herr *HTTPError
+		if !errors.As(err, &herr) {
+			t.Fatalf("status %d: expected *HTTPError; got %v", code, err)
+		}
+		if !herr.IsUnauthorized() {
+			t.Errorf("status %d: IsUnauthorized should be true", code)
+		}
+	}
+}
+
+// TestClient_Fetch_TruncatesLargeBody caps a body bigger than BodyCap
+// and appends the documented marker so the model knows there is more.
+func TestClient_Fetch_TruncatesLargeBody(t *testing.T) {
+	big := strings.Repeat("x", 20*1024) // 20 KiB
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"number":1,"title":"t","body":"` + big + `","state":"open"}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL, BodyCap: 1024}
+	iss, err := c.Fetch(context.Background(), "o", "r", 1, "")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(iss.Body) > 1024 {
+		t.Errorf("body should be truncated to ~1024; got %d", len(iss.Body))
+	}
+	if !strings.Contains(iss.Body, "truncated") {
+		t.Errorf("truncation marker missing; got: %q", iss.Body[len(iss.Body)-100:])
+	}
+}
+
+// TestClient_Fetch_RejectsBadArgs guards against zero / empty inputs.
+func TestClient_Fetch_RejectsBadArgs(t *testing.T) {
+	c := NewClient()
+	for _, tc := range []struct {
+		name   string
+		owner  string
+		repo   string
+		number int
+	}{
+		{"empty-owner", "", "r", 1},
+		{"empty-repo", "o", "", 1},
+		{"zero-number", "o", "r", 0},
+		{"negative-number", "o", "r", -1},
+	} {
+		_, err := c.Fetch(context.Background(), tc.owner, tc.repo, tc.number, "")
+		if err == nil {
+			t.Errorf("%s: expected error", tc.name)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `pkg/foreman/agent/githubissue` and wires it into `NativeAgentLoopExecutor`. When an AgenticTask is `Kind=issue-fix` with `Payload.Prompt` empty, the executor fetches the GitHub issue title + body + state + labels and prepends them to the user prompt before the loop's first turn.

Fixes #571.

## Why

The v0.3 rerun-4 batch (2026-05-27) had every task force-terminate on EditFreeStreak in ~21 seconds. Root cause traced from the transcripts: the model was asked to fix issues but never told what those issues were.

**rerun-4 code-510 trace** (the trivial AGENTS.md doc fix):

| Turns | What the model did |
|---|---|
| 2-3 | Read AGENTS.md ✓ |
| 4-5 | Tried absolute `cd`, rejected by cd-guard |
| 6-7 | Recovered with `pwd && git log` |
| **8-31** | **13 variants of `git log --all --grep "510"`** searching for prior work |
| 32 | Stuck-loop nudge |
| 33-34 | One more search → force-terminate |

The actual user prompt for that task ended with:

```
You are working on issue #510 of repository defilantech/LLMKube.

The repository is checked out in the workspace at the current branch.
Make the minimum change that addresses the issue, then call submit_result.
Include `Fixes #510` in the commit_message trailer when verdict is GO.
```

**That's it.** No issue body, no title, no hint about what #510 is actually asking for. Meanwhile the issue itself literally describes the fix:

> After PR #508 lands the `make lint-all` target, point contributors at it from `AGENTS.md` (and/or `CONTRIBUTING.md`)...

Carnice's response — searching git history for any clue about "510" — was the most rational thing it could do given what we gave it. The v0.3 harness layers (#560 repo-map, #567 sandbox, #544 stuck-loop detector) all work as designed; this PR fills the missing input that makes any of them useful.

## How

### `pkg/foreman/agent/githubissue/`

- `Fetcher` interface with a single `Fetch(ctx, owner, repo, number, token)` method.
- `Client` is the production implementation: calls `GET /repos/{owner}/{repo}/issues/{number}` with the executor's existing `repo.Auth` token. Unauthenticated requests work for public repos at the lower rate-limit tier.
- Returns `{Number, Title, Body, State, Labels}`. Body is truncated to 16 KiB by default (configurable) so a giant discussion can't blow the context window.
- `HTTPError` type carries the status code with `IsNotFound()` and `IsUnauthorized()` helpers; the executor logs the appropriate hint (issue gone vs token check vs transient).
- `ParseRepo("owner/repo")` helper.

### `pkg/foreman/agent/executor_native.go`

- `NativeAgentLoopExecutor` gains an `IssueFetcher githubissue.Fetcher` field.
- New `fetchIssueBodyIfNeeded` helper, called in `runLLMPath` immediately before `buildUserPrompt`. Best-effort: a nil fetcher, malformed repo, or any fetch failure logs a single line and falls back to the pre-#571 behavior.
- When the fetch succeeds, the helper composes a header-tagged block (`# Issue #N: <title>` + state + labels + body) and pastes it into `task.Spec.Payload.Prompt`. `buildUserPrompt` then renders it as the `Issue context:` section it always wanted to.

### `cmd/foreman-agent/main.go`

- One-line wire: `IssueFetcher: githubissue.NewClient()` on the production executor.

## Tests

**New (`pkg/foreman/agent/githubissue/fetch_test.go`, 7 tests):**

| Test | What it proves |
|---|---|
| `TestParseRepo` | "owner/repo" parsing rejects malformed inputs |
| `TestClient_Fetch_HappyPath` | Auth header, Accept + version headers, URL path; parses title/body/state/labels |
| `TestClient_Fetch_NoToken` | Anonymous fetch omits Authorization (rate-limited path) |
| `TestClient_Fetch_NotFound` | 404 surfaces as `*HTTPError` with `IsNotFound()=true` |
| `TestClient_Fetch_Unauthorized` | Both 401 and 403 set `IsUnauthorized()=true` |
| `TestClient_Fetch_TruncatesLargeBody` | Body cap honored with a truncation marker |
| `TestClient_Fetch_RejectsBadArgs` | Empty owner/repo, zero/negative issue number all error |

**New (`pkg/foreman/agent/executor_native_test.go`, 2 tests):**

| Test | What it proves |
|---|---|
| `TestNativeExecutor_FetchesIssueBodyWhenPromptEmpty` | Fetcher invoked exactly once with the `repo.Auth` token; first OAI request body contains `# Issue #9999`, the title, `State: open`, `Labels: bug, area/foreman`, and the body text |
| `TestNativeExecutor_NoFetcherFallsBackToEmptyBody` | When `IssueFetcher == nil`, the legacy "You are working on issue #N" line is present and the issue header is absent — pre-#571 behavior preserved |

## Checklist

- [x] `make manifests generate chart-crds fmt vet lint test` clean (no API or chart changes)
- [x] `GOOS=linux ./bin/golangci-lint run ./...` clean (cross-arch)
- [x] 7 unit tests + 2 integration tests
- [x] No CRD, Agent CR, RBAC, or chart changes
- [x] No new secret mounts (reuses existing `GITHUB_TOKEN` via `repo.Auth`)
- [x] Best-effort: a nil/failing fetcher preserves the pre-#571 behavior exactly
- [x] DCO sign-off

## Empirical impact projection

The model's failure mode in rerun-4 was "I don't know what to do." With this PR, the model will see the issue body before turn 2. The hypothesis: tasks that previously hit EditFreeStreak in 16 turns will now actually attempt the fix.

We won't know how Carnice handles the new starting point until we re-run a batch with this binary on the fleet. If the model still gets stuck in different ways (e.g., scope drift, wrong file chosen, test failures it can't recover from), that's a *different* class of problem to solve. But it'll be a real coder-agent problem, not a missing-input problem.

## Out of scope / follow-ups

- **Fetch in WorkloadReconciler (Option A from the discussion).** A v0.4 enhancement: the reconciler inlines the body at synthesis time so the data is on the task spec for audit / cascade purposes. Needs operator-side GitHub token + RBAC.
- **Fetch comments.** Discussion in issue comments often clarifies the ask. Started with title+body+state+labels; expanding to comments can come if empirical data shows the model needs them.
- **`closed` state handling.** Currently the body still goes to the model; could route a closed issue straight to NO-GO without invoking the loop. v0.4 candidate.
