### PR TITLE
fix(agent): retry endpoint registration with correct update semantics

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -845,8 +845,8 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 	processHealthy.WithLabelValues(isvc.Name, isvc.Namespace).Set(1)
 
 	// Register service endpoint in Kubernetes
-	if err := a.registry.RegisterEndpoint(ctx, isvc, process.Port); err != nil {
-		a.logger.Warnw(
+	if err := a.registry.RegisterEndpointWithRetry(ctx, isvc, process.Port); err != nil {
+		a.logger.Errorw(
 			"failed to register endpoint",
 			"namespace", isvc.Namespace,
 			"name", isvc.Name,

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -40,6 +42,8 @@ type ServiceRegistry struct {
 	client client.Client
 	hostIP string // explicit host IP; if empty, auto-detect via DNS
 	logger *zap.SugaredLogger
+	// retryBackoff bounds RegisterEndpointWithRetry. Overridable in tests.
+	retryBackoff wait.Backoff
 }
 
 // NewServiceRegistry creates a new service registry.
@@ -51,6 +55,12 @@ func NewServiceRegistry(k8sClient client.Client, hostIP string, logger *zap.Suga
 		client: k8sClient,
 		hostIP: hostIP,
 		logger: logger,
+		retryBackoff: wait.Backoff{
+			Duration: 2 * time.Second,
+			Factor:   2,
+			Steps:    5,
+			Cap:      30 * time.Second,
+		},
 	}
 }
 
@@ -128,6 +138,33 @@ func (r *ServiceRegistry) RegisterEndpoint(
 		"port", port,
 	)
 
+	return nil
+}
+
+// RegisterEndpointWithRetry retries RegisterEndpoint with exponential backoff
+// so a brief API-server outage during a process respawn cannot strand stale
+// Endpoints (issue #657). All errors are treated as retriable: the agent has
+// no path to durable success other than the API server coming back.
+func (r *ServiceRegistry) RegisterEndpointWithRetry(
+	ctx context.Context,
+	isvc *inferencev1alpha1.InferenceService,
+	port int,
+) error {
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, r.retryBackoff, func(ctx context.Context) (bool, error) {
+		if lastErr = r.RegisterEndpoint(ctx, isvc, port); lastErr != nil {
+			r.logger.Warnw("endpoint registration failed; will retry",
+				"namespace", isvc.Namespace, "name", isvc.Name, "port", port, "error", lastErr)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		if lastErr == nil {
+			lastErr = err // ctx cancelled before the first attempt
+		}
+		return fmt.Errorf("endpoint registration failed after retries: %w", lastErr)
+	}
 	return nil
 }
 

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -63,82 +64,61 @@ func (r *ServiceRegistry) RegisterEndpoint(
 	// Sanitize service name (replace dots with dashes for DNS-1035 compliance)
 	serviceName := sanitizeServiceName(isvc.Name)
 
-	// Create or update Service
 	service := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName,
-			Namespace: isvc.Namespace,
-			Labels: map[string]string{
-				"app":                          isvc.Name,
-				"llmkube.ai/managed-by":        "metal-agent",
-				"llmkube.ai/inference-service": isvc.Name,
-			},
-			Annotations: map[string]string{
-				"llmkube.ai/metal-accelerated": "true",
-				"llmkube.ai/native-process":    "true",
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "http",
-					Port:       8080,
-					TargetPort: intstr.FromInt(port),
-					Protocol:   corev1.ProtocolTCP,
-				},
-			},
-			// Note: No selector - we'll manually manage Endpoints
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: isvc.Namespace},
 	}
-
-	if err := r.client.Create(ctx, service); err != nil {
-		// Try update if already exists
-		if err := r.client.Update(ctx, service); err != nil {
-			return fmt.Errorf("failed to create/update service: %w", err)
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.client, service, func() error {
+		service.Labels = map[string]string{
+			"app":                          isvc.Name,
+			"llmkube.ai/managed-by":        "metal-agent",
+			"llmkube.ai/inference-service": isvc.Name,
 		}
+		service.Annotations = map[string]string{
+			"llmkube.ai/metal-accelerated": "true",
+			"llmkube.ai/native-process":    "true",
+		}
+		service.Spec.Type = corev1.ServiceTypeClusterIP
+		service.Spec.Ports = []corev1.ServicePort{{
+			Name:       "http",
+			Port:       8080,
+			TargetPort: intstr.FromInt(port),
+			Protocol:   corev1.ProtocolTCP,
+		}}
+		// No selector: Endpoints are managed manually.
+		service.Spec.Selector = nil
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to create/update service: %w", err)
 	}
 
-	// Create or update Endpoints to point to the host
 	//nolint:staticcheck // SA1019: Endpoints API is still functional and appropriate for manual endpoint management
 	endpoints := &corev1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName,
-			Namespace: isvc.Namespace,
-			Labels: map[string]string{
-				"app":                          isvc.Name,
-				"llmkube.ai/managed-by":        "metal-agent",
-				"llmkube.ai/inference-service": isvc.Name,
-			},
-		},
-		//nolint:staticcheck // SA1019: EndpointSubset still functional
-		Subsets: []corev1.EndpointSubset{
-			{
-				Addresses: []corev1.EndpointAddress{
-					{
-						IP: r.resolveHostIP(),
-						TargetRef: &corev1.ObjectReference{
-							Kind: "Pod",
-							Name: fmt.Sprintf("%s-metal", isvc.Name),
-						},
-					},
-				},
-				Ports: []corev1.EndpointPort{
-					{
-						Name:     "http",
-						Port:     int32(port), //nolint:gosec // G115: TCP port numbers 0-65535 fit in int32
-						Protocol: corev1.ProtocolTCP,
-					},
-				},
-			},
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: isvc.Namespace},
 	}
-
-	if err := r.client.Create(ctx, endpoints); err != nil {
-		// Try update if already exists
-		if err := r.client.Update(ctx, endpoints); err != nil {
-			return fmt.Errorf("failed to create/update endpoints: %w", err)
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.client, endpoints, func() error {
+		endpoints.Labels = map[string]string{
+			"app":                          isvc.Name,
+			"llmkube.ai/managed-by":        "metal-agent",
+			"llmkube.ai/inference-service": isvc.Name,
 		}
+		//nolint:staticcheck // SA1019: EndpointSubset still functional
+		endpoints.Subsets = []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP: r.resolveHostIP(),
+				TargetRef: &corev1.ObjectReference{
+					Kind: "Pod",
+					Name: fmt.Sprintf("%s-metal", isvc.Name),
+				},
+			}},
+			Ports: []corev1.EndpointPort{{
+				Name:     "http",
+				Port:     int32(port), //nolint:gosec // G115: TCP ports fit in int32
+				Protocol: corev1.ProtocolTCP,
+			}},
+		}}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to create/update endpoints: %w", err)
 	}
 
 	r.logger.Infow("registered endpoint",

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -489,3 +489,46 @@ func TestRegisterEndpoint_ExplicitHostIP(t *testing.T) {
 		t.Errorf("Endpoint IP = %q, want %q", endpoints.Subsets[0].Addresses[0].IP, "10.0.0.42")
 	}
 }
