### PR TITLE
fix(controller): make checkAcceleratorAvailability DRA-aware (#754)

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -152,9 +152,9 @@ type GPUSpec struct {
 	//   amd    -> amd.com/gpu
 	//   intel  -> gpu.intel.com/i915
 	// Set this for non-default device plugins (e.g. squat/generic-device-plugin
-	// advertising `squat.ai/dri-render`, NVIDIA MIG slices, or DRA-backed
-	// resources). When set, this value also drives the GPU toleration unless
-	// TolerationKey is provided explicitly.
+	// advertising `squat.ai/dri-render`, NVIDIA MIG slices). When set, this
+	// value also drives the GPU toleration unless TolerationKey is provided
+	// explicitly.
 	// +kubebuilder:validation:Pattern=`^[a-z0-9.\-]+/[a-z0-9._\-]+$`
 	// +optional
 	ResourceName string `json:"resourceName,omitempty"`

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -204,9 +204,9 @@ spec:
                             amd    -> amd.com/gpu
                             intel  -> gpu.intel.com/i915
                           Set this for non-default device plugins (e.g. squat/generic-device-plugin
-                          advertising `squat.ai/dri-render`, NVIDIA MIG slices, or DRA-backed
-                          resources). When set, this value also drives the GPU toleration unless
-                          TolerationKey is provided explicitly.
+                          advertising `squat.ai/dri-render`, NVIDIA MIG slices). When set, this
+                          value also drives the GPU toleration unless TolerationKey is provided
+                          explicitly.
                         pattern: ^[a-z0-9.\-]+/[a-z0-9._\-]+$
                         type: string
                       runtime:

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -200,9 +200,9 @@ spec:
                             amd    -> amd.com/gpu
                             intel  -> gpu.intel.com/i915
                           Set this for non-default device plugins (e.g. squat/generic-device-plugin
-                          advertising `squat.ai/dri-render`, NVIDIA MIG slices, or DRA-backed
-                          resources). When set, this value also drives the GPU toleration unless
-                          TolerationKey is provided explicitly.
+                          advertising `squat.ai/dri-render`, NVIDIA MIG slices). When set, this
+                          value also drives the GPU toleration unless TolerationKey is provided
+                          explicitly.
                         pattern: ^[a-z0-9.\-]+/[a-z0-9._\-]+$
                         type: string
                       runtime:

--- a/internal/controller/model_accelerator_test.go
+++ b/internal/controller/model_accelerator_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -69,6 +70,33 @@ func newModelReconcilerWithNodes(t *testing.T, nodes ...client.Object) *ModelRec
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nodes...).Build()
 	return &ModelReconciler{Client: c, Scheme: scheme}
+}
+
+func newModelReconcilerWithDRA(t *testing.T, objects ...client.Object) *ModelReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add inference: %v", err)
+	}
+	if err := resourcev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add resourcev1: %v", err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return &ModelReconciler{Client: c, Scheme: scheme}
+}
+
+func modelWithDRA(claims []corev1.PodResourceClaim) *inferencev1alpha1.Model {
+	m := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"}}
+	m.Spec.Hardware = &inferencev1alpha1.HardwareSpec{
+		Accelerator: "cuda",
+		GPU: &inferencev1alpha1.GPUSpec{
+			ResourceClaims: claims,
+		},
+	}
+	return m
 }
 
 func TestCheckAcceleratorAvailability(t *testing.T) {
@@ -133,4 +161,75 @@ func TestCheckAcceleratorAvailability(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckAcceleratorAvailability_DRA(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name    string
+		model   *inferencev1alpha1.Model
+		objects []client.Object
+		want    bool
+	}{
+		{
+			name: "DRA ResourceClaimName exists -> available",
+			model: modelWithDRA([]corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimName: ptrTo("gpu-claim")},
+			}),
+			objects: []client.Object{
+				&resourcev1.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "default"}},
+			},
+			want: true,
+		},
+		{
+			name: "DRA ResourceClaimName not found -> not available",
+			model: modelWithDRA([]corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimName: ptrTo("gpu-claim")},
+			}),
+			objects: nil,
+			want:    false,
+		},
+		{
+			name: "DRA ResourceClaimTemplateName exists -> available",
+			model: modelWithDRA([]corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimTemplateName: ptrTo("gpu-template")},
+			}),
+			objects: []client.Object{
+				&resourcev1.ResourceClaimTemplate{ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "default"}},
+			},
+			want: true,
+		},
+		{
+			name: "DRA ResourceClaimTemplateName not found -> not available",
+			model: modelWithDRA([]corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimTemplateName: ptrTo("gpu-template")},
+			}),
+			objects: nil,
+			want:    false,
+		},
+		{
+			name: "DRA takes precedence over resourceName",
+			model: modelWithDRA([]corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimName: ptrTo("gpu-claim")},
+			}),
+			objects: []client.Object{
+				&resourcev1.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "default"}},
+				nodeWithCapacity("gpu1", "nvidia.com/gpu", "1"),
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newModelReconcilerWithDRA(t, tc.objects...)
+			got := r.checkAcceleratorAvailability(ctx, tc.model)
+			if got != tc.want {
+				t.Errorf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func ptrTo(s string) *string {
+	return &s
 }

--- a/internal/controller/model_accelerator_test.go
+++ b/internal/controller/model_accelerator_test.go
@@ -99,6 +99,12 @@ func modelWithDRA(claims []corev1.PodResourceClaim) *inferencev1alpha1.Model {
 	return m
 }
 
+func modelWithDRAInNamespace(ns string, claims []corev1.PodResourceClaim) *inferencev1alpha1.Model {
+	m := modelWithDRA(claims)
+	m.Namespace = ns
+	return m
+}
+
 func TestCheckAcceleratorAvailability(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {
@@ -215,6 +221,16 @@ func TestCheckAcceleratorAvailability_DRA(t *testing.T) {
 			objects: []client.Object{
 				&resourcev1.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "default"}},
 				nodeWithCapacity("gpu1", "nvidia.com/gpu", "1"),
+			},
+			want: true,
+		},
+		{
+			name: "DRA ResourceClaim resolved in the model's own namespace, not default",
+			model: modelWithDRAInNamespace("prod", []corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimName: ptrTo("gpu-claim")},
+			}),
+			objects: []client.Object{
+				&resourcev1.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "prod"}},
 			},
 			want: true,
 		},

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -766,6 +767,14 @@ func (r *ModelReconciler) checkAcceleratorAvailability(ctx context.Context, mode
 		return true
 	}
 
