### PR TITLE
fix(foreman): expire stale claims so tasks survive agent death

### DIFF
--- a/internal/foreman/controller/agentictask_claim_expiry_test.go
+++ b/internal/foreman/controller/agentictask_claim_expiry_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// setAssignedRunning is a test helper that moves a task to the given in-flight
+// phase with an assigned node, mirroring the state left by the scheduler +
+// agent claim cycle.
+func setAssignedRunning(task *foremanv1alpha1.AgenticTask, phase foremanv1alpha1.AgenticTaskPhase, nodeName string) {
+	GinkgoHelper()
+	patch := client.MergeFrom(task.DeepCopy())
+	now := metav1.Now()
+	task.Status.Phase = phase
+	task.Status.AssignedNode = nodeName
+	task.Status.ClaimedAt = &now
+	task.Status.StartedAt = &now
+	Expect(k8sClient.Status().Patch(ctx, task, patch)).To(Succeed())
+}
+
+// setStaleNode creates or updates a FleetNode with a last heartbeat far enough
+// in the past to be considered stale (> FleetNodeHeartbeatTimeout).
+func setStaleNode(node *foremanv1alpha1.FleetNode) {
+	GinkgoHelper()
+	patch := client.MergeFrom(node.DeepCopy())
+	stale := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	node.Status.Phase = foremanv1alpha1.FleetNodePhaseReady
+	node.Status.LastHeartbeatTime = &stale
+	Expect(k8sClient.Status().Patch(ctx, node, patch)).To(Succeed())
+}
+
+// setExpiryAnnotation writes the claim-expiry counter annotation directly onto
+// the task's metadata.
+func setExpiryAnnotation(task *foremanv1alpha1.AgenticTask, value string) {
+	GinkgoHelper()
+	patch := client.MergeFrom(task.DeepCopy())
+	if task.Annotations == nil {
+		task.Annotations = map[string]string{}
+	}
+	task.Annotations[claimExpiriesAnnotation] = value
+	Expect(k8sClient.Patch(ctx, task, patch)).To(Succeed())
+}
+
+var _ = Describe("AgenticTaskReconciler claim expiry", func() {
+	var reconciler *AgenticTaskReconciler
+
+	BeforeEach(func() {
+		reconciler = &AgenticTaskReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+	})
+
+	It("releases a Running task whose node heartbeat is stale", func() {
+		// Test 1: Running + stale node -> Pending, fields cleared, ClaimExpired
+		// condition, annotation bumped to "1".
+		node := newFleetNode("stale-running-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setStaleNode(node)
+
+		task := newTask("stale-running-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setAssignedRunning(task, foremanv1alpha1.AgenticTaskPhaseRunning, node.Name)
+
+		res, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero()) // release returns immediately
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+
+		// Phase released to Pending.
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		// Claim fields cleared.
+		Expect(fresh.Status.AssignedNode).To(BeEmpty())
+		Expect(fresh.Status.ClaimedAt).To(BeNil())
+		Expect(fresh.Status.StartedAt).To(BeNil())
+
+		// ClaimExpired condition set.
+		cond := findCondition(fresh.Status.Conditions, "ClaimExpired")
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Reason).To(Equal("ClaimExpired"))
+		Expect(cond.Message).To(ContainSubstring(node.Name))
+
+		// Counter annotation incremented to 1.
+		Expect(fresh.Annotations[claimExpiriesAnnotation]).To(Equal("1"))
+	})
+
+	It("releases a Running task when the FleetNode is absent", func() {
+		// Test 2: Running + FleetNode not found -> same release semantics.
+		task := newTask("absent-node-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setAssignedRunning(task, foremanv1alpha1.AgenticTaskPhaseRunning, "ghost-node")
+
+		res, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		Expect(fresh.Status.AssignedNode).To(BeEmpty())
+		Expect(fresh.Status.ClaimedAt).To(BeNil())
+		Expect(fresh.Status.StartedAt).To(BeNil())
+
+		cond := findCondition(fresh.Status.Conditions, "ClaimExpired")
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Message).To(ContainSubstring("FleetNode not found"))
+
+		Expect(fresh.Annotations[claimExpiriesAnnotation]).To(Equal("1"))
+	})
+
+	It("leaves an in-flight task untouched and requeues when the node is fresh", func() {
+		// Test 3: Running + fresh node -> untouched, RequeueAfter > 0.
+		node := newFleetNode("fresh-running-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+
+		task := newTask("fresh-running-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setAssignedRunning(task, foremanv1alpha1.AgenticTaskPhaseRunning, node.Name)
+
+		res, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+		// Should requeue so staleness is re-checked.
+		Expect(res.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+
+		// Untouched: still Running with the same assigned node.
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseRunning))
+		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
+		// No expiry annotation.
+		Expect(fresh.Annotations[claimExpiriesAnnotation]).To(BeEmpty())
+	})
+
+	It("releases a Scheduled task whose node heartbeat is stale", func() {
+		// Test 4: Scheduled + stale node -> released to Pending.
+		node := newFleetNode("stale-scheduled-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setStaleNode(node)
+
+		task := newTask("stale-scheduled-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setAssignedRunning(task, foremanv1alpha1.AgenticTaskPhaseScheduled, node.Name)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		Expect(fresh.Status.AssignedNode).To(BeEmpty())
+		Expect(fresh.Annotations[claimExpiriesAnnotation]).To(Equal("1"))
+	})
+
+	It("terminal-fails a task that has already expired twice (3-strike ladder)", func() {
+		// Test 5: annotation "2" + stale node -> Failed/INCOMPLETE/InfrastructureError.
+		node := newFleetNode("limit-reached-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setStaleNode(node)
+
+		task := newTask("limit-reached-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setAssignedRunning(task, foremanv1alpha1.AgenticTaskPhaseRunning, node.Name)
+		setExpiryAnnotation(task, "2") // two prior expiries; this is the 3rd
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseFailed))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictIncomplete))
+		Expect(fresh.Status.FailureReason).To(Equal(foremanv1alpha1.FailureInfrastructureError))
+		Expect(fresh.Status.FinishedAt).NotTo(BeNil())
+
+		cond := findCondition(fresh.Status.Conditions, "Failed")
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Reason).To(Equal("ClaimExpiryLimitReached"))
+		Expect(cond.Message).To(ContainSubstring(node.Name))
+	})
+
+	It("leaves a Succeeded task untouched even when its former node is stale", func() {
+		// Test 6: Succeeded + stale node -> no-op, no requeue forced.
+		node := newFleetNode("stale-succeeded-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setStaleNode(node)
+
+		task := newTask("succeeded-stale-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+
+		// Put the task in terminal Succeeded state (as the agent would).
+		patch := client.MergeFrom(task.DeepCopy())
+		now := metav1.Now()
+		task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictGo
+		task.Status.AssignedNode = node.Name
+		task.Status.FinishedAt = &now
+		Expect(k8sClient.Status().Patch(ctx, task, patch)).To(Succeed())
+
+		res, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+		// Terminal phases must not produce a forced requeue.
+		Expect(res.RequeueAfter).To(BeZero())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+
+		// Still Succeeded; no expiry annotation.
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseSucceeded))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictGo))
+		Expect(fresh.Annotations[claimExpiriesAnnotation]).To(BeEmpty())
+	})
+})

