### PR TITLE
chore(foreman): add golangci-lint and controller-gen to the agent-builder image (#797)

### DIFF
--- a/Dockerfile.foreman-agent-builder
+++ b/Dockerfile.foreman-agent-builder
@@ -1,4 +1,5 @@
-# Foreman coder-Job builder image (#620).
+# Foreman coder-Job builder image (#620) and in-cluster foreman-agent
+# toolchain image (#797).
 #
 # The coder Job (pkg/foreman/agent/tools/coder_job_template.yaml) runs
 # `foreman-agent run-task`, whose `bash` tool shells out to
@@ -6,6 +7,10 @@
 # full toolchain (go + make + git), which the published, intentionally
 # minimal Dockerfile.foreman-agent (alpine + git, no go/make) does not
 # carry. This image bundles the foreman-agent binary with that toolchain.
+#
+# #797: the in-cluster foreman-agent also needs golangci-lint and
+# controller-gen so its fast gate can run gofmt / go vet / go build /
+# golangci-lint / go test without submitting a separate gate Job.
 #
 # Two stages:
 #   1. builder -- compile the static foreman-agent binary, identical to
@@ -66,6 +71,20 @@ RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH:-amd
     && chmod +x /usr/local/bin/helm \
     && rm -rf /tmp/linux-* \
     && helm version
+
+# golangci-lint: the in-cluster foreman-agent fast gate runs
+# `golangci-lint run` as part of its verification. Pinned to the same
+# version the Makefile uses (GOLANGCI_LINT_VERSION).
+ARG GOLANGCI_LINT_VERSION=v2.12.2
+RUN go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" \
+    && golangci-lint version
+
+# controller-gen: the in-cluster foreman-agent fast gate may need to
+# regenerate CRDs / DeepCopy methods as part of its verification. Pinned
+# to the same version the Makefile uses (CONTROLLER_TOOLS_VERSION).
+ARG CONTROLLER_TOOLS_VERSION=v0.19.0
+RUN go install "sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_TOOLS_VERSION}" \
+    && controller-gen --version
 
 # /usr/local/bin is on PATH in the golang image, so the template's bare
 # `command: ["foreman-agent"]` resolves here.

--- a/Makefile
+++ b/Makefile
@@ -344,9 +344,11 @@ build-router-proxy: fmt vet ## Build router-proxy binary into bin/.
 # cluster and for the helm-chart CI's smoke install.
 FOREMAN_OPERATOR_IMG     ?= ghcr.io/defilantech/llmkube-foreman-operator:dev
 FOREMAN_AGENT_IMG        ?= ghcr.io/defilantech/llmkube-foreman-agent:dev
-# Coder-Job builder image (#620): foreman-agent binary + go/make/git
-# toolchain on the gate's golang:1.26 base, so the in-Job coder can run
-# `make fmt vet lint test`. Referenced by Agent.spec.execution.image.
+# Coder-Job builder image (#620) and in-cluster foreman-agent toolchain
+# image (#797): foreman-agent binary + go/make/git/golangci-lint/
+# controller-gen on the gate's golang:1.26 base, so the in-Job coder
+# and the in-cluster foreman-agent fast gate can run `make fmt vet lint
+# test`. Referenced by Agent.spec.execution.image.
 FOREMAN_AGENT_BUILDER_IMG ?= ghcr.io/defilantech/llmkube-foreman-agent-builder:dev
 
 .PHONY: docker-build-foreman-operator
@@ -358,7 +360,7 @@ docker-build-foreman-agent: ## Build docker image for the foreman-agent.
 	$(CONTAINER_TOOL) build -f Dockerfile.foreman-agent -t ${FOREMAN_AGENT_IMG} .
 
 .PHONY: docker-build-foreman-agent-builder
-docker-build-foreman-agent-builder: ## Build the coder-Job builder image (foreman-agent + go/make/git).
+docker-build-foreman-agent-builder: ## Build the coder-Job builder image (foreman-agent + go/make/git/golangci-lint/controller-gen).
 	$(CONTAINER_TOOL) build -f Dockerfile.foreman-agent-builder -t ${FOREMAN_AGENT_BUILDER_IMG} .
 
 .PHONY: docker-push-foreman-operator


### PR DESCRIPTION
## What

Adds `golangci-lint` and `controller-gen` to the `Dockerfile.foreman-agent-builder` toolchain image so an in-cluster foreman-agent has the full Go build toolchain (`go`, `git`, `make`, `golangci-lint`, `controller-gen`, plus `helm`) needed to run coder loops in-cluster, not just submit gate Jobs.

## Why

Fixes #797

The published in-cluster `Dockerfile.foreman-agent` is intentionally minimal (alpine + git). The coder's fast gate runs `gofmt / go vet / go build / golangci-lint / go test` (and may regenerate CRDs), so an in-cluster agent could only submit gate Jobs, never run a coder loop itself. The existing `Dockerfile.foreman-agent-builder` (#620) already bundled `go`, `make`, `git`, and `helm`; the only gaps versus #797 were `golangci-lint` and `controller-gen`.

## How

- Install `golangci-lint` (v2.12.2) and `controller-gen` (v0.19.0) in `Dockerfile.foreman-agent-builder`, **pinned to the exact versions the Makefile already uses** (`GOLANGCI_LINT_VERSION`, `CONTROLLER_TOOLS_VERSION`).
- Update the image header comment and the Makefile target docs to note #797.
- The minimal `Dockerfile.foreman-agent` is intentionally left unchanged. The builder image is already referenceable via `Agent.spec.execution.image`, so the wiring path exists.

## Provenance (transparency)

This change was authored by a Foreman coder run on the AMD Strix node (dense Qwopus-27B, gateway-routed), then verified by hand: correct files only (no `pkg/cli`), tool versions match the Makefile exactly, minimal image untouched.

The automated reviewer returned **NO-GO**, but that is a **false negative**: the reviewer model paraphrased the issue ask as *"Update the toolchain image to v2"* (it pulled "v2" from the branch name), which failed the `issueAsk`-verbatim-quote rail and demoted an otherwise-GO verdict. The diff itself is on-scope and correct. A follow-up issue to make that rail semantic rather than verbatim is filed separately.

## Checklist

- [ ] Tests added/updated — N/A (Dockerfile + Makefile-comment change; no Go code)
- [x] Build verified — pinned versions confirmed against the Makefile; image build is `docker-build-foreman-agent-builder`
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [x] Documentation updated — image/Makefile comments reference #797
