### PR TITLE
feat(foreman): AgenticTask branches include workload name (#573)

### DIFF
--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -252,16 +252,23 @@ func (r *WorkloadReconciler) chooseSteps(w *foremanv1alpha1.Workload) (steps []f
 //     lands GATE-FAIL or GATE-ERROR rather than running the reviewer
 //     loop against a branch the gate already rejected.
 //
-// Payload.Branch is "foreman/issue-<N>" in all stages so each task
-// clones the branch the coder produced (the cloneURL passthrough from
-// #528 makes the gate hit the fork, not upstream).
+// Payload.Branch is "foreman/<workload-name>/issue-<N>" in all stages
+// so each task clones the branch the coder produced (the cloneURL
+// passthrough from #528 makes the gate hit the fork, not upstream).
+//
+// Including the workload name in the branch makes the branch unique
+// across reruns on the same issue set: a second Workload on the same
+// issues produces a distinct branch, the executor can push without
+// fast-forward conflicts, and the empirical artifact (the foreman-
+// authored branch) survives even when an earlier run already produced
+// a branch on the same issue. See #573 for the motivating trace.
 func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.PipelineStep {
 	tasksPerIssue := 2 + len(w.Spec.ReviewerAgentRefs)
 	steps := make([]foremanv1alpha1.PipelineStep, 0, len(w.Spec.Issues)*tasksPerIssue)
 	for _, n := range w.Spec.Issues {
 		codeName := fmt.Sprintf("code-%d", n)
 		verifyName := fmt.Sprintf("verify-%d", n)
-		branch := fmt.Sprintf("foreman/issue-%d", n)
+		branch := fmt.Sprintf("foreman/%s/issue-%d", w.Name, n)
 		steps = append(steps,
 			foremanv1alpha1.PipelineStep{
 				Name:     codeName,

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -148,7 +148,9 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "batch-shortcut-code-531"}, &code531)).To(Succeed())
 		Expect(code531.Spec.Kind).To(Equal(foremanv1alpha1.AgenticTaskKindIssueFix))
 		Expect(code531.Spec.Payload.Issue).To(Equal(int32(531)))
-		Expect(code531.Spec.Payload.Branch).To(Equal("foreman/issue-531"))
+		// #573: branch now includes the workload name to disambiguate
+		// reruns on the same issue across Workloads.
+		Expect(code531.Spec.Payload.Branch).To(Equal("foreman/batch-shortcut/issue-531"))
 		Expect(code531.Spec.AgentRef.Name).To(Equal("coder"))
 
 		var verify531 foremanv1alpha1.AgenticTask
@@ -196,7 +198,7 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		Expect(review5101.Spec.AgentRef.Name).To(Equal("reviewer-falsification"))
 		Expect(review5101.Spec.DependsOn).To(ConsistOf("batch-with-reviewers-verify-510"))
 		Expect(review5101.Spec.Payload.Issue).To(Equal(int32(510)))
-		Expect(review5101.Spec.Payload.Branch).To(Equal("foreman/issue-510"))
+		Expect(review5101.Spec.Payload.Branch).To(Equal("foreman/batch-with-reviewers/issue-510"))
 
 		// review-531-2: the third reviewer of the second issue. Confirms
 		// the cross-product expansion (per-issue x per-reviewer).

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -905,21 +905,45 @@ func objRefAsMap(ref corev1.ObjectReference) map[string]any {
 //
 //  1. Explicit task.Spec.Payload.Branch wins. This is the documented
 //     hand-off for verify tasks (which gate a branch the upstream coder
-//     task already produced) and the escape hatch for any task that
-//     wants to pin the branch name from the caller.
-//  2. issue-fix with Payload.Issue > 0 derives foreman/issue-<N>.
-//  3. Everything else falls back to foreman/<task-name>.
-//
-// v0.1 keeps slugs minimal; v0.2 may take an explicit IssueTitle field
-// on AgenticTaskPayload and slug it for the branch.
+//     task already produced), the M6 reconciler's prepopulated
+//     foreman/<workload>/issue-N name, and the escape hatch for any
+//     caller that wants to pin the branch name.
+//  2. issue-fix with Payload.Issue > 0 plus a Workload owner-ref
+//     derives foreman/<workload>/issue-N. The workload prefix is what
+//     makes the branch unique across reruns on the same issue (#573).
+//  3. issue-fix with Payload.Issue > 0 and no workload owner falls
+//     back to foreman/issue-N. Kept for hand-applied AgenticTasks
+//     that target a one-off issue with no parent Workload.
+//  4. Everything else falls back to foreman/<task-name>.
 func branchNameForTask(task *foremanv1alpha1.AgenticTask) string {
 	if task.Spec.Payload.Branch != "" {
 		return task.Spec.Payload.Branch
 	}
 	if task.Spec.Kind == foremanv1alpha1.AgenticTaskKindIssueFix && task.Spec.Payload.Issue > 0 {
+		if owner := workloadOwnerName(task); owner != "" {
+			return fmt.Sprintf("%s/%s/issue-%d", repo.BranchPrefix, owner, task.Spec.Payload.Issue)
+		}
 		return fmt.Sprintf("%s/issue-%d", repo.BranchPrefix, task.Spec.Payload.Issue)
 	}
 	return fmt.Sprintf("%s/%s", repo.BranchPrefix, task.Name)
+}
+
+// workloadOwnerName returns the .metadata.name of the Workload that
+// owns this AgenticTask (set by WorkloadReconciler via owner-ref), or
+// "" if no Workload owner exists. Used by branchNameForTask to
+// disambiguate per-rerun branches.
+//
+// The check is intentionally name-based, not UID-based: the reader
+// is human-friendly (foreman/v03-validation-batch-rerun-5/issue-510
+// is greppable; a UUID suffix is not), and the name is unique within
+// a namespace which is the only scope the executor cares about.
+func workloadOwnerName(task *foremanv1alpha1.AgenticTask) string {
+	for _, ref := range task.OwnerReferences {
+		if ref.Kind == "Workload" && ref.APIVersion == foremanv1alpha1.GroupVersion.String() {
+			return ref.Name
+		}
+	}
+	return ""
 }
 
 // buildUserPrompt assembles the prompt the loop sends as the first user

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -98,6 +98,61 @@ func TestBranchNameForTask(t *testing.T) {
 			},
 			want: "foreman/verify-only",
 		},
+		{
+			// #573: issue-fix with a Workload owner-ref produces a
+			// workload-prefixed branch so reruns on the same issue do
+			// not collide.
+			name: "issue-fix with workload owner produces workload-prefixed branch",
+			task: &foremanv1alpha1.AgenticTask{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "code-510",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: foremanv1alpha1.GroupVersion.String(),
+							Kind:       "Workload",
+							Name:       "v03-validation-batch-rerun-6",
+						},
+					},
+				},
+				Spec: foremanv1alpha1.AgenticTaskSpec{
+					Kind:    foremanv1alpha1.AgenticTaskKindIssueFix,
+					Payload: foremanv1alpha1.AgenticTaskPayload{Issue: 510},
+				},
+			},
+			want: "foreman/v03-validation-batch-rerun-6/issue-510",
+		},
+		{
+			// Backward-compat: hand-applied issue-fix task without a
+			// Workload owner still gets the legacy foreman/issue-N path.
+			name: "issue-fix without workload owner uses legacy form",
+			task: &foremanv1alpha1.AgenticTask{
+				ObjectMeta: metav1.ObjectMeta{Name: "code-503"},
+				Spec: foremanv1alpha1.AgenticTaskSpec{
+					Kind:    foremanv1alpha1.AgenticTaskKindIssueFix,
+					Payload: foremanv1alpha1.AgenticTaskPayload{Issue: 503},
+				},
+			},
+			want: "foreman/issue-503",
+		},
+		{
+			// A non-Workload owner-ref must not be mistaken for a
+			// Workload (cluster-roles can chain-own resources via
+			// arbitrary kinds; we only want our own kind).
+			name: "non-workload owner-ref does not affect branch name",
+			task: &foremanv1alpha1.AgenticTask{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "code-507",
+					OwnerReferences: []metav1.OwnerReference{
+						{APIVersion: "v1", Kind: "ConfigMap", Name: "irrelevant"},
+					},
+				},
+				Spec: foremanv1alpha1.AgenticTaskSpec{
+					Kind:    foremanv1alpha1.AgenticTaskKindIssueFix,
+					Payload: foremanv1alpha1.AgenticTaskPayload{Issue: 507},
+				},
+			},
+			want: "foreman/issue-507",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What

