### PR TITLE
docs(foreman): absolute paths in overview README cross-refs (fix llmkube-web prerender)

### DIFF
--- a/docs/site/foreman/README.md
+++ b/docs/site/foreman/README.md
@@ -116,8 +116,8 @@ That installs the foreman-operator (controllers for the four CRDs),
 plus a foreman-agent Deployment that registers a FleetNode for the
 gate-runner role on the Linux/K8s host. Apple Silicon coder /
 reviewer nodes run the foreman-agent binary directly via launchd;
-see [the M3 runbook](./runbook-m3) and
-[the M4 runbook](./runbook-m4) for hosts-side install.
+see [the M3 runbook](/docs/foreman/runbook-m3) and
+[the M4 runbook](/docs/foreman/runbook-m4) for hosts-side install.
 
 ## A minimal example
 
@@ -174,7 +174,7 @@ capabilities we know people will ask for and deliberately punted:
   past outcomes is on the roadmap; v0.1 records the data.
 - **Model-tool-protocol compatibility is implicit, not declared.**
   Foreman currently assumes every inference endpoint speaks OpenAI
-  `tool_calls`. See [model-compatibility](./model-compatibility)
+  `tool_calls`. See [model-compatibility](/docs/foreman/model-compatibility)
   for the calibrated table.
 
 The v0.1 CRD shape was designed so each of those additions is a
@@ -183,14 +183,14 @@ non-breaking extension. Pinning the foundation is the work of
 
 ## Deep references
 
-- **[M3 coder runbook](./runbook-m3)**: install the foreman-agent
+- **[M3 coder runbook](/docs/foreman/runbook-m3)**: install the foreman-agent
   on the coder host (M5 Max / Apple Silicon).
-- **[M4 verifier runbook](./runbook-m4)**: install Foreman as a chart
+- **[M4 verifier runbook](/docs/foreman/runbook-m4)**: install Foreman as a chart
   on the K8s cluster and stand up the gate Agent on a verifier
   node.
-- **[Verifier node install notes](./install-verifier-node)**:
+- **[Verifier node install notes](/docs/foreman/install-verifier-node)**:
   deeper notes on the ShadowStack reference verifier deployment.
-- **[Model compatibility table](./model-compatibility)**: which
+- **[Model compatibility table](/docs/foreman/model-compatibility)**: which
   models the v0.4 reviewer and coder roles have been empirically
   validated against.
 


### PR DESCRIPTION
## What

Switch the seven sub-page cross-refs in `docs/site/foreman/README.md` from relative (`./runbook-m3`, etc.) to absolute (`/docs/foreman/runbook-m3`).

## Why

Follow-up to #594. The Foreman docs overview renders at `/docs/foreman` (no trailing slash). RFC 3986 relative-URL resolution strips the last segment of the base URL before applying the relative path, so from a base of `/docs/foreman`, `./runbook-m3` resolves to `/docs/runbook-m3` — not the intended `/docs/foreman/runbook-m3`.

This worked elsewhere in `docs/site/` because every other page lives two segments deep under `/docs/` (e.g. `/docs/concepts/architecture` → `./crds` → `/docs/concepts/crds`). The Foreman overview is the first page at a one-segment URL with sub-pages below it.

The llmkube-web production redeploy after #594 merged caught this in the SvelteKit static-adapter prerender pass:

```
Error: 404 /docs/runbook-m3 (linked from /docs/foreman)
```

Absolute paths sidestep the issue and are robust regardless of trailing-slash configuration on the consuming site.

## How

Four `replace_all` substitutions covering seven references in `docs/site/foreman/README.md`:

| Old | New |
|---|---|
| `(./runbook-m3)` | `(/docs/foreman/runbook-m3)` |
| `(./runbook-m4)` | `(/docs/foreman/runbook-m4)` |
| `(./install-verifier-node)` | `(/docs/foreman/install-verifier-node)` |
| `(./model-compatibility)` | `(/docs/foreman/model-compatibility)` |

The sub-pages themselves (`install-verifier-node.md`, `runbook-m4.md`) still use relative refs to siblings: those work at two-segment URLs (`/docs/foreman/runbook-m4` + `./install-verifier-node` → `/docs/foreman/install-verifier-node`).

## Verification

Local llmkube-web build against this content + the matching render-docs.js images fix (Defilan/llmkube-web#79) prerenders clean: no `404` warnings, `✓ built in 2.26s`.

## Checklist

- [x] DCO sign-off
- [x] No CRD or code changes; docs-only single-file diff
- [x] Local prerender verified clean against operator `main`-style content
- [x] Sub-page-to-sub-page relative refs left as-is (they work; convention matches existing `docs/site/concepts/` pattern)