### PR TITLE
feat(metal-agent): event-driven endpoint withdrawal/recovery on health transitions (#662)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1151,6 +1151,60 @@ func (a *MetalAgent) scheduleRestart(ctx context.Context, name, namespace string
 	}
 }
 
+// withdrawEndpoint fetches the InferenceService for the given name/namespace
+// and calls registry.WithdrawEndpoint to flip the endpoint's Ready condition
+// to false. This is the event-driven path (#662): the health monitor calls
+// this immediately when it detects a healthy→unhealthy transition, rather
+// than waiting for the next heartbeat tick.
+func (a *MetalAgent) withdrawEndpoint(ctx context.Context, name, namespace string) {
+	isvc := &inferencev1alpha1.InferenceService{}
+	if err := a.config.K8sClient.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, isvc); err != nil {
+		a.logger.Warnw("failed to fetch InferenceService for withdrawal",
+			"name", name, "namespace", namespace, "error", err)
+		return
+	}
+
+	// Read the port from the managed process snapshot.
+	a.mu.RLock()
+	port := a.processes[types.NamespacedName{Namespace: namespace, Name: name}.String()].Port
+	a.mu.RUnlock()
+
+	if err := a.registry.WithdrawEndpoint(ctx, isvc, port); err != nil {
+		a.logger.Warnw("failed to withdraw endpoint",
+			"name", name, "namespace", namespace, "error", err)
+	}
+}
+
+// registerEndpoint fetches the InferenceService for the given name/namespace
+// and calls registry.RegisterEndpoint to flip the endpoint's Ready condition
+// back to true. This is the event-driven recovery path (#662): the health
+// monitor calls this immediately when it detects an unhealthy→healthy
+// transition, rather than waiting for the next heartbeat tick.
+func (a *MetalAgent) registerEndpoint(ctx context.Context, name, namespace string) {
+	isvc := &inferencev1alpha1.InferenceService{}
+	if err := a.config.K8sClient.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, isvc); err != nil {
+		a.logger.Warnw("failed to fetch InferenceService for registration",
+			"name", name, "namespace", namespace, "error", err)
+		return
+	}
+
+	// Read the port from the managed process snapshot.
+	a.mu.RLock()
+	port := a.processes[types.NamespacedName{Namespace: namespace, Name: name}.String()].Port
+	a.mu.RUnlock()
+
+	if err := a.registry.RegisterEndpoint(ctx, isvc, port); err != nil {
+		a.logger.Warnw("failed to register endpoint",
+			"name", name, "namespace", namespace, "error", err)
+	}
+}
+
 // heartbeatOnce re-registers the endpoint for every currently-running managed
 // process. It snapshots the running process set under RLock, releases the lock,
 // then performs one best-effort re-registration per process (no lock held during

--- a/pkg/agent/health.go
+++ b/pkg/agent/health.go
@@ -156,6 +156,9 @@ func (m *HealthMonitor) checkAll(ctx context.Context) {
 			m.agent.mu.Unlock()
 
 			processHealthy.WithLabelValues(snap.Name, snap.Namespace).Set(0)
+			// Immediately withdraw the endpoint so kube-proxy stops DNATing
+			// to the dead backend (#662).
+			m.agent.withdrawEndpoint(ctx, snap.Name, snap.Namespace)
 			m.agent.scheduleRestart(ctx, snap.Name, snap.Namespace)
 		} else if !snap.Healthy && healthy {
 			// unhealthy → healthy transition
@@ -169,6 +172,9 @@ func (m *HealthMonitor) checkAll(ctx context.Context) {
 			m.agent.mu.Unlock()
 
 			processHealthy.WithLabelValues(snap.Name, snap.Namespace).Set(1)
+			// Immediately re-register the endpoint so kube-proxy resumes
+			// routing to the recovered backend (#662).
+			m.agent.registerEndpoint(ctx, snap.Name, snap.Namespace)
 		}
 	}
 }

--- a/pkg/agent/health_test.go
+++ b/pkg/agent/health_test.go
@@ -25,7 +25,14 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
 
 // mockHealthChecker is a test double for ProcessHealthChecker.
