### PR TITLE
feat(selfupdate): bound download size + GC old agent versions

### DIFF
--- a/pkg/selfupdate/updater.go
+++ b/pkg/selfupdate/updater.go
@@ -46,6 +46,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -80,9 +81,33 @@ type Updater struct {
 	// http.DefaultClient when nil.
 	HTTPClient *http.Client
 
+	// MaxDownloadBytes caps the artifact download size. A malformed or
+	// malicious URL could otherwise stream an unbounded body and fill the
+	// partition before the SHA-256 verify runs. When zero, defaults to
+	// defaultMaxDownloadBytes (512 MiB). The cap is enforced two ways: a
+	// Content-Length precheck (fail before reading the body) and a
+	// LimitReader on the stream (fail mid-copy on overflow).
+	MaxDownloadBytes int64
+
+	// RetainVersions is the number of staged version directories to keep
+	// (beyond the always-retained current and previous targets) after a
+	// successful symlink flip. When zero, defaults to defaultRetainVersions
+	// (3). Older versions/<v> directories are pruned best-effort.
+	RetainVersions int
+
 	// Log is the structured logger. logr.Discard() silences all output.
 	Log logr.Logger
 }
+
+const (
+	// defaultMaxDownloadBytes is the artifact download ceiling when
+	// Updater.MaxDownloadBytes is zero: 512 MiB.
+	defaultMaxDownloadBytes int64 = 512 * 1024 * 1024
+
+	// defaultRetainVersions is the number of staged versions kept (beyond
+	// current and previous) when Updater.RetainVersions is zero.
+	defaultRetainVersions = 3
+)
 
 // Target describes the update to apply, sourced from
 // FleetNode.status.updateRequest.
@@ -172,7 +197,11 @@ func (u *Updater) MaybeApply(t Target) (ApplyResult, error) {
 		}
 	}()
 
-	if err := u.download(hc, t.URL, tmp); err != nil {
+	maxBytes := u.MaxDownloadBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxDownloadBytes
+	}
+	if err := u.download(hc, t.URL, tmp, maxBytes); err != nil {
 		_ = tmp.Close()
 		return ApplyResult{}, fmt.Errorf("download %s: %w", t.URL, err)
 	}
@@ -233,12 +262,91 @@ func (u *Updater) MaybeApply(t Target) (ApplyResult, error) {
 		return ApplyResult{}, fmt.Errorf("flip current symlink: %w", err)
 	}
 
+	// Prune old staged versions. Best-effort: the update already succeeded,
+	// so a prune failure must never block or revert it. current and previous
+	// (the running + rollback targets) are always retained.
+	retain := u.RetainVersions
+	if retain <= 0 {
+		retain = defaultRetainVersions
+	}
+	if err := u.pruneOldVersions(retain); err != nil {
+		log.Error(err, "self-update: pruning old versions failed (non-fatal)")
+	}
+
 	log.Info("self-update: staged and symlink flipped; will restart via supervisor")
 	return ApplyResult{Restarting: true}, nil
 }
 
