### PR TITLE
fix(foreman): recover orphaned phase=Running tasks on agent restart (#542)

### DIFF
--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -104,6 +104,14 @@ func (w *AgenticTaskWatcher) Run(ctx context.Context) error {
 
 	log.Info("starting", "interval", interval.String(), "namespace", ns, "executor", w.Executor.Kind())
 
+	// Recover any tasks orphaned in phase=Running by a previous agent
+	// process (crash, OOM, launchctl bounce) before we start polling, so
+	// the scheduler can re-dispatch them. Best-effort: a failure here is
+	// logged but must not prevent the poll loop from starting.
+	if err := w.recoverOrphanedTasks(ctx, ns); err != nil {
+		log.Error(err, "orphaned task recovery failed; continuing to poll loop")
+	}
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -125,6 +133,63 @@ func (w *AgenticTaskWatcher) Run(ctx context.Context) error {
 			consecutiveFails = 0
 		}
 	}
+}
+
+// recoverOrphanedTasks runs once at startup, before the poll loop. It
+// resets AgenticTasks left in phase=Running on this node by a previous
+// (now-dead) agent process. The poll loop only dispatches phase=Scheduled,
+// so without this a crashed or bounced agent would orphan its in-flight
+// task forever (it stays Running with a stale claimedAt and is never
+// re-examined). Reset-to-Pending is the simplest correct recovery so the
+// scheduler re-dispatches the work; resume-from-transcript is a future
+// refinement. Fixes defilantech/LLMKube#542.
+func (w *AgenticTaskWatcher) recoverOrphanedTasks(ctx context.Context, namespace string) error {
+	log := logf.FromContext(ctx).WithName("agentictask-watcher").WithValues("node", w.NodeName)
+
+	var list foremanv1alpha1.AgenticTaskList
+	if err := w.Client.List(ctx, &list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("list AgenticTasks for recovery: %w", err)
+	}
+
+	recovered := 0
+	for i := range list.Items {
+		t := &list.Items[i]
+		if t.Status.AssignedNode != w.NodeName || t.Status.Phase != foremanv1alpha1.AgenticTaskPhaseRunning {
+			continue
+		}
+		if err := w.resetOrphanedTask(ctx, t); err != nil {
+			// Best-effort: log and continue. A transient patch failure
+			// should not block the poll loop from starting; the next
+			// agent restart will retry.
+			log.Error(err, "failed to recover orphaned task", "task", t.Name)
+			continue
+		}
+		recovered++
+		log.Info("reset orphaned task to Pending for re-dispatch", "task", t.Name)
+	}
+	if recovered > 0 {
+		log.Info("orphaned task recovery complete", "recovered", recovered)
+	}
+	return nil
+}
+
+// resetOrphanedTask flips an orphaned Running task back to Pending and
+// clears the dead PID's claim, so the scheduler re-dispatches it.
+func (w *AgenticTaskWatcher) resetOrphanedTask(ctx context.Context, t *foremanv1alpha1.AgenticTask) error {
+	patch := client.MergeFrom(t.DeepCopy())
+	now := metav1.Now()
+	t.Status.Phase = foremanv1alpha1.AgenticTaskPhasePending
+	t.Status.AssignedNode = ""
+	t.Status.ClaimedAt = nil
+	t.Status.StartedAt = nil
+	setCondition(&t.Status.Conditions, metav1.Condition{
+		Type:               "Running",
+		Status:             metav1.ConditionFalse,
+		Reason:             "AgentRestartRecovery",
+		Message:            fmt.Sprintf("reset to Pending: %s restarted while this task was Running", w.NodeName),
+		LastTransitionTime: now,
+	})
+	return w.Client.Status().Patch(ctx, t, patch)
 }
 
 // pollOnce runs a single List() pass and dispatches any task assigned to

