### PR TITLE
build: version-stamp metal-agent + ship darwin foreman-agent archive

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -102,11 +102,13 @@ builds:
       - -X main.GitCommit={{.FullCommit}}
       - -X main.BuildDate={{.Date}}
 
-    # Linux containers only (the foreman-agent Linux Pod is
-    # Linux; the M5 Max + Mac Studio run from `go install` or a
-    # launchd-managed local binary, not the ghcr image).
+    # linux: the in-cluster foreman-agent Pod (consumed by the docker
+    # images below). darwin: the M5 Max + Mac Studio native agents, shipped
+    # as a release archive so Mac bootstraps and AgentRelease self-update
+    # artifacts can be download-based instead of build-from-source.
     goos:
       - linux
+      - darwin
 
     goarch:
       - amd64
@@ -164,6 +166,22 @@ archives:
       - README.md
       - examples/metal-quickstart/*
       - deployment/macos/*
+
+  - id: llmkube-foreman-agent
+    builds:
+      - llmkube-foreman-agent
+
+    # Archive name template. Produces darwin (Mac native agents) and linux
+    # (edge nodes) archives; the linux foreman-agent Pod still ships as a
+    # ghcr image via the dockers section below.
+    name_template: "{{ .ProjectName }}-foreman-agent_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+    # Files to include
+    files:
+      - LICENSE
+      - README.md
+      - deployment/macos/*
+      - deployment/linux/*
 
 checksum:
   name_template: "checksums.txt"

--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,18 @@ install-cli: build-cli ## Install llmkube CLI to /usr/local/bin (requires sudo).
 
 ##@ Metal Agent (macOS only)
 
+# METAL_AGENT_VERSION is stamped into the ldflags Version variable. Defaults to
+# the git-describe tag (matching build-foreman-agent-versioned); override on the
+# command line when releasing, e.g. `make build-metal-agent METAL_AGENT_VERSION=0.8.6`.
+METAL_AGENT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+
 .PHONY: build-metal-agent
 build-metal-agent: fmt vet ## Build Metal agent for macOS (requires macOS).
-	@echo "Building Metal agent for macOS..."
+	@echo "Building Metal agent for macOS ($(METAL_AGENT_VERSION))..."
 	GOOS=darwin GOARCH=$(shell uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/') \
-		go build -o bin/llmkube-metal-agent ./cmd/metal-agent
+		go build \
+		-ldflags "-X main.Version=$(METAL_AGENT_VERSION) -X main.GitCommit=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown) -X main.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		-o bin/llmkube-metal-agent ./cmd/metal-agent
 
 # LLMKUBE_METAL_AGENT_LABEL is the launchd service label for metal-agent.
 LLMKUBE_METAL_AGENT_LABEL ?= com.llmkube.metal-agent


### PR DESCRIPTION
## What

Two build-plumbing fixes so the fleet-update redeploy (and AgentRelease self-update artifacts) are versioned and download-based instead of build-from-source.

## Why

Surfaced during the 0.8.5 fleet redeploy:
1. `make build-metal-agent` had no `-ldflags`, so `make install-metal-agent` always stamped `Version="dev"` and the metal-agent's `llmkube.ai/agent-version` Endpoint annotation was wrong for local installs. (#681)
2. goreleaser built `foreman-agent` for linux only (the in-cluster Pod image), so there was no downloadable macOS binary: every Mac install was build-from-source and AgentRelease `artifacts[].url` had no first-party darwin binary to point at. (#682)

## How

- **Makefile (#681):** add `METAL_AGENT_VERSION` (defaults to `git describe`, overridable) and stamp `main.Version/GitCommit/BuildDate` in `build-metal-agent`, mirroring `build-foreman-agent-versioned`. Verified: `make build-metal-agent METAL_AGENT_VERSION=0.8.6-test` produces a binary reporting `0.8.6-test`.
- **goreleaser (#682):** add `darwin` to the `llmkube-foreman-agent` build goos and a matching `archives` entry, producing `foreman-agent` darwin + linux tarballs. The linux Pod still ships as a ghcr image via the unchanged `dockers` section. The new archive follows the existing `builds:` pattern used by the cli/metal-agent archives. Verified with `goreleaser check`: configuration is valid (the only warnings are pre-existing deprecations shared by all archives/dockers, not introduced here).

## Checklist

- [x] `make build-metal-agent` verified (stamps real version)
- [x] `goreleaser check` passes (config valid; pre-existing deprecations only)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated (no user-facing doc change)

Fixes #681
Fixes #682