### PR TITLE
fix(foreman): make install-foreman-agent produce a working plist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,11 +206,41 @@ build-foreman-agent-versioned: fmt vet ## Build foreman-agent with ldflags versi
 		./cmd/foreman-agent
 
 # FOREMAN_INSTALL_ROOT is the user-owned managed layout root for foreman-agent.
-# On macOS the default matches ResolveInstallRoot("foreman-agent").
-FOREMAN_INSTALL_ROOT ?= $(HOME)/Library/Application\ Support/llmkube/foreman-agent
+# On macOS the default matches ResolveInstallRoot("foreman-agent"). Do NOT
+# backslash-escape the space: this value is always consumed inside double quotes
+# (recipe commands) or a sed replacement, where a literal backslash would be
+# kept verbatim and corrupt the path.
+FOREMAN_INSTALL_ROOT ?= $(HOME)/Library/Application Support/llmkube/foreman-agent
+
+# foreman-agent runtime configuration rendered into the launchd plist by
+# install-foreman-agent. Override on the command line, e.g.:
+#   make install-foreman-agent \
+#     FOREMAN_INSTALLED_MODELS=qwen36-35b-carnice-mtp \
+#     FOREMAN_NODE_NAME=m5max-coder \
+#     FOREMAN_KUBECONFIG=$(HOME)/.kube/shadowstack.yaml \
+#     FOREMAN_ACCELERATOR=metal
+FOREMAN_NODE_NAME        ?= $(shell hostname -s)
+FOREMAN_KUBECONFIG       ?= $(HOME)/.kube/config
+FOREMAN_ACCELERATOR      ?= metal
+FOREMAN_GIT_REMOTE_URL   ?= $(shell git remote get-url origin 2>/dev/null)
+FOREMAN_COMMIT_EMAIL     ?= $(shell git config user.email 2>/dev/null)
+# Required: comma-separated model names this node serves (used to match tasks).
+FOREMAN_INSTALLED_MODELS ?=
+
+.PHONY: check-foreman-install-vars
+check-foreman-install-vars:
+	@if [ -z "$(FOREMAN_INSTALLED_MODELS)" ]; then \
+		echo "ERROR: FOREMAN_INSTALLED_MODELS is required (comma-separated model names this node serves)."; \
+		echo "       e.g. make install-foreman-agent FOREMAN_INSTALLED_MODELS=qwen36-35b-carnice-mtp"; \
+		exit 1; \
+	fi
+	@if [ -z "$(FOREMAN_NODE_NAME)" ]; then \
+		echo "ERROR: FOREMAN_NODE_NAME is empty (hostname -s returned nothing); set it explicitly."; \
+		exit 1; \
+	fi
 
 .PHONY: install-foreman-agent
-install-foreman-agent: build-foreman-agent-versioned ## Install foreman-agent into user-owned managed layout and start launchd service (macOS only, no sudo).
+install-foreman-agent: check-foreman-install-vars build-foreman-agent-versioned ## Install foreman-agent into user-owned managed layout and start launchd service (macOS only, no sudo).
 	@echo "Installing foreman-agent $(FOREMAN_AGENT_VERSION)..."
 	@# Create the versioned directory and stage the binary.
 	mkdir -p "$(FOREMAN_INSTALL_ROOT)/versions/$(FOREMAN_AGENT_VERSION)"
@@ -227,8 +257,17 @@ install-foreman-agent: build-foreman-agent-versioned ## Install foreman-agent in
 		"$(FOREMAN_INSTALL_ROOT)/current"
 	@echo "Staged at $(FOREMAN_INSTALL_ROOT)/current -> versions/$(FOREMAN_AGENT_VERSION)"
 	@echo "Installing launchd service..."
-	@# Substitute YOUR_USERNAME placeholder with the real home directory path.
-	@sed "s|/Users/YOUR_USERNAME/Library/Application Support/llmkube/foreman-agent|$(FOREMAN_INSTALL_ROOT)|g" \
+	@# Render the launchd plist: substitute the install-root path AND every
+	@# REPLACE_WITH_* placeholder, so the installed service has a complete,
+	@# working command line with no leftover placeholders.
+	@sed \
+		-e "s|/Users/YOUR_USERNAME/Library/Application Support/llmkube/foreman-agent|$(FOREMAN_INSTALL_ROOT)|g" \
+		-e "s|REPLACE_WITH_NODE_NAME|$(FOREMAN_NODE_NAME)|g" \
+		-e "s|REPLACE_WITH_ACCELERATOR|$(FOREMAN_ACCELERATOR)|g" \
+		-e "s|REPLACE_WITH_INSTALLED_MODELS|$(FOREMAN_INSTALLED_MODELS)|g" \
+		-e "s|REPLACE_WITH_KUBECONFIG|$(FOREMAN_KUBECONFIG)|g" \
+		-e "s|REPLACE_WITH_GIT_REMOTE_URL|$(FOREMAN_GIT_REMOTE_URL)|g" \
+		-e "s|REPLACE_WITH_EMAIL|$(FOREMAN_COMMIT_EMAIL)|g" \
 		deployment/macos/com.llmkube.foreman-agent.plist \
 		> ~/Library/LaunchAgents/$(LLMKUBE_FOREMAN_AGENT_LABEL).plist
 	@echo "Starting foreman-agent service..."

