### PR TITLE
fix(foreman/reviewer): ground-truth filesTouched + bump qwen maxTurns + tighten confabulation defenses

### DIFF
--- a/config/foreman/agents/devstral-24b-reviewer.yaml
+++ b/config/foreman/agents/devstral-24b-reviewer.yaml
@@ -82,8 +82,16 @@ spec:
     Required submit_result.extra:
       - reviewOutcome :: APPROVE | REQUEST-CHANGES | REJECT
       - findings      :: [{severity, area, message}]
-      - issueAsk      :: verbatim quote (<=200 chars) from issue body
-      - filesTouched  :: paths from git diff --stat
+      - issueAsk      :: verbatim quote (<=200 chars) from the
+                         issue body the fetch_issue tool returned.
+                         MUST be a literal substring. If you cannot
+                         quote it (empty body, fetch failed), submit
+                         verdict="ERROR" rather than inventing one.
+      - filesTouched  :: paths the diff actually changes. Derive
+                         from `git diff --name-only main...HEAD`.
+                         The executor ground-truths this server-side;
+                         your original list (if it differed) lands
+                         at filesTouchedClaimed for inspection.
 
     Do NOT call write_file, str_replace, git commit, git push, or
     any branch-mutating command. You are reading only.

--- a/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
+++ b/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
@@ -41,7 +41,16 @@ spec:
   # over-cold reviewers default to APPROVE more than they should.
   # Still conservative enough to keep verdicts stable across reruns.
   temperature: "0.35"
-  maxTurns: 40
+  # 80 turns instead of 40: the v0.4 prompt requires ~5-7 setup tool
+  # calls (Step 1), then 1 read_file per touched file (Section B-D),
+  # then grep for call sites (D), then `git show main:path` reads for
+  # regression checks (F), then read_file of every godoc context (G).
+  # On a 6-file diff that adds up to 35+ turns before the model is
+  # ready to call submit_result. 40 was empirically too tight on
+  # rerun-10 (qwen INCOMPLETE on #449 and #526). 80 gives ~3 minutes
+  # of headroom at qwen's ~2 turns/sec pace and lets full Section-A-
+  # through-H reviews of multi-file diffs converge. Closes #583.
+  maxTurns: 80
   maxRetries: 3
   # 15 min per HTTP request to llama-server. Reviewers read the diff,
   # the issue body, and a handful of files; they should never need
@@ -236,9 +245,20 @@ spec:
                              Each finding cites file/line or quoted
                              issue text.
       - `issueAsk`        :: short verbatim quote (<=200 chars) from
-                             the issue body, the anchor your scope
-                             judgment hangs on.
-      - `filesTouched`    :: `[]` of paths from `git diff --stat`.
+                             the issue body the `fetch_issue` tool
+                             returned. MUST be a literal substring
+                             of that body; paraphrasing counts as
+                             confabulation. If you cannot quote the
+                             operative sentence (empty body, fetch
+                             failed), submit `verdict="ERROR"`
+                             instead of inventing one.
+      - `filesTouched`    :: `[]` of paths the diff actually changes.
+                             Derive from `git diff --name-only
+                             main...HEAD` you ran in Step 1. The
+                             executor ground-truths this server-side;
+                             your original list (if it differed)
+                             lands at `filesTouchedClaimed` for
+                             operator inspection.
       Optional: `testsAdded` (int), `newSymbols` ([]string),
       `riskLevel` (`"low" | "medium" | "high"`).
 

--- a/config/foreman/system-prompts/reviewer.md
+++ b/config/foreman/system-prompts/reviewer.md
@@ -280,9 +280,25 @@ Call `submit_result` exactly once. Required fields:
                          that a maintainer can act on it without
                          re-deriving your reasoning.
   - `issueAsk`        :: a short verbatim quote (≤200 chars) of the
