### PR TITLE
fix(crd): guard GPU resourceClaims/resourceName CEL rule against absent field

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -122,7 +122,7 @@ type HardwareSpec struct {
 }
 
 // GPUSpec defines GPU-specific requirements.
-// +kubebuilder:validation:XValidation:rule="!(has(self.resourceName) && self.resourceClaims.size() > 0)",message="resourceClaims and resourceName are mutually exclusive: use one or the other for GPU scheduling"
+// +kubebuilder:validation:XValidation:rule="!(has(self.resourceName) && has(self.resourceClaims) && self.resourceClaims.size() > 0)",message="resourceClaims and resourceName are mutually exclusive: use one or the other for GPU scheduling"
 type GPUSpec struct {
 	// Enabled indicates whether GPU acceleration is enabled
 	// +optional

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -283,8 +283,8 @@ spec:
                     x-kubernetes-validations:
                     - message: 'resourceClaims and resourceName are mutually exclusive:
                         use one or the other for GPU scheduling'
-                      rule: '!(has(self.resourceName) && self.resourceClaims.size()
-                        > 0)'
+                      rule: '!(has(self.resourceName) && has(self.resourceClaims)
+                        && self.resourceClaims.size() > 0)'
                   memoryBudget:
                     description: |-
                       MemoryBudget is an absolute memory limit for the model process

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -279,8 +279,8 @@ spec:
                     x-kubernetes-validations:
                     - message: 'resourceClaims and resourceName are mutually exclusive:
                         use one or the other for GPU scheduling'
-                      rule: '!(has(self.resourceName) && self.resourceClaims.size()
-                        > 0)'
+                      rule: '!(has(self.resourceName) && has(self.resourceClaims)
+                        && self.resourceClaims.size() > 0)'
                   memoryBudget:
                     description: |-
                       MemoryBudget is an absolute memory limit for the model process

--- a/internal/controller/model_gpu_validation_test.go
+++ b/internal/controller/model_gpu_validation_test.go
@@ -1,0 +1,72 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// These specs exercise the GPUSpec mutual-exclusivity CEL rule against the
+// envtest apiserver (where CRD validation actually runs), not the in-process
+// deployment builder.
+var _ = Describe("Model GPU resourceName/resourceClaims CEL validation", func() {
+	newGPUModel := func(name string, gpu *inferencev1alpha1.GPUSpec) *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:       "https://example.com/model.gguf",
+				Format:       "gguf",
+				Quantization: "Q4_K_M",
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					Accelerator: "rocm",
+					GPU:         gpu,
+				},
+			},
+		}
+	}
+
+	It("admits a Model with resourceName and no resourceClaims", func() {
+		// Regression for the CEL rule evaluating resourceClaims.size() on an
+		// absent field: device-plugin Models (resourceName set, resourceClaims
+		// unset) were rejected with "no such key: resourceClaims".
+		model := newGPUModel("gpu-resourcename-only", &inferencev1alpha1.GPUSpec{
+			Enabled:      true,
+			Vendor:       "amd",
+			Count:        1,
+			ResourceName: "devic.es/rocm",
+		})
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, model)).To(Succeed())
+	})
+
+	It("admits a Model with resourceClaims and no resourceName", func() {
+		model := newGPUModel("gpu-claims-only", &inferencev1alpha1.GPUSpec{
+			Enabled: true,
+			Vendor:  "intel",
+			ResourceClaims: []corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimTemplateName: ptr.To("gpu-template")},
+			},
+		})
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, model)).To(Succeed())
+	})
+
+	It("rejects a Model that sets both resourceName and resourceClaims", func() {
+		model := newGPUModel("gpu-both", &inferencev1alpha1.GPUSpec{
+			Enabled:      true,
+			Vendor:       "amd",
+			ResourceName: "devic.es/rocm",
+			ResourceClaims: []corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimTemplateName: ptr.To("gpu-template")},
+			},
+		})
+		err := k8sClient.Create(ctx, model)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("mutually exclusive"))
+	})
+})


### PR DESCRIPTION
## What

Add a `has(self.resourceClaims)` guard to the `GPUSpec` mutual-exclusivity CEL rule so `resourceClaims.size()` is never evaluated when the field is absent.

## Why

The rule added in #750 (shipped in 0.8.9) is:

```
!(has(self.resourceName) && self.resourceClaims.size() > 0)
```

Setting `resourceName` forces CEL to evaluate `self.resourceClaims.size()`. For a Model on the device-plugin path (`resourceName` set, `resourceClaims` unset) there is no such key, so the apiserver rejects it on apply/dry-run:

```
spec.hardware.gpu: Invalid value: "object": no such key: resourceClaims
  evaluating rule: resourceClaims and resourceName are mutually exclusive
```

This rejects **every** `resourceName`-only Model (generic-device-plugin, NVIDIA MIG, any non-default extended resource) — a regression from #750. It slipped through because the DRA tests construct `GPUSpec` in-process via `constructDeployment` and never round-trip through the apiserver, where CEL actually runs.

## How

- Added the `has(self.resourceClaims)` guard; both fields still reject when set together, either alone is admitted.
- Regenerated CRDs (`make manifests` + `make chart-crds`) — `config/crd/bases` and the Helm chart CRD.
- Added an envtest spec that creates Models **through the apiserver** (closing the coverage gap): `resourceName`-only admitted, `resourceClaims`-only admitted, both-set rejected.

```
Ran 3 of 408 Specs — 3 Passed | 0 Failed   (envtest, k8s 1.36)
make lint — 0 issues
```

## Checklist

- [x] Tests added/updated
- [x] New envtest spec passes locally (focused run, envtest 1.36)
- [x] `make lint` passes locally (0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [ ] Documentation updated (not user-facing)