### PR TITLE
feat(agent,controller): heartbeat liveness for metal endpoint registrations

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "time"
+
+const (
+	// AnnotationAgentHeartbeat is stamped (RFC3339) on agent-managed Endpoints
+	// every heartbeat interval. The InferenceService controller treats
+	// registrations whose heartbeat is older than DefaultAgentHeartbeatTimeout
+	// as not ready (issue #663). Endpoints without the annotation (older
+	// agents) are exempt from expiry for backward compatibility.
+	AnnotationAgentHeartbeat = "llmkube.ai/agent-heartbeat"
+
+	// DefaultAgentHeartbeatInterval is how often the metal-agent re-asserts
+	// its registrations (which also self-heals any missed update, #657).
+	DefaultAgentHeartbeatInterval = 30 * time.Second
+
+	// DefaultAgentHeartbeatTimeout is how stale a heartbeat may be before the
+	// controller stops counting the registration as ready (6 intervals).
+	DefaultAgentHeartbeatTimeout = 3 * time.Minute
+)

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -154,7 +154,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			"Model source is a HuggingFace repo ID (resolved by the runtime at startup); set spec.skipModelInit=true so the init container does not run")
 	}
 
-	deployment, readyReplicas, result, err := r.reconcileDeployment(ctx, inferenceService, model, desiredReplicas, modelReady, isMetal)
+	deployment, readyReplicas, metalSnap, result, err := r.reconcileDeployment(ctx, inferenceService, model, desiredReplicas, modelReady, isMetal)
 	if err != nil || result != nil {
 		if result != nil {
 			return *result, err
@@ -175,9 +175,22 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	endpoint := r.constructEndpoint(inferenceService, service)
-	phase, schedulingInfo := r.determinePhase(ctx, inferenceService, readyReplicas, desiredReplicas, isMetal, deployment)
+	phase, schedulingInfo := r.determinePhase(ctx, inferenceService, readyReplicas, desiredReplicas, isMetal, deployment, metalSnap)
 
-	return r.updateStatusWithSchedulingInfo(ctx, inferenceService, phase, modelReady, readyReplicas, desiredReplicas, endpoint, "", schedulingInfo)
+	finalResult, statusErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, phase, modelReady, readyReplicas, desiredReplicas, endpoint, "", schedulingInfo)
+	if statusErr != nil {
+		return finalResult, statusErr
+	}
+
+	// On the metal path a heartbeat going stale generates no watch event, so
+	// force a periodic requeue when the Endpoints carry the annotation.
+	if isMetal {
+		if requeue := metalHeartbeatRequeueDuration(metalSnap); requeue > 0 {
+			finalResult.RequeueAfter = requeue
+		}
+	}
+
+	return finalResult, nil
 }
 
 func (r *InferenceServiceReconciler) getModelForInferenceService(ctx context.Context, isvc *inferencev1alpha1.InferenceService) (*inferencev1alpha1.Model, bool, *ctrl.Result, error) {
@@ -208,7 +221,7 @@ func (r *InferenceServiceReconciler) getModelForInferenceService(ctx context.Con
 	return model, modelReady, nil, nil
 }
 
-func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, desiredReplicas int32, modelReady bool, isMetal bool) (*appsv1.Deployment, int32, *ctrl.Result, error) {
+func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, desiredReplicas int32, modelReady bool, isMetal bool) (*appsv1.Deployment, int32, *metalSnapshot, *ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	if isMetal {
@@ -217,10 +230,10 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 		// and the server is healthy. Derive readyReplicas from the Endpoints rather
 		// than blindly returning desiredReplicas, otherwise Phase reports Ready
 		// before the agent has done anything (issue #374).
-		readyReplicas := r.metalReadyEndpoints(ctx, isvc)
+		snap := r.metalEndpointSnapshot(ctx, isvc)
 		log.Info("Metal accelerator detected, skipping Deployment creation",
-			"readyEndpoints", readyReplicas, "desiredReplicas", desiredReplicas)
-		return nil, readyReplicas, nil, nil
+			"readyEndpoints", snap.ReadyReplicas, "desiredReplicas", desiredReplicas)
+		return nil, snap.ReadyReplicas, snap, nil, nil
 	}
 
 	// Surface non-fatal vLLM spec problems as a status condition before we
@@ -232,7 +245,7 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	deployment := r.constructDeployment(isvc, model, desiredReplicas)
 	if err := setControllerReferenceUnblocked(isvc, deployment, r.Scheme); err != nil {
 		log.Error(err, "Failed to set controller reference for Deployment")
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 
 	existingDeployment := &appsv1.Deployment{}
@@ -242,12 +255,12 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 		if err := r.Create(ctx, deployment); err != nil {
 			log.Error(err, "Failed to create Deployment")
 			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create Deployment", nil)
-			return nil, 0, &result, updateErr
+			return nil, 0, nil, &result, updateErr
 		}
-		return deployment, 0, nil, nil
+		return deployment, 0, nil, nil, nil
 	} else if err != nil {
 		log.Error(err, "Failed to get Deployment")
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 
 	// Deployment.spec.selector is immutable. A Deployment created by an older
@@ -264,18 +277,18 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 			"newSelector", deployment.Spec.Selector)
 		if err := r.Delete(ctx, existingDeployment); err != nil && !apierrors.IsNotFound(err) {
 			log.Error(err, "Failed to delete stale Deployment for selector migration")
-			return nil, 0, nil, err
+			return nil, 0, nil, nil, err
 		}
 		if err := r.Create(ctx, deployment); err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				// The old Deployment is still terminating; recreate on the
 				// next reconcile once its deletion has propagated.
