### PR TITLE
feat(gateway): gateway-scoped audit access log + fail-loud auditLog in Gateway mode (2c)

### DIFF
--- a/charts/llmkube/templates/NOTES.txt
+++ b/charts/llmkube/templates/NOTES.txt
@@ -67,6 +67,16 @@ GETTING STARTED:
    - Inference alerts: {{ if .Values.prometheus.prometheusRule.rules.inference.enabled }}Enabled{{ else }}Disabled{{ end }}
 {{- end }}
 
+{{- if .Values.gateway.auditLog.enabled }}
+
+7. Gateway audit access log is enabled!
+   EnvoyProxy: {{ .Values.gateway.auditLog.envoyProxyName }} (namespace: {{ .Values.gateway.auditLog.envoyProxyNamespace | default .Release.Namespace }})
+   ACTION REQUIRED: reference this EnvoyProxy from your GatewayClass
+   (spec.parametersRef) or Gateway (spec.infrastructure.parametersRef);
+   the chart cannot own external gateway infra, so the access log only
+   takes effect once that parametersRef is wired.
+{{- end }}
+
 ---
 DOCUMENTATION:
 

--- a/charts/llmkube/templates/gateway-audit-envoyproxy.yaml
+++ b/charts/llmkube/templates/gateway-audit-envoyproxy.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.gateway.auditLog.enabled }}
+# Gateway-scoped audit access log (sub-slice 2c).
+#
+# Envoy Gateway configures access logging ONLY on the EnvoyProxy resource
+# (telemetry.accessLog), which attaches to the gateway via the GatewayClass or
+# Gateway parametersRef. There is no per-HTTPRoute access-log API, and the
+# operator references an EXTERNAL Gateway it does not own, so the audit trail is
+# shipped here as an opt-in, gateway-scoped artifact rather than a per-ModelRouter
+# compiled resource.
+#
+# IMPORTANT: the chart cannot own external gateway infra. You must reference this
+# EnvoyProxy from your GatewayClass (spec.parametersRef) or Gateway
+# (spec.infrastructure.parametersRef) for the access log to take effect.
+#
+# The logged fields are produced by other slices already on the wire (x-team from
+# JWT auth, x-ai-eg-model from the ext_proc, llm_*_token from the budget
+# llmRequestCosts), so they populate automatically once those slices are active.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: {{ .Values.gateway.auditLog.envoyProxyName }}
+  namespace: {{ .Values.gateway.auditLog.envoyProxyNamespace | default .Release.Namespace }}
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+spec:
+  telemetry:
+    accessLog:
+      settings:
+        - type: Route
+          format:
+            type: JSON
+            json:
+              # Header allowlist only: Authorization is NEVER logged; path and
+              # query string are omitted. Token fields are null on errors and
+              # non-final frames (present only at end-of-stream on success).
+              start_time: "%START_TIME%"
+              x_request_id: "%REQ(X-REQUEST-ID)%"
+              team: "%REQ(X-TEAM)%"
+              model: "%REQ(X-AI-EG-MODEL)%"
+              response_model: "%DYNAMIC_METADATA(io.envoy.ai_gateway:response_model)%"
+              backend: "%DYNAMIC_METADATA(io.envoy.ai_gateway:backend_name)%"
+              response_code: "%RESPONSE_CODE%"
+              response_code_details: "%RESPONSE_CODE_DETAILS%"
+              duration: "%DURATION%"
+              upstream_cluster: "%UPSTREAM_CLUSTER%"
+              llm_input_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
+              llm_output_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
+              llm_total_tokens: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"
+          sinks:
+            # File/stdout sink: always on when auditLog is enabled (local JSON
+            # fallback, collected by the cluster log stack).
+            - type: File
+              file:
+                path: /dev/stdout
+            {{- if .Values.gateway.auditLog.otel.enabled }}
+            # OpenTelemetry sink: the Loki/collector path, rendered only when
+            # gateway.auditLog.otel.enabled.
+            - type: OpenTelemetry
+              openTelemetry:
+                backendRefs:
+                  - name: {{ .Values.gateway.auditLog.otel.backendRef.name }}
+                    namespace: {{ .Values.gateway.auditLog.otel.backendRef.namespace | default .Release.Namespace }}
+                    port: {{ .Values.gateway.auditLog.otel.backendRef.port }}
+                resourceAttributes:
+                  service.name: {{ .Values.gateway.auditLog.otel.resourceAttributes.serviceName | quote }}
+                  k8s.cluster.name: {{ .Values.gateway.auditLog.otel.resourceAttributes.clusterName | quote }}
+            {{- end }}
+{{- end }}