--- a/pkg/foreman/agent/watcher_recovery_test.go
+++ b/pkg/foreman/agent/watcher_recovery_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func newRecoveryClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objs...).
+		WithStatusSubresource(&foremanv1alpha1.AgenticTask{}).
+		Build()
+}
+
+func runningTask(name, node string) *foremanv1alpha1.AgenticTask {
+	now := metav1.Now()
+	return &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status: foremanv1alpha1.AgenticTaskStatus{
+			Phase:        foremanv1alpha1.AgenticTaskPhaseRunning,
+			AssignedNode: node,
+			ClaimedAt:    &now,
+			StartedAt:    &now,
+		},
+	}
+}
+
+func getTask(t *testing.T, c client.Client, name string) foremanv1alpha1.AgenticTask {
+	t.Helper()
+	var got foremanv1alpha1.AgenticTask
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: name}, &got); err != nil {
+		t.Fatalf("get %s: %v", name, err)
+	}
+	return got
+}
+
+// A task left Running by a dead PID on this node must be reset to Pending
+// with assignedNode/claimedAt/startedAt cleared and a recovery condition,
+// so the scheduler re-dispatches it. Regression for defilantech/LLMKube#542.
+func TestRecoverOrphanedTasks_ResetsRunningTaskOnThisNode(t *testing.T) {
+	c := newRecoveryClient(t, runningTask("code-531", "m5max-coder"))
+	w := &AgenticTaskWatcher{Client: c, NodeName: "m5max-coder", Namespace: "default"}
+
+	if err := w.recoverOrphanedTasks(context.Background(), "default"); err != nil {
+		t.Fatalf("recoverOrphanedTasks: %v", err)
+	}
+
+	got := getTask(t, c, "code-531")
+	if got.Status.Phase != foremanv1alpha1.AgenticTaskPhasePending {
+		t.Fatalf("phase = %q, want Pending", got.Status.Phase)
+	}
+	if got.Status.AssignedNode != "" {
+		t.Fatalf("assignedNode = %q, want cleared", got.Status.AssignedNode)
+	}
+	if got.Status.ClaimedAt != nil || got.Status.StartedAt != nil {
+		t.Fatalf("claimedAt=%v startedAt=%v, want both cleared", got.Status.ClaimedAt, got.Status.StartedAt)
+	}
+	found := false
+	for _, cond := range got.Status.Conditions {
+		if cond.Reason == "AgentRestartRecovery" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an AgentRestartRecovery condition, got %+v", got.Status.Conditions)
+	}
+}
+
+// A Running task assigned to a different node is not this agent's to
+// recover; leave it untouched.
+func TestRecoverOrphanedTasks_IgnoresOtherNode(t *testing.T) {
+	c := newRecoveryClient(t, runningTask("other-node-task", "some-other-node"))
+	w := &AgenticTaskWatcher{Client: c, NodeName: "m5max-coder", Namespace: "default"}
+
+	if err := w.recoverOrphanedTasks(context.Background(), "default"); err != nil {
+		t.Fatalf("recoverOrphanedTasks: %v", err)
+	}
+
+	got := getTask(t, c, "other-node-task")
+	if got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseRunning {
+		t.Fatalf("phase = %q, want Running (untouched)", got.Status.Phase)
+	}
+}
+
+// Tasks on this node that are not Running (e.g. Scheduled) must not be
+// disturbed: only orphaned in-flight work is recovered.
+func TestRecoverOrphanedTasks_IgnoresNonRunningPhase(t *testing.T) {
+	scheduled := runningTask("scheduled-task", "m5max-coder")
+	scheduled.Status.Phase = foremanv1alpha1.AgenticTaskPhaseScheduled
+	c := newRecoveryClient(t, scheduled)
+	w := &AgenticTaskWatcher{Client: c, NodeName: "m5max-coder", Namespace: "default"}
+
+	if err := w.recoverOrphanedTasks(context.Background(), "default"); err != nil {
+		t.Fatalf("recoverOrphanedTasks: %v", err)
+	}
+
+	got := getTask(t, c, "scheduled-task")
+	if got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseScheduled {
+		t.Fatalf("phase = %q, want Scheduled (untouched)", got.Status.Phase)
+	}
+}


### PR DESCRIPTION
## What

Add startup recovery for AgenticTasks orphaned in `phase=Running` by a previous foreman-agent process. On startup, before the poll loop, the watcher lists tasks assigned to this node still in `Running` and resets each to `Pending` (clearing `assignedNode` / `claimedAt` / `startedAt` and recording an `AgentRestartRecovery` condition), so the scheduler re-dispatches them.

## Why

Fixes #542

The watcher only dispatches `phase=Scheduled`. If the agent crashes, is OOM-killed, or is bounced (`launchctl bootout`/`bootstrap`) while a task is `Running`, the replacement agent never re-examines it: the task stays `Running` with a stale `claimedAt` forever, and manual `kubectl patch --subresource=status` was the only recovery. This bit the Memorial Day v5 batch (`memorial-day-v5-code-531` stranded after a SIGQUIT goroutine-dump bounce).

## How

- `recoverOrphanedTasks` runs once at the top of `Run`, before the ticker loop. It lists AgenticTasks in the watched namespace and, for any with `assignedNode == myNodeName && phase == Running`, calls `resetOrphanedTask`.
- `resetOrphanedTask` flips the task to `Pending`, clears `assignedNode`/`claimedAt`/`startedAt` via a status merge patch, and records a `Running=False, reason=AgentRestartRecovery` condition. The scheduler then re-schedules it on its normal Pending path.
- Best-effort: a recovery failure is logged and the poll loop still starts (a transient apiserver error must not wedge the agent).
- Reset-to-Pending is the simplest correct recovery. Resume-from-transcript (continuing the in-flight task) is a deliberate follow-up if/when the value justifies the complexity.

## Checklist

- [x] Tests added/updated (reset path + ignores-other-node + ignores-non-Running guards; RED→GREEN)
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change) — no user-facing surface change; behavioral recovery only.
