### PR TITLE
feat(foreman): reviewer rubric checks for test/prod fidelity (real values + wired-up)

### DIFF
--- a/config/foreman/system-prompts/reviewer.md
+++ b/config/foreman/system-prompts/reviewer.md
@@ -240,6 +240,39 @@ families (`100.x.x.x` is CGNAT in `100.64.0.0/10`, not in
 When unsure whether a constant is justified, say so in the finding
 rather than omitting it.
 
+### I. Real values, not placeholders
+
+Do the tests exercise the change with the REAL values the system uses
+in production (CRD enum values, real field/label/annotation strings,
+real status phases, real runtime names), or with invented placeholders?
+If a change touches a cross-component contract (a value the producer
+emits and a consumer must handle), the test must use the actual
+contract value. A test that passes only because it uses a placeholder
+that happens to match the new code is a false positive.
+
+Worked example: a change to the runtime registry adds support for
+`"llamacpp"`. The test only exercises `"mlx-server"` — the value the
+test author picked because it was already in the test file. The CRD
+`+kubebuilder:default` and every real InferenceService CR use
+`"llamacpp"`. The test passes in isolation but the unregistered
+`"llamacpp"` key breaks production. This is the exact escape in
+issue #784.
+
+### J. Wired-up, not inert
+
+Is every new exported metric, flag, field, or runtime actually
+referenced by a production code path, or is it only touched by tests?
+A symbol that is defined, registered, and tested but never
+emitted/consumed in production is a defect. Use `grep` to find
+call sites of any new exported symbol; if the only hits are in test
+files or the registration site itself, flag it.
+
+Worked example: `llmkube_inference_ttft_seconds` and
+`llmkube_inference_request_errors_total` were registered and tested
+via self-increment, but never emitted by any production path. The
+dashboard shows a permanent flat zero. This is the exact escape in
+issue #786.
+
 ## Step 3 :: Report
 
 Call `submit_result` exactly once. Required fields:

--- a/pkg/foreman/agent/reviewer/findings.go
+++ b/pkg/foreman/agent/reviewer/findings.go
@@ -70,14 +70,16 @@ var validSeverities = map[Severity]struct{}{
 type Area string
 
 const (
-	AreaScope       Area = "scope"           // Section A: scope alignment
-	AreaStyle       Area = "style"           // Section B: minimal / idiomatic
-	AreaTests       Area = "tests"           // Section C: meaningful tests
-	AreaSideEffects Area = "side-effects"    // Section D: side effects
-	AreaDocs        Area = "docs"            // Section E: documentation / ergonomics
-	AreaRegression  Area = "regression"      // Section F: removed working logic
-	AreaDocConsist  Area = "doc-consistency" // Section G: doc vs code mismatch
-	AreaConstants   Area = "constants"       // Section H: magic-number justification
+	AreaScope            Area = "scope"              // Section A: scope alignment
+	AreaStyle            Area = "style"              // Section B: minimal / idiomatic
+	AreaTests            Area = "tests"              // Section C: meaningful tests
+	AreaSideEffects      Area = "side-effects"       // Section D: side effects
+	AreaDocs             Area = "docs"               // Section E: documentation / ergonomics
+	AreaRegression       Area = "regression"         // Section F: removed working logic
+	AreaDocConsist       Area = "doc-consistency"    // Section G: doc vs code mismatch
+	AreaConstants        Area = "constants"          // Section H: magic-number justification
+	AreaTestProdFidelity Area = "test-prod-fidelity" // Section I: real values, not placeholders
+	AreaWiredUp          Area = "wired-up"           // Section J: wired-up, not inert
 )
 
 // validAreas is the exhaustive set. Models occasionally invent areas
@@ -87,6 +89,7 @@ const (
 var validAreas = map[Area]struct{}{
 	AreaScope: {}, AreaStyle: {}, AreaTests: {}, AreaSideEffects: {},
 	AreaDocs: {}, AreaRegression: {}, AreaDocConsist: {}, AreaConstants: {},
+	AreaTestProdFidelity: {}, AreaWiredUp: {},
 }
 
 // Finding is one item in the reviewer's structured-findings list.

--- a/pkg/foreman/agent/reviewer/findings_test.go
+++ b/pkg/foreman/agent/reviewer/findings_test.go
@@ -178,3 +178,39 @@ func TestParseFindings_AllAreasAccepted(t *testing.T) {
 		})
 	}
 }
+
+// TestParseFindings_TestProdFidelityArea covers the new Section I
+// (real values, not placeholders) and Section J (wired-up, not
+// inert) areas added in #788. These areas must parse successfully
+// and carry the expected area constant.
+func TestParseFindings_TestProdFidelityArea(t *testing.T) {
+	extra := jsonExtra(t, `{
+		"findings": [
+			{
+				"severity": "blocker",
+				"area": "test-prod-fidelity",
+				"message": "test uses placeholder runtime mlx-server; production default is llamacpp",
+				"file": "pkg/agent/registry_test.go"
+			},
+			{
+				"severity": "major",
+				"area": "wired-up",
+				"message": "llmkube_inference_ttft_seconds registered but never emitted in production",
+				"file": "internal/metrics/metrics.go"
+			}
+		]
+	}`)
+	got, warnings := ParseFindings(extra)
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d findings; want 2", len(got))
+	}
+	if got[0].Area != AreaTestProdFidelity {
+		t.Errorf("first finding area: got %q; want %q", got[0].Area, AreaTestProdFidelity)
+	}
+	if got[1].Area != AreaWiredUp {
+		t.Errorf("second finding area: got %q; want %q", got[1].Area, AreaWiredUp)
+	}
+}


### PR DESCRIPTION
## What

Add two checks to the Foreman reviewer's rubric, and register the `Area` values that carry them:
- **real values, not placeholders** — tests must exercise a change with the real values the system uses in production (CRD enum values, real field/label strings), not made-up placeholders.
- **wired-up, not inert** — every new metric/flag/field must be referenced by a production code path, not only by tests.

## Why

Fixes #788. Two weekend escapes slipped through because tests passed without testing anything: #525 (a runtime change tested with a placeholder value, never the real `llamacpp` the fleet uses) and #409 (TTFT/error metrics registered + tested by self-increment but never emitted). These rubric checks encode those exact failure classes as explicit reviewer rules.

## How

- `config/foreman/system-prompts/reviewer.md`: two new rubric sections, each with a concrete worked example tied to a real escape, and (for wired-up) the operational `grep` mechanism the reviewer should run.
- `pkg/foreman/agent/reviewer/findings.go`: add `AreaTestProdFidelity` + `AreaWiredUp` to `validAreas` so `ParseFindings` accepts findings tagged with them (consumed in production by `logReviewerFindings` on the reviewer terminal path; without the map entries those findings would be silently dropped).
- `pkg/foreman/agent/reviewer/findings_test.go`: asserts the new areas parse and carry the right constant; the pre-existing `AllAreasAccepted` test covers them dynamically.

Foreman-authored (Strix Qwopus), gate-verified GO. Maintainer-reviewed: confirmed the new areas are genuinely wired (not dead), and the test bites.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes (gate-verified)
- [x] `make lint` passes
- [x] Commit messages follow conventional commits
- [x] All commits signed off (DCO)
- [x] Documentation updated (the reviewer system prompt is the doc here)
