### PR TITLE
fix(controller): honor GPU resourceName override in checkAcceleratorAvailability

### DIFF
--- a/internal/controller/model_accelerator_test.go
+++ b/internal/controller/model_accelerator_test.go
@@ -47,6 +47,17 @@ func modelWithAccelerator(accel string) *inferencev1alpha1.Model {
 	return m
 }
 
+func modelWithGPUResource(accel string, resourceName string) *inferencev1alpha1.Model {
+	m := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"}}
+	m.Spec.Hardware = &inferencev1alpha1.HardwareSpec{
+		Accelerator: accel,
+		GPU: &inferencev1alpha1.GPUSpec{
+			ResourceName: resourceName,
+		},
+	}
+	return m
+}
+
 func newModelReconcilerWithNodes(t *testing.T, nodes ...client.Object) *ModelReconciler {
 	t.Helper()
 	scheme := runtime.NewScheme()
@@ -63,35 +74,60 @@ func newModelReconcilerWithNodes(t *testing.T, nodes ...client.Object) *ModelRec
 func TestCheckAcceleratorAvailability(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {
-		name  string
-		accel string
-		nodes []client.Object
-		want  bool
+		name         string
+		accel        string
+		resourceName string
+		nodes        []client.Object
+		want         bool
 	}{
-		{"nil hardware is available", "", nil, true},
-		{"cpu is always available", "cpu", nil, true},
-		{"metal is assumed available (off-cluster agent)", "metal", nil, true},
+		{"nil hardware is available", "", "", nil, true},
+		{"cpu is always available", "cpu", "", nil, true},
+		{"metal is assumed available (off-cluster agent)", "metal", "", nil, true},
 		{
-			"cuda available when a node advertises nvidia.com/gpu", "cuda",
+			"cuda available when a node advertises nvidia.com/gpu", "cuda", "",
 			[]client.Object{nodeWithCapacity("gpu1", "nvidia.com/gpu", "1")}, true,
 		},
 		{
-			"cuda unavailable when no node has a GPU", "cuda",
+			"cuda unavailable when no node has a GPU", "cuda", "",
 			[]client.Object{nodeWithCapacity("cpu1", "cpu", "8")}, false,
 		},
 		{
-			"rocm available when a node advertises amd.com/gpu", "rocm",
+			"rocm available when a node advertises amd.com/gpu", "rocm", "",
 			[]client.Object{nodeWithCapacity("amd1", "amd.com/gpu", "1")}, true,
 		},
 		{
-			"rocm unavailable when only an nvidia node exists", "rocm",
+			"rocm unavailable when only an nvidia node exists", "rocm", "",
 			[]client.Object{nodeWithCapacity("gpu1", "nvidia.com/gpu", "1")}, false,
+		},
+		{
+			"rocm with resourceName override uses the override resource",
+			"rocm", "squat.ai/dri-render",
+			[]client.Object{nodeWithCapacity("gpu1", "squat.ai/dri-render", "1")},
+			true,
+		},
+		{
+			"rocm with resourceName override fails when override not on any node",
+			"rocm", "squat.ai/dri-render",
+			[]client.Object{nodeWithCapacity("gpu1", "nvidia.com/gpu", "1")},
+			false,
+		},
+		{
+			"cuda with resourceName override uses the override resource",
+			"cuda", "custom.gpu.io/gpu",
+			[]client.Object{nodeWithCapacity("gpu1", "custom.gpu.io/gpu", "2")},
+			true,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := newModelReconcilerWithNodes(t, tc.nodes...)
-			got := r.checkAcceleratorAvailability(ctx, modelWithAccelerator(tc.accel))
+			var model *inferencev1alpha1.Model
+			if tc.resourceName != "" {
+				model = modelWithGPUResource(tc.accel, tc.resourceName)
+			} else {
+				model = modelWithAccelerator(tc.accel)
+			}
+			got := r.checkAcceleratorAvailability(ctx, model)
 			if got != tc.want {
 				t.Errorf("accelerator %q: want %v, got %v", tc.accel, tc.want, got)
 			}

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -766,6 +766,14 @@ func (r *ModelReconciler) checkAcceleratorAvailability(ctx context.Context, mode
 		return true
 	}
 
+	// Honor the GPU resourceName override so the readiness check validates
+	// the same extended resource the pod will actually request.
+	if model.Spec.Hardware.GPU != nil {
+		if override := strings.TrimSpace(model.Spec.Hardware.GPU.ResourceName); override != "" {
+			return r.nodeHasResource(ctx, corev1.ResourceName(override))
+		}
+	}
+
 	var resName corev1.ResourceName
 	switch accel {
 	case acceleratorROCm:
@@ -777,17 +785,23 @@ func (r *ModelReconciler) checkAcceleratorAvailability(ctx context.Context, mode
 		resName = resolveGPUResourceName(model)
 	}
 
+	return r.nodeHasResource(ctx, resName)
+}
+
+// nodeHasResource reports whether any node in the cluster advertises the
+// given extended resource in its capacity. Returns true on a node-list error
+// (fail-open) so a transient or RBAC failure does not spuriously mark the
+// accelerator unavailable.
+func (r *ModelReconciler) nodeHasResource(ctx context.Context, res corev1.ResourceName) bool {
 	var nodes corev1.NodeList
 	if err := r.List(ctx, &nodes); err != nil {
-		// Cannot determine availability; fail open rather than spuriously
-		// reporting the accelerator unavailable on a transient or RBAC error.
 		log.FromContext(ctx).Error(err,
-			"checkAcceleratorAvailability: listing nodes failed; assuming available",
-			"accelerator", accel)
+			"nodeHasResource: listing nodes failed; assuming available",
+			"resource", res)
 		return true
 	}
 	for i := range nodes.Items {
-		if q, ok := nodes.Items[i].Status.Capacity[resName]; ok && !q.IsZero() {
+		if q, ok := nodes.Items[i].Status.Capacity[res]; ok && !q.IsZero() {
 			return true
 		}
 	}


### PR DESCRIPTION
## What

Makes `checkAcceleratorAvailability` honor the `spec.hardware.gpu.resourceName` override when checking node capacity, so `Status.AcceleratorReady` reflects the resource the pod actually requests.

## Why

After #709 introduced the configurable GPU `resourceName` escape hatch, the status path still resolved the extended-resource name from `spec.hardware.accelerator` only (`rocm -> amd.com/gpu`, `cuda -> nvidia.com/gpu`), ignoring the override. A Model using both `accelerator: rocm` and `gpu.resourceName: squat.ai/dri-render` reported `AcceleratorReady: false` (the check looked for `amd.com/gpu`, which no node advertises) even though the pod schedules fine against `squat.ai/dri-render`. Status-only inaccuracy, not a scheduling regression, but misleading.

Fixes #710

## How

- `internal/controller/model_controller.go`: `checkAcceleratorAvailability` now consults an explicit `GPU.ResourceName` override before falling back to accelerator-based resolution; the node-capacity loop is extracted into a shared `nodeHasResource` helper.
- `internal/controller/model_accelerator_test.go`: three regression tests covering the override path for `rocm` and `cuda`.

## Provenance

Authored end-to-end by Foreman (the project's agentic coding harness): Strix Qwen3.6-35B-A3B coder. Reviewed through the same heterogeneous pipeline (Devstral on Metal + Gemma4 on NVIDIA via gateway), both GO. Maintainer-validated: build + `internal/controller` tests green locally.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change) — N/A (status-accuracy fix, no user-facing surface)
