### PR TITLE
feat(foreman): escalation-only reviewer emission on base NO-GO

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -40,8 +40,10 @@ const (
 	// in WorkloadSpec.ReviewerAgentRefs, all parallel, all depending on
 	// the upstream verify task reaching GATE-PASS. The rollup from #548
 	// treats verdict=NO-GO as "Succeeded but incomplete," so any reviewer
-	// NO-GO marks the parent Workload review-failed; Day 4 escalates that
-	// case to a hybrid cloud reviewer Agent.
+	// NO-GO marks the parent Workload review-failed. When
+	// WorkloadSpec.EscalationReviewerAgentRefs is set (#546), a second
+	// reviewer tier is emitted per issue only after the base reviewers are
+	// terminal with at least one NO-GO.
 	AgenticTaskKindReview AgenticTaskKind = "review"
 	// AgenticTaskKindFreeform passes an arbitrary prompt to a named agent.
 	AgenticTaskKindFreeform AgenticTaskKind = "freeform"

--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -151,12 +151,16 @@ type WorkloadSpec struct {
 	// reviewers) to the small fraction of branches a cheap reviewer
 	// already flagged.
 	//
-	// Escalation verdicts are advisory in v0.2: they are recorded on
-	// the task and surfaced via the EscalationTriggered condition, but
-	// the base NO-GO still rolls the Workload to Failed so a human
-	// reviews both verdicts. Escalation tasks never trigger further
-	// escalation. Requires ReviewerAgentRefs to be non-empty; ignored
-	// in explicit Pipeline mode. Counts against MaxTasks.
+	// Escalation verdicts are advisory in v0.2: the
+	// EscalationTriggered condition records that the tier fired, the
+	// verdict itself is read from the escalation AgenticTask, and the
+	// base NO-GO still rolls the Workload to Failed so a human reviews
+	// both verdicts. Note that adding escalation refs to an
+	// already-Failed issue-batch Workload re-opens it: the next
+	// reconcile emits the escalation tier against the recorded NO-GO.
+	// Escalation tasks never trigger further escalation. Requires
+	// ReviewerAgentRefs to be non-empty; ignored in explicit Pipeline
+	// mode. Counts against MaxTasks.
 	// +optional
 	EscalationReviewerAgentRefs []corev1.LocalObjectReference `json:"escalationReviewerAgentRefs,omitempty"`
 

--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -124,7 +124,7 @@ type WorkloadSpec struct {
 	// rollup from #548 marks it under IncompleteTasks and the Workload
 	// reaches Phase=Failed with reason ChildrenIncomplete.
 	//
-	// v0.2 (Day 4): entries whose Agent has spec.provider="cloud-proxy"
+	// v0.2: entries whose Agent has spec.provider="cloud-proxy"
 	// are gated by AllowCloudReviewers (below) and by the operator-
 	// level --allow-cloud-providers kill switch. When either gate
 	// blocks, the WorkloadReconciler omits the cloud reviewer's task

--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -48,6 +48,9 @@ const (
 //     most common shape for v0.1. When ReviewerAgentRefs is also set
 //     (v0.2), each issue additionally fans out one parallel review
 //     task per listed reviewer Agent, depending on the verify task.
+//     When EscalationReviewerAgentRefs is also set, a second reviewer
+//     tier is emitted per issue only after a base reviewer returns
+//     NO-GO.
 //  3. LLM-planner (Intent only, no Pipeline, no Issues): deferred to v0.2.
 //     v0.1 marks the Workload Failed with reason NoPlannerOrPipeline.
 type WorkloadSpec struct {
@@ -135,6 +138,27 @@ type WorkloadSpec struct {
 	// providers.
 	// +optional
 	ReviewerAgentRefs []corev1.LocalObjectReference `json:"reviewerAgentRefs,omitempty"`
+
+	// EscalationReviewerAgentRefs is the optional second reviewer tier
+	// (v0.2, #546). For each issue N in issue-batch mode, the
+	// WorkloadReconciler emits one review task per listed Agent
+	// (rendered name "<workload>-escalate-<N>-<j>") ONLY after every
+	// base reviewer task for that issue (the ReviewerAgentRefs fan-out)
+	// is terminal AND at least one
+	// returned verdict=NO-GO. This bounds the cost of an expensive
+	// reviewer (typically a larger local model; a cloud-proxy Agent is
+	// allowed but stays behind the same sovereignty gates as base
+	// reviewers) to the small fraction of branches a cheap reviewer
+	// already flagged.
+	//
+	// Escalation verdicts are advisory in v0.2: they are recorded on
+	// the task and surfaced via the EscalationTriggered condition, but
+	// the base NO-GO still rolls the Workload to Failed so a human
+	// reviews both verdicts. Escalation tasks never trigger further
+	// escalation. Requires ReviewerAgentRefs to be non-empty; ignored
+	// in explicit Pipeline mode. Counts against MaxTasks.
+	// +optional
+	EscalationReviewerAgentRefs []corev1.LocalObjectReference `json:"escalationReviewerAgentRefs,omitempty"`
 
 	// AllowCloudReviewers gates whether reviewer Agents whose
 	// spec.provider is "cloud-proxy" (or any non-"local" value) may be

--- a/api/foreman/v1alpha1/zz_generated.deepcopy.go
+++ b/api/foreman/v1alpha1/zz_generated.deepcopy.go
@@ -613,6 +613,11 @@ func (in *WorkloadSpec) DeepCopyInto(out *WorkloadSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.EscalationReviewerAgentRefs != nil {
+		in, out := &in.EscalationReviewerAgentRefs, &out.EscalationReviewerAgentRefs
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	if in.AllowCloudReviewers != nil {
 		in, out := &in.AllowCloudReviewers, &out.AllowCloudReviewers
 		*out = new(bool)

--- a/charts/foreman/templates/agent-rbac.yaml
+++ b/charts/foreman/templates/agent-rbac.yaml
@@ -52,7 +52,7 @@ rules:
     resources: ["endpoints"]
     verbs: ["get", "list", "watch"]
 
-  # When an Agent's spec.provider is "cloud-proxy" (v0.2 Day 4), the
+  # When an Agent's spec.provider is "cloud-proxy" (v0.2), the
   # native executor reads providerConfig.apiKeySecretRef and dispatches
   # to the upstream HTTP endpoint with a Bearer token from the named
   # Secret. Scope is intentionally just `get`: the executor never

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -116,12 +116,16 @@ spec:
                   reviewers) to the small fraction of branches a cheap reviewer
                   already flagged.
 
-                  Escalation verdicts are advisory in v0.2: they are recorded on
-                  the task and surfaced via the EscalationTriggered condition, but
-                  the base NO-GO still rolls the Workload to Failed so a human
-                  reviews both verdicts. Escalation tasks never trigger further
-                  escalation. Requires ReviewerAgentRefs to be non-empty; ignored
-                  in explicit Pipeline mode. Counts against MaxTasks.
+                  Escalation verdicts are advisory in v0.2: the
+                  EscalationTriggered condition records that the tier fired, the
+                  verdict itself is read from the escalation AgenticTask, and the
+                  base NO-GO still rolls the Workload to Failed so a human reviews
+                  both verdicts. Note that adding escalation refs to an
+                  already-Failed issue-batch Workload re-opens it: the next
+                  reconcile emits the escalation tier against the recorded NO-GO.
+                  Escalation tasks never trigger further escalation. Requires
+                  ReviewerAgentRefs to be non-empty; ignored in explicit Pipeline
+                  mode. Counts against MaxTasks.
                 items:
                   description: |-
                     LocalObjectReference contains enough information to let you locate the

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -305,7 +305,7 @@ spec:
                   rollup from #548 marks it under IncompleteTasks and the Workload
                   reaches Phase=Failed with reason ChildrenIncomplete.
 
-                  v0.2 (Day 4): entries whose Agent has spec.provider="cloud-proxy"
+                  v0.2: entries whose Agent has spec.provider="cloud-proxy"
                   are gated by AllowCloudReviewers (below) and by the operator-
                   level --allow-cloud-providers kill switch. When either gate
                   blocks, the WorkloadReconciler omits the cloud reviewer's task

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -102,6 +102,43 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              escalationReviewerAgentRefs:
+                description: |-
+                  EscalationReviewerAgentRefs is the optional second reviewer tier
+                  (v0.2, #546). For each issue N in issue-batch mode, the
+                  WorkloadReconciler emits one review task per listed Agent
+                  (rendered name "<workload>-escalate-<N>-<j>") ONLY after every
+                  base reviewer task for that issue (the ReviewerAgentRefs fan-out)
+                  is terminal AND at least one
+                  returned verdict=NO-GO. This bounds the cost of an expensive
+                  reviewer (typically a larger local model; a cloud-proxy Agent is
+                  allowed but stays behind the same sovereignty gates as base
+                  reviewers) to the small fraction of branches a cheap reviewer
+                  already flagged.
+
+                  Escalation verdicts are advisory in v0.2: they are recorded on
+                  the task and surfaced via the EscalationTriggered condition, but
+                  the base NO-GO still rolls the Workload to Failed so a human
+                  reviews both verdicts. Escalation tasks never trigger further
+                  escalation. Requires ReviewerAgentRefs to be non-empty; ignored
+                  in explicit Pipeline mode. Counts against MaxTasks.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               intent:
                 description: |-
                   Intent is the natural-language description of what to do.

--- a/charts/foreman/templates/operator-deployment.yaml
+++ b/charts/foreman/templates/operator-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             # Cluster-wide sovereignty kill switch for cloud-proxy
             # reviewer Agents. False blocks dispatch to any non-local
             # provider regardless of per-Workload opt-in (#540 sibling,
-            # Day 4 v0.2). Air-gapped installs set this false.
+            # v0.2). Air-gapped installs set this false.
             - --allow-cloud-providers={{ .Values.foreman.allowCloudProviders }}
           ports:
             - name: health

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -26,7 +26,7 @@ networkPolicies:
   additionalEgressCIDRs: []
 foreman:
   # allowCloudProviders is the cluster-wide sovereignty kill switch
-  # for cloud-proxy reviewer Agents (v0.2 Day 4).
+  # for cloud-proxy reviewer Agents (v0.2).
   #
   # When true (default), reviewer Agents whose spec.provider is
   # "cloud-proxy" may dispatch, subject to per-Workload

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -116,12 +116,16 @@ spec:
                   reviewers) to the small fraction of branches a cheap reviewer
                   already flagged.
 
-                  Escalation verdicts are advisory in v0.2: they are recorded on
-                  the task and surfaced via the EscalationTriggered condition, but
-                  the base NO-GO still rolls the Workload to Failed so a human
-                  reviews both verdicts. Escalation tasks never trigger further
-                  escalation. Requires ReviewerAgentRefs to be non-empty; ignored
-                  in explicit Pipeline mode. Counts against MaxTasks.
+                  Escalation verdicts are advisory in v0.2: the
+                  EscalationTriggered condition records that the tier fired, the
+                  verdict itself is read from the escalation AgenticTask, and the
+                  base NO-GO still rolls the Workload to Failed so a human reviews
+                  both verdicts. Note that adding escalation refs to an
+                  already-Failed issue-batch Workload re-opens it: the next
+                  reconcile emits the escalation tier against the recorded NO-GO.
+                  Escalation tasks never trigger further escalation. Requires
+                  ReviewerAgentRefs to be non-empty; ignored in explicit Pipeline
+                  mode. Counts against MaxTasks.
                 items:
                   description: |-
                     LocalObjectReference contains enough information to let you locate the

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -305,7 +305,7 @@ spec:
                   rollup from #548 marks it under IncompleteTasks and the Workload
                   reaches Phase=Failed with reason ChildrenIncomplete.
 
-                  v0.2 (Day 4): entries whose Agent has spec.provider="cloud-proxy"
+                  v0.2: entries whose Agent has spec.provider="cloud-proxy"
                   are gated by AllowCloudReviewers (below) and by the operator-
                   level --allow-cloud-providers kill switch. When either gate
                   blocks, the WorkloadReconciler omits the cloud reviewer's task

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -102,6 +102,43 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              escalationReviewerAgentRefs:
+                description: |-
+                  EscalationReviewerAgentRefs is the optional second reviewer tier
+                  (v0.2, #546). For each issue N in issue-batch mode, the
+                  WorkloadReconciler emits one review task per listed Agent
+                  (rendered name "<workload>-escalate-<N>-<j>") ONLY after every
+                  base reviewer task for that issue (the ReviewerAgentRefs fan-out)
+                  is terminal AND at least one
+                  returned verdict=NO-GO. This bounds the cost of an expensive
+                  reviewer (typically a larger local model; a cloud-proxy Agent is
+                  allowed but stays behind the same sovereignty gates as base
+                  reviewers) to the small fraction of branches a cheap reviewer
+                  already flagged.
+
+                  Escalation verdicts are advisory in v0.2: they are recorded on
+                  the task and surfaced via the EscalationTriggered condition, but
+                  the base NO-GO still rolls the Workload to Failed so a human
+                  reviews both verdicts. Escalation tasks never trigger further
+                  escalation. Requires ReviewerAgentRefs to be non-empty; ignored
+                  in explicit Pipeline mode. Counts against MaxTasks.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               intent:
                 description: |-
                   Intent is the natural-language description of what to do.

--- a/examples/foreman/workload-with-escalation.yaml
+++ b/examples/foreman/workload-with-escalation.yaml
@@ -14,10 +14,10 @@
 # cloud-proxy Agent is allowed here but stays behind both sovereignty
 # gates (operator --allow-cloud-providers AND spec.allowCloudReviewers).
 #
-# Verdicts are advisory in v0.2: the escalation verdict is recorded on
-# its AgenticTask and surfaced via the EscalationTriggered condition,
-# but the base NO-GO still rolls the Workload to Failed so a human
-# reviews both verdicts side by side:
+# Verdicts are advisory in v0.2: the EscalationTriggered condition
+# records that the tier fired, the verdict itself lives on the
+# escalation AgenticTask, and the base NO-GO still rolls the Workload
+# to Failed so a human reviews both verdicts side by side:
 #
 #   kubectl get agentictasks -l foreman.llmkube.dev/workload=batch-escalation
 apiVersion: foreman.llmkube.dev/v1alpha1

--- a/examples/foreman/workload-with-escalation.yaml
+++ b/examples/foreman/workload-with-escalation.yaml
@@ -1,0 +1,42 @@
+# Escalation-only reviewer tier (#546, v0.2).
+#
+# Builds on workload-with-reviewers.yaml; read that first for the
+# base reviewer pipeline.
+#
+# The base reviewer fans out on every issue as usual. The escalation
+# reviewer is emitted per issue ONLY after every base reviewer for
+# that issue is terminal AND at least one returned verdict=NO-GO, so
+# the expensive reviewer runs on the small fraction of branches a
+# cheap reviewer already flagged.
+#
+# Local-first: the escalation tier is just "a bigger reviewer." The
+# recommended shape is a larger LOCAL model on a bigger node. A
+# cloud-proxy Agent is allowed here but stays behind both sovereignty
+# gates (operator --allow-cloud-providers AND spec.allowCloudReviewers).
+#
+# Verdicts are advisory in v0.2: the escalation verdict is recorded on
+# its AgenticTask and surfaced via the EscalationTriggered condition,
+# but the base NO-GO still rolls the Workload to Failed so a human
+# reviews both verdicts side by side:
+#
+#   kubectl get agentictasks -l foreman.llmkube.dev/workload=batch-escalation
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Workload
+metadata:
+  name: batch-escalation
+  namespace: default
+  labels:
+    app.kubernetes.io/part-of: foreman
+    foreman.llmkube.dev/milestone: v0.2
+spec:
+  intent: "fix the listed issues; escalate review on NO-GO"
+  repo: defilantech/LLMKube
+  issues: [641, 642]
+  coderAgentRef:
+    name: qwen36-35b-carnice-mtp-coder
+  verifierAgentRef:
+    name: gate
+  reviewerAgentRefs:           # base tier: cheap, eager, every issue
+    - name: qwen-reviewer
+  escalationReviewerAgentRefs: # escalation tier: only after base NO-GO
+    - name: big-local-reviewer

--- a/examples/foreman/workload-with-reviewers.yaml
+++ b/examples/foreman/workload-with-reviewers.yaml
@@ -27,10 +27,9 @@
 #     Workload to Phase=Failed with reason=ChildrenIncomplete, and
 #     surfaces "the gate passed, but at least one reviewer caught
 #     something the gate cannot."
-#   - Day 4 will extend this with a hybrid cloud reviewer Agent the
-#     rollup can escalate to when the local fleet says NO-GO; the
-#     local ensemble is the air-gap-friendly path, the cloud
-#     reviewer is the optional second opinion.
+#
+# For a second, escalation-only reviewer tier (runs only after a base
+# reviewer NO-GO), see workload-with-escalation.yaml.
 #
 # Multi-strategy reviewing (the v0.2 thesis): list three reviewer
 # Agent CRs with DIFFERENT system prompts and (optionally) the same
@@ -71,12 +70,12 @@ spec:
     - name: qwen36-35b-a3b-reviewer
     # - name: qwen36-35b-a3b-reviewer-falsification  # v0.2.x local variant
     # - name: qwen36-35b-a3b-reviewer-thinking       # v0.2.x local variant
-    # v0.2 Day 4: cloud reviewer for second opinion. Subject to
+    # v0.2 cloud reviewer for second opinion. Subject to
     # foreman.allowCloudProviders (chart) + spec.allowCloudReviewers
     # (below) sovereignty gates. Comment out for air-gap-only runs.
     - name: claude-sonnet-cloud-reviewer
 
-  # v0.2 Day 4: per-Workload sovereignty toggle. nil (unset) is
+  # v0.2: per-Workload sovereignty toggle. nil (unset) is
   # treated as true; set explicit false to suppress cloud-provider
   # reviewers for this specific batch even when the operator allows
   # them globally. The reconciler still emits local reviewers.

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -95,6 +95,13 @@ const conditionTypeCompleted = "Completed"
 // blocked each.
 const conditionTypeCloudReviewersSuppressed = "CloudReviewersSuppressed"
 
+// conditionTypeEscalationTriggered reports that at least one issue's
+// base reviewers all went terminal with a NO-GO among them, so the
+// escalation reviewer tier was emitted (#546). False with reason
+// NoBaseReviewers flags a spec that lists escalation reviewers
+// without any base reviewers to escalate from.
+const conditionTypeEscalationTriggered = "EscalationTriggered"
+
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads/finalizers,verbs=update
@@ -119,6 +126,12 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if len(children) > 0 {
+		// Second-pass emission (#546): escalation reviewers fire here,
+		// after base reviewer verdicts land, before status rollup.
+		children, err = r.emitEscalations(ctx, &workload, children)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("emit escalations: %w", err)
+		}
 		// Roll up child phases into the Workload's status.
 		return r.rollup(ctx, &workload, children)
 	}

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -143,7 +143,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return r.failWorkload(ctx, &workload, "NoPlannerOrPipeline", modeErr.Error())
 	}
 
-	// Sovereignty filter (#540's sibling, Day 4): when either the
+	// Sovereignty filter (#540's sibling, v0.2): when either the
 	// operator kill switch or the per-Workload gate blocks cloud
 	// providers, drop the steps whose Agent.spec.Provider is non-
 	// local. Cloud-blocked steps are returned in `suppressed` so the

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -591,6 +591,103 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		Expect(reviewerBlocksCompleted).NotTo(BeNil())
 		Expect(reviewerBlocksCompleted.Reason).To(Equal("ChildrenIncomplete"))
 	})
+
+	It("emits escalation reviewers only after a base reviewer NO-GO, advisory verdict (#546)", func() {
+		wl := newWorkload("escalation-happy", foremanv1alpha1.WorkloadSpec{
+			Intent:           "escalate on base NO-GO",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{641},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "base-reviewer"},
+			},
+			EscalationReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "big-reviewer"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		// First reconcile plans the base pipeline only: no escalate task.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Tasks).To(HaveLen(3)) // code + verify + review
+
+		// Drive the base pipeline to a reviewer NO-GO.
+		updates := []struct {
+			name    string
+			phase   foremanv1alpha1.AgenticTaskPhase
+			verdict foremanv1alpha1.AgenticTaskVerdict
+		}{
+			{"escalation-happy-code-641", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGo},
+			{"escalation-happy-verify-641", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGatePass},
+			{"escalation-happy-review-641-0", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo},
+		}
+		for _, u := range updates {
+			var task foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: u.name}, &task)).To(Succeed())
+			patch := client.MergeFrom(task.DeepCopy())
+			task.Status.Phase = u.phase
+			task.Status.Verdict = u.verdict
+			Expect(k8sClient.Status().Patch(ctx, &task, patch)).To(Succeed())
+		}
+
+		// Second reconcile (the rollup pass) must emit the escalation
+		// task and keep the Workload in flight while it runs.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var esc foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "escalation-happy-escalate-641-0"}, &esc)).To(Succeed())
+		Expect(esc.Spec.Kind).To(Equal(foremanv1alpha1.AgenticTaskKindReview))
+		Expect(esc.Spec.AgentRef.Name).To(Equal("big-reviewer"))
+		Expect(esc.Spec.Payload.Issue).To(Equal(int32(641)))
+		Expect(esc.Spec.Payload.Branch).To(Equal("foreman/escalation-happy/issue-641"))
+		Expect(esc.Spec.DependsOn).To(BeEmpty())
+		Expect(esc.Labels[labelStep]).To(Equal("escalate-641-0"))
+		Expect(esc.OwnerReferences).To(HaveLen(1))
+		Expect(esc.OwnerReferences[0].Name).To(Equal("escalation-happy"))
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseDispatched),
+			"workload must stay in flight while the escalation reviewer runs")
+		Expect(fresh.Status.Tasks).To(HaveLen(4))
+		escCond := findCondition(fresh.Status.Conditions, conditionTypeEscalationTriggered)
+		Expect(escCond).NotTo(BeNil())
+		Expect(escCond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(escCond.Message).To(ContainSubstring("641"))
+
+		// A third reconcile must NOT double-emit (idempotency).
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		var tasks foremanv1alpha1.AgenticTaskList
+		Expect(k8sClient.List(ctx, &tasks, client.InNamespace("default"),
+			client.MatchingLabels{labelWorkload: "escalation-happy"})).To(Succeed())
+		Expect(tasks.Items).To(HaveLen(4))
+
+		// Escalation GO is advisory in v0.2: the base NO-GO still rolls
+		// the Workload to Failed for human review.
+		var escTask foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "escalation-happy-escalate-641-0"}, &escTask)).To(Succeed())
+		patch := client.MergeFrom(escTask.DeepCopy())
+		escTask.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		escTask.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictGo
+		Expect(k8sClient.Status().Patch(ctx, &escTask, patch)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseFailed),
+			"advisory: escalation GO does not clear the base NO-GO in v0.2")
+		Expect(fresh.Status.SucceededTasks).To(Equal(int32(3)))  // code, verify, escalate
+		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(1))) // base reviewer NO-GO
+	})
 })
 
 // newWorkload builds a Workload with the test-conventional shape. Lets the

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -687,6 +688,193 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 			"advisory: escalation GO does not clear the base NO-GO in v0.2")
 		Expect(fresh.Status.SucceededTasks).To(Equal(int32(3)))  // code, verify, escalate
 		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(1))) // base reviewer NO-GO
