### PR TITLE
fix(controller): revalidate http/https model sources in init container

### DIFF
--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -303,7 +303,7 @@ var _ = Describe("ensureModelCachePVC", func() {
 
 var _ = Describe("buildModelInitCommand", func() {
 	It("should generate cached remote download command with env var references", func() {
-		cmd := buildModelInitCommand(false, true)
+		cmd := buildModelInitCommand(false, true, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 		Expect(cmd).To(ContainSubstring(`"$MODEL_PATH"`))
 		Expect(cmd).To(ContainSubstring("curl -f -L"))
@@ -311,20 +311,20 @@ var _ = Describe("buildModelInitCommand", func() {
 	})
 
 	It("should generate cached local copy command", func() {
-		cmd := buildModelInitCommand(true, true)
+		cmd := buildModelInitCommand(true, true, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 		Expect(cmd).To(ContainSubstring("cp /host-model/model.gguf"))
 		Expect(cmd).To(ContainSubstring(`"$MODEL_PATH"`))
 	})
 
 	It("should generate error exit for uncached local source", func() {
-		cmd := buildModelInitCommand(true, false)
+		cmd := buildModelInitCommand(true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring("ERROR: Local model source requires model cache"))
 		Expect(cmd).To(ContainSubstring("exit 1"))
 	})
 
 	It("should generate uncached remote download command with env var references", func() {
-		cmd := buildModelInitCommand(false, false)
+		cmd := buildModelInitCommand(false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring("curl -f -L"))
 		Expect(cmd).To(ContainSubstring(`"$MODEL_SOURCE"`))
 		Expect(cmd).To(ContainSubstring(`"$MODEL_PATH"`))
@@ -335,7 +335,7 @@ var _ = Describe("buildModelInitCommand", func() {
 		// Verify that a malicious source cannot appear in the shell script.
 		// The command is a static template with env var references only.
 		maliciousSource := `https://evil.com/$(touch /pwned).gguf`
-		cmd := buildModelInitCommand(false, true)
+		cmd := buildModelInitCommand(false, true, RefreshPolicyIfNotPresent)
 		Expect(cmd).NotTo(ContainSubstring(maliciousSource))
 		Expect(cmd).NotTo(ContainSubstring("touch"))
 		Expect(cmd).NotTo(ContainSubstring("evil.com"))
@@ -344,6 +344,85 @@ var _ = Describe("buildModelInitCommand", func() {
 		env := modelInitEnvVars(maliciousSource, "/models/abc123", "/models/abc123/model.gguf")
 		Expect(env[0].Name).To(Equal("MODEL_SOURCE"))
 		Expect(env[0].Value).To(Equal(maliciousSource))
+	})
+
+	Context("RefreshPolicy=OnChange (http/https revalidation, issue #619)", func() {
+		It("cached: emits curl conditional GET against an etag marker beside the model", func() {
+			cmd := buildModelInitCommand(false, true, RefreshPolicyOnChange)
+			// Still provisions the cache dir like IfNotPresent.
+			Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
+			// Conditional GET via curl's native ETag flags.
+			Expect(cmd).To(ContainSubstring("--etag-compare"))
+			Expect(cmd).To(ContainSubstring("--etag-save"))
+			// Marker is a dotfile sibling derived from the model path.
+			Expect(cmd).To(ContainSubstring(`.etag`))
+			Expect(cmd).To(ContainSubstring(`"$MODEL_PATH"`))
+			Expect(cmd).To(ContainSubstring(`"$MODEL_SOURCE"`))
+			// It is NOT the existence-only path.
+			Expect(cmd).NotTo(ContainSubstring("skipping download"))
+		})
+
+		It("uncached: emits the same conditional GET without the cache dir mkdir", func() {
+			cmd := buildModelInitCommand(false, false, RefreshPolicyOnChange)
+			Expect(cmd).To(ContainSubstring("--etag-compare"))
+			Expect(cmd).To(ContainSubstring("--etag-save"))
+			Expect(cmd).To(ContainSubstring(`"$MODEL_SOURCE"`))
+			Expect(cmd).NotTo(ContainSubstring("mkdir -p"))
+			Expect(cmd).NotTo(ContainSubstring("skipping download"))
+		})
+
+		It("keeps the cached file and exits 0 when revalidation is unreachable", func() {
+			cmd := buildModelInitCommand(false, true, RefreshPolicyOnChange)
+			// Robustness guard: a network blip must not take down a running
+			// InferenceService on pod restart.
+			Expect(cmd).To(ContainSubstring(`[ -f "$MODEL_PATH" ]`))
+			Expect(cmd).To(ContainSubstring("exit 0"))
+			Expect(cmd).To(ContainSubstring("kept cached copy"))
+			// A genuinely-missing file still fails the init container.
+			Expect(cmd).To(ContainSubstring("exit 1"))
+		})
+
+		It("does not change the local (file://) init path", func() {
+			// file:// sources are owned by the controller (#635); the init
+			// container path must be identical regardless of RefreshPolicy.
+			ifNotPresent := buildModelInitCommand(true, true, RefreshPolicyIfNotPresent)
+			onChange := buildModelInitCommand(true, true, RefreshPolicyOnChange)
+			Expect(onChange).To(Equal(ifNotPresent))
+			Expect(onChange).NotTo(ContainSubstring("--etag-compare"))
+		})
+
+		It("does not contain user-controlled values in the OnChange command string", func() {
+			cmd := buildModelInitCommand(false, true, RefreshPolicyOnChange)
+			Expect(cmd).NotTo(ContainSubstring("evil.com"))
+			Expect(cmd).NotTo(ContainSubstring("touch"))
+		})
+	})
+})
+
+var _ = Describe("buildCachedStorageConfig RefreshPolicy plumbing", func() {
+	It("threads Model.Spec.RefreshPolicy=OnChange into the init command", func() {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:        "https://example.com/model.gguf",
+				RefreshPolicy: RefreshPolicyOnChange,
+			},
+			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123def456"},
+		}
+		config := buildCachedStorageConfig(model, nil, "", "curl:8.18.0")
+		cmd := config.initContainers[0].Command[2]
+		Expect(cmd).To(ContainSubstring("--etag-compare"))
+		Expect(cmd).To(ContainSubstring("kept cached copy"))
+	})
+
+	It("keeps existence-only behavior when RefreshPolicy is unset (IfNotPresent default)", func() {
+		model := &inferencev1alpha1.Model{
+			Spec:   inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
+			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123def456"},
+		}
+		config := buildCachedStorageConfig(model, nil, "", "curl:8.18.0")
+		cmd := config.initContainers[0].Command[2]
+		Expect(cmd).NotTo(ContainSubstring("--etag-compare"))
+		Expect(cmd).To(ContainSubstring("skipping download"))
 	})
 })
 

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -44,10 +44,13 @@ func isLocalModelSource(source string) bool {
 	return isLocalSource(source)
 }
 
-func buildModelInitCommand(isLocal, useCache bool) string {
+func buildModelInitCommand(isLocal, useCache bool, refreshPolicy string) string {
 	if useCache {
 		if isLocal {
 			return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Copying model from local source...'; cp /host-model/model.gguf "$MODEL_PATH" && echo 'Model copied successfully'; else echo 'Model already cached, skipping copy'; fi`
+		}
+		if refreshPolicy == RefreshPolicyOnChange {
+			return "mkdir -p \"$CACHE_DIR\" && " + remoteRevalidateScript
 		}
 		return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH" "$MODEL_SOURCE" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
 	}
@@ -55,8 +58,37 @@ func buildModelInitCommand(isLocal, useCache bool) string {
 	if isLocal {
 		return `echo 'ERROR: Local model source requires model cache to be configured.'; exit 1`
 	}
+	if refreshPolicy == RefreshPolicyOnChange {
+		return remoteRevalidateScript
+	}
 	return `if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH" "$MODEL_SOURCE" && echo 'Model downloaded successfully'; else echo 'Model already exists, skipping download'; fi`
 }
+
+// remoteRevalidateScript implements RefreshPolicy=OnChange for http/https
+// sources fetched by the init container. It uses curl's native conditional
+// GET (--etag-compare / --etag-save) against a marker file kept next to the
+// model on the PVC: on a 304 curl leaves the cached file untouched, on a 200
+// (ETag changed) it overwrites in place. The cache layout is unchanged; the
+// marker is a dotfile sibling of the model file.
+//
+// Robustness: the init container gates pod startup, so a transient network
+// failure (air-gapped, upstream 5xx, DNS) must not take down an
+// InferenceService on pod restart. If revalidation fails but a cached copy
+// already exists, the script logs and exits 0, keeping the cached file. Only a
+// genuinely-missing file (nothing cached and the fetch failed) fails the init
+// container.
+//
+// curlimages/curl 8.x supports --etag-compare/--etag-save (added in curl
+// 7.68.0), so no HEAD-compare fallback is needed for the default image.
+const remoteRevalidateScript = `ETAG_MARKER="$(dirname "$MODEL_PATH")/.$(basename "$MODEL_PATH").etag"; ` +
+	`echo 'Revalidating model against upstream (RefreshPolicy=OnChange)...'; ` +
+	`if curl -fsSL --etag-compare "$ETAG_MARKER" --etag-save "$ETAG_MARKER" -o "$MODEL_PATH" "$MODEL_SOURCE"; then ` +
+	`echo 'Model revalidated (downloaded or unchanged)'; ` +
+	`elif [ -f "$MODEL_PATH" ]; then ` +
+	`echo 'Revalidation unreachable; kept cached copy'; exit 0; ` +
+	`else ` +
+	`echo 'ERROR: model missing and revalidation failed'; exit 1; ` +
+	`fi`
 
 func modelInitEnvVars(source, cacheDir, modelPath string) []corev1.EnvVar {
 	return []corev1.EnvVar{
@@ -157,7 +189,7 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1a
 		})
 	}
 
-	cmd := buildModelInitCommand(isLocalModelSource(model.Spec.Source), true)
+	cmd := buildModelInitCommand(isLocalModelSource(model.Spec.Source), true, model.Spec.RefreshPolicy)
 	env := modelInitEnvVars(model.Spec.Source, cacheDir, modelPath)
 	if caCertConfigMap != "" {
 		volumes = append(volumes, corev1.Volume{
@@ -205,7 +237,7 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 		},
 	}
 
-	cmd := buildModelInitCommand(isLocalModelSource(model.Spec.Source), false)
+	cmd := buildModelInitCommand(isLocalModelSource(model.Spec.Source), false, model.Spec.RefreshPolicy)
 	env := modelInitEnvVars(model.Spec.Source, "", modelPath)
 	if caCertConfigMap != "" {
 		volumes = append(volumes, corev1.Volume{


### PR DESCRIPTION
## What

Make the InferenceService init container honor the Model's `spec.refreshPolicy`
when fetching `http`/`https` sources into the per-namespace cache PVC. Under
`OnChange` the init container now revalidates the cached file against upstream
on each pod start; under `IfNotPresent` (the default) behavior is unchanged.

This is the init-container / http-https completion of #619. PR #635 landed the
controller half (refreshPolicy field, status drift tracking, `SourceDrifted`
condition, and `OnChange` re-download for `file:///local` sources). The
controller only downloads local sources in-process, so that change left a gap:
for `http`/`https` (the common HuggingFace case) the actual fetch is done by the
init container, which did an existence-only check and never re-fetched a drifted
source even under `OnChange`. This PR closes that gap.

## Why

A drifted `http`/`https` model surfaced the `SourceDrifted` condition (from #635)
but was never auto-refetched, so `refreshPolicy: OnChange` had no effect for the
most common source type.

Fixes #619

## How

- `buildModelInitCommand` gains a `refreshPolicy` argument, plumbed from
  `Model.Spec.RefreshPolicy` through `buildCachedStorageConfig` /
  `buildEmptyDirStorageConfig` (both already have the source URL).
- `IfNotPresent` (default): unchanged existence-only `curl -f -L` download. No
  behavior change for existing users.
- `OnChange` (http/https): a curl conditional GET using the native
  `--etag-compare` / `--etag-save` flags against a dotfile ETag marker kept
  beside the model on the PVC (`/models/<cacheKey>/.<file>.etag`). On a 304 curl
  keeps the cached file; on a 200 (ETag changed) it overwrites in place. The
  cache layout is unchanged: same `/models/<cacheKey>/<file>`, cacheKey stays
  `hash(source)`, no orphaned dirs.
- The init container gates pod startup, so revalidation is fail-open: if the
  conditional fetch fails (air-gapped, upstream 5xx, DNS) but a cached copy
  exists, the script logs `Revalidation unreachable; kept cached copy` and exits
  0 so the pod still starts. Only a genuinely-missing file (nothing cached and
  the fetch failed) fails the init container.
- `file:///local` sources are untouched (controller still owns them per #635).

### Mechanism choice: curl native ETag flags

The default init image is `docker.io/curlimages/curl:8.18.0`. curl's
`--etag-compare` / `--etag-save` were added in curl 7.68.0 (2020), so the 8.x
image fully supports them; no HEAD-compare shell fallback is needed for the
default image.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated (if user-facing change)
