### PR TITLE
fix(foreman): ERROR verdicts become terminal INCOMPLETE outcomes; watcher can no longer wedge

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -65,7 +65,7 @@ const (
 // v0.3 #559 introduces the enum + emission; per-reason retry policy
 // on AgenticTaskSpec and retry-with-correction in the loop are
 // follow-up work that consumes this signal.
-// +kubebuilder:validation:Enum=AgentNotFound;InferenceServiceUnavailable;AuthUnavailable;GitRemoteNotConfigured;CloneFailed;ModelMisunderstood;ToolFailed;MaxTurnsExhausted;ConstraintViolated;Timeout;InfrastructureError;GateFailed;GateError
+// +kubebuilder:validation:Enum=AgentNotFound;InferenceServiceUnavailable;AuthUnavailable;GitRemoteNotConfigured;CloneFailed;ModelMisunderstood;ToolFailed;MaxTurnsExhausted;ConstraintViolated;Timeout;InfrastructureError;GateFailed;GateError;ModelReportedError
 type AgenticTaskFailureReason string
 
 const (
@@ -149,6 +149,17 @@ const (
 	// (image pull error, PVC issue, timeout before any check ran).
 	// Infrastructure rather than diff-quality; retryable.
 	FailureGateError AgenticTaskFailureReason = "GateError"
+
+	// FailureModelReportedError means the model itself reported it could
+	// not complete the task via verdict ERROR (a reviewer's
+	// could-not-review, a coder's unrecoverable-error). Distinguishes
+	// model-reported inability from harness-detected failures; the stored
+	// verdict is INCOMPLETE.
+	//
+	// Maps from the model-facing "ERROR" verdict in submit_result, which
+	// the CRD intentionally does not store as a verdict (issue #649;
+	// INCOMPLETE-as-could-not-review per #644).
+	FailureModelReportedError AgenticTaskFailureReason = "ModelReportedError"
 )
 
 // AgenticTaskAccelerator pins which accelerator family a task needs from the

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -314,6 +314,7 @@ spec:
                 - InfrastructureError
                 - GateFailed
                 - GateError
+                - ModelReportedError
                 type: string
               finishedAt:
                 description: FinishedAt is when the executor produced a verdict (success

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -314,6 +314,7 @@ spec:
                 - InfrastructureError
                 - GateFailed
                 - GateError
+                - ModelReportedError
                 type: string
               finishedAt:
                 description: FinishedAt is when the executor produced a verdict (success

--- a/pkg/foreman/agent/executor_coderjob.go
+++ b/pkg/foreman/agent/executor_coderjob.go
@@ -179,7 +179,15 @@ func coderJobResultToResult(kind string, start time.Time, cjr CoderJobResult) *R
 		return r
 	case string(foremanv1alpha1.AgenticTaskVerdictIncomplete):
 		r := NewResult(kind, foremanv1alpha1.AgenticTaskVerdictIncomplete, cjr.Summary, time.Since(start))
-		r.FailureReason = foremanv1alpha1.FailureMaxTurnsExhausted
+		// Prefer the reason the in-pod run-task already computed (e.g.
+		// FailureModelReportedError when the model called submit_result with
+		// verdict=ERROR). Fall back to FailureMaxTurnsExhausted only when no
+		// structured reason was embedded in the FOREMAN-RESULT envelope.
+		if cjr.FailureReason != "" {
+			r.FailureReason = foremanv1alpha1.AgenticTaskFailureReason(cjr.FailureReason)
+		} else {
+			r.FailureReason = foremanv1alpha1.FailureMaxTurnsExhausted
+		}
 		r.Extra = map[string]any{
 			"outcome":        "INCOMPLETE",
 			"intendedBranch": cjr.Branch,

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -435,7 +435,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			"loop returned nil error but no terminal result"), nil
 	}
 
-	verdict := foremanv1alpha1.AgenticTaskVerdict(loopRes.Terminal.Verdict)
+	verdict, normalizedReason := normalizeModelVerdict(loopRes.Terminal.Verdict)
 
 	// 9. Non-GO verdicts: no commit, no push, just record the model's
 	// stated outcome and return.
@@ -493,7 +493,18 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			}
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
-		return e.modelDecidedResult(start, transcriptRef, loopRes, verdict), nil
+		r := e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
+		// Attach the normalized failure reason from the model-to-CRD
+		// mapping (e.g. ERROR→INCOMPLETE + ModelReportedError for #649). Only
+		// set when the normalizer produced a reason AND the result does
+		// not already carry one. The guard is defensive: nothing between
+		// modelDecidedResult() and here sets r.FailureReason today, but
+		// future reason-setting paths (e.g. additional enforcement passes)
+		// should not be silently clobbered.
+		if normalizedReason != "" && r.FailureReason == "" {
+			r.FailureReason = normalizedReason
+		}
+		return r, nil
 	}
 
 	// 10. GO verdict: check for changes first, then commit + push. If
@@ -584,8 +595,9 @@ func (e *NativeAgentLoopExecutor) executeDeterministic(
 	// task at least reaches Succeeded; the operator can inspect
 	// Result.Extra.toolOutput for what happened.
 	verdict := foremanv1alpha1.AgenticTaskVerdictGo
+	var detNormalizedReason foremanv1alpha1.AgenticTaskFailureReason
 	if result.Terminal && result.Verdict != "" {
-		verdict = foremanv1alpha1.AgenticTaskVerdict(result.Verdict)
+		verdict, detNormalizedReason = normalizeModelVerdict(result.Verdict)
 	}
 
 	summary := result.Summary
@@ -604,6 +616,11 @@ func (e *NativeAgentLoopExecutor) executeDeterministic(
 		r.FailureReason = foremanv1alpha1.FailureGateFailed
 	case foremanv1alpha1.AgenticTaskVerdictGateError:
 		r.FailureReason = foremanv1alpha1.FailureGateError
+	}
+	// Apply the model-to-CRD normalization reason (#649) only when the
+	// switch above did not already set a more-specific gate reason.
+	if detNormalizedReason != "" && r.FailureReason == "" {
+		r.FailureReason = detNormalizedReason
 	}
 	r.Extra = map[string]any{
 		"outcome":        "",
@@ -1601,4 +1618,24 @@ func durationFromSeconds(secs int32, fallbackSecs int) time.Duration {
 		return time.Duration(fallbackSecs) * time.Second
 	}
 	return time.Duration(secs) * time.Second
+}
+
+// normalizeModelVerdict maps the model-facing verdict vocabulary onto the
+// AgenticTaskVerdict enum. The submit_result tool contract allows "ERROR"
+// (model-reported inability to complete the task: a reviewer's
+// could-not-review, a coder's unrecoverable-error), which the CRD
+// intentionally does not store as a verdict: it becomes INCOMPLETE with
+// FailureModelReportedError so callers can distinguish model-reported
+// inability from harness-detected failures (issue #649; per #644).
+//
+// For all other verdicts the raw string is cast directly to the typed enum.
+// GATE-* and INCOMPLETE also arrive via run_gate_job and loop-synthesized
+// envelopes, not only submit_result. An unknown value here is a harness bug
+// rather than a model quirk; the watcher backstop handles any remaining
+// out-of-enum strings as a follow-up (issue #649).
+func normalizeModelVerdict(raw string) (foremanv1alpha1.AgenticTaskVerdict, foremanv1alpha1.AgenticTaskFailureReason) {
+	if raw == "ERROR" {
+		return foremanv1alpha1.AgenticTaskVerdictIncomplete, foremanv1alpha1.FailureModelReportedError
+	}
+	return foremanv1alpha1.AgenticTaskVerdict(raw), ""
 }

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1313,3 +1313,109 @@ func TestEnforceReviewerIssueAsk_NilExtraIsNoOp(t *testing.T) {
 		t.Errorf("nil extra must pass the verdict through; got %v", got)
 	}
 }
+
+// TestNormalizeModelVerdict_ErrorMapsToIncompleteWithModelReportedError pins
+// the #649 fix: the submit_result tool contract allows verdict="ERROR" (model
+// reports it cannot complete the task: a reviewer's could-not-review, a
+// coder's unrecoverable-error), but the CRD does not store ERROR as a
+// verdict. normalizeModelVerdict must convert it to INCOMPLETE with
+// FailureModelReportedError. The watcher backstop (issue #649 follow-up
+// commit) covers any remaining out-of-enum strings that reach the terminal
+// patch; normalizeModelVerdict handles only the ERROR contract case.
+//
+// All other verdicts (GO, NO-GO, GATE-PASS, GATE-FAIL, GATE-ERROR,
+// INCOMPLETE) must pass through unchanged with an empty failure reason.
+func TestNormalizeModelVerdict_ErrorMapsToIncompleteWithModelReportedError(t *testing.T) {
+	cases := []struct {
+		raw         string
+		wantVerdict foremanv1alpha1.AgenticTaskVerdict
+		wantReason  foremanv1alpha1.AgenticTaskFailureReason
+	}{
+		{
+			raw:         "ERROR",
+			wantVerdict: foremanv1alpha1.AgenticTaskVerdictIncomplete,
+			wantReason:  foremanv1alpha1.FailureModelReportedError,
+		},
+		{
+			raw:         "GO",
+			wantVerdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			wantReason:  "",
+		},
+		{
+			raw:         "NO-GO",
+			wantVerdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			wantReason:  "",
+		},
+		{
+			raw:         "INCOMPLETE",
+			wantVerdict: foremanv1alpha1.AgenticTaskVerdictIncomplete,
+			wantReason:  "",
+		},
+		{
+			raw:         "GATE-PASS",
+			wantVerdict: foremanv1alpha1.AgenticTaskVerdictGatePass,
+			wantReason:  "",
+		},
+		{
+			raw:         "GATE-FAIL",
+			wantVerdict: foremanv1alpha1.AgenticTaskVerdictGateFail,
+			wantReason:  "",
+		},
+		{
+			raw:         "GATE-ERROR",
+			wantVerdict: foremanv1alpha1.AgenticTaskVerdictGateError,
+			wantReason:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			gotVerdict, gotReason := normalizeModelVerdict(tc.raw)
+			if gotVerdict != tc.wantVerdict {
+				t.Errorf("verdict: want %q got %q", tc.wantVerdict, gotVerdict)
+			}
+			if gotReason != tc.wantReason {
+				t.Errorf("reason: want %q got %q", tc.wantReason, gotReason)
+			}
+		})
+	}
+}
+
+// TestCoderJobResultToResult_EmbeddedFailureReasonPreserved pins the
+// Job-mode supervisor fix: when an in-pod run-task produces an INCOMPLETE
+// verdict with FailureReason=ModelReportedError (model called submit_result
+// with ERROR), the supervisor must lift the embedded reason rather than
+// overwrite it with the generic FailureMaxTurnsExhausted.
+func TestCoderJobResultToResult_EmbeddedFailureReasonPreserved(t *testing.T) {
+	start := time.Now().Add(-time.Second)
+	cjr := CoderJobResult{
+		Verdict:       string(foremanv1alpha1.AgenticTaskVerdictIncomplete),
+		Summary:       "model reported it could not complete the task",
+		FailureReason: string(foremanv1alpha1.FailureModelReportedError),
+	}
+	r := coderJobResultToResult("issue-fix", start, cjr)
+	if r.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Errorf("verdict: want INCOMPLETE got %s", r.Verdict)
+	}
+	if r.FailureReason != foremanv1alpha1.FailureModelReportedError {
+		t.Errorf("failureReason: want ModelReportedError got %s", r.FailureReason)
+	}
+}
+
+// TestCoderJobResultToResult_NoEmbeddedReasonFallsBackToMaxTurns confirms
+// that an INCOMPLETE result with no embedded FailureReason still defaults
+// to FailureMaxTurnsExhausted (the pre-fix behavior for the common
+// max-turns case).
+func TestCoderJobResultToResult_NoEmbeddedReasonFallsBackToMaxTurns(t *testing.T) {
+	start := time.Now().Add(-time.Second)
+	cjr := CoderJobResult{
+		Verdict: string(foremanv1alpha1.AgenticTaskVerdictIncomplete),
+		Summary: "hit max turns without a verdict",
+	}
+	r := coderJobResultToResult("issue-fix", start, cjr)
+	if r.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Errorf("verdict: want INCOMPLETE got %s", r.Verdict)
+	}
+	if r.FailureReason != foremanv1alpha1.FailureMaxTurnsExhausted {
+		t.Errorf("failureReason: want MaxTurnsExhausted got %s", r.FailureReason)
+	}
+}

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -466,6 +466,22 @@ const submitNoGoBody = `{
   }]
 }`
 
