### PR TITLE
fix(foreman): drop deprecated Result.Requeue in workload terminal test

### DIFF
--- a/internal/foreman/controller/workload_webhook_terminal_test.go
+++ b/internal/foreman/controller/workload_webhook_terminal_test.go
@@ -128,7 +128,7 @@ func TestMarkPlanned_WebhookRejectionIsTerminal(t *testing.T) {
 				if err != nil {
 					t.Fatalf("terminal rejection must not return a requeue error, got %v", err)
 				}
-				if res.Requeue || res.RequeueAfter != 0 {
+				if res.RequeueAfter != 0 {
 					t.Fatalf("terminal rejection must not request a requeue, got %+v", res)
 				}
 				if fresh.Status.Phase != foremanv1alpha1.WorkloadPhaseFailed {


### PR DESCRIPTION
## What

Replace the deprecated `Result.Requeue` bool in the workload terminal-rejection test with a `RequeueAfter` check.

## Why

The full lint on `main` (`only-new-issues: false`) fails with:

```
internal/foreman/controller/workload_webhook_terminal_test.go:131:8:
SA1019: res.Requeue is deprecated: Use `RequeueAfter` instead. (staticcheck)
```

The line landed via #685; the PR's incremental lint (only-new-issues) did not surface it, but the full sweep on `main` does, blocking a clean release.

## How

The test asserts a terminal webhook rejection requests no requeue. `res.RequeueAfter != 0` proves that on its own, and a requeue-via-returned-error is already covered by the `err != nil` check just above, so the deprecated `res.Requeue ||` is redundant. Dropping it preserves the assertion and clears the SA1019.

`git grep` confirms no other deprecated bool-`Requeue` usages remain in the tree.

## Checklist

- [x] `make lint` (darwin + linux) passes locally: `0 issues.`
- [x] `go test ./internal/foreman/controller/ -run TestMarkPlanned_WebhookRejectionIsTerminal` passes (both subtests)
- [x] Conventional commit, signed off (DCO)
- [ ] Documentation updated (test-only change)