### PR TITLE
feat(metal-agent): stable host-side client proxy on a fixed port (#406)

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -61,6 +61,7 @@ type AgentConfig struct {
 	MLXServerBin              string
 	MLXServerPort             int
 	Port                      int
+	ClientPort                int
 	LogLevel                  string
 	HostIP                    string
 	MemoryFraction            float64
@@ -245,6 +246,8 @@ func main() {
 	flag.StringVar(&cfg.MLXServerBin, "mlx-server-bin", "", "Path to mlx-server binary (auto-detected if not set)")
 	flag.IntVar(&cfg.MLXServerPort, "mlx-server-port", 8080, "Fixed port for the mlx-server runtime")
 	flag.IntVar(&cfg.Port, "port", 9090, "Agent metrics/health port")
+	flag.IntVar(&cfg.ClientPort, "client-port", 9999,
+		"Stable host-side listener (127.0.0.1:<port>) that forwards /v1/* to the current inference child; 0 disables")
 	flag.StringVar(&cfg.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	flag.StringVar(&cfg.HostIP, "host-ip", "", "IP address to register in Kubernetes endpoints (auto-detected if empty)")
 	flag.Float64Var(&cfg.MemoryFraction, "memory-fraction", 0,
@@ -474,6 +477,7 @@ func main() {
 		MLXServerBin:              cfg.MLXServerBin,
 		MLXServerPort:             cfg.MLXServerPort,
 		Port:                      cfg.Port,
+		ClientPort:                cfg.ClientPort,
 		HostIP:                    cfg.HostIP,
 		Logger:                    logger,
 		MemoryFraction:            cfg.MemoryFraction,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -62,8 +62,13 @@ type MetalAgentConfig struct {
 	ModelStorePath string
 	LlamaServerBin string
 	Port           int
-	HostIP         string // explicit IP to register in K8s endpoints; empty = auto-detect
-	Logger         *zap.SugaredLogger
+	// ClientPort is the host-side client-proxy listener port (#406). When > 0
+	// the agent serves a stable 127.0.0.1:<ClientPort> endpoint that forwards
+	// to the current child's dynamic port, so host tools need not track it.
+	// 0 disables the proxy.
+	ClientPort int
+	HostIP     string // explicit IP to register in K8s endpoints; empty = auto-detect
+	Logger     *zap.SugaredLogger
 
 	// EventRecorder publishes Kubernetes events on managed InferenceService
 	// objects so operators can triage memory pressure / eviction / respawn
@@ -393,6 +398,19 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		}()
 	}
 
+	// Start the host-side client proxy (#406): a stable loopback listener that
+	// forwards /v1/* to whichever child is currently running, so host tools
+	// (opencode, aider, curl) target a fixed port instead of the agent's
+	// dynamic per-spawn child port. In-cluster clients are unaffected.
+	if a.config.ClientPort > 0 {
+		cp := NewClientProxy(a, a.config.ClientPort, a.logger.With("subsystem", "client-proxy"))
+		go func() {
+			if err := cp.Start(ctx); err != nil {
+				a.logger.Errorw("client proxy stopped", "err", err)
+			}
+		}()
+	}
+
 	// Start health monitor
 	monitor := NewHealthMonitor(
 		a,
@@ -606,6 +624,33 @@ func (a *MetalAgent) validateRuntimeFormat(model *inferencev1alpha1.Model) error
 // hash; if it changed, the existing process is stopped before a fresh one is
 // spawned so the new flags actually take effect. Replicas=0 stops the process
 // without restarting.
+// currentBackend returns the loopback address of the inference child the
+// host-side client proxy should forward to, satisfying backendProvider (#406).
+// The agent tracks one process per InferenceService but in practice runs one
+// at a time on a single Mac, so we return the first running child with an
+// allocated port, preferring a healthy one. ok is false when none is running.
+func (a *MetalAgent) currentBackend() (string, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	var fallback string
+	for _, p := range a.processes {
+		if p == nil || p.Port <= 0 {
+			continue
+		}
+		addr := fmt.Sprintf("127.0.0.1:%d", p.Port)
+		if p.Healthy {
+			return addr, true
+		}
+		if fallback == "" {
+			fallback = addr
+		}
+	}
+	if fallback != "" {
+		return fallback, true
+	}
+	return "", false
+}
+
 func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.InferenceService) error {
 	key := types.NamespacedName{
 		Namespace: isvc.Namespace,

--- a/pkg/agent/agentmetrics.go
+++ b/pkg/agent/agentmetrics.go
@@ -179,8 +179,19 @@ var (
 	)
 )
 
+// clientProxyRequests counts host-side client-proxy requests by outcome
+// (no_backend, 2xx, 3xx, 4xx, 5xx, other). See ClientProxy / #406.
+var clientProxyRequests = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "llmkube_metal_agent_client_proxy_requests_total",
+		Help: "Total host-side client-proxy requests, labeled by outcome.",
+	},
+	[]string{"outcome"},
+)
+
 func init() {
 	AgentRegistry.MustRegister(
+		clientProxyRequests,
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		managedProcesses,

--- a/pkg/agent/clientproxy.go
+++ b/pkg/agent/clientproxy.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// backendProvider returns the loopback address (host:port) of the inference
+// child the client proxy should currently forward to. ok is false when no
+// child is running.
+type backendProvider interface {
+	currentBackend() (addr string, ok bool)
+}
+
+// ClientProxy is a stable host-side HTTP listener that forwards requests to
+// whichever inference child the metal-agent is currently running. The child's
+// port is allocated dynamically per spawn, so host-side clients (opencode,
+// aider, curl) point at this fixed port and never have to track the moving
+// child port. In-cluster clients are unaffected; they reach the child via the
+// agent's Endpoints registration. See #406.
+type ClientProxy struct {
+	provider backendProvider
+	port     int
+	logger   *zap.SugaredLogger
+}
+
+// NewClientProxy builds a ClientProxy. A port <= 0 means Start is a no-op
+// (the listener is disabled); ServeHTTP still works for direct testing.
+func NewClientProxy(provider backendProvider, port int, logger *zap.SugaredLogger) *ClientProxy {
+	return &ClientProxy{provider: provider, port: port, logger: logger}
+}
+
+// ServeHTTP forwards the request to the current child. When no child is
+// running it returns 503 with a JSON error body (mirroring the prior
+// standalone vllm-swift-proxy.py behavior).
+func (p *ClientProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	addr, ok := p.provider.currentBackend()
+	if !ok {
+		clientProxyRequests.WithLabelValues("no_backend").Inc()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error": "no inference process is currently running on this agent",
+		})
+		return
+	}
+
+	rp := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: "http", Host: addr})
+	// Flush each chunk immediately so SSE / stream:true completions are not
+	// buffered by the proxy.
+	rp.FlushInterval = -1
+	rp.ErrorHandler = func(rw http.ResponseWriter, _ *http.Request, err error) {
+		p.logger.Warnw("client proxy upstream error", "target", addr, "err", err.Error())
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusBadGateway)
+		_ = json.NewEncoder(rw).Encode(map[string]string{"error": "upstream inference process unreachable"})
+	}
+
+	sw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+	rp.ServeHTTP(sw, r)
+	clientProxyRequests.WithLabelValues(statusClass(sw.status)).Inc()
+}
+
+// Start runs the listener on 127.0.0.1:<port> until ctx is cancelled. A
+// non-positive port disables the proxy and returns nil immediately.
+func (p *ClientProxy) Start(ctx context.Context) error {
+	if p.port <= 0 {
+		return nil
+	}
+	srv := &http.Server{
+		Addr:              fmt.Sprintf("127.0.0.1:%d", p.port),
+		Handler:           p,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	//nolint:gosec // G118: the parent ctx is already cancelled here; graceful
+	// shutdown needs a fresh, bounded context, so context.Background is correct.
+	go func() {
+		<-ctx.Done()
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	}()
+	p.logger.Infow("client proxy listening", "addr", srv.Addr)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+// statusRecorder captures the response status for metrics while delegating
+// Flush so the reverse proxy can stream SSE responses.
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	if !s.wroteHeader {
+		s.status = code
+		s.wroteHeader = true
+	}
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusRecorder) Flush() {
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func statusClass(code int) string {
+	switch {
+	case code >= 500:
+		return "5xx"
+	case code >= 400:
+		return "4xx"
+	case code >= 300:
+		return "3xx"
+	case code >= 200:
+		return "2xx"
+	default:
+		return "other"
+	}
+}

--- a/pkg/agent/clientproxy_test.go
+++ b/pkg/agent/clientproxy_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// fakeBackend is a test backendProvider standing in for the MetalAgent's
+// view of the currently-running child process.
+type fakeBackend struct {
+	addr string
+	ok   bool
+}
+
+func (f *fakeBackend) currentBackend() (string, bool) { return f.addr, f.ok }
+
+func TestClientProxy_ForwardsToCurrentBackend(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("backend got unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","data":[]}`)
+	}))
+	defer backend.Close()
+
+	p := NewClientProxy(&fakeBackend{addr: backend.Listener.Addr().String(), ok: true}, 0, zap.NewNop().Sugar())
+
+	rec := httptest.NewRecorder()
+	p.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"object":"list"`) {
+		t.Errorf("response not forwarded from backend: %q", rec.Body.String())
+	}
+}
+
+func TestClientProxy_503WhenNoBackend(t *testing.T) {
+	p := NewClientProxy(&fakeBackend{ok: false}, 0, zap.NewNop().Sugar())
+
+	rec := httptest.NewRecorder()
+	p.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: want 503 got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("503 should be JSON, got Content-Type %q", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "error") {
+		t.Errorf("503 body should carry a JSON error, got %q", rec.Body.String())
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> **Upgrade note.** The default `--client-port` is `9999`, the same port the
> legacy `~/.local/bin/vllm-swift-proxy.py` used. Stop that script before
> upgrading or the agent's listener won't bind (it logs the error and keeps
> running). Use `--client-port 0` to disable or another port to relocate.

## What

Adds a `--client-port` (default `9999`) listener to the metal-agent that forwards `/v1/*` to whichever inference child the agent is currently running, giving host-side clients a stable endpoint instead of the agent's dynamic per-spawn child port.

## Why

Fixes #406

The agent allocates a dynamic port per spawned child (llama-server / vllm-swift / mlx-server). Every agent restart or spec change moves the port, so host tools (opencode, aider, curl) had to re-discover it each time. In-cluster clients are fine (they use the Endpoints registration); host clients were not. This replaces the out-of-tree `~/.local/bin/vllm-swift-proxy.py` with an in-tree, service-managed, race-free version.

## How

- **`ClientProxy`** (`pkg/agent/clientproxy.go`): reverse-proxies to the current child's loopback address; returns `503` + JSON when no child is running; `FlushInterval = -1` so SSE / `stream: true` completions are not buffered; a per-outcome Prometheus counter (`llmkube_metal_agent_client_proxy_requests_total`) on the agent registry.
- **`MetalAgent.currentBackend()`**: returns the loopback `host:port` of the running child (prefers a healthy one), satisfying the proxy's `backendProvider`. O(1), no `ps` scraping.
- Wired via `MetalAgentConfig.ClientPort` + the `--client-port` flag; `0` disables. Listener binds `127.0.0.1` only.

## Behavior / rollout

Because the default is `9999`, an upgraded agent serves the stable endpoint automatically on next restart. Host tools can then pin a permanent `http://localhost:9999/v1` and never chase the child port again.

## Out of scope (per the issue)

- Auth on the listener (same unauthenticated-loopback posture as the script it replaces).
- Multiple concurrent children (route by `model` later); the agent runs one at a time in practice.
- TLS (loopback only).

## Checklist

- [x] Tests added (forwards to current backend; 503 JSON when none)
- [x] `go test ./pkg/agent/...` passes
- [x] `make lint` passes (native + `GOOS=linux`)
- [x] Commit signed off (DCO)
- [x] No CRD/RBAC/chart changes (agent flag only)

