### PR TITLE
feat(foreman): scope guard reads source extensions from GateProfile (Addresses #839)

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -497,7 +497,8 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			var scopeMatched []string
 			if scopeDiff, scopeErr := repo.DiffNameOnly(ctx, workspace, "main"); scopeErr == nil {
 				verdict = enforceReviewerScopeOverlap(log, loopRes.Terminal.Extra,
-					extractFetchIssueBody(loopRes.Transcript), scopeDiff, verdict)
+					extractFetchIssueBody(loopRes.Transcript), scopeDiff, verdict,
+					task.Spec.GateProfile.Resolve().SourceExtensions)
 				scopeDriftDetected, _ = loopRes.Terminal.Extra["scopeDriftDetected"].(bool)
 				scopeMatched, _ = loopRes.Terminal.Extra["scopeMatched"].([]string)
 			} else {

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -69,11 +69,18 @@ func extractIssuePathRefs(body string) []string {
 	return refs
 }
 
-// hasGoFile reports whether any path in paths ends with ".go".
-func hasGoFile(paths []string) bool {
+// hasSourceFile reports whether any path in paths ends with one of the
+// extensions in exts. If exts is empty, it defaults to [".go"] so
+// existing behavior is preserved.
+func hasSourceFile(paths []string, exts []string) bool {
+	if len(exts) == 0 {
+		exts = []string{".go"}
+	}
 	for _, p := range paths {
-		if strings.HasSuffix(p, ".go") {
-			return true
+		for _, ext := range exts {
+			if strings.HasSuffix(p, ext) {
+				return true
+			}
 		}
 	}
 	return false
@@ -122,6 +129,7 @@ func enforceReviewerScopeOverlap(
 	issueBody string,
 	diffFiles []string,
 	verdict foremanv1alpha1.AgenticTaskVerdict,
+	sourceExtensions []string,
 ) foremanv1alpha1.AgenticTaskVerdict {
 	if extra == nil || issueBody == "" || len(diffFiles) == 0 {
 		return verdict
@@ -152,10 +160,10 @@ func enforceReviewerScopeOverlap(
 		return verdict
 	}
 
-	// A diff with zero indexable Go files is not scope drift — it is a
+	// A diff with zero indexable source files is not scope drift — it is a
 	// legitimate docs- or YAML-only change (#800). Skip the scope check
 	// so the run proceeds.
-	if !hasGoFile(diffFiles) {
+	if !hasSourceFile(diffFiles, sourceExtensions) {
 		return verdict
 	}
 

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -106,7 +106,7 @@ func TestEnforceReviewerScopeOverlap_Issue379DriftDemotesGo(t *testing.T) {
 	}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("zero scope overlap on GO must demote to NO-GO; got %v", got)
 	}
@@ -136,7 +136,7 @@ func TestEnforceReviewerScopeOverlap_MatchedRefStands(t *testing.T) {
 	diff := []string{"AGENTS.md"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue510Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a diff touching a referenced file must not demote; got %v", got)
 	}
@@ -156,7 +156,7 @@ func TestEnforceReviewerScopeOverlap_BasenameMatch(t *testing.T) {
 	diff := []string{"config/rbac/role.yaml"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("basename match must not demote; got %v", got)
 	}
@@ -167,7 +167,7 @@ func TestEnforceReviewerScopeOverlap_NoRefsObserveOnly(t *testing.T) {
 	diff := []string{"pkg/agent/agent.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("no path refs in issue must not demote; got %v", got)
 	}
@@ -180,7 +180,7 @@ func TestEnforceReviewerScopeOverlap_DriftOnNoGoAnnotatesOnly(t *testing.T) {
 	diff := []string{"internal/foreman/controller/agentictask_controller.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictNoGo)
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("NO-GO must stay NO-GO; got %v", got)
 	}
@@ -200,7 +200,7 @@ func TestEnforceReviewerScopeOverlap_ZeroGoFilesSkipsScopeCheck(t *testing.T) {
 	diff := []string{"README.md", "config/crd/bases/inference.llmkube.dev_models.yaml"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("zero-Go-file diff must not demote GO; got %v", got)
 	}
@@ -217,7 +217,7 @@ func TestEnforceReviewerScopeOverlap_RealDriftStillBites(t *testing.T) {
 	diff := []string{"internal/foreman/controller/agentictask_controller.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("real drift with Go files must still demote GO; got %v", got)
 	}
@@ -228,12 +228,84 @@ func TestEnforceReviewerScopeOverlap_RealDriftStillBites(t *testing.T) {
 
 func TestEnforceReviewerScopeOverlap_NilOrEmptyInputsPassThrough(t *testing.T) {
 	if got := enforceReviewerScopeOverlap(logr.Discard(), nil, issue379Body,
-		[]string{"x.go"}, foremanv1alpha1.AgenticTaskVerdictGo); got != foremanv1alpha1.AgenticTaskVerdictGo {
+		[]string{"x.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil); got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("nil extra must pass through; got %v", got)
 	}
 	extra := map[string]any{}
 	if got := enforceReviewerScopeOverlap(logr.Discard(), extra, "", nil,
-		foremanv1alpha1.AgenticTaskVerdictGo); got != foremanv1alpha1.AgenticTaskVerdictGo {
+		foremanv1alpha1.AgenticTaskVerdictGo, nil); got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("empty body and diff must pass through; got %v", got)
+	}
+}
+
+func TestHasSourceFile(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		exts  []string
+		want  bool
+	}{
+		{
+			name:  "matches .go",
+			paths: []string{"pkg/foo.go"},
+			exts:  []string{".go"},
+			want:  true,
+		},
+		{
+			name:  "matches .py",
+			paths: []string{"src/main.py"},
+			exts:  []string{".py"},
+			want:  true,
+		},
+		{
+			name:  "no match for unrelated files",
+			paths: []string{"README.md", "config/crd/bases/model.yaml"},
+			exts:  []string{".go"},
+			want:  false,
+		},
+		{
+			name:  "empty exts defaults to .go",
+			paths: []string{"pkg/foo.go"},
+			exts:  nil,
+			want:  true,
+		},
+		{
+			name:  "empty exts defaults to .go - no match",
+			paths: []string{"src/main.py"},
+			exts:  nil,
+			want:  false,
+		},
+		{
+			name:  "multiple extensions",
+			paths: []string{"src/main.py"},
+			exts:  []string{".go", ".py"},
+			want:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasSourceFile(tt.paths, tt.exts); got != tt.want {
+				t.Errorf("hasSourceFile(%v, %v) = %v, want %v", tt.paths, tt.exts, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEnforceReviewerScopeOverlap_PythonExtensions verifies that with
+// sourceExtensions=[".py"], a diff of only non-.py files (e.g. .md)
+// whose paths do NOT match the issue refs skips the scope check
+// (returns the input verdict unchanged), because hasSourceFile returns
+// false for a diff with no .py files.
+func TestEnforceReviewerScopeOverlap_PythonExtensions(t *testing.T) {
+	// Issue references Go files; diff contains only .md files (no .py).
+	diff := []string{"README.md", "docs/guide.md"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"})
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("with .py extensions and no .py diff, scope check should skip; got %v", got)
+	}
+	if _, demoted := extra["verdictDemoted"]; demoted {
+		t.Error("should not claim demotion when no source files of configured type changed")
 	}
 }


### PR DESCRIPTION
## What

Slice 3 of #839 (language-configurable gate). The reviewer scope-overlap guard
no longer hardcodes the `.go` extension: it reads the source-file extensions
from the task's `GateProfile`, so a non-Go repo's scope guard recognizes its own
source files. The Go default is byte-identical.

## Why

`enforceReviewerScopeOverlap` skips the scope-drift check when the diff contains
zero indexable source files (the #800 docs/YAML-only fix), but it decided
"source file" by a hardcoded `.go` suffix. On a Python or Rust repo that would
mis-skip (or mis-enforce) the guard. This makes the extension set come from the
profile.

## How

- `scope_overlap.go`: `hasGoFile(paths)` becomes `hasSourceFile(paths, exts)`;
  empty `exts` defaults to `[".go"]`. `enforceReviewerScopeOverlap` takes a new
  `sourceExtensions []string` and uses it for the zero-source-file skip. The
  drift-detection logic (refs/matched/scopeDriftDetected) is unchanged.
- `executor_native.go`: the call site passes
  `task.Spec.GateProfile.Resolve().SourceExtensions` (nil-safe: `Resolve` on a
  nil profile returns the go preset, whose extensions are `[".go"]`).
- Tests for `hasSourceFile` (.go, non-go ext, empty-defaults-to-go) and the
  guard's skip behavior under a non-go extension set.

A nil or `go` profile resolves to `[".go"]`, so Go-repo scope-guard behavior is
unchanged. No api/CRD changes.

## Checklist

- [x] Tests added
- [x] `go build ./...` + full `pkg/foreman/agent` suite pass (Go scope path unaffected)
- [x] gofmt + lint clean for changed files
- [x] No CRD/api changes
- [x] DCO sign-off

Addresses #839
