### PR TITLE
docs(examples): spot-capacity GPU NodePool for Foreman gate Jobs (Fixes #659)

### DIFF
--- a/examples/foreman/spot-gate-job-patch.yaml
+++ b/examples/foreman/spot-gate-job-patch.yaml
@@ -1,0 +1,51 @@
+# Patch for a Foreman verification-gate Job that targets the spot GPU
+# NodePool defined in spot-nodepool-karpenter.yaml.
+#
+# Apply as a strategic merge patch against the Job created by the
+# foreman-agent gate executor:
+#
+#   kubectl patch job <gate-job-name> -n foreman-system \
+#     --type=strategic -p "$(cat examples/foreman/spot-gate-job-patch.yaml)"
+#
+# Or embed the toleration and nodeSelector directly in the gate Agent
+# spec if you control the Agent manifest.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gate-example
+spec:
+  template:
+    spec:
+      # Tolerate the nvidia.com/gpu taint on the spot NodePool.
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      # Pin to the spot GPU NodePool via its label.
+      nodeSelector:
+        karpenter.sh/nodepool: foreman-gate-spot
+      # Retry up to 3 times with a 30s backoff between attempts.
+      # Spot instances can be interrupted; the Job controller will
+      # reschedule on a new node if the pod is terminated.
+      restartPolicy: OnFailure
+      backoffLimit: 3
+      activeDeadlineSeconds: 900
+      containers:
+        - name: gate
+          image: ghcr.io/defilantech/foreman-agent:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              git clone https://github.com/defilantech/LLMKube.git /workspace
+              cd /workspace
+              make fmt vet lint test
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+              nvidia.com/gpu: "1"
+            limits:
+              nvidia.com/gpu: "1"

--- a/examples/foreman/spot-nodepool-cost-worksheet.md
+++ b/examples/foreman/spot-nodepool-cost-worksheet.md
@@ -1,0 +1,55 @@
+# Spot GPU NodePool Cost Worksheet
+
+This worksheet estimates the cost of running Foreman verification-gate
+Jobs on spot GPU capacity via the Karpenter NodePool defined in
+`spot-nodepool-karpenter.yaml`.
+
+## Assumptions
+
+- Region: us-east-1
+- Instance: g5.xlarge (1x NVIDIA A10G, 16 GiB VRAM)
+- On-demand price: ~$0.526/hr
+- Spot discount: ~60-70% off on-demand
+- Spot price: ~$0.16-0.21/hr
+- Gate Job runtime: 5-15 minutes (fmt, vet, lint, test)
+- Karpenter consolidationPolicy: WhenEmpty (nodes terminate within
+  1 minute of going idle)
+
+## Per-Run Cost
+
+| Item | Value |
+|------|-------|
+| Spot price (g5.xlarge) | $0.18/hr (avg) |
+| Job runtime | 10 min (avg) |
+| Provisioning overhead | 2 min |
+| Total time | 12 min |
+| Cost per gate run | $0.036 |
+
+## Daily Cost (10 gate runs/day)
+
+| Item | Value |
+|------|-------|
+| Runs per day | 10 |
+| Cost per run | $0.036 |
+| Daily cost | $0.36 |
+| Monthly cost (30 days) | $10.80 |
+
+## Comparison: On-Demand vs Spot
+
+| Scenario | On-demand | Spot | Savings |
+|----------|-----------|------|---------|
+| 10 runs/day | $1.75/day | $0.36/day | 79% |
+| 50 runs/day | $8.75/day | $1.80/day | 79% |
+| 100 runs/day | $17.50/day | $3.60/day | 79% |
+
+## Notes
+
+- Spot interruptions are handled by the Job's `backoffLimit: 3` and
+  `restartPolicy: OnFailure`. If a spot instance is reclaimed, the Job
+  reschedules on a new node.
+- The `consolidationPolicy: WhenEmpty` ensures Karpenter terminates
+  idle nodes within 1 minute, minimizing idle cost.
+- For higher throughput, add more instance types to the NodePool
+  requirements (e.g., g5.2xlarge) to increase spot capacity availability.
+- Actual spot prices vary by region and time. Use AWS Spot Instance
+  Advisor or `aws ec2 describe-spot-price-history` for current pricing.

--- a/examples/foreman/spot-nodepool-karpenter.yaml
+++ b/examples/foreman/spot-nodepool-karpenter.yaml
@@ -1,0 +1,47 @@
+# Karpenter NodePool for Foreman verification-gate Jobs on spot GPU capacity.
+#
+# This NodePool provisions spot instances with a single GPU, applies a
+# nvidia.com/gpu taint so only gate Jobs (which carry the matching
+# toleration) land here, and consolidates empty nodes via WhenEmpty.
+#
+# Apply after Karpenter is installed:
+#
+#   kubectl apply -f examples/foreman/spot-nodepool-karpenter.yaml
+#
+# The companion gate-Job patch is at
+# examples/foreman/spot-gate-job-patch.yaml.
+
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: foreman-gate-spot
+spec:
+  template:
+    spec:
+      requirements:
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values:
+            # Pick one or more GPU instance types that fit your budget.
+            # g5.xlarge (1x NVIDIA A10G, 16 GiB VRAM) is a common choice.
+            - g5.xlarge
+            - g5.2xlarge
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values:
+            - spot
+        - key: topology.kubernetes.io/region
+          operator: In
+          values:
+            - us-east-1
+      taints:
+        # Only pods with a matching toleration (the gate Job) schedule here.
+        - key: nvidia.com/gpu
+          effect: NoSchedule
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: foreman-gate-spot
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 1m

--- a/examples/foreman/spot-nodepool-karpenter.yaml
+++ b/examples/foreman/spot-nodepool-karpenter.yaml
@@ -11,7 +11,7 @@
 # The companion gate-Job patch is at
 # examples/foreman/spot-gate-job-patch.yaml.
 
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: foreman-gate-spot


### PR DESCRIPTION
## What

Adds an example (no operator code) under `examples/foreman/` for running Foreman verification-gate Jobs on cheap spot GPU capacity:
- `spot-nodepool-karpenter.yaml` — Karpenter NodePool, spot capacity, GPU taint, `consolidationPolicy: WhenEmpty`.
- `spot-gate-job-patch.yaml` — strategic-merge patch adding the matching toleration + nodeSelector to a gate Job.
- `spot-nodepool-cost-worksheet.md` — back-of-envelope cost worksheet.

## Why

Fixes #659

Gate Jobs are bursty; running them on spot GPU capacity that consolidates to zero when idle is much cheaper than a standing GPU node.

## How

Example manifests + worksheet only. No coupling to the operator; nothing under `internal/` or `api/` touched.

## Checklist
- [ ] Tests (n/a: examples only)
- [x] Conventional commit + DCO sign-off
- [x] Documentation/example added

> Produced by the Foreman coder (local Qwopus on AMD Strix), human-reviewed before opening.
