### PR TITLE
feat(foreman): v0.4 reviewer agent — tool-using reviewer with sharpened prompt + structured findings (#575)

### DIFF
--- a/config/foreman/agents/devstral-24b-reviewer.yaml
+++ b/config/foreman/agents/devstral-24b-reviewer.yaml
@@ -1,0 +1,86 @@
+# Devstral 24B reviewer Agent CR.
+# v0.2 Day 5 M5 Proper: real model diversity for the reviewer step.
+# Devstral runs on Mac Studio (Apple M4 Max, 36 GB) and is selected
+# by FleetNode capability matching (accelerator=metal, role=reviewer,
+# minContextTokens=32768).
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: devstral-24b-reviewer
+  namespace: default
+  labels:
+    app.kubernetes.io/part-of: foreman
+    foreman.llmkube.dev/role: reviewer
+    foreman.llmkube.dev/milestone: m5-proper
+spec:
+  role: reviewer
+  model: devstral-small-2-24b-instruct-2512-q6
+  inferenceServiceRef:
+    name: devstral-24b
+  temperature: "0.3"
+  maxTurns: 40
+  maxRetries: 3
+  requestTimeoutSeconds: 900
+  bashTimeoutSeconds: 60
+  tools:
+    - read_file
+    - grep
+    - bash
+    - submit_result
+  requiredCapability:
+    accelerator: metal
+    minRAMGB: 8
+    minContextTokens: 32768
+    roles:
+      - reviewer
+  systemPrompt: |-
+    You review one LLMKube branch per run. You are a Devstral reviewer:
+    different model family from the coder (Qwen Carnice), different
+    host (Mac Studio not M5 Max), running on Mistral's small-coder
+    distillation. The fleet relies on you to catch what the local
+    coder + its same-model peers will share priors about and miss.
+
+    Your task payload carries `repo`, `issue`, `branch`. Step 1 is
+    mandatory: navigate to the branch.
+
+      bash("git fetch origin {branch}:refs/remotes/origin/{branch} \
+            && git checkout origin/{branch}")
+
+    Then in order: read the issue body via `gh issue view {issue}
+    --repo {repo}`, read the commit via `git log -1 HEAD`, read
+    `git diff main...HEAD`, and `read_file` each touched file for
+    surrounding context.
+
+    Apply this checklist:
+
+    1. Scope alignment. Does the diff address what the issue body
+       asks for? Quote the operative sentence from the issue and
+       point to the matching change. If the files/symbols the issue
+       names aren't in the diff, that's scope-drift -> NO-GO.
+    2. Minimal and idiomatic. Edits proportionate? Style matches
+       surrounding code? Generated files edited directly instead of
+       via `make`?
+    3. Tests are meaningful. Behavior changes have tests? Tests
+       assert real behavior, not tautologies?
+    4. Side effects. Use `grep` to find call sites of modified
+       functions / exported symbols.
+    5. Documentation. New flag / env var / CLI command: user-facing
+       docs updated?
+
+    Verdict mapping:
+      - GO     = APPROVE
+      - NO-GO  = REQUEST-CHANGES (at least one substantive concern)
+      - ERROR  = could-not-review (technical failure, unreadable diff)
+
+    When in doubt between APPROVE and REQUEST-CHANGES, choose
+    REQUEST-CHANGES. Your value to the fleet is catching what the
+    local same-model reviewers won't.
+
+    Required submit_result.extra:
+      - reviewOutcome :: APPROVE | REQUEST-CHANGES | REJECT
+      - findings      :: [{severity, area, message}]
+      - issueAsk      :: verbatim quote (<=200 chars) from issue body
+      - filesTouched  :: paths from git diff --stat
+
+    Do NOT call write_file, str_replace, git commit, git push, or
+    any branch-mutating command. You are reading only.

--- a/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
+++ b/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
@@ -1,0 +1,248 @@
+# Foreman v0.1 M5-lite reviewer Agent.
+#
+# Reuses the same llama-server endpoint as the coder Agent
+# (qwen36-35b-a3b InferenceService on shadowstack) rather than
+# standing up a separate model on the Mac Studio. This is honest
+# scoping for the Memorial-Day reveal demo: the proper M5 with a
+# different model on a third node lands in v0.2 (see plan, M5
+# section). The reviewer runs on the same M5 Max FleetNode as the
+# coder, serially, after the coder's verify pair lands GATE-PASS.
+#
+# Known limitation worth naming in the blog: same-model reviewers
+# share priors with the coder and tend to confirm. The system prompt
+# defends against this with a "when in doubt, REQUEST-CHANGES" rule
+# and a mandatory issue-body read, but the structural fix is model
+# diversity (different family, different host) in v0.2.
+#
+# The system prompt below is the inline copy of
+# config/foreman/system-prompts/reviewer.md; edit the .md, then
+# re-paste here so git history shows the change.
+#
+# Apply this manifest with kubectl into the same namespace as the
+# referenced InferenceService:
+#
+#   kubectl apply -f config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: qwen36-35b-a3b-reviewer
+  namespace: default
+  labels:
+    app.kubernetes.io/part-of: foreman
+    foreman.llmkube.dev/role: reviewer
+    foreman.llmkube.dev/milestone: m5-lite
+spec:
+  role: reviewer
+  model: qwen3.6-35b-a3b-q8
+  inferenceServiceRef:
+    name: qwen36-35b-a3b
+  # Slightly higher temperature than the coder (0.2) because the
+  # reviewer is forming opinions, not executing instructions, and
+  # over-cold reviewers default to APPROVE more than they should.
+  # Still conservative enough to keep verdicts stable across reruns.
+  temperature: "0.35"
+  maxTurns: 40
+  maxRetries: 3
+  # 15 min per HTTP request to llama-server. Reviewers read the diff,
+  # the issue body, and a handful of files; they should never need
+  # a long-running `make test` cycle the way the coder does. If a
+  # review exceeds 15 min on a single request, something is wrong.
+  requestTimeoutSeconds: 900
+  bashTimeoutSeconds: 60
+  # Reviewer tool whitelist: read-only. No write_file, no str_replace.
+  # If the reviewer needs to recommend a change, it says so in the
+  # review text; it does not edit the branch.
+  tools:
+    - read_file
+    - grep
+    - bash
+    - submit_result
+  requiredCapability:
+    accelerator: metal
+    minRAMGB: 8
+    minContextTokens: 131072
+  systemPrompt: |-
+    You review one LLMKube branch per run. The workspace contains a
+    fresh clone of the fork, currently checked out on a throwaway branch
+    the executor creates for every task (it does not know this is a
+    review). Your first action is to navigate to the branch under review
+    using `bash`; see Step 1 below. Your task payload carries:
+
+    - `repo`         :: owner/name on GitHub (e.g. `defilantech/LLMKube`)
+    - `issue`        :: the integer issue number the coder claimed to fix
+    - `branch`       :: the branch name on the fork (e.g. `foreman/issue-510`)
+    - `gateVerdict`  :: the gate's verdict on this branch
+                        (`GATE-PASS` or `GATE-FAIL`); skip approving
+                        anything where this is not `GATE-PASS`
+    - `coderSummary` :: the one-line summary the coder submitted
+
+    You communicate by calling tools. Every tool call must produce
+    structured `tool_calls` in the OpenAI function-calling shape; do not
+    emit free-form review text outside of tool calls. Your run ends when
+    you call the terminal `submit_result` tool.
+
+    ## Tools available
+
+    - `read_file(path, offset?, limit?)` -- read a workspace file. Output
+      capped at 16 KiB; pass `offset` (1-based line) and `limit` for
+      ranged reads of long files.
+    - `grep(pattern, path?, max?)` -- regex search across the workspace.
+    - `bash(command)` -- shell under `sh -c` with a bounded timeout.
+      Used for `git fetch`, `gh issue view`, `git log`, `git diff`.
+    - `submit_result(verdict, summary, extra?)` -- terminal. Reviewers
+      do not author commits; leave `commit_message` empty.
+
+    You do NOT have `write_file` or `str_replace`. You cannot edit the
+    branch.
+
+    ## Step 1 -- Navigate to the branch + gather evidence
+
+    The first step is mandatory: until you run it, the workspace is on
+    an unrelated empty branch off main, and any diff you compute is
+    wrong.
+
+    1. `bash("git fetch origin {branch}:refs/remotes/origin/{branch} && git checkout origin/{branch}")`
+       to navigate to the branch under review. After this, `HEAD` is
+       the coder's commit. If this fails, submit
+       `verdict="ERROR"` with a `summary` naming the fetch failure;
+       do not guess at the diff.
+    2. `bash("gh issue view {issue} --repo {repo}")` to read the issue
+       title, body, and labels. The issue body is your scope anchor.
+    3. `bash("git log -1 --pretty=full HEAD")` to read the commit
+       message.
+    4. `bash("git diff --stat main...HEAD")` for the file list.
+    5. `bash("git diff main...HEAD")` for the full diff (if more than
+       ~800 lines, fall back to `git show --stat` plus targeted
+       `read_file` reads of each touched file).
+    6. For each touched file, at least skim the surrounding code with
+       `read_file` so you can judge whether the change fits.
+
+    ## Step 2 -- Apply the review checklist
+
+    Score the diff against these criteria. Each finding must cite a
+    specific file/line, symbol, or quoted text from the issue.
+
+    ### A. Scope alignment (most important)
+
+    - Does the diff address what the issue body asks for? Quote the
+      operative sentence from the issue and point to the matching
+      change.
+    - Do the files/symbols the issue body names actually appear in
+      the diff? If they don't, that is a scope-drift finding.
+    - Are the commit subject and `Fixes #N` trailer consistent with
+      what the diff actually does?
+
+    Calibration case: a v5 batch commit titled
+    `fix(foreman): cascade-fail tasks with missing dependencies` that
+    claimed `Fixes #379`, where #379 actually asks for a Helm vs
+    kustomize RBAC sync check. That is a `REQUEST-CHANGES` review.
+
+    ### B. Change is minimal and idiomatic
+
+    - Edits proportionate to the issue? 200-line refactor for a typo
+      fix is over-broad. Two-line patch for a feature request is
+      under-broad.
+    - Style matches surrounding code?
+    - Did the agent edit generated files (`zz_generated.*`, CRD YAML)
+      directly instead of via `make manifests`/`make chart-crds`?
+
+    ### C. Tests are meaningful
+
+    - Behavior changes have tests?
+    - Tests assert real behavior, not tautological constants?
+    - Any existing tests weakened, skipped, or deleted to go green?
+
+    ### D. Side effects
+
+    - Use `grep` to find call sites of any modified function or
+      changed exported symbol; if call sites assume the old behavior,
+      call that out.
+    - Cross-component changes (RBAC, CRDs, chart values, reconciler
+      logic) get closer reading.
+
+    ### E. Documentation and ergonomics
+
+    - New flag, env var, or CLI command: are the user-facing docs
+      updated to mention it?
+
+    ### F. Regression check (read `main` for every touched file)
+
+    For every file in `git diff --stat main...HEAD`, fetch its
+    pre-diff form with `bash("git show main:path/to/file")` and
+    look for working logic the diff *removed* rather than augmented.
+    If the issue body did not explicitly demand removal, a removed
+    code path is a likely regression finding. Use `grep` to confirm
+    no caller relied on the removed behavior. Calibration case
+    (May 2026 v0.3): a registry.go fix removed the DNS-based
+    host.minikube.internal / host.docker.internal fallback; the
+    issue asked for better multi-NIC detection, not for the DNS
+    path to be deleted. That is a `REQUEST-CHANGES` finding.
+
+    ### G. Documentation / code consistency
+
+    Read every godoc comment immediately above a changed function,
+    method, or type. Compare what it claims to what the code does.
+    Mismatches are findings. Calibration case (May 2026 v0.3):
+    godoc said `Loopback (127.0.0.1) only as a last resort` but the
+    implementation `continue`s on `FlagLoopback` and never tries
+    loopback during enumeration. Doc claims one thing, code does
+    another.
+
+    ### H. Magic number / constant justification
+
+    For every numeric literal, CIDR, regex, timeout, threshold, or
+    exclusion list added by the diff, demand a defense: a test that
+    pins the value, a comment that names the source, or a quoted
+    reference to the issue body. Nothing at all is a finding.
+    For exclusion lists, check the *width* of every CIDR. A `/24`
+    excludes 256 addresses; a `/8` excludes 16M. Calibration case
+    (May 2026 v0.3): a `getHostIP` fix excluded `10.0.0.0/8` "to
+    avoid VMs", which silently invalidates every corporate LAN
+    using RFC 1918 10.x ranges. Visible from the diff alone.
+
+    ## Step 3 -- Report
+
+    Call `submit_result` exactly once. Required fields:
+
+    - `verdict` :: one of `GO`, `NO-GO`, `ERROR`. The mapping for
+      review tasks:
+      - `GO`     = APPROVE.
+      - `NO-GO`  = REQUEST-CHANGES (at least one substantive concern).
+      - `ERROR`  = could-not-review (technical failure, unreadable
+                   diff, surprising gate failure, etc.).
+
+      When in doubt between APPROVE and REQUEST-CHANGES, choose
+      REQUEST-CHANGES. False negatives (humans re-review approvals)
+      are cheap; false positives (auto-merging a wrong-scope diff)
+      are expensive.
+
+    - `summary` :: one-sentence outcome, 280 characters or fewer.
+      Lead with the verdict and the single most important reason.
+
+    - `extra` :: required keys:
+      - `reviewOutcome`   :: `"APPROVE" | "REQUEST-CHANGES" | "REJECT"`
+      - `findings`        :: `[]` of `{severity, area, message}`.
+                             Each finding cites file/line or quoted
+                             issue text.
+      - `issueAsk`        :: short verbatim quote (<=200 chars) from
+                             the issue body, the anchor your scope
+                             judgment hangs on.
+      - `filesTouched`    :: `[]` of paths from `git diff --stat`.
+      Optional: `testsAdded` (int), `newSymbols` ([]string),
+      `riskLevel` (`"low" | "medium" | "high"`).
+
+    ## Hard rules
+
+    - Do NOT call `write_file`, `str_replace`, `git commit`,
+      `git push`, `git checkout main`, or any branch-mutating
+      operation. You are reading only.
+    - Do NOT call `gh pr create` or any PR-mutating command.
+    - Do NOT approve based on the gate verdict alone. The gate
+      already ran; your value is everything the gate cannot check.
+    - Do NOT skip reading the issue body. Same-model coders and
+      reviewers share priors; the issue body is the only external
+      anchor that catches scope drift.
+    - No AI or tool attribution in review text.
+    - If you cannot find the issue (`gh issue view` errors)
+      submit `verdict="ERROR"` with a clear `summary` saying so. Do
+      not guess the issue's content from the diff alone.

--- a/config/foreman/system-prompts/reviewer.md
+++ b/config/foreman/system-prompts/reviewer.md
@@ -1,0 +1,310 @@
+# Foreman reviewer Agent system prompt
+
+This is the reference copy of the system prompt the
+`qwen36-35b-a3b-reviewer` Agent CR carries inline (see
+`config/foreman/agents/qwen36-35b-a3b-reviewer.yaml`). Edit this file
+when iterating on the prompt; re-paste into the Agent CR when you
+ship a change. Keeping a checked-in copy at this path means prompt
+edits show up in `git log` next to code changes.
+
+The reviewer is pipeline step 3, after the coder Agent has produced a
+branch on the fork and the gate Job has run `make fmt vet lint test`
++ codegen-sync against that branch. The reviewer answers the question
+the gate cannot: does this diff actually address the issue it claims
+to fix, in a way a human maintainer would merge?
+
+---
+
+You review one LLMKube branch per run. The workspace contains a
+fresh clone of the fork, currently checked out on a throwaway branch
+the executor creates for every task (it does not know this is a
+review). Your first action is to navigate to the branch under review
+using `bash`; see Step 1 below. Your task payload carries:
+
+- `repo`         :: owner/name on GitHub (e.g. `defilantech/LLMKube`)
+- `issue`        :: the integer issue number the coder claimed to fix
+- `branch`       :: the branch name on the fork (e.g. `foreman/issue-510`)
+- `gateVerdict`  :: the gate's verdict on this branch
+                    (`GATE-PASS` or `GATE-FAIL`); skip approving
+                    anything where this is not `GATE-PASS`
+- `coderSummary` :: the one-line summary the coder submitted
+
+You communicate by calling tools. Every tool call must produce
+structured `tool_calls` in the OpenAI function-calling shape; do not
+emit free-form review text outside of tool calls. Your run ends when
+you call the terminal `submit_result` tool.
+
+## Tools available
+
+- `read_file(path, offset?, limit?)` :: read a workspace file. Output
+  capped at 16 KiB; pass `offset` (1-based line) and `limit` for
+  ranged reads of long files. Use this to look at edited files and
+  the tests around them.
+- `grep(pattern, path?, max?)` :: regex search across the workspace.
+  Useful for finding all call sites of a symbol the diff touched.
+- `bash(command)` :: run a shell command under `sh -c` with a bounded
+  timeout. You will use this for:
+  - `gh issue view <N> --repo <owner/name>` to read the full issue
+    body + labels (do NOT skip this; the issue body is the source of
+    truth for scope).
+  - `git show HEAD` or `git diff main...HEAD` to see the full diff.
+  - `git log -1 --pretty=full HEAD` to read the commit message
+    verbatim.
+  - `git diff --stat main...HEAD` to see the touched-files summary.
+- `submit_result(verdict, summary, extra?)` :: terminal. The loop
+  exits after this call. Reviewers do not author commits; leave
+  `commit_message` empty.
+
+You do NOT have `write_file` or `str_replace`. You cannot edit the
+branch. If you find something that needs fixing, you say so in your
+review; you do not fix it yourself.
+
+## Step 1 :: Navigate to the branch + gather evidence
+
+Always do these reads, in this order, before forming a judgment.
+The first step is mandatory: until you run it, the workspace is on
+an unrelated empty branch off main, and any diff you compute is
+wrong.
+
+1. `bash("git fetch origin {branch}:refs/remotes/origin/{branch} && git checkout origin/{branch}")`
+   to navigate to the branch under review. After this, `HEAD` is
+   the coder's commit. If this fails, submit
+   `verdict="ERROR"` with a `summary` naming the fetch failure;
+   do not guess at the diff.
+2. `bash("gh issue view {issue} --repo {repo}")` to read the issue
+   title, body, and labels. The issue body is your scope anchor.
+3. `bash("git log -1 --pretty=full HEAD")` to read the commit
+   message.
+4. `bash("git diff --stat main...HEAD")` for the file list.
+5. `bash("git diff main...HEAD")` for the full diff (if more than
+   ~800 lines, fall back to `git show --stat` plus targeted
+   `read_file` reads of each touched file).
+6. For each touched file, at least skim the surrounding code with
+   `read_file` so you can judge whether the change fits.
+
+If `gateVerdict` is not `GATE-PASS`, you still do the reads and
+write a useful review; you just do not approve. The branch already
+failed objective checks.
+
+## Step 2 :: Apply the review checklist
+
+Score the diff against these criteria. Each finding must cite a
+specific file/line, symbol, or quoted text from the issue. Vague
+"looks fine" is not a finding.
+
+### A. Scope alignment (most important)
+
+- Does the diff address what the issue body asks for? Quote the
+  specific ask from the issue body and point to the matching change.
+- Do the files/symbols/paths the issue body names actually appear in
+  the diff? If the issue says "edit `scripts/foo.sh`" and the diff
+  doesn't touch that path, that is a scope-drift finding.
+- Is the commit subject and `Fixes #N` trailer consistent with what
+  the diff does? If they disagree, the diff is wrong, not the commit
+  message.
+
+The May 2026 v5 batch contains a calibration case: a commit titled
+`fix(foreman): cascade-fail tasks with missing dependencies` that
+claimed `Fixes #379`, where #379 actually asked for a Helm vs
+kustomize RBAC sync check script. Same project, same agent, GATE
+green, but wrong scope. That is a `REQUEST-CHANGES` review with the
+explicit finding "diff addresses a different bug; #379 asks for X,
+this delivers Y."
+
+### B. Change is minimal and idiomatic
+
+- Are the edits proportionate to the issue? A 200-line refactor for
+  a typo fix is over-broad. A two-line patch for a feature request
+  is under-broad.
+- Does the change match surrounding code style? Naming, error
+  handling, log fields, indentation should match neighbors.
+- Did the agent edit generated files (`zz_generated.*`, CRD YAML
+  under `config/crd/bases/` or `charts/*/templates/crds/`)? Those
+  should only change via `make manifests` / `make chart-crds`; if
+  they were hand-edited, that is a finding.
+
+### C. Tests are meaningful
+
+- Did the agent add tests for behavior changes? A bug fix without a
+  regression test is a finding.
+- Do the new tests assert real behavior, or are they tautological
+  (asserting a constant the new code returns)? Read each new test
+  carefully.
+- Were any existing tests weakened, skipped, or deleted to make the
+  diff go green? That is a serious finding.
+
+### D. Side effects
+
+- Does the change have obvious downstream effects the diff does not
+  address? Use `grep` to find call sites of any modified function or
+  changed exported symbol; if call sites assume the old behavior,
+  call that out.
+- Does the change touch RBAC, CRDs, Helm chart values, or operator
+  reconciler logic? Cross-component changes deserve closer reading.
+- Are there magic numbers, hardcoded paths, or environment
+  assumptions that will surprise other contributors?
+
+### E. Documentation and ergonomics
+
+- If the change adds a flag, env var, or CLI command, are the
+  user-facing docs (README, AGENTS.md, CONTRIBUTING.md, docs/site)
+  updated to mention it?
+- If the change is purely internal, this section may not apply;
+  skip it cleanly rather than fishing.
+
+### F. Regression check (read `main` for every touched file)
+
+Same-model coders rewrite more than they augment. For every file in
+`git diff --stat main...HEAD`, fetch its pre-diff form with
+`bash("git show main:path/to/file")` (or `read_file` on the worktree
+after checking out `main`) and look for:
+
+- Working logic that the diff *removed* rather than augmented. If the
+  issue body did not explicitly ask for removal, the removed path is
+  a likely regression. The May 2026 v0.3 batch contains a calibration
+  case: a `pkg/agent/registry.go` fix removed the entire
+  `host.minikube.internal` / `host.docker.internal` DNS fallback. The
+  issue body asked for better multi-NIC detection; it did not ask for
+  the DNS path to be deleted. That is a major regression finding.
+- Documented environments the original code supported that the new
+  code no longer supports. If the codebase advertises a Docker
+  Desktop install path and the diff invalidates it, flag it.
+- Exported symbols that disappeared. Use `grep` against `pkg/` and
+  `cmd/` to find call sites that will break.
+
+If you cannot find a removed path that matters, say so explicitly in
+your `extra.findings` rather than omitting the section: positive
+signal that the regression check was performed.
+
+### G. Documentation / code consistency
+
+Read every godoc comment immediately above a changed function,
+method, or type. Compare what the doc claims to what the code does.
+Disagreements are findings. Examples:
+
+- Godoc says "returns an error when X" but the implementation panics
+  on X (different behavior).
+- Godoc lists a numbered preference order ("1. Foo, 2. Bar, 3. Baz")
+  but the code skips one of the cases entirely (the May 2026 v0.3
+  case: godoc said "Loopback only as a last resort" but the
+  implementation `continue`s on `FlagLoopback` and never tries it;
+  the hardcoded `127.0.0.1` fallback at the bottom is what handles
+  it instead, but the doc doesn't say so).
+- Godoc parameter names or types don't match the function signature
+  (e.g. doc says `timeout time.Duration` but signature has
+  `timeoutSec int`).
+
+These are almost always cheap to fix and almost always catch a real
+defect: the model wrote the doc *before* the implementation drifted,
+or vice versa, and never reconciled them.
+
+### H. Magic number / constant justification
+
+For every numeric literal, CIDR, regex, timeout, threshold, or
+exclusion list added by the diff, ask: *what defends this value?*
+
+- A test case that pins the value (a `wantCount = 5` assertion) is a
+  defense.
+- A code comment that names the source (RFC 1918, kubebuilder
+  default, Kubernetes service CIDR convention) is a defense.
+- A reference to the issue body that justifies the choice is a
+  defense.
+- Nothing at all is a finding.
+
+For exclusion lists specifically: check the *width* of every CIDR.
+A `/24` excludes 256 addresses; a `/8` excludes 16 million. The May
+2026 v0.3 case: a `getHostIP` fix excluded `10.0.0.0/8` "to avoid
+VMs", which silently invalidates every corporate LAN that uses
+RFC 1918 10.x ranges. The accompanying comment also mislabeled
+families (`100.x.x.x` is CGNAT in `100.64.0.0/10`, not in
+`10.0.0.0/8`). Both findings are visible from the diff alone.
+
+When unsure whether a constant is justified, say so in the finding
+rather than omitting it.
+
+## Step 3 :: Report
+
+Call `submit_result` exactly once. Required fields:
+
+- `verdict` :: one of `GO`, `NO-GO`, `ERROR`. The Foreman schema
+  reuses these three; for review tasks the mapping is:
+  - `GO`     = APPROVE. The diff addresses the issue at the right
+               scope, is minimal and idiomatic, has meaningful
+               tests, and no significant side effects you can find.
+  - `NO-GO`  = REQUEST-CHANGES. You found at least one substantive
+               concern (scope drift, missing tests, tautological
+               tests, weakened tests, scope creep, behavior-change-
+               without-callers-updated, etc.).
+  - `ERROR`  = could-not-review. The branch fails to clone, the
+               commit history is unreadable, the gate verdict is
+               `GATE-FAIL` AND the failures are not obvious from the
+               diff, or some technical issue prevents you from
+               forming an opinion.
+
+  When in doubt between APPROVE and REQUEST-CHANGES, choose
+  REQUEST-CHANGES. False negatives (humans re-review approvals) are
+  cheap; false positives (auto-merging a wrong-scope diff) are
+  expensive.
+
+- `summary` :: one-sentence outcome, 280 characters or fewer. This
+  becomes `AgenticTask.status.result.summary` and the human-readable
+  condition message. Lead with the verdict and the single most
+  important reason. Examples:
+  - `"APPROVE: diff matches #506's ask, regression test covers the
+    new branch, minimal scope."`
+  - `"REQUEST-CHANGES: #379 asks for a Helm vs kustomize RBAC sync
+    check; diff fixes an unrelated AgenticTaskReconciler bug."`
+  - `"ERROR: gate verdict was GATE-FAIL but no clear test failure
+    in diff context; needs human re-run."`
+
+- `extra` :: structured fields the next pipeline step or a human
+  triage UI can pivot on. Required keys:
+  - `reviewOutcome`   :: `"APPROVE" | "REQUEST-CHANGES" | "REJECT"`
+                         (REJECT is `NO-GO` + "do not retry"; reserve
+                         for scope mismatches that the agent cannot
+                         fix in a re-run, e.g. wrong issue
+                         identification.)
+  - `findings`        :: `[]` of `{severity: "blocker" | "major" |
+                         "minor", area: "scope" | "tests" | "style"
+                         | "side-effects" | "docs", message: "..."}`
+                         . Each finding must include enough specifics
+                         (file path, line number, quoted issue text)
+                         that a maintainer can act on it without
+                         re-deriving your reasoning.
+  - `issueAsk`        :: a short verbatim quote (≤200 chars) of the
+                         operative sentence from the issue body. This
+                         is the anchor your scope judgment hangs on.
+  - `filesTouched`    :: `[]` of paths from `git diff --stat`.
+
+  Optional keys: `testsAdded` (int), `newSymbols` ([]string),
+  `riskLevel` (`"low" | "medium" | "high"`).
+
+## Hard rules
+
+- Do NOT call `write_file`, `str_replace`, `git commit`, `git push`,
+  `git checkout`, or any branch operation. You are reading only.
+- Do NOT call `gh pr create` or any PR-mutating command. PR
+  authorship is a separate v0.2 pipeline step.
+- Do NOT approve based on the gate verdict alone. The gate already
+  ran; your value is everything the gate cannot check.
+- Do NOT skip reading the issue body. Same-model coders and
+  reviewers share priors; the issue body is the only external
+  anchor that catches scope drift.
+- No AI or tool attribution in the review text.
+- If you cannot find the issue (`gh issue view` errors, repo
+  inaccessible, etc.) submit `verdict="ERROR"` with a clear
+  `summary` saying so. Do not guess the issue's content from the
+  diff alone.
+
+## Calibration
+
+Reviews from this prompt are graded against three benchmarks:
+
+- The v5 #379 case: must produce `NO-GO` / `REQUEST-CHANGES` with a
+  scope-drift finding.
+- The v5 #449, #506, #510 cases: must produce `GO` / `APPROVE` with
+  at most minor findings.
+- Any branch where `gateVerdict != "GATE-PASS"`: must NOT produce
+  `GO`; appropriate verdicts are `NO-GO` (if the gate failure is
+  expected given the diff) or `ERROR` (if the gate failure is
+  surprising and needs human triage).

--- a/examples/foreman/workload-v04-default.yaml
+++ b/examples/foreman/workload-v04-default.yaml
@@ -1,0 +1,125 @@
+# Foreman v0.4 production default: code -> gate -> heterogeneous reviewer
+# ensemble.
+#
+# This is the recommended starting point for any v0.4+ deployment of
+# Foreman against LLMKube. It applies the full v0.3 harness stack
+# (repo-map prefix, workspace sandbox, stuck-loop detector,
+# issue-body fetch, per-workload branch namespacing) plus a two-
+# reviewer ensemble that catches the design-quality bugs the gate
+# cannot see.
+#
+# Why a two-reviewer ensemble (and not just one)
+# ----------------------------------------------
+#
+# Empirical: the May 25 reviewer-diversity experiment ran three
+# different reviewers against the same three v5-batch diffs. The
+# same-model self-reviewer rubber-stamped all three (priors shared
+# with the coder); a different-family local model caught one of
+# three; only a tool-using reviewer caught all three. The v0.4
+# thesis is that *prompt diversity + model-family diversity* gets
+# local reviewers most of the way to "tool-using reviewer" quality
+# without an egress dependency.
+#
+# This manifest pairs two Apple-Silicon reviewer agents on different
+# model families, both with `read_file` / `grep` / `bash` tools
+# (read-only by Agent CR design). The cascade rule (defilantech/
+# LLMKube#541) means a `NO-GO` verdict from EITHER reviewer drives
+# the Workload to `Phase=Failed` with `reason=ChildrenIncomplete`,
+# even if the gate passed.
+#
+# Why this is the v0.4 default rather than the v0.2 examples
+# ----------------------------------------------------------
+#
+# - workload-fix-small-bugs.yaml ships the M6 stub shortcut with
+#   coder + gate only. Use it when you want to validate the
+#   pipeline plumbing without the reviewer cost.
+# - workload-with-reviewers.yaml ships the multi-strategy demo
+#   from v0.2 Day 3, using three clones of the same reviewer Agent
+#   with strategy-varied prompts. Useful for prompt-diversity
+#   research; not the default because three clones share a model.
+# - workload-v04-default.yaml (this file) ships the v0.4
+#   production-shape default: two heterogeneous Apple-Silicon
+#   reviewers, sized for a 128GB-MacBook + 36GB-Mac-Studio fleet.
+#
+# What you need on the cluster before applying
+# --------------------------------------------
+#
+#   1. Foreman v0.8.0+ installed (operator + agent Deployments).
+#   2. Coder Agent CR `qwen36-35b-carnice-mtp-coder` applied.
+#   3. Gate Agent CR `gate` applied.
+#   4. Reviewer Agent CRs `qwen36-35b-a3b-reviewer` AND
+#      `devstral-24b-reviewer` applied. Both ship in
+#      config/foreman/agents/.
+#   5. A coder FleetNode (M5 Max or similar Apple Silicon, 128GB+).
+#   6. A verifier FleetNode (shadowstack or any Linux k8s node).
+#   7. A reviewer FleetNode (Mac Studio M4 Max or similar, 32GB+).
+#
+# What happens after `kubectl apply`
+# ----------------------------------
+#
+#   1. WorkloadReconciler expands `spec.issues` into one code +
+#      one verify + N review tasks per issue (N = len(reviewerAgentRefs)).
+#   2. Each code-N runs the coder Agent on the metal FleetNode.
+#      It commits to `foreman/<workload-name>/issue-N` on the fork.
+#   3. Each verify-N runs the gate Job. It clones the coder's branch
+#      and runs `make fmt vet lint test manifests chart-crds
+#      foreman-chart-crds`. Verdict GATE-PASS or GATE-FAIL.
+#   4. Each review-N-i runs in parallel after the gate passes.
+#      Read-only: the reviewer can read the diff, grep call sites,
+#      and check the diff against `main`, but cannot edit anything.
+#      Verdict GO (APPROVE) or NO-GO (REQUEST-CHANGES).
+#   5. Workload rollup: every child must end on-target
+#      (verdict GO / GATE-PASS) for the Workload to reach
+#      `Phase=Completed`. Any NO-GO from any reviewer flips the
+#      Workload to `Phase=Failed`. The fork branch is preserved
+#      either way for a human to inspect.
+#
+# Watch
+# -----
+#
+#   kubectl get workloads,agentictasks
+#   kubectl get workload v04-default-batch -o yaml | yq '.status'
+#   gh api /repos/Defilan/LLMKube/branches | jq '.[] | select(.name | startswith("foreman/v04-"))'
+
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Workload
+metadata:
+  name: v04-default-batch
+  namespace: default
+  labels:
+    app.kubernetes.io/part-of: foreman
+    foreman.llmkube.dev/milestone: v0.4
+spec:
+  intent: "v0.4 production-default batch: code + gate + two-reviewer ensemble"
+  repo: defilantech/LLMKube
+  # 4 issues × (1 code + 1 verify + 2 reviewers) = 16 tasks
+  maxTasks: 32
+  # Curate for scope: docs, small bug fixes, low-risk chores. The
+  # reviewers catch scope drift, but the coder is more reliable on
+  # narrower issues to begin with.
+  issues:
+    - 531   # .dockerignore re-include for the embedded gate-job YAML
+
+  coderAgentRef:
+    name: qwen36-35b-carnice-mtp-coder
+
+  verifierAgentRef:
+    name: gate
+
+  # Heterogeneous two-reviewer ensemble. The diversity argument:
+  # same-family priors miss the same bugs (the May 25 experiment).
+  # Two different model families with the same checklist prompt
+  # catch a strictly wider set of defects than one reviewer alone.
+  #
+  # Any NO-GO from either reviewer blocks the Workload from reaching
+  # Completed. The fork branch is preserved for human inspection
+  # either way.
+  reviewerAgentRefs:
+    - name: qwen36-35b-a3b-reviewer    # Apple Silicon, M4 Max
+    - name: devstral-24b-reviewer      # Apple Silicon, different family
+
+  # Sovereignty: local-only by default. Set `allowCloudReviewers: true`
+  # AND add `claude-sonnet-cloud-reviewer` (or similar) to the slice
+  # above to escalate hard cases to a cloud reviewer. Subject to the
+  # operator-side allow list in the foreman Helm chart values.
+  allowCloudReviewers: false

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -526,6 +526,71 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		Expect(completed).NotTo(BeNil())
 		Expect(completed.Reason).To(Equal("ChildrenIncomplete"))
 	})
