### PR TITLE
feat(foreman,agent): report agent version to the cluster

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -95,6 +95,13 @@ builds:
     main: ./cmd/foreman-agent
     binary: foreman-agent
 
+    # Set version information at build time.
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.GitCommit={{.FullCommit}}
+      - -X main.BuildDate={{.Date}}
+
     # Linux containers only (the foreman-agent Linux Pod is
     # Linux; the M5 Max + Mac Studio run from `go install` or a
     # launchd-managed local binary, not the ghcr image).

--- a/api/foreman/v1alpha1/fleetnode_types.go
+++ b/api/foreman/v1alpha1/fleetnode_types.go
@@ -139,7 +139,6 @@ type FleetNodeStatus struct {
 	// AgentKind identifies which agent binary manages this FleetNode.
 	// metal-agent does not register a FleetNode in v0.1, but the enum
 	// documents intent for future use.
-	// +kubebuilder:validation:Enum=foreman-agent;metal-agent
 	// +optional
 	AgentKind FleetNodeAgentKind `json:"agentKind,omitempty"`
 

--- a/api/foreman/v1alpha1/fleetnode_types.go
+++ b/api/foreman/v1alpha1/fleetnode_types.go
@@ -101,6 +101,10 @@ type FleetNodeSpec struct {
 	Roles []string `json:"roles,omitempty"`
 }
 
+// FleetNodeAgentKind identifies which agent binary manages the FleetNode.
+// +kubebuilder:validation:Enum=foreman-agent;metal-agent
+type FleetNodeAgentKind string
+
 // FleetNodeStatus is the FleetAgent's live view of its host. Updated on
 // every heartbeat (every 30s); the FleetNodeReconciler marks the phase
 // NotReady when the heartbeat goes stale.
@@ -126,6 +130,19 @@ type FleetNodeStatus struct {
 	// +optional
 	CurrentTask string `json:"currentTask,omitempty"`
 
+	// AgentVersion is the observed running version of the agent, reported
+	// on heartbeat. Set by the foreman-agent using the binary's build-time
+	// version string; empty for agents that predate this field.
+	// +optional
+	AgentVersion string `json:"agentVersion,omitempty"`
+
+	// AgentKind identifies which agent binary manages this FleetNode.
+	// metal-agent does not register a FleetNode in v0.1, but the enum
+	// documents intent for future use.
+	// +kubebuilder:validation:Enum=foreman-agent;metal-agent
+	// +optional
+	AgentKind FleetNodeAgentKind `json:"agentKind,omitempty"`
+
 	// Conditions track standard health signals: Ready, Draining, etc.
 	// +listType=map
 	// +listMapKey=type
@@ -137,6 +154,7 @@ type FleetNodeStatus struct {
 // +kubebuilder:resource:scope=Cluster,shortName=fn
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.agentVersion`
 // +kubebuilder:printcolumn:name="Accelerator",type=string,JSONPath=`.status.capability.accelerator`
 // +kubebuilder:printcolumn:name="RAM",type=integer,JSONPath=`.status.capability.availableRAMGB`
 // +kubebuilder:printcolumn:name="Current Task",type=string,JSONPath=`.status.currentTask`

--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -26,6 +26,13 @@ const (
 	// agents) are exempt from expiry for backward compatibility.
 	AnnotationAgentHeartbeat = "llmkube.ai/agent-heartbeat"
 
+	// AnnotationAgentVersion is stamped on agent-managed Endpoints with the
+	// running version of the metal-agent binary (e.g. "v0.8.4"). Set on every
+	// RegisterEndpoint call so the cluster can observe which version is
+	// managing a given InferenceService. Absent on Endpoints created by older
+	// agents that predate this annotation.
+	AnnotationAgentVersion = "llmkube.ai/agent-version"
+
 	// DefaultAgentHeartbeatInterval is how often the metal-agent re-asserts
 	// its registrations (which also self-heals any missed update, #657).
 	DefaultAgentHeartbeatInterval = 30 * time.Second

--- a/charts/foreman/templates/crds/fleetnodes.yaml
+++ b/charts/foreman/templates/crds/fleetnodes.yaml
@@ -93,17 +93,13 @@ spec:
               scheduler reads it; the agent writes it.
             properties:
               agentKind:
-                allOf:
-                - enum:
-                  - foreman-agent
-                  - metal-agent
-                - enum:
-                  - foreman-agent
-                  - metal-agent
                 description: |-
                   AgentKind identifies which agent binary manages this FleetNode.
                   metal-agent does not register a FleetNode in v0.1, but the enum
                   documents intent for future use.
+                enum:
+                - foreman-agent
+                - metal-agent
                 type: string
               agentVersion:
                 description: |-

--- a/charts/foreman/templates/crds/fleetnodes.yaml
+++ b/charts/foreman/templates/crds/fleetnodes.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.agentVersion
+      name: Version
+      type: string
     - jsonPath: .status.capability.accelerator
       name: Accelerator
       type: string
@@ -89,6 +92,25 @@ spec:
               status is the agent's heartbeat-driven view of its host. The
               scheduler reads it; the agent writes it.
             properties:
+              agentKind:
+                allOf:
+                - enum:
+                  - foreman-agent
+                  - metal-agent
+                - enum:
+                  - foreman-agent
+                  - metal-agent
+                description: |-
+                  AgentKind identifies which agent binary manages this FleetNode.
+                  metal-agent does not register a FleetNode in v0.1, but the enum
+                  documents intent for future use.
+                type: string
+              agentVersion:
+                description: |-
+                  AgentVersion is the observed running version of the agent, reported
+                  on heartbeat. Set by the foreman-agent using the binary's build-time
+                  version string; empty for agents that predate this field.
+                type: string
               capability:
                 description: Capability is what this node advertises to the scheduler.
                 properties:

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -68,6 +68,13 @@ import (
 )
 
 var (
+	// Version information injected at build time via -ldflags.
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+)
+
+var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
@@ -195,9 +202,18 @@ func main() {
 		"Key within --coder-git-secret that holds the token (e.g. GITHUB_TOKEN when reusing an "+
 			"existing git Secret).")
 
+	showVersion := flag.Bool("version", false, "Print version information and exit.")
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("foreman-agent version %s\n", Version)
+		fmt.Printf("  git commit: %s\n", GitCommit)
+		fmt.Printf("  build date: %s\n", BuildDate)
+		os.Exit(0)
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	if fleetNodeName == "" {
@@ -283,6 +299,8 @@ func main() {
 		Spec:     spec,
 		Provider: provider,
 		Interval: heartbeat,
+		Version:  Version,
+		Kind:     "foreman-agent",
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/metal-agent/main.go
+++ b/cmd/metal-agent/main.go
@@ -474,6 +474,7 @@ func main() {
 		LlamaServerBin:            cfg.LlamaServerBin,
 		LlamaServerPort:           cfg.LlamaServerPort,
 		Runtime:                   cfg.Runtime,
+		Version:                   Version,
 		OMLXBin:                   cfg.OMLXBin,
 		OMLXPort:                  cfg.OMLXPort,
 		OllamaPort:                cfg.OllamaPort,

--- a/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
@@ -93,17 +93,13 @@ spec:
               scheduler reads it; the agent writes it.
             properties:
               agentKind:
-                allOf:
-                - enum:
-                  - foreman-agent
-                  - metal-agent
-                - enum:
-                  - foreman-agent
-                  - metal-agent
                 description: |-
                   AgentKind identifies which agent binary manages this FleetNode.
                   metal-agent does not register a FleetNode in v0.1, but the enum
                   documents intent for future use.
+                enum:
+                - foreman-agent
+                - metal-agent
                 type: string
               agentVersion:
                 description: |-

--- a/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.agentVersion
+      name: Version
+      type: string
     - jsonPath: .status.capability.accelerator
       name: Accelerator
       type: string
@@ -89,6 +92,25 @@ spec:
               status is the agent's heartbeat-driven view of its host. The
               scheduler reads it; the agent writes it.
             properties:
+              agentKind:
+                allOf:
+                - enum:
+                  - foreman-agent
+                  - metal-agent
+                - enum:
+                  - foreman-agent
+                  - metal-agent
+                description: |-
+                  AgentKind identifies which agent binary manages this FleetNode.
+                  metal-agent does not register a FleetNode in v0.1, but the enum
+                  documents intent for future use.
+                type: string
+              agentVersion:
+                description: |-
+                  AgentVersion is the observed running version of the agent, reported
+                  on heartbeat. Set by the foreman-agent using the binary's build-time
+                  version string; empty for agents that predate this field.
+                type: string
               capability:
                 description: Capability is what this node advertises to the scheduler.
                 properties:

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -70,6 +70,7 @@ type MetalAgentConfig struct {
 	// 0 disables the proxy.
 	ClientPort int
 	HostIP     string // explicit IP to register in K8s endpoints; empty = auto-detect
+	Version    string // agent binary version string stamped on Endpoints annotations; empty omits the annotation
 	Logger     *zap.SugaredLogger
 
 	// EventRecorder publishes Kubernetes events on managed InferenceService
@@ -403,7 +404,12 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		a.executor = metalExec
 	}
 
-	a.registry = NewServiceRegistry(a.config.K8sClient, a.config.HostIP, a.logger.With("subsystem", "registry"))
+	a.registry = NewServiceRegistry(
+		a.config.K8sClient,
+		a.config.HostIP,
+		a.logger.With("subsystem", "registry"),
+		a.config.Version,
+	)
 
 	// Reconcile orphaned Service+Endpoints from prior agent sessions. The
 	// watcher's `seen` map starts fresh each Watch() call, so InferenceServices

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -160,7 +160,7 @@ func TestHandleEvent_CreateMissingModel(t *testing.T) {
 	})
 	agent.watcher = NewInferenceServiceWatcher(k8sClient, "default", newNopLogger())
 	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
-	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	event := InferenceServiceEvent{
 		Type: EventTypeCreated,
@@ -447,7 +447,7 @@ func TestDeleteProcess_StopFailureStillUnregistersEndpoint(t *testing.T) {
 
 	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient})
 	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
-	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 	agent.processes["default/test-model"] = &ManagedProcess{
 		Name:      "test-model",
 		Namespace: "default",
@@ -692,7 +692,7 @@ func runEnsureProcessExpectingMapEviction(
 
 	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
 	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
-	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	key := "default/" + name
 	agent.processes[key] = &ManagedProcess{
@@ -728,7 +728,7 @@ func TestEnsureProcess_ReplicasZeroNoOpWhenNoProcess(t *testing.T) {
 
 	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
 	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
-	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	zeroReplicas := int32(0)
 	isvc := &inferencev1alpha1.InferenceService{
@@ -780,7 +780,7 @@ func TestEnsureProcess_ReplicasZeroPatchesStatus(t *testing.T) {
 
 	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
 	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
-	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	if err := agent.ensureProcess(context.Background(), isvc); err != nil {
 		t.Fatalf("ensureProcess returned unexpected error: %v", err)
@@ -866,7 +866,7 @@ func TestEnsureProcess_ReplicasZeroStatusPatchIdempotent(t *testing.T) {
 
 	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
 	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
-	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	// Snapshot the *seeded* transition time as the fake client stored
 	// it. The fake client serializes metav1.Time at second precision,
@@ -914,7 +914,7 @@ func TestEnsureProcess_HealthyAndSpecMatchesIsNoOp(t *testing.T) {
 
 	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
 	agent.executor = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
-	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	ctx := int32(65536)
 	isvc := &inferencev1alpha1.InferenceService{
@@ -1029,7 +1029,7 @@ func TestEnsureProcess_InFlightGuard(t *testing.T) {
 	})
 	exec := &blockingExecutor{entered: make(chan struct{}), release: make(chan struct{})}
 	agent.executor = exec
-	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	// First caller proceeds and blocks inside StartProcess.
 	firstDone := make(chan error, 1)
@@ -1106,7 +1106,7 @@ func TestHeartbeatOnce(t *testing.T) {
 		},
 		logger: newNopLogger(),
 	}
-	a.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger())
+	a.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger(), "")
 
 	before := time.Now().Add(-time.Second)
 	a.heartbeatOnce(context.Background())
@@ -1181,7 +1181,7 @@ func TestHeartbeatOnce_ScaledToZero(t *testing.T) {
 		executor: nopExecutor{},
 		logger:   newNopLogger(),
 	}
-	a.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger())
+	a.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger(), "")
 
 	a.heartbeatOnce(context.Background())
 
@@ -1239,7 +1239,7 @@ func TestHeartbeatOnce_NotFound(t *testing.T) {
 		executor: nopExecutor{},
 		logger:   newNopLogger(),
 	}
-	a.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger())
+	a.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger(), "")
 
 	a.heartbeatOnce(context.Background())
 

--- a/pkg/agent/pressure_test.go
+++ b/pkg/agent/pressure_test.go
@@ -169,7 +169,7 @@ func TestHandleMemoryPressure_EvictsLowestPriorityWhenEnabledAndAboveGuard(t *te
 	a := newPressureTestAgent(t, low, high)
 	a.config.EvictionEnabled = true
 	a.executor = stubExecutor{}
-	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger(), "")
 
 	a.processes["default/svc-low"] = &ManagedProcess{
 		Name: "svc-low", Namespace: "default", Priority: "low",
@@ -206,7 +206,7 @@ func TestHandleMemoryPressure_DisabledHonorsCLIFlag(t *testing.T) {
 	a := newPressureTestAgent(t, isvc)
 	a.config.EvictionEnabled = false // explicit
 	a.executor = stubExecutor{}
-	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger(), "")
 
 	a.processes["default/svc-low"] = &ManagedProcess{
 		Name: "svc-low", Namespace: "default", Priority: "low",
@@ -430,7 +430,7 @@ func TestHandleMemoryPressure_IncrementsSkippedCounter(t *testing.T) {
 			a := newPressureTestAgent(t)
 			a.config.EvictionEnabled = tc.evictionEnable
 			a.executor = stubExecutor{}
-			a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+			a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger(), "")
 			tc.processes(a)
 
 			before := readSkippedCounter(t, tc.wantReason)
@@ -550,7 +550,7 @@ func TestHandleMemoryPressure_EmitsEvictedEvent(t *testing.T) {
 	a := newPressureTestAgent(t, low, high)
 	a.config.EvictionEnabled = true
 	a.executor = stubExecutor{}
-	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger(), "")
 	rec := record.NewFakeRecorder(32)
 	a.config.EventRecorder = rec
 
@@ -595,7 +595,7 @@ func TestHandleMemoryPressure_EmitsEvictionSkippedWhenDisabled(t *testing.T) {
 	a := newPressureTestAgent(t, isvc)
 	a.config.EvictionEnabled = false
 	a.executor = stubExecutor{}
-	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger())
+	a.registry = NewServiceRegistry(a.config.K8sClient, "", newNopLogger(), "")
 	rec := record.NewFakeRecorder(32)
 	a.config.EventRecorder = rec
 

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -39,9 +39,10 @@ import (
 // ServiceRegistry manages Kubernetes Service and Endpoint resources
 // to expose native Metal processes to the cluster
 type ServiceRegistry struct {
-	client client.Client
-	hostIP string // explicit host IP; if empty, auto-detect via DNS
-	logger *zap.SugaredLogger
+	client  client.Client
+	hostIP  string // explicit host IP; if empty, auto-detect via DNS
+	version string // agent binary version stamped on endpoint annotations
+	logger  *zap.SugaredLogger
 	// retryBackoff bounds RegisterEndpointWithRetry. Overridable in tests.
 	retryBackoff wait.Backoff
 	// now returns the current time. Defaults to time.Now; overridable in tests
@@ -53,11 +54,19 @@ type ServiceRegistry struct {
 // If hostIP is non-empty it is used as the endpoint address registered in
 // Kubernetes; otherwise the IP is auto-detected via DNS lookups
 // (host.minikube.internal / host.docker.internal).
-func NewServiceRegistry(k8sClient client.Client, hostIP string, logger *zap.SugaredLogger) *ServiceRegistry {
+// version is the agent binary's version string (e.g. "v0.8.4") stamped on
+// every Endpoints object as AnnotationAgentVersion; pass empty to omit it.
+func NewServiceRegistry(
+	k8sClient client.Client,
+	hostIP string,
+	logger *zap.SugaredLogger,
+	version string,
+) *ServiceRegistry {
 	return &ServiceRegistry{
-		client: k8sClient,
-		hostIP: hostIP,
-		logger: logger,
+		client:  k8sClient,
+		hostIP:  hostIP,
+		version: version,
+		logger:  logger,
 		retryBackoff: wait.Backoff{
 			Duration: 2 * time.Second,
 			Factor:   2,
@@ -119,6 +128,9 @@ func (r *ServiceRegistry) RegisterEndpoint(
 			endpoints.Annotations = map[string]string{}
 		}
 		endpoints.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat] = r.now().UTC().Format(time.RFC3339)
+		if r.version != "" {
+			endpoints.Annotations[inferencev1alpha1.AnnotationAgentVersion] = r.version
+		}
 		//nolint:staticcheck // SA1019: EndpointSubset still functional
 		endpoints.Subsets = []corev1.EndpointSubset{{
 			Addresses: []corev1.EndpointAddress{{

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -65,7 +65,7 @@ func TestNewServiceRegistry(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	if registry == nil {
 		t.Fatal("NewServiceRegistry returned nil")
@@ -78,7 +78,7 @@ func TestRegisterEndpoint(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	isvc := &inferencev1alpha1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -166,7 +166,7 @@ func TestRegisterEndpoint_SanitizedName(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	isvc := &inferencev1alpha1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -219,7 +219,7 @@ func TestUnregisterEndpoint(t *testing.T) {
 		WithRuntimeObjects(svc, endpoints).
 		Build()
 
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	err := registry.UnregisterEndpoint(context.Background(), "default", "test-model")
 	if err != nil {
@@ -261,7 +261,7 @@ func TestUnregisterEndpoint_SanitizedName(t *testing.T) {
 		WithRuntimeObjects(svc, endpoints).
 		Build()
 
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	// Pass the dotted name — UnregisterEndpoint should sanitize it
 	err := registry.UnregisterEndpoint(context.Background(), "default", "model.v1.0")
@@ -295,7 +295,7 @@ func TestUnregisterEndpoint_Idempotent(t *testing.T) {
 		WithScheme(scheme).
 		WithRuntimeObjects(svc, endpoints).
 		Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	if err := registry.UnregisterEndpoint(context.Background(), "default", "idempotent-model"); err != nil {
 		t.Fatalf("first UnregisterEndpoint returned error: %v", err)
@@ -363,7 +363,7 @@ func TestReconcileOrphanEndpoints(t *testing.T) {
 		WithRuntimeObjects(liveISVC, liveSvc, orphanSvc, orphanEndpoints, foreignSvc).
 		Build()
 
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	cleaned, err := registry.ReconcileOrphanEndpoints(context.Background(), "default")
 	if err != nil {
@@ -409,7 +409,7 @@ func TestReconcileOrphanEndpoints_EmptyCluster(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	cleaned, err := registry.ReconcileOrphanEndpoints(context.Background(), "default")
 	if err != nil {
@@ -433,7 +433,7 @@ func TestResolveHostIP_Explicit(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "100.103.147.52", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "100.103.147.52", newNopLogger(), "")
 
 	ip := registry.resolveHostIP()
 	if ip != "100.103.147.52" {
@@ -446,7 +446,7 @@ func TestResolveHostIP_AutoDetect(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	ip := registry.resolveHostIP()
 	if ip == "" {
@@ -460,7 +460,7 @@ func TestRegisterEndpoint_ExplicitHostIP(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "10.0.0.42", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "10.0.0.42", newNopLogger(), "")
 
 	isvc := &inferencev1alpha1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -505,7 +505,7 @@ func TestRegisterEndpoint_PortChange(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	isvc := &inferencev1alpha1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
@@ -555,7 +555,7 @@ func TestRegisterEndpointWithRetry_TransientFailure(t *testing.T) {
 				return c.Create(ctx, obj, opts...)
 			},
 		}).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 	registry.retryBackoff = wait.Backoff{Duration: time.Millisecond, Factor: 2, Steps: 5}
 
 	isvc := &inferencev1alpha1.InferenceService{
@@ -585,7 +585,7 @@ func TestRegisterEndpointWithRetry_Exhausted(t *testing.T) {
 				return apierrors.NewServerTimeout(corev1.Resource("services"), "create", 1)
 			},
 		}).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 	registry.retryBackoff = wait.Backoff{Duration: time.Millisecond, Factor: 2, Steps: 3}
 
 	isvc := &inferencev1alpha1.InferenceService{
@@ -612,7 +612,7 @@ func TestRegisterEndpoint_StampsHeartbeat(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
 	// Pin the clock so the annotation value is deterministic.
 	frozen := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
@@ -649,6 +649,81 @@ func TestRegisterEndpoint_StampsHeartbeat(t *testing.T) {
 	}
 }
 
+// TestRegisterEndpoint_StampsAgentVersion verifies that RegisterEndpoint stamps
+// the llmkube.ai/agent-version annotation on the Endpoints object when the
+// registry is created with a non-empty version string.
+func TestRegisterEndpoint_StampsAgentVersion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "v0.9.0")
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ver-model",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "ver-model",
+		},
+	}
+
+	if err := registry.RegisterEndpoint(context.Background(), isvc, 50051); err != nil {
+		t.Fatalf("RegisterEndpoint: %v", err)
+	}
+
+	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	eps := &corev1.Endpoints{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "ver-model", Namespace: "default"}, eps); err != nil {
+		t.Fatalf("get endpoints: %v", err)
+	}
+
+	got := eps.Annotations[inferencev1alpha1.AnnotationAgentVersion]
+	if got != "v0.9.0" {
+		t.Fatalf("agent-version annotation = %q, want %q", got, "v0.9.0")
+	}
+}
+
+// TestRegisterEndpoint_OmitsAgentVersionWhenEmpty verifies that the
+// llmkube.ai/agent-version annotation is absent when the registry is
+// created without a version string (older-agent compatibility).
+func TestRegisterEndpoint_OmitsAgentVersionWhenEmpty(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "") // empty version
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nover-model",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "nover-model",
+		},
+	}
+
+	if err := registry.RegisterEndpoint(context.Background(), isvc, 50051); err != nil {
+		t.Fatalf("RegisterEndpoint: %v", err)
+	}
+
+	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	eps := &corev1.Endpoints{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "nover-model", Namespace: "default"}, eps); err != nil {
+		t.Fatalf("get endpoints: %v", err)
+	}
+
+	if v, ok := eps.Annotations[inferencev1alpha1.AnnotationAgentVersion]; ok {
+		t.Fatalf("agent-version annotation should be absent, got %q", v)
+	}
+}
+
 // TestRegisterEndpointWithRetry_ContextCancelled verifies that when the context
 // is already cancelled before the first attempt, the returned error wraps
 // context.Canceled rather than rendering as a garbled %!w(<nil>).
@@ -658,7 +733,7 @@ func TestRegisterEndpointWithRetry_ContextCancelled(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	registry := NewServiceRegistry(k8sClient, "", newNopLogger())
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 	registry.retryBackoff = wait.Backoff{Duration: time.Millisecond, Factor: 2, Steps: 5}
 
 	isvc := &inferencev1alpha1.InferenceService{

--- a/pkg/foreman/agent/fleetnode.go
+++ b/pkg/foreman/agent/fleetnode.go
@@ -55,6 +55,16 @@ type Registrar struct {
 	Spec     foremanv1alpha1.FleetNodeSpec
 	Provider CapabilityProvider
 	Interval time.Duration // zero defaults to DefaultHeartbeatInterval
+
+	// Version is the agent binary's version string (e.g. "v0.8.4").
+	// Set from the build-time ldflags var and stamped on FleetNode.status
+	// every heartbeat so the cluster can observe which version is running.
+	// Empty string is accepted (older agents omit this field).
+	Version string
+
+	// Kind identifies the agent type. Conventionally "foreman-agent".
+	// Stamped on FleetNode.status.agentKind every heartbeat.
+	Kind string
 }
 
 // Upsert creates the FleetNode if missing, otherwise updates its Spec so
@@ -108,6 +118,12 @@ func (r *Registrar) PatchHeartbeat(ctx context.Context, phase foremanv1alpha1.Fl
 	node.Status.Phase = phase
 	node.Status.LastHeartbeatTime = &now
 	node.Status.Capability = r.Provider.Capability()
+	if r.Version != "" {
+		node.Status.AgentVersion = r.Version
+	}
+	if r.Kind != "" {
+		node.Status.AgentKind = foremanv1alpha1.FleetNodeAgentKind(r.Kind)
+	}
 	if err := r.Client.Status().Patch(ctx, &node, patch); err != nil {
 		return fmt.Errorf("patch FleetNode status: %w", err)
 	}

--- a/pkg/foreman/agent/fleetnode_test.go
+++ b/pkg/foreman/agent/fleetnode_test.go
@@ -256,6 +256,63 @@ func TestRegistrar_PatchHeartbeat_WritesPhaseAndCapability(t *testing.T) {
 	}
 }
 
+func TestRegistrar_PatchHeartbeat_StampsVersionAndKind(t *testing.T) {
+	existing := &foremanv1alpha1.FleetNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "studio"},
+		Spec:       foremanv1alpha1.FleetNodeSpec{NodeName: "studio"},
+	}
+	kc := newFakeClient(t, existing)
+	r := &Registrar{
+		Client:   kc,
+		NodeName: "studio",
+		Provider: &fixedCapability{},
+		Version:  "v0.9.0",
+		Kind:     "foreman-agent",
+	}
+	if err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
+		t.Fatalf("PatchHeartbeat: %v", err)
+	}
+	var got foremanv1alpha1.FleetNode
+	if err := kc.Get(context.Background(), types.NamespacedName{Name: "studio"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status.AgentVersion != "v0.9.0" {
+		t.Errorf("AgentVersion = %q, want %q", got.Status.AgentVersion, "v0.9.0")
+	}
+	if got.Status.AgentKind != foremanv1alpha1.FleetNodeAgentKind("foreman-agent") {
+		t.Errorf("AgentKind = %q, want %q", got.Status.AgentKind, "foreman-agent")
+	}
+}
+
+func TestRegistrar_PatchHeartbeat_EmptyVersionOmitted(t *testing.T) {
+	// When Version and Kind are not set, the status fields must remain empty
+	// (not overwrite a value set by a newer agent restart with blank).
+	existing := &foremanv1alpha1.FleetNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "studio2"},
+		Spec:       foremanv1alpha1.FleetNodeSpec{NodeName: "studio2"},
+	}
+	kc := newFakeClient(t, existing)
+	r := &Registrar{
+		Client:   kc,
+		NodeName: "studio2",
+		Provider: &fixedCapability{},
+		// Version and Kind intentionally zero
+	}
+	if err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
+		t.Fatalf("PatchHeartbeat: %v", err)
+	}
+	var got foremanv1alpha1.FleetNode
+	if err := kc.Get(context.Background(), types.NamespacedName{Name: "studio2"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status.AgentVersion != "" {
+		t.Errorf("AgentVersion = %q, want empty (version not set)", got.Status.AgentVersion)
+	}
+	if got.Status.AgentKind != "" {
+		t.Errorf("AgentKind = %q, want empty (kind not set)", got.Status.AgentKind)
+	}
+}
+
 func TestRegistrar_Run_DrainsAndExitsOnCancel(t *testing.T) {
 	existing := &foremanv1alpha1.FleetNode{
 		ObjectMeta: metav1.ObjectMeta{Name: "m5-max"},


### PR DESCRIPTION
## What

The cluster can now see what version each off-cluster agent runs — the foundation for managed fleet updates (no update behavior yet):

- **foreman-agent** gains `--version` (version/commit/build-date, stamped via goreleaser ldflags like metal-agent already had) and reports its running version + kind on its FleetNode heartbeat: new `FleetNode.status.agentVersion` and `status.agentKind` (enum foreman-agent;metal-agent), surfaced as a `Version` print column.
- **metal-agent** stamps a `llmkube.ai/agent-version` annotation on the InferenceService Endpoints it already manages (alongside the existing heartbeat annotation), so its version is visible without a FleetNode.

## Why

Deploying 0.8.4 across the Mac fleet showed the cluster had zero visibility into agent versions — drift (stale launchd processes, un-updated binaries) was invisible until hand-inspected. This is step one of a declarative, staged, health-gated agent-update capability: you can't safely roll out what you can't observe. Backward-compatible by design: an empty version omits the field/annotation, so older agents never blank out what a newer restart sets.

## How

- `FleetNode.status` already has multiple writers (agent heartbeat + reconciler staleness); the Registrar keeps its field-scoped `client.MergeFrom` status patch so it only ever touches its own fields.
- Tests pin both the present and the omitted-when-unset cases on both agents (Registrar heartbeat stamps version+kind; the registry stamps the annotation; empty values are omitted).
- CRD + chart CRD regenerated (`make manifests generate` + `make foreman-chart-crds`); deepcopy unaffected (plain value-type fields).

## Checklist

- [x] Tests added (4) and full `make test` green (incl. both controller envtest suites)
- [x] `make fmt vet lint` clean, plus `GOOS=linux golangci-lint run ./...`
- [x] CRD/chart regenerated, no drift; no RBAC change
- [x] DCO sign-off on all commits
