### PR TITLE
fix(controller): recreate InferenceService Deployment on immutable selector change (#606)

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -247,6 +248,34 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	} else if err != nil {
 		log.Error(err, "Failed to get Deployment")
 		return nil, 0, nil, err
+	}
+
+	// Deployment.spec.selector is immutable. A Deployment created by an older
+	// operator version can carry a smaller selector than we now generate
+	// (pre-0.8 used {app: <name>}; we now also add inference.llmkube.dev/service).
+	// An in-place Update then fails permanently with "field is immutable" and
+	// the controller hot-loops (#606). Migrate by recreating the Deployment
+	// with the correct selector. This is a one-time, logged recreate; the
+	// brief pod churn is unavoidable for an immutable-selector change.
+	if !apiequality.Semantic.DeepEqual(existingDeployment.Spec.Selector, deployment.Spec.Selector) {
+		log.Info("Deployment selector changed; recreating (selector is immutable)",
+			"name", deployment.Name,
+			"oldSelector", existingDeployment.Spec.Selector,
+			"newSelector", deployment.Spec.Selector)
+		if err := r.Delete(ctx, existingDeployment); err != nil && !apierrors.IsNotFound(err) {
+			log.Error(err, "Failed to delete stale Deployment for selector migration")
+			return nil, 0, nil, err
+		}
+		if err := r.Create(ctx, deployment); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// The old Deployment is still terminating; recreate on the
+				// next reconcile once its deletion has propagated.
+				return nil, 0, &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			}
+			log.Error(err, "Failed to recreate Deployment after selector change")
+			return nil, 0, nil, err
+		}
+		return deployment, 0, nil, nil
 	}
 
 	// Snapshot externally-set template metadata before the wholesale

--- a/internal/controller/inferenceservice_selector_migration_test.go
+++ b/internal/controller/inferenceservice_selector_migration_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Regression for #606: a Deployment created by an older operator carries a
+// smaller pod selector (pre-0.8: {app: <name>}) than the current operator
+// generates ({app, inference.llmkube.dev/service}). Deployment.spec.selector
+// is immutable, so an in-place Update fails forever with "field is immutable".
+// The controller must migrate it by recreating the Deployment.
+var _ = Describe("InferenceService Deployment selector migration (#606)", func() {
+	const modelName = "sel-mig-model"
+	const serviceName = "sel-mig-svc"
+	ctx := context.Background()
+	nn := types.NamespacedName{Name: serviceName, Namespace: "default"}
+
+	BeforeEach(func() {
+		model := &inferencev1alpha1.Model{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, model); err != nil && errors.IsNotFound(err) {
+			Expect(k8sClient.Create(ctx, &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:       "https://huggingface.co/test/model.gguf",
+					Format:       "gguf",
+					Quantization: "Q4_K_M",
+					Hardware:     &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+					Resources:    &inferencev1alpha1.ResourceRequirements{CPU: "1", Memory: "1Gi"},
+				},
+			})).To(Succeed())
+		}
+		isvc := &inferencev1alpha1.InferenceService{}
+		if err := k8sClient.Get(ctx, nn, isvc); err != nil && errors.IsNotFound(err) {
+			replicas := int32(1)
+			Expect(k8sClient.Create(ctx, &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server",
+				},
+			})).To(Succeed())
+		}
+	})
+
+	AfterEach(func() {
+		isvc := &inferencev1alpha1.InferenceService{}
+		if err := k8sClient.Get(ctx, nn, isvc); err == nil {
+			Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+		}
+		model := &inferencev1alpha1.Model{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, model); err == nil {
+			Expect(k8sClient.Delete(ctx, model)).To(Succeed())
+		}
+		dep := &appsv1.Deployment{}
+		if err := k8sClient.Get(ctx, nn, dep); err == nil {
+			Expect(k8sClient.Delete(ctx, dep)).To(Succeed())
+		}
+	})
+
+	It("recreates a Deployment whose selector predates the inference.llmkube.dev/service label", func() {
+		By("seeding a pre-0.8 Deployment with the old {app} selector only")
+		replicas := int32(1)
+		oldSelector := map[string]string{"app": serviceName}
+		Expect(k8sClient.Create(ctx, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: oldSelector},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: oldSelector},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Name:  "server",
+						Image: "ghcr.io/ggml-org/llama.cpp:server",
+					}}},
+				},
+			},
+		})).To(Succeed())
+
+		By("reconciling the Deployment with the model marked ready")
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		isvc := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, nn, isvc)).To(Succeed())
+		model := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, model)).To(Succeed())
+		_, _, _, err := reconciler.reconcileDeployment(ctx, isvc, model, 1, true, false)
+		Expect(err).NotTo(HaveOccurred(), "controller must migrate the selector, not loop on an immutable update")
+
+		By("the Deployment now carries the current selector")
+		migrated := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, nn, migrated)).To(Succeed())
+		Expect(migrated.Spec.Selector.MatchLabels).To(
+			HaveKeyWithValue("inference.llmkube.dev/service", serviceName),
+			"selector should have been migrated to the operator-managed label set",
+		)
+	})
+})


### PR DESCRIPTION
> [!IMPORTANT]
> **Upgrade impact (not an API break, but plan for it).** On the first reconcile
> after upgrading, each InferenceService Deployment created by a pre-0.8.0
> operator is **deleted and recreated** to migrate its immutable selector. That
> is a **one-time pod restart + model reload** for affected services (minutes of
> unavailability for large models, once). 0.8.x-created Deployments are
> unaffected.

## What

Migrates InferenceService Deployments whose pod selector predates the current operator's selector label set, by recreating them instead of hot-looping on an immutable in-place update.

## Why

Fixes #606

A Deployment created by an older operator carries a smaller selector than 0.8.x generates (pre-0.8: `{app: <name>}`; now also `inference.llmkube.dev/service: <name>`). `Deployment.spec.selector` is immutable, so `reconcileDeployment`'s wholesale `Spec` replace + `Update` failed forever with `field is immutable`, and the controller hot-looped, unable to reconcile any pre-0.8 InferenceService Deployment. Observed live after upgrading a cluster to 0.8.1 (~14 errors/min across every pre-0.8 service).

## How

In `reconcileDeployment`, after fetching the existing Deployment, compare its selector against the desired one. On mismatch (immutable), delete and recreate the Deployment with the correct selector; if the old one is still terminating, requeue. One-time, logged recreate; the brief pod churn is unavoidable for an immutable-selector change. Service selectors are mutable and unaffected.

## Testing

New envtest spec (`inferenceservice_selector_migration_test.go`) seeds a Deployment with the pre-0.8 `{app}`-only selector and calls `reconcileDeployment` with the model ready, asserting the selector is migrated to the current label set with no error. Because envtest runs a real apiserver, the immutable-selector rejection is genuine, so the test is red before the fix and green after.

## Checklist

- [x] Tests added/updated (envtest regression, faithful red-before-fix)
- [x] `make test` passes locally (full controller suite green)
- [x] `make lint` passes locally (native + `GOOS=linux`)
- [x] Commit signed off (DCO)
- [x] No CRD/RBAC/API changes (controller logic only)

