### PR TITLE
fix(chart): disable model cache when modelCache.enabled is false

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
         - --model-cache-storage-class={{ .Values.modelCache.storageClass }}
         {{- end }}
         - --model-cache-access-mode={{ .Values.modelCache.accessMode }}
+        {{- else }}
+        # Empty path disables caching (the flag defaults to /models otherwise).
+        - --model-cache-path=
         {{- end }}
         - --init-container-image={{ include "llmkube.initContainerImage" . }}
         # The default value is set in values.yaml. We do NOT use `| default 102`

--- a/charts/llmkube/tests/model-cache_test.yaml
+++ b/charts/llmkube/tests/model-cache_test.yaml
@@ -67,6 +67,23 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --model-cache-mode=perService
 
+  - it: passes an empty model-cache-path to disable caching when disabled
+    template: deployment.yaml
+    set:
+      modelCache.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--model-cache-path="
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --model-cache-path=/models
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: model-cache
+            mountPath: /models
+
   # In the default shared mode the chart creates the single cluster-wide PVC so
   # all InferenceServices share one cache and `cache list` can inspect it.
   - it: renders the shared PVC in shared mode (default)


### PR DESCRIPTION
## Problem

Setting `modelCache.enabled: false` does not actually disable the model cache. The operator's `--model-cache-path` flag defaults to `/models` (`cmd/main.go`), and caching is gated on that path being non-empty:

- `internal/controller/inferenceservice_controller.go`: `model.Status.CacheKey != "" && r.ModelCachePath != ""`
- `internal/controller/deployment_builder.go`: `useCache := model.Status.CacheKey != "" && r.ModelCachePath != ""`

The chart only emits the `--model-cache-*` flags when `enabled: true`, so when disabled the operator falls back to the non-empty `/models` default and keeps provisioning + mounting the cache (a shared 100Gi PVC) anyway.

## Fix

Emit an explicit empty `--model-cache-path=` in the disabled branch so the controller's `path != ""` gate evaluates false and caching is actually off.

## Test

Added a helm-unittest regression case to `tests/model-cache_test.yaml` asserting that with `modelCache.enabled: false` the deployment passes `--model-cache-path=` (empty), no `--model-cache-path=/models`, and no `/models` volume mount. Full suite passes (10/10).