### PR TITLE
feat(foreman,selfupdate): agent self-update so approved AgentReleases roll the fleet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,9 @@ build-metal-agent: fmt vet ## Build Metal agent for macOS (requires macOS).
 	GOOS=darwin GOARCH=$(shell uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/') \
 		go build -o bin/llmkube-metal-agent ./cmd/metal-agent
 
+# LLMKUBE_METAL_AGENT_LABEL is the launchd service label for metal-agent.
+LLMKUBE_METAL_AGENT_LABEL ?= com.llmkube.metal-agent
+
 .PHONY: install-metal-agent
 install-metal-agent: build-metal-agent ## Install Metal agent and launchd service (macOS only).
 	@echo "Installing Metal agent..."
@@ -159,8 +162,13 @@ install-metal-agent: build-metal-agent ## Install Metal agent and launchd servic
 	mkdir -p ~/Library/LaunchAgents
 	cp deployment/macos/com.llmkube.metal-agent.plist ~/Library/LaunchAgents/
 	@echo "Starting Metal agent service..."
-	launchctl load ~/Library/LaunchAgents/com.llmkube.metal-agent.plist || true
-	@echo "✅ Metal agent installed and started"
+	@# Bootstrap the plist the first time (noop if already bootstrapped).
+	@launchctl bootstrap gui/$$(id -u) ~/Library/LaunchAgents/$(LLMKUBE_METAL_AGENT_LABEL).plist 2>/dev/null || true
+	@# kickstart -k stops the running instance (if any) and starts a fresh one,
+	@# so reinstalls always exec the new binary. Unlike `launchctl load || true`
+	@# this actually restarts a running service.
+	launchctl kickstart -k gui/$$(id -u)/$(LLMKUBE_METAL_AGENT_LABEL)
+	@echo "Metal agent installed and restarted"
 	@echo ""
 	@echo "To check status: launchctl list | grep llmkube"
 	@echo "To view logs: tail -f /tmp/llmkube-metal-agent.log"
@@ -168,11 +176,66 @@ install-metal-agent: build-metal-agent ## Install Metal agent and launchd servic
 .PHONY: uninstall-metal-agent
 uninstall-metal-agent: ## Uninstall Metal agent and launchd service.
 	@echo "Stopping Metal agent service..."
-	launchctl unload ~/Library/LaunchAgents/com.llmkube.metal-agent.plist || true
+	@launchctl bootout gui/$$(id -u)/$(LLMKUBE_METAL_AGENT_LABEL) 2>/dev/null || true
 	@echo "Removing Metal agent..."
 	sudo rm -f /usr/local/bin/llmkube-metal-agent
-	rm -f ~/Library/LaunchAgents/com.llmkube.metal-agent.plist
-	@echo "✅ Metal agent uninstalled"
+	rm -f ~/Library/LaunchAgents/$(LLMKUBE_METAL_AGENT_LABEL).plist
+	@echo "Metal agent uninstalled"
+
+##@ Foreman Agent (macOS install)
+
+# LLMKUBE_FOREMAN_AGENT_LABEL is the launchd service label for foreman-agent.
+LLMKUBE_FOREMAN_AGENT_LABEL ?= com.llmkube.foreman-agent
+
+# FOREMAN_AGENT_VERSION is stamped into the versioned install layout and the
+# ldflags Version variable. Override on the command line when releasing.
+FOREMAN_AGENT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+
+.PHONY: build-foreman-agent-versioned
+build-foreman-agent-versioned: fmt vet ## Build foreman-agent with ldflags version info.
+	go build \
+		-ldflags "-X main.Version=$(FOREMAN_AGENT_VERSION) -X main.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown) -X main.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		-o bin/foreman-agent \
+		./cmd/foreman-agent
+
+# FOREMAN_INSTALL_ROOT is the user-owned managed layout root for foreman-agent.
+# On macOS the default matches ResolveInstallRoot("foreman-agent").
+FOREMAN_INSTALL_ROOT ?= $(HOME)/Library/Application\ Support/llmkube/foreman-agent
+
+.PHONY: install-foreman-agent
+install-foreman-agent: build-foreman-agent-versioned ## Install foreman-agent into user-owned managed layout and start launchd service (macOS only, no sudo).
+	@echo "Installing foreman-agent $(FOREMAN_AGENT_VERSION)..."
+	@# Create the versioned directory and stage the binary.
+	mkdir -p "$(FOREMAN_INSTALL_ROOT)/versions/$(FOREMAN_AGENT_VERSION)"
+	cp bin/foreman-agent "$(FOREMAN_INSTALL_ROOT)/versions/$(FOREMAN_AGENT_VERSION)/foreman-agent"
+	chmod 0755 "$(FOREMAN_INSTALL_ROOT)/versions/$(FOREMAN_AGENT_VERSION)/foreman-agent"
+	@# Atomically flip the current symlink (write temp then rename, POSIX-atomic).
+	@ln -sfn "$(FOREMAN_INSTALL_ROOT)/versions/$(FOREMAN_AGENT_VERSION)" \
+		"$(FOREMAN_INSTALL_ROOT)/current.tmp"
+	@mv -f "$(FOREMAN_INSTALL_ROOT)/current.tmp" "$(FOREMAN_INSTALL_ROOT)/current"
+	@echo "Staged at $(FOREMAN_INSTALL_ROOT)/current -> versions/$(FOREMAN_AGENT_VERSION)"
+	@echo "Installing launchd service..."
+	@# Substitute YOUR_USERNAME placeholder with the real home directory path.
+	@sed "s|/Users/YOUR_USERNAME/Library/Application Support/llmkube/foreman-agent|$(FOREMAN_INSTALL_ROOT)|g" \
+		deployment/macos/com.llmkube.foreman-agent.plist \
+		> ~/Library/LaunchAgents/$(LLMKUBE_FOREMAN_AGENT_LABEL).plist
+	@echo "Starting foreman-agent service..."
+	@# Bootstrap the plist the first time (noop if already bootstrapped).
+	@launchctl bootstrap gui/$$(id -u) ~/Library/LaunchAgents/$(LLMKUBE_FOREMAN_AGENT_LABEL).plist 2>/dev/null || true
+	@# kickstart -k ensures a running instance picks up the new binary.
+	launchctl kickstart -k gui/$$(id -u)/$(LLMKUBE_FOREMAN_AGENT_LABEL)
+	@echo "foreman-agent installed and restarted"
+	@echo ""
+	@echo "Edit ~/Library/LaunchAgents/$(LLMKUBE_FOREMAN_AGENT_LABEL).plist to set flags, then run:"
+	@echo "  launchctl kickstart -k gui/$$(id -u)/$(LLMKUBE_FOREMAN_AGENT_LABEL)"
+	@echo "To view logs: tail -f /tmp/llmkube-foreman-agent.log"
+
+.PHONY: uninstall-foreman-agent
+uninstall-foreman-agent: ## Uninstall foreman-agent launchd service (leaves install root intact for rollback).
+	@echo "Stopping foreman-agent service..."
+	@launchctl bootout gui/$$(id -u)/$(LLMKUBE_FOREMAN_AGENT_LABEL) 2>/dev/null || true
+	rm -f ~/Library/LaunchAgents/$(LLMKUBE_FOREMAN_AGENT_LABEL).plist
+	@echo "foreman-agent service uninstalled (install root preserved at $(FOREMAN_INSTALL_ROOT))"
 
 .PHONY: install-powermetrics-sudo
 install-powermetrics-sudo: ## Install NOPASSWD sudoers entry for /usr/bin/powermetrics (required for --apple-power-enabled).

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -456,9 +456,9 @@ func main() {
 	if err := g.Wait(); err != nil {
 		if errors.Is(err, foremanagent.ErrSelfUpdateRestart) {
 			// Self-update applied: exit cleanly so launchd/systemd
-			// restarts the process onto the new binary. Exit 0 satisfies
-			// KeepAlive.SuccessfulExit=false (launchd still restarts) and
-			// systemd Restart=always (always restarts regardless of code).
+			// restarts the process onto the new binary. The macOS plist
+			// uses KeepAlive=true so launchd relaunches on any exit;
+			// the systemd unit uses Restart=always (same effect).
 			setupLog.Info("foreman-agent exiting for self-update restart")
 			os.Exit(0)
 		}

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -34,10 +34,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"os"
 	"os/signal"
 	"regexp"
@@ -66,6 +68,7 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	foremantools "github.com/defilantech/llmkube/pkg/foreman/agent/tools"
+	"github.com/defilantech/llmkube/pkg/selfupdate"
 )
 
 var (
@@ -133,6 +136,10 @@ func main() {
 		// #620 coder-Job git Secret selection
 		coderGitSecret    string
 		coderGitSecretKey string
+
+		// PR4 self-update flags
+		selfUpdateEnabled bool
+		installRoot       string
 	)
 
 	flag.StringVar(&fleetNodeName, "fleet-node-name", "",
@@ -202,6 +209,16 @@ func main() {
 	flag.StringVar(&coderGitSecretKey, "coder-git-secret-key", "token",
 		"Key within --coder-git-secret that holds the token (e.g. GITHUB_TOKEN when reusing an "+
 			"existing git Secret).")
+
+	flag.BoolVar(&selfUpdateEnabled, "self-update", true,
+		"Enable self-update from FleetNode.status.updateRequest. Only engages when running from the "+
+			"managed install root (~/Library/Application Support/llmkube/foreman-agent on macOS). "+
+			"Set to false to disable entirely (e.g. for tests or manual installs outside the managed layout).")
+	flag.StringVar(&installRoot, "install-root", "",
+		"Override the managed install root path. Defaults to the platform-specific location "+
+			"(~/Library/Application Support/llmkube/foreman-agent on macOS, "+
+			"~/.local/share/llmkube/foreman-agent on Linux). "+
+			"Only used when --self-update=true.")
 
 	showVersion := flag.Bool("version", false, "Print version information and exit.")
 	opts := zap.Options{Development: true}
@@ -294,6 +311,51 @@ func main() {
 		StaticTotalRAMGB: clampInt32(staticTotalRAMGB),
 	})
 
+	// Build the self-updater. This is gated on --self-update and on whether
+	// the binary is running from the managed install root. Dev builds and
+	// direct invocations outside the managed layout skip the update path
+	// entirely so `go run` and test environments are never affected.
+	var updater foremanagent.UpdateApplier
+	if selfUpdateEnabled {
+		root := installRoot
+		if root == "" {
+			var err error
+			root, err = selfupdate.ResolveInstallRoot("foreman-agent")
+			if err != nil {
+				setupLog.Error(err, "failed to resolve self-update install root; self-update disabled")
+			}
+		}
+		if root != "" {
+			if selfupdate.RunningUnderManagedRoot(root) {
+				u := &selfupdate.Updater{
+					CurrentVersion: Version,
+					OS:             goruntime.GOOS,
+					Arch:           goruntime.GOARCH,
+					InstallRoot:    root,
+					BinaryName:     "foreman-agent",
+					Verifier:       &selfupdate.SHA256Verifier{},
+					HTTPClient:     &http.Client{Timeout: 10 * time.Minute},
+					Log:            ctrl.Log.WithName("selfupdate"),
+				}
+				updater = foremanagent.UpdateApplierFunc(func(version, url, sha256 string) (bool, error) {
+					res, err := u.MaybeApply(selfupdate.Target{
+						Version: version,
+						URL:     url,
+						SHA256:  sha256,
+					})
+					return res.Restarting, err
+				})
+				setupLog.Info("self-update enabled", "installRoot", root, "currentVersion", Version)
+			} else {
+				setupLog.Info("self-update disabled: not running from managed install root "+
+					"(dev build or direct invocation); set --self-update=false to silence this",
+					"installRoot", root)
+			}
+		}
+	} else {
+		setupLog.Info("self-update disabled via --self-update=false")
+	}
+
 	reg := &foremanagent.Registrar{
 		Client:   kc,
 		NodeName: fleetNodeName,
@@ -304,6 +366,7 @@ func main() {
 		Kind:     "foreman-agent",
 		OS:       goruntime.GOOS,
 		Arch:     goruntime.GOARCH,
+		Updater:  updater,
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -391,6 +454,14 @@ func main() {
 	g.Go(func() error { return watcher.Run(gctx) })
 
 	if err := g.Wait(); err != nil {
+		if errors.Is(err, foremanagent.ErrSelfUpdateRestart) {
+			// Self-update applied: exit cleanly so launchd/systemd
+			// restarts the process onto the new binary. Exit 0 satisfies
+			// KeepAlive.SuccessfulExit=false (launchd still restarts) and
+			// systemd Restart=always (always restarts regardless of code).
+			setupLog.Info("foreman-agent exiting for self-update restart")
+			os.Exit(0)
+		}
 		setupLog.Error(err, "foreman-agent exited with error")
 		os.Exit(1)
 	}

--- a/deployment/linux/llmkube-foreman-agent.service
+++ b/deployment/linux/llmkube-foreman-agent.service
@@ -1,0 +1,55 @@
+# llmkube-foreman-agent — user-level systemd unit for the Foreman node daemon.
+#
+# Install as a user unit (no root required):
+#
+#   mkdir -p ~/.config/systemd/user
+#   cp deployment/linux/llmkube-foreman-agent.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now llmkube-foreman-agent
+#
+# The ExecStart path points at the stable "current" symlink laid down by
+# `make install-foreman-agent` and updated on every self-update flip.
+# Systemd re-exec the new binary after each self-update restart because
+# ExecStart resolves the symlink at fork time, not at unit load time.
+#
+# Logs:
+#   journalctl --user -u llmkube-foreman-agent -f
+#
+# Edit the flags in ExecStart to match your environment before enabling.
+
+[Unit]
+Description=LLMKube Foreman Agent
+Documentation=https://llmkube.io/docs
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# The stable symlink path: ~/.local/share/llmkube/foreman-agent/current/foreman-agent
+# Edit flags below to match your environment.
+ExecStart=%h/.local/share/llmkube/foreman-agent/current/foreman-agent \
+    --fleet-node-name=REPLACE_WITH_NODE_NAME \
+    --roles=worker \
+    --agent-mode=native \
+    --git-remote-url=REPLACE_WITH_GIT_REMOTE_URL \
+    --commit-author-email=REPLACE_WITH_EMAIL \
+    --workspace-dir=/tmp/foreman-workspaces \
+    --task-namespace=default \
+    --foreman-namespace=foreman-system
+
+# Restart on any exit (including exit 0 from a self-update flip).
+Restart=always
+RestartSec=30
+
+# Prevent runaway restarts from hammering the apiserver.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+# Standard output goes to the journal.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=foreman-agent
+
+[Install]
+WantedBy=default.target

--- a/deployment/macos/com.llmkube.foreman-agent.plist
+++ b/deployment/macos/com.llmkube.foreman-agent.plist
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.llmkube.foreman-agent</string>
+
+    <!--
+        ProgramArguments[0] is the stable exec path through the "current"
+        symlink laid down by `make install-foreman-agent` (and updated on
+        every self-update flip).  Edit the flags below to match your
+        environment before loading the service.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOUR_USERNAME/Library/Application Support/llmkube/foreman-agent/current/foreman-agent</string>
+        <string>--fleet-node-name</string>
+        <string>REPLACE_WITH_NODE_NAME</string>
+        <string>--roles</string>
+        <string>worker</string>
+        <string>--agent-mode</string>
+        <string>native</string>
+        <string>--git-remote-url</string>
+        <string>REPLACE_WITH_GIT_REMOTE_URL</string>
+        <string>--commit-author-email</string>
+        <string>REPLACE_WITH_EMAIL</string>
+        <string>--workspace-dir</string>
+        <string>/tmp/foreman-workspaces</string>
+        <string>--task-namespace</string>
+        <string>default</string>
+        <string>--foreman-namespace</string>
+        <string>foreman-system</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!--
+        KeepAlive=true: launchd relaunches on any exit, including the
+        clean exit(0) the agent uses to restart onto a self-updated binary.
+        Intentional stop is via `launchctl bootout` (see uninstall-foreman-agent),
+        which removes the job so KeepAlive does not fight it.
+    -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/llmkube-foreman-agent.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/llmkube-foreman-agent.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <!-- Set KUBECONFIG if your kubeconfig is not at the default location -->
+        <!-- <key>KUBECONFIG</key> -->
+        <!-- <string>/Users/YOUR_USERNAME/.kube/config</string> -->
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/tmp</string>
+
+    <!-- Throttle restarts to avoid a tight loop on persistent failure -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+</dict>
+</plist>

--- a/pkg/foreman/agent/fleetnode.go
+++ b/pkg/foreman/agent/fleetnode.go
@@ -46,6 +46,25 @@ type CapabilityProvider interface {
 	Capability() foremanv1alpha1.FleetNodeCapability
 }
 
+// UpdateApplier applies a binary update given a (version, url, sha256) triple.
+// The canonical implementation wraps *selfupdate.Updater.MaybeApply; tests
+// may inject a fake via UpdateApplierFunc.
+//
+// Returns (restarting, err). restarting=true means the symlink was flipped
+// and the caller should drain then exit so the supervisor can relaunch.
+type UpdateApplier interface {
+	Apply(version, url, sha256 string) (restarting bool, err error)
+}
+
+// UpdateApplierFunc is a convenience adapter so a plain function satisfies
+// UpdateApplier without a named struct.
+type UpdateApplierFunc func(version, url, sha256 string) (bool, error)
+
+// Apply implements UpdateApplier.
+func (f UpdateApplierFunc) Apply(version, url, sha256 string) (bool, error) {
+	return f(version, url, sha256)
+}
+
 // Registrar owns the FleetNode CR for this host: upserts it on startup,
 // patches its status every heartbeat, and patches phase=Draining on
 // clean shutdown so the scheduler stops routing tasks to us promptly.
@@ -74,6 +93,14 @@ type Registrar struct {
 	// Arch is the CPU architecture this agent is running on (runtime.GOARCH).
 	// Stamped on FleetNode.status.arch every heartbeat.
 	Arch string
+
+	// Updater handles self-update when an UpdateRequest appears on the
+	// FleetNode status. When nil, update requests are logged and ignored
+	// (the pre-PR4 behaviour). The caller is responsible for gating the
+	// Updater on RunningUnderManagedRoot before setting it; if the binary
+	// is not running from the managed install root the caller should leave
+	// Updater nil so dev/test builds are unaffected.
+	Updater UpdateApplier
 }
 
 // Upsert creates the FleetNode if missing, otherwise updates its Spec so
@@ -125,20 +152,27 @@ func (r *Registrar) Upsert(ctx context.Context) error {
 //
 // The field-scoped MergeFrom patch ensures each writer only touches its
 // own fields without clobbering concurrent writes from others.
-func (r *Registrar) PatchHeartbeat(ctx context.Context, phase foremanv1alpha1.FleetNodePhase) error {
+//
+// The returned *FleetNodeUpdateRequest is the value observed on the node
+// at Get time (before the status patch). Run uses this to trigger
+// self-update after a successful Ready heartbeat, ensuring the operator
+// always sees the node as Ready before the flip rather than getting a
+// stale version in a post-flip Ready heartbeat.
+func (r *Registrar) PatchHeartbeat(ctx context.Context, phase foremanv1alpha1.FleetNodePhase) (*foremanv1alpha1.FleetNodeUpdateRequest, error) { //nolint:lll
 	log := logf.FromContext(ctx)
 	var node foremanv1alpha1.FleetNode
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: r.NodeName}, &node); err != nil {
-		return fmt.Errorf("get FleetNode for heartbeat: %w", err)
+		return nil, fmt.Errorf("get FleetNode for heartbeat: %w", err)
 	}
 
-	// Log any pending update request so an operator watching logs can see
-	// the dispatch. The actual self-update action is implemented in PR4;
-	// for now we surface the request without acting on it.
-	if node.Status.UpdateRequest != nil {
+	// Capture the update request BEFORE patching so we return it to the
+	// caller regardless of whether the patch succeeds. The operator owns
+	// this field; the agent never touches it.
+	updateReq := node.Status.UpdateRequest
+	if updateReq != nil {
 		log.Info("update requested",
-			"target", node.Status.UpdateRequest.TargetVersion,
-			"url", node.Status.UpdateRequest.URL,
+			"target", updateReq.TargetVersion,
+			"url", updateReq.URL,
 		)
 	}
 
@@ -160,17 +194,35 @@ func (r *Registrar) PatchHeartbeat(ctx context.Context, phase foremanv1alpha1.Fl
 		node.Status.Arch = r.Arch
 	}
 	if err := r.Client.Status().Patch(ctx, &node, patch); err != nil {
-		return fmt.Errorf("patch FleetNode status: %w", err)
+		return nil, fmt.Errorf("patch FleetNode status: %w", err)
 	}
-	return nil
+	return updateReq, nil
 }
+
+// ErrSelfUpdateRestart is returned from Run when a self-update was applied
+// and the process should exit so the supervisor can relaunch onto the new
+// binary. The errgroup in main.go propagates this return value, which
+// triggers cancellation of the sibling watcher goroutine (clean shutdown).
+var ErrSelfUpdateRestart = fmt.Errorf("self-update applied: exiting for supervisor restart")
 
 // Run blocks, heartbeating every Interval until ctx is cancelled. On
 // cancellation it makes a best-effort drain patch (phase=Draining) so
 // the scheduler stops dispatching to us before the process exits.
+//
+// Self-update flow (when r.Updater is set and the binary runs from the
+// managed install root):
+//  1. After each successful Ready heartbeat, check the observed UpdateRequest.
+//  2. If a new version is available, call r.Updater.Apply. On success:
+//     a. Emit a final Draining heartbeat (stops scheduler routing).
+//     b. Return ErrSelfUpdateRestart — the errgroup cancels the watcher.
+//  3. The process exits; launchd/systemd restarts it onto the new symlink.
+//
+// CRITICAL: between the symlink flip and the final return, no further
+// Ready heartbeat is sent. This ensures the rollout health gate never sees
+// the old version in a Ready state after the flip.
 func (r *Registrar) Run(ctx context.Context) error {
 	log := logf.FromContext(ctx)
-	if err := r.PatchHeartbeat(ctx, foremanv1alpha1.FleetNodePhaseReady); err != nil {
+	if _, err := r.PatchHeartbeat(ctx, foremanv1alpha1.FleetNodePhaseReady); err != nil {
 		return fmt.Errorf("initial heartbeat: %w", err)
 	}
 	log.Info("FleetNode Ready", "name", r.NodeName)
@@ -188,7 +240,7 @@ func (r *Registrar) Run(ctx context.Context) error {
 			// Best-effort drain. A short fresh timeout keeps us from
 			// hanging on a dead apiserver during shutdown.
 			drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			err := r.PatchHeartbeat(drainCtx, foremanv1alpha1.FleetNodePhaseDraining)
+			_, err := r.PatchHeartbeat(drainCtx, foremanv1alpha1.FleetNodePhaseDraining)
 			cancel()
 			if err != nil {
 				log.Error(err, "drain heartbeat failed")
@@ -197,15 +249,58 @@ func (r *Registrar) Run(ctx context.Context) error {
 			}
 			return nil
 		case <-ticker.C:
-			if err := r.PatchHeartbeat(ctx, foremanv1alpha1.FleetNodePhaseReady); err != nil {
+			updateReq, err := r.PatchHeartbeat(ctx, foremanv1alpha1.FleetNodePhaseReady)
+			if err != nil {
 				// Don't return on transient errors; the next tick can
 				// recover. A persistent failure is visible via stale
 				// LastHeartbeatTime, which is exactly the staleness
 				// signal the scheduler uses anyway.
 				log.Error(err, "heartbeat patch failed; will retry")
+				continue
+			}
+
+			// Check for a pending self-update after the heartbeat so the
+			// operator always observes at least one Ready beat with the
+			// current version before we flip.
+			if restarting := r.maybeApplySelfUpdate(ctx, updateReq); restarting {
+				// Symlink flipped. Drain before exiting so the scheduler
+				// stops routing tasks to us. A short timeout prevents
+				// blocking indefinitely on a slow apiserver.
+				drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				_, derr := r.PatchHeartbeat(drainCtx, foremanv1alpha1.FleetNodePhaseDraining)
+				cancel()
+				if derr != nil {
+					log.Error(derr, "self-update drain heartbeat failed; exiting anyway")
+				} else {
+					log.Info("FleetNode Draining for self-update restart", "name", r.NodeName)
+				}
+				return ErrSelfUpdateRestart
 			}
 		}
 	}
+}
+
+// maybeApplySelfUpdate checks the observed UpdateRequest and calls the
+// Updater if appropriate. Returns true when the binary was flipped and
+// the process should restart.
+//
+// Self-update is skipped when:
+//   - r.Updater is nil (PR3 / pre-PR4 deployments)
+//   - req is nil (no update request from the operator)
+//   - the binary is not running from the managed install root (dev builds)
+func (r *Registrar) maybeApplySelfUpdate(ctx context.Context, req *foremanv1alpha1.FleetNodeUpdateRequest) bool {
+	if r.Updater == nil || req == nil {
+		return false
+	}
+	log := logf.FromContext(ctx)
+
+	restarting, err := r.Updater.Apply(req.TargetVersion, req.URL, req.SHA256)
+	if err != nil {
+		log.Error(err, "self-update failed; will retry on next heartbeat",
+			"target", req.TargetVersion)
+		return false
+	}
+	return restarting
 }
 
 func specEqual(a, b foremanv1alpha1.FleetNodeSpec) bool {

--- a/pkg/foreman/agent/fleetnode_test.go
+++ b/pkg/foreman/agent/fleetnode_test.go
@@ -18,6 +18,8 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -226,7 +228,7 @@ func TestRegistrar_PatchHeartbeat_WritesPhaseAndCapability(t *testing.T) {
 		Provider: &fixedCapability{cap: cap},
 	}
 	before := time.Now().Add(-time.Second)
-	if err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
+	if _, err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
 		t.Fatalf("PatchHeartbeat: %v", err)
 	}
 	var got foremanv1alpha1.FleetNode
@@ -269,7 +271,7 @@ func TestRegistrar_PatchHeartbeat_StampsVersionAndKind(t *testing.T) {
 		Version:  "v0.9.0",
 		Kind:     "foreman-agent",
 	}
-	if err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
+	if _, err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
 		t.Fatalf("PatchHeartbeat: %v", err)
 	}
 	var got foremanv1alpha1.FleetNode
@@ -298,7 +300,7 @@ func TestRegistrar_PatchHeartbeat_EmptyVersionOmitted(t *testing.T) {
 		Provider: &fixedCapability{},
 		// Version and Kind intentionally zero
 	}
-	if err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
+	if _, err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
 		t.Fatalf("PatchHeartbeat: %v", err)
 	}
 	var got foremanv1alpha1.FleetNode
@@ -310,6 +312,108 @@ func TestRegistrar_PatchHeartbeat_EmptyVersionOmitted(t *testing.T) {
 	}
 	if got.Status.AgentKind != "" {
 		t.Errorf("AgentKind = %q, want empty (kind not set)", got.Status.AgentKind)
+	}
+}
+
+// TestRegistrar_Run_SelfUpdateDrainsAndReturnsRestartError verifies that
+// when an UpdateApplier signals Restarting=true, Run:
+//  1. emits a final Draining heartbeat so the operator stops routing tasks,
+//  2. returns ErrSelfUpdateRestart (not nil, not a generic error).
+func TestRegistrar_Run_SelfUpdateDrainsAndReturnsRestartError(t *testing.T) {
+	existing := &foremanv1alpha1.FleetNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "studio-update"},
+		Spec:       foremanv1alpha1.FleetNodeSpec{NodeName: "studio-update"},
+		Status: foremanv1alpha1.FleetNodeStatus{
+			UpdateRequest: &foremanv1alpha1.FleetNodeUpdateRequest{
+				TargetVersion: "v0.9.0",
+				URL:           "http://example.com/foreman-agent-v0.9.0",
+				SHA256:        "a" + strings.Repeat("b", 63),
+			},
+		},
+	}
+	kc := newFakeClient(t, existing)
+
+	// Fake applier: signals restarting=true on the first call.
+	applierCalled := false
+	applier := UpdateApplierFunc(func(_, _, _ string) (bool, error) {
+		applierCalled = true
+		return true, nil
+	})
+
+	r := &Registrar{
+		Client:   kc,
+		NodeName: "studio-update",
+		Provider: &fixedCapability{},
+		Interval: 20 * time.Millisecond,
+		Version:  "v0.8.4",
+		Updater:  applier,
+	}
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrSelfUpdateRestart) {
+			t.Fatalf("Run returned %v, want ErrSelfUpdateRestart", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return within 3s after self-update trigger")
+	}
+
+	if !applierCalled {
+		t.Error("UpdateApplier was never called")
+	}
+
+	// Final phase must be Draining (agent told operator it is going away).
+	var got foremanv1alpha1.FleetNode
+	if err := kc.Get(context.Background(), types.NamespacedName{Name: "studio-update"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status.Phase != foremanv1alpha1.FleetNodePhaseDraining {
+		t.Errorf("final phase = %q, want Draining", got.Status.Phase)
+	}
+}
+
+// TestRegistrar_Run_SelfUpdateNilUpdaterNoRestart verifies that when Updater
+// is nil (pre-PR4 / disabled) Run keeps heartbeating normally.
+func TestRegistrar_Run_SelfUpdateNilUpdaterNoRestart(t *testing.T) {
+	existing := &foremanv1alpha1.FleetNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "studio-noupdate"},
+		Spec:       foremanv1alpha1.FleetNodeSpec{NodeName: "studio-noupdate"},
+		Status: foremanv1alpha1.FleetNodeStatus{
+			UpdateRequest: &foremanv1alpha1.FleetNodeUpdateRequest{
+				TargetVersion: "v0.9.0",
+				URL:           "http://example.com/bin",
+				SHA256:        "a" + strings.Repeat("b", 63),
+			},
+		},
+	}
+	kc := newFakeClient(t, existing)
+	r := &Registrar{
+		Client:   kc,
+		NodeName: "studio-noupdate",
+		Provider: &fixedCapability{},
+		Interval: 20 * time.Millisecond,
+		// Updater intentionally nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	// Let a couple of ticks fire without triggering self-update.
+	time.Sleep(60 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned %v, want nil (Updater=nil skips update)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel")
 	}
 }
 

--- a/pkg/selfupdate/install_root_darwin.go
+++ b/pkg/selfupdate/install_root_darwin.go
@@ -1,0 +1,35 @@
+//go:build darwin
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfupdate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// resolveInstallRoot returns ~/Library/Application Support/llmkube/<binaryName>
+// on macOS. The directory is user-owned; no root access is required.
+func resolveInstallRoot(binaryName string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, "Library", "Application Support", "llmkube", binaryName), nil
+}

--- a/pkg/selfupdate/install_root_other.go
+++ b/pkg/selfupdate/install_root_other.go
@@ -1,0 +1,41 @@
+//go:build !darwin
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfupdate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// resolveInstallRoot returns ~/.local/share/llmkube/<binaryName> on Linux
+// and other non-darwin platforms, following the XDG Base Directory
+// Specification. The directory is user-owned; no root access is required.
+func resolveInstallRoot(binaryName string) (string, error) {
+	// Respect XDG_DATA_HOME if set, otherwise default to ~/.local/share.
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+		dataHome = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(dataHome, "llmkube", binaryName), nil
+}

--- a/pkg/selfupdate/updater.go
+++ b/pkg/selfupdate/updater.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package selfupdate performs in-place agent binary replacement. It
+// downloads a new binary, verifies its SHA-256 digest, stages it under
+// a versioned layout, and atomically flips the "current" symlink.
+//
+// RESTART DESIGN: MaybeApply does NOT restart the process. It only stages
+// the new binary and flips the symlink. The caller is responsible for
+// draining traffic and exiting cleanly so that the supervisor (launchd
+// KeepAlive / systemd Restart=always) relaunches the process, which will
+// exec the new binary through the updated "current" symlink.
+//
+// INSTALL ROOT LAYOUT:
+//
+//	<installRoot>/
+//	  versions/
+//	    <version>/
+//	      <binaryName>       (staged binary, chmod 0o755)
+//	  current  -> versions/<latestVersion>   (atomic symlink flip)
+//	  previous -> versions/<priorVersion>    (set on each successful flip)
+//
+// The agent binary is run as: <installRoot>/current/<binaryName>.
+// Self-update only engages when the running executable is under
+// <installRoot>/current; dev builds (e.g. `go run`) are ignored.
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+// Updater performs self-update of a managed binary. Zero value is not
+// usable; construct via struct literal and set all fields.
+type Updater struct {
+	// CurrentVersion is the version string of the currently running binary.
+	// Set from the build-time ldflags var (e.g. "v0.8.4").
+	CurrentVersion string
+
+	// OS and Arch are the platform this binary runs on (runtime.GOOS /
+	// runtime.GOARCH). Informational only; the operator selects the correct
+	// artifact URL before writing UpdateRequest.
+	OS, Arch string
+
+	// InstallRoot is the user-owned directory managed by this Updater.
+	// Conventionally ~/Library/Application Support/llmkube/<binaryName>
+	// on macOS or ~/.local/share/llmkube/<binaryName> on Linux.
+	// Use ResolveInstallRoot to get the platform default.
+	InstallRoot string
+
+	// BinaryName is the name of the executable file (e.g. "foreman-agent").
+	BinaryName string
+
+	// Verifier checks the downloaded artifact before staging. In production
+	// this is &SHA256Verifier{}; tests may inject a fake.
+	Verifier Verifier
+
+	// HTTPClient is used to download the artifact. Defaults to
+	// http.DefaultClient when nil.
+	HTTPClient *http.Client
+
+	// Log is the structured logger. logr.Discard() silences all output.
+	Log logr.Logger
+}
+
+// Target describes the update to apply, sourced from
+// FleetNode.status.updateRequest.
+type Target struct {
+	Version string
+	URL     string
+	SHA256  string
+}
+
+// ApplyResult is returned by MaybeApply.
+type ApplyResult struct {
+	// Restarting is true when the new binary was staged and the current
+	// symlink flipped. The caller should drain and exit; the supervisor
+	// will restart onto the new binary.
+	Restarting bool
+}
+
+// Verifier validates a downloaded artifact at path against an expected digest.
+type Verifier interface {
+	Verify(path, sha256Hex string) error
+}
+
+// SHA256Verifier streams a file and compares its SHA-256 against the
+// expected lowercase hex string.
+type SHA256Verifier struct{}
+
+// Verify computes the SHA-256 of the file at path and returns an error if
+// it does not match expectedHex (case-insensitive, trimmed).
+func (*SHA256Verifier) Verify(path, expectedHex string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hash %s: %w", path, err)
+	}
+
+	got := hex.EncodeToString(h.Sum(nil))
+	want := strings.ToLower(strings.TrimSpace(expectedHex))
+	if got != want {
+		return fmt.Errorf("sha256 mismatch: got %s, want %s", got, want)
+	}
+	return nil
+}
+
+// MaybeApply is a no-op when t.Version is empty or equals CurrentVersion.
+// Otherwise it downloads, verifies, stages, and atomically flips the
+// current symlink. It does NOT restart the process; Restarting=true is
+// the signal for the caller to drain and exit.
+//
+// On SHA-256 mismatch the temp file is deleted and the current symlink
+// is unchanged.
+func (u *Updater) MaybeApply(t Target) (ApplyResult, error) {
+	if t.Version == "" || t.Version == u.CurrentVersion {
+		return ApplyResult{}, nil
+	}
+
+	log := u.Log.WithValues("target", t.Version, "current", u.CurrentVersion)
+	log.Info("self-update: applying", "url", t.URL)
+
+	hc := u.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+
+	// Ensure the install root exists before writing temp files.
+	if err := os.MkdirAll(u.InstallRoot, 0o755); err != nil {
+		return ApplyResult{}, fmt.Errorf("create install root: %w", err)
+	}
+
+	// Download into a temp file INSIDE InstallRoot so os.Rename is on the
+	// same filesystem (avoiding EXDEV cross-device link errors).
+	tmp, err := os.CreateTemp(u.InstallRoot, "tmp-download-*")
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	// Cleanup: delete temp on any error path.
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := u.download(hc, t.URL, tmp); err != nil {
+		_ = tmp.Close()
+		return ApplyResult{}, fmt.Errorf("download %s: %w", t.URL, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return ApplyResult{}, fmt.Errorf("close temp file: %w", err)
+	}
+
+	// Verify before staging.
+	if err := u.Verifier.Verify(tmpPath, t.SHA256); err != nil {
+		return ApplyResult{}, fmt.Errorf("sha256 verify %s: %w", t.Version, err)
+	}
+
+	// Stage: installRoot/versions/<version>/<binaryName>
+	versionDir := filepath.Join(u.InstallRoot, "versions", t.Version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		return ApplyResult{}, fmt.Errorf("create version dir: %w", err)
+	}
+	stagedPath := filepath.Join(versionDir, u.BinaryName)
+	if err := os.Rename(tmpPath, stagedPath); err != nil {
+		return ApplyResult{}, fmt.Errorf("stage binary: %w", err)
+	}
+	success = true                                      // temp file consumed by Rename, no need to delete
+	if err := os.Chmod(stagedPath, 0o755); err != nil { //nolint:gosec // G302: 0755 is required for executable binaries
+		return ApplyResult{}, fmt.Errorf("chmod staged binary: %w", err)
+	}
+
+	// Record the current target as previous before flipping.
+	currentLink := filepath.Join(u.InstallRoot, "current")
+	if target, err := os.Readlink(currentLink); err == nil && target != "" {
+		previousLink := filepath.Join(u.InstallRoot, "previous")
+		// Atomic: write to previous.tmp then rename.
+		prevTmp := filepath.Join(u.InstallRoot, "previous.tmp")
+		if err := os.Symlink(target, prevTmp); err != nil {
+			// If prevTmp already exists, remove it first.
+			_ = os.Remove(prevTmp)
+			if err2 := os.Symlink(target, prevTmp); err2 != nil {
+				return ApplyResult{}, fmt.Errorf("create previous.tmp symlink: %w", err2)
+			}
+		}
+		if err := os.Rename(prevTmp, previousLink); err != nil {
+			_ = os.Remove(prevTmp)
+			return ApplyResult{}, fmt.Errorf("rename previous symlink: %w", err)
+		}
+	}
+
+	// Atomic symlink flip: write current.tmp -> new version dir, then
+	// rename over current. os.Rename is atomic on POSIX for both files
+	// and symlinks when source and destination are on the same filesystem.
+	currentTmp := filepath.Join(u.InstallRoot, "current.tmp")
+	if err := os.Symlink(versionDir, currentTmp); err != nil {
+		_ = os.Remove(currentTmp)
+		if err2 := os.Symlink(versionDir, currentTmp); err2 != nil {
+			return ApplyResult{}, fmt.Errorf("create current.tmp symlink: %w", err2)
+		}
+	}
+	if err := os.Rename(currentTmp, currentLink); err != nil {
+		_ = os.Remove(currentTmp)
+		return ApplyResult{}, fmt.Errorf("flip current symlink: %w", err)
+	}
+
+	log.Info("self-update: staged and symlink flipped; will restart via supervisor")
+	return ApplyResult{Restarting: true}, nil
+}
+
+// download streams the response body from url into dst.
+func (u *Updater) download(hc *http.Client, url string, dst *os.File) error {
+	resp, err := hc.Get(url) //nolint:noctx // URL is operator-provided; no extra cancellation needed
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: unexpected status %d", url, resp.StatusCode)
+	}
+	if _, err := io.Copy(dst, resp.Body); err != nil {
+		return fmt.Errorf("copy body: %w", err)
+	}
+	return nil
+}
+
+// ResolveInstallRoot returns the user-owned default install root for
+// binaryName on the current platform:
+//
+//   - darwin: ~/Library/Application Support/llmkube/<binaryName>
+//   - linux:  ~/.local/share/llmkube/<binaryName>
+//   - other:  ~/.local/share/llmkube/<binaryName>
+func ResolveInstallRoot(binaryName string) (string, error) {
+	return resolveInstallRoot(binaryName)
+}
+
+// resolveInstallRoot is the platform-specific implementation; defined in
+// platform-specific files (install_root_darwin.go, install_root_other.go).
+// Declared here as a forward reference so the package compiles.
+
+// RunningUnderManagedRoot reports whether the current os.Executable()
+// resolves to a path under installRoot/current/. This gates whether
+// self-update should engage: dev builds (go run, `go test`, direct binary)
+// return false and are safely ignored.
+func RunningUnderManagedRoot(installRoot string) bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	// Resolve symlinks so we compare real paths.
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		// If the link can't be resolved the binary may be in a transient
+		// state; treat as not-managed.
+		return false
+	}
+	return execUnderInstallRoot(exe, installRoot)
+}
+
+// ExecUnderInstallRootForTest is a test-only seam that lets unit tests
+// exercise the detection logic without relying on os.Executable().
+func ExecUnderInstallRootForTest(exe, installRoot string) bool {
+	return execUnderInstallRoot(exe, installRoot)
+}
+
+// execUnderInstallRoot checks whether exe is under installRoot/current/.
+func execUnderInstallRoot(exe, installRoot string) bool {
+	currentDir := filepath.Join(installRoot, "current")
+	// Normalize to absolute paths for comparison.
+	absExe, err := filepath.Abs(exe)
+	if err != nil {
+		return false
+	}
+	absCurrent, err := filepath.Abs(currentDir)
+	if err != nil {
+		return false
+	}
+	// Ensure absCurrent has a trailing separator so HasPrefix doesn't
+	// match /foo/current-extra.
+	if !strings.HasSuffix(absCurrent, string(filepath.Separator)) {
+		absCurrent += string(filepath.Separator)
+	}
+	return strings.HasPrefix(absExe, absCurrent)
+}

--- a/pkg/selfupdate/updater_test.go
+++ b/pkg/selfupdate/updater_test.go
@@ -1,0 +1,447 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfupdate_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"github.com/defilantech/llmkube/pkg/selfupdate"
+)
+
+// testBlob is a deterministic fake binary payload.
+const testBlob = "fake-foreman-agent-binary-v0.9.0"
+
+func blobSHA256(content string) string {
+	h := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(h[:])
+}
+
+// newUpdater builds an Updater wired to a temp directory with a httptest server.
+func newUpdater(t *testing.T, srv *httptest.Server, installRoot, binaryName, currentVersion string) *selfupdate.Updater { //nolint:lll,unparam
+	t.Helper()
+	return &selfupdate.Updater{
+		CurrentVersion: currentVersion,
+		OS:             "linux",
+		Arch:           "amd64",
+		InstallRoot:    installRoot,
+		BinaryName:     binaryName,
+		Verifier:       &selfupdate.SHA256Verifier{},
+		HTTPClient:     srv.Client(),
+		Log:            logr.Discard(),
+	}
+}
+
+// TestMaybeApply_NoopWhenVersionMatches ensures no file I/O when the
+// target version equals the running version.
+func TestMaybeApply_NoopWhenVersionMatches(t *testing.T) {
+	dir := t.TempDir()
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, filepath.Join(dir, "foreman-agent"), "foreman-agent", "v0.9.0")
+
+	result, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  blobSHA256(testBlob),
+	})
+	if err != nil {
+		t.Fatalf("MaybeApply: %v", err)
+	}
+	if result.Restarting {
+		t.Error("Restarting = true, want false for same version")
+	}
+	if called {
+		t.Error("HTTP server was called, expected no download for matching version")
+	}
+}
+
+// TestMaybeApply_NoopWhenVersionEmpty ensures no action when Target.Version
+// is empty (no update request present).
+func TestMaybeApply_NoopWhenVersionEmpty(t *testing.T) {
+	dir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("HTTP server should not be called")
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, filepath.Join(dir, "foreman-agent"), "foreman-agent", "v0.9.0")
+
+	result, err := u.MaybeApply(selfupdate.Target{})
+	if err != nil {
+		t.Fatalf("MaybeApply with empty target: %v", err)
+	}
+	if result.Restarting {
+		t.Error("Restarting = true, want false for empty target")
+	}
+}
+
+// TestMaybeApply_HappyPath tests the full successful update flow:
+// download -> verify sha256 -> stage at versions/<v>/<bin> -> flip current symlink.
+func TestMaybeApply_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, testBlob)
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.8.4")
+
+	result, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  blobSHA256(testBlob),
+	})
+	if err != nil {
+		t.Fatalf("MaybeApply: %v", err)
+	}
+	if !result.Restarting {
+		t.Fatal("Restarting = false, want true after successful update")
+	}
+
+	// The staged binary must exist at the versioned path.
+	stagedPath := filepath.Join(installRoot, "versions", "v0.9.0", "foreman-agent")
+	info, err := os.Stat(stagedPath)
+	if err != nil {
+		t.Fatalf("staged binary not found at %s: %v", stagedPath, err)
+	}
+	if info.Mode()&0o755 != 0o755 {
+		t.Errorf("staged binary mode = %o, want at least 0755", info.Mode())
+	}
+
+	// current symlink must resolve to the versioned directory.
+	currentLink := filepath.Join(installRoot, "current")
+	resolved, err := os.Readlink(currentLink)
+	if err != nil {
+		t.Fatalf("current symlink: %v", err)
+	}
+	wantTarget := filepath.Join(installRoot, "versions", "v0.9.0")
+	if resolved != wantTarget {
+		t.Errorf("current -> %q, want %q", resolved, wantTarget)
+	}
+
+	// Binary accessible via current symlink path.
+	viaCurrentPath := filepath.Join(currentLink, "foreman-agent")
+	data, err := os.ReadFile(viaCurrentPath)
+	if err != nil {
+		t.Fatalf("read via current: %v", err)
+	}
+	if string(data) != testBlob {
+		t.Errorf("content via current = %q, want %q", data, testBlob)
+	}
+}
+
+// TestMaybeApply_BadSHA256_Rejected verifies that a checksum mismatch:
+//  1. returns an error,
+//  2. cleans up the temp file,
+//  3. leaves the current symlink UNCHANGED (or absent if no prior version).
+func TestMaybeApply_BadSHA256_Rejected(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	// Pre-seed a prior good version so we can assert the symlink doesn't change.
+	priorVersion := "v0.8.4"
+	priorDir := filepath.Join(installRoot, "versions", priorVersion)
+	if err := os.MkdirAll(priorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	priorBin := filepath.Join(priorDir, "foreman-agent")
+	if err := os.WriteFile(priorBin, []byte("prior-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Create current symlink pointing at prior version.
+	currentLink := filepath.Join(installRoot, "current")
+	if err := os.Symlink(priorDir, currentLink); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, testBlob)
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.8.4")
+
+	_, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  "0000000000000000000000000000000000000000000000000000000000000000", // wrong
+	})
+	if err == nil {
+		t.Fatal("expected error for bad sha256, got nil")
+	}
+	if !strings.Contains(err.Error(), "sha256") {
+		t.Errorf("error %q does not mention sha256", err)
+	}
+
+	// current symlink must still point at prior version.
+	resolved, err2 := os.Readlink(currentLink)
+	if err2 != nil {
+		t.Fatalf("current symlink disappeared: %v", err2)
+	}
+	if resolved != priorDir {
+		t.Errorf("current -> %q after failed update, want %q (prior)", resolved, priorDir)
+	}
+
+	// No temp file should be left behind.
+	entries, _ := os.ReadDir(installRoot)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "tmp-") {
+			t.Errorf("temp file not cleaned up: %s", e.Name())
+		}
+	}
+}
+
+// TestMaybeApply_SecondUpdateSetsPrevious verifies that after a second successful
+// update the "previous" symlink captures the old version directory.
+func TestMaybeApply_SecondUpdateSetsPrevious(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	const blob1 = "binary-v0.9.0"
+	const blob2 = "binary-v0.9.1"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "v0.9.1") {
+			_, _ = fmt.Fprint(w, blob2)
+		} else {
+			_, _ = fmt.Fprint(w, blob1)
+		}
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.8.4")
+
+	// First update: v0.8.4 -> v0.9.0
+	_, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/v0.9.0",
+		SHA256:  blobSHA256(blob1),
+	})
+	if err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+
+	// Simulate the agent having restarted on v0.9.0
+	u.CurrentVersion = "v0.9.0"
+
+	// Second update: v0.9.0 -> v0.9.1
+	_, err = u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.1",
+		URL:     srv.URL + "/v0.9.1",
+		SHA256:  blobSHA256(blob2),
+	})
+	if err != nil {
+		t.Fatalf("second update: %v", err)
+	}
+
+	// current -> v0.9.1
+	currentLink := filepath.Join(installRoot, "current")
+	current, err := os.Readlink(currentLink)
+	if err != nil {
+		t.Fatalf("current symlink: %v", err)
+	}
+	wantCurrent := filepath.Join(installRoot, "versions", "v0.9.1")
+	if current != wantCurrent {
+		t.Errorf("current -> %q, want %q", current, wantCurrent)
+	}
+
+	// previous -> v0.9.0
+	previousLink := filepath.Join(installRoot, "previous")
+	previous, err := os.Readlink(previousLink)
+	if err != nil {
+		t.Fatalf("previous symlink: %v", err)
+	}
+	wantPrevious := filepath.Join(installRoot, "versions", "v0.9.0")
+	if previous != wantPrevious {
+		t.Errorf("previous -> %q, want %q", previous, wantPrevious)
+	}
+}
+
+// TestMaybeApply_AtomicFlip asserts the current symlink is never absent
+// during the flip (atomic rename over current.tmp).
+// We do this by verifying the old symlink exists before and the new one
+// exists after — no moment of absence.
+func TestMaybeApply_AtomicFlip(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	// Pre-seed prior version.
+	priorDir := filepath.Join(installRoot, "versions", "v0.8.4")
+	if err := os.MkdirAll(priorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(priorDir, "foreman-agent"), []byte("prior"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	currentLink := filepath.Join(installRoot, "current")
+	if err := os.Symlink(priorDir, currentLink); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, testBlob)
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.8.4")
+
+	result, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  blobSHA256(testBlob),
+	})
+	if err != nil {
+		t.Fatalf("MaybeApply: %v", err)
+	}
+	if !result.Restarting {
+		t.Fatal("Restarting = false, want true")
+	}
+
+	// After the flip, current.tmp must NOT exist (cleanup check).
+	tmpLink := filepath.Join(installRoot, "current.tmp")
+	if _, err := os.Lstat(tmpLink); err == nil {
+		t.Error("current.tmp was not cleaned up after atomic rename")
+	}
+
+	// current resolves to the new version.
+	resolved, err := os.Readlink(currentLink)
+	if err != nil {
+		t.Fatalf("current symlink: %v", err)
+	}
+	wantNew := filepath.Join(installRoot, "versions", "v0.9.0")
+	if resolved != wantNew {
+		t.Errorf("current -> %q, want %q", resolved, wantNew)
+	}
+}
+
+// TestSHA256Verifier_Accept verifies the real verifier passes a correctly-
+// hashed file.
+func TestSHA256Verifier_Accept(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "blob-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprint(f, testBlob)
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	v := &selfupdate.SHA256Verifier{}
+	if err := v.Verify(f.Name(), blobSHA256(testBlob)); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+}
+
+// TestSHA256Verifier_Reject verifies the real verifier rejects a wrong hash.
+func TestSHA256Verifier_Reject(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "blob-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprint(f, testBlob)
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	v := &selfupdate.SHA256Verifier{}
+	err = v.Verify(f.Name(), "deadbeef00000000000000000000000000000000000000000000000000000000")
+	if err == nil {
+		t.Fatal("expected error for wrong sha256, got nil")
+	}
+}
+
+// TestRunningUnderManagedRoot_False checks that a typical os.Executable()
+// path (e.g. the test binary) is NOT under the managed root.
+func TestRunningUnderManagedRoot_False(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+	if got := selfupdate.RunningUnderManagedRoot(installRoot); got {
+		t.Error("RunningUnderManagedRoot = true for unrelated binary, want false")
+	}
+}
+
+// TestRunningUnderManagedRoot_True verifies detection when the current
+// executable IS under installRoot/current/.
+func TestRunningUnderManagedRoot_True(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	// Build the layout the managed root expects.
+	versionDir := filepath.Join(installRoot, "versions", "v0.9.0")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a placeholder binary.
+	binPath := filepath.Join(versionDir, "foreman-agent")
+	if err := os.WriteFile(binPath, []byte("bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Create installRoot/current -> versionDir
+	currentLink := filepath.Join(installRoot, "current")
+	if err := os.Symlink(versionDir, currentLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// RunningUnderManagedRoot inspects os.Executable(). We can't override
+	// os.Executable in a unit test, so we exercise the helper via the
+	// exported ExecUnderInstallRoot test-seam instead.
+	// If the seam doesn't exist, skip — the integration is tested at the
+	// agent-wiring level.
+	underRoot := selfupdate.ExecUnderInstallRootForTest(filepath.Join(currentLink, "foreman-agent"), installRoot)
+	if !underRoot {
+		t.Error("ExecUnderInstallRootForTest = false for a path under current/")
+	}
+
+	notUnderRoot := selfupdate.ExecUnderInstallRootForTest("/usr/local/bin/foreman-agent", installRoot)
+	if notUnderRoot {
+		t.Error("ExecUnderInstallRootForTest = true for /usr/local/bin path")
+	}
+}
+
+// TestResolveInstallRoot checks the platform-specific default.
+func TestResolveInstallRoot(t *testing.T) {
+	root, err := selfupdate.ResolveInstallRoot("foreman-agent")
+	if err != nil {
+		t.Fatalf("ResolveInstallRoot: %v", err)
+	}
+	if root == "" {
+		t.Fatal("ResolveInstallRoot returned empty string")
+	}
+	// Must contain the binary name.
+	if !strings.Contains(root, "foreman-agent") {
+		t.Errorf("install root %q does not contain binary name", root)
+	}
+}


### PR DESCRIPTION
## What

The capstone of the v1 fleet-update capability: a `pkg/selfupdate` package and the foreman-agent integration that makes an **approved** AgentRelease actually roll the fleet end to end. Closes the loop opened by version observability (#672), the AgentRelease CRD (#674), and the rollout controller (#675).

- **`pkg/selfupdate`**: `Updater.MaybeApply(target)` downloads the artifact to a temp file inside the install root (same filesystem), verifies its SHA256 (the operator-approved value is the trust anchor; cosign is v1.1), stages it to `versions/<v>/<binary>`, atomically flips a `current` symlink, and records `previous` for manual rollback. A bad checksum leaves `current` untouched. It does not restart the process; it returns `Restarting:true`.
- **foreman-agent**: on each heartbeat it reads `FleetNode.status.updateRequest`; when a new version is requested it applies the update, emits a `Draining` heartbeat, and exits cleanly. The launchd/systemd supervisor relaunches the process onto the new `current` symlink. Crucially, no `Ready` heartbeat is sent between the symlink flip and exit, so the rollout's soak gate never sees the old version reported Ready post-flip.
- **Safety gates**: self-update only engages when the agent is actually running under the managed install root (`RunningUnderManagedRoot`) and the `--self-update` flag is on (default true); `go run`/dev invocations are a safe no-op.
- **Install scaffolding (user-owned, no root)**: a foreman-agent LaunchAgent plist + `make install-foreman-agent` laying out `~/Library/Application Support/llmkube/foreman-agent/{versions,current,previous}`, and a user systemd unit for the future Linux path. Also fixes `make install-metal-agent`'s `launchctl load` (a no-op on an already-loaded service) to `kickstart -k` so manual reinstalls actually pick up the new binary.

## Why

This is what turns the declarative rollout engine into a real managed update: the exact pain from deploying 0.8.4 (manual per-node `make install`, the launchd-load no-op leaving stale processes) is now an `AgentRelease` you approve and a controller that drives it safely.

## How / notes for review

- macOS restart uses `KeepAlive=true` (launchd relaunches on any exit, including the clean exit(0) self-update); intentional stop is `launchctl bootout`. systemd uses `Restart=always`. (An earlier draft used `SuccessfulExit=false`, which restarts only on non-zero exit and would have left the agent down after a clean self-update — fixed.)
- 11 `pkg/selfupdate` unit tests (httptest + tmpdir + real SHA256Verifier): no-op on version match, happy stage+flip, bad-SHA256 leaves `current` unchanged + cleans temp, `previous` set on second update, atomic flip, managed-root detection both directions. Plus agent tests for the drain-then-restart sentinel and the nil-updater no-op path.
- Follow-up (filed separately, non-blocking): bound the artifact download size, and GC old `versions/<v>/` dirs on long-lived nodes.

## Checklist

- [x] Full `make test` green (pkg/selfupdate + existing suites incl. controllers)
- [x] `make fmt vet lint` clean, plus `GOOS=linux golangci-lint run ./...` (selfupdate builds for linux via the darwin/other build-tag split)
- [x] No CRD/manifest drift; no RBAC change
- [x] DCO sign-off on all commits
