### PR TITLE
fix(metal-agent): prevent zero-byte stub files from failed model downloads (#642)

### DIFF
--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -249,7 +249,7 @@ func (e *MetalExecutor) ensureModel(ctx context.Context, source, name string) (s
 	filename := filepath.Base(source)
 	localPath := filepath.Join(e.modelStorePath, name, filename)
 
-	if _, err := os.Stat(localPath); err == nil {
+	if info, err := os.Stat(localPath); err == nil && info.Size() > 0 {
 		e.logger.Debugw("model already downloaded", "path", localPath)
 		return localPath, nil
 	}
@@ -268,7 +268,9 @@ func (e *MetalExecutor) ensureModel(ctx context.Context, source, name string) (s
 }
 
 func (e *MetalExecutor) downloadFile(ctx context.Context, url, filePath string) error {
-	out, err := os.Create(filePath)
+	tmpPath := filePath + ".partial"
+
+	out, err := os.Create(tmpPath)
 	if err != nil {
 		return err
 	}
@@ -280,11 +282,17 @@ func (e *MetalExecutor) downloadFile(ctx context.Context, url, filePath string) 
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
+		if rmErr := os.Remove(tmpPath); rmErr != nil {
+			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
+		}
 		return err
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		if rmErr := os.Remove(tmpPath); rmErr != nil {
+			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
+		}
 		return err
 	}
 	defer func() {
@@ -292,11 +300,34 @@ func (e *MetalExecutor) downloadFile(ctx context.Context, url, filePath string) 
 	}()
 
 	if resp.StatusCode != http.StatusOK {
+		if rmErr := os.Remove(tmpPath); rmErr != nil {
+			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
+		}
 		return fmt.Errorf("bad status: %s", resp.Status)
 	}
 
-	_, err = io.Copy(out, resp.Body)
-	return err
+	written, err := io.Copy(out, resp.Body)
+	if err != nil {
+		if rmErr := os.Remove(tmpPath); rmErr != nil {
+			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
+		}
+		return err
+	}
+
+	// Verify Content-Length against bytes written so a connection drop
+	// mid-download doesn't leave a truncated model that passes the stat
+	// check.
+	if resp.ContentLength > 0 && written != resp.ContentLength {
+		if rmErr := os.Remove(tmpPath); rmErr != nil {
+			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
+		}
+		return fmt.Errorf("download truncated: expected %d bytes, got %d", resp.ContentLength, written)
+	}
+
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		return fmt.Errorf("failed to rename downloaded model: %w", err)
+	}
+	return nil
 }
 
 func (e *MetalExecutor) waitForHealthy(port int, timeout time.Duration) error {

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package agent
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -448,5 +451,209 @@ func TestStopProcess_InvalidPID(t *testing.T) {
 	err := executor.StopProcess(-99999)
 	if err == nil {
 		t.Error("StopProcess with invalid PID should return error")
+	}
+}
+
+func TestDownloadFile_FailedDownloadLeavesNoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	executor := NewMetalExecutor("/bin/llama-server", tmpDir, newNopLogger())
+
+	// Server that returns 401 (e.g. gated Hugging Face repo)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	modelDir := filepath.Join(tmpDir, "gated-model")
+	if err := os.MkdirAll(modelDir, 0755); err != nil {
+		t.Fatalf("Failed to create model directory: %v", err)
+	}
+	localPath := filepath.Join(modelDir, "model.gguf")
+
+	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath)
+	if err == nil {
+		t.Fatal("downloadFile should return error for 401 response")
+	}
+
+	// The final path must not exist
+	if _, err := os.Stat(localPath); !os.IsNotExist(err) {
+		t.Errorf("failed download left file at %q: %v", localPath, err)
+	}
+
+	// No .partial stub should remain either
+	partialPath := localPath + ".partial"
+	if _, err := os.Stat(partialPath); !os.IsNotExist(err) {
+		t.Errorf("failed download left partial file at %q: %v", partialPath, err)
+	}
+}
+
+func TestEnsureModel_ZeroByteFileTriggersRedownload(t *testing.T) {
+	tmpDir := t.TempDir()
+	executor := NewMetalExecutor("/bin/llama-server", tmpDir, newNopLogger())
+
+	modelDir := filepath.Join(tmpDir, "stub-model")
+	if err := os.MkdirAll(modelDir, 0755); err != nil {
+		t.Fatalf("Failed to create model directory: %v", err)
+	}
+	localPath := filepath.Join(modelDir, "model.gguf")
+
+	// Pre-create a zero-byte stub (simulates a failed download from a
+	// previous run that left an empty file).
+	if err := os.WriteFile(localPath, nil, 0644); err != nil {
+		t.Fatalf("Failed to create stub file: %v", err)
+	}
+
+	// Server that returns a small valid payload.
+	payload := []byte("fake-gguf-data")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	_, err := executor.ensureModel(t.Context(), srv.URL+"/model.gguf", "stub-model")
+	if err != nil {
+		t.Fatalf("ensureModel should succeed when stub is zero bytes: %v", err)
+	}
+
+	// The file should now contain the downloaded data.
+	info, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("model file missing after download: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("model file is still zero bytes after ensureModel")
+	}
+}
+
+func TestDownloadFile_TruncatedDownloadFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	executor := NewMetalExecutor("/bin/llama-server", tmpDir, newNopLogger())
+
+	modelDir := filepath.Join(tmpDir, "trunc-model")
+	if err := os.MkdirAll(modelDir, 0755); err != nil {
+		t.Fatalf("Failed to create model directory: %v", err)
+	}
+	localPath := filepath.Join(modelDir, "model.gguf")
+
+	// Server that advertises a large Content-Length but sends fewer bytes.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1000")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("short"))
+	}))
+	defer srv.Close()
+
+	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath)
+	if err == nil {
+		t.Fatal("downloadFile should return error for truncated download")
+	}
+
+	// The final path must not exist (truncated file should be cleaned up).
+	if _, err := os.Stat(localPath); !os.IsNotExist(err) {
+		t.Errorf("truncated download left file at %q: %v", localPath, err)
+	}
+}
+
+func TestDownloadFile_SuccessRenamesTempFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	executor := NewMetalExecutor("/bin/llama-server", tmpDir, newNopLogger())
+
+	modelDir := filepath.Join(tmpDir, "ok-model")
+	if err := os.MkdirAll(modelDir, 0755); err != nil {
+		t.Fatalf("Failed to create model directory: %v", err)
+	}
+	localPath := filepath.Join(modelDir, "model.gguf")
+
+	payload := []byte("fake-gguf-data")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath)
+	if err != nil {
+		t.Fatalf("downloadFile should succeed: %v", err)
+	}
+
+	// The final path must exist and contain the data.
+	info, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("model file missing after download: %v", err)
+	}
+	if info.Size() != int64(len(payload)) {
+		t.Errorf("model file size = %d, want %d", info.Size(), len(payload))
+	}
+
+	// No .partial stub should remain.
+	partialPath := localPath + ".partial"
+	if _, err := os.Stat(partialPath); !os.IsNotExist(err) {
+		t.Errorf("partial file still exists at %q: %v", partialPath, err)
+	}
+}
+
+func TestDownloadFile_NoContentLength(t *testing.T) {
+	tmpDir := t.TempDir()
+	executor := NewMetalExecutor("/bin/llama-server", tmpDir, newNopLogger())
+
+	modelDir := filepath.Join(tmpDir, "no-cl-model")
+	if err := os.MkdirAll(modelDir, 0755); err != nil {
+		t.Fatalf("Failed to create model directory: %v", err)
+	}
+	localPath := filepath.Join(modelDir, "model.gguf")
+
+	payload := []byte("fake-gguf-data")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No Content-Length header; ContentLength will be 0.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath)
+	if err != nil {
+		t.Fatalf("downloadFile should succeed without Content-Length: %v", err)
+	}
+
+	info, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("model file missing after download: %v", err)
+	}
+	if info.Size() != int64(len(payload)) {
+		t.Errorf("model file size = %d, want %d", info.Size(), len(payload))
+	}
+}
+
+func TestDownloadFile_ContextCancellation(t *testing.T) {
+	tmpDir := t.TempDir()
+	executor := NewMetalExecutor("/bin/llama-server", tmpDir, newNopLogger())
+
+	modelDir := filepath.Join(tmpDir, "cancel-model")
+	if err := os.MkdirAll(modelDir, 0755); err != nil {
+		t.Fatalf("Failed to create model directory: %v", err)
+	}
+	localPath := filepath.Join(modelDir, "model.gguf")
+
+	// Server that blocks forever.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Never respond.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately.
+
+	err := executor.downloadFile(ctx, srv.URL+"/model.gguf", localPath)
+	if err == nil {
+		t.Fatal("downloadFile should return error when context is cancelled")
+	}
+
+	// No file should be left behind.
+	if _, err := os.Stat(localPath); !os.IsNotExist(err) {
+		t.Errorf("cancelled download left file at %q: %v", localPath, err)
 	}
 }


