### PR TITLE
fix(router): inject backend Model on dispatch so fallback chains degrade

### DIFF
--- a/internal/router/backend.go
+++ b/internal/router/backend.go
@@ -13,6 +13,7 @@ package router
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -212,9 +213,9 @@ func (d *Dispatcher) MarkUnhealthy(name string) {
 // upstream response. Caller is responsible for streaming the body to
 // the inbound client and closing it. On error the response is nil.
 //
-// requestBody is the already-buffered inbound body. The proxy reads the
-// body once (it needs to parse the "model" field) and reuses the bytes
-// across fallback attempts.
+// requestBody is the shared inbound body, reused across fallback attempts.
+// Dispatch rewrites the "model" field of an outbound copy (see
+// applyModelOverride) without mutating it.
 func (d *Dispatcher) Dispatch(
 	ctx context.Context,
 	backend *Backend,
@@ -227,7 +228,11 @@ func (d *Dispatcher) Dispatch(
 	}
 	url := joinURL(backend.Address, path)
 
-	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(requestBody))
+	// Send the backend's configured model, not the client-facing alias the
+	// router matched on.
+	outboundBody := applyModelOverride(requestBody, backend.Model)
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(outboundBody))
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
@@ -321,6 +326,31 @@ func (d *Dispatcher) applyCredentials(b *Backend, req *http.Request) error {
 		req.Header.Set("Authorization", "Bearer "+val)
 	}
 	return nil
