### PR TITLE
fix(foreman): workspace reset survives read-only files from prior runs

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -234,12 +235,12 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	}
 	// Reset workspace if it exists from a prior partial run; safer than
 	// re-using a half-cloned tree.
-	if err := os.RemoveAll(workspace); err != nil {
+	if err := removeAllResilient(workspace); err != nil {
 		return nil, fmt.Errorf("reset workspace: %w", err)
 	}
 	if !e.KeepWorkspace {
 		defer func() {
-			if rmErr := os.RemoveAll(workspace); rmErr != nil {
+			if rmErr := removeAllResilient(workspace); rmErr != nil {
 				log.Error(rmErr, "workspace cleanup failed")
 			}
 		}()
@@ -1638,4 +1639,40 @@ func normalizeModelVerdict(raw string) (foremanv1alpha1.AgenticTaskVerdict, fore
 		return foremanv1alpha1.AgenticTaskVerdictIncomplete, foremanv1alpha1.FailureModelReportedError
 	}
 	return foremanv1alpha1.AgenticTaskVerdict(raw), ""
+}
+
+// removeAllResilient removes path like os.RemoveAll, but tolerates
+// read-only files and directories left behind by prior runs (e.g.
+// envtest-fetched binaries, issue #654): on a permission error it walks
+// the tree restoring owner write+execute on directories and write on
+// files, then retries the removal once.
+//
+// WalkDir visits each directory node before descending into it, so
+// chmodding the dir in its own callback unblocks the subsequent descent
+// into its children. This means a single walk is sufficient to repair
+// arbitrarily deep read-only trees.
+func removeAllResilient(path string) error {
+	if err := os.RemoveAll(path); err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	// Best-effort permission repair; WalkDir visits what it can reach.
+	// Because WalkDir calls the function for a directory before reading
+	// its entries, chmodding the dir here allows the walk to descend and
+	// process its children in the same pass.
+	_ = filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // unreadable entries are handled by the retry below
+		}
+		if d.IsDir() {
+			_ = os.Chmod(p, 0o755) //nolint:gosec // intentional: restore owner rwx so RemoveAll can descend and unlink
+		} else if d.Type().IsRegular() {
+			_ = os.Chmod(p, 0o644) //nolint:gosec // intentional: restore owner write so RemoveAll can unlink
+		}
+		// Symlinks and other special entries get no chmod: os.Chmod follows
+		// links, which would rewrite the permissions of a target OUTSIDE the
+		// workspace (e.g. a model-created symlink to a host file). RemoveAll
+		// unlinks the link itself once its parent dir is writable.
+		return nil
+	})
+	return os.RemoveAll(path)
 }

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1419,3 +1419,184 @@ func TestCoderJobResultToResult_NoEmbeddedReasonFallsBackToMaxTurns(t *testing.T
 		t.Errorf("failureReason: want MaxTurnsExhausted got %s", r.FailureReason)
 	}
 }