+	})
+
+	It("suppresses a cloud-proxy escalation reviewer when the operator kill switch is off (#546)", func() {
+		reconciler.AllowCloudProviders = false
+		DeferCleanup(func() { reconciler.AllowCloudProviders = true })
+
+		Expect(k8sClient.Create(ctx, &foremanv1alpha1.Agent{
+			ObjectMeta: metav1.ObjectMeta{Name: "esc-local-base", Namespace: "default"},
+			Spec: foremanv1alpha1.AgentSpec{
+				Role:                foremanv1alpha1.AgentRoleReviewer,
+				Provider:            foremanv1alpha1.AgentProviderLocal,
+				InferenceServiceRef: corev1.LocalObjectReference{Name: "test-svc"},
+				SystemPrompt:        "you are a reviewer",
+				Tools:               []string{"submit_result"},
+				MaxTurns:            5,
+			},
+		})).To(Succeed())
+		Expect(k8sClient.Create(ctx, &foremanv1alpha1.Agent{
+			ObjectMeta: metav1.ObjectMeta{Name: "esc-cloud-big", Namespace: "default"},
+			Spec: foremanv1alpha1.AgentSpec{
+				Role:     foremanv1alpha1.AgentRoleReviewer,
+				Provider: foremanv1alpha1.AgentProviderCloudProxy,
+				ProviderConfig: &foremanv1alpha1.ProviderConfig{
+					BaseURL: "http://foundation-router.lan:4000/v1",
+					Model:   "claude-sonnet-4-6",
+				},
+				SystemPrompt: "you are an escalation reviewer",
+				Tools:        []string{"submit_result"},
+				MaxTurns:     5,
+			},
+		})).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, &foremanv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "esc-local-base", Namespace: "default"}})
+			_ = k8sClient.Delete(ctx, &foremanv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "esc-cloud-big", Namespace: "default"}})
+		})
+
+		wl := newWorkload("escalation-gated", foremanv1alpha1.WorkloadSpec{
+			Intent:           "cloud escalation suppressed by operator gate",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{642},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "esc-local-base"},
+			},
+			EscalationReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "esc-cloud-big"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		updates := []struct {
+			name    string
+			verdict foremanv1alpha1.AgenticTaskVerdict
+		}{
+			{"escalation-gated-code-642", foremanv1alpha1.AgenticTaskVerdictGo},
+			{"escalation-gated-verify-642", foremanv1alpha1.AgenticTaskVerdictGatePass},
+			{"escalation-gated-review-642-0", foremanv1alpha1.AgenticTaskVerdictNoGo},
+		}
+		for _, u := range updates {
+			var task foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: u.name}, &task)).To(Succeed())
+			patch := client.MergeFrom(task.DeepCopy())
+			task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+			task.Status.Verdict = u.verdict
+			Expect(k8sClient.Status().Patch(ctx, &task, patch)).To(Succeed())
+		}
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The cloud escalation reviewer must NOT have been created.
+		var escTask foremanv1alpha1.AgenticTask
+		err = k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "escalation-gated-escalate-642-0"}, &escTask)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cloud escalation task must be suppressed")
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		cond := findCondition(fresh.Status.Conditions, conditionTypeCloudReviewersSuppressed)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Message).To(ContainSubstring("esc-cloud-big"))
+		Expect(cond.Message).To(ContainSubstring("operator --allow-cloud-providers=false"))
+
+		escCond := findCondition(fresh.Status.Conditions, conditionTypeEscalationTriggered)
+		Expect(escCond).NotTo(BeNil())
+		Expect(escCond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(escCond.Message).To(ContainSubstring("0 task(s) created, 1 suppressed"))
+	})
+
+	It("suppresses escalation when MaxTasks leaves no room and reports it (#546)", func() {
+		wl := newWorkload("escalation-capped", foremanv1alpha1.WorkloadSpec{
+			Intent:           "maxTasks blocks escalation",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{643},
+			MaxTasks:         3, // code + verify + review fills the cap
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "base-reviewer"},
+			},
+			EscalationReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "big-reviewer"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		updates := []struct {
+			name    string
+			verdict foremanv1alpha1.AgenticTaskVerdict
+		}{
+			{"escalation-capped-code-643", foremanv1alpha1.AgenticTaskVerdictGo},
+			{"escalation-capped-verify-643", foremanv1alpha1.AgenticTaskVerdictGatePass},
+			{"escalation-capped-review-643-0", foremanv1alpha1.AgenticTaskVerdictNoGo},
+		}
+		for _, u := range updates {
+			var task foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: u.name}, &task)).To(Succeed())
+			patch := client.MergeFrom(task.DeepCopy())
+			task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+			task.Status.Verdict = u.verdict
+			Expect(k8sClient.Status().Patch(ctx, &task, patch)).To(Succeed())
+		}
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var escTask foremanv1alpha1.AgenticTask
+		err = k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "escalation-capped-escalate-643-0"}, &escTask)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "MaxTasks must suppress escalation emission")
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		trunc := findCondition(fresh.Status.Conditions, conditionTypeTruncated)
+		Expect(trunc).NotTo(BeNil())
+		Expect(trunc.Status).To(Equal(metav1.ConditionTrue))
+		Expect(trunc.Reason).To(Equal("MaxTasksEscalationCap"))
+		// And the workload still terminates Failed on the base NO-GO.
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseFailed))
+	})
+
+	It("flags escalation refs without base reviewers via EscalationTriggered=False (#546)", func() {
+		wl := newWorkload("escalation-nobase", foremanv1alpha1.WorkloadSpec{
+			Intent:           "escalation without base tier",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{644},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			EscalationReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "big-reviewer"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		// Plan, then trigger one rollup pass.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var escTask foremanv1alpha1.AgenticTask
+		err = k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "escalation-nobase-escalate-644-0"}, &escTask)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "no escalation may be emitted without a base reviewer tier")
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		cond := findCondition(fresh.Status.Conditions, conditionTypeEscalationTriggered)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal("NoBaseReviewers"))
 	})
 })
 

