### PR TITLE
fix(foreman): make the verify-gate bite check actually run, enable by default

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -725,6 +725,11 @@ func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL 
 		// The gate Job skips it safely when no test or no production files
 		// changed, so default-on costs nothing when there is nothing to check.
 		"biteCheck": true,
+		// baseBranch is the ref the bite check diffs the coder branch against
+		// and reverts production to. The clone is shallow + single-branch, so
+		// the bite check fetches this ref explicitly. LLMKube branches off
+		// main; the tool also defaults to main when empty.
+		"baseBranch": "main",
 	}
 	out, _ := json.Marshal(args)
 	return out

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -719,6 +719,12 @@ func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL 
 		"issue":    task.Spec.Payload.Issue,
 		"prompt":   task.Spec.Payload.Prompt,
 		"taskRef":  map[string]string{"namespace": task.Namespace, "name": task.Name},
+		// Bite check is on by default for the verify gate: every final
+		// verification confirms the coder's new/changed tests fail against
+		// pre-change production, rejecting self-confirming tests (#787/#799).
+		// The gate Job skips it safely when no test or no production files
+		// changed, so default-on costs nothing when there is nothing to check.
+		"biteCheck": true,
 	}
 	out, _ := json.Marshal(args)
 	return out

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -211,6 +211,12 @@ func TestBuildDeterministicArgs(t *testing.T) {
 		if ref["namespace"] != "default" || ref["name"] != "gate-510" {
 			t.Errorf("taskRef: want default/gate-510 got %v/%v", ref["namespace"], ref["name"])
 		}
+		// Bite check defaults on for the verify gate (#787/#799): the gate
+		// must reject self-confirming tests without anyone remembering to
+		// opt in. A gate you have to enable is a gate that is usually off.
+		if got["biteCheck"] != true {
+			t.Errorf("biteCheck: want true (default-on for verify gate) got %v", got["biteCheck"])
+		}
 	})
 
 	t.Run("cloneURL empty preserves M4 default", func(t *testing.T) {

--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -11,6 +11,9 @@
 #   .Image          -- container image (default: golang:1.26)
 #   .Repo           -- "owner/name", inlined verbatim into the clone URL
 #   .Branch         -- branch on the fork to clone shallowly
+#   .BaseBranch     -- base branch the coder branch was cut from (default
+#                      "main"); the bite check diffs against and reverts to
+#                      this ref to prove new tests bite.
 #   .Checks         -- list of make targets to run, in order
 #   .BiteCheck      -- when true, run the bite check after standard checks
 #   .PVCName        -- "foreman-gate-cache" PVC for GOMODCACHE/GOCACHE/XDG
@@ -72,43 +75,75 @@ spec:
               fi
               {{- if .BiteCheck }}
               # Bite check: verify new/changed tests actually fail against
-              # pre-change production code. Skipped if no test files changed.
-              # Errors surface as GATE-ERROR (fail loud).
-              echo "=== bite check ==="
-              test_files=$(git status --porcelain | grep '_test\.go$' | awk '{print $NF}')
-              if [ -z "$test_files" ]; then
-                echo "bite check: no test files changed, skipping"
+              # pre-change production code. The gate Job clones the coder
+              # branch as a shallow, single-branch checkout (everything is
+              # committed, working tree is clean), so change detection works
+              # on the committed diff against the base branch, NOT on
+              # `git status`. Skipped only when no test files changed.
+              # Inability to establish the base ref is GATE-ERROR (fail loud).
+              BASE="${BASE_BRANCH:-main}"
+              echo "=== bite check (base=$BASE) ==="
+              # The clone is shallow AND single-branch, so its refspec only
+              # tracks the coder branch; a plain `git fetch origin $BASE` would
+              # update FETCH_HEAD but never create refs/remotes/origin/$BASE.
+              # Fetch with an explicit refspec so origin/$BASE resolves, then
+              # verify it. Fail loud if the base ref cannot be established.
+              if ! git fetch --depth 1 origin "+refs/heads/$BASE:refs/remotes/origin/$BASE" >/dev/null 2>&1; then
+                echo "GATE-ERROR: bite check could not fetch base ref origin/$BASE"
+                rc=1
+              elif ! git rev-parse --verify --quiet "origin/$BASE" >/dev/null; then
+                echo "GATE-ERROR: bite check base ref origin/$BASE did not resolve after fetch"
+                rc=1
               else
-                # Identify production .go files that changed (added or modified).
-                # Both are handled by the scoped stash below.
-                prod_files=$(git status --porcelain | grep '\.go$' | grep -v '_test\.go$' | awk '{print $NF}')
-                if [ -z "$prod_files" ]; then
-                  echo "bite check: no production files changed, skipping"
+                # Detect changes by committed diff (tree-vs-tree, two-dot: no
+                # merge-base needed, works on shallow grafts). Assumes the coder
+                # branch was cut from base, which Foreman always does.
+                changed=$(git diff --name-only "origin/$BASE" HEAD)
+                test_files=$(echo "$changed" | grep '_test\.go$' || true)
+                if [ -z "$test_files" ]; then
+                  echo "bite check: no test files changed, skipping"
                 else
-                  # Revert ONLY the production files, keeping the coder's new
-                  # test changes in the working tree. A scoped stash push
-                  # reverts tracked prod to HEAD and removes untracked/added
-                  # prod (via -u), but leaves the changed _test.go files alone,
-                  # so the tests run below are the NEW tests against pre-change
-                  # production (the whole point). Stashing everything would
-                  # revert the new tests too and falsely flag them non-biting.
-                  # git stash pop restores production afterward.
-                  git stash push -u -- $prod_files || { echo "GATE-ERROR: bite check stash failed"; exit 1; }
-                  # Rebuild and run tests against reverted production code.
-                  echo "bite check: running tests against reverted production code"
-                  if ! go build ./...; then
-                    echo "bite check: build failed against reverted production (expected for some changes)"
-                  fi
-                  bite_rc=0
-                  go test -count=1 -timeout=180s ./... || bite_rc=1
-                  if [ "$bite_rc" -eq 0 ]; then
-                    echo "GATE FAIL: bite check: tests pass against pre-change production (non-biting test)"
-                    rc=1
+                  prod_files=$(echo "$changed" | grep '\.go$' | grep -v '_test\.go$' || true)
+                  if [ -z "$prod_files" ]; then
+                    echo "bite check: no production files changed, skipping"
                   else
-                    echo "bite check: tests fail against pre-change production (biting test, good)"
+                    # Revert ONLY production files to their base version, keeping
+                    # the coder's new tests in the tree. Files present in base
+                    # are checked out at base; files added in the branch are
+                    # removed. Tests then run against pre-change production --
+                    # the whole point. Restored to branch state afterward.
+                    bite_err=0
+                    for f in $prod_files; do
+                      if git cat-file -e "origin/$BASE:$f" 2>/dev/null; then
+                        git checkout "origin/$BASE" -- "$f" || { echo "GATE-ERROR: bite check revert failed for $f"; bite_err=1; break; }
+                      else
+                        rm -f "$f" || { echo "GATE-ERROR: bite check could not remove added prod file $f"; bite_err=1; break; }
+                      fi
+                    done
+                    if [ "$bite_err" -ne 0 ]; then
+                      rc=1
+                    else
+                      # Run ONLY the packages whose tests changed, never the whole
+                      # module: a module-wide `go test ./...` would fail on
+                      # unrelated packages (e.g. controller envtest needs
+                      # KUBEBUILDER_ASSETS, absent here) and the bite check would
+                      # misread that as "biting" -> false pass. Scoping to the
+                      # changed test packages isolates the signal to the coder's
+                      # own tests.
+                      test_pkgs=$(echo "$test_files" | xargs -n1 dirname | sort -u | sed 's;^;./;')
+                      echo "bite check: running changed test packages against reverted production: $test_pkgs"
+                      bite_rc=0
+                      go test -count=1 -timeout=180s $test_pkgs || bite_rc=1
+                      # Restore branch state regardless of test outcome.
+                      git checkout HEAD -- $prod_files || { echo "GATE-ERROR: bite check restore failed"; rc=1; }
+                      if [ "$bite_rc" -eq 0 ]; then
+                        echo "GATE FAIL: bite check: tests pass against pre-change production (non-biting test)"
+                        rc=1
+                      else
+                        echo "bite check: tests fail against pre-change production (biting test, good)"
+                      fi
+                    fi
                   fi
-                  # Restore the original state.
-                  git stash pop || { echo "GATE-ERROR: bite check restore failed"; exit 1; }
                 fi
               fi
               {{- end }}
@@ -117,6 +152,8 @@ spec:
           env:
             - name: BRANCH
               value: "{{ .Branch }}"
+            - name: BASE_BRANCH
+              value: "{{ .BaseBranch }}"
             - name: GOMODCACHE
               value: /cache/gomod
             - name: GOCACHE

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -156,12 +156,16 @@ type RunGateJobTool struct {
 // for; the gate must verify the branch on the fork where it actually
 // lives. Empty preserves the historical CloneURLBase + Repo behavior.
 type runGateJobArgs struct {
-	Repo      string   `json:"repo"`
-	Branch    string   `json:"branch"`
-	CloneURL  string   `json:"cloneURL,omitempty"`
-	Checks    []string `json:"checks,omitempty"`
-	BiteCheck bool     `json:"biteCheck,omitempty"`
-	TaskRef   struct {
+	Repo   string `json:"repo"`
+	Branch string `json:"branch"`
+	// BaseBranch is the branch the coder branch was cut from. The bite
+	// check diffs the coder branch against it and reverts production to it
+	// to verify new tests bite. Defaults to "main" when empty.
+	BaseBranch string   `json:"baseBranch,omitempty"`
+	CloneURL   string   `json:"cloneURL,omitempty"`
+	Checks     []string `json:"checks,omitempty"`
+	BiteCheck  bool     `json:"biteCheck,omitempty"`
+	TaskRef    struct {
 		Namespace string `json:"namespace"`
 		Name      string `json:"name"`
 	} `json:"taskRef"`
@@ -187,6 +191,7 @@ func (RunGateJobTool) Schema() oai.ToolSchemaDef {
 "properties": {
   "repo":      {"type": "string", "description": "owner/name slug of the repo (e.g. defilantech/LLMKube)"},
   "branch":    {"type": "string", "description": "branch on the fork to verify, e.g. foreman/issue-503"},
+  "baseBranch": {"type": "string", "description": "base branch the bite check diffs against (default main)"},
   "checks":    {"type": "array", "items": {"type": "string"},
     "description": "ordered list of make targets to run; defaults to the foreman gate suite"},
   "biteCheck": {"type": "boolean",
@@ -217,6 +222,9 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 	if len(a.Checks) == 0 {
 		a.Checks = DefaultGateChecks
 	}
+	if a.BaseBranch == "" {
+		a.BaseBranch = "main"
+	}
 
 	cfg := applyConfigDefaults(t.Cfg)
 
@@ -233,6 +241,7 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 		Image:                   cfg.Image,
 		Repo:                    a.Repo,
 		Branch:                  a.Branch,
+		BaseBranch:              a.BaseBranch,
 		Checks:                  a.Checks,
 		BiteCheck:               a.BiteCheck,
 		PVCName:                 cfg.PVCName,
@@ -376,6 +385,7 @@ type rendererInput struct {
 	Image                   string
 	Repo                    string
 	Branch                  string
+	BaseBranch              string
 	Checks                  []string
 	BiteCheck               bool
 	PVCName                 string
@@ -397,6 +407,9 @@ func renderGateJob(in rendererInput) (*batchv1.Job, error) {
 	}
 	if in.TaskName == "" {
 		in.TaskName = "unknown"
+	}
+	if in.BaseBranch == "" {
+		in.BaseBranch = "main"
 	}
 	tmpl, err := template.New("gate-job").Parse(gateJobTemplate)
 	if err != nil {

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -497,19 +497,41 @@ func TestRenderGateJob_BiteCheck_Enabled(t *testing.T) {
 	if !strings.Contains(args, "bite check") {
 		t.Errorf("bite check phase missing from rendered args:\\n%s", args)
 	}
-	// Must detect test files.
+	// Must detect changes by committed diff against the base branch, NOT by
+	// git status: the gate Job clones a committed branch, so the working tree
+	// is clean and git status would always be empty (the round-3 fix).
+	if !strings.Contains(args, `git diff --name-only "origin/$BASE" HEAD`) {
+		t.Errorf("bite check must detect changes via committed diff against base:\\n%s", args)
+	}
+	if strings.Contains(args, "git status --porcelain") {
+		t.Errorf("bite check must NOT use git status (clean tree on a committed clone):\\n%s", args)
+	}
+	// Must detect test files among the diff.
 	if !strings.Contains(args, "_test\\.go") {
 		t.Errorf("bite check must detect test files:\\n%s", args)
 	}
-	// Must revert ONLY production files via a scoped stash, keeping the new
+	// Must revert ONLY production files to their base version, keeping the new
 	// test changes so they run against pre-change production.
-	if !strings.Contains(args, "git stash push -u -- $prod_files") {
-		t.Errorf("bite check must revert only production files via scoped stash:\\n%s", args)
+	if !strings.Contains(args, `git checkout "origin/$BASE" -- "$f"`) {
+		t.Errorf("bite check must revert production files to the base version:\\n%s", args)
 	}
-	// Must NOT stash all changes (that reverts the new tests too and would
-	// falsely flag a biting test as non-biting).
-	if strings.Contains(args, "git stash save") {
-		t.Errorf("bite check must not stash all changes (reverts the new tests):\\n%s", args)
+	// Must NOT use the removed stash mechanism (no-op on a clean committed tree).
+	if strings.Contains(args, "git stash") {
+		t.Errorf("bite check must not use git stash (the round-3 fix removed it):\\n%s", args)
+	}
+	// Must restore branch state after the check.
+	if !strings.Contains(args, "git checkout HEAD -- $prod_files") {
+		t.Errorf("bite check must restore branch state via git checkout HEAD:\\n%s", args)
+	}
+	// Must run ONLY the changed test packages, never the whole module: a
+	// module-wide `go test ./...` fails on unrelated packages (controller
+	// envtest needs KUBEBUILDER_ASSETS, absent in the gate image) and the bite
+	// check would misread that as biting -> false pass.
+	if !strings.Contains(args, "test_pkgs=$(echo \"$test_files\" | xargs -n1 dirname | sort -u") {
+		t.Errorf("bite check must scope tests to the changed packages:\\n%s", args)
+	}
+	if strings.Contains(args, "go test -count=1 -timeout=180s ./...") {
+		t.Errorf("bite check must NOT run the whole module (./...); unrelated failures mask the signal:\\n%s", args)
 	}
 	// Must surface errors as GATE-ERROR.
 	if !strings.Contains(args, "GATE-ERROR") {
@@ -622,16 +644,18 @@ func TestRenderGateJob_BiteCheck_SkipsWhenNoProdFiles(t *testing.T) {
 	}
 }
 
-// TestRenderGateJob_BiteCheck_UsesStashForRestore asserts the bite check
-// uses git stash to save and restore state, ensuring the workspace is
-// clean after the check regardless of outcome. Regression for #799.
-func TestRenderGateJob_BiteCheck_UsesStashForRestore(t *testing.T) {
+// TestRenderGateJob_BiteCheck_FetchesBaseRef asserts the bite check fetches
+// the base ref with an explicit refspec (the clone is shallow + single-
+// branch, so a plain fetch would not create origin/$BASE) and fails loud
+// when the base ref cannot be established. Regression for the round-3 fix.
+func TestRenderGateJob_BiteCheck_FetchesBaseRef(t *testing.T) {
 	job, err := renderGateJob(rendererInput{
-		Name:                    "foreman-gate-stash",
+		Name:                    "foreman-gate-base",
 		Namespace:               "foreman-system",
 		Image:                   "golang:1.26",
 		Repo:                    "defilantech/LLMKube",
 		Branch:                  "foreman/issue-799",
+		BaseBranch:              "main",
 		Checks:                  []string{"fmt", "test"},
 		BiteCheck:               true,
 		PVCName:                 "foreman-gate-cache",
@@ -650,12 +674,68 @@ func TestRenderGateJob_BiteCheck_UsesStashForRestore(t *testing.T) {
 	}
 	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
 
-	// Must use a scoped git stash push to save (and revert) only production.
-	if !strings.Contains(args, "git stash push -u --") {
-		t.Errorf("bite check must use a scoped git stash push for production:\\n%s", args)
+	// Must fetch the base ref with an explicit refspec so origin/$BASE resolves.
+	if !strings.Contains(args, `git fetch --depth 1 origin "+refs/heads/$BASE:refs/remotes/origin/$BASE"`) {
+		t.Errorf("bite check must fetch base with an explicit refspec:\\n%s", args)
 	}
-	// Must use git stash pop to restore state.
-	if !strings.Contains(args, "git stash pop") {
-		t.Errorf("bite check must use git stash pop to restore state:\\n%s", args)
+	// Must verify the ref resolved and fail loud otherwise.
+	if !strings.Contains(args, `git rev-parse --verify --quiet "origin/$BASE"`) {
+		t.Errorf("bite check must verify the base ref resolved:\\n%s", args)
+	}
+	if !strings.Contains(args, "could not fetch base ref") {
+		t.Errorf("bite check must fail loud when the base ref cannot be fetched:\\n%s", args)
+	}
+}
+
+// TestRenderGateJob_BaseBranchEnv asserts the BASE_BRANCH env var is rendered
+// from the BaseBranch field and that an empty BaseBranch defaults to main.
+func TestRenderGateJob_BaseBranchEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"explicit", "release-1.0", "release-1.0"},
+		{"defaults to main", "", "main"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			job, err := renderGateJob(rendererInput{
+				Name:                    "foreman-gate-baseenv",
+				Namespace:               "foreman-system",
+				Image:                   "golang:1.26",
+				Repo:                    "defilantech/LLMKube",
+				Branch:                  "foreman/issue-799",
+				BaseBranch:              tc.in,
+				Checks:                  []string{"fmt", "test"},
+				BiteCheck:               true,
+				PVCName:                 "foreman-gate-cache",
+				ActiveDeadlineSeconds:   1800,
+				TTLSecondsAfterFinished: 86400,
+				CPURequest:              "2",
+				CPULimit:                "4",
+				MemRequest:              "4Gi",
+				MemLimit:                "8Gi",
+				CloneURLBase:            "https://github.com",
+				TaskNamespace:           "default",
+				TaskName:                "gate-799",
+			})
+			if err != nil {
+				t.Fatalf("renderGateJob: %v", err)
+			}
+			var got string
+			found := false
+			for _, e := range job.Spec.Template.Spec.Containers[0].Env {
+				if e.Name == "BASE_BRANCH" {
+					got = e.Value
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("BASE_BRANCH env var not rendered")
+			}
+			if got != tc.want {
+				t.Errorf("BASE_BRANCH = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Makes the Foreman verify-gate **bite check** actually function, and enables it by default. The bite check reverts the coder's production changes to the base branch, re-runs their new/changed tests, and fails the gate if those tests still pass (a self-confirming / non-biting test).

## Why

Fixes #787

The bite check shipped in #803 but was **inert**. The gate Job clones the coder branch with `git clone --depth 1 --branch <branch>` — a shallow, single-branch checkout where every change is already committed and the working tree is clean. Detection used `git status --porcelain` (uncommitted changes), which is always empty on such a clone, so the check logged "no test files changed, skipping" and returned pass on every run. Enabling it by default would have produced a green check that asserts nothing — false confidence in a trust gate.

## How

Rework the bite check to operate on the committed branch (`pkg/foreman/agent/tools/gate_job_template.yaml`), plus a new `baseBranch` arg plumbed through `run_gate_job.go` → `rendererInput` → `buildDeterministicArgs` as a `BASE_BRANCH` env var (default `main`):

- **Fetch the base ref with an explicit refspec** (`+refs/heads/$BASE:refs/remotes/origin/$BASE`) and verify it resolves. A `--branch` clone is single-branch, so a plain `git fetch origin main` updates `FETCH_HEAD` but never creates `origin/main`. Inability to establish the base ref is a loud `GATE-ERROR`.
- **Detect changes via committed diff** `git diff --name-only origin/$BASE HEAD` (two-dot, no merge-base needed on shallow grafts), not `git status`.
- **Revert only production files** to their base version (checkout for modified, `rm` for added), keeping the coder's new tests, then run them against pre-change production. Restore with `git checkout HEAD`.
- **Run only the changed test packages**, never `go test ./...`. A module-wide run fails on unrelated packages (the controller envtest needs `KUBEBUILDER_ASSETS`, absent in the gate image) and the bite check would misread that non-zero exit as "biting → good" — a false pass on every branch. Scoping isolates the signal to the coder's own tests.
- Removes the git-stash mechanism (a no-op on a clean committed tree).

**Validation:** logic exercised against real git repos across seven scenarios (skips with no test/no prod change; biting new file; biting modified file; non-biting → fail; non-biting amid an unrelated always-failing package → still correctly fails; missing base → fail-loud). Verified end-to-end in-cluster: a non-biting self-test branch `GATE FAIL`s and a biting one `GATE PASS`es.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (native + `GOOS=linux`)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated (if user-facing change) — internal harness behavior, no user-facing docs
