### PR TITLE
feat(foreman/reviewer): fetch_issue tool replaces gh issue view subshell

### DIFF
--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -412,6 +412,16 @@ func makeRegistryFactory(
 					LogTailFn: logTail,
 				},
 			},
+			// fetch_issue: read-only GitHub issue surface for the
+			// reviewer. The same token the foreman-agent already
+			// loads at startup (via repo.TokenFromEnvOrFile) reaches
+			// GitHub through one bounded Go-side call instead of
+			// being inherited by every bash subprocess via $GH_TOKEN.
+			// Closes #580.
+			&foremantools.FetchIssueTool{
+				Fetcher: githubissue.NewClient(),
+				Token:   repo.TokenFromEnvOrFile,
+			},
 		)
 		if err != nil {
 			return nil, fmt.Errorf("default registry: %w", err)

--- a/config/foreman/agents/devstral-24b-reviewer.yaml
+++ b/config/foreman/agents/devstral-24b-reviewer.yaml
@@ -26,6 +26,7 @@ spec:
     - read_file
     - grep
     - bash
+    - fetch_issue
     - submit_result
   requiredCapability:
     accelerator: metal
@@ -46,10 +47,12 @@ spec:
       bash("git fetch origin {branch}:refs/remotes/origin/{branch} \
             && git checkout origin/{branch}")
 
-    Then in order: read the issue body via `gh issue view {issue}
-    --repo {repo}`, read the commit via `git log -1 HEAD`, read
-    `git diff main...HEAD`, and `read_file` each touched file for
-    surrounding context.
+    Then in order: read the issue body via
+    `fetch_issue(repo, issue)` (the Go-side tool that uses the
+    foreman-agent's own GitHub token, so it works on every
+    FleetNode without per-host `gh auth login`), read the commit
+    via `git log -1 HEAD`, read `git diff main...HEAD`, and
+    `read_file` each touched file for surrounding context.
 
     Apply this checklist:
 

--- a/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
+++ b/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
@@ -56,6 +56,7 @@ spec:
     - read_file
     - grep
     - bash
+    - fetch_issue
     - submit_result
   requiredCapability:
     accelerator: metal
@@ -88,7 +89,14 @@ spec:
       ranged reads of long files.
     - `grep(pattern, path?, max?)` -- regex search across the workspace.
     - `bash(command)` -- shell under `sh -c` with a bounded timeout.
-      Used for `git fetch`, `gh issue view`, `git log`, `git diff`.
+      Used for `git fetch`, `git log`, `git diff`. Earlier prompt
+      revisions invoked `gh issue view` here; that path required
+      per-host `gh auth login` and silently degraded to an auth-error
+      stub on FleetNodes where `gh` was not authed (see #580). Use
+      `fetch_issue` below instead.
+    - `fetch_issue(repo, number)` -- read the issue title, body,
+      state, and labels through the foreman-agent's own GitHub token.
+      Works on every FleetNode without per-host `gh` config.
     - `submit_result(verdict, summary, extra?)` -- terminal. Reviewers
       do not author commits; leave `commit_message` empty.
 
@@ -106,8 +114,11 @@ spec:
        the coder's commit. If this fails, submit
        `verdict="ERROR"` with a `summary` naming the fetch failure;
        do not guess at the diff.
-    2. `bash("gh issue view {issue} --repo {repo}")` to read the issue
-       title, body, and labels. The issue body is your scope anchor.
+    2. `fetch_issue(repo, issue)` to read the issue title, body, and
+       labels. The issue body is your scope anchor. This calls the
+       foreman-agent's Go-side GitHub client, which uses the same
+       token the agent loaded at startup; no per-host `gh auth login`
+       is required.
     3. `bash("git log -1 --pretty=full HEAD")` to read the commit
        message.
     4. `bash("git diff --stat main...HEAD")` for the file list.
@@ -243,6 +254,7 @@ spec:
       reviewers share priors; the issue body is the only external
       anchor that catches scope drift.
     - No AI or tool attribution in review text.
-    - If you cannot find the issue (`gh issue view` errors)
-      submit `verdict="ERROR"` with a clear `summary` saying so. Do
-      not guess the issue's content from the diff alone.
+    - If you cannot find the issue (`fetch_issue` returns "issue
+      not found" or "unauthorized") submit `verdict="ERROR"` with a
+      clear `summary` saying so. Do not guess the issue's content
+      from the diff alone.

--- a/config/foreman/system-prompts/reviewer.md
+++ b/config/foreman/system-prompts/reviewer.md
@@ -44,13 +44,16 @@ you call the terminal `submit_result` tool.
   Useful for finding all call sites of a symbol the diff touched.
 - `bash(command)` :: run a shell command under `sh -c` with a bounded
   timeout. You will use this for:
-  - `gh issue view <N> --repo <owner/name>` to read the full issue
-    body + labels (do NOT skip this; the issue body is the source of
-    truth for scope).
   - `git show HEAD` or `git diff main...HEAD` to see the full diff.
   - `git log -1 --pretty=full HEAD` to read the commit message
     verbatim.
   - `git diff --stat main...HEAD` to see the touched-files summary.
+- `fetch_issue(repo, number)` :: read the issue body + title + labels
+  from GitHub via the foreman-agent's own token. This is the source
+  of truth for what the issue actually asks for; do NOT skip it.
+  Replaces the old `bash("gh issue view ...")` recipe, which silently
+  degraded to an auth-error stub on FleetNodes where `gh` was not
+  separately authenticated (see issue #580).
 - `submit_result(verdict, summary, extra?)` :: terminal. The loop
   exits after this call. Reviewers do not author commits; leave
   `commit_message` empty.
@@ -71,8 +74,13 @@ wrong.
    the coder's commit. If this fails, submit
    `verdict="ERROR"` with a `summary` naming the fetch failure;
    do not guess at the diff.
-2. `bash("gh issue view {issue} --repo {repo}")` to read the issue
-   title, body, and labels. The issue body is your scope anchor.
+2. `fetch_issue(repo, issue)` to read the issue title, body, and
+   labels. The issue body is your scope anchor: a `submit_result`
+   that approves a diff without quoting from the issue body is one
+   you did not do enough work for. (Earlier versions of this prompt
+   asked you to shell out to `gh issue view`; that path required
+   `gh` to be separately authed on every reviewer FleetNode and
+   silently degraded to an auth-error stub when it was not.)
 3. `bash("git log -1 --pretty=full HEAD")` to read the commit
    message.
 4. `bash("git diff --stat main...HEAD")` for the file list.
@@ -291,10 +299,10 @@ Call `submit_result` exactly once. Required fields:
   reviewers share priors; the issue body is the only external
   anchor that catches scope drift.
 - No AI or tool attribution in the review text.
-- If you cannot find the issue (`gh issue view` errors, repo
-  inaccessible, etc.) submit `verdict="ERROR"` with a clear
-  `summary` saying so. Do not guess the issue's content from the
-  diff alone.
+- If you cannot find the issue (`fetch_issue` returns "issue not
+  found" or "unauthorized", repo inaccessible, etc.) submit
+  `verdict="ERROR"` with a clear `summary` saying so. Do not guess
+  the issue's content from the diff alone.
 
 ## Calibration
 

--- a/pkg/foreman/agent/tools/fetch_issue.go
+++ b/pkg/foreman/agent/tools/fetch_issue.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// TokenSource resolves a GitHub PAT at FetchIssueTool.Execute time.
+// Production wires repo.TokenFromEnvOrFile; tests pass a closure that
+// returns a fixed string (or an error to exercise the fallback path).
+//
+// We resolve per call rather than caching the token on the tool struct
+// so:
+//
+//  1. The credential never sits in the tool's memory between calls.
+//  2. Rotating ~/.config/foreman/github-token while the foreman-agent
+//     is running takes effect on the next tool call.
+//  3. The tool stays a clean read-only surface even if its instance
+//     leaks into a debugger or transcript.
+type TokenSource func() (string, error)
+
+// FetchIssueTool is the reviewer's read-only path to a GitHub issue.
+// It wraps the same githubissue.Client the executor already uses for
+// the coder-side pre-fetch (PR #572) and exposes it as a first-class
+// tool so the reviewer never needs a separately-authed `gh` CLI on
+// its FleetNode.
+//
+// Why this exists (issue #580): the v0.4 reviewer prompt mandated
+// `bash("gh issue view {issue} --repo {repo}")` as the scope anchor.
+// On any FleetNode where `gh` was not authed (e.g. the Mac Studio
+// reviewer node during rerun-10), that call returned an auth-error
+// stub via stderr/exit-4. The reviewer kept going with empty issue
+// context, fell through to "the diff looks fine in isolation", and
+// emitted APPROVE verdicts on diffs whose scope it had never actually
+// checked against the issue body. The fix is to stop subshelling `gh`
+// and instead expose one bounded GitHub surface (this tool) using the
+// same token the foreman-agent already loads at startup.
+//
+// Security shape vs the GH_TOKEN-env alternative:
+//
+//   - Read-only by construction: exactly one
+//     GET /repos/{owner}/{repo}/issues/{number} per Execute. The
+//     model has no path to gh pr create / gh repo delete / generic
+//     authenticated REST writes through this tool.
+//   - The token lives behind a TokenSource closure; the struct
+//     stores no credentials between calls.
+//   - Containerised foreman-agents do not need `gh` installed in
+//     their image; pure Go HTTP suffices.
+//   - Token rotation surface is one file (~/.config/foreman/github-token)
+//     instead of also a per-user `gh` config or per-process env var
+//     inherited by every bash subprocess.
+type FetchIssueTool struct {
+	// Fetcher is the GitHub client. Required. Production wires
+	// githubissue.NewClient(); tests pass a fake or an httptest-backed
+	// Client.
+	Fetcher githubissue.Fetcher
+	// Token resolves the GitHub PAT at Execute time. Required.
+	Token TokenSource
+}
+
+type fetchIssueArgs struct {
+	Repo   string `json:"repo"`
+	Number int    `json:"number"`
+}
+
+// Name returns the tool name as advertised to the model.
+func (t *FetchIssueTool) Name() string { return "fetch_issue" }
+
+// Schema returns the OAI schema advertisement.
+func (t *FetchIssueTool) Schema() oai.ToolSchemaDef {
+	return oai.ToolSchemaDef{
+		Name: "fetch_issue",
+		Description: "Read a GitHub issue's title, body, state, and labels. " +
+			"Use this as the scope anchor before reviewing a diff: a " +
+			"verbatim sentence from the issue body is the right citation " +
+			"for whether the diff addresses what was asked. Returns " +
+			"title, body (truncated to ~16 KiB if needed), state, labels.",
+		Parameters: json.RawMessage(`{
+"type": "object",
+"properties": {
+  "repo":   {"type": "string", "description": "owner/name, e.g. \"defilantech/LLMKube\"."},
+  "number": {"type": "integer", "minimum": 1, "description": "Issue number."}
+},
+"required": ["repo", "number"]
+}`),
+	}
+}
+
+// Execute reads the GitHub issue at args.repo / args.number. All failure
+// modes are surfaced via the returned error, which the loop emits as
+// the tool-result content the model sees on its next turn.
+//
+//   - bad args (missing repo, non-positive number, malformed repo
+//     string): wrapped fmt.Errorf naming the field.
+//   - token resolution failure: wrapped error citing the env var /
+//     file the operator is expected to populate; this points at the
+//     foreman-agent host, not the model.
+//   - 404: "issue not found" so the model can choose to ERROR out
+//     rather than guess.
+//   - 401 / 403: "unauthorized" with a hint that the token is wrong
+//     or out of scope.
+//   - 5xx / network: generic transient failure; the model can retry
+//     once or call submit_result with verdict=ERROR.
+func (t *FetchIssueTool) Execute(ctx context.Context, args json.RawMessage) (*agent.ToolResult, error) {
+	if t.Fetcher == nil {
+		return nil, fmt.Errorf("fetch_issue: tool not configured (Fetcher is nil)")
+	}
+	if t.Token == nil {
+		return nil, fmt.Errorf("fetch_issue: tool not configured (Token resolver is nil)")
+	}
+	var a fetchIssueArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("fetch_issue: bad args: %w", err)
+	}
+	if a.Repo == "" {
+		return nil, fmt.Errorf("fetch_issue: repo is required (owner/name)")
+	}
+	if a.Number <= 0 {
+		return nil, fmt.Errorf("fetch_issue: number must be a positive integer (got %d)", a.Number)
+	}
+	owner, name, err := githubissue.ParseRepo(a.Repo)
+	if err != nil {
+		return nil, fmt.Errorf("fetch_issue: %w", err)
+	}
+	token, err := t.Token()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"fetch_issue: no GitHub token "+
+				"(set GITHUB_TOKEN env or populate "+
+				"~/.config/foreman/github-token on the FleetNode): %w", err)
+	}
+	issue, err := t.Fetcher.Fetch(ctx, owner, name, a.Number, token)
+	if err != nil {
+		var herr *githubissue.HTTPError
+		if errors.As(err, &herr) {
+			switch {
+			case herr.IsNotFound():
+				return nil, fmt.Errorf("fetch_issue: issue %s#%d not found", a.Repo, a.Number)
+			case herr.IsUnauthorized():
+				return nil, fmt.Errorf(
+					"fetch_issue: unauthorized for %s#%d; "+
+						"foreman-agent's GitHub token may be missing the repo scope, "+
+						"or the issue is in a private repo not visible to it",
+					a.Repo, a.Number)
+			}
+		}
+		return nil, fmt.Errorf("fetch_issue: %w", err)
+	}
+	return &agent.ToolResult{
+		Output: map[string]any{
+			"repo":   a.Repo,
+			"number": issue.Number,
+			"title":  issue.Title,
+			"body":   issue.Body,
+			"state":  issue.State,
+			"labels": issue.Labels,
+		},
+	}, nil
+}

--- a/pkg/foreman/agent/tools/fetch_issue_test.go
+++ b/pkg/foreman/agent/tools/fetch_issue_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+)
+
+// fakeFetcher lets a test inject a canned outcome without spinning up
+// an httptest server. Used for the failure-shape and arg-validation
+// cases; the body-truncation and authorization-header cases go through
+// a real Client + httptest server below.
+type fakeFetcher struct {
+	gotOwner  string
+	gotRepo   string
+	gotNumber int
+	gotToken  string
+	issue     *githubissue.Issue
+	err       error
+}
+
+func (f *fakeFetcher) Fetch(
+	_ context.Context, owner, repo string, number int, token string,
+) (*githubissue.Issue, error) {
+	f.gotOwner, f.gotRepo, f.gotNumber, f.gotToken = owner, repo, number, token
+	return f.issue, f.err
+}
+
+func staticToken(t string) TokenSource {
+	return func() (string, error) { return t, nil }
+}
+
+func errToken(msg string) TokenSource {
+	return func() (string, error) { return "", errors.New(msg) }
+}
+
+// TestFetchIssueTool_HappyPath verifies the tool round-trips a parsed
+// issue through a real githubissue.Client backed by httptest, and that
+// the Authorization header carries the token the TokenSource returns.
+func TestFetchIssueTool_HappyPath(t *testing.T) {
+	body := strings.Repeat("body line\n", 5)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer t-happy" {
+			t.Errorf("auth header: want 'Bearer t-happy' got %q", got)
+		}
+		if r.URL.Path != "/repos/defilantech/LLMKube/issues/526" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{
+		  "number": 526,
+		  "title": "[BUG] host-ip auto-detect picks unreachable virtual interface",
+		  "body": %q,
+		  "state": "open",
+		  "labels": [{"name":"bug"},{"name":"foreman"}]
+		}`, body)
+	}))
+	defer srv.Close()
+
+	tool := &FetchIssueTool{
+		Fetcher: &githubissue.Client{BaseURL: srv.URL},
+		Token:   staticToken("t-happy"),
+	}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"repo":"defilantech/LLMKube","number":526}`))
+	if err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+	out, _ := res.Output.(map[string]any)
+	if out["number"] != 526 {
+		t.Errorf("number: want 526 got %v", out["number"])
+	}
+	if !strings.Contains(out["title"].(string), "host-ip") {
+		t.Errorf("title: %v", out["title"])
+	}
+	if !strings.Contains(out["body"].(string), "body line") {
+		t.Errorf("body: %v", out["body"])
+	}
+	labels, _ := out["labels"].([]string)
+	if len(labels) != 2 || labels[0] != "bug" || labels[1] != "foreman" {
+		t.Errorf("labels: %v", labels)
+	}
+}
+
+func TestFetchIssueTool_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	tool := &FetchIssueTool{
+		Fetcher: &githubissue.Client{BaseURL: srv.URL},
+		Token:   staticToken("t"),
+	}
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"repo":"o/r","number":99999}`))
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("404 error should name 'not found': %v", err)
+	}
+}
+
+func TestFetchIssueTool_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer srv.Close()
+
+	tool := &FetchIssueTool{
+		Fetcher: &githubissue.Client{BaseURL: srv.URL},
+		Token:   staticToken("bad-token"),
+	}
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"repo":"o/r","number":1}`))
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !strings.Contains(err.Error(), "unauthorized") {
+		t.Errorf("401 error should name 'unauthorized': %v", err)
+	}
+}
+
+// TestFetchIssueTool_ArgValidation exercises the four arg-shape failures
+// in one table: bad JSON, missing repo, non-positive number, malformed
+// repo string. The fake fetcher is never called on these paths.
+func TestFetchIssueTool_ArgValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		args string
+		want string
+	}{
+		{"bad-json", `not-json`, "bad args"},
+		{"missing-repo", `{"number":1}`, "repo is required"},
+		{"zero-number", `{"repo":"o/r","number":0}`, "number must be a positive integer"},
+		{"negative-number", `{"repo":"o/r","number":-3}`, "number must be a positive integer"},
+		{"malformed-repo", `{"repo":"no-slash","number":1}`, "owner/repo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ff := &fakeFetcher{}
+			tool := &FetchIssueTool{Fetcher: ff, Token: staticToken("t")}
+			_, err := tool.Execute(context.Background(), json.RawMessage(tc.args))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error: want substring %q, got %v", tc.want, err)
+			}
+			if ff.gotNumber != 0 {
+				t.Errorf("fetcher should not have been called on arg-validation failure; called with number=%d", ff.gotNumber)
+			}
+		})
+	}
+}
+
+func TestFetchIssueTool_TokenResolutionFailure(t *testing.T) {
+	ff := &fakeFetcher{}
+	tool := &FetchIssueTool{Fetcher: ff, Token: errToken("askpass not configured")}
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"repo":"o/r","number":1}`))
+	if err == nil {
+		t.Fatal("expected error on token resolution failure")
+	}
+	if !strings.Contains(err.Error(), "no GitHub token") {
+		t.Errorf("token error should name 'no GitHub token': %v", err)
+	}
+	if !strings.Contains(err.Error(), "GITHUB_TOKEN") {
+		t.Errorf("token error should hint at GITHUB_TOKEN env var: %v", err)
+	}
+	if ff.gotNumber != 0 {
+		t.Errorf("fetcher should not have been called when token resolution fails; called with number=%d", ff.gotNumber)
+	}
+}
+
+func TestFetchIssueTool_NilDepsFailLoud(t *testing.T) {
+	cases := []struct {
+		name string
+		tool *FetchIssueTool
+		want string
+	}{
+		{"nil-fetcher", &FetchIssueTool{Fetcher: nil, Token: staticToken("t")}, "Fetcher is nil"},
+		{"nil-token", &FetchIssueTool{Fetcher: &fakeFetcher{}, Token: nil}, "Token resolver is nil"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.tool.Execute(context.Background(), json.RawMessage(`{"repo":"o/r","number":1}`))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error: want substring %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestFetchIssueTool_Schema verifies the OAI advertisement is wellformed
+// JSONSchema and names the two required args. The loop sends this
+// schema to the model verbatim; a typo here would be invisible until
+// the model decided not to call the tool at all.
+func TestFetchIssueTool_Schema(t *testing.T) {
+	tool := &FetchIssueTool{Fetcher: &fakeFetcher{}, Token: staticToken("t")}
+	if tool.Name() != "fetch_issue" {
+		t.Errorf("Name(): %q", tool.Name())
+	}
+	schema := tool.Schema()
+	if schema.Name != "fetch_issue" {
+		t.Errorf("schema.Name: %q", schema.Name)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(schema.Parameters, &parsed); err != nil {
+		t.Fatalf("schema parameters not valid JSON: %v", err)
+	}
+	required, _ := parsed["required"].([]any)
+	if len(required) != 2 {
+		t.Fatalf("required should have 2 fields, got %v", required)
+	}
+}
+
+// TestFetchIssueTool_FetcherReceivesParsedRepo confirms ParseRepo's
+// owner+name split flows through to the Fetcher call. A regression
+// where the tool passed the full "owner/name" string as owner is the
+// kind of bug that only surfaces against a real GitHub API; this test
+// pins the contract early.
+func TestFetchIssueTool_FetcherReceivesParsedRepo(t *testing.T) {
+	ff := &fakeFetcher{
+		issue: &githubissue.Issue{Number: 42, Title: "t", Body: "b", State: "open"},
+	}
+	tool := &FetchIssueTool{Fetcher: ff, Token: staticToken("tok")}
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"repo":"defilantech/LLMKube","number":42}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if ff.gotOwner != "defilantech" || ff.gotRepo != "LLMKube" || ff.gotNumber != 42 || ff.gotToken != "tok" {
+		t.Errorf("fetcher args: owner=%q repo=%q number=%d token=%q",
+			ff.gotOwner, ff.gotRepo, ff.gotNumber, ff.gotToken)
+	}
+}


### PR DESCRIPTION
## What

Add a `fetch_issue` tool to the foreman-agent's read-only tool surface and switch the reviewer Agents' mandatory issue-body read off `bash("gh issue view ...")` and onto the new tool. The token the foreman-agent already loads at startup now reaches GitHub through one bounded Go-side call instead of being implicit in whatever the host's `gh` CLI happens to have configured.

## Why

Issue #580: on Foreman v0.4 reviewer rerun-10 (2026-05-27), three devstral reviews on gate-pass branches landed `verdict=GO / reviewOutcome=APPROVE` with `submit_result.extra.issueAsk` text that had nothing to do with the real issue. Transcript reads showed devstral correctly running the full read-only flow (`git fetch`, `git diff`, `read_file` on the actually-modified file), and correctly running `gh issue view {N}` per Step 1. But on the Mac Studio reviewer FleetNode, `gh` was not separately authenticated; the tool result for that call was the well-known auth-error stub (`exit_code: 4`, `"To get started with GitHub CLI, please run: gh auth login"`). With no issue body in context, the reviewer fell through to reviewing the diff in isolation and confabulated a plausible-sounding `issueAsk` from training priors. The "scope alignment" check the v0.4 reviewer prompt was specifically designed to enforce was silently non-functional.

Fixes #580

## How

- New `pkg/foreman/agent/tools/fetch_issue.go` wraps the existing `githubissue.Client` (the same one the executor already uses for the coder-side issue-body pre-fetch shipped in #572). It exposes a single tool call: `fetch_issue(repo, number)`, which performs exactly one `GET /repos/{owner}/{repo}/issues/{number}` and returns `{title, body, state, labels}`.
- Token resolution is per-Execute via a `TokenSource` closure (`func() (string, error)`); production wires `repo.TokenFromEnvOrFile`. The credential never sits in the tool struct between calls; rotating `~/.config/foreman/github-token` while the foreman-agent is running takes effect on the next tool call.
- Both reviewer Agent CRs (`qwen36-35b-a3b-reviewer`, `devstral-24b-reviewer`) get `fetch_issue` added to `spec.tools`. The reviewer system prompt at `config/foreman/system-prompts/reviewer.md` and the inline qwen prompt are updated to instruct Step 1 to call `fetch_issue(repo, issue)` instead of `bash("gh issue view ...")`. The bash tool keeps `git fetch` / `git diff` / `git log`; only the gh-CLI subshell is removed.
- Failure modes from `fetch_issue` are surfaced as human-readable errors the model can act on: 404 -> "issue not found"; 401/403 -> "unauthorized; token may be missing repo scope"; network/5xx -> generic transient.

### Why a tool, not `GH_TOKEN` in the foreman-agent process env

The alternative discussed in #580 was to run `gh auth login` (or set `GH_TOKEN`) on every reviewer FleetNode. That works but extends the token's reach to every bash subprocess the model can spawn: a reviewer one prompt-injection away from `bash("gh pr merge --admin ...")` becomes a real possibility. The tool-based approach encapsulates the credential behind one Go function with hard-coded read-only scope, matching the reviewer's read-only intent at the credential layer too. Two additional wins: containerized foreman-agents don't need `gh` installed in their image; token-rotation surface stays at one file rather than also a per-user `gh` config.

## Checklist

- [x] Tests added/updated (11 new cases in `pkg/foreman/agent/tools/fetch_issue_test.go`: happy-path via httptest, 404, 401, arg validation x5, token-resolution failure, nil-deps fail-loud, schema parses to valid JSONSchema, fake-fetcher confirms ParseRepo splits through correctly)
- [x] `make test` passes locally (all foreman packages green; tools package coverage 85.0%)
- [x] `make lint` passes locally (also `GOOS=linux ./bin/golangci-lint run ./...` clean for cross-arch parity)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`feat(foreman/reviewer): ...`)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated: `config/foreman/system-prompts/reviewer.md` reflects the new Step 1; both reviewer Agent CRs carry the updated inline prompt and tool list
