### PR TITLE
feat(foreman/loop): support hybrid-thinking models via reasoning_content

### DIFF
--- a/docs/site/foreman/model-compatibility.md
+++ b/docs/site/foreman/model-compatibility.md
@@ -96,6 +96,21 @@ harness-authoritative, and the verdict now inherits that property:
 a verdict that contradicts the harness's evidence check cannot
 drive the cascade rule on its own.
 
+## Hybrid-thinking models
+
+Since [#651](https://github.com/defilantech/LLMKube/pull/651) the
+loop understands `reasoning_content`: a turn a thinking model spends
+reasoning without emitting a tool call gets a continuation nudge
+(bounded by `MaxReasoningOnlyRetries`, default 4) instead of the
+prose corrective, the reasoning is preserved in the transcript
+ConfigMap, and it is stripped from the wire so past thinking never
+re-enters the context budget. Before this, thinking models (North
+Mini Code, Qwen-family with reasoning enabled, Mellum2-Thinking)
+either death-spiraled in no-tool-call nudges or had to run with
+reasoning disabled via
+`InferenceService.spec.extraArgs: ["--reasoning-budget", "0"]`,
+which degrades models trained to reason before acting.
+
 ## What v0.5 changes
 
 The current `Agent` CRD shape doesn't carry an explicit tool

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -130,6 +131,15 @@ type LoopConfig struct {
 	// narration exhausts the budget. <= 0 falls back to
 	// DefaultMaxNoToolCallRetries.
 	MaxNoToolCallRetries int
+
+	// MaxReasoningOnlyRetries bounds the separate streak for turns where
+	// a hybrid-thinking model emitted reasoning_content but no tool call
+	// and no content (#650). Such a turn is a model mid-thought, not a
+	// model narrating prose, so it gets a gentler continuation nudge and
+	// a roomier budget than MaxNoToolCallRetries before the loop gives
+	// up with ErrAssistantReasoningOnly. Resets after any tool-calling
+	// turn. <= 0 falls back to DefaultMaxReasoningOnlyRetries.
+	MaxReasoningOnlyRetries int
 }
 
 // DefaultContextWindowTokens is the budget used when LoopConfig.ContextWindowTokens
@@ -144,6 +154,14 @@ const DefaultContextWindowTokens = 32768
 // submit_result, without letting a model that simply refuses to call
 // tools spin to MaxTurns.
 const DefaultMaxNoToolCallRetries = 2
+
+// DefaultMaxReasoningOnlyRetries is the budget used when
+// LoopConfig.MaxReasoningOnlyRetries is <= 0. Thinking models pause
+// mid-reasoning more often than prose models narrate, so the default is
+// roomier than DefaultMaxNoToolCallRetries; four consecutive
+// reasoning-only turns with no action means the model is circling, not
+// converging.
+const DefaultMaxReasoningOnlyRetries = 4
 
 // DefaultObservationWindowTurns is the floor used when
 // LoopConfig.ObservationWindowTurns is zero. Three recent tool results
@@ -225,6 +243,24 @@ func LoopBudgetExhaustedEnvelope(turn int) *ToolResult {
 // system-prompt iterations should make it rare.
 var ErrAssistantNoToolCalls = errors.New("loop: assistant turn had no tool_calls")
 
+// ErrAssistantReasoningOnly is returned when a hybrid-thinking model
+// exhausts MaxReasoningOnlyRetries with turns that carry
+// reasoning_content but no tool call and no content (#650). Distinct
+// from ErrAssistantNoToolCalls so the failure taxonomy can tell "the
+// model narrated prose" from "the model thought itself in circles."
+var ErrAssistantReasoningOnly = errors.New("loop: assistant turns carried only reasoning, no tool_calls")
+
+// ReasoningOnlyNudgeMessage is the continuation the loop appends after
+// a reasoning-only turn. Unlike NoToolCallNudgeMessage it does not
+// scold: the model was mid-thought, so the correction is "act on the
+// plan you just reasoned out." Exported so tests can assert on it.
+func ReasoningOnlyNudgeMessage() string {
+	return "Your previous reply contained only internal reasoning and no " +
+		"tool call. Continue from that reasoning and emit the tool call " +
+		"for your next action now. If your review or task is complete, " +
+		"call submit_result with your verdict."
+}
+
 // NoToolCallNudgeMessage is the corrective the loop appends as a user
 // message after a turn that returned text but no tool_calls. Every agent
 // finishes through a tool (submit_result); a prose-only reply makes no
@@ -279,6 +315,9 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	if cfg.MaxNoToolCallRetries <= 0 {
 		cfg.MaxNoToolCallRetries = DefaultMaxNoToolCallRetries
 	}
+	if cfg.MaxReasoningOnlyRetries <= 0 {
+		cfg.MaxReasoningOnlyRetries = DefaultMaxReasoningOnlyRetries
+	}
 	// Loop-wide wall-clock budget (#532). Distinct from the per-request
 	// header timeout baked into the OAI client: this bounds the whole
 	// run, so one slow long-context turn can't hang past the budget, and
@@ -302,6 +341,10 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	// a tool call. It resets to zero after any successful tool-calling
 	// turn, so only sustained narration exhausts MaxNoToolCallRetries.
 	noToolCallStreak := 0
+	// reasoningOnlyStreak is the sibling counter for reasoning-only
+	// turns (#650); separate so a thinking model's pauses don't consume
+	// the prose-narration budget and vice versa.
+	reasoningOnlyStreak := 0
 
 	for turn := 1; turn <= cfg.MaxTurns; turn++ {
 		res.Turns = turn
@@ -344,11 +387,27 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 				}
 				return res, turnErr
 			}
+			// Reasoning-only recovery (#650): the model was mid-thought,
+			// not narrating. Continue it with a gentler nudge on its own
+			// roomier budget; the reasoning itself is already in the
+			// transcript for archaeology.
+			if errors.Is(turnErr, ErrAssistantReasoningOnly) {
+				if reasoningOnlyStreak < cfg.MaxReasoningOnlyRetries {
+					reasoningOnlyStreak++
+					res.Transcript = append(res.Transcript, oai.Message{
+						Role:    oai.RoleUser,
+						Content: ReasoningOnlyNudgeMessage(),
+					})
+					continue
+				}
+				return res, turnErr
+			}
 			return res, turnErr
 		}
 
