### PR TITLE
feat(gateway): active HTTP health checks on the ModelRouter BTP for fast backend ejection (#662)

### DIFF
--- a/docs/proposals/661-ai-gateway-integration.md
+++ b/docs/proposals/661-ai-gateway-integration.md
@@ -211,8 +211,25 @@ Deliver the audit trail as a gateway-scoped access log, NOT a per-ModelRouter co
 
 **Deferred from 2c (with reasoning):** an operator-managed singleton EnvoyProxy keyed by `gatewayRef` that merges each ModelRouter's `auditLog` into one shared access-log config. It keeps the per-router field meaningful but makes the operator mutate gateway infra it does not own, with cross-router conflict/ordering risk; rejected for v1 in favor of the honest gateway-scoped artifact.
 
-### 5.3 Backend health bridging (sub-projects 3 + 4)
-metal-agent (#662) ejects/restores the address on its managed Endpoints object on health change and surfaces status. The operator (sub-project 4) compiles that health, plus pod health, into gateway `Backend` ejection/restoration, giving off-cluster Metal endpoints the event-driven detection that pods get from the EPP. This mutates the `Backend`s the MVP generates.
+### 5.3 Backend health bridging (sub-projects 3 + 4, issue #662)
+
+**The problem (measured in the spike).** A Metal backend is an fqdn `Backend` pointing at a selectorless Service's ClusterIP. When the Mac dies abruptly, Envoy still sees the ClusterIP as up: in-flight requests stall for the full per-attempt timeout (60s measured) and passive outlier detection never engages (a blackholed connection produces no consecutive 5xx). Pods behind an InferencePool fail new requests over in 2-4ms; off-cluster Metal has no equivalent because pools are structurally pods-only. Something must actively tell Envoy the tier is down.
+
+The chosen posture is **defense in depth**: an always-on active-probe safety net that catches abrupt death at probe speed, plus an event-driven layer that reacts instantly to health the agent/operator already knows. Three reviewable pieces:
+
+#### Slice 4a (detailed design): active health checks on the BTP
+
+Extend the `BackendTrafficPolicy` the operator already generates (2a, which carries retry + passive outlier `healthCheck`) with an `healthCheck.active` HTTP checker (EG v1.8 schema): `type: HTTP`, `http.path: /health` (the llama.cpp/llama-server health endpoint), `method: GET`, `expectedStatuses: [200]`, a short `interval` (default 2s, tunable), `timeout`, `unhealthyThreshold`, `healthyThreshold`. Envoy then probes every backend cluster directly (bypassing the route filters) and ejects a dead host, including an abruptly-killed Mac behind ClusterIP, without waiting on the request timeout. This is the smallest, most self-contained piece and the one that makes the lab failover demo work; it applies to all gateway-mode backends (pods benefit too). Active probing is independent of the long-generation request timeout (it hits `/health`, not the generation path), so it does not reintroduce the short-timeout conflict #662 calls out. The per-backend health path is `/health` for v1; making it configurable per runtime is a follow-up.
+
+#### Slice 3 (detailed design): metal-agent proactive withdraw/restore
+
+metal-agent already runs the three-probe runtime health check and manages its Endpoints registration (`RegisterEndpoint`/`UnregisterEndpoint`, with retry from #657). Wire the health signal outward: on the runtime going **unhealthy** (agent alive, runtime down), proactively `UnregisterEndpoint` (withdraw the address so kube-proxy stops DNATing) and surface the state; on recovery, re-register. This is event-driven and fast for the graceful case. Abrupt agent death (the Mac is yanked) is still covered by the operator's existing heartbeat-staleness expiry (#663) feeding Slice 4b, and at probe speed by Slice 4a.
+
+#### Slice 4b (detailed design): event-driven route-level ejection
+
+The operator watches Metal endpoint health (the #663 heartbeat classification `metalHBFresh/Stale` plus Slice 3's withdrawal, both visible as Endpoints changes) and recompiles the `AIGatewayRoute` to exclude backends whose referenced InferenceService is unhealthy, restoring them on recovery. This needs an InferenceService/Endpoints -> ModelRouter watch (enqueue the ModelRouters that reference a changed InferenceService) and a flap **debounce/soak** so a briefly-stale heartbeat does not thrash the route. This is the event-speed layer that reacts the instant the agent/operator knows, rather than at active-probe interval; it sits on top of 4a's safety net, not instead of it.
+
+**Ordering:** 4a first (self-contained, delivers the demo), then Slice 3 (agent-side, independent), then 4b (the most operator surface: new watch + ejection logic + debounce). **Deferred:** per-runtime configurable health path (4a hardcodes `/health`); making the active-check thresholds a ModelRouter API surface (hardcoded sensible defaults for v1, mirroring how the passive `healthCheck` block is hardcoded).
 
 ---
 

--- a/internal/controller/gateway_resources_modelrouter.go
+++ b/internal/controller/gateway_resources_modelrouter.go
@@ -42,8 +42,9 @@ var nonDNSChar = regexp.MustCompile(`[^a-z0-9-]+`)
 //   - one multi-rule AIGatewayRoute (a rule per spec.rules entry, matching on
 //     model name + headers, routing to the rule's backends with priority for
 //     failover or weight for weighted),
-//   - one BackendTrafficPolicy (retry + passive outlier healthCheck) targeting
-//     the generated HTTPRoute, which shares the AIGatewayRoute's name.
+//   - one BackendTrafficPolicy (retry + passive outlier + active HTTP
+//     healthCheck) targeting the generated HTTPRoute, which shares the
+//     AIGatewayRoute's name.
 //
 // Shapes mirror the validated spike manifests
 // (experiments/ai-gateway-spike/manifests/): 02/04-backend-*.yaml,
@@ -91,6 +92,29 @@ const (
 	// backendRef/targetRef name fields). Extracted to a const because slice 2d
 	// pushed the package-wide occurrence count past the goconst threshold.
 	metadataNameField = "name"
+
+	// Active HTTP health-check tunables compiled onto the BTP in slice 4a (#662).
+	// Hardcoded sensible defaults for v1, mirroring how the passive healthCheck
+	// block is hardcoded; a follow-up can promote them to the ModelRouter API.
+	// The short interval favors fast detection of an abruptly-killed Metal backend
+	// behind a ClusterIP (which passive outlier detection never ejects, since a
+	// blackholed connection returns no 5xx). The path is the llama.cpp /
+	// llama-server health endpoint, served by the llama.cpp/vLLM/TGI pod runtimes
+	// and the Metal llama/mlx runtime this slice targets.
+	//
+	// CAVEAT: this hardcodes GET /health for EVERY gateway-mode backend. Runtimes
+	// that do not serve HTTP /health (the TCP-probed PersonaPlex/Generic runtimes
+	// today, and external/cloud backends once dataPlane: Gateway supports them)
+	// would fail this probe and be ejected even while healthy. Gateway mode
+	// currently rejects external backends outright (resolveBackends), and the
+	// demo/target runtimes all serve /health, so this is safe to ship; the
+	// per-runtime configurable health path is the deferred follow-up that lifts
+	// the assumption (see proposal 5.3, slice 4a "Deferred").
+	activeHealthCheckInterval           = "2s"
+	activeHealthCheckTimeout            = "1s"
+	activeHealthCheckPath               = "/health"
+	activeHealthCheckUnhealthyThreshold = int64(2)
+	activeHealthCheckHealthyThreshold   = int64(1)
 )
 
 // aiGatewayTotalTokenKey is the dynamic-metadata key (within
@@ -361,12 +385,17 @@ func compileRuleBackendRefs(refs []routerBackendRef) []interface{} {
 	return out
 }
 
-// newRouterBackendTrafficPolicy builds the retry + passive-outlier
-// BackendTrafficPolicy that makes priority failover actually retry onto the
-// secondary backend. It targets the generated HTTPRoute (which shares the
-// AIGatewayRoute's name) by name. Mirrors spike 05-fallback-policy.yaml MINUS
-// the rateLimit/budget stanza (slice 2b adds that to THIS policy; two BTPs on
-// one target silently conflict, footgun 7.1).
+// newRouterBackendTrafficPolicy builds the retry + passive-outlier + active
+// HTTP health-check BackendTrafficPolicy that makes priority failover actually
+// retry onto the secondary backend and ejects dead backends fast. It targets the
+// generated HTTPRoute (which shares the AIGatewayRoute's name) by name. Mirrors
+// spike 05-fallback-policy.yaml MINUS the rateLimit/budget stanza (slice 2b adds
+// that to THIS policy; two BTPs on one target silently conflict, footgun 7.1).
+// The active HTTP check (slice 4a, #662) probes each backend cluster's /health
+// endpoint directly at the cluster level, bypassing the route filters, and is
+// independent of the long-generation request timeout (it hits /health, not the
+// generation path), so it ejects an abruptly-killed Metal backend behind a
+// ClusterIP without waiting on the per-attempt request timeout.
 func newRouterBackendTrafficPolicy(mr *inferencev1alpha1.ModelRouter, budgets []inferencev1alpha1.BudgetSpec) *unstructured.Unstructured {
 	name := modelRouterGatewayResourceName(mr)
 	spec := map[string]interface{}{
@@ -398,6 +427,24 @@ func newRouterBackendTrafficPolicy(mr *inferencev1alpha1.ModelRouter, budgets []
 				"consecutive5XxErrors": int64(3),
 				"interval":             "5s",
 				"maxEjectionPercent":   int64(100),
+			},
+			// Active HTTP probe (slice 4a, #662): Envoy hits each backend cluster's
+			// /health directly, bypassing the route filters, so a blackholed Metal
+			// backend (abrupt Mac death behind a ClusterIP) is ejected at probe speed
+			// rather than stalling for the per-attempt request timeout. Independent of
+			// the long-generation timeout since it probes /health, not the generation
+			// path.
+			"active": map[string]interface{}{
+				"type":               "HTTP",
+				"interval":           activeHealthCheckInterval,
+				"timeout":            activeHealthCheckTimeout,
+				"unhealthyThreshold": activeHealthCheckUnhealthyThreshold,
+				"healthyThreshold":   activeHealthCheckHealthyThreshold,
+				"http": map[string]interface{}{
+					"path":             activeHealthCheckPath,
+					"method":           "GET",
+					"expectedStatuses": []interface{}{int64(200)},
+				},
 			},
 		},
 	}

--- a/internal/controller/modelrouter_gateway_test.go
+++ b/internal/controller/modelrouter_gateway_test.go
@@ -200,6 +200,10 @@ func TestModelRouterGateway_FailoverProducesResources(t *testing.T) {
 	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "healthCheck", "passive"); !found {
 		t.Error("btp missing spec.healthCheck.passive")
 	}
+	// 4a adds an active HTTP health check alongside the passive block.
+	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "healthCheck", "active"); !found {
+		t.Error("btp missing spec.healthCheck.active")
+	}
 	// 2b adds rateLimit to THIS BTP; 2a must NOT include it.
 	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "rateLimit"); found {
 		t.Error("btp should not carry rateLimit in slice 2a")
@@ -215,6 +219,92 @@ func TestModelRouterGateway_FailoverProducesResources(t *testing.T) {
 	}
 	if cond := apimeta.FindStatusCondition(fresh.Status.Conditions, ModelRouterGatewayConditionReady); cond == nil || cond.Status != metav1.ConditionTrue {
 		t.Errorf("GatewayReady condition not True, got %+v", cond)
+	}
+}
+
+// TestModelRouterGateway_ActiveHealthCheck covers slice 4a (#662): the generated
+// BackendTrafficPolicy carries an active HTTP health check (type HTTP, GET
+// /health, expectedStatuses 200, with the tuned interval/timeout/threshold
+// consts) so Envoy probes each backend cluster directly and ejects a dead host
+// (including an abruptly-killed Mac behind a ClusterIP) without waiting on the
+// per-attempt request timeout. The existing passive block and retry stanza must
+// remain (adding active must not drop them).
+func TestModelRouterGateway_ActiveHealthCheck(t *testing.T) {
+	c, cfg, stop := startGatewayTestEnv(t, true)
+	defer stop()
+
+	makeBackendISvc(t, c, "qwen-cuda")
+
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "hc-router", Namespace: testNS},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+			GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "qwen-cuda", InferenceServiceRef: corev1LocalRef("qwen-cuda")},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:  "qwen",
+					Match: &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+					Route: inferencev1alpha1.RuleRoute{Backends: []string{"qwen-cuda"}},
+				},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), mr); err != nil {
+		t.Fatalf("create modelrouter: %v", err)
+	}
+
+	r := newModelRouterGatewayReconciler(t, cfg)
+	reconcileRouter(t, r, mr)
+
+	btp := getUnstructured(t, c, btpGVK(), "hc-router")
+
+	// Regression: retry and the passive outlier block must survive 4a.
+	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "retry"); !found {
+		t.Error("btp missing spec.retry (2a stanza must remain)")
+	}
+	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "healthCheck", "passive"); !found {
+		t.Error("btp missing spec.healthCheck.passive (2a stanza must remain)")
+	}
+
+	active, found, _ := unstructured.NestedMap(btp.Object, "spec", "healthCheck", "active")
+	if !found {
+		t.Fatal("btp missing spec.healthCheck.active")
+	}
+	if got, _ := active["type"].(string); got != "HTTP" {
+		t.Errorf("active.type = %q, want HTTP", got)
+	}
+	if got, _ := active["interval"].(string); got != activeHealthCheckInterval {
+		t.Errorf("active.interval = %q, want %q", got, activeHealthCheckInterval)
+	}
+	if got, _ := active["timeout"].(string); got != activeHealthCheckTimeout {
+		t.Errorf("active.timeout = %q, want %q", got, activeHealthCheckTimeout)
+	}
+	if got, _ := active["unhealthyThreshold"].(int64); got != activeHealthCheckUnhealthyThreshold {
+		t.Errorf("active.unhealthyThreshold = %d, want %d", got, activeHealthCheckUnhealthyThreshold)
+	}
+	if got, _ := active["healthyThreshold"].(int64); got != activeHealthCheckHealthyThreshold {
+		t.Errorf("active.healthyThreshold = %d, want %d", got, activeHealthCheckHealthyThreshold)
+	}
+
+	httpCheck, found, _ := unstructured.NestedMap(btp.Object, "spec", "healthCheck", "active", "http")
+	if !found {
+		t.Fatal("btp missing spec.healthCheck.active.http")
+	}
+	if got, _ := httpCheck["path"].(string); got != activeHealthCheckPath {
+		t.Errorf("active.http.path = %q, want %q", got, activeHealthCheckPath)
+	}
+	if got, _ := httpCheck["method"].(string); got != "GET" {
+		t.Errorf("active.http.method = %q, want GET", got)
+	}
+	statuses, _ := httpCheck["expectedStatuses"].([]interface{})
+	if len(statuses) != 1 {
+		t.Fatalf("active.http.expectedStatuses = %v, want exactly [200]", statuses)
+	}
+	if got, _ := statuses[0].(int64); got != int64(200) {
+		t.Errorf("active.http.expectedStatuses[0] = %v, want 200", statuses[0])
 	}
 }
 
