### PR TITLE
fix(foreman): scope guard skips check on zero-Go-file diffs; NUL-safe git status (Fixes #800)

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -149,19 +149,20 @@ func RunCoderGate(ctx context.Context, workspace, golangciPath string, run comma
 
 // changedTestPackages returns the workspace-relative Go package directories
 // (as "./<dir>/" patterns) that have uncommitted changes per
-// `git status --porcelain` and are not envtest-backed. It dedups packages
-// and ignores non-Go files and root-level (package main) changes. A git
+// `git status -z` and are not envtest-backed. It dedups packages and
+// ignores non-Go files and root-level (package main) changes. A git
 // error yields no packages (the tier is skipped rather than failing the
-// gate spuriously).
+// gate spuriously). NUL-terminated output is used so filenames with
+// embedded newlines are handled correctly.
 func changedTestPackages(ctx context.Context, workspace string, run commandRunner) []string {
-	out, err := run(ctx, workspace, nil, "git", "status", "--porcelain")
+	out, err := run(ctx, workspace, nil, "git", "status", "-z")
 	if err != nil {
 		return nil
 	}
 	seen := map[string]bool{}
 	var pkgs []string
-	for _, line := range strings.Split(out, "\n") {
-		fields := strings.Fields(strings.TrimSpace(line))
+	for _, entry := range strings.Split(out, "\x00") {
+		fields := strings.Fields(strings.TrimSpace(entry))
 		if len(fields) == 0 {
 			continue
 		}

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -222,13 +222,14 @@ func TestRunCoderGateLintCacheScopedToWorkspace(t *testing.T) {
 func TestChangedTestPackages_ExcludesEnvtestAndDedups(t *testing.T) {
 	run := func(_ context.Context, _ string, _ []string, name string, _ ...string) (string, error) {
 		if name == "git" {
-			return " M pkg/cli/cache_inspect.go\n" +
-				" M pkg/cli/cache_inspect_test.go\n" +
-				"?? pkg/foreman/agent/loop_session_test.go\n" +
-				" M internal/controller/model_controller.go\n" +
-				" M internal/foreman/controller/agentictask_controller.go\n" +
-				" M test/e2e/e2e_test.go\n" +
-				" M README.md\n", nil
+			// git status -z uses NUL-terminated entries.
+			return " M pkg/cli/cache_inspect.go\x00" +
+				" M pkg/cli/cache_inspect_test.go\x00" +
+				"?? pkg/foreman/agent/loop_session_test.go\x00" +
+				" M internal/controller/model_controller.go\x00" +
+				" M internal/foreman/controller/agentictask_controller.go\x00" +
+				" M test/e2e/e2e_test.go\x00" +
+				" M README.md\x00", nil
 		}
 		return "", nil
 	}
@@ -254,7 +255,7 @@ func TestRunCoderGate_FailsOnChangedPackageUnitTest(t *testing.T) {
 		case name == "gofmt":
 			return "", nil
 		case name == "git":
-			return " M pkg/cli/cache_inspect_test.go\n", nil
+			return " M pkg/cli/cache_inspect_test.go\x00", nil
 		case name == "go" && len(args) > 0 && args[0] == "test":
 			out := "panic: runtime error: invalid memory address\n" +
 				"FAIL\tgithub.com/defilantech/llmkube/pkg/cli"

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -69,6 +69,16 @@ func extractIssuePathRefs(body string) []string {
 	return refs
 }
 
+// hasGoFile reports whether any path in paths ends with ".go".
+func hasGoFile(paths []string) bool {
+	for _, p := range paths {
+		if strings.HasSuffix(p, ".go") {
+			return true
+		}
+	}
+	return false
+}
+
 // isPathRef reports whether a single cleaned token is a concrete file
 // reference per the rules documented on extractIssuePathRefs.
 func isPathRef(tok string) bool {
@@ -139,6 +149,13 @@ func enforceReviewerScopeOverlap(
 	extra["scopeMatched"] = matched
 	extra["scopeDriftDetected"] = drift
 	if !drift {
+		return verdict
+	}
+
+	// A diff with zero indexable Go files is not scope drift — it is a
+	// legitimate docs- or YAML-only change (#800). Skip the scope check
+	// so the run proceeds.
+	if !hasGoFile(diffFiles) {
 		return verdict
 	}
 

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -192,6 +192,40 @@ func TestEnforceReviewerScopeOverlap_DriftOnNoGoAnnotatesOnly(t *testing.T) {
 	}
 }
 
+// TestEnforceReviewerScopeOverlap_ZeroGoFilesSkipsScopeCheck verifies that
+// a diff with zero indexable Go files is not treated as scope drift (#800).
+// A legitimate docs- or YAML-only change should proceed.
+func TestEnforceReviewerScopeOverlap_ZeroGoFilesSkipsScopeCheck(t *testing.T) {
+	// Issue references Go files; diff contains only non-Go files.
+	diff := []string{"README.md", "config/crd/bases/inference.llmkube.dev_models.yaml"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("zero-Go-file diff must not demote GO; got %v", got)
+	}
+	if _, demoted := extra["verdictDemoted"]; demoted {
+		t.Error("should not claim demotion when zero Go files changed")
+	}
+}
+
+// TestEnforceReviewerScopeOverlap_RealDriftStillBites verifies that a diff
+// with Go files that do not match the issue refs is still flagged as drift
+// (#800).
+func TestEnforceReviewerScopeOverlap_RealDriftStillBites(t *testing.T) {
+	// Issue references Go files; diff contains Go files that don't match.
+	diff := []string{"internal/foreman/controller/agentictask_controller.go"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("real drift with Go files must still demote GO; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); !v {
+		t.Error("scopeDriftDetected must be true for real drift")
+	}
+}
+
 func TestEnforceReviewerScopeOverlap_NilOrEmptyInputsPassThrough(t *testing.T) {
 	if got := enforceReviewerScopeOverlap(logr.Discard(), nil, issue379Body,
 		[]string{"x.go"}, foremanv1alpha1.AgenticTaskVerdictGo); got != foremanv1alpha1.AgenticTaskVerdictGo {


### PR DESCRIPTION
## What

- Skip the reviewer scope-overlap check when a diff touches **zero indexable Go files** (a legitimate docs- or YAML-only change is not scope drift).
- Parse `git status` with NUL termination (`git status -z`) in `changedTestPackages` so filenames with embedded newlines are handled correctly.
- Add discrimination tests: skip-on-zero-Go vs still-bites-on-real-drift.

## Why

Fixes #800

The scope guard demoted legitimate docs/YAML-only changes as scope drift because the diff contained no Go files. This false-reject blocks valid non-Go work (examples, docs, manifests).

## How

`hasGoFile()` helper + an early return in `enforceReviewerScopeOverlap` (`pkg/foreman/agent/scope_overlap.go`); NUL-split parsing in `coder_gate.go`; two new tests in `scope_overlap_test.go`.

## Checklist
- [x] Tests added/updated
- [x] `make test` / `make lint` (verified by the Foreman fast gate; PR CI re-verifies)
- [x] Conventional commit + DCO sign-off
- [ ] Docs (n/a)

> Note: the optional `minRelevantFiles` rename from the issue's "also" list is deferred (cosmetic).
> Produced by the Foreman coder (local Qwopus on AMD Strix), human-reviewed before opening.
