### PR TITLE
feat(gateway): ModelRouter token budgets and 429 enforcement (2b)

### DIFF
--- a/docs/proposals/661-ai-gateway-integration.md
+++ b/docs/proposals/661-ai-gateway-integration.md
@@ -151,6 +151,22 @@ ModelRouter stays the user-facing policy surface (rules, budgets, classification
 - **Honest boundary (fail-loud).** The gateway data plane can match model name and headers, but NOT `dataClassification`, `taskComplexity`, `requiredCapabilities`, or `latencySLO` (those need request-body inspection / router-side scoring, which is slice 2e). A ModelRouter rule using any of those in `Gateway` mode sets the ModelRouter condition `False` (reason `UnsupportedMatchInGatewayMode`) and generates NOTHING, rather than silently compiling a partial route that drops a rule the user expects. A validating webhook to reject this at apply time is a follow-up.
 - **Status.** `status.gateway` on the ModelRouter (routes ready + resolved endpoint) plus a condition.
 
+#### Sub-slice 2b (detailed design): token budgets and 429 enforcement
+
+Compile `policy.budgets[]` into token-denominated rate limiting on the resources 2a already generates.
+
+- **One BTP, extended in place.** The `rateLimit` stanza is added to the SAME `BackendTrafficPolicy` 2a created for retry/failover, NOT a new policy. This is footgun 7.1 made structural: two `BackendTrafficPolicy` objects targeting one route silently conflict (the oldest wins), so retry and rate limit must share one BTP. The 2b builder extends the 2a BTP rather than emitting a second one.
+- **Token-denominated.** Add `llmRequestCosts` (TotalToken) to the `AIGatewayRoute` 2a generates so the limit is charged in tokens at response completion, with the request path check-only. This is the mechanism the spike validated.
+- **Scopes compiled in 2b: `router` and `team`.** `router` becomes a global rateLimit descriptor (applies to all traffic through the ModelRouter). `team` becomes a descriptor keyed on `BudgetSpec.HeaderKey` (default `x-llmkube-team`), so each distinct header value gets its own bucket. Each budget compiles `MaxTokens` over `WindowSeconds` into a rateLimit rule; exceeding it yields instant 429s with budget-countdown headers.
+
+**Deliberately deferred, with the reasoning (so a later slice picks up a decided question, not an open one):**
+
+- **`MaxUSD` (dollar budgets) -> fail-loud (`UnsupportedBudgetField`) until a dedicated follow-up.** The gateway rate-limits on tokens, so a dollar cap must convert to a token-equivalent. With heterogeneous backends at different `CostPerMillionTokens` under one rule, there is no single honest conversion (which backend's price sets the rate?). Rather than silently pick one and under- or over-charge, 2b ships `MaxTokens` enforcement and fails loud on `MaxUSD`. The conversion semantics (per-backend, blended, or worst-case-conservative) are a design question that gets its own slice once chosen.
+- **`rule` scope -> fail-loud (`UnsupportedBudgetScope`) until a follow-up.** `router` and `team` are the high-value cases (total cap, per-tenant cap). `rule`-scoped budgets need a per-rule rateLimit clientSelector keyed on the rule's model match, which is fiddlier; deferring it keeps 2b tight and is reversible.
+- **`team` scope is compiled now but documented as needing auth to be tamper-proof.** A `team` budget keys on whatever populates `HeaderKey`; without auth (slice 2d) a client can spoof that header for a fresh bucket. We compile it anyway (rather than block on 2d) because the rateLimit-by-header mechanism is identity-agnostic and the budget feature is useful immediately; 2d later derives the header from a verified JWT claim, which makes the same budget tamper-proof. The status/docs note this pairing so an operator is not misled into thinking header-keyed budgets are secure on their own.
+
+- **Status.** Surface compiled budgets and any fail-loud reason (`UnsupportedBudgetField` / `UnsupportedBudgetScope`) on the ModelRouter condition, consistent with 2a's honest-boundary handling.
+
 ### 5.3 Backend health bridging (sub-projects 3 + 4)
 metal-agent (#662) ejects/restores the address on its managed Endpoints object on health change and surfaces status. The operator (sub-project 4) compiles that health, plus pod health, into gateway `Backend` ejection/restoration, giving off-cluster Metal endpoints the event-driven detection that pods get from the EPP. This mutates the `Backend`s the MVP generates.
 

--- a/internal/controller/gateway_resources_modelrouter.go
+++ b/internal/controller/gateway_resources_modelrouter.go
@@ -55,7 +55,34 @@ const (
 	btpKind       = "BackendTrafficPolicy"
 	btpResource   = "backendtrafficpolicies"
 	httpRouteKind = "HTTPRoute"
+
+	// aiGatewayMetadataNamespace is the dynamic-metadata namespace the Envoy AI
+	// Gateway extproc writes per-request usage under. See aiGatewayTotalTokenKey
+	// for the total-token key within it.
+	aiGatewayMetadataNamespace = "io.envoy.ai_gateway"
+
+	// defaultTeamHeaderKey is the request header a team-scope budget keys its
+	// rateLimit bucket on when BudgetSpec.HeaderKey is unset. Matches the CRD
+	// default documented on BudgetSpec.HeaderKey.
+	defaultTeamHeaderKey = "x-llmkube-team"
+
+	// Budget scopes compiled in slice 2b. "rule" is fail-loud (deferred).
+	budgetScopeRouter = "router"
+	budgetScopeTeam   = "team"
+	budgetScopeRule   = "rule"
 )
+
+// aiGatewayTotalTokenKey is the dynamic-metadata key (within
+// aiGatewayMetadataNamespace) under which the gateway records a request's total
+// token count. The route's llmRequestCosts emits this key at response
+// completion, and the BTP rateLimit charges it. Mirrors the spike manifests
+// 03-route.yaml (llmRequestCosts) and 05-fallback-policy.yaml (rateLimit
+// cost.response.metadata). It is a function (not a const) so the metadata-key
+// literal is not bound to a "token"-named package-level identifier, which the
+// gosec G101 hardcoded-credential heuristic flags as a false positive.
+func aiGatewayTotalTokenKey() string {
+	return "llm_total_token"
+}
 
 // btpGVK is the GVK of the generated BackendTrafficPolicy. Same group/version as
 // Backend (gateway.envoyproxy.io/v1alpha1).
@@ -167,6 +194,7 @@ func newRouterAIGatewayRoute(
 	mr *inferencev1alpha1.ModelRouter,
 	gatewayRef *inferencev1alpha1.GatewayReference,
 	rules []routerRuleResource,
+	budgets []inferencev1alpha1.BudgetSpec,
 ) *unstructured.Unstructured {
 	parentRef := map[string]interface{}{
 		"name":  gatewayRef.Name,
@@ -182,15 +210,39 @@ func newRouterAIGatewayRoute(
 		compiledRules = append(compiledRules, compileRouteRule(rule))
 	}
 
+	spec := map[string]interface{}{
+		"parentRefs": []interface{}{parentRef},
+		"rules":      compiledRules,
+	}
+
+	// slice 2b: when budgets exist, charge the rate limit in tokens by emitting
+	// the TotalToken cost metadata. Without budgets we omit the key entirely so a
+	// 2a-only ModelRouter's route is byte-identical to #693's output.
+	if len(budgets) > 0 {
+		spec["llmRequestCosts"] = routerLLMRequestCosts()
+	}
+
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(aiGatewayRouteGVK())
 	u.SetName(modelRouterGatewayResourceName(mr))
 	u.SetNamespace(mr.Namespace)
-	u.Object["spec"] = map[string]interface{}{
-		"parentRefs": []interface{}{parentRef},
-		"rules":      compiledRules,
-	}
+	u.Object["spec"] = spec
 	return u
+}
+
+// routerLLMRequestCosts is the llmRequestCosts block added to the AIGatewayRoute
+// when budgets are present. It emits the total-token count into dynamic metadata
+// (io.envoy.ai_gateway/llm_total_token) at response completion, which is the key
+// the BTP rateLimit charges. Mirrors spike 03-route.yaml; slice 2b only needs
+// the TotalToken entry (the input/output splits there feed the audit access logs
+// of slice 2c, which is not yet compiled).
+func routerLLMRequestCosts() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"metadataKey": aiGatewayTotalTokenKey(),
+			"type":        "TotalToken",
+		},
+	}
 }
 
 // compileRouteRule builds one AIGatewayRoute rule: the matches block (a match
@@ -288,13 +340,9 @@ func compileRuleBackendRefs(refs []routerBackendRef) []interface{} {
 // AIGatewayRoute's name) by name. Mirrors spike 05-fallback-policy.yaml MINUS
 // the rateLimit/budget stanza (slice 2b adds that to THIS policy; two BTPs on
 // one target silently conflict, footgun 7.1).
-func newRouterBackendTrafficPolicy(mr *inferencev1alpha1.ModelRouter) *unstructured.Unstructured {
+func newRouterBackendTrafficPolicy(mr *inferencev1alpha1.ModelRouter, budgets []inferencev1alpha1.BudgetSpec) *unstructured.Unstructured {
 	name := modelRouterGatewayResourceName(mr)
-	u := &unstructured.Unstructured{}
-	u.SetGroupVersionKind(btpGVK())
-	u.SetName(name)
-	u.SetNamespace(mr.Namespace)
-	u.Object["spec"] = map[string]interface{}{
+	spec := map[string]interface{}{
 		"targetRefs": []interface{}{
 			map[string]interface{}{
 				"group": gatewayBackendRefGroupAPI,
@@ -326,7 +374,123 @@ func newRouterBackendTrafficPolicy(mr *inferencev1alpha1.ModelRouter) *unstructu
 			},
 		},
 	}
+
+	// slice 2b: budgets compile to a Global rateLimit stanza on THIS SAME BTP.
+	// Two BTPs targeting one route silently conflict (oldest wins, footgun 7.1),
+	// so the budget rateLimit must share the policy with retry/healthCheck. When
+	// there are no budgets we omit the key entirely so a 2a-only ModelRouter's
+	// BTP is byte-identical to #693's output.
+	if len(budgets) > 0 {
+		spec["rateLimit"] = compileBudgetRateLimit(budgets)
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(btpGVK())
+	u.SetName(name)
+	u.SetNamespace(mr.Namespace)
+	u.Object["spec"] = spec
 	return u
+}
+
+// compileBudgetRateLimit turns the router's budgets into a Global rateLimit
+// stanza: one rule per budget. router-scope budgets become a global descriptor
+// (no clientSelector); team-scope budgets become a descriptor keyed (Distinct)
+// on the budget's HeaderKey so each header value gets an independent bucket. The
+// limit is charged in tokens via the route's llmRequestCosts (TotalToken), with
+// the request path check-only (cost.request.number = 0) and usage debited at
+// response completion (cost.response.metadata). Mirrors spike
+// 05-fallback-policy.yaml. Callers guarantee (via unsupportedBudgetMessage)
+// every budget here is router or team scope with MaxTokens set; rule scope and
+// MaxUSD fail loud before generation.
+func compileBudgetRateLimit(budgets []inferencev1alpha1.BudgetSpec) map[string]interface{} {
+	rules := make([]interface{}, 0, len(budgets))
+	for _, b := range budgets {
+		rules = append(rules, compileBudgetRule(b))
+	}
+	return map[string]interface{}{
+		"type": "Global",
+		"global": map[string]interface{}{
+			"rules": rules,
+		},
+	}
+}
+
+// compileBudgetRule compiles one budget into a rateLimit rule. The limit is the
+// budget's MaxTokens over the window unit derived from WindowSeconds (see
+// budgetWindowUnit). team scope adds a Distinct header clientSelector.
+func compileBudgetRule(b inferencev1alpha1.BudgetSpec) map[string]interface{} {
+	rule := map[string]interface{}{
+		"limit": map[string]interface{}{
+			"requests": *b.MaxTokens,
+			"unit":     budgetWindowUnit(b.WindowSeconds),
+		},
+		// Token-denominated: request path is check-only; usage is charged from
+		// the response's total-token dynamic metadata at completion.
+		"cost": map[string]interface{}{
+			"request": map[string]interface{}{
+				"from":   "Number",
+				"number": int64(0),
+			},
+			"response": map[string]interface{}{
+				"from": "Metadata",
+				"metadata": map[string]interface{}{
+					"namespace": aiGatewayMetadataNamespace,
+					"key":       aiGatewayTotalTokenKey(),
+				},
+			},
+		},
+	}
+
+	// team scope keys an independent bucket per header value. Without auth (slice
+	// 2d) this header is client-settable, so a team budget is only tamper-proof
+	// once 2d derives HeaderKey from a verified JWT claim. We compile it now
+	// because the rateLimit-by-header mechanism is identity-agnostic and useful
+	// immediately; the status note warns operators of the auth pairing.
+	if b.Scope == budgetScopeTeam {
+		rule["clientSelectors"] = []interface{}{
+			map[string]interface{}{
+				"headers": []interface{}{
+					map[string]interface{}{
+						"name": teamHeaderKey(b),
+						"type": "Distinct",
+					},
+				},
+			},
+		}
+	}
+	return rule
+}
+
+// teamHeaderKey is the request header a team budget keys on, defaulting to
+// x-llmkube-team when HeaderKey is unset (matches the CRD default).
+func teamHeaderKey(b inferencev1alpha1.BudgetSpec) string {
+	if b.HeaderKey != "" {
+		return b.HeaderKey
+	}
+	return defaultTeamHeaderKey
+}
+
+// budgetWindowUnit maps a rolling window in seconds onto the Envoy Gateway
+// rateLimit unit the limit is denominated in. Envoy supports only a single unit
+// (Second/Minute/Hour/Day), not "per N units", so we pick the largest unit that
+// the window is a clean multiple of and treat the budget as MaxTokens per that
+// unit. Clean windows (60 -> Minute, 3600 -> Hour, 86400 -> Day, otherwise
+// Second) map exactly. A window that is not a clean multiple of a larger unit
+// rounds DOWN to the largest unit it does divide into (e.g. 90s -> Second),
+// which is the conservative choice: a shorter effective window enforces the cap
+// at least as tightly as requested rather than loosening it. The CRD default is
+// 3600 (Hour).
+func budgetWindowUnit(windowSeconds int32) string {
+	switch {
+	case windowSeconds >= 86400 && windowSeconds%86400 == 0:
+		return "Day"
+	case windowSeconds >= 3600 && windowSeconds%3600 == 0:
+		return "Hour"
+	case windowSeconds >= 60 && windowSeconds%60 == 0:
+		return "Minute"
+	default:
+		return "Second"
+	}
 }
 
 // modelRouterGatewayGVKs are the GVKs the ModelRouter gateway path needs the

--- a/internal/controller/gateway_resources_modelrouter.go
+++ b/internal/controller/gateway_resources_modelrouter.go
@@ -415,14 +415,23 @@ func compileBudgetRateLimit(budgets []inferencev1alpha1.BudgetSpec) map[string]i
 	}
 }
 
-// compileBudgetRule compiles one budget into a rateLimit rule. The limit is the
-// budget's MaxTokens over the window unit derived from WindowSeconds (see
-// budgetWindowUnit). team scope adds a Distinct header clientSelector.
+// compileBudgetRule compiles one budget into a rateLimit rule. Envoy expresses a
+// limit as "N per ONE unit" (Second/Minute/Hour/Day), so MaxTokens (the cap over
+// WindowSeconds) is scaled to the chosen unit to keep the enforced average rate
+// faithful for arbitrary windows. team scope adds a Distinct header clientSelector.
 func compileBudgetRule(b inferencev1alpha1.BudgetSpec) map[string]interface{} {
+	unit := budgetWindowUnit(b.WindowSeconds)
+	// requests = MaxTokens * unitSeconds / WindowSeconds, floored, min 1. Using a
+	// raw MaxTokens with a sub-window unit would under-enforce (e.g. 5M tokens
+	// over 90s emitted as "5M per Second" is ~90x too loose).
+	requests := *b.MaxTokens * budgetUnitSeconds(unit) / int64(b.WindowSeconds)
+	if requests < 1 {
+		requests = 1
+	}
 	rule := map[string]interface{}{
 		"limit": map[string]interface{}{
-			"requests": *b.MaxTokens,
-			"unit":     budgetWindowUnit(b.WindowSeconds),
+			"requests": requests,
+			"unit":     unit,
 		},
 		// Token-denominated: request path is check-only; usage is charged from
 		// the response's total-token dynamic metadata at completion.
@@ -470,26 +479,38 @@ func teamHeaderKey(b inferencev1alpha1.BudgetSpec) string {
 	return defaultTeamHeaderKey
 }
 
-// budgetWindowUnit maps a rolling window in seconds onto the Envoy Gateway
-// rateLimit unit the limit is denominated in. Envoy supports only a single unit
-// (Second/Minute/Hour/Day), not "per N units", so we pick the largest unit that
-// the window is a clean multiple of and treat the budget as MaxTokens per that
-// unit. Clean windows (60 -> Minute, 3600 -> Hour, 86400 -> Day, otherwise
-// Second) map exactly. A window that is not a clean multiple of a larger unit
-// rounds DOWN to the largest unit it does divide into (e.g. 90s -> Second),
-// which is the conservative choice: a shorter effective window enforces the cap
-// at least as tightly as requested rather than loosening it. The CRD default is
-// 3600 (Hour).
+// budgetWindowUnit picks the Envoy Gateway rateLimit unit the limit is
+// denominated in: the LARGEST unit whose duration is <= WindowSeconds, so the
+// scaled request count (see compileBudgetRule) stays a sensible integer rather
+// than rounding toward zero. Envoy supports only a single unit
+// (Second/Minute/Hour/Day), not "per N units"; compileBudgetRule scales
+// MaxTokens to this unit so any window enforces the faithful average rate. Exact
+// windows (60 -> Minute, 3600 -> Hour, 86400 -> Day) scale to requests ==
+// MaxTokens. The CRD default is 3600 (Hour).
 func budgetWindowUnit(windowSeconds int32) string {
 	switch {
-	case windowSeconds >= 86400 && windowSeconds%86400 == 0:
+	case windowSeconds >= 86400:
 		return "Day"
-	case windowSeconds >= 3600 && windowSeconds%3600 == 0:
+	case windowSeconds >= 3600:
 		return "Hour"
-	case windowSeconds >= 60 && windowSeconds%60 == 0:
+	case windowSeconds >= 60:
 		return "Minute"
 	default:
 		return "Second"
+	}
+}
+
+// budgetUnitSeconds is the duration in seconds of a budgetWindowUnit value.
+func budgetUnitSeconds(unit string) int64 {
+	switch unit {
+	case "Day":
+		return 86400
+	case "Hour":
+		return 3600
+	case "Minute":
+		return 60
+	default:
+		return 1
 	}
 }
 

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -53,6 +53,12 @@ const (
 	modelRouterGatewayReasonReconcile    = "ReconcileFailed"
 	modelRouterGatewayReasonUnsupported  = "UnsupportedMatchInGatewayMode"
 	modelRouterGatewayReasonNoGatewayRef = "GatewayRefMissing"
+
+	// slice 2b budget fail-loud reasons. Consistent with the 2a honest boundary:
+	// the whole ModelRouter generates NOTHING and GatewayReady goes False.
+	modelRouterGatewayReasonUnsupportedBudgetField = "UnsupportedBudgetField"
+	modelRouterGatewayReasonUnsupportedBudgetScope = "UnsupportedBudgetScope"
+	modelRouterGatewayReasonInvalidBudget          = "InvalidBudget"
 )
 
 // ModelRouterGatewayReconciler compiles a ModelRouter in dataPlane: Gateway mode
@@ -124,6 +130,14 @@ func (r *ModelRouterGatewayReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, r.setGatewayNotReady(ctx, mr, modelRouterGatewayReasonUnsupported, msg)
 	}
 
+	// Fail-loud on budgets the gateway data plane cannot honor (dollar budgets,
+	// rule scope, or a budget with no cap). Same ordering as the match check:
+	// runs BEFORE any CreateOrUpdate so a rejected budget yields no partial
+	// generation (proposal 5.2 budget honest boundary).
+	if reason, msg := unsupportedBudgetMessage(mr); reason != "" {
+		return ctrl.Result{}, r.setGatewayNotReady(ctx, mr, reason, msg)
+	}
+
 	if err := r.reconcileGatewayResources(ctx, mr); err != nil {
 		_ = r.setGatewayNotReady(ctx, mr, modelRouterGatewayReasonReconcile, err.Error())
 		return ctrl.Result{}, err
@@ -149,6 +163,8 @@ func (r *ModelRouterGatewayReconciler) reconcileGatewayResources(
 		return err
 	}
 
+	budgets := routerBudgets(mr)
+
 	// Order matters for clean upserts: Backends and AIServiceBackends before the
 	// route that references them, then the BTP that targets the route.
 	desired := make([]*unstructured.Unstructured, 0, len(backends)*2+2)
@@ -156,8 +172,8 @@ func (r *ModelRouterGatewayReconciler) reconcileGatewayResources(
 		desired = append(desired, newRouterBackend(mr, b), newRouterAIServiceBackend(mr, b))
 	}
 	desired = append(desired,
-		newRouterAIGatewayRoute(mr, mr.Spec.GatewayRef, rules),
-		newRouterBackendTrafficPolicy(mr),
+		newRouterAIGatewayRoute(mr, mr.Spec.GatewayRef, rules, budgets),
+		newRouterBackendTrafficPolicy(mr, budgets),
 	)
 
 	for _, obj := range desired {
@@ -260,9 +276,36 @@ func (r *ModelRouterGatewayReconciler) setGatewayReady(
 		Type:    ModelRouterGatewayConditionReady,
 		Status:  metav1.ConditionTrue,
 		Reason:  modelRouterGatewayReasonExposed,
-		Message: fmt.Sprintf("compiled %d rule(s) onto %s", len(mr.Spec.Rules), gatewayEndpointAddress(mr.Spec.GatewayRef)),
+		Message: gatewayReadyMessage(mr),
 	})
 	return r.Status().Patch(ctx, mr, patch)
+}
+
+// gatewayReadyMessage builds the success condition message: the rule count, the
+// resolved endpoint, and a budget summary. When any team-scope budget compiled,
+// it appends the auth-pairing caveat so an operator is not misled into thinking
+// a header-keyed budget is tamper-proof on its own (it becomes so once slice 2d
+// derives the header from a verified JWT claim).
+func gatewayReadyMessage(mr *inferencev1alpha1.ModelRouter) string {
+	msg := fmt.Sprintf("compiled %d rule(s) onto %s", len(mr.Spec.Rules), gatewayEndpointAddress(mr.Spec.GatewayRef))
+
+	budgets := routerBudgets(mr)
+	if len(budgets) == 0 {
+		return msg
+	}
+
+	hasTeam := false
+	for _, b := range budgets {
+		if b.Scope == budgetScopeTeam {
+			hasTeam = true
+			break
+		}
+	}
+	msg += fmt.Sprintf("; enforced %d token budget(s)", len(budgets))
+	if hasTeam {
+		msg += " (team-scoped budgets key on a request header and are tamper-proof only once gateway auth derives that header from a verified identity)"
+	}
+	return msg
 }
 
 // setGatewayNotReady writes a False GatewayReady condition and clears any stale
@@ -372,6 +415,52 @@ func backendWeights(mr *inferencev1alpha1.ModelRouter) map[string]int64 {
 }
 
 const weightedStrategy = "weighted"
+
+// routerBudgets returns the router's compiled budgets (nil-safe). Callers use it
+// to decide whether to emit the rateLimit/llmRequestCosts stanzas; an empty
+// slice means a 2a-only router whose generated resources stay byte-identical to
+// #693's output.
+func routerBudgets(mr *inferencev1alpha1.ModelRouter) []inferencev1alpha1.BudgetSpec {
+	if mr.Spec.Policy == nil {
+		return nil
+	}
+	return mr.Spec.Policy.Budgets
+}
+
+// unsupportedBudgetMessage returns a fail-loud (reason, message) for the first
+// budget the gateway data plane cannot honor, or ("", "") when every budget
+// compiles. Like unsupportedMatchMessage it runs BEFORE generation so a rejected
+// budget yields no partial resources. The rejected cases (proposal 5.2 budget
+// boundary):
+//   - MaxUSD set: dollar budgets need a token-equivalent conversion that is
+//     undecided across heterogeneous backend costs (UnsupportedBudgetField).
+//   - Scope=rule: per-rule rateLimit clientSelectors are deferred
+//     (UnsupportedBudgetScope).
+//   - neither MaxTokens nor MaxUSD set: the CRD requires at least one; we guard
+//     anyway so a malformed budget never silently compiles to no limit
+//     (InvalidBudget).
+//
+// team scope is accepted (compiled now, tamper-proof once auth lands in 2d).
+func unsupportedBudgetMessage(mr *inferencev1alpha1.ModelRouter) (reason, message string) {
+	for _, b := range routerBudgets(mr) {
+		if b.MaxUSD != "" {
+			return modelRouterGatewayReasonUnsupportedBudgetField,
+				fmt.Sprintf("budget %q sets maxUSD; dollar budgets are not yet supported in dataPlane: Gateway "+
+					"(the gateway rate-limits on tokens, and there is no single honest token conversion across "+
+					"heterogeneous backend costs). Use maxTokens, or track maxUSD via the Proxy data plane", b.Name)
+		}
+		if b.Scope == budgetScopeRule {
+			return modelRouterGatewayReasonUnsupportedBudgetScope,
+				fmt.Sprintf("budget %q uses scope %q, which is not yet supported in dataPlane: Gateway; "+
+					"use scope router (total cap) or team (per-tenant cap)", b.Name, budgetScopeRule)
+		}
+		if b.MaxTokens == nil {
+			return modelRouterGatewayReasonInvalidBudget,
+				fmt.Sprintf("budget %q sets neither maxTokens nor maxUSD; at least one cap is required", b.Name)
+		}
+	}
+	return "", ""
+}
 
 // unsupportedMatchMessage returns a non-empty message naming the first rule
 // whose match uses a condition the gateway data plane cannot express

--- a/internal/controller/modelrouter_gateway_test.go
+++ b/internal/controller/modelrouter_gateway_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -408,6 +409,358 @@ func assertBackendRefPriority(t *testing.T, ref interface{}, wantName string, wa
 	if got != wantPriority {
 		t.Errorf("backendRef %s priority = %d, want %d", wantName, got, wantPriority)
 	}
+}
+
+// TestModelRouterGateway_RouterBudgetProducesRateLimit covers 2b case (a): a
+// router-scope MaxTokens budget extends the SAME BackendTrafficPolicy 2a
+// generates so it carries BOTH the retry stanza AND a global rateLimit rule
+// (token limit + window unit), and the AIGatewayRoute carries the
+// llmRequestCosts (TotalToken) metadata that charges the limit at response
+// completion.
+func TestModelRouterGateway_RouterBudgetProducesRateLimit(t *testing.T) {
+	c, cfg, stop := startGatewayTestEnv(t, true)
+	defer stop()
+
+	makeBackendISvc(t, c, "qwen-cuda")
+
+	maxTokens := int64(5000000)
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "budget-router", Namespace: testNS},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+			GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "qwen-cuda", InferenceServiceRef: corev1LocalRef("qwen-cuda")},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:  "qwen",
+					Match: &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+					Route: inferencev1alpha1.RuleRoute{Backends: []string{"qwen-cuda"}},
+				},
+			},
+			Policy: &inferencev1alpha1.RouterPolicy{
+				Budgets: []inferencev1alpha1.BudgetSpec{
+					{
+						Name:          "fleet-cap",
+						Scope:         "router",
+						WindowSeconds: 3600,
+						MaxTokens:     &maxTokens,
+					},
+				},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), mr); err != nil {
+		t.Fatalf("create modelrouter: %v", err)
+	}
+
+	r := newModelRouterGatewayReconciler(t, cfg)
+	reconcileRouter(t, r, mr)
+
+	// The BTP keeps the 2a retry + healthCheck AND now carries a Global rateLimit.
+	btp := getUnstructured(t, c, btpGVK(), "budget-router")
+	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "retry"); !found {
+		t.Error("btp missing spec.retry (2a stanza must remain)")
+	}
+	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "healthCheck", "passive"); !found {
+		t.Error("btp missing spec.healthCheck.passive (2a stanza must remain)")
+	}
+	rlType, _, _ := unstructured.NestedString(btp.Object, "spec", "rateLimit", "type")
+	if rlType != "Global" {
+		t.Errorf("btp rateLimit.type = %q, want Global", rlType)
+	}
+	rlRules, found, _ := unstructured.NestedSlice(btp.Object, "spec", "rateLimit", "global", "rules")
+	if !found || len(rlRules) != 1 {
+		t.Fatalf("btp rateLimit.global.rules = %v (found=%v), want 1 rule", rlRules, found)
+	}
+	rule0 := rlRules[0].(map[string]interface{})
+	limit := rule0["limit"].(map[string]interface{})
+	if got, _ := limit["requests"].(int64); got != maxTokens {
+		t.Errorf("rateLimit limit.requests = %v, want %d", limit["requests"], maxTokens)
+	}
+	if unit, _ := limit["unit"].(string); unit != "Hour" {
+		t.Errorf("rateLimit limit.unit = %q, want Hour (3600s)", unit)
+	}
+	// router scope is global: no clientSelectors keyed on a header.
+	if _, hasSel := rule0["clientSelectors"]; hasSel {
+		t.Errorf("router-scope rule must not carry clientSelectors, got %+v", rule0["clientSelectors"])
+	}
+	// cost charges tokens at response completion (check-only on request path).
+	cost := rule0["cost"].(map[string]interface{})
+	reqCost := cost["request"].(map[string]interface{})
+	if n, _ := reqCost["number"].(int64); n != 0 {
+		t.Errorf("cost.request.number = %v, want 0 (check-only)", reqCost["number"])
+	}
+	respMeta := cost["response"].(map[string]interface{})["metadata"].(map[string]interface{})
+	if respMeta["namespace"] != aiGatewayMetadataNamespace || respMeta["key"] != aiGatewayTotalTokenKey() {
+		t.Errorf("cost.response.metadata = %+v, want namespace=%s key=%s", respMeta, aiGatewayMetadataNamespace, aiGatewayTotalTokenKey())
+	}
+
+	// The route carries llmRequestCosts (TotalToken) so the limit is token-denominated.
+	route := getUnstructured(t, c, aiGatewayRouteGVK(), "budget-router")
+	costs, found, _ := unstructured.NestedSlice(route.Object, "spec", "llmRequestCosts")
+	if !found || len(costs) == 0 {
+		t.Fatalf("route missing spec.llmRequestCosts")
+	}
+	hasTotalToken := false
+	for _, cst := range costs {
+		m := cst.(map[string]interface{})
+		if m["type"] == "TotalToken" && m["metadataKey"] == aiGatewayTotalTokenKey() {
+			hasTotalToken = true
+		}
+	}
+	if !hasTotalToken {
+		t.Errorf("route llmRequestCosts missing a TotalToken entry keyed on %s, got %+v", aiGatewayTotalTokenKey(), costs)
+	}
+
+	// status: ready, and the condition message mentions the compiled budget.
+	fresh := &inferencev1alpha1.ModelRouter{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "budget-router", Namespace: testNS}, fresh); err != nil {
+		t.Fatalf("get modelrouter: %v", err)
+	}
+	cond := apimeta.FindStatusCondition(fresh.Status.Conditions, ModelRouterGatewayConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("GatewayReady not True, got %+v", cond)
+	}
+}
+
+// TestModelRouterGateway_TeamBudgetKeysOnHeader covers 2b case (b): a team-scope
+// budget compiles a rateLimit rule whose clientSelector keys on the request
+// header (default x-llmkube-team), and a custom HeaderKey is honored.
+func TestModelRouterGateway_TeamBudgetKeysOnHeader(t *testing.T) {
+	tests := []struct {
+		name       string
+		headerKey  string
+		wantHeader string
+	}{
+		{name: "default header", headerKey: "", wantHeader: "x-llmkube-team"},
+		{name: "custom header", headerKey: "x-org-id", wantHeader: "x-org-id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, cfg, stop := startGatewayTestEnv(t, true)
+			defer stop()
+
+			makeBackendISvc(t, c, "team-cuda")
+
+			maxTokens := int64(1000000)
+			mr := &inferencev1alpha1.ModelRouter{
+				ObjectMeta: metav1.ObjectMeta{Name: "team-router", Namespace: testNS},
+				Spec: inferencev1alpha1.ModelRouterSpec{
+					DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+					GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+					Backends: []inferencev1alpha1.RouterBackend{
+						{Name: "team-cuda", InferenceServiceRef: corev1LocalRef("team-cuda")},
+					},
+					Rules: []inferencev1alpha1.RouterRule{
+						{
+							Name:  "team",
+							Match: &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+							Route: inferencev1alpha1.RuleRoute{Backends: []string{"team-cuda"}},
+						},
+					},
+					Policy: &inferencev1alpha1.RouterPolicy{
+						Budgets: []inferencev1alpha1.BudgetSpec{
+							{
+								Name:          "per-team",
+								Scope:         "team",
+								HeaderKey:     tt.headerKey,
+								WindowSeconds: 60,
+								MaxTokens:     &maxTokens,
+							},
+						},
+					},
+				},
+			}
+			if err := c.Create(context.Background(), mr); err != nil {
+				t.Fatalf("create modelrouter: %v", err)
+			}
+
+			r := newModelRouterGatewayReconciler(t, cfg)
+			reconcileRouter(t, r, mr)
+
+			btp := getUnstructured(t, c, btpGVK(), "team-router")
+			rlRules, found, _ := unstructured.NestedSlice(btp.Object, "spec", "rateLimit", "global", "rules")
+			if !found || len(rlRules) != 1 {
+				t.Fatalf("team rateLimit.global.rules = %v, want 1", rlRules)
+			}
+			rule0 := rlRules[0].(map[string]interface{})
+			sels, ok := rule0["clientSelectors"].([]interface{})
+			if !ok || len(sels) != 1 {
+				t.Fatalf("team rule clientSelectors = %v, want 1", rule0["clientSelectors"])
+			}
+			headers := sels[0].(map[string]interface{})["headers"].([]interface{})
+			h0 := headers[0].(map[string]interface{})
+			if h0["name"] != tt.wantHeader {
+				t.Errorf("team selector header name = %v, want %s", h0["name"], tt.wantHeader)
+			}
+			if h0["type"] != "Distinct" {
+				t.Errorf("team selector header type = %v, want Distinct (independent bucket per value)", h0["type"])
+			}
+			if unit, _ := rule0["limit"].(map[string]interface{})["unit"].(string); unit != "Minute" {
+				t.Errorf("team rateLimit unit = %q, want Minute (60s)", unit)
+			}
+		})
+	}
+}
+
+// TestModelRouterGateway_DollarBudgetFailsLoud covers 2b case (c): a MaxUSD
+// budget sets GatewayReady=False with reason UnsupportedBudgetField and
+// generates NOTHING (no partial route/BTP).
+func TestModelRouterGateway_DollarBudgetFailsLoud(t *testing.T) {
+	c, cfg, stop := startGatewayTestEnv(t, true)
+	defer stop()
+
+	makeBackendISvc(t, c, "usd-cuda")
+
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "usd-router", Namespace: testNS},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+			GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "usd-cuda", InferenceServiceRef: corev1LocalRef("usd-cuda")},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:  "qwen",
+					Match: &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+					Route: inferencev1alpha1.RuleRoute{Backends: []string{"usd-cuda"}},
+				},
+			},
+			Policy: &inferencev1alpha1.RouterPolicy{
+				Budgets: []inferencev1alpha1.BudgetSpec{
+					{Name: "dollar-cap", Scope: "router", WindowSeconds: 3600, MaxUSD: "100.00"},
+				},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), mr); err != nil {
+		t.Fatalf("create modelrouter: %v", err)
+	}
+
+	r := newModelRouterGatewayReconciler(t, cfg)
+	reconcileRouter(t, r, mr)
+
+	assertNotExists(t, c, backendGVK(), "usd-cuda")
+	assertNotExists(t, c, aiServiceBackendGVK(), "usd-cuda")
+	assertNotExists(t, c, aiGatewayRouteGVK(), "usd-router")
+	assertNotExists(t, c, btpGVK(), "usd-router")
+
+	fresh := &inferencev1alpha1.ModelRouter{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "usd-router", Namespace: testNS}, fresh); err != nil {
+		t.Fatalf("get modelrouter: %v", err)
+	}
+	cond := apimeta.FindStatusCondition(fresh.Status.Conditions, ModelRouterGatewayConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != modelRouterGatewayReasonUnsupportedBudgetField {
+		t.Errorf("expected GatewayReady=False/%s, got %+v", modelRouterGatewayReasonUnsupportedBudgetField, cond)
+	}
+	if cond != nil && !contains(cond.Message, "dollar-cap") {
+		t.Errorf("condition message should name the offending budget, got %q", cond.Message)
+	}
+}
+
+// TestModelRouterGateway_RuleScopeBudgetFailsLoud covers 2b case (d): a
+// rule-scope budget sets GatewayReady=False with reason UnsupportedBudgetScope
+// and generates NOTHING.
+func TestModelRouterGateway_RuleScopeBudgetFailsLoud(t *testing.T) {
+	c, cfg, stop := startGatewayTestEnv(t, true)
+	defer stop()
+
+	makeBackendISvc(t, c, "rule-cuda")
+
+	maxTokens := int64(1000)
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "rulescope-router", Namespace: testNS},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+			GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "rule-cuda", InferenceServiceRef: corev1LocalRef("rule-cuda")},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:  "qwen",
+					Match: &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+					Route: inferencev1alpha1.RuleRoute{Backends: []string{"rule-cuda"}},
+				},
+			},
+			Policy: &inferencev1alpha1.RouterPolicy{
+				Budgets: []inferencev1alpha1.BudgetSpec{
+					{Name: "rule-cap", Scope: "rule", RuleName: "qwen", WindowSeconds: 3600, MaxTokens: &maxTokens},
+				},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), mr); err != nil {
+		t.Fatalf("create modelrouter: %v", err)
+	}
+
+	r := newModelRouterGatewayReconciler(t, cfg)
+	reconcileRouter(t, r, mr)
+
+	assertNotExists(t, c, aiGatewayRouteGVK(), "rulescope-router")
+	assertNotExists(t, c, btpGVK(), "rulescope-router")
+
+	fresh := &inferencev1alpha1.ModelRouter{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "rulescope-router", Namespace: testNS}, fresh); err != nil {
+		t.Fatalf("get modelrouter: %v", err)
+	}
+	cond := apimeta.FindStatusCondition(fresh.Status.Conditions, ModelRouterGatewayConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != modelRouterGatewayReasonUnsupportedBudgetScope {
+		t.Errorf("expected GatewayReady=False/%s, got %+v", modelRouterGatewayReasonUnsupportedBudgetScope, cond)
+	}
+}
+
+// TestModelRouterGateway_NoBudgetsUnchangedFromSliceA covers 2b case (e): a
+// ModelRouter with NO budgets produces the exact 2a BTP (no rateLimit key) and
+// route (no llmRequestCosts key), guarding the #693 non-regression contract.
+func TestModelRouterGateway_NoBudgetsUnchangedFromSliceA(t *testing.T) {
+	c, cfg, stop := startGatewayTestEnv(t, true)
+	defer stop()
+
+	makeBackendISvc(t, c, "plain-cuda")
+
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "plain-router", Namespace: testNS},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+			GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "plain-cuda", InferenceServiceRef: corev1LocalRef("plain-cuda")},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:  "qwen",
+					Match: &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+					Route: inferencev1alpha1.RuleRoute{Backends: []string{"plain-cuda"}},
+				},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), mr); err != nil {
+		t.Fatalf("create modelrouter: %v", err)
+	}
+
+	r := newModelRouterGatewayReconciler(t, cfg)
+	reconcileRouter(t, r, mr)
+
+	// No budgets -> BTP carries no rateLimit key (byte-identical to 2a).
+	btp := getUnstructured(t, c, btpGVK(), "plain-router")
+	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "rateLimit"); found {
+		t.Error("no-budget BTP must NOT carry spec.rateLimit (2a non-regression)")
+	}
+	// No budgets -> route carries no llmRequestCosts key.
+	route := getUnstructured(t, c, aiGatewayRouteGVK(), "plain-router")
+	if _, found, _ := unstructured.NestedSlice(route.Object, "spec", "llmRequestCosts"); found {
+		t.Error("no-budget route must NOT carry spec.llmRequestCosts (2a non-regression)")
+	}
+}
+
+// contains is a tiny substring helper for condition-message assertions.
+func contains(s, sub string) bool {
+	return strings.Contains(s, sub)
 }
 
 // TestUnsupportedMatchMessage_GlobModel pins the fail-loud boundary for glob

