### PR TITLE
fix(controller): make model cache writable on fsGroupPolicy=None CSIs (#855)

### DIFF
--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -247,7 +247,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	var modelPath string
 	if backend.NeedsModelInit() && !skipInit {
 		useCache := model.Status.CacheKey != "" && r.ModelCachePath != ""
-		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.ModelCacheMode, r.CACertConfigMap, r.InitContainerImage)
+		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.ModelCacheMode, r.CACertConfigMap, r.InitContainerImage, r.DefaultFSGroup)
 		modelPath = storageConfig.modelPath
 	}
 

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -73,6 +73,11 @@ func sanitizeDNSName(name string) string {
 
 func boolPtr(b bool) *bool { return &b }
 
+// int64Ptr returns a pointer to the given int64 value. Used to construct
+// corev1 fields that take *int64 (e.g. SecurityContext.RunAsUser,
+// PodSecurityContext.FSGroup) from a plain int64 literal.
+func int64Ptr(v int64) *int64 { return &v }
+
 // initContainerSecurityContext returns the SecurityContext applied to the
 // model downloader init container. It inherits runAsUser/runAsGroup from the
 // pod-level Spec.PodSecurityContext when the user supplied one. The default

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -3388,8 +3388,8 @@ var _ = Describe("Security Context Configuration", func() {
 
 			deployment := reconciler.constructDeployment(isvc, cachedModel, 1)
 
-			Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(1))
-			initSecCtx := deployment.Spec.Template.Spec.InitContainers[0].SecurityContext
+			Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(2))
+			initSecCtx := deployment.Spec.Template.Spec.InitContainers[1].SecurityContext
 			Expect(initSecCtx).NotTo(BeNil())
 			Expect(*initSecCtx.AllowPrivilegeEscalation).To(BeFalse())
 			Expect(initSecCtx.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
@@ -3420,7 +3420,7 @@ var _ = Describe("Security Context Configuration", func() {
 
 			deployment := reconciler.constructDeployment(isvc, cachedModel, 1)
 
-			initSecCtx := deployment.Spec.Template.Spec.InitContainers[0].SecurityContext
+			initSecCtx := deployment.Spec.Template.Spec.InitContainers[1].SecurityContext
 			Expect(initSecCtx).NotTo(BeNil())
 			Expect(initSecCtx.RunAsNonRoot).To(BeNil())
 			Expect(initSecCtx.RunAsUser).To(BeNil())
@@ -3458,7 +3458,7 @@ var _ = Describe("Security Context Configuration", func() {
 
 			deployment := reconciler.constructDeployment(isvc, cachedModel, 1)
 
-			initSecCtx := deployment.Spec.Template.Spec.InitContainers[0].SecurityContext
+			initSecCtx := deployment.Spec.Template.Spec.InitContainers[1].SecurityContext
 			Expect(initSecCtx).NotTo(BeNil())
 			Expect(initSecCtx.RunAsUser).NotTo(BeNil())
 			Expect(*initSecCtx.RunAsUser).To(Equal(int64(2000)))

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -247,10 +247,10 @@ var _ = Describe("buildEmptyDirStorageConfig multi-file staging", func() {
 		config := buildEmptyDirStorageConfig(model, nil, "default", "", "curl:8.18.0")
 
 		Expect(config.modelPath).To(Equal("/models/default-empty-model/model.gguf"))
-		cmd := config.initContainers[1].Command[2]
+		cmd := config.initContainers[0].Command[2]
 		Expect(cmd).To(ContainSubstring("MODEL_FILES"))
 
-		env := config.initContainers[1].Env
+		env := config.initContainers[0].Env
 		modelFiles := getEnvVar(env, "MODEL_FILES")
 		Expect(modelFiles).To(ContainSubstring("extra.gguf"))
 	})
@@ -266,7 +266,7 @@ var _ = Describe("buildEmptyDirStorageConfig multi-file staging", func() {
 		}
 
 		config := buildEmptyDirStorageConfig(model, nil, "default", "", "curl:8.18.0")
-		cmd := config.initContainers[1].Command[2]
+		cmd := config.initContainers[0].Command[2]
 		Expect(cmd).To(ContainSubstring("--etag-compare"))
 		Expect(cmd).To(ContainSubstring("--etag-save"))
 		Expect(cmd).To(ContainSubstring("kept cached copy"))
@@ -389,13 +389,13 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 		Expect(config.volumes[0].EmptyDir).NotTo(BeNil())
 
 		// Verify env vars are set on the init container
-		env := config.initContainers[1].Env
+		env := config.initContainers[0].Env
 		Expect(getEnvVar(env, "MODEL_SOURCE")).To(Equal("https://example.com/model.gguf"))
 		Expect(getEnvVar(env, "CACHE_DIR")).To(Equal(""))
 		Expect(getEnvVar(env, "MODEL_PATH")).To(Equal("/models/default-my-model.gguf"))
 
 		// Verify the command does not contain the raw source URL
-		Expect(config.initContainers[1].Command[2]).NotTo(ContainSubstring("example.com"))
+		Expect(config.initContainers[0].Command[2]).NotTo(ContainSubstring("example.com"))
 	})
 
 	It("should add CA cert volume when caCertConfigMap is set", func() {
@@ -413,7 +413,7 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 			}
 		}
 		Expect(found).To(BeTrue())
-		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
 	})
 
 	It("should inherit runAsUser/runAsGroup in emptyDir storage", func() {
@@ -434,7 +434,7 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 		}
 		config := buildEmptyDirStorageConfig(model, isvc, "default", "", "curl:8.18.0")
 
-		initSecCtx := config.initContainers[1].SecurityContext
+		initSecCtx := config.initContainers[0].SecurityContext
 		Expect(initSecCtx).NotTo(BeNil())
 		Expect(initSecCtx.RunAsUser).NotTo(BeNil())
 		Expect(*initSecCtx.RunAsUser).To(Equal(int64(2000)))
@@ -928,9 +928,9 @@ var _ = Describe("cache prep init container (#855)", func() {
 		Expect(*sc.ReadOnlyRootFilesystem).To(BeTrue())
 
 		Expect(sc.Capabilities).NotTo(BeNil())
-		Expect(sc.Capabilities.Drop).To(ContainElement("ALL"))
-		Expect(sc.Capabilities.Add).To(ContainElement("CHOWN"))
-		Expect(sc.Capabilities.Add).To(ContainElement("FOWNER"))
+		Expect(sc.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+		Expect(sc.Capabilities.Add).To(ContainElement(corev1.Capability("CHOWN")))
+		Expect(sc.Capabilities.Add).To(ContainElement(corev1.Capability("FOWNER")))
 
 		Expect(sc.SeccompProfile).NotTo(BeNil())
 		Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -40,26 +40,27 @@ var _ = Describe("buildCachedStorageConfig", func() {
 				CacheKey: "abc123def456",
 			},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 
 		Expect(config.modelPath).To(Equal("/models/abc123def456/model.gguf"))
 		Expect(config.volumes).To(HaveLen(1))
 		Expect(config.volumes[0].Name).To(Equal("model-cache"))
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
-		Expect(config.initContainers).To(HaveLen(1))
-		Expect(config.initContainers[0].Name).To(Equal("model-downloader"))
-		Expect(config.initContainers[0].Image).To(Equal("curl:8.18.0"))
+		Expect(config.initContainers).To(HaveLen(2))
+		Expect(config.initContainers[0].Name).To(Equal("model-cache-prep"))
+		Expect(config.initContainers[1].Name).To(Equal("model-downloader"))
+		Expect(config.initContainers[1].Image).To(Equal("curl:8.18.0"))
 		Expect(config.volumeMounts[0].MountPath).To(Equal("/models"))
 		Expect(config.volumeMounts[0].ReadOnly).To(BeTrue())
 
 		// Verify env vars are set on the init container
-		env := config.initContainers[0].Env
+		env := config.initContainers[1].Env
 		Expect(getEnvVar(env, "MODEL_SOURCE")).To(Equal("https://example.com/model.gguf"))
 		Expect(getEnvVar(env, "CACHE_DIR")).To(Equal("/models/abc123def456"))
 		Expect(getEnvVar(env, "MODEL_PATH")).To(Equal("/models/abc123def456/model.gguf"))
 
 		// Verify the command does not contain the raw source URL
-		Expect(config.initContainers[0].Command[2]).NotTo(ContainSubstring("example.com"))
+		Expect(config.initContainers[1].Command[2]).NotTo(ContainSubstring("example.com"))
 	})
 
 	It("should add host-model volume for local source", func() {
@@ -71,14 +72,14 @@ var _ = Describe("buildCachedStorageConfig", func() {
 				CacheKey: "abc123",
 			},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 
 		Expect(config.volumes).To(HaveLen(2))
 		Expect(config.volumes[1].Name).To(Equal("host-model"))
 		Expect(config.volumes[1].HostPath.Path).To(Equal("/mnt/models/test.gguf"))
 
-		// Verify env vars are set
-		env := config.initContainers[0].Env
+		// Verify env vars are set on the downloader (initContainers[1])
+		env := config.initContainers[1].Env
 		Expect(getEnvVar(env, "MODEL_SOURCE")).To(Equal("file:///mnt/models/test.gguf"))
 	})
 
@@ -91,7 +92,7 @@ var _ = Describe("buildCachedStorageConfig", func() {
 				CacheKey: "abc123",
 			},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "my-ca-certs", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "my-ca-certs", "curl:8.18.0", 102)
 
 		var found bool
 		for _, v := range config.volumes {
@@ -101,7 +102,7 @@ var _ = Describe("buildCachedStorageConfig", func() {
 			}
 		}
 		Expect(found).To(BeTrue())
-		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
 	})
 })
 
@@ -120,14 +121,14 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
 		}
 
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 
 		Expect(config.modelPath).To(Equal("/models/abc123/gemma-4-31B-it-UD-Q4_K_XL.gguf"))
-		cmd := config.initContainers[0].Command[2]
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).To(ContainSubstring("MODEL_FILES"))
 		Expect(cmd).To(ContainSubstring(`printf '%s\n'`))
 
-		env := config.initContainers[0].Env
+		env := config.initContainers[1].Env
 		modelFiles := getEnvVar(env, "MODEL_FILES")
 		Expect(modelFiles).NotTo(BeEmpty())
 		Expect(modelFiles).To(ContainSubstring("gemma-4-31B-it-UD-Q4_K_XL.gguf"))
@@ -148,11 +149,11 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "key1"},
 		}
 
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
-		cmd := config.initContainers[0].Command[2]
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$(dirname "$dest")"`))
 