### PR DESCRIPTION
## What

Stop the metal-agent from leaving a zero-byte (or truncated) model file
behind when a download fails. `MetalExecutor.downloadFile` now writes to a
`.partial` temp file and renames into place only on success; any failure
(HTTP error, non-200, copy error, truncated body) removes the temp file.
`ensureModel` additionally treats a zero-size file as not-downloaded, and
the download verifies Content-Length against bytes written.

Produced by the Foreman agentic coder (Strix Qwopus-27B) in a single ~8 min
on-scope run; passed the fast verification gate before submission.

## Why

`downloadFile` called `os.Create` on the final path before issuing the GET,
so a failed request (e.g. 401 from a gated HF repo) left an empty file.
`ensureModel` then short-circuited on `os.Stat` success and handed
llama-server an empty model; the pre-#641 memory check also computed a
trivial 512 MB estimate from the 0-byte stub. Fixes #642.

## How

- `pkg/agent/executor.go`:
  - `downloadFile` writes to `filePath + ".partial"`, and on any error path
    removes the temp file; renames to the final path only after a fully
    successful copy.
  - Content-Length is compared to bytes written; a mismatch is treated as a
    truncated download (temp file removed, error returned).
  - `ensureModel` now requires `info.Size() > 0` before treating a model as
    already present, so a leftover zero-byte stub triggers a re-download.
- `pkg/agent/executor_test.go`: cover failed download (no file left),
  truncated download, and the zero-byte-stub re-download path.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go build ./...` + `go test ./pkg/agent/`)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [ ] Documentation updated (no user-facing surface change)
