### PR TITLE
ci: sign off release-please commits so release PRs pass DCO

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
+  "signoff": "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>",
   "packages": {
     ".": {
       "component": "",


### PR DESCRIPTION
## What

Adds a top-level `signoff` to `release-please-config.json` so release-please appends a `Signed-off-by:` trailer to the release commits it authors.

## Why

The DCO workflow (`.github/workflows/dco.yml`) requires `Signed-off-by: … <…@…>` on **every** commit in a PR and has no bot exemption. The `github-actions[bot]` release commit has never carried a sign-off, so every `chore: release` PR fails the DCO check — 0.8.4's release PR (#665) failed it and was merged via admin bypass. With `signoff` set, release-please stamps the trailer on its commit and the DCO check passes cleanly, so release PRs no longer need the bypass.

## How

`"signoff": "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"` (the bot's actual commit identity, so the trailer matches the author and the dco.yml regex `^Signed-off-by: .* <.*@.*>`). Verified `signoff` is a valid top-level key against the release-please config schema referenced in the file.

After this merges, release-please updates the open 0.8.5 release PR (#673) with a signed commit on its next run; the DCO check on it then goes green.

## Checklist

- [x] Valid JSON; `signoff` confirmed against the release-please schema
- [x] DCO sign-off on this commit
