### PR TITLE
feat: add vulkan accelerator enum and make readiness-check Vulkan-aware

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -92,8 +92,12 @@ type ModelSpec struct {
 
 // HardwareSpec defines hardware acceleration settings
 type HardwareSpec struct {
-	// Accelerator specifies the type of hardware acceleration
-	// +kubebuilder:validation:Enum=cpu;metal;cuda;rocm;intel
+	// Accelerator specifies the type of hardware acceleration.
+	// "vulkan" covers AMD and Intel GPUs using the Vulkan runtime
+	// (gpu.vendor: amd/intel + gpu.runtime: vulkan). When set to
+	// "vulkan" the readiness-check path uses devic.es/dri-render as
+	// the GPU resource name instead of amd.com/gpu or nvidia.com/gpu.
+	// +kubebuilder:validation:Enum=cpu;metal;cuda;rocm;intel;vulkan
 	// +kubebuilder:default=cpu
 	// +optional
 	Accelerator string `json:"accelerator,omitempty"`

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -80,13 +80,19 @@ spec:
                 properties:
                   accelerator:
                     default: cpu
-                    description: Accelerator specifies the type of hardware acceleration
+                    description: |-
+                      Accelerator specifies the type of hardware acceleration.
+                      "vulkan" covers AMD and Intel GPUs using the Vulkan runtime
+                      (gpu.vendor: amd/intel + gpu.runtime: vulkan). When set to
+                      "vulkan" the readiness-check path uses devic.es/dri-render as
+                      the GPU resource name instead of amd.com/gpu or nvidia.com/gpu.
                     enum:
                     - cpu
                     - metal
                     - cuda
                     - rocm
                     - intel
+                    - vulkan
                     type: string
                   gpu:
                     description: GPU specifies GPU device requirements

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -76,13 +76,19 @@ spec:
                 properties:
                   accelerator:
                     default: cpu
-                    description: Accelerator specifies the type of hardware acceleration
+                    description: |-
+                      Accelerator specifies the type of hardware acceleration.
+                      "vulkan" covers AMD and Intel GPUs using the Vulkan runtime
+                      (gpu.vendor: amd/intel + gpu.runtime: vulkan). When set to
+                      "vulkan" the readiness-check path uses devic.es/dri-render as
+                      the GPU resource name instead of amd.com/gpu or nvidia.com/gpu.
                     enum:
                     - cpu
                     - metal
                     - cuda
                     - rocm
                     - intel
+                    - vulkan
                     type: string
                   gpu:
                     description: GPU specifies GPU device requirements

--- a/internal/controller/gpu_resources.go
+++ b/internal/controller/gpu_resources.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	acceleratorIntel           = "intel"
+	acceleratorVulkan          = "vulkan"
 	intelGPUResourceEnvVar     = "LLMKUBE_INTEL_GPU_RESOURCE"
 	defaultInsufficientGPUHint = "Insufficient "
 )
@@ -29,7 +30,9 @@ var (
 	// vulkanDRIResourceName is the generic-device-plugin resource that
 	// advertises /dev/dri render nodes. Requesting it makes the plugin inject
 	// the render device(s) into the container, so no hostPath device mount is
-	// required. Used as the default GPU resource for the AMD/Vulkan path.
+	// required. Used as the default GPU resource for the AMD/Vulkan path
+	// (both the scheduling path via gpuResourceNameForSpec and the
+	// readiness path via resolveGPUResourceName).
 	vulkanDRIResourceName = corev1.ResourceName("devic.es/dri-render")
 )
 
@@ -102,6 +105,10 @@ func resolveGPUResourceName(model *inferencev1alpha1.Model) corev1.ResourceName 
 		if model.Spec.Hardware.GPU != nil && strings.EqualFold(model.Spec.Hardware.GPU.Vendor, acceleratorIntel) {
 			return resolveIntelGPUResourceName()
 		}
+
+		if strings.EqualFold(model.Spec.Hardware.Accelerator, acceleratorVulkan) {
+			return vulkanDRIResourceName
+		}
 	}
 
 	return nvidiaGPUResourceName
