### PR TITLE
fix(foreman): scope coder-gate golangci-lint cache per workspace

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -98,8 +98,12 @@ func RunCoderGate(ctx context.Context, workspace, golangciPath string, run comma
 
 	// 4. golangci-lint run ./... fails with a non-nil error. GOOS=linux is
 	// required: on macOS, plain lint silently skips //go:build !darwin
-	// files and would not match CI.
-	if out, err := run(ctx, workspace, []string{"GOOS=linux"}, golangciPath, "run", "./..."); err != nil {
+	// files and would not match CI. GOLANGCI_LINT_CACHE is scoped to a
+	// per-workspace sibling directory so stale analysis results from
+	// another coder workspace cannot pollute this run's lint (#759); the
+	// sibling location keeps the cache out of the workspace git tree.
+	lintEnv := []string{"GOOS=linux", "GOLANGCI_LINT_CACHE=" + workspace + ".golangci-cache"}
+	if out, err := run(ctx, workspace, lintEnv, golangciPath, "run", "./..."); err != nil {
 		failures = append(failures, checkFailure{name: golangciPath + " run ./...", output: out})
 	}
 

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -180,6 +180,42 @@ func TestRunCoderGateLintEnv(t *testing.T) {
 	}
 }
 
+// TestRunCoderGateLintCacheScopedToWorkspace asserts the lint check runs
+// with a GOLANGCI_LINT_CACHE scoped to a per-workspace sibling directory,
+// so stale results from another coder workspace cannot pollute this run's
+// lint (#759).
+func TestRunCoderGateLintCacheScopedToWorkspace(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	run, calls := newFakeRunner(map[string]fakeCommand{
+		"gofmt":      {},
+		"go":         {},
+		golangciPath: {},
+	})
+
+	RunCoderGate(context.Background(), "/work", golangciPath, run)
+
+	var lintCall *recordedCall
+	for i := range *calls {
+		if (*calls)[i].name == golangciPath {
+			lintCall = &(*calls)[i]
+		}
+	}
+	if lintCall == nil {
+		t.Fatal("golangci-lint was never invoked")
+	}
+
+	want := "GOLANGCI_LINT_CACHE=/work.golangci-cache"
+	found := false
+	for _, e := range lintCall.extraEnv {
+		if e == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("lint extraEnv = %v, want it to include %q (workspace-scoped lint cache)", lintCall.extraEnv, want)
+	}
+}
+
 // TestRunCoderGateTruncation verifies per-check output is capped and marked.
 func TestRunCoderGateTruncation(t *testing.T) {
 	const golangciPath = "./bin/golangci-lint"


### PR DESCRIPTION
## What

Scope the coder verification gate's `golangci-lint` cache to a per-workspace sibling directory (`<workspace>.golangci-cache`) via `GOLANGCI_LINT_CACHE`, instead of using golangci-lint's shared default cache.

## Why

Fixes #759

`RunCoderGate` ran `golangci-lint run ./...` with only `GOOS=linux`, so it used the shared default cache (`~/.cache/golangci-lint`). On a host running many coder tasks, that cache retained analysis entries from deleted sibling workspaces, which surfaced as phantom lint findings against files outside the current workspace (paths like `../<other-task>/...`, with `no such file or directory` warnings). The coder cannot fix files it does not have, so the fix-retry loop was guaranteed to exhaust its attempts and return a false `CODER-GATE-FAILED` / INCOMPLETE even when its own diff was clean.

Observed live: a coder solved #731 and reached a GO, but the gate failed it after 3 attempts on 25 lint issues, 23 of which were phantom entries from a deleted sibling workspace and only 2 real.

## How

The lint invocation now passes `GOLANGCI_LINT_CACHE=<workspace>.golangci-cache` alongside `GOOS=linux`. The cache is:
- per-workspace, so a sibling task's stale results can never pollute this run;
- concurrency-safe, unlike a global `golangci-lint cache clean` (matters for parallel coders);
- a sibling of the workspace, keeping it out of the workspace git tree so it cannot appear as untracked in the coder's `git status` checks.

## Checklist

- [x] Tests added/updated (`TestRunCoderGateLintCacheScopedToWorkspace`; existing gate tests still pass)
- [ ] `make test` passes locally (ran targeted `go test ./pkg/foreman/agent/ -run TestRunCoderGate`; did not run full envtest suite)
- [x] `make lint` passes locally (incl. `GOOS=linux golangci-lint`, 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change) (n/a; internal harness behavior)
