### PR TITLE
feat(metrics): TTFT histogram, request error counter, vLLM metrics flag (#409)

### DIFF
--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -123,6 +123,14 @@ spec:
       labels:
         latency_kind: end_to_end
 
+    # Per-request error rate by status class, sourced from the controller's
+    # llmkube_inference_request_errors_total counter.
+    - record: llmkube:inference:request_errors:rate5m
+      expr: |
+        sum by (service, namespace, runtime, status_class) (
+          rate(llmkube_inference_request_errors_total[5m])
+        )
+
     # Inference pod restart rate as a coarse error proxy. Per-request
     # 4xx/5xx counters are tracked in #409 and will replace this once the
     # upstream metric paths are confirmed for each runtime. The container

--- a/docs/grafana/llmkube-inference.json
+++ b/docs/grafana/llmkube-inference.json
@@ -150,6 +150,34 @@
       ],
       "title": "Inference container restart rate (5m)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "errors/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 18},
+      "id": 5,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube:inference:request_errors:rate5m",
+          "legendFormat": "{{service}} ({{runtime}}, {{status_class}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Request error rate by status class (5m)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -3522,8 +3522,11 @@ var _ = Describe("RuntimeBackend interface", func() {
 			Expect(args).NotTo(ContainElement("--model"))
 			Expect(args).To(ContainElements("--host", "0.0.0.0"))
 			Expect(args).To(ContainElements("--port", "8000"))
-			// Five elements: <model> --host 0.0.0.0 --port 8000.
-			Expect(args).To(HaveLen(5))
+			// --enable-metrics is always set so vLLM pods expose /metrics for
+			// PodMonitor scraping (#409).
+			Expect(args).To(ContainElement("--enable-metrics"))
+			// Six elements: <model> --host 0.0.0.0 --port 8000 --enable-metrics.
+			Expect(args).To(HaveLen(6))
 		})
 
 		It("should append extraArgs after typed flags", func() {

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -68,6 +68,7 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 		source,
 		"--host", "0.0.0.0",
 		"--port", fmt.Sprintf("%d", port),
+		"--enable-metrics",
 	}
 
 	var err error

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -76,6 +76,25 @@ var (
 		[]string{"inferenceservice", "namespace"},
 	)
 
+	// Inference request metrics
+
+	InferenceTTFT = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "llmkube_inference_ttft_seconds",
+			Help:    "Time to first token for inference requests.",
+			Buckets: prometheus.ExponentialBuckets(0.01, 2, 14), // 10ms to ~131s
+		},
+		[]string{"service", "namespace", "runtime"},
+	)
+
+	InferenceRequestErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llmkube_inference_request_errors_total",
+			Help: "Total number of inference request errors by status class.",
+		},
+		[]string{"service", "namespace", "runtime", "status_class"},
+	)
+
 	// Reconcile metrics
 
 	ReconcileTotal = prometheus.NewCounterVec(
@@ -104,6 +123,8 @@ func init() {
 		InferenceServicePhase,
 		GPUQueueDepth,
 		GPUQueueWaitDuration,
+		InferenceTTFT,
+		InferenceRequestErrors,
 		ReconcileTotal,
 		ReconcileDuration,
 	)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -52,6 +52,8 @@ func TestMetricsRegistered(t *testing.T) {
 		{"llmkube_inferenceservice_phase", InferenceServicePhase},
 		{"llmkube_gpu_queue_depth", GPUQueueDepth},
 		{"llmkube_gpu_queue_wait_duration_seconds", GPUQueueWaitDuration},
+		{"llmkube_inference_ttft_seconds", InferenceTTFT},
+		{"llmkube_inference_request_errors_total", InferenceRequestErrors},
 		{"llmkube_reconcile_total", ReconcileTotal},
 		{"llmkube_reconcile_duration_seconds", ReconcileDuration},
 	}
@@ -187,6 +189,7 @@ func TestHistogramBuckets(t *testing.T) {
 		{"InferenceServiceReadyDuration", InferenceServiceReadyDuration, []string{"bkt-test", "default"}, 10},
 		{"GPUQueueWaitDuration", GPUQueueWaitDuration, []string{"bkt-test", "default"}, 10},
 		{"ReconcileDuration", ReconcileDuration, []string{"bkt-test-ctrl"}, 11},
+		{"InferenceTTFT", InferenceTTFT, []string{"ttft-svc", "default", "vllm"}, 14},
 	}
 
 	for _, tt := range tests {
@@ -197,5 +200,37 @@ func TestHistogramBuckets(t *testing.T) {
 				t.Errorf("expected at least %d buckets, got %d", tt.minBkts, bucketCount)
 			}
 		})