-		// A successful tool-calling turn clears the no-tool-call streak.
+		// A successful tool-calling turn clears both streaks.
 		noToolCallStreak = 0
+		reasoningOnlyStreak = 0
 
 		// Consult the progress monitor. The most recent assistant
 		// message in the transcript has this turn's tool_calls.
@@ -385,6 +444,32 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	return res, ErrMaxTurnsExhausted
 }
 
+// stripReasoningForWire returns a wire view of the transcript with
+// reasoning_content removed from assistant messages. The transcript
+// keeps the reasoning for the persisted ConfigMap; the wire drops it,
+// mirroring how chat templates exclude think blocks from history, so
+// past reasoning never re-enters the context window or the token
+// budget (#650). Copies lazily: if no message carries reasoning, the
+// input slice is returned as-is.
+func stripReasoningForWire(msgs []oai.Message) []oai.Message {
+	needsCopy := false
+	for i := range msgs {
+		if msgs[i].ReasoningContent != "" {
+			needsCopy = true
+			break
+		}
+	}
+	if !needsCopy {
+		return msgs
+	}
+	wire := make([]oai.Message, len(msgs))
+	copy(wire, msgs)
+	for i := range wire {
+		wire[i].ReasoningContent = ""
+	}
+	return wire
+}
+
 // mostRecentAssistantToolCalls walks the transcript backwards and
 // returns the tool_calls from the latest assistant message. Empty if
 // no assistant message exists. Used by the progress monitor to inspect
