### PR TITLE
feat(controller): real accelerator availability check for Model status (#230)

### DIFF
--- a/charts/llmkube/templates/clusterrole.yaml
+++ b/charts/llmkube/templates/clusterrole.yaml
@@ -23,6 +23,7 @@ rules:
   - ""
   resources:
   - endpoints
+  - nodes
   - pods
   - secrets
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,7 @@ rules:
   - ""
   resources:
   - endpoints
+  - nodes
   - pods
   - secrets
   verbs:

--- a/internal/controller/gpu_resources.go
+++ b/internal/controller/gpu_resources.go
@@ -17,6 +17,7 @@ const (
 
 var (
 	nvidiaGPUResourceName    = corev1.ResourceName("nvidia.com/gpu")
+	amdGPUResourceName       = corev1.ResourceName("amd.com/gpu")
 	intelGPUResourceNameI915 = corev1.ResourceName("gpu.intel.com/i915")
 	intelGPUResourceNameXE   = corev1.ResourceName("gpu.intel.com/xe")
 )

--- a/internal/controller/model_accelerator_test.go
+++ b/internal/controller/model_accelerator_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func nodeWithCapacity(name string, res corev1.ResourceName, qty string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{res: resource.MustParse(qty)},
+		},
+	}
+}
+
+func modelWithAccelerator(accel string) *inferencev1alpha1.Model {
+	m := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"}}
+	if accel != "" {
+		m.Spec.Hardware = &inferencev1alpha1.HardwareSpec{Accelerator: accel}
+	}
+	return m
+}
+
+func newModelReconcilerWithNodes(t *testing.T, nodes ...client.Object) *ModelReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add inference: %v", err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nodes...).Build()
+	return &ModelReconciler{Client: c, Scheme: scheme}
+}
+
+func TestCheckAcceleratorAvailability(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name  string
+		accel string
+		nodes []client.Object
+		want  bool
+	}{
+		{"nil hardware is available", "", nil, true},
+		{"cpu is always available", "cpu", nil, true},
+		{"metal is assumed available (off-cluster agent)", "metal", nil, true},
+		{
+			"cuda available when a node advertises nvidia.com/gpu", "cuda",
+			[]client.Object{nodeWithCapacity("gpu1", "nvidia.com/gpu", "1")}, true,
+		},
+		{
+			"cuda unavailable when no node has a GPU", "cuda",
+			[]client.Object{nodeWithCapacity("cpu1", "cpu", "8")}, false,
+		},
+		{
+			"rocm available when a node advertises amd.com/gpu", "rocm",
+			[]client.Object{nodeWithCapacity("amd1", "amd.com/gpu", "1")}, true,
+		},
+		{
+			"rocm unavailable when only an nvidia node exists", "rocm",
+			[]client.Object{nodeWithCapacity("gpu1", "nvidia.com/gpu", "1")}, false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newModelReconcilerWithNodes(t, tc.nodes...)
+			got := r.checkAcceleratorAvailability(ctx, modelWithAccelerator(tc.accel))
+			if got != tc.want {
+				t.Errorf("accelerator %q: want %v, got %v", tc.accel, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -53,6 +53,9 @@ const (
 	// acceleratorMetal is the Model.Spec.Hardware.Accelerator value for the
 	// host metal-agent path.
 	acceleratorMetal      = "metal"
+	acceleratorCUDA       = "cuda"
+	acceleratorROCm       = "rocm"
+	acceleratorCPU        = "cpu"
 	DefaultModelCachePath = "/models"
 
 	ConditionAvailable   = "Available"
@@ -72,6 +75,7 @@ type ModelReconciler struct {
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 
 func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reconcileStart := time.Now()
@@ -150,7 +154,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		model.Status.Path = finalPath
 		model.Status.Size = formatBytes(fileInfo.Size())
 		model.Status.CacheKey = cacheKey
-		model.Status.AcceleratorReady = r.checkAcceleratorAvailability(model.Spec.Hardware)
+		model.Status.AcceleratorReady = r.checkAcceleratorAvailability(ctx, model)
 		now := metav1.Now()
 		model.Status.LastUpdated = &now
 
@@ -261,7 +265,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	model.Status.Path = finalPath
 	model.Status.Size = formatBytes(size)
 	model.Status.CacheKey = cacheKey
-	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(model.Spec.Hardware)
+	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(ctx, model)
 	now := metav1.Now()
 	model.Status.LastUpdated = &now
 
@@ -329,7 +333,7 @@ func (r *ModelReconciler) reconcilePVCSource(ctx context.Context, model *inferen
 	model.Status.Phase = PhaseReady
 	model.Status.Path = mountPath
 	model.Status.CacheKey = cacheKey
-	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(model.Spec.Hardware)
+	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(ctx, model)
 	now := metav1.Now()
 	model.Status.LastUpdated = &now
 
@@ -438,7 +442,7 @@ func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, mo
 	model.Status.Path = ""
 	model.Status.CacheKey = cacheKey
 	model.Status.Size = "0"
-	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(model.Spec.Hardware)
+	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(ctx, model)
 	now := metav1.Now()
 	model.Status.LastUpdated = &now
 
@@ -631,13 +635,54 @@ func (r *ModelReconciler) updateStatus(ctx context.Context, model *inferencev1al
 	return r.Status().Update(ctx, model)
 }
 
+// checkAcceleratorAvailability reports whether the accelerator the Model
+// requests is actually present in the cluster, so status.acceleratorReady
+// reflects reality instead of always being true (#230). CPU and an unset
+// accelerator are always available. Metal runs on an off-cluster metal-agent
+// for which the operator has no reliable in-cluster liveness signal yet, so it
+// is treated as available (probing the agent is a follow-up). GPU accelerators
+// (cuda/rocm/intel) require at least one Node advertising the matching
+// extended resource in its capacity.
+//
 //nolint:unparam
-func (r *ModelReconciler) checkAcceleratorAvailability(hardware *inferencev1alpha1.HardwareSpec) bool {
-	if hardware == nil {
+func (r *ModelReconciler) checkAcceleratorAvailability(ctx context.Context, model *inferencev1alpha1.Model) bool {
+	if model == nil || model.Spec.Hardware == nil {
 		return true
 	}
-	// TODO: implement actual GPU/Metal availability checking
-	return true
+	accel := strings.ToLower(strings.TrimSpace(model.Spec.Hardware.Accelerator))
+	switch accel {
+	case "", acceleratorCPU:
+		return true
+	case acceleratorMetal:
+		return true
+	}
+
+	var resName corev1.ResourceName
+	switch accel {
+	case acceleratorROCm:
+		resName = amdGPUResourceName
+	case acceleratorCUDA:
+		resName = nvidiaGPUResourceName
+	default:
+		// intel (and any other GPU vendor resolveGPUResourceName knows).
+		resName = resolveGPUResourceName(model)
+	}
+
+	var nodes corev1.NodeList
+	if err := r.List(ctx, &nodes); err != nil {
+		// Cannot determine availability; fail open rather than spuriously
+		// reporting the accelerator unavailable on a transient or RBAC error.
+		log.FromContext(ctx).Error(err,
+			"checkAcceleratorAvailability: listing nodes failed; assuming available",
+			"accelerator", accel)
+		return true
+	}
+	for i := range nodes.Items {
+		if q, ok := nodes.Items[i].Status.Capacity[resName]; ok && !q.IsZero() {
+			return true
+		}
+	}
+	return false
 }
 
 func formatBytes(bytes int64) string {

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -798,16 +798,9 @@ var _ = Describe("computeCacheKey", func() {
 	})
 })
 
-var _ = Describe("checkAcceleratorAvailability", func() {
-	It("should return true when hardware is nil", func() {
-		reconciler := &ModelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-		Expect(reconciler.checkAcceleratorAvailability(nil)).To(BeTrue())
-	})
-	It("should return true when hardware is non-nil", func() {
-		reconciler := &ModelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-		Expect(reconciler.checkAcceleratorAvailability(&inferencev1alpha1.HardwareSpec{Accelerator: "cuda"})).To(BeTrue())
-	})
-})
+// checkAcceleratorAvailability is covered comprehensively by the table-driven
+// TestCheckAcceleratorAvailability in model_accelerator_test.go (nil/cpu/metal
+// available; cuda/rocm gated on node capacity).
 
 var _ = Describe("copyLocalModel", func() {
 	It("should copy file successfully", func() {


### PR DESCRIPTION
## What

Replaces the always-true `checkAcceleratorAvailability` stub so `Model.status.acceleratorReady` reflects whether the requested accelerator is actually present in the cluster.

## Why

Fixes #230

The stub returned `true` for everything, so `acceleratorReady` was `true` even with no GPU in the cluster, misleading users into thinking GPU acceleration was active when it wasn't.

## How

- **nil / cpu / unset** → available (no accelerator required).
- **metal** → available. The metal-agent runs off-cluster and the operator has no reliable in-cluster liveness signal for it yet; probing it is a documented follow-up.
- **cuda / rocm / intel** → available only if at least one `Node` advertises the matching extended resource (`nvidia.com/gpu`, `amd.com/gpu`, `gpu.intel.com/*`) in its `status.capacity`. On a `List` error the check **fails open** (assumes available) rather than spuriously reporting unavailable on a transient/RBAC hiccup.
- Adds a `core/nodes` `get;list;watch` kubebuilder RBAC marker, regenerated into `config/rbac/role.yaml` and mirrored into the llmkube chart ClusterRole. The **RBAC sync check from #379 caught the chart drift** — nice validation of that guard.
- Adds `amd.com/gpu` to the known GPU resource names.

## Testing

Table-driven `TestCheckAcceleratorAvailability` (fake client) covers nil/cpu/metal (available) and cuda/rocm gated on node capacity (available with a matching node, unavailable without). Full controller envtest suite green; lint clean native + `GOOS=linux`. The prior stub-era envtest specs are superseded and removed.

## Notes / follow-up

- Metal reachability probing is deferred (needs a cross-component liveness signal for the off-cluster agent).
- Behavior change: `acceleratorReady` can now be `false` for a GPU model on a cluster with no matching GPU nodes — which is the point. It's a status/informational field, not a gate.

## Checklist

- [x] Tests added (table-driven, fake client)
- [x] `make test` passes (controller suite)
- [x] `make lint` passes (native + `GOOS=linux`)
- [x] `make check-helm-rbac` passes (chart ClusterRole synced)
- [x] Commit signed off (DCO)