-				return nil, 0, &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+				return nil, 0, nil, &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 			}
 			log.Error(err, "Failed to recreate Deployment after selector change")
-			return nil, 0, nil, err
+			return nil, 0, nil, nil, err
 		}
-		return deployment, 0, nil, nil
+		return deployment, 0, nil, nil, nil
 	}
 
 	// Snapshot externally-set template metadata before the wholesale
@@ -306,10 +319,10 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	}
 	if err := r.Update(ctx, existingDeployment); err != nil {
 		log.Error(err, "Failed to update Deployment")
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 
-	return deployment, existingDeployment.Status.ReadyReplicas, nil, nil
+	return deployment, existingDeployment.Status.ReadyReplicas, nil, nil, nil
 }
 
 func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc *inferencev1alpha1.InferenceService, modelReady bool, desiredReplicas int32, isMetal bool) (*corev1.Service, *ctrl.Result, error) {
@@ -350,12 +363,42 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 	return service, nil, nil
 }
 
-// metalReadyEndpoints returns the count of ready addresses on the Endpoints
-// object that the metal-agent is expected to populate when its host-side
-// llama-server has fetched the model and become healthy. The Endpoints object
-// shares the sanitized name of the metal stub Service (see reconcileService's
-// metal branch). Missing-or-unpopulated Endpoints return 0, which is the
-// correct readyReplicas value while we wait on the agent.
+// metalHeartbeatKind classifies the heartbeat annotation on a metal Endpoints
+// object so that callers can produce appropriately differentiated status
+// messages without re-fetching the Endpoints.
+type metalHeartbeatKind int
+
+const (
+	// metalHBNone: no Endpoints object exists yet (agent has not registered).
+	metalHBNone metalHeartbeatKind = iota
+	// metalHBLegacy: Endpoints exist but carry no heartbeat annotation (older agent).
+	metalHBLegacy
+	// metalHBFresh: Endpoints exist with a current, valid heartbeat.
+	metalHBFresh
+	// metalHBStale: Endpoints exist but the heartbeat timestamp has expired.
+	metalHBStale
+	// metalHBUnparseable: Endpoints exist but the heartbeat annotation cannot be parsed.
+	metalHBUnparseable
+)
+
+// metalSnapshot captures the result of a single Endpoints fetch for the metal
+// path. It is produced by metalEndpointSnapshot and consumed by
+// determinePhase and metalHeartbeatRequeueDuration, eliminating the second Get
+// that the old metalHeartbeatRequeue performed.
+type metalSnapshot struct {
+	ReadyReplicas int32
+	Kind          metalHeartbeatKind
+	// RawHeartbeat is the annotation value verbatim (empty when Kind == metalHBNone).
+	RawHeartbeat string
+	// ParseErr is set when Kind == metalHBUnparseable.
+	ParseErr error
+}
+
+// metalEndpointSnapshot fetches the Endpoints for isvc once and returns a
+// metalSnapshot summarising both the ready-replica count and the heartbeat
+// state. It is the single source of truth for the metal path; both
+// metalReadyEndpoints and metalHeartbeatRequeueDuration are thin wrappers
+// around it.
 //
 // We read core/v1 Endpoints (deprecated in k8s v1.33+) rather than
 // discovery/v1 EndpointSlice because pkg/agent/registry.go still creates
@@ -363,7 +406,7 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 // as a follow-up; doing it in this PR would balloon scope.
 //
 //nolint:staticcheck // SA1019: see comment above; agent and controller migrate together
-func (r *InferenceServiceReconciler) metalReadyEndpoints(ctx context.Context, isvc *inferencev1alpha1.InferenceService) int32 {
+func (r *InferenceServiceReconciler) metalEndpointSnapshot(ctx context.Context, isvc *inferencev1alpha1.InferenceService) *metalSnapshot {
 	log := logf.FromContext(ctx)
 	endpoints := &corev1.Endpoints{}
 	name := sanitizeDNSName(isvc.Name)
@@ -372,8 +415,26 @@ func (r *InferenceServiceReconciler) metalReadyEndpoints(ctx context.Context, is
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Failed to get Endpoints for metal accelerator", "name", name)
 		}
-		return 0
+		return &metalSnapshot{Kind: metalHBNone}
 	}
+
+	raw, hasAnnotation := endpoints.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat]
+	if hasAnnotation {
+		ts, perr := time.Parse(time.RFC3339, raw)
+		if perr != nil {
+			log.Info("Metal endpoint heartbeat annotation unparseable; treating as not ready",
+				"name", name, "heartbeat", raw, "parseError", perr)
+			return &metalSnapshot{Kind: metalHBUnparseable, RawHeartbeat: raw, ParseErr: perr}
+		}
+		age := time.Since(ts)
+		if age > inferencev1alpha1.DefaultAgentHeartbeatTimeout {
+			log.Info("Metal endpoint heartbeat stale; treating as not ready",
+				"name", name, "heartbeat", raw, "age", age.Round(time.Second), "timeout", inferencev1alpha1.DefaultAgentHeartbeatTimeout)
+			return &metalSnapshot{Kind: metalHBStale, RawHeartbeat: raw}
+		}
+	}
+	// No annotation: legacy agent without heartbeats; fall through and count.
+
 	var ready int32
 	for _, subset := range endpoints.Subsets {
 		// In a kind/k8s cluster the agent typically registers a small handful
@@ -386,7 +447,40 @@ func (r *InferenceServiceReconciler) metalReadyEndpoints(ctx context.Context, is
 		}
 		ready += int32(n) //nolint:gosec // bounded above
 	}