-		env := config.initContainers[0].Env
+		env := config.initContainers[1].Env
 		modelFiles := getEnvVar(env, "MODEL_FILES")
 		Expect(modelFiles).To(ContainSubstring("MTP/weights.gguf"))
 	})
@@ -167,8 +168,8 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "key2"},
 		}
 
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
-		env := config.initContainers[0].Env
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+		env := config.initContainers[1].Env
 		source := getEnvVar(env, "MODEL_SOURCE")
 		Expect(source).To(Equal("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF"))
 	})
@@ -183,7 +184,7 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "key3"},
 		}
 
-		config := buildCachedStorageConfig(model, nil, "", "my-ca-certs", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "my-ca-certs", "curl:8.18.0", 102)
 
 		var foundCA bool
 		for _, v := range config.volumes {
@@ -193,7 +194,7 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 			}
 		}
 		Expect(foundCA).To(BeTrue())
-		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
 	})
 
 	It("uses OnChange per-file etag revalidation for multi-file model", func() {
@@ -207,8 +208,8 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "key4"},
 		}
 
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
-		cmd := config.initContainers[0].Command[2]
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).To(ContainSubstring("--etag-compare"))
 		Expect(cmd).To(ContainSubstring("--etag-save"))
 		Expect(cmd).To(ContainSubstring("kept cached copy"))
