### PR TITLE
fix(controller): honor RouterRule.Timeout in gateway-mode AIGatewayRoute generation

### DIFF
--- a/internal/controller/gateway_resources_modelrouter.go
+++ b/internal/controller/gateway_resources_modelrouter.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -188,6 +189,10 @@ type routerRuleResource struct {
 	// BackendRefs are the ordered destinations. For primary-fallback each ref
 	// carries an ascending Priority; for weighted each carries a Weight.
 	BackendRefs []routerBackendRef
+	// Timeout is the per-rule request timeout (RouterRule.Timeout). When set it
+	// becomes the AIGatewayRoute rule's timeouts.request, overriding Envoy's
+	// 60s default.
+	Timeout *metav1.Duration
 }
 
 // routerBackendRef is one backendRef in a compiled rule.
@@ -316,12 +321,19 @@ func routerLLMRequestCosts() []interface{} {
 
 // compileRouteRule builds one AIGatewayRoute rule: the matches block (a match
 // per model name, ANDed with header matches; a header-only match when the rule
-// declares no models, e.g. a catch-all) and the backendRefs block.
+// declares no models, e.g. a catch-all), the backendRefs block, and an
+// optional timeouts.request derived from RouterRule.Timeout.
 func compileRouteRule(rule routerRuleResource) map[string]interface{} {
-	return map[string]interface{}{
+	ruleMap := map[string]interface{}{
 		"matches":     compileRuleMatches(rule),
 		"backendRefs": compileRuleBackendRefs(rule.BackendRefs),
 	}
+	if rule.Timeout != nil && rule.Timeout.Duration > 0 {
+		ruleMap["timeouts"] = map[string]interface{}{
+			"request": rule.Timeout.Duration.String(),
+		}
+	}
+	return ruleMap
 }
 
 // compileRuleMatches turns a rule's model names + data classifications + headers

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -533,7 +533,7 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 		if err != nil {
 			return nil, err
 		}
-		resolved := routerRuleResource{BackendRefs: refs}
+		resolved := routerRuleResource{BackendRefs: refs, Timeout: rule.Timeout}
 		if rule.Match != nil {
 			resolved.Models = rule.Match.Models
 			resolved.Headers = rule.Match.Headers

--- a/internal/controller/modelrouter_gateway_test.go
+++ b/internal/controller/modelrouter_gateway_test.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1894,5 +1895,130 @@ func TestUnsupportedAuditLogMessage(t *testing.T) {
 				t.Errorf("expected auditLog accepted, got rejection: %s", msg)
 			}
 		})
+	}
+}
+
+// TestModelRouterGateway_RuleTimeoutPropagates verifies that RouterRule.Timeout
+// propagates to the AIGatewayRoute rule's timeouts.request, fixing the #734 bug
+// where the gateway data plane silently applied Envoy's 60s default.
+func TestModelRouterGateway_RuleTimeoutPropagates(t *testing.T) {
+	c, cfg, stop := startGatewayTestEnv(t, true)
+	defer stop()
+
+	makeBackendISvc(t, c, "timeout-cuda")
+
+	timeout := metav1.Duration{Duration: 30 * 60 * time.Second} // 30m
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "timeout-router", Namespace: testNS},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+			GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "timeout-cuda", InferenceServiceRef: corev1LocalRef("timeout-cuda")},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:    "qwen",
+					Match:   &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+					Route:   inferencev1alpha1.RuleRoute{Backends: []string{"timeout-cuda"}},
+					Timeout: &timeout,
+				},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), mr); err != nil {
+		t.Fatalf("create modelrouter: %v", err)
+	}
+
+	r := newModelRouterGatewayReconciler(t, cfg)
+	reconcileRouter(t, r, mr)
+
+	route := getUnstructured(t, c, aiGatewayRouteGVK(), "timeout-router")
+
+	// Verify the route has exactly one rule with timeouts.request == "30m0s".
+	rules, found, err := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if err != nil {
+		t.Fatalf("spec.rules: %v", err)
+	}
+	if !found || len(rules) != 1 {
+		t.Fatalf("expected 1 rule, found %d", len(rules))
+	}
+
+	ruleMap, ok := rules[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("rule[0] is not a map")
+	}
+
+	// Check timeouts.request.
+	timeouts, found, err := unstructured.NestedMap(ruleMap, "timeouts")
+	if !found {
+		t.Fatal("expected spec.rules[0].timeouts to be set, not found")
+	}
+	if err != nil {
+		t.Fatalf("timeouts: %v", err)
+	}
+
+	req, found, err := unstructured.NestedString(timeouts, "request")
+	if !found {
+		t.Fatal("expected timeouts.request to be set")
+	}
+	if err != nil {
+		t.Fatalf("timeouts.request: %v", err)
+	}
+	if req != "30m0s" {
+		t.Errorf("expected timeouts.request=30m0s, got %q", req)
+	}
+}
+
+// TestModelRouterGateway_NoTimeoutNoTimeoutsBlock verifies that when no rule
+// declares a Timeout, the generated AIGatewayRoute rule carries no timeouts
+// block (preserving Envoy's default).
+func TestModelRouterGateway_NoTimeoutNoTimeoutsBlock(t *testing.T) {
+	c, cfg, stop := startGatewayTestEnv(t, true)
+	defer stop()
+
+	makeBackendISvc(t, c, "notimeout-cuda")
+
+	mr := &inferencev1alpha1.ModelRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "notimeout-router", Namespace: testNS},
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			DataPlane:  inferencev1alpha1.ModelRouterDataPlaneGateway,
+			GatewayRef: &inferencev1alpha1.GatewayReference{Name: "ai-gateway", Namespace: "ai-gateway"},
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "notimeout-cuda", InferenceServiceRef: corev1LocalRef("notimeout-cuda")},
+			},
+			Rules: []inferencev1alpha1.RouterRule{
+				{
+					Name:  "qwen",
+					Match: &inferencev1alpha1.RuleMatch{Models: []string{"qwen35-27b"}},
+					Route: inferencev1alpha1.RuleRoute{Backends: []string{"notimeout-cuda"}},
+				},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), mr); err != nil {
+		t.Fatalf("create modelrouter: %v", err)
+	}
+
+	r := newModelRouterGatewayReconciler(t, cfg)
+	reconcileRouter(t, r, mr)
+
+	route := getUnstructured(t, c, aiGatewayRouteGVK(), "notimeout-router")
+
+	rules, found, err := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if err != nil {
+		t.Fatalf("spec.rules: %v", err)
+	}
+	if !found || len(rules) != 1 {
+		t.Fatalf("expected 1 rule, found %d", len(rules))
+	}
+
+	ruleMap, ok := rules[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("rule[0] is not a map")
+	}
+
+	if _, found, _ := unstructured.NestedMap(ruleMap, "timeouts"); found {
+		t.Error("expected no timeouts block when rule.Timeout is nil")
 	}
 }


