### PR TITLE
fix(controller): make model cache writable on fsGroupPolicy=None CSIs (#855)

### DIFF
--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -247,7 +247,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	var modelPath string
 	if backend.NeedsModelInit() && !skipInit {
 		useCache := model.Status.CacheKey != "" && r.ModelCachePath != ""
-		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.ModelCacheMode, r.CACertConfigMap, r.InitContainerImage)
+		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.ModelCacheMode, r.CACertConfigMap, r.InitContainerImage, r.DefaultFSGroup)
 		modelPath = storageConfig.modelPath
 	}
 

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -73,6 +73,11 @@ func sanitizeDNSName(name string) string {
 
 func boolPtr(b bool) *bool { return &b }
 
+// int64Ptr returns a pointer to the given int64. Used to construct
+// *int64 fields on SecurityContext / PodSecurityContext from a literal value
+// without an intermediate variable.
+func int64Ptr(v int64) *int64 { return &v }
+
 // initContainerSecurityContext returns the SecurityContext applied to the
 // model downloader init container. It inherits runAsUser/runAsGroup from the
 // pod-level Spec.PodSecurityContext when the user supplied one. The default

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 var _ = Describe("buildCachedStorageConfig", func() {
-	It("should configure PVC volume and init container for remote model", func() {
+	It("should configure PVC volume and init containers for remote model", func() {
 		model := &inferencev1alpha1.Model{
 			Spec: inferencev1alpha1.ModelSpec{
 				Source: "https://example.com/model.gguf",
@@ -40,27 +40,29 @@ var _ = Describe("buildCachedStorageConfig", func() {
 				CacheKey: "abc123def456",
 			},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 
 		Expect(config.modelPath).To(Equal("/models/abc123def456/model.gguf"))
 		Expect(config.volumes).To(HaveLen(1))
 		Expect(config.volumes[0].Name).To(Equal("model-cache"))
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
-		Expect(config.initContainers).To(HaveLen(1))
-		Expect(config.initContainers[0].Name).To(Equal("model-downloader"))
-		Expect(config.initContainers[0].Image).To(Equal("curl:8.18.0"))
+		// Prep container (model-cache-permissions) + downloader = 2 init containers.
+		Expect(config.initContainers).To(HaveLen(2))
+		Expect(config.initContainers[0].Name).To(Equal("model-cache-permissions"))
+		Expect(config.initContainers[1].Name).To(Equal("model-downloader"))
+		Expect(config.initContainers[1].Image).To(Equal("curl:8.18.0"))
 		Expect(config.volumeMounts[0].MountPath).To(Equal("/models"))
 		Expect(config.volumeMounts[0].ReadOnly).To(BeTrue())
 
-		// Verify env vars are set on the init container
-		env := config.initContainers[0].Env
+		// Verify env vars are set on the downloader init container
+		env := config.initContainers[1].Env
 		Expect(env).To(HaveLen(3))
 		Expect(env[0]).To(Equal(corev1.EnvVar{Name: "MODEL_SOURCE", Value: "https://example.com/model.gguf"}))
 		Expect(env[1]).To(Equal(corev1.EnvVar{Name: "CACHE_DIR", Value: "/models/abc123def456"}))
 		Expect(env[2]).To(Equal(corev1.EnvVar{Name: "MODEL_PATH", Value: "/models/abc123def456/model.gguf"}))
 
 		// Verify the command does not contain the raw source URL
-		Expect(config.initContainers[0].Command[2]).NotTo(ContainSubstring("example.com"))
+		Expect(config.initContainers[1].Command[2]).NotTo(ContainSubstring("example.com"))
 	})
 
 	It("should add host-model volume for local source", func() {
@@ -72,14 +74,14 @@ var _ = Describe("buildCachedStorageConfig", func() {
 				CacheKey: "abc123",
 			},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 
 		Expect(config.volumes).To(HaveLen(2))
 		Expect(config.volumes[1].Name).To(Equal("host-model"))
 		Expect(config.volumes[1].HostPath.Path).To(Equal("/mnt/models/test.gguf"))
 
-		// Verify env vars are set
-		env := config.initContainers[0].Env
+		// Verify env vars are set on the downloader (index 1, after prep)
+		env := config.initContainers[1].Env
 		Expect(env).To(HaveLen(3))
 		Expect(env[0]).To(Equal(corev1.EnvVar{Name: "MODEL_SOURCE", Value: "file:///mnt/models/test.gguf"}))
 	})
@@ -93,7 +95,7 @@ var _ = Describe("buildCachedStorageConfig", func() {
 				CacheKey: "abc123",
 			},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "my-ca-certs", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "my-ca-certs", "curl:8.18.0", 102)
 
 		var found bool
 		for _, v := range config.volumes {
@@ -103,7 +105,123 @@ var _ = Describe("buildCachedStorageConfig", func() {
 			}
 		}
 		Expect(found).To(BeTrue())
-		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+	})
+})
+
+var _ = Describe("buildCachedStorageConfig prep init container (#855)", func() {
+	It("emits a model-cache-permissions prep container ordered before model-downloader (default fsGroup)", func() {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "https://example.com/model.gguf",
+			},
+			Status: inferencev1alpha1.ModelStatus{
+				CacheKey: "abc123def456",
+			},
+		}
+		// No explicit podSecurityContext -> resolved fsGroup == defaultFSGroup (102).
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+
+		Expect(config.initContainers).To(HaveLen(2))
+		Expect(config.initContainers[0].Name).To(Equal("model-cache-permissions"))
+		Expect(config.initContainers[1].Name).To(Equal("model-downloader"))
+
+		// Default path: chown to 0:<resolvedFSGroup>, give group rw on files,
+		// rwx on dirs. Non-recursive (shared cache holds other models' files).
+		cmd := config.initContainers[0].Command[2]
+		Expect(cmd).To(Equal("chown 0:102 /models && chmod g+rwX /models"))
+		Expect(cmd).NotTo(ContainSubstring("-R"))
+
+		// Prep reuses the same initContainerImage as the downloader (air-gapped
+		// clusters mirror one image).
+		Expect(config.initContainers[0].Image).To(Equal("curl:8.18.0"))
+		Expect(config.initContainers[1].Image).To(Equal("curl:8.18.0"))
+	})
+
+	It("honours an InferenceService podSecurityContext.FSGroup override (3000 vs default 102)", func() {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "https://example.com/model.gguf",
+			},
+			Status: inferencev1alpha1.ModelStatus{
+				CacheKey: "abc123def456",
+			},
+		}
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				PodSecurityContext: &corev1.PodSecurityContext{
+					FSGroup: int64Ptr(3000),
+				},
+			},
+		}
+		// defaultFSGroup=102, isvc overrides to 3000 -> prep must chown 0:3000.
+		config := buildCachedStorageConfig(model, isvc, "", "", "curl:8.18.0", 102)
+
+		Expect(config.initContainers).To(HaveLen(2))
+		Expect(config.initContainers[0].Name).To(Equal("model-cache-permissions"))
+		cmd := config.initContainers[0].Command[2]
+		Expect(cmd).To(Equal("chown 0:3000 /models && chmod g+rwX /models"))
+		// The override wins: the default 102 must NOT appear in the prep command.
+		Expect(cmd).NotTo(ContainSubstring("102"))
+	})
+
+	It("uses uid 100 when fsGroup is disabled (<=0)", func() {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "https://example.com/model.gguf",
+			},
+			Status: inferencev1alpha1.ModelStatus{
+				CacheKey: "abc123def456",
+			},
+		}
+		// defaultFSGroup=0 disables the default; no isvc override either.
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 0)
+
+		Expect(config.initContainers).To(HaveLen(2))
+		Expect(config.initContainers[0].Name).To(Equal("model-cache-permissions"))
+		cmd := config.initContainers[0].Command[2]
+		Expect(cmd).To(Equal("chown 100:100 /models && chmod 770 /models"))
+	})
+
+	It("applies hardened prep SecurityContext (runAsUser=0, drop ALL, add CHOWN+FOWNER, no privilege escalation, read-only root, seccomp RuntimeDefault)", func() {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "https://example.com/model.gguf",
+			},
+			Status: inferencev1alpha1.ModelStatus{
+				CacheKey: "abc123def456",
+			},
+		}
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+
+		sc := config.initContainers[0].SecurityContext
+		Expect(sc).NotTo(BeNil())
+		Expect(*sc.RunAsUser).To(Equal(int64(0)))
+		Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
+		Expect(*sc.ReadOnlyRootFilesystem).To(BeTrue())
+		Expect(sc.Capabilities).NotTo(BeNil())
+		Expect(sc.Capabilities.Drop).To(ContainElement("ALL"))
+		Expect(sc.Capabilities.Add).To(ContainElement("CHOWN"))
+		Expect(sc.Capabilities.Add).To(ContainElement("FOWNER"))
+		Expect(sc.SeccompProfile).NotTo(BeNil())
+		Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+	})
+
+	It("does not emit the prep container for the emptyDir path", func() {
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
+		}
+		config := buildEmptyDirStorageConfig(model, nil, "default", "", "curl:8.18.0")
+
+		var prepFound bool
+		for _, c := range config.initContainers {
+			if c.Name == "model-cache-permissions" {
+				prepFound = true
+			}
+		}
+		Expect(prepFound).To(BeFalse())
 	})
 })
 
