### PR TITLE
fix(foreman): propagate Job-mode branch + commit SHA to AgenticTask status

### DIFF
--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -338,6 +338,17 @@ func (w *AgenticTaskWatcher) patchTerminal(
 	// in {GO, GATE-PASS}); set on Phase=Succeeded + non-success
 	// Verdict (NO-GO, GATE-FAIL, INCOMPLETE).
 	fresh.Status.FailureReason = res.FailureReason
+	// #624: lift the produced branch + head commit out of the Result
+	// envelope onto status so downstream consumers (verify/gate auto-spawn)
+	// can key off them. Both executors stash these in Result.Extra: the
+	// in-process path (goResult) and the Job-mode path (coderJobResultToResult)
+	// set "branch"/"commitSHA" on a GO and "intendedBranch" on a non-GO, so we
+	// coalesce them the same way runTaskResultFromResult does. Before this the
+	// fields stayed empty even though the branch was pushed.
+	if res.Extra != nil {
+		fresh.Status.Branch = firstStringField(res.Extra, "branch", "intendedBranch")
+		fresh.Status.CommitSHA = stringField(res.Extra, "commitSHA")
+	}
 	raw, err := json.Marshal(res)
 	if err != nil {
 		return fmt.Errorf("marshal result: %w", err)

--- a/pkg/foreman/agent/watcher_branch_test.go
+++ b/pkg/foreman/agent/watcher_branch_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func pendingTask(name string) *foremanv1alpha1.AgenticTask {
+	return &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status: foremanv1alpha1.AgenticTaskStatus{
+			Phase: foremanv1alpha1.AgenticTaskPhaseRunning,
+		},
+	}
+}
+
+// patchTerminal must lift the pushed branch + head commit out of the GO
+// Result envelope and onto AgenticTask.status.branch / .status.commitSHA so
+// downstream consumers (verify/gate auto-spawn) have something to key off.
+// Both the in-process executor (goResult) and the Job-mode executor
+// (coderJobResultToResult) populate Result.Extra["branch"]/["commitSHA"] on a
+// GO, so a single lift covers both paths.
+//
+// Regression for defilantech/LLMKube#624: Job-mode coder pushed the branch but
+// status.branch / status.commitSHA came back empty.
+func TestPatchTerminal_LiftsBranchAndCommitOnGo(t *testing.T) {
+	c := newRecoveryClient(t, pendingTask("code-624"))
+	w := &AgenticTaskWatcher{Client: c, NodeName: "coder", Namespace: "default"}
+
+	res := NewResult("issue-fix", foremanv1alpha1.AgenticTaskVerdictGo,
+		"fixed the bug", time.Second)
+	res.Extra = map[string]any{
+		"outcome":   "",
+		"branch":    "foreman/issue-624",
+		"commitSHA": "abc1234def5678",
+	}
+
+	if err := w.patchTerminal(context.Background(), pendingTask("code-624"), res, nil); err != nil {
+		t.Fatalf("patchTerminal: %v", err)
+	}
+
+	got := getTask(t, c, "code-624")
+	if got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseSucceeded {
+		t.Fatalf("phase = %q, want Succeeded", got.Status.Phase)
+	}
+	if got.Status.Branch != "foreman/issue-624" {
+		t.Fatalf("status.branch = %q, want %q", got.Status.Branch, "foreman/issue-624")
+	}
+	if got.Status.CommitSHA != "abc1234def5678" {
+		t.Fatalf("status.commitSHA = %q, want %q", got.Status.CommitSHA, "abc1234def5678")
+	}
+}
+
+// A non-GO terminal outcome carries only an intendedBranch (no push happened),
+// so status.commitSHA stays empty. status.branch reflects the branch the run
+// targeted so an operator can still locate the intended work.
+func TestPatchTerminal_NoGoLeavesCommitEmpty(t *testing.T) {
+	c := newRecoveryClient(t, pendingTask("code-nogo"))
+	w := &AgenticTaskWatcher{Client: c, NodeName: "coder", Namespace: "default"}
+
+	res := NewResult("issue-fix", foremanv1alpha1.AgenticTaskVerdictNoGo,
+		"model declined", time.Second)
+	res.Extra = map[string]any{
+		"outcome":        "MODEL-NO-GO",
+		"intendedBranch": "foreman/issue-nogo",
+	}
+
+	if err := w.patchTerminal(context.Background(), pendingTask("code-nogo"), res, nil); err != nil {
+		t.Fatalf("patchTerminal: %v", err)
+	}
+
+	got := getTask(t, c, "code-nogo")
+	if got.Status.Branch != "foreman/issue-nogo" {
+		t.Fatalf("status.branch = %q, want %q", got.Status.Branch, "foreman/issue-nogo")
+	}
+	if got.Status.CommitSHA != "" {
+		t.Fatalf("status.commitSHA = %q, want empty on NO-GO", got.Status.CommitSHA)
+	}
+}


### PR DESCRIPTION
## What

Lift the produced work branch and head commit SHA out of the executor's `Result` envelope onto `AgenticTask.status.branch` / `.status.commitSHA` in the watcher's terminal-status patch.

## Why

Fixes #624

When a coder Agent runs in `execution.mode: Job` (#620), a successful `GO` pushed the work branch to the remote, but `AgenticTask.status.branch` and `.status.commitSHA` came back empty. Downstream consumers that key off `status.branch` (verify / gate auto-spawn) therefore had nothing to act on, and the gate task had to be created by hand.

The root cause is in the watcher, not the Job plumbing: the Job-mode result envelope (`run_coder_job` -> `CoderJobResult` -> `coderJobResultToResult`) already carries `branch` / `commitSHA` in `Result.Extra`, exactly like the in-process path (`goResult`). But `patchTerminal` only serialized the whole `Result` into `status.result` and set `phase` / `verdict` / `failureReason`; it never lifted the branch / commit onto the dedicated status fields. Nothing in the repo wrote `status.branch` / `status.commitSHA`, so both execution paths left them empty.

## How

`patchTerminal` now coalesces `branch` / `intendedBranch` from `Result.Extra` onto `status.branch` and reads `commitSHA` onto `status.commitSHA`, using the same `firstStringField` / `stringField` helpers `runTaskResultFromResult` already uses for the Job result line. Placing the lift at the single status-writing chokepoint means both the in-process and Job-mode executors surface the fields identically, with no change to the executor envelopes or CRD types.

- GO: `status.branch` = pushed branch, `status.commitSHA` = head commit.
- NO-GO / INCOMPLETE: `status.branch` = intended branch (no push happened), `status.commitSHA` stays empty.

No CRD type change (`status.branch` / `status.commitSHA` already exist), so no `make manifests` / `chart-crds` regeneration needed. No build-tagged files touched.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change)