-// download streams the response body from url into dst.
-func (u *Updater) download(hc *http.Client, url string, dst *os.File) error {
+// pruneOldVersions deletes stale versions/<v> directories, keeping:
+//   - the directory that "current" resolves to (the running target),
+//   - the directory that "previous" resolves to (the rollback target),
+//   - the newest `retain` of the remaining directories, by mtime.
+//
+// It is best-effort: callers treat the returned error as non-fatal. current
+// and previous are never deleted regardless of their mtime.
+func (u *Updater) pruneOldVersions(retain int) error {
+	versionsDir := filepath.Join(u.InstallRoot, "versions")
+
+	// Resolve the protected targets. A missing or dangling symlink is not an
+	// error here; it just means there is nothing to protect on that slot.
+	protected := map[string]struct{}{}
+	for _, link := range []string{"current", "previous"} {
+		if target, err := os.Readlink(filepath.Join(u.InstallRoot, link)); err == nil && target != "" {
+			// Symlinks store an absolute path to versions/<v>; normalize the
+			// base name so comparison is independent of how it was written.
+			protected[filepath.Base(target)] = struct{}{}
+		}
+	}
+
+	entries, err := os.ReadDir(versionsDir)
+	if err != nil {
+		return fmt.Errorf("read versions dir: %w", err)
+	}
+
+	type versionDir struct {
+		name  string
+		mtime int64
+	}
+	var prunable []versionDir
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, ok := protected[e.Name()]; ok {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil {
+			// Unreadable entry: skip it rather than abort the whole prune.
+			continue
+		}
+		prunable = append(prunable, versionDir{name: e.Name(), mtime: info.ModTime().UnixNano()})
+	}
+
+	if len(prunable) <= retain {
+		return nil
+	}
+
+	// Newest first by mtime; keep the first `retain`, delete the rest.
+	sort.Slice(prunable, func(i, j int) bool {
+		return prunable[i].mtime > prunable[j].mtime
+	})
+
+	var firstErr error
+	for _, vd := range prunable[retain:] {
+		if rmErr := os.RemoveAll(filepath.Join(versionsDir, vd.name)); rmErr != nil && firstErr == nil {
+			firstErr = fmt.Errorf("remove %s: %w", vd.name, rmErr)
+		}
+	}
+	return firstErr
+}
+
+// download streams the response body from url into dst, enforcing a maxBytes
+// ceiling. The cap is checked twice: an advertised Content-Length over the
+// limit fails before the body is read, and the stream is wrapped in an
+// io.LimitReader(maxBytes+1) so an unadvertised (chunked) overflow fails
+// mid-copy. Either overflow returns an "exceeds max" error before staging.
+func (u *Updater) download(hc *http.Client, url string, dst *os.File, maxBytes int64) error {
 	resp, err := hc.Get(url) //nolint:noctx // URL is operator-provided; no extra cancellation needed
 	if err != nil {
 		return fmt.Errorf("GET %s: %w", url, err)
@@ -247,8 +355,21 @@ func (u *Updater) download(hc *http.Client, url string, dst *os.File) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("GET %s: unexpected status %d", url, resp.StatusCode)
 	}
-	if _, err := io.Copy(dst, resp.Body); err != nil {
+
+	// Precheck: a trustworthy Content-Length over the limit fails fast
+	// without reading the body at all.
+	if resp.ContentLength >= 0 && resp.ContentLength > maxBytes {
+		return fmt.Errorf("artifact size %d exceeds max %d bytes", resp.ContentLength, maxBytes)
+	}
+
+	// Stream with a hard cap. Read up to maxBytes+1 so that copying exactly
+	// maxBytes+1 bytes signals overflow (the body had more than maxBytes).
+	n, err := io.Copy(dst, io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
 		return fmt.Errorf("copy body: %w", err)
+	}
+	if n > maxBytes {
+		return fmt.Errorf("artifact size %d exceeds max %d bytes", n, maxBytes)
 	}
 	return nil
 }

--- a/pkg/selfupdate/updater.go
+++ b/pkg/selfupdate/updater.go
@@ -327,9 +327,15 @@ func (u *Updater) pruneOldVersions(retain int) error {
 		return nil
 	}
 
-	// Newest first by mtime; keep the first `retain`, delete the rest.
+	// Newest first by mtime; keep the first `retain`, delete the rest. Break
+	// mtime ties by name so the survivor set is deterministic when several
+	// version dirs share a coarse-granularity mtime (current and previous are
+	// protected on a separate key, so a tie can never drop a needed version).
 	sort.Slice(prunable, func(i, j int) bool {
-		return prunable[i].mtime > prunable[j].mtime
+		if prunable[i].mtime != prunable[j].mtime {
+			return prunable[i].mtime > prunable[j].mtime
+		}
+		return prunable[i].name > prunable[j].name
 	})
 
 	var firstErr error

--- a/pkg/selfupdate/updater_test.go
+++ b/pkg/selfupdate/updater_test.go
@@ -24,8 +24,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -463,6 +465,315 @@ func TestExecUnderInstallRoot_ResolvedCurrentSymlink(t *testing.T) {
 	if !selfupdate.ExecUnderInstallRootForTest(resolvedExe, installRoot) {
 		t.Errorf("ExecUnderInstallRootForTest(resolved exe) = false, want true; "+
 			"resolvedExe=%s installRoot=%s", resolvedExe, installRoot)
+	}
+}
+
+// TestMaybeApply_DownloadExceedsMaxBytes_Streamed verifies that a response
+// body larger than the configured MaxDownloadBytes is rejected with a size
+// error BEFORE staging, that no versions/<v> directory is created, and that
+// the pre-existing current symlink is left untouched. This covers the case
+// where the server does NOT advertise Content-Length (chunked/streamed), so
+// the overflow can only be detected mid-stream.
+func TestMaybeApply_DownloadExceedsMaxBytes_Streamed(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	// Pre-seed a prior good version + current symlink to assert it survives.
+	priorVersion := "v0.8.4"
+	priorDir := filepath.Join(installRoot, "versions", priorVersion)
+	if err := os.MkdirAll(priorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(priorDir, "foreman-agent"), []byte("prior"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	currentLink := filepath.Join(installRoot, "current")
+	if err := os.Symlink(priorDir, currentLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// Server streams a body larger than the tiny limit, without a
+	// Content-Length header (force chunked by flushing).
+	bigBody := strings.Repeat("A", 4096)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fl, _ := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, bigBody[:2048])
+		if fl != nil {
+			fl.Flush()
+		}
+		_, _ = fmt.Fprint(w, bigBody[2048:])
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.8.4")
+	u.MaxDownloadBytes = 1024 // tiny ceiling
+
+	_, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  blobSHA256(bigBody),
+	})
+	if err == nil {
+		t.Fatal("expected error for oversized download, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds max") {
+		t.Errorf("error %q does not mention size limit", err)
+	}
+
+	// No versions/<v0.9.0> directory must be created.
+	newVersionDir := filepath.Join(installRoot, "versions", "v0.9.0")
+	if _, statErr := os.Stat(newVersionDir); !os.IsNotExist(statErr) {
+		t.Errorf("versions/v0.9.0 should not exist after oversized download, stat err=%v", statErr)
+	}
+
+	// current symlink must still point at prior version.
+	resolved, rerr := os.Readlink(currentLink)
+	if rerr != nil {
+		t.Fatalf("current symlink disappeared: %v", rerr)
+	}
+	if resolved != priorDir {
+		t.Errorf("current -> %q after failed download, want %q (prior)", resolved, priorDir)
+	}
+
+	// No temp download file left behind.
+	entries, _ := os.ReadDir(installRoot)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "tmp-download") {
+			t.Errorf("temp download file not cleaned up: %s", e.Name())
+		}
+	}
+}
+
+// contentLengthLyingHandler advertises a huge Content-Length but never
+// streams the body. It also records whether the body write path was reached,
+// so the test can assert the precheck rejected BEFORE reading the body.
+type contentLengthLiar struct {
+	streamed bool
+}
+
+func (c *contentLengthLiar) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Length", "1073741824") // 1 GiB
+	w.WriteHeader(http.StatusOK)
+	// Intentionally do not write the advertised bytes. If the client honors
+	// the precheck it will close the connection before reading the body.
+	c.streamed = true
+}
+
+// TestMaybeApply_ContentLengthOverLimit_RejectedWithoutReading verifies that
+// when resp.ContentLength exceeds the limit, the download fails fast without
+// streaming the body.
+func TestMaybeApply_ContentLengthOverLimit_RejectedWithoutReading(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	handler := &contentLengthLiar{}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.8.4")
+	u.MaxDownloadBytes = 1024
+
+	_, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  blobSHA256("anything"),
+	})
+	if err == nil {
+		t.Fatal("expected error for Content-Length over limit, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds max") {
+		t.Errorf("error %q does not mention size limit", err)
+	}
+
+	// No versions/<v0.9.0> created.
+	if _, statErr := os.Stat(filepath.Join(installRoot, "versions", "v0.9.0")); !os.IsNotExist(statErr) {
+		t.Errorf("versions/v0.9.0 should not exist, stat err=%v", statErr)
+	}
+}
+
+// TestMaybeApply_WithinMaxBytes_Succeeds verifies a body within the limit
+// still completes the full flow (good SHA, flip happens) when MaxDownloadBytes
+// is set explicitly.
+func TestMaybeApply_WithinMaxBytes_Succeeds(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, testBlob)
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.8.4")
+	u.MaxDownloadBytes = 1 << 20 // 1 MiB, comfortably above testBlob
+
+	result, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  blobSHA256(testBlob),
+	})
+	if err != nil {
+		t.Fatalf("MaybeApply: %v", err)
+	}
+	if !result.Restarting {
+		t.Fatal("Restarting = false, want true within-limit success")
+	}
+
+	stagedPath := filepath.Join(installRoot, "versions", "v0.9.0", "foreman-agent")
+	if _, statErr := os.Stat(stagedPath); statErr != nil {
+		t.Fatalf("staged binary not found at %s: %v", stagedPath, statErr)
+	}
+}
+
+// seedVersion creates installRoot/versions/<v>/foreman-agent with the given
+// mtime and returns the version directory path.
+func seedVersion(t *testing.T, installRoot, version string, mtime time.Time) string {
+	t.Helper()
+	vdir := filepath.Join(installRoot, "versions", version)
+	if err := os.MkdirAll(vdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vdir, "foreman-agent"), []byte("bin-"+version), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(vdir, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	return vdir
+}
+
+// remainingVersions returns the set of version directory names under
+// installRoot/versions.
+func remainingVersions(t *testing.T, installRoot string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(installRoot, "versions"))
+	if err != nil {
+		t.Fatalf("read versions dir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestPruneOldVersions_ProtectsCurrentAndPrevious builds an install root with
+// several version dirs of varying mtime plus current and previous symlinks,
+// runs MaybeApply (which triggers prune at flip time), and asserts that
+// current's and previous's targets survive regardless of mtime, only the
+// newest RetainVersions of the rest survive, and older ones are deleted.
+func TestPruneOldVersions_ProtectsCurrentAndPrevious(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	now := time.Now()
+	// Old "current" target: oldest mtime, but must survive because current
+	// will point at it during the run (before the flip moves current forward).
+	curDir := seedVersion(t, installRoot, "v0.1.0", now.Add(-100*time.Hour))
+	// "previous" target: also old, must survive.
+	prevDir := seedVersion(t, installRoot, "v0.2.0", now.Add(-90*time.Hour))
+	// A spread of other versions with descending age.
+	seedVersion(t, installRoot, "v0.3.0", now.Add(-50*time.Hour)) // oldest of the rest -> pruned
+	seedVersion(t, installRoot, "v0.4.0", now.Add(-40*time.Hour)) // pruned
+	seedVersion(t, installRoot, "v0.5.0", now.Add(-30*time.Hour)) // kept (newest 3 of rest)
+	seedVersion(t, installRoot, "v0.6.0", now.Add(-20*time.Hour)) // kept
+	seedVersion(t, installRoot, "v0.7.0", now.Add(-10*time.Hour)) // kept
+
+	currentLink := filepath.Join(installRoot, "current")
+	if err := os.Symlink(curDir, currentLink); err != nil {
+		t.Fatal(err)
+	}
+	previousLink := filepath.Join(installRoot, "previous")
+	if err := os.Symlink(prevDir, previousLink); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, testBlob)
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.1.0")
+	u.RetainVersions = 3
+
+	// Apply v0.9.0. After the flip: current -> v0.9.0, previous -> v0.1.0
+	// (the old current). prune keeps current (v0.9.0) + previous (v0.1.0)
+	// unconditionally, plus the newest 3 of the remaining dirs by mtime.
+	_, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  blobSHA256(testBlob),
+	})
+	if err != nil {
+		t.Fatalf("MaybeApply: %v", err)
+	}
+
+	got := remainingVersions(t, installRoot)
+	gotSet := map[string]bool{}
+	for _, n := range got {
+		gotSet[n] = true
+	}
+
+	// Protected: new current (v0.9.0) and new previous (v0.1.0, the old current).
+	for _, must := range []string{"v0.9.0", "v0.1.0"} {
+		if !gotSet[must] {
+			t.Errorf("protected version %s was pruned; remaining=%v", must, got)
+		}
+	}
+	// Remaining pool (excluding the two protected dirs) is:
+	// v0.2.0(-90h), v0.3.0(-50h), v0.4.0(-40h), v0.5.0(-30h), v0.6.0(-20h), v0.7.0(-10h).
+	// Newest 3 by mtime kept: v0.5.0, v0.6.0, v0.7.0.
+	for _, kept := range []string{"v0.5.0", "v0.6.0", "v0.7.0"} {
+		if !gotSet[kept] {
+			t.Errorf("expected %s retained (newest 3 of rest); remaining=%v", kept, got)
+		}
+	}
+	// Older ones pruned.
+	for _, pruned := range []string{"v0.2.0", "v0.3.0", "v0.4.0"} {
+		if gotSet[pruned] {
+			t.Errorf("expected %s pruned; remaining=%v", pruned, got)
+		}
+	}
+}
+
+// TestPruneOldVersions_NonFatalOnError verifies that a prune failure does not
+// fail MaybeApply: the update still reports Restarting=true and the current
+// symlink points at the new version. We provoke a non-fatal situation by
+// using RetainVersions large enough that nothing is pruned, while also
+// confirming a missing previous symlink does not abort.
+func TestPruneOldVersions_NonFatalOnError(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	// No prior current/previous: first-ever update. Prune must be a harmless
+	// no-op (nothing to protect beyond the freshly flipped current).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, testBlob)
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.8.4")
+	u.RetainVersions = 3
+
+	result, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  blobSHA256(testBlob),
+	})
+	if err != nil {
+		t.Fatalf("MaybeApply: %v", err)
+	}
+	if !result.Restarting {
+		t.Fatal("Restarting = false, want true")
+	}
+	current, err := os.Readlink(filepath.Join(installRoot, "current"))
+	if err != nil {
+		t.Fatalf("current symlink: %v", err)
+	}
+	if current != filepath.Join(installRoot, "versions", "v0.9.0") {
+		t.Errorf("current -> %q, want versions/v0.9.0", current)
 	}
 }
 