--- a/internal/foreman/controller/agentictask_claim_expiry_test.go
+++ b/internal/foreman/controller/agentictask_claim_expiry_test.go
@@ -253,4 +253,123 @@ var _ = Describe("AgenticTaskReconciler claim expiry", func() {
 		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictGo))
 		Expect(fresh.Annotations[claimExpiriesAnnotation]).To(BeEmpty())
 	})
+
+	// Tests 7 + 8 exercise the concurrent-terminal guard by calling the
+	// helpers directly with a stale snapshot. This models the race that
+	// envtest cannot stage deterministically through Reconcile: the
+	// informer's view says Running, but the agent's terminal patch landed
+	// between checkClaimExpiry's staleness decision and the write, so the
+	// live object is already Succeeded when releaseExpiredClaim /
+	// terminalFailExpired performs its re-fetch.
+
+	It("releaseExpiredClaim is a no-op when the live object is already Succeeded (stale snapshot)", func() {
+		// Test 7: guard in releaseExpiredClaim.
+		// 1. Create the task and put it in Succeeded state in etcd.
+		// 2. Build a stale in-memory snapshot that claims it is still Running.
+		// 3. Call releaseExpiredClaim directly with that snapshot.
+		// 4. Confirm the live object is untouched.
+		node := newFleetNode("guard-release-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+
+		task := newTask("guard-release-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+
+		// Write Succeeded into etcd (what a concurrent agent terminal patch
+		// would have done).
+		succPatch := client.MergeFrom(task.DeepCopy())
+		finishedAt := metav1.Now()
+		task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictGo
+		task.Status.AssignedNode = node.Name
+		task.Status.FinishedAt = &finishedAt
+		Expect(k8sClient.Status().Patch(ctx, task, succPatch)).To(Succeed())
+
+		// Build a stale snapshot: the informer still thinks the task is Running
+		// on the same node. We construct it from the original task pointer
+		// (before the Succeeded patch) so its resourceVersion is older.
+		staleSnapshot := task.DeepCopy()
+		now := metav1.Now()
+		staleSnapshot.Status.Phase = foremanv1alpha1.AgenticTaskPhaseRunning
+		staleSnapshot.Status.AssignedNode = node.Name
+		staleSnapshot.Status.ClaimedAt = &now
+		staleSnapshot.Status.StartedAt = &now
+
+		res, err := reconciler.releaseExpiredClaim(ctx, staleSnapshot, node.Name, "FleetNode not found")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero())
+
+		// Live object must still be Succeeded, not regressed to Pending.
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseSucceeded))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictGo))
+		Expect(fresh.Annotations[claimExpiriesAnnotation]).To(BeEmpty())
+	})
+
+	It("terminalFailExpired is a no-op when the live object is already Succeeded (stale snapshot)", func() {
+		// Test 8: guard in terminalFailExpired.
+		// Same setup as Test 7 but exercises the 3-strike code path.
+		node := newFleetNode("guard-termfail-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+
+		task := newTask("guard-termfail-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+
+		// Write Succeeded into etcd.
+		succPatch := client.MergeFrom(task.DeepCopy())
+		finishedAt := metav1.Now()
+		task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictGo
+		task.Status.AssignedNode = node.Name
+		task.Status.FinishedAt = &finishedAt
+		Expect(k8sClient.Status().Patch(ctx, task, succPatch)).To(Succeed())
+
+		// Stale snapshot: two prior expiries, still Running.
+		staleSnapshot := task.DeepCopy()
+		claimedAt := metav1.Now()
+		staleSnapshot.Status.Phase = foremanv1alpha1.AgenticTaskPhaseRunning
+		staleSnapshot.Status.AssignedNode = node.Name
+		staleSnapshot.Status.ClaimedAt = &claimedAt
+		if staleSnapshot.Annotations == nil {
+			staleSnapshot.Annotations = map[string]string{}
+		}
+		staleSnapshot.Annotations[claimExpiriesAnnotation] = "2"
+
+		res, err := reconciler.terminalFailExpired(ctx, staleSnapshot, node.Name, 2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero())
+
+		// Live object must still be Succeeded, not overwritten with Failed.
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseSucceeded))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictGo))
+	})
+
+	It("incrementExpiryCounter uses max(fresh, snapshot) to avoid counter regression", func() {
+		// Test 9: counter freshness. If the annotation in etcd already holds a
+		// higher value than the reconcile snapshot (informer lag), the write must
+		// advance from the higher value, not the snapshot.
+		task := newTask("counter-freshness-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+
+		// etcd already has counter=2 (a prior expiry beat us to the write).
+		setExpiryAnnotation(task, "2")
+
+		// Snapshot only knows about counter=1 (informer lag).
+		snapshotPrior := 1
+
+		err := reconciler.incrementExpiryCounter(ctx, task, snapshotPrior)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Result must be max(2, 1)+1 = 3, not 1+1 = 2.
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Annotations[claimExpiriesAnnotation]).To(Equal("3"))
+	})
 })

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strconv"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,6 +35,16 @@ import (
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
+
+// claimExpiriesAnnotation tracks how many times this task has been released
+// back to Pending due to a stale or absent FleetNode. The 3-strike ladder
+// (>= 2 prior expiries) terminal-fails the task to bound poison loops.
+const claimExpiriesAnnotation = "foreman.llmkube.dev/claim-expiries"
+
+// claimExpiryLimit is the maximum number of prior expiries before the task is
+// terminal-failed. At count >= claimExpiryLimit this would be the
+// (claimExpiryLimit+1)th expiry, which we refuse.
+const claimExpiryLimit = 2
 
 // AgenticTaskReconciler is the Foreman v0.1 scheduler. It watches
 // AgenticTask resources and routes each Pending task to the first Ready
