### PR TITLE
fix(foreman): detect stale FleetNodes via heartbeat window

### DIFF
--- a/api/foreman/v1alpha1/fleetnode_types.go
+++ b/api/foreman/v1alpha1/fleetnode_types.go
@@ -17,8 +17,16 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// FleetNodeHeartbeatTimeout is how long the controller waits past the most
+// recent heartbeat before it marks a FleetNode NotReady. The FleetAgent
+// heartbeats every 30s, so 90s tolerates two missed beats before a node is
+// declared dead.
+const FleetNodeHeartbeatTimeout = 90 * time.Second
 
 // FleetNodePhase is the heartbeat-driven health state of a fleet worker.
 // +kubebuilder:validation:Enum=Ready;Draining;NotReady;Unknown
@@ -152,6 +160,17 @@ type FleetNode struct {
 	// scheduler reads it; the agent writes it.
 	// +optional
 	Status FleetNodeStatus `json:"status,omitempty"`
+}
+
+// HeartbeatStale reports whether the node's most recent heartbeat is older
+// than FleetNodeHeartbeatTimeout relative to now. A node that has never
+// heart-beat (nil LastHeartbeatTime) is treated as stale: there is no
+// evidence the FleetAgent is alive.
+func (n *FleetNode) HeartbeatStale(now time.Time) bool {
+	if n == nil || n.Status.LastHeartbeatTime == nil {
+		return true
+	}
+	return now.Sub(n.Status.LastHeartbeatTime.Time) > FleetNodeHeartbeatTimeout
 }
 
 // +kubebuilder:object:root=true

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -257,9 +257,10 @@ func (r *AgenticTaskReconciler) firstFitNode(ctx context.Context, required forem
 	sort.Slice(nodes.Items, func(i, j int) bool {
 		return nodes.Items[i].Name < nodes.Items[j].Name
 	})
+	now := time.Now()
 	for i := range nodes.Items {
 		n := &nodes.Items[i]
-		if n.Status.Phase != foremanv1alpha1.FleetNodePhaseReady {
+		if !nodeSchedulable(n, now) {
 			continue
 		}
 		if n.Status.CurrentTask != "" {
@@ -271,6 +272,19 @@ func (r *AgenticTaskReconciler) firstFitNode(ctx context.Context, required forem
 		return n.Name, nil
 	}
 	return "", nil
+}
+
+// nodeSchedulable reports whether the scheduler may dispatch to a node. It
+// must read Phase=Ready AND have a fresh heartbeat: the FleetNodeReconciler
+// flips a dead node to NotReady, but that is level-triggered and may lag a
+// heartbeat. Re-checking staleness here (defense-in-depth) prevents
+// dispatching a task into a node whose agent has gone dark but whose phase
+// has not yet been reconciled. See defilantech/LLMKube#627.
+func nodeSchedulable(n *foremanv1alpha1.FleetNode, now time.Time) bool {
+	if n.Status.Phase != foremanv1alpha1.FleetNodePhaseReady {
+		return false
+	}
+	return !n.HeartbeatStale(now)
 }
 
 // capabilitySatisfies returns true when the node's advertised capability

--- a/internal/foreman/controller/agentictask_matcher_test.go
+++ b/internal/foreman/controller/agentictask_matcher_test.go
@@ -18,6 +18,9 @@ package controller
 
 import (
 	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
@@ -25,8 +28,50 @@ import (
 func nodeWithCapability(cap foremanv1alpha1.FleetNodeCapability) *foremanv1alpha1.FleetNode {
 	n := &foremanv1alpha1.FleetNode{}
 	n.Status.Phase = foremanv1alpha1.FleetNodePhaseReady
+	// Default to a fresh heartbeat so capability tests are not accidentally
+	// gated out by the staleness check.
+	now := metav1.Now()
+	n.Status.LastHeartbeatTime = &now
 	n.Status.Capability = cap
 	return n
+}
+
+// A node that still reads Phase=Ready but has not heart-beat within the
+// staleness window must be treated as ineligible by the scheduler: the
+// FleetAgent on it may be dead, so dispatching there is a black hole.
+// Defense-in-depth for defilantech/LLMKube#627.
+func TestNodeSchedulable_StaleHeartbeatExcludedDespiteReady(t *testing.T) {
+	now := time.Now()
+	stale := metav1.NewTime(now.Add(-2 * foremanv1alpha1.FleetNodeHeartbeatTimeout))
+	node := nodeWithCapability(foremanv1alpha1.FleetNodeCapability{Accelerator: "metal"})
+	node.Status.LastHeartbeatTime = &stale
+
+	if nodeSchedulable(node, now) {
+		t.Fatalf("expected stale-heartbeat node to be unschedulable despite Phase=Ready")
+	}
+}
+
+// A fresh Ready node is schedulable.
+func TestNodeSchedulable_FreshReadyNode(t *testing.T) {
+	now := time.Now()
+	fresh := metav1.NewTime(now.Add(-1 * time.Second))
+	node := nodeWithCapability(foremanv1alpha1.FleetNodeCapability{Accelerator: "metal"})
+	node.Status.LastHeartbeatTime = &fresh
+
+	if !nodeSchedulable(node, now) {
+		t.Fatalf("expected fresh Ready node to be schedulable")
+	}
+}
+
+// A node that has never heart-beat (nil LastHeartbeatTime) is not
+// schedulable: we have no evidence the agent is alive.
+func TestNodeSchedulable_NeverHeartbeat(t *testing.T) {
+	node := nodeWithCapability(foremanv1alpha1.FleetNodeCapability{Accelerator: "metal"})
+	node.Status.LastHeartbeatTime = nil
+
+	if nodeSchedulable(node, time.Now()) {
+		t.Fatalf("expected node with no heartbeat to be unschedulable")
+	}
 }
 
 // A reviewer Agent's model is already loaded on the node, so the loop

--- a/internal/foreman/controller/fleetnode_controller.go
+++ b/internal/foreman/controller/fleetnode_controller.go
@@ -18,7 +18,10 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,12 +31,9 @@ import (
 )
 
 // FleetNodeReconciler watches FleetNode objects and marks them NotReady when
-// their heartbeat goes stale. On a phase transition to NotReady it triggers
-// re-queue of any AgenticTask whose status.assignedNode points at the
-// stale node and whose phase is still Scheduled or Running.
-//
-// v0.1 / M0: stub. Heartbeat-staleness sweep lands in M1 (alongside the
-// FleetAgent that writes the heartbeats in the first place).
+// their heartbeat goes stale, returning them to Ready when the heartbeat
+// resumes. The scheduler reads status.phase (and independently re-checks
+// heartbeat freshness) to decide eligibility.
 type FleetNodeReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -52,14 +52,61 @@ func (r *FleetNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	log.Info("reconciling FleetNode",
+	log.V(1).Info("reconciling FleetNode",
 		"nodeName", node.Spec.NodeName,
 		"phase", node.Status.Phase,
 		"currentTask", node.Status.CurrentTask,
 	)
 
-	// M0 stub: no-op. Heartbeat staleness check lands in M1.
-	return ctrl.Result{}, nil
+	// A node the agent is intentionally draining is the agent's domain;
+	// the scheduler already treats Draining as ineligible. Don't fight it.
+	if node.Status.Phase == foremanv1alpha1.FleetNodePhaseDraining {
+		return ctrl.Result{RequeueAfter: foremanv1alpha1.FleetNodeHeartbeatTimeout}, nil
+	}
+
+	now := time.Now()
+	stale := node.HeartbeatStale(now)
+
+	desiredPhase := foremanv1alpha1.FleetNodePhaseReady
+	cond := metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "HeartbeatFresh",
+		Message:            "FleetAgent heartbeat is current",
+		LastTransitionTime: metav1.NewTime(now),
+	}
+	if stale {
+		desiredPhase = foremanv1alpha1.FleetNodePhaseNotReady
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "HeartbeatStale"
+		cond.Message = fmt.Sprintf("no heartbeat within %s", foremanv1alpha1.FleetNodeHeartbeatTimeout)
+	}
+
+	if node.Status.Phase != desiredPhase || !hasCondition(node.Status.Conditions, cond) {
+		patch := client.MergeFrom(node.DeepCopy())
+		node.Status.Phase = desiredPhase
+		setCondition(&node.Status.Conditions, cond)
+		if err := r.Status().Patch(ctx, &node, patch); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Requeue so a node that goes stale between heartbeats is detected
+	// without waiting for an external event.
+	return ctrl.Result{RequeueAfter: foremanv1alpha1.FleetNodeHeartbeatTimeout}, nil
+}
+
+// hasCondition reports whether conds already holds a condition matching c
+// on the fields the reconciler manages (type, status, reason). Lets us skip
+// a no-op status patch when nothing meaningful changed, avoiding a churn of
+// LastTransitionTime-only updates.
+func hasCondition(conds []metav1.Condition, c metav1.Condition) bool {
+	for i := range conds {
+		if conds[i].Type == c.Type {
+			return conds[i].Status == c.Status && conds[i].Reason == c.Reason
+		}
+	}
+	return false
 }
 
 // SetupWithManager wires the reconciler into the controller-runtime manager.

--- a/internal/foreman/controller/fleetnode_controller_test.go
+++ b/internal/foreman/controller/fleetnode_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -27,11 +29,13 @@ import (
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
 
-// M0/M1 ship the FleetNodeReconciler as a logging stub. The
-// stale-heartbeat -> NotReady logic lands in M2. These smoke tests pin
-// the no-mutation contract today.
+// The FleetNodeReconciler evaluates status.lastHeartbeatTime against
+// FleetNodeHeartbeatTimeout and drives the phase: a node that stops
+// heart-beating transitions Ready -> NotReady (with a HeartbeatStale
+// condition), and a node whose heartbeat resumes returns to Ready.
+// Regression for defilantech/LLMKube#627.
 
-var _ = Describe("FleetNodeReconciler (M0 stub)", func() {
+var _ = Describe("FleetNodeReconciler heartbeat staleness", func() {
 	var reconciler *FleetNodeReconciler
 
 	BeforeEach(func() {
@@ -48,26 +52,119 @@ var _ = Describe("FleetNodeReconciler (M0 stub)", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("reconciles an existing FleetNode without mutating status (M0 stub)", func() {
+	It("transitions a Ready node with a stale heartbeat to NotReady", func() {
 		fn := &foremanv1alpha1.FleetNode{
-			ObjectMeta: metav1.ObjectMeta{Name: "stub-fleetnode"},
+			ObjectMeta: metav1.ObjectMeta{Name: "stale-node"},
 			Spec: foremanv1alpha1.FleetNodeSpec{
-				NodeName: "stub-fleetnode",
+				NodeName: "stale-node",
 				Roles:    []string{"worker"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, fn)).To(Succeed())
-		DeferCleanup(func() {
-			_ = k8sClient.Delete(ctx, fn)
-		})
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, fn) })
+
+		stale := metav1.NewTime(time.Now().Add(-2 * foremanv1alpha1.FleetNodeHeartbeatTimeout))
+		fn.Status.Phase = foremanv1alpha1.FleetNodePhaseReady
+		fn.Status.LastHeartbeatTime = &stale
+		Expect(k8sClient.Status().Update(ctx, fn)).To(Succeed())
 
 		_, err := reconciler.Reconcile(ctx, ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: "stub-fleetnode"},
+			NamespacedName: types.NamespacedName{Name: "stale-node"},
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		var fresh foremanv1alpha1.FleetNode
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "stub-fleetnode"}, &fresh)).To(Succeed())
-		Expect(string(fresh.Status.Phase)).To(BeEmpty())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "stale-node"}, &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.FleetNodePhaseNotReady))
+
+		cond := meta(fresh.Status.Conditions, "Ready")
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal("HeartbeatStale"))
+	})
+
+	It("keeps a node with a fresh heartbeat Ready", func() {
+		fn := &foremanv1alpha1.FleetNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "fresh-node"},
+			Spec: foremanv1alpha1.FleetNodeSpec{
+				NodeName: "fresh-node",
+				Roles:    []string{"worker"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, fn)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, fn) })
+
+		fresh := metav1.NewTime(time.Now().Add(-1 * time.Second))
+		fn.Status.Phase = foremanv1alpha1.FleetNodePhaseReady
+		fn.Status.LastHeartbeatTime = &fresh
+		Expect(k8sClient.Status().Update(ctx, fn)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "fresh-node"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var got foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "fresh-node"}, &got)).To(Succeed())
+		Expect(got.Status.Phase).To(Equal(foremanv1alpha1.FleetNodePhaseReady))
+	})
+
+	It("returns a node whose heartbeat resumes from NotReady to Ready", func() {
+		fn := &foremanv1alpha1.FleetNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "recovered-node"},
+			Spec: foremanv1alpha1.FleetNodeSpec{
+				NodeName: "recovered-node",
+				Roles:    []string{"worker"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, fn)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, fn) })
+
+		fresh := metav1.NewTime(time.Now().Add(-1 * time.Second))
+		fn.Status.Phase = foremanv1alpha1.FleetNodePhaseNotReady
+		fn.Status.LastHeartbeatTime = &fresh
+		Expect(k8sClient.Status().Update(ctx, fn)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "recovered-node"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var got foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "recovered-node"}, &got)).To(Succeed())
+		Expect(got.Status.Phase).To(Equal(foremanv1alpha1.FleetNodePhaseReady))
+	})
+
+	It("requeues after the heartbeat timeout so staleness is detected without an external trigger", func() {
+		fn := &foremanv1alpha1.FleetNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "requeue-node"},
+			Spec: foremanv1alpha1.FleetNodeSpec{
+				NodeName: "requeue-node",
+				Roles:    []string{"worker"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, fn)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, fn) })
+
+		fresh := metav1.NewTime(time.Now().Add(-1 * time.Second))
+		fn.Status.Phase = foremanv1alpha1.FleetNodePhaseReady
+		fn.Status.LastHeartbeatTime = &fresh
+		Expect(k8sClient.Status().Update(ctx, fn)).To(Succeed())
+
+		res, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "requeue-node"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
 	})
 })
