### PR TITLE
feat(cli): download heartbeat for llmkube deploy --wait (#719)

### DIFF
--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -39,6 +39,11 @@ import (
 
 const defaultGPUVendor = "nvidia"
 
+// heartbeatInterval is the minimum time between heartbeat lines during
+// the Downloading phase. It keeps the CLI from looking hung on large
+// model downloads.
+const heartbeatInterval = 5 * time.Second
+
 type deployOptions struct {
 	name                string
 	namespace           string
@@ -464,6 +469,7 @@ func waitForReady(ctx context.Context, k8sClient client.Client, name, namespace 
 
 	startTime := time.Now()
 	lastPhase := ""
+	lastHeartbeat := time.Time{}
 
 	for {
 		select {
@@ -487,6 +493,15 @@ func waitForReady(ctx context.Context, k8sClient client.Client, name, namespace 
 				elapsed := time.Since(startTime).Round(time.Second)
 				fmt.Printf("[%s] %s\n", elapsed, currentPhase)
 				lastPhase = currentPhase
+				lastHeartbeat = time.Time{}
+			}
+
+			// Heartbeat: during Downloading phase, print a progress line at a
+			// fixed interval so the CLI never looks hung.
+			if shouldHeartbeat(model.Status.Phase, lastHeartbeat) {
+				elapsed := time.Since(startTime).Round(time.Second)
+				fmt.Printf("[%s] ⏳ Downloading model...\n", elapsed)
+				lastHeartbeat = time.Now()
 			}
 
 			if model.Status.Phase == "Ready" && isvc.Status.Phase == "Ready" {
@@ -653,6 +668,19 @@ func applyCatalogDefaults(opts *deployOptions, catalogModel *Model) {
 	if opts.contextSize == 0 && catalogModel.ContextSize > 0 {
 		opts.contextSize = int32(catalogModel.ContextSize) //nolint:gosec // G115: catalog ContextSize positive
 	}
+}
+
+// shouldHeartbeat returns true when a heartbeat line should be printed.
+// It emits a heartbeat only during the "Downloading" phase and only after
+// heartbeatInterval has elapsed since the last heartbeat.
+func shouldHeartbeat(phase string, lastHeartbeat time.Time) bool {
+	if phase != "Downloading" {
+		return false
+	}
+	if lastHeartbeat.IsZero() {
+		return true
+	}
+	return time.Since(lastHeartbeat) >= heartbeatInterval
 }
 
 func isLocalSourcePath(source string) bool {

--- a/pkg/cli/deploy_test.go
+++ b/pkg/cli/deploy_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -700,4 +701,83 @@ func searchString(s, substr string) bool {
 
 func ptrInt32(v int32) *int32 {
 	return &v
+}
+
+func TestShouldHeartbeat(t *testing.T) {
+	tests := []struct {
+		name          string
+		phase         string
+		lastHeartbeat time.Time
+		want          bool
+	}{
+		{
+			name:          "Downloading with no prior heartbeat",
+			phase:         "Downloading",
+			lastHeartbeat: time.Time{},
+			want:          true,
+		},
+		{
+			name:          "Downloading with recent heartbeat",
+			phase:         "Downloading",
+			lastHeartbeat: time.Now().Add(-2 * time.Second),
+			want:          false,
+		},
+		{
+			name:          "Downloading with old heartbeat",
+			phase:         "Downloading",
+			lastHeartbeat: time.Now().Add(-10 * time.Second),
+			want:          true,
+		},
+		{
+			name:          "Downloading with heartbeat exactly at interval",
+			phase:         "Downloading",
+			lastHeartbeat: time.Now().Add(-5 * time.Second),
+			want:          true,
+		},
+		{
+			name:          "Downloading with heartbeat just before interval",
+			phase:         "Downloading",
+			lastHeartbeat: time.Now().Add(-4 * time.Second),
+			want:          false,
+		},
+		{
+			name:          "Ready phase should not heartbeat",
+			phase:         "Ready",
+			lastHeartbeat: time.Time{},
+			want:          false,
+		},
+		{
+			name:          "Pending phase should not heartbeat",
+			phase:         "Pending",
+			lastHeartbeat: time.Time{},
+			want:          false,
+		},
+		{
+			name:          "Failed phase should not heartbeat",
+			phase:         "Failed",
+			lastHeartbeat: time.Time{},
+			want:          false,
+		},
+		{
+			name:          "Copying phase should not heartbeat",
+			phase:         "Copying",
+			lastHeartbeat: time.Time{},
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldHeartbeat(tt.phase, tt.lastHeartbeat)
+			if got != tt.want {
+				t.Errorf("shouldHeartbeat(%q, %v) = %v, want %v", tt.phase, tt.lastHeartbeat, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeartbeatInterval(t *testing.T) {
+	if heartbeatInterval != 5*time.Second {
+		t.Errorf("heartbeatInterval = %v, want 5s", heartbeatInterval)
+	}
 }


### PR DESCRIPTION
## What

Emit a periodic download heartbeat during `llmkube deploy --wait` so the CLI
no longer appears hung while a large GGUF downloads: while the Model is in the
`Downloading` phase it prints an elapsed-time line every 5s
(`[1m5s] ⏳ Downloading model...`) instead of going silent between phase
transitions. Fixes #719.

Foreman-authored (Strix Qwopus-27B), gate-verified (verify gate, GATE-PASS).

## How

- `pkg/cli/deploy.go`: in the `--wait` poll loop, a `shouldHeartbeat(phase,
  lastHeartbeat)` gate prints a heartbeat only during `Downloading` and only
  after `heartbeatInterval` (5s) has elapsed since the last one.
- `pkg/cli/deploy_test.go`: table tests for `shouldHeartbeat` across the phase
  and interval boundaries.

## Reviewer note

This is a "moving indicator" (one of the options the issue lists), not a
byte/percent bar. True byte-percent would require the controller/agent to
surface downloaded-bytes in Model status, which it doesn't today; that could
be a follow-up. The heartbeat resolves the core complaint ("tell the CLI is
working rather than hung").

## Checklist

- [x] Tests added/updated
- [x] `make test` passes (verify gate Job, GATE-PASS)
- [x] `make lint` passes
- [x] Commits signed off (DCO)
