### PR TITLE
fix(foreman): split per-turn timeout from loop-wide budget (#532)

### DIFF
--- a/api/foreman/v1alpha1/agent_types.go
+++ b/api/foreman/v1alpha1/agent_types.go
@@ -222,13 +222,28 @@ type AgentSpec struct {
 	// +optional
 	StuckLoopDetection *StuckLoopDetectionSpec `json:"stuckLoopDetection,omitempty"`
 
-	// RequestTimeoutSeconds bounds a single chat-completions HTTP
-	// request. Long-context decode on a local model can be slow; default
-	// is generous.
-	// +kubebuilder:default=600
+	// RequestTimeoutSeconds is the loop-wide wall-clock budget for the
+	// whole agent run (#532). When the budget is exhausted mid-turn the
+	// loop exits gracefully with an INCOMPLETE verdict and the partial
+	// transcript preserved, rather than failing the task with a
+	// retry-less ExecutorError. This is distinct from the per-request
+	// header timeout (RequestTurnTimeoutSeconds): a single slow turn no
+	// longer caps the whole loop, and vice versa.
+	// +kubebuilder:default=3600
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	RequestTimeoutSeconds int32 `json:"requestTimeoutSeconds,omitempty"`
+
+	// RequestTurnTimeoutSeconds bounds a single chat-completions HTTP
+	// request's "awaiting response headers" wait, i.e. how long the agent
+	// waits for the first token of one turn before treating the request
+	// as a transient timeout and retrying it (up to MaxRetries). Keep this
+	// tight relative to RequestTimeoutSeconds so a slow warm-context turn
+	// fails fast and retries instead of hanging out the whole loop budget.
+	// +kubebuilder:default=120
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	RequestTurnTimeoutSeconds int32 `json:"requestTurnTimeoutSeconds,omitempty"`
 
 	// BashTimeoutSeconds bounds a single bash tool invocation. The bash
 	// tool runs under "sh -c" with cwd pinned to the workspace and a

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -220,11 +220,27 @@ spec:
                     type: string
                 type: object
               requestTimeoutSeconds:
-                default: 600
+                default: 3600
                 description: |-
-                  RequestTimeoutSeconds bounds a single chat-completions HTTP
-                  request. Long-context decode on a local model can be slow; default
-                  is generous.
+                  RequestTimeoutSeconds is the loop-wide wall-clock budget for the
+                  whole agent run (#532). When the budget is exhausted mid-turn the
+                  loop exits gracefully with an INCOMPLETE verdict and the partial
+                  transcript preserved, rather than failing the task with a
+                  retry-less ExecutorError. This is distinct from the per-request
+                  header timeout (RequestTurnTimeoutSeconds): a single slow turn no
+                  longer caps the whole loop, and vice versa.
+                format: int32
+                minimum: 1
+                type: integer
+              requestTurnTimeoutSeconds:
+                default: 120
+                description: |-
+                  RequestTurnTimeoutSeconds bounds a single chat-completions HTTP
+                  request's "awaiting response headers" wait, i.e. how long the agent
+                  waits for the first token of one turn before treating the request
+                  as a transient timeout and retrying it (up to MaxRetries). Keep this
+                  tight relative to RequestTimeoutSeconds so a slow warm-context turn
+                  fails fast and retries instead of hanging out the whole loop budget.
                 format: int32
                 minimum: 1
                 type: integer

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -220,11 +220,27 @@ spec:
                     type: string
                 type: object
               requestTimeoutSeconds:
-                default: 600
+                default: 3600
                 description: |-
-                  RequestTimeoutSeconds bounds a single chat-completions HTTP
-                  request. Long-context decode on a local model can be slow; default
-                  is generous.
+                  RequestTimeoutSeconds is the loop-wide wall-clock budget for the
+                  whole agent run (#532). When the budget is exhausted mid-turn the
+                  loop exits gracefully with an INCOMPLETE verdict and the partial
+                  transcript preserved, rather than failing the task with a
+                  retry-less ExecutorError. This is distinct from the per-request
+                  header timeout (RequestTurnTimeoutSeconds): a single slow turn no
+                  longer caps the whole loop, and vice versa.
+                format: int32
+                minimum: 1
+                type: integer
+              requestTurnTimeoutSeconds:
+                default: 120
+                description: |-
+                  RequestTurnTimeoutSeconds bounds a single chat-completions HTTP
+                  request's "awaiting response headers" wait, i.e. how long the agent
+                  waits for the first token of one turn before treating the request
+                  as a transient timeout and retrying it (up to MaxRetries). Keep this
+                  tight relative to RequestTimeoutSeconds so a slow warm-context turn
+                  fails fast and retries instead of hanging out the whole loop budget.
                 format: int32
                 minimum: 1
                 type: integer

--- a/config/foreman/agents/claude-sonnet-cloud-reviewer.yaml
+++ b/config/foreman/agents/claude-sonnet-cloud-reviewer.yaml
@@ -73,12 +73,15 @@ spec:
   temperature: "0.2"
   maxTurns: 30
   maxRetries: 2
-  # Cloud-proxy reviewers should be fast; if the proxy is slow we
-  # want to know quickly. The upstream model itself may take longer
-  # to think; this bounds the time we wait for the HEADER of the
-  # streaming response, not the total body duration. Total is
-  # bounded by the Agent's MaxTurns + the AgenticTask's TimeoutSeconds.
-  requestTimeoutSeconds: 300
+  # Cloud-proxy reviewers should be fast; if the proxy is slow we want to
+  # know quickly. requestTurnTimeoutSeconds bounds the wait for the HEADER
+  # of one streaming response (not the total body); a turn over the limit
+  # is retried up to maxRetries. requestTimeoutSeconds is the loop-wide
+  # wall-clock budget (#532): the review ends INCOMPLETE with its transcript
+  # preserved if it fires. Total is also bounded by the Agent's MaxTurns and
+  # the AgenticTask's TimeoutSeconds.
+  requestTurnTimeoutSeconds: 300
+  requestTimeoutSeconds: 1800
   bashTimeoutSeconds: 60
 
   tools:

--- a/config/foreman/agents/devstral-24b-reviewer.yaml
+++ b/config/foreman/agents/devstral-24b-reviewer.yaml
@@ -20,7 +20,13 @@ spec:
   temperature: "0.3"
   maxTurns: 40
   maxRetries: 3
-  requestTimeoutSeconds: 900
+  # Timeouts (#532): requestTurnTimeoutSeconds bounds one HTTP request (a
+  # turn over its limit is retried up to maxRetries); requestTimeoutSeconds
+  # is the loop-wide wall-clock budget (the review ends INCOMPLETE with its
+  # transcript preserved on exhaustion). Per-turn keeps the prior 15-min
+  # per-request bound; the 1h loop budget covers a 40-turn review.
+  requestTurnTimeoutSeconds: 900
+  requestTimeoutSeconds: 3600
   bashTimeoutSeconds: 60
   tools:
     - read_file

--- a/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
+++ b/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
@@ -52,11 +52,15 @@ spec:
   # through-H reviews of multi-file diffs converge. Closes #583.
   maxTurns: 80
   maxRetries: 3
-  # 15 min per HTTP request to llama-server. Reviewers read the diff,
-  # the issue body, and a handful of files; they should never need
-  # a long-running `make test` cycle the way the coder does. If a
-  # review exceeds 15 min on a single request, something is wrong.
-  requestTimeoutSeconds: 900
+  # Timeouts (#532). requestTurnTimeoutSeconds bounds one HTTP request to
+  # llama-server; a turn over the limit is retried up to maxRetries.
+  # Reviewers read the diff, the issue body, and a handful of files; they
+  # should never need a long `make test` cycle the way the coder does, so
+  # 15 min per turn is already generous. requestTimeoutSeconds is the
+  # loop-wide budget (review ends INCOMPLETE, transcript preserved, on
+  # exhaustion); 90 min covers an 80-turn review.
+  requestTurnTimeoutSeconds: 900
+  requestTimeoutSeconds: 5400
   bashTimeoutSeconds: 60
   # Reviewer tool whitelist: read-only. No write_file, no str_replace.
   # If the reviewer needs to recommend a change, it says so in the

--- a/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
+++ b/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
@@ -49,12 +49,17 @@ spec:
     editFreeTurnsLimit: 15
     contextSoftCap: 90000
     contextHardCap: 140000
-  # 30 min per HTTP request to llama-server. With the tool-output caps
-  # in pkg/foreman/agent/tools (read_file at 16 KiB default + ranged reads,
-  # bash at 16 KiB per stream) this is well above the natural per-turn
-  # ceiling but gives headroom for issues that legitimately need long
-  # bash invocations (e.g. `make test` on a cold gate-cache).
-  requestTimeoutSeconds: 1800
+  # Timeouts (#532). requestTurnTimeoutSeconds bounds one HTTP request to
+  # llama-server (the wait for the first token of a turn); a turn that
+  # exceeds it is retried up to maxRetries. requestTimeoutSeconds is the
+  # loop-wide wall-clock budget for the whole task; when it fires the loop
+  # ends with an INCOMPLETE verdict and the partial transcript preserved.
+  # The per-turn value keeps the previous 30-min per-request headroom for
+  # long-context prompt-eval on Carnice; the 2h loop budget comfortably
+  # covers an 80-turn run. Tighten requestTurnTimeoutSeconds toward the
+  # 120s default to fail fast and retry sooner on a warm, degraded context.
+  requestTurnTimeoutSeconds: 1800
+  requestTimeoutSeconds: 7200
   bashTimeoutSeconds: 60
   tools:
     - read_file

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -294,7 +294,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	}
 	oaiClient := oai.New(
 		endpoint.baseURL,
-		durationFromSeconds(agent.Spec.RequestTimeoutSeconds, 600),
+		// Per-request header timeout (#532): how long one turn waits for
+		// the first token before retrying. The loop-wide budget is
+		// applied separately via LoopConfig.LoopBudget below.
+		durationFromSeconds(agent.Spec.RequestTurnTimeoutSeconds, 120),
 		int(agent.Spec.MaxRetries),
 		oaiOpts...,
 	)
@@ -348,6 +351,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		ContextWindowTokens:    int(agent.Spec.ContextWindowTokens),
 		ObservationWindowTurns: int(agent.Spec.ObservationWindowTurns),
 		Progress:               progressConfigFromAgent(agent),
+		// Loop-wide wall-clock budget (#532). Repurposed from the old
+		// per-request meaning of RequestTimeoutSeconds; the per-request
+		// header timeout now lives on the OAI client above.
+		LoopBudget: durationFromSeconds(agent.Spec.RequestTimeoutSeconds, 3600),
 	}
 
 	// 8. Run the loop. Always persist the transcript afterwards,

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -109,6 +109,16 @@ type LoopConfig struct {
 	// The executor maps Agent.spec.stuckLoopDetection here; an unset
 	// Agent CR field yields DefaultProgressConfig.
 	Progress ProgressConfig
+
+	// LoopBudget is the loop-wide wall-clock ceiling (#532). When > 0 the
+	// loop wraps its context with this deadline; if a turn's request is
+	// still pending when the budget fires, the loop exits gracefully with
+	// an INCOMPLETE terminal (transcript preserved) rather than bubbling a
+	// retry-less error that kills the AgenticTask. <= 0 disables it (only
+	// MaxTurns and the per-request timeout bound the run). The executor
+	// maps Agent.spec.requestTimeoutSeconds here; the per-request header
+	// timeout is the separate Agent.spec.requestTurnTimeoutSeconds.
+	LoopBudget time.Duration
 }
 
 // DefaultContextWindowTokens is the budget used when LoopConfig.ContextWindowTokens
@@ -161,6 +171,35 @@ var ErrMaxTurnsExhausted = errors.New("loop: max turns exhausted")
 // surfaces in AgenticTask.status.result.
 const StuckLoopOutcome = "STUCK-LOOP-DETECTED"
 
+// LoopBudgetOutcome is the value the loop sets in
+// LoopResult.Terminal.Extra["outcome"] when LoopConfig.LoopBudget is
+// exhausted mid-turn (#532). Like the stuck-loop case, the loop returns
+// a nil error with a populated INCOMPLETE terminal so the executor's
+// normal terminal-handling path persists the partial transcript instead
+// of recording a retry-less ExecutorError.
+const LoopBudgetOutcome = "LOOP-BUDGET-EXHAUSTED"
+
+// LoopBudgetExhaustedEnvelope synthesizes the INCOMPLETE terminal the
+// loop returns when its wall-clock budget fires. turn is the turn that
+// was in flight when the deadline hit.
+func LoopBudgetExhaustedEnvelope(turn int) *ToolResult {
+	const summary = "loop wall-clock budget exhausted before the agent finished"
+	return &ToolResult{
+		Terminal:      true,
+		Verdict:       "INCOMPLETE",
+		Summary:       summary,
+		CommitMessage: "",
+		Output: map[string]any{
+			"verdict": "INCOMPLETE",
+			"summary": summary,
+		},
+		Extra: map[string]any{
+			"outcome":       LoopBudgetOutcome,
+			"terminateTurn": turn,
+		},
+	}
+}
+
 // ErrAssistantNoToolCalls is returned when the model replies with text
 // only and no tool_calls. The loop has no way to make forward progress
 // in that case because every agent ends through submit_result. We
@@ -204,6 +243,16 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	if cfg.ObservationWindowTurns <= 0 {
 		cfg.ObservationWindowTurns = DefaultObservationWindowTurns
 	}
+	// Loop-wide wall-clock budget (#532). Distinct from the per-request
+	// header timeout baked into the OAI client: this bounds the whole
+	// run, so one slow long-context turn can't hang past the budget, and
+	// the per-request timeout can stay tight without doubling as the
+	// loop cap.
+	if cfg.LoopBudget > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cfg.LoopBudget)
+		defer cancel()
+	}
 	res := &LoopResult{
 		Transcript: []oai.Message{
 			{Role: oai.RoleSystem, Content: cfg.SystemPrompt},
@@ -225,6 +274,15 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 		turnErr := l.runOneTurn(ctx, cfg, schemas, res)
 		if turnErr != nil {
 			if errors.Is(turnErr, errTerminalReached) {
+				return res, nil
+			}
+			// Loop-wide budget exhausted: exit gracefully with an
+			// INCOMPLETE terminal so the executor persists the partial
+			// transcript instead of recording a retry-less ExecutorError
+			// (#532). Only the loop's own deadline maps here; an external
+			// cancellation (context.Canceled) still propagates as an error.
+			if cfg.LoopBudget > 0 && errors.Is(turnErr, context.DeadlineExceeded) {
+				res.Terminal = LoopBudgetExhaustedEnvelope(turn)
 				return res, nil
 			}
 			return res, turnErr

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -190,6 +190,58 @@ func newTestLoop(srv *httptest.Server, reg ToolRegistry) *Loop {
 	return NewLoop(client, reg, nil)
 }
 
+// blockingOAIServer never sends a response; it holds each request open
+// until the client's context is cancelled. Simulates a turn whose
+// prompt-eval is so slow that the loop's wall-clock budget fires before
+// any headers arrive (the #532 failure shape).
+func blockingOAIServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hold the request open until the client gives up, but bound the
+		// block so srv.Close() in t.Cleanup never hangs if the client-side
+		// cancellation is slow to propagate to the server context.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestLoop_LoopBudgetExhausted_GracefulTerminal(t *testing.T) {
+	// A turn that never returns before the loop-wide budget fires must
+	// end the loop gracefully: an INCOMPLETE terminal with the transcript
+	// preserved, NOT a hard error that the executor maps to a retry-less
+	// ExecutorError that kills the whole AgenticTask. Regression for #532.
+	srv := blockingOAIServer(t)
+	// Generous per-request timeout so the loop budget, not the per-turn
+	// header timeout, is the thing that fires.
+	client := oai.New(srv.URL+"/v1", 10*time.Second, 0)
+	reg := &fakeRegistry{results: map[string]*ToolResult{}}
+	loop := NewLoop(client, reg, nil)
+
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model:        "test",
+		SystemPrompt: "sys",
+		UserPrompt:   "go",
+		MaxTurns:     50,
+		LoopBudget:   80 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("expected graceful nil error on budget exhaustion, got %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "INCOMPLETE" {
+		t.Fatalf("expected INCOMPLETE terminal, got %+v", res.Terminal)
+	}
+	if got := res.Terminal.Extra["outcome"]; got != LoopBudgetOutcome {
+		t.Errorf("outcome: want %q got %v", LoopBudgetOutcome, got)
+	}
+	if len(res.Transcript) < 2 || res.Transcript[0].Role != oai.RoleSystem {
+		t.Errorf("transcript not preserved: %+v", res.Transcript)
+	}
+}
+
 func TestLoop_HappyPath_TerminalSubmitResult(t *testing.T) {
 	srv, calls := scriptedOAIServer(t, []string{toolCallReadFile, toolCallSubmitGo})
 	reg := &fakeRegistry{

--- a/pkg/foreman/agent/oai/client.go
+++ b/pkg/foreman/agent/oai/client.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -141,12 +142,33 @@ func (c *Client) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, erro
 		if err == nil {
 			return resp, nil
 		}
-		if !errors.Is(err, ErrTruncatedToolCallArguments) {
+		// Never retry once the parent context is done: a loop-wide budget
+		// (#532) or external cancellation must propagate so the caller can
+		// exit gracefully instead of spinning retries against a model that
+		// will not answer in time. Checked before classification because a
+		// context deadline also satisfies net.Error.Timeout().
+		if ctx.Err() != nil {
 			return nil, err
 		}
-		lastErr = err
+		// Retry a truncated tool-call stream (a streaming hiccup) and a
+		// transient per-request header timeout (slow prompt-eval on a warm
+		// long context, #532). Any other error is returned as-is.
+		if errors.Is(err, ErrTruncatedToolCallArguments) || isRetryableTimeout(err) {
+			lastErr = err
+			continue
+		}
+		return nil, err
 	}
 	return nil, fmt.Errorf("after %d retries: %w", c.maxRetries, lastErr)
+}
+
+// isRetryableTimeout reports whether err is a network timeout (e.g. the
+// transport's ResponseHeaderTimeout firing while awaiting the first
+// token). Callers must rule out a done parent context first, since
+// context.DeadlineExceeded also satisfies net.Error.Timeout().
+func isRetryableTimeout(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
 }
 
 // sleepBackoff blocks for backoffs[i] +/- 20% jitter, honoring ctx

--- a/pkg/foreman/agent/oai/client_test.go
+++ b/pkg/foreman/agent/oai/client_test.go
@@ -228,6 +228,70 @@ func TestClient_Chat_RetriesTruncatedThenSucceeds(t *testing.T) {
 	}
 }
 
+func TestClient_Chat_RetriesHeaderTimeoutThenSucceeds(t *testing.T) {
+	// A per-request header timeout (the #532 shape: prompt-eval so slow
+	// the first token never arrives within requestTimeout) should be
+	// retried, not surfaced as a hard error. First attempt stalls past
+	// the 60ms header timeout; the retry responds immediately.
+	var attempts atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			time.Sleep(250 * time.Millisecond) // > requestTimeout, no headers
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(chatResponseToSSE(t, okBodyOneToolCall)))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", 60*time.Millisecond, 3, WithBackoffs(noJitterBackoffs))
+	resp, err := c.Chat(context.Background(), ChatRequest{Model: "test"})
+	if err != nil {
+		t.Fatalf("Chat should recover from a transient header timeout via retry, got: %v", err)
+	}
+	if got := attempts.Load(); got < 2 {
+		t.Errorf("expected at least one retry after the header timeout; attempts=%d", got)
+	}
+	if resp.Choices[0].Message.ToolCalls[0].Function.Name != "read_file" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+}
+
+func TestClient_Chat_NoRetryWhenContextDone(t *testing.T) {
+	// When the parent context is done (e.g. the loop-wide budget fired),
+	// a timeout must propagate immediately so the loop sees
+	// context.DeadlineExceeded and exits gracefully, rather than being
+	// swallowed by a retry storm against a model that won't answer.
+	var attempts atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+	}))
+	defer srv.Close()
+
+	// Generous per-request timeout; the short parent deadline is what fires.
+	c := New(srv.URL+"/v1", 5*time.Second, 3, WithBackoffs(noJitterBackoffs))
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := c.Chat(ctx, ChatRequest{Model: "test"})
+	if err == nil {
+		t.Fatal("expected an error when the parent context expires")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error chain must include context.DeadlineExceeded, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("Chat should return promptly on ctx expiry, took %s (retry storm?)", elapsed)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("must not retry once the parent ctx is done; attempts=%d", got)
+	}
+}
+
 func TestClient_Chat_ExhaustsRetries(t *testing.T) {
 	var attempts atomic.Int64
 	srv := httptest.NewServer(scriptedHandler(t, &attempts,


### PR DESCRIPTION
> [!WARNING]
> **Behavior change (breaking, surfaced as a `BREAKING CHANGE:` footer).**
> `Agent.spec.requestTimeoutSeconds` changes meaning from a *per-request* HTTP
> timeout to a *loop-wide wall-clock budget*, and its default moves **600 → 3600**.
> The former per-request bound is now the new **`requestTurnTimeoutSeconds`** (default 120).
> An Agent that set a low `requestTimeoutSeconds` for per-request bounding will now have
> its **entire run** capped at that value — move that bound to `requestTurnTimeoutSeconds`.
> This bumps the next release to **0.9.0** (pre-1.0 breaking change). The example Agent CRs
> in `config/foreman/agents/` have been migrated to the two-knob model (per-request behavior
> preserved, plus a generous loop budget); operators should sanity-check the values for their
> own hardware.
>
> **Scope:** this is confined to Foreman. Non-Foreman llmkube users (the inference
> operator, `Model`/`InferenceService` only) are unaffected — the change lives in the
> `foreman-agent` binary and the `foreman.llmkube.dev/Agent` CRD, a separate add-on
> chart. `cmd/main.go` imports no Foreman code and `charts/llmkube` ships no Foreman CRDs.
>
> **Upgrade step:** kubebuilder defaults apply only at create/update, so Agents already
> in a cluster inherit the new 120s `requestTurnTimeoutSeconds` default until re-applied.
> After upgrading, `kubectl apply` the updated `config/foreman/agents/*.yaml` so existing
> Agents pick up explicit per-turn / loop-budget values.

## What

Splits the single `Agent.spec.requestTimeoutSeconds` knob into two: a tight per-turn HTTP header timeout and a separate loop-wide wall-clock budget, and makes a transient per-turn timeout retryable instead of fatal.

## Why

Fixes #532

The one timeout (default 600s) served as both "how long a turn waits for the first token" and the de facto ceiling on the whole run. On a warm long-context loop, prompt-eval latency could push a single turn past 600s "awaiting headers"; the timeout fired in the OAI client's non-retry path, so the entire AgenticTask died with a retry-less `ExecutorError` even though the model was healthy (a fresh smoke test returned 94 tok/s right after).

## How

- **`Agent.spec.requestTurnTimeoutSeconds`** (new, default 120s): the per-request "awaiting headers" bound. A timeout here is now treated as transient and retried up to `MaxRetries`, so a slow warm-context turn fails fast and gets another chance instead of being surfaced as a hard error.
- **`Agent.spec.requestTimeoutSeconds`** (default bumped 600 → 3600): repurposed as the loop-wide wall-clock budget. The loop wraps its context with this deadline; when it fires mid-turn the loop returns a graceful `INCOMPLETE` terminal with the partial transcript preserved (`LoopBudgetOutcome`), not a retry-less `ExecutorError`.
- The OAI client never retries once the parent context is done, so a loop-budget deadline (or external cancellation) propagates cleanly rather than being swallowed by a retry storm. Guarded before timeout classification because `context.DeadlineExceeded` also satisfies `net.Error.Timeout()`.

Design note: this matches option (1) in the issue (cleanest minimum surface). The metal-agent context-watchdog (option 2) is the longer-term complement and stays out of scope.

## Checklist

- [x] Tests added/updated (loop budget → graceful terminal; client retries a transient header timeout; client does not retry once ctx is done)
- [x] `make test` passes locally (foreman packages + api)
- [x] `make lint` passes locally (native + `GOOS=linux`)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (if user-facing change) — CRD field docs are inline on the spec; no separate docs page references the old field

