### PR TITLE
ci: add Trivy container image scanning to the release workflow (part of #233)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -73,6 +73,49 @@ jobs:
           name: release-artifacts
           path: dist/*
 
+  trivy-scan:
+    needs:
+      - release-please
+      - goreleaser
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/defilantech/llmkube-controller:${{ needs.release-please.outputs.version }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Scan foreman-operator
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/defilantech/llmkube-foreman-operator:${{ needs.release-please.outputs.version }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Scan foreman-agent
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/defilantech/llmkube-foreman-agent:${{ needs.release-please.outputs.version }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Scan router-proxy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/defilantech/llmkube-router-proxy:${{ needs.release-please.outputs.version }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
   release-helm:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}


### PR DESCRIPTION
## What

Adds Trivy container image scanning to the release workflow so releases fail on CRITICAL/HIGH severity CVEs in the published images.

## Why

Part of #233 (container image scanning + supply-chain security). This PR delivers the **Container Scanning** item.

## How

- New `trivy-scan` job in `.github/workflows/release-please.yml`, gated on `needs: [release-please, goreleaser]` and `release_created == true`, so it runs after the `goreleaser` job has built and pushed the images to GHCR.
- Scans all four published images (`llmkube-controller`, `llmkube-foreman-operator`, `llmkube-foreman-agent`, `llmkube-router-proxy`) at the released version.
- `exit-code: 1` on `severity: CRITICAL,HIGH` (fails the release), `ignore-unfixed: true` (don't block on CVEs with no available fix), action SHA-pinned.

## Scope notes (what this does NOT do)

- **`govulncheck`** (the issue's Dependency Scanning item) already exists in `.github/workflows/security.yml`, so it is intentionally not duplicated.
- The issue's remaining items are **not** in this PR and #233 should stay open for them:
  - **SLSA provenance** generation in GoReleaser output.
  - **Signed images** (cosign/sigstore) published alongside the images in GHCR.

This is CI configuration, so it cannot be exercised by the local/verify gate; the YAML was reviewed for correctness and conventional style (placement after the image push, SHA-pinned action, severity/exit-code semantics).

## Provenance (transparency)

Authored by a Foreman coder run on the AMD Strix node (dense Qwopus-27B, gateway-routed), then hand-verified (placement validated against the goreleaser image-push step).

## Checklist

- [ ] Tests added/updated — N/A (CI workflow change)
- [x] Conventional-commit messages, DCO signed off
- [x] Reviewed for workflow correctness (runs after images are pushed; SHA-pinned)
- [x] Issue intentionally left open for the remaining supply-chain items