@@ -216,7 +334,7 @@ var _ = Describe("buildModelStorageConfig PVC dispatch", func() {
 			Spec:       inferencev1alpha1.ModelSpec{Source: "pvc://my-claim/model.gguf"},
 			Status:     inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
 		}
-		config := buildModelStorageConfig(model, nil, "default", true, "", "", "curl:8.18.0")
+		config := buildModelStorageConfig(model, nil, "default", true, "", "", "curl:8.18.0", 102)
 
 		// Should use PVC config, not cached config
 		Expect(config.volumes[0].Name).To(Equal("model-source"))
@@ -417,7 +535,7 @@ var _ = Describe("buildCachedStorageConfig cache mode selection (#728)", func() 
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-isvc"},
 		}
-		config := buildCachedStorageConfig(model, isvc, ModelCacheModePerService, "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, isvc, ModelCacheModePerService, "", "curl:8.18.0", 102)
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("my-isvc-model-cache"))
 	})
 
@@ -425,7 +543,7 @@ var _ = Describe("buildCachedStorageConfig cache mode selection (#728)", func() 
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-isvc"},
 		}
-		config := buildCachedStorageConfig(model, isvc, ModelCacheModeShared, "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, isvc, ModelCacheModeShared, "", "curl:8.18.0", 102)
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
 	})
 