@@ -1248,6 +1338,9 @@ func TestModelRouterGateway_RouterBudgetProducesRateLimit(t *testing.T) {
 	}
 	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "healthCheck", "passive"); !found {
 		t.Error("btp missing spec.healthCheck.passive (2a stanza must remain)")
+	}
+	if _, found, _ := unstructured.NestedMap(btp.Object, "spec", "healthCheck", "active"); !found {
+		t.Error("btp missing spec.healthCheck.active (4a stanza must remain)")
 	}
 	rlType, _, _ := unstructured.NestedString(btp.Object, "spec", "rateLimit", "type")
 	if rlType != "Global" {


### PR DESCRIPTION
## What

PR1 of #662 (Slice 4a): add an active HTTP health check to the `BackendTrafficPolicy` the operator generates for every `dataPlane: Gateway` ModelRouter, so Envoy probes each backend directly (`GET /health`, 2s interval) and ejects dead hosts fast.

## Why

Part of #661 / #662. A Metal backend is an fqdn `Backend` pointing at a selectorless Service's ClusterIP. When the Mac dies abruptly, endpoint death is invisible to Envoy: in-flight requests stall for the full per-attempt timeout (60s measured) and passive outlier detection never engages (a blackholed connection produces no consecutive 5xx). Pods behind an InferencePool fail over in 2-4ms; off-cluster Metal had no equivalent. An active probe gives Envoy a connection-level health signal so failover actually fires. This is the always-on safety net half of the "both" (defense-in-depth) approach chosen for #662; the event-driven layer (agent withdrawal + route-level ejection) follows in later PRs.

## How

- Extend `newRouterBackendTrafficPolicy` (`internal/controller/gateway_resources_modelrouter.go`) with `healthCheck.active` alongside the existing `healthCheck.passive`: `type: HTTP`, `http.{path: /health, method: GET, expectedStatuses: [200]}`, `interval: 2s`, `timeout: 1s`, `unhealthyThreshold: 2`, `healthyThreshold: 1` (~4s to eject). EG v1.8 schema verified against source.
- Tunables are hoisted to named consts (a follow-up can promote them to the ModelRouter API, mirroring how the passive block is hardcoded).
- The active probe hits the backend cluster directly, bypassing the route filters, so it needs no JWT and is independent of the long-generation request timeout (it probes `/health`, not the generation path).
- Applies to all gateway-mode backends (pods benefit too). `retry`, `healthCheck.passive`, and the 2b `rateLimit` stanza all stay on the same BTP intact (footgun 7.1 respected).
- A const comment flags the one caveat surfaced in review: `/health` is assumed for every backend, so TCP-probed runtimes (PersonaPlex/Generic) or external/cloud backends would be falsely ejected if ever fronted by a gateway ModelRouter. External backends are a hard error in gateway mode today, and the target runtimes all serve `/health`, so this is safe to ship; per-runtime configurable health path is the deferred follow-up.
- Design reasoning in `docs/proposals/661-ai-gateway-integration.md` (section 5.3, slice 4a).

An adversarial review verified the EG v1.8 schema (the highest-risk item: bare-int `expectedStatuses` is correct), that `/health` and the probe port line up for the target runtimes, that the probe bypasses auth at the cluster level, and that the shared BTP stays intact.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint run ./...`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change)
