### PR TITLE
fix(metal-agent): prefer routable interface for host-IP auto-detect (#526)

### DIFF
--- a/pkg/agent/hostip_test.go
+++ b/pkg/agent/hostip_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"net"
+	"testing"
+)
+
+func cand(iface, ip string) hostIPCandidate {
+	return hostIPCandidate{iface: iface, ip: net.ParseIP(ip)}
+}
+
+// The reported failure: a Mac with LAN, Tailscale, and a vmnet bridge.
+// Auto-detect must pick the Tailscale address and reject the bridge.
+// Regression for defilantech/LLMKube#526.
+func TestSelectHostIP_PrefersTailscaleAndExcludesBridge(t *testing.T) {
+	candidates := []hostIPCandidate{
+		cand("en0", "192.168.1.47"),
+		cand("utun3", "100.116.176.101"),
+		cand("bridge100", "192.168.65.254"),
+	}
+
+	chosen, ok, rejected := selectHostIP(candidates)
+	if !ok {
+		t.Fatalf("expected a chosen IP, got none")
+	}
+	if chosen.ip.String() != "100.116.176.101" {
+		t.Fatalf("chosen = %s, want Tailscale 100.116.176.101", chosen.ip)
+	}
+	if !rejectedContains(rejected, "192.168.65.254") {
+		t.Fatalf("expected 192.168.65.254 to be rejected, got %+v", rejected)
+	}
+}
+
+// With no Tailscale interface, fall through to the primary LAN address,
+// still excluding the bridge.
+func TestSelectHostIP_FallsBackToLAN(t *testing.T) {
+	candidates := []hostIPCandidate{
+		cand("bridge100", "192.168.65.254"),
+		cand("en0", "192.168.1.47"),
+	}
+
+	chosen, ok, _ := selectHostIP(candidates)
+	if !ok {
+		t.Fatalf("expected a chosen IP, got none")
+	}
+	if chosen.ip.String() != "192.168.1.47" {
+		t.Fatalf("chosen = %s, want LAN 192.168.1.47", chosen.ip)
+	}
+}
+
+// Docker (172.17/16) and kind/service (10.96/12) ranges are bridge/NAT
+// nets and must never be chosen.
+func TestSelectHostIP_ExcludesDockerAndKindNets(t *testing.T) {
+	candidates := []hostIPCandidate{
+		cand("docker0", "172.17.0.1"),
+		cand("kind", "10.96.0.1"),
+		cand("en0", "10.0.0.5"),
+	}
+
+	chosen, ok, _ := selectHostIP(candidates)
+	if !ok || chosen.ip.String() != "10.0.0.5" {
+		t.Fatalf("chosen = %v (ok=%v), want routable 10.0.0.5", chosen.ip, ok)
+	}
+}
+
+// Only loopback and a bridge present: nothing routable, return ok=false
+// so the caller can fall back rather than registering a bad address.
+func TestSelectHostIP_NoRoutableInterface(t *testing.T) {
+	candidates := []hostIPCandidate{
+		cand("lo0", "127.0.0.1"),
+		cand("bridge100", "192.168.65.7"),
+		cand("llw0", "169.254.1.2"),
+	}
+
+	if _, ok, _ := selectHostIP(candidates); ok {
+		t.Fatalf("expected no routable IP, but one was chosen")
+	}
+}
+
+func rejectedContains(rejected []rejectedHostIP, ip string) bool {
+	for _, r := range rejected {
+		if r.ip == ip {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -291,13 +291,162 @@ func sanitizeServiceName(name string) string {
 
 // resolveHostIP returns the IP address that Kubernetes uses to reach this host.
 // If an explicit hostIP was provided via --host-ip, that value is returned.
-// Otherwise it falls back to DNS auto-detection (host.minikube.internal,
-// host.docker.internal) for co-located setups.
+// Otherwise it inspects the host's interfaces and applies selectHostIP's
+// preference order (Tailscale > primary LAN, excluding bridge/NAT ranges),
+// which a remote cluster or tailnet peer can actually route to. Only when no
+// routable interface exists does it fall back to the legacy DNS detection for
+// co-located minikube / Docker Desktop setups. Fixes defilantech/LLMKube#526.
 func (r *ServiceRegistry) resolveHostIP() string {
 	if r.hostIP != "" {
 		return r.hostIP
 	}
-	return getHostIP()
+
+	candidates := gatherHostIPCandidates()
+	chosen, ok, rejected := selectHostIP(candidates)
+	if ok {
+		r.logger.Infow("auto-detected host IP",
+			"ip", chosen.ip.String(),
+			"interface", chosen.iface,
+			"rejected", formatRejected(rejected),
+		)
+		return chosen.ip.String()
+	}
+
+	fallback := getHostIP()
+	r.logger.Warnw("no routable interface for host-IP auto-detect; using co-located DNS fallback",
+		"ip", fallback,
+		"rejected", formatRejected(rejected),
+	)
+	return fallback
+}
+
+// gatherHostIPCandidates enumerates the host's up, non-loopback interfaces
+// and returns their unicast addresses as host-IP candidates.
+func gatherHostIPCandidates() []hostIPCandidate {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	var out []hostIPCandidate
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			var ip net.IP
+			switch v := a.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil {
+				continue
+			}
+			out = append(out, hostIPCandidate{iface: iface.Name, ip: ip})
+		}
+	}
+	return out
+}
+
+// formatRejected renders rejected candidates as "iface=ip (reason)" strings
+// for a single structured log field.
+func formatRejected(rejected []rejectedHostIP) []string {
+	out := make([]string, 0, len(rejected))
+	for _, r := range rejected {
+		out = append(out, fmt.Sprintf("%s=%s (%s)", r.iface, r.ip, r.reason))
+	}
+	return out
+}
+
+// hostIPCandidate is a usable address discovered on a host network interface.
+type hostIPCandidate struct {
+	iface string
+	ip    net.IP
+}
+
+// rejectedHostIP records a candidate the selector skipped and why, so the
+// chosen-vs-rejected decision is visible in logs without a debug rerun.
+type rejectedHostIP struct {
+	iface  string
+	ip     string
+	reason string
+}
+
+// selectHostIP applies the host-IP preference policy to a candidate list:
+// Tailscale (100.64.0.0/10 CGNAT) first, then any other routable IPv4,
+// excluding loopback, link-local, and bridge/NAT ranges (lima/colima
+// vmnet, Docker, kind/service nets). Returns ok=false when nothing
+// routable is found so the caller can fall back. Pure for unit testing.
+func selectHostIP(candidates []hostIPCandidate) (chosen hostIPCandidate, ok bool, rejected []rejectedHostIP) {
+	var tailscale, lan *hostIPCandidate
+	for i := range candidates {
+		c := candidates[i]
+		ip4 := c.ip.To4()
+		switch {
+		case ip4 == nil:
+			rejected = append(rejected, rejectedHostIP{c.iface, c.ip.String(), "not IPv4"})
+		case c.ip.IsLoopback():
+			rejected = append(rejected, rejectedHostIP{c.iface, c.ip.String(), "loopback"})
+		case c.ip.IsLinkLocalUnicast():
+			rejected = append(rejected, rejectedHostIP{c.iface, c.ip.String(), "link-local"})
+		case inAnyNet(ip4, excludedHostNets):
+			rejected = append(rejected, rejectedHostIP{c.iface, c.ip.String(), "bridge/NAT range"})
+		case tailscaleCGNAT.Contains(ip4):
+			if tailscale == nil {
+				cc := c
+				tailscale = &cc
+			}
+		default:
+			if lan == nil {
+				cc := c
+				lan = &cc
+			}
+		}
+	}
+	switch {
+	case tailscale != nil:
+		return *tailscale, true, rejected
+	case lan != nil:
+		return *lan, true, rejected
+	default:
+		return hostIPCandidate{}, false, rejected
+	}
+}
+
+// tailscaleCGNAT is the 100.64.0.0/10 carrier-grade NAT range Tailscale
+// assigns to tailnet nodes; preferred because a remote cluster joined to
+// the same tailnet can always reach it.
+var tailscaleCGNAT = mustParseCIDR("100.64.0.0/10")
+
+// excludedHostNets are bridge / NAT / service ranges a remote cluster or
+// peer cannot route to: lima/colima/Docker-Desktop vmnet, the Docker
+// default bridge, and the kind / Kubernetes service CIDR.
+var excludedHostNets = []*net.IPNet{
+	mustParseCIDR("192.168.65.0/24"), // lima / colima / Docker Desktop vmnet
+	mustParseCIDR("172.17.0.0/16"),   // Docker default bridge
+	mustParseCIDR("10.96.0.0/12"),    // kind / Kubernetes service CIDR
+}
+
+func mustParseCIDR(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(fmt.Sprintf("invalid CIDR %q: %v", s, err))
+	}
+	return n
+}
+
+func inAnyNet(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // getHostIP returns the auto-detected IP address that Kubernetes can use to


### PR DESCRIPTION
## What

Replace the metal-agent's host-IP auto-detect with interface-based selection that prefers a routable address. Preference order: Tailscale (`100.64.0.0/10` CGNAT) > primary LAN, excluding loopback, link-local, and bridge/NAT ranges (lima/colima/Docker-Desktop vmnet `192.168.65.0/24`, Docker bridge `172.17.0.0/16`, kind/service `10.96.0.0/12`). The legacy DNS detection remains only as a last-resort fallback when no routable interface exists.

## Why

Fixes #526

`getHostIP()` resolved `host.minikube.internal` (or hard-fell-back to `192.168.65.254`). On a multi-NIC Mac that yields a vmnet bridge address, which is unreachable from a remote cluster or tailnet peer. The bad IP was then advertised in the Service's Endpoints, silently breaking every cross-cluster InferenceService on a Tailscale-joined fleet. The only workaround was passing `--host-ip` explicitly. Observed 2026-05-24 on the M5 Max: auto-detect picked `192.168.65.254` while ShadowStack reached the host over Tailscale at `100.116.176.101`.

## How

- `selectHostIP([]hostIPCandidate)` is a pure function implementing the preference/exclusion policy and returning the chosen candidate plus the rejected ones with reasons. Unit-tested against a fake interface list (the reported Tailscale+LAN+bridge case, LAN fallback, Docker/kind exclusion, and the no-routable case).
- `gatherHostIPCandidates()` enumerates up, non-loopback interfaces; `resolveHostIP()` runs selection, logs the chosen interface and each rejected candidate with its reason, and falls back to the legacy DNS path only when nothing routable is found.
- Explicit `--host-ip` still short-circuits everything (loopback opt-in unchanged).

## Checklist

- [x] Tests added/updated (`selectHostIP` table cases; RED→GREEN)
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change) — `--host-ip` flag help already documents auto-detect; behavior is now more correct.

## Note

Behavior change for co-located minikube on a host that also has a LAN interface: auto-detect now prefers the LAN address over the `192.168.65.254` bridge. Such setups can still pin the bridge with `--host-ip 192.168.65.254` if their pods reach the host only via that NAT gateway.
