### PR TITLE
feat(foreman/reviewer): computable scope-overlap check demotes drifted GO verdicts

### DIFF
--- a/docs/site/foreman/model-compatibility.md
+++ b/docs/site/foreman/model-compatibility.md
@@ -81,6 +81,15 @@ verification result is *enforced*, not just recorded:
   in the transcript, a harness-side gap rather than model
   dishonesty), enforcement does not fire.
 
+[#647](https://github.com/defilantech/LLMKube/issues/647) adds a
+second, fully computable check: when the issue body names concrete
+files (`config/rbac/role.yaml`, `AGENTS.md`) and the ground-truth
+diff touches none of them, the executor flags scope drift
+deterministically (`scopeRefs`, `scopeMatched`,
+`scopeDriftDetected` in the result extra) and demotes a GO the
+same way. No model judgment is involved; an issue that names no
+files keeps the check observe-only.
+
 The *anchor fields* downstream tools pivot on (which files did the
 diff touch? what does the issue actually ask for?) remain
 harness-authoritative, and the verdict now inherits that property:

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -470,6 +470,17 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// issueAsk demotes a GO to NO-GO so it routes to escalation
 			// instead of approving a branch on fabricated understanding.
 			verdict = enforceReviewerIssueAsk(log, loopRes.Terminal.Extra, verdict)
+			// Computable scope-overlap check (#647): when the issue names
+			// concrete files and the diff touches none of them, demote a
+			// GO deterministically. Runs after the issueAsk enforcement
+			// so an already-demoted verdict is annotated, not re-demoted.
+			if scopeDiff, scopeErr := repo.DiffNameOnly(ctx, workspace, "main"); scopeErr == nil {
+				verdict = enforceReviewerScopeOverlap(log, loopRes.Terminal.Extra,
+					extractFetchIssueBody(loopRes.Transcript), scopeDiff, verdict)
+			} else {
+				log.Info("reviewer scope: ground-truth diff unavailable; skipping scope check",
+					"err", scopeErr.Error())
+			}
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
 		return e.modelDecidedResult(start, transcriptRef, loopRes, verdict), nil

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// pathRefExtensions are the file extensions a token must carry to count
+// as a concrete path reference in an issue body. The set is deliberately
+// small: under-extracting is safe (no refs means the scope check stays
+// observe-only) while over-extracting risks false drift flags, so
+// identifiers, commands, and API groups must not slip through.
+var pathRefExtensions = map[string]bool{
+	"go": true, "md": true, "yaml": true, "yml": true, "sh": true,
+	"json": true, "mod": true, "sum": true, "tmpl": true, "proto": true,
+	"toml": true, "mk": true,
+}
+
+// extractIssuePathRefs pulls concrete file references out of an issue
+// body: tokens that are either a path (slash-separated segments ending
+// in a known source extension, like `config/rbac/role.yaml`) or a bare
+// filename (`AGENTS.md`). Commands (`make manifests`), RBAC groups
+// (`core/endpoints`), marker annotations (`kubebuilder:rbac`), and API
+// type paths (`discovery.k8s.io/v1.EndpointSlice`) do not qualify.
+// Escaped backticks (as returned by the GitHub API) are normalized
+// away before tokenizing. Results are deduplicated in first-occurrence
+// order.
+func extractIssuePathRefs(body string) []string {
+	if body == "" {
+		return nil
+	}
+	normalized := strings.ReplaceAll(body, "\\`", "`")
+	normalized = strings.NewReplacer("`", " ", "(", " ", ")", " ", "[", " ", "]", " ",
+		"{", " ", "}", " ", "\"", " ", "'", " ", ",", " ", ";", " ").Replace(normalized)
+
+	var refs []string
+	seen := map[string]bool{}
+	for _, tok := range strings.Fields(normalized) {
+		tok = strings.Trim(tok, ".:!?")
+		if tok == "" || seen[tok] {
+			continue
+		}
+		if isPathRef(tok) {
+			seen[tok] = true
+			refs = append(refs, tok)
+		}
+	}
+	return refs
+}
+
+// isPathRef reports whether a single cleaned token is a concrete file
+// reference per the rules documented on extractIssuePathRefs.
+func isPathRef(tok string) bool {
+	ext := strings.ToLower(strings.TrimPrefix(path.Ext(tok), "."))
+	if !pathRefExtensions[ext] {
+		return false
+	}
+	for _, seg := range strings.Split(tok, "/") {
+		if seg == "" || strings.IndexFunc(seg, func(r rune) bool {
+			return !(r == '.' || r == '_' || r == '-' ||
+				(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
+		}) != -1 {
+			return false
+		}
+	}
+	return true
+}
+
+// enforceReviewerScopeOverlap is the computable half of scope-drift
+// detection (#647). The issue body names concrete files; the ground-truth
+// diff says which files actually changed. When the issue names at least
+// one file and the diff touches none of them, that is the #379 drift
+// signature, and it is detectable without any model judgment, which
+// matters because review judgment is demonstrably stochastic: the same
+// devstral that caught #379's drift in May approved it in June.
+//
+// Policy mirrors enforceReviewerIssueAsk:
+//   - refs exist, none matched, verdict GO: demote to NO-GO so the
+//     workload controller's escalation emission routes the branch to a
+//     bigger reviewer.
+//   - refs exist, none matched, other verdict: annotate only.
+//   - no refs in the issue, or no diff available: observe-only, no
+//     annotations (absence of signal is not evidence of drift).
+//
+// Matching is generous on purpose (exact path or basename equality):
+// a false drift flag costs one escalation review, while a missed match
+// would demote a legitimate branch.
+func enforceReviewerScopeOverlap(
+	log logr.Logger,
+	extra map[string]any,
+	issueBody string,
+	diffFiles []string,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+) foremanv1alpha1.AgenticTaskVerdict {
+	if extra == nil || issueBody == "" || len(diffFiles) == 0 {
+		return verdict
+	}
+	refs := extractIssuePathRefs(issueBody)
+	if len(refs) == 0 {
+		return verdict
+	}
+
+	diffBases := make(map[string]bool, len(diffFiles))
+	diffPaths := make(map[string]bool, len(diffFiles))
+	for _, f := range diffFiles {
+		diffPaths[f] = true
+		diffBases[path.Base(f)] = true
+	}
+	matched := []string{}
+	for _, r := range refs {
+		if diffPaths[r] || diffBases[path.Base(r)] {
+			matched = append(matched, r)
+		}
+	}
+
+	drift := len(matched) == 0
+	extra["scopeRefs"] = refs
+	extra["scopeMatched"] = matched
+	extra["scopeDriftDetected"] = drift
+	if !drift {
+		return verdict
+	}
+
+	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		log.Info("reviewer scope: diff touches none of the files the issue names; verdict already non-GO, annotating only",
+			"verdict", verdict, "scopeRefs", refs)
+		return verdict
+	}
+	extra["verdictDemoted"] = true
+	extra["verdictClaimed"] = string(verdict)
+	extra["demotionReason"] = fmt.Sprintf(
+		"scope drift: the issue names %d file(s) (%s) and the diff touches none of them",
+		len(refs), strings.Join(refs, ", "))
+	log.Info("reviewer scope: drift detected on GO verdict; demoting to NO-GO",
+		"scopeRefs", refs, "diffFiles", diffFiles)
+	return foremanv1alpha1.AgenticTaskVerdictNoGo
+}

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+// Whitebox tests for the computable scope-overlap check (#647). The
+// extraction fixtures are the real issue bodies from the cases that
+// motivated the feature: #379 (the scope-drift trap every reviewer
+// model except tool-using Claude has missed at least once) and #510
+// (a docs nudge a reviewer once NO-GO'd against a hallucinated ask).
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// issue379Body is the verbatim body of defilantech/LLMKube#379,
+// including the escaped backticks GitHub's API returns.
+const issue379Body = "## Background\n\n" +
+	"PR #376 (the metal-accelerator phase-Ready fix) added a new RBAC marker " +
+	"(\\`core/endpoints\\` get/list/watch) to the controller via \\`kubebuilder:rbac\\` " +
+	"annotation. \\`make manifests\\` regenerated \\`config/rbac/role.yaml\\` " +
+	"as expected. But the Helm chart's hand-synced " +
+	"\\`charts/llmkube/templates/clusterrole.yaml\\` was NOT updated " +
+	"automatically — there's no equivalent to PR #367's CRD sync guard for RBAC.\n\n" +
+	"## What's needed\n\n" +
+	"A CI guard that diffs the Helm chart's ClusterRole rules against the " +
+	"kubebuilder-source ClusterRole rules " +
+	"(\\`config/rbac/role.yaml\\` after \\`make manifests\\`) and fails if they " +
+	"disagree. Mirror of \\`scripts/sync-crds.sh\\` " +
+	"and the corresponding CI step from PR #367, but for RBAC.\n\n" +
+	"## Implementation sketch\n\n" +
+	"1. Script \\`scripts/check-helm-rbac.sh\\` (or similar): parse both YAMLs, " +
+	"compare rules sets, exit non-zero on diff.\n" +
+	"2. Workflow step in the existing GitHub Actions job that runs CRD sync check, " +
+	"or a sibling job.\n" +
+	"3. Optionally: a companion \\`scripts/sync-helm-rbac.sh\\` that auto-applies " +
+	"the kubebuilder-generated rules into " +
+	"the chart template, so contributors can run \\`make chart-rbac\\` like they " +
+	"run \\`make chart-crds\\`.\n"
+
+const issue510Body = "## Feature Description\n\n" +
+	"After PR #508 lands the `make lint-all` target, point contributors at it from\n" +
+	"`AGENTS.md` (and/or `CONTRIBUTING.md`) so they actually use it. Today the\n" +
+	"target is discoverable only via `make help`; a one-line nudge in the standards\n" +
+	"doc costs almost nothing and saves a CI round\n"
+
+func TestExtractIssuePathRefs_Issue379(t *testing.T) {
+	got := extractIssuePathRefs(issue379Body)
+	want := []string{
+		"config/rbac/role.yaml",
+		"charts/llmkube/templates/clusterrole.yaml",
+		"scripts/sync-crds.sh",
+		"scripts/check-helm-rbac.sh",
+		"scripts/sync-helm-rbac.sh",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("extractIssuePathRefs(#379) = %v, want %v", got, want)
+	}
+}
+
+func TestExtractIssuePathRefs_Issue510BareFilenames(t *testing.T) {
+	got := extractIssuePathRefs(issue510Body)
+	want := []string{"AGENTS.md", "CONTRIBUTING.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("extractIssuePathRefs(#510) = %v, want %v", got, want)
+	}
+}
+
+func TestExtractIssuePathRefs_IgnoresCommandsAndAPIGroups(t *testing.T) {
+	body := "Run `make manifests` then check `core/endpoints` and `kubebuilder:rbac` " +
+		"plus `discovery.k8s.io/v1.EndpointSlice` and plain words."
+	if got := extractIssuePathRefs(body); len(got) != 0 {
+		t.Errorf("commands, API groups, and identifiers must not extract as path refs; got %v", got)
+	}
+}
+
+func TestExtractIssuePathRefs_EmptyBody(t *testing.T) {
+	if got := extractIssuePathRefs(""); len(got) != 0 {
+		t.Errorf("empty body should yield no refs; got %v", got)
+	}
+}
+
+func TestEnforceReviewerScopeOverlap_Issue379DriftDemotesGo(t *testing.T) {
+	// The actual drifted diff from foreman/issue-379.
+	diff := []string{
+		"internal/foreman/controller/agentictask_controller.go",
+		"internal/foreman/controller/agentictask_controller_test.go",
+	}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("zero scope overlap on GO must demote to NO-GO; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); !v {
+		t.Errorf("scopeDriftDetected must be true; got %v", extra["scopeDriftDetected"])
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("demotion must set verdictDemoted=true")
+	}
+	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+		t.Errorf("verdictClaimed should archive GO; got %v", extra["verdictClaimed"])
+	}
+	if reason, _ := extra["demotionReason"].(string); reason == "" {
+		t.Errorf("demotionReason must explain the demotion")
+	}
+	refs, _ := extra["scopeRefs"].([]string)
+	if len(refs) != 5 {
+		t.Errorf("scopeRefs should carry the 5 extracted paths; got %v", refs)
+	}
+	matched, _ := extra["scopeMatched"].([]string)
+	if len(matched) != 0 {
+		t.Errorf("scopeMatched should be empty on full drift; got %v", matched)
+	}
+}
+
+func TestEnforceReviewerScopeOverlap_MatchedRefStands(t *testing.T) {
+	diff := []string{"AGENTS.md"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue510Body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("a diff touching a referenced file must not demote; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); v {
+		t.Errorf("scopeDriftDetected should be false when a ref matches")
+	}
+	matched, _ := extra["scopeMatched"].([]string)
+	if !reflect.DeepEqual(matched, []string{"AGENTS.md"}) {
+		t.Errorf("scopeMatched = %v, want [AGENTS.md]", matched)
+	}
+}
+
+func TestEnforceReviewerScopeOverlap_BasenameMatch(t *testing.T) {
+	// Issue says `role.yaml`-style short ref; diff touches it under its
+	// full path. Basename equality must count as a match.
+	body := "Update `role.yaml` to include the new verbs."
+	diff := []string{"config/rbac/role.yaml"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("basename match must not demote; got %v", got)
+	}
+}
+
+func TestEnforceReviewerScopeOverlap_NoRefsObserveOnly(t *testing.T) {
+	body := "The error message when a model is missing is confusing; improve it."
+	diff := []string{"pkg/agent/agent.go"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("no path refs in issue must not demote; got %v", got)
+	}
+	if _, present := extra["scopeDriftDetected"]; present {
+		t.Errorf("no refs should add no scope annotations; got %v", extra)
+	}
+}
+
+func TestEnforceReviewerScopeOverlap_DriftOnNoGoAnnotatesOnly(t *testing.T) {
+	diff := []string{"internal/foreman/controller/agentictask_controller.go"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
+		foremanv1alpha1.AgenticTaskVerdictNoGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("NO-GO must stay NO-GO; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); !v {
+		t.Errorf("drift should still be annotated on NO-GO")
+	}
+	if _, demoted := extra["verdictDemoted"]; demoted {
+		t.Errorf("a NO-GO verdict was not demoted and must not claim to be")
+	}
+}
+
+func TestEnforceReviewerScopeOverlap_NilOrEmptyInputsPassThrough(t *testing.T) {
+	if got := enforceReviewerScopeOverlap(logr.Discard(), nil, issue379Body,
+		[]string{"x.go"}, foremanv1alpha1.AgenticTaskVerdictGo); got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("nil extra must pass through; got %v", got)
+	}
+	extra := map[string]any{}
+	if got := enforceReviewerScopeOverlap(logr.Discard(), extra, "", nil,
+		foremanv1alpha1.AgenticTaskVerdictGo); got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("empty body and diff must pass through; got %v", got)
+	}
+}


### PR DESCRIPTION
## What

Adds the second review-integrity lever: a fully deterministic scope-drift check in the native executor's reviewer path.

- `extractIssuePathRefs` pulls concrete file references from the fetched issue body: slash-separated paths with a known source extension (`config/rbac/role.yaml`) and bare filenames (`AGENTS.md`). Commands (`make manifests`), RBAC groups (`core/endpoints`), marker annotations (`kubebuilder:rbac`), and API type paths (`discovery.k8s.io/v1.EndpointSlice`) deliberately do not qualify.
- `enforceReviewerScopeOverlap` matches the refs against the ground-truth diff (`repo.DiffNameOnly`, exact path or basename) and applies the #645 policy: refs exist + none matched + verdict GO → demote to NO-GO with `verdictDemoted`/`verdictClaimed`/`demotionReason`; non-GO verdicts are annotated only; no refs or no diff → observe-only.
- Results carry `scopeRefs`, `scopeMatched`, `scopeDriftDetected` for inspection.
- Runs after the #645 issueAsk enforcement, so an already-demoted verdict is annotated rather than re-demoted.

## Why

Scope drift of the #379 class is mechanically detectable without any model judgment, and depending on judgment is provably unreliable: in the 2026-06-11 re-review of `foreman/issue-379`, devstral missed the same drift it caught in May (review judgment is stochastic across runs), and the verdict was saved only by the #645 issueAsk demotion firing for an unrelated reason. With this check, the #379 signature (issue names 5 files, diff touches 0 of them) demotes deterministically every time.

Matching is generous on purpose (exact or basename): a false drift flag costs one escalation review, while a missed match would demote a legitimate branch. Under-extraction is similarly safe: an issue that names no files keeps the check observe-only.

Fixes #647

## How

- New `pkg/foreman/agent/scope_overlap.go` + whitebox tests whose extraction fixtures are the verbatim issue bodies of #379 (5 path refs, drifted diff → demote) and #510 (bare `.md` filenames, matching diff → stands).
- Wired into the reviewer block of `executor_native.go` beside the existing reconcilers; a failed ground-truth diff logs and skips (observe-only), mirroring `reconcileReviewerFilesTouched`'s failure handling.
- `docs/site/foreman/model-compatibility.md` enforcement section updated.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint run ./...`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (model-compatibility.md)