### PR TITLE
feat(foreman): loop convergence forcing (EditFreeStreak + final-turns submit)

### DIFF
--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -335,7 +335,27 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 		},
 	}
 	schemas := l.registry.Schemas()
+	restrictedSchemas := filterForcedEditSchemas(schemas)
 	monitor := NewLoopProgressMonitor(cfg.Progress)
+
+	// EditFreeStreak forcing function. A soft text nudge alone has poor
+	// recovery rates: a confused model just keeps reading (empirically,
+	// #730: a reasoning-off MoE read 16 files, ignored the nudge, and got
+	// force-terminated without ever editing). So once the monitor nudges on
+	// EditFreeStreak we enter a bounded "forcing phase": for up to
+	// maxRestrictedEditTurns turns we drop the exploration tools (grep,
+	// bash) from the advertised set -- read_file stays so the model can
+	// fetch the exact text to edit -- and the phase ends only when an edit
+	// actually lands (a successful write_file/str_replace, NOT a
+	// str_replace that errors on a wrong old_string). If no edit lands
+	// within the budget, the run is force-terminated as a stuck loop.
+	//
+	// forceEditOnly is whether we are currently in the forcing phase;
+	// restrictedTurnsUsed counts forcing-phase turns spent without a
+	// successful edit.
+	forceEditOnly := false
+	restrictedTurnsUsed := 0
+	const maxRestrictedEditTurns = 3
 
 	// noToolCallStreak counts consecutive turns that returned text without
 	// a tool call. It resets to zero after any successful tool-calling
