### PR TITLE
chore(metal): migrate Endpoints to discovery/v1 EndpointSlice

### DIFF
--- a/charts/foreman/templates/agent-rbac.yaml
+++ b/charts/foreman/templates/agent-rbac.yaml
@@ -44,12 +44,12 @@ rules:
 
   # When --inference-base-url-host-override is set (off-cluster,
   # same-host installs), the native executor reads the live llama-
-  # server port from the v1 Endpoints object the metal-agent maintains
-  # for each InferenceService. The controller-runtime cache backs this
-  # with a watch so a respawn-driven port roll is picked up on the
-  # next task dispatch (#540).
-  - apiGroups: [""]
-    resources: ["endpoints"]
+  # server port from the EndpointSlice the metal-agent maintains for
+  # each InferenceService. The controller-runtime cache backs this with
+  # a watch so a respawn-driven port roll is picked up on the next task
+  # dispatch (#540).
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
 
   # When an Agent's spec.provider is "cloud-proxy" (v0.2), the

--- a/charts/llmkube/templates/clusterrole.yaml
+++ b/charts/llmkube/templates/clusterrole.yaml
@@ -22,10 +22,17 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
   - nodes
   - pods
   - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,7 +20,13 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   - pods
   - secrets
@@ -28,13 +34,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 - apiGroups:
   - ""
   resources:
@@ -69,6 +68,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - foreman.llmkube.dev

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,7 +99,7 @@ func initContainerSecurityContext(isvc *inferencev1alpha1.InferenceService) *cor
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=get;list;watch
@@ -363,26 +364,26 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 	return service, nil, nil
 }
 
-// metalHeartbeatKind classifies the heartbeat annotation on a metal Endpoints
-// object so that callers can produce appropriately differentiated status
-// messages without re-fetching the Endpoints.
+// metalHeartbeatKind classifies the heartbeat annotation on a metal
+// EndpointSlice so that callers can produce appropriately differentiated status
+// messages without re-listing the slices.
 type metalHeartbeatKind int
 
 const (
-	// metalHBNone: no Endpoints object exists yet (agent has not registered).
+	// metalHBNone: no EndpointSlice exists yet (agent has not registered).
 	metalHBNone metalHeartbeatKind = iota
-	// metalHBLegacy: Endpoints exist but carry no heartbeat annotation (older agent).
+	// metalHBLegacy: slices exist but carry no heartbeat annotation (older agent).
 	metalHBLegacy
-	// metalHBFresh: Endpoints exist with a current, valid heartbeat.
+	// metalHBFresh: slices exist with a current, valid heartbeat.
 	metalHBFresh
-	// metalHBStale: Endpoints exist but the heartbeat timestamp has expired.
+	// metalHBStale: slices exist but the heartbeat timestamp has expired.
 	metalHBStale
-	// metalHBUnparseable: Endpoints exist but the heartbeat annotation cannot be parsed.
+	// metalHBUnparseable: slices exist but the heartbeat annotation cannot be parsed.
 	metalHBUnparseable
 )
 
-// metalSnapshot captures the result of a single Endpoints fetch for the metal
-// path. It is produced by metalEndpointSnapshot and consumed by
+// metalSnapshot captures the result of a single EndpointSlice list for the
+// metal path. It is produced by metalEndpointSnapshot and consumed by
 // determinePhase and metalHeartbeatRequeueDuration, eliminating the second Get
 // that the old metalHeartbeatRequeue performed.
 type metalSnapshot struct {
@@ -394,65 +395,103 @@ type metalSnapshot struct {
 	ParseErr error
 }
 
-// metalEndpointSnapshot fetches the Endpoints for isvc once and returns a
+// metalEndpointSnapshot lists the EndpointSlices for isvc and returns a
 // metalSnapshot summarising both the ready-replica count and the heartbeat
 // state. It is the single source of truth for the metal path; both
 // metalReadyEndpoints and metalHeartbeatRequeueDuration are thin wrappers
 // around it.
 //
-// We read core/v1 Endpoints (deprecated in k8s v1.33+) rather than
-// discovery/v1 EndpointSlice because pkg/agent/registry.go still creates
-// Endpoints. Migrating both producer and consumer to EndpointSlice is tracked
-// as a follow-up; doing it in this PR would balloon scope.
-//
-//nolint:staticcheck // SA1019: see comment above; agent and controller migrate together
+// Slices are listed by the well-known kubernetes.io/service-name label rather
+// than fetched by name because there can be more than one: the metal-agent
+// produces one directly, and Kubernetes' EndpointSliceMirroring controller may
+// produce another from a legacy Endpoints object during a mid-upgrade window.
+// When multiple slices carry a heartbeat annotation we classify against the
+// freshest one. Mirrored slices have no heartbeat annotation, so an upgrade
+// window degrades gracefully to the legacy-exempt path.
 func (r *InferenceServiceReconciler) metalEndpointSnapshot(ctx context.Context, isvc *inferencev1alpha1.InferenceService) *metalSnapshot {
 	log := logf.FromContext(ctx)
-	endpoints := &corev1.Endpoints{}
 	name := sanitizeDNSName(isvc.Name)
-	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: isvc.Namespace}, endpoints)
+	slices := &discoveryv1.EndpointSliceList{}
+	err := r.List(ctx, slices,
+		client.InNamespace(isvc.Namespace),
+		client.MatchingLabels{"kubernetes.io/service-name": name},
+	)
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Error(err, "Failed to get Endpoints for metal accelerator", "name", name)
-		}
+		log.Error(err, "Failed to list EndpointSlices for metal accelerator", "name", name)
+		return &metalSnapshot{Kind: metalHBNone}
+	}
+	if len(slices.Items) == 0 {
 		return &metalSnapshot{Kind: metalHBNone}
 	}
 