@@ -90,8 +101,22 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return r.setInitialPending(ctx, &task)
 	}
 
-	// The scheduler only acts on Pending. Every other phase is the
-	// FleetAgent's domain.
+	// Terminal phases are done; nothing left to do.
+	if task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded ||
+		task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed {
+		return ctrl.Result{}, nil
+	}
+
+	// In-flight phases (Scheduled / Running / Verifying) with an AssignedNode
+	// need claim-expiry checking: if the node is gone or stale the task must
+	// be released back to Pending so the scheduler can re-dispatch it.
+	if task.Status.Phase != foremanv1alpha1.AgenticTaskPhasePending &&
+		task.Status.AssignedNode != "" {
+		return r.checkClaimExpiry(ctx, &task)
+	}
+
+	// For non-Pending phases with no assigned node (unexpected but safe to
+	// ignore), and for phases not handled above, do nothing.
 	if task.Status.Phase != foremanv1alpha1.AgenticTaskPhasePending {
 		return ctrl.Result{}, nil
 	}
@@ -380,6 +405,137 @@ func (r *AgenticTaskReconciler) failTask(ctx context.Context, task *foremanv1alp
 	return ctrl.Result{}, r.Status().Patch(ctx, task, patch)
 }
 
+// checkClaimExpiry inspects the FleetNode named by task.status.assignedNode.
+// If the node is absent or its heartbeat is stale the task is either
+// released back to Pending (3-strike ladder: < claimExpiryLimit prior
+// expiries) or terminal-failed (>= claimExpiryLimit prior expiries).
+// If the node is fresh the task is left untouched and a requeue is scheduled
+// at FleetNodeHeartbeatTimeout/2 so staleness is caught promptly without
+// relying solely on events.
+//
+// Counter ordering: the metadata annotation (counter) is updated BEFORE the
+// status patch so that a crash between the two errs toward counting more
+// expiries rather than fewer, bounding poison loops conservatively.
+func (r *AgenticTaskReconciler) checkClaimExpiry(ctx context.Context, task *foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	var node foremanv1alpha1.FleetNode
+	nodeNotFound := false
+	lastHeartbeatMsg := ""
+
+	if err := r.Get(ctx, types.NamespacedName{Name: task.Status.AssignedNode}, &node); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("get FleetNode %s: %w", task.Status.AssignedNode, err)
+		}
+		nodeNotFound = true
+		lastHeartbeatMsg = "FleetNode not found"
+	}
+
+	// Node is present and heartbeat is fresh: nothing to do yet.
+	if !nodeNotFound && !node.HeartbeatStale(time.Now()) {
+		return ctrl.Result{RequeueAfter: foremanv1alpha1.FleetNodeHeartbeatTimeout / 2}, nil
+	}
+
+	if !nodeNotFound {
+		// Build the last-heartbeat context for the condition message.
+		if node.Status.LastHeartbeatTime != nil {
+			lastHeartbeatMsg = fmt.Sprintf("last heartbeat %s", node.Status.LastHeartbeatTime.Format(time.RFC3339))
+		} else {
+			lastHeartbeatMsg = "no heartbeat recorded"
+		}
+	}
+
+	// Read the prior expiry count from the annotation.
+	prior := 0
+	if raw, ok := task.Annotations[claimExpiriesAnnotation]; ok {
+		if n, err := strconv.Atoi(raw); err == nil {
+			prior = n
+		}
+	}
+
+	nodeName := task.Status.AssignedNode
+
+	if prior >= claimExpiryLimit {
+		// 3-strike limit reached: terminal-fail.
+		log.Info("claim expiry limit reached; terminal-failing task",
+			"task", task.Name, "node", nodeName, "priorExpiries", prior)
+		return r.terminalFailExpired(ctx, task, nodeName, prior)
+	}
+
+	// Release: increment counter first (crash-safe ordering), then release.
+	log.Info("claim expired; releasing task to Pending",
+		"task", task.Name, "node", nodeName, "priorExpiries", prior, "heartbeat", lastHeartbeatMsg)
+	if err := r.incrementExpiryCounter(ctx, task, prior); err != nil {
+		return ctrl.Result{}, err
+	}
+	return r.releaseExpiredClaim(ctx, task, nodeName, lastHeartbeatMsg)
+}
+
+// incrementExpiryCounter writes prior+1 into the claim-expiries annotation.
+// This is a metadata (non-status) Update, distinct from the status patch
+// that follows. It must happen first so a crash between the two errs toward
+// counting more expiries.
+func (r *AgenticTaskReconciler) incrementExpiryCounter(ctx context.Context, task *foremanv1alpha1.AgenticTask, prior int) error {
+	// Re-fetch to get the current resourceVersion for the metadata patch.
+	var current foremanv1alpha1.AgenticTask
+	if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: task.Name}, &current); err != nil {
+		return fmt.Errorf("re-fetch for expiry counter: %w", err)
+	}
+	patch := client.MergeFrom(current.DeepCopy())
+	if current.Annotations == nil {
+		current.Annotations = map[string]string{}
+	}
+	current.Annotations[claimExpiriesAnnotation] = strconv.Itoa(prior + 1)
+	return r.Patch(ctx, &current, patch)
+}
+
+// releaseExpiredClaim resets the task to Pending, clears the claim fields,
+// and records a ClaimExpired condition.
+func (r *AgenticTaskReconciler) releaseExpiredClaim(ctx context.Context, task *foremanv1alpha1.AgenticTask, nodeName, heartbeatMsg string) (ctrl.Result, error) {
+	var current foremanv1alpha1.AgenticTask
+	if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: task.Name}, &current); err != nil {
+		return ctrl.Result{}, fmt.Errorf("re-fetch for claim release: %w", err)
+	}
+	patch := client.MergeFrom(current.DeepCopy())
+	now := metav1.Now()
+	current.Status.Phase = foremanv1alpha1.AgenticTaskPhasePending
+	current.Status.AssignedNode = ""
+	current.Status.ClaimedAt = nil
+	current.Status.StartedAt = nil
+	setCondition(&current.Status.Conditions, metav1.Condition{
+		Type:               "ClaimExpired",
+		Status:             metav1.ConditionTrue,
+		Reason:             "ClaimExpired",
+		Message:            fmt.Sprintf("released from node %q: %s", nodeName, heartbeatMsg),
+		LastTransitionTime: now,
+	})
+	return ctrl.Result{}, r.Status().Patch(ctx, &current, patch)
+}
+
+// terminalFailExpired marks a task Failed after it has exhausted the
+// 3-strike expiry ladder.
+func (r *AgenticTaskReconciler) terminalFailExpired(ctx context.Context, task *foremanv1alpha1.AgenticTask, nodeName string, priorExpiries int) (ctrl.Result, error) {
+	var current foremanv1alpha1.AgenticTask
+	if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: task.Name}, &current); err != nil {
+		return ctrl.Result{}, fmt.Errorf("re-fetch for expiry terminal-fail: %w", err)
+	}
+	patch := client.MergeFrom(current.DeepCopy())
+	now := metav1.Now()
+	current.Status.Phase = foremanv1alpha1.AgenticTaskPhaseFailed
+	current.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+	current.Status.FailureReason = foremanv1alpha1.FailureInfrastructureError
+	current.Status.FinishedAt = &now
+	setCondition(&current.Status.Conditions, metav1.Condition{
+		Type:   "Failed",
+		Status: metav1.ConditionTrue,
+		Reason: "ClaimExpiryLimitReached",
+		Message: fmt.Sprintf("task on node %q expired %d time(s); terminal-failing to prevent poison loop",
+			nodeName, priorExpiries+1),
+		LastTransitionTime: now,
+	})
+	return ctrl.Result{}, r.Status().Patch(ctx, &current, patch)
+}
+
 // setCondition upserts a condition by type. Local to the controller
 // because the watcher in pkg/foreman/agent has its own copy; promote to
 // an internal helpers package if a third writer appears.
