### PR TITLE
feat(crd): make GPU resource name configurable to support AMD/Vulkan/Intel scheduling

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -140,6 +140,27 @@ type GPUSpec struct {
 	// +optional
 	Vendor string `json:"vendor,omitempty"`
 
+	// ResourceName overrides the extended resource the operator requests for
+	// this Model's pods. Defaults are derived from Vendor:
+	//   nvidia -> nvidia.com/gpu
+	//   amd    -> amd.com/gpu
+	//   intel  -> gpu.intel.com/i915
+	// Set this for non-default device plugins (e.g. squat/generic-device-plugin
+	// advertising `squat.ai/dri-render`, NVIDIA MIG slices, or DRA-backed
+	// resources). When set, this value also drives the GPU toleration unless
+	// TolerationKey is provided explicitly.
+	// +kubebuilder:validation:Pattern=`^[a-z0-9.\-]+/[a-z0-9._\-]+$`
+	// +optional
+	ResourceName string `json:"resourceName,omitempty"`
+
+	// TolerationKey overrides the taint key the operator tolerates when
+	// scheduling GPU pods. Defaults to ResourceName (or the vendor default
+	// resource name when ResourceName is unset), so in most cases this can
+	// be left empty.
+	// +kubebuilder:validation:Pattern=`^[a-z0-9.\-]+/[a-z0-9._\-]+$`
+	// +optional
+	TolerationKey string `json:"tolerationKey,omitempty"`
+
 	// Layers specifies layer offloading configuration for multi-GPU
 	// Format: number of layers to offload to GPU (e.g., 32 for full offload on 7B model)
 	// -1 means auto-detect optimal layer split

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -115,6 +115,19 @@ spec:
                         description: Memory specifies minimum GPU memory required
                           per GPU (e.g., "8Gi", "16Gi")
                         type: string
+                      resourceName:
+                        description: |-
+                          ResourceName overrides the extended resource the operator requests for
+                          this Model's pods. Defaults are derived from Vendor:
+                            nvidia -> nvidia.com/gpu
+                            amd    -> amd.com/gpu
+                            intel  -> gpu.intel.com/i915
+                          Set this for non-default device plugins (e.g. squat/generic-device-plugin
+                          advertising `squat.ai/dri-render`, NVIDIA MIG slices, or DRA-backed
+                          resources). When set, this value also drives the GPU toleration unless
+                          TolerationKey is provided explicitly.
+                        pattern: ^[a-z0-9.\-]+/[a-z0-9._\-]+$
+                        type: string
                       sharding:
                         description: |-
                           Sharding defines how to shard the model across multiple GPUs
@@ -147,6 +160,14 @@ spec:
                             - none
                             type: string
                         type: object
+                      tolerationKey:
+                        description: |-
+                          TolerationKey overrides the taint key the operator tolerates when
+                          scheduling GPU pods. Defaults to ResourceName (or the vendor default
+                          resource name when ResourceName is unset), so in most cases this can
+                          be left empty.
+                        pattern: ^[a-z0-9.\-]+/[a-z0-9._\-]+$
+                        type: string
                       vendor:
                         default: nvidia
                         description: |-

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -111,6 +111,19 @@ spec:
                         description: Memory specifies minimum GPU memory required
                           per GPU (e.g., "8Gi", "16Gi")
                         type: string
+                      resourceName:
+                        description: |-
+                          ResourceName overrides the extended resource the operator requests for
+                          this Model's pods. Defaults are derived from Vendor:
+                            nvidia -> nvidia.com/gpu
+                            amd    -> amd.com/gpu
+                            intel  -> gpu.intel.com/i915
+                          Set this for non-default device plugins (e.g. squat/generic-device-plugin
+                          advertising `squat.ai/dri-render`, NVIDIA MIG slices, or DRA-backed
+                          resources). When set, this value also drives the GPU toleration unless
+                          TolerationKey is provided explicitly.
+                        pattern: ^[a-z0-9.\-]+/[a-z0-9._\-]+$
+                        type: string
                       sharding:
                         description: |-
                           Sharding defines how to shard the model across multiple GPUs
@@ -143,6 +156,14 @@ spec:
                             - none
                             type: string
                         type: object
+                      tolerationKey:
+                        description: |-
+                          TolerationKey overrides the taint key the operator tolerates when
+                          scheduling GPU pods. Defaults to ResourceName (or the vendor default
+                          resource name when ResourceName is unset), so in most cases this can
+                          be left empty.
+                        pattern: ^[a-z0-9.\-]+/[a-z0-9._\-]+$
+                        type: string
                       vendor:
                         default: nvidia
                         description: |-

--- a/config/samples/model_amd_vulkan_igpu.yaml
+++ b/config/samples/model_amd_vulkan_igpu.yaml
@@ -1,0 +1,94 @@
+# Example: AMD APU / iGPU with llama.cpp Vulkan backend
+#
+# This manifest demonstrates scheduling onto an AMD integrated GPU that
+# exposes a generic render node via a community device plugin such as
+# squat/generic-device-plugin (https://github.com/squat/generic-device-plugin).
+#
+# Use case: air-gapped workstations and small-form-factor nodes where a
+# discrete NVIDIA GPU is unavailable, but the APU's integrated Radeon
+# graphics is enough to accelerate a small model (Phi-3 mini, Llama 3.2 1B/3B,
+# Qwen2.5 3B) via the Vulkan backend shipped in a custom llama.cpp build.
+#
+# Cluster prerequisites:
+#   1. The target node has an AMD APU / dGPU with /dev/dri/renderD* visible.
+#   2. squat/generic-device-plugin (or equivalent) is installed and advertising
+#      the extended resource `squat.ai/dri-render` on the node, with a matching
+#      `squat.ai/dri-render=present:NoSchedule` taint for dedicated GPU nodes.
+#   3. The container image under spec.image is a llama.cpp build with Vulkan
+#      support compiled in (e.g. a derivative of ghcr.io/ggml-org/llama.cpp
+#      built with -DGGML_VULKAN=ON). The operator does not ship a Vulkan
+#      runtime image; bring your own.
+#
+# Usage:
+#   kubectl apply -f config/samples/model_amd_vulkan_igpu.yaml
+#   kubectl get models,inferenceservices -w
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-3b-amd-vulkan
+  namespace: default
+spec:
+  # Source: a small GGUF quantized for Vulkan/ROCm-friendly inference.
+  source: https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf
+  format: gguf
+  quantization: Q4_K_M
+
+  hardware:
+    # The runtime backend is selected by spec.runtime on the InferenceService;
+    # the Model only declares what GPU resource the device plugin advertises.
+    gpu:
+      enabled: true
+      count: 1
+      vendor: amd
+
+      # Escape hatch: the AMD ROCm device plugin is not the only way to expose
+      # an AMD GPU on a node. squat/generic-device-plugin advertises the
+      # generic render node under a different extended resource name, which
+      # is what this Model targets. Defaults would have produced
+      # amd.com/gpu; the override selects squat.ai/dri-render instead.
+      resourceName: squat.ai/dri-render
+
+      # The device plugin taints nodes it owns with the resource name as the
+      # key, so tolerationKey can be left unset (it falls back to
+      # resourceName). Set it explicitly only when the plugin's taint key
+      # differs from the resource it advertises.
+      # tolerationKey: squat.ai/dri-render
+
+  resources:
+    cpu: "4"
+    memory: "8Gi"
+
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: llama-3b-amd-vulkan-service
+  namespace: default
+spec:
+  modelRef: llama-3b-amd-vulkan
+
+  replicas: 1
+
+  # Bring-your-own Vulkan-enabled llama.cpp image. The default
+  # ghcr.io/defilantech/llmkube-llama.cpp image is CUDA-only; swap it for
+  # a build with -DGGML_VULKAN=ON (or ROCm) when targeting AMD hardware.
+  image: ghcr.io/example/llama.cpp-vulkan:latest
+
+  resources:
+    gpu: 1
+    cpu: "2"
+    memory: "4Gi"
+
+  endpoint:
+    port: 8080
+    type: ClusterIP
+
+---
+# Optional: apply, then verify the pod scheduled onto the AMD APU node.
+#
+#   kubectl wait --for=condition=Available inferenceservice/llama-3b-amd-vulkan-service --timeout=600s
+#   POD=$(kubectl get pod -l app=llama-3b-amd-vulkan-service -o jsonpath='{.items[0].metadata.name}')
+#   kubectl describe pod $POD | grep -E 'Tolerations|Node-Selectors|squat.ai/dri-render'
+#   kubectl logs $POD -c llama-server | grep -i vulkan
+#   # Expected: "ggml_vulkan: detected" + "offloaded NN/XX layers to GPU"

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -231,7 +231,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	}
 
 	gpuCount := resolveGPUCount(isvc, model)
