### PR TITLE
feat(foreman): durable audit-log record + llmkube audit export (#837)

### DIFF
--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -34,6 +34,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/audit"
 )
 
 // claimExpiriesAnnotation tracks how many times this task has been released
@@ -61,6 +62,10 @@ const claimExpiryLimit = 2
 type AgenticTaskReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	// AuditNamespace is where durable audit-record ConfigMaps are written.
+	// Empty means each record lands in its task's own namespace.
+	AuditNamespace string
 }
 
 // requeueNoFit is the backoff when no FleetNode satisfies the task's
@@ -101,9 +106,14 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return r.setInitialPending(ctx, &task)
 	}
 
-	// Terminal phases are done; nothing left to do.
+	// Terminal phases are done; record the durable audit entry once
+	// (best-effort: a failed audit write must not wedge reconciliation),
+	// then nothing left to do.
 	if task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded ||
 		task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed {
+		if err := audit.RecordTerminal(ctx, r.Client, &task, r.AuditNamespace, log); err != nil {
+			log.Error(err, "audit: failed to record terminal run (continuing)")
+		}
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/cli/audit.go
+++ b/pkg/cli/audit.go
@@ -52,7 +52,7 @@ func newAuditExportCommand() *cobra.Command {
 				if ferr != nil {
 					return fmt.Errorf("create %s: %w", output, ferr)
 				}
-				defer f.Close()
+				defer func() { _ = f.Close() }()
 				out = f
 			}
 			return exportAuditRecords(cmd.Context(), c, namespace, repo, since, out)

--- a/pkg/cli/audit.go
+++ b/pkg/cli/audit.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/defilantech/llmkube/pkg/foreman/audit"
+)
+
+// NewAuditCommand is the `llmkube audit` group: export the durable Foreman
+// audit records as a portable JSONL bundle for compliance review.
+func NewAuditCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Inspect and export Foreman run audit records",
+		Long:  "Aggregate the durable per-run audit records Foreman writes for compliance review.",
+	}
+	cmd.AddCommand(newAuditExportCommand())
+	return cmd
+}
+
+func newAuditExportCommand() *cobra.Command {
+	var namespace, repo, since, output string
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export audit records as JSONL",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newAuditClient()
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if output != "" {
+				f, ferr := os.Create(output)
+				if ferr != nil {
+					return fmt.Errorf("create %s: %w", output, ferr)
+				}
+				defer f.Close()
+				out = f
+			}
+			return exportAuditRecords(cmd.Context(), c, namespace, repo, since, out)
+		},
+	}
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "namespace to read audit records from")
+	cmd.Flags().StringVar(&repo, "repo", "", "filter to records for this repo (owner/name)")
+	cmd.Flags().StringVar(&since, "since", "", "only records with recordedAt >= this RFC3339 timestamp")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "write JSONL to this file instead of stdout")
+	return cmd
+}
+
+func newAuditClient() (client.Client, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+	return client.New(cfg, client.Options{Scheme: scheme.Scheme})
+}
+
+// exportAuditRecords lists audit ConfigMaps, decodes them, applies repo/since
+// filters, sorts by recordedAt, and writes one JSON Record per line.
+func exportAuditRecords(ctx context.Context, c client.Client, namespace, repo, since string, w io.Writer) error {
+	var cms corev1.ConfigMapList
+	if err := c.List(ctx, &cms,
+		client.InNamespace(namespace),
+		client.MatchingLabels{audit.AuditLabel: "true"},
+	); err != nil {
+		return fmt.Errorf("list audit records: %w", err)
+	}
+
+	records := make([]audit.Record, 0, len(cms.Items))
+	for i := range cms.Items {
+		raw, ok := cms.Items[i].Data["audit.json"]
+		if !ok {
+			continue
+		}
+		var rec audit.Record
+		if err := json.Unmarshal([]byte(raw), &rec); err != nil {
+			continue // skip malformed record rather than abort the export
+		}
+		if repo != "" && rec.Repo != repo {
+			continue
+		}
+		if since != "" && rec.RecordedAt < since {
+			continue // RFC3339 strings sort lexicographically by time
+		}
+		records = append(records, rec)
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		return records[i].RecordedAt < records[j].RecordedAt
+	})
+
+	enc := json.NewEncoder(w)
+	for i := range records {
+		if err := enc.Encode(records[i]); err != nil {
+			return fmt.Errorf("encode record: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/cli/audit_test.go
+++ b/pkg/cli/audit_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/defilantech/llmkube/pkg/foreman/audit"
+)
+
+func auditCM(name, recordedAt, repo, verdict string) *corev1.ConfigMap {
+	rec := audit.Record{
+		SchemaVersion: audit.SchemaVersion,
+		RecordedAt:    recordedAt,
+		Task:          audit.TaskRef{Name: name, Namespace: "default"},
+		Repo:          repo, Verdict: verdict,
+	}
+	data, _ := json.Marshal(rec)
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foreman-audit-" + name, Namespace: "default",
+			Labels: map[string]string{audit.AuditLabel: "true", audit.AuditTaskLabel: name},
+		},
+		Data: map[string]string{"audit.json": string(data)},
+	}
+}
+
+func TestExportAuditRecordsOrderedAndFiltered(t *testing.T) {
+	c := fake.NewClientBuilder().WithObjects(
+		auditCM("b", "2026-06-25T02:00:00Z", "defilantech/LLMKube", "GO"),
+		auditCM("a", "2026-06-25T01:00:00Z", "defilantech/LLMKube", "NO-GO"),
+		auditCM("c", "2026-06-25T03:00:00Z", "other/repo", "GO"),
+	).Build()
+
+	var buf strings.Builder
+	if err := exportAuditRecords(context.Background(), c, "default", "", "", &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 JSONL lines, got %d: %q", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[0], `"name":"a"`) || !strings.Contains(lines[2], `"name":"c"`) {
+		t.Errorf("not ordered by recordedAt: %v", lines)
+	}
+
+	var buf2 strings.Builder
+	if err := exportAuditRecords(context.Background(), c, "default", "defilantech/LLMKube", "", &buf2); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(strings.Split(strings.TrimSpace(buf2.String()), "\n")); n != 2 {
+		t.Errorf("repo filter: want 2, got %d", n)
+	}
+
+	var buf3 strings.Builder
+	if err := exportAuditRecords(context.Background(), c, "default", "", "2026-06-25T02:00:00Z", &buf3); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(strings.Split(strings.TrimSpace(buf3.String()), "\n")); n != 2 {
+		t.Errorf("since filter: want 2, got %d", n)
+	}
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -50,6 +50,7 @@ built-in observability, SLO enforcement, and edge-native capabilities.`,
 	cmd.AddCommand(NewCacheCommand())
 	cmd.AddCommand(NewInspectCommand())
 	cmd.AddCommand(NewLicenseCommand())
+	cmd.AddCommand(NewAuditCommand())
 
 	return cmd
 }

--- a/pkg/foreman/audit/record.go
+++ b/pkg/foreman/audit/record.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+// Package audit builds and persists durable, structured records of every
+// terminal Foreman run for compliance/audit export. See GitHub issue #837.
+package audit
+
+import (
+	"encoding/json"
+	"time"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// SchemaVersion identifies the on-disk shape of an audit Record.
+const SchemaVersion = "foreman.audit.v1"
+
+// Record is one terminal run's audit entry. Optional blocks are nil when
+// the run did not produce them (e.g. a coder run has no reviewer block).
+type Record struct {
+	SchemaVersion     string           `json:"schemaVersion"`
+	RecordedAt        string           `json:"recordedAt,omitempty"`
+	Task              TaskRef          `json:"task"`
+	Repo              string           `json:"repo,omitempty"`
+	Issue             int              `json:"issue,omitempty"`
+	Agent             *AgentRef        `json:"agent,omitempty"`
+	AssignedNode      string           `json:"assignedNode,omitempty"`
+	ClaimedAt         string           `json:"claimedAt,omitempty"`
+	StartedAt         string           `json:"startedAt,omitempty"`
+	FinishedAt        string           `json:"finishedAt,omitempty"`
+	ElapsedSec        float64          `json:"elapsedSec,omitempty"`
+	Verdict           string           `json:"verdict,omitempty"`
+	FailureReason     string           `json:"failureReason,omitempty"`
+	SucceededOnTarget bool             `json:"succeededOnTarget"`
+	Gate              *GateOutcome     `json:"gate,omitempty"`
+	ScopeGuard        *ScopeOutcome    `json:"scopeGuard,omitempty"`
+	IssueAsk          *IssueAskOutcome `json:"issueAsk,omitempty"`
+	Reviewer          *ReviewerOutcome `json:"reviewer,omitempty"`
+	Branch            string           `json:"branch,omitempty"`
+	CommitSHA         string           `json:"commitSHA,omitempty"`
+	TurnCount         int              `json:"turnCount,omitempty"`
+	FilesChanged      []string         `json:"filesChanged,omitempty"`
+	TestsAdded        int              `json:"testsAdded,omitempty"`
+	TranscriptRef     string           `json:"transcriptRef,omitempty"`
+}
+
+// TaskRef identifies the AgenticTask the record describes.
+type TaskRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	UID       string `json:"uid,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+}
+
+// AgentRef records which agent/model/endpoint served the run. The Endpoint
+// is the inference-provenance proof (where the model traffic went).
+type AgentRef struct {
+	Name     string `json:"name"`
+	Role     string `json:"role,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"`
+}
+
+// GateOutcome is the fast in-workspace gate result. Passed is false when
+// the run terminated CODER-GATE-FAILED.
+type GateOutcome struct {
+	Attempts int  `json:"attempts"`
+	Passed   bool `json:"passed"`
+}
+
+// ScopeOutcome is the scope-drift guard result.
+type ScopeOutcome struct {
+	Drift   bool     `json:"drift"`
+	Matched []string `json:"matched,omitempty"`
+}
+
+// IssueAskOutcome is the reviewer issueAsk verification result.
+type IssueAskOutcome struct {
+	Verified bool   `json:"verified"`
+	Claimed  string `json:"claimed,omitempty"`
+}
+
+// ReviewerOutcome is the reviewer's verdict for a review-kind task.
+type ReviewerOutcome struct {
+	Outcome string `json:"outcome,omitempty"`
+}
+
+// resultPayload is the subset of the foreman.v1 Result JSON we read.
+type resultPayload struct {
+	ElapsedSec float64 `json:"elapsedSec"`
+	Extra      struct {
+		TurnCount  int `json:"turnCount"`
+		ModelExtra struct {
+			GateAttempts       int      `json:"gateAttempts"`
+			Outcome            string   `json:"outcome"`
+			ScopeDriftDetected bool     `json:"scopeDriftDetected"`
+			ScopeMatched       []string `json:"scopeMatched"`
+			IssueAskVerified   bool     `json:"issueAskVerified"`
+			IssueAskClaimed    string   `json:"issueAskClaimed"`
+			ReviewOutcome      string   `json:"reviewOutcome"`
+			FilesChanged       []string `json:"filesChanged"`
+			TestsAdded         int      `json:"testsAdded"`
+		} `json:"modelExtra"`
+	} `json:"extra"`
+}
+
+// BuildRecord maps a terminal AgenticTask (and its resolved Agent, which
+// may be nil) to an audit Record. It reads typed status fields plus the
+// opaque status.Result JSON. Missing optional data yields nil blocks, never
+// fabricated values. RecordedAt is the run's FinishedAt (deterministic).
+func BuildRecord(task *foremanv1alpha1.AgenticTask, agent *foremanv1alpha1.Agent) Record {
+	rec := Record{
+		SchemaVersion:     SchemaVersion,
+		Task:              TaskRef{Name: task.Name, Namespace: task.Namespace, UID: string(task.UID), Kind: string(task.Spec.Kind)},
+		Repo:              task.Spec.Payload.Repo,
+		Issue:             int(task.Spec.Payload.Issue),
+		AssignedNode:      task.Status.AssignedNode,
+		Verdict:           string(task.Status.Verdict),
+		FailureReason:     string(task.Status.FailureReason),
+		SucceededOnTarget: task.SucceededOnTarget(),
+		Branch:            task.Status.Branch,
+		CommitSHA:         task.Status.CommitSHA,
+		TranscriptRef:     task.Status.TranscriptRef,
+	}
+	if task.Status.ClaimedAt != nil {
+		rec.ClaimedAt = task.Status.ClaimedAt.UTC().Format(time.RFC3339)
+	}
+	if task.Status.StartedAt != nil {
+		rec.StartedAt = task.Status.StartedAt.UTC().Format(time.RFC3339)
+	}
+	if task.Status.FinishedAt != nil {
+		rec.FinishedAt = task.Status.FinishedAt.UTC().Format(time.RFC3339)
+		rec.RecordedAt = rec.FinishedAt
+	}
+	if agent != nil {
+		rec.Agent = &AgentRef{
+			Name:     agent.Name,
+			Role:     string(agent.Spec.Role),
+			Model:    agent.Spec.Model,
+			Provider: string(agent.Spec.Provider),
+		}
+		if agent.Spec.ProviderConfig != nil {
+			rec.Agent.Endpoint = agent.Spec.ProviderConfig.BaseURL
+		}
+	}
+	if task.Status.Result != nil && len(task.Status.Result.Raw) > 0 {
+		var rp resultPayload
+		if err := json.Unmarshal(task.Status.Result.Raw, &rp); err == nil {
+			rec.ElapsedSec = rp.ElapsedSec
+			rec.TurnCount = rp.Extra.TurnCount
+			me := rp.Extra.ModelExtra
+			rec.FilesChanged = me.FilesChanged
+			rec.TestsAdded = me.TestsAdded
+			if me.GateAttempts > 0 || me.Outcome != "" {
+				rec.Gate = &GateOutcome{Attempts: me.GateAttempts, Passed: me.Outcome != "CODER-GATE-FAILED"}
+			}
+			if me.ScopeDriftDetected || len(me.ScopeMatched) > 0 {
+				rec.ScopeGuard = &ScopeOutcome{Drift: me.ScopeDriftDetected, Matched: me.ScopeMatched}
+			}
+			if me.ReviewOutcome != "" || me.IssueAskClaimed != "" {
+				rec.IssueAsk = &IssueAskOutcome{Verified: me.IssueAskVerified, Claimed: me.IssueAskClaimed}
+				rec.Reviewer = &ReviewerOutcome{Outcome: me.ReviewOutcome}
+			}
+		}
+	}
+	return rec
+}

--- a/pkg/foreman/audit/record.go
+++ b/pkg/foreman/audit/record.go
@@ -115,8 +115,13 @@ type resultPayload struct {
 // fabricated values. RecordedAt is the run's FinishedAt (deterministic).
 func BuildRecord(task *foremanv1alpha1.AgenticTask, agent *foremanv1alpha1.Agent) Record {
 	rec := Record{
-		SchemaVersion:     SchemaVersion,
-		Task:              TaskRef{Name: task.Name, Namespace: task.Namespace, UID: string(task.UID), Kind: string(task.Spec.Kind)},
+		SchemaVersion: SchemaVersion,
+		Task: TaskRef{
+			Name:      task.Name,
+			Namespace: task.Namespace,
+			UID:       string(task.UID),
+			Kind:      string(task.Spec.Kind),
+		},
 		Repo:              task.Spec.Payload.Repo,
 		Issue:             int(task.Spec.Payload.Issue),
 		AssignedNode:      task.Status.AssignedNode,

--- a/pkg/foreman/audit/record_test.go
+++ b/pkg/foreman/audit/record_test.go
@@ -72,7 +72,8 @@ func TestBuildRecordCoder(t *testing.T) {
 	if rec.Repo != "defilantech/LLMKube" || rec.Issue != 89 {
 		t.Errorf("repo/issue wrong: %q #%d", rec.Repo, rec.Issue)
 	}
-	if rec.Agent == nil || rec.Agent.Model != "coder-amd" || rec.Agent.Endpoint != "http://gw/v1" || rec.Agent.Role != "coder" {
+	if rec.Agent == nil || rec.Agent.Model != "coder-amd" ||
+		rec.Agent.Endpoint != "http://gw/v1" || rec.Agent.Role != "coder" {
 		t.Errorf("agent ref wrong: %+v", rec.Agent)
 	}
 	if rec.Verdict != "GO" || !rec.SucceededOnTarget {

--- a/pkg/foreman/audit/record_test.go
+++ b/pkg/foreman/audit/record_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package audit
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func coderTask() *foremanv1alpha1.AgenticTask {
+	loc := metav1.Now().Location()
+	finished := metav1.Date(2026, 6, 25, 1, 29, 0, 0, loc)
+	started := metav1.Date(2026, 6, 25, 0, 39, 20, 0, loc)
+	return &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "coder-89", Namespace: "default", UID: types.UID("uid-1")},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind:     foremanv1alpha1.AgenticTaskKindIssueFix,
+			AgentRef: &corev1.LocalObjectReference{Name: "gateway-coder-amd"},
+			Payload:  foremanv1alpha1.AgenticTaskPayload{Repo: "defilantech/LLMKube", Issue: 89},
+		},
+		Status: foremanv1alpha1.AgenticTaskStatus{
+			Phase:         foremanv1alpha1.AgenticTaskPhaseSucceeded,
+			AssignedNode:  "m5max-coder",
+			StartedAt:     &started,
+			FinishedAt:    &finished,
+			Verdict:       foremanv1alpha1.AgenticTaskVerdictGo,
+			Branch:        "foreman/issue-89",
+			CommitSHA:     "71f4343",
+			TranscriptRef: "foreman-transcript-coder-89",
+			Result: &runtime.RawExtension{Raw: []byte(`{
+				"verdict":"GO","elapsedSec":2980,
+				"extra":{"branch":"foreman/issue-89","commitSHA":"71f4343","turnCount":38,
+					"modelExtra":{"gateAttempts":1,"outcome":"","scopeDriftDetected":false,
+						"scopeMatched":["internal/router"],"filesChanged":["internal/router/pure_test.go"],
+						"testsAdded":35}}}`)},
+		},
+	}
+}
+
+func coderAgent() *foremanv1alpha1.Agent {
+	return &foremanv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "gateway-coder-amd", Namespace: "default"},
+		Spec: foremanv1alpha1.AgentSpec{
+			Role:           foremanv1alpha1.AgentRoleCoder,
+			Model:          "coder-amd",
+			Provider:       foremanv1alpha1.AgentProviderCloudProxy,
+			ProviderConfig: &foremanv1alpha1.ProviderConfig{BaseURL: "http://gw/v1"},
+		},
+	}
+}
+
+func TestBuildRecordCoder(t *testing.T) {
+	rec := BuildRecord(coderTask(), coderAgent())
+
+	if rec.SchemaVersion != SchemaVersion {
+		t.Errorf("schemaVersion = %q, want %q", rec.SchemaVersion, SchemaVersion)
+	}
+	if rec.Task.Name != "coder-89" || rec.Task.Namespace != "default" || rec.Task.Kind != "issue-fix" {
+		t.Errorf("task ref wrong: %+v", rec.Task)
+	}
+	if rec.Repo != "defilantech/LLMKube" || rec.Issue != 89 {
+		t.Errorf("repo/issue wrong: %q #%d", rec.Repo, rec.Issue)
+	}
+	if rec.Agent == nil || rec.Agent.Model != "coder-amd" || rec.Agent.Endpoint != "http://gw/v1" || rec.Agent.Role != "coder" {
+		t.Errorf("agent ref wrong: %+v", rec.Agent)
+	}
+	if rec.Verdict != "GO" || !rec.SucceededOnTarget {
+		t.Errorf("verdict/onTarget wrong: %q %v", rec.Verdict, rec.SucceededOnTarget)
+	}
+	if rec.RecordedAt == "" || rec.FinishedAt == "" {
+		t.Errorf("timestamps unset: recordedAt=%q finishedAt=%q", rec.RecordedAt, rec.FinishedAt)
+	}
+	if rec.Gate == nil || rec.Gate.Attempts != 1 || !rec.Gate.Passed {
+		t.Errorf("gate wrong: %+v", rec.Gate)
+	}
+	if rec.ScopeGuard == nil || rec.ScopeGuard.Drift || len(rec.ScopeGuard.Matched) != 1 {
+		t.Errorf("scope wrong: %+v", rec.ScopeGuard)
+	}
+	if rec.TurnCount != 38 || rec.TestsAdded != 35 || len(rec.FilesChanged) != 1 {
+		t.Errorf("effort fields wrong: turns=%d tests=%d files=%v", rec.TurnCount, rec.TestsAdded, rec.FilesChanged)
+	}
+	if rec.IssueAsk != nil || rec.Reviewer != nil {
+		t.Errorf("coder task must not carry reviewer/issueAsk blocks: %+v %+v", rec.IssueAsk, rec.Reviewer)
+	}
+}
+
+func TestBuildRecordNilAgentAndNoResult(t *testing.T) {
+	task := coderTask()
+	task.Spec.AgentRef = nil
+	task.Status.Result = nil
+	rec := BuildRecord(task, nil)
+	if rec.Agent != nil {
+		t.Errorf("nil agent should produce no agent block, got %+v", rec.Agent)
+	}
+	if rec.Gate != nil || rec.ScopeGuard != nil {
+		t.Errorf("nil result should produce no rail blocks")
+	}
+	if rec.Task.Name != "coder-89" {
+		t.Errorf("task ref still required, got %+v", rec.Task)
+	}
+}

--- a/pkg/foreman/audit/writer.go
+++ b/pkg/foreman/audit/writer.go
@@ -96,7 +96,13 @@ func WriteRecord(ctx context.Context, c client.Client, namespace string, rec Rec
 // referenced Agent is fetched best-effort (a missing Agent yields a record
 // with no agent block, not an error). On success it stamps AuditedAnnotation
 // so subsequent reconciles skip the write.
-func RecordTerminal(ctx context.Context, c client.Client, task *foremanv1alpha1.AgenticTask, auditNamespace string, log logr.Logger) error {
+func RecordTerminal(
+	ctx context.Context,
+	c client.Client,
+	task *foremanv1alpha1.AgenticTask,
+	auditNamespace string,
+	log logr.Logger,
+) error {
 	if task.Annotations[AuditedAnnotation] == "true" {
 		return nil
 	}

--- a/pkg/foreman/audit/writer.go
+++ b/pkg/foreman/audit/writer.go
@@ -17,6 +17,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
 
 const (
@@ -29,6 +31,10 @@ const (
 	auditDataKey = "audit.json"
 
 	auditNamePrefix = "foreman-audit-"
+
+	// AuditedAnnotation guards against re-writing a record on every reconcile
+	// of an already-terminal task (which would emit duplicate audit lines).
+	AuditedAnnotation = "foreman.llmkube.dev/audited"
 )
 
 // AuditConfigMapName returns the ConfigMap name for a task's audit record.
@@ -81,5 +87,48 @@ func WriteRecord(ctx context.Context, c client.Client, namespace string, rec Rec
 		"task", rec.Task.Name, "namespace", rec.Task.Namespace,
 		"verdict", rec.Verdict, "node", rec.AssignedNode,
 		"repo", rec.Repo, "issue", rec.Issue, "schemaVersion", rec.SchemaVersion)
+	return nil
+}
+
+// RecordTerminal writes the audit record for a terminal task exactly once.
+// It is a no-op if the task already carries AuditedAnnotation. auditNamespace
+// is the namespace for the record; empty means the task's own namespace. The
+// referenced Agent is fetched best-effort (a missing Agent yields a record
+// with no agent block, not an error). On success it stamps AuditedAnnotation
+// so subsequent reconciles skip the write.
+func RecordTerminal(ctx context.Context, c client.Client, task *foremanv1alpha1.AgenticTask, auditNamespace string, log logr.Logger) error {
+	if task.Annotations[AuditedAnnotation] == "true" {
+		return nil
+	}
+	ns := auditNamespace
+	if ns == "" {
+		ns = task.Namespace
+	}
+
+	var agent *foremanv1alpha1.Agent
+	if task.Spec.AgentRef != nil && task.Spec.AgentRef.Name != "" {
+		var a foremanv1alpha1.Agent
+		key := client.ObjectKey{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
+		if err := c.Get(ctx, key, &a); err == nil {
+			agent = &a
+		} else {
+			log.Info("audit: agent not resolvable; recording without agent block",
+				"agent", task.Spec.AgentRef.Name, "err", err.Error())
+		}
+	}
+
+	rec := BuildRecord(task, agent)
+	if err := WriteRecord(ctx, c, ns, rec, log); err != nil {
+		return err
+	}
+
+	patch := client.MergeFrom(task.DeepCopy())
+	if task.Annotations == nil {
+		task.Annotations = map[string]string{}
+	}
+	task.Annotations[AuditedAnnotation] = "true"
+	if err := c.Patch(ctx, task, patch); err != nil {
+		return fmt.Errorf("audit: set audited annotation: %w", err)
+	}
 	return nil
 }

--- a/pkg/foreman/audit/writer.go
+++ b/pkg/foreman/audit/writer.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// AuditLabel marks an audit-record ConfigMap; AuditTaskLabel carries the
+	// task name for filtered discovery (`-l foreman.llmkube.dev/audit=true`).
+	AuditLabel     = "foreman.llmkube.dev/audit"
+	AuditTaskLabel = "foreman.llmkube.dev/audit-task"
+
+	// auditDataKey is the ConfigMap data key holding the JSON Record.
+	auditDataKey = "audit.json"
+
+	auditNamePrefix = "foreman-audit-"
+)
+
+// AuditConfigMapName returns the ConfigMap name for a task's audit record.
+func AuditConfigMapName(taskName string) string { return auditNamePrefix + taskName }
+
+// WriteRecord upserts a durable, NON-owner-ref'd ConfigMap holding rec, plus
+// emits the record as a single structured log line. The absence of an owner
+// reference is deliberate: the record must outlive the AgenticTask so it
+// remains a compliance trail after task garbage-collection. namespace is the
+// audit namespace (caller passes the task namespace when unset upstream).
+func WriteRecord(ctx context.Context, c client.Client, namespace string, rec Record, log logr.Logger) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("audit: marshal record: %w", err)
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      AuditConfigMapName(rec.Task.Name),
+			Namespace: namespace,
+			Labels: map[string]string{
+				AuditLabel:                  "true",
+				AuditTaskLabel:              rec.Task.Name,
+				"app.kubernetes.io/part-of": "foreman",
+			},
+			// No OwnerReferences: survives task GC by design.
+		},
+		Data: map[string]string{auditDataKey: string(data)},
+	}
+
+	existing := &corev1.ConfigMap{}
+	key := client.ObjectKey{Namespace: namespace, Name: cm.Name}
+	switch getErr := c.Get(ctx, key, existing); {
+	case apierrors.IsNotFound(getErr):
+		if err := c.Create(ctx, cm); err != nil {
+			return fmt.Errorf("audit: create configmap: %w", err)
+		}
+	case getErr == nil:
+		existing.Data = cm.Data
+		existing.Labels = cm.Labels
+		if err := c.Update(ctx, existing); err != nil {
+			return fmt.Errorf("audit: update configmap: %w", err)
+		}
+	default:
+		return fmt.Errorf("audit: get configmap: %w", getErr)
+	}
+
+	// Structured audit stream line for SIEM/Loki ingestion. The durable
+	// ConfigMap above is the primary record; this is the streaming copy.
+	log.Info("foreman.audit",
+		"task", rec.Task.Name, "namespace", rec.Task.Namespace,
+		"verdict", rec.Verdict, "node", rec.AssignedNode,
+		"repo", rec.Repo, "issue", rec.Issue, "schemaVersion", rec.SchemaVersion)
+	return nil
+}

--- a/pkg/foreman/audit/writer_test.go
+++ b/pkg/foreman/audit/writer_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestWriteRecordCreatesDurableConfigMap(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+	rec := Record{SchemaVersion: SchemaVersion, Task: TaskRef{Name: "coder-89", Namespace: "default"}, Verdict: "GO"}
+
+	if err := WriteRecord(context.Background(), c, "default", rec, logr.Discard()); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+
+	var cm corev1.ConfigMap
+	key := types.NamespacedName{Namespace: "default", Name: "foreman-audit-coder-89"}
+	if err := c.Get(context.Background(), key, &cm); err != nil {
+		t.Fatalf("audit ConfigMap not created: %v", err)
+	}
+	if len(cm.OwnerReferences) != 0 {
+		t.Errorf("audit ConfigMap MUST NOT be owner-ref'd (must survive task GC), got %d refs", len(cm.OwnerReferences))
+	}
+	if cm.Labels[AuditLabel] != "true" || cm.Labels[AuditTaskLabel] != "coder-89" {
+		t.Errorf("labels wrong: %v", cm.Labels)
+	}
+	var got Record
+	if err := json.Unmarshal([]byte(cm.Data[auditDataKey]), &got); err != nil {
+		t.Fatalf("decode audit.json: %v", err)
+	}
+	if got.Verdict != "GO" || got.Task.Name != "coder-89" {
+		t.Errorf("round-trip wrong: %+v", got)
+	}
+}
+
+func TestWriteRecordIdempotentUpsert(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+	rec := Record{SchemaVersion: SchemaVersion, Task: TaskRef{Name: "t", Namespace: "default"}, Verdict: "GO"}
+	ctx := context.Background()
+	if err := WriteRecord(ctx, c, "default", rec, logr.Discard()); err != nil {
+		t.Fatal(err)
+	}
+	rec.Verdict = "NO-GO"
+	if err := WriteRecord(ctx, c, "default", rec, logr.Discard()); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	var cm corev1.ConfigMap
+	_ = c.Get(ctx, types.NamespacedName{Namespace: "default", Name: "foreman-audit-t"}, &cm)
+	var got Record
+	_ = json.Unmarshal([]byte(cm.Data[auditDataKey]), &got)
+	if got.Verdict != "NO-GO" {
+		t.Errorf("upsert did not update, verdict=%q", got.Verdict)
+	}
+}

--- a/pkg/foreman/audit/writer_test.go
+++ b/pkg/foreman/audit/writer_test.go
@@ -14,8 +14,12 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
 
 func TestWriteRecordCreatesDurableConfigMap(t *testing.T) {
@@ -63,5 +67,44 @@ func TestWriteRecordIdempotentUpsert(t *testing.T) {
 	_ = json.Unmarshal([]byte(cm.Data[auditDataKey]), &got)
 	if got.Verdict != "NO-GO" {
 		t.Errorf("upsert did not update, verdict=%q", got.Verdict)
+	}
+}
+
+func TestRecordTerminalWritesOnceAndSetsAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = foremanv1alpha1.AddToScheme(scheme)
+
+	task := coderTask() // from record_test.go (same package)
+	agent := coderAgent()
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(task, agent).
+		WithStatusSubresource(task).Build()
+	ctx := context.Background()
+
+	if err := RecordTerminal(ctx, c, task, "", logr.Discard()); err != nil {
+		t.Fatalf("RecordTerminal: %v", err)
+	}
+	// audit CM exists in the task namespace (empty audit ns -> task ns)
+	var cm corev1.ConfigMap
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "default", Name: "foreman-audit-coder-89"}, &cm); err != nil {
+		t.Fatalf("audit CM not written: %v", err)
+	}
+	// annotation guard set on the task
+	var got foremanv1alpha1.AgenticTask
+	_ = c.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-89"}, &got)
+	if got.Annotations[AuditedAnnotation] != "true" {
+		t.Errorf("audited annotation not set: %v", got.Annotations)
+	}
+
+	// second call is a no-op (already audited): delete the CM, call again,
+	// confirm it is NOT recreated.
+	_ = c.Delete(ctx, &cm)
+	if err := RecordTerminal(ctx, c, &got, "", logr.Discard()); err != nil {
+		t.Fatalf("second RecordTerminal: %v", err)
+	}
+	err := c.Get(ctx, types.NamespacedName{Namespace: "default", Name: "foreman-audit-coder-89"}, &corev1.ConfigMap{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("already-audited task must not re-write the record; got err=%v", err)
 	}
 }


### PR DESCRIPTION
## What

Adds a durable, structured, exportable **audit record** for every terminal
Foreman run, plus an `llmkube audit export` CLI to aggregate them into a JSONL
bundle. This is the audit-export v1 of #837; governance-mode enforcement is a
planned fast-follow (separate issue).

## Why

The audit-relevant data already exists on `AgenticTask.status` (verdict,
node, timestamps, branch/commitSHA) and `status.result.extra.modelExtra` (gate
attempts, scope-drift, issueAsk verification, reviewer outcome), but both the
task and its transcript ConfigMap are owner-ref'd and garbage-collected with the
task, so there is no lasting trail and no stable schema or export path. Regulated
and air-gapped operators need a durable compliance artifact that proves what each
autonomous run did, which model/endpoint served it, and what vetting it passed.

## How

- **`pkg/foreman/audit`** (new package):
  - `record.go`: versioned `Record` schema (`foreman.audit.v1`) + `BuildRecord`,
    which maps typed status fields plus the opaque `status.Result` JSON. Missing
    optional data yields nil blocks, never fabricated values.
  - `writer.go`: `WriteRecord` upserts a **non-owner-ref'd** ConfigMap
    `foreman-audit-<task>` labeled `foreman.llmkube.dev/audit=true` (survives task
    GC) plus a structured `foreman.audit` log line for SIEM/Loki; `RecordTerminal`
    is an annotation-guarded write-once that best-effort-resolves the Agent.
- **Controller**: `AgenticTaskReconciler` calls `audit.RecordTerminal` on the
  terminal-phase branch, best-effort (a failed audit write logs but never wedges
  reconciliation). New `AuditNamespace` field (empty = the task's own namespace).
- **CLI**: `llmkube audit export` (`pkg/cli/audit.go`) lists audit ConfigMaps by
  label, filters (`--repo/--since/--namespace`), sorts by `recordedAt`, and emits
  JSONL to stdout or `--output <file>`.

All tests are fake-client (no envtest). No CRD/api type changes (the durable
store is a labeled ConfigMap, not a new CRD), so no `make manifests` needed.

Note: there is intentionally no standalone `biteCheck` field; the bite check is
part of a verify-task's `GATE-PASS`/`GATE-FAIL` verdict, captured by that task's
own audit record.

## Checklist

- [x] Tests added (fake-client unit tests for BuildRecord, WriteRecord, RecordTerminal, export)
- [x] `go build ./...` passes
- [x] `gofmt` + `GOOS=linux golangci-lint` clean on changed packages
- [x] DCO sign-off on all commits
- [x] No CRD/api changes (no `make manifests`/`chart-crds` required)

Fixes #837
