### PR TITLE
docs(foreman): fix overview link that 404s the site build

### DIFF
--- a/docs/site/foreman/language-gates.md
+++ b/docs/site/foreman/language-gates.md
@@ -155,5 +155,5 @@ fails buggy code, which is the whole point.
 ## See also
 
 - [`defilantech/foreman-python-example`](https://github.com/defilantech/foreman-python-example): clone-and-run sample project for this page.
-- [Foreman overview](./foreman): the CRDs and the coder / verifier / reviewer pipeline.
+- [Foreman overview](/docs/foreman): the CRDs and the coder / verifier / reviewer pipeline.
 - [M4 verifier runbook](./runbook-m4): standing up the verify gate on a node.


### PR DESCRIPTION
## What

One-line docs fix: the "Foreman overview" link on the new language-gates page used `./foreman`, which resolves to `/docs/foreman/foreman` (404) from `/docs/foreman/language-gates`. Changed to the absolute `/docs/foreman`.

## Why

The SvelteKit prerender link check on llmkube-web treats a 404 as a hard error, so this broke the site build:

```
Error: 404 /docs/foreman/foreman (linked from /docs/foreman/language-gates)
```

The overview is the parent route, not a sibling, so `./` was wrong.

## How

`[Foreman overview](./foreman)` -> `[Foreman overview](/docs/foreman)`. Audited every other link on the page: the remaining `./runbook-m4` (sibling) and the external links all resolve.

Addresses #839