+	}
+}
+
+func TestInferenceTTFT(t *testing.T) {
+	m := getHistogramMetric(t, InferenceTTFT, []string{"ttft-svc", "default", "vllm"}, 0.25)
+
+	if m.GetHistogram().GetSampleCount() == 0 {
+		t.Error("expected sample count > 0 after observation")
+	}
+	if m.GetHistogram().GetSampleSum() < 0.25 {
+		t.Errorf("expected sample sum >= 0.25, got %f", m.GetHistogram().GetSampleSum())
+	}
+}
+
+func TestInferenceRequestErrors(t *testing.T) {
+	InferenceRequestErrors.WithLabelValues("err-svc", "default", "vllm", "4xx").Inc()
+	InferenceRequestErrors.WithLabelValues("err-svc", "default", "vllm", "4xx").Inc()
+	InferenceRequestErrors.WithLabelValues("err-svc", "default", "vllm", "5xx").Inc()
+
+	var m dto.Metric
+	if err := InferenceRequestErrors.WithLabelValues("err-svc", "default", "vllm", "4xx").Write(&m); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if m.GetCounter().GetValue() < 2 {
+		t.Errorf("expected 4xx counter >= 2, got %f", m.GetCounter().GetValue())
+	}
+
+	if err := InferenceRequestErrors.WithLabelValues("err-svc", "default", "vllm", "5xx").Write(&m); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if m.GetCounter().GetValue() < 1 {
+		t.Errorf("expected 5xx counter >= 1, got %f", m.GetCounter().GetValue())
 	}
 }


### PR DESCRIPTION
## What

Add request-shape inference observability to the controller: a
`llmkube_inference_ttft_seconds` histogram and a
`llmkube_inference_request_errors_total` counter, wire `--enable-metrics`
into the vLLM runtime, add an error-rate recording rule, and add an
error-rate panel to the Grafana dashboard. Includes registration +
cardinality unit tests.

This was produced by the Foreman agentic coder (Strix Qwopus-27B) in a
single ~10 min run and passed the fast verification gate
(gofmt/vet/build/golangci-lint + unit tests) before submission.

## Why

LLMKube exposes infra-level metrics (download duration, queue wait,
reconcile timings) but not the request-shape view operators expect on day
one: time-to-first-token and per-request error rate. These are also
prerequisites for any SLO work. Addresses #409.

## How

- `internal/metrics/metrics.go`: `InferenceTTFT` histogram (labels
  `service`, `namespace`, `runtime`; exponential buckets 10ms to ~131s) and
  `InferenceRequestErrors` counter (labels `service`, `namespace`,
  `runtime`, `status_class`), both registered in `init()`.
- `internal/controller/runtime_vllm.go`: add `--enable-metrics` to vLLM
  `BuildArgs` so vLLM pods are scraped on the same `/metrics` path as
  llama.cpp.
- `charts/llmkube/templates/prometheusrule.yaml`: add
  `llmkube:inference:request_errors:rate5m` recording rule.
- `docs/grafana/llmkube-inference.json`: add a request-error-rate panel.
- `internal/metrics/metrics_test.go`: assert registration succeeds and
  label cardinality matches the documented set.

### Scope / follow-ups (why #409 stays open)

This lands the gate-verifiable core. The following remain and are not in
this PR, so I have intentionally not used a closing keyword:

- Data wiring: PodMonitor `metricRelabelings` to populate TTFT from the
  llama.cpp/vLLM runtime series, and the error-count source per runtime
  (the metrics are registered but not yet observed).
- The `llmkube:inference:ttft_seconds:p95_5m` recording rule.
- The full three-panel dashboard (TTFT p50/p95/p99, errors, queue-wait p95).
- The e2e Kind test described in the issue.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (build + `internal/metrics` unit tests)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [ ] Documentation updated (dashboard JSON added; user docs are a follow-up)