-                         operative sentence from the issue body. This
-                         is the anchor your scope judgment hangs on.
-  - `filesTouched`    :: `[]` of paths from `git diff --stat`.
+                         operative sentence from the issue body, as
+                         returned by `fetch_issue`. This MUST be a
+                         literal substring of the body the tool gave
+                         you. Paraphrasing is a finding against your
+                         own review; if you cannot quote the operative
+                         sentence (e.g. issue body was empty or the
+                         fetch failed), submit `verdict="ERROR"`
+                         instead of inventing one.
+  - `filesTouched`    :: `[]` of paths the diff actually changes.
+                         You should derive this from
+                         `git diff --name-only main...HEAD` you ran
+                         in Step 1, but the executor ground-truths
+                         this field server-side against the same
+                         command before storing the result, so do
+                         your best and the harness corrects any
+                         drift. Your original list (if it differed)
+                         lands at `filesTouchedClaimed` for the
+                         operator to inspect; chronic drift here is
+                         a model-quality signal.
 
   Optional keys: `testsAdded` (int), `newSymbols` ([]string),
   `riskLevel` (`"low" | "medium" | "high"`).

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -415,6 +415,13 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// reviewer/findings.go for the schema).
 		if agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer &&
 			loopRes.Terminal != nil {
+			// Ground-truth filesTouched against the actual diff before
+			// findings are logged. Devstral, in particular, hallucinates
+			// this field on multi-file diffs (#582) even when its tool
+			// calls returned correct data; the server-side rewrite makes
+			// the model's claim a debugging artifact and the diff the
+			// authoritative answer.
+			reconcileReviewerFilesTouched(ctx, log, workspace, loopRes.Terminal.Extra)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
 		return e.modelDecidedResult(start, transcriptRef, loopRes, verdict), nil
@@ -1024,6 +1031,104 @@ func buildUserPrompt(task *foremanv1alpha1.AgenticTask) string {
 // See pkg/foreman/agent/reviewer/findings.go for the schema and
 // config/foreman/system-prompts/reviewer.md for the contract the
 // reviewer agent is asked to honor.
+// reconcileReviewerFilesTouched overwrites
+// `submit_result.extra.filesTouched` with the ground-truth file list
+// from `git diff --name-only main...HEAD` in the reviewer's workspace.
+// Preserves the model's original claim under `filesTouchedClaimed` so
+// the discrepancy stays inspectable in the AgenticTask result.
+//
+// Why this exists (#582): devstral on multi-file diffs reliably emits
+// a confabulated filesTouched even when its earlier read_file / bash
+// tool calls accessed the correct files. The "trust the model's
+// terminal payload" assumption is wrong for reviewers above a small
+// complexity threshold. The fix is structural: the executor knows
+// what changed (the workspace has the diff), so it should be the
+// authority on filesTouched, not the model.
+//
+// Failure modes are non-fatal: a git error or an absent main ref
+// just logs a warning and leaves the model's claim untouched. The
+// reviewer's verdict + findings still surface; only the filesTouched
+// field is downgraded to "model-reported" instead of "ground-truth."
+//
+// Note about base ref selection: we use the local `main` branch.
+// `repo.Clone` defaults to cloning from origin with main checked out;
+// when the model runs Step 1 (`git fetch <branch> + git checkout`),
+// the local main branch stays at clone-time HEAD, which is the right
+// base for the three-dot diff (compare HEAD against the merge-base
+// with main).
+func reconcileReviewerFilesTouched(
+	ctx context.Context, log logr.Logger,
+	workspace string, extra map[string]any,
+) {
+	if extra == nil || workspace == "" {
+		return
+	}
+	groundTruth, err := repo.DiffNameOnly(ctx, workspace, "main")
+	if err != nil {
+		log.Info("reviewer filesTouched: ground-truth diff failed; preserving model claim",
+			"err", err.Error())
+		return
+	}
+	prev := extra["filesTouched"]
+	if !fileListsEqual(prev, groundTruth) {
+		// Preserve what the model said so the confabulation case is
+		// inspectable (kubectl get agentictask -o yaml). filesTouched
+		// becomes the source of truth; filesTouchedClaimed is the
+		// archaeology field.
+		extra["filesTouchedClaimed"] = prev
+		log.Info("reviewer filesTouched: overwriting model claim with diff ground truth",
+			"groundTruth", groundTruth,
+			"modelClaim", prev,
+		)
+	}
+	extra["filesTouched"] = groundTruth
+}
+
+// fileListsEqual returns true when prev (which is `any` because it
+// came through map[string]any from a json.Unmarshal of the model's
+// submit_result.extra) names the same set of files as groundTruth.
+// Used to skip the noisy "overwriting" log line when the model
+// already got it right; the executor still rewrites the field so the
+// stored payload is a canonical []string.
+func fileListsEqual(prev any, groundTruth []string) bool {
+	got, ok := prev.([]any)
+	if !ok {
+		if s, sok := prev.([]string); sok {
+			if len(s) != len(groundTruth) {
+				return false
+			}
+			seen := make(map[string]bool, len(s))
+			for _, v := range s {
+				seen[v] = true
+			}
+			for _, g := range groundTruth {
+				if !seen[g] {
+					return false
+				}
+			}
+			return true
+		}
+		return false
+	}
+	if len(got) != len(groundTruth) {
+		return false
+	}
+	seen := make(map[string]bool, len(got))
+	for _, v := range got {
+		s, ok := v.(string)
+		if !ok {
+			return false
+		}
+		seen[s] = true
+	}
+	for _, g := range groundTruth {
+		if !seen[g] {
+			return false
+		}
+	}
+	return true
+}
+
 func logReviewerFindings(log logr.Logger, extra map[string]any) {
 	findings, warnings := reviewer.ParseFindings(extra)
 	for _, w := range warnings {

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -25,10 +25,15 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -837,4 +842,199 @@ func TestBuildUserPrompt_ReviewerCaseProducesNonEmptyContent(t *testing.T) {
 			t.Errorf("reviewer prompt missing %q in:\n%s", want, got)
 		}
 	}
+}
+
+// TestFileListsEqual_TypeShapes covers the two ways the model's
+// claim shows up in extra: as []string (the executor's own writes)
+// or as []any (the standard shape after a json.Unmarshal pass over
+// submit_result.extra). Equality is order-insensitive because git's
+// diff order is deterministic but not semantically meaningful.
+// Closes part of #582.
+func TestFileListsEqual_TypeShapes(t *testing.T) {
+	gt := []string{"a.go", "b.go", "c.go"}
+
+	cases := []struct {
+		name string
+		prev any
+		want bool
+	}{
+		{"any-slice-same-order", []any{"a.go", "b.go", "c.go"}, true},
+		{"any-slice-different-order", []any{"c.go", "a.go", "b.go"}, true},
+		{"any-slice-missing-one", []any{"a.go", "b.go"}, false},
+		{"any-slice-extra-one", []any{"a.go", "b.go", "c.go", "d.go"}, false},
+		{"string-slice-same", []string{"b.go", "a.go", "c.go"}, true},
+		{"string-slice-different", []string{"x.go", "y.go", "z.go"}, false},
+		{"nil-claim", nil, false},
+		{"wrong-type", "a.go,b.go,c.go", false},
+		{"any-with-non-string", []any{"a.go", 42, "c.go"}, false},
+		{"both-empty-vs-non-empty-gt", []any{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fileListsEqual(tc.prev, gt)
+			if got != tc.want {
+				t.Errorf("fileListsEqual: want %v got %v", tc.want, got)
+			}
+		})
+	}
+
+	if !fileListsEqual([]any{}, []string{}) {
+		t.Error("two empty lists should be equal")
+	}
+}
+
+// TestReconcileReviewerFilesTouched_OverwritesAndPreservesClaim is the
+// headline test for #582: a model that confabulates filesTouched gets
+// its claim preserved under filesTouchedClaimed while the actual
+// reported filesTouched gets rewritten to the diff's ground truth.
+func TestReconcileReviewerFilesTouched_OverwritesAndPreservesClaim(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ws := setupTestRepoWithFeatureBranch(t)
+
+	confabulatedClaim := []any{
+		"internal/controller/fake.go",
+		"internal/controller/also-fake.go",
+		"internal/controller/never-existed.go",
+	}
+	extra := map[string]any{
+		"reviewOutcome": "REQUEST-CHANGES",
+		"issueAsk":      "Some asks here",
+		"filesTouched":  confabulatedClaim,
+		"findings":      []any{},
+	}
+
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), ws, extra)
+
+	got, ok := extra["filesTouched"].([]string)
+	if !ok {
+		t.Fatalf("filesTouched should be []string after reconcile, got %T (%v)",
+			extra["filesTouched"], extra["filesTouched"])
+	}
+	wantSet := map[string]bool{"a.go": true, "c.go": true}
+	if len(got) != len(wantSet) {
+		t.Errorf("filesTouched: want 2 files got %d (%v)", len(got), got)
+	}
+	for _, p := range got {
+		if !wantSet[p] {
+			t.Errorf("filesTouched contains unexpected %q (b.go was unchanged)", p)
+		}
+	}
+
+	claim, ok := extra["filesTouchedClaimed"].([]any)
+	if !ok {
+		t.Fatalf("filesTouchedClaimed should be []any (preserved); got %T",
+			extra["filesTouchedClaimed"])
+	}
+	if !reflect.DeepEqual(claim, confabulatedClaim) {
+		t.Errorf("filesTouchedClaimed mutated: want %v got %v", confabulatedClaim, claim)
+	}
+
+	if extra["reviewOutcome"] != "REQUEST-CHANGES" {
+		t.Error("reviewOutcome should be untouched by reconciliation")
+	}
+	if extra["issueAsk"] != "Some asks here" {
+		t.Error("issueAsk should be untouched by reconciliation")
+	}
+}
+
+func TestReconcileReviewerFilesTouched_HonestClaimNoClaimedFieldAdded(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ws := setupTestRepoWithFeatureBranch(t)
+
+	honestClaim := []any{"a.go", "c.go"}
+	extra := map[string]any{"filesTouched": honestClaim}
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), ws, extra)
+
+	if _, present := extra["filesTouchedClaimed"]; present {
+		t.Errorf("filesTouchedClaimed should NOT be set when claim matched; got %v",
+			extra["filesTouchedClaimed"])
+	}
+	got, ok := extra["filesTouched"].([]string)
+	if !ok {
+		t.Fatalf("filesTouched should be canonicalized to []string; got %T",
+			extra["filesTouched"])
+	}
+	if len(got) != 2 {
+		t.Errorf("filesTouched: want 2 entries got %v", got)
+	}
+}
+
+func TestReconcileReviewerFilesTouched_NilExtraIsNoOp(t *testing.T) {
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), "/tmp", nil)
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), "", map[string]any{"x": 1})
+}
+
+func TestReconcileReviewerFilesTouched_GitFailurePreservesClaim(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ws := t.TempDir()
+	if out, err := exec.Command("git", "-C", ws, "init", "-b", "main").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	originalClaim := []any{"some-file.go"}
+	extra := map[string]any{"filesTouched": originalClaim}
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), ws, extra)
+
+	got, ok := extra["filesTouched"].([]any)
+	if !ok {
+		t.Fatalf("filesTouched should keep model's original type on git failure; got %T",
+			extra["filesTouched"])
+	}
+	if !reflect.DeepEqual(got, originalClaim) {
+		t.Errorf("filesTouched mutated on git failure: want %v got %v", originalClaim, got)
+	}
+	if _, claimed := extra["filesTouchedClaimed"]; claimed {
+		t.Errorf("filesTouchedClaimed should not be set when reconciliation could not run")
+	}
+}
+
+func setupTestRepoWithFeatureBranch(t *testing.T) string {
+	t.Helper()
+	ws := t.TempDir()
+	ctx := context.Background()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(ws, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdirall %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+	write("a.go", "package a\n")
+	write("b.go", "package b\n")
+	run("add", ".")
+	run("commit", "-m", "initial")
+
+	run("checkout", "-b", "feature")
+	write("a.go", "package a\n// edit\n")
+	write("c.go", "package c\n")
+	run("add", ".")
+	run("commit", "-m", "feature work")
+
+	return ws
 }

--- a/pkg/foreman/agent/repo/diff.go
+++ b/pkg/foreman/agent/repo/diff.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// DiffNameOnly returns the file paths that differ between `base` and
+// HEAD in the workspace. Uses `git diff --name-only base...HEAD`, the
+// three-dot form, which compares HEAD against the merge-base with
+// `base`: it is the right shape for "files this branch touched on
+// top of base," excluding files that changed on `base` since the
+// branch diverged.
+//
+// Used by the reviewer-result executor path to ground-truth
+// `submit_result.extra.filesTouched` (a model-reported field that
+// devstral, in particular, confabulates on multi-file diffs even when
+// its earlier tool calls returned correct data; see #582).
+//
+// An empty diff is not an error: the reviewer's workspace will be on
+// an unrelated empty branch off `base` until the model itself runs
+// the mandatory Step 1 `git fetch + checkout`. If the model skipped
+// Step 1, the diff really is empty -- the executor surfaces that as
+// "no files touched" and the caller decides what to do with the
+// discrepancy between an empty ground truth and a non-empty model
+// claim.
+func DiffNameOnly(ctx context.Context, workspace, base string) ([]string, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("DiffNameOnly: workspace is required")
+	}
+	if base == "" {
+		return nil, fmt.Errorf("DiffNameOnly: base ref is required")
+	}
+	out, err := runGit(ctx, workspace, baseEnv(), "diff", "--name-only", base+"...HEAD")
+	if err != nil {
+		return nil, err
+	}
+	return parseNameOnly(out), nil
+}
+
+// parseNameOnly splits a `git diff --name-only` output into a clean
+// slice of paths. Strips empty lines and trims surrounding whitespace
+// off each entry. Returns nil (not []string{}) when the output yields
+// no paths, so DeepEqual against a nil expectation works in callers
+// and tests.
+func parseNameOnly(out string) []string {
+	if out == "" {
+		return nil
+	}
+	var paths []string
+	for _, l := range strings.Split(out, "\n") {
+		l = strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		paths = append(paths, l)
+	}
+	return paths
+}