+
+// meta finds a condition by type, or nil.
+func meta(conds []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == condType {
+			return &conds[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Implement stale-FleetNode detection in the `FleetNodeReconciler` and add a defense-in-depth heartbeat re-check in the scheduler.

- New exported constant `FleetNodeHeartbeatTimeout = 90s` (two missed 30s FleetAgent beats) plus a `FleetNode.HeartbeatStale(now)` helper in `api/foreman/v1alpha1`.
- The reconciler evaluates `status.lastHeartbeatTime`: a stale heartbeat transitions the node `Ready -> NotReady` and sets a `Ready=False` condition with `reason: HeartbeatStale`; a resumed (fresh) heartbeat returns it to `Ready` (`reason: HeartbeatFresh`). It requeues after the timeout so a node going stale between heartbeats is caught with no external trigger. `Draining` is left untouched (the agent owns it) but still requeued.
- The scheduler's `firstFitNode` now selects via `nodeSchedulable`, which requires both `Phase==Ready` and a fresh heartbeat, so a node that still reads `Ready` but has gone dark since the last reconcile is skipped.

## Why

The `FleetNodeReconciler` was a no-op stub that never read `status.lastHeartbeatTime`, so a FleetNode whose metal-agent crashed, whose host powered off, or that partitioned away stayed `Phase: Ready` forever. The scheduler selected nodes on `Phase == Ready` alone, so it kept dispatching AgenticTasks into dead nodes (a black hole). The FleetNode docs promised a ~90s heartbeat window that nothing implemented.

Fixes #627

## How

- Staleness threshold lives as an exported const so it is testable and discoverable, and the staleness predicate is a method on the type so both the reconciler and the scheduler share one definition.
- The reconciler patches status with `client.MergeFrom` and skips the patch when neither phase nor the managed condition fields changed, avoiding `LastTransitionTime`-only churn. It is idempotent and level-triggered.
- Scope is intentionally limited to detection + non-scheduling. Re-queuing in-flight tasks already dispatched to a now-dead node is a follow-up, not part of this change.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change)
