### PR TITLE
Add revisionHistoryLimit to ModelRouter and InferenceService

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -73,6 +73,13 @@ type InferenceServiceSpec struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// RevisionHistoryLimit caps how many old ReplicaSets the inference
+	// Deployment keeps for rollback. Unset uses the Kubernetes default (10);
+	// 0 keeps none.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+
 	// Autoscaling configures horizontal pod autoscaling for the inference service.
 	// When set, the controller creates and manages an HPA resource targeting the
 	// inference Deployment. Requires Prometheus Adapter for custom metrics.

--- a/api/v1alpha1/modelrouter_types.go
+++ b/api/v1alpha1/modelrouter_types.go
@@ -542,6 +542,14 @@ type RouterProxySpec struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// RevisionHistoryLimit caps how many old ReplicaSets the proxy Deployment
+	// keeps for rollback. Unset uses the Kubernetes default (10); 0 keeps none.
+	// Useful to bound ReplicaSet buildup, since the proxy re-rolls on every
+	// config change.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+
 	// Image overrides the default router-proxy container image. Useful
 	// for air-gapped clusters that pin to an internal registry digest.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -417,6 +417,11 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RevisionHistoryLimit != nil {
+		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Autoscaling != nil {
 		in, out := &in.Autoscaling, &out.Autoscaling
 		*out = new(AutoscalingSpec)
@@ -1194,6 +1199,11 @@ func (in *RouterProxySpec) DeepCopyInto(out *RouterProxySpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
+	if in.RevisionHistoryLimit != nil {
+		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
 		*out = new(int32)
 		**out = **in
 	}

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -1408,6 +1408,14 @@ spec:
                     description: Memory requests (e.g., "4Gi")
                     type: string
                 type: object
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit caps how many old ReplicaSets the inference
+                  Deployment keeps for rollback. Unset uses the Kubernetes default (10);
+                  0 keeps none.
+                format: int32
+                minimum: 0
+                type: integer
               ropeScaling:
                 description: |-
                   RopeScaling configures RoPE-based context extension so a model can be

--- a/charts/llmkube/templates/crds/modelrouters.yaml
+++ b/charts/llmkube/templates/crds/modelrouters.yaml
@@ -710,6 +710,15 @@ spec:
                       and RouterBackend.Timeout) tighten this on a per-request basis
                       but cannot extend it beyond this cap.
                     type: string
+                  revisionHistoryLimit:
+                    description: |-
+                      RevisionHistoryLimit caps how many old ReplicaSets the proxy Deployment
+                      keeps for rollback. Unset uses the Kubernetes default (10); 0 keeps none.
+                      Useful to bound ReplicaSet buildup, since the proxy re-rolls on every
+                      config change.
+                    format: int32
+                    minimum: 0
+                    type: integer
                 type: object
               rules:
                 description: |-

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1404,6 +1404,14 @@ spec:
                     description: Memory requests (e.g., "4Gi")
                     type: string
                 type: object
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit caps how many old ReplicaSets the inference
+                  Deployment keeps for rollback. Unset uses the Kubernetes default (10);
+                  0 keeps none.
+                format: int32
+                minimum: 0
+                type: integer
               ropeScaling:
                 description: |-
                   RopeScaling configures RoPE-based context extension so a model can be

--- a/config/crd/bases/inference.llmkube.dev_modelrouters.yaml
+++ b/config/crd/bases/inference.llmkube.dev_modelrouters.yaml
@@ -706,6 +706,15 @@ spec:
                       and RouterBackend.Timeout) tighten this on a per-request basis
                       but cannot extend it beyond this cap.
                     type: string
+                  revisionHistoryLimit:
+                    description: |-
+                      RevisionHistoryLimit caps how many old ReplicaSets the proxy Deployment
+                      keeps for rollback. Unset uses the Kubernetes default (10); 0 keeps none.
+                      Useful to bound ReplicaSet buildup, since the proxy re-rolls on every
+                      config change.
+                    format: int32
+                    minimum: 0
+                    type: integer
                 type: object
               rules:
                 description: |-