@@ -399,30 +555,49 @@ func setCondition(conds *[]metav1.Condition, c metav1.Condition) {
 func (r *AgenticTaskReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&foremanv1alpha1.AgenticTask{}).
-		Watches(&foremanv1alpha1.FleetNode{}, handler.EnqueueRequestsFromMapFunc(r.fleetNodeEnqueuesPending)).
+		Watches(&foremanv1alpha1.FleetNode{}, handler.EnqueueRequestsFromMapFunc(r.fleetNodeEnqueues)).
 		Named("agentictask").
 		Complete(r)
 }
 
-// fleetNodeEnqueuesPending re-enqueues every Pending AgenticTask when a
-// FleetNode event arrives. Cheap because the controller-runtime
-// workqueue dedupes; expensive in the limit only when there are many
-// Pending tasks, which is exactly when faster dispatch matters.
-func (r *AgenticTaskReconciler) fleetNodeEnqueuesPending(ctx context.Context, _ client.Object) []ctrl.Request {
+// fleetNodeEnqueues re-enqueues AgenticTasks when a FleetNode event arrives:
+//   - Every Pending task (scheduling: a newly-Ready node may satisfy a waiting
+//     task immediately rather than waiting for the requeue-after timer).
+//   - Every in-flight task (Scheduled/Running/Verifying) whose AssignedNode
+//     matches the changed node (claim expiry: a node going stale or deleted
+//     must trigger the expiry check on its assigned task promptly rather than
+//     waiting for the 45s backstop requeue).
+//
+// The workqueue dedupes so the worst-case cost is one reconcile per task per
+// FleetNode event, which is acceptable at v0.1 task volumes.
+func (r *AgenticTaskReconciler) fleetNodeEnqueues(ctx context.Context, obj client.Object) []ctrl.Request {
 	var list foremanv1alpha1.AgenticTaskList
 	if err := r.List(ctx, &list); err != nil {
 		logf.FromContext(ctx).Error(err, "fleetnode-trigger list failed")
 		return nil
 	}
+	changedNodeName := obj.GetName()
 	requests := make([]ctrl.Request, 0, len(list.Items))
+	seen := make(map[types.NamespacedName]struct{}, len(list.Items))
 	for i := range list.Items {
 		t := &list.Items[i]
-		if t.Status.Phase != foremanv1alpha1.AgenticTaskPhasePending {
-			continue
+		key := types.NamespacedName{Namespace: t.Namespace, Name: t.Name}
+		switch t.Status.Phase {
+		case foremanv1alpha1.AgenticTaskPhasePending:
+			if _, ok := seen[key]; !ok {
+				seen[key] = struct{}{}
+				requests = append(requests, ctrl.Request{NamespacedName: key})
+			}
+		case foremanv1alpha1.AgenticTaskPhaseScheduled,
+			foremanv1alpha1.AgenticTaskPhaseRunning,
+			foremanv1alpha1.AgenticTaskPhaseVerifying:
+			if t.Status.AssignedNode == changedNodeName {
+				if _, ok := seen[key]; !ok {
+					seen[key] = struct{}{}
+					requests = append(requests, ctrl.Request{NamespacedName: key})
+				}
+			}
 		}
-		requests = append(requests, ctrl.Request{
-			NamespacedName: types.NamespacedName{Namespace: t.Namespace, Name: t.Name},
-		})
 	}
 	return requests
 }

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -471,30 +471,65 @@ func (r *AgenticTaskReconciler) checkClaimExpiry(ctx context.Context, task *fore
 	return r.releaseExpiredClaim(ctx, task, nodeName, lastHeartbeatMsg)
 }
 
-// incrementExpiryCounter writes prior+1 into the claim-expiries annotation.
+// incrementExpiryCounter writes max(freshValue, snapshotValue)+1 into the
+// claim-expiries annotation, where freshValue is read from the live object.
+// Using the live value closes an informer-lag window: if a prior expiry
+// landed between the reconcile snapshot and this write, the snapshot's
+// counter would be stale and we would double-count the expiry on the next
+// reconcile (or under-count after a crash). Taking the max ensures we
+// never regress the counter regardless of which view is ahead.
+//
 // This is a metadata (non-status) Update, distinct from the status patch
 // that follows. It must happen first so a crash between the two errs toward
 // counting more expiries.
-func (r *AgenticTaskReconciler) incrementExpiryCounter(ctx context.Context, task *foremanv1alpha1.AgenticTask, prior int) error {
+func (r *AgenticTaskReconciler) incrementExpiryCounter(ctx context.Context, task *foremanv1alpha1.AgenticTask, snapshotPrior int) error {
 	// Re-fetch to get the current resourceVersion for the metadata patch.
 	var current foremanv1alpha1.AgenticTask
 	if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: task.Name}, &current); err != nil {
 		return fmt.Errorf("re-fetch for expiry counter: %w", err)
 	}
+	// Read the freshly-fetched counter; fall back to 0 if absent/invalid.
+	freshPrior := 0
+	if raw, ok := current.Annotations[claimExpiriesAnnotation]; ok {
+		if n, err := strconv.Atoi(raw); err == nil {
+			freshPrior = n
+		}
+	}
+	// Advance from whichever view is higher to avoid regressing the counter.
+	base := freshPrior
+	if snapshotPrior > base {
+		base = snapshotPrior
+	}
 	patch := client.MergeFrom(current.DeepCopy())
 	if current.Annotations == nil {
 		current.Annotations = map[string]string{}
 	}
-	current.Annotations[claimExpiriesAnnotation] = strconv.Itoa(prior + 1)
+	current.Annotations[claimExpiriesAnnotation] = strconv.Itoa(base + 1)
 	return r.Patch(ctx, &current, patch)
 }
 
 // releaseExpiredClaim resets the task to Pending, clears the claim fields,
 // and records a ClaimExpired condition.
+//
+// Guard: after the re-fetch the function bails out without patching if the
+// live object has already moved to a terminal phase (Succeeded/Failed) or if
+// its AssignedNode no longer matches the node we judged stale. Either
+// condition means a concurrent terminal patch landed in the window between
+// checkClaimExpiry's staleness decision and this write; yanking the task back
+// to Pending in that case would undo legitimate agent progress.
 func (r *AgenticTaskReconciler) releaseExpiredClaim(ctx context.Context, task *foremanv1alpha1.AgenticTask, nodeName, heartbeatMsg string) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	var current foremanv1alpha1.AgenticTask
 	if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: task.Name}, &current); err != nil {
 		return ctrl.Result{}, fmt.Errorf("re-fetch for claim release: %w", err)
+	}
+	if current.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded ||
+		current.Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed ||
+		current.Status.AssignedNode != nodeName {
+		log.Info("claim expiry superseded by concurrent state change; skipping release",
+			"task", current.Name, "node", nodeName,
+			"livePhase", current.Status.Phase, "liveAssignedNode", current.Status.AssignedNode)
+		return ctrl.Result{}, nil
 	}
 	patch := client.MergeFrom(current.DeepCopy())
 	now := metav1.Now()
