### PR TITLE
fix(foreman/loop): keep wire-stripped reasoning-only turns template-valid

### DIFF
--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -465,7 +465,20 @@ func stripReasoningForWire(msgs []oai.Message) []oai.Message {
 	wire := make([]oai.Message, len(msgs))
 	copy(wire, msgs)
 	for i := range wire {
+		if wire[i].ReasoningContent == "" {
+			continue
+		}
 		wire[i].ReasoningContent = ""
+		// A reasoning-only turn would become a fully empty assistant
+		// message, which llama-server rejects with 400 ("Assistant
+		// message must contain either 'content' or 'tool_calls'!"),
+		// poisoning every later turn of the conversation. Leave a
+		// placeholder so the template stays valid and the adjacent
+		// continuation nudge still reads coherently.
+		if wire[i].Role == oai.RoleAssistant &&
+			strings.TrimSpace(wire[i].Content) == "" && len(wire[i].ToolCalls) == 0 {
+			wire[i].Content = "[paused to reason internally; no action taken this turn]"
+		}
 	}
 	return wire
 }

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -646,3 +646,25 @@ func TestStripReasoningForWire(t *testing.T) {
 		t.Errorf("original transcript must be untouched, got %q", transcript[1].ReasoningContent)
 	}
 }
+
+func TestStripReasoningForWire_NeverEmptiesAssistantMessage(t *testing.T) {
+	// Stripping reasoning from a reasoning-only assistant turn must not
+	// leave an empty assistant message on the wire: llama-server rejects
+	// the request with 400 "Assistant message must contain either
+	// 'content' or 'tool_calls'!", poisoning every subsequent turn of
+	// the conversation.
+	transcript := []oai.Message{
+		{Role: oai.RoleAssistant, ReasoningContent: "thinking only, no action"},
+		{Role: oai.RoleUser, Content: ReasoningOnlyNudgeMessage()},
+	}
+	wire := stripReasoningForWire(transcript)
+	if wire[0].ReasoningContent != "" {
+		t.Errorf("reasoning must be stripped, got %q", wire[0].ReasoningContent)
+	}
+	if wire[0].Content == "" && len(wire[0].ToolCalls) == 0 {
+		t.Errorf("wire assistant message must carry content or tool_calls after stripping; got empty message")
+	}
+	if transcript[0].ReasoningContent == "" || transcript[0].Content != "" {
+		t.Errorf("original transcript must be untouched: %+v", transcript[0])
+	}
+}


### PR DESCRIPTION
## What

`stripReasoningForWire` now substitutes a short placeholder (`[paused to reason internally; no action taken this turn]`) when stripping `reasoning_content` would leave an assistant message with no content and no tool calls.

## Why

A reasoning-only turn stripped to a fully empty assistant message is rejected by llama-server with 400 `Assistant message must contain either 'content' or 'tool_calls'!` — and because the message stays in the transcript, every subsequent request in the same loop fails identically. Observed live on the North Mini fair-exam reruns for #379 and #522: seventeen clean turns, one reasoning-only pause, then 400s until the loop died. (#510 passed on the same configuration because it happened to never pause reasoning-only.)

Follow-up to #651/#652; with this the reasoning-turn path is exercised end to end.

## How

TDD: `TestStripReasoningForWire_NeverEmptiesAssistantMessage` pins that a wire assistant message always carries content or tool calls after stripping, with the transcript untouched. Full suite + both lints green.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint run ./...`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (n/a: internal wire behavior)