+	// DRA path: if the model uses resourceClaims, check that the referenced
+	// ResourceClaim or ResourceClaimTemplate exists. Return false on NotFound
+	// so AcceleratorReady reflects reality; fail-open (true) for transient or
+	// RBAC errors.
+	if model.Spec.Hardware.GPU != nil && len(model.Spec.Hardware.GPU.ResourceClaims) > 0 {
+		return r.hasDRAAvailability(ctx, model.Spec.Hardware.GPU.ResourceClaims)
+	}
+
 	// Honor the GPU resourceName override so the readiness check validates
 	// the same extended resource the pod will actually request.
 	if model.Spec.Hardware.GPU != nil {
@@ -806,6 +815,45 @@ func (r *ModelReconciler) nodeHasResource(ctx context.Context, res corev1.Resour
 		}
 	}
 	return false
+}
+
+// hasDRAAvailability checks whether the DRA ResourceClaim or ResourceClaimTemplate
+// referenced by each claim in the model's GPU spec exists. Returns false if any
+// claim is NotFound; returns true if all claims are found or on transient/RBAC
+// errors (fail-open).
+func (r *ModelReconciler) hasDRAAvailability(ctx context.Context, claims []corev1.PodResourceClaim) bool {
+	for _, claim := range claims {
+		if claim.ResourceClaimName != nil {
+			var rc resourcev1.ResourceClaim
+			if err := r.Get(ctx, types.NamespacedName{Name: *claim.ResourceClaimName, Namespace: "default"}, &rc); err != nil {
+				if errors.IsNotFound(err) {
+					log.FromContext(ctx).Info("DRA ResourceClaim not found; accelerator not ready",
+						"resourceClaim", *claim.ResourceClaimName)
+					return false
+				}
+				// Transient or RBAC error: fail-open.
+				log.FromContext(ctx).Error(err,
+					"hasDRAAvailability: getting ResourceClaim failed; assuming available",
+					"resourceClaim", *claim.ResourceClaimName)
+				return true
+			}
+		} else if claim.ResourceClaimTemplateName != nil {
+			var rct resourcev1.ResourceClaimTemplate
+			if err := r.Get(ctx, types.NamespacedName{Name: *claim.ResourceClaimTemplateName, Namespace: "default"}, &rct); err != nil {
+				if errors.IsNotFound(err) {
+					log.FromContext(ctx).Info("DRA ResourceClaimTemplate not found; accelerator not ready",
+						"resourceClaimTemplate", *claim.ResourceClaimTemplateName)
+					return false
+				}
+				// Transient or RBAC error: fail-open.
+				log.FromContext(ctx).Error(err,
+					"hasDRAAvailability: getting ResourceClaimTemplate failed; assuming available",
+					"resourceClaimTemplate", *claim.ResourceClaimTemplateName)
+				return true
+			}
+		}
+	}
+	return true
 }
 
 func formatBytes(bytes int64) string {

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -772,7 +772,7 @@ func (r *ModelReconciler) checkAcceleratorAvailability(ctx context.Context, mode
 	// so AcceleratorReady reflects reality; fail-open (true) for transient or
 	// RBAC errors.
 	if model.Spec.Hardware.GPU != nil && len(model.Spec.Hardware.GPU.ResourceClaims) > 0 {
-		return r.hasDRAAvailability(ctx, model.Spec.Hardware.GPU.ResourceClaims)
+		return r.hasDRAAvailability(ctx, model.Namespace, model.Spec.Hardware.GPU.ResourceClaims)
 	}
 
 	// Honor the GPU resourceName override so the readiness check validates
@@ -821,11 +821,11 @@ func (r *ModelReconciler) nodeHasResource(ctx context.Context, res corev1.Resour
 // referenced by each claim in the model's GPU spec exists. Returns false if any
 // claim is NotFound; returns true if all claims are found or on transient/RBAC
 // errors (fail-open).
-func (r *ModelReconciler) hasDRAAvailability(ctx context.Context, claims []corev1.PodResourceClaim) bool {
+func (r *ModelReconciler) hasDRAAvailability(ctx context.Context, namespace string, claims []corev1.PodResourceClaim) bool {
 	for _, claim := range claims {
 		if claim.ResourceClaimName != nil {
 			var rc resourcev1.ResourceClaim
-			if err := r.Get(ctx, types.NamespacedName{Name: *claim.ResourceClaimName, Namespace: "default"}, &rc); err != nil {
+			if err := r.Get(ctx, types.NamespacedName{Name: *claim.ResourceClaimName, Namespace: namespace}, &rc); err != nil {
 				if errors.IsNotFound(err) {
 					log.FromContext(ctx).Info("DRA ResourceClaim not found; accelerator not ready",
 						"resourceClaim", *claim.ResourceClaimName)
@@ -839,7 +839,7 @@ func (r *ModelReconciler) hasDRAAvailability(ctx context.Context, claims []corev
 			}
 		} else if claim.ResourceClaimTemplateName != nil {
 			var rct resourcev1.ResourceClaimTemplate
-			if err := r.Get(ctx, types.NamespacedName{Name: *claim.ResourceClaimTemplateName, Namespace: "default"}, &rct); err != nil {
+			if err := r.Get(ctx, types.NamespacedName{Name: *claim.ResourceClaimTemplateName, Namespace: namespace}, &rct); err != nil {
 				if errors.IsNotFound(err) {
 					log.FromContext(ctx).Info("DRA ResourceClaimTemplate not found; accelerator not ready",
 						"resourceClaimTemplate", *claim.ResourceClaimTemplateName)


### PR DESCRIPTION
## What

Make `checkAcceleratorAvailability` DRA-aware: a Model that requests a GPU via
`hardware.gpu.resourceClaims` (no `resourceName`) now resolves
`AcceleratorReady` from the referenced ResourceClaim/ResourceClaimTemplate
instead of falling through to a vendor-default extended-resource check. Also
removes the misleading "DRA-backed resources" mention from the `resourceName`
field doc (now that the two are mutually exclusive). Fixes #754.

## How

- `internal/controller/model_controller.go`: DRA branch in
  `checkAcceleratorAvailability` -> `hasDRAAvailability`, which returns
  **false** when the referenced ResourceClaim/ResourceClaimTemplate is
  NotFound (accurate readiness) and fails open (true) only on transient/RBAC
  errors. Claims are resolved in the **model's own namespace**.
- `api/v1alpha1/model_types.go`: `resourceName` doc cleanup.
- regenerated CRDs + controller tests (including a non-default-namespace case).

## Provenance / review

Foreman coder (Strix Qwopus-27B) over two cycles plus human review, gate-verified
by the in-cluster verify gate (full `make test`, GATE-PASS):
- cycle 1 produced a hollow check (`hasDRAAvailability` did lookups but always
  returned true) and stale CRDs;
- the cluster gate caught the codegen drift, review caught the hollow check;
- cycle 2 fixed the logic + CRDs but hardcoded `Namespace: "default"`;
- review caught the namespace regression; fixed by hand with a
  non-default-namespace test that fails against the hardcoded version.

## Checklist

- [x] Tests added/updated (including non-default namespace)
- [x] `make test` passes (verify gate Job: full `make test`, GATE-PASS)
- [x] `make lint` passes (`GOOS=linux golangci-lint run`, 0 issues)
- [x] CRDs regenerated (`make manifests` / `make chart-crds`)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
