### PR TITLE
fix(metal-agent): fail closed when memory admission check cannot complete

### DIFF
--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -65,6 +65,7 @@ type AgentConfig struct {
 	LogLevel                  string
 	HostIP                    string
 	MemoryFraction            float64
+	MemoryCheckMode           string
 	WatchdogInterval          time.Duration
 	MemoryPressureWarning     float64
 	MemoryPressureCritical    float64
@@ -252,6 +253,9 @@ func main() {
 	flag.StringVar(&cfg.HostIP, "host-ip", "", "IP address to register in Kubernetes endpoints (auto-detected if empty)")
 	flag.Float64Var(&cfg.MemoryFraction, "memory-fraction", 0,
 		"Fraction of system memory to budget for models (0 = auto-detect based on total RAM)")
+	flag.StringVar(&cfg.MemoryCheckMode, "memory-check-mode", agent.MemoryCheckModeEnforce,
+		"What to do when the pre-flight memory check cannot be completed: "+
+			"\"enforce\" refuses to start the process (fail closed), \"warn\" logs and starts it anyway")
 	flag.DurationVar(&cfg.WatchdogInterval, "memory-watchdog-interval", 10*time.Second,
 		"How often to check memory pressure (0 to disable)")
 	flag.Float64Var(&cfg.MemoryPressureWarning, "memory-pressure-warning", 0.20,
@@ -481,6 +485,7 @@ func main() {
 		HostIP:                    cfg.HostIP,
 		Logger:                    logger,
 		MemoryFraction:            cfg.MemoryFraction,
+		MemoryCheckMode:           cfg.MemoryCheckMode,
 		MaxWatchFailures:          cfg.MaxWatchFailures,
 		InferenceServiceAllowlist: splitCSV(cfg.InferenceServiceAllowlist),
 		LlamaServerStartupTimeout: cfg.LlamaServerStartupTimeout,

--- a/docs/site/guides/macos-metal.md
+++ b/docs/site/guides/macos-metal.md
@@ -252,6 +252,16 @@ inference machine, or `0.5` if the Mac is also your daily-driver
 workstation. Add the flag to the launchd plist's `ProgramArguments`
 the same way as `--host-ip`.
 
+If the agent cannot complete the check at all (the model is not on
+disk yet, the Model's `status.size` is not populated, and a HEAD
+probe of the source fails), it **fails closed**: the process is not
+started and the InferenceService is marked with
+`status.schedulingStatus: MemoryCheckFailed` explaining why. On
+Apple Silicon an unsized model is wired into unevictable memory, so
+admitting it blind risks a host-level stall instead of a failed pod.
+Set `--memory-check-mode warn` to restore the older log-and-proceed
+behavior if you need an escape hatch.
+
 The agent also implements **memory-pressure protection**: if
 macOS reports critical memory pressure, the agent can evict the
 lowest-priority running InferenceService and refuse to spawn new
@@ -385,6 +395,17 @@ shrink the model (use a smaller quantization), reduce the context
 size in the `InferenceService` spec, or raise
 `--memory-fraction`. If the Mac is the only Mac in the cluster and
 this is a dedicated inference machine, `0.9` is reasonable.
+
+**InferenceService stuck in `MemoryCheckFailed`**
+The agent could not size the model at all, so it refused to start
+it. `status.schedulingMessage` lists every source it tried (local
+file, Model `status.size`, HEAD probe of the source URL). The most
+common causes are a gated Hugging Face repo rejecting the HEAD
+probe (401) or a source URL that does not return `Content-Length`.
+Fix the source so it can be probed, wait for the Model controller
+to populate `status.size`, or start the agent with
+`--memory-check-mode warn` to admit unsized models at your own
+risk.
 
 **macOS firewall prompt on first run**
 The Metal Agent listens on `127.0.0.1:9090` for its own

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1300,7 +1300,10 @@ func (a *MetalAgent) failMemoryCheck(
 		return nil
 	}
 
-	a.logger.Errorw("memory check incomplete, refusing to start process",
+	// Warn, not error: the watcher retries every poll interval and zap
+	// attaches stacktraces at error level, which floods the log for a
+	// condition already surfaced via status and a Kubernetes event.
+	a.logger.Warnw("memory check incomplete, refusing to start process",
 		"reason", reason, "namespace", isvc.Namespace, "name", isvc.Name)
 	isvc.Status.SchedulingStatus = "MemoryCheckFailed"
 	isvc.Status.SchedulingMessage = reason

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -104,6 +105,11 @@ type MetalAgentConfig struct {
 	MemoryProvider MemoryProvider
 	// MemoryFraction is the fraction of total memory to budget for models (0 = auto-detect).
 	MemoryFraction float64
+	// MemoryCheckMode controls what happens when the pre-flight memory check
+	// cannot be completed: MemoryCheckModeEnforce (default, also for "") fails
+	// closed and refuses to start the process; MemoryCheckModeWarn logs and
+	// proceeds (the legacy behavior).
+	MemoryCheckMode string
 
 	// WatchdogConfig configures the memory pressure watchdog. Nil disables it.
 	WatchdogConfig *MemoryWatchdogConfig
@@ -183,6 +189,10 @@ type MetalAgent struct {
 	mu             sync.RWMutex
 	memoryProvider MemoryProvider
 	memoryFraction float64
+	// memoryCheckWarnOnly is true when config.MemoryCheckMode resolved to
+	// MemoryCheckModeWarn; an incomplete admission check then logs and
+	// proceeds instead of failing closed.
+	memoryCheckWarnOnly bool
 
 	// pressureBlocked records namespacedName keys of processes the agent
 	// evicted under memory pressure. Subsequent ensureProcess calls for these
@@ -266,15 +276,28 @@ func NewMetalAgent(config MetalAgentConfig) *MetalAgent {
 		}
 	}
 
+	// Resolve memory check mode. Unknown values fall back to enforce: the
+	// fail-open direction is the dangerous one, so a typo must not pick it.
+	warnOnly := false
+	switch config.MemoryCheckMode {
+	case "", MemoryCheckModeEnforce:
+	case MemoryCheckModeWarn:
+		warnOnly = true
+	default:
+		logger.Warnw("unknown memory-check-mode, defaulting to enforce",
+			"mode", config.MemoryCheckMode)
+	}
+
 	return &MetalAgent{
-		config:           config,
-		processes:        make(map[string]*ManagedProcess),
-		logger:           logger.With("component", "metal-agent"),
-		memoryProvider:   provider,
-		memoryFraction:   fraction,
-		pressureBlocked:  make(map[string]bool),
-		pressureObserved: make(map[string]MemoryPressureLevel),
-		starting:         make(map[string]bool),
+		config:              config,
+		processes:           make(map[string]*ManagedProcess),
+		logger:              logger.With("component", "metal-agent"),
+		memoryProvider:      provider,
+		memoryFraction:      fraction,
+		memoryCheckWarnOnly: warnOnly,
+		pressureBlocked:     make(map[string]bool),
+		pressureObserved:    make(map[string]MemoryPressureLevel),
+		starting:            make(map[string]bool),
 	}
 }
 
@@ -283,10 +306,15 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 	// Log effective memory budget and set gauge
 	if total, err := a.memoryProvider.TotalMemory(); err == nil {
 		budget := uint64(float64(total) * a.memoryFraction)
+		checkMode := MemoryCheckModeEnforce
+		if a.memoryCheckWarnOnly {
+			checkMode = MemoryCheckModeWarn
+		}
 		a.logger.Infow("memory budget",
 			"total", formatMemory(total),
 			"fraction", a.memoryFraction,
 			"budget", formatMemory(budget),
+			"checkMode", checkMode,
 		)
 		memoryBudgetBytes.Set(float64(budget))
 	} else {
@@ -762,66 +790,8 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 	cacheTypeK, cacheTypeV := resolveCacheTypes(isvc)
 
 	// Pre-flight memory check
-	if estimate, err := a.estimateModelMemory(model, contextSize, cacheTypeK, cacheTypeV); err != nil {
-		a.logger.Warnw("memory estimation failed, proceeding without check", "error", err)
-	} else {
-		memoryEstimatedBytes.WithLabelValues(isvc.Name, isvc.Namespace).Set(float64(estimate.TotalBytes))
-
-		resolved, resolveErr := ResolveMemoryBudget(model.Spec.Hardware, a.memoryFraction)
-		if resolveErr != nil {
-			a.logger.Warnw("memory budget resolution failed, proceeding without check", "error", resolveErr)
-		} else {
-			a.logger.Infow("resolved memory budget",
-				"mode", resolved.Mode, "source", resolved.Source)
-
-			var budget *MemoryBudget
-			switch resolved.Mode {
-			case BudgetModeAbsolute:
-				budget = CheckMemoryBudgetAbsolute(resolved.Bytes, estimate)
-				memoryBudgetBytes.Set(float64(resolved.Bytes))
-			default: // BudgetModeFraction
-				var budgetErr error
-				budget, budgetErr = CheckMemoryBudget(a.memoryProvider, estimate, resolved.Fraction)
-				if budgetErr != nil {
-					a.logger.Warnw("memory budget check failed, proceeding without check", "error", budgetErr)
-				}
-			}
-
-			if budget != nil && !budget.Fits {
-				var msg string
-				if resolved.Mode == BudgetModeAbsolute {
-					msg = fmt.Sprintf("estimated %s required, budget %s (absolute from CRD)",
-						formatMemory(budget.EstimateBytes),
-						formatMemory(budget.BudgetBytes),
-					)
-				} else {
-					msg = fmt.Sprintf("estimated %s required, budget %s (%s total * %.0f%%)",
-						formatMemory(budget.EstimateBytes),
-						formatMemory(budget.BudgetBytes),
-						formatMemory(budget.TotalBytes),
-						resolved.Fraction*100,
-					)
-				}
-				a.logger.Warnw("model does not fit in memory budget",
-					"estimate", formatMemory(budget.EstimateBytes),
-					"budget", formatMemory(budget.BudgetBytes),
-					"source", resolved.Source,
-				)
-				isvc.Status.SchedulingStatus = "InsufficientMemory"
-				isvc.Status.SchedulingMessage = msg
-				if updateErr := a.config.K8sClient.Status().Update(ctx, isvc); updateErr != nil {
-					a.logger.Warnw("failed to update InferenceService status", "error", updateErr)
-				}
-				return fmt.Errorf("insufficient memory: %s", msg)
-			} else if budget != nil {
-				a.logger.Infow("memory check passed",
-					"estimate", formatMemory(budget.EstimateBytes),
-					"budget", formatMemory(budget.BudgetBytes),
-					"headroom", formatMemory(budget.HeadroomBytes),
-					"source", resolved.Source,
-				)
-			}
-		}
+	if err := a.checkMemoryAdmission(ctx, isvc, model, contextSize, cacheTypeK, cacheTypeV); err != nil {
+		return err
 	}
 
 	// Apple Silicon defaults: flash-attn and mlock both ON. The user can
@@ -1236,16 +1206,130 @@ func (a *MetalAgent) HealthCheck() map[string]bool {
 	return health
 }
 
-// estimateModelMemory builds a MemoryEstimate for a model using the file on disk
-// (preferred) or the Status.Size string, plus GGUF metadata when available.
-// Cache types are passed through so quantized KV caches (q8_0, turbo3, turbo4)
-// produce a realistic estimate instead of always assuming f16.
+// checkMemoryAdmission runs the pre-flight memory check for an
+// InferenceService: estimate the model's memory need, resolve the budget, and
+// reject the service when it does not fit. A check that cannot be completed
+// (unknown model size, unreadable budget, memory query failure) FAILS CLOSED
+// by default: an unsized llama-server wires its weights and KV cache into
+// unevictable memory, and admitting one blind is how the 2026-06-09 host
+// panic happened. MemoryCheckModeWarn restores the legacy log-and-proceed
+// behavior.
+func (a *MetalAgent) checkMemoryAdmission(
+	ctx context.Context,
+	isvc *inferencev1alpha1.InferenceService,
+	model *inferencev1alpha1.Model,
+	contextSize int,
+	cacheTypeK, cacheTypeV string,
+) error {
+	estimate, err := a.estimateModelMemory(ctx, model, contextSize, cacheTypeK, cacheTypeV)
+	if err != nil {
+		return a.failMemoryCheck(ctx, isvc, fmt.Sprintf("memory estimation failed: %v", err))
+	}
+	memoryEstimatedBytes.WithLabelValues(isvc.Name, isvc.Namespace).Set(float64(estimate.TotalBytes))
+
+	resolved, resolveErr := ResolveMemoryBudget(model.Spec.Hardware, a.memoryFraction)
+	if resolveErr != nil {
+		return a.failMemoryCheck(ctx, isvc, fmt.Sprintf("memory budget resolution failed: %v", resolveErr))
+	}
+	a.logger.Infow("resolved memory budget",
+		"mode", resolved.Mode, "source", resolved.Source)
+
+	var budget *MemoryBudget
+	switch resolved.Mode {
+	case BudgetModeAbsolute:
+		budget = CheckMemoryBudgetAbsolute(resolved.Bytes, estimate)
+		memoryBudgetBytes.Set(float64(resolved.Bytes))
+	default: // BudgetModeFraction
+		var budgetErr error
+		budget, budgetErr = CheckMemoryBudget(a.memoryProvider, estimate, resolved.Fraction)
+		if budgetErr != nil {
+			return a.failMemoryCheck(ctx, isvc, fmt.Sprintf("memory budget check failed: %v", budgetErr))
+		}
+	}
+
+	if !budget.Fits {
+		var msg string
+		if resolved.Mode == BudgetModeAbsolute {
+			msg = fmt.Sprintf("estimated %s required, budget %s (absolute from CRD)",
+				formatMemory(budget.EstimateBytes),
+				formatMemory(budget.BudgetBytes),
+			)
+		} else {
+			msg = fmt.Sprintf("estimated %s required, budget %s (%s total * %.0f%%)",
+				formatMemory(budget.EstimateBytes),
+				formatMemory(budget.BudgetBytes),
+				formatMemory(budget.TotalBytes),
+				resolved.Fraction*100,
+			)
+		}
+		a.logger.Warnw("model does not fit in memory budget",
+			"estimate", formatMemory(budget.EstimateBytes),
+			"budget", formatMemory(budget.BudgetBytes),
+			"source", resolved.Source,
+		)
+		isvc.Status.SchedulingStatus = "InsufficientMemory"
+		isvc.Status.SchedulingMessage = msg
+		if updateErr := a.config.K8sClient.Status().Update(ctx, isvc); updateErr != nil {
+			a.logger.Warnw("failed to update InferenceService status", "error", updateErr)
+		}
+		return fmt.Errorf("insufficient memory: %s", msg)
+	}
+
+	a.logger.Infow("memory check passed",
+		"estimate", formatMemory(budget.EstimateBytes),
+		"budget", formatMemory(budget.BudgetBytes),
+		"headroom", formatMemory(budget.HeadroomBytes),
+		"source", resolved.Source,
+	)
+	return nil
+}
+
+// failMemoryCheck handles a memory admission check that could not be
+// completed. In enforce mode (default) it records why on the
+// InferenceService status, emits a warning event, and returns an error so
+// the caller refuses to start the process. In warn mode it logs and returns
+// nil, preserving the pre-fail-closed behavior.
+func (a *MetalAgent) failMemoryCheck(
+	ctx context.Context,
+	isvc *inferencev1alpha1.InferenceService,
+	reason string,
+) error {
+	if a.memoryCheckWarnOnly {
+		a.logger.Warnw("memory check incomplete, proceeding without check (memory-check-mode=warn)",
+			"reason", reason)
+		return nil
+	}
+
+	a.logger.Errorw("memory check incomplete, refusing to start process",
+		"reason", reason, "namespace", isvc.Namespace, "name", isvc.Name)
+	isvc.Status.SchedulingStatus = "MemoryCheckFailed"
+	isvc.Status.SchedulingMessage = reason
+	if updateErr := a.config.K8sClient.Status().Update(ctx, isvc); updateErr != nil {
+		a.logger.Warnw("failed to update InferenceService status", "error", updateErr)
+	}
+	a.emitInferenceEvent(ctx, &ManagedProcess{Namespace: isvc.Namespace, Name: isvc.Name},
+		corev1.EventTypeWarning, EventReasonMemoryCheckFailed,
+		"Memory admission check could not be completed and failed closed: %s", reason,
+	)
+	return fmt.Errorf("memory admission check failed: %s", reason)
+}
+
+// estimateModelMemory builds a MemoryEstimate for a model using the file on
+// disk (preferred), the Status.Size string, or a HEAD probe of an http(s)
+// source as a last resort, plus GGUF metadata when available. Cache types are
+// passed through so quantized KV caches (q8_0, turbo3, turbo4) produce a
+// realistic estimate instead of always assuming f16. The remote fallback
+// matters on fresh hosts: with no file on disk and a not-yet-populated status
+// size ("0"), the old chain errored out and the caller started the process
+// unchecked.
 func (a *MetalAgent) estimateModelMemory(
+	ctx context.Context,
 	model *inferencev1alpha1.Model,
 	contextSize int,
 	cacheTypeK, cacheTypeV string,
 ) (MemoryEstimate, error) {
 	var fileSizeBytes uint64
+	var reasons []string
 
 	// A model with an absolute local-path source is loaded in place by the
 	// host agent (the Metal path) and is never copied into the model store,
@@ -1254,31 +1338,51 @@ func (a *MetalAgent) estimateModelMemory(
 	if filepath.IsAbs(model.Spec.Source) {
 		if size, err := localModelSize(model.Spec.Source); err == nil {
 			fileSizeBytes = size
+		} else {
+			reasons = append(reasons, fmt.Sprintf("local source not readable: %v", err))
 		}
 	}
 
 	// Try to stat the model file in the model store (downloaded models).
 	filename := filepath.Base(model.Spec.Source)
 	localPath := filepath.Join(a.config.ModelStorePath, model.Name, filename)
-	if fileSizeBytes != 0 {
-		// already sized from the local-path source above
-	} else if info, err := os.Stat(localPath); err == nil {
-		fileSizeBytes = uint64(info.Size()) //nolint:gosec // G115: os.FileInfo.Size is non-negative by contract
-	} else if model.Status.Size != "" {
-		// Fall back to parsing the human-readable size from model status
-		parsed, err := parseSize(model.Status.Size)
-		if err != nil {
-			return MemoryEstimate{}, fmt.Errorf(
-				"cannot determine model size: file not found at %s and failed to parse status size %q: %w",
-				localPath, model.Status.Size, err,
-			)
+	if fileSizeBytes == 0 {
+		if info, err := os.Stat(localPath); err == nil {
+			fileSizeBytes = uint64(info.Size()) //nolint:gosec // G115: os.FileInfo.Size is non-negative by contract
+		} else {
+			reasons = append(reasons, fmt.Sprintf("file not found at %s", localPath))
 		}
-		fileSizeBytes = parsed
-	} else {
+	}
+
+	// Fall back to parsing the human-readable size from model status. A
+	// literal "0" means the controller has not measured the model yet; treat
+	// it as absent rather than an error so the remote probe below still runs.
+	if fileSizeBytes == 0 && model.Status.Size != "" {
+		parsed, err := parseSize(model.Status.Size)
+		switch {
+		case err != nil:
+			reasons = append(reasons, fmt.Sprintf("status size %q unparseable", model.Status.Size))
+		case parsed == 0:
+			reasons = append(reasons, "status size not populated yet")
+		default:
+			fileSizeBytes = parsed
+		}
+	}
+
+	// Last resort: HEAD the source for its Content-Length.
+	if fileSizeBytes == 0 &&
+		(strings.HasPrefix(model.Spec.Source, "http://") || strings.HasPrefix(model.Spec.Source, "https://")) {
+		size, err := remoteModelSize(ctx, model.Spec.Source)
+		if err != nil {
+			reasons = append(reasons, fmt.Sprintf("remote size probe failed: %v", err))
+		} else {
+			fileSizeBytes = size
+		}
+	}
+
+	if fileSizeBytes == 0 {
 		return MemoryEstimate{}, fmt.Errorf(
-			"cannot determine model size: file not found at %s and no status size available",
-			localPath,
-		)
+			"cannot determine model size: %s", strings.Join(reasons, "; "))
 	}
 
 	var layerCount, embeddingSize uint64

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -19,6 +19,8 @@ package agent
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -989,10 +991,18 @@ func TestEnsureProcess_InFlightGuard(t *testing.T) {
 	scheme := newTestScheme()
 	_ = corev1.AddToScheme(scheme)
 
+	// The model file must exist on disk: ensureProcess's memory admission
+	// fails closed when the model cannot be sized, which would return before
+	// the StartProcess race this test exercises.
+	modelPath := filepath.Join(t.TempDir(), "race-model.gguf")
+	if err := os.WriteFile(modelPath, []byte("stub-weights"), 0o644); err != nil {
+		t.Fatalf("failed to write stub model file: %v", err)
+	}
+
 	model := &inferencev1alpha1.Model{
 		ObjectMeta: metav1.ObjectMeta{Name: "race-model", Namespace: "default"},
 		Spec: inferencev1alpha1.ModelSpec{
-			Source:   "/tmp/race-model.gguf",
+			Source:   modelPath,
 			Format:   "gguf",
 			Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
 		},

--- a/pkg/agent/memory.go
+++ b/pkg/agent/memory.go
@@ -17,14 +17,29 @@ limitations under the License.
 package agent
 
 import (
+	"context"
 	"fmt"
 	"math"
+	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+const (
+	// MemoryCheckModeEnforce rejects an InferenceService when the pre-flight
+	// memory check cannot be completed (fail closed). This is the default.
+	MemoryCheckModeEnforce = "enforce"
+	// MemoryCheckModeWarn preserves the legacy behavior of logging a warning
+	// and starting the process anyway when the check cannot be completed.
+	// An incomplete check allowed unsized models through on 2026-06-09 and
+	// wired all 128 GB of host RAM, panicking the machine; use only as an
+	// operational escape hatch.
+	MemoryCheckModeWarn = "warn"
 )
 
 // MemoryPressureLevel represents the severity of memory pressure.
@@ -243,6 +258,36 @@ func formatMemory(bytes uint64) string {
 		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(gb))
 	}
 	return fmt.Sprintf("%.0f MB", float64(bytes)/float64(mb))
+}
+
+// remoteModelSize probes an http(s) model source with a HEAD request and
+// returns its Content-Length. It is the last-resort size source for the
+// pre-flight memory check: used when the model is not on disk yet and the
+// Model CR carries no usable status size, so admission can still be decided
+// before the download begins instead of failing open.
+func remoteModelSize(ctx context.Context, source string) (uint64, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, source, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("bad status: %s", resp.Status)
+	}
+	if resp.ContentLength <= 0 {
+		return 0, fmt.Errorf("no Content-Length in HEAD response")
+	}
+	return uint64(resp.ContentLength), nil
 }
 
 // parseSize parses a human-readable size string (as produced by model_controller's

--- a/pkg/agent/memory_admission_test.go
+++ b/pkg/agent/memory_admission_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func newAdmissionTestModel(source, statusSize string) *inferencev1alpha1.Model {
+	return &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.ModelSpec{
+			Source: source,
+		},
+		Status: inferencev1alpha1.ModelStatus{
+			Size: statusSize,
+		},
+	}
+}
+
+func newAdmissionTestISVC() *inferencev1alpha1.InferenceService {
+	return &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-isvc",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "test-model",
+		},
+	}
+}
+
+// newAdmissionTestAgent builds a MetalAgent whose fake client already holds
+// the given InferenceService (with the status subresource enabled so
+// Status().Update works) and whose model store is an empty temp dir.
+func newAdmissionTestAgent(t *testing.T, isvc *inferencev1alpha1.InferenceService, cfg MetalAgentConfig) *MetalAgent {
+	t.Helper()
+	builder := fake.NewClientBuilder().WithScheme(newTestScheme())
+	if isvc != nil {
+		builder = builder.
+			WithObjects(isvc).
+			WithStatusSubresource(isvc)
+	}
+	cfg.K8sClient = builder.Build()
+	if cfg.ModelStorePath == "" {
+		cfg.ModelStorePath = t.TempDir()
+	}
+	return NewMetalAgent(cfg)
+}
+
+func TestRemoteModelSize_UsesContentLength(t *testing.T) {
+	const wantSize = 14_000_000_000
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Errorf("expected HEAD request, got %s", r.Method)
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", wantSize))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	size, err := remoteModelSize(context.Background(), ts.URL+"/model.gguf")
+	if err != nil {
+		t.Fatalf("remoteModelSize returned error: %v", err)
+	}
+	if size != wantSize {
+		t.Errorf("size = %d, want %d", size, wantSize)
+	}
+}
+
+func TestRemoteModelSize_NonOKStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	if _, err := remoteModelSize(context.Background(), ts.URL+"/gated.gguf"); err == nil {
+		t.Fatal("expected error for 401 response, got nil")
+	}
+}
+
+func TestRemoteModelSize_MissingContentLength(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Chunked response: no Content-Length header.
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	if _, err := remoteModelSize(context.Background(), ts.URL+"/model.gguf"); err == nil {
+		t.Fatal("expected error for missing Content-Length, got nil")
+	}
+}
+
+// The crash scenario from 2026-06-09: model not on disk yet (fresh boot wiped
+// /tmp) and Model status.size is the literal string "0". The estimate must
+// fall back to a HEAD probe of the source instead of erroring out (which the
+// old call site then treated as "proceed without check").
+func TestEstimateModelMemory_RemoteHEADFallback(t *testing.T) {
+	const wantSize = uint64(20_000_000_000)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", wantSize))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	agent := newAdmissionTestAgent(t, nil, MetalAgentConfig{})
+	model := newAdmissionTestModel(ts.URL+"/model.gguf", "0")
+
+	estimate, err := agent.estimateModelMemory(context.Background(), model, 2048, "", "")
+	if err != nil {
+		t.Fatalf("estimateModelMemory returned error: %v", err)
+	}
+	if estimate.WeightsBytes != wantSize {
+		t.Errorf("WeightsBytes = %d, want %d", estimate.WeightsBytes, wantSize)
+	}
+}
+
+func TestEstimateModelMemory_StatusSizePreferredOverRemote(t *testing.T) {
+	// Valid status size: must be used without any HTTP traffic (source is
+	// unreachable on purpose).
+	agent := newAdmissionTestAgent(t, nil, MetalAgentConfig{})
+	model := newAdmissionTestModel("https://model-host.invalid/model.gguf", "20.0 GiB")
+
+	estimate, err := agent.estimateModelMemory(context.Background(), model, 2048, "", "")
+	if err != nil {
+		t.Fatalf("estimateModelMemory returned error: %v", err)
+	}
+	want := uint64(20 * 1024 * 1024 * 1024)
+	if estimate.WeightsBytes != want {
+		t.Errorf("WeightsBytes = %d, want %d", estimate.WeightsBytes, want)
+	}
+}
+
+func TestEstimateModelMemory_AllSourcesExhausted(t *testing.T) {
+	agent := newAdmissionTestAgent(t, nil, MetalAgentConfig{})
+	model := newAdmissionTestModel("https://model-host.invalid/model.gguf", "0")
+
+	_, err := agent.estimateModelMemory(context.Background(), model, 2048, "", "")
+	if err == nil {
+		t.Fatal("expected error when no size source is available, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot determine model size") {
+		t.Errorf("error %q should mention being unable to determine model size", err)
+	}
+}
+
+// Fail closed: when the model size cannot be determined at all, admission
+// must reject the service instead of starting an unsized llama-server.
+func TestCheckMemoryAdmission_FailsClosedWhenSizeUnknown(t *testing.T) {
+	isvc := newAdmissionTestISVC()
+	agent := newAdmissionTestAgent(t, isvc, MetalAgentConfig{
+		MemoryProvider: &mockMemoryProvider{totalBytes: 128 * 1024 * 1024 * 1024},
+	})
+	model := newAdmissionTestModel("https://model-host.invalid/model.gguf", "0")
+
+	err := agent.checkMemoryAdmission(context.Background(), isvc, model, 2048, "", "")
+	if err == nil {
+		t.Fatal("expected admission to fail closed, got nil error")
+	}
+
+	updated := &inferencev1alpha1.InferenceService{}
+	if getErr := agent.config.K8sClient.Get(context.Background(),
+		types.NamespacedName{Namespace: "default", Name: "test-isvc"}, updated); getErr != nil {
+		t.Fatalf("failed to re-fetch InferenceService: %v", getErr)
+	}
+	if updated.Status.SchedulingStatus != "MemoryCheckFailed" {
+		t.Errorf("SchedulingStatus = %q, want %q", updated.Status.SchedulingStatus, "MemoryCheckFailed")
+	}
+	if updated.Status.SchedulingMessage == "" {
+		t.Error("SchedulingMessage should explain why admission failed")
+	}
+}
+
+func TestCheckMemoryAdmission_WarnModeProceeds(t *testing.T) {
+	isvc := newAdmissionTestISVC()
+	agent := newAdmissionTestAgent(t, isvc, MetalAgentConfig{
+		MemoryProvider:  &mockMemoryProvider{totalBytes: 128 * 1024 * 1024 * 1024},
+		MemoryCheckMode: MemoryCheckModeWarn,
+	})
+	model := newAdmissionTestModel("https://model-host.invalid/model.gguf", "0")
+
+	if err := agent.checkMemoryAdmission(context.Background(), isvc, model, 2048, "", ""); err != nil {
+		t.Fatalf("warn mode should preserve the legacy proceed-without-check behavior, got: %v", err)
+	}
+}
+
+func TestCheckMemoryAdmission_RejectsOverBudget(t *testing.T) {
+	isvc := newAdmissionTestISVC()
+	agent := newAdmissionTestAgent(t, isvc, MetalAgentConfig{
+		MemoryProvider: &mockMemoryProvider{totalBytes: 8 * 1024 * 1024 * 1024},
+		MemoryFraction: 0.75,
+	})
+	model := newAdmissionTestModel("https://model-host.invalid/model.gguf", "100.0 GiB")
+
+	err := agent.checkMemoryAdmission(context.Background(), isvc, model, 2048, "", "")
+	if err == nil {
+		t.Fatal("expected insufficient-memory rejection, got nil error")
+	}
+	if !strings.Contains(err.Error(), "insufficient memory") {
+		t.Errorf("error %q should mention insufficient memory", err)
+	}
+
+	updated := &inferencev1alpha1.InferenceService{}
+	if getErr := agent.config.K8sClient.Get(context.Background(),
+		types.NamespacedName{Namespace: "default", Name: "test-isvc"}, updated); getErr != nil {
+		t.Fatalf("failed to re-fetch InferenceService: %v", getErr)
+	}
+	if updated.Status.SchedulingStatus != "InsufficientMemory" {
+		t.Errorf("SchedulingStatus = %q, want %q", updated.Status.SchedulingStatus, "InsufficientMemory")
+	}
+}
+
+func TestCheckMemoryAdmission_PassesWithinBudget(t *testing.T) {
+	isvc := newAdmissionTestISVC()
+	agent := newAdmissionTestAgent(t, isvc, MetalAgentConfig{
+		MemoryProvider: &mockMemoryProvider{totalBytes: 128 * 1024 * 1024 * 1024},
+		MemoryFraction: 0.75,
+	})
+	model := newAdmissionTestModel("https://model-host.invalid/model.gguf", "20.0 GiB")
+
+	if err := agent.checkMemoryAdmission(context.Background(), isvc, model, 2048, "", ""); err != nil {
+		t.Fatalf("model within budget should pass admission, got: %v", err)
+	}
+}

--- a/pkg/agent/pressure.go
+++ b/pkg/agent/pressure.go
@@ -52,6 +52,7 @@ const (
 	EventReasonEvicted                    = "Evicted"
 	EventReasonEvictionSkipped            = "EvictionSkipped"
 	EventReasonRespawnBlocked             = "RespawnBlocked"
+	EventReasonMemoryCheckFailed          = "MemoryCheckFailed"
 )
 
 // emitInferenceEvent publishes a Kubernetes event on the InferenceService


### PR DESCRIPTION
## What

The metal-agent's pre-flight memory check now fails closed: when the check cannot be completed (unknown model size, budget resolution error, memory query failure), the agent refuses to start the inference process, records `SchedulingStatus: MemoryCheckFailed` on the InferenceService, and emits a `MemoryCheckFailed` warning event. A new `--memory-check-mode` flag (`enforce` | `warn`, default `enforce`) keeps the old log-and-proceed behavior available as an operational escape hatch.

To keep the stricter check from rejecting legitimate not-yet-downloaded models, `estimateModelMemory` gains two fallbacks:

- A Model `status.size` of `"0"` is treated as "not measured yet" instead of a hard parse error.
- When neither the disk nor the status carries a size, an http(s) source is probed with a HEAD request (10s timeout) and sized from `Content-Length`, so admission is decided before the download starts.

## Why

The previous behavior logged `proceeding without check` and started the process anyway. On a fresh host (empty model store, `status.size` still `"0"`), every InferenceService bypassed the memory budget this way. On 2026-06-09 concurrent unsized llama-server loads wired 123.4 GB of a 128 GB Apple Silicon host into unevictable memory (`--mlock` weights + Metal KV buffers); the machine stalled and died with a watchdog-timeout kernel panic. Admitting a model blind is strictly worse than refusing it: wired memory cannot be paged or jetsam-killed, so the failure mode is a host panic rather than a failed pod.

Fixes #640

## How

- Extracted the admission block from `ensureProcess` into `checkMemoryAdmission`; all three previously fail-open paths route through `failMemoryCheck`, which enforces or warns based on the resolved mode.
- Added `remoteModelSize` (HEAD probe) in `pkg/agent/memory.go` and restructured `estimateModelMemory` into an explicit fallback chain (local source path → model store stat → status size → remote HEAD) that accumulates the reasons each source was unusable into the final error.
- Unknown `--memory-check-mode` values resolve to `enforce` so a typo cannot select the dangerous direction; the resolved mode is logged in the startup `memory budget` line.
- `TestEnsureProcess_InFlightGuard` now writes a real stub model file: its unsized model is correctly rejected by admission before reaching the `StartProcess` race it exercises.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint run ./...` for the cross-arch files)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (macos-metal guide: memory budgets section + MemoryCheckFailed troubleshooting entry)