### PR TITLE
feat(router): optional backend displayName for /v1/models id (Fixes #792)

### DIFF
--- a/api/v1alpha1/modelrouter_types.go
+++ b/api/v1alpha1/modelrouter_types.go
@@ -144,6 +144,15 @@ type RouterBackend struct {
 	// +kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9-]{0,62}$`
 	Name string `json:"name"`
 
+	// DisplayName is an optional freeform label published as the model id
+	// on /v1/models and used by BackendNameMatch to resolve a request's
+	// model field to a backend. When unset, Name is used for both
+	// purposes (current behavior). This lets the k8s-safe Name differ
+	// from the user-facing model identifier (e.g. Name "claude-opus-4"
+	// with DisplayName "claude-opus-4-20250514").
+	// +optional
+	DisplayName string `json:"displayName,omitempty"`
+
 	// InferenceServiceRef references an in-cluster InferenceService.
 	// Mutually exclusive with External.
 	// +optional

--- a/charts/llmkube/templates/crds/modelrouters.yaml
+++ b/charts/llmkube/templates/crds/modelrouters.yaml
@@ -97,6 +97,15 @@ spec:
                           pattern: ^[0-9]+(\.[0-9]+)?$
                           type: string
                       type: object
+                    displayName:
+                      description: |-
+                        DisplayName is an optional freeform label published as the model id
+                        on /v1/models and used by BackendNameMatch to resolve a request's
+                        model field to a backend. When unset, Name is used for both
+                        purposes (current behavior). This lets the k8s-safe Name differ
+                        from the user-facing model identifier (e.g. Name "claude-opus-4"
+                        with DisplayName "claude-opus-4-20250514").
+                      type: string
                     external:
                       description: |-
                         External describes an out-of-cluster provider (Anthropic, OpenAI,

--- a/config/crd/bases/inference.llmkube.dev_modelrouters.yaml
+++ b/config/crd/bases/inference.llmkube.dev_modelrouters.yaml
@@ -93,6 +93,15 @@ spec:
                           pattern: ^[0-9]+(\.[0-9]+)?$
                           type: string
                       type: object
+                    displayName:
+                      description: |-
+                        DisplayName is an optional freeform label published as the model id
+                        on /v1/models and used by BackendNameMatch to resolve a request's
+                        model field to a backend. When unset, Name is used for both
+                        purposes (current behavior). This lets the k8s-safe Name differ
+                        from the user-facing model identifier (e.g. Name "claude-opus-4"
+                        with DisplayName "claude-opus-4-20250514").
+                      type: string
                     external:
                       description: |-
                         External describes an out-of-cluster provider (Anthropic, OpenAI,

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -546,13 +546,18 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 	}
 
 	// BackendNameMatch compiles to one model-match rule per backend (model ==
-	// backend Name) inserted ahead of the defaultRoute catch-all. First-match
-	// ordering mirrors the proxy: explicit rules win, then a request whose
-	// model names a backend routes straight to it, then defaultRoute.
+	// backend published id: DisplayName or Name) inserted ahead of the
+	// defaultRoute catch-all. First-match ordering mirrors the proxy:
+	// explicit rules win, then a request whose model names a backend routes
+	// straight to it, then defaultRoute.
 	if mr.Spec.DefaultRouteStrategy == inferencev1alpha1.DefaultRouteStrategyBackendNameMatch {
 		for _, b := range mr.Spec.Backends {
+			modelID := b.Name
+			if b.DisplayName != "" {
+				modelID = b.DisplayName
+			}
 			rules = append(rules, routerRuleResource{
-				Models:      []string{b.Name},
+				Models:      []string{modelID},
 				BackendRefs: []routerBackendRef{{Name: b.Name}},
 			})
 		}

--- a/internal/controller/modelrouter_gateway_test.go
+++ b/internal/controller/modelrouter_gateway_test.go
@@ -1746,6 +1746,138 @@ func TestCompileBudgetRule_WindowScaling(t *testing.T) {
 	}
 }
 
+// TestCompileRouterRules_BackendNameMatch confirms that the BackendNameMatch
+// default-route strategy compiles to one model==name rule per backend, inserted
+// after the explicit rules and before the defaultRoute catch-all so first-match
+// ordering mirrors the proxy.
+func TestCompileRouterRules_BackendNameMatch(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "local-a"},
+				{Name: "local-b"},
+			},
+			Rules: []inferencev1alpha1.RouterRule{{
+				Name:  "explicit",
+				Match: &inferencev1alpha1.RuleMatch{Models: []string{"foo-*"}},
+				Route: inferencev1alpha1.RuleRoute{Backends: []string{"local-a"}},
+			}},
+			DefaultRoute:         "local-a",
+			DefaultRouteStrategy: inferencev1alpha1.DefaultRouteStrategyBackendNameMatch,
+		},
+	}
+
+	rules, err := compileRouterRules(mr)
+	if err != nil {
+		t.Fatalf("compileRouterRules: %v", err)
+	}
+	// explicit rule, one name rule per backend, then the defaultRoute catch-all.
+	if len(rules) != 4 {
+		t.Fatalf("expected 4 rules, got %d: %+v", len(rules), rules)
+	}
+	if got := rules[0].Models; len(got) != 1 || got[0] != "foo-*" {
+		t.Errorf("rules[0] should be the explicit rule, got models %v", got)
+	}
+	for i, wantBackend := range []string{"local-a", "local-b"} {
+		r := rules[i+1]
+		if len(r.Models) != 1 || r.Models[0] != wantBackend {
+			t.Errorf("rules[%d] models = %v, want [%s]", i+1, r.Models, wantBackend)
+		}
+		if len(r.BackendRefs) != 1 || r.BackendRefs[0].Name != wantBackend {
+			t.Errorf("rules[%d] backendRefs = %+v, want single %s", i+1, r.BackendRefs, wantBackend)
+		}
+	}
+	// The catch-all is last and matches on nothing.
+	last := rules[len(rules)-1]
+	if len(last.Models) != 0 {
+		t.Errorf("catch-all should have no model match, got %v", last.Models)
+	}
+	if len(last.BackendRefs) != 1 || last.BackendRefs[0].Name != "local-a" {
+		t.Errorf("catch-all backendRefs = %+v, want single local-a", last.BackendRefs)
+	}
+}
+
+// TestCompileRouterRules_StaticOmitsNameRules confirms the default Static
+// strategy compiles no per-backend name rules: only the explicit rules plus the
+// defaultRoute catch-all.
+func TestCompileRouterRules_StaticOmitsNameRules(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "local-a"},
+				{Name: "local-b"},
+			},
+			Rules: []inferencev1alpha1.RouterRule{{
+				Name:  "explicit",
+				Match: &inferencev1alpha1.RuleMatch{Models: []string{"foo-*"}},
+				Route: inferencev1alpha1.RuleRoute{Backends: []string{"local-a"}},
+			}},
+			DefaultRoute:         "local-a",
+			DefaultRouteStrategy: inferencev1alpha1.DefaultRouteStrategyStatic,
+		},
+	}
+
+	rules, err := compileRouterRules(mr)
+	if err != nil {
+		t.Fatalf("compileRouterRules: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("expected explicit rule + catch-all only, got %d: %+v", len(rules), rules)
+	}
+	// rules[0] is the explicit rule; rules[1] is the defaultRoute catch-all
+	// (no model match) — and crucially no per-backend name rule sits between.
+	if got := rules[0].Models; len(got) != 1 || got[0] != "foo-*" {
+		t.Errorf("rules[0] should be the explicit rule, got models %v", got)
+	}
+	catchAll := rules[1]
+	if len(catchAll.Models) != 0 {
+		t.Errorf("rules[1] should be the catch-all with no model match, got %v", catchAll.Models)
+	}
+	if len(catchAll.BackendRefs) != 1 || catchAll.BackendRefs[0].Name != "local-a" {
+		t.Errorf("catch-all backendRefs = %+v, want single local-a", catchAll.BackendRefs)
+	}
+}
+
+// TestCompileRouterRules_BackendNameMatchDisplayName confirms that when a
+// backend has a DisplayName, the compiled model-match rule uses the
+// DisplayName (not the Name) so the gateway route matches the published id.
+func TestCompileRouterRules_BackendNameMatchDisplayName(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{
+		Spec: inferencev1alpha1.ModelRouterSpec{
+			Backends: []inferencev1alpha1.RouterBackend{
+				{Name: "local-a", DisplayName: "qwen3-coder-30b"},
+				{Name: "local-b"},
+			},
+			DefaultRoute:         "local-a",
+			DefaultRouteStrategy: inferencev1alpha1.DefaultRouteStrategyBackendNameMatch,
+		},
+	}
+
+	rules, err := compileRouterRules(mr)
+	if err != nil {
+		t.Fatalf("compileRouterRules: %v", err)
+	}
+	// Two name-match rules (one per backend) plus the catch-all.
+	if len(rules) != 3 {
+		t.Fatalf("expected 3 rules, got %d: %+v", len(rules), rules)
+	}
+	// First backend has DisplayName; its model match should be the DisplayName.
+	if len(rules[0].Models) != 1 || rules[0].Models[0] != "qwen3-coder-30b" {
+		t.Errorf("rules[0] models = %v, want [qwen3-coder-30b]", rules[0].Models)
+	}
+	// Second backend has no DisplayName; its model match should be the Name.
+	if len(rules[1].Models) != 1 || rules[1].Models[0] != "local-b" {
+		t.Errorf("rules[1] models = %v, want [local-b]", rules[1].Models)
+	}
+	// Both backendRefs still use the k8s-safe Name.
+	if rules[0].BackendRefs[0].Name != "local-a" {
+		t.Errorf("rules[0] backendRef = %s, want local-a", rules[0].BackendRefs[0].Name)
+	}
+	if rules[1].BackendRefs[0].Name != "local-b" {
+		t.Errorf("rules[1] backendRef = %s, want local-b", rules[1].BackendRefs[0].Name)
+	}
+}
+
 // TestModelRouterGateway_AuditLogFailsLoud covers the 2c honest boundary: a
 // dataPlane: Gateway router with policy.auditLog set is refused loudly
 // (GatewayReady=False, reason UnsupportedAuditLogInGatewayMode) and generates