-	return ready
+
+	kind := metalHBLegacy
+	if hasAnnotation {
+		kind = metalHBFresh
+	}
+	return &metalSnapshot{ReadyReplicas: ready, Kind: kind, RawHeartbeat: raw}
+}
+
+// metalReadyEndpoints is a convenience wrapper that returns only the
+// ready-replica count for callers that do not need the full snapshot (e.g.,
+// unit tests). Production reconcile paths use metalEndpointSnapshot directly.
+func (r *InferenceServiceReconciler) metalReadyEndpoints(ctx context.Context, isvc *inferencev1alpha1.InferenceService) int32 {
+	return r.metalEndpointSnapshot(ctx, isvc).ReadyReplicas
+}
+
+// metalHeartbeatRequeueDuration returns the RequeueAfter duration to use after
+// a successful metal reconcile. It operates on the already-fetched metalSnapshot
+// so no additional API call is needed.
+//
+// When the Endpoints carry a heartbeat annotation (fresh or stale) the
+// reconciler must periodically re-check staleness because no watch event fires
+// when a heartbeat simply ages out. We return half the timeout so we notice
+// expiry within one extra interval. Legacy agents (no annotation) and
+// not-yet-registered services (no Endpoints) need no forced requeue.
+func metalHeartbeatRequeueDuration(snap *metalSnapshot) time.Duration {
+	if snap == nil {
+		return 0
+	}
+	switch snap.Kind {
+	case metalHBFresh, metalHBStale:
+		return inferencev1alpha1.DefaultAgentHeartbeatTimeout / 2
+	default:
+		return 0
+	}
 }
 
 func needsSkipModelInit(isvc *inferencev1alpha1.InferenceService) bool {

--- a/internal/controller/inferenceservice_metal_heartbeat_test.go
+++ b/internal/controller/inferenceservice_metal_heartbeat_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// metalEndpoints builds a corev1.Endpoints fixture for the metal-agent path.
+// name must be the sanitized InferenceService name (dots replaced by hyphens).
+// heartbeat is stamped as the AnnotationAgentHeartbeat annotation when non-empty.
+//
+//nolint:staticcheck // SA1019: v1 Endpoints; see metalReadyEndpoints comment
+func metalEndpoints(name, heartbeat string) *corev1.Endpoints {
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				"llmkube.ai/managed-by": "metal-agent",
+			},
+		},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "192.0.2.10"}},
+			Ports:     []corev1.EndpointPort{{Port: 50051, Name: "http", Protocol: corev1.ProtocolTCP}},
+		}},
+	}
+	if heartbeat != "" {
+		ep.Annotations = map[string]string{
+			inferencev1alpha1.AnnotationAgentHeartbeat: heartbeat,
+		}
+	}
+	return ep
+}
+
+var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
+	var (
+		reconciler *InferenceServiceReconciler
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		reconciler = &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+	})
+
+	Context("direct unit tests of metalReadyEndpoints", func() {
+		const namespace = "default"
+
+		It("should return 1 for Endpoints with a fresh heartbeat annotation", func() {
+			const isvcName = "hb-fresh"
+			fresh := time.Now().UTC().Format(time.RFC3339)
+			ep := metalEndpoints(isvcName, fresh)
+			Expect(k8sClient.Create(ctx, ep)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, ep) })
+
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
+			}
+			Expect(reconciler.metalReadyEndpoints(ctx, isvc)).To(Equal(int32(1)))
+		})
+
+		It("should return 0 for Endpoints with a stale heartbeat annotation (10 minutes old)", func() {
+			const isvcName = "hb-stale"
+			stale := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+			ep := metalEndpoints(isvcName, stale)
+			Expect(k8sClient.Create(ctx, ep)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, ep) })
+
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
+			}
+			Expect(reconciler.metalReadyEndpoints(ctx, isvc)).To(Equal(int32(0)))
+		})
+
+		It("should return 0 for Endpoints with an unparseable heartbeat annotation", func() {
+			const isvcName = "hb-bad"
+			ep := metalEndpoints(isvcName, "not-a-timestamp")
+			Expect(k8sClient.Create(ctx, ep)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, ep) })
+
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
+			}
+			Expect(reconciler.metalReadyEndpoints(ctx, isvc)).To(Equal(int32(0)))
+		})
+
+		It("should return 1 for Endpoints WITHOUT the annotation (legacy agent exemption)", func() {
+			const isvcName = "hb-legacy"
+			ep := metalEndpoints(isvcName, "") // no annotation
+			Expect(k8sClient.Create(ctx, ep)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, ep) })
+
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
+			}
+			Expect(reconciler.metalReadyEndpoints(ctx, isvc)).To(Equal(int32(1)))
+		})
+	})
+
+	Context("Reconcile requeue for metal InferenceService with heartbeat Endpoints", func() {
+		const namespace = "default"
+		const modelName = "hb-metal-model"
+		const isvcName = "hb-metal-isvc"
+
+		BeforeEach(func() {
+			model := &inferencev1alpha1.Model{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: namespace}, model)
+			if err != nil && errors.IsNotFound(err) {
+				model = &inferencev1alpha1.Model{
+					ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: namespace},
+					Spec: inferencev1alpha1.ModelSpec{
+						Source:   "https://example.com/hb-model.gguf",
+						Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+					},
+				}
+				Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			}
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			isvc := &inferencev1alpha1.InferenceService{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, isvc)
+			if err != nil && errors.IsNotFound(err) {
+				replicas := int32(1)
+				isvc = &inferencev1alpha1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
+					Spec: inferencev1alpha1.InferenceServiceSpec{
+						ModelRef: modelName,
+						Replicas: &replicas,
+					},
+				}
+				Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			isvc := &inferencev1alpha1.InferenceService{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, isvc); err == nil {
+				_ = k8sClient.Delete(ctx, isvc)
+			}
+
+			model := &inferencev1alpha1.Model{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: namespace}, model); err == nil {
+				_ = k8sClient.Delete(ctx, model)
+			}
+
+			ep := &corev1.Endpoints{} //nolint:staticcheck
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, ep); err == nil {
+				_ = k8sClient.Delete(ctx, ep)
+			}
+		})
+
+		It("should return a non-zero RequeueAfter when Endpoints carry a fresh heartbeat annotation", func() {
+			fresh := time.Now().UTC().Format(time.RFC3339)
+			ep := metalEndpoints(isvcName, fresh)
+			Expect(k8sClient.Create(ctx, ep)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+				"expected a non-zero RequeueAfter for a metal service with heartbeat Endpoints")
+			Expect(result.RequeueAfter).To(Equal(inferencev1alpha1.DefaultAgentHeartbeatTimeout / 2))
+		})
+	})
+
+	Context("Reconcile with a stale metal-agent heartbeat", func() {
+		const namespace = "default"
+		const modelName = "hb-stale-model"
+		const isvcName = "hb-stale-isvc"
+
+		BeforeEach(func() {
+			model := &inferencev1alpha1.Model{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: namespace}, model)
+			if err != nil && errors.IsNotFound(err) {
+				model = &inferencev1alpha1.Model{
+					ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: namespace},
+					Spec: inferencev1alpha1.ModelSpec{
+						Source:   "https://example.com/stale-model.gguf",
+						Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+					},
+				}
+				Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			}
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			isvc := &inferencev1alpha1.InferenceService{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, isvc)
+			if err != nil && errors.IsNotFound(err) {
+				replicas := int32(1)
+				isvc = &inferencev1alpha1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
+					Spec: inferencev1alpha1.InferenceServiceSpec{
+						ModelRef: modelName,
+						Replicas: &replicas,
+					},
+				}
+				Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			isvc := &inferencev1alpha1.InferenceService{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, isvc); err == nil {
+				_ = k8sClient.Delete(ctx, isvc)
+			}
+
+			model := &inferencev1alpha1.Model{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: namespace}, model); err == nil {
+				_ = k8sClient.Delete(ctx, model)
+			}
+
+			ep := &corev1.Endpoints{} //nolint:staticcheck
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, ep); err == nil {
+				_ = k8sClient.Delete(ctx, ep)
+			}
+		})
+
+		It("should report stale status, zero readyReplicas, and still requeue after a 10-minute-old heartbeat", func() {
+			stale := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+			ep := metalEndpoints(isvcName, stale)
+			Expect(k8sClient.Create(ctx, ep)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The re-check loop must survive staleness: a stale heartbeat still
+			// needs periodic re-evaluation in case the agent comes back online.
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+				"expected a non-zero RequeueAfter so the controller re-checks once the agent recovers")
+
+			// The operator must reflect 0 ready replicas when the heartbeat has expired.
+			isvc := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, isvc)).To(Succeed())
+			Expect(isvc.Status.ReadyReplicas).To(Equal(int32(0)),
+				"stale heartbeat should zero out readyReplicas")
+
+			// The scheduling status must indicate a stale heartbeat, not initial provisioning.
+			Expect(isvc.Status.SchedulingStatus).To(Equal("AgentHeartbeatStale"),
+				"stale heartbeat must report AgentHeartbeatStale, not WaitingForMetalAgent")
+			Expect(isvc.Status.SchedulingMessage).To(ContainSubstring("last seen"),
+				"stale heartbeat message must include the last-seen timestamp")
+		})
+	})
+})