@@ -514,10 +549,23 @@ func (r *AgenticTaskReconciler) releaseExpiredClaim(ctx context.Context, task *f
 
 // terminalFailExpired marks a task Failed after it has exhausted the
 // 3-strike expiry ladder.
+//
+// Guard: same as releaseExpiredClaim. If the live object is already terminal
+// or has been reassigned away from the stale node, a concurrent patch already
+// resolved the task; bail out without patching to avoid overwriting it.
 func (r *AgenticTaskReconciler) terminalFailExpired(ctx context.Context, task *foremanv1alpha1.AgenticTask, nodeName string, priorExpiries int) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	var current foremanv1alpha1.AgenticTask
 	if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: task.Name}, &current); err != nil {
 		return ctrl.Result{}, fmt.Errorf("re-fetch for expiry terminal-fail: %w", err)
+	}
+	if current.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded ||
+		current.Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed ||
+		current.Status.AssignedNode != nodeName {
+		log.Info("claim expiry superseded by concurrent state change; skipping terminal-fail",
+			"task", current.Name, "node", nodeName,
+			"livePhase", current.Status.Phase, "liveAssignedNode", current.Status.AssignedNode)
+		return ctrl.Result{}, nil
 	}
 	patch := client.MergeFrom(current.DeepCopy())
 	now := metav1.Now()

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -334,6 +334,83 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseRunning))
 		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
 	})