+
+	It("fails the Workload when gate passes but any reviewer emits NO-GO (#575)", func() {
+		// v0.4 regression test: this lock-in confirms the
+		// cascade-on-verdict behavior from #541 also catches the
+		// reviewer-NO-GO + gate-PASS case. The reviewer is the
+		// design-quality second pass after the gate's mechanical
+		// `make` checks; REQUEST-CHANGES from any reviewer MUST
+		// drive the Workload to Failed even when the gate said the
+		// commit was technically buildable.
+		wl := newWorkload("reviewer-blocks", foremanv1alpha1.WorkloadSpec{
+			Intent:           "reviewer NO-GO blocks workload completion",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{1234},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "reviewer"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Coder GO, verifier GATE-PASS, reviewer NO-GO (the
+		// "design quality" failure mode the v0.4 reviewer is
+		// designed to catch).
+		updates := []struct {
+			name    string
+			phase   foremanv1alpha1.AgenticTaskPhase
+			verdict foremanv1alpha1.AgenticTaskVerdict
+		}{
+			{"reviewer-blocks-code-1234", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGo},
+			{"reviewer-blocks-verify-1234", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGatePass},
+			{"reviewer-blocks-review-1234-0", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo},
+		}
+		for _, u := range updates {
+			var t foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: u.name}, &t)).To(Succeed())
+			patch := client.MergeFrom(t.DeepCopy())
+			t.Status.Phase = u.phase
+			t.Status.Verdict = u.verdict
+			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
+		}
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		// Two on-target (coder GO, verify GATE-PASS) + one
+		// reviewer NO-GO = workload Failed with one IncompleteTask.
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseFailed),
+			"reviewer NO-GO must drive Workload to Failed even when gate passed")
+		Expect(fresh.Status.SucceededTasks).To(Equal(int32(2)))
+		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(1)))
+		Expect(fresh.Status.FailedTasks).To(Equal(int32(0)))
+		reviewerBlocksCompleted := findCondition(fresh.Status.Conditions, conditionTypeCompleted)
+		Expect(reviewerBlocksCompleted).NotTo(BeNil())
+		Expect(reviewerBlocksCompleted.Reason).To(Equal("ChildrenIncomplete"))
+	})
 })
 
 // newWorkload builds a Workload with the test-conventional shape. Lets the

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -41,6 +41,7 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repomap"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
 )
 
 // NativeAgentLoopExecutor is the M3 production executor. It resolves an
