### PR TITLE
chore(foreman): make reviewer issueAsk best-effort now that the harness verifies it

### DIFF
--- a/config/foreman/system-prompts/reviewer.md
+++ b/config/foreman/system-prompts/reviewer.md
@@ -289,15 +289,17 @@ Call `submit_result` exactly once. Required fields:
                          (file path, line number, quoted issue text)
                          that a maintainer can act on it without
                          re-deriving your reasoning.
-  - `issueAsk`        :: a short verbatim quote (≤200 chars) of the
-                         operative sentence from the issue body, as
-                         returned by `fetch_issue`. This MUST be a
-                         literal substring of the body the tool gave
-                         you. Paraphrasing is a finding against your
-                         own review; if you cannot quote the operative
-                         sentence (e.g. issue body was empty or the
-                         fetch failed), submit `verdict="ERROR"`
-                         instead of inventing one.
+  - `issueAsk`        :: a short quote (≤200 chars) capturing the
+                         operative ask of the issue body, taken from
+                         the `fetch_issue` result as closely as you
+                         can. Quote rather than paraphrase where
+                         possible, but the executor verifies and, if
+                         needed, corrects this field against the
+                         fetched body server-side (an unverifiable
+                         quote also demotes a GO verdict to NO-GO),
+                         so give your best understanding and never
+                         block or delay your verdict over quote
+                         precision.
   - `filesTouched`    :: `[]` of paths the diff actually changes.
                          You should derive this from
                          `git diff --name-only main...HEAD` you ran


### PR DESCRIPTION
## What

Rewrites the `issueAsk` clause in the canonical reviewer contract (`config/foreman/system-prompts/reviewer.md`) from "MUST be a literal substring / submit ERROR if you cannot quote" to the same harness-owned shape as the `filesTouched` clause directly below it: quote as closely as you can, the executor verifies and corrects server-side (#587/#645), never block the verdict on field precision.

## Why

Live fleet data across four model families says the old clause demands the impossible and punishes honesty:

- `issueAskVerified=false` on essentially every local review ever run (Devstral, Mellum2, North Mini, Qwen-family) — verbatim quoting is uniformly beyond current local models
- Since #645, the harness owns the integrity outcome anyway: unverifiable quotes are corrected server-side and demote GO verdicts to NO-GO
- The ERROR escape hatch wedges the task entirely (#649), and during the North Mini reviewer exam the unsatisfiable mandate visibly contributed to verdict paralysis (six `fetch_issue` calls in one review, no verdict in 45 minutes)

The agent-CR-level version of this change was validated during the 2026-06-11 exam runs. The remaining `verdict="ERROR"` mandates for genuine technical failures (checkout or fetch broke) stay as-is pending #649's resolution.

## Checklist

- [x] Tests added/updated (n/a: prompt contract text)
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (the prompt file is the documentation)