### PR TITLE
fix(foreman): harden the agent loop against false-negative INCOMPLETE terminations

### DIFF
--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -119,6 +119,17 @@ type LoopConfig struct {
 	// maps Agent.spec.requestTimeoutSeconds here; the per-request header
 	// timeout is the separate Agent.spec.requestTurnTimeoutSeconds.
 	LoopBudget time.Duration
+
+	// MaxNoToolCallRetries is how many consecutive no-tool-call turns the
+	// loop tolerates by appending a forceful corrective ("call a tool; if
+	// done, call submit_result") and retrying before giving up with
+	// ErrAssistantNoToolCalls. Local models sometimes narrate their
+	// conclusion as prose instead of emitting the terminal submit_result
+	// call; a single such turn should not fail the whole task. The streak
+	// resets after any successful tool-calling turn, so only sustained
+	// narration exhausts the budget. <= 0 falls back to
+	// DefaultMaxNoToolCallRetries.
+	MaxNoToolCallRetries int
 }
 
 // DefaultContextWindowTokens is the budget used when LoopConfig.ContextWindowTokens
@@ -126,6 +137,13 @@ type LoopConfig struct {
 // the system prompt, user prompt, and a handful of recent tool results
 // (which can each be ~16 KB / ~4K tokens for a verbose `bash` output).
 const DefaultContextWindowTokens = 32768
+
+// DefaultMaxNoToolCallRetries is the number of corrective retries used
+// when LoopConfig.MaxNoToolCallRetries is <= 0. Two is enough to recover
+// a model that narrated its conclusion once or twice instead of calling
+// submit_result, without letting a model that simply refuses to call
+// tools spin to MaxTurns.
+const DefaultMaxNoToolCallRetries = 2
 
 // DefaultObservationWindowTurns is the floor used when
 // LoopConfig.ObservationWindowTurns is zero. Three recent tool results
@@ -207,6 +225,21 @@ func LoopBudgetExhaustedEnvelope(turn int) *ToolResult {
 // system-prompt iterations should make it rare.
 var ErrAssistantNoToolCalls = errors.New("loop: assistant turn had no tool_calls")
 
+// NoToolCallNudgeMessage is the corrective the loop appends as a user
+// message after a turn that returned text but no tool_calls. Every agent
+// finishes through a tool (submit_result); a prose-only reply makes no
+// forward progress. The message is forceful and unambiguous so a model
+// that narrated its conclusion converts that prose into the terminal
+// tool call on the retry. Exported so tests and callers can assert on it.
+func NoToolCallNudgeMessage() string {
+	return "Your previous reply contained no tool call. You cannot finish " +
+		"or make progress by writing prose: every action, including " +
+		"finishing, happens through a tool call. If your work is complete " +
+		"and verified, you MUST call submit_result now with your verdict " +
+		"(GO or NO_GO), a summary, and the commit message. Otherwise call " +
+		"the appropriate tool to continue. Respond with a tool call, not text."
+}
+
 // Loop runs the native agent loop against a single OAI endpoint. It is
 // safe to reuse a Loop across many Run calls; each call starts a fresh
 // transcript and is self-contained.
@@ -243,6 +276,9 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	if cfg.ObservationWindowTurns <= 0 {
 		cfg.ObservationWindowTurns = DefaultObservationWindowTurns
 	}
+	if cfg.MaxNoToolCallRetries <= 0 {
+		cfg.MaxNoToolCallRetries = DefaultMaxNoToolCallRetries
+	}
 	// Loop-wide wall-clock budget (#532). Distinct from the per-request
 	// header timeout baked into the OAI client: this bounds the whole
 	// run, so one slow long-context turn can't hang past the budget, and
@@ -261,6 +297,11 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	}
 	schemas := l.registry.Schemas()
 	monitor := NewLoopProgressMonitor(cfg.Progress)
+
+	// noToolCallStreak counts consecutive turns that returned text without
+	// a tool call. It resets to zero after any successful tool-calling
+	// turn, so only sustained narration exhausts MaxNoToolCallRetries.
+	noToolCallStreak := 0
 
 	for turn := 1; turn <= cfg.MaxTurns; turn++ {
 		res.Turns = turn
@@ -285,8 +326,29 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 				res.Terminal = LoopBudgetExhaustedEnvelope(turn)
 				return res, nil
 			}
+			// No-tool-call recovery: a prose-only reply makes no forward
+			// progress, but local models sometimes narrate their
+			// conclusion instead of calling submit_result. Append a
+			// forceful corrective and retry, bounded by
+			// MaxNoToolCallRetries, before surfacing the error. The
+			// failing assistant turn is already in the transcript, so the
+			// model sees its own prose followed by the correction.
+			if errors.Is(turnErr, ErrAssistantNoToolCalls) {
+				if noToolCallStreak < cfg.MaxNoToolCallRetries {
+					noToolCallStreak++
+					res.Transcript = append(res.Transcript, oai.Message{
+						Role:    oai.RoleUser,
+						Content: NoToolCallNudgeMessage(),
+					})
+					continue
+				}
+				return res, turnErr
+			}
 			return res, turnErr
 		}
