### PR TITLE
fix(foreman): scope-overlap rail rescues honest paraphrase from false NO-GO

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -478,21 +478,28 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// #582/filesTouched fix: harness owns the authoritative
 			// field, model's claim is archived under issueAskClaimed.
 			reconcileReviewerIssueAsk(log, loopRes.Transcript, loopRes.Terminal.Extra)
-			// Enforce the verification result (#644): an unverifiable
-			// issueAsk demotes a GO to NO-GO so it routes to escalation
-			// instead of approving a branch on fabricated understanding.
-			verdict = enforceReviewerIssueAsk(log, loopRes.Terminal.Extra, verdict)
 			// Computable scope-overlap check (#647): when the issue names
 			// concrete files and the diff touches none of them, demote a
-			// GO deterministically. Runs after the issueAsk enforcement
-			// so an already-demoted verdict is annotated, not re-demoted.
+			// GO deterministically. Runs before issueAsk enforcement so
+			// the scope signal can rescue an honest paraphrase (#744).
+			var scopeDriftDetected bool
+			var scopeMatched []string
 			if scopeDiff, scopeErr := repo.DiffNameOnly(ctx, workspace, "main"); scopeErr == nil {
 				verdict = enforceReviewerScopeOverlap(log, loopRes.Terminal.Extra,
 					extractFetchIssueBody(loopRes.Transcript), scopeDiff, verdict)
+				scopeDriftDetected, _ = loopRes.Terminal.Extra["scopeDriftDetected"].(bool)
+				scopeMatched, _ = loopRes.Terminal.Extra["scopeMatched"].([]string)
 			} else {
 				log.Info("reviewer scope: ground-truth diff unavailable; skipping scope check",
 					"err", scopeErr.Error())
 			}
+			// Enforce the verification result (#644): an unverifiable
+			// issueAsk demotes a GO to NO-GO so it routes to escalation
+			// instead of approving a branch on fabricated understanding.
+			// When scope-overlap vouches for the diff, keep GO even if
+			// the model paraphrased the issue ask (#744).
+			verdict = enforceReviewerIssueAsk(log, loopRes.Terminal.Extra, verdict,
+				scopeDriftDetected, scopeMatched)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
 		r := e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