--- a/internal/controller/modelrouter_gateway_test.go
+++ b/internal/controller/modelrouter_gateway_test.go
@@ -817,3 +817,36 @@ func TestUnsupportedMatchMessage_GlobModel(t *testing.T) {
 		})
 	}
 }
+
+// TestCompileBudgetRule_WindowScaling pins the window-to-unit scaling: Envoy
+// expresses a limit as "N per ONE unit", so MaxTokens (the cap over
+// WindowSeconds) must be scaled to the chosen unit. Exact-unit windows keep
+// requests == MaxTokens; non-exact windows scale so the enforced average rate
+// stays faithful (a raw MaxTokens with a sub-window unit silently under-enforces).
+func TestCompileBudgetRule_WindowScaling(t *testing.T) {
+	maxTok := int64(5_000_000)
+	tests := []struct {
+		window   int32
+		wantUnit string
+		wantReq  int64
+	}{
+		{3600, "Hour", 5_000_000},  // exact: 1 hour
+		{60, "Minute", 5_000_000},  // exact: 1 minute
+		{86400, "Day", 5_000_000},  // exact: 1 day
+		{120, "Minute", 2_500_000}, // 5M*60/120
+		{7200, "Hour", 2_500_000},  // 5M*3600/7200
+		{90, "Minute", 3_333_333},  // 5M*60/90 floored
+		{3601, "Hour", 4_998_611},  // 5M*3600/3601 floored (was ~3600x too loose)
+		{30, "Second", 166_666},    // 5M/30 floored
+	}
+	for _, tt := range tests {
+		b := inferencev1alpha1.BudgetSpec{Scope: "router", WindowSeconds: tt.window, MaxTokens: &maxTok}
+		limit := compileBudgetRule(b)["limit"].(map[string]interface{})
+		if limit["unit"] != tt.wantUnit {
+			t.Errorf("window %ds: unit = %v, want %s", tt.window, limit["unit"], tt.wantUnit)
+		}
+		if got, _ := limit["requests"].(int64); got != tt.wantReq {
+			t.Errorf("window %ds: requests = %d, want %d", tt.window, got, tt.wantReq)
+		}
+	}
+}