@@ -413,8 +498,9 @@ func (l *Loop) runOneTurn(ctx context.Context, cfg LoopConfig, schemas []oai.Too
 	start := time.Now()
 
 	req := oai.ChatRequest{
-		Model:       cfg.Model,
-		Messages:    maskTranscriptForWire(res.Transcript, cfg.ObservationWindowTurns, cfg.ContextWindowTokens),
+		Model: cfg.Model,
+		Messages: stripReasoningForWire(
+			maskTranscriptForWire(res.Transcript, cfg.ObservationWindowTurns, cfg.ContextWindowTokens)),
 		Tools:       schemas,
 		Temperature: cfg.Temperature,
 	}
@@ -439,6 +525,14 @@ func (l *Loop) runOneTurn(ctx context.Context, cfg LoopConfig, schemas []oai.Too
 	res.Transcript = append(res.Transcript, msg)
 
 	if len(msg.ToolCalls) == 0 {
+		// Distinguish a thinking model mid-reasoning (reasoning_content
+		// present, no prose) from a model narrating its conclusion as
+		// prose. The two get different correctives and budgets (#650).
+		if msg.ReasoningContent != "" && strings.TrimSpace(msg.Content) == "" {
+			err := fmt.Errorf("turn %d: %w", res.Turns, ErrAssistantReasoningOnly)
+			span.RecordError(err)
+			return err
+		}
 		err := fmt.Errorf("turn %d: %w", res.Turns, ErrAssistantNoToolCalls)
 		span.RecordError(err)
 		return err

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -72,8 +72,9 @@ func chatJSONToSSE(t *testing.T, body string) string {
 				{
 					Index: ch.Index,
 					Delta: oai.MessageDelta{
-						Role:    ch.Message.Role,
-						Content: ch.Message.Content,
+						Role:             ch.Message.Role,
+						Content:          ch.Message.Content,
+						ReasoningContent: ch.Message.ReasoningContent,
 					},
 					FinishReason: ch.FinishReason,
 				},
@@ -561,4 +562,87 @@ func contains(haystack, needle string) bool {
 		}
 	}
 	return false
+}
+
+const assistantReasoningOnly = `{
+  "id": "t5",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "reasoning_content": "Let me think about which file to read next."
+    },
+    "finish_reason": "stop"
+  }]
+}`
+
+func TestLoop_ReasoningOnlyTurn_ContinuesAndRecovers(t *testing.T) {
+	// A hybrid-thinking model that spends a turn reasoning without a
+	// tool call must get a continuation nudge, not the prose corrective,
+	// and the run must recover when the next turn acts (#650).
+	srv, calls := scriptedOAIServer(t, []string{assistantReasoningOnly, toolCallSubmitGo})
+	reg := &fakeRegistry{results: map[string]*ToolResult{
+		"submit_result": {Terminal: true, Verdict: "GO"},
+	}}
+	loop := newTestLoop(srv, reg)
+
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", SystemPrompt: "sys", UserPrompt: "go", MaxTurns: 5,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Fatalf("expected GO terminal after recovery, got %+v", res.Terminal)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("calls: want 2 got %d", calls.Load())
+	}
+	var sawNudge, sawReasoning bool
+	for _, m := range res.Transcript {
+		if m.Role == oai.RoleUser && m.Content == ReasoningOnlyNudgeMessage() {
+			sawNudge = true
+		}
+		if m.Role == oai.RoleAssistant && m.ReasoningContent != "" {
+			sawReasoning = true
+		}
+	}
+	if !sawNudge {
+		t.Errorf("transcript should contain the reasoning continuation nudge")
+	}
+	if !sawReasoning {
+		t.Errorf("transcript should preserve the model's reasoning_content")
+	}
+}
+
+func TestLoop_ReasoningOnlyExhausted(t *testing.T) {
+	srv, _ := scriptedOAIServer(t, []string{assistantReasoningOnly, assistantReasoningOnly})
+	reg := &fakeRegistry{results: map[string]*ToolResult{}}
+	loop := newTestLoop(srv, reg)
+
+	_, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", SystemPrompt: "sys", UserPrompt: "go",
+		MaxTurns: 10, MaxReasoningOnlyRetries: 1,
+	})
+	if !errors.Is(err, ErrAssistantReasoningOnly) {
+		t.Fatalf("want ErrAssistantReasoningOnly after budget exhaustion, got %v", err)
+	}
+}
+
+func TestStripReasoningForWire(t *testing.T) {
+	transcript := []oai.Message{
+		{Role: oai.RoleSystem, Content: "sys"},
+		{Role: oai.RoleAssistant, ReasoningContent: "thinking", Content: "answer"},
+		{Role: oai.RoleUser, Content: "next"},
+	}
+	wire := stripReasoningForWire(transcript)
+	if wire[1].ReasoningContent != "" {
+		t.Errorf("wire copy must strip reasoning_content, got %q", wire[1].ReasoningContent)
+	}
+	if wire[1].Content != "answer" {
+		t.Errorf("wire copy must keep content, got %q", wire[1].Content)
+	}
+	if transcript[1].ReasoningContent != "thinking" {
+		t.Errorf("original transcript must be untouched, got %q", transcript[1].ReasoningContent)
+	}
 }

