### PR TITLE
feat(foreman): verify-gate Job runs resolved commands for non-Go profiles (Addresses #839)

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -724,6 +724,10 @@ func pickDeterministicTool(tools []string) string {
 // not on the upstream payload.repo where the branch does not yet
 // exist. Empty cloneURL preserves the M4 default (upstream + repo).
 func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL string) json.RawMessage {
+	// Resolve once. Resolve() is nil-safe: a nil GateProfile yields the go
+	// preset (image golang:1.26, the make-target checks), so a Go task stays
+	// byte-identical to before this field existed.
+	resolved := task.Spec.GateProfile.Resolve()
 	args := map[string]any{
 		"repo":     task.Spec.Payload.Repo,
 		"branch":   branch,
@@ -742,12 +746,26 @@ func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL 
 		// the bite check fetches this ref explicitly. LLMKube branches off
 		// main; the tool also defaults to main when empty.
 		"baseBranch": "main",
-		// image is the container image the gate Job runs. Resolve() is
-		// nil-safe: a nil GateProfile returns the go preset whose Image
-		// is "golang:1.26", preserving byte-identical behavior for Go
-		// tasks.
-		"image": task.Spec.GateProfile.Resolve().Image,
+		// image is the container image the gate Job runs.
+		"image": resolved.Image,
 	}
+
+	// Non-Go GateProfiles switch the verify gate off the Go path (make
+	// targets + bite check) and onto the resolved commands, run in order.
+	// The bite check is Go-specific and intentionally not run on the generic
+	// path in this slice. A nil or "go" profile leaves args without
+	// "generic"/"commands", so the Go gate is byte-identical.
+	if usesGenericGate(task.Spec.GateProfile) {
+		var cmds []string
+		for _, c := range []string{resolved.Format, resolved.Lint, resolved.Build, resolved.Test, resolved.CodegenCheck} {
+			if strings.TrimSpace(c) != "" {
+				cmds = append(cmds, c)
+			}
+		}
+		args["generic"] = true
+		args["commands"] = cmds
+	}
+
 	out, _ := json.Marshal(args)
 	return out
 }

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -239,6 +239,9 @@ func TestBuildDeterministicArgs(t *testing.T) {
 		if got["image"] != "golang:1.26" {
 			t.Errorf("image: want golang:1.26 (nil GateProfile default) got %v", got["image"])
 		}
+		if _, ok := got["generic"]; ok {
+			t.Errorf("nil GateProfile must keep the Go gate path (no generic key); got %v", got["generic"])
+		}
 	})
 
 	t.Run("python GateProfile resolves to python image", func(t *testing.T) {
@@ -262,6 +265,20 @@ func TestBuildDeterministicArgs(t *testing.T) {
 		}
 		if got["image"] != "python:3.13" {
 			t.Errorf("image: want python:3.13 got %v", got["image"])
+		}
+		if got["generic"] != true {
+			t.Errorf("python GateProfile must set generic=true; got %v", got["generic"])
+		}
+		cmds, ok := got["commands"].([]any)
+		if !ok || len(cmds) == 0 {
+			t.Fatalf("python GateProfile must set non-empty commands; got %v", got["commands"])
+		}
+		joined := ""
+		for _, c := range cmds {
+			joined += c.(string) + "\n"
+		}
+		if !strings.Contains(joined, "pytest") || !strings.Contains(joined, "ruff") {
+			t.Errorf("commands should be the python preset (ruff/pytest); got %v", cmds)
 		}
 	})
 }

--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -65,6 +65,11 @@ spec:
                 "{{ if .CloneURL }}{{ .CloneURL }}{{ else }}{{ .CloneURLBase }}/{{ .Repo }}.git{{ end }}" /work || { echo "GATE FAIL: clone"; exit 1; }
               cd /work
               rc=0
+              {{- if .Generic }}
+              {{- range .Commands }}
+              echo "=== {{ . }} ==="; ( {{ . }} ) || rc=1
+              {{- end }}
+              {{- else }}
               {{- range .Checks }}
               echo "=== make {{ . }} ==="; make {{ . }} || rc=1
               {{- end }}
@@ -146,6 +151,7 @@ spec:
                   fi
                 fi
               fi
