### PR TITLE
feat(foreman/reviewer): demote unverifiable review verdicts to NO-GO

### DIFF
--- a/docs/site/foreman/model-compatibility.md
+++ b/docs/site/foreman/model-compatibility.md
@@ -64,10 +64,28 @@ A new boolean field `issueAskVerified` signals to downstream
 consumers whether the stored value came from the model
 verbatim or from the harness rewrite.
 
-This means the *verdict* (which drives the cascade rule) is still
-based on the model's reasoning, but the *anchor fields* downstream
-tools pivot on (which file did the diff touch? what does the
-issue actually ask for?) are harness-authoritative.
+Since [#645](https://github.com/defilantech/LLMKube/pull/645) the
+verification result is *enforced*, not just recorded:
+
+- An unverified `issueAsk` on a **GO** verdict demotes the verdict
+  to **NO-GO**. A reviewer that cannot prove it read the issue
+  cannot approve a branch. Because escalation reviewers are emitted
+  on base NO-GO, the branch is automatically re-reviewed by the
+  escalation model instead of being green-lit.
+- An unverified `issueAsk` on any other verdict keeps the verdict
+  but marks it untrusted.
+- In both cases the result extra carries `verdictDemoted: true`,
+  `verdictClaimed` (the model's original verdict), and a
+  `demotionReason`, mirroring the `issueAskClaimed` convention.
+- If `issueAskVerified` is absent entirely (no `fetch_issue` body
+  in the transcript, a harness-side gap rather than model
+  dishonesty), enforcement does not fire.
+
+The *anchor fields* downstream tools pivot on (which files did the
+diff touch? what does the issue actually ask for?) remain
+harness-authoritative, and the verdict now inherits that property:
+a verdict that contradicts the harness's evidence check cannot
+drive the cascade rule on its own.
 
 ## What v0.5 changes
 

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -466,6 +466,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// #582/filesTouched fix: harness owns the authoritative
 			// field, model's claim is archived under issueAskClaimed.
 			reconcileReviewerIssueAsk(log, loopRes.Transcript, loopRes.Terminal.Extra)
+			// Enforce the verification result (#644): an unverifiable
+			// issueAsk demotes a GO to NO-GO so it routes to escalation
+			// instead of approving a branch on fabricated understanding.
+			verdict = enforceReviewerIssueAsk(log, loopRes.Terminal.Extra, verdict)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
 		return e.modelDecidedResult(start, transcriptRef, loopRes, verdict), nil
@@ -1234,6 +1238,58 @@ func reconcileReviewerIssueAsk(log logr.Logger, msgs []oai.Message, extra map[st
 		"modelClaim", claim,
 		"rewrittenTo", replaced,
 	)
+}
+
+// enforceReviewerIssueAsk converts a failed issueAsk verification from
+// an observation into a routing decision (#644). reconcileReviewerIssueAsk
+// records whether the model's stated understanding of the issue is a
+// verbatim quote of the body it fetched; until now a `false` there was
+// archaeology while the verdict stood. The 2026-06-10 Mellum2 battery
+// showed why that is not enough: 5/5 runs failed verification, including
+// a GO on a known scope-drift branch and a NO-GO justified by a fully
+// hallucinated ask. Both confidently wrong verdicts stood.
+//
+// Policy:
+//   - verified false + GO: demote to NO-GO. A reviewer that cannot prove
+//     it read the issue must not approve a branch. Because the workload
+//     controller emits escalation reviewers on base NO-GO, demotion
+//     routes the branch to a bigger model instead of green-lighting it.
+//   - verified false + any other verdict: keep the verdict but mark it,
+//     so the escalation reviewer and operators know the base review's
+//     reasoning is untrusted.
+//   - verified absent (no fetch_issue body in the transcript, a
+//     harness-side gap rather than model dishonesty): observe-only,
+//     unchanged.
+//
+// The original verdict is archived under verdictClaimed and the
+// rewritten one flagged with verdictDemoted + demotionReason, mirroring
+// the issueAskClaimed convention.
+func enforceReviewerIssueAsk(
+	log logr.Logger,
+	extra map[string]any,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+) foremanv1alpha1.AgenticTaskVerdict {
+	if extra == nil {
+		return verdict
+	}
+	verified, present := extra["issueAskVerified"].(bool)
+	if !present || verified {
+		return verdict
+	}
+
+	extra["verdictDemoted"] = true
+	extra["verdictClaimed"] = string(verdict)
+	extra["demotionReason"] = "issueAsk could not be verified as a verbatim quote of the " +
+		"fetched issue body; review verdict is untrusted"
+
+	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		log.Info("reviewer integrity: unverified issueAsk on non-GO verdict; keeping verdict but marking untrusted",
+			"verdict", verdict)
+		return verdict
+	}
+	log.Info("reviewer integrity: unverified issueAsk on GO verdict; demoting to NO-GO",
+		"verdictClaimed", verdict)
+	return foremanv1alpha1.AgenticTaskVerdictNoGo
 }
 
 // extractFetchIssueBody finds the most recent fetch_issue tool result

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1250,3 +1250,66 @@ func TestReconcileReviewerIssueAsk_EmptyClaimFilledFromBody(t *testing.T) {
 func TestReconcileReviewerIssueAsk_NilExtraIsNoOp(t *testing.T) {
 	reconcileReviewerIssueAsk(logr.Discard(), nil, nil) // must not panic
 }
+
+func TestEnforceReviewerIssueAsk_VerifiedGoStands(t *testing.T) {
+	extra := map[string]any{"issueAskVerified": true}
+	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("verified GO should stand; got %v", got)
+	}
+	if _, demoted := extra["verdictDemoted"]; demoted {
+		t.Errorf("verified review should not be annotated as demoted")
+	}
+}
+
+func TestEnforceReviewerIssueAsk_UnverifiedGoDemotedToNoGo(t *testing.T) {
+	extra := map[string]any{"issueAskVerified": false}
+	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Errorf("unverified GO must demote to NO-GO; got %v", got)
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("demotion must set verdictDemoted=true; got %v", extra["verdictDemoted"])
+	}
+	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+		t.Errorf("verdictClaimed should archive the original GO; got %v", extra["verdictClaimed"])
+	}
+	if reason, _ := extra["demotionReason"].(string); reason == "" {
+		t.Errorf("demotionReason must explain the demotion")
+	}
+}
+
+func TestEnforceReviewerIssueAsk_UnverifiedNoGoKeptButMarked(t *testing.T) {
+	extra := map[string]any{"issueAskVerified": false}
+	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Errorf("unverified NO-GO should stay NO-GO; got %v", got)
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("unverified NO-GO must still be marked verdictDemoted=true so the escalation reviewer knows the base verdict is untrusted")
+	}
+	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictNoGo) {
+		t.Errorf("verdictClaimed should archive the original NO-GO; got %v", extra["verdictClaimed"])
+	}
+}
+
+func TestEnforceReviewerIssueAsk_AbsentFieldIsObserveOnly(t *testing.T) {
+	// issueAskVerified absent means the harness had no fetch_issue body
+	// to verify against (a harness-side gap, not model dishonesty);
+	// enforcement must not fire.
+	extra := map[string]any{"issueAsk": "some claim"}
+	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("absent issueAskVerified must not demote; got %v", got)
+	}
+	if _, demoted := extra["verdictDemoted"]; demoted {
+		t.Errorf("absent issueAskVerified should not be annotated as demoted")
+	}
+}
+
+func TestEnforceReviewerIssueAsk_NilExtraIsNoOp(t *testing.T) {
+	got := enforceReviewerIssueAsk(logr.Discard(), nil, foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("nil extra must pass the verdict through; got %v", got)
+	}
+}