+
+	It("skips a stale-heartbeat Ready node and schedules to the fresh one", func() {
+		// Regression: firstFitNode must not dispatch to a node whose agent has
+		// gone dark even though Phase=Ready has not yet been reconciled to
+		// NotReady. The stale node is given an alphabetically-earlier name so
+		// it would sort first under a naive Phase-only filter, proving the
+		// heartbeat gate is active. Both nodes advertise the same metal
+		// capability so only the heartbeat check distinguishes them.
+		staleNode := newFleetNode("aaa-sched-stale-node")
+		Expect(k8sClient.Create(ctx, staleNode)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, staleNode) })
+		// Mark Phase=Ready but with a heartbeat 5 minutes in the past.
+		setStaleNodeReady(staleNode, foremanv1alpha1.FleetNodeCapability{
+			Accelerator:    foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:     64,
+			AvailableRAMGB: 48,
+		})
+
+		freshNode := newFleetNode("zzz-sched-fresh-node")
+		Expect(k8sClient.Create(ctx, freshNode)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, freshNode) })
+		setNodeReady(freshNode, foremanv1alpha1.FleetNodeCapability{
+			Accelerator:    foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:     64,
+			AvailableRAMGB: 48,
+		})
+
+		task := newTask("skip-stale-target")
+		task.Spec.RequiredCapability = foremanv1alpha1.RequiredCapability{
+			Accelerator: foremanv1alpha1.AgenticTaskAccelerator("metal"),
+		}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		// Must land on the fresh node, not the alphabetically-first stale one.
+		Expect(fresh.Status.AssignedNode).To(Equal(freshNode.Name))
+	})
+
+	It("leaves a Pending task unscheduled when all Ready nodes have stale heartbeats", func() {
+		// Regression: if every Phase=Ready node has a stale heartbeat, the
+		// scheduler must return no-fit and requeue rather than dispatching to
+		// a dead node.
+		staleNode := newFleetNode("all-stale-only-node")
+		Expect(k8sClient.Create(ctx, staleNode)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, staleNode) })
+		setStaleNodeReady(staleNode, foremanv1alpha1.FleetNodeCapability{
+			Accelerator:    foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:     64,
+			AvailableRAMGB: 48,
+		})
+
+		task := newTask("all-stale-pending-task")
+		task.Spec.RequiredCapability = foremanv1alpha1.RequiredCapability{
+			Accelerator: foremanv1alpha1.AgenticTaskAccelerator("metal"),
+		}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		res, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+		// No fit: must requeue.
+		Expect(res.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		// Task must remain Pending with no assigned node.
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		Expect(fresh.Status.AssignedNode).To(BeEmpty())
+	})
 })
 
 var _ = Describe("capabilitySatisfies jobMode", func() {
@@ -433,6 +510,19 @@ func setNodeReady(node *foremanv1alpha1.FleetNode, cap foremanv1alpha1.FleetNode
 	node.Status.Capability = cap
 	now := metav1.Now()
 	node.Status.LastHeartbeatTime = &now
+	Expect(k8sClient.Status().Patch(ctx, node, patch)).To(Succeed())
+}
+
+// setStaleNodeReady puts a node in Phase=Ready with the given capability but
+// with a LastHeartbeatTime 5 minutes in the past, making it appear alive to a
+// Phase-only check but dead to nodeSchedulable's heartbeat gate.
+func setStaleNodeReady(node *foremanv1alpha1.FleetNode, cap foremanv1alpha1.FleetNodeCapability) {
+	GinkgoHelper()
+	patch := client.MergeFrom(node.DeepCopy())
+	node.Status.Phase = foremanv1alpha1.FleetNodePhaseReady
+	node.Status.Capability = cap
+	stale := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	node.Status.LastHeartbeatTime = &stale
 	Expect(k8sClient.Status().Patch(ctx, node, patch)).To(Succeed())
 }
 

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -307,15 +307,23 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		Expect(fresh.Status.AssignedNode).To(Equal(verifierNode.Name))
 	})
 
