### PR TITLE
fix(metal-agent): clear SchedulingStatus on memory-check-pass (#777)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1453,6 +1453,16 @@ func (a *MetalAgent) checkMemoryAdmission(
 		"headroom", formatMemory(budget.HeadroomBytes),
 		"source", resolved.Source,
 	)
+
+	// Clear any stale scheduling status from a previous failed check.
+	if isvc.Status.SchedulingStatus != "" || isvc.Status.SchedulingMessage != "" {
+		isvc.Status.SchedulingStatus = ""
+		isvc.Status.SchedulingMessage = ""
+		if updateErr := a.config.K8sClient.Status().Update(ctx, isvc); updateErr != nil {
+			a.logger.Warnw("failed to clear scheduling status", "error", updateErr)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/agent/memory_admission_test.go
+++ b/pkg/agent/memory_admission_test.go
@@ -250,3 +250,34 @@ func TestCheckMemoryAdmission_PassesWithinBudget(t *testing.T) {
 		t.Fatalf("model within budget should pass admission, got: %v", err)
 	}
 }
+
+// Regression test for #777: when a previous memory check failed and set
+// SchedulingStatus/Message, a subsequent passing check must clear those
+// fields so the status reflects the current healthy state.
+func TestCheckMemoryAdmission_ClearsStaleSchedulingStatus(t *testing.T) {
+	isvc := newAdmissionTestISVC()
+	isvc.Status.SchedulingStatus = "InsufficientMemory"
+	isvc.Status.SchedulingMessage = "estimated 100 GiB required, budget 6 GiB"
+
+	agent := newAdmissionTestAgent(t, isvc, MetalAgentConfig{
+		MemoryProvider: &mockMemoryProvider{totalBytes: 128 * 1024 * 1024 * 1024},
+		MemoryFraction: 0.75,
+	})
+	model := newAdmissionTestModel("https://model-host.invalid/model.gguf", "20.0 GiB")
+
+	if err := agent.checkMemoryAdmission(context.Background(), isvc, model, 2048, "", ""); err != nil {
+		t.Fatalf("model within budget should pass admission, got: %v", err)
+	}
+
+	updated := &inferencev1alpha1.InferenceService{}
+	if getErr := agent.config.K8sClient.Get(context.Background(),
+		types.NamespacedName{Namespace: "default", Name: "test-isvc"}, updated); getErr != nil {
+		t.Fatalf("failed to re-fetch InferenceService: %v", getErr)
+	}
+	if updated.Status.SchedulingStatus != "" {
+		t.Errorf("SchedulingStatus = %q, want empty (stale status should be cleared)", updated.Status.SchedulingStatus)
+	}
+	if updated.Status.SchedulingMessage != "" {
+		t.Errorf("SchedulingMessage = %q, want empty (stale message should be cleared)", updated.Status.SchedulingMessage)
+	}
+}


### PR DESCRIPTION
## What

Have the metal-agent clear `status.schedulingStatus` / `status.schedulingMessage`
when a memory admission check passes, so a service that recovers (memory freed,
then starts) no longer shows a stale `InsufficientMemory` / `MemoryCheckFailed`.
Fixes #777.

Foreman-authored (Strix Qwopus-27B), gate-verified by the in-cluster verify
gate (full `make test`, GATE-PASS).

## Why

The agent only *set* these fields on a failed check; nothing cleared them on
success. With #643 / PR #774 the controller correctly stopped clobbering them,
which (correctly) exposed that the agent owns them but never cleared them. Net
before this fix: the rejection persisted forever after recovery.

## How

- `pkg/agent/agent.go`: on the memory-check-pass path (after the "memory check
  passed" log, before `return nil`), clear both fields and push a status update
  — only when one is non-empty, to avoid a spurious write on every pass.
  Best-effort with a warn log, matching the existing status-write pattern.
  Leaves the controller-owned `WaitingFor` untouched.
- `pkg/agent/memory_admission_test.go`: assert a pre-set scheduling status is
  cleared after a passing check.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes (verify gate Job, GATE-PASS)
- [x] `make lint` passes
- [x] Commits signed off (DCO)