--- a/internal/foreman/controller/workload_escalation.go
+++ b/internal/foreman/controller/workload_escalation.go
@@ -17,8 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
@@ -95,4 +102,148 @@ func escalationSteps(
 		escalated = append(escalated, n)
 	}
 	return steps, escalated
+}
+
+// emitEscalations is the second-pass emission hook (#546): called from
+// Reconcile's children-exist branch before rollup. Synthesizes the due
+// escalate-<N>-<j> steps, applies MaxTasks accounting and the
+// sovereignty gates, creates the tasks, and patches status (Tasks list
+// + EscalationTriggered + CloudReviewersSuppressed / Truncated as
+// applicable). Returns the refreshed children slice so rollup counts
+// the new tasks as in-flight; on a no-op it returns the input slice.
+func (r *WorkloadReconciler) emitEscalations(
+	ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
+) ([]foremanv1alpha1.AgenticTask, error) {
+	log := logf.FromContext(ctx).WithName("workload").WithValues("workload", client.ObjectKeyFromObject(w))
+
+	if len(w.Spec.Pipeline) > 0 {
+		// Explicit Pipeline mode: the user authors their own DAG, and
+		// user-authored step names could false-match the review-<N>-*
+		// prefixes escalationSteps scans. Escalation is an issue-batch
+		// feature (see the field's CRD doc).
+		return children, nil
+	}
+
+	if len(w.Spec.EscalationReviewerAgentRefs) > 0 && len(w.Spec.ReviewerAgentRefs) == 0 {
+		// There is no base tier to escalate from; surface the
+		// misconfiguration once and continue as a no-reviewer batch.
+		if cond := apimeta.FindStatusCondition(w.Status.Conditions, conditionTypeEscalationTriggered); cond != nil &&
+			cond.Status == metav1.ConditionFalse && cond.Reason == "NoBaseReviewers" {
+			return children, nil
+		}
+		patch := client.MergeFrom(w.DeepCopy())
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeEscalationTriggered,
+			Status:             metav1.ConditionFalse,
+			Reason:             "NoBaseReviewers",
+			Message:            "spec.escalationReviewerAgentRefs is set but spec.reviewerAgentRefs is empty; there is no base reviewer tier to escalate from",
+			LastTransitionTime: metav1.Now(),
+		})
+		if err := r.Status().Patch(ctx, w, patch); err != nil {
+			return children, fmt.Errorf("patch NoBaseReviewers condition: %w", err)
+		}
+		return children, nil
+	}
+
+	steps, escalated := escalationSteps(w, children)
+	if len(steps) == 0 {
+		return children, nil
+	}
+
+	patch := client.MergeFrom(w.DeepCopy())
+	now := metav1.Now()
+
+	if w.Spec.MaxTasks > 0 && len(children)+len(steps) > int(w.Spec.MaxTasks) {
+		// No silent cap: report why the escalation tier did not run.
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeTruncated,
+			Status:             metav1.ConditionTrue,
+			Reason:             "MaxTasksEscalationCap",
+			Message:            fmt.Sprintf("MaxTasks=%d leaves no room for %d escalation task(s)", w.Spec.MaxTasks, len(steps)),
+			LastTransitionTime: now,
+		})
+		if err := r.Status().Patch(ctx, w, patch); err != nil {
+			return children, fmt.Errorf("patch escalation truncation condition: %w", err)
+		}
+		return children, nil
+	}
+
+	steps, suppressed, err := r.filterCloudProviders(ctx, w, steps)
+	if err != nil {
+		return children, fmt.Errorf("filter escalation providers: %w", err)
+	}
+
+	created, createErr := r.renderAndCreate(ctx, w, steps)
+	if createErr != nil {
+		log.Error(createErr, "creating escalation AgenticTasks failed mid-way", "createdSoFar", len(created))
+	}
+
+	msg := fmt.Sprintf("issues %s escalated after base reviewer NO-GO (%d task(s) created, %d suppressed)",
+		joinInt32(escalated), len(created), len(suppressed))
+
+	// Steady-state short-circuit: when nothing was created (e.g. every
+	// escalation ref is cloud-suppressed) and the condition already
+	// says exactly this, re-patching every rollup would only churn
+	// LastTransitionTime. escalationSteps re-proposes these steps on
+	// every reconcile because no escalate child ever exists.
+	if len(created) == 0 && createErr == nil {
+		if cond := apimeta.FindStatusCondition(w.Status.Conditions, conditionTypeEscalationTriggered); cond != nil &&
+			cond.Status == metav1.ConditionTrue && cond.Message == msg {
+			return children, nil
+		}
+	}
+
+	w.Status.Tasks = appendNewTaskRefs(w.Status.Tasks, created)
+	setCondition(&w.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeEscalationTriggered,
+		Status:             metav1.ConditionTrue,
+		Reason:             "BaseReviewerNoGo",
+		Message:            msg,
+		LastTransitionTime: now,
+	})
+	if len(suppressed) > 0 {
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeCloudReviewersSuppressed,
+			Status:             metav1.ConditionTrue,
+			Reason:             "SovereigntyGate",
+			Message:            fmt.Sprintf("skipped %d cloud-provider Agent(s): %s", len(suppressed), strings.Join(suppressed, "; ")),
+			LastTransitionTime: now,
+		})
+	}
+	if err := r.Status().Patch(ctx, w, patch); err != nil {
+		return children, fmt.Errorf("patch workload status after escalation emission: %w", err)
+	}
+	if createErr != nil {
+		return children, createErr
+	}
+
+	// Refresh so rollup sees the new tasks as in-flight in this same
+	// reconcile instead of waiting for the next watch event.
+	return r.listChildren(ctx, w)
+}
+
+// joinInt32 renders issue numbers as "641, 643" for condition messages.
+func joinInt32(ns []int32) string {
+	parts := make([]string, len(ns))
+	for i, n := range ns {
+		parts[i] = fmt.Sprintf("%d", n)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// appendNewTaskRefs appends only refs not already present by name, so
+// a reconcile echo against a stale AgenticTask cache cannot duplicate
+// Status.Tasks bookkeeping (the tasks themselves are AlreadyExists-
+// deduped by renderAndCreate).
+func appendNewTaskRefs(existing, created []corev1.ObjectReference) []corev1.ObjectReference {
+	seen := make(map[string]struct{}, len(existing))
+	for _, ref := range existing {
+		seen[ref.Name] = struct{}{}
+	}
+	for _, ref := range created {
+		if _, dup := seen[ref.Name]; !dup {
+			existing = append(existing, ref)
+		}
+	}
+	return existing
 }

--- a/internal/foreman/controller/workload_escalation.go
+++ b/internal/foreman/controller/workload_escalation.go
@@ -38,10 +38,12 @@ import (
 // Failed) AND at least one carries verdict=NO-GO. A cascade
 // INCOMPLETE after GATE-FAIL/GATE-ERROR (#548) is terminal but is
 // not a NO-GO, so a branch the gate already rejected never burns
-// escalation compute. Any existing escalate-<N>-* child suppresses
-// re-emission, which makes the rollup-driven call sites idempotent;
-// it also means an escalation reviewer's own NO-GO can never trigger
-// another round (the tier is exactly two levels deep).
+// escalation compute. Steps whose escalate-<N>-<j> child already
+// exists are skipped individually, so a partial create failure is
+// repaired on the next reconcile instead of stranding the missing
+// reviewers. Because the trigger only scans review-<N>-* children,
+// an escalation reviewer's own NO-GO can never trigger another round
+// (the tier is exactly two levels deep).
 //
 // Pure function: no API calls, no status writes. The caller owns
 // MaxTasks accounting, sovereignty filtering, and creation.
@@ -63,12 +65,13 @@ func escalationSteps(
 		basePrefix := fmt.Sprintf("review-%d-", n)
 		escPrefix := fmt.Sprintf("escalate-%d-", n)
 
-		var baseTotal, baseTerminal, baseNoGo, escExisting int
+		var baseTotal, baseTerminal, baseNoGo int
+		existingEsc := map[string]struct{}{}
 		for i := range children {
 			step := children[i].Labels[labelStep]
 			switch {
 			case strings.HasPrefix(step, escPrefix):
-				escExisting++
+				existingEsc[step] = struct{}{}
 			case strings.HasPrefix(step, basePrefix):
 				baseTotal++
 				phase := children[i].Status.Phase
@@ -82,14 +85,19 @@ func escalationSteps(
 			}
 		}
 
-		if escExisting > 0 || baseTotal == 0 || baseTerminal < baseTotal || baseNoGo == 0 {
+		if baseTotal == 0 || baseTerminal < baseTotal || baseNoGo == 0 {
 			continue
 		}
 
 		branch := fmt.Sprintf("foreman/%s/issue-%d", w.Name, n)
+		issueEscalated := false
 		for j, ref := range w.Spec.EscalationReviewerAgentRefs {
+			name := fmt.Sprintf("escalate-%d-%d", n, j)
+			if _, exists := existingEsc[name]; exists {
+				continue
+			}
 			steps = append(steps, foremanv1alpha1.PipelineStep{
-				Name:     fmt.Sprintf("escalate-%d-%d", n, j),
+				Name:     name,
 				Kind:     foremanv1alpha1.AgenticTaskKindReview,
 				AgentRef: ref,
 				Payload: foremanv1alpha1.AgenticTaskPayload{
@@ -98,8 +106,11 @@ func escalationSteps(
 					Branch: branch,
 				},
 			})
+			issueEscalated = true
 		}
-		escalated = append(escalated, n)
+		if issueEscalated {
+			escalated = append(escalated, n)
+		}
 	}
 	return steps, escalated
 }
@@ -217,9 +228,25 @@ func (r *WorkloadReconciler) emitEscalations(
 		return children, createErr
 	}
 
-	// Refresh so rollup sees the new tasks as in-flight in this same
-	// reconcile instead of waiting for the next watch event.
-	return r.listChildren(ctx, w)
+	// Rollup must see the new tasks as in-flight in this same pass. A
+	// cache-backed List here could miss tasks created microseconds ago
+	// (informer lag) and let rollup mark the Workload Failed before the
+	// create's watch event arrives, so synthesize placeholders instead:
+	// rollup buckets by Status.Phase and a zero-value phase counts as
+	// in-flight.
+	existing := make(map[string]struct{}, len(children))
+	for i := range children {
+		existing[children[i].Name] = struct{}{}
+	}
+	for _, ref := range created {
+		if _, ok := existing[ref.Name]; ok {
+			continue
+		}
+		children = append(children, foremanv1alpha1.AgenticTask{
+			ObjectMeta: metav1.ObjectMeta{Name: ref.Name, Namespace: ref.Namespace},
+		})
+	}
+	return children, nil
 }
 
 // joinInt32 renders issue numbers as "641, 643" for condition messages.

--- a/internal/foreman/controller/workload_escalation.go
+++ b/internal/foreman/controller/workload_escalation.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// escalationSteps decides which escalate-<N>-<j> review steps to emit
+// NOW, given the Workload spec and its current children (#546).
+//
+// For each issue N the trigger is: every base reviewer child
+// (step label "review-<N>-<i>") is terminal (Phase Succeeded or
+// Failed) AND at least one carries verdict=NO-GO. A cascade
+// INCOMPLETE after GATE-FAIL/GATE-ERROR (#548) is terminal but is
+// not a NO-GO, so a branch the gate already rejected never burns
+// escalation compute. Any existing escalate-<N>-* child suppresses
+// re-emission, which makes the rollup-driven call sites idempotent;
+// it also means an escalation reviewer's own NO-GO can never trigger
+// another round (the tier is exactly two levels deep).
+//
+// Pure function: no API calls, no status writes. The caller owns
+// MaxTasks accounting, sovereignty filtering, and creation.
+// Callers must also restrict invocation to issue-batch mode: an
+// explicit spec.Pipeline takes precedence over Issues at planning
+// time, and user-authored pipeline step names could otherwise
+// false-match the review-<N>-* prefixes scanned here.
+func escalationSteps(
+	w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
+) (steps []foremanv1alpha1.PipelineStep, escalated []int32) {
+	if len(w.Spec.EscalationReviewerAgentRefs) == 0 ||
+		len(w.Spec.ReviewerAgentRefs) == 0 ||
+		len(w.Spec.Issues) == 0 {
+		return nil, nil
+	}
+
+	for _, n := range w.Spec.Issues {
+		// The trailing dash keeps issue 64 from matching review-641-0.
+		basePrefix := fmt.Sprintf("review-%d-", n)
+		escPrefix := fmt.Sprintf("escalate-%d-", n)
+
+		var baseTotal, baseTerminal, baseNoGo, escExisting int
+		for i := range children {
+			step := children[i].Labels[labelStep]
+			switch {
+			case strings.HasPrefix(step, escPrefix):
+				escExisting++
+			case strings.HasPrefix(step, basePrefix):
+				baseTotal++
+				phase := children[i].Status.Phase
+				if phase == foremanv1alpha1.AgenticTaskPhaseSucceeded ||
+					phase == foremanv1alpha1.AgenticTaskPhaseFailed {
+					baseTerminal++
+				}
+				if children[i].Status.Verdict == foremanv1alpha1.AgenticTaskVerdictNoGo {
+					baseNoGo++
+				}
+			}
+		}
+
+		if escExisting > 0 || baseTotal == 0 || baseTerminal < baseTotal || baseNoGo == 0 {
+			continue
+		}
+
+		branch := fmt.Sprintf("foreman/%s/issue-%d", w.Name, n)
+		for j, ref := range w.Spec.EscalationReviewerAgentRefs {
+			steps = append(steps, foremanv1alpha1.PipelineStep{
+				Name:     fmt.Sprintf("escalate-%d-%d", n, j),
+				Kind:     foremanv1alpha1.AgenticTaskKindReview,
+				AgentRef: ref,
+				Payload: foremanv1alpha1.AgenticTaskPayload{
+					Repo:   w.Spec.Repo,
+					Issue:  n,
+					Branch: branch,
+				},
+			})
+		}
+		escalated = append(escalated, n)
+	}
+	return steps, escalated
+}

--- a/internal/foreman/controller/workload_escalation_test.go
+++ b/internal/foreman/controller/workload_escalation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -115,6 +116,16 @@ func TestEscalationSteps(t *testing.T) {
 				child("review-641-0", succeeded, noGo),
 				child("escalate-641-0", running, ""),
 			},
+		},
+		{
+			name: "partial create failure repaired: only the missing escalation step is re-emitted",
+			w:    escalationWorkload([]int32{641}, 1, 2),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+				child("escalate-641-0", running, ""),
+			},
+			wantSteps:     []string{"escalate-641-1"},
+			wantEscalated: []int32{641},
 		},
 		{
 			name: "cascade INCOMPLETE after GATE-FAIL does not escalate",
@@ -221,5 +232,29 @@ func TestEscalationSteps(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The explicit-Pipeline guard returns before any client call, so a
+// zero-value reconciler suffices: user-authored pipeline step names
+// (here review-9-0) must never trigger escalation.
+func TestEmitEscalationsSkipsPipelineMode(t *testing.T) {
+	r := &WorkloadReconciler{}
+	w := escalationWorkload([]int32{9}, 1, 1)
+	w.Spec.Pipeline = []foremanv1alpha1.PipelineStep{{
+		Name:     "review-9-0",
+		Kind:     foremanv1alpha1.AgenticTaskKindReview,
+		AgentRef: corev1.LocalObjectReference{Name: "user-authored"},
+	}}
+	children := []foremanv1alpha1.AgenticTask{
+		child("review-9-0", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo),
+	}
+
+	got, err := r.emitEscalations(context.Background(), w, children)
+	if err != nil {
+		t.Fatalf("emitEscalations: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "wl-review-9-0" {
+		t.Fatalf("children mutated: %v", got)
 	}
 }

--- a/internal/foreman/controller/workload_escalation_test.go
+++ b/internal/foreman/controller/workload_escalation_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// child builds a minimal AgenticTask carrying only what escalationSteps
+// reads: the step label, phase, and verdict.
+func child(step string, phase foremanv1alpha1.AgenticTaskPhase, verdict foremanv1alpha1.AgenticTaskVerdict) foremanv1alpha1.AgenticTask {
+	return foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "wl-" + step,
+			Labels: map[string]string{labelWorkload: "wl", labelStep: step},
+		},
+		Status: foremanv1alpha1.AgenticTaskStatus{Phase: phase, Verdict: verdict},
+	}
+}
+
+func escalationWorkload(issues []int32, baseRefs, escRefs int) *foremanv1alpha1.Workload {
+	spec := foremanv1alpha1.WorkloadSpec{
+		Intent: "escalation unit test",
+		Repo:   "defilantech/LLMKube",
+		Issues: issues,
+	}
+	for i := 0; i < baseRefs; i++ {
+		spec.ReviewerAgentRefs = append(spec.ReviewerAgentRefs, corev1.LocalObjectReference{Name: "base-reviewer"})
+	}
+	for i := 0; i < escRefs; i++ {
+		spec.EscalationReviewerAgentRefs = append(spec.EscalationReviewerAgentRefs, corev1.LocalObjectReference{Name: "big-reviewer"})
+	}
+	w := &foremanv1alpha1.Workload{Spec: spec}
+	w.Name = "wl"
+	return w
+}
+
+func TestEscalationSteps(t *testing.T) {
+	succeeded := foremanv1alpha1.AgenticTaskPhaseSucceeded
+	running := foremanv1alpha1.AgenticTaskPhaseRunning
+	failed := foremanv1alpha1.AgenticTaskPhaseFailed
+	noGo := foremanv1alpha1.AgenticTaskVerdictNoGo
+	gateFail := foremanv1alpha1.AgenticTaskVerdictGateFail
+	incomplete := foremanv1alpha1.AgenticTaskVerdictIncomplete
+	gatePass := foremanv1alpha1.AgenticTaskVerdictGatePass
+	goVerdict := foremanv1alpha1.AgenticTaskVerdictGo
+
+	cases := []struct {
+		name          string
+		w             *foremanv1alpha1.Workload
+		children      []foremanv1alpha1.AgenticTask
+		wantSteps     []string // expected step names, in order
+		wantEscalated []int32
+	}{
+		{
+			name: "single base reviewer NO-GO triggers one escalation per ref",
+			w:    escalationWorkload([]int32{641}, 1, 2),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+				child("verify-641", succeeded, gatePass),
+				child("review-641-0", succeeded, noGo),
+			},
+			wantSteps:     []string{"escalate-641-0", "escalate-641-1"},
+			wantEscalated: []int32{641},
+		},
+		{
+			name: "all base reviewers GO emits nothing",
+			w:    escalationWorkload([]int32{641}, 1, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, goVerdict),
+			},
+		},
+		{
+			name: "waits for every base reviewer to be terminal",
+			w:    escalationWorkload([]int32{641}, 2, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+				child("review-641-1", running, ""),
+			},
+		},
+		{
+			name: "emits once both base reviewers are terminal with one NO-GO",
+			w:    escalationWorkload([]int32{641}, 2, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+				child("review-641-1", succeeded, goVerdict),
+			},
+			wantSteps:     []string{"escalate-641-0"},
+			wantEscalated: []int32{641},
+		},
+		{
+			name: "existing escalation child blocks re-emission (idempotency)",
+			w:    escalationWorkload([]int32{641}, 1, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+				child("escalate-641-0", running, ""),
+			},
+		},
+		{
+			name: "cascade INCOMPLETE after GATE-FAIL does not escalate",
+			w:    escalationWorkload([]int32{641}, 1, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("verify-641", succeeded, gateFail),
+				child("review-641-0", succeeded, incomplete),
+			},
+		},
+		{
+			name: "base reviewer Phase=Failed without NO-GO does not escalate",
+			w:    escalationWorkload([]int32{641}, 1, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", failed, ""),
+			},
+		},
+		{
+			name: "no escalation refs is a no-op",
+			w:    escalationWorkload([]int32{641}, 1, 0),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+			},
+		},
+		{
+			name: "no base refs is a no-op (validated separately by the controller)",
+			w:    escalationWorkload([]int32{641}, 0, 1),
+		},
+		{
+			name: "per-issue isolation: only the NO-GO issue escalates",
+			w:    escalationWorkload([]int32{641, 642}, 1, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+				child("review-642-0", succeeded, goVerdict),
+			},
+			wantSteps:     []string{"escalate-641-0"},
+			wantEscalated: []int32{641},
+		},
+		{
+			name: "two issues escalate simultaneously in spec.Issues order",
+			w:    escalationWorkload([]int32{641, 642}, 1, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-642-0", succeeded, noGo),
+				child("review-641-0", succeeded, noGo),
+			},
+			wantSteps:     []string{"escalate-641-0", "escalate-642-0"},
+			wantEscalated: []int32{641, 642},
+		},
+		{
+			name: "issue number prefixes do not cross-match (64 vs 641)",
+			w:    escalationWorkload([]int32{64}, 1, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			steps, escalated := escalationSteps(tc.w, tc.children)
+
+			var gotNames []string
+			for _, s := range steps {
+				gotNames = append(gotNames, s.Name)
+			}
+			if len(gotNames) != len(tc.wantSteps) {
+				t.Fatalf("steps = %v, want %v", gotNames, tc.wantSteps)
+			}
+			for i := range tc.wantSteps {
+				if gotNames[i] != tc.wantSteps[i] {
+					t.Fatalf("steps = %v, want %v", gotNames, tc.wantSteps)
+				}
+			}
+			if len(escalated) != len(tc.wantEscalated) {
+				t.Fatalf("escalated = %v, want %v", escalated, tc.wantEscalated)
+			}
+			for i := range tc.wantEscalated {
+				if escalated[i] != tc.wantEscalated[i] {
+					t.Fatalf("escalated = %v, want %v", escalated, tc.wantEscalated)
+				}
+			}
+
+			// Every emitted step must be a review step carrying the
+			// issue payload and the workload-scoped branch. The
+			// expected issue number is parsed from the step name
+			// (escalate-<N>-<j>) so multi-issue cases stay honest.
+			for _, s := range steps {
+				if s.Kind != foremanv1alpha1.AgenticTaskKindReview {
+					t.Errorf("step %s kind = %s, want review", s.Name, s.Kind)
+				}
+				if s.Payload.Repo != "defilantech/LLMKube" {
+					t.Errorf("step %s repo = %q", s.Name, s.Payload.Repo)
+				}
+				var issue, idx int32
+				if _, err := fmt.Sscanf(s.Name, "escalate-%d-%d", &issue, &idx); err != nil {
+					t.Fatalf("step name %q does not match escalate-<N>-<j>: %v", s.Name, err)
+				}
+				wantBranch := fmt.Sprintf("foreman/wl/issue-%d", issue)
+				if s.Payload.Issue != issue || s.Payload.Branch != wantBranch {
+					t.Errorf("step %s payload = issue %d branch %q, want %d %q",
+						s.Name, s.Payload.Issue, s.Payload.Branch, issue, wantBranch)
+				}
+				if s.AgentRef.Name != "big-reviewer" {
+					t.Errorf("step %s agentRef = %q, want big-reviewer", s.Name, s.AgentRef.Name)
+				}
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -203,7 +203,7 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	//     InferenceServiceRef AND provider unset / "local". The
 	//     executor runs the agent's first non-terminal tool directly
 	//     and skips the model loop entirely.
-	//   - Cloud-proxy Agent (v0.2 Day 4): provider="cloud-proxy",
+	//   - Cloud-proxy Agent (v0.2): provider="cloud-proxy",
 	//     dispatch via providerConfig.BaseURL + auth header from the
 	//     referenced Secret. No InferenceService lookup.
 	//   - Local Agent (default): resolveInferenceBaseURL reads


### PR DESCRIPTION
## What

Adds `WorkloadSpec.escalationReviewerAgentRefs`: a second reviewer tier emitted per issue only after every base reviewer is terminal and at least one returned NO-GO. Escalation verdicts are advisory in v0.2: the new `EscalationTriggered` condition records that the tier fired, the verdict lives on the escalation AgenticTask, and the base NO-GO still routes the Workload to Failed for human review.

## Why

Part of #546. Today all `reviewerAgentRefs` fan out eagerly on every issue. The cost-bounding design in #546 wants the expensive reviewer (typically a larger local model; cloud-proxy stays opt-in behind both sovereignty gates) to run only on branches a cheap reviewer already flagged. Empirical driver: the 2026-05-25 reviewer-diversity comparison, where local 24-26B reviewers caught 0/3 structural bugs and a stronger tool-using reviewer caught 3/3.

## How

- New optional `escalationReviewerAgentRefs` slice on WorkloadSpec (CRDs + foreman chart copies regenerated).
- `escalationSteps` (pure function): per-issue trigger = all base `review-<N>-<i>` children terminal AND at least one NO-GO. Cascade INCOMPLETE after GATE-FAIL never triggers; per-step name dedup makes emission idempotent AND repairs partial create failures; escalation children are never scanned for triggers, so the tier is exactly two levels deep.
- `emitEscalations` in the Reconcile children-exist path, before rollup: explicit-Pipeline workloads are excluded (user-authored step names could false-match), MaxTasks is a hard cap with reported suppression (`Truncated`/`MaxTasksEscalationCap`), sovereignty filtering reuses `filterCloudProviders` + `CloudReviewersSuppressed`, and misconfiguration (escalation refs without base reviewers) surfaces `EscalationTriggered=False/NoBaseReviewers`.
- Rollup bucket math is untouched: newly created tasks are handed to rollup as in-flight placeholders (no cache-backed re-list, so no false-Failed flap under informer lag), the Workload stays Dispatched while escalation runs, and it still terminates Failed on the base NO-GO (advisory semantics). Authoritative override is deferred to v0.3 as one new case in the bucket switch.
- Steady-state short-circuits avoid status churn when nothing new can be emitted (e.g. every escalation ref cloud-suppressed).
- Tests: 13 table cases for the trigger function, a Pipeline-mode guard unit test, and envtest coverage for the happy path (emission, idempotency, advisory terminal state), operator-gate suppression, MaxTasks suppression, and NoBaseReviewers.
- Docs: `examples/foreman/workload-with-escalation.yaml`, cross-reference from the reviewers example, and retirement of all stale "Day 4" forward references.

Follow-ups deliberately out of scope (tracked on #546): reviewer-architecture docs page, authoritative escalation verdicts (v0.3), empirical validation run.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change)