--- a/pkg/foreman/agent/repo/diff_test.go
+++ b/pkg/foreman/agent/repo/diff_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repo
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseNameOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"whitespace-only", "  \n\n  \n", nil},
+		{"single-line", "pkg/agent/registry.go", []string{"pkg/agent/registry.go"}},
+		{
+			"multi-line",
+			"pkg/agent/registry.go\npkg/agent/registry_test.go\n",
+			[]string{"pkg/agent/registry.go", "pkg/agent/registry_test.go"},
+		},
+		{
+			"trailing-blanks-and-trims",
+			"  pkg/a.go  \n\npkg/b.go\n\n\n",
+			[]string{"pkg/a.go", "pkg/b.go"},
+		},
+		{
+			"paths-with-spaces-preserved",
+			"docs/site/concepts/model router.md\n.goreleaser.yaml",
+			[]string{"docs/site/concepts/model router.md", ".goreleaser.yaml"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseNameOnly(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiffNameOnly_RejectsEmptyArgs(t *testing.T) {
+	ctx := context.Background()
+	if _, err := DiffNameOnly(ctx, "", "main"); err == nil {
+		t.Error("DiffNameOnly: empty workspace should error")
+	}
+	if _, err := DiffNameOnly(ctx, "/tmp", ""); err == nil {
+		t.Error("DiffNameOnly: empty base should error")
+	}
+}
+
+// TestDiffNameOnly_RoundTrip exercises the full happy path against a
+// real bare git workspace: init a repo, commit two files on main,
+// branch off, modify both + add a third on the branch, and assert
+// DiffNameOnly returns exactly the three changed paths in any order.
+// Skipped if `git` is not on PATH.
+func TestDiffNameOnly_RoundTrip(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ws := t.TempDir()
+	ctx := context.Background()
+
+	run := func(args ...string) {
+		t.Helper()
+		if _, err := runGit(ctx, ws, baseEnv(), args...); err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+	}
+
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(ws, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdirall %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	// init repo + initial commit on main
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+	mustWrite("a.go", "package a\n")
+	mustWrite("b.go", "package b\n")
+	run("add", ".")
+	run("commit", "-m", "initial")
+
+	// branch off, change a.go, add c.go (leave b.go untouched)
+	run("checkout", "-b", "feature")
+	mustWrite("a.go", "package a\n// edit\n")
+	mustWrite("c.go", "package c\n")
+	run("add", ".")
+	run("commit", "-m", "feature work")
+
+	got, err := DiffNameOnly(ctx, ws, "main")
+	if err != nil {
+		t.Fatalf("DiffNameOnly: %v", err)
+	}
+	want := map[string]bool{"a.go": true, "c.go": true}
+	if len(got) != len(want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected path %q in diff (b.go should have been excluded)", p)
+		}
+	}
+
+	// switching back to main and asking for the same diff returns empty:
+	// HEAD == main means there are no commits ahead.
+	run("checkout", "main")
+	got, err = DiffNameOnly(ctx, ws, "main")
+	if err != nil {
+		t.Fatalf("DiffNameOnly main vs HEAD: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("HEAD == base should yield empty diff; got %v", got)
+	}
+}


### PR DESCRIPTION
## What

Two narrowly-scoped reviewer-quality fixes empirically motivated by yesterday's v0.4 reviewer dogfood batches.

1. **Ground-truth `filesTouched` server-side.** A new `repo.DiffNameOnly(ctx, workspace, "main")` helper runs `git diff --name-only main...HEAD` in the reviewer's workspace; the executor overwrites `submit_result.extra.filesTouched` with that list at terminal time, preserving the model's original claim under `filesTouchedClaimed` for inspection.
2. **Bump qwen reviewer `maxTurns` 40 -> 80.** The v0.4 prompt's mandatory Section-A-through-H budget is bigger than 40 turns on multi-file diffs; qwen at ~2 turns/sec hit the cap before `submit_result` on the rerun-10 medium-complexity branches. 80 turns gives ~3 minutes of headroom.

Plus a small prompt tightening: `extra.issueAsk` MUST be a literal substring of the `fetch_issue` body, and the model is told to `verdict="ERROR"` when it cannot quote rather than paraphrasing.

## Why

Yesterday's post-#581 rereview batch (qwen × devstral × {449, 510, 526}) made two of the v0.4 reviewer ensemble's structural weaknesses visible with apples-to-apples data:

**devstral confabulates `filesTouched` on multi-file diffs (#582):** on rerun-10-issue-449, devstral listed three `internal/controller/*` files as touched; the real diff is `.goreleaser.yaml`, `charts/llmkube/values.yaml`, `docs/site/concepts/model-router.md`. Transcript shows devstral correctly called `fetch_issue` and ran 19 `read_file`s on the actually-modified files, then emitted a confabulated `filesTouched` in the terminal payload. The "trust the model's terminal envelope" assumption is wrong for reviewers above a small complexity threshold. The fix is structural: the executor knows what the diff is, so it should be the authority on filesTouched, not the model.

**qwen reviewer hit `maxTurns: 40` cap on real diffs (#583):** the v0.4 prompt requires ~5-7 setup calls (Step 1), 1 `read_file` per touched file, `grep` for call sites, `read_file` per godoc context (Section G), `git show main:path` per regression check (Section F). A 6-file diff burns 35+ turns before the model is ready to call `submit_result`. qwen completed #510 (trivial dockerignore-style change) in 15 turns; ran out on #449 and #526 at 40.

Fixes #582
Fixes #583

## How

### `repo.DiffNameOnly` + reconciliation seam

`pkg/foreman/agent/repo/diff.go` is a 60-line helper. Uses the three-dot diff form (`main...HEAD`) so files that changed on `main` since the branch diverged don't show up as "touched by this branch." Returns `nil` for empty output so callers / tests can `reflect.DeepEqual` against a nil expectation.

`pkg/foreman/agent/executor_native.go::reconcileReviewerFilesTouched` runs once per review terminal, right before `logReviewerFindings`. Failure modes (no `main` ref, git error, nil extra map) are non-fatal: log a warning, preserve the model's claim, let the verdict + findings still surface. The function is exercised by `TestReconcileReviewerFilesTouched_*` against real git workspaces; `fileListsEqual` is exercised separately with 11 type-shape cases (any-slice, string-slice, order-insensitive, nil/wrong-type defenses).

### Prompt + Agent CR updates

`config/foreman/agents/qwen36-35b-a3b-reviewer.yaml`: `maxTurns: 80`; inline prompt updated for the new `filesTouched` ground-truth contract and the `issueAsk`-must-be-verbatim rule.

`config/foreman/agents/devstral-24b-reviewer.yaml`: inline prompt updated to match. devstral keeps `maxTurns: 40` (its per-turn time is longer than qwen's and its multi-file confabulation profile is the #582 territory, not a turn-budget territory).

`config/foreman/system-prompts/reviewer.md`: the canonical reviewer prompt reference is updated in lockstep so future edits can be made there and re-pasted into the CRs.

### Why not just swap devstral for a different model?

Considered. The Mac Studio inventory check shows only the Devstral-Small-2 24B Q6_K GGUF is on disk; a Gemma 3 27B-it or Qwen3-32B swap is download-gated (~30-60 min for a 17-20 GB GGUF). The model swap is also model-specific; the executor-side ground-truth fix is model-agnostic and benefits every future reviewer regardless of family. Filing the model swap as a separate v0.5+ experiment is the right shape; this PR is the immediate confidence-building win.

## Checklist

- [x] Tests added/updated (9 new repo cases, 15 new internal executor cases)
- [x] `make test` passes locally (all foreman packages green; tools 85.0%, reviewer 97.4%, repo 67.5%)
- [x] `make lint` passes locally (`GOOS=linux ./bin/golangci-lint run ./...` clean for cross-arch parity)
- [x] Commit messages follow conventional commits (`fix(foreman/reviewer): ...`)
- [x] All commits are signed off (DCO)
- [x] Documentation updated (reviewer.md, both Agent CR inline prompts)
