### PR TITLE
docs(roadmap): rewrite around the heterogeneous sovereign fleet thesis + milestones

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,149 +1,124 @@
 # LLMKube Roadmap
 
-**Current Version:** 0.7.0 (released 2026-04-18)
-**Last Updated:** 2026-04-21
+**Current Version:** 0.8.1 (released 2026-06-01)
+**Last Updated:** 2026-06-08
 
 ---
 
 ## Vision
 
-Make GPU-accelerated LLM inference on Kubernetes **dead simple**. Deploy production-ready inference services in minutes, not days.
+**Run LLMs on any accelerator you own, anywhere, under one governed control plane.**
 
-**Target Users:**
-- Developers building AI-powered applications
-- Platform teams running internal LLM services
-- Organizations needing air-gapped / edge deployments
-- Anyone wanting OpenAI-compatible APIs on their own infrastructure
+LLMKube treats a fleet of mixed hardware as a single inference substrate, then layers governance on top. It exists for organizations that cannot or will not send AI workloads to a cloud API and need to run them sovereignly across the infrastructure they already operate.
+
+Two pillars:
+
+1. **Heterogeneous fleet.** NVIDIA datacenter GPUs, AMD/Intel, Apple Silicon, and edge nodes, managed by one Kubernetes operator. Apple Silicon as a first-class Kubernetes fleet member is the part nobody else does.
+2. **Sovereign and governed.** Air-gapped by design, with policy-aware routing (what data may leave the perimeter), economic accountability (what each team and model costs on your own hardware and power), SLO enforcement, and agentic batch execution on local models.
+
+**Who it's for:** platform and AI-ops teams at regulated, multi-site, or sovereignty-driven organizations (manufacturing, finance, defense, healthcare, public sector) running Kubernetes, who need production LLM inference on-prem and at the edge.
+
+Every feature ladders to one of three jobs: make the heterogeneous fleet **schedulable**, make it **governable**, or make it **economically legible**.
 
 ---
 
-## What's Working Now (v0.7.0)
+## The architecture (north star)
 
-### Core Platform
+A control plane in four planes, with strict dependency direction. Policy flows down, state flows up, the Kubernetes API server is the only shared state.
+
+- **Serving** (`Model`, `InferenceService`) schedules inference onto the fleet within declared resource and SLO limits.
+- **Policy / routing** (`ModelRouter`) is the governance boundary: all traffic, human and agentic, enters through a router that enforces data classification, SLO-aware routing, and durable audit. Nothing talks to an `InferenceService` directly in production.
+- **Economics** (InferCost, companion project) enforces token and dollar budgets synchronously and computes marginal cost per team per deployment from real hardware and power.
+- **Agentic** (Foreman) submits batch workloads to the top of the stack with budget and SLO constraints that propagate downward before a GPU cycle is spent.
+
+The current work (see milestones below) is about coupling these planes into one loop, not just shipping them as siblings.
+
+---
+
+## What's shipped (v0.8.x)
+
+### Serving core
 - Kubernetes-native CRDs (`Model`, `InferenceService`)
-- Automatic model download from HuggingFace / HTTP / PVC / local file
-- OpenAI-compatible `/v1/chat/completions` API
-- Multi-replica deployment with Horizontal Pod Autoscaling (HPA)
-- Full CLI (`llmkube deploy/list/status/delete/queue/cache/benchmark/inspect/license`)
-- Helm chart for easy installation
-- Model catalog with pre-configured models and one-command deploy
-- Air-gapped mode with `file://` and local path model sources
+- Model sources: HuggingFace / HTTP / PVC / `file://` (air-gapped), PVC-based cache with SHA256 keys
+- OpenAI-compatible `/v1/chat/completions`, multi-replica with HPA and `kubectl scale`
+- Full CLI (`deploy/list/status/queue/cache/benchmark/inspect/license`), Helm chart, model catalog
+- Runtimes: **llama.cpp** (CUDA/Metal), **vLLM** (PagedAttention), **mlx-server** (Apple Silicon MLX)
 