+const submitErrorBody = `{
+  "id": "t1",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "tool_calls": [{
+        "id": "tc-1",
+        "type": "function",
+        "function": {"name": "submit_result", "arguments": "{\"verdict\":\"ERROR\",\"summary\":\"could not clone\"}"}
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }]
+}`
+
 func TestNativeExecutor_ModelEmitsNoGo(t *testing.T) {
 	gitOrSkip(t)
 	root := t.TempDir()
@@ -663,6 +679,54 @@ func TestNativeExecutor_ReviewerGoIsApproveNotCommit(t *testing.T) {
 	var cm corev1.ConfigMap
 	if err := c.Get(context.Background(), cmKey, &cm); err != nil {
 		t.Errorf("transcript should exist on reviewer path: %v", err)
+	}
+}
+
+// TestNativeExecutor_ReviewerERRORMapsToIncompleteWithModelReportedError checks
+// that a reviewer-role Agent emitting verdict=ERROR is correctly wired
+// through normalizeModelVerdict. The CRD has no ERROR verdict; the harness
+// converts it to INCOMPLETE and tags the result with
+// FailureModelReportedError so operators can distinguish "model reported
+// inability" from other incomplete outcomes (issue #649).
+func TestNativeExecutor_ReviewerERRORMapsToIncompleteWithModelReportedError(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitErrorBody})
+
+	agent, task := reviewerTaskAndAgent("error-verdict")
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true,
+				Verdict:  "ERROR",
+				Summary:  "could not clone",
+			},
+		},
+	}
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "B", Email: "b@x"},
+		CommitCommitter:          repo.Identity{Name: "B", Email: "b@x"},
+		RegistryFactory: func(_ string, _ *foremanv1alpha1.Agent) (foremanagent.ToolRegistry, error) {
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Errorf("verdict: want INCOMPLETE got %s", res.Verdict)
+	}
+	if res.FailureReason != foremanv1alpha1.FailureModelReportedError {
+		t.Errorf("failureReason: want ModelReportedError got %s", res.FailureReason)
 	}
 }
 