@@ -1295,10 +1302,15 @@ func reconcileReviewerIssueAsk(log logr.Logger, msgs []oai.Message, extra map[st
 // hallucinated ask. Both confidently wrong verdicts stood.
 //
 // Policy:
-//   - verified false + GO: demote to NO-GO. A reviewer that cannot prove
-//     it read the issue must not approve a branch. Because the workload
-//     controller emits escalation reviewers on base NO-GO, demotion
-//     routes the branch to a bigger model instead of green-lighting it.
+//   - verified false + GO + scope vouches (scopeDriftDetected==false,
+//     scopeMatched non-empty): keep GO. The deterministic scope-overlap
+//     rail confirms the diff is in-scope even though the model paraphrased
+//     the issue ask instead of quoting it verbatim (#744).
+//   - verified false + GO + no scope vouch (drift detected or no refs):
+//     demote to NO-GO. A reviewer that cannot prove it read the issue
+//     must not approve a branch. Because the workload controller emits
+//     escalation reviewers on base NO-GO, demotion routes the branch to
+//     a bigger model instead of green-lighting it.
 //   - verified false + any other verdict: keep the verdict but mark it,
 //     so the escalation reviewer and operators know the base review's
 //     reasoning is untrusted.
@@ -1313,6 +1325,8 @@ func enforceReviewerIssueAsk(
 	log logr.Logger,
 	extra map[string]any,
 	verdict foremanv1alpha1.AgenticTaskVerdict,
+	scopeDriftDetected bool,
+	scopeMatched []string,
 ) foremanv1alpha1.AgenticTaskVerdict {
 	if extra == nil {
 		return verdict
@@ -1324,14 +1338,32 @@ func enforceReviewerIssueAsk(
 
 	extra["verdictDemoted"] = true
 	extra["verdictClaimed"] = string(verdict)
-	extra["demotionReason"] = "issueAsk could not be verified as a verbatim quote of the " +
-		"fetched issue body; review verdict is untrusted"
 
 	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		extra["demotionReason"] = "issueAsk could not be verified as a verbatim quote of the " +
+			"fetched issue body; review verdict is untrusted"
 		log.Info("reviewer integrity: unverified issueAsk on non-GO verdict; keeping verdict but marking untrusted",
 			"verdict", verdict)
 		return verdict
 	}
+
+	// Scope-overlap vouch: when the issue names concrete files and the
+	// diff touches at least one of them, the deterministic scope rail
+	// confirms the reviewer was in-scope even though it paraphrased the
+	// issue ask. Keep GO and annotate the outcome (#744).
+	scopeVouches := !scopeDriftDetected && len(scopeMatched) > 0
+	if scopeVouches {
+		extra["issueAskVerified"] = false
+		extra["scopeVouched"] = true
+		extra["demotionReason"] = "issueAsk could not be verified as a verbatim quote of the " +
+			"fetched issue body; scope-overlap confirms in-scope review"
+		log.Info("reviewer integrity: unverified issueAsk on GO verdict; scope-overlap vouches, keeping GO",
+			"scopeMatched", scopeMatched)
+		return verdict
+	}
+
+	extra["demotionReason"] = "issueAsk could not be verified as a verbatim quote of the " +
+		"fetched issue body; review verdict is untrusted"
 	log.Info("reviewer integrity: unverified issueAsk on GO verdict; demoting to NO-GO",
 		"verdictClaimed", verdict)
 	return foremanv1alpha1.AgenticTaskVerdictNoGo

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1266,7 +1266,7 @@ func TestReconcileReviewerIssueAsk_NilExtraIsNoOp(t *testing.T) {
 
 func TestEnforceReviewerIssueAsk_VerifiedGoStands(t *testing.T) {
 	extra := map[string]any{"issueAskVerified": true}
-	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo)
+	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo, false, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("verified GO should stand; got %v", got)
 	}
@@ -1277,7 +1277,7 @@ func TestEnforceReviewerIssueAsk_VerifiedGoStands(t *testing.T) {
 
 func TestEnforceReviewerIssueAsk_UnverifiedGoDemotedToNoGo(t *testing.T) {
 	extra := map[string]any{"issueAskVerified": false}
-	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo)
+	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo, true, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Errorf("unverified GO must demote to NO-GO; got %v", got)
 	}
@@ -1294,7 +1294,7 @@ func TestEnforceReviewerIssueAsk_UnverifiedGoDemotedToNoGo(t *testing.T) {
 
 func TestEnforceReviewerIssueAsk_UnverifiedNoGoKeptButMarked(t *testing.T) {
 	extra := map[string]any{"issueAskVerified": false}
-	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo)
+	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, true, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Errorf("unverified NO-GO should stay NO-GO; got %v", got)
 	}
@@ -1311,7 +1311,7 @@ func TestEnforceReviewerIssueAsk_AbsentFieldIsObserveOnly(t *testing.T) {
 	// to verify against (a harness-side gap, not model dishonesty);
 	// enforcement must not fire.
 	extra := map[string]any{"issueAsk": "some claim"}
-	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo)
+	got := enforceReviewerIssueAsk(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo, false, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("absent issueAskVerified must not demote; got %v", got)
 	}
@@ -1321,9 +1321,70 @@ func TestEnforceReviewerIssueAsk_AbsentFieldIsObserveOnly(t *testing.T) {
 }
 
 func TestEnforceReviewerIssueAsk_NilExtraIsNoOp(t *testing.T) {
-	got := enforceReviewerIssueAsk(logr.Discard(), nil, foremanv1alpha1.AgenticTaskVerdictGo)
+	got := enforceReviewerIssueAsk(logr.Discard(), nil, foremanv1alpha1.AgenticTaskVerdictGo, false, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("nil extra must pass the verdict through; got %v", got)
+	}
+}
+
+// TestEnforceReviewerIssueAsk_UnverifiedGoScopeVouchKeepsGo covers #744:
+// an honest reviewer that paraphrases the issue ask (issueAskVerified==false)
+// but whose diff touches a file named in the issue (scope vouch) must keep
+// GO instead of being demoted to NO-GO.
+func TestEnforceReviewerIssueAsk_UnverifiedGoScopeVouchKeepsGo(t *testing.T) {
+	extra := map[string]any{"issueAskVerified": false}
+	got := enforceReviewerIssueAsk(logr.Discard(), extra,
+		foremanv1alpha1.AgenticTaskVerdictGo, false, []string{"internal/controller/model_controller.go"})
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("unverified GO with scope vouch must keep GO; got %v", got)
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("demotion flag must still be set for observability; got %v", extra["verdictDemoted"])
+	}
+	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+		t.Errorf("verdictClaimed should archive the original GO; got %v", extra["verdictClaimed"])
+	}
+	if v, _ := extra["scopeVouched"].(bool); !v {
+		t.Errorf("scopeVouched should be true when scope rail confirms in-scope")
+	}
+	if reason, _ := extra["demotionReason"].(string); reason == "" {
+		t.Errorf("demotionReason must explain the scope-vouch outcome")
+	}
+}
+
+// TestEnforceReviewerIssueAsk_UnverifiedGoNoScopeVouchDemotes covers the
+// case where the model paraphrases the issue ask AND scope-overlap detects
+// drift (or has no refs to vouch). This must still demote to NO-GO.
+func TestEnforceReviewerIssueAsk_UnverifiedGoNoScopeVouchDemotes(t *testing.T) {
+	extra := map[string]any{"issueAskVerified": false}
+	got := enforceReviewerIssueAsk(logr.Discard(), extra,
+		foremanv1alpha1.AgenticTaskVerdictGo, true, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Errorf("unverified GO with scope drift must demote to NO-GO; got %v", got)
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("demotion must set verdictDemoted=true; got %v", extra["verdictDemoted"])
+	}
+	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+		t.Errorf("verdictClaimed should archive the original GO; got %v", extra["verdictClaimed"])
+	}
+	if reason, _ := extra["demotionReason"].(string); reason == "" {
+		t.Errorf("demotionReason must explain the demotion")
+	}
+}
+
+// TestEnforceReviewerIssueAsk_UnverifiedGoNoRefsNoVouchDemotes covers the
+// case where the issue has no concrete file refs (scope observe-only) and
+// the model paraphrased the ask. Without scope vouch, must demote.
+func TestEnforceReviewerIssueAsk_UnverifiedGoNoRefsNoVouchDemotes(t *testing.T) {
+	extra := map[string]any{"issueAskVerified": false}
+	got := enforceReviewerIssueAsk(logr.Discard(), extra,
+		foremanv1alpha1.AgenticTaskVerdictGo, false, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Errorf("unverified GO with no scope refs must demote to NO-GO; got %v", got)
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("demotion must set verdictDemoted=true; got %v", extra["verdictDemoted"])
 	}
 }
 


### PR DESCRIPTION
## What

Lets the deterministic scope-overlap rail rescue an honest paraphrase from a false NO-GO. When a reviewer's `issueAsk` is not a verbatim quote of the issue body but the scope-overlap rail confirms the diff is in-scope (`scopeDriftDetected=false` with a non-empty `scopeMatched`), the review keeps its `GO` verdict instead of being demoted.

## Why

The reviewer integrity rails produced a false NO-GO on a correct, in-scope review whenever the model paraphrased the issue ask instead of quoting it verbatim. `enforceReviewerIssueAsk` demoted `GO`→`NO-GO` unconditionally on `issueAskVerified=false`, and `enforceReviewerScopeOverlap` ran *after* and could only annotate, not re-demote, so a correct positive scope signal could not rescue the verdict.

Observed live in an end-to-end heterogeneous dogfood run: a Strix Qwen coder produced a correct in-scope fix (issue #710), and both reviewer model families (Devstral on Metal, Gemma4 on NVIDIA via gateway) independently returned the correct `APPROVE` — yet both were demoted to `NO-GO` identically, because each paraphrased the ask. The scope-overlap rail correctly computed `scopeDriftDetected=false, scopeMatched=[internal/controller/model_controller.go]` but could not act on it.

Fixes #744

## How

- Reorder the rails in `runLLMPath`: run the computable scope-overlap check **before** issueAsk enforcement so its signal is available.
- Extend `enforceReviewerIssueAsk` to take `scopeDriftDetected` and `scopeMatched`. When `issueAskVerified=false` and verdict is `GO`, demote **only if** scope-overlap does not vouch.
- When scope vouches, keep `GO`, set `scopeVouched=true`, and record a `demotionReason` that explains the scope-confirmed outcome. Behavior is unchanged for: paraphrase + scope drift (demote), paraphrase + no path refs (demote), verified quote (stands), and non-GO verdicts (annotate only).
- Verbatim-quote enforcement is preserved as the confabulation guard; scope-overlap only rescues the in-scope case.

Escalation routing keys off the verdict value (`Status.Verdict == NO-GO`), not the observability `verdictDemoted` flag, so a vouched `GO` correctly does not trigger escalation.

## Provenance

Authored end-to-end by Foreman (the project's agentic coding harness): Strix Qwen3.6-35B-A3B coder, GO in 662s. Maintainer-validated: build, full `pkg/foreman/agent` suite (incl. three new regression tests covering vouch / drift / no-refs), and cross-arch lint all green. The commit message was amended to remove an em dash; the code is unmodified from Foreman's output.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change) — N/A (internal reviewer-integrity logic; policy doc-comments updated in code)