--- a/charts/llmkube/tests/gateway_audit_test.yaml
+++ b/charts/llmkube/tests/gateway_audit_test.yaml
@@ -1,0 +1,86 @@
+suite: gateway audit access log
+templates:
+  - gateway-audit-envoyproxy.yaml
+
+tests:
+  # Default OFF: existing installs must be unaffected.
+  - it: should render nothing when auditLog is disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an EnvoyProxy when auditLog is enabled
+    set:
+      gateway.auditLog.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: EnvoyProxy
+      - equal:
+          path: apiVersion
+          value: gateway.envoyproxy.io/v1alpha1
+
+  - it: should name the EnvoyProxy from values
+    set:
+      gateway.auditLog.enabled: true
+      gateway.auditLog.envoyProxyName: my-audit
+      gateway.auditLog.envoyProxyNamespace: ai-gateway
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-audit
+      - equal:
+          path: metadata.namespace
+          value: ai-gateway
+
+  # File/stdout sink always on; OTel sink gated off by default.
+  - it: should emit only the File sink when otel is disabled
+    set:
+      gateway.auditLog.enabled: true
+    asserts:
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].type
+          value: Route
+      - lengthEqual:
+          path: spec.telemetry.accessLog.settings[0].sinks
+          count: 1
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].sinks[0].type
+          value: File
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].sinks[0].file.path
+          value: /dev/stdout
+
+  # OTel sink appended only when enabled, wired from values.
+  - it: should append the OpenTelemetry sink when otel is enabled
+    set:
+      gateway.auditLog.enabled: true
+      gateway.auditLog.otel.enabled: true
+      gateway.auditLog.otel.backendRef.name: otel-collector
+      gateway.auditLog.otel.backendRef.namespace: envoy-gateway-system
+      gateway.auditLog.otel.backendRef.port: 4317
+    asserts:
+      - lengthEqual:
+          path: spec.telemetry.accessLog.settings[0].sinks
+          count: 2
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].sinks[1].type
+          value: OpenTelemetry
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].sinks[1].openTelemetry.backendRefs[0].name
+          value: otel-collector
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].sinks[1].openTelemetry.backendRefs[0].port
+          value: 4317
+
+  # Security posture: Authorization is never logged.
+  - it: should not log the Authorization header
+    set:
+      gateway.auditLog.enabled: true
+    asserts:
+      - notExists:
+          path: spec.telemetry.accessLog.settings[0].format.json.authorization
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].format.json.team
+          value: "%REQ(X-TEAM)%"

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -280,6 +280,45 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auditLog": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "envoyProxyName": { "type": "string", "minLength": 1 },
+            "envoyProxyNamespace": { "type": "string" },
+            "otel": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "backendRef": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": { "type": "string", "minLength": 1 },
+                    "namespace": { "type": "string" },
+                    "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+                  }
+                },
+                "resourceAttributes": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "serviceName": { "type": "string" },
+                    "clusterName": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "imagePullSecrets": {
       "type": "array",
       "items": {

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -169,6 +169,52 @@ metrics:
     nodePort: ""
     annotations: {}
 
+# Gateway-scoped audit access log (sub-slice 2c).
+#
+# Envoy Gateway configures access logging ONLY on the EnvoyProxy resource
+# (telemetry.accessLog), gateway-infrastructure-scoped, not per route. The
+# operator references an EXTERNAL Gateway via gatewayRef and does not own the
+# EnvoyProxy, so the audit trail ships here as an opt-in, gateway-scoped artifact
+# rather than a per-ModelRouter compiled resource. Default off, so existing
+# installs are unaffected.
+#
+# Security posture (from the homelab spike):
+#   - Header allowlist only: the Authorization header is NEVER logged.
+#   - Request path and query string are omitted.
+#   - Token fields (llm_input/output/total_token) are null on errors and
+#     non-final frames; they are present only at end-of-stream on success.
+#   - Request/response bodies are not loggable via access logs at all.
+#
+# The audit fields are produced by other slices already on the wire, so they
+# populate automatically once those slices are active:
+#   - team (x-team) from JWT auth (ModelRouter policy.auth.jwt),
+#   - model (x-ai-eg-model) from the ext_proc,
+#   - llm_*_token from the budget llmRequestCosts metadata.
+gateway:
+  auditLog:
+    # Enable the gateway audit EnvoyProxy. Off by default.
+    enabled: false
+    # Name/namespace of the rendered EnvoyProxy. You MUST reference this
+    # EnvoyProxy from your GatewayClass (spec.parametersRef) or Gateway
+    # (spec.infrastructure.parametersRef): the chart cannot own external gateway
+    # infra, so the access log only takes effect once you wire that parametersRef.
+    envoyProxyName: llmkube-audit
+    # Namespace for the EnvoyProxy (defaults to the release namespace).
+    envoyProxyNamespace: ""
+    # OpenTelemetry sink (the Loki/collector path). When disabled, only the
+    # File/stdout JSON sink is emitted.
+    otel:
+      enabled: false
+      # gRPC backend reference for the OTel collector.
+      backendRef:
+        name: otel-collector
+        namespace: ""
+        port: 4317
+      # Resource attributes attached to every emitted log record.
+      resourceAttributes:
+        serviceName: llmkube-ai-gateway
+        clusterName: llmkube
+
 # Prometheus Operator integration
 prometheus:
   # Enable Prometheus ServiceMonitor

--- a/docs/proposals/661-ai-gateway-integration.md
+++ b/docs/proposals/661-ai-gateway-integration.md
@@ -195,6 +195,22 @@ Add a per-team model **allowlist** surface and compile it into the `authorizatio
 
 **Deferred from 2d.2 (with reasoning):** cross-validating allowlist model names against the union of `spec.rules[].match.models` (catch a typo that silently denies) is a useful guard but couples authZ to rule/`defaultRoute` resolution (header-only rules, catch-alls) and is reversible; it is a follow-up. A validating webhook to reject these fail-loud cases at apply time (rather than status-only) is the same cross-slice follow-up noted for 2a/2d-core.
 
+#### Sub-slice 2c (detailed design): audit log via gateway access logs
+
+Deliver the audit trail as a gateway-scoped access log, NOT a per-ModelRouter compiled resource. This is a deliberate departure from the per-route compilation pattern of 2a/2b/2d, forced by how Envoy Gateway works.
+
+- **Why gateway-scoped, not per-router.** Envoy Gateway access logging is configured ONLY on the `EnvoyProxy` resource (`telemetry.accessLog.settings`, `type: Route|Listener`), which attaches to the gateway via `GatewayClass.parametersRef` or `Gateway.spec.infrastructure.parametersRef`. There is no per-`HTTPRoute` or per-`BackendTrafficPolicy` access-log API. The operator references an EXTERNAL Gateway via `gatewayRef` and does not own the GatewayClass / Gateway / EnvoyProxy, so it cannot compile a per-router resource for audit and must not fight other ModelRouters over the shared proxy.
+
+- **The fields are already on the wire.** The spike's validated access-log field set (`start_time`, `x_request_id`, `team` from `x-team`, `model` from `x-ai-eg-model`, `response_model` / `backend` / `llm_input|output|total_token` from the `io.envoy.ai_gateway` dynamic metadata, `response_code`, `duration`) is emitted with NO per-route change: 2d's `claimToHeaders` lands `x-team`, the extproc lands `x-ai-eg-model`, and 2b's `llmRequestCosts` lands the token metadata. 2c is purely the sink config; the producers already shipped.
+
+- **Deliverable: an opt-in, Helm-managed EnvoyProxy access-log template** in `charts/llmkube` (gated on a `gateway.auditLog.enabled` value, default off). It renders the proven field set to two sinks: a `File` sink to `/dev/stdout` (JSON, local fallback) and an `OpenTelemetry` sink (gRPC to a configurable collector, the Loki path), both values-driven. Because the chart cannot own external gateway infra, the chart ships the EnvoyProxy and documents that the operator references it from their GatewayClass/Gateway `parametersRef` (values let them name/namespace it to match).
+
+- **Security defaults (from the spike).** Header allowlist only (NEVER log `Authorization`); PATH and query string omitted; token fields are null on errors and non-final frames (they exist only at end-of-stream on success via `llmRequestCosts`). Request/response bodies are not loggable via access logs at all.
+
+- **Honest boundary (fail-loud), consistent with 2a/2b/2d.** `spec.policy.auditLog` is a Proxy-mode field (it names the router-proxy container and a file path). In `dataPlane: Gateway` mode it has no per-router meaning, so it is fail-loud (`UnsupportedAuditLogInGatewayMode`): set `GatewayReady=False`, generate NOTHING, and point the operator to the gateway-level config. Generate-nothing is especially defensible for audit: silently ignoring an audit directive a user believes is active is a compliance footgun, so refuse loudly. The field stays fully valid in Proxy mode (the router-proxy path is untouched).
+
+**Deferred from 2c (with reasoning):** an operator-managed singleton EnvoyProxy keyed by `gatewayRef` that merges each ModelRouter's `auditLog` into one shared access-log config. It keeps the per-router field meaningful but makes the operator mutate gateway infra it does not own, with cross-router conflict/ordering risk; rejected for v1 in favor of the honest gateway-scoped artifact.
+
 ### 5.3 Backend health bridging (sub-projects 3 + 4)
 metal-agent (#662) ejects/restores the address on its managed Endpoints object on health change and surfaces status. The operator (sub-project 4) compiles that health, plus pod health, into gateway `Backend` ejection/restoration, giving off-cluster Metal endpoints the event-driven detection that pods get from the EPP. This mutates the `Backend`s the MVP generates.
 

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -70,6 +70,13 @@ const (
 	// GatewayReady False, consistent with the 2a/2b/2d-core honest boundary.
 	modelRouterGatewayReasonAuthzRequiresJWT = "AuthorizationRequiresJWT"
 	modelRouterGatewayReasonInvalidAuthz     = "InvalidAuthorization"
+
+	// slice 2c audit-log fail-loud reason. policy.auditLog is a Proxy-mode-only
+	// field (it names the router-proxy container and a file path); in Gateway mode
+	// it has no per-router meaning, so it is refused loudly rather than silently
+	// ignored. Consistent with the 2a/2b/2d honest boundary: GatewayReady goes
+	// False and the router generates NOTHING.
+	modelRouterGatewayReasonUnsupportedAuditLog = "UnsupportedAuditLogInGatewayMode"
 )
 
 // ModelRouterGatewayReconciler compiles a ModelRouter in dataPlane: Gateway mode
@@ -165,6 +172,16 @@ func (r *ModelRouterGatewayReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// would silently lock everyone out).
 	if reason, msg := invalidAuthorizationMessage(mr); reason != "" {
 		return ctrl.Result{}, r.setGatewayNotReady(ctx, mr, reason, msg)
+	}
+
+	// Fail-loud on a per-router auditLog directive: policy.auditLog is a Proxy-mode
+	// field with no per-route Gateway equivalent (Envoy Gateway access logging is
+	// configured on the gateway-scoped EnvoyProxy, not per route). Silently ignoring
+	// an audit directive a user believes is active is a compliance footgun, so we
+	// generate NOTHING and point the operator at the gateway-level access-log config.
+	// Same ordering as the auth checks (before any CreateOrUpdate).
+	if msg := unsupportedAuditLogMessage(mr); msg != "" {
+		return ctrl.Result{}, r.setGatewayNotReady(ctx, mr, modelRouterGatewayReasonUnsupportedAuditLog, msg)
 	}
 
 	if err := r.reconcileGatewayResources(ctx, mr); err != nil {
@@ -529,6 +546,26 @@ func routerAllowlists(mr *inferencev1alpha1.ModelRouter) []inferencev1alpha1.Tea
 		return nil
 	}
 	return mr.Spec.Policy.Auth.Allowlists
+}
+
+// unsupportedAuditLogMessage returns a non-empty message when policy.auditLog is
+// set on a router in dataPlane: Gateway mode, or "" when it is absent. Any
+// auditLog block present means the user asked for per-router audit, which is a
+// Proxy-mode-only feature (it names the router-proxy container and a file path).
+// Envoy Gateway access logging is configured on the gateway-scoped EnvoyProxy
+// (telemetry.accessLog), not per route, and the operator does not own that
+// external gateway infra, so a per-router auditLog has no Gateway equivalent. Like
+// invalidAuthMessage it runs BEFORE generation so a rejected auditLog yields no
+// partial resources; refusing loudly avoids silently dropping an audit directive
+// (a compliance footgun). The field stays fully valid in Proxy mode.
+func unsupportedAuditLogMessage(mr *inferencev1alpha1.ModelRouter) string {
+	if mr.Spec.Policy == nil || mr.Spec.Policy.AuditLog == nil {
+		return ""
+	}
+	return "policy.auditLog is a Proxy-mode field with no per-router equivalent in dataPlane: Gateway; " +
+		"Envoy Gateway access logging is configured on the gateway-scoped EnvoyProxy (telemetry.accessLog), " +
+		"not per route. Enable the chart's gateway.auditLog values to ship the audit EnvoyProxy and reference " +
+		"it from your GatewayClass/Gateway parametersRef, or remove policy.auditLog"
 }
 
 // invalidAuthMessage returns a non-empty message when policy.auth.jwt is set but

--- a/internal/controller/modelrouter_gateway_test.go
+++ b/internal/controller/modelrouter_gateway_test.go
@@ -1633,3 +1633,155 @@ func TestCompileBudgetRule_WindowScaling(t *testing.T) {
 		}
 	}
 }
+
+// TestModelRouterGateway_AuditLogFailsLoud covers the 2c honest boundary: a
+// dataPlane: Gateway router with policy.auditLog set is refused loudly
+// (GatewayReady=False, reason UnsupportedAuditLogInGatewayMode) and generates
+// NOTHING. auditLog is a Proxy-mode field; in Gateway mode audit is configured on
+// the gateway-scoped EnvoyProxy (the chart's gateway.auditLog values), not per
+// router, so silently ignoring it would be a compliance footgun.
+func TestModelRouterGateway_AuditLogFailsLoud(t *testing.T) {
+	c, cfg, stop := startGatewayTestEnv(t, true)
+	defer stop()
+
+	makeBackendISvc(t, c, "audit-cuda")
+
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "audit-router", Namespace: testNS},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+			GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "audit-cuda", InferenceServiceRef: corev1LocalRef("audit-cuda")},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:  "qwen",
+					Match: &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+					Route: inferencev1alpha1.RuleRoute{Backends: []string{"audit-cuda"}},
+				},
+			},
+			Policy: &inferencev1alpha1.RouterPolicy{
+				AuditLog: &inferencev1alpha1.AuditLogPolicy{Sink: "stdout"},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), mr); err != nil {
+		t.Fatalf("create modelrouter: %v", err)
+	}
+
+	r := newModelRouterGatewayReconciler(t, cfg)
+	reconcileRouter(t, r, mr)
+
+	// Generates NOTHING: no Backend, AIServiceBackend, route, SecurityPolicy, or BTP.
+	assertNotExists(t, c, backendGVK(), "audit-cuda")
+	assertNotExists(t, c, aiServiceBackendGVK(), "audit-cuda")
+	assertNotExists(t, c, aiGatewayRouteGVK(), "audit-router")
+	assertNotExists(t, c, securityPolicyGVK(), "audit-router")
+	assertNotExists(t, c, btpGVK(), "audit-router")
+
+	fresh := &inferencev1alpha1.ModelRouter{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "audit-router", Namespace: testNS}, fresh); err != nil {
+		t.Fatalf("get modelrouter: %v", err)
+	}
+	cond := apimeta.FindStatusCondition(fresh.Status.Conditions, ModelRouterGatewayConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != modelRouterGatewayReasonUnsupportedAuditLog {
+		t.Errorf("expected GatewayReady=False/%s, got %+v", modelRouterGatewayReasonUnsupportedAuditLog, cond)
+	}
+	if fresh.Status.Gateway != nil && fresh.Status.Gateway.RouteReady {
+		t.Errorf("status.gateway.routeReady should be false on unsupported auditLog")
+	}
+}
+
+// TestModelRouterGateway_NoAuditLogStillReady is the positive control for the 2c
+// fail-loud check: an otherwise-identical router WITHOUT policy.auditLog reaches
+// GatewayReady=True and generates its resources, proving the auditLog guard is not
+// over-broad.
+func TestModelRouterGateway_NoAuditLogStillReady(t *testing.T) {
+	c, cfg, stop := startGatewayTestEnv(t, true)
+	defer stop()
+
+	makeBackendISvc(t, c, "noaudit-cuda")
+
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "noaudit-router", Namespace: testNS},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+			GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "noaudit-cuda", InferenceServiceRef: corev1LocalRef("noaudit-cuda")},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:  "qwen",
+					Match: &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+					Route: inferencev1alpha1.RuleRoute{Backends: []string{"noaudit-cuda"}},
+				},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), mr); err != nil {
+		t.Fatalf("create modelrouter: %v", err)
+	}
+
+	r := newModelRouterGatewayReconciler(t, cfg)
+	reconcileRouter(t, r, mr)
+
+	// Resources are generated and the router reaches Ready.
+	getUnstructured(t, c, aiGatewayRouteGVK(), "noaudit-router")
+
+	fresh := &inferencev1alpha1.ModelRouter{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "noaudit-router", Namespace: testNS}, fresh); err != nil {
+		t.Fatalf("get modelrouter: %v", err)
+	}
+	cond := apimeta.FindStatusCondition(fresh.Status.Conditions, ModelRouterGatewayConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Errorf("expected GatewayReady=True, got %+v", cond)
+	}
+}
+
+// TestUnsupportedAuditLogMessage is a pure-function unit test for the 2c
+// fail-loud guard: nil policy and a policy without auditLog return "" (no
+// rejection); a policy with any auditLog block returns a non-empty message.
+func TestUnsupportedAuditLogMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		policy     *inferencev1alpha1.RouterPolicy
+		wantReject bool
+	}{
+		{
+			name:       "nil policy compiles",
+			policy:     nil,
+			wantReject: false,
+		},
+		{
+			name:       "policy without auditLog compiles",
+			policy:     &inferencev1alpha1.RouterPolicy{},
+			wantReject: false,
+		},
+		{
+			name:       "policy with empty auditLog block rejected",
+			policy:     &inferencev1alpha1.RouterPolicy{AuditLog: &inferencev1alpha1.AuditLogPolicy{}},
+			wantReject: true,
+		},
+		{
+			name:       "policy with populated auditLog rejected",
+			policy:     &inferencev1alpha1.RouterPolicy{AuditLog: &inferencev1alpha1.AuditLogPolicy{Sink: "otlp"}},
+			wantReject: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr := &inferencev1alpha1.ModelRouter{
+				Spec: inferencev1alpha1.ModelRouterSpec{Policy: tt.policy},
+			}
+			msg := unsupportedAuditLogMessage(mr)
+			if tt.wantReject && msg == "" {
+				t.Errorf("expected auditLog rejected, got empty message")
+			}
+			if !tt.wantReject && msg != "" {
+				t.Errorf("expected auditLog accepted, got rejection: %s", msg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Slice 2c of the AI Gateway epic: the audit trail for `ModelRouter` in `dataPlane: Gateway` mode, delivered as a gateway-scoped access log. Two parts: an opt-in, Helm-managed `EnvoyProxy` access-log template in `charts/llmkube`, and a fail-loud guard that refuses the Proxy-mode-only `spec.policy.auditLog` field in Gateway mode.

## Why

Part of #661. The lab acceptance scenario's "reconstruct who-did-what" requirement needs an audit trail. Envoy Gateway configures access logging ONLY on the `EnvoyProxy` resource (`telemetry.accessLog`), which is gateway-infrastructure-scoped, not per-route, and the operator references an external Gateway it does not own. So audit cannot be a per-ModelRouter compiled resource (unlike 2a/2b/2d); it is shipped as a gateway-scoped artifact, and the per-router field is made honest.

## How

- **Helm `EnvoyProxy` access-log template** (`charts/llmkube/templates/gateway-audit-envoyproxy.yaml`), gated on `gateway.auditLog.enabled` (default `false`, so existing installs are unaffected). It emits the homelab-spike-validated audit field set (`start_time`, `x_request_id`, `team`, `model`, `response_model`, `backend`, `response_code`, `duration`, `llm_input/output/total_token`, etc.) to an always-on `File`/stdout JSON sink plus an optional `OpenTelemetry` sink (the Loki path), both values-driven.
- **The fields are already on the wire.** No per-route change: 2d's `claimToHeaders` lands `x-team`, the ext_proc lands `x-ai-eg-model`, and 2b's `llmRequestCosts` lands the token dynamic metadata. 2c is purely the sink config.
- **Security posture (from the spike):** header allowlist only (never logs `Authorization`); path/query omitted; token fields are null on errors and non-final frames.
- **Ownership boundary:** the chart cannot own external gateway infra, so it ships the `EnvoyProxy` (name/namespace values-driven) and documents (values comments + NOTES.txt) that the operator must reference it from their GatewayClass/Gateway `parametersRef`.
- **Fail-loud, consistent with 2a/2b/2d:** `spec.policy.auditLog` in Gateway mode sets `GatewayReady=False` (reason `UnsupportedAuditLogInGatewayMode`) and generates NOTHING, pointing to the gateway-level config. Generate-nothing is especially defensible for audit (silently ignoring an audit directive is a compliance footgun). The field stays valid in Proxy mode.
- Design reasoning documented in `docs/proposals/661-ai-gateway-integration.md` (sub-slice 2c).

An adversarial review verified the template (default-off, sink gating, exact field set, no sensitive fields), the schema, and the fail-loud guard; its one non-blocking note (add a chart-side test) is addressed with a helm-unittest suite for the template.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint run ./...`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change)
