### PR TITLE
feat: add defaultRouteStrategy with BackendNameMatch to ModelRouter

### DIFF
--- a/api/v1alpha1/modelrouter_types.go
+++ b/api/v1alpha1/modelrouter_types.go
@@ -34,6 +34,20 @@ const (
 	ModelRouterDataPlaneGateway ModelRouterDataPlane = "Gateway"
 )
 
+// DefaultRouteStrategy selects what the router does when no rule matches a
+// request, before falling back to DefaultRoute.
+type DefaultRouteStrategy string
+
+const (
+	// DefaultRouteStrategyStatic always routes unmatched requests to the named
+	// DefaultRoute. This is the default.
+	DefaultRouteStrategyStatic DefaultRouteStrategy = "Static"
+
+	// DefaultRouteStrategyBackendNameMatch matches an unmatched request to a
+	// backend whose Name equals the request "model" field before DefaultRoute.
+	DefaultRouteStrategyBackendNameMatch DefaultRouteStrategy = "BackendNameMatch"
+)
+
 // ModelRouterSpec defines the desired state of a ModelRouter.
 //
 // A ModelRouter exposes a single OpenAI-compatible HTTP endpoint that
@@ -77,8 +91,9 @@ type ModelRouterSpec struct {
 	Backends []RouterBackend `json:"backends"`
 
 	// Rules are evaluated in declaration order. The first matching rule wins.
-	// If no rule matches, DefaultRoute is used. If neither a matching rule
-	// nor DefaultRoute is set, the request is rejected with HTTP 503.
+	// If no rule matches, the fallback is governed by DefaultRouteStrategy,
+	// ending at DefaultRoute. If nothing resolves, the request is rejected
+	// with HTTP 503.
 	// +optional
 	Rules []RouterRule `json:"rules,omitempty"`
 
@@ -86,6 +101,18 @@ type ModelRouterSpec struct {
 	// Must reference the Name of an entry in Backends.
 	// +optional
 	DefaultRoute string `json:"defaultRoute,omitempty"`
+
+	// DefaultRouteStrategy decides what happens when no rule matches.
+	// "Static" (default) routes to DefaultRoute. "BackendNameMatch" first
+	// tries to match the request's model to a backend Name, falling back to
+	// DefaultRoute only if none matches. BackendNameMatch makes every backend,
+	// including cloud-tier ones, directly addressable by name; sensitive-data
+	// protection still relies on a matching failClosed rule, which is evaluated
+	// first and therefore continues to gate before any name match.
+	// +kubebuilder:validation:Enum=Static;BackendNameMatch
+	// +kubebuilder:default=Static
+	// +optional
+	DefaultRouteStrategy DefaultRouteStrategy `json:"defaultRouteStrategy,omitempty"`
 
 	// Policy holds cross-cutting controls (budgets, classification, audit).
 	// +optional

--- a/charts/llmkube/templates/crds/modelrouters.yaml
+++ b/charts/llmkube/templates/crds/modelrouters.yaml
@@ -251,6 +251,20 @@ spec:
                   DefaultRoute names a backend used when no rule matches.
                   Must reference the Name of an entry in Backends.
                 type: string
+              defaultRouteStrategy:
+                default: Static
+                description: |-
+                  DefaultRouteStrategy decides what happens when no rule matches.
+                  "Static" (default) routes to DefaultRoute. "BackendNameMatch" first
+                  tries to match the request's model to a backend Name, falling back to
+                  DefaultRoute only if none matches. BackendNameMatch makes every backend,
+                  including cloud-tier ones, directly addressable by name; sensitive-data
+                  protection still relies on a matching failClosed rule, which is evaluated
+                  first and therefore continues to gate before any name match.
+                enum:
+                - Static
+                - BackendNameMatch
+                type: string
               endpoint:
                 description: |-
                   Endpoint defines the Kubernetes Service the router-proxy is exposed
@@ -714,8 +728,9 @@ spec:
               rules:
                 description: |-
                   Rules are evaluated in declaration order. The first matching rule wins.
-                  If no rule matches, DefaultRoute is used. If neither a matching rule
-                  nor DefaultRoute is set, the request is rejected with HTTP 503.
+                  If no rule matches, the fallback is governed by DefaultRouteStrategy,
+                  ending at DefaultRoute. If nothing resolves, the request is rejected
+                  with HTTP 503.
                 items:
                   description: RouterRule pairs a match expression with a routing
                     action.

--- a/config/crd/bases/inference.llmkube.dev_modelrouters.yaml
+++ b/config/crd/bases/inference.llmkube.dev_modelrouters.yaml
@@ -247,6 +247,20 @@ spec:
                   DefaultRoute names a backend used when no rule matches.
                   Must reference the Name of an entry in Backends.
                 type: string
+              defaultRouteStrategy:
+                default: Static
+                description: |-
+                  DefaultRouteStrategy decides what happens when no rule matches.
+                  "Static" (default) routes to DefaultRoute. "BackendNameMatch" first
+                  tries to match the request's model to a backend Name, falling back to
+                  DefaultRoute only if none matches. BackendNameMatch makes every backend,
+                  including cloud-tier ones, directly addressable by name; sensitive-data
+                  protection still relies on a matching failClosed rule, which is evaluated
+                  first and therefore continues to gate before any name match.
+                enum:
+                - Static
+                - BackendNameMatch
+                type: string
               endpoint:
                 description: |-
                   Endpoint defines the Kubernetes Service the router-proxy is exposed
@@ -710,8 +724,9 @@ spec:
               rules:
                 description: |-
                   Rules are evaluated in declaration order. The first matching rule wins.
-                  If no rule matches, DefaultRoute is used. If neither a matching rule
-                  nor DefaultRoute is set, the request is rejected with HTTP 503.
+                  If no rule matches, the fallback is governed by DefaultRouteStrategy,
+                  ending at DefaultRoute. If nothing resolves, the request is rejected
+                  with HTTP 503.
                 items:
                   description: RouterRule pairs a match expression with a routing
                     action.

--- a/docs/site/concepts/model-router.md
+++ b/docs/site/concepts/model-router.md
@@ -133,6 +133,19 @@ Point any OpenAI-compatible client at that URL and it just works. Headers that c
 | `x-llmkube-task-complexity: complex` | Matches `complex-to-cloud` rule; tries Opus first, falls back to Qwen on 5xx. |
 | (no headers) | Falls through to `defaultRoute: local-qwen`. |
 
+## Default-route strategy
+
+`defaultRouteStrategy` controls what happens to a request that matches no rule, before the `defaultRoute` fallback applies:
+
+- **`Static`** (default) routes every unmatched request to `defaultRoute`.
+- **`BackendNameMatch`** first checks whether the request's `model` field exactly equals a backend `name`; if so, it routes straight to that backend. Only when no backend name matches does it fall back to `defaultRoute`. This lets clients address a backend directly (`{"model": "cloud-opus"}`) without writing a pass-through rule for each one.
+
+The lookup is against backend `name` — the identifier you publish to clients — never the upstream provider `model`, so the proxied API surface stays on its own side of the boundary. Explicit rules always win: name matching only fires when no rule accepted the request, and it never bypasses a `failClosed` rule.
+
+`BackendNameMatch` widens the trust boundary deliberately: every backend, including cloud-tier ones, becomes directly addressable by any client that names it. That is the point — it lets a single flag replace a per-backend passthrough rule for each model you want clients to reach by name. It does not weaken the fail-closed gate, because `failClosed` rules are ordinary rules and are evaluated first: a sensitive request that matches such a rule never reaches the name-match step. The same caveat as `defaultRoute` applies, though — a sensitive request that matches *no* rule will fall through to name matching (and then `defaultRoute`) exactly as it would fall through to `defaultRoute` under `Static`. Per-rule fail-closed protection is not a global PII-egress invariant; if you route sensitive classifications, gate them with an explicit `failClosed` rule.
+
+A request whose model names a backend that is currently unhealthy fails fast (HTTP 502/503) rather than silently rerouting to `defaultRoute` — naming a backend is a request for *that* backend, and answering from a different model the client did not ask for would be worse than an honest error. This matches how an explicit single-backend rule behaves on backend outage.
+
 ## Composition with LiteLLM
 
 LLMKube does not replace [LiteLLM](https://github.com/BerriAI/litellm). For organizations already running a LiteLLM proxy as their cloud-provider abstraction, point a `ModelRouter` external backend at it:

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -527,7 +527,7 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 	headerOnly := classificationMode(mr) == classificationModeHeaderOnly
 	classHeaderKey := classificationHeaderKey(mr)
 
-	rules := make([]routerRuleResource, 0, len(mr.Spec.Rules)+1)
+	rules := make([]routerRuleResource, 0, len(mr.Spec.Rules)+len(mr.Spec.Backends)+1)
 	for _, rule := range mr.Spec.Rules {
 		refs, err := compileBackendRefs(rule.Name, rule.Route, weights)
 		if err != nil {
@@ -543,6 +543,19 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 			}
 		}
 		rules = append(rules, resolved)
+	}
+
+	// BackendNameMatch compiles to one model-match rule per backend (model ==
+	// backend Name) inserted ahead of the defaultRoute catch-all. First-match
+	// ordering mirrors the proxy: explicit rules win, then a request whose
+	// model names a backend routes straight to it, then defaultRoute.
+	if mr.Spec.DefaultRouteStrategy == inferencev1alpha1.DefaultRouteStrategyBackendNameMatch {
+		for _, b := range mr.Spec.Backends {
+			rules = append(rules, routerRuleResource{
+				Models:      []string{b.Name},
+				BackendRefs: []routerBackendRef{{Name: b.Name}},
+			})
+		}
 	}
 
 	// defaultRoute compiles to a trailing catch-all rule (no model/header match)

--- a/internal/controller/modelrouter_gateway_test.go
+++ b/internal/controller/modelrouter_gateway_test.go
@@ -1746,6 +1746,98 @@ func TestCompileBudgetRule_WindowScaling(t *testing.T) {
 	}
 }
 
+// TestCompileRouterRules_BackendNameMatch confirms that the BackendNameMatch
+// default-route strategy compiles to one model==name rule per backend, inserted
+// after the explicit rules and before the defaultRoute catch-all so first-match
+// ordering mirrors the proxy.
+func TestCompileRouterRules_BackendNameMatch(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "local-a"},
+				{Name: "local-b"},
+			},
+			Rules: []inferencev1alpha1.RouterRule{{
+				Name:  "explicit",
+				Match: &inferencev1alpha1.RuleMatch{Models: []string{"foo-*"}},
+				Route: inferencev1alpha1.RuleRoute{Backends: []string{"local-a"}},
+			}},
+			DefaultRoute:         "local-a",
+			DefaultRouteStrategy: inferencev1alpha1.DefaultRouteStrategyBackendNameMatch,
+		},
+	}
+
+	rules, err := compileRouterRules(mr)
+	if err != nil {
+		t.Fatalf("compileRouterRules: %v", err)
+	}
+	// explicit rule, one name rule per backend, then the defaultRoute catch-all.
+	if len(rules) != 4 {
+		t.Fatalf("expected 4 rules, got %d: %+v", len(rules), rules)
+	}
+	if got := rules[0].Models; len(got) != 1 || got[0] != "foo-*" {
+		t.Errorf("rules[0] should be the explicit rule, got models %v", got)
+	}
+	for i, wantBackend := range []string{"local-a", "local-b"} {
+		r := rules[i+1]
+		if len(r.Models) != 1 || r.Models[0] != wantBackend {
+			t.Errorf("rules[%d] models = %v, want [%s]", i+1, r.Models, wantBackend)
+		}
+		if len(r.BackendRefs) != 1 || r.BackendRefs[0].Name != wantBackend {
+			t.Errorf("rules[%d] backendRefs = %+v, want single %s", i+1, r.BackendRefs, wantBackend)
+		}
+	}
+	// The catch-all is last and matches on nothing.
+	last := rules[len(rules)-1]
+	if len(last.Models) != 0 {
+		t.Errorf("catch-all should have no model match, got %v", last.Models)
+	}
+	if len(last.BackendRefs) != 1 || last.BackendRefs[0].Name != "local-a" {
+		t.Errorf("catch-all backendRefs = %+v, want single local-a", last.BackendRefs)
+	}
+}
+
+// TestCompileRouterRules_StaticOmitsNameRules confirms the default Static
+// strategy compiles no per-backend name rules: only the explicit rules plus the
+// defaultRoute catch-all.
+func TestCompileRouterRules_StaticOmitsNameRules(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "local-a"},
+				{Name: "local-b"},
+			},
+			Rules: []inferencev1alpha1.RouterRule{{
+				Name:  "explicit",
+				Match: &inferencev1alpha1.RuleMatch{Models: []string{"foo-*"}},
+				Route: inferencev1alpha1.RuleRoute{Backends: []string{"local-a"}},
+			}},
+			DefaultRoute:         "local-a",
+			DefaultRouteStrategy: inferencev1alpha1.DefaultRouteStrategyStatic,
+		},
+	}
+
+	rules, err := compileRouterRules(mr)
+	if err != nil {
+		t.Fatalf("compileRouterRules: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("expected explicit rule + catch-all only, got %d: %+v", len(rules), rules)
+	}
+	// rules[0] is the explicit rule; rules[1] is the defaultRoute catch-all
+	// (no model match) — and crucially no per-backend name rule sits between.
+	if got := rules[0].Models; len(got) != 1 || got[0] != "foo-*" {
+		t.Errorf("rules[0] should be the explicit rule, got models %v", got)
+	}
+	catchAll := rules[1]
+	if len(catchAll.Models) != 0 {
+		t.Errorf("rules[1] should be the catch-all with no model match, got %v", catchAll.Models)
+	}
+	if len(catchAll.BackendRefs) != 1 || catchAll.BackendRefs[0].Name != "local-a" {
+		t.Errorf("catch-all backendRefs = %+v, want single local-a", catchAll.BackendRefs)
+	}
+}
+
 // TestModelRouterGateway_AuditLogFailsLoud covers the 2c honest boundary: a
 // dataPlane: Gateway router with policy.auditLog set is refused loudly
 // (GatewayReady=False, reason UnsupportedAuditLogInGatewayMode) and generates