--- a/pkg/selfupdate/updater_test.go
+++ b/pkg/selfupdate/updater_test.go
@@ -738,6 +738,66 @@ func TestPruneOldVersions_ProtectsCurrentAndPrevious(t *testing.T) {
 	}
 }
 
+// TestPruneOldVersions_DeterministicOnMtimeTie verifies that when several
+// prunable version dirs share an identical mtime (coarse-granularity FS, or
+// versions staged within the same clock tick), the survivor set is
+// deterministic: the comparator breaks mtime ties by name. The protected
+// current/previous targets survive on a separate key regardless.
+func TestPruneOldVersions_DeterministicOnMtimeTie(t *testing.T) {
+	dir := t.TempDir()
+	installRoot := filepath.Join(dir, "foreman-agent")
+
+	now := time.Now()
+	// Initial current target; becomes previous after the flip, so it is
+	// protected and must survive.
+	curDir := seedVersion(t, installRoot, "v0.1.0", now.Add(-100*time.Hour))
+	// The tie pool: four dirs sharing one identical mtime.
+	tie := now.Add(-30 * time.Hour)
+	seedVersion(t, installRoot, "v0.5.0", tie)
+	seedVersion(t, installRoot, "v0.5.1", tie)
+	seedVersion(t, installRoot, "v0.5.2", tie)
+	seedVersion(t, installRoot, "v0.5.3", tie)
+
+	if err := os.Symlink(curDir, filepath.Join(installRoot, "current")); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, testBlob)
+	}))
+	defer srv.Close()
+
+	u := newUpdater(t, srv, installRoot, "foreman-agent", "v0.1.0")
+	u.RetainVersions = 2
+
+	if _, err := u.MaybeApply(selfupdate.Target{
+		Version: "v0.9.0",
+		URL:     srv.URL + "/download",
+		SHA256:  blobSHA256(testBlob),
+	}); err != nil {
+		t.Fatalf("MaybeApply: %v", err)
+	}
+
+	gotSet := map[string]bool{}
+	for _, n := range remainingVersions(t, installRoot) {
+		gotSet[n] = true
+	}
+
+	// Protected on a separate key: new current and the old current (now previous).
+	for _, must := range []string{"v0.9.0", "v0.1.0"} {
+		if !gotSet[must] {
+			t.Errorf("protected version %s was pruned; remaining=%v", must, gotSet)
+		}
+	}
+	// Tie pool, retain=2, name-descending tiebreak keeps the two highest names.
+	if !gotSet["v0.5.3"] || !gotSet["v0.5.2"] {
+		t.Errorf("expected v0.5.3 and v0.5.2 retained on name tiebreak; remaining=%v", gotSet)
+	}
+	if gotSet["v0.5.0"] || gotSet["v0.5.1"] {
+		t.Errorf("expected v0.5.0 and v0.5.1 pruned on name tiebreak; remaining=%v", gotSet)
+	}
+}
+
 // TestPruneOldVersions_NonFatalOnError verifies that a prune failure does not
 // fail MaybeApply: the update still reports Restarting=true and the current
 // symlink points at the new version. We provoke a non-fatal situation by


