### PR TITLE
fix(controller): preserve agent-written schedulingStatus on reconcile (#643)

### DIFF
--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -1036,5 +1036,67 @@ var _ = Describe("Reconcile lifecycle", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ModelCachePVCName, Namespace: "default"}, pvc)).To(Succeed())
 			Expect(pvc.OwnerReferences).To(BeEmpty())
 		})
+
+		It("should preserve agent-written schedulingStatus on status update", func() {
+			modelName := "model-sched-preserve"
+			isvcName := "isvc-sched-preserve"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server",
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, isvc)
+				dep := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+					_ = k8sClient.Delete(ctx, dep)
+				}
+				svc := &corev1.Service{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+					_ = k8sClient.Delete(ctx, svc)
+				}
+			}()
+
+			// Simulate the metal-agent writing a scheduling rejection.
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, isvc)).To(Succeed())
+			isvc.Status.SchedulingStatus = "MemoryCheckFailed"
+			isvc.Status.SchedulingMessage = "host memory insufficient for model"
+			Expect(k8sClient.Status().Update(ctx, isvc)).To(Succeed())
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+			// The controller must not clobber the agent-written scheduling fields.
+			Expect(updated.Status.SchedulingStatus).To(Equal("MemoryCheckFailed"))
+			Expect(updated.Status.SchedulingMessage).To(Equal("host memory insufficient for model"))
+		})
 	})
 })

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -135,11 +135,10 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 		isvc.Status.SchedulingStatus = schedulingInfo.Status
 		isvc.Status.SchedulingMessage = schedulingInfo.Message
 		isvc.Status.WaitingFor = schedulingInfo.WaitingFor
-	} else {
-		isvc.Status.SchedulingStatus = ""
-		isvc.Status.SchedulingMessage = ""
-		isvc.Status.WaitingFor = ""
 	}
+	// When schedulingInfo is nil, preserve agent-written scheduling fields
+	// (e.g. InsufficientMemory, MemoryCheckFailed) so the controller does not
+	// clobber them on its next status update (#643).
 
 	if phase == PhaseWaitingForGPU {
 		queuePos, err := r.calculateQueuePosition(ctx, isvc)


### PR DESCRIPTION
## What

Stop the InferenceService controller from clobbering the metal-agent's
`status.schedulingStatus` / `status.schedulingMessage`. `updateStatusWithSchedulingInfo`
zeroed those fields whenever `schedulingInfo == nil`, wiping the agent's
`InsufficientMemory` / `MemoryCheckFailed` writes almost immediately.

Foreman-authored (Strix Qwopus-27B), gate-verified: the in-cluster verify
gate ran the full `make test` (controller envtest) to **GATE-PASS**.

## Why

The agent writes the scheduling rejection so `kubectl describe/get` shows
why a service won't start, but the controller's next reconcile erased it.
Fixes #643.

## How

- `internal/controller/status_builder.go`: drop the `else` branch that set
  the scheduling fields to `""`; when `schedulingInfo == nil`, leave the
  agent-owned fields intact. (The preserve approach from the issue's two
  suggestions; the SSA-field-manager alternative was not taken.)
- `internal/controller/inferenceservice_reconcile_test.go`: envtest spec
  asserting an agent-written scheduling status survives a controller status
  update.

## Reviewer note (follow-up, not blocking this fix)

With the controller no longer clearing on `schedulingInfo == nil`, and the
metal-agent only *setting* `SchedulingStatus` (`pkg/agent/agent.go:1388`,
`:1426`) without clearing it on a later successful memory check
(`:1396` returns nil without clearing), the field will now **persist after
the condition resolves** — a recovered service can show a stale
`InsufficientMemory`. This fix is still a net improvement (the bug was that
the rejection was never visible), but a follow-up should have the agent
clear `SchedulingStatus`/`SchedulingMessage` on memory-check-pass.