@@ -221,13 +222,13 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 			},
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123def456"},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 
 		Expect(config.modelPath).To(Equal("/models/abc123def456/model.gguf"))
-		env := config.initContainers[0].Env
+		env := config.initContainers[1].Env
 		Expect(getEnvVar(env, "MODEL_PATH")).To(Equal("/models/abc123def456/model.gguf"))
 		Expect(getEnvVar(env, "MODEL_FILES")).To(BeEmpty())
-		cmd := config.initContainers[0].Command[2]
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).NotTo(ContainSubstring("MODEL_FILES"))
 		Expect(cmd).To(ContainSubstring(`"$MODEL_PATH"`))
 	})
@@ -246,10 +247,10 @@ var _ = Describe("buildEmptyDirStorageConfig multi-file staging", func() {
 		config := buildEmptyDirStorageConfig(model, nil, "default", "", "curl:8.18.0")
 
 		Expect(config.modelPath).To(Equal("/models/default-empty-model/model.gguf"))
-		cmd := config.initContainers[0].Command[2]
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).To(ContainSubstring("MODEL_FILES"))
 
-		env := config.initContainers[0].Env
+		env := config.initContainers[1].Env
 		modelFiles := getEnvVar(env, "MODEL_FILES")
 		Expect(modelFiles).To(ContainSubstring("extra.gguf"))
 	})