--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -267,7 +267,7 @@ var _ = Describe("determinePhase", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		}
-		phase, info := reconciler.determinePhase(context.Background(), isvc, 2, 2, false, &appsv1.Deployment{})
+		phase, info := reconciler.determinePhase(context.Background(), isvc, 2, 2, false, &appsv1.Deployment{}, nil)
 		Expect(phase).To(Equal("Ready"))
 		Expect(info).To(BeNil())
 	})
@@ -276,7 +276,7 @@ var _ = Describe("determinePhase", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		}
-		phase, info := reconciler.determinePhase(context.Background(), isvc, 1, 3, false, &appsv1.Deployment{})
+		phase, info := reconciler.determinePhase(context.Background(), isvc, 1, 3, false, &appsv1.Deployment{}, nil)
 		Expect(phase).To(Equal("Progressing"))
 		Expect(info).To(BeNil())
 	})
@@ -285,7 +285,7 @@ var _ = Describe("determinePhase", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "no-pods-test", Namespace: "default"},
 		}
-		phase, _ := reconciler.determinePhase(context.Background(), isvc, 0, 1, false, &appsv1.Deployment{})
+		phase, _ := reconciler.determinePhase(context.Background(), isvc, 0, 1, false, &appsv1.Deployment{}, nil)
 		Expect(phase).To(Equal("Creating"))
 	})
 