-	It("does not touch a task already past Pending (FleetAgent's domain)", func() {
+	It("does not reschedule a Running task whose assigned node is fresh", func() {
+		// The scheduler must leave Running tasks alone when the FleetNode is
+		// healthy; only claim expiry (stale/absent node) may alter them.
+		node := newFleetNode("hands-off-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+
 		task := newTask("hands-off")
 		Expect(k8sClient.Create(ctx, task)).To(Succeed())
 		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
 		setPhase(task, foremanv1alpha1.AgenticTaskPhaseRunning)
 
-		// Also set assignedNode to confirm the scheduler doesn't clobber.
 		patch := client.MergeFrom(task.DeepCopy())
-		task.Status.AssignedNode = "some-node"
+		task.Status.AssignedNode = node.Name
 		Expect(k8sClient.Status().Patch(ctx, task, patch)).To(Succeed())
 
 		_, err := reconciler.Reconcile(ctx, reqFor(task))
@@ -324,7 +332,7 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		var fresh foremanv1alpha1.AgenticTask
 		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
 		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseRunning))
-		Expect(fresh.Status.AssignedNode).To(Equal("some-node"))
+		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
 	})
 })
 


### PR DESCRIPTION
## What

AgenticTasks claimed by a dead or partitioned foreman-agent now self-heal instead of staying Running forever:

- The AgenticTask controller expires stale claims: any in-flight task (Scheduled/Running/Verifying) whose AssignedNode FleetNode is missing or has a stale heartbeat (>90s, the #633 window) is released back to Pending with AssignedNode/ClaimedAt/StartedAt cleared and a `ClaimExpired` condition naming the node and its last heartbeat.
- A 3-strike ladder bounds poison loops: the `foreman.llmkube.dev/claim-expiries` annotation counts releases (incremented before the status patch, so crashes err toward more strikes, and written as max(fresh, snapshot)+1 against informer lag); the third expiry fails the task terminally (INCOMPLETE / InfrastructureError / `ClaimExpiryLimitReached`).
- Fresh-node tasks requeue every 45s (half the heartbeat timeout) so staleness is caught without watch events; the FleetNode watch also enqueues a node's in-flight tasks on transitions for prompt detection.
- Release and terminal-fail both re-validate after their re-fetch and stand down if the task completed or moved nodes underfoot (the healed-partition race), and envtest pins the scheduler's heartbeat gate (shipped with #627) so released tasks cannot ping-pong onto a stale-but-still-Ready node.

## Why

Fixes #656. Observed live: a Tailscale outage tripped the watcher's poll-failure threshold, both agents restarted by design, and the in-flight task sat Running with a stale claim until manually deleted. The controller only acted on Pending tasks and agent-side recovery only covers its own node, so a dead node's tasks were nobody's responsibility.

Release-to-Pending (rather than fail) follows the agent's own restart-recovery semantics: retries are safe because each task gets an isolated workspace that is wiped on executor start and a fresh branch.

## How

TDD throughout: nine envtest cases covering release (stale heartbeat, missing node, Scheduled phase), the untouched fresh-node path with its requeue, the 3-strike terminal failure, terminal-phase immunity, both concurrent-state-change guards (live object Succeeded while the snapshot said Running), counter freshness, and the two scheduler-gate regressions (stale-but-Ready node skipped; all-stale stays Pending).

Known follow-up, filed as #668 and out of scope here: the agent-side half of the healed-partition race (`patchTerminal` should abort when the task is no longer its own).

## Checklist

- [x] Tests added (9 envtest cases) and full `make test` green
- [x] `make fmt vet lint` clean, plus `GOOS=linux golangci-lint run ./...`
- [x] No API/CRD changes (conditions + annotations only); no generated drift
- [x] DCO sign-off on all commits