+              {{- end }}
               {{- end }}
               [ "$rc" -eq 0 ] && echo "GATE PASS" || echo "GATE FAIL"
               exit "$rc"

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -166,7 +166,14 @@ type runGateJobArgs struct {
 	Image      string   `json:"image,omitempty"`
 	Checks     []string `json:"checks,omitempty"`
 	BiteCheck  bool     `json:"biteCheck,omitempty"`
-	TaskRef    struct {
+	// Generic switches the Job from the Go path (make-target Checks plus the
+	// bite check) to running Commands directly. Set for non-Go GateProfiles.
+	Generic bool `json:"generic,omitempty"`
+	// Commands are the resolved shell commands the generic path runs in
+	// order; each is a check and a non-zero exit fails the gate. Ignored
+	// unless Generic is true.
+	Commands []string `json:"commands,omitempty"`
+	TaskRef  struct {
 		Namespace string `json:"namespace"`
 		Name      string `json:"name"`
 	} `json:"taskRef"`
@@ -220,7 +227,7 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 	if a.Branch == "" {
 		return nil, errors.New("run_gate_job: branch is required")
 	}
-	if len(a.Checks) == 0 {
+	if !a.Generic && len(a.Checks) == 0 {
 		a.Checks = DefaultGateChecks
 	}
 	if a.BaseBranch == "" {
@@ -252,6 +259,8 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 		BaseBranch:              a.BaseBranch,
 		Checks:                  a.Checks,
 		BiteCheck:               a.BiteCheck,
+		Generic:                 a.Generic,
+		Commands:                a.Commands,
 		PVCName:                 cfg.PVCName,
 		ActiveDeadlineSeconds:   cfg.ActiveDeadlineSeconds,
 		TTLSecondsAfterFinished: cfg.TTLSecondsAfterFinished,
@@ -396,6 +405,8 @@ type rendererInput struct {
 	BaseBranch              string
 	Checks                  []string
 	BiteCheck               bool
+	Generic                 bool
+	Commands                []string
 	PVCName                 string
 	ActiveDeadlineSeconds   int32
 	TTLSecondsAfterFinished int32

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -391,6 +391,45 @@ func TestRenderGateJob_RendersChecksAndPVCMount(t *testing.T) {
 	}
 }
 
+func TestRenderGateJob_GenericRunsCommandsNotMakeOrBiteCheck(t *testing.T) {
+	job, err := renderGateJob(rendererInput{
+		Name:                    "foreman-gate-py",
+		Namespace:               "foreman-system",
+		Image:                   "python:3.13",
+		Repo:                    "acme/widgets",
+		Branch:                  "foreman/issue-1",
+		BiteCheck:               true, // must be ignored on the generic path
+		Generic:                 true,
+		Commands:                []string{"ruff check .", "pytest -q"},
+		PVCName:                 "foreman-gate-cache",
+		ActiveDeadlineSeconds:   1800,
+		TTLSecondsAfterFinished: 86400,
+		CPURequest:              "2",
+		CPULimit:                "4",
+		MemRequest:              "4Gi",
+		MemLimit:                "8Gi",
+		CloneURLBase:            "https://github.com",
+		TaskNamespace:           "default",
+		TaskName:                "gate-1",
+	})
+	if err != nil {
+		t.Fatalf("renderGateJob: %v", err)
+	}
+	if got := job.Spec.Template.Spec.Containers[0].Image; got != "python:3.13" {
+		t.Errorf("Image: %q", got)
+	}
+	args := strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
+	if !strings.Contains(args, "( ruff check . )") || !strings.Contains(args, "( pytest -q )") {
+		t.Errorf("generic args missing the resolved commands:\n%s", args)
+	}
+	if strings.Contains(args, "make ") {
+		t.Errorf("generic path must not run make targets:\n%s", args)
+	}
+	if strings.Contains(args, "bite check") {
+		t.Errorf("generic path must not run the Go-specific bite check:\n%s", args)
+	}
+}
+
 // TestRenderGateJob_CloneURLOverride asserts the template branches
 // correctly on the CloneURL field: when set, the git clone target is
 // the override URL verbatim; when empty, the historical


### PR DESCRIPTION
## What

Slice 4b of #839 (language-configurable gate). The clean-room **verify-gate
Job** now runs the resolved profile commands for a non-Go repo. Combined with
slice 4 (image), a Python or Rust verify gate now runs in its own image AND its
own checks. The Go path is byte-identical.

## Why

The verify-gate Job ran `make <target>` checks plus a Go-specific bite check. A
non-Go repo has no Makefile and no `go test`. This adds a generic path so the
Job runs the profile's resolved commands directly.

## How

- `gate_job_template.yaml`: the existing Go logic (make-target checks +
  tree-dirty check + bite check) is wrapped in an `{{- else }}` branch (so the
  Go path is the **original template verbatim**), and a `{{- if .Generic }}`
  branch runs each resolved command via subshell (`( <cmd> ) || rc=1`), with no
  make and no bite check.
- `run_gate_job.go`: `runGateJobArgs` and `rendererInput` gain `Generic` +
  `Commands`; the `Checks` default is skipped when `Generic`.
- `executor_native.go` `buildDeterministicArgs`: for a non-Go profile
  (`usesGenericGate`), sets `generic: true` and `commands` from the resolved
  Format/Lint/Build/Test/Codegen. A nil/`go` profile sets neither, so the Go
  gate is unchanged.

Tests: generic render (commands present, no `make`, no bite check), the
existing Go render still passes, and `buildDeterministicArgs` (nil → no generic;
python → generic + ruff/pytest commands).

**Known limitation (follow-up):** the bite check is not generalized to non-Go
repos in this slice; the generic path runs the profile's commands only. The Go
path keeps its bite check.

## Checklist

- [x] Tests added (generic render + args; Go render unchanged)
- [x] `go build ./...` + full `pkg/foreman/agent/...` suite pass
- [x] gofmt + lint clean for changed files
- [x] Go branch of the template is the original verbatim (wrapped only)
- [x] DCO sign-off

Addresses #839
