### PR TITLE
fix(foreman/reviewer): ground-truth issueAsk + cap qwen Section D

### DIFF
--- a/config/foreman/agents/devstral-24b-reviewer.yaml
+++ b/config/foreman/agents/devstral-24b-reviewer.yaml
@@ -65,8 +65,12 @@ spec:
        via `make`?
     3. Tests are meaningful. Behavior changes have tests? Tests
        assert real behavior, not tautologies?
-    4. Side effects. Use `grep` to find call sites of modified
-       functions / exported symbols.
+    4. Side effects. Budget: at most 5 `grep`/`bash` calls. The gate
+       already ran `make test`, so existing exported-symbol callers
+       surface as test failures, not as your job. Your value here is
+       call sites OUTSIDE Go test coverage (shell scripts, YAML,
+       Helm chains, docs pinning a flag name). Skip Section 4 entirely
+       on diffs that only touch generated files, YAML, or markdown.
     5. Documentation. New flag / env var / CLI command: user-facing
        docs updated?
 

--- a/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
+++ b/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
@@ -174,6 +174,17 @@ spec:
 
     ### D. Side effects
 
+    **Budget: at most 5 `grep` / `bash` calls in this section.** The
+    gate already ran `make test`, so existing exported-symbol callers
+    usually surface as test failures before you see the diff. Your
+    value in Section D is the *minority* case where a call site lives
+    outside Go test coverage: shell scripts, YAML templates, Helm
+    value chains, generated CRDs, docs that pin a flag name. Pick the
+    1-3 most-likely-to-be-misused symbols changed by the diff and
+    grep those. Stop after 5 calls. If the diff only touches generated
+    files, YAML, or markdown (no Go exported symbols), skip Section D
+    entirely.
+
     - Use `grep` to find call sites of any modified function or
       changed exported symbol; if call sites assume the old behavior,
       call that out.

--- a/config/foreman/system-prompts/reviewer.md
+++ b/config/foreman/system-prompts/reviewer.md
@@ -143,8 +143,18 @@ this delivers Y."
 
 ### D. Side effects
 
-- Does the change have obvious downstream effects the diff does not
-  address? Use `grep` to find call sites of any modified function or
+**Budget: spend at most 5 `grep` / `bash` calls in this section.** The
+gate has already run `make test`, so existing exported-symbol callers
+that depend on the old behavior usually surface as test failures
+before you see the diff at all. Your value in Section D is the
+*minority* case where a call site lives outside Go test coverage:
+shell scripts, YAML templates, Helm value chains, generated CRDs,
+docs that pin a flag name. Pick the 1-3 most-likely-to-be-misused
+symbols changed by the diff and grep those. Stop after 5 calls. If
+the diff only touches generated files, YAML, or markdown (no Go
+exported symbols), skip Section D entirely.
+
+- Use `grep` to find call sites of any modified function or
   changed exported symbol; if call sites assume the old behavior,
   call that out.
 - Does the change touch RBAC, CRDs, Helm chart values, or operator

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -422,6 +422,15 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// the model's claim a debugging artifact and the diff the
 			// authoritative answer.
 			reconcileReviewerFilesTouched(ctx, log, workspace, loopRes.Terminal.Extra)
+			// Ground-truth issueAsk against the fetch_issue tool result
+			// the model already had in its context. Devstral on the same
+			// post-#584 batch confabulated issueAsk on every multi-file
+			// diff -- the prompt-tightening to require verbatim quoting
+			// did not change the model behavior, and the confabulated
+			// ask then drove a *false NO-GO* on #526. Mirror of the
+			// #582/filesTouched fix: harness owns the authoritative
+			// field, model's claim is archived under issueAskClaimed.
+			reconcileReviewerIssueAsk(log, loopRes.Transcript, loopRes.Terminal.Extra)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
 		return e.modelDecidedResult(start, transcriptRef, loopRes, verdict), nil
