### PR TITLE
feat(cli): add `llmkube scale` subcommand to scale InferenceService replicas

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -41,6 +41,7 @@ built-in observability, SLO enforcement, and edge-native capabilities.`,
 	cmd.AddCommand(NewDeployCommand())
 	cmd.AddCommand(NewListCommand())
 	cmd.AddCommand(NewDeleteCommand())
+	cmd.AddCommand(NewScaleCommand())
 	cmd.AddCommand(NewStatusCommand())
 	cmd.AddCommand(NewQueueCommand())
 	cmd.AddCommand(NewVersionCommand())

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -36,6 +36,7 @@ func TestNewRootCommand(t *testing.T) {
 		"deploy":    false,
 		"list":      false,
 		"delete":    false,
+		"scale":     false,
 		"status":    false,
 		"queue":     false,
 		"version":   false,

--- a/pkg/cli/scale.go
+++ b/pkg/cli/scale.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+type scaleOptions struct {
+	name      string
+	namespace string
+	replicas  int32
+}
+
+func NewScaleCommand() *cobra.Command {
+	opts := &scaleOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "scale [NAME]",
+		Short: "Scale an InferenceService deployment",
+		Long: `Scale an existing InferenceService deployment in place.
+
+This command changes the replica count of an InferenceService without
+deleting and redeploying. Use --replicas 0 to stop a deployment (the
+Model and config are preserved) or --replicas N>0 to scale back up.
+
+Examples:
+  # Scale down to zero (stop the deployment)
+  llmkube scale gemma-fable5-q6k --replicas 0
+
+  # Scale back up to 1 replica
+  llmkube scale gemma-fable5-q6k --replicas 1
+
+  # Scale to multiple replicas
+  llmkube scale qwen-3-32b --replicas 3 --namespace production`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.name = args[0]
+			return runScale(opts)
+		},
+	}
+
+	cmd.Flags().Int32VarP(&opts.replicas, "replicas", "r", 1, "Desired number of replicas")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Kubernetes namespace")
+
+	return cmd
+}
+
+func runScale(opts *scaleOptions) error {
+	ctx := context.Background()
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	if err := inferencev1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		return fmt.Errorf("failed to add scheme: %w", err)
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	isvc := &inferencev1alpha1.InferenceService{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: opts.name, Namespace: opts.namespace}, isvc); err != nil {
+		return fmt.Errorf("failed to get InferenceService '%s': %w", opts.name, err)
+	}
+
+	// Build a strategic merge patch for spec.replicas
+	patch := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"replicas": opts.replicas,
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+
+	if err := k8sClient.Patch(ctx, isvc, client.RawPatch(types.MergePatchType, patchBytes)); err != nil {
+		return fmt.Errorf("failed to scale InferenceService '%s': %w", opts.name, err)
+	}
+
+	fmt.Printf("Scaled InferenceService '%s' to %d replicas\n", opts.name, opts.replicas)
+	return nil
+}

--- a/pkg/cli/scale_test.go
+++ b/pkg/cli/scale_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+)
+
+func TestNewScaleCommand(t *testing.T) {
+	cmd := NewScaleCommand()
+
+	if cmd.Use != "scale [NAME]" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "scale [NAME]")
+	}
+
+	if f := cmd.Flags().Lookup("replicas"); f == nil {
+		t.Error("Missing --replicas flag")
+	} else {
+		if f.Shorthand != "r" {
+			t.Errorf("replicas shorthand = %q, want %q", f.Shorthand, "r")
+		}
+		if f.DefValue != "1" {
+			t.Errorf("replicas default = %q, want %q", f.DefValue, "1")
+		}
+	}
+
+	if f := cmd.Flags().Lookup("namespace"); f == nil {
+		t.Error("Missing --namespace flag")
+	} else {
+		if f.Shorthand != "n" {
+			t.Errorf("namespace shorthand = %q, want %q", f.Shorthand, "n")
+		}
+		if f.DefValue != testDefaultNamespace {
+			t.Errorf("namespace default = %q, want %q", f.DefValue, testDefaultNamespace)
+		}
+	}
+}
+
+func TestScaleCommandRequiresArg(t *testing.T) {
+	cmd := NewScaleCommand()
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("Expected error when no argument provided")
+	}
+}


### PR DESCRIPTION
## What

Add `llmkube scale <name> --replicas N` to change the replica count of an existing InferenceService in place (including scale-to-zero to stop, and back up to start).

## Why

Fixes #721

There was no way to start/stop or resize a deployment without editing the CR by hand or redeploying. `scale` gives a first-class CLI verb for it.

## How

- New `pkg/cli/scale.go` Cobra subcommand: looks up the InferenceService, patches `spec.replicas`, registered in `root.go`.
- Unit tests for the command (`scale_test.go`).

Provenance: generated end-to-end by Foreman (the agentic coder) on a self-hosted local model (reasoning-off Qwen3.6-35B-A3B on an AMD Strix Halo node), routed through the Envoy AI Gateway; commit authored by Foreman Bot. Branched from current `main`; no human code edits.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (pkg/cli)
- [x] `make lint` passes locally (pkg/cli, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated (if user-facing change) — CLI help text covers it; docs site update can follow