### PR TITLE
feat(foreman): add opt-in NetworkPolicy to the Foreman Helm chart

### DIFF
--- a/charts/foreman/templates/network-policy.yaml
+++ b/charts/foreman/templates/network-policy.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "foreman.fullname" . }}-network-policy
+  namespace: {{ include "foreman.namespace" . }}
+  labels:
+    {{- include "foreman.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "foreman.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.operator.health.port }}
+  {{- if .Values.operator.metrics.enabled }}
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.operator.metrics.port }}
+  {{- end }}
+  egress:
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  - ports:
+    - protocol: TCP
+      port: 443
+  - ports:
+    - protocol: TCP
+      port: 8080
+  {{- with .Values.networkPolicies.additionalEgressCIDRs }}
+  - to:
+    {{- range . }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -21,6 +21,9 @@ imagePullSecrets: []
 
 # Foreman-wide policy knobs that span operator + agent. Add new
 # settings here when they are not naturally scoped to one component.
+networkPolicies:
+  enabled: false
+  additionalEgressCIDRs: []
 foreman:
   # allowCloudProviders is the cluster-wide sovereignty kill switch
   # for cloud-proxy reviewer Agents (v0.2 Day 4).


### PR DESCRIPTION
## What

Adds an opt-in `NetworkPolicy` to the Foreman Helm chart (`charts/foreman/templates/network-policy.yaml`), gated behind `networkPolicies.enabled` (default `false`), parallel to the existing `charts/llmkube/templates/network-policy.yaml`.

The policy selects the foreman pods (operator + agent) via `foreman.selectorLabels` and denies all traffic by default except:
- **Ingress:** the operator's health/probe port (`.Values.operator.health.port`, 8082) and, when `operator.metrics.enabled`, its metrics port (`.Values.operator.metrics.port`, 8081).
- **Egress:** DNS (UDP/TCP 53); HTTPS 443 (in-cluster API server via `kubernetes.default.svc` and GitHub, which the gate Job clones from); and the in-cluster InferenceService endpoint (TCP 8080) so an in-process foreman-agent can reach model endpoints.
- `additionalEgressCIDRs` escape hatch for parity with the llmkube policy.

## Why

Fixes #522

Foreman lacked the network-hardening posture the llmkube chart already ships. The policy is opt-in so it is inert by default and only enforced where operators want defense-in-depth.

## How

- Ports are taken from chart **value references** (`.Values.operator.health.port` / `.metrics.port`) rather than hardcoded, so the policy tracks the deployment. Verified by rendering `helm template --set networkPolicies.enabled=true`: the `podSelector` matches both the operator and agent pods, and the allowed ingress ports equal the operator's actual containerPorts (8082 health, 8081 metrics). The agent exposes no inbound port, so the ingress rules are inert on it.
- Mirrors the llmkube reference structure (opt-in gate, selectorLabels, DNS/HTTPS egress, additionalEgressCIDRs).

Note: this change was produced end-to-end by Foreman's agentic coder (Qwen3-Coder-30B running on-prem) against the issue, then reviewed and validated. The deterministic gate passes (`make` checks + `helm lint`).

## Checklist

- [x] Tests added/updated — N/A (Helm template only; validated via `helm template`/`helm lint`)
- [x] `make test` passes locally (gate Job: GATE-PASS)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits — please squash-merge with this PR's conventional title (the branch commit subject lacks the `feat(foreman):` prefix)
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated (if user-facing change) — consider a note in the foreman chart README for the new `networkPolicies` values (follow-up)