@@ -293,7 +293,7 @@ var _ = Describe("determinePhase", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		}
-		phase, _ := reconciler.determinePhase(context.Background(), isvc, 0, 1, true, nil)
+		phase, _ := reconciler.determinePhase(context.Background(), isvc, 0, 1, true, nil, nil)
 		Expect(phase).To(Equal("Creating"))
 	})
 
@@ -301,7 +301,7 @@ var _ = Describe("determinePhase", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		}
-		phase, info := reconciler.determinePhase(context.Background(), isvc, 0, 0, false, &appsv1.Deployment{})
+		phase, info := reconciler.determinePhase(context.Background(), isvc, 0, 0, false, &appsv1.Deployment{}, nil)
 		Expect(phase).To(Equal(PhaseStopped))
 		Expect(info).To(BeNil())
 	})
@@ -310,7 +310,7 @@ var _ = Describe("determinePhase", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		}
-		phase, info := reconciler.determinePhase(context.Background(), isvc, 0, 0, true, nil)
+		phase, info := reconciler.determinePhase(context.Background(), isvc, 0, 0, true, nil, nil)
 		Expect(phase).To(Equal(PhaseStopped))
 		Expect(info).To(BeNil())
 	})

--- a/internal/controller/inferenceservice_selector_migration_test.go
+++ b/internal/controller/inferenceservice_selector_migration_test.go
@@ -113,7 +113,7 @@ var _ = Describe("InferenceService Deployment selector migration (#606)", func()
 		Expect(k8sClient.Get(ctx, nn, isvc)).To(Succeed())
 		model := &inferencev1alpha1.Model{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, model)).To(Succeed())
-		_, _, _, err := reconciler.reconcileDeployment(ctx, isvc, model, 1, true, false)
+		_, _, _, _, err := reconciler.reconcileDeployment(ctx, isvc, model, 1, true, false)
 		Expect(err).NotTo(HaveOccurred(), "controller must migrate the selector, not loop on an immutable update")
 
 		By("the Deployment now carries the current selector")

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -63,7 +63,7 @@ type SchedulingInfo struct {
 	WaitingFor string
 }
 