--- a/docs/site/concepts/model-router.md
+++ b/docs/site/concepts/model-router.md
@@ -70,6 +70,8 @@ LLMs are increasingly composed: an agent does some work on a fast local model, h
 
 The controller compiles `ModelRouter.spec` into a JSON config, writes it to a `ConfigMap`, and reconciles a `Deployment` plus `Service` that mounts the ConfigMap and runs the [router-proxy binary](https://github.com/defilantech/LLMKube/blob/main/cmd/router-proxy). The ConfigMap content is hashed and the hash lands on the pod template annotation, so any spec change triggers a clean rollout.
 
+Since every spec change re-rolls the pods, set `spec.proxy.revisionHistoryLimit` to cap how many old `ReplicaSet`s are kept (`0` keeps none); unset uses the Kubernetes default of 10. `InferenceService` has the same knob at `spec.revisionHistoryLimit`.
+
 ## The fail-closed gate
 
 The headline differentiator. A rule that matches sensitive classifications (default: `pii`, `phi`) and is marked `failClosed: true` has two guarantees:

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -267,7 +267,8 @@ func (r *InferenceServiceReconciler) constructDeployment(
 			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
+			Replicas:             &replicas,
+			RevisionHistoryLimit: isvc.Spec.RevisionHistoryLimit,
 			Selector: &metav1.LabelSelector{
 				// Selector uses the immutable subset only; the model label
 				// is allowed to change when the user edits spec.modelRef

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -512,6 +512,64 @@ var _ = Describe("Multi-GPU Deployment Construction", func() {
 		})
 	})
 
+	Context("when verifying revisionHistoryLimit configuration", func() {
+		var (
+			reconciler *InferenceServiceReconciler
+			model      *inferencev1alpha1.Model
+		)
+
+		BeforeEach(func() {
+			reconciler = &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+				DefaultFSGroup:     102,
+			}
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rhl-model",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:       "https://example.com/model.gguf",
+					Format:       "gguf",
+					Quantization: "Q4_K_M",
+					Hardware:     &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+				Status: inferencev1alpha1.ModelStatus{Phase: "Ready"},
+			}
+		})
+
+		newISVC := func(limit *int32) *inferencev1alpha1.InferenceService {
+			replicas := int32(1)
+			return &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rhl-service",
+					Namespace: "default",
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:             "rhl-model",
+					Replicas:             &replicas,
+					Image:                "ghcr.io/ggml-org/llama.cpp:server",
+					RevisionHistoryLimit: limit,
+				},
+			}
+		}
+
+		It("should leave the field nil when unset (apiserver default applies)", func() {
+			deployment := reconciler.constructDeployment(newISVC(nil), model, 1)
+			Expect(deployment.Spec.RevisionHistoryLimit).To(BeNil())
+		})
+
+		It("should plumb an explicit value (including 0) onto the Deployment", func() {
+			for _, want := range []int32{0, 5} {
+				deployment := reconciler.constructDeployment(newISVC(&want), model, 1)
+				Expect(deployment.Spec.RevisionHistoryLimit).NotTo(BeNil())
+				Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(want))
+			}
+		})
+	})
+
 	Context("when verifying tolerations and node selectors", func() {
 		var (
 			reconciler *InferenceServiceReconciler

--- a/internal/controller/router_builders_test.go
+++ b/internal/controller/router_builders_test.go
@@ -453,6 +453,33 @@ func TestRouterDeploymentBuilderRespectsOverrides(t *testing.T) {
 	}
 }
 
+// TestRouterDeploymentBuilderRevisionHistoryLimit checks that
+// spec.proxy.revisionHistoryLimit reaches the Deployment, and that
+// omitting it leaves the field nil (apiserver default).
+func TestRouterDeploymentBuilderRevisionHistoryLimit(t *testing.T) {
+	r := &ModelRouterReconciler{RouterProxyImage: "ghcr.io/test/router-proxy:v1"}
+
+	depDefault := r.newRouterDeployment(canonicalModelRouter(), "hash")
+	if depDefault.Spec.RevisionHistoryLimit != nil {
+		t.Errorf("revisionHistoryLimit = %v, want nil when unset",
+			*depDefault.Spec.RevisionHistoryLimit)
+	}
+
+	for _, want := range []int32{0, 3} {
+		mr := canonicalModelRouter()
+		mr.Spec.Proxy = &inferencev1alpha1.RouterProxySpec{
+			RevisionHistoryLimit: ptrInt32B(want),
+		}
+		dep := r.newRouterDeployment(mr, "hash")
+		if dep.Spec.RevisionHistoryLimit == nil {
+			t.Fatalf("revisionHistoryLimit = nil, want %d", want)
+		}
+		if got := *dep.Spec.RevisionHistoryLimit; got != want {
+			t.Errorf("revisionHistoryLimit = %d, want %d", got, want)
+		}
+	}
+}
+
 // TestRouterDeploymentBuilderQuarantineDuration covers the
 // spec.proxy.quarantineDuration plumbing: the controller has to
 // render the value as a --quarantine-duration flag on the proxy

--- a/internal/controller/router_deployment_builder.go
+++ b/internal/controller/router_deployment_builder.go
@@ -59,6 +59,7 @@ func (r *ModelRouterReconciler) reconcileRouterDeployment(
 	// labels). Operator-owned keys win on collision; foreign keys
 	// pass through. Fixes #456.
 	existing.Spec.Replicas = desired.Spec.Replicas
+	existing.Spec.RevisionHistoryLimit = desired.Spec.RevisionHistoryLimit
 	existing.Spec.Template.Spec = desired.Spec.Template.Spec
 	existing.Spec.Template.Labels = mergePreservingExternal(
 		existing.Spec.Template.Labels,
@@ -87,11 +88,13 @@ func (r *ModelRouterReconciler) newRouterDeployment(
 	image := r.routerProxyImage()
 	var resources corev1.ResourceRequirements
 	var imagePullSecrets []corev1.LocalObjectReference
+	var revisionHistoryLimit *int32
 
 	if mr.Spec.Proxy != nil {
 		if mr.Spec.Proxy.Replicas != nil {
 			replicas = *mr.Spec.Proxy.Replicas
 		}
+		revisionHistoryLimit = mr.Spec.Proxy.RevisionHistoryLimit
 		if mr.Spec.Proxy.Image != "" {
 			image = mr.Spec.Proxy.Image
 		}
@@ -121,8 +124,9 @@ func (r *ModelRouterReconciler) newRouterDeployment(
 			Labels:    routerProxyLabels(mr),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+			Replicas:             &replicas,
+			RevisionHistoryLimit: revisionHistoryLimit,
+			Selector:             &metav1.LabelSelector{MatchLabels: podLabels},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      podLabels,


### PR DESCRIPTION
The router-proxy and inference Deployments offer no way to cap how many old ReplicaSets Kubernetes retains, so they fall back to the default of 10. The router-proxy re-rolls its pods on every compiled-config change (the ConfigMap hash lands on the pod template), so superseded ReplicaSets pile up quickly on a frequently-edited router.

## What changed

- Add an optional `revisionHistoryLimit` field to both CRDs:
  - `ModelRouter` → `spec.proxy.revisionHistoryLimit`
  - `InferenceService` → `spec.revisionHistoryLimit`
- Plumb the value through to each Deployment. The router-proxy reconciler copies mutable fields individually, so it gets an explicit copy in the update path; the InferenceService reconciler replaces `Spec` wholesale, so it propagates automatically.
- Pure passthrough: unset defers to the Kubernetes default (10); `0` keeps no history. No operator-imposed default.
- Regenerated CRD manifests + deepcopy, synced the Helm chart CRDs, and documented the knob in the model-router concept doc.

## Validation

`go build`, `go vet`, the full `internal/controller` envtest suite, and the `api/...` tests pass. Added unit tests covering the nil-when-unset and explicit-value (including `0`) paths for both builders.

_Assisted by Claude Opus 4.8_