### PR TITLE
feat(foreman): per-Agent contextStrategy with session mode (stable cache-friendly prefix)

### DIFF
--- a/api/foreman/v1alpha1/agent_types.go
+++ b/api/foreman/v1alpha1/agent_types.go
@@ -256,6 +256,22 @@ type AgentSpec struct {
 	// +optional
 	ObservationWindowTurns int32 `json:"observationWindowTurns,omitempty"`
 
+	// ContextStrategy selects how the loop builds each request's message
+	// list. "window" (default) applies observation masking bounded by
+	// ObservationWindowTurns: older tool results are masked, keeping the
+	// payload small for small-context models but rewriting the prefix each
+	// turn (which defeats prompt caching). "session" keeps a stable,
+	// append-only prefix so a caching runtime reuses it across turns, and
+	// compacts (drops the oldest middle turns, pinning the system prompt,
+	// the task, and the most recent turn) only when the payload approaches
+	// ContextWindowTokens. Use "session" for large-context models on
+	// caching runtimes; set ContextHardCap >= the server context size so a
+	// healthy deep session is not aborted early. See issue #756.
+	// +kubebuilder:validation:Enum=window;session
+	// +kubebuilder:default=window
+	// +optional
+	ContextStrategy string `json:"contextStrategy,omitempty"`
+
 	// StuckLoopDetection configures the per-Agent stuck-loop detector
 	// (#544). When nil the executor applies a conservative default
 	// (5 repeated calls / 15 edit-free turns / 90k soft cap / 140k

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -73,6 +73,24 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              contextStrategy:
+                default: window
+                description: |-
+                  ContextStrategy selects how the loop builds each request's message
+                  list. "window" (default) applies observation masking bounded by
+                  ObservationWindowTurns: older tool results are masked, keeping the
+                  payload small for small-context models but rewriting the prefix each
+                  turn (which defeats prompt caching). "session" keeps a stable,
+                  append-only prefix so a caching runtime reuses it across turns, and
+                  compacts (drops the oldest middle turns, pinning the system prompt,
+                  the task, and the most recent turn) only when the payload approaches
+                  ContextWindowTokens. Use "session" for large-context models on
+                  caching runtimes; set ContextHardCap >= the server context size so a
+                  healthy deep session is not aborted early. See issue #756.
+                enum:
+                - window
+                - session
+                type: string
               contextWindowTokens:
                 description: |-
                   ContextWindowTokens is the soft token budget for the wire payload

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -73,6 +73,24 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              contextStrategy:
+                default: window
+                description: |-
+                  ContextStrategy selects how the loop builds each request's message
+                  list. "window" (default) applies observation masking bounded by
+                  ObservationWindowTurns: older tool results are masked, keeping the
+                  payload small for small-context models but rewriting the prefix each
+                  turn (which defeats prompt caching). "session" keeps a stable,
+                  append-only prefix so a caching runtime reuses it across turns, and
+                  compacts (drops the oldest middle turns, pinning the system prompt,
+                  the task, and the most recent turn) only when the payload approaches
+                  ContextWindowTokens. Use "session" for large-context models on
+                  caching runtimes; set ContextHardCap >= the server context size so a
+                  healthy deep session is not aborted early. See issue #756.
+                enum:
+                - window
+                - session
+                type: string
               contextWindowTokens:
                 description: |-
                   ContextWindowTokens is the soft token budget for the wire payload

--- a/docs/site/foreman/model-compatibility.md
+++ b/docs/site/foreman/model-compatibility.md
@@ -150,3 +150,29 @@ an issue or PR with:
 The table grows the same way LLMKube's hardware matrix does:
 people running real workloads on real hardware reporting what
 they actually saw.
+
+## Context strategy: window vs session
+
+Foreman builds each turn's request from the running transcript using one of
+two strategies, set per Agent via `spec.contextStrategy`.
+
+**`window` (default).** Observation masking: tool results older than
+`observationWindowTurns` are masked to a header, bounding the payload. Correct
+for small-context models. Because masking rewrites the older part of the
+prompt every turn, it defeats prompt caching on runtimes that support it.
+
+**`session`.** A stable, append-only prefix. Nothing is masked, so a caching
+runtime (for example llama.cpp's prompt cache) reuses the prefix and only
+prefills the new tokens each turn. When the payload approaches
+`contextWindowTokens`, Foreman compacts by dropping the oldest middle turns,
+always keeping the system prompt, the original task, and the most recent turn.
+
+Use `session` for large-context models on caching runtimes. Two settings
+matter:
+
+- Set `stuckLoopDetection.contextHardCap` at or above the server's context
+  size (`n_ctx`) and `contextSoftCap` proportionally, so a healthy deep
+  session is not aborted before it reaches the ceiling.
+- Tradeoff: `session` trades an occasional cold re-prefill (one per compaction
+  event, rare when the ceiling is high) for cheap, cache-hit steady-state
+  turns. `window` makes the opposite trade.

--- a/docs/superpowers/plans/2026-06-20-foreman-context-strategy-session.md
+++ b/docs/superpowers/plans/2026-06-20-foreman-context-strategy-session.md
@@ -1,0 +1,581 @@
+# Foreman `contextStrategy` session mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-Agent `contextStrategy: window|session` field so large-context models can keep a stable, cache-friendly append-only prompt prefix instead of forced observation masking.
+
+**Architecture:** A new pure function `compactTranscriptForWire` implements the session strategy (passthrough under budget; drop oldest middle turn-groups, pinning head + newest group, when over budget). A thin `selectWireTranscript` branches on `LoopConfig.ContextStrategy` at the single existing wire-build callsite (`loop.go:744`). The window path (`maskTranscriptForWire`) is untouched. A new CRD field is threaded through the executor. Spec: `docs/superpowers/specs/2026-06-20-foreman-context-strategy-session-design.md`. Tracks issue #756.
+
+**Tech Stack:** Go 1.25, Kubebuilder/controller-runtime CRDs, `oai.Message` chat types, whitebox `go test` (no envtest needed for these unit tests).
+
+---
+
+## Background the engineer needs
+
+- **The chokepoint.** Every turn builds its request at `pkg/foreman/agent/loop.go:741-747`. The message list is `stripReasoningForWire(maskTranscriptForWire(res.Transcript, cfg.ObservationWindowTurns, cfg.ContextWindowTokens))`. We will replace the inner `maskTranscriptForWire(...)` call with `selectWireTranscript(cfg, res.Transcript)` and leave `stripReasoningForWire(...)` wrapping it.
+- **`oai.Message`** (`pkg/foreman/agent/oai/types.go:55`): fields `Role Role`, `Content string`, `ToolCalls []ToolCall`, `ToolCallID string`, `Name string`, `ReasoningContent string`. Roles: `oai.RoleSystem`, `oai.RoleUser`, `oai.RoleAssistant`, `oai.RoleTool`.
+- **Transcript shape**: `[system]`, `[user task]`, then repeating `[assistant (with ToolCalls)]`, `[tool result]`. An assistant message and the tool results that answer it must travel together or the OAI server rejects an orphaned `tool_call_id`.
+- **Existing helper** `approxTokens(messages []oai.Message) int` (`loop.go:973`) is a chars/4 estimate. Reuse it; do not write a new one.
+- **Test fixture** `transcriptFixture(nToolTurns, toolBytes int) []oai.Message` already exists in `loop_masking_test.go:33` and builds exactly the shape above (system + user + n*(assistant+tool), each tool carrying `toolBytes` bytes). Reuse it.
+- **Running unit tests without envtest:** the `agent` package has both pure and envtest-backed tests. Run only the new ones with a `-run` filter, e.g. `go test ./pkg/foreman/agent/ -run TestCompact -v`. Do NOT run the whole package (it would pull envtest).
+
+---
+
+## File structure
+
+- `pkg/foreman/agent/loop.go` — add `turnGroup` type, `compactTranscriptForWire`, `assembleSessionWire`, `selectWireTranscript`, strategy constants, `LoopConfig.ContextStrategy`; change the callsite.
+- `pkg/foreman/agent/loop_session_test.go` — **new** whitebox test file for the session helpers.
+- `api/foreman/v1alpha1/agent_types.go` — add `ContextStrategy` field.
+- `pkg/foreman/agent/executor_native.go` — map `agent.Spec.ContextStrategy` into `LoopConfig`.
+- `config/crd/bases/foreman.llmkube.dev_agents.yaml` + `charts/foreman/templates/crds/...agents.yaml` — regenerated, not hand-edited.
+- `docs/site/foreman/model-compatibility.md` — operator note (caps tuning + tradeoff).
+
+---
+
+### Task 1: `compactTranscriptForWire` passthrough (cache-stability invariant)
+
+**Files:**
+- Create: `pkg/foreman/agent/loop_session_test.go`
+- Modify: `pkg/foreman/agent/loop.go` (add new function near `maskTranscriptForWire`, ~line 945)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/foreman/agent/loop_session_test.go`:
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+// Whitebox tests for the "session" context strategy helpers
+// (compactTranscriptForWire / selectWireTranscript) in loop.go. These
+// pin the cache-stability and compaction behavior in isolation.
+
+import (
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// assertNoOrphanedToolMessages fails if any RoleTool message in wire has
+// a ToolCallID without a preceding assistant ToolCall of the same ID.
+func assertNoOrphanedToolMessages(t *testing.T, wire []oai.Message) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, m := range wire {
+		if m.Role == oai.RoleAssistant {
+			for _, tc := range m.ToolCalls {
+				seen[tc.ID] = true
+			}
+		}
+		if m.Role == oai.RoleTool && !seen[m.ToolCallID] {
+			t.Errorf("orphaned tool message: tool_call_id %q has no preceding assistant call", m.ToolCallID)
+		}
+	}
+}
+
+func TestCompactTranscript_UnderBudgetReturnsIdentical(t *testing.T) {
+	tx := transcriptFixture(5, 200) // small, well under budget
+	wire := compactTranscriptForWire(tx, 100000)
+	if len(wire) != len(tx) {
+		t.Fatalf("wire length: want %d got %d", len(tx), len(wire))
+	}
+	for i := range tx {
+		if wire[i].Content != tx[i].Content || wire[i].Role != tx[i].Role {
+			t.Errorf("message %d changed under budget (cache-stability violated)", i)
+		}
+	}
+}
+
+func TestCompactTranscript_ZeroBudgetReturnsIdentical(t *testing.T) {
+	tx := transcriptFixture(5, 200)
+	wire := compactTranscriptForWire(tx, 0)
+	if len(wire) != len(tx) {
+		t.Fatalf("wire length: want %d got %d", len(tx), len(wire))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/foreman/agent/ -run TestCompactTranscript -v`
+Expected: FAIL — `undefined: compactTranscriptForWire`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/foreman/agent/loop.go`, after `maskedToolMessage` (~line 972), add:
+
+```go
+// compactTranscriptForWire implements the "session" context strategy: a
+// stable, append-only prefix that lets a caching runtime reuse the prompt
+// prefix across turns. Under budget the transcript is returned unchanged
+// (cache-stable). Over budget, the oldest whole turn-groups in the middle
+// are dropped, pinning the head (leading system messages + the first user
+// task message) and the most recent turn-group, so the agent never loses
+// its instructions, its task, or its latest work. Dropping is in
+// turn-group units so a tool_call_id is never orphaned. See issue #756.
+func compactTranscriptForWire(transcript []oai.Message, ctxBudget int) []oai.Message {
+	// Compaction is added in a later task; for now always passthrough.
+	return transcript
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run TestCompactTranscript -v`
+Expected: PASS (both passthrough tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/foreman/agent/loop.go pkg/foreman/agent/loop_session_test.go
+git commit -s -m "feat(foreman): compactTranscriptForWire passthrough for session strategy (#756)"
+```
+
+---
+
+### Task 2: `compactTranscriptForWire` compaction (drop oldest middle turn-groups)
+
+**Files:**
+- Modify: `pkg/foreman/agent/loop.go` (replace the placeholder return; add `assembleSessionWire`)
+- Modify: `pkg/foreman/agent/loop_session_test.go` (add compaction test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/foreman/agent/loop_session_test.go`:
+
+```go
+func TestCompactTranscript_OverBudgetDropsOldestMiddle(t *testing.T) {
+	// 8 turn-groups, each tool ~4000 bytes (~1000 tokens). Head is tiny.
+	tx := transcriptFixture(8, 4000)
+	budget := 3500 // tokens: keeps head + a few newest groups
+	wire := compactTranscriptForWire(tx, budget)
+
+	// Something was dropped.
+	if len(wire) >= len(tx) {
+		t.Fatalf("expected compaction to drop messages: in=%d out=%d", len(tx), len(wire))
+	}
+	// Head preserved: system then the original task message.
+	if wire[0].Role != oai.RoleSystem {
+		t.Fatalf("head[0] not system: %s", wire[0].Role)
+	}
+	if wire[1].Role != oai.RoleUser || wire[1].Content != "fix issue 510" {
+		t.Fatalf("original task message not pinned: %+v", wire[1])
+	}
+	// Most recent turn-group preserved: last two messages of tx survive
+	// as the last two of wire.
+	if wire[len(wire)-1].Content != tx[len(tx)-1].Content {
+		t.Errorf("most recent tool result not kept")
+	}
+	if wire[len(wire)-2].Role != oai.RoleAssistant {
+		t.Errorf("most recent assistant turn not kept")
+	}
+	// Under budget after compaction.
+	if approxTokens(wire) > budget {
+		t.Errorf("still over budget after compaction: %d > %d", approxTokens(wire), budget)
+	}
+	// No orphaned tool_call_id.
+	assertNoOrphanedToolMessages(t, wire)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/foreman/agent/ -run TestCompactTranscript_OverBudget -v`
+Expected: FAIL — placeholder returns the full transcript, so `len(wire) >= len(tx)` fails.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/foreman/agent/loop.go`, add the `turnGroup` type just above `compactTranscriptForWire`:
+
+```go
+// turnGroup is a half-open index range [start,end) into a transcript: a
+// leading assistant/user message plus the tool results that answer it.
+type turnGroup struct{ start, end int }
+```
+
+Then replace the entire `compactTranscriptForWire` function from Task 1 (the
+passthrough stub) with the full implementation below, and add
+`assembleSessionWire` directly after it (keep the existing godoc comment above
+the function):
+
+```go
+func compactTranscriptForWire(transcript []oai.Message, ctxBudget int) []oai.Message {
+	if ctxBudget <= 0 || approxTokens(transcript) <= ctxBudget {
+		return transcript
+	}
+
+	// headEnd is the exclusive index of the pinned head: all leading
+	// system messages plus the first user message (the task).
+	headEnd := 0
+	for headEnd < len(transcript) && transcript[headEnd].Role == oai.RoleSystem {
+		headEnd++
+	}
+	if headEnd < len(transcript) && transcript[headEnd].Role == oai.RoleUser {
+		headEnd++
+	}
+
+	// Partition the tail into turn-groups: each starts at a non-tool
+	// message and absorbs the tool messages that follow it.
+	var groups []turnGroup
+	for i := headEnd; i < len(transcript); {
+		start := i
+		i++ // leading assistant/user message
+		for i < len(transcript) && transcript[i].Role == oai.RoleTool {
+			i++
+		}
+		groups = append(groups, turnGroup{start, i})
+	}
+
+	if len(groups) <= 1 {
+		return transcript // nothing droppable; degenerate guard handled by caller budget
+	}
+
+	// Drop oldest groups (after head, before the last group) until under
+	// budget or only the last group remains.
+	for dropCount := 1; dropCount < len(groups); dropCount++ {
+		kept := assembleSessionWire(transcript, headEnd, groups, dropCount)
+		if approxTokens(kept) <= ctxBudget {
+			return kept
+		}
+	}
+	// Degenerate: only head + last group remain (still possibly over budget).
+	return assembleSessionWire(transcript, headEnd, groups, len(groups)-1)
+}
+
+// assembleSessionWire builds the wire payload: the pinned head
+// (transcript[:headEnd]) followed by every turn-group from index
+// dropCount onward (the oldest dropCount groups are omitted).
+func assembleSessionWire(transcript []oai.Message, headEnd int, groups []turnGroup, dropCount int) []oai.Message {
+	out := make([]oai.Message, 0, len(transcript))
+	out = append(out, transcript[:headEnd]...)
+	for g := dropCount; g < len(groups); g++ {
+		out = append(out, transcript[groups[g].start:groups[g].end]...)
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run TestCompactTranscript -v`
+Expected: PASS (passthrough + compaction).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/foreman/agent/loop.go pkg/foreman/agent/loop_session_test.go
+git commit -s -m "feat(foreman): session compaction drops oldest middle turn-groups (#756)"
+```
+
+---
+
+### Task 3: degenerate case (head + newest group over budget)
+
+**Files:**
+- Modify: `pkg/foreman/agent/loop_session_test.go` (add degenerate test)
+
+No code change expected — Task 2's final `return assembleSessionWire(..., len(groups)-1)` already handles it. This task pins that behavior so it cannot regress.
+
+- [ ] **Step 1: Write the test**
+
+Append to `pkg/foreman/agent/loop_session_test.go`:
+
+```go
+func TestCompactTranscript_DegenerateKeepsHeadAndLastGroup(t *testing.T) {
+	tx := transcriptFixture(4, 8000) // each tool ~2000 tokens
+	wire := compactTranscriptForWire(tx, 100) // absurdly small budget
+
+	if wire[0].Role != oai.RoleSystem || wire[1].Role != oai.RoleUser {
+		t.Fatalf("head not preserved: %+v", wire[:2])
+	}
+	// Last turn-group (assistant + tool) preserved as the final two messages.
+	if wire[len(wire)-1].Role != oai.RoleTool || wire[len(wire)-2].Role != oai.RoleAssistant {
+		t.Fatalf("last turn-group not preserved: tail=%+v", wire[len(wire)-2:])
+	}
+	assertNoOrphanedToolMessages(t, wire)
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run TestCompactTranscript_Degenerate -v`
+Expected: PASS (no implementation change needed; if it fails, the bug is in Task 2's degenerate return).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/foreman/agent/loop_session_test.go
+git commit -s -m "test(foreman): pin session compaction degenerate case (#756)"
+```
+
+---
+
+### Task 4: `selectWireTranscript` routing + strategy constants + callsite
+
+**Files:**
+- Modify: `pkg/foreman/agent/loop.go` (constants, `LoopConfig.ContextStrategy`, `selectWireTranscript`, callsite at `:744`)
+- Modify: `pkg/foreman/agent/loop_session_test.go` (routing tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/foreman/agent/loop_session_test.go`:
+
+```go
+func TestSelectWireTranscript_SessionDoesNotMask(t *testing.T) {
+	tx := transcriptFixture(6, 4000)
+	cfg := LoopConfig{ContextStrategy: ContextStrategySession, ContextWindowTokens: 1000000}
+	wire := selectWireTranscript(cfg, tx)
+	for i := range tx {
+		if wire[i].Content != tx[i].Content {
+			t.Errorf("session strategy masked content at %d", i)
+		}
+	}
+}
+
+func TestSelectWireTranscript_WindowMasks(t *testing.T) {
+	tx := transcriptFixture(6, 4000)
+	cfg := LoopConfig{ContextStrategy: ContextStrategyWindow, ObservationWindowTurns: 1}
+	wire := selectWireTranscript(cfg, tx)
+	changed := false
+	for i := range tx {
+		if tx[i].Role == oai.RoleTool && wire[i].Content != tx[i].Content {
+			changed = true
+		}
+	}
+	if !changed {
+		t.Error("window strategy did not mask any tool messages")
+	}
+}
+
+func TestSelectWireTranscript_EmptyDefaultsToWindow(t *testing.T) {
+	tx := transcriptFixture(6, 4000)
+	got := selectWireTranscript(LoopConfig{ObservationWindowTurns: 1}, tx)
+	want := maskTranscriptForWire(tx, 1, 0)
+	if len(got) != len(want) {
+		t.Fatalf("empty strategy did not route to window: len got=%d want=%d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i].Content != want[i].Content {
+			t.Errorf("message %d differs from window output", i)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/foreman/agent/ -run TestSelectWireTranscript -v`
+Expected: FAIL — `undefined: ContextStrategySession` / `selectWireTranscript` / `LoopConfig.ContextStrategy`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/foreman/agent/loop.go`, add the constants near the other loop defaults (just below `DefaultObservationWindowTurns`, ~line 181):
+
+```go
+const (
+	// ContextStrategyWindow applies observation masking bounded by
+	// ObservationWindowTurns (the default strategy).
+	ContextStrategyWindow = "window"
+	// ContextStrategySession keeps a stable, append-only prefix and
+	// compacts only at the ContextWindowTokens ceiling. See issue #756.
+	ContextStrategySession = "session"
+)
+```
+
+Add the field to `LoopConfig` (after `ObservationWindowTurns`, ~line 105):
+
+```go
+	// ContextStrategy selects the wire-payload builder. "" or "window"
+	// applies observation masking (ObservationWindowTurns); "session"
+	// keeps an append-only prefix and compacts at ContextWindowTokens.
+	// See selectWireTranscript and issue #756.
+	ContextStrategy string
+```
+
+Add `selectWireTranscript` next to `compactTranscriptForWire`:
+
+```go
+// selectWireTranscript routes the transcript through the configured
+// context strategy. "session" uses compactTranscriptForWire (stable
+// prefix, compact at budget); anything else (including "" and "window")
+// uses maskTranscriptForWire (observation masking).
+func selectWireTranscript(cfg LoopConfig, transcript []oai.Message) []oai.Message {
+	if cfg.ContextStrategy == ContextStrategySession {
+		return compactTranscriptForWire(transcript, cfg.ContextWindowTokens)
+	}
+	return maskTranscriptForWire(transcript, cfg.ObservationWindowTurns, cfg.ContextWindowTokens)
+}
+```
+
+Change the callsite at `loop.go:743-744` from:
+
+```go
+		Messages: stripReasoningForWire(
+			maskTranscriptForWire(res.Transcript, cfg.ObservationWindowTurns, cfg.ContextWindowTokens)),
+```
+
+to:
+
+```go
+		Messages: stripReasoningForWire(
+			selectWireTranscript(cfg, res.Transcript)),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run 'TestSelectWireTranscript|TestCompactTranscript|TestMaskTranscript' -v`
+Expected: PASS (new routing tests + existing masking tests, proving no regression).
+
+- [ ] **Step 5: Verify build**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/foreman/agent/loop.go pkg/foreman/agent/loop_session_test.go
+git commit -s -m "feat(foreman): selectWireTranscript routes window vs session strategy (#756)"
+```
+
+---
+
+### Task 5: CRD field + executor mapping + regenerate manifests
+
+**Files:**
+- Modify: `api/foreman/v1alpha1/agent_types.go` (add `ContextStrategy`)
+- Modify: `pkg/foreman/agent/executor_native.go` (map into `LoopConfig`)
+- Regenerated: `config/crd/bases/foreman.llmkube.dev_agents.yaml`, `charts/foreman/templates/crds/foreman.llmkube.dev_agents.yaml`
+
+- [ ] **Step 1: Add the CRD field**
+
+In `api/foreman/v1alpha1/agent_types.go`, immediately after the `ObservationWindowTurns` field (~line 257), add:
+
+```go
+	// ContextStrategy selects how the loop builds each request's message
+	// list. "window" (default) applies observation masking bounded by
+	// ObservationWindowTurns: older tool results are masked, keeping the
+	// payload small for small-context models but rewriting the prefix each
+	// turn (which defeats prompt caching). "session" keeps a stable,
+	// append-only prefix so a caching runtime reuses it across turns, and
+	// compacts (drops the oldest middle turns, pinning the system prompt,
+	// the task, and the most recent turn) only when the payload approaches
+	// ContextWindowTokens. Use "session" for large-context models on
+	// caching runtimes; set ContextHardCap >= the server context size so a
+	// healthy deep session is not aborted early. See issue #756.
+	// +kubebuilder:validation:Enum=window;session
+	// +kubebuilder:default=window
+	// +optional
+	ContextStrategy string `json:"contextStrategy,omitempty"`
+```
+
+- [ ] **Step 2: Map it in the executor**
+
+In `pkg/foreman/agent/executor_native.go`, in the `cfg := LoopConfig{...}` literal (~line 375), add after the `ObservationWindowTurns:` line:
+
+```go
+		ContextStrategy:        agent.Spec.ContextStrategy,
+```
+
+- [ ] **Step 3: Regenerate CRDs (deepcopy + manifests + foreman chart)**
+
+Run: `make manifests generate foreman-chart-crds`
+Expected: `config/crd/bases/foreman.llmkube.dev_agents.yaml` and `charts/foreman/templates/crds/foreman.llmkube.dev_agents.yaml` now contain a `contextStrategy` property with `enum: [window, session]` and `default: window`.
+
+- [ ] **Step 4: Verify the generated CRD and build**
+
+Run: `grep -A3 'contextStrategy' config/crd/bases/foreman.llmkube.dev_agents.yaml`
+Expected: shows the enum + default.
+
+Run: `git status --porcelain`
+Expected: only the four files above changed (types, executor, two CRDs); no other drift. If other files changed, the generated output is stale elsewhere — investigate before committing.
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/foreman/v1alpha1/agent_types.go pkg/foreman/agent/executor_native.go config/crd/bases/foreman.llmkube.dev_agents.yaml charts/foreman/templates/crds/foreman.llmkube.dev_agents.yaml
+git commit -s -m "feat(foreman): add Agent.spec.contextStrategy field (window|session) (#756)"
+```
+
+---
+
+### Task 6: Operator documentation
+
+**Files:**
+- Modify: `docs/site/foreman/model-compatibility.md`
+
+- [ ] **Step 1: Add a context-strategy section**
+
+Append to `docs/site/foreman/model-compatibility.md`:
+
+```markdown
+## Context strategy: window vs session
+
+Foreman builds each turn's request from the running transcript using one of
+two strategies, set per Agent via `spec.contextStrategy`.
+
+**`window` (default).** Observation masking: tool results older than
+`observationWindowTurns` are masked to a header, bounding the payload. Correct
+for small-context models. Because masking rewrites the older part of the
+prompt every turn, it defeats prompt caching on runtimes that support it.
+
+**`session`.** A stable, append-only prefix. Nothing is masked, so a caching
+runtime (for example llama.cpp's prompt cache) reuses the prefix and only
+prefills the new tokens each turn. When the payload approaches
+`contextWindowTokens`, Foreman compacts by dropping the oldest middle turns,
+always keeping the system prompt, the original task, and the most recent turn.
+
+Use `session` for large-context models on caching runtimes. Two settings
+matter:
+
+- Set `stuckLoopDetection.contextHardCap` at or above the server's context
+  size (`n_ctx`) and `contextSoftCap` proportionally, so a healthy deep
+  session is not aborted before it reaches the ceiling.
+- Tradeoff: `session` trades an occasional cold re-prefill (one per compaction
+  event, rare when the ceiling is high) for cheap, cache-hit steady-state
+  turns. `window` makes the opposite trade.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/site/foreman/model-compatibility.md
+git commit -s -m "docs(foreman): document window vs session context strategy (#756)"
+```
+
+---
+
+### Task 7: Final verification
+
+- [ ] **Step 1: Run the full new test set**
+
+Run: `go test ./pkg/foreman/agent/ -run 'TestCompactTranscript|TestSelectWireTranscript|TestMaskTranscript' -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Build + lint (cross-arch, per AGENTS.md)**
+
+Run: `go build ./... && go vet ./pkg/foreman/... && GOOS=linux ./bin/golangci-lint run ./pkg/foreman/... ./api/foreman/...`
+Expected: clean. (Install golangci-lint via `make golangci-lint` if `./bin/golangci-lint` is missing.)
+
+- [ ] **Step 3: Confirm CRD sync**
+
+Run: `make foreman-chart-crds && git status --porcelain`
+Expected: no changes (the chart CRD already matches `config/crd/bases`). A diff means Task 5's regen was incomplete.

--- a/docs/superpowers/specs/2026-06-20-foreman-context-strategy-session-design.md
+++ b/docs/superpowers/specs/2026-06-20-foreman-context-strategy-session-design.md
@@ -1,0 +1,159 @@
+# Foreman `contextStrategy`: session mode design
+
+**Issue:** [#756](https://github.com/defilantech/LLMKube/issues/756)
+**Status:** Design approved, pending implementation plan.
+
+## Summary
+
+Add a per-Agent `contextStrategy` field that selects how Foreman builds the
+wire payload across an agentic loop:
+
+- `window` (default, current behavior): observation masking. Older tool
+  results are masked each turn, bounded by `observationWindowTurns`. Correct
+  for small-context local models.
+- `session`: a stable, append-only prompt prefix with no per-turn masking, so
+  a caching runtime (llama.cpp prompt cache) reuses the prefix and only
+  prefills the new delta each turn. Compaction (drop oldest middle turns)
+  happens only when context approaches `contextWindowTokens`.
+
+## Problem
+
+Foreman's only context strategy today is observation masking, and
+`observationWindowTurns` is CRD-capped at 50. Masking rewrites the older
+portion of the prompt every turn, which defeats prompt caching on runtimes
+that support it.
+
+Measured on a dense 27B coder (AMD Strix, llama.cpp Vulkan, 256k ctx):
+
+- While masking was effectively inactive (turns < 50), the runtime prompt
+  cache hit and per-turn prefill was ~31 tokens at 56k context. The run
+  climbed stably to ~76k context.
+- The moment the run crossed the 50-turn cap, masking resumed, the prefix was
+  rewritten, the cache broke, and every turn became a full cold re-prefill of
+  the ~75k context (~17 min/turn). The run churned and could not converge.
+
+The point at which a long task most needs sustained context is exactly where
+the current cap forces masking back on and collapses caching.
+
+## Approach
+
+Separate function + branch at the single callsite.
+
+`maskTranscriptForWire` (`pkg/foreman/agent/loop.go:881`) is the one place the
+transcript is transformed into the wire payload, called once at
+`loop.go:744`. Add a sibling `compactTranscriptForWire`; branch on the
+strategy at the callsite. The existing masking function is left untouched
+(zero regression risk for window-mode agents) and each function is
+independently testable.
+
+Rejected alternatives:
+- One function with a strategy parameter branching internally: mixes two
+  unrelated policies in one body, muddier and riskier to the existing path.
+- A strategy interface with two implementations: over-engineered for two
+  cases (YAGNI).
+
+## API change
+
+`api/foreman/v1alpha1/agent_types.go`, on `AgentSpec`:
+
+```go
+// ContextStrategy selects how the loop builds the wire payload.
+// "window" (default) applies observation masking bounded by
+// ObservationWindowTurns. "session" keeps a stable append-only prefix
+// (cache-friendly) and compacts only at the ContextWindowTokens ceiling.
+// +kubebuilder:validation:Enum=window;session
+// +kubebuilder:default=window
+// +optional
+ContextStrategy string `json:"contextStrategy,omitempty"`
+```
+
+- `window`: exact current behavior. Default, so existing Agents are byte-for-byte
+  unchanged.
+- `session`: new behavior (below).
+- `observationWindowTurns` applies only to `window`. `contextWindowTokens` is
+  the ceiling/budget in both strategies.
+
+Threaded through `LoopConfig` (`pkg/foreman/agent/loop.go`) and the executor
+mapping (`pkg/foreman/agent/executor_native.go`, next to the existing
+`ObservationWindowTurns` map at ~`:382`). Regenerate CRDs:
+`make manifests generate foreman-chart-crds`.
+
+## Core logic: `compactTranscriptForWire(transcript []oai.Message, ctxBudget int) []oai.Message`
+
+1. If `ctxBudget <= 0` OR `approxTokens(transcript) <= ctxBudget`: return the
+   transcript **as-is** (append-only -> prompt-cache hits). This is the common
+   path and the entire point of the strategy.
+2. Over budget: drop the oldest whole **turn-groups** from the *middle*,
+   preserving:
+   - the **head**: the leading system message(s) and the original user task
+     message (the issue). The agent must never lose its instructions or its
+     task.
+   - the **most recent turn-group** (always kept).
+   Drop in turn-group units so a `tool_call_id` is never orphaned. A
+   turn-group is an assistant message plus the tool result messages that
+   answer its tool calls. OAI validity requires an assistant tool_call and its
+   tool results travel together.
+3. Degenerate case (head + newest group alone exceeds budget): return that
+   minimal set and log a warning. Rare; the ceiling is normally far above one
+   turn.
+
+The function is non-mutating: it returns the same message values when under
+budget (cache stability) and a new slice when it drops.
+
+### Turn-group identification
+
+Walk the transcript after the pinned head. A new group starts at each
+assistant message; the tool messages immediately following it belong to that
+group. (User messages mid-run, if any, start their own group.) Index 0..k is
+the pinned head (system messages + first user/task message); the remaining
+groups are drop candidates oldest-first, excluding the final group.
+
+## Interactions
+
+- Stuck-loop `contextSoftCap`/`contextHardCap` (`progress.go`, default
+  90k/140k) stay operator-tunable and keep working as a backstop. **Document**:
+  for session mode set `contextHardCap` >= the server `n_ctx` (and
+  `contextSoftCap` proportionally) so a healthy deep session is not aborted
+  prematurely. This is exactly the manual tuning validated during the Strix
+  run.
+- Compaction tradeoff to **document**: session mode trades occasional cold
+  re-prefills (one per compaction event, rare when the ceiling is high) for
+  cheap, cache-hit steady-state turns. window mode trades the opposite.
+
+## Out of scope (tracked as #756 follow-ups)
+
+- Summary-based compaction (an extra model call to summarize dropped turns) ->
+  v2. v1 is drop-oldest only.
+- The agent streaming-idle cancel (~30s) can cancel-churn a long cold prefill;
+  session mode wants it raised. Tracked separately.
+- Large-context AMD node prerequisites docs (`amdgpu.lockup_timeout` above the
+  2s default; size the runtime prompt cache to hold the session).
+
+## Testing
+
+Mirror `pkg/foreman/agent/loop_masking_test.go` fixtures
+(`transcriptFixture`):
+
+- **Cache-stability invariant**: under-budget session input returns a wire
+  payload byte-identical to the input (no message content changed). This is
+  the core guarantee.
+- **Compaction**: over-budget input drops the oldest middle turn-groups; the
+  head (system + task) and the most recent group are kept; no orphaned
+  `tool_call_id`; message structure stays OAI-valid.
+- **Degenerate**: head + newest group over budget returns the minimal set
+  without panic.
+- **Regression**: `window` strategy output is unchanged (existing masking
+  tests continue to pass; add a case asserting the callsite routes `window`
+  to `maskTranscriptForWire`).
+
+## Files
+
+- `api/foreman/v1alpha1/agent_types.go` — add `ContextStrategy`.
+- `pkg/foreman/agent/loop.go` — `LoopConfig.ContextStrategy`; branch at
+  `:744`; new `compactTranscriptForWire`.
+- `pkg/foreman/agent/executor_native.go` — map `agent.Spec.ContextStrategy`
+  into `LoopConfig`.
+- `pkg/foreman/agent/loop_session_test.go` — new test file.
+- `config/crd/bases/...agents.yaml` + `charts/foreman/templates/crds/...` —
+  regenerated.
+- Docs: the two documented notes above (interactions + tradeoff).

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -380,6 +380,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		MaxTurns:               int(agent.Spec.MaxTurns),
 		ContextWindowTokens:    int(agent.Spec.ContextWindowTokens),
 		ObservationWindowTurns: int(agent.Spec.ObservationWindowTurns),
+		ContextStrategy:        agent.Spec.ContextStrategy,
 		Progress:               progressConfigFromAgent(agent),
 		// Loop-wide wall-clock budget (#532). Repurposed from the old
 		// per-request meaning of RequestTimeoutSeconds; the per-request

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -1006,7 +1006,7 @@ func compactTranscriptForWire(transcript []oai.Message, ctxBudget int) []oai.Mes
 	}
 
 	if len(groups) <= 1 {
-		return transcript // nothing droppable; degenerate guard handled below
+		return transcript // 0 or 1 groups: nothing to drop (head + at most one group is the floor)
 	}
 
 	// Drop oldest groups (after head, before the last group) until under

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -104,6 +104,12 @@ type LoopConfig struct {
 	// to DefaultObservationWindowTurns (3).
 	ObservationWindowTurns int
 
+	// ContextStrategy selects the wire-payload builder. "" or "window"
+	// applies observation masking (ObservationWindowTurns); "session"
+	// keeps an append-only prefix and compacts at ContextWindowTokens.
+	// See selectWireTranscript and issue #756.
+	ContextStrategy string
+
 	// Progress configures the stuck-loop detector (#544). The default
 	// value (all zeros) disables detection; callers wanting the
 	// debut-quality default should set this to DefaultProgressConfig.
@@ -183,6 +189,15 @@ const DefaultMaxReasoningOnlyRetries = 4
 // is enough for the model to chain a read -> edit -> verify sequence
 // without losing the just-observed file contents.
 const DefaultObservationWindowTurns = 3
+
+const (
+	// ContextStrategyWindow applies observation masking bounded by
+	// ObservationWindowTurns (the default strategy).
+	ContextStrategyWindow = "window"
+	// ContextStrategySession keeps a stable, append-only prefix and
+	// compacts only at the ContextWindowTokens ceiling. See issue #756.
+	ContextStrategySession = "session"
+)
 
 // charsPerTokenApprox is the rough chars-per-token ratio used for
 // budget estimation. Real tokenizers vary by model and language; for
@@ -741,7 +756,7 @@ func (l *Loop) runOneTurn(
 	req := oai.ChatRequest{
 		Model: cfg.Model,
 		Messages: stripReasoningForWire(
-			maskTranscriptForWire(res.Transcript, cfg.ObservationWindowTurns, cfg.ContextWindowTokens)),
+			selectWireTranscript(cfg, res.Transcript)),
 		Tools:       schemas,
 		Temperature: cfg.Temperature,
 	}
@@ -1019,6 +1034,17 @@ func compactTranscriptForWire(transcript []oai.Message, ctxBudget int) []oai.Mes
 	}
 	// Degenerate: only head + last group remain (still possibly over budget).
 	return assembleSessionWire(transcript, headEnd, groups, len(groups)-1)
+}
+
+// selectWireTranscript routes the transcript through the configured
+// context strategy. "session" uses compactTranscriptForWire (stable
+// prefix, compact at budget); anything else (including "" and "window")
+// uses maskTranscriptForWire (observation masking).
+func selectWireTranscript(cfg LoopConfig, transcript []oai.Message) []oai.Message {
+	if cfg.ContextStrategy == ContextStrategySession {
+		return compactTranscriptForWire(transcript, cfg.ContextWindowTokens)
+	}
+	return maskTranscriptForWire(transcript, cfg.ObservationWindowTurns, cfg.ContextWindowTokens)
 }
 
 // assembleSessionWire builds the wire payload: the pinned head

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -966,6 +966,19 @@ func maskedToolMessage(m oai.Message) oai.Message {
 	}
 }
 
+// compactTranscriptForWire implements the "session" context strategy: a
+// stable, append-only prefix that lets a caching runtime reuse the prompt
+// prefix across turns. Under budget the transcript is returned unchanged
+// (cache-stable). Over budget, the oldest whole turn-groups in the middle
+// are dropped, pinning the head (leading system messages + the first user
+// task message) and the most recent turn-group, so the agent never loses
+// its instructions, its task, or its latest work. Dropping is in
+// turn-group units so a tool_call_id is never orphaned. See issue #756.
+func compactTranscriptForWire(transcript []oai.Message, ctxBudget int) []oai.Message {
+	// Compaction is added in a later task; for now always passthrough.
+	return transcript
+}
+
 // approxTokens returns a chars/4 approximation of the wire payload's
 // token count. Real tokenization varies by model and language; the
 // "Complexity Trap" empirical result is that this level of precision

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -966,6 +966,10 @@ func maskedToolMessage(m oai.Message) oai.Message {
 	}
 }
 
+// turnGroup is a half-open index range [start,end) into a transcript: a
+// leading assistant/user message plus the tool results that answer it.
+type turnGroup struct{ start, end int }
+
 // compactTranscriptForWire implements the "session" context strategy: a
 // stable, append-only prefix that lets a caching runtime reuse the prompt
 // prefix across turns. Under budget the transcript is returned unchanged
@@ -975,8 +979,58 @@ func maskedToolMessage(m oai.Message) oai.Message {
 // its instructions, its task, or its latest work. Dropping is in
 // turn-group units so a tool_call_id is never orphaned. See issue #756.
 func compactTranscriptForWire(transcript []oai.Message, ctxBudget int) []oai.Message {
-	// Compaction is added in a later task; for now always passthrough.
-	return transcript
+	if ctxBudget <= 0 || approxTokens(transcript) <= ctxBudget {
+		return transcript
+	}
+
+	// headEnd is the exclusive index of the pinned head: all leading
+	// system messages plus the first user message (the task).
+	headEnd := 0
+	for headEnd < len(transcript) && transcript[headEnd].Role == oai.RoleSystem {
+		headEnd++
+	}
+	if headEnd < len(transcript) && transcript[headEnd].Role == oai.RoleUser {
+		headEnd++
+	}
+
+	// Partition the tail into turn-groups: each starts at a non-tool
+	// message and absorbs the tool messages that follow it.
+	var groups []turnGroup
+	for i := headEnd; i < len(transcript); {
+		start := i
+		i++ // leading assistant/user message
+		for i < len(transcript) && transcript[i].Role == oai.RoleTool {
+			i++
+		}
+		groups = append(groups, turnGroup{start, i})
+	}
+
+	if len(groups) <= 1 {
+		return transcript // nothing droppable; degenerate guard handled below
+	}
+
+	// Drop oldest groups (after head, before the last group) until under
+	// budget or only the last group remains.
+	for dropCount := 1; dropCount < len(groups); dropCount++ {
+		kept := assembleSessionWire(transcript, headEnd, groups, dropCount)
+		if approxTokens(kept) <= ctxBudget {
+			return kept
+		}
+	}
+	// Degenerate: only head + last group remain (still possibly over budget).
+	return assembleSessionWire(transcript, headEnd, groups, len(groups)-1)
+}
+
+// assembleSessionWire builds the wire payload: the pinned head
+// (transcript[:headEnd]) followed by every turn-group from index
+// dropCount onward (the oldest dropCount groups are omitted).
+func assembleSessionWire(transcript []oai.Message, headEnd int, groups []turnGroup, dropCount int) []oai.Message {
+	out := make([]oai.Message, 0, len(transcript))
+	out = append(out, transcript[:headEnd]...)
+	for g := dropCount; g < len(groups); g++ {
+		out = append(out, transcript[groups[g].start:groups[g].end]...)
+	}
+	return out
 }
 
 // approxTokens returns a chars/4 approximation of the wire payload's

--- a/pkg/foreman/agent/loop_session_test.go
+++ b/pkg/foreman/agent/loop_session_test.go
@@ -96,3 +96,17 @@ func TestCompactTranscript_OverBudgetDropsOldestMiddle(t *testing.T) {
 	// No orphaned tool_call_id.
 	assertNoOrphanedToolMessages(t, wire)
 }
+
+func TestCompactTranscript_DegenerateKeepsHeadAndLastGroup(t *testing.T) {
+	tx := transcriptFixture(4, 8000) // each tool ~2000 tokens
+	wire := compactTranscriptForWire(tx, 100) // absurdly small budget
+
+	if wire[0].Role != oai.RoleSystem || wire[1].Role != oai.RoleUser {
+		t.Fatalf("head not preserved: %+v", wire[:2])
+	}
+	// Last turn-group (assistant + tool) preserved as the final two messages.
+	if wire[len(wire)-1].Role != oai.RoleTool || wire[len(wire)-2].Role != oai.RoleAssistant {
+		t.Fatalf("last turn-group not preserved: tail=%+v", wire[len(wire)-2:])
+	}
+	assertNoOrphanedToolMessages(t, wire)
+}

--- a/pkg/foreman/agent/loop_session_test.go
+++ b/pkg/foreman/agent/loop_session_test.go
@@ -63,3 +63,36 @@ func TestCompactTranscript_ZeroBudgetReturnsIdentical(t *testing.T) {
 		t.Fatalf("wire length: want %d got %d", len(tx), len(wire))
 	}
 }
+
+func TestCompactTranscript_OverBudgetDropsOldestMiddle(t *testing.T) {
+	// 8 turn-groups, each tool ~4000 bytes (~1000 tokens). Head is tiny.
+	tx := transcriptFixture(8, 4000)
+	budget := 3500 // tokens: keeps head + a few newest groups
+	wire := compactTranscriptForWire(tx, budget)
+
+	// Something was dropped.
+	if len(wire) >= len(tx) {
+		t.Fatalf("expected compaction to drop messages: in=%d out=%d", len(tx), len(wire))
+	}
+	// Head preserved: system then the original task message.
+	if wire[0].Role != oai.RoleSystem {
+		t.Fatalf("head[0] not system: %s", wire[0].Role)
+	}
+	if wire[1].Role != oai.RoleUser || wire[1].Content != "fix issue 510" {
+		t.Fatalf("original task message not pinned: %+v", wire[1])
+	}
+	// Most recent turn-group preserved: last two messages of tx survive
+	// as the last two of wire.
+	if wire[len(wire)-1].Content != tx[len(tx)-1].Content {
+		t.Errorf("most recent tool result not kept")
+	}
+	if wire[len(wire)-2].Role != oai.RoleAssistant {
+		t.Errorf("most recent assistant turn not kept")
+	}
+	// Under budget after compaction.
+	if approxTokens(wire) > budget {
+		t.Errorf("still over budget after compaction: %d > %d", approxTokens(wire), budget)
+	}
+	// No orphaned tool_call_id.
+	assertNoOrphanedToolMessages(t, wire)
+}

--- a/pkg/foreman/agent/loop_session_test.go
+++ b/pkg/foreman/agent/loop_session_test.go
@@ -110,3 +110,43 @@ func TestCompactTranscript_DegenerateKeepsHeadAndLastGroup(t *testing.T) {
 	}
 	assertNoOrphanedToolMessages(t, wire)
 }
+
+func TestSelectWireTranscript_SessionDoesNotMask(t *testing.T) {
+	tx := transcriptFixture(6, 4000)
+	cfg := LoopConfig{ContextStrategy: ContextStrategySession, ContextWindowTokens: 1000000}
+	wire := selectWireTranscript(cfg, tx)
+	for i := range tx {
+		if wire[i].Content != tx[i].Content {
+			t.Errorf("session strategy masked content at %d", i)
+		}
+	}
+}
+
+func TestSelectWireTranscript_WindowMasks(t *testing.T) {
+	tx := transcriptFixture(6, 4000)
+	cfg := LoopConfig{ContextStrategy: ContextStrategyWindow, ObservationWindowTurns: 1}
+	wire := selectWireTranscript(cfg, tx)
+	changed := false
+	for i := range tx {
+		if tx[i].Role == oai.RoleTool && wire[i].Content != tx[i].Content {
+			changed = true
+		}
+	}
+	if !changed {
+		t.Error("window strategy did not mask any tool messages")
+	}
+}
+
+func TestSelectWireTranscript_EmptyDefaultsToWindow(t *testing.T) {
+	tx := transcriptFixture(6, 4000)
+	got := selectWireTranscript(LoopConfig{ObservationWindowTurns: 1}, tx)
+	want := maskTranscriptForWire(tx, 1, 0)
+	if len(got) != len(want) {
+		t.Fatalf("empty strategy did not route to window: len got=%d want=%d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i].Content != want[i].Content {
+			t.Errorf("message %d differs from window output", i)
+		}
+	}
+}

--- a/pkg/foreman/agent/loop_session_test.go
+++ b/pkg/foreman/agent/loop_session_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+// Whitebox tests for the "session" context strategy helpers
+// (compactTranscriptForWire / selectWireTranscript) in loop.go. These
+// pin the cache-stability and compaction behavior in isolation.
+
+import (
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// assertNoOrphanedToolMessages fails if any RoleTool message in wire has
+// a ToolCallID without a preceding assistant ToolCall of the same ID.
+func assertNoOrphanedToolMessages(t *testing.T, wire []oai.Message) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, m := range wire {
+		if m.Role == oai.RoleAssistant {
+			for _, tc := range m.ToolCalls {
+				seen[tc.ID] = true
+			}
+		}
+		if m.Role == oai.RoleTool && !seen[m.ToolCallID] {
+			t.Errorf("orphaned tool message: tool_call_id %q has no preceding assistant call", m.ToolCallID)
+		}
+	}
+}
+
+func TestCompactTranscript_UnderBudgetReturnsIdentical(t *testing.T) {
+	tx := transcriptFixture(5, 200) // small, well under budget
+	wire := compactTranscriptForWire(tx, 100000)
+	if len(wire) != len(tx) {
+		t.Fatalf("wire length: want %d got %d", len(tx), len(wire))
+	}
+	for i := range tx {
+		if wire[i].Content != tx[i].Content || wire[i].Role != tx[i].Role {
+			t.Errorf("message %d changed under budget (cache-stability violated)", i)
+		}
+	}
+}
+
+func TestCompactTranscript_ZeroBudgetReturnsIdentical(t *testing.T) {
+	tx := transcriptFixture(5, 200)
+	wire := compactTranscriptForWire(tx, 0)
+	if len(wire) != len(tx) {
+		t.Fatalf("wire length: want %d got %d", len(tx), len(wire))
+	}
+}

--- a/pkg/foreman/agent/loop_session_test.go
+++ b/pkg/foreman/agent/loop_session_test.go
@@ -98,7 +98,7 @@ func TestCompactTranscript_OverBudgetDropsOldestMiddle(t *testing.T) {
 }
 
 func TestCompactTranscript_DegenerateKeepsHeadAndLastGroup(t *testing.T) {
-	tx := transcriptFixture(4, 8000) // each tool ~2000 tokens
+	tx := transcriptFixture(4, 8000)          // each tool ~2000 tokens
 	wire := compactTranscriptForWire(tx, 100) // absurdly small budget
 
 	if wire[0].Role != oai.RoleSystem || wire[1].Role != oai.RoleUser {


### PR DESCRIPTION
## What

Adds a per-Agent `spec.contextStrategy` field (`window` | `session`) to Foreman. `window` (the default) is the existing observation-masking behavior. `session` keeps a stable, append-only prompt prefix so a caching runtime (for example llama.cpp's prompt cache) reuses the prefix and only prefills the new delta each turn; when the payload approaches `contextWindowTokens` it compacts by dropping the oldest middle turn-groups while pinning the head (system prompt + original task) and the most recent turn-group.

## Why

Fixes #756

Foreman's only context strategy was observation masking, which rewrites the older part of the prompt every turn and therefore defeats prompt caching on runtimes that support it. Measured on a dense 27B coder (AMD Strix, llama.cpp Vulkan, 256k ctx): with masking effectively inactive, the prompt cache hit and per-turn prefill dropped to ~31 tokens at 56k context; once masking resumed it became a full cold re-prefill (~17 min/turn) and the run could not converge. The point where a long task most needs sustained context is exactly where masking collapses caching.

## How

- New pure function `compactTranscriptForWire` implements the session strategy: passthrough (byte-identical, cache-stable) under budget; over budget, drop the oldest whole turn-groups from the middle, pinning the head and the most recent turn-group. Dropping is in turn-group units so a `tool_call_id` is never orphaned.
- `selectWireTranscript` branches on `LoopConfig.ContextStrategy` at the single existing wire-build callsite; the `window` path (`maskTranscriptForWire`) is untouched, so default behavior is unchanged (empty string and `"window"` both route to masking with identical args, still wrapped by `stripReasoningForWire`).
- New CRD field with `+kubebuilder:validation:Enum=window;session` / `default=window`, threaded through the executor into `LoopConfig`.
- Operator docs cover both strategies and the key tuning note: for `session`, set `stuckLoopDetection.contextHardCap` at or above the server `n_ctx`.

Known limitation (deliberately out of scope, documented): the stuck-loop `contextHardCap` measures the full untrimmed transcript while session compaction bounds only the wire payload, so a long session can still hard-cap on full-transcript size. Tighter integration, summary-based compaction, and the streaming-idle timeout are tracked as #756 follow-ups.

Verification run this session: `go test ./pkg/foreman/agent/` (13 new/related tests pass: cache-stability, compaction, degenerate case, routing, plus the existing masking suite as a regression guard), `go build ./...`, `GOOS=linux golangci-lint run` (0 issues), and the CRD sync check (`make manifests generate foreman-chart-crds` produces no diff). Full `make test` (envtest across controllers) was not run in this session.

## Checklist

- [x] Tests added/updated
- [ ] `make test` passes locally (ran targeted `go test ./pkg/foreman/agent/`; did not run full envtest suite)
- [x] `make lint` passes locally (incl. `GOOS=linux golangci-lint`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change)