--- a/pkg/foreman/agent/tools/run_coder_job.go
+++ b/pkg/foreman/agent/tools/run_coder_job.go
@@ -349,6 +349,13 @@ func (r *RunCoderJob) Run(ctx context.Context, args RunCoderJobArgs) (CoderJobRe
 	res.Branch = parsed.Branch
 	res.CommitSHA = parsed.CommitSHA
 	res.CommitMessage = parsed.CommitMessage
+	// Lift the structured FailureReason out of the embedded Result so the
+	// Job-mode supervisor (coderJobResultToResult) can preserve it rather
+	// than overwriting with a generic reason. This matters for INCOMPLETE
+	// verdicts carrying FailureModelReportedError from an in-pod model ERROR.
+	if parsed.Result != nil && parsed.Result.FailureReason != "" {
+		res.FailureReason = string(parsed.Result.FailureReason)
+	}
 	if res.Verdict == "" {
 		// Succeeded Job but no recognizable result line: treat as a
 		// run-failure rather than silently dropping it.

--- a/pkg/foreman/agent/tools/run_coder_job.go
+++ b/pkg/foreman/agent/tools/run_coder_job.go
@@ -188,8 +188,10 @@ type CoderJobResult struct {
 	// CommitMessage is the model's commit message on a GO verdict.
 	CommitMessage string
 
-	// FailureReason is a short machine-ish reason set only on an ERROR
-	// verdict (job-failed, poll-timeout, create-failed, render-failed).
+	// FailureReason is a short machine-ish reason. On an ERROR verdict it is
+	// a job-infrastructure tag (job-failed, poll-timeout, create-failed,
+	// render-failed); on INCOMPLETE it carries the typed failure reason
+	// lifted from the in-pod FOREMAN-RESULT envelope when present.
 	FailureReason string
 
 	// LogTail is the captured pod log tail, for operator triage.

--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -361,7 +362,60 @@ func (w *AgenticTaskWatcher) patchTerminal(
 		Message:            res.Summary,
 		LastTransitionTime: now,
 	})
-	return w.Client.Status().Patch(ctx, &fresh, patch)
+	patchErr := w.Client.Status().Patch(ctx, &fresh, patch)
+	if patchErr == nil {
+		return nil
+	}
+	if !apierrors.IsInvalid(patchErr) {
+		return patchErr
+	}
+
+	// The apiserver rejected the patch, most likely because res.Verdict or
+	// res.FailureReason carries a string value not (yet) in the CRD enum.
+	// This can happen when a future contract version emits a verdict string
+	// that the currently-installed CRD does not know about. Without a
+	// fallback the task would stay in Running forever, wedging the node.
+	//
+	// Defensive recovery: re-fetch, overwrite with minimal known-valid
+	// status, and patch again. The raw Result JSON is preserved in
+	// status.result because that field is x-kubernetes-preserve-unknown-fields
+	// and is therefore not subject to enum validation.
+	log := logf.FromContext(ctx).WithName("agentictask-watcher").WithValues("task", t.Name)
+	log.Error(patchErr, "terminal patch rejected by apiserver; falling back to InfrastructureError",
+		"rejectedVerdict", res.Verdict,
+		"rejectedFailureReason", res.FailureReason,
+	)
+
+	var fallback foremanv1alpha1.AgenticTask
+	if getErr := w.Client.Get(ctx, key, &fallback); getErr != nil {
+		return fmt.Errorf("fallback refetch %s: %w", key, getErr)
+	}
+	fallbackPatch := client.MergeFrom(fallback.DeepCopy())
+	fallbackNow := metav1.Now()
+	fallback.Status.Phase = foremanv1alpha1.AgenticTaskPhaseFailed
+	fallback.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+	fallback.Status.FailureReason = foremanv1alpha1.FailureInfrastructureError
+	fallback.Status.FinishedAt = &fallbackNow
+	// Preserve the raw result envelope: status.result is
+	// x-kubernetes-preserve-unknown-fields so it survives the patch even
+	// if Verdict inside the JSON is not in the current enum.
+	fallback.Status.Result = &runtime.RawExtension{Raw: raw}
+
+	// Truncate the validation error message so the condition stays within
+	// apiserver limits (conditions.message is limited to 32768 chars).
+	patchErrMsg := patchErr.Error()
+	const maxErrLen = 512
+	if len(patchErrMsg) > maxErrLen {
+		patchErrMsg = patchErrMsg[:maxErrLen] + "... (truncated)"
+	}
+	setCondition(&fallback.Status.Conditions, metav1.Condition{
+		Type:               "Completed",
+		Status:             metav1.ConditionFalse,
+		Reason:             "TerminalPatchRejected",
+		Message:            fmt.Sprintf("original verdict %q rejected by apiserver: %s", res.Verdict, patchErrMsg),
+		LastTransitionTime: fallbackNow,
+	})
+	return w.Client.Status().Patch(ctx, &fallback, fallbackPatch)
 }
 
 // setCondition upserts a condition by type. Unexported because both the

--- a/pkg/foreman/agent/watcher_recovery_test.go
+++ b/pkg/foreman/agent/watcher_recovery_test.go
@@ -18,12 +18,17 @@ package agent
 
 import (
 	"context"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
@@ -122,5 +127,104 @@ func TestRecoverOrphanedTasks_IgnoresNonRunningPhase(t *testing.T) {
 	got := getTask(t, c, "scheduled-task")
 	if got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseScheduled {
 		t.Fatalf("phase = %q, want Scheduled (untouched)", got.Status.Phase)
+	}
+}
+
+// If the apiserver rejects the primary terminal-status patch (e.g. because a
+// future contract drift produces an enum value not yet in the CRD), the watcher
+// must NOT leave the task wedged in Running forever. It must fall back to a
+// minimal valid status: Phase=Failed, Verdict=INCOMPLETE,
+// FailureReason=InfrastructureError, and a "TerminalPatchRejected" condition
+// whose message includes the original bogus verdict string.
+//
+// Regression for defilantech/LLMKube#649.
+func TestPatchTerminal_FallsBackOnRejectedVerdict(t *testing.T) {
+	task := pendingTask("code-649")
+
+	// Build a real fake client that holds the task, then wrap it in an
+	// interceptor that rejects the FIRST SubResourcePatch with an Invalid
+	// error (simulating apiserver enum validation rejection), then lets the
+	// second patch (the fallback) pass through to the underlying client.
+	base := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(task).
+		WithStatusSubresource(&foremanv1alpha1.AgenticTask{}).
+		Build()
+
+	var patchCalls atomic.Int32
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		SubResourcePatch: func(
+			ctx context.Context, c client.Client, subResourceName string,
+			obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption,
+		) error {
+			n := patchCalls.Add(1)
+			if n == 1 {
+				// Simulate apiserver rejecting the patch because "BOGUS" is not in
+				// the verdict enum.
+				return apierrors.NewInvalid(
+					schema.GroupKind{Group: "foreman.llmkube.dev", Kind: "AgenticTask"},
+					obj.GetName(),
+					nil,
+				)
+			}
+			// Let the fallback patch go through.
+			return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	w := &AgenticTaskWatcher{Client: c, NodeName: "coder", Namespace: "default"}
+
+	bogusResult := &Result{
+		SchemaVersion: ResultSchemaVersion,
+		Kind:          "issue-fix",
+		Verdict:       foremanv1alpha1.AgenticTaskVerdict("BOGUS"),
+		Summary:       "contract drift test",
+	}
+
+	// patchTerminal must not return an error: the fallback patch should succeed.
+	if err := w.patchTerminal(context.Background(), task, bogusResult, nil); err != nil {
+		t.Fatalf("patchTerminal returned error: %v", err)
+	}
+
+	// The underlying fake client holds the real state; read from it directly.
+	got := getTask(t, base, "code-649")
+
+	if got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseFailed {
+		t.Fatalf("phase = %q, want Failed", got.Status.Phase)
+	}
+	if got.Status.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Fatalf("verdict = %q, want INCOMPLETE", got.Status.Verdict)
+	}
+	if got.Status.FailureReason != foremanv1alpha1.FailureInfrastructureError {
+		t.Fatalf("failureReason = %q, want InfrastructureError", got.Status.FailureReason)
+	}
+	if got.Status.FinishedAt == nil {
+		t.Fatal("finishedAt is nil, want non-nil on fallback outcome")
+	}
+	if got.Status.Result == nil {
+		t.Fatal("result is nil, want non-nil on fallback outcome")
+	}
+
+	var rejCond *metav1.Condition
+	for i := range got.Status.Conditions {
+		if got.Status.Conditions[i].Reason == "TerminalPatchRejected" {
+			rejCond = &got.Status.Conditions[i]
+			break
+		}
+	}
+	if rejCond == nil {
+		t.Fatalf("expected a TerminalPatchRejected condition, got %+v", got.Status.Conditions)
+	}
+	if rejCond.Status != metav1.ConditionFalse {
+		t.Fatalf("TerminalPatchRejected condition status = %q, want False", rejCond.Status)
+	}
+
+	// The message must contain the original bogus verdict so an operator can
+	// correlate logs with the task object without needing to grep the agent log.
+	const bogusVerdict = "BOGUS"
+	if msg := rejCond.Message; len(msg) == 0 {
+		t.Fatal("TerminalPatchRejected condition message is empty")
+	} else if !strings.Contains(msg, bogusVerdict) {
+		t.Fatalf("TerminalPatchRejected message %q does not contain original verdict %q", msg, bogusVerdict)
 	}
 }


### PR DESCRIPTION
## What

A model-submitted `verdict="ERROR"` becomes a terminal, queryable outcome instead of wedging the AgenticTask in Running forever, and the watcher is now structurally incapable of wedging a task on a rejected terminal patch:

- The executor maps the contract verdict `ERROR` (could-not-review for reviewers, unrecoverable-error for coders) to `INCOMPLETE` with a new distinct failure reason `ModelReportedError`, at every model-string-to-verdict boundary (native loop and deterministic paths). The reviewer/coder prompt contracts and the verdict enum are unchanged.
- Job mode preserves the reason end to end: the in-pod FOREMAN-RESULT envelope's `failureReason` is lifted through the log parse and preferred by the supervisor over the hardcoded `MaxTurnsExhausted` on INCOMPLETE.
- The watcher's terminal patch gains a defensive fallback: if the apiserver rejects the status as Invalid (any unknown future verdict string), it re-patches a minimal valid status (Failed / INCOMPLETE / InfrastructureError) with a `TerminalPatchRejected` condition carrying the original verdict and a truncated validation error, preserving the raw Result envelope. No future contract drift can wedge a task.

## Why

Fixes #649. The reviewer system prompt has promised `verdict="ERROR"` since the role was introduced, and `submit_result` accepts it, but the CRD enum cannot store it; the first model to honor the clause (the North Mini Code entrance exam on issue 449) wedged its task in Running with `patching terminal status failed ... is invalid`. Per the #644 discussion, INCOMPLETE is the semantically correct could-not-review verdict; the new failure reason keeps the outcome distinguishable and queryable (`status.failureReason=ModelReportedError`).

## How

- TDD at three levels: a table test for the normalization helper (all six enum verdicts pass through untouched), an executor-level wiring test where the scripted model submits ERROR (verified failing against the bare cast), and a watcher test that injects an Invalid rejection on the first status patch and asserts the fallback status lands (verified failing against the old code).
- The new failure reason is one CRD enum value; `config/crd/bases` and `charts/foreman/templates/crds` regenerated and in sync (no other drift; `charts/llmkube` untouched).
- Rollup semantics unchanged on purpose: a mapped ERROR lands in the workload's incomplete bucket like any other INCOMPLETE; per-reason escalation branching is future work.

Ops note (from the issue): the shadowstack cluster's installed CRDs predate `status.failureReason` (#559), so a CRD refresh is needed on the next release upgrade for the new reason to be visible there.

## Checklist

- [x] Tests added at helper, executor, and watcher levels; full `make test` green
- [x] `make fmt vet lint` clean, plus `GOOS=linux golangci-lint run ./...`
- [x] CRD sync: `make manifests && make chart-crds && make foreman-chart-crds`, both foreman CRD copies identical
- [x] DCO sign-off on all commits