-func (r *InferenceServiceReconciler) determinePhase(ctx context.Context, isvc *inferencev1alpha1.InferenceService, readyReplicas, desiredReplicas int32, isMetal bool, deployment *appsv1.Deployment) (string, *SchedulingInfo) {
+func (r *InferenceServiceReconciler) determinePhase(ctx context.Context, isvc *inferencev1alpha1.InferenceService, readyReplicas, desiredReplicas int32, isMetal bool, deployment *appsv1.Deployment, snap *metalSnapshot) (string, *SchedulingInfo) {
 	log := logf.FromContext(ctx)
 
 	if readyReplicas == desiredReplicas && readyReplicas > 0 {
@@ -85,6 +85,20 @@ func (r *InferenceServiceReconciler) determinePhase(ctx context.Context, isvc *i
 		}
 	}
 	if isMetal {
+		if snap != nil {
+			switch snap.Kind {
+			case metalHBStale:
+				return PhaseCreating, &SchedulingInfo{
+					Status:  "AgentHeartbeatStale",
+					Message: fmt.Sprintf("metal-agent heartbeat stale (last seen %s); host may be offline", snap.RawHeartbeat),
+				}
+			case metalHBUnparseable:
+				return PhaseCreating, &SchedulingInfo{
+					Status:  "AgentHeartbeatStale",
+					Message: fmt.Sprintf("metal-agent heartbeat unparseable (value %q); host may be offline", snap.RawHeartbeat),
+				}
+			}
+		}
 		return PhaseCreating, &SchedulingInfo{
 			Status:  "WaitingForMetalAgent",
 			Message: "Waiting for the host metal-agent to fetch the model and register Endpoints",

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -31,6 +31,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -447,6 +448,11 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		a.logger.With("subsystem", "health-monitor"),
 	)
 	go monitor.Run(ctx)
+
+	// Start heartbeat loop: periodically re-registers every running process's
+	// endpoint to refresh the llmkube.ai/agent-heartbeat annotation and
+	// self-heal any missed registration (#663, #657).
+	go a.runHeartbeatLoop(ctx)
 
 	// Start Apple Silicon power sampler (if enabled). The sampler shells out
 	// to powermetrics under sudo and publishes the apple_power_*_watts gauges
@@ -1136,6 +1142,95 @@ func (a *MetalAgent) scheduleRestart(ctx context.Context, name, namespace string
 
 	if err := a.ensureProcess(ctx, isvc); err != nil {
 		a.logger.Warnw("failed to restart process", "name", name, "namespace", namespace, "error", err)
+	}
+}
+
+// heartbeatOnce re-registers the endpoint for every currently-running managed
+// process. It snapshots the running process set under RLock, releases the lock,
+// then performs one best-effort re-registration per process (no lock held during
+// network I/O). Failures are logged at Warn and skipped; the next tick is the
+// retry (no separate backoff wrapper here because the interval itself provides
+// the retry cadence, and using RegisterEndpointWithRetry would serialize all
+// heartbeats behind a single stalled one).
+//
+// Two additional safety checks run per entry before re-registering:
+//   - If the InferenceService is scaled to zero (spec.replicas == 0) or has a
+//     DeletionTimestamp, skip re-registration — re-asserting Service+Endpoints
+//     for a deleted or scaled-to-zero service would leave a routable ClusterIP
+//     pointing at a dead port with no self-heal path.
+//   - If the InferenceService is NotFound, treat it as a missed deletion event
+//     and tear the process down via deleteProcess (the same path the watch event
+//     handler uses), then continue to the next entry.
+func (a *MetalAgent) heartbeatOnce(ctx context.Context) {
+	a.mu.RLock()
+	// Snapshot name/namespace/port while holding the lock so we don't hold it
+	// across the API calls below.
+	type entry struct {
+		namespace, name string
+		port            int
+	}
+	entries := make([]entry, 0, len(a.processes))
+	for _, p := range a.processes {
+		if p == nil || p.Port <= 0 {
+			continue
+		}
+		entries = append(entries, entry{p.Namespace, p.Name, p.Port})
+	}
+	a.mu.RUnlock()
+
+	for _, e := range entries {
+		isvc := &inferencev1alpha1.InferenceService{}
+		if err := a.config.K8sClient.Get(ctx, types.NamespacedName{
+			Namespace: e.namespace,
+			Name:      e.name,
+		}, isvc); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Missed deletion event: tear the process down via the same path
+				// the watch-event handler uses. deleteProcess acquires its own
+				// lock so it is safe to call here without holding a.mu.
+				key := types.NamespacedName{Namespace: e.namespace, Name: e.name}.String()
+				a.logger.Warnw("heartbeat: InferenceService gone; tearing down lingering process",
+					"namespace", e.namespace, "name", e.name)
+				if tearErr := a.deleteProcess(ctx, key); tearErr != nil {
+					a.logger.Warnw("heartbeat: teardown failed",
+						"namespace", e.namespace, "name", e.name, "error", tearErr)
+				}
+				continue
+			}
+			a.logger.Warnw("heartbeat: failed to fetch InferenceService",
+				"namespace", e.namespace, "name", e.name, "error", err)
+			continue
+		}
+
+		// Skip re-registration when the service is being deleted or has been
+		// scaled to zero. Re-asserting Service+Endpoints here would resurrect
+		// networking that deleteProcess (or handleScaleToZero) just cleaned up.
+		if isvc.DeletionTimestamp != nil || (isvc.Spec.Replicas != nil && *isvc.Spec.Replicas == 0) {
+			continue
+		}
+
+		if err := a.registry.RegisterEndpoint(ctx, isvc, e.port); err != nil {
+			a.logger.Warnw("heartbeat: failed to re-register endpoint",
+				"namespace", e.namespace, "name", e.name, "error", err)
+		}
+	}
+}
+
+// runHeartbeatLoop periodically re-registers every running process's
+// endpoint. This both refreshes the llmkube.ai/agent-heartbeat annotation
+// (the controller expires registrations whose heartbeat goes stale, #663)
+// and re-asserts the registration content, healing any update the agent
+// failed to deliver earlier (#657).
+func (a *MetalAgent) runHeartbeatLoop(ctx context.Context) {
+	ticker := time.NewTicker(inferencev1alpha1.DefaultAgentHeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			a.heartbeatOnce(ctx)
+		}
 	}
 }
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -27,6 +27,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -1069,5 +1070,196 @@ func TestEnsureProcess_InFlightGuard(t *testing.T) {
 	agent.mu.Unlock()
 	if leftover != 0 {
 		t.Errorf("starting map not cleared after spawn, has %d entries", leftover)
+	}
+}
+
+// TestHeartbeatOnce verifies that heartbeatOnce re-registers the endpoint for
+// each tracked process and that the resulting Endpoints object carries a fresh
+// llmkube.ai/agent-heartbeat annotation (issue #663).
+func TestHeartbeatOnce(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "hb-once-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "hb-once-model"},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(isvc).
+		Build()
+
+	a := &MetalAgent{
+		config: MetalAgentConfig{
+			K8sClient: k8sClient,
+			Namespace: "default",
+		},
+		processes: map[string]*ManagedProcess{
+			"default/hb-once-model": {
+				Name:      "hb-once-model",
+				Namespace: "default",
+				Port:      50051,
+				Healthy:   true,
+			},
+		},
+		logger: newNopLogger(),
+	}
+	a.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger())
+
+	before := time.Now().Add(-time.Second)
+	a.heartbeatOnce(context.Background())
+
+	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	eps := &corev1.Endpoints{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "hb-once-model", Namespace: "default"}, eps); err != nil {
+		t.Fatalf("get endpoints after heartbeatOnce: %v", err)
+	}
+
+	raw := eps.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat]
+	if raw == "" {
+		t.Fatalf("heartbeat annotation absent after heartbeatOnce")
+	}
+	ts, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatalf("heartbeat annotation %q not RFC3339: %v", raw, err)
+	}
+	if ts.Before(before) {
+		t.Fatalf("heartbeat timestamp %v predates test start %v", ts, before)
+	}
+}
+
+// nopExecutor is a minimal ProcessExecutor stub for tests that exercise paths
+// that call deleteProcess but do not need a real inference runtime.
+type nopExecutor struct{}
+
+func (nopExecutor) StartProcess(_ context.Context, _ ExecutorConfig) (*ManagedProcess, error) {
+	return nil, nil
+}
+func (nopExecutor) StopProcess(_ int) error { return nil }
+
+// TestHeartbeatOnce_ScaledToZero verifies that heartbeatOnce does NOT
+// re-register the Service+Endpoints for a process whose InferenceService has
+// been scaled to zero (spec.replicas == 0). Re-asserting networking for a
+// scaled-to-zero service would recreate the ClusterIP routing that
+// handleScaleToZero / deleteProcess just removed, leaving a live routable
+// address to a dead port with no self-heal path.
+func TestHeartbeatOnce_ScaledToZero(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	zero := int32(0)
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "scaled-zero", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "scaled-zero",
+			Replicas: &zero,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(isvc).
+		Build()
+
+	a := &MetalAgent{
+		config: MetalAgentConfig{
+			K8sClient: k8sClient,
+			Namespace: "default",
+		},
+		processes: map[string]*ManagedProcess{
+			"default/scaled-zero": {
+				Name:      "scaled-zero",
+				Namespace: "default",
+				Port:      50052,
+				Healthy:   true,
+			},
+		},
+		executor: nopExecutor{},
+		logger:   newNopLogger(),
+	}
+	a.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger())
+
+	a.heartbeatOnce(context.Background())
+
+	// The heartbeat must NOT have created Service or Endpoints for the
+	// scaled-to-zero service.
+	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	eps := &corev1.Endpoints{}
+	err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "scaled-zero", Namespace: "default"}, eps)
+	if err == nil {
+		t.Fatal("heartbeatOnce must not create Endpoints for a scaled-to-zero InferenceService")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("unexpected error checking for Endpoints: %v", err)
+	}
+}
+
+// TestHeartbeatOnce_NotFound verifies that when heartbeatOnce discovers that
+// an InferenceService no longer exists in the API server (NotFound), it treats
+// the condition as a missed deletion event and tears the process down via
+// deleteProcess — the same path the watch-event handler uses. After the call
+// the process must be absent from the map and its Endpoints must be gone.
+func TestHeartbeatOnce_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	// The fake client starts with NO InferenceService for "gone-model".
+	// Pre-populate the Endpoints so UnregisterEndpoint has something to delete.
+	existingEps := &corev1.Endpoints{ //nolint:staticcheck // SA1019: matches production path
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gone-model",
+			Namespace: "default",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(existingEps).
+		Build()
+
+	a := &MetalAgent{
+		config: MetalAgentConfig{
+			K8sClient: k8sClient,
+			Namespace: "default",
+		},
+		processes: map[string]*ManagedProcess{
+			"default/gone-model": {
+				Name:      "gone-model",
+				Namespace: "default",
+				Port:      50053,
+				Healthy:   true,
+			},
+		},
+		executor: nopExecutor{},
+		logger:   newNopLogger(),
+	}
+	a.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger())
+
+	a.heartbeatOnce(context.Background())
+
+	// Process must be removed from the map.
+	a.mu.RLock()
+	_, still := a.processes["default/gone-model"]
+	a.mu.RUnlock()
+	if still {
+		t.Fatal("heartbeatOnce_NotFound: process must be removed from map after teardown")
+	}
+
+	// Endpoints must be deleted by UnregisterEndpoint inside deleteProcess.
+	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	eps := &corev1.Endpoints{}
+	err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "gone-model", Namespace: "default"}, eps)
+	if err == nil {
+		t.Fatal("heartbeatOnce_NotFound: Endpoints must be deleted after teardown")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("heartbeatOnce_NotFound: unexpected error checking Endpoints: %v", err)
 	}
 }

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -44,6 +44,9 @@ type ServiceRegistry struct {
 	logger *zap.SugaredLogger
 	// retryBackoff bounds RegisterEndpointWithRetry. Overridable in tests.
 	retryBackoff wait.Backoff
+	// now returns the current time. Defaults to time.Now; overridable in tests
+	// to assert deterministic heartbeat annotation values.
+	now func() time.Time
 }
 
 // NewServiceRegistry creates a new service registry.