@@ -1127,6 +1136,151 @@ func fileListsEqual(prev any, groundTruth []string) bool {
 		}
 	}
 	return true
+}
+
+// reconcileReviewerIssueAsk grounds the reviewer's
+// `submit_result.extra.issueAsk` field against the real issue body
+// that came back from the reviewer's `fetch_issue` tool call. The
+// claim has to be a literal substring of that body; if it is not,
+// the harness archives the model's claim under `issueAskClaimed`
+// and rewrites `issueAsk` with the first useful prose paragraph of
+// the body (skipping markdown headers). Pairs with #582's filesTouched
+// fix: same shape, different field.
+//
+// Why this is structural rather than a prompt-tightening fix: the
+// post-#584 rereview showed devstral on the Mac Studio confabulating
+// `issueAsk` on every multi-file diff *even though* the prompt was
+// explicitly tightened to require verbatim quoting and to set
+// verdict=ERROR on failure to quote. The model's claim was a confident
+// hallucination ("Add a cluster-wide default LiteLLM URL ..." for
+// #449, "reconcile orphaned endpoints" for #526) that then drove a
+// false NO-GO on #526 because the diff did not address the
+// hallucinated ask. Prompt tightening did not move the model below
+// its confabulation ceiling; the harness has to own the field.
+//
+// Failure modes are non-fatal: a missing fetch_issue tool result,
+// malformed tool content JSON, or a missing body field all log a
+// warning and leave the model's claim untouched. The reviewer's
+// verdict + findings still surface; only the issueAsk field is
+// downgraded to "model-reported" instead of "ground-truth."
+func reconcileReviewerIssueAsk(log logr.Logger, msgs []oai.Message, extra map[string]any) {
+	if extra == nil {
+		return
+	}
+	body := extractFetchIssueBody(msgs)
+	if body == "" {
+		log.Info("reviewer issueAsk: no fetch_issue body in transcript; preserving model claim")
+		return
+	}
+	claim, _ := extra["issueAsk"].(string)
+	claim = strings.TrimSpace(claim)
+	if claim == "" {
+		// Model omitted the field. Fill it from the body so downstream
+		// has *some* scope anchor; mark unverified for archaeology.
+		extra["issueAsk"] = firstBodyParagraph(body, 200)
+		extra["issueAskVerified"] = false
+		return
+	}
+	if strings.Contains(body, claim) {
+		// Honest claim: model quoted from the body verbatim. Leave alone
+		// and mark verified so downstream knows the field is trustworthy.
+		extra["issueAskVerified"] = true
+		return
+	}
+	// Confabulation: claim is not a substring of the body the model
+	// itself fetched. Archive it and rewrite issueAsk with a real
+	// excerpt from the body.
+	extra["issueAskClaimed"] = claim
+	replaced := firstBodyParagraph(body, 200)
+	extra["issueAsk"] = replaced
+	extra["issueAskVerified"] = false
+	log.Info("reviewer issueAsk: model claim not a substring of fetch_issue body; rewriting from body",
+		"modelClaim", claim,
+		"rewrittenTo", replaced,
+	)
+}
+
+// extractFetchIssueBody finds the most recent fetch_issue tool result
+// in the transcript and pulls the "body" field out of its JSON content.
+// Returns "" if no fetch_issue call landed in the transcript or if
+// the result content was malformed; either case is non-fatal in the
+// reconciler.
+//
+// Multiple fetch_issue calls are unusual but legal (the model might
+// retry on transient failure); we take the last successful one.
+func extractFetchIssueBody(msgs []oai.Message) string {
+	// First pass: collect ids of every fetch_issue tool_call the model
+	// emitted. Second pass: find their matching tool-role results.
+	fetchIDs := make(map[string]bool, 2)
+	for _, m := range msgs {
+		if m.Role != oai.RoleAssistant {
+			continue
+		}
+		for _, tc := range m.ToolCalls {
+			if tc.Function.Name == "fetch_issue" {
+				fetchIDs[tc.ID] = true
+			}
+		}
+	}
+	if len(fetchIDs) == 0 {
+		return ""
+	}
+	var lastBody string
+	for _, m := range msgs {
+		if m.Role != oai.RoleTool {
+			continue
+		}
+		if !fetchIDs[m.ToolCallID] {
+			continue
+		}
+		var parsed struct {
+			Body string `json:"body"`
+		}
+		if err := json.Unmarshal([]byte(m.Content), &parsed); err != nil {
+			continue
+		}
+		if parsed.Body != "" {
+			lastBody = parsed.Body
+		}
+	}
+	return lastBody
+}
+
+// firstBodyParagraph returns up to maxChars of the first useful
+// paragraph in an issue body. Skips leading markdown headers
+// ("## ...", "# ...") and blank lines so the rewritten issueAsk
+// points at actual prose rather than a section title.
+func firstBodyParagraph(body string, maxChars int) string {
+	lines := strings.Split(body, "\n")
+	var paragraph strings.Builder
+	for _, l := range lines {
+		stripped := strings.TrimSpace(l)
+		if stripped == "" {
+			if paragraph.Len() > 0 {
+				break
+			}
+			continue
+		}
+		if strings.HasPrefix(stripped, "#") {
+			// Markdown heading: skip; the prose starts after it.
+			if paragraph.Len() > 0 {
+				break
+			}
+			continue
+		}
+		if paragraph.Len() > 0 {
+			paragraph.WriteByte(' ')
+		}
+		paragraph.WriteString(stripped)
+		if paragraph.Len() >= maxChars {
+			break
+		}
+	}
+	out := paragraph.String()
+	if len(out) > maxChars {
+		out = out[:maxChars]
+	}
+	return out
 }
 
 func logReviewerFindings(log logr.Logger, extra map[string]any) {

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -42,6 +42,7 @@ import (
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
 )
 
 // TestBranchNameForTask covers the precedence rule between explicit
@@ -1037,4 +1038,215 @@ func setupTestRepoWithFeatureBranch(t *testing.T) string {
 	run("commit", "-m", "feature work")
 
 	return ws
+}
+
+// ---- issueAsk reconciliation (#582 follow-on; second confabulation fix) ----
+
+func TestFirstBodyParagraph_SkipsHeadersTakesFirstProse(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"empty", "", 200, ""},
+		{"plain-prose", "Fix the thing.", 200, "Fix the thing."},
+		{
+			"strips-leading-h2",
+			"## Bug Description\n\nThe metal-agent picks the wrong IP.",
+			200,
+			"The metal-agent picks the wrong IP.",
+		},
+		{
+			"strips-leading-h1",
+			"# Feature\n\nAdd a make lint-all target nudge to AGENTS.md.",
+			200,
+			"Add a make lint-all target nudge to AGENTS.md.",
+		},
+		{
+			"joins-wrapped-lines-of-first-paragraph",
+			"## Bug Description\n\nLine one of the bug\nstill same paragraph\n\nLine of paragraph two",
+			200,
+			"Line one of the bug still same paragraph",
+		},
+		{
+			"truncates-at-maxchars",
+			"short header\n\n" + strings.Repeat("x", 300),
+			50,
+			"short header",
+		},
+		{
+			"only-headers-no-prose",
+			"## Bug Description\n## Steps\n## Expected",
+			200,
+			"",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := firstBodyParagraph(tc.in, tc.max)
+			if got != tc.want {
+				t.Errorf("got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractFetchIssueBody_HappyAndMissing(t *testing.T) {
+	// Synthesize a fetch_issue tool-call + tool-result pair in a
+	// realistic transcript shape.
+	mkMsgs := func(toolID, content string) []oai.Message {
+		return []oai.Message{
+			{Role: oai.RoleUser, Content: "you are reviewing the branch ..."},
+			{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{{
+				ID:   toolID,
+				Type: "function",
+				Function: oai.ToolCallFunction{
+					Name:      "fetch_issue",
+					Arguments: `{"repo":"defilantech/LLMKube","number":510}`,
+				},
+			}}},
+			{Role: oai.RoleTool, ToolCallID: toolID, Content: content},
+		}
+	}
+
+	body := extractFetchIssueBody(mkMsgs("tc-1",
+		`{"number":510,"title":"docs","body":"The real issue body here.","state":"open"}`))
+	if body != "The real issue body here." {
+		t.Errorf("happy path body: got %q", body)
+	}
+
+	if body := extractFetchIssueBody(nil); body != "" {
+		t.Errorf("nil msgs: want empty got %q", body)
+	}
+
+	if body := extractFetchIssueBody([]oai.Message{
+		{Role: oai.RoleUser, Content: "no tool calls here"},
+	}); body != "" {
+		t.Errorf("no fetch_issue call: want empty got %q", body)
+	}
+
+	if body := extractFetchIssueBody(mkMsgs("tc-2", `not-valid-json`)); body != "" {
+		t.Errorf("malformed JSON tool content: want empty got %q", body)
+	}
+
+	if body := extractFetchIssueBody(mkMsgs("tc-3",
+		`{"number":510,"title":"docs","state":"open"}`)); body != "" {
+		t.Errorf("missing body field: want empty got %q", body)
+	}
+
+	// Multiple fetch_issue calls: last successful body wins.
+	msgs := []oai.Message{
+		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{{ID: "tc-a", Type: "function",
+			Function: oai.ToolCallFunction{Name: "fetch_issue", Arguments: `{"number":1}`}}}},
+		{Role: oai.RoleTool, ToolCallID: "tc-a",
+			Content: `{"body":"first body"}`},
+		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{{ID: "tc-b", Type: "function",
+			Function: oai.ToolCallFunction{Name: "fetch_issue", Arguments: `{"number":2}`}}}},
+		{Role: oai.RoleTool, ToolCallID: "tc-b",
+			Content: `{"body":"second body"}`},
+	}
+	if got := extractFetchIssueBody(msgs); got != "second body" {
+		t.Errorf("last-wins: want %q got %q", "second body", got)
+	}
+}
+
+func TestReconcileReviewerIssueAsk_VerbatimQuotePreserved(t *testing.T) {
+	body := "## Feature Description\n\nAdd a `make lint-all` nudge to AGENTS.md per #508 follow-up."
+	msgs := []oai.Message{
+		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{{
+			ID: "tc-1", Type: "function",
+			Function: oai.ToolCallFunction{
+				Name: "fetch_issue", Arguments: `{"repo":"o/r","number":510}`,
+			},
+		}}},
+		{Role: oai.RoleTool, ToolCallID: "tc-1",
+			Content: `{"body":"` + strings.ReplaceAll(body, "`", "\\u0060") + `"}`},
+	}
+	// Pre-serialize the body via json.Marshal so escaping is correct.
+	content, _ := json.Marshal(map[string]string{"body": body})
+	msgs[1].Content = string(content)
+
+	extra := map[string]any{
+		"issueAsk": "Add a `make lint-all` nudge to AGENTS.md per #508 follow-up.",
+	}
+	reconcileReviewerIssueAsk(logr.Discard(), msgs, extra)
+
+	if extra["issueAsk"] != "Add a `make lint-all` nudge to AGENTS.md per #508 follow-up." {
+		t.Errorf("verbatim claim should be preserved unchanged; got %v", extra["issueAsk"])
+	}
+	if v, _ := extra["issueAskVerified"].(bool); !v {
+		t.Errorf("verbatim claim should set issueAskVerified=true; got %v", extra["issueAskVerified"])
+	}
+	if _, claimed := extra["issueAskClaimed"]; claimed {
+		t.Errorf("issueAskClaimed should not be set for honest quote")
+	}
+}
+
+func TestReconcileReviewerIssueAsk_ConfabulationRewritten(t *testing.T) {
+	body := "## Bug Description\n\nmetal-agent picks the wrong IP on multi-NIC macOS hosts."
+	content, _ := json.Marshal(map[string]string{"body": body})
+	msgs := []oai.Message{
+		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{{
+			ID: "tc-1", Type: "function",
+			Function: oai.ToolCallFunction{Name: "fetch_issue"},
+		}}},
+		{Role: oai.RoleTool, ToolCallID: "tc-1", Content: string(content)},
+	}
+
+	confab := "Add a reconciler that cleans up orphaned Service+Endpoints objects when agent restarts."
+	extra := map[string]any{"issueAsk": confab}
+	reconcileReviewerIssueAsk(logr.Discard(), msgs, extra)
+
+	if extra["issueAsk"] != "metal-agent picks the wrong IP on multi-NIC macOS hosts." {
+		t.Errorf("confabulated claim should be rewritten with body excerpt; got %v",
+			extra["issueAsk"])
+	}
+	if v, _ := extra["issueAskVerified"].(bool); v {
+		t.Errorf("rewritten issueAsk should mark issueAskVerified=false; got true")
+	}
+	if extra["issueAskClaimed"] != confab {
+		t.Errorf("issueAskClaimed should preserve original confabulation; got %v",
+			extra["issueAskClaimed"])
+	}
+}
+
+func TestReconcileReviewerIssueAsk_NoFetchInTranscript(t *testing.T) {
+	extra := map[string]any{"issueAsk": "some claim"}
+	reconcileReviewerIssueAsk(logr.Discard(), []oai.Message{
+		{Role: oai.RoleUser, Content: "no fetch_issue here"},
+	}, extra)
+	if extra["issueAsk"] != "some claim" {
+		t.Errorf("with no fetch_issue body in transcript, claim should be preserved unchanged; got %v", extra["issueAsk"])
+	}
+	if _, verified := extra["issueAskVerified"]; verified {
+		t.Errorf("issueAskVerified should NOT be set when reconciliation could not run")
+	}
+}
+
+func TestReconcileReviewerIssueAsk_EmptyClaimFilledFromBody(t *testing.T) {
+	body := "## Feature\n\nDocument the new --lint-all flag."
+	content, _ := json.Marshal(map[string]string{"body": body})
+	msgs := []oai.Message{
+		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{{
+			ID: "tc-1", Type: "function",
+			Function: oai.ToolCallFunction{Name: "fetch_issue"},
+		}}},
+		{Role: oai.RoleTool, ToolCallID: "tc-1", Content: string(content)},
+	}
+	extra := map[string]any{} // model omitted issueAsk entirely
+	reconcileReviewerIssueAsk(logr.Discard(), msgs, extra)
+	if extra["issueAsk"] != "Document the new --lint-all flag." {
+		t.Errorf("empty claim should be filled from body excerpt; got %v", extra["issueAsk"])
+	}
+	if v, _ := extra["issueAskVerified"].(bool); v {
+		t.Errorf("body-derived issueAsk should mark issueAskVerified=false")
+	}
+	if _, claimed := extra["issueAskClaimed"]; claimed {
+		t.Errorf("issueAskClaimed should not be set when model had no claim to archive")
+	}
+}
+
+func TestReconcileReviewerIssueAsk_NilExtraIsNoOp(t *testing.T) {
+	reconcileReviewerIssueAsk(logr.Discard(), nil, nil) // must not panic
 }