+
+// TestRegisterEndpoint_PortChange verifies that calling RegisterEndpoint
+// twice for the same InferenceService with a new port (respawn scenario) updates
+// both the Service targetPort and the Endpoints port rather than leaving stale values.
+func TestRegisterEndpoint_PortChange(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "test-model"},
+	}
+
+	if err := registry.RegisterEndpoint(context.Background(), isvc, 50051); err != nil {
+		t.Fatalf("first RegisterEndpoint: %v", err)
+	}
+	// Respawn scenario: same service, new dynamic port.
+	if err := registry.RegisterEndpoint(context.Background(), isvc, 50099); err != nil {
+		t.Fatalf("second RegisterEndpoint (port change): %v", err)
+	}
+
+	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	eps := &corev1.Endpoints{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "test-model", Namespace: "default"}, eps); err != nil {
+		t.Fatalf("get endpoints: %v", err)
+	}
+	if got := eps.Subsets[0].Ports[0].Port; got != 50099 {
+		t.Fatalf("endpoints port = %d, want 50099 (stale port left behind)", got)
+	}
+	svc := &corev1.Service{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "test-model", Namespace: "default"}, svc); err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+	if got := svc.Spec.Ports[0].TargetPort.IntValue(); got != 50099 {
+		t.Fatalf("service targetPort = %d, want 50099", got)
+	}
+}

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -18,13 +18,19 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -530,5 +536,94 @@ func TestRegisterEndpoint_PortChange(t *testing.T) {
 	}
 	if got := svc.Spec.Ports[0].TargetPort.IntValue(); got != 50099 {
 		t.Fatalf("service targetPort = %d, want 50099", got)
+	}
+}
+
+func TestRegisterEndpointWithRetry_TransientFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	var calls int
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				calls++
+				if calls <= 2 {
+					return apierrors.NewServerTimeout(corev1.Resource("services"), "create", 1)
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry.retryBackoff = wait.Backoff{Duration: time.Millisecond, Factor: 2, Steps: 5}
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "retry-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "retry-model"},
+	}
+	if err := registry.RegisterEndpointWithRetry(context.Background(), isvc, 50051); err != nil {
+		t.Fatalf("expected retries to absorb 2 transient failures, got: %v", err)
+	}
+	// The interceptor fires on every Create call. RegisterEndpoint calls
+	// CreateOrUpdate for Service (attempt 1: fail, attempt 2: fail, attempt 3:
+	// success = 3 Create calls across 2 retry iterations + 1 success) plus one
+	// Create for Endpoints on the winning attempt, totalling 4 calls.
+	if calls != 4 {
+		t.Fatalf("expected 4 Create calls (2 service failures + 1 service success + 1 endpoints), got %d", calls)
+	}
+}
+
+func TestRegisterEndpointWithRetry_Exhausted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				return apierrors.NewServerTimeout(corev1.Resource("services"), "create", 1)
+			},
+		}).Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry.retryBackoff = wait.Backoff{Duration: time.Millisecond, Factor: 2, Steps: 3}
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "doomed-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "doomed-model"},
+	}
+	err := registry.RegisterEndpointWithRetry(context.Background(), isvc, 50051)
+	if err == nil {
+		t.Fatal("expected error after exhausted retries, got nil")
+	}
+	// The underlying server-timeout cause must survive the fmt.Errorf wrap.
+	if !apierrors.IsServerTimeout(errors.Unwrap(err)) {
+		t.Fatalf("expected wrapped cause to be a server-timeout API error, got: %v", errors.Unwrap(err))
+	}
+}
+
+// TestRegisterEndpointWithRetry_ContextCancelled verifies that when the context
+// is already cancelled before the first attempt, the returned error wraps
+// context.Canceled rather than rendering as a garbled %!w(<nil>).
+func TestRegisterEndpointWithRetry_ContextCancelled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry.retryBackoff = wait.Backoff{Duration: time.Millisecond, Factor: 2, Steps: 5}
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "cancelled-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "cancelled-model"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the first attempt
+
+	err := registry.RegisterEndpointWithRetry(ctx, isvc, 50051)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled in error chain, got: %v", err)
 	}
 }