### PR DESCRIPTION
## What

Makes gateway-mode `ModelRouter` honor `RouterRule.Timeout`: the per-rule timeout now propagates to the generated AIGatewayRoute rule's `timeouts.request`, overriding Envoy's 60s default.

## Why

In gateway mode the operator generated AIGatewayRoute rules with no `timeouts`, so every route fell back to Envoy AI Gateway's 60s request-timeout default. That silently caps long and streaming requests: a long reasoning/streaming turn past 60s gets its SSE stream cut with `unexpected EOF`. Observed live with a long gateway-routed reviewer run (cut at ~7 min). The `RouterRule.Timeout` field already existed but was ignored.

Fixes #734

## How

- `internal/controller/gateway_resources_modelrouter.go`: add a `Timeout *metav1.Duration` field to the intermediate `routerRuleResource`; in `compileRouteRule`, emit `timeouts.request` from it when set (`Duration > 0`).
- `internal/controller/modelrouter_gateway_controller.go`: populate `Timeout: rule.Timeout` when compiling each rule from the source `RouterRule`.
- `internal/controller/modelrouter_gateway_test.go`: `TestModelRouterGateway_RuleTimeoutPropagatesToRoute` plus coverage for the unset (default) case.

## Provenance

Authored end-to-end by Foreman (Strix Qwen3.6-35B-A3B coder), GO in 49 turns. Maintainer-validated: gofmt/vet/build and `GOOS=linux golangci-lint` all clean locally; the envtest controller suite runs in CI. Retires the manual 1800s AIGatewayRoute timeout patch we had been re-applying by hand.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — envtest suite runs in CI (not runnable in the author workspace)
- [x] `make lint` passes locally (`GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change) — N/A (operator-internal route generation)
