### PR TITLE
feat: AMD/Vulkan runtime image selection (hardware.gpu.runtime)

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -161,6 +161,24 @@ type GPUSpec struct {
 	// +optional
 	TolerationKey string `json:"tolerationKey,omitempty"`
 
+	// Runtime selects the GPU compute backend the operator schedules for this
+	// Model, independent of the Vendor field. It exists so `vendor: amd` is not
+	// overloaded to mean both "ROCm" and "Vulkan".
+	//
+	// For the llama.cpp inference backend with `vendor: amd`:
+	//   - "vulkan": schedule LLMKube's Vulkan llama.cpp image and request the
+	//     generic-device-plugin resource `devic.es/dri-render` (unless
+	//     ResourceName overrides it). The plugin injects /dev/dri; the non-root
+	//     container still needs the host render group, supplied via
+	//     InferenceService.spec.podSecurityContext.supplementalGroups.
+	//   - "rocm": the historical behavior (amd -> amd.com/gpu, stock image).
+	//   - "" (empty): back-compatible, identical to "rocm".
+	//
+	// Ignored for non-AMD vendors and non-llama.cpp backends.
+	// +kubebuilder:validation:Enum=vulkan;rocm
+	// +optional
+	Runtime string `json:"runtime,omitempty"`
+
 	// Layers specifies layer offloading configuration for multi-GPU
 	// Format: number of layers to offload to GPU (e.g., 32 for full offload on 7B model)
 	// -1 means auto-detect optimal layer split

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -128,6 +128,26 @@ spec:
                           TolerationKey is provided explicitly.
                         pattern: ^[a-z0-9.\-]+/[a-z0-9._\-]+$
                         type: string
+                      runtime:
+                        description: |-
+                          Runtime selects the GPU compute backend the operator schedules for this
+                          Model, independent of the Vendor field. It exists so `vendor: amd` is not
+                          overloaded to mean both "ROCm" and "Vulkan".
+
+                          For the llama.cpp inference backend with `vendor: amd`:
+                            - "vulkan": schedule LLMKube's Vulkan llama.cpp image and request the
+                              generic-device-plugin resource `devic.es/dri-render` (unless
+                              ResourceName overrides it). The plugin injects /dev/dri; the non-root
+                              container still needs the host render group, supplied via
+                              InferenceService.spec.podSecurityContext.supplementalGroups.
+                            - "rocm": the historical behavior (amd -> amd.com/gpu, stock image).
+                            - "" (empty): back-compatible, identical to "rocm".
+
+                          Ignored for non-AMD vendors and non-llama.cpp backends.
+                        enum:
+                        - vulkan
+                        - rocm
+                        type: string
                       sharding:
                         description: |-
                           Sharding defines how to shard the model across multiple GPUs

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -124,6 +124,26 @@ spec:
                           TolerationKey is provided explicitly.
                         pattern: ^[a-z0-9.\-]+/[a-z0-9._\-]+$
                         type: string
+                      runtime:
+                        description: |-
+                          Runtime selects the GPU compute backend the operator schedules for this
+                          Model, independent of the Vendor field. It exists so `vendor: amd` is not
+                          overloaded to mean both "ROCm" and "Vulkan".
+
+                          For the llama.cpp inference backend with `vendor: amd`:
+                            - "vulkan": schedule LLMKube's Vulkan llama.cpp image and request the
+                              generic-device-plugin resource `devic.es/dri-render` (unless
+                              ResourceName overrides it). The plugin injects /dev/dri; the non-root
+                              container still needs the host render group, supplied via
+                              InferenceService.spec.podSecurityContext.supplementalGroups.
+                            - "rocm": the historical behavior (amd -> amd.com/gpu, stock image).
+                            - "" (empty): back-compatible, identical to "rocm".
+
+                          Ignored for non-AMD vendors and non-llama.cpp backends.
+                        enum:
+                        - vulkan
+                        - rocm
+                        type: string
                       sharding:
                         description: |-
                           Sharding defines how to shard the model across multiple GPUs

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,30 @@ import (
 // which is true). This keeps the legacy service-link env-var injection on for
 // llama.cpp / generic / personaplex / tgi where it is harmless, and disables
 // it for vLLM where the v0.20+ env-var validator turns it into log noise.
+// resolveRuntimeImage returns the container image for the runtime, making the
+// otherwise vendor-blind backend.DefaultImage() vendor- and runtime-aware where
+// it matters. Today the only divergence is the llama.cpp backend with an
+// AMD/Vulkan Model: it uses LLMKube's pinned Vulkan image instead of the stock
+// upstream image. Every other backend/vendor/runtime combination falls through
+// to backend.DefaultImage(). An explicit InferenceService.spec.image still wins
+// over whatever this returns (handled by the caller).
+func resolveRuntimeImage(backend RuntimeBackend, model *inferencev1alpha1.Model) string {
+	if _, ok := backend.(*LlamaCppBackend); ok && isVulkanAMDModel(model) {
+		return llamaCppVulkanImage
+	}
+	return backend.DefaultImage()
+}
+
+// isVulkanAMDModel reports whether the Model requests the AMD vendor with the
+// Vulkan GPU runtime.
+func isVulkanAMDModel(model *inferencev1alpha1.Model) bool {
+	if model == nil || model.Spec.Hardware == nil || model.Spec.Hardware.GPU == nil {
+		return false
+	}
+	gpu := model.Spec.Hardware.GPU
+	return strings.EqualFold(strings.TrimSpace(gpu.Vendor), "amd") && isVulkanRuntime(gpu.Runtime)
+}
+
 func resolveEnableServiceLinks(backend RuntimeBackend) *bool {
 	if d, ok := backend.(ServiceLinksOptOut); ok && d.DisableServiceLinks() {
 		f := false
@@ -158,7 +183,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 		"inference.llmkube.dev/runtime": runtimeNameLabel(isvc),
 	}
 
-	image := backend.DefaultImage()
+	image := resolveRuntimeImage(backend, model)
 	if isvc.Spec.Image != "" {
 		image = isvc.Spec.Image
 	}

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -66,12 +66,46 @@ func TestGPUResourceNameForSpec(t *testing.T) {
 			expected: nvidiaGPUResourceName,
 		},
 		{
+			name:     "vendor amd with runtime rocm maps to amd.com/gpu",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "amd", Runtime: "rocm"},
+			expected: amdGPUResourceName,
+		},
+		{
+			name:     "vendor amd with empty runtime maps to amd.com/gpu",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "amd", Runtime: ""},
+			expected: amdGPUResourceName,
+		},
+		{
+			name:     "vendor amd with runtime vulkan maps to devic.es/dri-render",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "amd", Runtime: "vulkan"},
+			expected: vulkanDRIResourceName,
+		},
+		{
+			name:     "vulkan runtime is case-insensitive",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "amd", Runtime: "Vulkan"},
+			expected: vulkanDRIResourceName,
+		},
+		{
+			name:     "vulkan runtime only applies to amd vendor",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "nvidia", Runtime: "vulkan"},
+			expected: nvidiaGPUResourceName,
+		},
+		{
 			name: "explicit ResourceName overrides vendor mapping",
 			gpu: &inferencev1alpha1.GPUSpec{
 				Vendor:       "amd",
 				ResourceName: "squat.ai/dri-render",
 			},
 			expected: corev1.ResourceName("squat.ai/dri-render"),
+		},
+		{
+			name: "explicit ResourceName wins over the vulkan default",
+			gpu: &inferencev1alpha1.GPUSpec{
+				Vendor:       "amd",
+				Runtime:      "vulkan",
+				ResourceName: "amd.com/gpu",
+			},
+			expected: amdGPUResourceName,
 		},
 		{
 			name: "explicit ResourceName wins even when vendor is unset",
@@ -99,6 +133,87 @@ func TestGPUResourceNameForSpec(t *testing.T) {
 			got := gpuResourceNameForSpec(model)
 			if got != tc.expected {
 				t.Fatalf("gpuResourceNameForSpec() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func amdModel(runtime string) *inferencev1alpha1.Model {
+	return &inferencev1alpha1.Model{
+		Spec: inferencev1alpha1.ModelSpec{
+			Hardware: &inferencev1alpha1.HardwareSpec{
+				GPU: &inferencev1alpha1.GPUSpec{
+					Vendor:  "amd",
+					Runtime: runtime,
+				},
+			},
+		},
+	}
+}
+
+func TestResolveRuntimeImage(t *testing.T) {
+	stockLlamaCpp := (&LlamaCppBackend{}).DefaultImage()
+
+	cases := []struct {
+		name     string
+		backend  RuntimeBackend
+		model    *inferencev1alpha1.Model
+		expected string
+	}{
+		{
+			name:     "llamacpp amd vulkan selects the pinned vulkan image",
+			backend:  &LlamaCppBackend{},
+			model:    amdModel("vulkan"),
+			expected: llamaCppVulkanImage,
+		},
+		{
+			name:     "llamacpp amd vulkan is case-insensitive",
+			backend:  &LlamaCppBackend{},
+			model:    amdModel("Vulkan"),
+			expected: llamaCppVulkanImage,
+		},
+		{
+			name:     "llamacpp amd rocm keeps the stock image",
+			backend:  &LlamaCppBackend{},
+			model:    amdModel("rocm"),
+			expected: stockLlamaCpp,
+		},
+		{
+			name:     "llamacpp amd empty runtime keeps the stock image",
+			backend:  &LlamaCppBackend{},
+			model:    amdModel(""),
+			expected: stockLlamaCpp,
+		},
+		{
+			name:    "llamacpp nvidia keeps the stock image even with vulkan runtime",
+			backend: &LlamaCppBackend{},
+			model: &inferencev1alpha1.Model{
+				Spec: inferencev1alpha1.ModelSpec{
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{Vendor: "nvidia", Runtime: "vulkan"},
+					},
+				},
+			},
+			expected: stockLlamaCpp,
+		},
+		{
+			name:     "non-llamacpp backend ignores vulkan and uses its default image",
+			backend:  &VLLMBackend{},
+			model:    amdModel("vulkan"),
+			expected: (&VLLMBackend{}).DefaultImage(),
+		},
+		{
+			name:     "nil model uses backend default",
+			backend:  &LlamaCppBackend{},
+			model:    &inferencev1alpha1.Model{},
+			expected: stockLlamaCpp,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveRuntimeImage(tc.backend, tc.model); got != tc.expected {
+				t.Fatalf("resolveRuntimeImage() = %q, want %q", got, tc.expected)
 			}
 		})
 	}

--- a/internal/controller/gpu_resources.go
+++ b/internal/controller/gpu_resources.go
@@ -37,12 +37,14 @@ var (
 // GPU scheduling. Resolution order:
 //
 //  1. Model.Spec.Hardware.GPU.ResourceName, when set, wins over everything
-//     else. This is the escape hatch for non-default device plugins
-//     (e.g. squat/generic-device-plugin advertising squat.ai/dri-render).
-//  2. Model.Spec.Hardware.GPU.Vendor maps to the device-plugin default for
-//     that vendor (nvidia -> nvidia.com/gpu, amd -> amd.com/gpu,
+//     else. This is the escape hatch for non-default device plugins (e.g. a
+//     custom name like squat.ai/dri-render is just an illustrative override).
+//  2. amd + runtime=vulkan -> devic.es/dri-render (the built-in Vulkan default;
+//     the generic device plugin injects /dev/dri for this resource).
+//  3. Model.Spec.Hardware.GPU.Vendor maps to the device-plugin default for
+//     that vendor (nvidia -> nvidia.com/gpu, amd -> amd.com/gpu [ROCm],
 //     intel -> gpu.intel.com/i915).
-//  3. Unset / unknown -> nvidia.com/gpu (backwards-compatible default).
+//  4. Unset / unknown -> nvidia.com/gpu (backwards-compatible default).
 //
 // Used by the deployment builder; the accelerator-aware variant
 // resolveGPUResourceName is used by the Model reconciler's readiness check

--- a/internal/controller/gpu_resources.go
+++ b/internal/controller/gpu_resources.go
@@ -15,11 +15,22 @@ const (
 	defaultInsufficientGPUHint = "Insufficient "
 )
 
+// gpuRuntimeVulkan selects the Vulkan llama.cpp compute backend (LLMKube's own
+// image + the generic-device-plugin /dev/dri resource). The other accepted
+// enum value, "rocm", needs no constant: it falls through to the historical
+// amd.com/gpu + stock-image path, identical to an empty runtime.
+const gpuRuntimeVulkan = "vulkan"
+
 var (
 	nvidiaGPUResourceName    = corev1.ResourceName("nvidia.com/gpu")
 	amdGPUResourceName       = corev1.ResourceName("amd.com/gpu")
 	intelGPUResourceNameI915 = corev1.ResourceName("gpu.intel.com/i915")
 	intelGPUResourceNameXE   = corev1.ResourceName("gpu.intel.com/xe")
+	// vulkanDRIResourceName is the generic-device-plugin resource that
+	// advertises /dev/dri render nodes. Requesting it makes the plugin inject
+	// the render device(s) into the container, so no hostPath device mount is
+	// required. Used as the default GPU resource for the AMD/Vulkan path.
+	vulkanDRIResourceName = corev1.ResourceName("devic.es/dri-render")
 )
 
 // gpuResourceNameForSpec resolves the extended resource the pod requests for
@@ -37,6 +48,12 @@ var (
 // resolveGPUResourceName is used by the Model reconciler's readiness check
 // and intentionally stays separate so the two code paths can evolve
 // independently.
+// isVulkanRuntime reports whether the GPU runtime selector requests the Vulkan
+// compute backend. Comparison is case-insensitive and trims surrounding space.
+func isVulkanRuntime(runtime string) bool {
+	return strings.EqualFold(strings.TrimSpace(runtime), gpuRuntimeVulkan)
+}
+
 func gpuResourceNameForSpec(model *inferencev1alpha1.Model) corev1.ResourceName {
 	if model != nil && model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil {
 		if override := strings.TrimSpace(model.Spec.Hardware.GPU.ResourceName); override != "" {
@@ -45,6 +62,11 @@ func gpuResourceNameForSpec(model *inferencev1alpha1.Model) corev1.ResourceName 
 
 		switch strings.ToLower(strings.TrimSpace(model.Spec.Hardware.GPU.Vendor)) {
 		case "amd":
+			// The Vulkan runtime schedules against the generic-device-plugin
+			// /dev/dri resource, not the ROCm amd.com/gpu resource.
+			if isVulkanRuntime(model.Spec.Hardware.GPU.Runtime) {
+				return vulkanDRIResourceName
+			}
 			return amdGPUResourceName
 		case "intel":
 			return intelGPUResourceNameI915

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -4523,3 +4523,139 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 // warning to HuggingFace repo IDs (the only source type that's truly
 // runtime-resolved). Below: the warning's full truth table so the heuristic
 // can't drift again.
+
+var _ = Describe("AMD Vulkan Deployment Construction", func() {
+	var (
+		reconciler *InferenceServiceReconciler
+		replicas   int32
+	)
+
+	BeforeEach(func() {
+		reconciler = &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			DefaultFSGroup:     102,
+		}
+		replicas = 1
+	})
+
+	vulkanModel := func() *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "vulkan-model", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:       "https://example.com/model.gguf",
+				Format:       "gguf",
+				Quantization: "Q4_K_M",
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					GPU: &inferencev1alpha1.GPUSpec{
+						Enabled: true,
+						Count:   1,
+						Vendor:  "amd",
+						Runtime: "vulkan",
+					},
+				},
+			},
+			Status: inferencev1alpha1.ModelStatus{
+				Phase: "Ready",
+				Path:  "/tmp/llmkube/models/test-model.gguf",
+			},
+		}
+	}
+
+	It("uses the pinned Vulkan image and devic.es/dri-render for vendor=amd runtime=vulkan", func() {
+		model := vulkanModel()
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "vulkan-service", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "vulkan-model",
+				Replicas:  &replicas,
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+			},
+		}
+
+		deployment := reconciler.constructDeployment(isvc, model, 1)
+		container := deployment.Spec.Template.Spec.Containers[0]
+
+		Expect(container.Image).To(Equal(llamaCppVulkanImage))
+		gpuLimit := container.Resources.Limits[vulkanDRIResourceName]
+		Expect(gpuLimit).To(Equal(resource.MustParse("1")))
+		// The ROCm resource must not be requested on the Vulkan path.
+		_, hasROCm := container.Resources.Limits[amdGPUResourceName]
+		Expect(hasROCm).To(BeFalse())
+	})
+
+	It("honors supplementalGroups via spec.podSecurityContext for the render group", func() {
+		model := vulkanModel()
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "vulkan-service-sg", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "vulkan-model",
+				Replicas:  &replicas,
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				PodSecurityContext: &corev1.PodSecurityContext{
+					SupplementalGroups: []int64{44},
+				},
+			},
+		}
+
+		deployment := reconciler.constructDeployment(isvc, model, 1)
+		Expect(deployment.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.SecurityContext.SupplementalGroups).To(ContainElement(int64(44)))
+	})
+
+	It("lets spec.image override the pinned Vulkan image", func() {
+		model := vulkanModel()
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "vulkan-service-img", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "vulkan-model",
+				Replicas:  &replicas,
+				Image:     "ghcr.io/example/custom-vulkan:dev",
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+			},
+		}
+
+		deployment := reconciler.constructDeployment(isvc, model, 1)
+		Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/example/custom-vulkan:dev"))
+	})
+
+	It("lets resourceName override devic.es/dri-render on the Vulkan path", func() {
+		model := vulkanModel()
+		model.Spec.Hardware.GPU.ResourceName = "amd.com/gpu"
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "vulkan-service-res", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "vulkan-model",
+				Replicas:  &replicas,
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+			},
+		}
+
+		deployment := reconciler.constructDeployment(isvc, model, 1)
+		container := deployment.Spec.Template.Spec.Containers[0]
+		gpuLimit := container.Resources.Limits[amdGPUResourceName]
+		Expect(gpuLimit).To(Equal(resource.MustParse("1")))
+		// Image is still the pinned Vulkan image; resourceName only affects scheduling.
+		Expect(container.Image).To(Equal(llamaCppVulkanImage))
+	})
+
+	It("keeps amd.com/gpu and the stock image for runtime=rocm", func() {
+		model := vulkanModel()
+		model.Spec.Hardware.GPU.Runtime = "rocm"
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "rocm-service", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "vulkan-model",
+				Replicas:  &replicas,
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+			},
+		}
+
+		deployment := reconciler.constructDeployment(isvc, model, 1)
+		container := deployment.Spec.Template.Spec.Containers[0]
+		Expect(container.Image).To(Equal((&LlamaCppBackend{}).DefaultImage()))
+		gpuLimit := container.Resources.Limits[amdGPUResourceName]
+		Expect(gpuLimit).To(Equal(resource.MustParse("1")))
+	})
+})

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -14,6 +14,11 @@ import (
 // BuildArgs.
 var llamaCppLog = logf.Log.WithName("runtime.llamacpp")
 
+// llamaCppVulkanImage is LLMKube's hardware-validated Vulkan llama.cpp server
+// image. Pinned by digest for reproducibility; the digest corresponds to tag
+// :b9663-llmkube1. Bump this via PR when the promoter publishes a new :stable.
+const llamaCppVulkanImage = "ghcr.io/defilantech/llmkube-llama-vulkan@sha256:cbab8af682ecac9b5c865d85219d808dc356814326c70346e05b8b20b333e295"
+
 // LlamaCppBackend generates container configuration for the llama.cpp inference server.
 type LlamaCppBackend struct{}
 

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -15,8 +15,9 @@ import (
 var llamaCppLog = logf.Log.WithName("runtime.llamacpp")
 
 // llamaCppVulkanImage is LLMKube's hardware-validated Vulkan llama.cpp server
-// image. Pinned by digest for reproducibility; the digest corresponds to tag
-// :b9663-llmkube1. Bump this via PR when the promoter publishes a new :stable.
+// image, built and promoted by defilantech/llmkube-runtimes. Pinned by digest
+// for reproducibility; this digest is the :stable / :b9663-llmkube1 image. Bump
+// it via PR when the promoter publishes a new :stable digest.
 const llamaCppVulkanImage = "ghcr.io/defilantech/llmkube-llama-vulkan@sha256:cbab8af682ecac9b5c865d85219d808dc356814326c70346e05b8b20b333e295"
 
 // LlamaCppBackend generates container configuration for the llama.cpp inference server.


### PR DESCRIPTION
## What

Wires the operator to schedule LLMKube's own AMD/Vulkan llama.cpp runtime image via a new explicit runtime selector, `hardware.gpu.runtime: vulkan|rocm`.

## Why

Fixes #697. Until now `vendor: amd` resolved to the ROCm resource `amd.com/gpu` and the llama.cpp image was vendor-blind (`ghcr.io/ggml-org/llama.cpp:server`), so an AMD node had no image to actually offload with. We now build and hardware-validate our own Vulkan image (`defilantech/llmkube-runtimes`); this makes the operator use it. `vendor: amd` was overloaded between the Vulkan tier (#697) and the ROCm tier (#701), so the runtime selector disambiguates them rather than silently changing the existing `amd.com/gpu` default.

## How

- **API:** add `Runtime` (optional, kubebuilder enum `vulkan;rocm`) to `hardware.gpu`. Empty = back-compat.
- **Image:** `vendor: amd` + `runtime: vulkan` (llama.cpp backend) pins the validated Vulkan image by digest (`ghcr.io/defilantech/llmkube-llama-vulkan@sha256:cbab8af6…`, the `:stable` / `:b9663-llmkube1` build). `spec.image` still overrides.
- **Resource:** the same path defaults the GPU resource to `devic.es/dri-render` (generic device plugin, which injects `/dev/dri`) instead of `amd.com/gpu`. `hardware.gpu.resourceName` still overrides.
- **/dev/dri group access:** no hardcoded GID — the non-root container gets the host render group via the existing `spec.podSecurityContext.supplementalGroups` passthrough (documented on the field).
- `runtime: rocm` or empty is unchanged (`amd.com/gpu` + stock image). nvidia/intel and non-llama.cpp backends untouched.
- Regenerated CRDs (`config/crd/bases/` + `charts/llmkube/templates/crds/`).

Validated end-to-end out of band: the pinned digest is the image the promoter smoke-passed on a gfx1151 node (Vulkan0 RADV STRIX_HALO, ~250 tok/s).

## Checklist

- [x] Tests added/updated (unit + envtest: vulkan→digest+dri-render, rocm/empty→amd.com/gpu+stock, image+resourceName overrides win, supplementalGroups propagates)
- [x] `make test` passes locally
- [x] `make lint` passes locally (+ `GOOS=linux golangci-lint`)
- [x] Conventional commits
- [x] All commits signed off (DCO)
- [x] Documentation updated (field godoc; CRDs regenerated)