@@ -121,6 +128,7 @@ func detectInsufficientGPUResource(message string) (corev1.ResourceName, bool) {
 		nvidiaGPUResourceName,
 		intelGPUResourceNameI915,
 		intelGPUResourceNameXE,
+		vulkanDRIResourceName,
 	}
 
 	configuredIntelResource := resolveIntelGPUResourceName()

--- a/internal/controller/gpu_resources_test.go
+++ b/internal/controller/gpu_resources_test.go
@@ -70,6 +70,35 @@ func TestResolveGPUResourceName(t *testing.T) {
 			t.Fatalf("resolveGPUResourceName() = %q, want %q", got, intelGPUResourceNameXE)
 		}
 	})
+
+	t.Run("uses vulkan resource when accelerator is vulkan", func(t *testing.T) {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					Accelerator: "vulkan",
+				},
+			},
+		}
+
+		if got := resolveGPUResourceName(model); got != vulkanDRIResourceName {
+			t.Fatalf("resolveGPUResourceName() = %q, want %q", got, vulkanDRIResourceName)
+		}
+	})
+
+	t.Run("uses vulkan resource when accelerator is vulkan with amd gpu vendor", func(t *testing.T) {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					Accelerator: "vulkan",
+					GPU:         &inferencev1alpha1.GPUSpec{Vendor: "amd"},
+				},
+			},
+		}
+
+		if got := resolveGPUResourceName(model); got != vulkanDRIResourceName {
+			t.Fatalf("resolveGPUResourceName() = %q, want %q", got, vulkanDRIResourceName)
+		}
+	})
 }
 
 func TestDetectInsufficientGPUResource(t *testing.T) {
@@ -115,6 +144,18 @@ func TestDetectInsufficientGPUResource(t *testing.T) {
 
 		if _, ok := detectInsufficientGPUResource(message); ok {
 			t.Fatalf("detectInsufficientGPUResource() ok = true, want false")
+		}
+	})
+
+	t.Run("detects vulkan insufficient resource", func(t *testing.T) {
+		message := "0/1 nodes are available: 1 Insufficient devic.es/dri-render."
+
+		got, ok := detectInsufficientGPUResource(message)
+		if !ok {
+			t.Fatalf("detectInsufficientGPUResource() ok = false, want true")
+		}
+		if got != vulkanDRIResourceName {
+			t.Fatalf("detectInsufficientGPUResource() = %q, want %q", got, vulkanDRIResourceName)
 		}
 	})
 }


### PR DESCRIPTION
## What

Add `vulkan` to the `hardware.accelerator` CRD enum and make the readiness-check path (`resolveGPUResourceName` / `detectInsufficientGPUResource`) recognize it, resolving to `devic.es/dri-render` for AMD/Vulkan GPUs.

## Why

Fixes #730

`hardware.accelerator` was `cpu;metal;cuda;rocm;intel` with no AMD/Vulkan value, so a Vulkan Model had to leave `accelerator` blank. The scheduling path already keys off `gpu.vendor: amd` + `gpu.runtime: vulkan` (→ `devic.es/dri-render`), but the readiness/availability path keys off `accelerator` and so computed status against the wrong resource. This closes that divergence by making `vulkan` first-class and teaching the readiness path about it.

## How

- Add `vulkan` to the `+kubebuilder:validation:Enum` on `HardwareSpec.Accelerator` (with docs) and regenerate the CRDs (`config/crd/bases` + chart copy).
- `resolveGPUResourceName` returns the existing `vulkanDRIResourceName` (`devic.es/dri-render`) when `accelerator == "vulkan"`.
- `detectInsufficientGPUResource` recognizes `devic.es/dri-render` in scheduler insufficient-resource messages.
- Regression tests for both vulkan paths.

Provenance: this change was generated end-to-end by Foreman (the agentic coder) running a local model on an AMD Strix Halo node, routed through the Envoy AI Gateway; the commit is authored by Foreman Bot. It was rebased onto current `main` (deduping against the `vulkanDRIResourceName` constant `main` had since grown) with CRDs regenerated.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (changed controller package)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (if user-facing change) — enum doc comment + regenerated CRDs