### PR TITLE
test: guard nil-deref after t.Fatalf to satisfy staticcheck SA5011

### DIFF
--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -1326,6 +1326,7 @@ func TestNativeExecutor_JobModeWithoutSubmitterRunsInProcess(t *testing.T) {
 	// failure path, never a JOB-* outcome.
 	if res == nil {
 		t.Fatalf("expected an in-process failure result, got nil")
+		return
 	}
 	if got, _ := res.Extra["executionMode"].(string); got == "Job" {
 		t.Errorf("must NOT take Job path without a submitter; got executionMode=Job")

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -47,6 +47,7 @@ func TestGet(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatalf("Get(%q) = nil, want non-nil", tt.id)
+				return
 			}
 			if got.Name != tt.wantName {
 				t.Errorf("Get(%q).Name = %q, want %q", tt.id, got.Name, tt.wantName)


### PR DESCRIPTION
## What

Add an explicit `return` in two test nil-guards so the subsequent dereference is provably unreachable when the pointer is nil:

- `pkg/foreman/agent/executor_native_test.go` (after `if res == nil { t.Fatalf(...) }`)
- `pkg/license/license_test.go` (after `if got == nil { t.Fatalf(...) }`)

## Why

`main` went red on Lint with four staticcheck **SA5011** (possible nil pointer dereference) findings in these two test files. staticcheck does not treat `t.Fatalf` as terminating, so it considers the dereference after the nil-guard reachable with a nil pointer.

Notably the Go code did not change: the failure surfaced on a cold-cache lint re-analysis on `main` (a docs-only merge triggered it), and a re-run reproduced it deterministically. So this is pre-existing lint debt, not a regression. The `return` makes the guard unambiguous and clears SA5011 regardless of whether the linter recognizes `t.Fatalf`.

## How

Test-only, two added lines, no behavior change. `go vet` clean on both packages.

> Note: my local `golangci-lint` is a modified build that does not reproduce SA5011, so I'm relying on this PR's CI (the official pinned v2.12.2) to confirm the fix clears it.

## Checklist

- [x] Tests added/updated (test guard hardening)
- [ ] `make test` passes locally (N/A here; CI runs it)
- [ ] `make lint` passes locally (local binary can't reproduce; CI is authoritative)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [ ] Documentation updated (N/A)
