### PR TITLE
fix(foreman/executor): map reasoning-only exhaustion to INCOMPLETE

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -404,6 +404,16 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			return e.incompleteResult(start, transcriptRef, loopRes,
 				foremanv1alpha1.FailureModelMisunderstood,
 				"model returned text without tool_calls; loop cannot make progress"), nil
+		case errors.Is(loopErr, ErrAssistantReasoningOnly):
+			// A thinking model that exhausted its reasoning-only budget
+			// (#650/#651) is a model behavior outcome, not an
+			// infrastructure failure: record INCOMPLETE and persist the
+			// transcript (the reasoning trace is the evidence an
+			// operator needs) instead of bubbling an ExecutorError that
+			// drops both.
+			return e.incompleteResult(start, transcriptRef, loopRes,
+				foremanv1alpha1.FailureModelMisunderstood,
+				"model exhausted its reasoning-only budget without emitting a tool call"), nil
 		case errors.Is(loopErr, context.Canceled), errors.Is(loopErr, context.DeadlineExceeded):
 			return e.incompleteResult(start, transcriptRef, loopRes,
 				foremanv1alpha1.FailureTimeout,


### PR DESCRIPTION
## What

Adds the missing executor switch case for `ErrAssistantReasoningOnly` (#651): a thinking model that exhausts its reasoning-only budget now produces an INCOMPLETE result with `FailureModelMisunderstood` and a persisted transcript, beside the existing `ErrAssistantNoToolCalls` mapping.

## Why

The loop half of #651 handled the new sentinel, but the executor's loop-error switch did not, so exhaustion fell into the default branch and surfaced as a raw ExecutorError: the AgenticTask failed with zero result data and no transcript. Observed live on the North Mini fair-exam runs for #379/#522 (~10 minutes of slow thinking turns, then nothing to inspect), while #510 on the same configuration completed normally. The reasoning trace is exactly the evidence an operator needs to see why the model circled, so dropping the transcript is the worst possible handling.

Follow-up to #651.

## How

One switch case mirroring the adjacent `ErrAssistantNoToolCalls` mapping. `make test` and both lints green.

## Checklist

- [x] Tests added/updated (covered by the existing loop-level tests for the sentinel; the mapping mirrors an adjacent untested-by-convention case)
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint run ./...`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change)