### PR TITLE
fix(cache): restore shared model cache as the default (perService becomes opt-in)

### DIFF
--- a/charts/llmkube/tests/model-cache_test.yaml
+++ b/charts/llmkube/tests/model-cache_test.yaml
@@ -1,13 +1,13 @@
-suite: model cache mode (perService default | shared) and operator no-mount (#728)
+suite: model cache mode (shared default | perService opt-in)
 templates:
   - deployment.yaml
   - model-cache-pvc.yaml
 
 tests:
-  # #728: the operator no longer mounts the SHARED, node-pinned cache PVC.
-  # It still needs a WRITABLE /models for its local-source (file://) copy +
-  # validation path under readOnlyRootFilesystem: an emptyDir scratch in
-  # perService (pins no node), or the shared PVC in shared mode.
+  # The operator always needs a WRITABLE /models for its local-source (file://)
+  # copy + validation path under readOnlyRootFilesystem: the shared PVC in the
+  # default shared mode, or an emptyDir scratch in perService (which pins no
+  # node, #728).
   - it: operator mounts model-cache at /models (writable scratch)
     template: deployment.yaml
     set:
@@ -19,10 +19,24 @@ tests:
             name: model-cache
             mountPath: /models
 
+  # Default (shared): the operator model-cache is backed by the shared PVC.
+  - it: shared mode (default) backs the operator model-cache with the shared PVC
+    template: deployment.yaml
+    set:
+      modelCache.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: model-cache
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-llmkube-model-cache
+
   - it: perService mode backs the operator model-cache with an emptyDir (no shared PVC)
     template: deployment.yaml
     set:
       modelCache.enabled: true
+      modelCache.mode: perService
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -36,59 +50,38 @@ tests:
             persistentVolumeClaim:
               claimName: RELEASE-NAME-llmkube-model-cache
 
-  - it: shared mode backs the operator model-cache with the shared PVC
+  # --model-cache-mode is wired through from the chart value.
+  - it: passes shared mode to the operator by default
     template: deployment.yaml
-    set:
-      modelCache.enabled: true
-      modelCache.mode: shared
-    asserts:
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: model-cache
-            persistentVolumeClaim:
-              claimName: RELEASE-NAME-llmkube-model-cache
-
-  # Task 5: --model-cache-mode is wired through from the chart value.
-  - it: passes perService mode to the operator by default
-    template: deployment.yaml
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --model-cache-mode=perService
-
-  - it: passes shared mode to the operator when configured
-    template: deployment.yaml
-    set:
-      modelCache.mode: shared
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --model-cache-mode=shared
 
-  # Task 5: in the default perService mode the chart creates NO cluster-wide PVC;
-  # the operator provisions per-isvc PVCs at reconcile time.
-  - it: does not render the shared PVC in perService mode (default)
-    template: model-cache-pvc.yaml
-    asserts:
-      - hasDocuments:
-          count: 0
-
-  - it: does not render the shared PVC in perService mode even when explicit
-    template: model-cache-pvc.yaml
+  - it: passes perService mode to the operator when configured
+    template: deployment.yaml
     set:
-      modelCache.enabled: true
       modelCache.mode: perService
     asserts:
-      - hasDocuments:
-          count: 0
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --model-cache-mode=perService
 
-  # Task 5: shared mode keeps the single cluster-wide PVC (back-compat / RWX).
-  - it: renders the shared PVC in shared mode
+  # In the default shared mode the chart creates the single cluster-wide PVC so
+  # all InferenceServices share one cache and `cache list` can inspect it.
+  - it: renders the shared PVC in shared mode (default)
+    template: model-cache-pvc.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-llmkube-model-cache
+
+  - it: renders the shared PVC with the configured access mode
     template: model-cache-pvc.yaml
     set:
       modelCache.enabled: true
-      modelCache.mode: shared
       modelCache.accessMode: ReadWriteMany
     asserts:
       - hasDocuments:
@@ -100,11 +93,21 @@ tests:
           path: spec.accessModes
           content: ReadWriteMany
 
+  # In the opt-in perService mode the chart creates NO cluster-wide PVC; the
+  # operator provisions per-isvc PVCs at reconcile time.
+  - it: does not render the shared PVC in perService mode
+    template: model-cache-pvc.yaml
+    set:
+      modelCache.enabled: true
+      modelCache.mode: perService
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: does not render the shared PVC when modelCache disabled
     template: model-cache-pvc.yaml
     set:
       modelCache.enabled: false
-      modelCache.mode: shared
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -262,7 +262,8 @@
         "enabled": { "type": "boolean" },
         "mode": {
           "type": "string",
-          "enum": ["perService", "shared"]
+          "enum": ["perService", "shared"],
+          "default": "shared"
         },
         "size": { "type": "string", "minLength": 1 },
         "storageClass": { "type": "string" },

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -273,24 +273,27 @@ modelCache:
   # per `mode` below.
   enabled: true
   # Cache provisioning mode:
-  #   perService (default): each InferenceService gets its own RWO,
-  #     WaitForFirstConsumer cache PVC ("<isvc>-model-cache") that binds on the
-  #     node its serving pod schedules to. This is required for multi-node
-  #     clusters where the GPU node differs from the operator's node: the cache
-  #     co-locates with the workload instead of pinning to one node (#728). The
-  #     tradeoff is no cross-isvc dedup; each InferenceService downloads its
-  #     model on first schedule.
-  #   shared: a single cluster-wide "<release>-model-cache" PVC is created
-  #     (honoring accessMode below). Use with an RWX storage class (NFS/EFS) when
-  #     you want cross-isvc dedup. This is the pre-#728 behavior.
-  # Migration: existing deployments that relied on the single shared cache must
-  # set `mode: shared` to keep it; the default is now perService.
-  mode: perService
+  #   shared (default): a single cluster-wide "<release>-model-cache" PVC is
+  #     created (honoring accessMode below). The operator mounts it and the
+  #     InferenceService init container downloads remote models into it, so all
+  #     InferenceServices share one cache (cross-isvc dedup) and `llmkube cache
+  #     list` can inspect it. This is the proven default. On a multi-node cluster
+  #     use an RWX storage class (NFS/EFS) so the cache is reachable from any
+  #     node; the cluster default RWO class only works single-node.
+  #   perService: each InferenceService gets its own RWO, WaitForFirstConsumer
+  #     cache PVC ("<isvc>-model-cache") that binds on the node its serving pod
+  #     schedules to. Use this as the opt-in escape hatch for multi-node clusters
+  #     that do NOT have an RWX storage class: the cache co-locates with the
+  #     workload instead of pinning to one node (#728). The tradeoff is no
+  #     cross-isvc dedup (each InferenceService downloads its own copy) and
+  #     `cache list` is not per-isvc aware yet.
+  mode: shared
   # Storage size for each model cache PVC
   size: 100Gi
-  # Storage class (leave empty for the cluster default). For perService the
-  # default class should use volumeBindingMode WaitForFirstConsumer so the PVC
-  # binds on the serving node; for shared use an RWX class.
+  # Storage class (leave empty for the cluster default). For shared on a
+  # multi-node cluster use an RWX class; for perService the default class should
+  # use volumeBindingMode WaitForFirstConsumer so the PVC binds on the serving
+  # node.
   storageClass: ""
   # Access mode for the shared cache PVC (only used when mode=shared):
   # ReadWriteOnce (single-node) or ReadWriteMany (multi-node with NFS/EFS).

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,10 +123,12 @@ func main() {
 		"Storage class for model cache PVCs (empty for default).")
 	flag.StringVar(&modelCacheAccessMode, "model-cache-access-mode", "ReadWriteOnce",
 		"Access mode for the shared model cache PVC (only used when --model-cache-mode=shared).")
-	flag.StringVar(&modelCacheMode, "model-cache-mode", controller.ModelCacheModePerService,
-		"Model cache provisioning mode: perService (default) gives each InferenceService its own "+
-			"RWO, WaitForFirstConsumer cache PVC that binds on the serving node (multi-node correct); "+
-			"shared uses a single cluster-wide llmkube-model-cache PVC (back-compat, RWX setups).")
+	flag.StringVar(&modelCacheMode, "model-cache-mode", controller.ModelCacheModeShared,
+		"Model cache provisioning mode: shared (default) uses a single cluster-wide "+
+			"llmkube-model-cache PVC the operator mounts and all InferenceServices share "+
+			"(cross-isvc dedup, cache list works; use an RWX class on multi-node clusters); "+
+			"perService gives each InferenceService its own RWO, WaitForFirstConsumer cache PVC "+
+			"that binds on the serving node (opt-in escape hatch for multi-node clusters without RWX).")
 	flag.DurationVar(&modelRevalidateInterval, "model-revalidate-interval", controller.DefaultRevalidateInterval,
 		"Minimum interval between upstream source revalidation checks for a Model. "+
 			"Bounds the HEAD traffic the controller generates; drift is surfaced via the "+

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -104,10 +104,13 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
-        # Writable scratch for the controller's local-source (file://) copy and
-        # validation path. NOT a shared model cache (#728): an emptyDir pins no
-        # node. Inference pods download into their own per-isvc cache; the
-        # operator only needs a writable /models under readOnlyRootFilesystem.
+        # Writable scratch at /models for the controller's local-source (file://)
+        # copy and validation path under readOnlyRootFilesystem. The actual model
+        # cache PVC (shared llmkube-model-cache by default, or a per-isvc PVC in
+        # perService mode) is provisioned per-namespace at reconcile time and
+        # mounted by the inference pods, not by this operator pod. An emptyDir
+        # here pins no node. The Helm chart can back this with the shared PVC when
+        # mode=shared; the kustomize manager uses emptyDir scratch in all modes.
         - name: model-cache
           mountPath: /models
       volumes:

--- a/docs/model-storage.md
+++ b/docs/model-storage.md
@@ -1,24 +1,18 @@
 # Model storage
 
-LLMKube downloads each model's GGUF once and serves it from a PersistentVolumeClaim mounted into the inference pod. How that cache is provisioned is controlled by `modelCache.mode`.
+LLMKube serves each model's GGUF from a PersistentVolumeClaim mounted into the inference pod. How that cache is provisioned is controlled by `modelCache.mode`.
 
 ## Modes
 
-### `perService` (default)
+### `shared` (default)
 
-Each InferenceService gets its own cache PVC (`<inferenceservice>-model-cache`), created by the operator in the InferenceService's namespace:
+A single cluster-wide cache PVC (`llmkube-model-cache`) that the operator mounts and every inference pod shares, created by the operator in the InferenceService's namespace:
 
-- **RWO**, no explicit StorageClass, so it binds `WaitForFirstConsumer` — on whatever node the inference pod is scheduled to.
-- The pod's **init container downloads the model into that PVC**, so the download and the server land on the same node by construction.
-- Owner-referenced to the InferenceService, so it is garbage-collected when the service is deleted.
+- The pod's **init container downloads each remote model into the shared PVC**, so all InferenceServices reuse one cache (**cross-service dedup**: a model is downloaded once and reused by every service that references it).
+- `llmkube cache list` inspects this PVC, so cache inspection works out of the box.
+- This is the proven default and is a drop-in for existing single-node clusters.
 
-This is what makes **heterogeneous, multi-node clusters work**: an InferenceService whose accelerator is on node B (e.g. an AMD/Vulkan node distinct from the operator's node) schedules on node B and caches its model there. A single shared cache cannot do this — an RWO hostpath PVC is pinned to one node, so a GPU on any other node hits a `volume node affinity conflict` (see #728).
-
-Trade-off: models are **not deduplicated across InferenceServices** — each service downloads and stores its own copy. For a cluster running many services off the same model on one node, that is more storage and more downloads. Use `shared` if you have RWX storage and want dedup.
-
-### `shared`
-
-A single cluster-wide cache PVC (`llmkube-model-cache`) that every inference pod mounts. This is the pre-0.9 behavior and is best paired with **ReadWriteMany** storage (NFS, CephFS, etc.) so all nodes can mount it:
+On a **multi-node** cluster, pair `shared` with **ReadWriteMany** storage (NFS, CephFS, EFS, etc.) so the cache is reachable from any node:
 
 ```yaml
 modelCache:
@@ -27,12 +21,33 @@ modelCache:
   storageClass: <your-rwx-class>
 ```
 
-With an RWX backend, `shared` gives cross-service dedup and works multi-node. With an RWO backend it pins all inference to one node (single-node clusters only).
+With the default RWO storage class the shared PVC is pinned to one node, so it only works single-node (a GPU on any other node would hit a `volume node affinity conflict`). If your multi-node cluster has no RWX storage class, use `perService` instead.
+
+### `perService` (opt-in escape hatch)
+
+For multi-node clusters **without** an RWX storage class. Each InferenceService gets its own cache PVC (`<inferenceservice>-model-cache`):
+
+- **RWO**, no explicit StorageClass, so it binds `WaitForFirstConsumer` — on whatever node the inference pod is scheduled to.
+- The pod's **init container downloads the model into that PVC**, so the download and the server land on the same node by construction.
+- Owner-referenced to the InferenceService, so it is garbage-collected when the service is deleted.
+
+This makes **heterogeneous, multi-node clusters work without RWX**: an InferenceService whose accelerator is on node B (e.g. an AMD/Vulkan node distinct from the operator's node) schedules on node B and caches its model there (see #728).
+
+```yaml
+modelCache:
+  mode: perService
+```
+
+Trade-offs: models are **not deduplicated across InferenceServices** (each service downloads and stores its own copy), and `llmkube cache list` is not per-isvc cache aware yet. Prefer `shared` + an RWX storage class on multi-node clusters that have one.
+
+## Choosing a mode
+
+| Cluster | Recommendation |
+| --- | --- |
+| Single-node | `shared` (default) |
+| Multi-node with an RWX storage class | `shared` + `accessMode: ReadWriteMany` + `storageClass: <rwx-class>` |
+| Multi-node without RWX | `perService` |
 
 ## Metadata
 
-The operator reads GGUF metadata (architecture, layer count, context length, etc.) for `Model.Status` by reading **only the file header** over HTTP range requests — it never downloads the whole model itself. The full model bytes are fetched only by the per-service init container, on the serving node. `pvc://` and HuggingFace-repo sources are resolved at pod runtime and are unaffected.
-
-## Migration
-
-Upgrading from a release that used the shared cache: the default is now `perService`. To keep the previous single-cache behavior, set `modelCache.mode: shared` (and an RWX `accessMode`/`storageClass` if you run multi-node).
+In `perService` mode the operator reads GGUF metadata (architecture, layer count, context length, etc.) for `Model.Status` by reading **only the file header** over HTTP range requests — it never downloads the whole model itself. The full model bytes are fetched only by the init container, on the serving node. `pvc://` and HuggingFace-repo sources are resolved at pod runtime and are unaffected.

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -50,10 +50,13 @@ type InferenceServiceReconciler struct {
 	ModelCacheClass      string
 	ModelCacheAccessMode string
 	// ModelCacheMode selects how model cache PVCs are provisioned:
-	// ModelCacheModePerService (default) gives each InferenceService its own
-	// RWO, WaitForFirstConsumer PVC that binds on the serving node (#728);
-	// ModelCacheModeShared uses the single cluster-wide llmkube-model-cache PVC
-	// for RWX setups. An empty value is treated as perService.
+	// ModelCacheModeShared (default) uses the single cluster-wide
+	// llmkube-model-cache PVC that the operator mounts and all InferenceServices
+	// share (cross-isvc dedup, cache list works; needs an RWX class on multi-node
+	// clusters); ModelCacheModePerService gives each InferenceService its own RWO,
+	// WaitForFirstConsumer PVC that binds on the serving node (#728), the opt-in
+	// escape hatch for multi-node clusters without RWX. An empty value is treated
+	// as shared (see resolveCacheMode).
 	ModelCacheMode     string
 	CACertConfigMap    string
 	InitContainerImage string

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -4689,12 +4689,12 @@ var _ = Describe("constructDeployment model cache PVC wiring (#728, Task 3)", fu
 		return nil
 	}
 
-	It("mounts the per-isvc cache PVC in perService mode (default)", func() {
+	It("mounts the per-isvc cache PVC in perService mode", func() {
 		reconciler := &InferenceServiceReconciler{
 			ModelCachePath:     "/tmp/llmkube/models",
 			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
 			DefaultFSGroup:     102,
-			// ModelCacheMode left empty: must behave as perService.
+			ModelCacheMode:     ModelCacheModePerService,
 		}
 		deployment := reconciler.constructDeployment(newISVC(), newModel(), 1)
 		vol := findCacheVolume(deployment)
@@ -4703,7 +4703,21 @@ var _ = Describe("constructDeployment model cache PVC wiring (#728, Task 3)", fu
 		Expect(vol.PersistentVolumeClaim.ClaimName).To(Equal("cache-isvc-model-cache"))
 	})
 
-	It("mounts the shared cache PVC in shared mode", func() {
+	It("mounts the shared cache PVC in shared mode (default, empty mode)", func() {
+		reconciler := &InferenceServiceReconciler{
+			ModelCachePath:     "/tmp/llmkube/models",
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			DefaultFSGroup:     102,
+			// ModelCacheMode left empty: must resolve to shared.
+		}
+		deployment := reconciler.constructDeployment(newISVC(), newModel(), 1)
+		vol := findCacheVolume(deployment)
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.PersistentVolumeClaim).NotTo(BeNil())
+		Expect(vol.PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
+	})
+
+	It("mounts the shared cache PVC when shared mode is explicit", func() {
 		reconciler := &InferenceServiceReconciler{
 			ModelCachePath:     "/tmp/llmkube/models",
 			InitContainerImage: "docker.io/curlimages/curl:8.18.0",

--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -1013,11 +1013,8 @@ var _ = Describe("Reconcile lifecycle", func() {
 				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
 					_ = k8sClient.Delete(ctx, svc)
 				}
-				// Default mode is perService: the cache PVC is named after the isvc.
-				pvc := &corev1.PersistentVolumeClaim{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName + "-model-cache", Namespace: "default"}, pvc); err == nil {
-					_ = k8sClient.Delete(ctx, pvc)
-				}
+				// Default mode is shared: the cluster-wide PVC is created once and
+				// may be reused by other specs, so leave it for suite teardown.
 			}()
 
 			reconciler := &InferenceServiceReconciler{
@@ -1025,19 +1022,19 @@ var _ = Describe("Reconcile lifecycle", func() {
 				Scheme:             k8sClient.Scheme(),
 				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
 				ModelCachePath:     "/models",
+				// ModelCacheMode left empty: must resolve to the shared default.
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// In the default perService mode the operator provisions a per-isvc
-			// cache PVC "<isvc>-model-cache" (owner-ref'd to the isvc), not the
-			// cluster-wide shared PVC.
+			// In the default shared mode the operator provisions the single
+			// cluster-wide "llmkube-model-cache" PVC (no owner reference, since it
+			// outlives any one InferenceService), not a per-isvc PVC.
 			pvc := &corev1.PersistentVolumeClaim{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName + "-model-cache", Namespace: "default"}, pvc)).To(Succeed())
-			Expect(pvc.OwnerReferences).To(HaveLen(1))
-			Expect(pvc.OwnerReferences[0].Name).To(Equal(isvcName))
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ModelCachePVCName, Namespace: "default"}, pvc)).To(Succeed())
+			Expect(pvc.OwnerReferences).To(BeEmpty())
 		})
 	})
 })

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -309,7 +309,7 @@ var _ = Describe("ensureModelCachePVC (shared mode)", func() {
 	})
 })
 
-var _ = Describe("ensureModelCachePVC (perService mode, default, #728)", func() {
+var _ = Describe("ensureModelCachePVC (perService mode, opt-in, #728)", func() {
 	var reconciler *InferenceServiceReconciler
 	var isvc *inferencev1alpha1.InferenceService
 	var pvcName string
@@ -332,6 +332,10 @@ var _ = Describe("ensureModelCachePVC (perService mode, default, #728)", func() 
 	}
 
 	BeforeEach(func() {
+		// Clear any shared PVC a sibling (shared-default) spec may have left in
+		// the namespace, so the "does not create the shared PVC" assertion below
+		// is not polluted by test ordering.
+		deletePVCForcibly(context.Background(), "default")
 		// A real InferenceService gives the PVC a valid owner UID/GVK.
 		isvc = &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{
@@ -342,10 +346,12 @@ var _ = Describe("ensureModelCachePVC (perService mode, default, #728)", func() 
 		}
 		Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
 		pvcName = isvc.Name + "-model-cache"
-		// Empty ModelCacheMode must behave as perService (default).
+		// perService is the opt-in mode; it must be set explicitly now that the
+		// default (empty mode) resolves to shared.
 		reconciler = &InferenceServiceReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:         k8sClient,
+			Scheme:         k8sClient.Scheme(),
+			ModelCacheMode: ModelCacheModePerService,
 		}
 	})
 
@@ -407,7 +413,7 @@ var _ = Describe("buildCachedStorageConfig cache mode selection (#728)", func() 
 		Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123def456"},
 	}
 
-	It("references the per-isvc PVC in perService mode (default)", func() {
+	It("references the per-isvc PVC in perService mode", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-isvc"},
 		}
@@ -415,7 +421,7 @@ var _ = Describe("buildCachedStorageConfig cache mode selection (#728)", func() 
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("my-isvc-model-cache"))
 	})
 
-	It("references the shared PVC in shared mode", func() {
+	It("references the shared PVC in shared mode (default)", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-isvc"},
 		}
@@ -423,12 +429,30 @@ var _ = Describe("buildCachedStorageConfig cache mode selection (#728)", func() 
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
 	})
 
-	It("empty mode defaults to per-isvc PVC", func() {
+	It("empty mode defaults to the shared PVC", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-isvc"},
 		}
 		config := buildCachedStorageConfig(model, isvc, "", "", "curl:8.18.0")
-		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("my-isvc-model-cache"))
+		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
+	})
+})
+
+var _ = Describe("resolveCacheMode", func() {
+	It("maps an empty mode to the shared default", func() {
+		Expect(resolveCacheMode("")).To(Equal(ModelCacheModeShared))
+	})
+
+	It("maps an unknown mode to the shared default", func() {
+		Expect(resolveCacheMode("bogus")).To(Equal(ModelCacheModeShared))
+	})
+
+	It("preserves an explicit perService mode", func() {
+		Expect(resolveCacheMode(ModelCacheModePerService)).To(Equal(ModelCacheModePerService))
+	})
+
+	It("preserves an explicit shared mode", func() {
+		Expect(resolveCacheMode(ModelCacheModeShared)).To(Equal(ModelCacheModeShared))
 	})
 })
 

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -38,28 +38,44 @@ import (
 // This file also owns provisioning of the shared cache PVC per namespace.
 
 // ModelCachePVCName is the name of the shared, cluster-single model cache PVC.
-// It is used only in shared mode (ModelCacheModeShared); the default
+// It is used in the default shared mode (ModelCacheModeShared); the opt-in
 // per-InferenceService mode names each cache PVC after its InferenceService
 // (see modelCachePVCName).
 const ModelCachePVCName = "llmkube-model-cache"
 
-// Model cache provisioning modes. perService (the default) gives each
-// InferenceService its own RWO, WaitForFirstConsumer cache PVC that binds on
-// the node the serving pod schedules to, so the GPU pod and its cache co-locate
-// even when the operator runs on a different node (#728). shared keeps the
-// single, cluster-wide llmkube-model-cache PVC (back-compat for RWX setups that
-// want cross-isvc dedup).
+// Model cache provisioning modes. shared (the default) keeps a single,
+// cluster-wide llmkube-model-cache PVC that the operator mounts and every
+// InferenceService init container downloads into, giving cross-isvc dedup and a
+// cache `llmkube cache list` can inspect. This is the proven default; on a
+// multi-node cluster it needs an RWX storage class so any node can reach it.
+// perService is the opt-in escape hatch for multi-node clusters WITHOUT RWX: it
+// gives each InferenceService its own RWO, WaitForFirstConsumer cache PVC that
+// binds on the node the serving pod schedules to, so the GPU pod and its cache
+// co-locate even when the operator runs on a different node (#728), at the cost
+// of cross-isvc dedup.
 const (
 	ModelCacheModePerService = "perService"
 	ModelCacheModeShared     = "shared"
 )
 
+// resolveCacheMode maps an unset mode to the default (shared). An empty string
+// reaches the reconciler when the operator is run without --model-cache-mode
+// (e.g. ad-hoc envtest), so callers must funnel through this rather than
+// comparing the raw field.
+func resolveCacheMode(mode string) string {
+	if mode == ModelCacheModePerService {
+		return ModelCacheModePerService
+	}
+	return ModelCacheModeShared
+}
+
 // modelCachePVCName returns the name of the model cache PVC for the given mode.
-// In shared mode this is the single cluster-wide PVC; otherwise it is the
-// per-InferenceService PVC "<isvc>-model-cache". A nil isvc (unit tests that
-// exercise the builder directly) falls back to the shared name.
+// In shared mode (the default, and the resolution of an empty mode) this is the
+// single cluster-wide PVC; in perService mode it is the per-InferenceService PVC
+// "<isvc>-model-cache". A nil isvc (unit tests that exercise the builder
+// directly) falls back to the shared name.
 func modelCachePVCName(isvc *inferencev1alpha1.InferenceService, mode string) string {
-	if mode == ModelCacheModeShared || isvc == nil {
+	if resolveCacheMode(mode) == ModelCacheModeShared || isvc == nil {
 		return ModelCachePVCName
 	}
 	return fmt.Sprintf("%s-model-cache", isvc.Name)
@@ -302,21 +318,24 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 // ensureModelCachePVC creates the model cache PVC for an InferenceService if it
 // does not already exist.
 //
-// In the default perService mode the PVC is named "<isvc>-model-cache", is RWO,
+// In the default shared mode the single cluster-wide llmkube-model-cache PVC is
+// created (no owner reference, since it outlives any one InferenceService) so
+// every InferenceService shares one cache (cross-isvc dedup) and `cache list`
+// can inspect it. On a multi-node cluster this needs an RWX storage class so any
+// node can reach it.
+//
+// In the opt-in perService mode the PVC is named "<isvc>-model-cache", is RWO,
 // uses the cluster default storage class (which is WaitForFirstConsumer in the
 // common topology-aware case) unless an explicit class is configured, and is
 // owner-ref'd to the InferenceService so it is garbage-collected with it. RWO +
-// WaitForFirstConsumer is the #728 fix: the PVC binds on the node the serving
+// WaitForFirstConsumer is the #728 path: the PVC binds on the node the serving
 // pod schedules to (the GPU node), co-locating download and serve instead of
-// pinning the cache to the operator's node.
-//
-// In shared mode the single cluster-wide llmkube-model-cache PVC is created (no
-// owner reference, since it outlives any one InferenceService) for RWX setups
-// that want cross-isvc dedup. This restores the pre-#728 behavior.
+// pinning the cache to the operator's node. Use it on multi-node clusters that
+// have no RWX storage class.
 func (r *InferenceServiceReconciler) ensureModelCachePVC(ctx context.Context, isvc *inferencev1alpha1.InferenceService) error {
 	log := logf.FromContext(ctx)
 
-	shared := r.ModelCacheMode == ModelCacheModeShared
+	shared := resolveCacheMode(r.ModelCacheMode) == ModelCacheModeShared
 	namespace := isvc.Namespace
 	pvcName := modelCachePVCName(isvc, r.ModelCacheMode)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1773,12 +1773,6 @@ spec:
 			// Longhorn; #418/#419 fsGroup regression coverage is provided by
 			// the other specs in the suite which run on Longhorn unchanged.
 			BeforeEach(func() {
-				// #731: `llmkube cache list` inspects the shared
-				// llmkube-model-cache PVC, but the perService default (#729)
-				// gives each InferenceService its own <isvc>-model-cache PVC,
-				// so the operator never creates the name this spec waits for.
-				// Re-enabled when cache inspection becomes per-isvc aware.
-				Skip("pending #731: cache list is not yet per-InferenceService-cache aware")
 				if os.Getenv("LLMKUBE_E2E_LONGHORN") == "true" {
 					Skip("cache list inspector-pod path is incompatible with Longhorn RWO; covered on default kind storage")
 				}
@@ -1883,10 +1877,6 @@ spec:
 			// Depends on PVC + cache_inspect.go inspector-pod path, both
 			// incompatible with Longhorn RWO. See sibling Context above.
 			BeforeEach(func() {
-				// #731: depends on the shared llmkube-model-cache PVC the
-				// operator no longer creates under the perService default
-				// (#729). Re-enabled when cache inspection is per-isvc aware.
-				Skip("pending #731: cache list is not yet per-InferenceService-cache aware")
 				if os.Getenv("LLMKUBE_E2E_LONGHORN") == "true" {
 					Skip("test exercises multi-RWO PVC mounts; covered on default kind storage")
 				}


### PR DESCRIPTION
## What

Make `modelCache.mode: shared` the default again, and demote per-InferenceService caches to an opt-in (`perService`). Restores the proven, non-breaking cache behavior that #729 changed.

## Why

#729 (per-node cache) shipped `perService` as the default. That was the wrong default: it broke `llmkube cache list` (which inspects the shared `llmkube-model-cache` PVC) for everyone, turned the upcoming release into a silent breaking change (re-downloads, no dedup, redeploys on upgrade), and made the per-isvc cache the common-case path when it should be the advanced opt-in.

The right shape: the default serves the common case (single node, or shared storage), and multi-node without shared storage is the opt-in. This PR flips it back.

Note: pre-#729, remote `http(s)` sources already downloaded via the InferenceService Pod's init container; the controller only ever downloads `file://`. #729's only behavioral break was the cache PVC name (shared to per-isvc), so restoring the shared default restores `cache list`, dedup, and the non-breaking behavior without touching the download path.

## How

- Default `modelCache.mode` flips `perService` to `shared` (chart values + `values.schema.json` + the operator's `resolveCacheMode`, where empty/unknown now resolves to `shared`).
- `shared`: single cluster-wide `llmkube-model-cache` PVC, operator mounts it, init container downloads into it, `cache list` inspects it, cross-isvc dedup. For multi-node, pair with an RWX storage class.
- `perService` (opt-in, unchanged from #729): per-isvc `<isvc>-model-cache` PVC (RWO, WaitForFirstConsumer, owner-ref'd) + init-container download. The escape hatch for multi-node clusters without RWX.
- Un-skip the two `cache list` e2e specs (they pass again under the shared default); #731 (per-isvc-aware `cache list`) now only matters for the `perService` opt-in.
- `docs/model-storage.md` updated: shared is the default; perService is the no-RWX multi-node escape hatch; recommend shared + RWX for multi-node.

## How tested

- `make test`, `make lint`, `GOOS=linux golangci-lint`, `make manifests`+`chart-crds` (clean), `make check-helm-rbac`, `helm unittest` (30/30) all pass.
- Unit/envtest: shared-default reconcile creates `llmkube-model-cache` + the Deployment mounts it; perService creates the owner-ref'd per-isvc PVC; empty mode resolves to shared; `spec.image` / `hardware.gpu.resourceName` overrides still win; unreachable `file://` still reports Failed/CopyFailed.
- Render checks: `helm template` default mounts + creates the shared PVC (`--model-cache-mode=shared`); perService gives the `/models` emptyDir + no shared PVC. `kubectl kustomize config/default` renders a usable `/models`.
- The e2e cache-list specs are un-skipped and exercised by CI under the shared default.

## Checklist

- [x] Tests added/updated
- [x] `make test` / `make lint` pass locally
- [x] Conventional commits, DCO signed
- [x] Documentation updated
- [x] Not a breaking change (restores the prior default)