+}
+
+// applyModelOverride returns a copy of body with the OpenAI "model" field
+// set to the backend's configured Model, so external providers receive an
+// identifier they recognize and a fallback chain degrades across models
+// instead of re-sending the client alias. Empty Model (all local backends)
+// and non-JSON-object bodies are returned unchanged.
+func applyModelOverride(body []byte, model string) []byte {
+	if model == "" {
+		return body
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return body
+	}
+	enc, err := json.Marshal(model)
+	if err != nil {
+		return body
+	}
+	obj["model"] = enc
+	rewritten, err := json.Marshal(obj)
+	if err != nil {
+		return body
+	}
+	return rewritten
 }
 
 func joinURL(base, p string) string {

--- a/internal/router/backend_test.go
+++ b/internal/router/backend_test.go
@@ -12,6 +12,7 @@ package router
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -399,6 +400,131 @@ func TestDispatchConnectionFailureStillQuarantines(t *testing.T) {
 	}
 	if disp.IsHealthy("dead") {
 		t.Error("backend should be marked unhealthy after a connect failure")
+	}
+}
+
+// TestApplyModelOverride is the unit-level contract: rewrite only when the
+// backend declares a Model; pass everything else through untouched.
+func TestApplyModelOverride(t *testing.T) {
+	modelOf := func(t *testing.T, body []byte) string {
+		t.Helper()
+		var m struct {
+			Model string `json:"model"`
+		}
+		if err := json.Unmarshal(body, &m); err != nil {
+			t.Fatalf("result is not JSON: %v (%s)", err, body)
+		}
+		return m.Model
+	}
+
+	t.Run("rewrites existing model", func(t *testing.T) {
+		out := applyModelOverride([]byte(`{"model":"opus","messages":[]}`), "claude-opus-4-7")
+		if got := modelOf(t, out); got != "claude-opus-4-7" {
+			t.Errorf("model = %q, want claude-opus-4-7", got)
+		}
+	})
+
+	t.Run("preserves sibling fields", func(t *testing.T) {
+		out := applyModelOverride([]byte(`{"model":"opus","temperature":0.5,"stream":true}`), "x")
+		var m struct {
+			Temperature float64 `json:"temperature"`
+			Stream      bool    `json:"stream"`
+		}
+		if err := json.Unmarshal(out, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if m.Temperature != 0.5 || !m.Stream {
+			t.Errorf("sibling fields not preserved: %s", out)
+		}
+	})
+
+	t.Run("injects model when absent", func(t *testing.T) {
+		out := applyModelOverride([]byte(`{"messages":[]}`), "sonnet")
+		if got := modelOf(t, out); got != "sonnet" {
+			t.Errorf("model = %q, want sonnet (injected)", got)
+		}
+	})
+
+	t.Run("empty Model is a no-op", func(t *testing.T) {
+		in := `{"model":"opus"}`
+		if out := applyModelOverride([]byte(in), ""); string(out) != in {
+			t.Errorf("empty Model rewrote body to %q; want unchanged", out)
+		}
+	})
+
+	t.Run("non-object body is returned unchanged", func(t *testing.T) {
+		for _, in := range []string{`not json`, `[1,2,3]`, `"a string"`, ``} {
+			if out := applyModelOverride([]byte(in), "sonnet"); string(out) != in {
+				t.Errorf("body %q rewritten to %q; want unchanged", in, out)
+			}
+		}
+	})
+}
+
+// TestDispatchRewritesModelForExternalBackend proves the override reaches
+// the wire: an external backend's Model replaces the client alias upstream.
+func TestDispatchRewritesModelForExternalBackend(t *testing.T) {
+	var gotModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var m struct {
+			Model string `json:"model"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&m)
+		gotModel = m.Model
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cfg := &Config{Backends: []Backend{{
+		Name: "cloud-sonnet", Tier: "cloud", Address: srv.URL,
+		Provider: "anthropic", Model: "claude-sonnet-4-6",
+	}}}
+	disp := NewDispatcher(cfg)
+
+	resp, err := disp.Dispatch(context.Background(), &cfg.Backends[0],
+		http.MethodPost, "/v1/chat/completions", http.Header{},
+		[]byte(`{"model":"ha","messages":[]}`))
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if gotModel != "claude-sonnet-4-6" {
+		t.Errorf("upstream received model %q, want claude-sonnet-4-6 (external.model override)", gotModel)
+	}
+}
+
+// TestDispatchLeavesBodyForLocalBackend is the inverse: a local backend
+// declares no Model, so the body's model passes through verbatim.
+func TestDispatchLeavesBodyForLocalBackend(t *testing.T) {
+	var gotModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var m struct {
+			Model string `json:"model"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&m)
+		gotModel = m.Model
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cfg := &Config{Backends: []Backend{{
+		Name: "local-gemma", Tier: "local", Address: srv.URL,
+	}}}
+	disp := NewDispatcher(cfg)
+
+	resp, err := disp.Dispatch(context.Background(), &cfg.Backends[0],
+		http.MethodPost, "/v1/chat/completions", http.Header{},
+		[]byte(`{"model":"gemma-4-e4b","messages":[]}`))
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if gotModel != "gemma-4-e4b" {
+		t.Errorf("local upstream received model %q, want gemma-4-e4b (verbatim)", gotModel)
 	}
 }
 

--- a/internal/router/proxy_test.go
+++ b/internal/router/proxy_test.go
@@ -29,11 +29,21 @@ import (
 // swap per case. It also tracks call counts so tests can assert which
 // backend(s) were hit.
 type fakeBackend struct {
-	srv    *httptest.Server
-	calls  atomic.Int64
-	status atomic.Int64 // status code to return; defaults to 200
-	body   atomic.Pointer[string]
-	stream atomic.Bool
+	srv       *httptest.Server
+	calls     atomic.Int64
+	status    atomic.Int64 // status code to return; defaults to 200
+	body      atomic.Pointer[string]
+	stream    atomic.Bool
+	lastModel atomic.Pointer[string] // "model" field of the last received body
+}
+
+// LastModel returns the OpenAI "model" field of the most recent request
+// this backend received, or "" if it has not been called.
+func (fb *fakeBackend) LastModel() string {
+	if p := fb.lastModel.Load(); p != nil {
+		return *p
+	}
+	return ""
 }
 
 func newFakeBackend(t *testing.T) *fakeBackend {
@@ -45,6 +55,14 @@ func newFakeBackend(t *testing.T) *fakeBackend {
 
 	fb.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fb.calls.Add(1)
+		if raw, _ := io.ReadAll(r.Body); len(raw) > 0 {
+			var m struct {
+				Model string `json:"model"`
+			}
+			if json.Unmarshal(raw, &m) == nil {
+				fb.lastModel.Store(&m.Model)
+			}
+		}
 		status := int(fb.status.Load())
 		body := *fb.body.Load()
 
@@ -296,6 +314,29 @@ func TestProxyPrimaryFallbackOnUpstream5xx(t *testing.T) {
 	}
 	if h.localBack.calls.Load() != 1 {
 		t.Errorf("local should be tried as fallback, calls = %d", h.localBack.calls.Load())
+	}
+}
+
+// TestProxyDegradesModelAcrossFallback is the end-to-end proof: when the
+// primary cloud backend fails and the chain falls back, each backend
+// receives its own model — cloud gets its configured Model, the local
+// fallback gets the verbatim client alias.
+func TestProxyDegradesModelAcrossFallback(t *testing.T) {
+	h := newProxyHarness(t)
+	// Primary (cloud-opus, Model: claude-opus-4-7) 5xxs so the complex rule
+	// falls back to local-qwen (no Model).
+	h.cloudBack.status.Store(http.StatusInternalServerError)
+
+	resp := h.post(t, map[string]any{"model": "opus-alias"}, map[string]string{
+		"x-llmkube-task-complexity": "complex",
+	})
+	_ = resp.Body.Close()
+
+	if got := h.cloudBack.LastModel(); got != "claude-opus-4-7" {
+		t.Errorf("cloud backend saw model %q, want claude-opus-4-7 (external.model override)", got)
+	}
+	if got := h.localBack.LastModel(); got != "opus-alias" {
+		t.Errorf("local fallback saw model %q, want opus-alias (local backend, verbatim)", got)
 	}
 }
 


### PR DESCRIPTION
The router-proxy matched routing rules on the client-facing `model` string and then forwarded the request body verbatim, never applying a backend's configured `Model`. `Backend.Model` is documented as "the upstream model identifier passed to the provider" and is surfaced in `/v1/models`, but it was inert on the dispatch path. This had two consequences:

- **External providers received the client alias** (e.g. `ha`, `opus`) instead of a real upstream id, so any backend whose alias differs from its upstream model name failed.
- **A `primary-fallback` chain across cloud backends was a silent no-op:** every attempt re-sent the same frozen client model, so `[opus, sonnet, haiku]` retried `opus` three times instead of degrading across models.

It also blocks the one fallback that has no other home: **local-primary → cloud-fallback.** A downstream proxy (e.g. LiteLLM) only ever sees the cloud leg, so cross-tier degradation can only live in the router.

## What changed

`Dispatch` now rewrites the `model` field of an *outbound copy* of the request body to the chosen backend's `Model`, via a new `applyModelOverride` helper. The override is gated on a non-empty `Model`: local backends leave it empty and pass through verbatim, and non-JSON bodies are returned unchanged. The shared inbound buffer (reused across fallback attempts) is never mutated.

This is a behavior change in that `Backend.Model` was previously inert and is now applied — but it makes runtime behavior match the field's documented contract rather than changing an intended one.

## Validation

`go test ./internal/router/`, `go vet`, and `gofmt` all clean; full module builds. New coverage:

- `TestApplyModelOverride` — rewrites existing model, injects when absent, preserves sibling fields, no-op on empty Model, no-op on non-object/non-JSON bodies.
- `TestDispatchRewritesModelForExternalBackend` / `TestDispatchLeavesBodyForLocalBackend` — wire-level assertion that an external backend's `Model` reaches the upstream and a local backend's body passes through verbatim.
- `TestProxyDegradesModelAcrossFallback` — end-to-end: when the primary cloud backend 5xxs and the chain falls back, the cloud backend receives its configured `Model` and the local fallback receives the verbatim client alias.

_Assisted by Claude Opus 4.8_