--- a/deployment/macos/com.llmkube.foreman-agent.plist
+++ b/deployment/macos/com.llmkube.foreman-agent.plist
@@ -8,8 +8,14 @@
     <!--
         ProgramArguments[0] is the stable exec path through the "current"
         symlink laid down by `make install-foreman-agent` (and updated on
-        every self-update flip).  Edit the flags below to match your
-        environment before loading the service.
+        every self-update flip).
+
+        The REPLACE_WITH_* tokens below are substituted by
+        `make install-foreman-agent` from its FOREMAN_* variables
+        (FOREMAN_NODE_NAME, FOREMAN_ACCELERATOR, FOREMAN_INSTALLED_MODELS,
+        FOREMAN_KUBECONFIG, FOREMAN_GIT_REMOTE_URL, FOREMAN_COMMIT_EMAIL).
+        If you install this plist by hand, replace every REPLACE_WITH_*
+        token yourself before loading the service.
     -->
     <key>ProgramArguments</key>
     <array>
@@ -18,6 +24,12 @@
         <string>REPLACE_WITH_NODE_NAME</string>
         <string>--roles</string>
         <string>worker</string>
+        <string>--accelerator</string>
+        <string>REPLACE_WITH_ACCELERATOR</string>
+        <string>--installed-models</string>
+        <string>REPLACE_WITH_INSTALLED_MODELS</string>
+        <string>--kubeconfig</string>
+        <string>REPLACE_WITH_KUBECONFIG</string>
         <string>--agent-mode</string>
         <string>native</string>
         <string>--git-remote-url</string>
@@ -54,9 +66,7 @@
     <dict>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-        <!-- Set KUBECONFIG if your kubeconfig is not at the default location -->
-        <!-- <key>KUBECONFIG</key> -->
-        <!-- <string>/Users/YOUR_USERNAME/.kube/config</string> -->
+        <!-- The kubeconfig path is passed explicitly via --kubeconfig above. -->
     </dict>
 
     <key>WorkingDirectory</key>


### PR DESCRIPTION
## What

Makes `make install-foreman-agent` produce a working, fully-specified launchd plist on macOS.

## Why

Deploying the foreman-agent via `make install-foreman-agent` produced a non-functional agent due to two compounding defects (found while recovering the M5 Max coder node, which had to be hand-fixed):

1. `FOREMAN_INSTALL_ROOT` backslash-escaped the space in `Application\ Support`. Every consumer uses the value inside double quotes (recipe commands) or a sed replacement, where the backslash is kept literally, so the binary staged to a bogus `Application\ Support` path and the `current` symlink never flipped: the running agent silently kept the old binary.
2. The plist template shipped `REPLACE_WITH_*` placeholders the install target never substituted, and omitted flags a working agent requires (`--kubeconfig`, `--installed-models`, `--accelerator`). A fresh install registered under a placeholder node name, fell back to `~/.kube/config`, and advertised no `installedModels`, so it could never match a task.

Fixes #740

## How

- `Makefile`: drop the backslash from `FOREMAN_INSTALL_ROOT` (rely on the quoting already present at every use site). Add `FOREMAN_*` config variables (node name, accelerator, installed models, kubeconfig, git remote, commit email) with sensible defaults, and render every placeholder via a multi-expression `sed`. Add a `check-foreman-install-vars` preflight prerequisite that fails fast when the required `FOREMAN_INSTALLED_MODELS` / `FOREMAN_NODE_NAME` are empty.
- `deployment/macos/com.llmkube.foreman-agent.plist`: add the three missing flag pairs (`--accelerator`, `--installed-models`, `--kubeconfig`), update the header comment to explain the `REPLACE_WITH_*` substitution, and drop the now-redundant commented-out `KUBECONFIG` env hint.

## Verification

- Rendered the template through the exact install-target `sed` with sample values: `plutil -lint` passes, no `REPLACE_WITH_*`/`YOUR_USERNAME` tokens remain in the output, and all required flags are present.
- `check-foreman-install-vars` exits non-zero without `FOREMAN_INSTALLED_MODELS` and passes when set.
- Final launchd behavior (`bootstrap` + `kickstart -k`, symlink flip on re-install) can only be exercised on a real Mac, not in CI: human-verified on macOS before merge.

## Checklist

- [x] Tests added/updated — N/A (packaging/Makefile; verified via render + lint + guard checks above)
- [x] `make test` passes locally — no Go code changed
- [x] `make lint` passes locally — no Go code changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change) — plist header comment + Makefile var docs
