### PR TITLE
fix(cli): correct --node-port help text and add NodePort test coverage

### DIFF
--- a/internal/controller/inferenceservice_service_test.go
+++ b/internal/controller/inferenceservice_service_test.go
@@ -71,6 +71,49 @@ var _ = Describe("constructService", func() {
 		Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
 	})
 
+	It("should set ServicePort.NodePort only when endpoint.nodePort is set on a NodePort service", func() {
+		nodePort := int32(30080)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Endpoint: &inferencev1alpha1.EndpointSpec{
+					Type:     "NodePort",
+					NodePort: &nodePort,
+				},
+			},
+		}
+		svc := reconciler.constructService(isvc)
+		Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+		Expect(svc.Spec.Ports[0].NodePort).To(Equal(nodePort))
+	})
+
+	It("should not set ServicePort.NodePort when endpoint.nodePort is nil on a NodePort service", func() {
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Endpoint: &inferencev1alpha1.EndpointSpec{Type: "NodePort"},
+			},
+		}
+		svc := reconciler.constructService(isvc)
+		Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+		Expect(svc.Spec.Ports[0].NodePort).To(Equal(int32(0)))
+	})
+
+	It("should not set ServicePort.NodePort for ClusterIP service", func() {
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Endpoint: &inferencev1alpha1.EndpointSpec{
+					Type:     "ClusterIP",
+					NodePort: ptrInt32(30080),
+				},
+			},
+		}
+		svc := reconciler.constructService(isvc)
+		Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+		Expect(svc.Spec.Ports[0].NodePort).To(Equal(int32(0)))
+	})
+
 	It("should create LoadBalancer service", func() {
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default"},

--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -149,7 +149,8 @@ Examples:
 	cmd.Flags().Int32VarP(&opts.replicas, "replicas", "r", 1, "Number of replicas")
 	cmd.Flags().Int32Var(&opts.nodePort, "node-port", 0,
 		"Pin a stable NodePort (30000-32767) for the service. "+
-			"Implies --endpoint-type NodePort. Default: auto-assign.")
+			"Sets the endpoint type to NodePort and pins this port. "+
+			"Default: auto-assign / ClusterIP.")
 	cmd.Flags().Int32Var(&opts.minReplicas, "min-replicas", 0,
 		"Minimum replicas for autoscaling (enables HPA when set with --max-replicas)")
 	cmd.Flags().Int32Var(&opts.maxReplicas, "max-replicas", 0,

--- a/pkg/cli/deploy_test.go
+++ b/pkg/cli/deploy_test.go
@@ -34,6 +34,8 @@ func TestBuildInferenceService(t *testing.T) {
 		wantGPUMemory string
 		wantContext   bool
 		wantParallel  bool
+		wantEndpoint  string
+		wantNodePort  *int32
 	}{
 		{
 			name: "CPU defaults",
@@ -47,6 +49,7 @@ func TestBuildInferenceService(t *testing.T) {
 			},
 			wantGPU:       0,
 			wantGPUMemory: "",
+			wantEndpoint:  "ClusterIP",
 		},
 		{
 			name: "GPU with memory",
@@ -63,6 +66,7 @@ func TestBuildInferenceService(t *testing.T) {
 			},
 			wantGPU:       2,
 			wantGPUMemory: "16Gi",
+			wantEndpoint:  "ClusterIP",
 		},
 		{
 			name: "GPU without memory",
@@ -78,6 +82,7 @@ func TestBuildInferenceService(t *testing.T) {
 			},
 			wantGPU:       1,
 			wantGPUMemory: "",
+			wantEndpoint:  "ClusterIP",
 		},
 		{
 			name: "with context size",
@@ -90,7 +95,8 @@ func TestBuildInferenceService(t *testing.T) {
 				memory:      "4Gi",
 				contextSize: 8192,
 			},
-			wantContext: true,
+			wantContext:  true,
+			wantEndpoint: "ClusterIP",
 		},
 		{
 			name: "with parallel slots",
@@ -104,6 +110,7 @@ func TestBuildInferenceService(t *testing.T) {
 				parallelSlots: 4,
 			},
 			wantParallel: true,
+			wantEndpoint: "ClusterIP",
 		},
 		{
 			name: "zero context and parallel are omitted",
@@ -119,6 +126,34 @@ func TestBuildInferenceService(t *testing.T) {
 			},
 			wantContext:  false,
 			wantParallel: false,
+			wantEndpoint: "ClusterIP",
+		},
+		{
+			name: "node-port sets NodePort type and pins the port",
+			opts: &deployOptions{
+				name:      "nodeport-model",
+				namespace: testDefaultNamespace,
+				replicas:  1,
+				image:     "ghcr.io/ggml-org/llama.cpp:server",
+				cpu:       "2",
+				memory:    "4Gi",
+				nodePort:  30080,
+			},
+			wantEndpoint: "NodePort",
+			wantNodePort: ptrInt32(30080),
+		},
+		{
+			name: "no node-port defaults to ClusterIP with nil NodePort",
+			opts: &deployOptions{
+				name:      "default-model",
+				namespace: testDefaultNamespace,
+				replicas:  1,
+				image:     "ghcr.io/ggml-org/llama.cpp:server",
+				cpu:       "2",
+				memory:    "4Gi",
+			},
+			wantEndpoint: "ClusterIP",
+			wantNodePort: nil,
 		},
 	}
 
@@ -155,8 +190,19 @@ func TestBuildInferenceService(t *testing.T) {
 			if isvc.Spec.Endpoint.Path != "/v1/chat/completions" {
 				t.Errorf("Path = %q, want /v1/chat/completions", isvc.Spec.Endpoint.Path)
 			}
-			if isvc.Spec.Endpoint.Type != "ClusterIP" {
-				t.Errorf("Type = %q, want ClusterIP", isvc.Spec.Endpoint.Type)
+			if isvc.Spec.Endpoint.Type != tt.wantEndpoint {
+				t.Errorf("Type = %q, want %q", isvc.Spec.Endpoint.Type, tt.wantEndpoint)
+			}
+			if tt.wantNodePort == nil {
+				if isvc.Spec.Endpoint.NodePort != nil {
+					t.Errorf("NodePort = %d, want nil", *isvc.Spec.Endpoint.NodePort)
+				}
+			} else {
+				if isvc.Spec.Endpoint.NodePort == nil {
+					t.Error("NodePort is nil, want non-nil")
+				} else if *isvc.Spec.Endpoint.NodePort != *tt.wantNodePort {
+					t.Errorf("NodePort = %d, want %d", *isvc.Spec.Endpoint.NodePort, *tt.wantNodePort)
+				}
 			}
 
 			// GPU
@@ -650,4 +696,8 @@ func searchString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func ptrInt32(v int32) *int32 {
+	return &v
 }


### PR DESCRIPTION
## What

Corrects the `--node-port` flag help text and adds the test coverage that #737 shipped without.

## Why

The `--node-port` help text claimed it "Implies `--endpoint-type NodePort`", but no `--endpoint-type` flag exists, so the guidance was unfollowable. The feature also merged without unit tests (acknowledged in the #737 PR body), which #739 was filed to track.

Fixes #739

## How

- `pkg/cli/deploy.go`: reword the help text to describe the actual behavior (passing `--node-port` sets the endpoint type to NodePort and pins the port).
- `pkg/cli/deploy_test.go`: `buildInferenceService` sets `Endpoint.Type=NodePort` and `Endpoint.NodePort` when `--node-port` is passed, and leaves ClusterIP with a nil NodePort when it is not.
- `internal/controller/inferenceservice_service_test.go`: `constructService` sets `ServicePort.NodePort` only for NodePort-type services with `endpoint.nodePort` set.

This fix was produced end-to-end by Foreman (the project's agentic coding harness) and verified locally.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change) — flag help text corrected
