### PR TITLE
feat(ci): publish Helm charts as OCI artifacts to GHCR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -101,6 +101,22 @@ jobs:
       - name: Sync Chart CRDs Before Packaging
         run: make chart-crds
 
+      - name: Log in to GHCR for Helm OCI
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | helm registry login ghcr.io --username "$GHCR_USER" --password-stdin
+
+      - name: Package and push charts to GHCR (OCI)
+        env:
+          VERSION: ${{ needs.release-please.outputs.version }}
+          OCI_REPO: oci://ghcr.io/defilantech/charts
+        run: |
+          for chart in llmkube foreman; do
+            helm package "charts/$chart" --destination dist-charts
+            helm push "dist-charts/$chart-${VERSION}.tgz" "$OCI_REPO"
+          done
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:

--- a/charts/llmkube/README.md
+++ b/charts/llmkube/README.md
@@ -27,6 +27,14 @@ helm install llmkube llmkube/llmkube \
   --create-namespace
 ```
 
+### Install from the OCI Registry
+
+```bash
+helm install llmkube oci://ghcr.io/defilantech/charts/llmkube \
+  --namespace llmkube-system \
+  --create-namespace
+```
+
 ### Install from Local Chart
 
 ```bash


### PR DESCRIPTION
## Summary

Adds OCI publishing of the Helm charts to GHCR as part of the existing release pipeline.

## Changes

- **`.github/workflows/release-please.yml`** — in the `release-helm` job (runs only when release-please creates a release):
  - Log in to GHCR for Helm OCI using `GITHUB_TOKEN` (the job already has `packages: write`). Credentials are passed via `env:` + `--password-stdin` to avoid shell interpolation.
  - Package and push the `llmkube` and `foreman` charts at the release version to `oci://ghcr.io/defilantech/charts`.
- **`charts/llmkube/README.md`** — document installing from the OCI registry.

## Resulting artifacts per release

- `ghcr.io/defilantech/charts/llmkube:<version>`
- `ghcr.io/defilantech/charts/foreman:<version>`

## Install

```bash
helm install llmkube oci://ghcr.io/defilantech/charts/llmkube \
  --namespace llmkube-system --create-namespace
```
