### PR TITLE
fix(controller): propagate backend displayName into router-proxy config

### DIFF
--- a/internal/controller/router_builders_test.go
+++ b/internal/controller/router_builders_test.go
@@ -624,6 +624,41 @@ func TestCompileRouterConfigCopiesBackendTimeout(t *testing.T) {
 	}
 }
 
+// TestCompileRouterConfigCopiesDisplayName guards the controller half of
+// the per-backend displayName feature (#826): the CRD stores DisplayName
+// and the proxy publishes/matches on it, but only if the controller
+// actually emits it into config.json. resolveBackend used to drop it, so
+// the published id silently fell back to Name. A backend with a
+// DisplayName must surface it in the compiled config; one without keeps
+// it empty (the proxy then uses Name).
+func TestCompileRouterConfigCopiesDisplayName(t *testing.T) {
+	mr := canonicalModelRouter()
+	mr.Spec.Backends[1].DisplayName = "cloud/opus"
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "qwen3-coder", Namespace: testBuilderNs},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "anthropic-key", Namespace: testBuilderNs},
+		Data:       map[string][]byte{"ANTHROPIC_API_KEY": []byte("test")},
+	}
+	r := newRouterReconcilerForTest(t, mr, isvc, secret)
+	compiled, err := r.compileRouterConfig(context.Background(), mr)
+	if err != nil {
+		t.Fatalf("compileRouterConfig: %v", err)
+	}
+	var cfg router.Config
+	if err := json.Unmarshal(compiled.JSON, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.Backends[1].DisplayName != "cloud/opus" {
+		t.Errorf("backend displayName = %q, want cloud/opus", cfg.Backends[1].DisplayName)
+	}
+	if cfg.Backends[0].DisplayName != "" {
+		t.Errorf("backend without displayName = %q, want empty", cfg.Backends[0].DisplayName)
+	}
+}
+
 // TestRouterServiceBuilder confirms ClusterIP default and the
 // canonical selector label.
 func TestRouterServiceBuilder(t *testing.T) {

--- a/internal/controller/router_config_builder.go
+++ b/internal/controller/router_config_builder.go
@@ -119,6 +119,7 @@ func (r *ModelRouterReconciler) resolveBackend(
 	}
 	wire := router.Backend{
 		Name:         b.Name,
+		DisplayName:  b.DisplayName,
 		Tier:         b.Tier,
 		Capabilities: append([]string(nil), b.Capabilities...),
 	}


### PR DESCRIPTION
PR #826 added the optional per-backend `displayName` — published as the `/v1/models` model id and used by `BackendNameMatch` — to the CRD, the router-proxy publish/match path (`internal/router`), and the Gateway-API rule compiler. But the standalone router-proxy config builder was missed: `resolveBackend` in `internal/controller/router_config_builder.go` builds the `router.Backend` wire shape written to the proxy's `config.json` ConfigMap and never copied `DisplayName`. So for router-proxy deployments (the `proxy.image` + mounted `config.json` mode), the operator silently dropped the field, the proxy never saw it, and `publishedID()` fell back to `Name` — `/v1/models` and `BackendNameMatch` both used the bare backend name. Only the Gateway-API path honored `displayName`. Reproduced on v0.8.17 and current `main`.

The existing `internal/router` tests (`TestProxyModelsDisplayName`, `TestMatchBackendNameMatchResolvesDisplayName`) pass because they construct the proxy config by hand, bypassing the controller's builder — so nothing covered the controller→`config.json` hop.

## What changed

- `resolveBackend` now copies `b.DisplayName` onto the wire `router.Backend`, so it reaches `config.json`.
- Add `TestCompileRouterConfigCopiesDisplayName` (controller-level): a backend with a `displayName` surfaces it in the compiled config; one without keeps it empty. The test fails without the one-line fix.

## Validation

- `go test ./internal/controller/...` passes including the envtest suites; the new test fails on `main` and passes with the fix.
- `go vet` and `gofmt` clean.

_Assisted by Claude Opus 4.8_