### PR TITLE
fix(selfupdate): resolve current symlink in managed-root detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,10 +209,15 @@ install-foreman-agent: build-foreman-agent-versioned ## Install foreman-agent in
 	mkdir -p "$(FOREMAN_INSTALL_ROOT)/versions/$(FOREMAN_AGENT_VERSION)"
 	cp bin/foreman-agent "$(FOREMAN_INSTALL_ROOT)/versions/$(FOREMAN_AGENT_VERSION)/foreman-agent"
 	chmod 0755 "$(FOREMAN_INSTALL_ROOT)/versions/$(FOREMAN_AGENT_VERSION)/foreman-agent"
-	@# Atomically flip the current symlink (write temp then rename, POSIX-atomic).
+	@# Flip the current symlink. `ln -sfn` replaces the link in place; -n keeps
+	@# it from following an existing current -> versions/<v> symlink. The old
+	@# "ln to current.tmp then mv -f current.tmp current" form was broken on
+	@# re-install: when current already points at a directory, mv descends INTO
+	@# that directory instead of replacing the link, so the flip silently no-ops
+	@# and the agent keeps running the previous version. (The self-update code
+	@# path uses os.Rename, which replaces the symlink atomically and is correct.)
 	@ln -sfn "$(FOREMAN_INSTALL_ROOT)/versions/$(FOREMAN_AGENT_VERSION)" \
-		"$(FOREMAN_INSTALL_ROOT)/current.tmp"
-	@mv -f "$(FOREMAN_INSTALL_ROOT)/current.tmp" "$(FOREMAN_INSTALL_ROOT)/current"
+		"$(FOREMAN_INSTALL_ROOT)/current"
 	@echo "Staged at $(FOREMAN_INSTALL_ROOT)/current -> versions/$(FOREMAN_AGENT_VERSION)"
 	@echo "Installing launchd service..."
 	@# Substitute YOUR_USERNAME placeholder with the real home directory path.