@@ -61,6 +64,7 @@ func NewServiceRegistry(k8sClient client.Client, hostIP string, logger *zap.Suga
 			Steps:    5,
 			Cap:      30 * time.Second,
 		},
+		now: time.Now,
 	}
 }
 
@@ -111,6 +115,10 @@ func (r *ServiceRegistry) RegisterEndpoint(
 			"llmkube.ai/managed-by":        "metal-agent",
 			"llmkube.ai/inference-service": isvc.Name,
 		}
+		if endpoints.Annotations == nil {
+			endpoints.Annotations = map[string]string{}
+		}
+		endpoints.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat] = r.now().UTC().Format(time.RFC3339)
 		//nolint:staticcheck // SA1019: EndpointSubset still functional
 		endpoints.Subsets = []corev1.EndpointSubset{{
 			Addresses: []corev1.EndpointAddress{{

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -602,6 +602,53 @@ func TestRegisterEndpointWithRetry_Exhausted(t *testing.T) {
 	}
 }
 
+// TestRegisterEndpoint_StampsHeartbeat verifies that RegisterEndpoint stamps the
+// llmkube.ai/agent-heartbeat annotation on the Endpoints object with a
+// deterministic RFC3339 timestamp on every call (issue #663). The clock is
+// pinned so the assertion is exact rather than "after test start".
+func TestRegisterEndpoint_StampsHeartbeat(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+
+	// Pin the clock so the annotation value is deterministic.
+	frozen := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	registry.now = func() time.Time { return frozen }
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hb-model",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "hb-model",
+		},
+	}
+
+	if err := registry.RegisterEndpoint(context.Background(), isvc, 50051); err != nil {
+		t.Fatalf("RegisterEndpoint: %v", err)
+	}
+
+	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	eps := &corev1.Endpoints{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "hb-model", Namespace: "default"}, eps); err != nil {
+		t.Fatalf("get endpoints: %v", err)
+	}
+
+	raw := eps.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat]
+	if raw == "" {
+		t.Fatalf("heartbeat annotation %q absent on endpoints", inferencev1alpha1.AnnotationAgentHeartbeat)
+	}
+	const want = "2026-06-12T12:00:00Z"
+	if raw != want {
+		t.Fatalf("heartbeat annotation = %q, want %q", raw, want)
+	}
+}
+
 // TestRegisterEndpointWithRetry_ContextCancelled verifies that when the context
 // is already cancelled before the first attempt, the returned error wraps
 // context.Canceled rather than rendering as a garbled %!w(<nil>).