--- a/pkg/foreman/agent/oai/client.go
+++ b/pkg/foreman/agent/oai/client.go
@@ -361,6 +361,7 @@ func (a *chatAggregator) absorb(chunk ChatChunk) {
 			ch.Message.Role = cd.Delta.Role
 		}
 		ch.Message.Content += cd.Delta.Content
+		ch.Message.ReasoningContent += cd.Delta.ReasoningContent
 
 		// Tool call fragments arrive keyed by their own per-message
 		// Index (distinct from the choice index). Aggregate into the

--- a/pkg/foreman/agent/oai/client_test.go
+++ b/pkg/foreman/agent/oai/client_test.go
@@ -95,8 +95,9 @@ func chatResponseToSSE(t *testing.T, body string) string {
 				{
 					Index: ch.Index,
 					Delta: MessageDelta{
-						Role:    ch.Message.Role,
-						Content: ch.Message.Content,
+						Role:             ch.Message.Role,
+						Content:          ch.Message.Content,
+						ReasoningContent: ch.Message.ReasoningContent,
 					},
 					FinishReason: ch.FinishReason,
 				},
@@ -553,5 +554,45 @@ func TestClient_Chat_AggregatesMultiChunkArguments(t *testing.T) {
 	}
 	if tcs[0].ID != "tc-x" || tcs[0].Function.Name != "read_file" {
 		t.Errorf("metadata lost in aggregation: %+v", tcs[0])
+	}
+}
+
+const okBodyReasoningOnly = `{
+  "id": "r1",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "reasoning_content": "pondering the diff before acting"
+    },
+    "finish_reason": "stop"
+  }]
+}`
+
+// A hybrid-thinking model can spend a whole turn reasoning without
+// emitting content or tool calls. That is a complete, well-formed
+// response (finish_reason=stop), not a truncated one: the client must
+// surface it with ReasoningContent aggregated, not retry it as
+// truncated output (#650).
+func TestClient_Chat_AggregatesReasoningContent(t *testing.T) {
+	var attempts atomic.Int64
+	srv := httptest.NewServer(scriptedHandler(t, &attempts,
+		[]int{http.StatusOK}, []string{okBodyReasoningOnly}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", time.Second, 0, WithBackoffs(noJitterBackoffs))
+	resp, err := c.Chat(context.Background(), ChatRequest{Model: "test"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if attempts.Load() != 1 {
+		t.Errorf("reasoning-only response must not be retried as truncated; attempts: want 1 got %d", attempts.Load())
+	}
+	msg := resp.Choices[0].Message
+	if msg.ReasoningContent != "pondering the diff before acting" {
+		t.Errorf("ReasoningContent: want aggregated text, got %q", msg.ReasoningContent)
+	}
+	if msg.Content != "" {
+		t.Errorf("Content should stay empty, got %q", msg.Content)
 	}
 }

--- a/pkg/foreman/agent/oai/types.go
+++ b/pkg/foreman/agent/oai/types.go
@@ -58,6 +58,14 @@ type Message struct {
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string     `json:"tool_call_id,omitempty"`
 	Name       string     `json:"name,omitempty"`
+
+	// ReasoningContent is the thinking trace hybrid-reasoning models
+	// emit alongside (or instead of) content when the server's
+	// reasoning-format separates it out (llama.cpp default). Preserved
+	// in transcripts for archaeology; stripped from the wire by the
+	// loop before the next request, mirroring how chat templates drop
+	// think blocks from history (#650).
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 // MarshalJSON serializes a Message such that non-assistant roles always
@@ -189,9 +197,10 @@ type ChoiceDelta struct {
 // accumulating as tokens are generated, and ToolCalls arriving with
 // their Function.Arguments streamed in fragments.
 type MessageDelta struct {
-	Role      Role            `json:"role,omitempty"`
-	Content   string          `json:"content,omitempty"`
-	ToolCalls []ToolCallDelta `json:"tool_calls,omitempty"`
+	Role             Role            `json:"role,omitempty"`
+	Content          string          `json:"content,omitempty"`
+	ReasoningContent string          `json:"reasoning_content,omitempty"`
+	ToolCalls        []ToolCallDelta `json:"tool_calls,omitempty"`
 }
 
 // ToolCallDelta is the streamed-piece counterpart to ToolCall. The


### PR DESCRIPTION
## What

Teaches the native agent loop to work with hybrid-thinking models:

- `oai.Message` / `oai.MessageDelta` gain `ReasoningContent` (`reasoning_content`), and the streaming aggregator accumulates it like content.
- The loop distinguishes a **reasoning-only turn** (reasoning present, no content, no tool calls) from prose narration. Reasoning-only turns get a gentler continuation nudge ("continue from that reasoning and emit the tool call") on a separate, roomier budget (`MaxReasoningOnlyRetries`, default 4), surfacing as a distinct `ErrAssistantReasoningOnly` when exhausted so the failure taxonomy can tell thought-in-circles from narrated-conclusions.
- Reasoning is preserved in the persisted transcript for archaeology but stripped from the wire before each request (`stripReasoningForWire`), mirroring how chat templates exclude think blocks from history — past reasoning never re-enters the context budget.

## Why

Until now the client silently dropped `reasoning_content`, so a thinking turn looked like an empty assistant reply: the loop fired the prose corrective, the model re-thought, and turns burned to INCOMPLETE. On the 2026-06-10 North Mini Code reviewer entrance exam, every thinking-enabled review died this way (~11 minutes each, zero results), and the `--reasoning-budget 0` workaround ran the model lobotomized — it initially could not conclude reviews at all, and its judgment cannot be fairly assessed against benchmarks earned with reasoning on.

Third member of the tool-protocol compatibility family (#589 Gemma markdown tool blocks, #590 Mistral first-request hang).

Fixes #650

## How

TDD: failing tests first for the client aggregation (`TestClient_Chat_AggregatesReasoningContent`, which also pins that a reasoning-only `finish_reason=stop` response is not retried as truncated), loop recovery and exhaustion (`TestLoop_ReasoningOnlyTurn_ContinuesAndRecovers`, `TestLoop_ReasoningOnlyExhausted`), and wire-stripping with transcript preservation (`TestStripReasoningForWire`). The SSE test fixtures' delta serializers pass the new field through.

No CRD changes: the per-Agent reasoning-handling knob from #650's wishlist is deferred until the default policy proves insufficient.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint run ./...`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (model-compatibility.md: hybrid-thinking models section)