### PR TITLE
feat(foreman): bite check in the verify-gate Job (reject non-biting tests)

### DIFF
--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -12,6 +12,7 @@
 #   .Repo           -- "owner/name", inlined verbatim into the clone URL
 #   .Branch         -- branch on the fork to clone shallowly
 #   .Checks         -- list of make targets to run, in order
+#   .BiteCheck      -- when true, run the bite check after standard checks
 #   .PVCName        -- "foreman-gate-cache" PVC for GOMODCACHE/GOCACHE/XDG
 #   .ActiveDeadlineSeconds -- max wall-clock for the Job
 #   .TTLSecondsAfterFinished -- how long the Job's resources linger so
@@ -69,6 +70,52 @@ spec:
                 git diff --stat
                 rc=1
               fi
+              {{- if .BiteCheck }}
+              # Bite check: verify new/changed tests actually fail against
+              # pre-change production code. Skipped if no test files changed.
+              # Errors surface as GATE-ERROR (fail loud).
+              echo "=== bite check ==="
+              test_files=$(git status --porcelain | grep '_test\.go$' | awk '{print $NF}')
+              if [ -z "$test_files" ]; then
+                echo "bite check: no test files changed, skipping"
+              else
+                # Identify production .go files that are added (untracked) or modified.
+                # Added files must be removed; modified files must be reverted.
+                prod_files=$(git status --porcelain | grep '\.go$' | grep -v '_test\.go$' | awk '{print $NF}')
+                if [ -z "$prod_files" ]; then
+                  echo "bite check: no production files changed, skipping"
+                else
+                  # Save the current state so we can restore on error.
+                  git stash save "bite-check-snapshot" || { echo "GATE-ERROR: bite check stash failed"; exit 1; }
+                  # Revert production files: for added (untracked) files, remove them;
+                  # for modified files, checkout the original version.
+                  for f in $prod_files; do
+                    if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+                      # Tracked file: revert to HEAD
+                      git checkout HEAD -- "$f" || { echo "GATE-ERROR: bite check revert failed for $f"; exit 1; }
+                    else
+                      # Untracked (newly added) file: remove it
+                      rm -f "$f" || { echo "GATE-ERROR: bite check remove failed for $f"; exit 1; }
+                    fi
+                  done
+                  # Rebuild and run tests against reverted production code.
+                  echo "bite check: running tests against reverted production code"
+                  if ! go build ./...; then
+                    echo "bite check: build failed against reverted production (expected for some changes)"
+                  fi
+                  bite_rc=0
+                  go test -count=1 -timeout=180s ./... || bite_rc=1
+                  if [ "$bite_rc" -eq 0 ]; then
+                    echo "GATE FAIL: bite check: tests pass against pre-change production (non-biting test)"
+                    rc=1
+                  else
+                    echo "bite check: tests fail against pre-change production (biting test, good)"
+                  fi
+                  # Restore the original state.
+                  git stash pop || { echo "GATE-ERROR: bite check restore failed"; exit 1; }
+                fi
+              fi
+              {{- end }}
               [ "$rc" -eq 0 ] && echo "GATE PASS" || echo "GATE FAIL"
               exit "$rc"
           env:

--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -79,25 +79,21 @@ spec:
               if [ -z "$test_files" ]; then
                 echo "bite check: no test files changed, skipping"
               else
-                # Identify production .go files that are added (untracked) or modified.
-                # Added files must be removed; modified files must be reverted.
+                # Identify production .go files that changed (added or modified).
+                # Both are handled by the scoped stash below.
                 prod_files=$(git status --porcelain | grep '\.go$' | grep -v '_test\.go$' | awk '{print $NF}')
                 if [ -z "$prod_files" ]; then
                   echo "bite check: no production files changed, skipping"
                 else