@@ -433,7 +551,7 @@ var _ = Describe("buildCachedStorageConfig cache mode selection (#728)", func() 
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-isvc"},
 		}
-		config := buildCachedStorageConfig(model, isvc, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, isvc, "", "", "curl:8.18.0", 102)
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
 	})
 })
@@ -563,8 +681,8 @@ var _ = Describe("buildCachedStorageConfig RefreshPolicy plumbing", func() {
 			},
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123def456"},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
-		cmd := config.initContainers[0].Command[2]
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).To(ContainSubstring("--etag-compare"))
 		Expect(cmd).To(ContainSubstring("kept cached copy"))
 	})
@@ -574,8 +692,8 @@ var _ = Describe("buildCachedStorageConfig RefreshPolicy plumbing", func() {
 			Spec:   inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123def456"},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
-		cmd := config.initContainers[0].Command[2]
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).NotTo(ContainSubstring("--etag-compare"))
 		Expect(cmd).To(ContainSubstring("skipping download"))
 	})

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -1596,13 +1596,13 @@ var _ = Describe("Issue #363 regression — controller / workload cache disconne
 		// assert the init container's MODEL_PATH lines up with the Model's
 		// CacheKey. The init container's `if [ ! -f "$MODEL_PATH" ]` check
 		// only works when both sides agree on the path.
-		config := buildCachedStorageConfig(updated, nil, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(updated, nil, "", "", "curl:8.18.0", 102)
 		expectedPrefix := "/models/" + updated.Status.CacheKey + "/"
 		Expect(config.modelPath).To(HavePrefix(expectedPrefix),
 			"init container MODEL_PATH must live under /models/<Status.CacheKey>/")
 
 		var modelPathEnv string
-		for _, e := range config.initContainers[0].Env {
+		for _, e := range config.initContainers[1].Env {
 			if e.Name == "MODEL_PATH" {
 				modelPathEnv = e.Value
 			}

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -147,12 +147,12 @@ type modelStorageConfig struct {
 	volumeMounts   []corev1.VolumeMount
 }
 
-func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string) modelStorageConfig {
+func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64) modelStorageConfig {
 	if isPVCSource(model.Spec.Source) {
 		return buildPVCStorageConfig(model)
 	}
 	if useCache {
-		return buildCachedStorageConfig(model, isvc, cacheMode, caCertConfigMap, initContainerImage)
+		return buildCachedStorageConfig(model, isvc, cacheMode, caCertConfigMap, initContainerImage, defaultFSGroup)
 	}
 	return buildEmptyDirStorageConfig(model, isvc, namespace, caCertConfigMap, initContainerImage)
 }
@@ -183,7 +183,7 @@ func buildPVCStorageConfig(model *inferencev1alpha1.Model) modelStorageConfig {
 	}
 }
 
-func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, cacheMode string, caCertConfigMap string, initContainerImage string) modelStorageConfig {
+func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64) modelStorageConfig {
 	cacheDir := fmt.Sprintf("/models/%s", model.Status.CacheKey)
 	// Match the basename the Model controller renames the file to after
 	// parsing GGUF metadata. If the controller has already populated
@@ -250,20 +250,92 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1a
 		cmd = fmt.Sprintf("export CURL_CA_BUNDLE=/custom-certs/$(ls /custom-certs | grep -v '^\\.' | head -n 1) && %s", cmd)
 	}
 
-	return modelStorageConfig{
-		modelPath: modelPath,
-		initContainers: []corev1.Container{
-			{
-				Name:            "model-downloader",
-				Image:           initContainerImage,
-				Command:         []string{"sh", "-c", cmd},
-				Env:             env,
-				VolumeMounts:    initVolumeMounts,
-				SecurityContext: initContainerSecurityContext(isvc),
+	// Resolve the fsGroup the pod will actually run with. CSI drivers with
+	// fsGroupPolicy=None (CephFS, NFS) do not propagate the pod-level fsGroup
+	// into the volume, so the PVC root stays root:root 0755 and a non-root
+	// init container (curlimages/curl, uid 100) gets "permission denied" when
+	// it tries to create its cache subdir. The prep init container below runs
+	// as root and chowns/chmods the mount root so the downloader can write.
+	//
+	// The resolved fsGroup must mirror inferPodSecurityContext exactly: when
+	// the InferenceService sets its own podSecurityContext.FSGroup, that is
+	// what the pod actually runs with, so the chown target must match.
+	resolvedFSGroup := defaultFSGroup
+	if isvc != nil && isvc.Spec.PodSecurityContext != nil && isvc.Spec.PodSecurityContext.FSGroup != nil {
+		resolvedFSGroup = *isvc.Spec.PodSecurityContext.FSGroup
+	}
+
+	initContainers := []corev1.Container{}
+
+	// Prep init container: run as root to chown/chmod the mount root so the
+	// non-root downloader can write into it. Non-recursive (a shared cache
+	// holds other models' files).
+	if resolvedFSGroup > 0 {
+		// Default path: chown to the resolved fsGroup, give the group rw access
+		// to files and rwx to directories (g+rwX), so the downloader and the
+		// inference container can read/write regardless of their primary UID.
+		initContainers = append(initContainers, corev1.Container{
+			Name:    "model-cache-permissions",
+			Image:   initContainerImage,
+			Command: []string{"sh", "-c", fmt.Sprintf("chown 0:%d /models && chmod g+rwX /models", resolvedFSGroup)},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "model-cache", MountPath: "/models"},
 			},
-		},
-		volumes:      volumes,
-		volumeMounts: []corev1.VolumeMount{{Name: "model-cache", MountPath: "/models", ReadOnly: true}},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:                int64Ptr(0),
+				AllowPrivilegeEscalation: boolPtr(false),
+				ReadOnlyRootFilesystem:   boolPtr(true),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+					Add:  []corev1.Capability{"CHOWN", "FOWNER"},
+				},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+		})
+	} else {
+		// fsGroup disabled (e.g. OpenShift restricted-v2 SCC manages it). The
+		// downloader runs with its own UID (curlimages/curl default 100); chown
+		// the mount root to that UID so the downloader can write.
+		initContainers = append(initContainers, corev1.Container{
+			Name:    "model-cache-permissions",
+			Image:   initContainerImage,
+			Command: []string{"sh", "-c", "chown 100:100 /models && chmod 770 /models"},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "model-cache", MountPath: "/models"},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:                int64Ptr(0),
+				AllowPrivilegeEscalation: boolPtr(false),
+				ReadOnlyRootFilesystem:   boolPtr(true),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+					Add:  []corev1.Capability{"CHOWN", "FOWNER"},
+				},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+		})
+	}
+
+	// model-downloader follows the prep container. Order matters: the prep
+	// container must run first so the downloader sees a writable mount.
+	initContainers = append(initContainers, corev1.Container{
+		Name:            "model-downloader",
+		Image:           initContainerImage,
+		Command:         []string{"sh", "-c", cmd},
+		Env:             env,
+		VolumeMounts:    initVolumeMounts,
+		SecurityContext: initContainerSecurityContext(isvc),
+	})
+
+	return modelStorageConfig{
+		modelPath:      modelPath,
+		initContainers: initContainers,
+		volumes:        volumes,
+		volumeMounts:   []corev1.VolumeMount{{Name: "model-cache", MountPath: "/models", ReadOnly: true}},
 	}
 }
 