@@ -405,6 +406,17 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// status.result.
 	if verdict != foremanv1alpha1.AgenticTaskVerdictGo ||
 		agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer {
+		// For reviewer terminals, validate the structured findings
+		// payload and log a one-line summary so operators can see what
+		// the reviewer flagged without opening the transcript ConfigMap.
+		// Malformed findings are dropped with a warning; the verdict
+		// (GO=APPROVE / NO-GO=REQUEST-CHANGES) is the authoritative
+		// signal regardless of findings validity (see pkg/foreman/agent/
+		// reviewer/findings.go for the schema).
+		if agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer &&
+			loopRes.Terminal != nil {
+			logReviewerFindings(log, loopRes.Terminal.Extra)
+		}
 		return e.modelDecidedResult(start, transcriptRef, loopRes, verdict), nil
 	}
 
@@ -968,6 +980,34 @@ func buildUserPrompt(task *foremanv1alpha1.AgenticTask) string {
 		b.WriteString(p.Prompt)
 	}
 	return b.String()
+}
+
+// logReviewerFindings parses the reviewer's submit_result.extra
+// findings payload and emits a single info log line summarizing the
+// findings count by severity. Malformed findings produce warning log
+// lines but do not change task state. The reviewer's verdict
+// (NO-GO = REQUEST-CHANGES) remains the cascade-affecting signal;
+// findings are decoration that helps operators debug.
+//
+// See pkg/foreman/agent/reviewer/findings.go for the schema and
+// config/foreman/system-prompts/reviewer.md for the contract the
+// reviewer agent is asked to honor.
+func logReviewerFindings(log logr.Logger, extra map[string]any) {
+	findings, warnings := reviewer.ParseFindings(extra)
+	for _, w := range warnings {
+		log.Info("reviewer findings: malformed entry dropped", "warning", w)
+	}
+	if len(findings) == 0 {
+		return
+	}
+	counts := reviewer.CountBySeverity(findings)
+	log.Info("reviewer findings",
+		"total", len(findings),
+		"blocker", counts[reviewer.SeverityBlocker],
+		"major", counts[reviewer.SeverityMajor],
+		"minor", counts[reviewer.SeverityMinor],
+		"hasBlockers", reviewer.HasBlockers(findings),
+	)
 }
 
 // fetchIssueBodyIfNeeded populates task.Spec.Payload.Prompt from the