--- a/internal/controller/router_config_builder.go
+++ b/internal/controller/router_config_builder.go
@@ -64,9 +64,10 @@ func (r *ModelRouterReconciler) compileRouterConfig(
 	mr *inferencev1alpha1.ModelRouter,
 ) (*compiledConfig, error) {
 	out := &router.Config{
-		DefaultRoute: mr.Spec.DefaultRoute,
-		Backends:     make([]router.Backend, 0, len(mr.Spec.Backends)),
-		Rules:        make([]router.Rule, 0, len(mr.Spec.Rules)),
+		DefaultRoute:         mr.Spec.DefaultRoute,
+		DefaultRouteStrategy: string(mr.Spec.DefaultRouteStrategy),
+		Backends:             make([]router.Backend, 0, len(mr.Spec.Backends)),
+		Rules:                make([]router.Rule, 0, len(mr.Spec.Rules)),
 	}
 	statuses := make([]inferencev1alpha1.BackendStatus, 0, len(mr.Spec.Backends))
 	var warnings []string

--- a/internal/router/config.go
+++ b/internal/router/config.go
@@ -30,6 +30,18 @@ import (
 	"time"
 )
 
+// Default-route strategies. These mirror the CRD enum and decide what the
+// matcher does for a request that no rule accepted.
+const (
+	// DefaultRouteStrategyStatic routes unmatched requests straight to
+	// DefaultRoute. The zero value, so an absent field behaves this way.
+	DefaultRouteStrategyStatic = "Static"
+
+	// DefaultRouteStrategyBackendNameMatch tries to match the request model
+	// to a backend Name before falling back to DefaultRoute.
+	DefaultRouteStrategyBackendNameMatch = "BackendNameMatch"
+)
+
 // Config is the on-disk representation read by the router-proxy. The
 // controller produces this from a ModelRouter spec; the wire shape is a
 // stable contract between the two components.
@@ -43,6 +55,12 @@ type Config struct {
 
 	// DefaultRoute names the backend used when no rule matches.
 	DefaultRoute string `json:"defaultRoute,omitempty"`
+
+	// DefaultRouteStrategy decides how unmatched requests resolve before
+	// DefaultRoute. Empty or "Static" routes straight to DefaultRoute;
+	// "BackendNameMatch" first tries to match the request model to a backend
+	// Name. See the DefaultRouteStrategy* constants.
+	DefaultRouteStrategy string `json:"defaultRouteStrategy,omitempty"`
 
 	// Policy holds cross-cutting controls (classification, audit). Budget
 	// enforcement and persistence land in #434 / #440.
@@ -217,6 +235,12 @@ func (c *Config) Validate() error {
 	}
 	if c.DefaultRoute != "" && !names[c.DefaultRoute] {
 		return fmt.Errorf("defaultRoute %q does not name an existing backend", c.DefaultRoute)
+	}
+	switch c.DefaultRouteStrategy {
+	case "", DefaultRouteStrategyStatic, DefaultRouteStrategyBackendNameMatch:
+	default:
+		return fmt.Errorf("defaultRouteStrategy %q must be %q or %q",
+			c.DefaultRouteStrategy, DefaultRouteStrategyStatic, DefaultRouteStrategyBackendNameMatch)
 	}
 	for i, r := range c.Rules {
 		if r.Name == "" {

--- a/internal/router/config_test.go
+++ b/internal/router/config_test.go
@@ -115,6 +115,13 @@ func TestConfigValidateRejections(t *testing.T) {
 			},
 			wantSubstr: `does not name an existing backend`,
 		},
+		{
+			name: "unknown default-route strategy",
+			mutate: func(c *Config) {
+				c.DefaultRouteStrategy = "Whatever"
+			},
+			wantSubstr: `defaultRouteStrategy "Whatever" must be`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -149,6 +156,9 @@ func TestLoadConfigRoundTrip(t *testing.T) {
 	}
 	if cfg.DefaultRoute != "local-qwen" {
 		t.Errorf("DefaultRoute = %q, want local-qwen", cfg.DefaultRoute)
+	}
+	if cfg.DefaultRouteStrategy != DefaultRouteStrategyBackendNameMatch {
+		t.Errorf("DefaultRouteStrategy = %q, want BackendNameMatch", cfg.DefaultRouteStrategy)
 	}
 	if !cfg.Rules[0].FailClosed {
 		t.Error("expected FailClosed=true on pii rule")
@@ -238,6 +248,7 @@ const canonicalJSON = `{
      "failClosed": true}
   ],
   "defaultRoute": "local-qwen",
+  "defaultRouteStrategy": "BackendNameMatch",
   "policy": {
     "classification": {"mode": "header-only"},
     "auditLog": {"sink": "stdout"}

--- a/internal/router/match.go
+++ b/internal/router/match.go
@@ -77,9 +77,11 @@ func NewMatcher(cfg *Config) *Matcher {
 }
 
 // Match evaluates the rule set against the request features and returns
-// the routing decision. If no rule matches and DefaultRoute is empty,
-// returns a MatchResult with nil Backends, which the proxy translates to
-// HTTP 503.
+// the routing decision. If no rule matches, the fallback depends on
+// DefaultRouteStrategy: BackendNameMatch first tries to resolve the request
+// model to a backend Name, then both strategies fall back to DefaultRoute.
+// If nothing resolves, returns a MatchResult with nil Backends, which the
+// proxy translates to HTTP 503.
 func (m *Matcher) Match(features *RequestFeatures) MatchResult {
 	for i := range m.cfg.Rules {
 		rule := &m.cfg.Rules[i]
@@ -91,6 +93,19 @@ func (m *Matcher) Match(features *RequestFeatures) MatchResult {
 			Backends:   rule.Route.Backends,
 			Strategy:   strategyOrDefault(rule.Route.Strategy),
 			FailClosed: rule.FailClosed,
+		}
+	}
+
+	// No rule matched. Under BackendNameMatch, try to address a backend
+	// directly by Name using the request model before falling back to
+	// DefaultRoute. The lookup is against backend Name (our client-facing
+	// identifier), never the upstream provider Model.
+	if m.cfg.DefaultRouteStrategy == DefaultRouteStrategyBackendNameMatch && features.Model != "" {
+		if b := m.backendsByName[features.Model]; b != nil {
+			return MatchResult{
+				Backends: []string{b.Name},
+				Strategy: strategyPrimaryFallback,
+			}
 		}
 	}
 

--- a/internal/router/match_test.go
+++ b/internal/router/match_test.go
@@ -143,3 +143,77 @@ func TestMatchFirstRuleWins(t *testing.T) {
 		t.Errorf("expected first rule to win, got %v", got.Rule)
 	}
 }
+
+func TestMatchBackendNameMatchAddressesBackendByName(t *testing.T) {
+	cfg := validConfig()
+	cfg.DefaultRouteStrategy = DefaultRouteStrategyBackendNameMatch
+	// "public" classification matches no rule; model names a backend, so
+	// BackendNameMatch routes there instead of falling back to DefaultRoute.
+	got := NewMatcher(cfg).Match(&RequestFeatures{Classification: "public", Model: "cloud-opus"})
+	if got.Rule != nil {
+		t.Errorf("expected no rule match, got %q", got.Rule.Name)
+	}
+	if len(got.Backends) != 1 || got.Backends[0] != "cloud-opus" {
+		t.Errorf("expected name match to cloud-opus, got %v", got.Backends)
+	}
+	if got.Strategy != strategyPrimaryFallback {
+		t.Errorf("strategy = %q, want primary-fallback", got.Strategy)
+	}
+}
+
+func TestMatchBackendNameMatchFallsBackToDefault(t *testing.T) {
+	cfg := validConfig()
+	cfg.DefaultRouteStrategy = DefaultRouteStrategyBackendNameMatch
+	// Model names no backend, so it falls through to DefaultRoute.
+	got := NewMatcher(cfg).Match(&RequestFeatures{Classification: "public", Model: "ghost-model"})
+	if len(got.Backends) != 1 || got.Backends[0] != "local-qwen" {
+		t.Errorf("expected fallback to default local-qwen, got %v", got.Backends)
+	}
+}
+
+func TestMatchBackendNameMatchDoesNotOverrideRules(t *testing.T) {
+	cfg := validConfig()
+	cfg.DefaultRouteStrategy = DefaultRouteStrategyBackendNameMatch
+	// A matching rule wins even when the model also names a backend; name
+	// matching only fires when no rule accepts the request.
+	got := NewMatcher(cfg).Match(&RequestFeatures{Classification: "pii", Model: "cloud-opus"})
+	if got.Rule == nil || got.Rule.Name != "pii-stays-local" {
+		t.Errorf("expected pii rule to win over name match, got %v", got.Rule)
+	}
+}
+
+func TestMatchStaticIgnoresBackendName(t *testing.T) {
+	cfg := validConfig()
+	cfg.DefaultRouteStrategy = DefaultRouteStrategyStatic
+	// Under Static, a model that names a backend is irrelevant; unmatched
+	// requests go straight to DefaultRoute.
+	got := NewMatcher(cfg).Match(&RequestFeatures{Classification: "public", Model: "cloud-opus"})
+	if len(got.Backends) != 1 || got.Backends[0] != "local-qwen" {
+		t.Errorf("expected static default to local-qwen, got %v", got.Backends)
+	}
+}
+
+func TestMatchBackendNameMatchNoDefaultReturns503(t *testing.T) {
+	cfg := validConfig()
+	cfg.Rules = nil
+	cfg.DefaultRoute = ""
+	cfg.DefaultRouteStrategy = DefaultRouteStrategyBackendNameMatch
+	// No rule, no name match, no DefaultRoute: nothing resolves, which the
+	// proxy surfaces as HTTP 503.
+	got := NewMatcher(cfg).Match(&RequestFeatures{Model: "ghost-model"})
+	if len(got.Backends) != 0 {
+		t.Errorf("expected no backends (503), got %v", got.Backends)
+	}
+}
+
+func TestMatchBackendNameMatchEmptyModelFallsBack(t *testing.T) {
+	cfg := validConfig()
+	cfg.Rules = nil
+	cfg.DefaultRouteStrategy = DefaultRouteStrategyBackendNameMatch
+	// An empty model skips the name lookup entirely (no map[""] probe) and
+	// falls through to DefaultRoute.
+	got := NewMatcher(cfg).Match(&RequestFeatures{Model: ""})
+	if len(got.Backends) != 1 || got.Backends[0] != "local-qwen" {
+		t.Errorf("expected empty model to fall back to local-qwen, got %v", got.Backends)
+	}
+}


### PR DESCRIPTION
## What

Add an optional `spec.defaultRouteStrategy` field to the `ModelRouter` CRD — an enum of `Static` (default) and `BackendNameMatch` — controlling what happens to a request that matches no routing rule:

- **`Static`** preserves current behavior: route to `defaultRoute` (or HTTP 503 if it is unset).
- **`BackendNameMatch`**: first resolve the request's `model` field against a backend of the same `name`; if one exists, route straight to it; otherwise fall back to `defaultRoute`, then HTTP 503.

The lookup is against backend `name` — the identifier published to clients — never the upstream provider `model`, keeping the proxied API surface on its own side of the boundary.

## Why

A ModelRouter configuration tends to accumulate a large block of pure identity-passthrough rules: one rule per backend whose only job is to match `models: [X]` and route to `backends: [X]` for a backend also named `X`. That boilerplate grows linearly with backend count, is easy to get wrong, and buries the rules that carry real routing semantics (failover chains, fail-closed gates, semantic aliases) in noise.

`BackendNameMatch` collapses every one of those identity rules into a single strategy flag. Rules that carry real semantics stay exactly as they are; the per-backend passthrough rules disappear.

## How

- New `DefaultRouteStrategy` typed enum and `spec.defaultRouteStrategy` field (kubebuilder enum + default `Static`, optional). CRDs regenerated and synced to the Helm chart.
- **Proxy data plane:** the matcher resolves an unmatched request's model to a backend by name between the rule loop and the `defaultRoute` fallback (`internal/router/match.go`). The wire config carries the field with a defensive validation guard.
- **Gateway data plane:** `compileRouterRules` emits one `model == <name>` rule per backend, ordered after explicit rules and before the `defaultRoute` catch-all — preserving first-match parity with the proxy.
- Explicit rules, including `failClosed`, are evaluated first and continue to gate before any name match. The behavior, the trust-boundary implication (every backend, including cloud-tier, becomes directly addressable by name), and the fail-fast-on-unhealthy semantics are documented in the concept guide and the field doc.

Notes for reviewers:

- **Back-compat:** additive optional field defaulting to `Static`; existing `ModelRouter`s are unaffected.
- A request naming a backend that is currently unhealthy fails fast (502/503) rather than silently rerouting to `defaultRoute` — naming a backend is a request for *that* backend, and this matches how an explicit single-backend rule behaves on outage. Parity holds across both data planes.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [x] Documentation updated

_Assisted by Claude Opus 4.8_