@@ -265,7 +266,7 @@ var _ = Describe("buildEmptyDirStorageConfig multi-file staging", func() {
 		}
 
 		config := buildEmptyDirStorageConfig(model, nil, "default", "", "curl:8.18.0")
-		cmd := config.initContainers[0].Command[2]
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).To(ContainSubstring("--etag-compare"))
 		Expect(cmd).To(ContainSubstring("--etag-save"))
 		Expect(cmd).To(ContainSubstring("kept cached copy"))
@@ -388,13 +389,13 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 		Expect(config.volumes[0].EmptyDir).NotTo(BeNil())
 
 		// Verify env vars are set on the init container
-		env := config.initContainers[0].Env
+		env := config.initContainers[1].Env
 		Expect(getEnvVar(env, "MODEL_SOURCE")).To(Equal("https://example.com/model.gguf"))
 		Expect(getEnvVar(env, "CACHE_DIR")).To(Equal(""))
 		Expect(getEnvVar(env, "MODEL_PATH")).To(Equal("/models/default-my-model.gguf"))
 
 		// Verify the command does not contain the raw source URL
-		Expect(config.initContainers[0].Command[2]).NotTo(ContainSubstring("example.com"))
+		Expect(config.initContainers[1].Command[2]).NotTo(ContainSubstring("example.com"))
 	})
 
 	It("should add CA cert volume when caCertConfigMap is set", func() {
@@ -412,7 +413,7 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 			}
 		}
 		Expect(found).To(BeTrue())
-		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
 	})
 
 	It("should inherit runAsUser/runAsGroup in emptyDir storage", func() {
@@ -433,7 +434,7 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 		}
 		config := buildEmptyDirStorageConfig(model, isvc, "default", "", "curl:8.18.0")
 
-		initSecCtx := config.initContainers[0].SecurityContext
+		initSecCtx := config.initContainers[1].SecurityContext
 		Expect(initSecCtx).NotTo(BeNil())
 		Expect(initSecCtx.RunAsUser).NotTo(BeNil())
 		Expect(*initSecCtx.RunAsUser).To(Equal(int64(2000)))
@@ -482,7 +483,7 @@ var _ = Describe("buildModelStorageConfig PVC dispatch", func() {
 			Spec:       inferencev1alpha1.ModelSpec{Source: "pvc://my-claim/model.gguf"},
 			Status:     inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
 		}
-		config := buildModelStorageConfig(model, nil, "default", true, "", "", "curl:8.18.0")
+		config := buildModelStorageConfig(model, nil, "default", true, "", "", "curl:8.18.0", 102)
 
 		// Should use PVC config, not cached config
 		Expect(config.volumes[0].Name).To(Equal("model-source"))
@@ -683,7 +684,7 @@ var _ = Describe("buildCachedStorageConfig cache mode selection (#728)", func() 
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-isvc"},
 		}
-		config := buildCachedStorageConfig(model, isvc, ModelCacheModePerService, "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, isvc, ModelCacheModePerService, "", "curl:8.18.0", 102)
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("my-isvc-model-cache"))
 	})
 
@@ -691,7 +692,7 @@ var _ = Describe("buildCachedStorageConfig cache mode selection (#728)", func() 
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-isvc"},
 		}
-		config := buildCachedStorageConfig(model, isvc, ModelCacheModeShared, "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, isvc, ModelCacheModeShared, "", "curl:8.18.0", 102)
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
 	})
 
@@ -699,7 +700,7 @@ var _ = Describe("buildCachedStorageConfig cache mode selection (#728)", func() 
 		isvc := &inferencev1alpha1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-isvc"},
 		}
