### PR TITLE
feat(foreman): verify-gate Job image from GateProfile (Addresses #839)

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -742,6 +742,11 @@ func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL 
 		// the bite check fetches this ref explicitly. LLMKube branches off
 		// main; the tool also defaults to main when empty.
 		"baseBranch": "main",
+		// image is the container image the gate Job runs. Resolve() is
+		// nil-safe: a nil GateProfile returns the go preset whose Image
+		// is "golang:1.26", preserving byte-identical behavior for Go
+		// tasks.
+		"image": task.Spec.GateProfile.Resolve().Image,
 	}
 	out, _ := json.Marshal(args)
 	return out

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -229,6 +229,41 @@ func TestBuildDeterministicArgs(t *testing.T) {
 			t.Errorf("cloneURL: want empty (so tool falls back to CloneURLBase+Repo) got %v", got["cloneURL"])
 		}
 	})
+
+	t.Run("nil GateProfile resolves to golang image", func(t *testing.T) {
+		raw := buildDeterministicArgs(task, "foreman/issue-510", "")
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("decode args: %v", err)
+		}
+		if got["image"] != "golang:1.26" {
+			t.Errorf("image: want golang:1.26 (nil GateProfile default) got %v", got["image"])
+		}
+	})
+
+	t.Run("python GateProfile resolves to python image", func(t *testing.T) {
+		pyTask := &foremanv1alpha1.AgenticTask{
+			ObjectMeta: metav1.ObjectMeta{Name: "gate-py", Namespace: "default"},
+			Spec: foremanv1alpha1.AgenticTaskSpec{
+				Kind: foremanv1alpha1.AgenticTaskKindVerify,
+				Payload: foremanv1alpha1.AgenticTaskPayload{
+					Repo:  "defilantech/LLMKube",
+					Issue: 839,
+				},
+				GateProfile: &foremanv1alpha1.GateProfile{
+					Language: foremanv1alpha1.GateLanguagePython,
+				},
+			},
+		}
+		raw := buildDeterministicArgs(pyTask, "foreman/issue-839", "")
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("decode args: %v", err)
+		}
+		if got["image"] != "python:3.13" {
+			t.Errorf("image: want python:3.13 got %v", got["image"])
+		}
+	})
 }
 
 // resolveSchemeForTests builds a runtime scheme with the API types the

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -163,6 +163,7 @@ type runGateJobArgs struct {
 	// to verify new tests bite. Defaults to "main" when empty.
 	BaseBranch string   `json:"baseBranch,omitempty"`
 	CloneURL   string   `json:"cloneURL,omitempty"`
+	Image      string   `json:"image,omitempty"`
 	Checks     []string `json:"checks,omitempty"`
 	BiteCheck  bool     `json:"biteCheck,omitempty"`
 	TaskRef    struct {
@@ -228,6 +229,13 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 
 	cfg := applyConfigDefaults(t.Cfg)
 
+	// Use the per-call image if provided; otherwise fall back to the
+	// config default (golang:1.26).
+	image := a.Image
+	if image == "" {
+		image = cfg.Image
+	}
+
 	taskName := a.TaskRef.Name
 	if taskName == "" {
 		taskName = "task"
@@ -238,7 +246,7 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 	rendered, err := renderGateJob(rendererInput{
 		Name:                    jobName,
 		Namespace:               cfg.Namespace,
-		Image:                   cfg.Image,
+		Image:                   image,
 		Repo:                    a.Repo,
 		Branch:                  a.Branch,
 		BaseBranch:              a.BaseBranch,

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -739,3 +739,88 @@ func TestRenderGateJob_BaseBranchEnv(t *testing.T) {
 		})
 	}
 }
+
+// TestRunGateJob_ImageOverride asserts that a non-empty per-call image
+// in the args overrides cfg.Image in the rendered Job, and that an
+// empty per-call image falls back to cfg.Image. Regression for #839.
+func TestRunGateJob_ImageOverride(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cases := []struct {
+		name    string
+		argsImg string
+		cfgImg  string
+		wantImg string
+	}{
+		{
+			name:    "args image overrides cfg image",
+			argsImg: "python:3.13",
+			cfgImg:  "golang:1.26",
+			wantImg: "python:3.13",
+		},
+		{
+			name:    "empty args image falls back to cfg image",
+			argsImg: "",
+			cfgImg:  "golang:1.26",
+			wantImg: "golang:1.26",
+		},
+		{
+			name:    "empty args image falls back to cfg custom image",
+			argsImg: "",
+			cfgImg:  "rust:1",
+			wantImg: "rust:1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(gateScheme(t)).WithStatusSubresource(&batchv1.Job{}).Build()
+			jobName := "foreman-gate-img-" + tc.name
+			key := types.NamespacedName{Namespace: "foreman-system", Name: jobName}
+
+			go flipStatusOnce(ctx, c, key, 1, 0)
+
+			args := map[string]any{
+				"repo":   "defilantech/LLMKube",
+				"branch": "foreman/issue-839",
+				"image":  tc.argsImg,
+				"taskRef": map[string]string{
+					"namespace": "default",
+					"name":      "gate-839",
+				},
+			}
+			argsJSON, err := json.Marshal(args)
+			if err != nil {
+				t.Fatalf("marshal args: %v", err)
+			}
+
+			tool := &RunGateJobTool{
+				Client: c,
+				Cfg: RunGateJobToolConfig{
+					Image:        tc.cfgImg,
+					NameFn:       pinName(jobName),
+					PollInterval: 5 * time.Millisecond,
+					PollTimeout:  2 * time.Second,
+				},
+			}
+
+			res, err := tool.Execute(ctx, argsJSON)
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if res.Verdict != VerdictGatePass {
+				t.Fatalf("Verdict: want %s got %s", VerdictGatePass, res.Verdict)
+			}
+
+			// Verify the Job was created with the expected image.
+			var job batchv1.Job
+			if err := c.Get(ctx, key, &job); err != nil {
+				t.Fatalf("Job should exist: %v", err)
+			}
+			if got := job.Spec.Template.Spec.Containers[0].Image; got != tc.wantImg {
+				t.Errorf("Image: want %q got %q", tc.wantImg, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Slice 4 of #839 (image only). The clean-room verify-gate Job's container image
now comes from the task's `GateProfile`, so a non-Go gate can run in its own
toolchain image (e.g. `python:3.13`). The Go default (`golang:1.26`) is
byte-identical.

## Why

The verify-gate Job hardcoded `golang:1.26`. A Python or Rust repo needs its own
image to run its checks in the clean room. This parameterizes just the image,
the smallest, lowest-risk piece of the Job.

## How

- `run_gate_job.go`: `runGateJobArgs` gains an `image` field; `Execute` uses the
  per-call image if set, else falls back to `cfg.Image` (which already defaults
  to `golang:1.26`), so an unset image is unchanged behavior.
- `executor_native.go` `buildDeterministicArgs`: adds
  `"image": task.Spec.GateProfile.Resolve().Image` (nil-safe: `Resolve` on a nil
  profile returns the go preset whose image is `golang:1.26`).
- Tests for the per-call override / cfg fallback and the resolved-image arg.

**Deliberately out of scope** (separate follow-up): the Job's checks (`make`
targets) and the Go-specific bite check are NOT touched. `gate_job_template.yaml`
is unchanged (0 lines). Generalizing those is the higher-risk half of the gate
and is tracked as a follow-up slice.

## Checklist

- [x] Tests added (image override + fallback + resolved arg)
- [x] `go build ./...` + `pkg/foreman/agent/...` tests pass
- [x] gofmt + lint clean for changed files
- [x] `gate_job_template.yaml` unchanged; no CRD/api changes
- [x] DCO sign-off

Addresses #839