--- a/internal/router/config.go
+++ b/internal/router/config.go
@@ -73,6 +73,11 @@ type Config struct {
 type Backend struct {
 	Name string `json:"name"`
 
+	// DisplayName is the user-facing model id published on /v1/models
+	// and used by BackendNameMatch to resolve a request's model field.
+	// When empty, Name is used for both purposes (current behavior).
+	DisplayName string `json:"displayName,omitempty"`
+
 	// Tier is "local" or "cloud". Used by the fail-closed gate: sensitive-
 	// data rules cannot route to cloud-tier backends.
 	Tier string `json:"tier"`

--- a/internal/router/match.go
+++ b/internal/router/match.go
@@ -76,6 +76,16 @@ func NewMatcher(cfg *Config) *Matcher {
 	return &Matcher{cfg: cfg, backendsByName: byName}
 }
 
+// publishedID returns the user-facing model id for a backend: DisplayName
+// when set, otherwise Name. This is the identifier published on /v1/models
+// and used by BackendNameMatch to resolve a request's model field.
+func publishedID(b *Backend) string {
+	if b.DisplayName != "" {
+		return b.DisplayName
+	}
+	return b.Name
+}
+
 // Match evaluates the rule set against the request features and returns
 // the routing decision. If no rule matches, the fallback depends on
 // DefaultRouteStrategy: BackendNameMatch first tries to resolve the request
@@ -97,11 +107,11 @@ func (m *Matcher) Match(features *RequestFeatures) MatchResult {
 	}
 
 	// No rule matched. Under BackendNameMatch, try to address a backend
-	// directly by Name using the request model before falling back to
-	// DefaultRoute. The lookup is against backend Name (our client-facing
-	// identifier), never the upstream provider Model.
+	// directly by its published id (DisplayName or Name) using the
+	// request model before falling back to DefaultRoute. The lookup is
+	// against the published id, never the upstream provider Model.
 	if m.cfg.DefaultRouteStrategy == DefaultRouteStrategyBackendNameMatch && features.Model != "" {
-		if b := m.backendsByName[features.Model]; b != nil {
+		if b := m.backendByPublishedID(features.Model); b != nil {
 			return MatchResult{
 				Backends: []string{b.Name},
 				Strategy: strategyPrimaryFallback,
@@ -122,6 +132,19 @@ func (m *Matcher) Match(features *RequestFeatures) MatchResult {
 // so the per-request lookup is O(1).
 func (m *Matcher) BackendByName(name string) *Backend {
 	return m.backendsByName[name]
+}
+
+// backendByPublishedID returns the backend whose published id (DisplayName
+// or Name) matches the given string, or nil. It scans the config because
+// DisplayName is not unique-keyed in the map; the scan is over typical
+// config sizes (10s of backends).
+func (m *Matcher) backendByPublishedID(id string) *Backend {
+	for i := range m.cfg.Backends {
+		if publishedID(&m.cfg.Backends[i]) == id {
+			return &m.cfg.Backends[i]
+		}
+	}
+	return nil
 }
 
 const (

--- a/internal/router/match_test.go
+++ b/internal/router/match_test.go
@@ -217,3 +217,33 @@ func TestMatchBackendNameMatchEmptyModelFallsBack(t *testing.T) {
 		t.Errorf("expected empty model to fall back to local-qwen, got %v", got.Backends)
 	}
 }
+
+func TestMatchBackendNameMatchResolvesDisplayName(t *testing.T) {
+	cfg := validConfig()
+	cfg.Rules = nil
+	cfg.DefaultRouteStrategy = DefaultRouteStrategyBackendNameMatch
+	// Give the cloud backend a DisplayName that differs from its Name.
+	cfg.Backends[1].DisplayName = "claude-opus-4-20250514"
+	// A request whose model matches the DisplayName should resolve to the
+	// backend (returning the backend Name, not the DisplayName).
+	got := NewMatcher(cfg).Match(&RequestFeatures{Model: "claude-opus-4-20250514"})
+	if len(got.Backends) != 1 || got.Backends[0] != "cloud-opus" {
+		t.Errorf("expected name match to cloud-opus via DisplayName, got %v", got.Backends)
+	}
+	// The old Name should no longer match (DisplayName takes precedence).
+	got2 := NewMatcher(cfg).Match(&RequestFeatures{Model: "cloud-opus"})
+	if len(got2.Backends) != 1 || got2.Backends[0] != "local-qwen" {
+		t.Errorf("expected old Name to fall through to default, got %v", got2.Backends)
+	}
+}
+
+func TestMatchBackendNameMatchDisplayNameUnsetUsesName(t *testing.T) {
+	cfg := validConfig()
+	cfg.Rules = nil
+	cfg.DefaultRouteStrategy = DefaultRouteStrategyBackendNameMatch
+	// No DisplayName set; Name is used as the published id.
+	got := NewMatcher(cfg).Match(&RequestFeatures{Model: "cloud-opus"})
+	if len(got.Backends) != 1 || got.Backends[0] != "cloud-opus" {
+		t.Errorf("expected name match to cloud-opus, got %v", got.Backends)
+	}
+}

--- a/internal/router/proxy.go
+++ b/internal/router/proxy.go
@@ -86,7 +86,8 @@ func (p *Proxy) handleHealth(w http.ResponseWriter, _ *http.Request) {
 
 // handleModels returns an OpenAI-compatible /v1/models payload listing
 // every backend in the config. Cloud backends report their upstream
-// Model field; local backends report their backend name.
+// Model field; local backends report their backend name. When a backend
+// has a DisplayName, that is published as the model id instead of Name.
 func (p *Proxy) handleModels(w http.ResponseWriter, _ *http.Request) {
 	type model struct {
 		ID      string `json:"id"`
@@ -98,7 +99,9 @@ func (p *Proxy) handleModels(w http.ResponseWriter, _ *http.Request) {
 	models := make([]model, 0, len(p.cfg.Backends))
 	for _, b := range p.cfg.Backends {
 		id := b.Name
-		if b.Model != "" {
+		if b.DisplayName != "" {
+			id = b.DisplayName
+		} else if b.Model != "" {
 			id = b.Model
 		}
 		owned := "llmkube"

--- a/internal/router/proxy_test.go
+++ b/internal/router/proxy_test.go
@@ -214,6 +214,31 @@ func TestProxyModels(t *testing.T) {
 	}
 }
 
+func TestProxyModelsDisplayName(t *testing.T) {
+	h := newProxyHarness(t)
+	// Give the local backend a DisplayName that differs from its Name.
+	h.cfg.Backends[0].DisplayName = "qwen3-coder-30b"
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+	h.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/v1/models = %d, want 200", rec.Code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode /v1/models: %v", err)
+	}
+	data, _ := got["data"].([]any)
+	// First model should use DisplayName, second should use Model (cloud backend).
+	if len(data) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(data))
+	}
+	first, _ := data[0].(map[string]any)
+	if first["id"] != "qwen3-coder-30b" {
+		t.Errorf("first model id = %v, want qwen3-coder-30b", first["id"])
+	}
+}
+
 func TestProxyRoutesPIIToLocal(t *testing.T) {
 	h := newProxyHarness(t)
 	resp := h.post(t, map[string]any{"model": "any"}, map[string]string{


### PR DESCRIPTION
## What

Adds an optional `displayName` to `RouterBackend` so the model id published on `/v1/models` (and used by `BackendNameMatch` to resolve a request's `model`) can differ from the k8s-safe backend `Name`. Unset = `Name` for both (byte-identical to current behavior).

## Why

Fixes #792

A backend `Name` must be a k8s-safe identifier, but the user-facing model id often needs to be something else (e.g. `Name: claude-opus-4` vs published `claude-opus-4-20250514`). This decouples the two.

## How

`DisplayName` field on the backend type; `publishedID(b)` helper (DisplayName else Name); `backendByPublishedID` for `BackendNameMatch` resolution in both data planes (`internal/router` + the gateway compiler). CRDs regenerated (`make manifests/chart-crds`).

## Checklist
- [x] Tests added/updated
- [x] Conventional commit + DCO sign-off
- [x] CRDs regenerated (no codegen drift)
- [ ] Docs (follow-up if needed)

> Produced by the Foreman coder (local Qwopus on AMD Strix), human-reviewed before opening. Supersedes a first attempt that the harness correctly held back for codegen drift.