+
+// ---- workspace resilience (#654) ----
+
+// TestRemoveAllResilient_HappyPath verifies that removeAllResilient
+// removes a normal (all-writable) tree successfully.
+func TestRemoveAllResilient_HappyPath(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "file.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	target := filepath.Join(root, "sub")
+	if err := removeAllResilient(target); err != nil {
+		t.Fatalf("removeAllResilient on normal tree: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("target should not exist after removal; stat err: %v", err)
+	}
+}
+
+// TestRemoveAllResilient_ReadOnlyTree verifies that removeAllResilient
+// succeeds when the workspace contains a read-only file (0444) inside
+// a read-only directory (0555) — the shape left behind by envtest-
+// fetched etcd binaries (issue #654). A bare os.RemoveAll fails with
+// "permission denied" on this fixture; removeAllResilient must not.
+//
+// Fixture layout:
+//
+//	<target>/
+//	  child/         (0555: read-only dir — blocks unlink of its children)
+//	    data.bin     (0444: read-only file)
+//
+// On Linux and macOS the kernel checks the *parent directory* write
+// permission before allowing unlink; making the dir 0555 is what
+// causes permission denied, not merely the file mode.
+//
+// Two separate temp-rooted fixtures are used:
+//  1. A "canary" fixture proves that bare os.RemoveAll actually fails on
+//     this platform/user combination; the test is skipped (not failed) if
+//     the OS bypasses permission checks (e.g. running as root in CI).
+//  2. A fresh "target" fixture is passed to removeAllResilient so the
+//     helper does its own chmod-and-retry without relying on any pre-
+//     applied chmod from the canary phase.
+func TestRemoveAllResilient_ReadOnlyTree(t *testing.T) {
+	buildFixture := func(root string) (target, child string) {
+		target = filepath.Join(root, "workspace")
+		child = filepath.Join(target, "child")
+		if err := os.MkdirAll(child, 0o755); err != nil {
+			t.Fatalf("mkdir child: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(child, "data.bin"), []byte("binary"), 0o444); err != nil {
+			t.Fatalf("write data.bin: %v", err)
+		}
+		if err := os.Chmod(child, 0o555); err != nil { //nolint:gosec // intentional: building read-only fixture to test resilient removal
+			t.Fatalf("chmod child: %v", err)
+		}
+		return target, child
+	}
+
+	// Phase 1: confirm the fixture actually breaks bare os.RemoveAll.
+	// Use a dedicated temp root so a failed partial RemoveAll does not
+	// corrupt the fixture used in phase 2.
+	canaryRoot := t.TempDir()
+	canaryTarget, canaryChild := buildFixture(canaryRoot)
+	_ = canaryChild
+	if err := os.RemoveAll(canaryTarget); err == nil {
+		// Running as root (some CI environments) bypasses permission
+		// checks. Skip rather than false-pass.
+		t.Skip("os.RemoveAll succeeded on read-only fixture (running as root?); skipping")
+	}
+	// Repair the canary so t.TempDir's own cleanup can remove it.
+	_ = os.Chmod(canaryChild, 0o755) //nolint:gosec // intentional: restoring writable perms so test cleanup succeeds
+
+	// Phase 2: build a fresh fixture and test removeAllResilient.
+	targetRoot := t.TempDir()
+	target, _ := buildFixture(targetRoot)
+
+	if err := removeAllResilient(target); err != nil {
+		t.Fatalf("removeAllResilient failed on read-only tree: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("target should not exist after resilient removal; stat err: %v", err)
+	}
+}
+
+// TestRemoveAllResilient_NonExistent verifies that a non-existent path
+// is treated as a no-op (mirrors os.RemoveAll behaviour).
+func TestRemoveAllResilient_NonExistent(t *testing.T) {
+	if err := removeAllResilient(filepath.Join(t.TempDir(), "does-not-exist")); err != nil {
+		t.Fatalf("removeAllResilient on non-existent path should be a no-op: %v", err)
+	}
+}
+
+// TestRemoveAllResilient_SymlinkToExternal is a security regression test for
+// the case where the workspace contains a symlink pointing to a file OUTSIDE
+// the workspace. os.Chmod follows symlinks, so a naive chmod of every entry
+// would silently rewrite the target's permissions.
+//
+// Fixture layout:
+//
+//	<workspaceRoot>/
+//	  workspace/
+//	    readonly/        (0555: blocks RemoveAll without repair)
+//	      link -> <externalRoot>/victim.txt
+//
+//	<externalRoot>/
+//	  victim.txt         (0755: mode that must not change)
+//
+// Assertions:
+//  1. The workspace tree is fully removed.
+//  2. The external victim still exists with its original mode (0755).
+func TestRemoveAllResilient_SymlinkToExternal(t *testing.T) {
+	// Build external target in its own temp root.
+	externalRoot := t.TempDir()
+	victim := filepath.Join(externalRoot, "victim.txt")
+	if err := os.WriteFile(victim, []byte("external"), 0o755); err != nil { //nolint:gosec // intentional: specific mode for assertion
+		t.Fatalf("create victim: %v", err)
+	}
+
+	// Build the workspace.
+	workspaceRoot := t.TempDir()
+	workspace := filepath.Join(workspaceRoot, "workspace")
+	readonly := filepath.Join(workspace, "readonly")
+	if err := os.MkdirAll(readonly, 0o755); err != nil {
+		t.Fatalf("mkdir readonly: %v", err)
+	}
+	link := filepath.Join(readonly, "link")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// Make the directory read-only so RemoveAll needs the chmod-and-retry path.
+	if err := os.Chmod(readonly, 0o555); err != nil { //nolint:gosec // intentional: building read-only fixture to test resilient removal
+		t.Fatalf("chmod readonly: %v", err)
+	}
+
+	// Phase 1: confirm the fixture actually breaks bare os.RemoveAll.
+	// If it doesn't (e.g. running as root), skip rather than give a false pass.
+	canaryRoot := t.TempDir()
+	canaryWorkspace := filepath.Join(canaryRoot, "workspace")
+	canaryReadonly := filepath.Join(canaryWorkspace, "readonly")
+	if err := os.MkdirAll(canaryReadonly, 0o755); err != nil {
+		t.Fatalf("mkdir canary readonly: %v", err)
+	}
+	if err := os.Symlink(victim, filepath.Join(canaryReadonly, "link")); err != nil {
+		t.Fatalf("canary symlink: %v", err)
+	}
+	if err := os.Chmod(canaryReadonly, 0o555); err != nil { //nolint:gosec // intentional: building read-only canary fixture
+		t.Fatalf("chmod canary readonly: %v", err)
+	}
+	if removeErr := os.RemoveAll(canaryWorkspace); removeErr == nil {
+		// Running as root bypasses permission checks; repair canary and skip.
+		_ = os.Chmod(canaryReadonly, 0o755) //nolint:gosec // intentional: restoring writable perms so test cleanup succeeds
+		t.Skip("os.RemoveAll succeeded on read-only fixture (running as root?); skipping")
+	}
+	_ = os.Chmod(canaryReadonly, 0o755) //nolint:gosec // intentional: restoring writable perms so test cleanup succeeds
+
+	// Phase 2: run removeAllResilient on the real workspace fixture.
+	if err := removeAllResilient(workspace); err != nil {
+		t.Fatalf("removeAllResilient failed: %v", err)
+	}
+
+	// Assertion (a): workspace fully removed.
+	if _, err := os.Stat(workspace); !os.IsNotExist(err) {
+		t.Errorf("workspace should not exist after removal; stat err: %v", err)
+	}
+
+	// Assertion (b): external victim still exists with its original mode.
+	info, err := os.Stat(victim)
+	if err != nil {
+		t.Fatalf("external victim should still exist: %v", err)
+	}
+	gotMode := info.Mode().Perm()
+	const wantMode = os.FileMode(0o755)
+	if gotMode != wantMode {
+		t.Errorf("external victim mode changed: got %04o, want %04o", gotMode, wantMode)
+	}
+}


### PR DESCRIPTION
## What

Workspace reset (and the deferred cleanup) survives whatever permissions a previous run left behind: a new `removeAllResilient` helper tries `os.RemoveAll`, and on failure walks the tree restoring owner write on directories and regular files before retrying once. Symlinks and other special entries are deliberately never chmodded: `os.Chmod` follows links, so a model-created symlink to a host path would otherwise get its **target's** permissions rewritten outside the workspace (caught in review with an empirical repro; pinned by a regression test asserting an external symlink target's mode is untouched while the workspace is fully removed).

## Why

Fixes #654. A run that fetched envtest binaries left a read-only etcd inside a read-only directory; every rerun of the task name then failed at `reset workspace: unlinkat ... permission denied` before the loop started, until an operator manually intervened. Reset should behave like `go clean -modcache`: read-only debris is the tool's problem, not the operator's.

## How

- Single WalkDir pass works for arbitrarily deep read-only trees: the callback visits (and chmods) a directory before its entries are read, so descent unblocks as it goes.
- Walk errors are swallowed deliberately (best-effort repair); the final `RemoveAll`'s error is the one surfaced, with the original "reset workspace" wrap preserved.
- Four tests: read-only tree (with a canary proving bare `os.RemoveAll` genuinely fails on the platform, skipping only for root environments; upstream CI runs unprivileged so it executes there), happy path, nonexistent path, and the symlink-escape regression.

## Checklist

- [x] Tests added (4) and full `make test` green
- [x] `make fmt vet lint` clean, plus `GOOS=linux golangci-lint run ./...`
- [x] No API/CRD changes
- [x] DCO sign-off