-### Runtime Backends (pluggable)
-- **llama.cpp** — default CPU/GPU backend with GGUF model support
-- **vLLM** — high-throughput batched inference with PagedAttention
-- **TGI** — Hugging Face Text Generation Inference
-- **PersonaPlex (Moshi)** — real-time voice/speech model serving
-- **Ollama / oMLX** — Metal-accelerated backends for Apple Silicon
+### Heterogeneous GPU + Apple Silicon fleet
+- NVIDIA (T4/L4/A100/H100/Blackwell) via CUDA 13 images; automatic GPU layer offload
+- Single-node multi-GPU sharding (layer-split and tensor-split); hybrid CPU/GPU offload for MoE
+- **Apple Silicon as a Kubernetes fleet member** via the metal-agent, with TurboQuant KV cache for long-context, memory pre-flight validation, and health monitoring
+- GPU scheduling, contention visibility (`WaitingForGPU`), priority classes, queue management
 
-### GPU Acceleration
-- NVIDIA GPU support (T4, L4, A100, H100, Blackwell) via CUDA 13 images
-- 17x performance improvement vs CPU (64+ tok/s on L4 for 3B models)
-- Automatic GPU layer offloading
-- Single-node multi-GPU sharding (layer-split and tensor-split modes, custom layer splits)
-- Hybrid GPU/CPU offloading for MoE models (CPU-resident expert layers)
-- Cost optimization (spot instances, auto-scale to zero, HPA)
+### Governance and agentic
+- **ModelRouter (Phase 1):** one OpenAI-compatible endpoint across local `InferenceService`s and external providers, with fail-closed routing for sensitive data and a per-request audit log
+- **Foreman (v0.1):** Kubernetes-native agentic pipeline (coder / verifier / reviewer) dispatched across a heterogeneous local fleet, gated against the repo's own build and tests, including Job-mode execution against in-cluster models
 
-### Apple Silicon (Metal) Support
-- Metal Agent daemon for native macOS llama-server processes
-- oMLX and Ollama as alternative Metal-native backends
-- Pre-flight memory validation with GGUF-based estimation
-- Per-model `memoryBudget` and `memoryFraction` CRD fields
-- Continuous health monitoring, agent metrics, Homebrew auto-detection
-- Heterogeneous clusters (mix NVIDIA and Apple Silicon nodes)
-
-### GPU Scheduling & Queue Management
-- GPU contention visibility (`WaitingForGPU` phase)
-- Queue position tracking for pending services
-- Priority classes (critical / high / normal / low / batch)
-- `llmkube queue` command
-
-### Observability
-- 10+ custom Prometheus metrics (downloads, phases, queues, reconciliation, HPA)
-- OpenTelemetry tracing to Tempo (gRPC port 4317)
-- GPU metrics via DCGM exporter
-- PodMonitor for inference pod scraping
-- Pre-built Grafana dashboards (operator + inference)
-- SLO alerts for GPU health and service availability
-
-### Model Management
-- PVC-based model caching with SHA256 cache keys
-- `llmkube cache` (list, clear, preload, inspect)
-- Native GGUF parser with metadata extraction
-- `llmkube inspect` for GGUF file introspection
-- License compliance scanning (`llmkube license`)
-- Init container customization with custom CA certificate support
-- Agentic-coding flags for extended reasoning and long-context workloads
-
-### Benchmarking
-- `llmkube benchmark` (load, stress, sweep modes)
-- Concurrency / context / token sweeps
-- Per-request latency (p50, p95, p99) and throughput capture
-- GPU monitoring during benchmarks
-
-### Deployment Options
-- Minikube / Kind (local dev)
-- GKE / EKS / AKS with GPU support (Terraform modules)
-- NetworkPolicy-ready Helm chart
+### Observability and economics
+- 10+ Prometheus metrics, OpenTelemetry tracing to Tempo, DCGM GPU metrics, Grafana dashboards, PodMonitor
+- **InferCost** (companion project): cost-per-token from hardware amortization + electricity + DCGM power, per-team attribution, and cloud-vs-on-prem break-even
 
 ---
 
-## Near-term Focus
+## Roadmap
 
