### PR TITLE
docs: fix DGX Spark guide for ARM64 (GPU operator + GB10 image)

### DIFF
--- a/docs/dgx-spark-microk8s.md
+++ b/docs/dgx-spark-microk8s.md
@@ -6,10 +6,10 @@ using MicroK8s for the Kubernetes layer.
 > **Read this first.** The DGX Spark is an **ARM64** machine (GB10 Grace-Blackwell
 > superchip, unified memory) running DGX OS, which already ships the NVIDIA driver
 > and CUDA. LLMKube's control plane is arm64-ready (its images are multi-arch), so
-> the operator, CRDs, and scheduling all work. **The catch is the GPU serving
-> image:** the GB10 GPU is Blackwell (compute capability `sm_121`), which is
-> bleeding-edge, and the stock upstream `llama.cpp` CUDA image does **not** run on
-> it out of the box. You will need a GB10-built serving image (see
+> the operator, CRDs, and scheduling all work. **The thing to get right is the GPU
+> serving image:** the GB10 GPU is Blackwell (compute capability `sm_121`), which
+> is bleeding-edge, so use the upstream `llama.cpp` **CUDA-13** image (the CUDA-12
+> tag predates `sm_121`); if that does not work, fall back to a GB10-built image (see
 > [Step 5](#5-the-gb10-serving-image-the-important-part)). LLMKube does not yet
 > validate Blackwell in CI (tracked in #413), so treat this as a working-but-not-yet-certified path.
 
@@ -24,27 +24,62 @@ using MicroK8s for the Kubernetes layer.
 nvidia-smi   # lists the GB10 Blackwell GPU; DGX OS ships the driver + CUDA
 ```
 
-## 2. Install MicroK8s and the GPU addon
+## 2. Install MicroK8s
 
 ```bash
 sudo snap install microk8s --classic
 sudo usermod -aG microk8s "$USER" && newgrp microk8s
 microk8s status --wait-ready
 
-# Core addons: DNS, a default StorageClass for the model-cache PVC, and Helm.
+# DNS, a default StorageClass for the model-cache PVC, and Helm.
 microk8s enable dns hostpath-storage helm3
-
-# GPU: installs the NVIDIA GPU Operator. On a DGX the host driver is already
-# present, so the addon configures the operator to use it.
-sudo microk8s enable gpu
 ```
 
-The `gpu` addon is the path documented by Canonical for DGX systems. If the
-operator's driver pods crash-loop because they try to install a driver over the
-host one, reconfigure its ClusterPolicy to use the host driver
-(`driver.enabled=false`); see the
-[MicroK8s DGX guide](https://canonical.com/microk8s/docs/nvidia-dgx) and the
-[NVIDIA GPU Operator docs](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html).
+## 2b. GPU support: install the NVIDIA GPU Operator via Helm (NOT the addon)
+
+> **Do not use `microk8s enable gpu` on the DGX Spark.** The MicroK8s `gpu` /
+> `nvidia` addons declare `supported_architectures: [amd64]`, so on this ARM64
+> machine they are filtered out and `enable gpu` fails with
+> "Addon gpu was not found in any repository". (`enable community` does not help;
+> `gpu` is a core addon, and the limitation is the architecture, not the repo.)
+> The NVIDIA GPU Operator itself supports arm64, so install it directly via Helm.
+
+This mirrors what the MicroK8s addon does internally (same containerd wiring),
+minus the amd64 gate. `driver.enabled=false` because DGX OS already provides the
+host driver:
+
+```bash
+microk8s helm3 repo add nvidia https://helm.ngc.nvidia.com/nvidia
+microk8s helm3 repo update
+
+# Use a values file rather than inline --set-json: multi-line JSON pasted into a
+# terminal gets mangled (helm then sees the flags as positional args and fails
+# with "expected at most two arguments").
+cat > /tmp/gpu-operator-values.yaml <<'EOF'
+operator:
+  defaultRuntime: containerd
+driver:
+  enabled: false
+toolkit:
+  env:
+    - name: CONTAINERD_CONFIG
+      value: /var/snap/microk8s/current/args/containerd-template.toml
+    - name: CONTAINERD_SOCKET
+      value: /var/snap/microk8s/common/run/containerd.sock
+    - name: CONTAINERD_SET_AS_DEFAULT
+      value: "true"
+EOF
+
+microk8s helm3 install gpu-operator nvidia/gpu-operator -n gpu-operator-resources --create-namespace -f /tmp/gpu-operator-values.yaml
+```
+
+The two `CONTAINERD_*` paths are the MicroK8s-specific bit: they let the
+operator's toolkit wire the `nvidia` runtime into MicroK8s's containerd.
+`CONTAINERD_SET_AS_DEFAULT=true` makes `nvidia` the default runtime so GPU pods
+work without per-pod config. (If you prefer not to change the default runtime,
+drop that env and instead set `spec.runtimeClassName: nvidia` on each
+`InferenceService` (LLMKube supports it), which is also required on MicroK8s
+1.36+ where the addon no longer forces a default runtime.)
 
 ## 3. Confirm Kubernetes sees the GPU
 
@@ -70,33 +105,41 @@ microk8s helm3 install llmkube llmkube/llmkube \
 microk8s kubectl -n llmkube-system rollout status deploy/llmkube-controller-manager
 ```
 
-## 5. The GB10 serving image (the important part)
+## 5. The GB10 serving image (try the stock CUDA-13 tag first)
 
 LLMKube schedules a `llama.cpp` server pod for each `InferenceService`. The
-default serving image is the upstream `ghcr.io/ggml-org/llama.cpp` build, and
-**the stock CUDA tags do not run on the GB10 Blackwell GPU**: they are missing the
-`sm_121` compute target and trip an `LD_LIBRARY_PATH` issue against the CUDA 13
-compatibility libraries. You must supply a serving image built for GB10:
+default serving image is the upstream `ghcr.io/ggml-org/llama.cpp` build. The GB10
+GPU is `sm_121`, which is a CUDA-13-era target, so **set the serving image to the
+CUDA-13 tag** and test it:
+
+```bash
+brew install defilantech/tap/llmkube   # or download the linux-arm64 binary from GitHub Releases
+llmkube deploy llama-3.2-3b --gpu --image ghcr.io/ggml-org/llama.cpp:server-cuda13
+# or set spec.image: ghcr.io/ggml-org/llama.cpp:server-cuda13 on the InferenceService
+```
+
+Watch the pod logs for `ggml_vulkan`/`CUDA` device detection and `offloaded N
+layers to GPU`. The CUDA-12 tag (`server-cuda`) predates `sm_121` and will not
+work; the CUDA-13 tag is built on CUDA 13, which knows `sm_121`, so it has a good
+chance of working out of the box (this is bleeding-edge and not yet
+project-validated, so confirm on the node).
+
+**If the CUDA-13 image fails** with an `sm_121` / `libcuda.so.1` error, build a
+GB10-specific image and point `--image` / `spec.image` at it:
 
 - CUDA **13.0.2 or 13.1.0**
 - `CMAKE_CUDA_ARCHITECTURES=121a-real` (the GB10 Blackwell target)
 - the build/runtime `LD_LIBRARY_PATH` set to include `/usr/local/cuda-13/compat`
 - an arm64 base image
 
-Until upstream ships a GB10 tag, this is a custom build. The community has working
-Dockerfiles; see the upstream [llama.cpp Docker docs](https://github.com/ggml-org/llama.cpp/blob/master/docs/docker.md)
+The community has working Dockerfiles; see the upstream
+[llama.cpp Docker docs](https://github.com/ggml-org/llama.cpp/blob/master/docs/docker.md)
 and the NVIDIA developer forum thread
 [Building llama.cpp container images for Spark/GB10](https://forums.developer.nvidia.com/t/building-llama-cpp-container-images-for-spark-gb10/353664).
-Push your built image to a registry the node can reach.
 
-Then point LLMKube at it. With the CLI, pass `--image`:
-
-```bash
-brew install defilantech/tap/llmkube   # or download the linux-arm64 binary from GitHub Releases
-llmkube deploy llama-3.2-3b --gpu --image <your-registry>/llama.cpp-gb10:latest
-```
-
-Or, applying CRDs directly, set `spec.image` on the `InferenceService`:
+Either way, set the image explicitly on the `InferenceService` (the operator's
+default serving image is not the CUDA-13 tag, so a GPU model with no `image` set
+will not accelerate here):
 
 ```yaml
 apiVersion: inference.llmkube.dev/v1alpha1
@@ -106,13 +149,10 @@ metadata:
 spec:
   modelRef: llama-3-2-3b
   replicas: 1
-  image: <your-registry>/llama.cpp-gb10:latest   # REQUIRED on GB10; the default image will not run
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda13   # or your GB10-built image if this fails
   resources:
     gpu: 1
 ```
-
-> The operator's default serving image targets CPU/standard CUDA, not GB10. A GPU
-> `InferenceService` with no `image` set will not accelerate on this hardware.
 
 ## 6. Test the endpoint
 


### PR DESCRIPTION
## What

Corrects the DGX Spark (GB10) MicroK8s guide added in #717, which had three problems once it met the actual ARM64 hardware.

## Why

#717 was authored/merged before the guide was run on a real DGX Spark. On the box, the GPU-enable step fails outright and one serving-image claim was overstated.

## How

1. **GPU enable was wrong for ARM64.** The MicroK8s `gpu`/`nvidia` addons declare `supported_architectures: [amd64]`, so on the GB10 (arm64) they are filtered out and `microk8s enable gpu` fails with `Addon gpu was not found in any repository`. Replaced with a direct **NVIDIA GPU Operator Helm install** (the operator supports arm64), mirroring the MicroK8s addon's own containerd wiring (`CONTAINERD_CONFIG`/`CONTAINERD_SOCKET` paths) with `driver.enabled=false` for the DGX host driver. Delivered via a **values file** rather than inline `--set-json`, because the multi-line JSON gets mangled on paste (helm then errors with "expected at most two arguments" - hit live).
2. **Overstated GB10 serving-image claim.** The guide said the stock image cannot run on GB10. The CUDA-13 tag (`server-cuda13`) is built on CUDA 13, which knows `sm_121`, so the guide now says to **try `server-cuda13` first** and treats a custom GB10 build (CUDA 13.0.2/13.1.0, `CMAKE_CUDA_ARCHITECTURES=121a-real`) as the fallback only if it fails.
3. Em-dash cleanup.

Verified against the MicroK8s core-addons manifests (the amd64-only arch gate), the addon's enable script (the containerd values), and the upstream llama.cpp CUDA Dockerfile (CUDA 12.8.1 default arch, plus the separate CUDA-13 tag). Docs-only.

## Checklist

- [x] Documentation updated (this PR is the documentation)
- [x] Commit signed off (DCO)