@@ -225,6 +232,132 @@ func TestHealthMonitor_RecordsRestartCount(t *testing.T) {
 	agent.mu.RUnlock()
 	if healthy {
 		t.Error("process should be unhealthy after failed check")
+	}
+}
+
+// TestHealthMonitor_WithdrawsOnUnhealthy verifies that the health monitor
+// immediately withdraws the endpoint (Ready=false) when it detects a
+// healthy→unhealthy transition, rather than waiting for the next heartbeat
+// tick (#662).
+func TestHealthMonitor_WithdrawsOnUnhealthy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "withdraw-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "withdraw-model"},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(isvc).
+		Build()
+
+	agent := &MetalAgent{
+		config: MetalAgentConfig{
+			K8sClient: k8sClient,
+			Namespace: "default",
+		},
+		processes: map[string]*ManagedProcess{
+			"default/withdraw-model": {
+				Name:      "withdraw-model",
+				Namespace: "default",
+				Port:      8080,
+				Healthy:   true,
+			},
+		},
+		starting: make(map[string]bool),
+		logger:   newNopLogger(),
+	}
+	agent.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger(), "")
+
+	// First register the endpoint so it starts Ready=true.
+	if err := agent.registry.RegisterEndpoint(context.Background(), isvc, 8080); err != nil {
+		t.Fatalf("RegisterEndpoint: %v", err)
+	}
+
+	checker := &mockHealthChecker{result: false}
+	monitor := NewHealthMonitor(agent, checker, time.Second, newNopLogger())
+
+	monitor.checkAll(context.Background())
+
+	// The endpoint should now be withdrawn (Ready=false).
+	slice := &discoveryv1.EndpointSlice{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "withdraw-model", Namespace: "default"}, slice); err != nil {
+		t.Fatalf("get endpointslice after health monitor: %v", err)
+	}
+	if len(slice.Endpoints) != 1 {
+		t.Fatalf("EndpointSlice has %d endpoints, want 1", len(slice.Endpoints))
+	}
+	if slice.Endpoints[0].Conditions.Ready == nil || *slice.Endpoints[0].Conditions.Ready {
+		t.Errorf("endpoint Conditions.Ready = %v, want false after health monitor withdrawal",
+			slice.Endpoints[0].Conditions.Ready)
+	}
+}
+
+// TestHealthMonitor_RegistersOnRecovery verifies that the health monitor
+// immediately re-registers the endpoint (Ready=true) when it detects an
+// unhealthy→healthy transition, rather than waiting for the next heartbeat
+// tick (#662).
+func TestHealthMonitor_RegistersOnRecovery(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "recover-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "recover-model"},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(isvc).
+		Build()
+
+	agent := &MetalAgent{
+		config: MetalAgentConfig{
+			K8sClient: k8sClient,
+			Namespace: "default",
+		},
+		processes: map[string]*ManagedProcess{
+			"default/recover-model": {
+				Name:      "recover-model",
+				Namespace: "default",
+				Port:      8080,
+				Healthy:   false,
+			},
+		},
+		starting: make(map[string]bool),
+		logger:   newNopLogger(),
+	}
+	agent.registry = NewServiceRegistry(k8sClient, "10.0.0.1", newNopLogger(), "")
+
+	// First withdraw the endpoint so it starts Ready=false.
+	if err := agent.registry.WithdrawEndpoint(context.Background(), isvc, 8080); err != nil {
+		t.Fatalf("WithdrawEndpoint: %v", err)
+	}
+
+	checker := &mockHealthChecker{result: true}
+	monitor := NewHealthMonitor(agent, checker, time.Second, newNopLogger())
+
+	monitor.checkAll(context.Background())
+
+	// The endpoint should now be registered (Ready=true).
+	slice := &discoveryv1.EndpointSlice{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "recover-model", Namespace: "default"}, slice); err != nil {
+		t.Fatalf("get endpointslice after health monitor: %v", err)
+	}
+	if len(slice.Endpoints) != 1 {
+		t.Fatalf("EndpointSlice has %d endpoints, want 1", len(slice.Endpoints))
+	}
+	if slice.Endpoints[0].Conditions.Ready == nil || !*slice.Endpoints[0].Conditions.Ready {
+		t.Errorf("endpoint Conditions.Ready = %v, want true after health monitor recovery",
+			slice.Endpoints[0].Conditions.Ready)
 	}
 }
 


### PR DESCRIPTION
## What

Make the metal-agent's health monitor act on health transitions at event
speed: on a healthy→unhealthy transition it immediately withdraws the
endpoint (flips Ready=false via the existing `registry.WithdrawEndpoint`),
and on unhealthy→healthy it immediately re-registers it. Previously the
endpoint state only changed on the next heartbeat tick (30s default).

Produced by the Foreman agentic coder (Strix Qwopus-27B) in a single
on-scope run; passed the fast verification gate before submission.

## Why

Off-cluster Metal endpoints (selectorless Service + agent-managed
Endpoints) reachable through the gateway hide endpoint death from Envoy:
an abruptly-unhealthy backend keeps receiving DNAT'd traffic until the
next heartbeat re-registration, stalling in-flight requests. This gives
Metal endpoints the same event-driven ejection/restoration that in-cluster
pods get from the Inference Extension's endpoint picker. Fixes #662.

## How

- `pkg/agent/agent.go`: add `withdrawEndpoint` / `registerEndpoint` helpers
  that fetch the InferenceService, read the managed process port under
  RLock (released before the call, matching the `heartbeatOnce` pattern),
  and call `registry.WithdrawEndpoint` / `registry.RegisterEndpoint`
  best-effort with warn-level logging.
- `pkg/agent/health.go`: call them at the existing transition points in
  `HealthMonitor.checkAll` (withdraw before scheduling the restart;
  re-register on recovery). Transition-gated, so no per-tick churn.
- `pkg/agent/health_test.go`: cover both transitions.

### Scope

Issue parts 1 (withdraw on unhealthy) and 2 (restore on recovery) are the
agent-side work and are implemented here. Part 3 (operator compiling health
state into gateway Backend ejection) is explicitly the gateway-integration
umbrella's scope (#661) and is out of scope for this PR.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go build ./...` + `go test ./pkg/agent/`)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [ ] Documentation updated (no user-facing surface change)