@@ -349,13 +369,19 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	for turn := 1; turn <= cfg.MaxTurns; turn++ {
 		res.Turns = turn
 
+		// During the forcing phase, advertise the restricted set (no grep,
+		// no bash) so the model acts on what it has already read instead of
+		// launching a fresh exploration sweep.
+		activeSchemas := schemas
+		if forceEditOnly {
+			activeSchemas = restrictedSchemas
+		}
+
 		// runOneTurn appends the assistant message + tool messages to
 		// res.Transcript. It returns errTerminalReached on submit_result.
-		// We capture the assistant message's tool_calls before consulting
-		// the monitor; cleanest place to read them is after the turn
-		// returns successfully (errTerminalReached counts as success
-		// here -- submit_result is the model's chosen terminal).
-		turnErr := l.runOneTurn(ctx, cfg, schemas, res)
+		// editSucceeded reports whether a write_file/str_replace landed this
+		// turn (gates the forcing phase below).
+		editSucceeded, turnErr := l.runOneTurn(ctx, cfg, activeSchemas, res)
 		if turnErr != nil {
 			if errors.Is(turnErr, errTerminalReached) {
 				return res, nil
@@ -413,6 +439,48 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 		// message in the transcript has this turn's tool_calls.
 		calls := mostRecentAssistantToolCalls(res.Transcript)
 		decision := monitor.Observe(turn, calls, res.Transcript)
+
+		// A non-EditFreeStreak force-terminate (e.g. ContextHardCap, the
+		// deadliest signal) always wins, even mid-forcing-phase.
+		if decision.Action == ProgressForceTerminate && decision.Signal != signalEditFreeStreak {
+			res.Terminal = ForceTerminateEnvelope(decision, turn)
+			return res, nil
+		}
+
+		// Forcing phase: the loop, not the monitor, owns EditFreeStreak
+		// termination here so the model gets a bounded number of restricted
+		// turns to recover (a failed str_replace often needs one re-read to
+		// fix). The monitor's own EditFreeStreak escalation is intercepted
+		// below by skipping its decision while we are in the phase.
+		if forceEditOnly {
+			if editSucceeded {
+				// The forced edit landed; leave the phase and fall through
+				// to normal handling (the decision is typically Continue
+				// because an edit resets the monitor's streak).
+				forceEditOnly = false
+				restrictedTurnsUsed = 0
+			} else {
+				// No edit this turn. Spend one restricted turn; terminate
+				// when the budget is exhausted, otherwise remind and retry.
+				restrictedTurnsUsed++
+				if restrictedTurnsUsed >= maxRestrictedEditTurns {
+					res.Terminal = ForceTerminateEnvelope(ProgressDecision{
+						Action: ProgressForceTerminate,
+						Signal: signalEditFreeStreak,
+						Detail: fmt.Sprintf(
+							"no successful edit in %d restricted turns after the "+
+								"edit-free nudge (turn %d)", restrictedTurnsUsed, turn),
+					}, turn)
+					return res, nil
+				}
+				res.Transcript = append(res.Transcript, oai.Message{
+					Role:    oai.RoleUser,
+					Content: ForcedEditReminderMessage(maxRestrictedEditTurns - restrictedTurnsUsed),
+				})
+				continue
+			}
+		}
+
 		switch decision.Action {
 		case ProgressContinue:
 			// nothing to do
@@ -424,18 +492,22 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 				Role:    oai.RoleUser,
 				Content: NudgeMessage(decision),
 			})
+			// Enter the forcing phase for the EditFreeStreak signal so the
+			// nudge is a hard constraint (restricted tools + bounded turns),
+			// not just a suggestion the model can ignore.
+			if decision.Signal == signalEditFreeStreak {
+				forceEditOnly = true
+				restrictedTurnsUsed = 0
+			}
 		case ProgressForceTerminate:
-			// Synthesize a submit_result envelope and exit. The
-			// transcript is left intact so the executor can persist
-			// the trajectory for review; res.Terminal carries the
-			// synthesized envelope so downstream consumers see a
-			// normal terminal shape. We return a NIL error here on
-			// purpose: a force-terminate is a clean structural outcome
-			// (not an infrastructure failure) and the executor's
-			// terminal-handling path needs to run so the synthesized
-			// verdict + Extra.outcome propagate to AgenticTask status.
-			// Callers can distinguish this case from a model-emitted
-			// terminal by checking Terminal.Extra["outcome"] for
+			// Reachable only for EditFreeStreak while NOT in the forcing
+			// phase (other signals handled above; an active phase consumes
+			// the EditFreeStreak escalation via restrictedTurnsUsed). Treat
+			// it as a clean structural outcome: synthesize a submit_result
+			// envelope and exit with a NIL error so the executor's terminal
+			// path runs and the synthesized verdict + Extra.outcome
+			// propagate to AgenticTask status. Callers distinguish this from
+			// a model-emitted terminal via Terminal.Extra["outcome"] ==
 			// StuckLoopOutcome (see ForceTerminateEnvelope).
 			res.Terminal = ForceTerminateEnvelope(decision, turn)
 			return res, nil
@@ -503,8 +575,12 @@ var errTerminalReached = errors.New("loop: terminal tool invoked")
 
 // runOneTurn drives one chat-completions request + tool dispatch. It
 // appends to res.Transcript in place. Returns errTerminalReached when
-// the model invoked the terminal (submit_result) tool.
-func (l *Loop) runOneTurn(ctx context.Context, cfg LoopConfig, schemas []oai.Tool, res *LoopResult) error {
+// the model invoked the terminal (submit_result) tool. editSucceeded
+// reports whether a write_file/str_replace landed this turn (used by the
+// EditFreeStreak forcing function in Run).
+func (l *Loop) runOneTurn(
+	ctx context.Context, cfg LoopConfig, schemas []oai.Tool, res *LoopResult,
+) (editSucceeded bool, err error) {
 	ctx, span := l.tracer.Start(ctx, "foreman.agent.turn",
 		trace.WithAttributes(attribute.Int("turn", res.Turns)))
 	defer span.End()
@@ -520,12 +596,12 @@ func (l *Loop) runOneTurn(ctx context.Context, cfg LoopConfig, schemas []oai.Too
 	resp, err := l.client.Chat(ctx, req)
 	if err != nil {
 		span.RecordError(err)
-		return fmt.Errorf("turn %d: chat: %w", res.Turns, err)
+		return false, fmt.Errorf("turn %d: chat: %w", res.Turns, err)
 	}
 	if len(resp.Choices) == 0 {
 		err := fmt.Errorf("turn %d: %w", res.Turns, oai.ErrNoChoices)
 		span.RecordError(err)
-		return err
+		return false, err
 	}
 
 	msg := resp.Choices[0].Message
@@ -544,24 +620,25 @@ func (l *Loop) runOneTurn(ctx context.Context, cfg LoopConfig, schemas []oai.Too
 		if msg.ReasoningContent != "" && strings.TrimSpace(msg.Content) == "" {
 			err := fmt.Errorf("turn %d: %w", res.Turns, ErrAssistantReasoningOnly)
 			span.RecordError(err)
-			return err
+			return false, err
 		}
 		err := fmt.Errorf("turn %d: %w", res.Turns, ErrAssistantNoToolCalls)
 		span.RecordError(err)
-		return err
+		return false, err
 	}
 
-	terminal := l.dispatchToolCalls(ctx, msg.ToolCalls, res)
+	terminal, editSucceeded := l.dispatchToolCalls(ctx, msg.ToolCalls, res)
 	span.SetAttributes(
 		attribute.Int("tool_calls", len(msg.ToolCalls)),
 		attribute.Int64("elapsed_ms", time.Since(start).Milliseconds()),
 		attribute.Bool("terminal", terminal != nil),
+		attribute.Bool("edit_succeeded", editSucceeded),
 	)
 	if terminal != nil {
 		res.Terminal = terminal
-		return errTerminalReached
+		return editSucceeded, errTerminalReached
 	}
-	return nil
+	return editSucceeded, nil
 }
 
 // dispatchToolCalls executes every tool_call in a single assistant turn
@@ -570,9 +647,15 @@ func (l *Loop) runOneTurn(ctx context.Context, cfg LoopConfig, schemas []oai.Too
 // loop still completes the rest of the turn before exiting (the model
 // authored them as one batch).
 //
-// Returns the first terminal *ToolResult observed, or nil if none.
-func (l *Loop) dispatchToolCalls(ctx context.Context, calls []oai.ToolCall, res *LoopResult) *ToolResult {
-	var terminal *ToolResult
+// Returns the first terminal *ToolResult observed (or nil) and whether any
+// edit-producing tool (write_file, str_replace) dispatched successfully
+// this turn. editSucceeded gates the EditFreeStreak forcing function: a
+// str_replace that errors with "old_string found 0 times" must NOT count as
+// progress, or a model that guesses the wrong text escapes the forcing
+// phase without ever landing a fix.
+func (l *Loop) dispatchToolCalls(
+	ctx context.Context, calls []oai.ToolCall, res *LoopResult,
+) (terminal *ToolResult, editSucceeded bool) {
 	for _, tc := range calls {
 		argsRaw := json.RawMessage(tc.Function.Arguments)
 		if len(argsRaw) == 0 {
@@ -595,6 +678,13 @@ func (l *Loop) dispatchToolCalls(ctx context.Context, calls []oai.ToolCall, res 
 			if result.Terminal && terminal == nil {
 				terminal = result
 			}
+			// A successful write_file/str_replace is a real edit. (We
+			// reuse editProducingTools but exclude submit_result here: a
+			// successful submit short-circuits the loop before the
+			// forcing-function check, so its edit status is moot.)
+			if tc.Function.Name == "write_file" || tc.Function.Name == "str_replace" {
+				editSucceeded = true
+			}
 		}
 		res.Transcript = append(res.Transcript, oai.Message{
 			Role:       oai.RoleTool,
@@ -603,7 +693,7 @@ func (l *Loop) dispatchToolCalls(ctx context.Context, calls []oai.ToolCall, res 
 			Content:    content,
 		})
 	}
-	return terminal
+	return terminal, editSucceeded
 }
 
 // maskTranscriptForWire returns a copy of transcript with older tool

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -357,6 +357,18 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	restrictedTurnsUsed := 0
 	const maxRestrictedEditTurns = 3
 
+	// Final-turns convergence guard. In the last forceSubmitFinalTurns turns
+	// before MaxTurns, an agent that still has not called submit_result is
+	// advertised submit_result ONLY (plus a one-time hard nudge), so it
+	// produces a terminal verdict instead of silently hitting
+	// ErrMaxTurnsExhausted with no result. This is the reviewer loop's
+	// convergence mechanism: reviewers have EditFreeStreak disabled (they
+	// legitimately read for many turns), so without this a non-converging
+	// reviewer just rambles to MaxTurns and yields an empty INCOMPLETE.
+	// Coders get it as a backstop behind the EditFreeStreak forcing function.
+	const forceSubmitFinalTurns = 3
+	forceSubmitAnnounced := false
+
 	// noToolCallStreak counts consecutive turns that returned text without
 	// a tool call. It resets to zero after any successful tool-calling
 	// turn, so only sustained narration exhausts MaxNoToolCallRetries.
@@ -375,6 +387,21 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 		activeSchemas := schemas
 		if forceEditOnly {
 			activeSchemas = restrictedSchemas
+		}
+
+		// Final-turns convergence guard (takes precedence over the forcing
+		// phase): in the last forceSubmitFinalTurns turns, advertise
+		// submit_result only and append a one-time hard nudge, so the model
+		// must conclude rather than exhaust MaxTurns with no verdict.
+		if cfg.MaxTurns > forceSubmitFinalTurns && turn > cfg.MaxTurns-forceSubmitFinalTurns {
+			activeSchemas = filterSubmitOnlySchemas(schemas)
+			if !forceSubmitAnnounced {
+				res.Transcript = append(res.Transcript, oai.Message{
+					Role:    oai.RoleUser,
+					Content: ForceSubmitMessage(cfg.MaxTurns - turn + 1),
+				})
+				forceSubmitAnnounced = true
+			}
 		}
 
 		// runOneTurn appends the assistant message + tool messages to

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -329,6 +329,217 @@ func TestLoop_UnknownToolBecomesToolErrorMessage(t *testing.T) {
 	}
 }
 
+const toolCallWriteFile = `{
+  "id": "tw",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "tool_calls": [{
+        "id": "tc-wf",
+        "type": "function",
+        "function": {"name": "write_file", "arguments": "{\"path\":\"x.go\",\"content\":\"package x\"}"}
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }]
+}`
+
+// sixToolSchemas returns the full production tool advertisement set so a
+// test can assert which subset the loop advertises on a given turn.
+func sixToolSchemas() []oai.Tool {
+	names := []string{"read_file", "write_file", "str_replace", "grep", "bash", "submit_result"}
+	out := make([]oai.Tool, 0, len(names))
+	for _, n := range names {
+		out = append(out, oai.Tool{Type: "function", Function: oai.ToolSchemaDef{Name: n}})
+	}
+	return out
+}
+
+// recordingScriptedServer behaves like scriptedOAIServer but also records,
+// per request, the set of tool names the loop advertised in that request's
+// `tools` array. advertised[i] is the sorted-ish slice for the i-th call.
+func recordingScriptedServer(t *testing.T, bodies []string) (*httptest.Server, *[][]string) {
+	t.Helper()
+	var calls atomic.Int64
+	advertised := make([][]string, len(bodies))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		i := int(calls.Add(1) - 1)
+		if i >= len(bodies) {
+			t.Errorf("recordingScriptedServer: %d-th call exceeds script (%d)", i+1, len(bodies))
+			http.Error(w, "script exhausted", http.StatusInternalServerError)
+			return
+		}
+		var req oai.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("recordingScriptedServer: decode request: %v", err)
+		}
+		names := make([]string, 0, len(req.Tools))
+		for _, tl := range req.Tools {
+			names = append(names, tl.Function.Name)
+		}
+		advertised[i] = names
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(chatJSONToSSE(t, bodies[i])))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &advertised
+}
+
+func hasTool(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// toolCallStrReplaceBad is a str_replace whose registry result is an error
+// (e.g. "old_string found 0 times") -- a failed edit attempt.
+const toolCallStrReplaceBad = `{
+  "id": "tsr",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "tool_calls": [{
+        "id": "tc-sr-bad",
+        "type": "function",
+        "function": {
+          "name": "str_replace",
+          "arguments": "{\"path\":\"x.go\",\"old_string\":\"nope\",\"new_string\":\"y\"}"
+        }
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }]
+}`
+
+func TestLoop_EditFreeStreak_ForcingPhaseDropsExplorationKeepsRead(t *testing.T) {
+	// When EditFreeStreak nudges, the forcing phase drops grep+bash but
+	// KEEPS read_file (so the model can fetch exact text to fix an edit).
+	// The phase lifts only when an edit actually lands. Script: two reads
+	// trip EditFreeTurnsLimit=2; turn 3 (restricted) the model reads to get
+	// the text; turn 4 it writes successfully (lifting the phase); turn 5
+	// the full tool set is restored and it submits.
+	srv, advertised := recordingScriptedServer(t, []string{
+		toolCallReadFile, toolCallReadFile, toolCallReadFile, toolCallWriteFile, toolCallSubmitGo,
+	})
+	reg := &fakeRegistry{
+		schemas: sixToolSchemas(),
+		results: map[string]*ToolResult{
+			"read_file":     {Output: map[string]any{"content": "x"}},
+			"write_file":    {Output: map[string]any{"ok": true}},
+			"submit_result": {Terminal: true, Verdict: "GO", Summary: "done"},
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", MaxTurns: 10,
+		Progress: ProgressConfig{EditFreeTurnsLimit: 2},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Fatalf("expected GO terminal, got %+v", res.Terminal)
+	}
+	adv := *advertised
+	if len(adv) < 5 {
+		t.Fatalf("expected 5 recorded requests, got %d", len(adv))
+	}
+	// Turns 1 and 2: full tool set.
+	for _, turn := range []int{0, 1} {
+		if len(adv[turn]) != 6 {
+			t.Errorf("turn %d: expected full 6-tool set, got %v", turn+1, adv[turn])
+		}
+	}
+	// Turns 3 and 4 (forcing phase): grep+bash gone, read_file kept.
+	for _, turn := range []int{2, 3} {
+		r := adv[turn]
+		if hasTool(r, "grep") || hasTool(r, "bash") {
+			t.Errorf("turn %d: expected grep/bash removed, got %v", turn+1, r)
+		}
+		if !hasTool(r, "read_file") || !hasTool(r, "write_file") ||
+			!hasTool(r, "str_replace") || !hasTool(r, "submit_result") {
+			t.Errorf("turn %d: expected read_file + edit tools present, got %v", turn+1, r)
+		}
+	}
+	// Turn 5: phase lifted after the successful write; full set restored.
+	if len(adv[4]) != 6 {
+		t.Errorf("turn 5: expected full tool set restored, got %v", adv[4])
+	}
+}
+
+func TestLoop_EditFreeStreak_FailedEditDoesNotLiftPhase(t *testing.T) {
+	// A str_replace that ERRORS ("old_string found 0 times") must not count
+	// as progress: the phase stays armed and the model gets another
+	// restricted turn to recover, instead of escaping back to exploration.
+	// Script: two reads trip the limit; then three failed str_replace
+	// attempts exhaust the 3-turn restricted budget -> force-terminate.
+	srv, _ := recordingScriptedServer(t, []string{
+		toolCallReadFile, toolCallReadFile,
+		toolCallStrReplaceBad, toolCallStrReplaceBad, toolCallStrReplaceBad,
+	})
+	reg := &fakeRegistry{
+		schemas: sixToolSchemas(),
+		results: map[string]*ToolResult{
+			"read_file": {Output: map[string]any{"content": "x"}},
+			// str_replace absent from results -> Dispatch returns an error,
+			// modeling a failed edit (wrong old_string).
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", MaxTurns: 10,
+		Progress: ProgressConfig{EditFreeTurnsLimit: 2},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil {
+		t.Fatalf("expected force-terminate envelope, got nil")
+	}
+	if got := res.Terminal.Extra["signal"]; got != "EditFreeStreak" {
+		t.Errorf("signal: want EditFreeStreak got %v", got)
+	}
+	if got := res.Terminal.Extra["outcome"]; got != StuckLoopOutcome {
+		t.Errorf("outcome: want %q got %v", StuckLoopOutcome, got)
+	}
+}
+
+func TestLoop_EditFreeStreak_TerminatesAfterRestrictedBudget(t *testing.T) {
+	// A model that keeps reading inside the forcing phase (never editing)
+	// is force-terminated once the restricted-turn budget is spent, not on
+	// the first restricted turn. With EditFreeTurnsLimit=2 the nudge fires
+	// after turn 2; turns 3,4,5 are restricted reads; the run terminates at
+	// turn 5 (the 3rd restricted turn).
+	srv, _ := recordingScriptedServer(t, []string{
+		toolCallReadFile, toolCallReadFile, toolCallReadFile, toolCallReadFile, toolCallReadFile,
+	})
+	reg := &fakeRegistry{
+		schemas: sixToolSchemas(),
+		results: map[string]*ToolResult{
+			"read_file": {Output: map[string]any{"content": "x"}},
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", MaxTurns: 10,
+		Progress: ProgressConfig{EditFreeTurnsLimit: 2},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Extra["signal"] != "EditFreeStreak" {
+		t.Fatalf("expected EditFreeStreak force-terminate, got %+v", res.Terminal)
+	}
+	if res.Turns != 5 {
+		t.Errorf("expected termination at turn 5 (nudge@2 + 3 restricted turns), got %d", res.Turns)
+	}
+}
+
 func TestLoop_AssistantNoToolCalls_RetriesThenErrors(t *testing.T) {
 	// A model that replies with prose and no tool_calls cannot make
 	// forward progress, but rather than failing the whole task on the

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -540,6 +540,55 @@ func TestLoop_EditFreeStreak_TerminatesAfterRestrictedBudget(t *testing.T) {
 	}
 }
 
+func TestLoop_FinalTurnsForceSubmit(t *testing.T) {
+	// In the last forceSubmitFinalTurns (3) turns before MaxTurns, the loop
+	// advertises submit_result ONLY, so a non-concluding agent (e.g. a reviewer
+	// with EditFreeStreak disabled) is forced to produce a terminal verdict
+	// instead of exhausting MaxTurns with no result. MaxTurns=8 -> final window
+	// is turns 6,7,8. The model reads 5 turns, then submits on turn 6 (when only
+	// submit_result is available).
+	srv, advertised := recordingScriptedServer(t, []string{
+		toolCallReadFile, toolCallReadFile, toolCallReadFile,
+		toolCallReadFile, toolCallReadFile, toolCallSubmitGo,
+	})
+	reg := &fakeRegistry{
+		schemas: sixToolSchemas(),
+		results: map[string]*ToolResult{
+			"read_file":     {Output: map[string]any{"content": "x"}},
+			"submit_result": {Terminal: true, Verdict: "GO", Summary: "done"},
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	res, err := loop.Run(context.Background(), LoopConfig{Model: "test", MaxTurns: 8})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Fatalf("expected GO terminal, got %+v", res.Terminal)
+	}
+	adv := *advertised
+	if len(adv) < 6 {
+		t.Fatalf("expected >=6 recorded requests, got %d", len(adv))
+	}
+	for _, turn := range []int{0, 1, 2, 3, 4} {
+		if len(adv[turn]) != 6 {
+			t.Errorf("turn %d: expected full 6-tool set, got %v", turn+1, adv[turn])
+		}
+	}
+	if len(adv[5]) != 1 || adv[5][0] != "submit_result" {
+		t.Errorf("turn 6: expected [submit_result] only, got %v", adv[5])
+	}
+	var sawNudge bool
+	for _, m := range res.Transcript {
+		if m.Role == oai.RoleUser && strings.Contains(m.Content, "ONLY tool available") {
+			sawNudge = true
+		}
+	}
+	if !sawNudge {
+		t.Errorf("expected ForceSubmitMessage in transcript")
+	}
+}
+
 func TestLoop_AssistantNoToolCalls_RetriesThenErrors(t *testing.T) {
 	// A model that replies with prose and no tool_calls cannot make
 	// forward progress, but rather than failing the whole task on the

--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -220,6 +220,42 @@ func filterForcedEditSchemas(schemas []oai.Tool) []oai.Tool {
 	return out
 }
 
+// filterSubmitOnlySchemas returns ONLY the submit_result tool. Used by the
+// loop's final-turns convergence guard: in the last few turns before MaxTurns,
+// an agent that still has not concluded is advertised submit_result alone, so
+// it must produce a terminal verdict instead of silently exhausting MaxTurns
+// with no result. This is the reviewer loop's convergence mechanism (reviewers
+// have EditFreeStreak disabled by design, since they legitimately read for many
+// turns; see progressConfigFromAgent), and a safety net for coders. If
+// submit_result is somehow not advertised, the input is returned unchanged.
+func filterSubmitOnlySchemas(schemas []oai.Tool) []oai.Tool {
+	for _, s := range schemas {
+		if s.Function.Name == "submit_result" {
+			return []oai.Tool{s}
+		}
+	}
+	return schemas
+}
+
+// ForceSubmitMessage is the synthetic user message appended when the loop
+// enters the final-turns force-submit window. It tells the model it is out of
+// runway and must call submit_result now; turnsLeft is how many turns remain.
+func ForceSubmitMessage(turnsLeft int) string {
+	plural := "turns"
+	if turnsLeft == 1 {
+		plural = "turn"
+	}
+	return fmt.Sprintf(
+		"You are almost out of turns (%d %s left) and have not concluded. "+
+			"submit_result is now the ONLY tool available: you MUST call it now "+
+			"with your verdict, summary, and the required extra fields (for a "+
+			"review: reviewOutcome, findings, issueAsk, filesTouched). Do not "+
+			"attempt to read or search further; decide on the evidence you have "+
+			"and submit. If you genuinely cannot conclude, submit verdict=\"ERROR\" "+
+			"(or NO-GO for a review) with a summary of what blocked you.",
+		turnsLeft, plural)
+}
+
 // Observe records the result of one turn and returns a decision for
 // the loop to act on. The transcript argument is the full transcript
 // after the turn's tool messages were appended (i.e. what the next

--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -168,6 +168,17 @@ func NewLoopProgressMonitor(cfg ProgressConfig) *LoopProgressMonitor {
 	return &LoopProgressMonitor{cfg: cfg}
 }
 
+// Signal names, used in ProgressDecision.Signal and matched by the loop
+// to decide whether the EditFreeStreak forcing function should arm. These
+// strings also surface in telemetry and the force-terminate envelope, so
+// their values are part of the observable contract.
+const (
+	signalRepeatedToolCall = "RepeatedToolCall"
+	signalEditFreeStreak   = "EditFreeStreak"
+	signalContextSoftCap   = "ContextSoftCap"
+	signalContextHardCap   = "ContextHardCap"
+)
+
 // editProducingTools are the tool names that count as "made progress"
 // for the EditFreeStreak signal. submit_result is included so a
 // model that immediately submits without editing (legitimate for
@@ -177,6 +188,36 @@ var editProducingTools = map[string]struct{}{
 	"write_file":    {},
 	"str_replace":   {},
 	"submit_result": {},
+}
+
+// explorationTools are the open-ended search tools removed from the
+// advertised set during the EditFreeStreak forcing phase. read_file is
+// deliberately NOT here: a model recovering from a failed str_replace must
+// re-read the target file to get the exact text, and read_file of a
+// specific file is part of a legitimate read->edit->verify cycle. The
+// pathology the forcing function kills is open-ended *searching*
+// (repo-wide grep, bash find, scanning many files), which is what these
+// two tools enable.
+var explorationTools = map[string]struct{}{
+	"grep": {},
+	"bash": {},
+}
+
+// filterForcedEditSchemas returns the advertised tool set for a turn inside
+// the EditFreeStreak forcing phase: everything EXCEPT the exploration tools
+// (grep, bash). The model keeps read_file/write_file/str_replace/
+// submit_result so it can read the specific file it is editing and then
+// land the change, but it cannot fan out into a fresh exploration sweep.
+// Order is preserved.
+func filterForcedEditSchemas(schemas []oai.Tool) []oai.Tool {
+	out := make([]oai.Tool, 0, len(schemas))
+	for _, s := range schemas {
+		if _, ok := explorationTools[s.Function.Name]; ok {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
 }
 
 // Observe records the result of one turn and returns a decision for
@@ -208,7 +249,7 @@ func (m *LoopProgressMonitor) Observe(turn int, calls []oai.ToolCall, transcript
 	if m.cfg.ContextHardCap > 0 && m.contextTokens >= m.cfg.ContextHardCap {
 		return ProgressDecision{
 			Action: ProgressForceTerminate,
-			Signal: "ContextHardCap",
+			Signal: signalContextHardCap,
 			Detail: fmt.Sprintf(
 				"approximate wire-token count %d >= hard cap %d at turn %d",
 				m.contextTokens, m.cfg.ContextHardCap, turn),
@@ -220,7 +261,7 @@ func (m *LoopProgressMonitor) Observe(turn int, calls []oai.ToolCall, transcript
 		if m.nudgedContextSoft {
 			return ProgressDecision{
 				Action: ProgressForceTerminate,
-				Signal: "ContextSoftCap",
+				Signal: signalContextSoftCap,
 				Detail: fmt.Sprintf(
 					"approximate wire-token count %d >= soft cap %d for second "+
 						"consecutive turn (turn %d); model did not call submit_result "+
@@ -231,7 +272,7 @@ func (m *LoopProgressMonitor) Observe(turn int, calls []oai.ToolCall, transcript
 		m.nudgedContextSoft = true
 		return ProgressDecision{
 			Action: ProgressNudge,
-			Signal: "ContextSoftCap",
+			Signal: signalContextSoftCap,
 			Detail: fmt.Sprintf(
 				"approximate wire-token count %d >= soft cap %d at turn %d",
 				m.contextTokens, m.cfg.ContextSoftCap, turn),
@@ -243,7 +284,7 @@ func (m *LoopProgressMonitor) Observe(turn int, calls []oai.ToolCall, transcript
 		if m.nudgedEditFree {
 			return ProgressDecision{
 				Action: ProgressForceTerminate,
-				Signal: "EditFreeStreak",
+				Signal: signalEditFreeStreak,
 				Detail: fmt.Sprintf(
 					"no write_file/str_replace/submit_result tool call in %d "+
 						"consecutive turns (turn %d); model did not change behavior "+
@@ -254,7 +295,7 @@ func (m *LoopProgressMonitor) Observe(turn int, calls []oai.ToolCall, transcript
 		m.nudgedEditFree = true
 		return ProgressDecision{
 			Action: ProgressNudge,
-			Signal: "EditFreeStreak",
+			Signal: signalEditFreeStreak,
 			Detail: fmt.Sprintf(
 				"no write_file/str_replace/submit_result tool call in %d consecutive turns (turn %d)",
 				m.editFreeStreak, turn),
@@ -273,7 +314,7 @@ func (m *LoopProgressMonitor) Observe(turn int, calls []oai.ToolCall, transcript
 				if h == m.nudgedRepeatedToolHash {
 					return ProgressDecision{
 						Action: ProgressForceTerminate,
-						Signal: "RepeatedToolCall",
+						Signal: signalRepeatedToolCall,
 						Detail: fmt.Sprintf(
 							"%s called again with identical arguments (hash %s) at turn %d after a prior nudge for the same pattern",
 							extractToolName(h), h, turn),
@@ -290,7 +331,7 @@ func (m *LoopProgressMonitor) Observe(turn int, calls []oai.ToolCall, transcript
 			m.recentCallHashes = m.recentCallHashes[:0]
 			return ProgressDecision{
 				Action: ProgressNudge,
-				Signal: "RepeatedToolCall",
+				Signal: signalRepeatedToolCall,
 				Detail: fmt.Sprintf(
 					"%s called >= %d times with identical arguments (hash %s) at turn %d",
 					name, m.cfg.RepeatedToolThreshold, hash, turn),
@@ -477,11 +518,50 @@ func NudgeMessage(d ProgressDecision) string {
 	var b strings.Builder
 	b.WriteString("PROGRESS MONITOR ALERT: ")
 	b.WriteString(d.Detail)
+
+	// EditFreeStreak is backed by a forcing function in the loop: the next
+	// few turns drop the exploration tools (grep, bash) and the run is
+	// force-terminated unless an edit lands. Tell the model so the
+	// instruction agrees with the tool set it is about to see; read_file
+	// stays available so it can fetch the exact text to edit.
+	if d.Signal == signalEditFreeStreak {
+		b.WriteString("\n\nYou have been exploring without making any change. Stop searching. " +
+			"The grep and bash tools are now DISABLED; you may use read_file to re-read " +
+			"the specific file you are changing, but your goal now is to act, not to keep " +
+			"looking. Either:\n")
+		b.WriteString("  - make the edit the issue calls for (write_file or str_replace; " +
+			"read_file first only if you need the exact current text), OR\n")
+		b.WriteString("  - if the issue is not fixable or out of scope, call " +
+			"submit_result(verdict=\"NO-GO\") with a clear summary.\n\n")
+		b.WriteString("You have only a few turns to land a successful edit or submit; " +
+			"continuing to only read will be force-terminated as a stuck loop.")
+		return b.String()
+	}
+
 	b.WriteString("\n\nThis pattern is not making progress. Stop. Either:\n")
 	b.WriteString("  - call submit_result(verdict=\"NO-GO\") with a clear summary of what is blocking you, OR\n")
 	b.WriteString("  - change your approach entirely (different tool, different arguments, different file).\n\n")
 	b.WriteString("Continuing the same pattern will be force-terminated as a stuck loop.")
 	return b.String()
+}
+
+// ForcedEditReminderMessage is the synthetic user message the loop appends
+// on each turn of the EditFreeStreak forcing phase in which the model still
+// did not land a successful edit. It restates the constraint and counts
+// down the remaining attempts so the model knows the run is about to be
+// force-terminated. turnsLeft is how many forced-edit turns remain.
+func ForcedEditReminderMessage(turnsLeft int) string {
+	plural := "turns"
+	if turnsLeft == 1 {
+		plural = "turn"
+	}
+	return fmt.Sprintf(
+		"Still no successful edit. grep and bash remain DISABLED. You have %d %s "+
+			"left to either land an edit (write_file or str_replace -- use read_file "+
+			"first to copy the exact current text if your last str_replace did not "+
+			"match) or call submit_result(verdict=\"NO-GO\"). After that the run is "+
+			"force-terminated as a stuck loop.",
+		turnsLeft, plural)
 }
 
 // ForceTerminateEnvelope builds the synthetic submit_result envelope


### PR DESCRIPTION
## What

Two loop-level convergence mechanisms for the Foreman native agent:

1. **EditFreeStreak forcing function** (coders): when the stuck-loop monitor fires its EditFreeStreak nudge, the loop now enters a bounded forcing phase that drops the exploration tools (`grep`, `bash`) from the advertised set while deliberately keeping `read_file`, lifts the phase only when an edit actually lands, and force-terminates if no edit lands within a 3-turn budget.
2. **Final-turns force-submit** (reviewers): in the last 3 turns before `MaxTurns`, the loop advertises `submit_result` only and appends a one-time hard nudge, so an agent that would otherwise ramble to `MaxTurns` and yield an empty `INCOMPLETE` is forced to produce a terminal verdict.

## Why

Reviewers have EditFreeStreak disabled by design (a thorough review legitimately reads for many turns), which left them with no convergence backstop: a non-converging reviewer ran all 40 turns and returned an empty `INCOMPLETE` with no verdict or findings (observed live with a Gemma reviewer). On the coder side, the prior EditFreeStreak behavior only appended a text nudge before force-terminating; a confused model ignored the suggestion, kept reading, and got cut without ever attempting a fix (observed in #730: a reasoning-off MoE read 16 files, ignored the nudge, never edited).

These two mechanisms are the convergence machinery for the autonomous heterogeneous pipeline (coder on one accelerator, reviewers on others).

Related: #730 (the run that surfaced both failure modes)

## How

- `progress.go`: centralized the four progress-signal names as constants; added `explorationTools` + `filterForcedEditSchemas` (drops grep/bash), `filterSubmitOnlySchemas` (submit_result only), and `ForceSubmitMessage`; reconciled the EditFreeStreak nudge text with the restricted tool set plus a per-turn countdown reminder.
- `loop.go`: `dispatchToolCalls` now reports whether an edit actually landed (a successful `write_file`/`str_replace`, not a `str_replace` that errored on a wrong `old_string`); the loop owns the forcing-phase termination so the model gets a bounded recovery budget; the final-turns force-submit window is gated on `MaxTurns > forceSubmitFinalTurns` so it never false-fires on short runs.
- The forcing phase is superseded only for EditFreeStreak; other signals (e.g. ContextHardCap) still terminate immediately.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change) — internal harness behavior, no user-facing surface