-		config := buildCachedStorageConfig(model, isvc, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(model, isvc, "", "", "curl:8.18.0", 102)
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
 	})
 })
@@ -829,8 +830,8 @@ var _ = Describe("buildCachedStorageConfig RefreshPolicy plumbing", func() {
 			},
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123def456"},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
-		cmd := config.initContainers[0].Command[2]
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).To(ContainSubstring("--etag-compare"))
 		Expect(cmd).To(ContainSubstring("kept cached copy"))
 	})
@@ -840,10 +841,127 @@ var _ = Describe("buildCachedStorageConfig RefreshPolicy plumbing", func() {
 			Spec:   inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
 			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123def456"},
 		}
-		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0")
-		cmd := config.initContainers[0].Command[2]
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+		cmd := config.initContainers[1].Command[2]
 		Expect(cmd).NotTo(ContainSubstring("--etag-compare"))
 		Expect(cmd).To(ContainSubstring("skipping download"))
+	})
+})
+
+var _ = Describe("cache prep init container (#855)", func() {
+	// Helper: build a cache-backed single-file model (no multi-file staging).
+	cacheModel := func() *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{
+			Spec:   inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
+			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
+		}
+	}
+
+	It("prep is present and ordered BEFORE model-downloader in the single-file path", func() {
+		config := buildCachedStorageConfig(cacheModel(), nil, "", "", "curl:8.18.0", 102)
+		Expect(config.initContainers).To(HaveLen(2))
+		Expect(config.initContainers[0].Name).To(Equal("model-cache-prep"))
+		Expect(config.initContainers[1].Name).To(Equal("model-downloader"))
+	})
+
+	It("prep is present and ordered BEFORE model-downloader in the multi-file staging path", func() {
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "gemma", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "hf://unsloth/gemma-4-31B-it-GGUF",
+				Files:  []string{"gemma-4-31B-it-UD-Q4_K_XL.gguf", "MTP/gemma-4-31B-it-Q8_0-MTP.gguf"},
+				Mmproj: "mmproj-F16.gguf",
+			},
+			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
+		}
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+		Expect(config.initContainers).To(HaveLen(2))
+		Expect(config.initContainers[0].Name).To(Equal("model-cache-prep"))
+		Expect(config.initContainers[1].Name).To(Equal("model-downloader"))
+	})
+
+	It("DEFAULT case (no explicit podSecurityContext, defaultFSGroup 102): prep command is exactly 'chown 0:102 /models && chmod g+rwX /models'", func() {
+		config := buildCachedStorageConfig(cacheModel(), nil, "", "", "curl:8.18.0", 102)
+		prep := config.initContainers[0]
+		Expect(prep.Command).To(Equal([]string{"sh", "-c", "chown 0:102 /models && chmod g+rwX /models"}))
+		// No recursive flag anywhere in the command.
+		Expect(prep.Command[2]).NotTo(ContainSubstring("-R"))
+	})
+
+	It("EXPLICIT OVERRIDE case: isvc FSGroup=3000, defaultFSGroup=102 -> prep command contains 'chown 0:3000' and NOT '102'", func() {
+		isvc := &inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				PodSecurityContext: &corev1.PodSecurityContext{
+					FSGroup: int64Ptr(3000),
+				},
+			},
+		}
+		config := buildCachedStorageConfig(cacheModel(), isvc, "", "", "curl:8.18.0", 102)
+		prep := config.initContainers[0]
+		cmd := prep.Command[2]
+		Expect(cmd).To(ContainSubstring("chown 0:3000"))
+		Expect(cmd).NotTo(ContainSubstring("102"))
+	})
+
+	It("fsGroup<=0 case: prep command is 'chown 100:100 /models && chmod 770 /models'", func() {
+		config := buildCachedStorageConfig(cacheModel(), nil, "", "", "curl:8.18.0", 0)
+		prep := config.initContainers[0]
+		Expect(prep.Command).To(Equal([]string{"sh", "-c", "chown 100:100 /models && chmod 770 /models"}))
+	})
+
+	It("prep reuses initContainerImage (no hardcoded image)", func() {
+		config := buildCachedStorageConfig(cacheModel(), nil, "", "", "my-registry.io/init:v1.2.3", 102)
+		prep := config.initContainers[0]
+		Expect(prep.Image).To(Equal("my-registry.io/init:v1.2.3"))
+		// And the downloader also uses the same image.
+		dl := config.initContainers[1]
+		Expect(dl.Image).To(Equal("my-registry.io/init:v1.2.3"))
+	})
+
+	It("prep SecurityContext: RunAsUser=0, AllowPrivilegeEscalation=false, Capabilities.Drop=[ALL], Capabilities.Add has CHOWN and FOWNER, ReadOnlyRootFilesystem=true, SeccompProfile.Type=RuntimeDefault", func() {
+		config := buildCachedStorageConfig(cacheModel(), nil, "", "", "curl:8.18.0", 102)
+		prep := config.initContainers[0]
+		sc := prep.SecurityContext
+		Expect(sc).NotTo(BeNil())
+		Expect(*sc.RunAsUser).To(Equal(int64(0)))
+		Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
+		Expect(*sc.ReadOnlyRootFilesystem).To(BeTrue())
+
+		Expect(sc.Capabilities).NotTo(BeNil())
+		Expect(sc.Capabilities.Drop).To(ContainElement("ALL"))
+		Expect(sc.Capabilities.Add).To(ContainElement("CHOWN"))
+		Expect(sc.Capabilities.Add).To(ContainElement("FOWNER"))
+
+		Expect(sc.SeccompProfile).NotTo(BeNil())
+		Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+	})
+
+	It("prep NOT emitted for the invalid-fileset fail-closed path", func() {
+		// Force an invalid fileset by setting Files to a pattern that ResolveFileSet rejects.
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "bad", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "hf://org/repo",
+				Files:  []string{"../../etc/passwd"}, // path escape -> invalid
+			},
+			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
+		}
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+		// The fail-closed path returns only the invalid-fileset init container,
+		// no prep.
+		Expect(config.initContainers).To(HaveLen(1))
+		Expect(config.initContainers[0].Name).To(Equal("model-downloader"))
+		// And its command exits 1 with the InvalidFileSet message.
+		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("ERROR: InvalidFileSet"))
+	})
+
+	It("prep NOT emitted for the emptyDir path (buildEmptyDirStorageConfig)", func() {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
+		}
+		config := buildEmptyDirStorageConfig(model, nil, "default", "", "curl:8.18.0")
+		Expect(config.initContainers).To(HaveLen(1))
+		Expect(config.initContainers[0].Name).To(Equal("model-downloader"))
 	})
 })
 

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -1849,13 +1849,15 @@ var _ = Describe("Issue #363 regression — controller / workload cache disconne
 		// assert the init container's MODEL_PATH lines up with the Model's
 		// CacheKey. The init container's `if [ ! -f "$MODEL_PATH" ]` check
 		// only works when both sides agree on the path.
-		config := buildCachedStorageConfig(updated, nil, "", "", "curl:8.18.0")
+		config := buildCachedStorageConfig(updated, nil, "", "", "curl:8.18.0", 102)
 		expectedPrefix := "/models/" + updated.Status.CacheKey + "/"
 		Expect(config.modelPath).To(HavePrefix(expectedPrefix),
 			"init container MODEL_PATH must live under /models/<Status.CacheKey>/")
 
+		// initContainers[0] is the cache-prep container; the downloader is [1].
+		downloader := config.initContainers[1]
 		var modelPathEnv string
-		for _, e := range config.initContainers[0].Env {
+		for _, e := range downloader.Env {
 			if e.Name == "MODEL_PATH" {
 				modelPathEnv = e.Value
 			}

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -209,6 +209,49 @@ func invalidFileSetInitContainer(initImage string) corev1.Container {
 	}
 }
 
+// cachePrepInitContainer returns the root-run prep init container that runs
+// BEFORE model-downloader in the cache-backed path. CSI drivers with
+// fsGroupPolicy=None (CephFS, NFS) never apply the pod fsGroup to the volume,
+// so the PVC root stays root:root 0755 and the non-root downloader (uid 100)
+// gets "permission denied" on mkdir. The prep chowns/chmods the mount root so
+// the downloader can write, without recursing over /models.
+//
+// When resolvedFSGroup > 0 the prep chowns to 0:<fsGroup> and grants group
+// rw on existing and future files/dirs (g+rwX). When resolvedFSGroup <= 0
+// (fsGroup disabled, e.g. OpenShift) the prep chowns to 100:100 (the
+// downloader's UID/GID) and sets 770 so only the downloader can write.
+//
+// The prep reuses the configurable initContainerImage (no hardcoded busybox)
+// so air-gapped clusters that mirror initContainerImage are covered.
+func cachePrepInitContainer(initImage string, resolvedFSGroup int64) corev1.Container {
+	var cmd string
+	if resolvedFSGroup > 0 {
+		cmd = fmt.Sprintf("chown 0:%d /models && chmod g+rwX /models", resolvedFSGroup)
+	} else {
+		cmd = "chown 100:100 /models && chmod 770 /models"
+	}
+	return corev1.Container{
+		Name:    "model-cache-prep",
+		Image:   initImage,
+		Command: []string{"sh", "-c", cmd},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "model-cache", MountPath: "/models"},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                int64Ptr(0),
+			AllowPrivilegeEscalation: boolPtr(false),
+			ReadOnlyRootFilesystem:   boolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+				Add:  []corev1.Capability{"CHOWN", "FOWNER"},
+			},
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
+	}
+}
+
 // multiFileInitEnvVars returns env vars for a multi-file init container.
 // MODEL_SOURCE is normalized (hf:// -> https://huggingface.co/), and
 // MODEL_FILES is newline-delimited.