--- a/pkg/selfupdate/updater.go
+++ b/pkg/selfupdate/updater.go
@@ -304,6 +304,22 @@ func execUnderInstallRoot(exe, installRoot string) bool {
 	if err != nil {
 		return false
 	}
+	// Resolve symlinks on BOTH sides before comparing. The managed layout
+	// points `current` at `versions/<v>` via a symlink, and the supervisor
+	// execs the binary through current/, so os.Executable() resolves (in
+	// RunningUnderManagedRoot) to versions/<v>/<binary>. Comparing that
+	// resolved exe against the literal current/ prefix never matches, which
+	// silently disabled self-update on every real managed install. Resolving
+	// `current` here makes both sides land on the same real versions/<v> path.
+	// EvalSymlinks fails for a non-existent path (e.g. an unrelated
+	// /usr/local/bin binary in tests); in that case we keep the absolute path
+	// and the prefix check still rejects it.
+	if resolved, rerr := filepath.EvalSymlinks(absExe); rerr == nil {
+		absExe = resolved
+	}
+	if resolved, rerr := filepath.EvalSymlinks(absCurrent); rerr == nil {
+		absCurrent = resolved
+	}
 	// Ensure absCurrent has a trailing separator so HasPrefix doesn't
 	// match /foo/current-extra.
 	if !strings.HasSuffix(absCurrent, string(filepath.Separator)) {

--- a/pkg/selfupdate/updater_test.go
+++ b/pkg/selfupdate/updater_test.go
@@ -431,6 +431,40 @@ func TestRunningUnderManagedRoot_True(t *testing.T) {
 	}
 }
 
+// TestExecUnderInstallRoot_ResolvedCurrentSymlink reproduces the production
+// flow that the literal-path test above missed: launchd/systemd exec the
+// binary through installRoot/current/<binary>, and RunningUnderManagedRoot
+// symlink-resolves os.Executable() to its real path under versions/<v>/ before
+// the check. The detector must therefore resolve the current symlink too;
+// without that, the resolved exe never matches the literal current/ prefix and
+// self-update is silently disabled on every real managed install.
+func TestExecUnderInstallRoot_ResolvedCurrentSymlink(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	versionDir := filepath.Join(installRoot, "versions", "v0.9.0")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "foreman-agent"), []byte("bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(versionDir, filepath.Join(installRoot, "current")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mimic RunningUnderManagedRoot: resolve the exe's symlinks (current ->
+	// versions/v0.9.0) exactly as os.Executable()+EvalSymlinks would in prod.
+	resolvedExe, err := filepath.EvalSymlinks(filepath.Join(installRoot, "current", "foreman-agent"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !selfupdate.ExecUnderInstallRootForTest(resolvedExe, installRoot) {
+		t.Errorf("ExecUnderInstallRootForTest(resolved exe) = false, want true; resolvedExe=%s installRoot=%s", resolvedExe, installRoot)
+	}
+}
+
 // TestResolveInstallRoot checks the platform-specific default.
 func TestResolveInstallRoot(t *testing.T) {
 	root, err := selfupdate.ResolveInstallRoot("foreman-agent")

--- a/pkg/selfupdate/updater_test.go
+++ b/pkg/selfupdate/updater_test.go
@@ -461,7 +461,8 @@ func TestExecUnderInstallRoot_ResolvedCurrentSymlink(t *testing.T) {
 	}
 
 	if !selfupdate.ExecUnderInstallRootForTest(resolvedExe, installRoot) {
-		t.Errorf("ExecUnderInstallRootForTest(resolved exe) = false, want true; resolvedExe=%s installRoot=%s", resolvedExe, installRoot)
+		t.Errorf("ExecUnderInstallRootForTest(resolved exe) = false, want true; "+
+			"resolvedExe=%s installRoot=%s", resolvedExe, installRoot)
 	}
 }
 


### PR DESCRIPTION
## What

Two fixes to the foreman-agent managed-install / self-update symlink handling:

1. **self-update managed-root detection** now engages when the agent runs from the managed `current -> versions/<v>` symlink layout.
2. **`install-foreman-agent` Makefile target** now actually re-flips the `current` symlink on re-install.

## Why

**(1) Detection bug.** Every agent running from the user-owned managed layout logged `self-update disabled: not running from managed install root` at startup, even when running from `current/`. The v1 fleet-update path (#672/#674/#675/#676) therefore never engaged outside unit tests.

Root cause in `pkg/selfupdate/updater.go`: `RunningUnderManagedRoot` symlink-resolves `os.Executable()` (so the exe becomes `<root>/versions/<v>/<binary>`), but `execUnderInstallRoot` then checks `HasPrefix(absExe, <root>/current/)`. The sides are resolved asymmetrically: the exe resolves to `versions/<v>/`, the comparison prefix stays the literal `current/`, so it never matches and self-update is silently disabled. The pre-existing `TestRunningUnderManagedRoot_True` masked this by feeding an unresolved `current/<binary>` path, never exercising the production resolve step.

**(2) Makefile re-flip bug.** `install-foreman-agent` flipped `current` with `ln -sfn ... current.tmp` then `mv -f current.tmp current`. On a re-install `current` already points at `versions/<old>` (a directory), and `mv` descends INTO that directory instead of replacing the link, so the flip silently no-ops and the agent keeps execing the previous version. (Found while staging the live test below.)

## How

- `execUnderInstallRoot`: resolve the `current` symlink on the comparison side too (best-effort `filepath.EvalSymlinks`, with a fall-through that keeps the absolute path so unrelated paths like `/usr/local/bin/...` are still rejected). Both sides now land on the same real `versions/<v>` path.
- Add `TestExecUnderInstallRoot_ResolvedCurrentSymlink`, which builds a real `current -> versions/<v>` symlink layout and resolves the exe the way `RunningUnderManagedRoot` does. It fails against the old logic and passes with the fix.
- `install-foreman-agent`: replace the temp+`mv` flip with a direct `ln -sfn <target> current` (`-n` prevents following the existing symlink). The self-update code path already uses `os.Rename`, which replaces the symlink atomically and is unaffected.

**Verified live** on a Shadowstack FleetNode: a patched agent logged `self-update enabled` and completed a full AgentRelease rollout end-to-end (AwaitingApproval -> approve -> download/SHA256-verify/stage/symlink-flip/drain/restart -> health gate -> `Succeeded`), with the FleetNode transitioning to the target version and the release reporting `Complete=True(AllNodesUpdated)`.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go test ./pkg/selfupdate/` green; new test fails without the fix)
- [x] gofmt + `go vet` clean
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated (no user-facing doc change)