### PR TITLE
style: gofmt test/e2e/license_e2e_test.go

### DIFF
--- a/test/e2e/license_e2e_test.go
+++ b/test/e2e/license_e2e_test.go
@@ -90,4 +90,3 @@ var _ = Describe("License E2E Tests", Ordered, func() {
 	})
 
 })
-


### PR DESCRIPTION
## What

Remove a trailing blank line from `test/e2e/license_e2e_test.go` so the file is gofmt-clean.

## Why

The file has a trailing blank line that `gofmt` flags. The Foreman coder verification gate runs `gofmt -l .` over the whole workspace, so this pre-existing violation failed every automated coder run regardless of the task it was working on (the coder would burn its fix attempts on a file unrelated to its change). Observed live: #731 coder runs were blocked solely by this.

Note: CI currently has no standalone `gofmt` check, which is how this reached `main`. Adding gofmt enforcement to CI (or enabling the gofmt linter in golangci-lint) would prevent recurrence; tracked separately.

## How

`gofmt -w test/e2e/license_e2e_test.go` (one line removed).

## Checklist

- [x] Tests added/updated (n/a; formatting-only)
- [ ] `make test` passes locally (formatting-only change; no logic touched)
- [x] `make lint` passes locally (file is now gofmt-clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (if user-facing change) (n/a)
