### PR TITLE
fix: bump Go toolchain to 1.26.4 to patch standard-library CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/defilantech/llmkube
 
-go 1.26.3
+go 1.26.4
 
 require (
+	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/prometheus/client_golang v1.23.2
@@ -36,7 +37,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect


### PR DESCRIPTION
## What

Bumps the `go` directive in `go.mod` from `1.26.3` to `1.26.4`.

## Why

`govulncheck` is failing on every open PR because go1.26.3 ships three standard-library vulnerabilities, all fixed in go1.26.4:

- **GO-2026-5039** — `net/textproto`
- **GO-2026-5038** — `mime`
- **GO-2026-5037** — `crypto/x509`

These are inherited from the toolchain on `main`, not introduced by any PR, so nothing else clears them. This bump greens `govulncheck` across all open PRs once they rebase.

## How

- One-line change to `go.mod`. Every CI job resolves the toolchain via `setup-go`'s `go-version-file: go.mod`, and the Dockerfiles use the floating `golang:1.26` tag, so the bump propagates everywhere with no other edits.
- `go.sum` is unchanged. Verified locally under go1.26.4: `go build ./...` passes and `govulncheck ./...` reports **No vulnerabilities found**.

## Checklist

- [x] Tests added/updated — N/A (toolchain bump)
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (if user-facing change) — N/A