### PR TITLE
docs(readme): lead hero with heterogeneous hardware + Foreman; add AMD to comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
   ### The Kubernetes operator for self-hosted LLM inference
 
-  **Your models. Your hardware. Your rules.**
+  **Run models across NVIDIA, Apple Silicon, and AMD from one spec. Your models. Your hardware. Your rules.**
+
+  *Plus [Foreman](#foreman): an agentic harness that runs coding agents on your own fleet. It has shipped real fixes to this repo.*
 
   <p>
     <a href="https://github.com/defilantech/LLMKube/actions/workflows/test.yml">
@@ -299,7 +301,8 @@ Foreman is meant for shops where on-prem hardware, sovereignty constraints, or s
 | **Kubernetes-native CRDs** | Yes | No (manual Deployments) | No | Yes | No |
 | **Apple Silicon Metal GPU** | Native (Metal Agent) | No | Local only | No | CPU only |
 | **NVIDIA GPU** | Yes | Yes | Limited | Yes | Yes |
-| **Heterogeneous clusters** (NVIDIA + Metal) | Yes | No | No | No | No |
+| **AMD GPU** (Vulkan, incl. Strix Halo) | Yes | No | Limited | No | Limited |
+| **Heterogeneous clusters** (NVIDIA + Apple Silicon + AMD) | Yes | No | No | No | No |
 | **Hybrid local + cloud routing with policy** | `ModelRouter` CRD | No | No | No | No |
 | **Fail-closed for regulated data (PII/PHI)** | Static + runtime, K8s-enforced | No | No | No | No |
 | **Per-rule / per-backend timeout budgets** | Yes (`spec.rules[].timeout`) | No | No | No | No |


### PR DESCRIPTION
## What

Sharpen the README hero and align the comparison table with shipped reality:

- **Hero bold line** now leads with the differentiator: *"Run models across NVIDIA, Apple Silicon, and AMD from one spec."* before the "Your models. Your hardware. Your rules." sovereignty line.
- **Foreman pointer** added under the hero: a one-line nod to the agentic harness that has shipped real fixes to this repo, linking to the existing `#foreman` section.
- **Comparison table**: added an `AMD GPU (Vulkan, incl. Strix Halo)` row and widened the heterogeneous-clusters row to `NVIDIA + Apple Silicon + AMD`.

## Why

The old tagline ("self-hosted LLM inference") is undifferentiated: it's what every adjacent project also claims. The thing that's actually distinct, running across NVIDIA + Apple Silicon + AMD on hardware you own, plus an agentic harness, wasn't visible in the 15-second scan. The comparison table was also stale: AMD/Vulkan (Strix Halo) is shipped now but the table still said heterogeneous = "NVIDIA + Metal" only.

Part of an adoption-focused docs pass. No code or behavior changes.

## How

Copy-only edit to `README.md` (hero block + one comparison-table row added, one relabeled).

## Checklist

- [ ] Tests added/updated (N/A: docs only)
- [ ] `make test` passes locally (N/A: docs only)
- [ ] `make lint` passes locally (N/A: docs only)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (this is the doc change)