### PR DESCRIPTION
## What

Endpoint registration in the metal-agent now survives transient API-server failures, and registration updates are actually correct:

- `ServiceRegistry.RegisterEndpoint` is refactored onto `controllerutil.CreateOrUpdate` with mutate functions. The previous code called `Create` and, on any error, blind-`Update`d a fresh object with no `resourceVersion`; true updates (e.g. a new dynamic port after a llama-server respawn) could not succeed as written, and a Service stub update would also trip clusterIP immutability against a real apiserver.
- New `RegisterEndpointWithRetry` wraps registration in bounded exponential backoff (2s base, factor 2, 5 steps, 30s cap) and is now used at the post-respawn call site. Context cancellation surfaces `context.Canceled` instead of a garbled wrap.

## Why

Fixes #657. When llama-server respawns it gets a new dynamic port; if the K8s API hiccups at that moment, the failed registration was logged at Warn and dropped, leaving the Endpoints pointing at the dead old port. Anything routing through the Service (including gateways) then black-holes.

A follow-up PR adds a periodic heartbeat re-registration loop as the durable self-heal for outages longer than the retry budget (see #663 for the liveness half).

## How

- TDD throughout: `TestRegisterEndpoint_PortChange` pins the respawn scenario (register twice with different ports; both the Service targetPort and the Endpoints port must follow) and fails against the old code with the fake client's resourceVersion conflict.
- Retry tests use fake-client `interceptor.Funcs` to inject typed `ServerTimeout` errors through the real registration path: transient (2 failures then success), exhausted (cause preserved through the error wrap, verified via `apierrors.IsServerTimeout`), and cancelled-context.
- Known trade-off, intentionally unchanged: registration runs on the agent's event-loop path, so a full retry cycle can stall event handling up to ~30s. The dominant failure mode (API server down) stalls the watcher anyway, and the follow-up heartbeat loop moves durable repair off the event path.

## Checklist

- [x] Tests added (4 new) and full suite passing (`make test`)
- [x] `make fmt vet lint` clean, plus `GOOS=linux golangci-lint run ./...` (build-tagged agent files)
- [x] No CRD/RBAC changes (no manifest sync needed)
- [x] DCO sign-off on all commits
