### PR TITLE
ci(release): build and push llmkube-router-proxy image on release (#449)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -108,6 +108,22 @@ builds:
     env:
       - CGO_ENABLED=0
 
+  - id: llmkube-router-proxy
+    main: ./cmd/router-proxy
+    binary: router-proxy
+
+    # Linux containers only (the controller spawns the router-proxy
+    # in-cluster for ModelRouter resources).
+    goos:
+      - linux
+
+    goarch:
+      - amd64
+      - arm64
+
+    env:
+      - CGO_ENABLED=0
+
 archives:
   - id: llmkube-cli
     builds:
@@ -249,6 +265,40 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
 
+  - id: router-proxy-amd64
+    goos: linux
+    goarch: amd64
+    ids:
+      - llmkube-router-proxy
+    image_templates:
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-amd64"
+    dockerfile: Dockerfile.router-proxy.goreleaser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=llmkube-router-proxy"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
+  - id: router-proxy-arm64
+    goos: linux
+    goarch: arm64
+    ids:
+      - llmkube-router-proxy
+    image_templates:
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-arm64"
+    dockerfile: Dockerfile.router-proxy.goreleaser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=llmkube-router-proxy"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
 docker_manifests:
   - name_template: "ghcr.io/defilantech/llmkube-controller:{{ .Version }}"
     image_templates:
@@ -264,6 +314,11 @@ docker_manifests:
     image_templates:
       - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-amd64"
       - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-amd64"
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-arm64"
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"

--- a/Dockerfile.router-proxy.goreleaser
+++ b/Dockerfile.router-proxy.goreleaser
@@ -1,0 +1,15 @@
+# Dockerfile for GoReleaser builds of the router-proxy. Expects a pre-built
+# binary at the build context root; GoReleaser stages one per (goos, goarch)
+# into the docker build directory. Mirrors Dockerfile.router-proxy's runtime
+# (distroless, non-root, port 8080) but skips the in-image Go build since
+# GoReleaser already produced the binary.
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY router-proxy /usr/local/bin/router-proxy
+
+# Default HTTP port; the binary's --listen flag overrides.
+EXPOSE 8080
+
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/router-proxy"]


### PR DESCRIPTION
## What

Adds the `router-proxy` image to the GoReleaser release pipeline so every tagged release publishes `ghcr.io/defilantech/llmkube-router-proxy:<version>` alongside the controller.

## Why

Fixes #449

The release built `llmkube-controller` but not the `llmkube-router-proxy` the controller spawns for `ModelRouter` resources. The chart default `controllerManager.routerProxy.tag` was pinned to `"dev"` and users had to build the image themselves (`ImagePullBackOff` otherwise), which limited ModelRouter / routing adoption (and feeds into the enterprise gateway plan).

## How

Mirrors the controller and foreman images:
- New GoReleaser build `llmkube-router-proxy` (`./cmd/router-proxy`, linux amd64+arm64, CGO off).
- New `Dockerfile.router-proxy.goreleaser` (distroless, non-root, port 8080) that stages the prebuilt binary, matching `Dockerfile.router-proxy`'s runtime.
- Per-arch `dockers:` entries + a multi-arch `docker_manifests:` at `ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}`.

Matches existing conventions deliberately: **versioned tag only** (no `:latest`, like controller/foreman) and **no cosign** (verified: the controller/foreman images aren't signed today). The issue's "ideally :latest / digest pin" is left out to stay consistent; can revisit fleet-wide.

## Verification

- `goreleaser check` (`~> v2`): configuration is valid (only the repo's pre-existing deprecation notices remain; no new ones introduced).
- `./cmd/router-proxy` builds for `linux/amd64` and `linux/arm64`.
- Full docker buildx + push runs only at tag time in CI (no local Docker here), exactly as the controller/foreman images do.

## Out of scope (follow-up PR, per the issue)

After a release actually publishes the image: flip the chart default `controllerManager.routerProxy.tag` from `"dev"` to `""` (track chart appVersion) and remove the interim warning in `docs/site/concepts/model-router.md` + `charts/llmkube/values.yaml`. Doing it now would point the chart at an image that doesn't exist until the next release.

## Checklist

- [x] `goreleaser check` valid; both arches build
- [x] Commit signed off (DCO)
- [x] No code/CRD/chart changes (release config only)