-	raw, hasAnnotation := endpoints.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat]
-	if hasAnnotation {
+	// Pick the freshest heartbeat across all slices. A slice without the
+	// annotation contributes to the count but not to heartbeat freshness.
+	var (
+		rawHeartbeat   string
+		hasAnnotation  bool
+		freshestTS     time.Time
+		freshestParsed bool
+		parseErr       error
+		parseErrRaw    string
+	)
+	for i := range slices.Items {
+		raw, ok := slices.Items[i].Annotations[inferencev1alpha1.AnnotationAgentHeartbeat]
+		if !ok {
+			continue
+		}
+		hasAnnotation = true
 		ts, perr := time.Parse(time.RFC3339, raw)
 		if perr != nil {
-			log.Info("Metal endpoint heartbeat annotation unparseable; treating as not ready",
-				"name", name, "heartbeat", raw, "parseError", perr)
-			return &metalSnapshot{Kind: metalHBUnparseable, RawHeartbeat: raw, ParseErr: perr}
+			// Remember the first unparseable value but keep scanning: a
+			// sibling slice may carry a parseable, fresher heartbeat.
+			if parseErr == nil {
+				parseErr = perr
+				parseErrRaw = raw
+			}
+			continue
 		}
-		age := time.Since(ts)
-		if age > inferencev1alpha1.DefaultAgentHeartbeatTimeout {
-			log.Info("Metal endpoint heartbeat stale; treating as not ready",
-				"name", name, "heartbeat", raw, "age", age.Round(time.Second), "timeout", inferencev1alpha1.DefaultAgentHeartbeatTimeout)
-			return &metalSnapshot{Kind: metalHBStale, RawHeartbeat: raw}
+		if !freshestParsed || ts.After(freshestTS) {
+			freshestTS = ts
+			freshestParsed = true
+			rawHeartbeat = raw
 		}
 	}
-	// No annotation: legacy agent without heartbeats; fall through and count.
+
+	switch {
+	case freshestParsed:
+		// At least one parseable heartbeat: classify against the freshest.
+		age := time.Since(freshestTS)
+		if age > inferencev1alpha1.DefaultAgentHeartbeatTimeout {
+			log.Info("Metal endpoint heartbeat stale; treating as not ready",
+				"name", name, "heartbeat", rawHeartbeat, "age", age.Round(time.Second), "timeout", inferencev1alpha1.DefaultAgentHeartbeatTimeout)
+			return &metalSnapshot{Kind: metalHBStale, RawHeartbeat: rawHeartbeat}
+		}
+	case hasAnnotation:
+		// Every heartbeat annotation present was unparseable.
+		log.Info("Metal endpoint heartbeat annotation unparseable; treating as not ready",
+			"name", name, "heartbeat", parseErrRaw, "parseError", parseErr)
+		return &metalSnapshot{Kind: metalHBUnparseable, RawHeartbeat: parseErrRaw, ParseErr: parseErr}
+	}
+	// No annotation on any slice: legacy agent without heartbeats; fall
+	// through and count.
 
 	var ready int32
-	for _, subset := range endpoints.Subsets {
-		// In a kind/k8s cluster the agent typically registers a small handful
-		// of addresses (one per host-mode replica). Cap the per-subset count
-		// well below int32 max so the conversion is guaranteed safe even if a
-		// pathological Endpoints object lands in the cache.
-		n := len(subset.Addresses)
-		if n > 1<<20 {
-			n = 1 << 20
+	for i := range slices.Items {
+		for j := range slices.Items[i].Endpoints {
+			cond := slices.Items[i].Endpoints[j].Conditions.Ready
+			if cond == nil || *cond {
+				// Ready==nil is treated as ready, matching the EndpointSlice
+				// convention that an absent condition means "ready".
+				ready += int32(len(slices.Items[i].Endpoints[j].Addresses)) //nolint:gosec // one address per metal endpoint; bounded
+			}
 		}
-		ready += int32(n) //nolint:gosec // bounded above
 	}
 
 	kind := metalHBLegacy
 	if hasAnnotation {
 		kind = metalHBFresh
 	}
-	return &metalSnapshot{ReadyReplicas: ready, Kind: kind, RawHeartbeat: raw}
+	return &metalSnapshot{ReadyReplicas: ready, Kind: kind, RawHeartbeat: rawHeartbeat}
 }
 
 // metalReadyEndpoints is a convenience wrapper that returns only the
@@ -466,11 +505,11 @@ func (r *InferenceServiceReconciler) metalReadyEndpoints(ctx context.Context, is
 // a successful metal reconcile. It operates on the already-fetched metalSnapshot
 // so no additional API call is needed.
 //
-// When the Endpoints carry a heartbeat annotation (fresh or stale) the
+// When the slices carry a heartbeat annotation (fresh or stale) the
 // reconciler must periodically re-check staleness because no watch event fires
 // when a heartbeat simply ages out. We return half the timeout so we notice
 // expiry within one extra interval. Legacy agents (no annotation) and
-// not-yet-registered services (no Endpoints) need no forced requeue.
+// not-yet-registered services (no slices) need no forced requeue.
 func metalHeartbeatRequeueDuration(snap *metalSnapshot) time.Duration {
 	if snap == nil {
 		return 0
@@ -528,28 +567,41 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.findInferenceServicesForModel),
 		).
 		Watches(
-			&corev1.Endpoints{}, //nolint:staticcheck // SA1019: the metal-agent registers v1 Endpoints; EndpointSlice migration is tracked separately
+			&discoveryv1.EndpointSlice{},
 			handler.EnqueueRequestsFromMapFunc(r.findInferenceServiceForEndpoints),
 		).
 		Named("inferenceservice").
 		Complete(r)
 }
 
-// findInferenceServiceForEndpoints enqueues the InferenceService that a set of
-// Endpoints belongs to. On the Metal path there is no Deployment or Pod, so
-// the Pod watch never fires; the metal-agent signals readiness by creating a
-// v1 Endpoints object named after the InferenceService. Without this watch a
-// Metal service stays Creating until the next periodic resync. Only the
-// agent's own Endpoints are considered: the Deployment path is already
-// covered by the Pod watch.
+// findInferenceServiceForEndpoints enqueues the InferenceService that an
+// EndpointSlice belongs to. On the Metal path there is no Deployment or Pod, so
+// the Pod watch never fires; the metal-agent signals readiness by creating an
+// EndpointSlice named after the InferenceService. Without this watch a Metal
+// service stays Creating until the next periodic resync.
+//
+// The InferenceService name is derived from the kubernetes.io/service-name
+// label (== sanitizeDNSName(isvc.Name)) rather than the slice's own name,
+// because a slice produced by the EndpointSliceMirroring controller during an
+// upgrade window has a generated name (<service>-<hash>) and only carries the
+// service-name label, not our managed-by label. Either of those labels is
+// enough to recognise a metal slice and route it back to its service.
 func (r *InferenceServiceReconciler) findInferenceServiceForEndpoints(ctx context.Context, obj client.Object) []reconcile.Request {
-	if obj.GetLabels()["llmkube.ai/managed-by"] != "metal-agent" {
+	labels := obj.GetLabels()
+	svcName := labels["kubernetes.io/service-name"]
+	if labels["llmkube.ai/managed-by"] != "metal-agent" && svcName == "" {
 		return nil
+	}
+	// Prefer the service-name label (covers both our own and mirrored slices);
+	// fall back to the object name for an agent slice that predates the label.
+	name := svcName
+	if name == "" {
+		name = obj.GetName()
 	}
 	return []reconcile.Request{
 		{
 			NamespacedName: types.NamespacedName{
-				Name:      obj.GetName(),
+				Name:      name,
 				Namespace: obj.GetNamespace(),
 			},
 		},

--- a/internal/controller/inferenceservice_metal_heartbeat_test.go
+++ b/internal/controller/inferenceservice_metal_heartbeat_test.go
@@ -23,39 +23,48 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
 
-// metalEndpoints builds a corev1.Endpoints fixture for the metal-agent path.
-// name must be the sanitized InferenceService name (dots replaced by hyphens).
+// metalEndpoints builds a discovery/v1 EndpointSlice fixture for the metal-agent
+// path. name must be the sanitized InferenceService name (dots replaced by
+// hyphens); it is used both as the slice name and as the required
+// kubernetes.io/service-name label so the consumer's list-by-label finds it.
 // heartbeat is stamped as the AnnotationAgentHeartbeat annotation when non-empty.
-//
-//nolint:staticcheck // SA1019: v1 Endpoints; see metalReadyEndpoints comment
-func metalEndpoints(name, heartbeat string) *corev1.Endpoints {
-	ep := &corev1.Endpoints{
+func metalEndpoints(name, heartbeat string) *discoveryv1.EndpointSlice {
+	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "default",
 			Labels: map[string]string{
-				"llmkube.ai/managed-by": "metal-agent",
+				"kubernetes.io/service-name": name,
+				"llmkube.ai/managed-by":      "metal-agent",
 			},
 		},
-		Subsets: []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{IP: "192.0.2.10"}},
-			Ports:     []corev1.EndpointPort{{Port: 50051, Name: "http", Protocol: corev1.ProtocolTCP}},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses:  []string{"192.0.2.10"},
+			Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+		}},
+		Ports: []discoveryv1.EndpointPort{{
+			Name:     ptr.To("http"),
+			Port:     ptr.To(int32(50051)),
+			Protocol: ptr.To(corev1.ProtocolTCP),
 		}},
 	}
 	if heartbeat != "" {
-		ep.Annotations = map[string]string{
+		slice.Annotations = map[string]string{
 			inferencev1alpha1.AnnotationAgentHeartbeat: heartbeat,
 		}
 	}
-	return ep
+	return slice
 }
 
 var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
@@ -174,9 +183,9 @@ var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
 				_ = k8sClient.Delete(ctx, model)
 			}
 
-			ep := &corev1.Endpoints{} //nolint:staticcheck
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, ep); err == nil {
-				_ = k8sClient.Delete(ctx, ep)
+			slice := &discoveryv1.EndpointSlice{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, slice); err == nil {
+				_ = k8sClient.Delete(ctx, slice)
 			}
 		})
 
@@ -242,9 +251,9 @@ var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
 				_ = k8sClient.Delete(ctx, model)
 			}
 
-			ep := &corev1.Endpoints{} //nolint:staticcheck
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, ep); err == nil {
-				_ = k8sClient.Delete(ctx, ep)
+			slice := &discoveryv1.EndpointSlice{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: namespace}, slice); err == nil {
+				_ = k8sClient.Delete(ctx, slice)
 			}
 		})
 