-Direction of travel, not dated commitments. Community feedback shapes priority.
+Milestones are tracked in [GitHub Milestones](https://github.com/defilantech/LLMKube/milestones). Dates are targets, sequenced around a concrete enterprise deployment (datacenter B200 + multi-site edge fleet) landing in production in Q3 2026.
 
-### API stability (v1beta1 prep)
-- Consolidate runtime-specific config into per-runtime substructs (`LlamaCppConfig` to mirror existing `VLLMConfig` / `TGIConfig` / `PersonaPlexConfig`)
-- Replace negative-boolean flags with clearer enums (e.g., `NoKvOffload` → `KVCacheDevice`)
-- Audit `ExtraArgs` usage and promote common flags to typed fields
-- Add validating webhook (Secret existence, `MinReplicas ≤ MaxReplicas`, resource quantity strings)
-- Conversion webhook for `v1alpha1` ↔ `v1beta1`
-- Status Phase → standard Conditions migration
+### [M1: Trustworthy fleet](https://github.com/defilantech/LLMKube/milestone/1) - July 2026
+*Fix what shipped and make the fleet substrate reliable before extending it.*
 
-### Supply-chain hardening
-- cosign-sign binaries, controller images, and Helm chart
-- SBOM publication with each release
-- Checksum verification in `install.sh`
-- `govulncheck` and security linters in CI
+The heterogeneous-fleet claim is only as good as the fleet's ability to tell a live node from a dead one and to ship a correct change. This milestone closes the two correctness bugs on the core paths, adds liveness detection for fleet nodes (#627), migrates the metal-agent off deprecated `Endpoints` (#377), and lands Foreman v0.2 with a CI e2e gate.
 
-### Operator decomposition
-- Split `inferenceservice_controller.go` into focused per-concern files (model storage, HPA, scheduling, deployment builder, status)
+### [M2: Sovereign enterprise (B200-ready)](https://github.com/defilantech/LLMKube/milestone/2) - August 2026
+*The enterprise gate.*
 
----
+Multi-cluster federation (#630) so a datacenter cluster and multiple edge sites are one fleet rather than islands; NVIDIA Blackwell B200 validation (#413); air-gapped model sources (#53); declarable SLOs via Pyrra (#415); GPUQuota for multi-tenant clusters (#416); supply-chain provenance (#233); and multi-vendor GPU scheduling for AMD/Intel (#395).
 
-## Medium-term
+### [M3: Governed + heterogeneous breadth](https://github.com/defilantech/LLMKube/milestone/3) - Q4 2026
+*Make governance real, and extend the fleet's reach.*
 
-- **Distributed inference** across nodes (llama.cpp RPC, vLLM distributed)
-- **Additional GPU vendors** — AMD ROCm, Intel oneAPI
-- **Advanced autoscaling** — queue-depth and latency-based signals
-- **K3s / edge** compatibility, broader ARM64 node support
-- **Additional model formats** — SafeTensors, HuggingFace native (alongside GGUF)
-- **Cost tracking** — per-deployment cost attribution
+ModelRouter to GA (#437) with routing metrics, hierarchical budgets, and audit; **SLO-aware routing and scheduling** that turns SLOs from a dashboard into enforcement (#629); **InferCost token budgets as synchronous admission gates** rather than retrospective reports (#631); and runtime breadth across the fleet (per-CR metal runtime #525, multi-model edge serving #516, speculative decoding #502).
+
+### [M4: Foundation + depth](https://github.com/defilantech/LLMKube/milestone/4) - ongoing
+Testing and coverage, EndpointSlice migration follow-through, and depth on the Apple Silicon / TurboQuant path.
+
+### [Backlog (Q1 2027+)](https://github.com/defilantech/LLMKube/milestone/5)
+Real value, wrong moment: multi-node distributed inference via NVIDIA Dynamo (#517), signed private model registry (#22), LoRA adapters (#12), and advanced opt-in SLO auto-remediation (#10).
 
 ---
 
-## Performance Goals
+## What we focus on, and what we don't
 
-| Milestone | Target | Status |
-|-----------|--------|--------|
-| Single GPU (3B model) | >60 tok/s | ✅ Achieved (64 tok/s on L4) |
-| Multi-GPU (8B model) | >60 tok/s | ✅ Achieved (~65 tok/s on 2×RTX 5060 Ti) |
-| Multi-GPU (13B model) | >40 tok/s | ✅ Achieved (~44 tok/s on 2×RTX 5060 Ti) |
-| Multi-node (70B model) | <500 ms P99 latency | 🎯 Planned |
-| Model load time | <30 s for any model | 🎯 Planned |
+We own a compound that no single project covers: **sovereign + heterogeneous + on-prem agentic + FinOps.** We are deliberately *not* trying to win:
+
+- **Maximum throughput** at hyperscaler scale. llm-d, NVIDIA Dynamo, and AIBrix own multi-node KV-disaggregated serving for large GPU fabrics. We integrate with vLLM rather than compete on its benchmark.
+- **Day-one simplicity.** If you want the single simplest way to serve one model, other tools are simpler. We make *regulated, heterogeneous, agentic* deployments tractable, which is a different job.
+- **Single-machine Apple Silicon speed.** That is a property of the runtime (MLX, llama.cpp), which everyone shares. Our differentiator is managing a *fleet* of Apple Silicon as governed Kubernetes nodes.
 
 ---
 
-## Past Releases
+## Performance goals
 
-- **v0.7.0** — April 2026 · Hybrid CPU/GPU offload for MoE, tensor overrides, batch-size controls, runtime-resolved HF sources, agentic-coding flags, vLLM `extraArgs` passthrough (breaking)
-- **v0.6.0** — April 2026 · Pluggable runtime backends (vLLM, TGI, PersonaPlex), HPA, custom GPU layer splits, CUDA 13 default image
-- **v0.5.3** — March 2026 · oMLX and Ollama as alternative Metal runtimes; KV cache type configuration
-- **v0.5.0** — March 2026 · Metal agent, memory validation, health monitoring, benchmarking
-- **v0.4.13** — February 2026 · GGUF parser, init container customization, NetworkPolicy
-- **v0.4.9** — December 2025 · GPU scheduling & priority classes
-- **v0.4.1** — November 2025 · Persistent model cache (PVC)
-- **v0.4.0** — November 2025 · Multi-GPU support
+| Target | Status |
+|--------|--------|
+| Single GPU (3B): >60 tok/s | Achieved (64 tok/s on L4) |
+| 2-GPU consumer (26B-A4B MoE): >80 tok/s | Achieved (~87 tok/s on 2x RTX 5060 Ti) |
+| Multi-GPU (13B): >40 tok/s | Achieved (~44 tok/s on 2x RTX 5060 Ti) |
+| Multi-node (70B): <500 ms P99 | Planned (Backlog, distributed inference) |
+| Model load: <30 s any model | Planned |
+
+---
+
+## Past releases
+
+- **v0.8.1** - June 2026 · docs site restructure, Foreman overview cross-refs, release hardening
+- **v0.8.0** - May 2026 · Foreman debut (Kubernetes-native agentic coder/verifier/reviewer fleet), Intel GPU contribution
+- **v0.7.9** - May 2026 · mlx-server runtime for Apple Silicon, `kubectl scale` subresource
+- **v0.7.8** - May 2026 · ModelRouter Phase 1 (cross-engine routing, fail-closed PII routing, audit log)
+- **v0.7.7** - May 2026 · OpenShift first-class, vllm-swift + TurboQuant on Apple Silicon
+- **v0.7.0** - April 2026 · Hybrid CPU/GPU offload for MoE, runtime-resolved HF sources, agentic-coding flags
+- **v0.5.0** - March 2026 · Metal agent, memory validation, benchmarking
+- **v0.4.0** - November 2025 · Multi-GPU support
 
 See [CHANGELOG.md](CHANGELOG.md) for the full history.
 
@@ -151,62 +126,47 @@ See [CHANGELOG.md](CHANGELOG.md) for the full history.
 
 ## Principles
 
-1. **Ease of Use** — If it takes more than 5 minutes to deploy, we're doing it wrong
-2. **Show, Don't Tell** — Working examples over lengthy docs
-3. **Performance Matters** — GPU acceleration should be automatic and obvious
-4. **Production-Ready** — Observability and reliability from day one
-5. **Community-First** — Build what users need, not what we think they need
-6. **Keep it Simple** — Avoid over-engineering until there's proven demand
+1. **Sovereign by default** - no external call-home, air-gap ready, audit-trail native.
+2. **Heterogeneous, honestly** - if we claim we manage a fleet of any accelerator, a dead node must be detectable and the metal path must be genuinely Kubernetes-native.
+3. **Governance is enforcement, not a dashboard** - budgets, SLOs, and data-residency rules either gate behavior or they are not features.
+4. **Measure before claiming** - controlled benchmarks, quality anchored to speed, honest caveats. A number that looks too good is usually a broken harness.
+5. **Production-ready from day one** - observability and reliability are table stakes.
 
 ---
 
-## How to Contribute
+## How to contribute
 
-We're actively looking for contributors — especially for:
+We are actively looking for contributors, especially on the milestone themes:
 
-- Distributed inference (llama.cpp RPC, vLLM distributed)
-- Additional GPU vendors (AMD ROCm, Intel oneAPI)
-- v1beta1 API cleanup and conversion webhook
-- Additional runtime backends (SGLang, MLC-LLM, …)
-- Documentation, examples, and getting-started guides
+- Multi-cluster federation (status rollup, model distribution, federation router)
+- Multi-vendor GPU scheduling (AMD ROCm, Intel oneAPI)
+- SLO-aware routing and Pyrra integration
+- Apple Silicon / metal-agent coverage and the mlx-server path
+- Documentation, examples, and getting-started guides (see the [docs sprint](https://github.com/defilantech/LLMKube/issues/628))
 
-**Good first issues:**
-- Documentation improvements
-- Example manifests and tutorials
-- Additional model catalog entries
-- Testing on different K8s platforms
-
-**Before starting:** comment on the issue or open a [discussion](https://github.com/defilantech/LLMKube/discussions) to avoid duplicate work.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, commit conventions, and the DCO sign-off requirement.
+**Before starting:** comment on the issue or open a [discussion](https://github.com/defilantech/LLMKube/discussions) to avoid duplicate work. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, commit conventions, and the DCO sign-off requirement.
 
 ---
 
-## Release Cadence
+## Release cadence
 
-- **Patch (0.x.y)** — bug fixes, minor improvements as needed
-- **Minor (0.x.0)** — new features, mostly backward compatible (breaking changes flagged in CHANGELOG while on v0.x)
-- **Major (x.0.0)** — reserved for post-v1.0
+- **Patch (0.x.y)** - bug fixes and minor improvements as needed
+- **Minor (0.x.0)** - features, mostly backward compatible (breaking changes flagged in CHANGELOG while on v0.x)
+- **Major (x.0.0)** - reserved for post-v1.0
 
 ---
 
 ## Feedback
 
-Your feedback shapes our roadmap:
-
-- What features would make LLMKube more useful for you?
-- What's blocking production adoption?
-- Which models / use cases should we prioritize?
-
-- 💬 [GitHub Discussions](https://github.com/defilantech/LLMKube/discussions)
-- 🐛 [GitHub Issues](https://github.com/defilantech/LLMKube/issues)
-- ⭐ Star the repo if you find it useful
+- [GitHub Discussions](https://github.com/defilantech/LLMKube/discussions)
+- [GitHub Issues](https://github.com/defilantech/LLMKube/issues)
+- Star the repo if you find it useful
 
 ---
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE)
+Apache 2.0 - see [LICENSE](LICENSE)
 
 ---
 


### PR DESCRIPTION
## What

Rewrites `ROADMAP.md` (which was stale at v0.7.0 and contradicted the new GitHub milestones) to the current product thesis and the filed milestone structure.

- **Vision** reframed to "run LLMs on any accelerator you own, anywhere, under one governed control plane" (two pillars: heterogeneous fleet + sovereign governance), replacing the prior "dead simple" framing.
- **North-star architecture:** the four-plane governed loop (serving, policy/routing, economics, agentic).
- **Shipped state** refreshed to v0.8.x (ModelRouter Phase 1, Foreman v0.1, mlx-server, TurboQuant on Apple Silicon).
- **Roadmap section** replaces the undated near/medium/long-term lists with the five [GitHub Milestones](https://github.com/defilantech/LLMKube/milestones) (M1 Trustworthy fleet, M2 Sovereign enterprise / B200-ready, M3 Governed + heterogeneous breadth, M4 Foundation + depth, Backlog), each linked and with its headline issues.
- Adds a "what we focus on, and what we don't" positioning section (own sovereign + heterogeneous + agentic + FinOps; do not chase max throughput / day-one simplicity / single-machine Apple speed).
- Refreshed principles, contribute, and past-releases sections.

## Why

The public roadmap should tell the same story as the backlog. The milestones were just filed; this aligns the narrative doc with them and with the heterogeneous-sovereign-fleet thesis.

## Notes

Docs-only change. No em dashes per house style.