-	gpuResourceName := resolveGPUResourceName(model)
+	gpuResourceName := gpuResourceNameForSpec(model)
 
 	if gpuCount > 0 {
 		container.Resources = corev1.ResourceRequirements{
@@ -301,7 +301,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 
 		tolerations := []corev1.Toleration{
 			{
-				Key:      string(gpuResourceName),
+				Key:      gpuTolerationKeyForSpec(model),
 				Operator: corev1.TolerationOpEqual,
 				Value:    "present",
 				Effect:   corev1.TaintEffectNoSchedule,

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func TestGPUResourceNameForSpec(t *testing.T) {
+	cases := []struct {
+		name     string
+		gpu      *inferencev1alpha1.GPUSpec
+		expected corev1.ResourceName
+	}{
+		{
+			name:     "nil GPU spec defaults to nvidia",
+			gpu:      nil,
+			expected: nvidiaGPUResourceName,
+		},
+		{
+			name:     "empty GPU spec defaults to nvidia",
+			gpu:      &inferencev1alpha1.GPUSpec{},
+			expected: nvidiaGPUResourceName,
+		},
+		{
+			name:     "vendor nvidia maps to nvidia.com/gpu",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "nvidia"},
+			expected: nvidiaGPUResourceName,
+		},
+		{
+			name:     "vendor amd maps to amd.com/gpu",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "amd"},
+			expected: amdGPUResourceName,
+		},
+		{
+			name:     "vendor intel maps to gpu.intel.com/i915",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "intel"},
+			expected: intelGPUResourceNameI915,
+		},
+		{
+			name:     "vendor is case-insensitive",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "AMD"},
+			expected: amdGPUResourceName,
+		},
+		{
+			name:     "unknown vendor falls back to nvidia",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "mystery"},
+			expected: nvidiaGPUResourceName,
+		},
+		{
+			name: "explicit ResourceName overrides vendor mapping",
+			gpu: &inferencev1alpha1.GPUSpec{
+				Vendor:       "amd",
+				ResourceName: "squat.ai/dri-render",
+			},
+			expected: corev1.ResourceName("squat.ai/dri-render"),
+		},
+		{
+			name: "explicit ResourceName wins even when vendor is unset",
+			gpu: &inferencev1alpha1.GPUSpec{
+				ResourceName: "nvidia.com/gpu.shared",
+			},
+			expected: corev1.ResourceName("nvidia.com/gpu.shared"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := &inferencev1alpha1.Model{
+				Spec: inferencev1alpha1.ModelSpec{
+					Hardware: &inferencev1alpha1.HardwareSpec{GPU: tc.gpu},
+				},
+			}
+
+			if model.Spec.Hardware.GPU == nil {
+				// Use a Hardware with no GPU at all for the nil cases so the
+				// helper exercises the outer "GPU == nil" branch.
+				model.Spec.Hardware = &inferencev1alpha1.HardwareSpec{}
+			}
+
+			got := gpuResourceNameForSpec(model)
+			if got != tc.expected {
+				t.Fatalf("gpuResourceNameForSpec() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGPUTolerationKeyForSpec(t *testing.T) {
+	cases := []struct {
+		name     string
+		gpu      *inferencev1alpha1.GPUSpec
+		expected string
+	}{
+		{
+			name:     "nil GPU defaults to nvidia resource name",
+			gpu:      nil,
+			expected: string(nvidiaGPUResourceName),
+		},
+		{
+			name:     "vendor amd toleration key falls back to amd.com/gpu",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "amd"},
+			expected: string(amdGPUResourceName),
+		},
+		{
+			name:     "vendor intel toleration key falls back to gpu.intel.com/i915",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "intel"},
+			expected: string(intelGPUResourceNameI915),
+		},
+		{
+			name: "explicit TolerationKey wins over ResourceName",
+			gpu: &inferencev1alpha1.GPUSpec{
+				Vendor:        "amd",
+				ResourceName:  "amd.com/gpu",
+				TolerationKey: "nvidia.com/gpu",
+			},
+			expected: "nvidia.com/gpu",
+		},
+		{
+			name: "TolerationKey falls back to ResourceName when unset",
+			gpu: &inferencev1alpha1.GPUSpec{
+				Vendor:       "amd",
+				ResourceName: "squat.ai/dri-render",
+			},
+			expected: "squat.ai/dri-render",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := &inferencev1alpha1.Model{
+				Spec: inferencev1alpha1.ModelSpec{
+					Hardware: &inferencev1alpha1.HardwareSpec{GPU: tc.gpu},
+				},
+			}
+
+			if model.Spec.Hardware.GPU == nil {
+				model.Spec.Hardware = &inferencev1alpha1.HardwareSpec{}
+			}
+
+			got := gpuTolerationKeyForSpec(model)
+			if got != tc.expected {
+				t.Fatalf("gpuTolerationKeyForSpec() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/controller/gpu_resources.go
+++ b/internal/controller/gpu_resources.go
@@ -22,6 +22,53 @@ var (
 	intelGPUResourceNameXE   = corev1.ResourceName("gpu.intel.com/xe")
 )
 
+// gpuResourceNameForSpec resolves the extended resource the pod requests for
+// GPU scheduling. Resolution order:
+//
+//  1. Model.Spec.Hardware.GPU.ResourceName, when set, wins over everything
+//     else. This is the escape hatch for non-default device plugins
+//     (e.g. squat/generic-device-plugin advertising squat.ai/dri-render).
+//  2. Model.Spec.Hardware.GPU.Vendor maps to the device-plugin default for
+//     that vendor (nvidia -> nvidia.com/gpu, amd -> amd.com/gpu,
+//     intel -> gpu.intel.com/i915).
+//  3. Unset / unknown -> nvidia.com/gpu (backwards-compatible default).
+//
+// Used by the deployment builder; the accelerator-aware variant
+// resolveGPUResourceName is used by the Model reconciler's readiness check
+// and intentionally stays separate so the two code paths can evolve
+// independently.
+func gpuResourceNameForSpec(model *inferencev1alpha1.Model) corev1.ResourceName {
+	if model != nil && model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil {
+		if override := strings.TrimSpace(model.Spec.Hardware.GPU.ResourceName); override != "" {
+			return corev1.ResourceName(override)
+		}
+
+		switch strings.ToLower(strings.TrimSpace(model.Spec.Hardware.GPU.Vendor)) {
+		case "amd":
+			return amdGPUResourceName
+		case "intel":
+			return intelGPUResourceNameI915
+		}
+	}
+
+	return nvidiaGPUResourceName
+}
+
+// gpuTolerationKeyForSpec returns the taint key the GPU toleration should
+// match. Defaults to the resource name (so the operator tolerates the taint
+// the device plugin typically applies to advertise its nodes), with an
+// explicit override via Model.Spec.Hardware.GPU.TolerationKey for setups
+// where the two differ.
+func gpuTolerationKeyForSpec(model *inferencev1alpha1.Model) string {
+	if model != nil && model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil {
+		if override := strings.TrimSpace(model.Spec.Hardware.GPU.TolerationKey); override != "" {
+			return override
+		}
+	}
+
+	return string(gpuResourceNameForSpec(model))
+}
+
 func resolveGPUResourceName(model *inferencev1alpha1.Model) corev1.ResourceName {
 	if model != nil && model.Spec.Hardware != nil {
 		if strings.EqualFold(model.Spec.Hardware.Accelerator, acceleratorIntel) {


### PR DESCRIPTION
## What

Makes `Model.spec.hardware.gpu.resourceName` and `tolerationKey` first-class CRD fields, with a new deployment-builder helper that resolves the GPU extended resource and toleration key from `vendor` (or an explicit override) instead of hardcoding `nvidia.com/gpu`.

## Why

`deployment_builder.go` hardcoded `nvidia.com/gpu` at the resource limit and the GPU toleration, even though the CRD already exposed a `nvidia | amd | intel` vendor enum. That made AMD and Intel nodes unreachable through LLMKube — surfaced by a community user running llama.cpp's Vulkan backend on an AMD APU (#395). The vendor field was effectively dead on the pod-spec path.

A free-form `resourceName` override is also exposed for non-default device plugins (`squat/generic-device-plugin` advertising `squat.ai/dri-render`, NVIDIA MIG slices, time-slicing variants, DRA).

## How

Resolution order in the new `gpuResourceNameForSpec` / `gpuTolerationKeyForSpec` helpers:

1. `spec.hardware.gpu.resourceName` (escape hatch) — wins over everything.
2. `spec.hardware.gpu.vendor` maps to the device-plugin default (`nvidia` → `nvidia.com/gpu`, `amd` → `amd.com/gpu`, `intel` → `gpu.intel.com/i915`).
3. Unset / unknown → `nvidia.com/gpu` (backwards-compatible default).

`tolerationKey` defaults to the resolved resource name and is independently overridable.

The accelerator-aware `resolveGPUResourceName` used by `Model.checkAcceleratorAvailability` is intentionally left alone — it serves a different consumer and the two paths can evolve independently.

### Files

- `api/v1alpha1/model_types.go` — new optional fields on `GPUSpec` with kubebuilder pattern validation.
- `internal/controller/gpu_resources.go` — new helpers; existing `resolveGPUResourceName` unchanged.
- `internal/controller/deployment_builder.go` — the two hardcoded `nvidia.com/gpu` references route through the helpers.
- `internal/controller/deployment_builder_test.go` — new table-driven tests (14 subtests) covering: nil/empty GPU, each vendor mapping, case-insensitivity, unknown vendor fallback, explicit `resourceName` override (with and without vendor), `tolerationKey` fallback to `resourceName`, and explicit `tolerationKey` override.
- `config/samples/model_amd_vulkan_igpu.yaml` — end-to-end sample: `vendor: amd` + `resourceName: squat.ai/dri-render` + user-supplied Vulkan llama.cpp image.
- `config/crd/bases/inference.llmkube.dev_models.yaml` + `charts/llmkube/templates/crds/models.yaml` — regenerated via `make manifests` + `make chart-crds`.

### Backwards compatibility

`nvidia.com/gpu` remains the default when no fields are set. The existing Ginkgo cases in `inferenceservice_deployment_test.go` that pin `nvidia.com/gpu` continue to pass unchanged.

## Checklist

- [x] Code passes all tests (`make test`)
- [x] Linter passes (`make lint` + `make lint-all`)
- [x] Branch is up-to-date with `main`
- [x] Commit message follows conventions (conventional commit, DCO signed)
- [x] Generated files committed (CRD + Helm chart synced)

Fixes #395