### PR DESCRIPTION
## What

Slice 2b of the AI Gateway epic (#661): compile ModelRouter `policy.budgets[]` into token-denominated rate limiting, producing instant 429s when a budget is exceeded. Design + reasoning: `docs/proposals/661-ai-gateway-integration.md` section 5.2 sub-slice 2b (updated in this PR).

## How

- **One BTP (footgun made structural).** The `rateLimit` (Global) stanza is appended to the SAME `BackendTrafficPolicy` 2a generates for retry/failover, never a second policy. Two BTPs on one route silently conflict (oldest wins), so retry and rate limit must share one BTP.
- **Token-denominated.** Adds `llmRequestCosts` (TotalToken) to the `AIGatewayRoute` 2a generates, so the limit charges tokens at response completion (request path check-only). Mirrors the spike's validated shape.
- **Scopes `router` and `team`.** `router` = a global descriptor; `team` = a `Distinct` clientSelector on `HeaderKey` (default `x-llmkube-team`), one bucket per value.
- **Faithful window scaling.** Envoy expresses a limit as "N per ONE unit", so `MaxTokens` (the cap over `WindowSeconds`) is scaled to the largest unit <= the window: `requests = MaxTokens * unitSeconds / WindowSeconds`. Exact-unit windows (60/3600/86400) keep `requests == MaxTokens`.

## Deferred, with reasoning (documented in the proposal)

- **`MaxUSD` fails loud (`UnsupportedBudgetField`)**: no single honest token conversion across heterogeneous backend `CostPerMillionTokens`; dollar budgets get their own slice once the conversion is decided.
- **`rule` scope fails loud (`UnsupportedBudgetScope`)**: per-rule rateLimit selectors are fiddlier; `router`/`team` are the high-value cases.
- **`team` scope is compiled now but documented as needing auth (2d)** to be tamper-proof (the keyed header is client-settable until 2d derives it from a verified JWT claim).

## Review fix

Adversarial review caught a silent under-enforcement bug pre-merge: the rate-limit value was not scaled to the chosen unit, so a non-exact window (e.g. `windowSeconds: 3601`) enforced a limit ~3600x too loose while reporting `GatewayReady=True`. Fixed by scaling `requests` to the unit, with a test covering exact and non-exact windows. The one-BTP footgun, fail-loud ordering, no-budget non-regression, and the `llmRequestCosts`/cost metadata shape were all verified clean.

## Checklist

- [x] envtest coverage (router + team rateLimit on the shared BTP, llmRequestCosts, MaxUSD/rule fail-loud, no-budget non-regression, window-scaling unit test)
- [x] `make test` passes (`internal/controller` 80.4%, 14 gateway tests)
- [x] `make lint` + `GOOS=linux ./bin/golangci-lint run ./...` pass
- [x] `make check-helm-rbac` passes; CRDs + chart-crds in sync
- [x] Conventional commits, signed off (DCO); design doc updated

Part of #661 (slice 2b; the epic stays open for audit (2c), auth (2d), classification (2e), and backend-health bridging).