+
+		// A successful tool-calling turn clears the no-tool-call streak.
+		noToolCallStreak = 0
 
 		// Consult the progress monitor. The most recent assistant
 		// message in the transcript has this turn's tool_calls.

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -328,13 +328,98 @@ func TestLoop_UnknownToolBecomesToolErrorMessage(t *testing.T) {
 	}
 }
 
-func TestLoop_AssistantNoToolCallsIsError(t *testing.T) {
-	srv, _ := scriptedOAIServer(t, []string{assistantNoCalls})
+func TestLoop_AssistantNoToolCalls_RetriesThenErrors(t *testing.T) {
+	// A model that replies with prose and no tool_calls cannot make
+	// forward progress, but rather than failing the whole task on the
+	// first such turn the loop appends a forceful corrective and gives the
+	// model a bounded number of chances to recover. Three consecutive
+	// no-tool-call turns (initial + 2 retries) exhausts the budget and
+	// surfaces ErrAssistantNoToolCalls.
+	srv, calls := scriptedOAIServer(t, []string{assistantNoCalls, assistantNoCalls, assistantNoCalls})
 	reg := &fakeRegistry{}
 	loop := newTestLoop(srv, reg)
-	_, err := loop.Run(context.Background(), LoopConfig{Model: "test", MaxTurns: 3})
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", MaxTurns: 10, MaxNoToolCallRetries: 2,
+	})
 	if !errors.Is(err, ErrAssistantNoToolCalls) {
-		t.Errorf("expected ErrAssistantNoToolCalls, got %v", err)
+		t.Fatalf("expected ErrAssistantNoToolCalls after retries, got %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("OAI calls: want 3 (initial + 2 retries) got %d", got)
+	}
+	// The corrective nudges must be persisted so the trajectory shows the
+	// harness tried to recover before giving up.
+	var nudges int
+	for _, m := range res.Transcript {
+		if m.Role == oai.RoleUser && m.Content == NoToolCallNudgeMessage() {
+			nudges++
+		}
+	}
+	if nudges != 2 {
+		t.Errorf("expected 2 corrective nudges in transcript, got %d", nudges)
+	}
+}
+
+func TestLoop_AssistantNoToolCalls_RecoversAfterNudge(t *testing.T) {
+	// The model narrates with no tool call on turn 1, then (after the
+	// corrective nudge) calls submit_result on turn 2. The loop must
+	// recover and finish with the model's terminal rather than fail. This
+	// is the common local-model failure: the model states its conclusion
+	// as prose instead of calling submit_result.
+	srv, calls := scriptedOAIServer(t, []string{assistantNoCalls, toolCallSubmitGo})
+	reg := &fakeRegistry{
+		results: map[string]*ToolResult{
+			"submit_result": {Terminal: true, Verdict: "GO", Summary: "done"},
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", MaxTurns: 10, MaxNoToolCallRetries: 2,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Errorf("expected GO terminal after recovery, got %+v", res.Terminal)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("OAI calls: want 2 got %d", got)
+	}
+	var sawNudge bool
+	for _, m := range res.Transcript {
+		if m.Role == oai.RoleUser && m.Content == NoToolCallNudgeMessage() {
+			sawNudge = true
+		}
+	}
+	if !sawNudge {
+		t.Errorf("expected corrective nudge in transcript before recovery")
+	}
+}
+
+func TestLoop_AssistantNoToolCalls_StreakResetsOnToolCall(t *testing.T) {
+	// A single mid-run narration followed by normal tool-calling must not
+	// accumulate toward the retry budget: the streak resets after any
+	// successful tool turn. Sequence: narrate, recover (read_file), narrate
+	// again, recover (submit_result). With a budget of 1 this would error
+	// if the streak did not reset; it must instead finish cleanly.
+	srv, _ := scriptedOAIServer(t, []string{
+		assistantNoCalls, toolCallReadFile, assistantNoCalls, toolCallSubmitGo,
+	})
+	reg := &fakeRegistry{
+		results: map[string]*ToolResult{
+			"read_file":     {Output: map[string]any{"content": "# README\n"}},
+			"submit_result": {Terminal: true, Verdict: "GO", Summary: "done"},
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", MaxTurns: 10, MaxNoToolCallRetries: 1,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Errorf("expected GO terminal, got %+v", res.Terminal)
 	}
 }
 

--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -19,6 +19,7 @@ package agent
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -325,15 +326,89 @@ func (m *LoopProgressMonitor) recordCalls(calls []oai.ToolCall) {
 // updateEditFreeStreak increments the streak counter when the turn
 // contains zero edit-producing calls; resets it when any edit tool
 // fires (including submit_result, since that means the model is
-// converging).
+// converging). A bash call that writes a workspace file (cat heredoc,
+// sed -i, tee, etc.) also counts: models routinely edit through the
+// shell instead of the write_file/str_replace tools, and the coder
+// commits with `git add -A`, so those changes are real progress.
 func (m *LoopProgressMonitor) updateEditFreeStreak(calls []oai.ToolCall) {
 	for _, tc := range calls {
 		if _, ok := editProducingTools[tc.Function.Name]; ok {
 			m.editFreeStreak = 0
 			return
 		}
+		if tc.Function.Name == "bash" && bashCallMutatesWorkspace(tc.Function.Arguments) {
+			m.editFreeStreak = 0
+			return
+		}
 	}
 	m.editFreeStreak++
+}
+
+// fileWritingBashTokens are substrings that indicate a bash command
+// mutates files in place or writes new ones.
+var fileWritingBashTokens = []string{
+	"sed -i", "tee ", "mv ", "cp ", "patch ", "dd ", "truncate ", "install ",
+}
+
+// bashCallMutatesWorkspace parses a bash tool call's JSON arguments and
+// reports whether the command likely writes a workspace file. Malformed
+// arguments are treated as non-mutating (no reset).
+func bashCallMutatesWorkspace(arguments string) bool {
+	var args struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &args); err != nil {
+		return false
+	}
+	return bashLikelyMutatesWorkspace(args.Command)
+}
+
+// bashLikelyMutatesWorkspace reports whether a bash command probably
+// writes or edits a file. It is a heuristic: the EditFreeStreak signal
+// is an early warning, not a security control, so the bias is toward
+// detecting a write. A false positive merely delays the signal; a false
+// negative force-terminates a model that is legitimately editing through
+// the shell.
+func bashLikelyMutatesWorkspace(command string) bool {
+	for _, tok := range fileWritingBashTokens {
+		if strings.Contains(command, tok) {
+			return true
+		}
+	}
+	return bashRedirectsToFile(command)
+}
+
+// bashRedirectsToFile reports whether the command contains an output
+// redirection ('>' or '>>') whose target is a real file, ignoring
+// /dev/{null,stdout,stderr} and file-descriptor duplications (2>&1, >&2).
+func bashRedirectsToFile(command string) bool {
+	for i := 0; i < len(command); i++ {
+		if command[i] != '>' {
+			continue
+		}
+		j := i + 1
+		for j < len(command) && command[j] == '>' { // collapse '>>'
+			j++
+		}
+		for j < len(command) && (command[j] == ' ' || command[j] == '\t') {
+			j++
+		}
+		if j >= len(command) || command[j] == '&' {
+			// End of string or fd duplication like '>&2'; not a file write.
+			continue
+		}
+		k := j
+		for k < len(command) && !strings.ContainsRune(" \t\n;|&)", rune(command[k])) {
+			k++
+		}
+		switch command[j:k] {
+		case "/dev/null", "/dev/stdout", "/dev/stderr":
+			continue
+		default:
+			return true
+		}
+	}
+	return false
 }
 
 // findRepeatedCall scans the recentCallHashes buffer for any hash

--- a/pkg/foreman/agent/progress_test.go
+++ b/pkg/foreman/agent/progress_test.go
@@ -180,6 +180,83 @@ func TestProgressMonitor_EditResetsStreak(t *testing.T) {
 	}
 }
 
+// TestProgressMonitor_BashFileWriteResetsStreak verifies that creating
+// or editing a workspace file through the bash tool (cat heredoc, sed
+// -i, etc.) counts as an edit. Models commonly write files via the
+// shell instead of the dedicated write_file/str_replace tools; without
+// this the EditFreeStreak detector force-terminates a run that is
+// actually making changes (observed with Gemma 4 on issue #522).
+func TestProgressMonitor_BashFileWriteResetsStreak(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{EditFreeTurnsLimit: 3})
+	transcript := []oai.Message{}
+
+	// 2 reads, then a bash heredoc that writes a new file, then 2 reads:
+	// the streak must reset on the bash write so it does NOT trip.
+	_ = mon.Observe(1, []oai.ToolCall{makeCall("a", "read_file", `{}`)}, transcript)
+	_ = mon.Observe(2, []oai.ToolCall{makeCall("b", "read_file", `{}`)}, transcript)
+	heredoc := `{"command":"cat <<EOF > charts/foreman/templates/network-policy.yaml\nkind: NetworkPolicy\nEOF"}`
+	d := mon.Observe(3, []oai.ToolCall{makeCall("c", "bash", heredoc)}, transcript)
+	if d.Action != ProgressContinue {
+		t.Fatalf("turn 3 (bash heredoc write): expected Continue; got %+v", d)
+	}
+	d = mon.Observe(4, []oai.ToolCall{makeCall("d", "read_file", `{}`)}, transcript)
+	if d.Action != ProgressContinue {
+		t.Fatalf("turn 4: expected Continue (streak reset by bash write); got %+v", d)
+	}
+	sedCmd := `{"command":"sed -i 's/a/b/' charts/foreman/values.yaml"}`
+	d = mon.Observe(5, []oai.ToolCall{makeCall("e", "bash", sedCmd)}, transcript)
+	if d.Action != ProgressContinue {
+		t.Fatalf("turn 5 (sed -i): expected Continue; got %+v", d)
+	}
+}
+
+// TestProgressMonitor_ReadOnlyBashStillTripsStreak verifies that
+// read-only bash commands (ls, helm lint, cat, redirect to /dev/null)
+// do NOT reset the streak, so a model that only inspects via the shell
+// is still caught.
+func TestProgressMonitor_ReadOnlyBashStillTripsStreak(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{EditFreeTurnsLimit: 3})
+	transcript := []oai.Message{}
+	cmds := []string{
+		`{"command":"ls -R charts/"}`,
+		`{"command":"helm lint charts/foreman"}`,
+		`{"command":"go test ./... > /dev/null 2>&1"}`,
+	}
+	var d ProgressDecision
+	for i, c := range cmds {
+		d = mon.Observe(i+1, []oai.ToolCall{makeCall("x", "bash", c)}, transcript)
+	}
+	if d.Signal != "EditFreeStreak" {
+		t.Fatalf("read-only bash should trip EditFreeStreak; got %+v", d)
+	}
+}
+
+func TestBashLikelyMutatesWorkspace(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want bool
+	}{
+		{"cat <<EOF > foo.yaml\nx\nEOF", true},
+		{"echo hi >> notes.txt", true},
+		{"sed -i 's/a/b/' f", true},
+		{"tee f.yaml", true},
+		{"mv a b", true},
+		{"cp a b", true},
+		{"patch -p1 < x.diff", true},
+		{"ls -R charts/", false},
+		{"helm lint charts/foreman", false},
+		{"cat foo.yaml", false},
+		{"grep -r foo .", false},
+		{"go test ./... > /dev/null 2>&1", false},
+		{"echo done 2>&1", false},
+	}
+	for _, c := range cases {
+		if got := bashLikelyMutatesWorkspace(c.cmd); got != c.want {
+			t.Errorf("bashLikelyMutatesWorkspace(%q)=%v want %v", c.cmd, got, c.want)
+		}
+	}
+}
+
 // TestProgressMonitor_ContextHardCapImmediate verifies the hard cap
 // force-terminates without a nudge stage.
 func TestProgressMonitor_ContextHardCapImmediate(t *testing.T) {


### PR DESCRIPTION
## What

Two fixes to the Foreman native agent loop so it stops failing tasks that are actually making progress:

1. **No-tool-call retry** (`loop.go`): a turn that returns prose with no `tool_calls` no longer fails the task immediately. The loop appends a forceful corrective ("call a tool; if done, call `submit_result`") and retries, bounded by `LoopConfig.MaxNoToolCallRetries` (default 2). The streak resets after any successful tool-calling turn, so only sustained narration exhausts the budget.

2. **Bash edits count as edits** (`progress.go`): the `EditFreeStreak` stuck-loop detector now recognizes file-mutating `bash` commands (in-place editors like `sed -i`/`tee`/`mv`/`cp`, and output redirection to a real file, ignoring `/dev/null` and fd duplications) as edits. Previously only `write_file`/`str_replace`/`submit_result` counted, so a model editing through the shell was force-terminated for "no edits." The coder commits with `git add -A`, so those changes are real.

## Why

Fixes #622

Both failure modes were observed dogfooding a Gemma 4 26B coder run: it created a NetworkPolicy via `cat <<EOF >` and edited values.yaml via `sed -i`, then was killed at turn 16 for "no edits." With these fixes the same task lands a correct `GO` + branch + `GATE-PASS`.

## How

- `MaxNoToolCallRetries` added to `LoopConfig` (default `DefaultMaxNoToolCallRetries = 2`); `Run` tracks a consecutive no-tool-call streak and appends `NoToolCallNudgeMessage()` before retrying.
- `progress.go` gains `bashLikelyMutatesWorkspace` (heuristic, biased toward detecting a write since a false positive only delays the signal while a false negative kills a working model); `updateEditFreeStreak` resets on a mutating `bash` call.
- General loop-resilience; orthogonal to the #620 Job-mode work.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (native + `GOOS=linux`)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated (if user-facing change) — N/A, internal loop behavior