### PR TITLE
fix(foreman): warm-path reviewer scheduling on macOS (#578, #579)

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -163,6 +163,18 @@ type RequiredCapability struct {
 	// +optional
 	MinRAMGB int32 `json:"minRAMGB,omitempty"`
 
+	// RequiresModelInstalled, when true, scopes scheduling to FleetNodes
+	// that already have this Agent's model resident (the model name,
+	// resolved from Agent.spec.model or Agent.spec.inferenceServiceRef,
+	// must appear in the node's status.capability.installedModels). In
+	// that mode the minRAMGB gate is intentionally ignored: the model is
+	// already loaded, so the agent loop needs ~0 additional RAM. This is
+	// the warm-driver path reviewer-class Agents always take; minRAMGB is
+	// correct only for the cold-load path. When false (default), minRAMGB
+	// is enforced as before.
+	// +optional
+	RequiresModelInstalled bool `json:"requiresModelInstalled,omitempty"`
+
 	// MinContextTokens is the minimum context window the node's installed
 	// model must support. Set to 0 to leave unconstrained.
 	// +kubebuilder:validation:Minimum=0

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -173,6 +173,18 @@ spec:
                       key are eligible. Used for tasks that must run on a specific node
                       (e.g. verify tasks targeting the gate runner).
                     type: object
+                  requiresModelInstalled:
+                    description: |-
+                      RequiresModelInstalled, when true, scopes scheduling to FleetNodes
+                      that already have this Agent's model resident (the model name,
+                      resolved from Agent.spec.model or Agent.spec.inferenceServiceRef,
+                      must appear in the node's status.capability.installedModels). In
+                      that mode the minRAMGB gate is intentionally ignored: the model is
+                      already loaded, so the agent loop needs ~0 additional RAM. This is
+                      the warm-driver path reviewer-class Agents always take; minRAMGB is
+                      correct only for the cold-load path. When false (default), minRAMGB
+                      is enforced as before.
+                    type: boolean
                   roles:
                     description: |-
                       Roles filters to FleetNodes whose spec.roles include every named

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -265,6 +265,18 @@ spec:
                       key are eligible. Used for tasks that must run on a specific node
                       (e.g. verify tasks targeting the gate runner).
                     type: object
+                  requiresModelInstalled:
+                    description: |-
+                      RequiresModelInstalled, when true, scopes scheduling to FleetNodes
+                      that already have this Agent's model resident (the model name,
+                      resolved from Agent.spec.model or Agent.spec.inferenceServiceRef,
+                      must appear in the node's status.capability.installedModels). In
+                      that mode the minRAMGB gate is intentionally ignored: the model is
+                      already loaded, so the agent loop needs ~0 additional RAM. This is
+                      the warm-driver path reviewer-class Agents always take; minRAMGB is
+                      correct only for the cold-load path. When false (default), minRAMGB
+                      is enforced as before.
+                    type: boolean
                   roles:
                     description: |-
                       Roles filters to FleetNodes whose spec.roles include every named

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -173,6 +173,18 @@ spec:
                       key are eligible. Used for tasks that must run on a specific node
                       (e.g. verify tasks targeting the gate runner).
                     type: object
+                  requiresModelInstalled:
+                    description: |-
+                      RequiresModelInstalled, when true, scopes scheduling to FleetNodes
+                      that already have this Agent's model resident (the model name,
+                      resolved from Agent.spec.model or Agent.spec.inferenceServiceRef,
+                      must appear in the node's status.capability.installedModels). In
+                      that mode the minRAMGB gate is intentionally ignored: the model is
+                      already loaded, so the agent loop needs ~0 additional RAM. This is
+                      the warm-driver path reviewer-class Agents always take; minRAMGB is
+                      correct only for the cold-load path. When false (default), minRAMGB
+                      is enforced as before.
+                    type: boolean
                   roles:
                     description: |-
                       Roles filters to FleetNodes whose spec.roles include every named

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -265,6 +265,18 @@ spec:
                       key are eligible. Used for tasks that must run on a specific node
                       (e.g. verify tasks targeting the gate runner).
                     type: object
+                  requiresModelInstalled:
+                    description: |-
+                      RequiresModelInstalled, when true, scopes scheduling to FleetNodes
+                      that already have this Agent's model resident (the model name,
+                      resolved from Agent.spec.model or Agent.spec.inferenceServiceRef,
+                      must appear in the node's status.capability.installedModels). In
+                      that mode the minRAMGB gate is intentionally ignored: the model is
+                      already loaded, so the agent loop needs ~0 additional RAM. This is
+                      the warm-driver path reviewer-class Agents always take; minRAMGB is
+                      correct only for the cold-load path. When false (default), minRAMGB
+                      is enforced as before.
+                    type: boolean
                   roles:
                     description: |-
                       Roles filters to FleetNodes whose spec.roles include every named

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -115,7 +116,7 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// it wins: we look up the Agent and use its capability. The task's own
 	// spec.requiredCapability is ignored in that path; that is the locked
 	// M3 contract. An Agent that does not exist fails the task fast.
-	required, err := r.effectiveRequiredCapability(ctx, &task)
+	required, requiredModel, err := r.effectiveRequiredCapability(ctx, &task)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return r.failTask(ctx, &task, "AgentNotFound",
@@ -125,7 +126,7 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// Find a FleetNode that satisfies the effective RequiredCapability.
-	nodeName, err := r.firstFitNode(ctx, required)
+	nodeName, err := r.firstFitNode(ctx, required, requiredModel)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -141,16 +142,27 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // match against. When spec.agentRef is set the Agent's capability wins;
 // otherwise the task's own. NotFound on AgentRef is propagated so the
 // caller can fail the task with a clear reason.
-func (r *AgenticTaskReconciler) effectiveRequiredCapability(ctx context.Context, task *foremanv1alpha1.AgenticTask) (foremanv1alpha1.RequiredCapability, error) {
+func (r *AgenticTaskReconciler) effectiveRequiredCapability(ctx context.Context, task *foremanv1alpha1.AgenticTask) (foremanv1alpha1.RequiredCapability, string, error) {
 	if task.Spec.AgentRef == nil || task.Spec.AgentRef.Name == "" {
-		return task.Spec.RequiredCapability, nil
+		return task.Spec.RequiredCapability, "", nil
 	}
 	var agent foremanv1alpha1.Agent
 	key := types.NamespacedName{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
 	if err := r.Get(ctx, key, &agent); err != nil {
-		return foremanv1alpha1.RequiredCapability{}, err
+		return foremanv1alpha1.RequiredCapability{}, "", err
 	}
-	return agent.Spec.RequiredCapability, nil
+	return agent.Spec.RequiredCapability, agentModelIdentity(&agent), nil
+}
+
+// agentModelIdentity returns the model name used to test installedModels
+// membership for RequiresModelInstalled scheduling. Prefers the explicit
+// spec.model; falls back to the InferenceService reference name (which,
+// in single-model fleets, matches the advertised installedModels entry).
+func agentModelIdentity(agent *foremanv1alpha1.Agent) string {
+	if agent.Spec.Model != "" {
+		return agent.Spec.Model
+	}
+	return agent.Spec.InferenceServiceRef.Name
 }
 
 // setInitialPending writes phase=Pending the first time we see the task.
@@ -230,7 +242,7 @@ func (r *AgenticTaskReconciler) allDepsSucceeded(ctx context.Context, task *fore
 // firstFitNode picks the alphabetically-first Ready FleetNode whose
 // advertised capability satisfies the effective RequiredCapability and
 // that is not already running another task.
-func (r *AgenticTaskReconciler) firstFitNode(ctx context.Context, required foremanv1alpha1.RequiredCapability) (string, error) {
+func (r *AgenticTaskReconciler) firstFitNode(ctx context.Context, required foremanv1alpha1.RequiredCapability, requiredModel string) (string, error) {
 	var nodes foremanv1alpha1.FleetNodeList
 	if err := r.List(ctx, &nodes); err != nil {
 		return "", err
@@ -246,7 +258,7 @@ func (r *AgenticTaskReconciler) firstFitNode(ctx context.Context, required forem
 		if n.Status.CurrentTask != "" {
 			continue // v0.1: one task per node
 		}
-		if !capabilitySatisfies(required, n) {
+		if !capabilitySatisfies(required, requiredModel, n) {
 			continue
 		}
 		return n.Name, nil
@@ -257,7 +269,7 @@ func (r *AgenticTaskReconciler) firstFitNode(ctx context.Context, required forem
 // capabilitySatisfies returns true when the node's advertised capability
 // meets every requirement the task declares. Unset requirements are
 // unconstrained; an "any" accelerator matches everything.
-func capabilitySatisfies(req foremanv1alpha1.RequiredCapability, n *foremanv1alpha1.FleetNode) bool {
+func capabilitySatisfies(req foremanv1alpha1.RequiredCapability, requiredModel string, n *foremanv1alpha1.FleetNode) bool {
 	cap := n.Status.Capability
 
 	if req.Accelerator != "" && req.Accelerator != foremanv1alpha1.AgenticTaskAccelerator("any") {
@@ -265,7 +277,17 @@ func capabilitySatisfies(req foremanv1alpha1.RequiredCapability, n *foremanv1alp
 			return false
 		}
 	}
-	if req.MinRAMGB > 0 && req.MinRAMGB > cap.AvailableRAMGB {
+	if req.RequiresModelInstalled {
+		// Warm-driver path: the Agent's model must already be resident on
+		// the node, and the minRAMGB gate is bypassed (the loaded model
+		// has already paid the RAM cost; the loop adds ~0). An empty
+		// requiredModel is a misconfiguration we cannot confirm, so it
+		// fails the match rather than silently bypassing the gate.
+		// See defilantech/LLMKube#579.
+		if requiredModel == "" || !slices.Contains(cap.InstalledModels, requiredModel) {
+			return false
+		}
+	} else if req.MinRAMGB > 0 && req.MinRAMGB > cap.AvailableRAMGB {
 		return false
 	}
 	if req.MinContextTokens > 0 && req.MinContextTokens > cap.MaxContextTokens {

--- a/internal/foreman/controller/agentictask_matcher_test.go
+++ b/internal/foreman/controller/agentictask_matcher_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func nodeWithCapability(cap foremanv1alpha1.FleetNodeCapability) *foremanv1alpha1.FleetNode {
+	n := &foremanv1alpha1.FleetNode{}
+	n.Status.Phase = foremanv1alpha1.FleetNodePhaseReady
+	n.Status.Capability = cap
+	return n
+}
+
+// A reviewer Agent's model is already loaded on the node, so the loop
+// needs ~0 additional RAM. With RequiresModelInstalled set, the matcher
+// must treat installedModels membership as sufficient and ignore the
+// minRAMGB gate (which is sized for the cold-load path).
+// Regression for defilantech/LLMKube#579.
+func TestCapabilitySatisfies_RequiresModelInstalledBypassesRAMGate(t *testing.T) {
+	req := foremanv1alpha1.RequiredCapability{
+		Accelerator:            "metal",
+		MinRAMGB:               8, // higher than the node's available RAM
+		RequiresModelInstalled: true,
+	}
+	node := nodeWithCapability(foremanv1alpha1.FleetNodeCapability{
+		Accelerator:     "metal",
+		AvailableRAMGB:  7, // below MinRAMGB on purpose
+		InstalledModels: []string{"devstral-24b"},
+	})
+
+	if !capabilitySatisfies(req, "devstral-24b", node) {
+		t.Fatalf("expected match: model loaded on node, RAM gate should be bypassed")
+	}
+}
+
+// RequiresModelInstalled with the required model absent from the node
+// must NOT match: the whole point is to pin the task to the model's home.
+func TestCapabilitySatisfies_RequiresModelInstalledButModelAbsent(t *testing.T) {
+	req := foremanv1alpha1.RequiredCapability{
+		Accelerator:            "metal",
+		RequiresModelInstalled: true,
+	}
+	node := nodeWithCapability(foremanv1alpha1.FleetNodeCapability{
+		Accelerator:     "metal",
+		AvailableRAMGB:  64,
+		InstalledModels: []string{"qwen3-coder-30b"},
+	})
+
+	if capabilitySatisfies(req, "devstral-24b", node) {
+		t.Fatalf("expected no match: required model not in node's installedModels")
+	}
+}
+
+// RequiresModelInstalled with no resolvable model name is a
+// misconfiguration; the matcher cannot confirm residency, so it must
+// not match rather than silently bypassing the gate.
+func TestCapabilitySatisfies_RequiresModelInstalledWithEmptyModel(t *testing.T) {
+	req := foremanv1alpha1.RequiredCapability{
+		Accelerator:            "metal",
+		RequiresModelInstalled: true,
+	}
+	node := nodeWithCapability(foremanv1alpha1.FleetNodeCapability{
+		Accelerator:     "metal",
+		AvailableRAMGB:  64,
+		InstalledModels: []string{"devstral-24b"},
+	})
+
+	if capabilitySatisfies(req, "", node) {
+		t.Fatalf("expected no match: no resolvable model to confirm residency")
+	}
+}
+
+// Default path (RequiresModelInstalled unset) keeps enforcing minRAMGB.
+func TestCapabilitySatisfies_DefaultStillEnforcesRAMGate(t *testing.T) {
+	req := foremanv1alpha1.RequiredCapability{
+		Accelerator: "metal",
+		MinRAMGB:    32,
+	}
+	node := nodeWithCapability(foremanv1alpha1.FleetNodeCapability{
+		Accelerator:    "metal",
+		AvailableRAMGB: 16, // below MinRAMGB
+	})
+
+	if capabilitySatisfies(req, "", node) {
+		t.Fatalf("expected no match: 16 < 32 and RequiresModelInstalled not set")
+	}
+}

--- a/pkg/agent/memory_darwin.go
+++ b/pkg/agent/memory_darwin.go
@@ -42,27 +42,42 @@ func (p *DarwinMemoryProvider) TotalMemory() (uint64, error) {
 }
 
 // AvailableMemory returns an estimate of available memory by parsing vm_stat output.
-// It sums free and inactive pages multiplied by the page size.
 // Apple Silicon uses 16KB pages.
 func (p *DarwinMemoryProvider) AvailableMemory() (uint64, error) {
 	out, err := exec.Command("vm_stat").Output()
 	if err != nil {
 		return 0, fmt.Errorf("vm_stat: %w", err)
 	}
+	return availableBytesFromVMStat(string(out)), nil
+}
 
-	pageSize, bodyLines := parseVMStatHeader(string(out))
+// availableBytesFromVMStat computes available memory from raw vm_stat
+// output. Pure (no exec) so it can be unit-tested with a fixture.
+func availableBytesFromVMStat(output string) uint64 {
+	pageSize, bodyLines := parseVMStatHeader(output)
 
-	var freePages, inactivePages uint64
+	// macOS treats free, inactive, speculative, and purgeable pages as
+	// reclaimable/available (matching Activity Monitor's "memory
+	// available" heuristic). Counting only free+inactive severely
+	// undercounts on a host with a Metal-wired model loaded, where a
+	// large fraction of RAM is wired and the rest of the available
+	// budget lives in speculative + purgeable. See defilantech/LLMKube#578.
+	var freePages, inactivePages, speculativePages, purgeablePages uint64
 	for _, line := range bodyLines {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "Pages free:") {
+		switch {
+		case strings.HasPrefix(line, "Pages free:"):
 			freePages = parseVMStatValue(line)
-		} else if strings.HasPrefix(line, "Pages inactive:") {
+		case strings.HasPrefix(line, "Pages inactive:"):
 			inactivePages = parseVMStatValue(line)
+		case strings.HasPrefix(line, "Pages speculative:"):
+			speculativePages = parseVMStatValue(line)
+		case strings.HasPrefix(line, "Pages purgeable:"):
+			purgeablePages = parseVMStatValue(line)
 		}
 	}
 
-	return (freePages + inactivePages) * pageSize, nil
+	return (freePages + inactivePages + speculativePages + purgeablePages) * pageSize
 }
 
 // WiredMemory returns the amount of wired (non-pageable) memory by parsing vm_stat.

--- a/pkg/agent/memory_darwin_test.go
+++ b/pkg/agent/memory_darwin_test.go
@@ -1,0 +1,70 @@
+//go:build darwin
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import "testing"
+
+// Representative vm_stat output from an Apple Silicon host with a large
+// Metal-wired model loaded: most RAM sits in "wired down", and the
+// reclaimable budget is spread across free, inactive, speculative, and
+// purgeable. macOS counts all four as "available". Regression fixture
+// for defilantech/LLMKube#578.
+const sampleVMStat = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                          58000.
+Pages active:                       450000.
+Pages inactive:                     440000.
+Pages speculative:                   20000.
+Pages throttled:                         0.
+Pages wired down:                  1250000.
+Pages purgeable:                     30000.
+Pages stored in compressor:         100000.
+Pages occupied by compressor:        40000.
+File-backed pages:                  300000.
+Anonymous pages:                    590000.
+`
+
+func TestAvailableBytesFromVMStat_IncludesPurgeableAndSpeculative(t *testing.T) {
+	const pageSize uint64 = 16384
+	// free + inactive + speculative + purgeable
+	want := uint64(58000+440000+20000+30000) * pageSize
+
+	got := availableBytesFromVMStat(sampleVMStat)
+
+	if got != want {
+		t.Fatalf("availableBytesFromVMStat = %d, want %d (free+inactive+speculative+purgeable)", got, want)
+	}
+}
+
+// A node that omits the optional speculative/purgeable lines must still
+// compute free+inactive without error (older macOS / unusual output).
+func TestAvailableBytesFromVMStat_ToleratesMissingOptionalLines(t *testing.T) {
+	const out = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                          58000.
+Pages inactive:                     440000.
+Pages wired down:                  1250000.
+`
+	const pageSize uint64 = 16384
+	want := uint64(58000+440000) * pageSize
+
+	got := availableBytesFromVMStat(out)
+
+	if got != want {
+		t.Fatalf("availableBytesFromVMStat = %d, want %d (free+inactive only)", got, want)
+	}
+}


### PR DESCRIPTION
## What

Two paired scheduling fixes for the macOS warm-driver (reviewer) path:

1. **macOS available-RAM probe** (#578): `DarwinMemoryProvider.AvailableMemory` now counts purgeable + speculative pages on top of free + inactive, matching the macOS "memory available" heuristic.
2. **Capability matcher** (#579): new `RequiredCapability.requiresModelInstalled`. When set, scheduling requires the Agent's resolved model to be present in the node's `installedModels` and skips the `minRAMGB` gate (the model is already loaded, so the loop needs ~0 additional RAM).

## Why

Fixes #578
Fixes #579

During the v0.4 reviewer rerun-10 (2026-05-27), three `devstral-24b` reviewer tasks sat `Pending` for >45 minutes while qwen reviewers ran normally. Two separate bugs combined:

- A 36 GB Mac with a Metal-wired model reported `availableRAMGB` ~7 GB, because the probe ignored purgeable + speculative pages (most RAM shows as `wired`).
- Even with the correct number, `minRAMGB` is the wrong predicate for a reviewer Agent whose model is already resident: that gate is sized for the cold-load path. Hand-patching `minRAMGB` to 1 unblocked scheduling within one poll interval.

Together they unblock the v0.2 reviewer step.

## How

- Extracted vm_stat parsing into a pure `availableBytesFromVMStat` helper so it is unit-testable with a fixture (no `exec`); added purgeable + speculative to the reclaimable sum. The unreliable "compressor-recoverable" term is deliberately not included.
- Added `requiresModelInstalled` to `RequiredCapability`. The reconciler resolves the Agent's model identity (`spec.model`, falling back to `inferenceServiceRef` name) and threads it into the matcher. With the flag set, `installedModels` membership is required and `minRAMGB` is bypassed; an empty/unresolvable model fails the match rather than silently bypassing the gate. Default behavior (flag unset) is unchanged.
- CRDs regenerated and synced to `charts/foreman`.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint` for the build-tagged darwin file)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change) — the new field is self-documented via its CRD description; a Foreman-docs mention of `requiresModelInstalled` can follow.

## Notes for deployment

- For #579 to take effect, the reviewer Agent CR needs `requiredCapability.requiresModelInstalled: true` (and `spec.model` if the InferenceService name does not match the node's `installedModels` entry).
- Both fixes require the rebuilt foreman-agent / metal-agent binary on the macOS node.