--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -25,8 +25,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -34,6 +36,35 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// metalEndpointSliceFixture builds an EndpointSlice the metal-agent would
+// register for isvcName with the given ready addresses, labeled so the
+// controller's list-by-service-name finds it.
+func metalEndpointSliceFixture(isvcName string, addresses ...string) *discoveryv1.EndpointSlice {
+	eps := make([]discoveryv1.Endpoint, 0, len(addresses))
+	for _, a := range addresses {
+		eps = append(eps, discoveryv1.Endpoint{
+			Addresses:  []string{a},
+			Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+		})
+	}
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      isvcName,
+			Namespace: "default",
+			Labels: map[string]string{
+				"kubernetes.io/service-name": isvcName,
+				"llmkube.ai/managed-by":      "metal-agent",
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints:   eps,
+		Ports: []discoveryv1.EndpointPort{{
+			Port:     ptr.To(int32(8080)),
+			Protocol: ptr.To(corev1.ProtocolTCP),
+		}},
+	}
+}
 
 var _ = Describe("InferenceService Controller", func() {
 	Context("When reconciling a resource", func() {
@@ -593,20 +624,12 @@ var _ = Describe("Reconcile lifecycle", func() {
 				_ = k8sClient.Delete(ctx, isvc)
 			}()
 
-			// Simulate the metal-agent registering Endpoints once llama-server
-			// is healthy. core/v1 Endpoints is deprecated in k8s v1.33+, but
-			// pkg/agent/registry.go still uses it; migration to EndpointSlice
-			// is tracked as a follow-up to this PR.
-			endpoints := &corev1.Endpoints{ //nolint:staticcheck // SA1019: agent + controller migrate together
-				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
-				Subsets: []corev1.EndpointSubset{{ //nolint:staticcheck // SA1019: same
-					Addresses: []corev1.EndpointAddress{{IP: "192.0.2.10"}},
-					Ports:     []corev1.EndpointPort{{Port: 8080, Protocol: corev1.ProtocolTCP}},
-				}},
-			}
-			Expect(k8sClient.Create(ctx, endpoints)).To(Succeed())
+			// Simulate the metal-agent registering an EndpointSlice once
+			// llama-server is healthy.
+			slice := metalEndpointSliceFixture(isvcName, "192.0.2.10")
+			Expect(k8sClient.Create(ctx, slice)).To(Succeed())
 			defer func() {
-				_ = k8sClient.Delete(ctx, endpoints)
+				_ = k8sClient.Delete(ctx, slice)
 			}()
 
 			reconciler := &InferenceServiceReconciler{
@@ -858,15 +881,9 @@ var _ = Describe("Reconcile lifecycle", func() {
 			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
 
 			// Simulate the metal-agent registering 2 ready endpoints
-			endpoints := &corev1.Endpoints{ //nolint:staticcheck // SA1019: agent + controller migrate together
-				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
-				Subsets: []corev1.EndpointSubset{{ //nolint:staticcheck
-					Addresses: []corev1.EndpointAddress{{IP: "192.0.2.10"}, {IP: "192.0.2.11"}},
-					Ports:     []corev1.EndpointPort{{Port: 8080, Protocol: corev1.ProtocolTCP}},
-				}},
-			}
-			Expect(k8sClient.Create(ctx, endpoints)).To(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, endpoints) }()
+			slice := metalEndpointSliceFixture(isvcName, "192.0.2.10", "192.0.2.11")
+			Expect(k8sClient.Create(ctx, slice)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, slice) }()
 
 			reconciler := &InferenceServiceReconciler{
 				Client:             k8sClient,
@@ -921,15 +938,9 @@ var _ = Describe("Reconcile lifecycle", func() {
 			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
 
-			endpoints := &corev1.Endpoints{ //nolint:staticcheck
-				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
-				Subsets: []corev1.EndpointSubset{{ //nolint:staticcheck
-					Addresses: []corev1.EndpointAddress{{IP: "192.0.2.20"}},
-					Ports:     []corev1.EndpointPort{{Port: 8080, Protocol: corev1.ProtocolTCP}},
-				}},
-			}
-			Expect(k8sClient.Create(ctx, endpoints)).To(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, endpoints) }()
+			slice := metalEndpointSliceFixture(isvcName, "192.0.2.20")
+			Expect(k8sClient.Create(ctx, slice)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, slice) }()
 
 			reconciler := &InferenceServiceReconciler{
 				Client:             k8sClient,
@@ -953,7 +964,7 @@ var _ = Describe("Reconcile lifecycle", func() {
 			Expect(*updated.Spec.Replicas).To(Equal(int32(0)))
 
 			By("verifying status.replicas is 0 after reconcile with no endpoints")
-			Expect(k8sClient.Delete(ctx, endpoints)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, slice)).To(Succeed())
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
 			})

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -27,6 +27,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -425,6 +426,7 @@ func TestDeleteProcess_StopFailureStillUnregistersEndpoint(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -432,17 +434,17 @@ func TestDeleteProcess_StopFailureStillUnregistersEndpoint(t *testing.T) {
 			Namespace: "default",
 		},
 	}
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	endpoints := &corev1.Endpoints{
+	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-model",
 			Namespace: "default",
 		},
+		AddressType: discoveryv1.AddressTypeIPv4,
 	}
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithRuntimeObjects(svc, endpoints).
+		WithRuntimeObjects(svc, slice).
 		Build()
 
 	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient})
@@ -471,13 +473,12 @@ func TestDeleteProcess_StopFailureStillUnregistersEndpoint(t *testing.T) {
 		t.Fatal("service should be deleted even when StopProcess fails")
 	}
 
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
 	err = k8sClient.Get(context.Background(), types.NamespacedName{
 		Name:      "test-model",
 		Namespace: "default",
-	}, &corev1.Endpoints{})
+	}, &discoveryv1.EndpointSlice{})
 	if err == nil {
-		t.Fatal("endpoints should be deleted even when StopProcess fails")
+		t.Fatal("endpointslice should be deleted even when StopProcess fails")
 	}
 }
 
@@ -680,14 +681,17 @@ func runEnsureProcessExpectingMapEviction(
 	t.Helper()
 	scheme := newTestScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
-	//nolint:staticcheck // SA1019: Endpoints API matches production code under test
-	endpoints := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
+	slice := &discoveryv1.EndpointSlice{
+		ObjectMeta:  metav1.ObjectMeta{Name: name, Namespace: "default"},
+		AddressType: discoveryv1.AddressTypeIPv4,
+	}
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithRuntimeObjects(svc, endpoints).
+		WithRuntimeObjects(svc, slice).
 		Build()
 
 	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
@@ -753,6 +757,7 @@ func TestEnsureProcess_ReplicasZeroNoOpWhenNoProcess(t *testing.T) {
 func TestEnsureProcess_ReplicasZeroPatchesStatus(t *testing.T) {
 	scheme := newTestScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	zero := int32(0)
 	isvc := &inferencev1alpha1.InferenceService{
@@ -832,6 +837,7 @@ func TestEnsureProcess_ReplicasZeroPatchesStatus(t *testing.T) {
 func TestEnsureProcess_ReplicasZeroStatusPatchIdempotent(t *testing.T) {
 	scheme := newTestScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	zero := int32(0)
 	prev := metav1.Now().Add(-time.Hour)
@@ -991,6 +997,7 @@ func (e *blockingExecutor) StopProcess(_ int) error { return nil }
 func TestEnsureProcess_InFlightGuard(t *testing.T) {
 	scheme := newTestScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	// The model file must exist on disk: ensureProcess's memory admission
 	// fails closed when the model cannot be sized, which would return before
@@ -1013,13 +1020,15 @@ func TestEnsureProcess_InFlightGuard(t *testing.T) {
 		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "race-model"},
 	}
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "race-isvc", Namespace: "default"}}
-	//nolint:staticcheck // SA1019: Endpoints API matches production code under test
-	endpoints := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "race-isvc", Namespace: "default"}}
+	slice := &discoveryv1.EndpointSlice{
+		ObjectMeta:  metav1.ObjectMeta{Name: "race-isvc", Namespace: "default"},
+		AddressType: discoveryv1.AddressTypeIPv4,
+	}
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&inferencev1alpha1.InferenceService{}).
-		WithRuntimeObjects(model, isvc, svc, endpoints).
+		WithRuntimeObjects(model, isvc, svc, slice).
 		Build()
 
 	agent := NewMetalAgent(MetalAgentConfig{
@@ -1080,6 +1089,7 @@ func TestHeartbeatOnce(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	isvc := &inferencev1alpha1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{Name: "hb-once-model", Namespace: "default"},
@@ -1111,14 +1121,13 @@ func TestHeartbeatOnce(t *testing.T) {
 	before := time.Now().Add(-time.Second)
 	a.heartbeatOnce(context.Background())
 
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	eps := &corev1.Endpoints{}
+	slice := &discoveryv1.EndpointSlice{}
 	if err := k8sClient.Get(context.Background(),
-		types.NamespacedName{Name: "hb-once-model", Namespace: "default"}, eps); err != nil {
-		t.Fatalf("get endpoints after heartbeatOnce: %v", err)
+		types.NamespacedName{Name: "hb-once-model", Namespace: "default"}, slice); err != nil {
+		t.Fatalf("get endpointslice after heartbeatOnce: %v", err)
 	}
 
-	raw := eps.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat]
+	raw := slice.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat]
 	if raw == "" {
 		t.Fatalf("heartbeat annotation absent after heartbeatOnce")
 	}
@@ -1141,7 +1150,7 @@ func (nopExecutor) StartProcess(_ context.Context, _ ExecutorConfig) (*ManagedPr
 func (nopExecutor) StopProcess(_ int) error { return nil }
 
 // TestHeartbeatOnce_ScaledToZero verifies that heartbeatOnce does NOT
-// re-register the Service+Endpoints for a process whose InferenceService has
+// re-register the Service+EndpointSlice for a process whose InferenceService has
 // been scaled to zero (spec.replicas == 0). Re-asserting networking for a
 // scaled-to-zero service would recreate the ClusterIP routing that
 // handleScaleToZero / deleteProcess just removed, leaving a live routable
@@ -1150,6 +1159,7 @@ func TestHeartbeatOnce_ScaledToZero(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	zero := int32(0)
 	isvc := &inferencev1alpha1.InferenceService{
@@ -1185,17 +1195,16 @@ func TestHeartbeatOnce_ScaledToZero(t *testing.T) {
 
 	a.heartbeatOnce(context.Background())
 
-	// The heartbeat must NOT have created Service or Endpoints for the
+	// The heartbeat must NOT have created Service or EndpointSlice for the
 	// scaled-to-zero service.
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	eps := &corev1.Endpoints{}
+	slice := &discoveryv1.EndpointSlice{}
 	err := k8sClient.Get(context.Background(),
-		types.NamespacedName{Name: "scaled-zero", Namespace: "default"}, eps)
+		types.NamespacedName{Name: "scaled-zero", Namespace: "default"}, slice)
 	if err == nil {
-		t.Fatal("heartbeatOnce must not create Endpoints for a scaled-to-zero InferenceService")
+		t.Fatal("heartbeatOnce must not create EndpointSlice for a scaled-to-zero InferenceService")
 	}
 	if !apierrors.IsNotFound(err) {
-		t.Fatalf("unexpected error checking for Endpoints: %v", err)
+		t.Fatalf("unexpected error checking for EndpointSlice: %v", err)
 	}
 }
 
@@ -1203,24 +1212,26 @@ func TestHeartbeatOnce_ScaledToZero(t *testing.T) {
 // an InferenceService no longer exists in the API server (NotFound), it treats
 // the condition as a missed deletion event and tears the process down via
 // deleteProcess — the same path the watch-event handler uses. After the call
-// the process must be absent from the map and its Endpoints must be gone.
+// the process must be absent from the map and its EndpointSlice must be gone.
 func TestHeartbeatOnce_NotFound(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	// The fake client starts with NO InferenceService for "gone-model".
-	// Pre-populate the Endpoints so UnregisterEndpoint has something to delete.
-	existingEps := &corev1.Endpoints{ //nolint:staticcheck // SA1019: matches production path
+	// Pre-populate the EndpointSlice so UnregisterEndpoint has something to delete.
+	existingSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gone-model",
 			Namespace: "default",
 		},
+		AddressType: discoveryv1.AddressTypeIPv4,
 	}
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithRuntimeObjects(existingEps).
+		WithRuntimeObjects(existingSlice).
 		Build()
 
 	a := &MetalAgent{
@@ -1251,15 +1262,14 @@ func TestHeartbeatOnce_NotFound(t *testing.T) {
 		t.Fatal("heartbeatOnce_NotFound: process must be removed from map after teardown")
 	}
 
-	// Endpoints must be deleted by UnregisterEndpoint inside deleteProcess.
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	eps := &corev1.Endpoints{}
+	// EndpointSlice must be deleted by UnregisterEndpoint inside deleteProcess.
+	slice := &discoveryv1.EndpointSlice{}
 	err := k8sClient.Get(context.Background(),
-		types.NamespacedName{Name: "gone-model", Namespace: "default"}, eps)
+		types.NamespacedName{Name: "gone-model", Namespace: "default"}, slice)
 	if err == nil {
-		t.Fatal("heartbeatOnce_NotFound: Endpoints must be deleted after teardown")
+		t.Fatal("heartbeatOnce_NotFound: EndpointSlice must be deleted after teardown")
 	}
 	if !apierrors.IsNotFound(err) {
-		t.Fatalf("heartbeatOnce_NotFound: unexpected error checking Endpoints: %v", err)
+		t.Fatalf("heartbeatOnce_NotFound: unexpected error checking EndpointSlice: %v", err)
 	}
 }

--- a/pkg/agent/pressure_test.go
+++ b/pkg/agent/pressure_test.go
@@ -24,6 +24,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,13 +38,14 @@ import (
 
 func newPressureTestAgent(t *testing.T, isvcs ...*inferencev1alpha1.InferenceService) *MetalAgent {
 	t.Helper()
-	// We need corev1 in the scheme so deleteProcess -> UnregisterEndpoint can
-	// issue Delete calls against Service/Endpoints (the fake client returns
-	// "no kind registered" instead of NotFound otherwise, and that error
-	// would be misinterpreted as a real failure).
+	// We need corev1 and discovery/v1 in the scheme so deleteProcess ->
+	// UnregisterEndpoint can issue Delete calls against Service/EndpointSlice
+	// (the fake client returns "no kind registered" instead of NotFound
+	// otherwise, and that error would be misinterpreted as a real failure).
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 	builder := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.InferenceService{})
 	for _, isvc := range isvcs {
 		builder = builder.WithObjects(isvc)

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -25,16 +25,24 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
+
+// labelServiceName is the well-known EndpointSlice label that ties a slice to
+// its Service. kube-proxy requires it for wiring, and every consumer lists
+// slices by it. Kubernetes' built-in EndpointSliceMirroring controller stamps
+// the same label on slices it mirrors from a legacy Endpoints object.
+const labelServiceName = "kubernetes.io/service-name"
 
 // ServiceRegistry manages Kubernetes Service and Endpoint resources
 // to expose native Metal processes to the cluster
@@ -55,7 +63,7 @@ type ServiceRegistry struct {
 // Kubernetes; otherwise the IP is auto-detected via DNS lookups
 // (host.minikube.internal / host.docker.internal).
 // version is the agent binary's version string (e.g. "v0.8.4") stamped on
-// every Endpoints object as AnnotationAgentVersion; pass empty to omit it.
+// every EndpointSlice as AnnotationAgentVersion; pass empty to omit it.
 func NewServiceRegistry(
 	k8sClient client.Client,
 	hostIP string,
@@ -77,7 +85,7 @@ func NewServiceRegistry(
 	}
 }
 
-// RegisterEndpoint creates/updates a Kubernetes Service and Endpoints
+// RegisterEndpoint creates/updates a Kubernetes Service and EndpointSlice
 // to expose the native process to the cluster
 func (r *ServiceRegistry) RegisterEndpoint(
 	ctx context.Context,
@@ -114,41 +122,45 @@ func (r *ServiceRegistry) RegisterEndpoint(
 		return fmt.Errorf("failed to create/update service: %w", err)
 	}
 
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and appropriate for manual endpoint management
-	endpoints := &corev1.Endpoints{
+	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: isvc.Namespace},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.client, endpoints, func() error {
-		endpoints.Labels = map[string]string{
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.client, slice, func() error {
+		slice.Labels = map[string]string{
+			labelServiceName:               serviceName,
 			"app":                          isvc.Name,
 			"llmkube.ai/managed-by":        "metal-agent",
 			"llmkube.ai/inference-service": isvc.Name,
 		}
-		if endpoints.Annotations == nil {
-			endpoints.Annotations = map[string]string{}
+		if slice.Annotations == nil {
+			slice.Annotations = map[string]string{}
 		}
-		endpoints.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat] = r.now().UTC().Format(time.RFC3339)
+		slice.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat] = r.now().UTC().Format(time.RFC3339)
 		if r.version != "" {
-			endpoints.Annotations[inferencev1alpha1.AnnotationAgentVersion] = r.version
+			slice.Annotations[inferencev1alpha1.AnnotationAgentVersion] = r.version
 		}
-		//nolint:staticcheck // SA1019: EndpointSubset still functional
-		endpoints.Subsets = []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{
-				IP: r.resolveHostIP(),
-				TargetRef: &corev1.ObjectReference{
-					Kind: "Pod",
-					Name: fmt.Sprintf("%s-metal", isvc.Name),
-				},
-			}},
-			Ports: []corev1.EndpointPort{{
-				Name:     "http",
-				Port:     int32(port), //nolint:gosec // G115: TCP ports fit in int32
-				Protocol: corev1.ProtocolTCP,
-			}},
+		// resolveHostIP returns an IPv4 in every routable case and in the
+		// minikube/Docker-Desktop DNS fallback (host.minikube.internal ->
+		// 192.168.65.254). The fallback never yields a hostname, so IPv4 is a
+		// safe AddressType. If a future host-IP source could return an FQDN,
+		// this must branch on the address shape.
+		slice.AddressType = discoveryv1.AddressTypeIPv4
+		slice.Endpoints = []discoveryv1.Endpoint{{
+			Addresses:  []string{r.resolveHostIP()},
+			Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+			TargetRef: &corev1.ObjectReference{
+				Kind: "Pod",
+				Name: fmt.Sprintf("%s-metal", isvc.Name),
+			},
+		}}
+		slice.Ports = []discoveryv1.EndpointPort{{
+			Name:     ptr.To("http"),
+			Port:     ptr.To(int32(port)), //nolint:gosec // G115: TCP ports fit in int32
+			Protocol: ptr.To(corev1.ProtocolTCP),
 		}}
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to create/update endpoints: %w", err)
+		return fmt.Errorf("failed to create/update endpointslice: %w", err)
 	}
 
 	r.logger.Infow("registered endpoint",
@@ -188,7 +200,7 @@ func (r *ServiceRegistry) RegisterEndpointWithRetry(
 	return nil
 }
 
-// UnregisterEndpoint removes the Service and Endpoints for a process
+// UnregisterEndpoint removes the Service and EndpointSlice for a process
 func (r *ServiceRegistry) UnregisterEndpoint(ctx context.Context, namespace, name string) error {
 	// Sanitize service name (replace dots with dashes for DNS-1035 compliance)
 	serviceName := sanitizeServiceName(name)
@@ -211,20 +223,19 @@ func (r *ServiceRegistry) UnregisterEndpoint(ctx context.Context, namespace, nam
 		)
 	}
 
-	// Delete Endpoints
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and appropriate for manual endpoint management
-	endpoints := &corev1.Endpoints{
+	// Delete EndpointSlice
+	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: namespace,
 		},
 	}
-	if err := r.client.Delete(ctx, endpoints); err != nil {
+	if err := r.client.Delete(ctx, slice); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete endpoints: %w", err)
+			return fmt.Errorf("failed to delete endpointslice: %w", err)
 		}
 		r.logger.Debugw(
-			"endpoints already deleted during endpoint cleanup",
+			"endpointslice already deleted during endpoint cleanup",
 			"namespace", namespace,
 			"name", serviceName,
 		)

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -63,6 +64,7 @@ func TestNewServiceRegistry(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -76,6 +78,7 @@ func TestRegisterEndpoint(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -135,28 +138,43 @@ func TestRegisterEndpoint(t *testing.T) {
 		t.Errorf("Service type = %q, want ClusterIP", svc.Spec.Type)
 	}
 
-	// Verify Endpoints was created
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	endpoints := &corev1.Endpoints{}
+	// Verify EndpointSlice was created
+	slice := &discoveryv1.EndpointSlice{}
 	err = k8sClient.Get(context.Background(), types.NamespacedName{
 		Name:      "test-model",
 		Namespace: "default",
-	}, endpoints)
+	}, slice)
 	if err != nil {
-		t.Fatalf("Failed to get created Endpoints: %v", err)
+		t.Fatalf("Failed to get created EndpointSlice: %v", err)
 	}
 
-	if len(endpoints.Subsets) != 1 {
-		t.Fatalf("Endpoints has %d subsets, want 1", len(endpoints.Subsets))
+	// The service-name label is required for kube-proxy wiring and for
+	// consumers to list the slice.
+	if slice.Labels["kubernetes.io/service-name"] != "test-model" {
+		t.Errorf("EndpointSlice label kubernetes.io/service-name = %q, want %q",
+			slice.Labels["kubernetes.io/service-name"], "test-model")
 	}
-	if len(endpoints.Subsets[0].Addresses) != 1 {
-		t.Fatalf("Endpoints has %d addresses, want 1", len(endpoints.Subsets[0].Addresses))
+	if slice.Labels["llmkube.ai/managed-by"] != "metal-agent" {
+		t.Errorf("EndpointSlice label llmkube.ai/managed-by = %q, want %q",
+			slice.Labels["llmkube.ai/managed-by"], "metal-agent")
 	}
-	if len(endpoints.Subsets[0].Ports) != 1 {
-		t.Fatalf("Endpoints has %d ports, want 1", len(endpoints.Subsets[0].Ports))
+	if slice.AddressType != discoveryv1.AddressTypeIPv4 {
+		t.Errorf("EndpointSlice AddressType = %q, want %q", slice.AddressType, discoveryv1.AddressTypeIPv4)
 	}
-	if endpoints.Subsets[0].Ports[0].Port != 8080 {
-		t.Errorf("Endpoint port = %d, want 8080", endpoints.Subsets[0].Ports[0].Port)
+	if len(slice.Endpoints) != 1 {
+		t.Fatalf("EndpointSlice has %d endpoints, want 1", len(slice.Endpoints))
+	}
+	if len(slice.Endpoints[0].Addresses) != 1 {
+		t.Fatalf("EndpointSlice endpoint has %d addresses, want 1", len(slice.Endpoints[0].Addresses))
+	}
+	if slice.Endpoints[0].Conditions.Ready == nil || !*slice.Endpoints[0].Conditions.Ready {
+		t.Errorf("EndpointSlice endpoint Conditions.Ready = %v, want true", slice.Endpoints[0].Conditions.Ready)
+	}
+	if len(slice.Ports) != 1 {
+		t.Fatalf("EndpointSlice has %d ports, want 1", len(slice.Ports))
+	}
+	if slice.Ports[0].Port == nil || *slice.Ports[0].Port != 8080 {
+		t.Errorf("EndpointSlice port = %v, want 8080", slice.Ports[0].Port)
 	}
 }
 
@@ -164,6 +182,7 @@ func TestRegisterEndpoint_SanitizedName(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -198,6 +217,7 @@ func TestUnregisterEndpoint(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	// Pre-create Service and Endpoints
 	svc := &corev1.Service{
@@ -206,17 +226,17 @@ func TestUnregisterEndpoint(t *testing.T) {
 			Namespace: "default",
 		},
 	}
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	endpoints := &corev1.Endpoints{
+	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-model",
 			Namespace: "default",
 		},
+		AddressType: discoveryv1.AddressTypeIPv4,
 	}
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithRuntimeObjects(svc, endpoints).
+		WithRuntimeObjects(svc, slice).
 		Build()
 
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -240,6 +260,7 @@ func TestUnregisterEndpoint_SanitizedName(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	// Pre-create with sanitized name
 	svc := &corev1.Service{
@@ -248,17 +269,17 @@ func TestUnregisterEndpoint_SanitizedName(t *testing.T) {
 			Namespace: "default",
 		},
 	}
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	endpoints := &corev1.Endpoints{
+	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "model-v1-0",
 			Namespace: "default",
 		},
+		AddressType: discoveryv1.AddressTypeIPv4,
 	}
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithRuntimeObjects(svc, endpoints).
+		WithRuntimeObjects(svc, slice).
 		Build()
 
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -274,6 +295,7 @@ func TestUnregisterEndpoint_Idempotent(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	// Pre-create resources so first cleanup does actual deletes; second call should
 	// tolerate NotFound and still return nil.
@@ -283,17 +305,17 @@ func TestUnregisterEndpoint_Idempotent(t *testing.T) {
 			Namespace: "default",
 		},
 	}
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	endpoints := &corev1.Endpoints{
+	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "idempotent-model",
 			Namespace: "default",
 		},
+		AddressType: discoveryv1.AddressTypeIPv4,
 	}
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithRuntimeObjects(svc, endpoints).
+		WithRuntimeObjects(svc, slice).
 		Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
 
@@ -309,6 +331,7 @@ func TestReconcileOrphanEndpoints(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	// Live InferenceService whose Service+Endpoints should NOT be cleaned up.
 	liveISVC := &inferencev1alpha1.InferenceService{
@@ -337,16 +360,17 @@ func TestReconcileOrphanEndpoints(t *testing.T) {
 			},
 		},
 	}
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	orphanEndpoints := &corev1.Endpoints{
+	orphanSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "orphan-model",
 			Namespace: "default",
 			Labels: map[string]string{
+				"kubernetes.io/service-name":   "orphan-model",
 				"llmkube.ai/managed-by":        "metal-agent",
 				"llmkube.ai/inference-service": "orphan-model",
 			},
 		},
+		AddressType: discoveryv1.AddressTypeIPv4,
 	}
 
 	// Foreign Service that we don't own — must be ignored entirely.
@@ -360,7 +384,7 @@ func TestReconcileOrphanEndpoints(t *testing.T) {
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithRuntimeObjects(liveISVC, liveSvc, orphanSvc, orphanEndpoints, foreignSvc).
+		WithRuntimeObjects(liveISVC, liveSvc, orphanSvc, orphanSlice, foreignSvc).
 		Build()
 
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -387,12 +411,11 @@ func TestReconcileOrphanEndpoints(t *testing.T) {
 		t.Error("orphan Service should have been deleted")
 	}
 
-	// Orphan Endpoints must also be gone.
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
+	// Orphan EndpointSlice must also be gone.
 	if err := k8sClient.Get(context.Background(),
 		types.NamespacedName{Name: "orphan-model", Namespace: "default"},
-		&corev1.Endpoints{}); err == nil {
-		t.Error("orphan Endpoints should have been deleted")
+		&discoveryv1.EndpointSlice{}); err == nil {
+		t.Error("orphan EndpointSlice should have been deleted")
 	}
 
 	// Foreign Service (not labeled managed-by us) must be untouched.
@@ -407,6 +430,7 @@ func TestReconcileOrphanEndpoints_EmptyCluster(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -431,6 +455,7 @@ func TestGetHostIP(t *testing.T) {
 func TestResolveHostIP_Explicit(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "100.103.147.52", newNopLogger(), "")
@@ -444,6 +469,7 @@ func TestResolveHostIP_Explicit(t *testing.T) {
 func TestResolveHostIP_AutoDetect(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -458,6 +484,7 @@ func TestRegisterEndpoint_ExplicitHostIP(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "10.0.0.42", newNopLogger(), "")
@@ -477,32 +504,32 @@ func TestRegisterEndpoint_ExplicitHostIP(t *testing.T) {
 		t.Fatalf("RegisterEndpoint returned error: %v", err)
 	}
 
-	// Verify the Endpoint uses the explicit host IP
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	endpoints := &corev1.Endpoints{}
+	// Verify the EndpointSlice uses the explicit host IP
+	slice := &discoveryv1.EndpointSlice{}
 	err = k8sClient.Get(context.Background(), types.NamespacedName{
 		Name:      "remote-model",
 		Namespace: "default",
-	}, endpoints)
+	}, slice)
 	if err != nil {
-		t.Fatalf("Failed to get created Endpoints: %v", err)
+		t.Fatalf("Failed to get created EndpointSlice: %v", err)
 	}
 
-	if len(endpoints.Subsets) != 1 || len(endpoints.Subsets[0].Addresses) != 1 {
-		t.Fatal("Expected exactly 1 subset with 1 address")
+	if len(slice.Endpoints) != 1 || len(slice.Endpoints[0].Addresses) != 1 {
+		t.Fatal("Expected exactly 1 endpoint with 1 address")
 	}
-	if endpoints.Subsets[0].Addresses[0].IP != "10.0.0.42" {
-		t.Errorf("Endpoint IP = %q, want %q", endpoints.Subsets[0].Addresses[0].IP, "10.0.0.42")
+	if slice.Endpoints[0].Addresses[0] != "10.0.0.42" {
+		t.Errorf("EndpointSlice address = %q, want %q", slice.Endpoints[0].Addresses[0], "10.0.0.42")
 	}
 }
 
 // TestRegisterEndpoint_PortChange verifies that calling RegisterEndpoint
 // twice for the same InferenceService with a new port (respawn scenario) updates
-// both the Service targetPort and the Endpoints port rather than leaving stale values.
+// both the Service targetPort and the EndpointSlice port rather than leaving stale values.
 func TestRegisterEndpoint_PortChange(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -520,14 +547,13 @@ func TestRegisterEndpoint_PortChange(t *testing.T) {
 		t.Fatalf("second RegisterEndpoint (port change): %v", err)
 	}
 
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	eps := &corev1.Endpoints{}
+	slice := &discoveryv1.EndpointSlice{}
 	if err := k8sClient.Get(context.Background(),
-		types.NamespacedName{Name: "test-model", Namespace: "default"}, eps); err != nil {
-		t.Fatalf("get endpoints: %v", err)
+		types.NamespacedName{Name: "test-model", Namespace: "default"}, slice); err != nil {
+		t.Fatalf("get endpointslice: %v", err)
 	}
-	if got := eps.Subsets[0].Ports[0].Port; got != 50099 {
-		t.Fatalf("endpoints port = %d, want 50099 (stale port left behind)", got)
+	if slice.Ports[0].Port == nil || *slice.Ports[0].Port != 50099 {
+		t.Fatalf("endpointslice port = %v, want 50099 (stale port left behind)", slice.Ports[0].Port)
 	}
 	svc := &corev1.Service{}
 	if err := k8sClient.Get(context.Background(),
@@ -543,6 +569,7 @@ func TestRegisterEndpointWithRetry_TransientFailure(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	var calls int
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
@@ -568,9 +595,9 @@ func TestRegisterEndpointWithRetry_TransientFailure(t *testing.T) {
 	// The interceptor fires on every Create call. RegisterEndpoint calls
 	// CreateOrUpdate for Service (attempt 1: fail, attempt 2: fail, attempt 3:
 	// success = 3 Create calls across 2 retry iterations + 1 success) plus one
-	// Create for Endpoints on the winning attempt, totalling 4 calls.
+	// Create for the EndpointSlice on the winning attempt, totalling 4 calls.
 	if calls != 4 {
-		t.Fatalf("expected 4 Create calls (2 service failures + 1 service success + 1 endpoints), got %d", calls)
+		t.Fatalf("expected 4 Create calls (2 service failures + 1 service success + 1 endpointslice), got %d", calls)
 	}
 }
 
@@ -578,6 +605,7 @@ func TestRegisterEndpointWithRetry_Exhausted(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
 		WithInterceptorFuncs(interceptor.Funcs{
@@ -603,13 +631,14 @@ func TestRegisterEndpointWithRetry_Exhausted(t *testing.T) {
 }
 
 // TestRegisterEndpoint_StampsHeartbeat verifies that RegisterEndpoint stamps the
-// llmkube.ai/agent-heartbeat annotation on the Endpoints object with a
+// llmkube.ai/agent-heartbeat annotation on the EndpointSlice with a
 // deterministic RFC3339 timestamp on every call (issue #663). The clock is
 // pinned so the assertion is exact rather than "after test start".
 func TestRegisterEndpoint_StampsHeartbeat(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
@@ -632,16 +661,15 @@ func TestRegisterEndpoint_StampsHeartbeat(t *testing.T) {
 		t.Fatalf("RegisterEndpoint: %v", err)
 	}
 
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	eps := &corev1.Endpoints{}
+	slice := &discoveryv1.EndpointSlice{}
 	if err := k8sClient.Get(context.Background(),
-		types.NamespacedName{Name: "hb-model", Namespace: "default"}, eps); err != nil {
-		t.Fatalf("get endpoints: %v", err)
+		types.NamespacedName{Name: "hb-model", Namespace: "default"}, slice); err != nil {
+		t.Fatalf("get endpointslice: %v", err)
 	}
 
-	raw := eps.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat]
+	raw := slice.Annotations[inferencev1alpha1.AnnotationAgentHeartbeat]
 	if raw == "" {
-		t.Fatalf("heartbeat annotation %q absent on endpoints", inferencev1alpha1.AnnotationAgentHeartbeat)
+		t.Fatalf("heartbeat annotation %q absent on endpointslice", inferencev1alpha1.AnnotationAgentHeartbeat)
 	}
 	const want = "2026-06-12T12:00:00Z"
 	if raw != want {
@@ -650,12 +678,13 @@ func TestRegisterEndpoint_StampsHeartbeat(t *testing.T) {
 }
 
 // TestRegisterEndpoint_StampsAgentVersion verifies that RegisterEndpoint stamps
-// the llmkube.ai/agent-version annotation on the Endpoints object when the
+// the llmkube.ai/agent-version annotation on the EndpointSlice when the
 // registry is created with a non-empty version string.
 func TestRegisterEndpoint_StampsAgentVersion(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "v0.9.0")
@@ -674,14 +703,13 @@ func TestRegisterEndpoint_StampsAgentVersion(t *testing.T) {
 		t.Fatalf("RegisterEndpoint: %v", err)
 	}
 
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	eps := &corev1.Endpoints{}
+	slice := &discoveryv1.EndpointSlice{}
 	if err := k8sClient.Get(context.Background(),
-		types.NamespacedName{Name: "ver-model", Namespace: "default"}, eps); err != nil {
-		t.Fatalf("get endpoints: %v", err)
+		types.NamespacedName{Name: "ver-model", Namespace: "default"}, slice); err != nil {
+		t.Fatalf("get endpointslice: %v", err)
 	}
 
-	got := eps.Annotations[inferencev1alpha1.AnnotationAgentVersion]
+	got := slice.Annotations[inferencev1alpha1.AnnotationAgentVersion]
 	if got != "v0.9.0" {
 		t.Fatalf("agent-version annotation = %q, want %q", got, "v0.9.0")
 	}
@@ -694,6 +722,7 @@ func TestRegisterEndpoint_OmitsAgentVersionWhenEmpty(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "") // empty version
@@ -712,14 +741,13 @@ func TestRegisterEndpoint_OmitsAgentVersionWhenEmpty(t *testing.T) {
 		t.Fatalf("RegisterEndpoint: %v", err)
 	}
 
-	//nolint:staticcheck // SA1019: Endpoints API is still functional and matches production code under test
-	eps := &corev1.Endpoints{}
+	slice := &discoveryv1.EndpointSlice{}
 	if err := k8sClient.Get(context.Background(),
-		types.NamespacedName{Name: "nover-model", Namespace: "default"}, eps); err != nil {
-		t.Fatalf("get endpoints: %v", err)
+		types.NamespacedName{Name: "nover-model", Namespace: "default"}, slice); err != nil {
+		t.Fatalf("get endpointslice: %v", err)
 	}
 
-	if v, ok := eps.Annotations[inferencev1alpha1.AnnotationAgentVersion]; ok {
+	if v, ok := slice.Annotations[inferencev1alpha1.AnnotationAgentVersion]; ok {
 		t.Fatalf("agent-version annotation should be absent, got %q", v)
 	}
 }
@@ -731,6 +759,7 @@ func TestRegisterEndpointWithRetry_ContextCancelled(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = inferencev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -815,14 +816,11 @@ func (e *NativeAgentLoopExecutor) resolveInferenceBaseURL(
 
 // rewriteHostFromEndpoints replaces the host of baseURL with the
 // configured InferenceBaseURLHostOverride and the live port from the
-// InferenceService's v1 Endpoints object. The Endpoints name mirrors
-// the operator's sanitizeDNSName (dots become hyphens; see
-// internal/controller/inferenceservice_controller.go).
-//
-// EndpointSlice migration is tracked separately and producer + consumer
-// move together.
-//
-//nolint:staticcheck // SA1019: the metal-agent registers v1 Endpoints;
+// InferenceService's EndpointSlice. Slices are listed by the well-known
+// kubernetes.io/service-name label (== sanitizeDNSName(isvcName); dots
+// become hyphens; see internal/controller/inferenceservice_controller.go)
+// because the metal-agent and the EndpointSliceMirroring controller may
+// each produce one.
 func (e *NativeAgentLoopExecutor) rewriteHostFromEndpoints(
 	ctx context.Context, namespace, isvcName, baseURL string,
 ) (string, error) {
@@ -830,41 +828,50 @@ func (e *NativeAgentLoopExecutor) rewriteHostFromEndpoints(
 	if err != nil {
 		return "", fmt.Errorf("parse status.endpoint %q: %w", baseURL, err)
 	}
-	var eps corev1.Endpoints
-	epsName := strings.ReplaceAll(isvcName, ".", "-")
-	key := types.NamespacedName{Namespace: namespace, Name: epsName}
-	if err := e.Client.Get(ctx, key, &eps); err != nil {
-		return "", fmt.Errorf("get Endpoints %s for host-override resolution: %w", key, err)
+	svcName := strings.ReplaceAll(isvcName, ".", "-")
+	var slices discoveryv1.EndpointSliceList
+	if err := e.Client.List(ctx, &slices,
+		client.InNamespace(namespace),
+		client.MatchingLabels{"kubernetes.io/service-name": svcName},
+	); err != nil {
+		return "", fmt.Errorf("list EndpointSlices for service %s/%s host-override resolution: %w", namespace, svcName, err)
 	}
-	port, err := firstReadyPort(eps)
+	port, err := firstReadyPort(slices)
 	if err != nil {
-		return "", fmt.Errorf("Endpoints %s: %w", key, err)
+		return "", fmt.Errorf("EndpointSlices for service %s/%s: %w", namespace, svcName, err)
 	}
 	u.Host = fmt.Sprintf("%s:%d", e.InferenceBaseURLHostOverride, port)
 	return strings.TrimRight(u.String(), "/"), nil
 }
 
-// firstReadyPort returns the first port advertised on a subset that
-// has at least one ready address. metal-agent registers one address +
-// one port per InferenceService today; a future multi-replica metal
-// path would need a smarter selector, but for the v0.2 same-host case
-// "the only port" is the right port.
-//
-//nolint:staticcheck // SA1019: see rewriteHostFromEndpoints note.
-func firstReadyPort(eps corev1.Endpoints) (int32, error) {
-	for _, subset := range eps.Subsets {
-		if len(subset.Addresses) == 0 {
+// firstReadyPort returns the first port advertised by a slice that has at
+// least one ready endpoint. metal-agent registers one address + one port per
+// InferenceService today; a future multi-replica metal path would need a
+// smarter selector, but for the v0.2 same-host case "the only port" is the
+// right port. An endpoint with Conditions.Ready unset is treated as ready,
+// matching the EndpointSlice convention.
+func firstReadyPort(slices discoveryv1.EndpointSliceList) (int32, error) {
+	for i := range slices.Items {
+		slice := &slices.Items[i]
+		hasReady := false
+		for j := range slice.Endpoints {
+			if cond := slice.Endpoints[j].Conditions.Ready; cond == nil || *cond {
+				hasReady = true
+				break
+			}
+		}
+		if !hasReady {
 			continue
 		}
-		for _, p := range subset.Ports {
-			if p.Port > 0 {
-				return p.Port, nil
+		for _, p := range slice.Ports {
+			if p.Port != nil && *p.Port > 0 {
+				return *p.Port, nil
 			}
 		}
 	}
 	// metal-agent has not registered llama-server yet, or just
 	// respawned and is between unregister + register.
-	return 0, errors.New("no ready address with a port on the Endpoints object")
+	return 0, errors.New("no ready endpoint with a port on the EndpointSlices")
 }
 
 // buildAuth resolves credentials via the configured AuthFactory or

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -35,8 +35,10 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -224,14 +226,18 @@ func TestBuildDeterministicArgs(t *testing.T) {
 }
 
 // resolveSchemeForTests builds a runtime scheme with the API types the
-// resolveInferenceBaseURL tests touch. corev1 covers Endpoints,
+// resolveInferenceBaseURL tests touch. discovery/v1 covers EndpointSlice,
 // inferencev1alpha1 covers InferenceService, foreman covers the
-// Agent CR field types referenced incidentally.
+// Agent CR field types referenced incidentally. corev1 is registered for
+// the incidental object references the executor builds.
 func resolveSchemeForTests(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
 	if err := corev1.AddToScheme(s); err != nil {
 		t.Fatalf("corev1: %v", err)
+	}
+	if err := discoveryv1.AddToScheme(s); err != nil {
+		t.Fatalf("discoveryv1: %v", err)
 	}
 	if err := inferencev1alpha1.AddToScheme(s); err != nil {
 		t.Fatalf("inferencev1alpha1: %v", err)
@@ -243,12 +249,12 @@ func resolveSchemeForTests(t *testing.T) *runtime.Scheme {
 }
 
 // TestResolveInferenceBaseURL pins the precedence rules among the
-// three resolution modes (full override, host override + Endpoints,
+// three resolution modes (full override, host override + EndpointSlice,
 // status.endpoint default) and the error shapes the caller sees when
 // any prerequisite is missing. Regression for #540: the static
 // override locked the port at install time, so every metal-agent
 // respawn broke every subsequent task; the host-override path re-reads
-// the live port from Endpoints on each call.
+// the live port from the EndpointSlice on each call.
 func TestResolveInferenceBaseURL(t *testing.T) {
 	// Helpers that build the canned cluster objects each case may want
 	// the fake client seeded with.
@@ -266,16 +272,27 @@ func TestResolveInferenceBaseURL(t *testing.T) {
 			Status:     inferencev1alpha1.InferenceServiceStatus{Endpoint: endpoint},
 		}
 	}
-	//nolint:staticcheck // SA1019: matches production code path.
-	mkEndpoints := func(name string, port int32, withAddress bool) *corev1.Endpoints {
-		eps := &corev1.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
-			Subsets:    []corev1.EndpointSubset{{Ports: []corev1.EndpointPort{{Port: port}}}},
+	// mkEndpoints builds the EndpointSlice the metal-agent registers, labeled
+	// with the kubernetes.io/service-name the consumer lists by. name is the
+	// sanitized (hyphenated) service name. When withAddress is false the slice
+	// has a port but no ready endpoint, modelling a respawn gap.
+	mkEndpoints := func(name string, port int32, withAddress bool) *discoveryv1.EndpointSlice {
+		slice := &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    map[string]string{"kubernetes.io/service-name": name},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Ports:       []discoveryv1.EndpointPort{{Port: ptr.To(port)}},
 		}
 		if withAddress {
-			eps.Subsets[0].Addresses = []corev1.EndpointAddress{{IP: "10.42.0.5"}}
+			slice.Endpoints = []discoveryv1.Endpoint{{
+				Addresses:  []string{"10.42.0.5"},
+				Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+			}}
 		}
-		return eps
+		return slice
 	}
 
 	cases := []struct {
@@ -324,14 +341,14 @@ func TestResolveInferenceBaseURL(t *testing.T) {
 			want: "http://127.0.0.1:49931/v1",
 		},
 		{
-			name: "host override: dotted InferenceService name maps to hyphenated Endpoints",
+			name: "host override: dotted InferenceService name maps to hyphenated service-name label",
 			executor: NativeAgentLoopExecutor{
 				InferenceBaseURLHostOverride: "127.0.0.1",
 			},
 			seedObjects: []any{
 				// Agent references the dotted name; the operator
-				// sanitizes dots to hyphens when naming the Endpoints
-				// object the metal-agent registers.
+				// sanitizes dots to hyphens for the service-name label
+				// the metal-agent stamps on the EndpointSlice.
 				func() *foremanv1alpha1.Agent { return mkAgent("inf.svc.dotted") }(),
 				mkISvc("inf.svc.dotted", "http://inf-svc-dotted.default.svc.cluster.local:80/v1/chat/completions"),
 				mkEndpoints("inf-svc-dotted", 60177, true),
@@ -345,20 +362,20 @@ func TestResolveInferenceBaseURL(t *testing.T) {
 			},
 			seedObjects: []any{
 				mkISvc("test-svc", "http://test-svc.default.svc.cluster.local:80/v1/chat/completions"),
-				// no Endpoints object
+				// no EndpointSlice object: an empty list resolves to no ready port
 			},
-			wantErrFrag: "get Endpoints",
+			wantErrFrag: "no ready endpoint with a port",
 		},
 		{
-			name: "host override: Endpoints exists but has no ready address",
+			name: "host override: EndpointSlice exists but has no ready endpoint",
 			executor: NativeAgentLoopExecutor{
 				InferenceBaseURLHostOverride: "127.0.0.1",
 			},
 			seedObjects: []any{
 				mkISvc("test-svc", "http://test-svc.default.svc.cluster.local:80/v1/chat/completions"),
-				mkEndpoints("test-svc", 60177, false), // port present, no addresses
+				mkEndpoints("test-svc", 60177, false), // port present, no ready endpoint
 			},
-			wantErrFrag: "no ready address with a port",
+			wantErrFrag: "no ready endpoint with a port",
 		},
 		{
 			name:        "default: InferenceService not found",
@@ -390,11 +407,7 @@ func TestResolveInferenceBaseURL(t *testing.T) {
 					b = b.WithObjects(v)
 				case *inferencev1alpha1.InferenceService:
 					b = b.WithObjects(v)
-				//nolint:staticcheck // SA1019: mirrors the production
-				// resolveInferenceBaseURL path; producer + consumer
-				// migrate from v1 Endpoints to discoveryv1 EndpointSlice
-				// together.
-				case *corev1.Endpoints:
+				case *discoveryv1.EndpointSlice:
 					b = b.WithObjects(v)
 				default:
 					t.Fatalf("unhandled seed object type %T", obj)


### PR DESCRIPTION
## What

Migrate the metal inference path from the deprecated `core/v1.Endpoints` to `discovery.k8s.io/v1.EndpointSlice` across the producer and all consumers in one coordinated change, and drop the `//nolint:staticcheck // SA1019` debt.

## Why

`core/v1.Endpoints` is deprecated (SA1019). Producer and consumers must switch together: if the agent emits an EndpointSlice while a consumer still reads Endpoints, `readyReplicas` stays 0 and metal InferenceServices never report Ready. This is the coordinated cutover.

## How

- **Producer** (`pkg/agent/registry.go`): `RegisterEndpoint`/`UnregisterEndpoint` create/delete a selectorless-Service-backed `EndpointSlice` labeled `kubernetes.io/service-name=<svc>`, `Conditions.Ready=true`. Both agent annotations move onto the slice: `llmkube.ai/agent-heartbeat` (always) and `llmkube.ai/agent-version` (when set).
- **Controller** (`internal/controller/inferenceservice_controller.go`): `metalEndpointSnapshot` lists slices by the `service-name` label (handles multiple slices, picks the freshest parseable heartbeat, sums ready across slices). Watch + mapper switched to `EndpointSlice`; the mapper now resolves a slice to its InferenceService via the `service-name` label so mirror-created slices still enqueue. Heartbeat classification (None/Legacy/Fresh/Stale/Unparseable), the legacy-exemption, RequeueAfter, and `AgentHeartbeatStale` status are preserved exactly.
- **Foreman native executor** (`pkg/foreman/agent/executor_native.go`): the `--inference-base-url-host-override` port reader now reads the EndpointSlice ports (this reader was extra scope beyond the issue text). Missing slice / no-ready-port still yields a clear pre-dispatch error.
- **RBAC**: controller + foreman-agent markers and chart ClusterRoles switched `core/endpoints` -> `discovery.k8s.io/endpointslices` (get;list;watch); regenerated `config/rbac/role.yaml` and chart grants; `make check-helm-rbac` green.

### Backward-compat (mid-upgrade safety)
Because consumers list by `kubernetes.io/service-name`, a cluster mid-upgrade (new controller, old agent still emitting Endpoints) keeps working: the built-in EndpointSliceMirroring controller mirrors the legacy Endpoints into a slice, which the consumer reads. The mirror does not copy our heartbeat annotation, so a legacy agent's mirrored slice is treated as `Legacy` (exempt from expiry) until the agent upgrades. No flip-day outage.

### Reviewer notes (non-defects)
- The watch mapper now enqueues on any EndpointSlice carrying a `service-name` label, not just metal-agent slices. Harmless: unrelated names resolve to NotFound and return early; InferenceService reconcile is idempotent.
- `AddressTypeIPv4` relies on `resolveHostIP()` returning an IPv4 string (true on every path); documented inline. Pre-existing assumption, unchanged from the Endpoints code.

## Checklist

- [x] Tests added/updated (producer, controller heartbeat + reconcile fixtures, foreman reader all converted to EndpointSlice; both annotations asserted)
- [x] `make test` passes locally
- [x] `make lint` + `GOOS=linux ./bin/golangci-lint run ./...` pass locally
- [x] `make check-helm-rbac` passes; zero `corev1.Endpoints`/`EndpointSubset` references remain on the metal path; SA1019 metal nolints removed
- [x] Commits follow conventional commits and are signed off (DCO)
- [ ] Documentation updated (no user-facing doc change)

Fixes #377