-                  # Save the current state so we can restore on error.
-                  git stash save "bite-check-snapshot" || { echo "GATE-ERROR: bite check stash failed"; exit 1; }
-                  # Revert production files: for added (untracked) files, remove them;
-                  # for modified files, checkout the original version.
-                  for f in $prod_files; do
-                    if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
-                      # Tracked file: revert to HEAD
-                      git checkout HEAD -- "$f" || { echo "GATE-ERROR: bite check revert failed for $f"; exit 1; }
-                    else
-                      # Untracked (newly added) file: remove it
-                      rm -f "$f" || { echo "GATE-ERROR: bite check remove failed for $f"; exit 1; }
-                    fi
-                  done
+                  # Revert ONLY the production files, keeping the coder's new
+                  # test changes in the working tree. A scoped stash push
+                  # reverts tracked prod to HEAD and removes untracked/added
+                  # prod (via -u), but leaves the changed _test.go files alone,
+                  # so the tests run below are the NEW tests against pre-change
+                  # production (the whole point). Stashing everything would
+                  # revert the new tests too and falsely flag them non-biting.
+                  # git stash pop restores production afterward.
+                  git stash push -u -- $prod_files || { echo "GATE-ERROR: bite check stash failed"; exit 1; }
                   # Rebuild and run tests against reverted production code.
                   echo "bite check: running tests against reverted production code"
                   if ! go build ./...; then

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -156,11 +156,12 @@ type RunGateJobTool struct {
 // for; the gate must verify the branch on the fork where it actually
 // lives. Empty preserves the historical CloneURLBase + Repo behavior.
 type runGateJobArgs struct {
-	Repo     string   `json:"repo"`
-	Branch   string   `json:"branch"`
-	CloneURL string   `json:"cloneURL,omitempty"`
-	Checks   []string `json:"checks,omitempty"`
-	TaskRef  struct {
+	Repo      string   `json:"repo"`
+	Branch    string   `json:"branch"`
+	CloneURL  string   `json:"cloneURL,omitempty"`
+	Checks    []string `json:"checks,omitempty"`
+	BiteCheck bool     `json:"biteCheck,omitempty"`
+	TaskRef   struct {
 		Namespace string `json:"namespace"`
 		Name      string `json:"name"`
 	} `json:"taskRef"`
@@ -184,10 +185,12 @@ func (RunGateJobTool) Schema() oai.ToolSchemaDef {
 		Parameters: json.RawMessage(`{
 "type": "object",
 "properties": {
-  "repo":   {"type": "string", "description": "owner/name slug of the repo (e.g. defilantech/LLMKube)"},
-  "branch": {"type": "string", "description": "branch on the fork to verify, e.g. foreman/issue-503"},
-  "checks": {"type": "array", "items": {"type": "string"},
-    "description": "ordered list of make targets to run; defaults to the foreman gate suite"}
+  "repo":      {"type": "string", "description": "owner/name slug of the repo (e.g. defilantech/LLMKube)"},
+  "branch":    {"type": "string", "description": "branch on the fork to verify, e.g. foreman/issue-503"},
+  "checks":    {"type": "array", "items": {"type": "string"},
+    "description": "ordered list of make targets to run; defaults to the foreman gate suite"},
+  "biteCheck": {"type": "boolean",
+    "description": "when true, run the bite check after standard checks"}
 },
 "required": ["repo", "branch"]
 }`),
@@ -231,6 +234,7 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 		Repo:                    a.Repo,
 		Branch:                  a.Branch,
 		Checks:                  a.Checks,
+		BiteCheck:               a.BiteCheck,
 		PVCName:                 cfg.PVCName,
 		ActiveDeadlineSeconds:   cfg.ActiveDeadlineSeconds,
 		TTLSecondsAfterFinished: cfg.TTLSecondsAfterFinished,
@@ -373,6 +377,7 @@ type rendererInput struct {
 	Repo                    string
 	Branch                  string
 	Checks                  []string
+	BiteCheck               bool
 	PVCName                 string
 	ActiveDeadlineSeconds   int32
 	TTLSecondsAfterFinished int32

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -501,13 +501,15 @@ func TestRenderGateJob_BiteCheck_Enabled(t *testing.T) {
 	if !strings.Contains(args, "_test\\.go") {
 		t.Errorf("bite check must detect test files:\\n%s", args)
 	}
-	// Must handle added (untracked) production files by removing them.
-	if !strings.Contains(args, "rm -f") {
-		t.Errorf("bite check must remove untracked prod files:\\n%s", args)
+	// Must revert ONLY production files via a scoped stash, keeping the new
+	// test changes so they run against pre-change production.
+	if !strings.Contains(args, "git stash push -u -- $prod_files") {
+		t.Errorf("bite check must revert only production files via scoped stash:\\n%s", args)
 	}
-	// Must revert tracked production files.
-	if !strings.Contains(args, "git checkout HEAD") {
-		t.Errorf("bite check must revert tracked prod files:\\n%s", args)
+	// Must NOT stash all changes (that reverts the new tests too and would
+	// falsely flag a biting test as non-biting).
+	if strings.Contains(args, "git stash save") {
+		t.Errorf("bite check must not stash all changes (reverts the new tests):\\n%s", args)
 	}
 	// Must surface errors as GATE-ERROR.
 	if !strings.Contains(args, "GATE-ERROR") {
@@ -648,9 +650,9 @@ func TestRenderGateJob_BiteCheck_UsesStashForRestore(t *testing.T) {
 	}
 	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
 
-	// Must use git stash to save state.
-	if !strings.Contains(args, "git stash save") {
-		t.Errorf("bite check must use git stash to save state:\\n%s", args)
+	// Must use a scoped git stash push to save (and revert) only production.
+	if !strings.Contains(args, "git stash push -u --") {
+		t.Errorf("bite check must use a scoped git stash push for production:\\n%s", args)
 	}
 	// Must use git stash pop to restore state.
 	if !strings.Contains(args, "git stash pop") {

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -463,3 +463,197 @@ func TestRenderGateJob_CloneURLOverride(t *testing.T) {
 		})
 	}
 }
+
+// TestRenderGateJob_BiteCheck_Enabled asserts the bite check phase is
+// rendered when BiteCheck is true, and that it contains the key logic
+// for detecting test files, reverting production, and checking test
+// results. Regression for #799.
+func TestRenderGateJob_BiteCheck_Enabled(t *testing.T) {
+	job, err := renderGateJob(rendererInput{
+		Name:                    "foreman-gate-bite",
+		Namespace:               "foreman-system",
+		Image:                   "golang:1.26",
+		Repo:                    "defilantech/LLMKube",
+		Branch:                  "foreman/issue-799",
+		Checks:                  []string{"fmt", "test"},
+		BiteCheck:               true,
+		PVCName:                 "foreman-gate-cache",
+		ActiveDeadlineSeconds:   1800,
+		TTLSecondsAfterFinished: 86400,
+		CPURequest:              "2",
+		CPULimit:                "4",
+		MemRequest:              "4Gi",
+		MemLimit:                "8Gi",
+		CloneURLBase:            "https://github.com",
+		TaskNamespace:           "default",
+		TaskName:                "gate-799",
+	})
+	if err != nil {
+		t.Fatalf("renderGateJob: %v", err)
+	}
+	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
+
+	// The bite check phase must be present.
+	if !strings.Contains(args, "bite check") {
+		t.Errorf("bite check phase missing from rendered args:\\n%s", args)
+	}
+	// Must detect test files.
+	if !strings.Contains(args, "_test\\.go") {
+		t.Errorf("bite check must detect test files:\\n%s", args)
+	}
+	// Must handle added (untracked) production files by removing them.
+	if !strings.Contains(args, "rm -f") {
+		t.Errorf("bite check must remove untracked prod files:\\n%s", args)
+	}
+	// Must revert tracked production files.
+	if !strings.Contains(args, "git checkout HEAD") {
+		t.Errorf("bite check must revert tracked prod files:\\n%s", args)
+	}
+	// Must surface errors as GATE-ERROR.
+	if !strings.Contains(args, "GATE-ERROR") {
+		t.Errorf("bite check must surface errors as GATE-ERROR:\\n%s", args)
+	}
+	// Must report non-biting tests as GATE FAIL.
+	if !strings.Contains(args, "non-biting") {
+		t.Errorf("bite check must report non-biting tests:\\n%s", args)
+	}
+}
+
+// TestRenderGateJob_BiteCheck_Disabled asserts the bite check phase is
+// absent when BiteCheck is false (the default). Regression for #799.
+func TestRenderGateJob_BiteCheck_Disabled(t *testing.T) {
+	job, err := renderGateJob(rendererInput{
+		Name:                    "foreman-gate-no-bite",
+		Namespace:               "foreman-system",
+		Image:                   "golang:1.26",
+		Repo:                    "defilantech/LLMKube",
+		Branch:                  "foreman/issue-799",
+		Checks:                  []string{"fmt", "test"},
+		BiteCheck:               false,
+		PVCName:                 "foreman-gate-cache",
+		ActiveDeadlineSeconds:   1800,
+		TTLSecondsAfterFinished: 86400,
+		CPURequest:              "2",
+		CPULimit:                "4",
+		MemRequest:              "4Gi",
+		MemLimit:                "8Gi",
+		CloneURLBase:            "https://github.com",
+		TaskNamespace:           "default",
+		TaskName:                "gate-799",
+	})
+	if err != nil {
+		t.Fatalf("renderGateJob: %v", err)
+	}
+	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
+
+	// The bite check phase must NOT be present.
+	if strings.Contains(args, "bite check") {
+		t.Errorf("bite check phase should not be present when BiteCheck is false:\\n%s", args)
+	}
+}
+
+// TestRenderGateJob_BiteCheck_SkipsWhenNoTestFiles asserts the bite check
+// phase includes logic to skip when no test files changed, preventing
+// false rejections of PRs that add/modify no test files. Regression for #799.
+func TestRenderGateJob_BiteCheck_SkipsWhenNoTestFiles(t *testing.T) {
+	job, err := renderGateJob(rendererInput{
+		Name:                    "foreman-gate-skip",
+		Namespace:               "foreman-system",
+		Image:                   "golang:1.26",
+		Repo:                    "defilantech/LLMKube",
+		Branch:                  "foreman/issue-799",
+		Checks:                  []string{"fmt", "test"},
+		BiteCheck:               true,
+		PVCName:                 "foreman-gate-cache",
+		ActiveDeadlineSeconds:   1800,
+		TTLSecondsAfterFinished: 86400,
+		CPURequest:              "2",
+		CPULimit:                "4",
+		MemRequest:              "4Gi",
+		MemLimit:                "8Gi",
+		CloneURLBase:            "https://github.com",
+		TaskNamespace:           "default",
+		TaskName:                "gate-799",
+	})
+	if err != nil {
+		t.Fatalf("renderGateJob: %v", err)
+	}
+	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
+
+	// Must have the skip logic for no test files.
+	if !strings.Contains(args, "no test files changed, skipping") {
+		t.Errorf("bite check must skip when no test files changed:\\n%s", args)
+	}
+}
+
+// TestRenderGateJob_BiteCheck_SkipsWhenNoProdFiles asserts the bite check
+// phase includes logic to skip when no production files changed, preventing
+// false rejections of PRs that only add tests. Regression for #799.
+func TestRenderGateJob_BiteCheck_SkipsWhenNoProdFiles(t *testing.T) {
+	job, err := renderGateJob(rendererInput{
+		Name:                    "foreman-gate-skip-prod",
+		Namespace:               "foreman-system",
+		Image:                   "golang:1.26",
+		Repo:                    "defilantech/LLMKube",
+		Branch:                  "foreman/issue-799",
+		Checks:                  []string{"fmt", "test"},
+		BiteCheck:               true,
+		PVCName:                 "foreman-gate-cache",
+		ActiveDeadlineSeconds:   1800,
+		TTLSecondsAfterFinished: 86400,
+		CPURequest:              "2",
+		CPULimit:                "4",
+		MemRequest:              "4Gi",
+		MemLimit:                "8Gi",
+		CloneURLBase:            "https://github.com",
+		TaskNamespace:           "default",
+		TaskName:                "gate-799",
+	})
+	if err != nil {
+		t.Fatalf("renderGateJob: %v", err)
+	}
+	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
+
+	// Must have the skip logic for no production files.
+	if !strings.Contains(args, "no production files changed, skipping") {
+		t.Errorf("bite check must skip when no production files changed:\\n%s", args)
+	}
+}
+
+// TestRenderGateJob_BiteCheck_UsesStashForRestore asserts the bite check
+// uses git stash to save and restore state, ensuring the workspace is
+// clean after the check regardless of outcome. Regression for #799.
+func TestRenderGateJob_BiteCheck_UsesStashForRestore(t *testing.T) {
+	job, err := renderGateJob(rendererInput{
+		Name:                    "foreman-gate-stash",
+		Namespace:               "foreman-system",
+		Image:                   "golang:1.26",
+		Repo:                    "defilantech/LLMKube",
+		Branch:                  "foreman/issue-799",
+		Checks:                  []string{"fmt", "test"},
+		BiteCheck:               true,
+		PVCName:                 "foreman-gate-cache",
+		ActiveDeadlineSeconds:   1800,
+		TTLSecondsAfterFinished: 86400,
+		CPURequest:              "2",
+		CPULimit:                "4",
+		MemRequest:              "4Gi",
+		MemLimit:                "8Gi",
+		CloneURLBase:            "https://github.com",
+		TaskNamespace:           "default",
+		TaskName:                "gate-799",
+	})
+	if err != nil {
+		t.Fatalf("renderGateJob: %v", err)
+	}
+	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
+
+	// Must use git stash to save state.
+	if !strings.Contains(args, "git stash save") {
+		t.Errorf("bite check must use git stash to save state:\\n%s", args)
+	}
+	// Must use git stash pop to restore state.
+	if !strings.Contains(args, "git stash pop") {
+		t.Errorf("bite check must use git stash pop to restore state:\\n%s", args)
+	}
+}


### PR DESCRIPTION
## What

Add a "bite check" to the Foreman verify-gate Job: a new or changed test must FAIL against the pre-change production code, otherwise the gate rejects it as a non-biting test. This catches self-confirming tests (the #525 / #409 class) where tests pass without exercising the change.

## Why

Fixes #799. Supersedes the first attempt (#787), which was placed in the fast in-workspace gate, used `git checkout --` on untracked files (false-rejecting new-file PRs), swallowed errors, and shipped with most of its own tests non-biting.

## How

- `gate_job_template.yaml`: a `.BiteCheck`-gated phase in the clean-room Job. It detects changed `_test.go` files, reverts ONLY the production files via a scoped `git stash push -u -- $prod_files` (reverts tracked prod to HEAD, removes untracked/added prod, **keeps the new test changes**), runs the tests against pre-change production, and flags a GATE FAIL if they pass. `git stash pop` restores production. Every git step surfaces failures as GATE-ERROR (fail loud); skips cleanly when no test or no production files changed.
- `run_gate_job.go`: a `biteCheck` boolean arg plumbed through to the renderer.
- Tests assert the rendered phase, the scoped stash, the skip cases, and that it does NOT stash all changes.

## Review note (maintainer)

The initial rework correctly fixed placement, added-file handling, and error surfacing, but a follow-up review caught that `git stash save` reverted the new test changes too, falsely flagging tests added to an existing `_test.go` as non-biting. The final commit fixes that with the scoped stash. Foreman-authored (Strix Qwopus), then maintainer-corrected.

## Checklist

- [x] Tests added/updated (and updated to assert the scoped stash)
- [x] `make test` / package tests pass locally
- [x] `gofmt` + `GOOS=linux go vet` clean
- [x] Conventional commits, DCO signed off
- [x] Documentation updated (the gate Job template carries inline rationale)