### PR DESCRIPTION
## What

Two follow-on reviewer-quality fixes empirically motivated by the post-#584 rereview batch.

1. **Ground-truth `issueAsk` server-side** (mirror of #584's `filesTouched` fix). New `reconcileReviewerIssueAsk` scans the transcript for the most recent `fetch_issue` tool result, checks whether the model's claimed `issueAsk` is a literal substring of the body, and rewrites it with the body's first useful paragraph when it is not. Model's claim preserved under `issueAskClaimed`; new `issueAskVerified` boolean signals trustworthiness to downstream.
2. **Cap qwen Section D ("call-site archaeology") at 5 calls.** Add a budget cap + skip clause + scoping cue to the reviewer prompt. The gate already runs `make test`; Section D's residual value is the minority of call sites outside Go test coverage.

## Why

#584's post-merge rereview matrix made two structural gaps visible.

**Devstral confabulates `issueAsk` below the prompt-fix horizon.** #584's prompt-tightening (require verbatim quotes; set `verdict="ERROR"` on failure to quote) did not change devstral's behavior. On the post-#584 rereview:

- validate-584-review-449-devstral (verdict=GO): `issueAsk = "Add a cluster-wide default LiteLLM URL configuration"`. Real issue #449: "ci(release): build and push llmkube-router-proxy image alongside the controller." No overlap.
- validate-584-review-526-devstral (verdict=NO-GO): `issueAsk = "The agent should reconcile orphaned endpoints when it starts up..."`. Real issue #526: "metal-agent --host-ip auto-detect picks unreachable virtual interface on multi-NIC macOS." The confabulated ask drove a *false NO-GO* on a diff that correctly addresses the real issue.

Transcripts in both cases show devstral called `fetch_issue` successfully and got the real body. The body was in its context; the model still confabulated the terminal `issueAsk`. The prompt-tightening doesn't reach below that ceiling; the harness has to own the field. Same shape as #584's filesTouched fix.

**qwen Section D archaeology is unbounded.** validate-584-review-449-qwen with the post-#583 maxTurns=80 burned the full budget with 74 `bash` calls (top repeat: 5x grep of a non-touched file). The section's prompt told qwen to grep for call sites of changed symbols and never bounded the search. The gate already runs `make test` so most exported-symbol callers surface there; Section D should keep its narrow residual value (non-Go callers: shell, YAML, Helm chains, docs) and stop spiraling.

Fixes #585
Fixes #586

## How

### `reconcileReviewerIssueAsk` (executor_native.go)

Called once per reviewer terminal, right after `reconcileReviewerFilesTouched`. Public surface stays the same; the field schema gains an `issueAskClaimed` field (the model's original claim) and an `issueAskVerified` boolean.

- `extractFetchIssueBody(msgs)` scans the transcript twice: first to collect every `fetch_issue` tool_call id the model emitted, then to find the matching tool-role result and pull the `body` field out of its JSON content. Multiple fetch_issue calls (model retried on transient failure) take the last successful body.
- `firstBodyParagraph(body, max)` strips leading markdown headers (`#`, `##`, etc.), joins wrapped lines of the first non-empty paragraph, and truncates at `max` chars. Tested with 7 cases including the headers-only edge.
- All failure modes (missing tool result, malformed JSON, empty body, nil extra) log + preserve the model's claim.

### Section D prompt tightening

Three explicit cues added to `config/foreman/system-prompts/reviewer.md` Section D and to the inline copies in both reviewer Agent CRs:

1. Hard budget: at most 5 `grep`/`bash` calls.
2. Skip clause: skip Section D entirely on diffs that only touch YAML/generated/markdown (no Go exported symbols).
3. Scoping cue: pick 1-3 most-likely-misused symbols; the gate's `make test` already covers Go-test call sites.

The intent is "look for the rare callsite outside Go test coverage" rather than "audit every callsite of every changed symbol."

## Checklist

- [x] Tests added/updated (19 new cases: 7 firstBodyParagraph + 6 extractFetchIssueBody scenarios + 6 reconcileReviewerIssueAsk paths)
- [x] `make test` passes locally (all foreman packages green; reviewer 97.4%, repo 67.5%, tools 85.0%)
- [x] `make lint` passes locally (`GOOS=linux ./bin/golangci-lint run ./...` clean for cross-arch parity)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [x] Documentation updated (reviewer.md + both Agent CR inline prompts)
