### PR TITLE
docs: mention make lint-all in AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,18 @@ A change is not done until all of these pass:
 3. `make lint`
 4. `make test`
 
+## Before pushing a PR
+
+Run the cross-arch lint pass:
+
+```sh
+make lint-all
+```
+
+This catches `//go:build`-tagged files that the host's default `GOOS` would
+silently skip. About 2× slower than `make lint`; intentional opt-in so the
+inner loop stays fast.
+
 If you edited CRD types in `api/v1alpha1/`, also run:
 
 5. `make generate` — DeepCopy methods

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,6 +264,8 @@ make test
 
 - [ ] Code passes all tests (`make test`)
 - [ ] Linter passes (`make lint`)
+- [ ] Cross-arch lint passes (`make lint-all`) — catches `//go:build`-tagged files
+  that the host's default `GOOS` would silently skip
 - [ ] Manually tested in a Kubernetes cluster
 - [ ] GPU tests pass (if GPU-related: `./test/e2e/gpu_test.sh`)
 - [ ] Documentation updated (if adding features)


### PR DESCRIPTION
## What

Two-file docs nudge pointing contributors at the `make lint-all` target shipped in #508:

- `AGENTS.md`: new "Before pushing a PR" section that names `make lint-all` alongside `make test`
- `CONTRIBUTING.md`: PR checklist item

Net: +14 lines, -0 lines, no code touched.

## Why

`make lint-all` (the cross-arch lint pass added in #508) is currently discoverable only via `make help`. The cross-arch gap it covers (`//go:build !darwin` files silently skipped by the default `make lint` on macOS) bit PR #501 twice during the M3 epic. A one-line nudge in the standards docs costs almost nothing and saves a CI round-trip the next time someone touches a build-tagged file from a Mac.

Fixes #510

## How: authorship + verification

This is the second upstream-merged contribution authored by **Foreman v0.4** (the LLMKube agentic orchestrator that ships as an opt-in add-on in this same repo — `pkg/foreman/`). The pipeline that produced this branch:

1. **Coder Agent** (`qwen36-35b-carnice-mtp-coder`, M5 Max, Apple Silicon Metal) read the issue body via the `fetch_issue` tool (#581), made the two-file edit, and ran `submit_result` with `verdict=GO`. Commit `6ff5059` is the model-authored DCO-signed result.
2. **Verifier Agent** (`shadowstack-gate`, x86_64 NVIDIA, Kubernetes Job) cloned the branch and ran `make fmt vet lint test manifests chart-crds foreman-chart-crds`. Verdict: `GATE-PASS`.
3. **Reviewer Agent** (`qwen36-35b-a3b-reviewer`, M5 Max) re-read the issue body via `fetch_issue`, scored the diff against Sections A–H of the reviewer prompt (`config/foreman/system-prompts/reviewer.md`), and submitted `verdict=GO / reviewOutcome=APPROVE` in 22 turns / 46 seconds wall. Findings: zero blockers.
4. **Reviewer Agent** (`devstral-24b-reviewer`, Mac Studio Apple Silicon Metal) ran the smoke-test variant of the same pipeline against this branch on 2026-05-27 (`validate-581-fetch-issue-510`): `verdict=GO / reviewOutcome=APPROVE` in 11 turns / 4m15s wall, with `fetch_issue` calls confirmed in the transcript ConfigMap.

Both reviewers agreed on this branch. The contribution is human-reviewable (you're reading the PR), but the Foreman pipeline has already verified gate-clean + dual-reviewer-APPROVE on local hardware before this PR was opened.

## Foreman v0.4 receipts

The harness that drove this contribution shipped tonight in three PRs:

- #581: `fetch_issue` tool replaces the `gh issue view` subshell — the reviewer's scope anchor now uses the foreman-agent's own GitHub token, not per-host `gh auth login`
- #584: server-side ground-truth for `filesTouched` (the executor overwrites the model's claim with `git diff --name-only main...HEAD` output) plus a Section D budget cap on qwen reviewer
- #587: server-side ground-truth for `issueAsk` plus the parallel `issueAskClaimed` archaeology field

Every one of those landed because dogfood batches surfaced reviewer-quality bugs in Foreman itself within hours of each other. The branch in this PR is the first one to round-trip through the post-#587 stack with reviewer evidence on both M5 Max and Mac Studio.

## Checklist

- [x] Tests not applicable (docs-only)
- [x] `make fmt vet lint test manifests chart-crds foreman-chart-crds` clean via the gate Agent verification
- [x] Commit message follows conventional commits
- [x] DCO sign-off present
- [x] Two reviewers approved (qwen + devstral on different hosts)
