### PR TITLE
feat(foreman): run the fast gate from the resolved GateProfile (Addresses #839)

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -395,7 +395,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// fast checks is sent back for a fix instead of landing dirty.
 	if agent.Spec.Role == foremanv1alpha1.AgentRoleCoder {
 		cfg.MaxVerifyRetries = coderGateMaxRetries
-		cfg.VerifyTerminal = makeCoderGateVerifier(workspace, log)
+		cfg.VerifyTerminal = makeCoderGateVerifier(workspace, log, task.Spec.GateProfile)
 	}
 
 	// 8. Run the loop. Always persist the transcript afterwards,
@@ -576,13 +576,24 @@ const coderGateMaxRetries = 3
 // use; a bootstrap or run error is reported as could-not-verify so the
 // terminal stands and the clean-room gate Job remains the authoritative
 // backstop.
-func makeCoderGateVerifier(workspace string, log logr.Logger) TerminalVerifier {
+func makeCoderGateVerifier(workspace string, log logr.Logger, profile *foremanv1alpha1.GateProfile) TerminalVerifier {
 	return func(ctx context.Context, terminal *ToolResult, _ []oai.Message) (bool, string, error) {
 		if terminal == nil {
 			return true, "", nil
 		}
 		if v, _ := normalizeModelVerdict(terminal.Verdict); v != foremanv1alpha1.AgenticTaskVerdictGo {
 			return true, "", nil
+		}
+		// Non-Go GateProfiles run the language-agnostic generic gate from the
+		// resolved commands. The Go path below is left byte-identical: a nil,
+		// empty-language, or explicit-"go" profile takes it unchanged.
+		if usesGenericGate(profile) {
+			pass, feedback := RunGenericGate(ctx, workspace, profile.Resolve(), execCommandRunner)
+			if !pass {
+				log.Info("coder gate (generic): fast checks failed; returning feedback to the loop for a fix",
+					"language", string(profile.Language))
+			}
+			return pass, feedback, nil
 		}
 		lintPath := filepath.Join(workspace, "bin", "golangci-lint")
 		if _, statErr := os.Stat(lintPath); statErr != nil {

--- a/pkg/foreman/agent/generic_gate.go
+++ b/pkg/foreman/agent/generic_gate.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"strings"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// usesGenericGate reports whether a task's GateProfile should run the
+// language-agnostic generic gate (RunGenericGate) instead of the
+// specialized Go gate (RunCoderGate). A nil profile, an empty language, or
+// an explicit "go" language all use the Go path, so existing Go tasks are
+// unaffected and the Go gate stays byte-identical.
+func usesGenericGate(profile *foremanv1alpha1.GateProfile) bool {
+	return profile != nil &&
+		profile.Language != "" &&
+		profile.Language != foremanv1alpha1.GateLanguageGo
+}
+
+// RunGenericGate runs a language-agnostic fast gate by executing the
+// resolved profile's commands in the workspace via `sh -c`. Each non-empty
+// command (format, lint, build, test, codegen) is one check, and a non-zero
+// exit is a failure. Like RunCoderGate, every check runs regardless of
+// earlier failures so the feedback reports everything wrong at once.
+//
+// Non-Go GateProfiles use this path. The Go profile keeps the specialized
+// RunCoderGate, which carries the Go-specific semantics (gofmt's
+// output-not-error signal, golangci-lint's env and binary path, the
+// changed-package test tier, and the controller-gen codegen-drift check)
+// that do not generalize to other toolchains.
+func RunGenericGate(
+	ctx context.Context,
+	workspace string,
+	gate foremanv1alpha1.ResolvedGate,
+	run commandRunner,
+) (pass bool, feedback string) {
+	checks := []struct {
+		name string
+		cmd  string
+	}{
+		{"format", gate.Format},
+		{"lint", gate.Lint},
+		{"build", gate.Build},
+		{"test", gate.Test},
+		{"codegen", gate.CodegenCheck},
+	}
+
+	var failures []checkFailure
+	for _, c := range checks {
+		cmd := strings.TrimSpace(c.cmd)
+		if cmd == "" {
+			continue
+		}
+		if out, err := run(ctx, workspace, nil, "sh", "-c", cmd); err != nil {
+			failures = append(failures, checkFailure{name: c.name + ": " + cmd, output: out})
+		}
+	}
+
+	if len(failures) == 0 {
+		return true, ""
+	}
+	return false, buildFeedback(failures)
+}

--- a/pkg/foreman/agent/generic_gate_test.go
+++ b/pkg/foreman/agent/generic_gate_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func TestUsesGenericGate(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile *foremanv1alpha1.GateProfile
+		want    bool
+	}{
+		{"nil profile -> go path", nil, false},
+		{"empty language -> go path", &foremanv1alpha1.GateProfile{}, false},
+		{"explicit go -> go path", &foremanv1alpha1.GateProfile{Language: foremanv1alpha1.GateLanguageGo}, false},
+		{"python -> generic", &foremanv1alpha1.GateProfile{Language: foremanv1alpha1.GateLanguagePython}, true},
+		{"rust -> generic", &foremanv1alpha1.GateProfile{Language: foremanv1alpha1.GateLanguageRust}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := usesGenericGate(tc.profile); got != tc.want {
+				t.Errorf("usesGenericGate = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type gateCall struct {
+	name string
+	args []string
+}
+
+func TestRunGenericGateAllPassRunsEachViaShC(t *testing.T) {
+	var calls []gateCall
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		calls = append(calls, gateCall{name, args})
+		return "", nil
+	}
+	gate := foremanv1alpha1.ResolvedGate{
+		Format: "ruff format --check .",
+		Lint:   "ruff check .",
+		Build:  "python -m compileall .",
+		Test:   "pytest -q",
+	}
+	pass, fb := RunGenericGate(context.Background(), "/ws", gate, run)
+	if !pass || fb != "" {
+		t.Fatalf("want pass with empty feedback; got pass=%v feedback=%q", pass, fb)
+	}
+	if len(calls) != 4 {
+		t.Fatalf("want 4 commands run (empty codegen skipped), got %d: %+v", len(calls), calls)
+	}
+	for _, c := range calls {
+		if c.name != "sh" || len(c.args) != 2 || c.args[0] != "-c" {
+			t.Errorf("command not run via `sh -c`: %+v", c)
+		}
+	}
+}
+
+func TestRunGenericGateSkipsEmptyAndCollectsFailures(t *testing.T) {
+	run := func(_ context.Context, _ string, _ []string, _ string, args ...string) (string, error) {
+		cmd := strings.Join(args, " ")
+		if strings.Contains(cmd, "ruff check") || strings.Contains(cmd, "pytest") {
+			return "boom", errors.New("exit status 1")
+		}
+		return "", nil
+	}
+	gate := foremanv1alpha1.ResolvedGate{
+		// Format, Build, Codegen empty -> skipped.
+		Lint: "ruff check .",
+		Test: "pytest -q",
+	}
+	pass, fb := RunGenericGate(context.Background(), "/ws", gate, run)
+	if pass {
+		t.Fatal("want fail when lint and test fail")
+	}
+	if !strings.Contains(fb, "ruff check") || !strings.Contains(fb, "pytest") {
+		t.Errorf("feedback should name both failing checks; got %q", fb)
+	}
+}


### PR DESCRIPTION
## What

Slice 2 of #839 (language-configurable gate). The **fast in-workspace coder
gate** now consumes the `GateProfile` that slice 1 added. A non-Go profile runs
a new language-agnostic `RunGenericGate` built from the resolved commands; the
Go profile keeps the specialized `RunCoderGate`, byte-for-byte unchanged.

## Why

Foreman's fast gate was hardcoded to the Go toolchain, the main blocker to
running it on a Python or Rust repo. This slice makes the gate actually consume
the profile, so a non-Go task gates with its own commands, while existing Go
tasks are provably unaffected.

## How

- `pkg/foreman/agent/generic_gate.go` (new): `RunGenericGate` runs each
  non-empty resolved command (format, lint, build, test, codegen) via `sh -c`
  in the workspace; a non-zero exit is a failure, and every check runs so the
  feedback reports everything at once (same shape as `RunCoderGate`).
  `usesGenericGate(profile)` is the selector: nil, empty language, or explicit
  `go` all use the Go path.
- `executor_native.go`: `makeCoderGateVerifier` takes the task's
  `GateProfile` and branches: `usesGenericGate` -> `RunGenericGate`, else the
  unchanged Go path. Call site passes `task.Spec.GateProfile`.
- `RunCoderGate` and `coder_gate.go` are **not touched** (0 lines changed vs
  main), so the Go gate is byte-identical by construction.

Out of scope (later slices): the scope guard's `.go` extension, and the
clean-room verify-gate Job's test command and image.

## Checklist

- [x] Tests added (`usesGenericGate` table + `RunGenericGate` pass/fail/skip-empty)
- [x] `go build ./...` passes; full `pkg/foreman/agent` test suite passes (Go path unaffected)
- [x] gofmt clean; lint clean for changed files
- [x] `coder_gate.go` unchanged vs main (verified `git diff` is empty)
- [x] DCO sign-off
- [x] No CRD/api changes

Addresses #839