### PR DESCRIPTION
## What

Two hardening refinements to the agent self-update path (`pkg/selfupdate`), follow-ups from the fleet-agent-update v1 review.

## Why

1. `Updater.MaybeApply` streamed the artifact via `io.Copy` with only the HTTP client timeout as a bound, before the SHA-256 check. A wrong/huge artifact URL could fill the node partition before verification failed.
2. The install root accumulates `versions/<v>/<binary>` on every update and only kept `previous` as a rollback pointer, so disk grew unbounded on long-lived edge/Mac nodes.

## How

**Bounded download** (`MaxDownloadBytes`, default 512 MiB; overridable):
- Reject before reading the body if `Content-Length` exceeds the ceiling.
- Otherwise stream through `io.LimitReader(body, max+1)` and error with a clear "exceeds max" message if it overflows, before verify/stage. The temp file is cleaned up and no `versions/<v>` dir is created on overflow; `current` is untouched.

**GC old versions** (`RetainVersions`, default 3; overridable):
- After a successful `current` symlink flip, prune `versions/<v>` dirs: always keep whatever `current` and `previous` resolve to (running + rollback targets), then keep the newest `RetainVersions` of the rest by mtime and delete the older ones. mtime ties break by name for a deterministic survivor set.
- Pruning is best-effort and non-fatal: a prune error is logged and never fails the update or suppresses `Restarting=true`. It runs strictly after the flip, so it can never leave `current` unset.

Design note: pruning happens at flip-time in the agent (not on a controller soak signal) because that is where the agent has disk access and it is always safe (current/previous are protected). The retain buffer covers the one-extra-cycle lag versus soak-confirmed pruning.

## Checklist

- [x] Tests added (download: streamed-overflow, Content-Length precheck, within-limit success; prune: protects current/previous, newest-N, mtime-tie determinism, non-fatal)
- [x] `make test` passes (`pkg/selfupdate` 77.9%)
- [x] `make lint` + `GOOS=linux ./bin/golangci-lint run ./...` pass
- [x] Conventional commits, signed off (DCO)
- [ ] Documentation updated (no user-facing doc change)

Fixes #677