AgenticTask branches now include the parent Workload's name, so two reruns on the same issue produce distinct branches and the executor can push both. Two surfaces:

1. **`WorkloadReconciler.synthesizeIssueBatch`** emits `foreman/<workload-name>/issue-N` for every stage in a pipeline.
2. **`branchNameForTask`** in the executor reads the OwnerReferences chain and prepends the workload name when an issue-fix task is owned by a Workload.

Fixes #573.

## Why

Trace from rerun-5 (2026-05-27 09:30 UTC, post-#571 issue-body fetch):

Carnice produced a real commit on issue #449 — `da76f23f0c3148b86b46d559e169e9b92e630e81` — and the executor tried to push it. Push rejected:

```
! [rejected]        foreman/issue-449 -> foreman/issue-449 (non-fast-forward)
error: failed to push some refs to 'https://github.com/Defilan/LLMKube.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart.
```

`refs/heads/foreman/issue-449` already existed on the fork from the V5 batch on 2026-05-25 (a different rerun, days earlier). The executor is right to refuse a silent force-push, but the model's work was lost. Same shape on #510 in the same batch.

After this PR the rerun-5 batch would have produced `foreman/v03-validation-batch-rerun-5/issue-449` — distinct from any prior run, pushes cleanly, the model's commit lands.

## How

### `internal/foreman/controller/workload_controller.go`

`synthesizeIssueBatch` constructs the branch as `foreman/<workload-name>/issue-N` and uses it for the code, verify, and reviewer stages (all stages need the same branch so they all clone the coder's commit). The doc comment now describes the rerun-collision motivation.

### `pkg/foreman/agent/executor_native.go`

`branchNameForTask` precedence is now:

```
1. Payload.Branch wins (explicit hand-off / pipeline mode override)
2. issue-fix + Workload owner-ref  ->  foreman/<workload>/issue-N
3. issue-fix without owner          ->  foreman/issue-N    (legacy)
4. anything else                    ->  foreman/<task-name> (legacy)
```

The new `workloadOwnerName` helper walks `task.OwnerReferences` and returns the name of the first ref with `Kind=Workload` and the matching APIVersion. Name-based (not UID-based) on purpose: the resulting branch is greppable and human-readable.

Backward compatible: hand-applied AgenticTasks without a parent Workload still get the legacy `foreman/issue-N` form. The new path only fires when the M6 reconciler (or any future planner) sets the owner-ref.

## Tests

**Extended `pkg/foreman/agent/executor_native_internal_test.go`** with three new cases for `branchNameForTask`:

| Case | What it proves |
|---|---|
| `issue-fix with workload owner produces workload-prefixed branch` | New path: `foreman/v03-validation-batch-rerun-6/issue-510` |
| `issue-fix without workload owner uses legacy form` | Backward-compat: hand-applied tasks still get `foreman/issue-503` |
| `non-workload owner-ref does not affect branch name` | Owner kind matters: a ConfigMap ownerref is ignored |

**Updated `internal/foreman/controller/workload_controller_test.go`**:

- `code-531` branch expectation: `foreman/batch-shortcut/issue-531` (was `foreman/issue-531`)
- `review-510-1` branch expectation: `foreman/batch-with-reviewers/issue-510` (was `foreman/issue-510`)

All other tests unchanged; the existing `TestBranchNameForTask` precedence cases (explicit branch overrides, verify hand-off) still pass without modification.

## Checklist

- [x] `make lint test` clean both arches
- [x] No CRD changes
- [x] No Agent CR changes
- [x] No chart changes
- [x] Backward compatible: tasks without a Workload owner unchanged
- [x] Empirical motivation captured in PR body + commit message + issue body
- [x] DCO sign-off

## Empirical follow-up

After this PR merges and rolls to the fleet, the next rerun will produce branches like `foreman/v03-validation-batch-rerun-6/issue-449`. They will:

- Push cleanly (no fast-forward conflicts with stale branches from prior runs)
- Be discoverable on the fork via `git branch -a | grep foreman/v03-validation-batch-rerun-6`
- Group naturally with `git for-each-ref refs/heads/foreman/v03-validation-batch-rerun-6` for cleanup later

The 4 currently-stale branches on the fork (`foreman/issue-{379,449,506,510}`) remain. They can be deleted manually any time; they no longer block forward progress because new runs don't collide with them.

## Out of scope

- **Force-with-lease on collision.** Considered; rejected. Silently overwriting published branches is the wrong default for a system designed to leave an audit trail. An opt-in `Workload.spec.allowOverwrite` flag could come later if real automated retries need it.
- **Branch garbage collection.** A follow-up CronJob or finalizer could prune Workload-owned branches after the Workload is deleted. Not in this PR.

## References

- Issue #573 (this PR's spec)
- rerun-5 batch transcripts on shadowstack: `kubectl --context shadowstack -n default get agentictasks | grep v03-validation-batch-rerun-5` — code-449 and code-510 each have a PUSH-FAILED outcome with the rejected SHA in `status.result.extra`