### PR DESCRIPTION
## What

The native executor's reviewer path now enforces the #587 issueAsk ground-truthing instead of just recording it. After `reconcileReviewerIssueAsk` runs, a new `enforceReviewerIssueAsk` step applies this policy:

- `issueAskVerified=false` + verdict GO: **demote to NO-GO**. A reviewer that cannot prove it read the issue must not approve a branch.
- `issueAskVerified=false` + any other verdict: keep the verdict, but mark it untrusted.
- `issueAskVerified` absent (no `fetch_issue` body in the transcript — a harness-side gap, not model dishonesty): observe-only, unchanged.

In all enforcement cases the result extra is annotated with `verdictDemoted: true`, `verdictClaimed: <original>`, and `demotionReason`, mirroring the existing `issueAskClaimed` convention.

## Why

A 5-branch review battery with Mellum2-12B (2026-06-10) showed the cost of observe-only verification: `issueAskVerified=false` on 5 of 5 runs, including a GO on a branch with known scope drift and a NO-GO justified by a fully hallucinated ask ("add mlx model format support" against an issue that requests a one-line docs nudge). Both confidently wrong verdicts stood.

Because the workload controller emits escalation reviewers on base NO-GO (#639), demotion automatically routes integrity failures to a bigger model — no controller changes needed. Under this policy, every wrong verdict from the battery becomes a correct escalation instead.

Fixes #644

## How

- New `enforceReviewerIssueAsk` helper beside the #587 reconciler in `pkg/foreman/agent/executor_native.go`, wired into the reviewer block immediately after reconciliation.
- Demoting to NO-GO (rather than INCOMPLETE) was chosen deliberately: INCOMPLETE does not trigger #639's escalation emission, and extending that trigger is a larger design change noted in #644 as a possible follow-up.
- Five whitebox tests in `executor_native_internal_test.go` pin the policy, including the absent-field observe-only case and nil-extra passthrough.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint run ./...`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (model-compatibility.md: enforcement semantics added to the confabulation section)