### PR DESCRIPTION
## What

Metal-agent endpoint registrations now carry a liveness heartbeat, and the operator expires registrations whose heartbeat goes stale:

- Every registration stamps `llmkube.ai/agent-heartbeat` (RFC3339 UTC) on the agent-managed Endpoints, re-asserted by a new 30s re-registration loop in the agent (which also permanently self-heals any registration update the agent failed to deliver, completing #657's story).
- The InferenceService controller treats a heartbeat older than 3 minutes (6 missed ticks) as not ready: `readyReplicas` drops to 0 and the scheduling status reports `AgentHeartbeatStale` with the last-seen timestamp, instead of pretending the fleet has capacity. A `RequeueAfter` of 90s makes staleness detectable without watch events.
- Endpoints without the annotation (older agents) are exempt from both expiry and the forced requeue: fully backward compatible.
- The heartbeat loop also hardens two missed-event cases found in review: it skips re-registration for scaled-to-zero/deleting services (would otherwise resurrect networking objects that teardown just removed), and treats a NotFound InferenceService as a missed DELETE, tearing down the lingering process instead of warn-looping forever.

## Why

Fixes #663. Observed live in my homelab: an InferenceService whose Mac went offline stayed at `readyReplicas=1` for 25 days, black-holing anything routed at the Service. Registrations had no liveness mechanism at all; the fleet lied about capacity, and gateways faithfully routed at the corpse.

## How

- Shared constants in `api/v1alpha1/constants.go` (annotation key, 30s interval, 3m timeout) consumed by both agent and controller; no literals.
- Agent: heartbeat stamped inside the registration mutate function (injectable clock for deterministic tests); `heartbeatOnce` snapshots the process map under RLock and releases before any network I/O; one plain `RegisterEndpoint` per process per tick (the next tick is the retry, so one stalled endpoint cannot serialize the rest).
- Controller: a single Endpoints snapshot per reconcile feeds both readiness (with distinguishable fresh/stale/unparseable/legacy/none states) and the requeue decision; stale and unparseable heartbeats produce distinct structured logs.
- Tests: pinned-clock stamp determinism; heartbeatOnce safety paths (scaled-to-zero skip, NotFound teardown) under `-race`; envtest coverage for all snapshot states plus full-Reconcile fresh and stale paths.

Known trade-offs, intentionally accepted and documented for review: each heartbeat is a real Endpoints write every 30s per metal service (fine at metal-fleet scale; Lease objects are the at-scale answer if ever needed); a Stopped service with orphaned stale Endpoints keeps a 90s requeue poll (it notices the agent's return); heartbeat asserts agent liveness, not process health (the health monitor owns that).

## Checklist

- [x] Tests added (agent unit + race, controller envtest) and full `make test` green
- [x] `make fmt vet lint` clean, plus `GOOS=linux golangci-lint run ./...`
- [x] No CRD schema or RBAC changes (annotation + constants only; no manifest sync needed)
- [x] DCO sign-off on all commits; commits build independently (bisectable)
