### PR TITLE
fix(foreman): retry transient SSE/transport errors in the OAI client (#815)

### DIFF
--- a/pkg/foreman/agent/oai/client.go
+++ b/pkg/foreman/agent/oai/client.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -150,10 +151,12 @@ func (c *Client) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, erro
 		if ctx.Err() != nil {
 			return nil, err
 		}
-		// Retry a truncated tool-call stream (a streaming hiccup) and a
+		// Retry a truncated tool-call stream (a streaming hiccup), a
 		// transient per-request header timeout (slow prompt-eval on a warm
-		// long context, #532). Any other error is returned as-is.
-		if errors.Is(err, ErrTruncatedToolCallArguments) || isRetryableTimeout(err) {
+		// long context, #532), and a transient transport disconnect
+		// (mid-stream EOF, connection reset, #815). Any other error is
+		// returned as-is.
+		if errors.Is(err, ErrTruncatedToolCallArguments) || isRetryableTimeout(err) || isRetryableTransportError(err) {
 			lastErr = err
 			continue
 		}
@@ -169,6 +172,37 @@ func (c *Client) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, erro
 func isRetryableTimeout(err error) bool {
 	var ne net.Error
 	return errors.As(err, &ne) && ne.Timeout()
+}
+
+// isRetryableTransportError reports whether err is a transient transport
+// failure that can be retried by re-issuing the same request. This
+// covers mid-stream disconnects (io.ErrUnexpectedEOF, io.EOF), network
+// timeouts (net.Error.Timeout), and connection resets (syscall.ECONNRESET
+// or "connection reset by peer"). Genuine API errors (4xx/5xx JSON error
+// bodies) are NOT retryable and must pass through unchanged.
+func isRetryableTransportError(err error) bool {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	// io.EOF mid-stream: the server closed the connection without
+	// sending [DONE] or a finish_reason. This is a transport-level
+	// disconnect, not a protocol-level end-of-stream.
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	// "connection reset by peer" can appear as a plain string in some
+	// Go versions / platforms where the syscall error is not wrapped.
+	if strings.Contains(err.Error(), "connection reset by peer") {
+		return true
+	}
+	return false
 }
 
 // sleepBackoff blocks for backoffs[i] +/- 20% jitter, honoring ctx

--- a/pkg/foreman/agent/oai/client_test.go
+++ b/pkg/foreman/agent/oai/client_test.go
@@ -475,6 +475,79 @@ func TestClient_Chat_TerminatesOnFinishReasonWithoutDONE(t *testing.T) {
 	}
 }
 
+// TestClient_Chat_RetriesTransportErrorThenSucceeds verifies that a
+// mid-stream transport disconnect (io.ErrUnexpectedEOF) is retried
+// and ultimately returns the full response. This is the #815 fix: a
+// single transient blip on a long run should not discard all prior
+// turns.
+func TestClient_Chat_RetriesTransportErrorThenSucceeds(t *testing.T) {
+	var attempts atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+
+		// First attempt: send a partial SSE stream then drop the
+		// connection mid-stream (simulating a gateway timeout or
+		// network blip).
+		if n == 1 {
+			partialChunk := "data: {\"id\":\"t1\",\"object\":\"chat.completion.chunk\"," +
+				"\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n"
+			_, _ = w.Write([]byte(partialChunk))
+			flusher.Flush()
+			// Close the connection without sending [DONE] or
+			// finish_reason. The client will see io.ErrUnexpectedEOF.
+			hijacker, ok := w.(http.Hijacker)
+			if ok {
+				conn, _, err := hijacker.Hijack()
+				if err == nil {
+					_ = conn.Close()
+				}
+			}
+			return
+		}
+		// Second attempt: complete response.
+		_, _ = w.Write([]byte(chatResponseToSSE(t, okBodyOneToolCall)))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", time.Second, 3, WithBackoffs(noJitterBackoffs))
+	resp, err := c.Chat(context.Background(), ChatRequest{Model: "test"})
+	if err != nil {
+		t.Fatalf("Chat should recover from a transient transport error via retry, got: %v", err)
+	}
+	if got := attempts.Load(); got < 2 {
+		t.Errorf("expected at least one retry after the transport error; attempts=%d", got)
+	}
+	if resp.Choices[0].Message.ToolCalls[0].Function.Name != "read_file" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+}
+
+// TestClient_Chat_TransportErrorNotRetriedOnAPIError verifies that a
+// genuine API error (400 with a JSON error body) is NOT retried.
+// Only transport-level errors should be retried; API errors are
+// non-retryable.
+func TestClient_Chat_TransportErrorNotRetriedOnAPIError(t *testing.T) {
+	var attempts atomic.Int64
+	srv := httptest.NewServer(scriptedHandler(t, &attempts,
+		[]int{http.StatusBadRequest}, []string{`{"error":"invalid model"}`}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", time.Second, 3, WithBackoffs(noJitterBackoffs))
+	_, err := c.Chat(context.Background(), ChatRequest{Model: "test"})
+	if err == nil {
+		t.Fatal("expected error on 400")
+	}
+	if !strings.Contains(err.Error(), "status 400") {
+		t.Errorf("error did not mention status: %v", err)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("API error must not retry; attempts=%d", got)
+	}
+}
+
 // TestClient_Chat_AggregatesMultiChunkArguments covers the streaming
 // aggregation path the real server uses: tool-call arguments arrive in
 // fragments, often character-by-character or token-by-token. The


### PR DESCRIPTION
## What

Retries transient transport errors in the OAI streaming client instead of failing the entire AgenticTask on a single mid-stream disconnect.

## Why

Fixes #815

A dropped SSE response mid-completion (`read SSE stream: unexpected EOF`, `oai/client.go`) bubbled up as a retry-less `ExecutorError`, discarding a whole multi-turn run. On long gateway-routed coder runs this is costly: two ~50-turn Strix runs died this way (turn 36, turn 50). The model is fine and the same request succeeds on a retry.

## How

In `pkg/foreman/agent/oai/client.go`, classify transport-level errors as retryable and fold them into the client's **existing** Chat retry loop (alongside `ErrTruncatedToolCallArguments` and timeout retries), so they get the existing bounded exponential backoff:

- New `isRetryableTransportError`: `io.ErrUnexpectedEOF`, mid-stream `io.EOF`, `net.Error` timeouts, `syscall.ECONNRESET`, and the `"connection reset by peer"` string form.
- Genuine API errors (4xx/5xx JSON error bodies) are explicitly **not** retried and pass through unchanged.
- Tests (`client_test.go`) cover: an httptest server that drops the stream then succeeds on retry, and a non-retryable API error that is not retried.

Surgical: no client restructuring, reuses the established retry/backoff path.

## Provenance (transparency)

Authored by a Foreman coder run on the AMD Strix node (dense Qwopus-27B, gateway-routed), then hand-verified for scope (`oai/` only) and correctness. GO + deterministic verify gate GATE-PASS.

Note: deploying this makes long gateway-routed runs resilient to the very class of drop that has been failing them, which unblocks reliably completing larger harness changes (e.g. #813).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes (verify gate GATE-PASS)
- [x] `make lint` passes (verify gate)
- [x] Conventional-commit message, DCO signed off
- [ ] Documentation updated (if user-facing change) — internal client behavior, no user-facing docs