@@ -273,12 +316,12 @@ type modelStorageConfig struct {
 	volumeMounts   []corev1.VolumeMount
 }
 
-func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string) modelStorageConfig {
+func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64) modelStorageConfig {
 	if isPVCSource(model.Spec.Source) {
 		return buildPVCStorageConfig(model)
 	}
 	if useCache {
-		return buildCachedStorageConfig(model, isvc, cacheMode, caCertConfigMap, initContainerImage)
+		return buildCachedStorageConfig(model, isvc, cacheMode, caCertConfigMap, initContainerImage, defaultFSGroup)
 	}
 	return buildEmptyDirStorageConfig(model, isvc, namespace, caCertConfigMap, initContainerImage)
 }
@@ -309,8 +352,19 @@ func buildPVCStorageConfig(model *inferencev1alpha1.Model) modelStorageConfig {
 	}
 }
 
-func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, cacheMode string, caCertConfigMap string, initContainerImage string) modelStorageConfig {
+func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64) modelStorageConfig {
 	cacheDir := fmt.Sprintf("/models/%s", model.Status.CacheKey)
+
+	// Resolve the fsGroup that the CSI will actually apply to the volume.
+	// When the InferenceService sets its own FSGroup, that wins over the
+	// operator default (see inferPodSecurityContext in deployment_builder.go);
+	// chown'ing to the wrong GID would leave the downloader unable to write.
+	// A value <= 0 means the operator disabled fsGroup (e.g. OpenShift), so
+	// the prep must chown to the downloader's own UID instead.
+	resolvedFSGroup := defaultFSGroup
+	if isvc != nil && isvc.Spec.PodSecurityContext != nil && isvc.Spec.PodSecurityContext.FSGroup != nil {
+		resolvedFSGroup = *isvc.Spec.PodSecurityContext.FSGroup
+	}
 
 	// Multi-file staging branch: when spec.files or spec.mmproj are set, use
 	// the staging plan to download all artifacts. Returns early.
@@ -357,18 +411,23 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1a
 
 		addCACertVolume(&volumes, &initVolumeMounts, &cmd, caCertConfigMap)
 
-		return modelStorageConfig{
-			modelPath: modelPath,
-			initContainers: []corev1.Container{{
+		initContainers := []corev1.Container{
+			cachePrepInitContainer(initContainerImage, resolvedFSGroup),
+			{
 				Name:            "model-downloader",
 				Image:           initContainerImage,
 				Command:         []string{"sh", "-c", cmd},
 				Env:             env,
 				VolumeMounts:    initVolumeMounts,
 				SecurityContext: initContainerSecurityContext(isvc),
-			}},
-			volumes:      volumes,
-			volumeMounts: []corev1.VolumeMount{{Name: "model-cache", MountPath: "/models", ReadOnly: true}},
+			},
+		}
+
+		return modelStorageConfig{
+			modelPath:      modelPath,
+			initContainers: initContainers,
+			volumes:        volumes,
+			volumeMounts:   []corev1.VolumeMount{{Name: "model-cache", MountPath: "/models", ReadOnly: true}},
 		}
 	}
 
@@ -422,20 +481,23 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1a
 	env := modelInitEnvVars(model.Spec.Source, cacheDir, modelPath)
 	addCACertVolume(&volumes, &initVolumeMounts, &cmd, caCertConfigMap)
 
-	return modelStorageConfig{
-		modelPath: modelPath,
-		initContainers: []corev1.Container{
-			{
-				Name:            "model-downloader",
-				Image:           initContainerImage,
-				Command:         []string{"sh", "-c", cmd},
-				Env:             env,
-				VolumeMounts:    initVolumeMounts,
-				SecurityContext: initContainerSecurityContext(isvc),
-			},
+	initContainers := []corev1.Container{
+		cachePrepInitContainer(initContainerImage, resolvedFSGroup),
+		{
+			Name:            "model-downloader",
+			Image:           initContainerImage,
+			Command:         []string{"sh", "-c", cmd},
+			Env:             env,
+			VolumeMounts:    initVolumeMounts,
+			SecurityContext: initContainerSecurityContext(isvc),
 		},
-		volumes:      volumes,
-		volumeMounts: []corev1.VolumeMount{{Name: "model-cache", MountPath: "/models", ReadOnly: true}},
+	}
+
+	return modelStorageConfig{
+		modelPath:      modelPath,
+		initContainers: initContainers,
+		volumes:        volumes,
+		volumeMounts:   []corev1.VolumeMount{{Name: "model-cache", MountPath: "/models", ReadOnly: true}},
 	}
 }
 


### PR DESCRIPTION
## What

Adds a root-run `model-cache-perm` prep init container before `model-downloader` in the cache-backed storage path. It chowns/chmods the cache mount root so the non-root downloader (uid 100) can write on CSIs that ignore `fsGroup` (CephFS/NFS). Inserted in both the single-file and multi-file (#853) download paths via one helper.

## Why

On a `fsGroupPolicy: None` CSI the kubelet never applies the pod `fsGroup` to the volume, so a freshly-provisioned cache PVC root stays `root:root 0755` and the non-root `model-downloader` gets `permission denied` on `mkdir`, leaving the InferenceService stuck at `Init:Error`. Affects shared RWX caches on CephFS and NFS, which commonly ship `fsGroupPolicy: None`. Fixes #855.

## How

The prep chowns the mount root **non-recursively** (so a shared cache does not get every other model's files rewritten on each pod start) to the **resolved** pod fsGroup:

- `isvc.Spec.PodSecurityContext.FSGroup` when set, else the operator default `r.DefaultFSGroup` (the `--default-fsgroup` flag, default 102), mirroring `inferPodSecurityContext`. The chown target must match the fsGroup the pod actually runs with, because the kubelet still adds that GID to the downloader's supplemental groups even when the CSI skips the volume.
- When fsGroup is disabled (`<= 0`), it chowns to the downloader's uid (100) instead.

It reuses the configurable `initContainerImage` (air-gap friendly) and runs least-privilege: `runAsUser 0` (required to chown a root-owned mount), drop `ALL` + add only `CHOWN`/`FOWNER`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, seccomp `RuntimeDefault`. Downloader and server stay unprivileged. The prep is added to both the multi-file staging and single-file cache downloaders, and is not emitted for the fail-closed invalid-fileset path or for emptyDir storage.

## Checklist

- [x] `go build`, `go vet`, `gofmt`, `golangci-lint` clean
- [x] Unit tests: ordering before downloader in both single-file and multi-file paths; default fsGroup 102; explicit isvc override (3000 over default 102); fsGroup-disabled -> uid 100; image reuse; hardened SecurityContext; not emitted for fail-closed or emptyDir
- [ ] Live validation on a real `fsGroupPolicy: None` CSI (CephFS): manual follow-up; the init-container path is not reproducible in CI

Note: the prep is root-by-necessity (chowning a root-owned mount), so it does not satisfy PSA `restricted` namespaces; that constraint is inherent to the fix. Supersedes #857 (which conflicted with #853).
