### PR TITLE
test(cli): cover untested pure helpers (formatBool, catalog parse/validate) (Addresses #89)

### DIFF
--- a/pkg/cli/benchmark_catalog_test.go
+++ b/pkg/cli/benchmark_catalog_test.go
@@ -47,3 +47,64 @@ func TestGPUVendor(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCatalogModelIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"single model", "llama-3.1-8b", []string{"llama-3.1-8b"}},
+		{"multiple models", "llama-3.1-8b,qwen-2.5-coder-7b,mistral-7b",
+			[]string{"llama-3.1-8b", "qwen-2.5-coder-7b", "mistral-7b"}},
+		{"with spaces", "llama-3.1-8b , qwen-2.5-coder-7b , mistral-7b",
+			[]string{"llama-3.1-8b", "qwen-2.5-coder-7b", "mistral-7b"}},
+		{"with leading/trailing spaces", "  llama-3.1-8b  ,  qwen-2.5-coder-7b  ",
+			[]string{"llama-3.1-8b", "qwen-2.5-coder-7b"}},
+		{"empty string", "", []string{""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCatalogModelIDs(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Errorf("parseCatalogModelIDs(%q) returned %d items, want %d", tt.input, len(got), len(tt.expected))
+				return
+			}
+			for i, v := range got {
+				if v != tt.expected[i] {
+					t.Errorf("parseCatalogModelIDs(%q)[%d] = %q, want %q", tt.input, i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCatalogModels(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelIDs  []string
+		wantError bool
+	}{
+		{"valid models", []string{"llama-3.1-8b", "mistral-7b"}, false},
+		{"single valid model", []string{"qwen-2.5-coder-7b"}, false},
+		{"invalid model", []string{"nonexistent-model-xyz"}, true},
+		{"mixed valid and invalid", []string{"llama-3.1-8b", "nonexistent-model-xyz"}, true},
+		{"empty list", []string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			models, err := validateCatalogModels(tt.modelIDs)
+			if tt.wantError && err == nil {
+				t.Errorf("validateCatalogModels(%v) = nil error, want error", tt.modelIDs)
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("validateCatalogModels(%v) = error %v, want nil", tt.modelIDs, err)
+			}
+			if !tt.wantError && len(models) != len(tt.modelIDs) {
+				t.Errorf("validateCatalogModels(%v) returned %d models, want %d", tt.modelIDs, len(models), len(tt.modelIDs))
+			}
+		})
+	}
+}

--- a/pkg/cli/license_test.go
+++ b/pkg/cli/license_test.go
@@ -64,6 +64,26 @@ func TestNewLicenseCheckCommand(t *testing.T) {
 	}
 }
 
+func TestFormatBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    bool
+		expected string
+	}{
+		{"true", true, "Yes"},
+		{"false", false, "No"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatBool(tt.input)
+			if result != tt.expected {
+				t.Errorf("formatBool(%v) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestRunLicenseList(t *testing.T) {
 	old := os.Stdout
 	r, w, _ := os.Pipe()


### PR DESCRIPTION
## What
Unit tests for three untested pure `pkg/cli` helpers: `formatBool`, `parseCatalogModelIDs`, `validateCatalogModels`.

## Why
Addresses #89. Slice scoped to `pkg/cli`.

## How
Test-only.

## Checklist
- [x] Tests added
- [x] Conventional commit + DCO

> Produced by the Foreman coder (local Qwopus on AMD Strix), human-reviewed before opening.