--- a/pkg/foreman/agent/reviewer/findings.go
+++ b/pkg/foreman/agent/reviewer/findings.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package reviewer codifies the structured-findings shape the v0.4
+// reviewer Agent emits via submit_result.extra. The schema is
+// documented in config/foreman/system-prompts/reviewer.md; this
+// package keeps the Go and prompt definitions in lockstep so a future
+// downstream consumer (GitHub PR-comment poster, analytics, audit
+// trail) reads from one place.
+//
+// Validation is intentionally lenient: a malformed findings payload
+// logs a warning and is dropped, but does not change the reviewer's
+// verdict. The verdict (GO / NO-GO / ERROR) is the authoritative
+// signal; findings enrich it. The cascade rule (defilantech/LLMKube
+// #541) gates on verdict, not on findings.
+package reviewer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Severity classifies the urgency of a single review finding. The
+// reviewer prompt uses three values; we accept them case-insensitively
+// because models vary on capitalization.
+type Severity string
+
+const (
+	// SeverityBlocker means "this diff should not merge as-is, full
+	// stop." Reviewers use this for scope drift, removed working
+	// logic, or any defect that would regress production behavior.
+	SeverityBlocker Severity = "blocker"
+	// SeverityMajor means "this needs a fix before merge but the
+	// shape of the diff is correct." Reviewers use this for missing
+	// tests, mismatched docs, or unjustified magic numbers.
+	SeverityMajor Severity = "major"
+	// SeverityMinor means "consider this in a follow-up." Reviewers
+	// use this for style nits, naming preferences, or optional
+	// docs improvements.
+	SeverityMinor Severity = "minor"
+)
+
+// validSeverities is the exhaustive set normalize() will accept.
+// Anything outside this set produces a validation error and the
+// finding is dropped.
+var validSeverities = map[Severity]struct{}{
+	SeverityBlocker: {},
+	SeverityMajor:   {},
+	SeverityMinor:   {},
+}
+
+// Area names the review-checklist section the finding belongs to.
+// Tracks the section headers in reviewer.md (A. Scope alignment, B.
+// Change is minimal and idiomatic, etc.) so downstream filtering /
+// reporting can roll up by category.
+type Area string
+
+const (
+	AreaScope       Area = "scope"           // Section A: scope alignment
+	AreaStyle       Area = "style"           // Section B: minimal / idiomatic
+	AreaTests       Area = "tests"           // Section C: meaningful tests
+	AreaSideEffects Area = "side-effects"    // Section D: side effects
+	AreaDocs        Area = "docs"            // Section E: documentation / ergonomics
+	AreaRegression  Area = "regression"      // Section F: removed working logic
+	AreaDocConsist  Area = "doc-consistency" // Section G: doc vs code mismatch
+	AreaConstants   Area = "constants"       // Section H: magic-number justification
+)
+
+// validAreas is the exhaustive set. Models occasionally invent areas
+// (e.g. "security", "performance"); we drop unknown areas with a
+// warning rather than failing the parse, because a finding with a
+// bad area is still useful to a human reading the review.
+var validAreas = map[Area]struct{}{
+	AreaScope: {}, AreaStyle: {}, AreaTests: {}, AreaSideEffects: {},
+	AreaDocs: {}, AreaRegression: {}, AreaDocConsist: {}, AreaConstants: {},
+}
+
+// Finding is one item in the reviewer's structured-findings list.
+// File and Line are optional but strongly encouraged: a finding the
+// reviewer can pin to a specific source location is much more useful
+// downstream than a free-form complaint.
+type Finding struct {
+	// Severity is required. Empty / unknown values cause the finding
+	// to be dropped with a warning.
+	Severity Severity `json:"severity"`
+	// Area is required. Tracks reviewer.md section headers.
+	Area Area `json:"area"`
+	// Message is the finding text. Required, non-empty.
+	Message string `json:"message"`
+	// File is the workspace-relative path the finding cites, when
+	// applicable. Optional but strongly preferred.
+	File string `json:"file,omitempty"`
+	// Line is a 1-based line number in File. Zero means "not pinned
+	// to a specific line." Use a range like "10-25" via Message
+	// when a finding spans multiple lines.
+	Line int `json:"line,omitempty"`
+	// Suggestion is an optional fix the reviewer proposes. Free-form
+	// text the model can quote or paraphrase from the issue body.
+	Suggestion string `json:"suggestion,omitempty"`
+}
+
+// ParseFindings extracts the findings list from a reviewer's
+// submit_result.extra payload. The expected shape is:
+//
+//	{"findings": [{"severity":"major","area":"scope","message":"..."}]}
+//
+// Returns the parsed findings (only the valid ones) plus a slice of
+// warning strings describing dropped findings. A nil extra map or a
+// missing/empty findings key returns (nil, nil) without error.
+//
+// Lenient by design: a malformed findings array does not fail the
+// whole reviewer task. The verdict remains authoritative; this
+// function exists so downstream consumers can light up structured
+// findings when present and gracefully degrade when not.
+func ParseFindings(extra map[string]any) ([]Finding, []string) {
+	if len(extra) == 0 {
+		return nil, nil
+	}
+	raw, ok := extra["findings"]
+	if !ok {
+		return nil, nil
+	}
+	// Round-trip through JSON to handle both []any (decoded JSON) and
+	// []Finding (Go-native callers) uniformly. Marshal+Unmarshal is
+	// cheap relative to anything else in the executor's terminal
+	// path and keeps the parser shape-agnostic.
+	buf, err := json.Marshal(raw)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("findings: marshal failed: %v", err)}
+	}
+	var decoded []Finding
+	if err := json.Unmarshal(buf, &decoded); err != nil {
+		return nil, []string{fmt.Sprintf("findings: unmarshal failed: %v", err)}
+	}
+
+	var (
+		valid    []Finding
+		warnings []string
+	)
+	for i, f := range decoded {
+		ok, reason := f.normalize()
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("findings[%d]: %s", i, reason))
+			continue
+		}
+		valid = append(valid, f)
+	}
+	return valid, warnings
+}
+
+// normalize lowercases the severity / area, trims whitespace, and
+// validates the required fields. Returns ok=true with the receiver
+// mutated in place, or ok=false with a human-readable reason.
+//
+// Lenient on casing because model output varies ("Major", "MAJOR",
+// "major"); strict on emptiness and unknown values because those
+// indicate the model did not understand the schema.
+func (f *Finding) normalize() (ok bool, reason string) {
+	f.Severity = Severity(strings.ToLower(strings.TrimSpace(string(f.Severity))))
+	f.Area = Area(strings.ToLower(strings.TrimSpace(string(f.Area))))
+	f.Message = strings.TrimSpace(f.Message)
+
+	if f.Message == "" {
+		return false, "empty message"
+	}
+	if _, ok := validSeverities[f.Severity]; !ok {
+		return false, fmt.Sprintf("unknown severity %q", f.Severity)
+	}
+	if _, ok := validAreas[f.Area]; !ok {
+		return false, fmt.Sprintf("unknown area %q", f.Area)
+	}
+	if f.Line < 0 {
+		return false, fmt.Sprintf("negative line number %d", f.Line)
+	}
+	return true, ""
+}
+
+// CountBySeverity returns a map of severity -> count for the input
+// findings. Useful for the executor's log line and for future
+// metrics / dashboards.
+func CountBySeverity(findings []Finding) map[Severity]int {
+	counts := make(map[Severity]int, 3)
+	for _, f := range findings {
+		counts[f.Severity]++
+	}
+	return counts
+}
+
+// HasBlockers reports whether any finding is severity=blocker. The
+// reviewer's verdict (NO-GO) is still the authoritative cascade
+// signal; this helper is for downstream consumers (e.g. a future
+// PR-comment poster) that want to render the worst-severity finding
+// prominently.
+func HasBlockers(findings []Finding) bool {
+	for _, f := range findings {
+		if f.Severity == SeverityBlocker {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/foreman/agent/reviewer/findings_test.go
+++ b/pkg/foreman/agent/reviewer/findings_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reviewer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// jsonExtra is a test helper: round-trip a JSON string through
+// json.Unmarshal into the map[string]any shape ParseFindings expects.
+// Mirrors how the executor builds the extra map from submit_result.
+func jsonExtra(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("jsonExtra: %v", err)
+	}
+	return m
+}
+
+func TestParseFindings_HappyPath(t *testing.T) {
+	extra := jsonExtra(t, `{
+		"findings": [
+			{"severity":"blocker","area":"scope","message":"diff addresses a different bug","file":"pkg/agent/registry.go"},
+			{"severity":"major","area":"regression","message":"removed DNS fallback","file":"pkg/agent/registry.go","line":307},
+			{"severity":"minor","area":"docs","message":"godoc claim does not match","suggestion":"update the godoc"}
+		]
+	}`)
+	got, warnings := ParseFindings(extra)
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d findings; want 3", len(got))
+	}
+	if got[0].Severity != SeverityBlocker || got[0].Area != AreaScope {
+		t.Errorf("first finding: got %+v", got[0])
+	}
+	if got[1].Line != 307 {
+		t.Errorf("second finding: want line 307; got %d", got[1].Line)
+	}
+	if got[2].Suggestion != "update the godoc" {
+		t.Errorf("third finding suggestion not preserved: %q", got[2].Suggestion)
+	}
+}
+
+func TestParseFindings_NilOrEmpty(t *testing.T) {
+	if got, warns := ParseFindings(nil); got != nil || warns != nil {
+		t.Errorf("nil extra: want (nil, nil); got (%v, %v)", got, warns)
+	}
+	if got, warns := ParseFindings(map[string]any{}); got != nil || warns != nil {
+		t.Errorf("empty extra: want (nil, nil); got (%v, %v)", got, warns)
+	}
+	if got, warns := ParseFindings(map[string]any{"unrelated": "value"}); got != nil || warns != nil {
+		t.Errorf("no findings key: want (nil, nil); got (%v, %v)", got, warns)
+	}
+}
+
+// TestParseFindings_DropsInvalidLenient covers the lenient-by-design
+// promise: bad rows are dropped with a warning, good rows still
+// parse, the verdict (separately on the result envelope) wins
+// regardless. Models WILL emit oddly-cased severities or invent area
+// names; that should not fail the run.
+func TestParseFindings_DropsInvalidLenient(t *testing.T) {
+	extra := jsonExtra(t, `{
+		"findings": [
+			{"severity":"BLOCKER","area":"SCOPE","message":"loud caps still ok"},
+			{"severity":"critical","area":"scope","message":"unknown severity dropped"},
+			{"severity":"major","area":"security","message":"unknown area dropped"},
+			{"severity":"minor","area":"docs","message":""},
+			{"severity":"major","area":"tests","message":"valid one"}
+		]
+	}`)
+	got, warnings := ParseFindings(extra)
+	if len(got) != 2 {
+		t.Errorf("want 2 valid; got %d (%+v)", len(got), got)
+	}
+	if len(warnings) != 3 {
+		t.Errorf("want 3 warnings; got %d (%v)", len(warnings), warnings)
+	}
+	// Loud-caps row was normalized successfully.
+	if got[0].Severity != SeverityBlocker || got[0].Area != AreaScope {
+		t.Errorf("normalize did not lowercase: %+v", got[0])
+	}
+}
+
+func TestParseFindings_MalformedJSONDoesNotPanic(t *testing.T) {
+	// A non-array under "findings": we expect a single warning, no
+	// findings returned, no panic.
+	extra := map[string]any{"findings": "this should be a list"}
+	got, warnings := ParseFindings(extra)
+	if got != nil {
+		t.Errorf("expected nil findings on malformed input; got %v", got)
+	}
+	if len(warnings) == 0 {
+		t.Errorf("expected a warning on malformed input; got none")
+	}
+}
+
+func TestParseFindings_NegativeLineRejected(t *testing.T) {
+	extra := jsonExtra(t, `{"findings":[{"severity":"major","area":"scope","message":"x","line":-5}]}`)
+	got, warnings := ParseFindings(extra)
+	if len(got) != 0 {
+		t.Errorf("negative line should drop the finding; got %v", got)
+	}
+	if len(warnings) != 1 {
+		t.Errorf("want 1 warning; got %d", len(warnings))
+	}
+}
+
+func TestCountBySeverity(t *testing.T) {
+	findings := []Finding{
+		{Severity: SeverityBlocker, Area: AreaScope, Message: "x"},
+		{Severity: SeverityMajor, Area: AreaTests, Message: "x"},
+		{Severity: SeverityMajor, Area: AreaDocs, Message: "x"},
+		{Severity: SeverityMinor, Area: AreaStyle, Message: "x"},
+	}
+	got := CountBySeverity(findings)
+	if got[SeverityBlocker] != 1 || got[SeverityMajor] != 2 || got[SeverityMinor] != 1 {
+		t.Errorf("counts: got %v", got)
+	}
+}
+
+func TestHasBlockers(t *testing.T) {
+	noBlockers := make([]Finding, 0, 3)
+	noBlockers = append(noBlockers,
+		Finding{Severity: SeverityMajor, Area: AreaTests, Message: "x"},
+		Finding{Severity: SeverityMinor, Area: AreaStyle, Message: "x"},
+	)
+	if HasBlockers(noBlockers) {
+		t.Error("HasBlockers: expected false on no-blocker list")
+	}
+	withBlocker := append(noBlockers, Finding{
+		Severity: SeverityBlocker, Area: AreaScope, Message: "x",
+	})
+	if !HasBlockers(withBlocker) {
+		t.Error("HasBlockers: expected true when a blocker is present")
+	}
+}
+
+// TestParseFindings_AllAreasAccepted is a calibration test: every
+// area constant the package defines must be acceptable, because the
+// reviewer prompt's checklist references all of them. If we add an
+// area to validAreas but forget to update the prompt, the diff alone
+// won't catch it; if we remove one from validAreas without updating
+// the prompt, this test fails.
+func TestParseFindings_AllAreasAccepted(t *testing.T) {
+	for area := range validAreas {
+		t.Run(string(area), func(t *testing.T) {
+			extra := map[string]any{
+				"findings": []any{
+					map[string]any{
+						"severity": "major",
+						"area":     string(area),
+						"message":  "test",
+					},
+				},
+			}
+			got, warns := ParseFindings(extra)
+			if len(got) != 1 {
+				t.Errorf("area %q: want 1 finding; got %d (warns=%v)", area, len(got), warns)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

v0.4 reviewer agent pass. Ships the reviewer-with-tools workflow that catches the design-quality bugs the deterministic gate cannot. Five phases (A–E) land together; empirical validation (Phase F) is intentionally deferred to a separate exercise.

Fixes #575.

## Why

Concrete failure mode this addresses: the rerun-6 batch's `#526` task (commit `9dc8289` on `foreman/v03-validation-batch-rerun-6/issue-526`) hit GATE-PASS with three substantive defects that a tool-using reviewer with the right checklist would have caught:

1. **`10.0.0.0/8` overexclusion** — silently invalidates every corporate LAN using RFC 1918 10.x ranges. CIDR-family comment is also wrong (`100.x` is CGNAT, not in `10.0.0.0/8`).
2. **DNS fallback regression** — the prior `host.minikube.internal` / `host.docker.internal` path was deleted entirely. The issue didn't ask for that removal; Docker Desktop / minikube installs now break.
3. **Godoc / code mismatch** — function godoc says "Loopback (127.0.0.1) only as a last resort" but the implementation skips loopback entirely during enumeration.

All three visible from the diff + repository read access. None require novel reasoning. **The gate's `make fmt vet lint test` cannot catch any of them.** A reviewer with `read_file` + `grep` + `bash` (the existing tool whitelist) plus a sharper system-prompt checklist catches all three.

## How

### Phase A — Reviewer Agent CRs first-class

`config/foreman/agents/devstral-24b-reviewer.yaml` + `qwen36-35b-a3b-reviewer.yaml` ship in tree. Both had been live on the cluster from prior sessions but never committed; this PR makes them canonical next to the coder + gate Agent CRs. Tool whitelist: `read_file`, `grep`, `bash`, `submit_result` (read-only by design — `write_file` and `str_replace` blocked by omission, not by a CRD validator).

### Phase B — Reviewer system prompt: three new check sections

`config/foreman/system-prompts/reviewer.md` gains sections F, G, H corresponding to the three rerun-6 #526 failure modes:

- **F. Regression check** — use `git show main:path` to compare against trunk; flag working logic that was removed rather than augmented. Includes the #526 DNS-fallback removal as a calibration case.
- **G. Documentation / code consistency** — read every godoc near a changed function; flag mismatches. Includes the #526 loopback-godoc/code mismatch as a calibration case.
- **H. Magic-number / constant justification** — every literal, CIDR, regex, timeout needs a test, a comment, or an issue-body quote. Includes the #526 `10.0.0.0/8` overexclusion as a calibration case.

The qwen reviewer's inline `systemPrompt` mirrors the new sections. The devstral reviewer keeps its abbreviated prompt by design — prompt diversity is one of the v0.4 reviewer's value props; same-checklist-across-families would lose half the point of the ensemble.

### Phase C — Findings schema codified in Go

New `pkg/foreman/agent/reviewer` package with:

- `Severity` enum (blocker/major/minor)
- `Area` enum (8 sections, A–H, tracking reviewer.md headers)
- `Finding` struct with `severity`, `area`, `message`, plus optional `file`, `line`, `suggestion`
- `ParseFindings(extra)` lenient parser: malformed rows are dropped with warnings, valid rows return clean, nil/empty input is not an error
- `CountBySeverity` + `HasBlockers` helpers for downstream consumers

The verdict (`GO` / `NO-GO` / `ERROR`) on the result envelope remains the authoritative cascade signal — findings enrich it, the cascade rule from #541 still gates on verdict alone.

Test coverage: happy path, nil/empty, lenient drop-and-warn, malformed JSON no-panic, negative-line rejection, count-by-severity, has-blockers, plus a calibration test that locks every valid `Area` constant against reviewer.md's section list. **15 sub-tests across 8 test functions.**

Executor wiring: `pkg/foreman/agent/executor_native.go::logReviewerFindings` is called from the reviewer-result path. One INFO log line per terminal: `reviewer findings total=N blocker=B major=M minor=m hasBlockers=bool`. Operators see the summary without opening the transcript ConfigMap.

### Phase D — Regression test for the reviewer NO-GO cascade

`internal/foreman/controller/workload_controller_test.go` gains a Ginkgo case that locks in the cascade-on-verdict behavior from #541 for the reviewer-side: coder GO + verify GATE-PASS + reviewer NO-GO → Workload Phase=Failed with reason=ChildrenIncomplete. The behavior already exists (this is a regression test, not a behavior change); the value is that any future refactor of the rollup logic can't silently break the v0.4 reviewer's signal path.

### Phase E — Canonical v0.4 default Workload example

`examples/foreman/workload-v04-default.yaml` is the recommended starting point for v0.4+ deployments: Carnice coder + gate + two heterogeneous reviewer Agents on different model families (qwen + devstral). Includes a long-form comment explaining the empirical case for prompt-and-model diversity (the May 25 reviewer-diversity experiment: same-family priors miss the same bugs; different families catch a strictly wider set).

The existing `workload-with-reviewers.yaml` stays for the v0.2 multi-strategy demo; the new file is the v0.4 production starting shape.

## Tests

```
$ go test ./pkg/foreman/agent/reviewer/... -count=1
ok  pkg/foreman/agent/reviewer  (15 sub-tests across 8 functions)

$ go test ./internal/foreman/controller/... -count=1
ok  internal/foreman/controller (12 Ginkgo specs, new reviewer-NO-GO case included)

$ make lint && GOOS=linux ./bin/golangci-lint run ./...
0 issues. 0 issues.
```

## Checklist

- [x] `make fmt vet lint test` clean both arches
- [x] No CRD changes
- [x] No new RBAC
- [x] No new dependencies
- [x] Existing reviewer Agent CRs are now first-class (Phase A)
- [x] Reviewer.md prompt + qwen Agent CR inline systemPrompt mirror each other for sections F-H
- [x] DCO sign-off

## What this PR explicitly does NOT do

- **Phase F (empirical validation).** Deferred. The rerun-6 batch's `#526` commit is on the fork at `foreman/v03-validation-batch-rerun-6/issue-526` and contains the three calibration defects this PR's prompt is designed to catch. A rerun-7 with the reviewer ensemble enabled will measure whether the design works. Tracked as the v0.4 next step; not in this PR's contract.
- **Posting reviewer findings to a GitHub PR.** Defer to v0.5+.
- **New reviewer Agent CRs beyond the two already shipped.**
- **Reviewer model swaps.**

## Empirical impact projection

When the rerun-6 `#526` diff is presented to a reviewer running this PR's prompt:

| Defect | Catchable by section | Evidence the reviewer has |
|---|---|---|
| `10.0.0.0/8` overexclusion | H. Magic-number / constant justification | The CIDR list literal in the diff; the prompt explicitly says "check the *width* of every CIDR" with the `/24` vs `/8` math |
| DNS fallback regression | F. Regression check | `git show main:pkg/agent/registry.go` shows the removed function; prompt explicitly directs the reviewer to do this read |
| Godoc / code mismatch | G. Documentation / code consistency | Both the godoc and the implementation are in the diff; prompt explicitly directs the reviewer to compare them |

Whether the local reviewer models will actually emit findings against all three is the empirical question Phase F answers. The prompt gives them the structure; the empirical test measures the outcome.

## References

- Issue #575 (this PR's spec)
- Issue #541 (cascade-on-verdict — the regression test in Phase D locks in its reviewer-side behavior)
- rerun-6 transcripts on shadowstack: `kubectl --context shadowstack -n default get cm | grep v03-validation-batch-rerun-6` for the failing review-state evidence
- May 25 reviewer-diversity experiment (saved in memory: reference_reviewer_diversity_empirical.md)
