### PR TITLE
fix(metal-agent): register llamacpp runtime alias for llama.cpp executor

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -41,12 +41,19 @@ import (
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
 
-// Inference runtime identifiers used by MetalAgentConfig.Runtime.
+// Inference runtime identifiers used by MetalAgentConfig.Runtime and
+// InferenceService.Spec.Runtime. runtimeLlamaCPP ("llamacpp") is the
+// canonical llama.cpp value the CRD and the in-cluster controller emit;
+// runtimeLlamaServer ("llama-server") is the metal-agent's historical
+// key and the global --runtime default. Both map to the same llama.cpp
+// executor (#784) so CRs authored with either value resolve correctly.
 const (
-	runtimeOMLX      = "omlx"
-	runtimeOllama    = "ollama"
-	runtimeVLLMSwift = "vllm-swift"
-	runtimeMLXServer = "mlx-server"
+	runtimeLlamaServer = "llama-server"
+	runtimeLlamaCPP    = "llamacpp"
+	runtimeOMLX        = "omlx"
+	runtimeOllama      = "ollama"
+	runtimeVLLMSwift   = "vllm-swift"
+	runtimeMLXServer   = "mlx-server"
 )
 
 // Model format identifiers (Model.Spec.Format) the agent recognizes for
@@ -311,59 +318,26 @@ func NewMetalAgent(config MetalAgentConfig) *MetalAgent {
 }
 
 // Start begins watching for InferenceService resources and managing processes
-func (a *MetalAgent) Start(ctx context.Context) error {
-	// Log effective memory budget and set gauge
-	if total, err := a.memoryProvider.TotalMemory(); err == nil {
-		budget := uint64(float64(total) * a.memoryFraction)
-		checkMode := MemoryCheckModeEnforce
-		if a.memoryCheckWarnOnly {
-			checkMode = MemoryCheckModeWarn
-		}
-		a.logger.Infow("memory budget",
-			"total", formatMemory(total),
-			"fraction", a.memoryFraction,
-			"budget", formatMemory(budget),
-			"checkMode", checkMode,
-		)
-		memoryBudgetBytes.Set(float64(budget))
-	} else {
-		a.logger.Warnw("unable to query total memory", "error", err)
+// buildExecutors populates a.executors with one ProcessExecutor per runtime
+// whose binary path is configured, so each InferenceService can pick its own
+// backend via spec.runtime (#525). The llama.cpp executor is always created
+// because it is the default fallback, and it is registered under BOTH
+// runtimeLlamaServer ("llama-server", the historical key and --runtime
+// default) and runtimeLlamaCPP ("llamacpp", the CRD/controller canonical
+// value) so CRs authored with either runtime name resolve to it (#784).
+func (a *MetalAgent) buildExecutors() {
+	metalExec := NewMetalExecutor(
+		a.config.LlamaServerBin,
+		a.config.ModelStorePath,
+		a.logger.With("subsystem", "executor"),
+	)
+	if a.config.LlamaServerStartupTimeout > 0 {
+		metalExec.SetStartupTimeout(a.config.LlamaServerStartupTimeout)
 	}
+	metalExec.SetPort(a.config.LlamaServerPort)
+	a.executors[runtimeLlamaServer] = metalExec
+	a.executors[runtimeLlamaCPP] = metalExec
 
-	// fatalErrChan carries terminal failures from background subsystems
-	// (watcher, health server) up to the main select loop, so the agent can
-	// return cleanly and let the supervisor restart the process.
-	fatalErrChan := make(chan error, 2)
-
-	// Initialize components
-	a.watcher = NewInferenceServiceWatcher(a.config.K8sClient, a.config.Namespace, a.logger.With("subsystem", "watcher"))
-	if a.config.MaxWatchFailures > 0 {
-		a.watcher.SetMaxConsecutiveFailures(a.config.MaxWatchFailures)
-	}
-	if len(a.config.InferenceServiceAllowlist) > 0 {
-		a.watcher.SetNameAllowlist(a.config.InferenceServiceAllowlist)
-		a.logger.Infow(
-			"InferenceService name allowlist active (#524 multi-Mac partition)",
-			"allowed", a.config.InferenceServiceAllowlist,
-		)
-	}
-
-	// Build executors for every runtime whose binary path is configured.
-	// This lets the agent host multiple runtimes concurrently; each
-	// InferenceService picks its own backend via spec.runtime (#525).
-	// llama-server is always created because it is the default fallback.
-	{
-		metalExec := NewMetalExecutor(
-			a.config.LlamaServerBin,
-			a.config.ModelStorePath,
-			a.logger.With("subsystem", "executor"),
-		)
-		if a.config.LlamaServerStartupTimeout > 0 {
-			metalExec.SetStartupTimeout(a.config.LlamaServerStartupTimeout)
-		}
-		metalExec.SetPort(a.config.LlamaServerPort)
-		a.executors["llama-server"] = metalExec
-	}
 	if a.config.OMLXBin != "" {
 		port := a.config.OMLXPort
 		if port == 0 {
@@ -417,6 +391,46 @@ func (a *MetalAgent) Start(ctx context.Context) error {
 		}
 		a.executors[runtimeMLXServer] = mlxServerExec
 	}
+}
+
+func (a *MetalAgent) Start(ctx context.Context) error {
+	// Log effective memory budget and set gauge
+	if total, err := a.memoryProvider.TotalMemory(); err == nil {
+		budget := uint64(float64(total) * a.memoryFraction)
+		checkMode := MemoryCheckModeEnforce
+		if a.memoryCheckWarnOnly {
+			checkMode = MemoryCheckModeWarn
+		}
+		a.logger.Infow("memory budget",
+			"total", formatMemory(total),
+			"fraction", a.memoryFraction,
+			"budget", formatMemory(budget),
+			"checkMode", checkMode,
+		)
+		memoryBudgetBytes.Set(float64(budget))
+	} else {
+		a.logger.Warnw("unable to query total memory", "error", err)
+	}
+
+	// fatalErrChan carries terminal failures from background subsystems
+	// (watcher, health server) up to the main select loop, so the agent can
+	// return cleanly and let the supervisor restart the process.
+	fatalErrChan := make(chan error, 2)
+
+	// Initialize components
+	a.watcher = NewInferenceServiceWatcher(a.config.K8sClient, a.config.Namespace, a.logger.With("subsystem", "watcher"))
+	if a.config.MaxWatchFailures > 0 {
+		a.watcher.SetMaxConsecutiveFailures(a.config.MaxWatchFailures)
+	}
+	if len(a.config.InferenceServiceAllowlist) > 0 {
+		a.watcher.SetNameAllowlist(a.config.InferenceServiceAllowlist)
+		a.logger.Infow(
+			"InferenceService name allowlist active (#524 multi-Mac partition)",
+			"allowed", a.config.InferenceServiceAllowlist,
+		)
+	}
+
+	a.buildExecutors()
 
 	a.registry = NewServiceRegistry(
 		a.config.K8sClient,
@@ -642,7 +656,7 @@ func (a *MetalAgent) resolveRuntime(isvc *inferencev1alpha1.InferenceService) st
 	if a.config.Runtime != "" {
 		return a.config.Runtime
 	}
-	return "llama-server"
+	return runtimeLlamaServer
 }
 
 // validateRuntimeFormat returns an error if the model's format is incompatible
@@ -675,7 +689,7 @@ func (a *MetalAgent) validateRuntimeFormat(model *inferencev1alpha1.Model, runti
 		runtimeLabel = runtimeMLXServer
 	default:
 		bad = modelFormat == formatMLX
-		runtimeLabel = "llama-server"
+		runtimeLabel = runtimeLlamaServer
 	}
 	if !bad {
 		return nil
@@ -953,7 +967,7 @@ func (a *MetalAgent) deleteProcess(ctx context.Context, key string) error {
 	if exec == nil {
 		// Fallback to the default executor if the runtime is unknown
 		// (e.g. a process spawned before the multi-runtime refactor).
-		exec = a.executors["llama-server"]
+		exec = a.executors[runtimeLlamaServer]
 	}
 
 	// For shared-daemon runtimes (oMLX, Ollama), unload the specific model
@@ -1382,7 +1396,7 @@ func (a *MetalAgent) Shutdown(ctx context.Context) error {
 		exec := a.executors[process.Runtime]
 		if exec == nil {
 			// Fallback to the default executor if the runtime is unknown.
-			exec = a.executors["llama-server"]
+			exec = a.executors[runtimeLlamaServer]
 		}
 
 		// For shared-daemon runtimes (oMLX, Ollama), unload each model instead of

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -87,6 +87,78 @@ func TestNewMetalAgent(t *testing.T) {
 	}
 }
 
+// TestBuildExecutors_RegistersLlamaCppAlias verifies the llama.cpp executor is
+// reachable under BOTH the canonical CRD runtime value "llamacpp" and the
+// historical "llama-server" key, and that they are the same executor (#784).
+// Before the fix only "llama-server" was registered, so a CR with
+// spec.runtime: llamacpp failed with "no executor registered".
+func TestBuildExecutors_RegistersLlamaCppAlias(t *testing.T) {
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	agent := NewMetalAgent(MetalAgentConfig{
+		K8sClient:      k8sClient,
+		Namespace:      "test-ns",
+		ModelStorePath: "/tmp/test-models",
+		LlamaServerBin: "/usr/local/bin/llama-server",
+	})
+
+	agent.buildExecutors()
+
+	llamaServer, ok := agent.executors[runtimeLlamaServer]
+	if !ok || llamaServer == nil {
+		t.Fatalf("executors[%q] not registered", runtimeLlamaServer)
+	}
+	llamacpp, ok := agent.executors[runtimeLlamaCPP]
+	if !ok || llamacpp == nil {
+		t.Fatalf("executors[%q] not registered (regression #784)", runtimeLlamaCPP)
+	}
+	if llamacpp != llamaServer {
+		t.Errorf("executors[%q] and executors[%q] must be the same llama.cpp executor",
+			runtimeLlamaCPP, runtimeLlamaServer)
+	}
+}
+
+// TestMetalAgentServesCRDLlamaCppRuntime is a producer->consumer contract test
+// for the #784 regression. The InferenceService CRD declares
+//
+//	+kubebuilder:validation:Enum=llamacpp;personaplex;vllm;tgi;generic
+//	+kubebuilder:default=llamacpp
+//
+// (api/v1alpha1/inferenceservice_types.go) and the in-cluster controller emits
+// "llamacpp" as the canonical llama.cpp runtime (resolveBackend's default). A
+// default metal-agent — only a llama-server binary configured, as on a real Mac
+// — must therefore resolve AND register an executor for the literal CRD value
+// "llamacpp", or every default-runtime CR fails to serve with "no executor
+// registered for runtime". The literal is intentional and must NOT be replaced
+// with the runtimeLlamaCPP constant: pinning to the CRD's external contract
+// value is what catches the agent's own constant drifting away from the CRD
+// (the exact failure mode of #784, where the agent keyed on "llama-server"
+// while every CR used "llamacpp").
+func TestMetalAgentServesCRDLlamaCppRuntime(t *testing.T) {
+	const crdDefaultRuntime = "llamacpp" // mirror of the CRD Runtime +kubebuilder:default
+
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	agent := NewMetalAgent(MetalAgentConfig{
+		K8sClient:      k8sClient,
+		ModelStorePath: "/tmp/test-models",
+		LlamaServerBin: "/usr/local/bin/llama-server",
+	})
+	agent.buildExecutors()
+
+	isvc := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{Runtime: crdDefaultRuntime},
+	}
+	resolved := agent.resolveRuntime(isvc)
+	if resolved != crdDefaultRuntime {
+		t.Fatalf("resolveRuntime(%q) = %q, want the value unchanged", crdDefaultRuntime, resolved)
+	}
+	if _, ok := agent.executors[resolved]; !ok {
+		t.Fatalf("CRD default runtime %q does not resolve to a registered metal-agent "+
+			"executor (regression #784)", crdDefaultRuntime)
+	}
+}
+
 func TestHealthCheck_Empty(t *testing.T) {
 	scheme := newTestScheme()
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()


### PR DESCRIPTION
## What

Register the metal-agent's llama.cpp executor under the canonical `llamacpp` runtime key in addition to the historical `llama-server` key, so InferenceServices authored with `spec.runtime: llamacpp` serve again.

## Why

Fixes #784

The per-CR runtime change (#525, shipped in v0.8.12) made `resolveRuntime` honor `spec.runtime` verbatim, but the llama.cpp executor is only registered under `llama-server`. `llamacpp` is the canonical value the CRD and the in-cluster controller (`runtime_llamacpp`) use, and every InferenceService in the fleet is authored with it. So on 0.8.12 every metal-served `llamacpp` CR fails with:

```
no executor registered for runtime "llamacpp"
```

Pre-#525 (<= 0.8.6) the metal-agent ignored `spec.runtime`, so this is a backward-incompatible regression. Confirmed live: a metal-served reviewer model went dead (`/health` -> HTTP 000) immediately after the agent was upgraded to 0.8.12. CRs that omit `spec.runtime` were unaffected (they fall back to the `--runtime` default).

## How

- Extracted the executor-wiring block out of `Start()` into a testable `buildExecutors()` method.
- Register the llama.cpp executor under both `runtimeLlamaCPP` (`"llamacpp"`) and `runtimeLlamaServer` (`"llama-server"`) — same executor instance, so either runtime name resolves correctly.
- Added named constants for the two keys and routed the remaining magic-string lookups (fallbacks, `resolveRuntime` default, `validateRuntimeFormat` label) through them.
- `validateRuntimeFormat`'s `default` case already treats `llamacpp` as a GGUF-compatible llama.cpp runtime, so no change was needed there.

Two unit tests reproduce the regression (both fail without the alias line, verified): one asserts `buildExecutors()` registers `llamacpp` as the same executor as `llama-server`; the other walks the real failure path (`resolveRuntime` on a `llamacpp` CR -> executor lookup must succeed).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (pkg/agent suite green)
- [x] `make lint` passes locally (incl. `GOOS=linux` cross-arch lint)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (no user-facing doc change; runtime values unchanged)