### PR DESCRIPTION
## What

Adds a root-run `model-cache-permissions` init container before `model-downloader` in the cache-backed storage path. It chowns/chmods the cache mount root so the non-root downloader (uid 100) can write on CSIs that ignore `fsGroup` (CephFS/NFS).

## Why

On a `fsGroupPolicy: None` CSI the kubelet never applies the pod `fsGroup` to the volume, so a freshly-provisioned cache PVC root stays `root:root 0755` and the non-root `model-downloader` gets `permission denied` on `mkdir`, leaving the InferenceService stuck at `Init:Error`. Affects shared RWX caches on the two most common RWX backends (CephFS, NFS), which frequently ship `fsGroupPolicy: None`. Fixes #855.

## How

The prep container chowns the mount root **non-recursively** (so a shared cache does not get every other model's files rewritten on each pod start) to the **resolved** pod fsGroup:

- `isvc.Spec.PodSecurityContext.FSGroup` when the InferenceService sets it, else the operator default `r.DefaultFSGroup` (the `--default-fsgroup` flag, default 102). The resolution mirrors `inferPodSecurityContext` so the chown target matches the fsGroup the pod actually runs with (this is load-bearing: chowning to the wrong group leaves the downloader, which carries fsGroup as a supplemental group, unable to write).
- When fsGroup is disabled (`<= 0`), there is no supplemental group, so it chowns to the downloader's own uid (100) instead.

It reuses the configurable `initContainerImage` (air-gap friendly, no hardcoded busybox) and runs least-privilege: `runAsUser 0` (required to chown a root-owned mount), drop `ALL` and add back only `CHOWN`/`FOWNER`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, seccomp `RuntimeDefault`. The downloader and llama-server containers stay unprivileged.

## Checklist

- [x] `go build`, `go vet`, `gofmt`, `golangci-lint` clean
- [x] Unit tests: ordering before downloader; default fsGroup 102; explicit isvc override (3000 over default 102); fsGroup-disabled -> uid 100; image reuse; hardened SecurityContext; not emitted for emptyDir
- [ ] Live validation on a real `fsGroupPolicy: None` CSI (CephFS): manual, follow-up. The init-container path is not reproducible in CI.

Note: the prep is root-by-necessity (chowning a root-owned mount), so it does not satisfy PSA `restricted` namespaces; that constraint is inherent to the fix.
