### PR TITLE
feat(foreman): detect changed envtest packages + gate-job delegation seam (part 1 of #859)

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -49,6 +49,19 @@ type commandRunner func(
 	args ...string,
 ) (output string, err error)
 
+// envtestJobRunner is the seam between the coder gate and the clean-room
+// gate Job machinery. When changed envtest packages exist, the gate
+// delegates their verification to a Kubernetes Job that runs `make test`
+// under envtest (with KUBEBUILDER_ASSETS). The Job's outcome is folded
+// into the gate's pass/fail result.
+//
+// The dependency direction is the reason it lives here: the tools package
+// imports the agent package (for ToolResult), so the agent package cannot
+// import tools without a cycle. cmd/foreman-agent wires a closure over
+// the gate Job submitter into the executor, which then passes it to the
+// gate via RunCoderGateConfig.
+type envtestJobRunner func(ctx context.Context) (pass bool, feedback string)
+
 // execCommandRunner is the production commandRunner backed by os/exec. It
 // appends extraEnv to the inherited process environment and captures
 // combined stdout+stderr. Wired into the coder agent loop via
@@ -88,7 +101,17 @@ type checkFailure struct {
 // intentionally out of scope; they run in a separate clean-room
 // Kubernetes Job. All checks run regardless of earlier failures so the
 // feedback reports everything wrong at once.
-func RunCoderGate(ctx context.Context, workspace, golangciPath string, run commandRunner) (pass bool, feedback string) {
+//
+// When envtestJobRunner is non-nil and changed envtest packages exist,
+// the gate delegates verification of those packages to a clean-room
+// gate Job after the in-workspace checks pass. A Job failure folds into
+// the gate's not-pass result with feedback.
+func RunCoderGate(
+	ctx context.Context,
+	workspace, golangciPath string,
+	run commandRunner,
+	envtestJobRunner envtestJobRunner,
+) (pass bool, feedback string) {
 	var failures []checkFailure
 
 	// 1. gofmt -l . lists misformatted files on stdout and exits 0 even
@@ -140,6 +163,20 @@ func RunCoderGate(ctx context.Context, workspace, golangciPath string, run comma
 		failures = append(failures, checkFailure{name: "codegen drift", output: out})
 	}
 
+	// 7. Envtest package verification: when changed envtest packages exist
+	// and the in-workspace checks otherwise pass, delegate verification
+	// of those packages to a clean-room gate Job that runs `make test`
+	// under envtest (with KUBEBUILDER_ASSETS). A Job failure folds into
+	// the gate's not-pass result with feedback.
+	if len(failures) == 0 && envtestJobRunner != nil {
+		if pkgs := changedEnvtestPackages(ctx, workspace, run); len(pkgs) > 0 {
+			pass, fb := envtestJobRunner(ctx)
+			if !pass {
+				failures = append(failures, checkFailure{name: "envtest gate job", output: fb})
+			}
+		}
+	}
+
 	if len(failures) == 0 {
 		return true, ""
 	}
@@ -147,14 +184,14 @@ func RunCoderGate(ctx context.Context, workspace, golangciPath string, run comma
 	return false, buildFeedback(failures)
 }
 
-// changedTestPackages returns the workspace-relative Go package directories
+// changedPackages returns the workspace-relative Go package directories
 // (as "./<dir>/" patterns) that have uncommitted changes per
-// `git status -z` and are not envtest-backed. It dedups packages and
-// ignores non-Go files and root-level (package main) changes. A git
-// error yields no packages (the tier is skipped rather than failing the
-// gate spuriously). NUL-terminated output is used so filenames with
-// embedded newlines are handled correctly.
-func changedTestPackages(ctx context.Context, workspace string, run commandRunner) []string {
+// `git status -z`. It dedups packages and ignores non-Go files and
+// root-level (package main) changes. A git error yields no packages
+// (the tier is skipped rather than failing the gate spuriously).
+// NUL-terminated output is used so filenames with embedded newlines
+// are handled correctly.
+func changedPackages(ctx context.Context, workspace string, run commandRunner) []string {
 	out, err := run(ctx, workspace, nil, "git", "status", "-z")
 	if err != nil {
 		return nil
@@ -177,20 +214,60 @@ func changedTestPackages(ctx context.Context, workspace string, run commandRunne
 			continue // root package main; not part of the unit-test tier
 		}
 		dirKey := dir + "/"
-		excluded := false
-		for _, pfx := range envtestPackagePrefixes {
-			if strings.HasPrefix(dirKey, pfx) {
-				excluded = true
-				break
-			}
-		}
-		if excluded || seen[dirKey] {
+		if seen[dirKey] {
 			continue
 		}
 		seen[dirKey] = true
 		pkgs = append(pkgs, "./"+dirKey)
 	}
 	return pkgs
+}
+
+// changedTestPackages returns the workspace-relative Go package directories
+// (as "./<dir>/" patterns) that have uncommitted changes per
+// `git status -z` and are not envtest-backed. It dedups packages and
+// ignores non-Go files and root-level (package main) changes. A git
+// error yields no packages (the tier is skipped rather than failing the
+// gate spuriously). NUL-terminated output is used so filenames with
+// embedded newlines are handled correctly.
+func changedTestPackages(ctx context.Context, workspace string, run commandRunner) []string {
+	all := changedPackages(ctx, workspace, run)
+	var pkgs []string
+	for _, p := range all {
+		if isEnvtestPackage(p) {
+			continue
+		}
+		pkgs = append(pkgs, p)
+	}
+	return pkgs
+}
+
+// changedEnvtestPackages returns the workspace-relative Go package
+// directories (as "./<dir>/" patterns) that have uncommitted changes
+// per `git status -z` and DO match envtestPackagePrefixes. These are
+// the packages whose tests require KUBEBUILDER_ASSETS and must be
+// verified in a clean-room gate Job.
+func changedEnvtestPackages(ctx context.Context, workspace string, run commandRunner) []string {
+	all := changedPackages(ctx, workspace, run)
+	var pkgs []string
+	for _, p := range all {
+		if !isEnvtestPackage(p) {
+			continue
+		}
+		pkgs = append(pkgs, p)
+	}
+	return pkgs
+}
+
+// isEnvtestPackage reports whether the given package path (e.g.
+// "./internal/controller/") matches any envtestPackagePrefix.
+func isEnvtestPackage(pkg string) bool {
+	for _, pfx := range envtestPackagePrefixes {
+		if strings.HasPrefix(pkg, "./"+pfx) {
+			return true
+		}
+	}
+	return false
 }
 
 // checkCodegenDrift regenerates manifests and CRDs, then checks whether

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -112,7 +112,7 @@ func TestRunCoderGate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			run, _ := newFakeRunner(tt.responses)
-			pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+			pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
 
 			if pass != tt.wantPass {
 				t.Fatalf("pass = %v, want %v (feedback: %q)", pass, tt.wantPass, feedback)
@@ -144,7 +144,7 @@ func TestRunCoderGateLintEnv(t *testing.T) {
 		golangciPath: {},
 	})
 
-	RunCoderGate(context.Background(), "/work", golangciPath, run)
+	RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
 
 	var lintCall *recordedCall
 	for i := range *calls {
@@ -192,7 +192,7 @@ func TestRunCoderGateLintCacheScopedToWorkspace(t *testing.T) {
 		golangciPath: {},
 	})
 
-	RunCoderGate(context.Background(), "/work", golangciPath, run)
+	RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
 
 	var lintCall *recordedCall
 	for i := range *calls {
@@ -266,7 +266,7 @@ func TestRunCoderGate_FailsOnChangedPackageUnitTest(t *testing.T) {
 			return "", nil // golangci-lint
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run, nil)
 	if pass {
 		t.Fatal("gate should fail when a changed package's unit test fails")
 	}
@@ -285,7 +285,7 @@ func TestRunCoderGate_SkipsTestTierWhenNoChangedPackages(t *testing.T) {
 		}
 		return "", nil // git status empty, all checks clean
 	}
-	if pass, _ := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run); !pass {
+	if pass, _ := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run, nil); !pass {
 		t.Fatal("gate should pass when all checks are clean and nothing changed")
 	}
 	if sawGoTest {
@@ -303,7 +303,7 @@ func TestRunCoderGateTruncation(t *testing.T) {
 		golangciPath: {output: huge, err: errors.New("boom")},
 	})
 
-	_, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	_, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
 
 	if !strings.Contains(feedback, "...(truncated)...") {
 		t.Error("expected truncation marker in feedback")
@@ -347,7 +347,7 @@ func TestRunCoderGate_CodegenDrift_FailsWhenDrifted(t *testing.T) {
 			return "", nil
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
 	if pass {
 		t.Fatal("gate should fail when codegen drift is detected")
 	}
@@ -383,7 +383,7 @@ func TestRunCoderGate_CodegenDrift_PassesWhenClean(t *testing.T) {
 			return "", nil
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
 	if !pass {
 		t.Fatalf("gate should pass when codegen is clean; feedback:\n%s", feedback)
 	}
@@ -413,7 +413,7 @@ func TestRunCoderGate_CodegenDrift_SkippedWhenNoControllerGen(t *testing.T) {
 			return "", nil
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
 	if !pass {
 		t.Fatalf("gate should pass when controller-gen is unavailable; feedback:\n%s", feedback)
 	}
@@ -444,11 +444,260 @@ func TestRunCoderGate_CodegenDrift_FailsWhenMakeFails(t *testing.T) {
 			return "", nil
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
 	if pass {
 		t.Fatal("gate should fail when make manifests fails")
 	}
 	if !strings.Contains(feedback, "codegen drift") {
 		t.Errorf("feedback should cite codegen drift; got:\n%s", feedback)
+	}
+}
+
+// TestChangedEnvtestPackages returns only the envtest-matching changed
+// packages, while the existing exclude tier still returns only the
+// non-envtest ones (same git-status input).
+func TestChangedEnvtestPackages(t *testing.T) {
+	run := func(_ context.Context, _ string, _ []string, name string, _ ...string) (string, error) {
+		if name == "git" {
+			return " M pkg/cli/cache_inspect.go\x00" +
+				" M internal/controller/model_controller.go\x00" +
+				" M internal/foreman/controller/agentictask_controller.go\x00" +
+				" M test/e2e/e2e_test.go\x00" +
+				" M README.md\x00", nil
+		}
+		return "", nil
+	}
+
+	nonEnvtest := changedTestPackages(context.Background(), "/work", run)
+	envtest := changedEnvtestPackages(context.Background(), "/work", run)
+
+	// Non-envtest packages should not include any envtest paths.
+	wantNonEnvtest := map[string]bool{"./pkg/cli/": true}
+	if len(nonEnvtest) != len(wantNonEnvtest) {
+		t.Fatalf("changedTestPackages = %v, want exactly %v", nonEnvtest, wantNonEnvtest)
+	}
+	for _, p := range nonEnvtest {
+		if !wantNonEnvtest[p] {
+			t.Errorf("unexpected non-envtest package %q", p)
+		}
+	}
+
+	// Envtest packages should include only envtest paths.
+	wantEnvtest := map[string]bool{
+		"./internal/controller/":         true,
+		"./internal/foreman/controller/": true,
+		"./test/e2e/":                    true,
+	}
+	if len(envtest) != len(wantEnvtest) {
+		t.Fatalf("changedEnvtestPackages = %v, want exactly %v", envtest, wantEnvtest)
+	}
+	for _, p := range envtest {
+		if !wantEnvtest[p] {
+			t.Errorf("unexpected envtest package %q", p)
+		}
+	}
+
+	// The two sets must be disjoint.
+	for _, p := range nonEnvtest {
+		for _, q := range envtest {
+			if p == q {
+				t.Errorf("overlap between non-envtest and envtest: %q", p)
+			}
+		}
+	}
+}
+
+// TestIsEnvtestPackage verifies the helper classifies package paths
+// against envtestPackagePrefixes.
+func TestIsEnvtestPackage(t *testing.T) {
+	tests := []struct {
+		pkg  string
+		want bool
+	}{
+		{"./internal/controller/", true},
+		{"./internal/controller/foo/", true},
+		{"./internal/foreman/controller/", true},
+		{"./test/", true},
+		{"./test/e2e/", true},
+		{"./pkg/cli/", false},
+		{"./pkg/foreman/agent/", false},
+		{"./cmd/", false},
+	}
+	for _, tt := range tests {
+		got := isEnvtestPackage(tt.pkg)
+		if got != tt.want {
+			t.Errorf("isEnvtestPackage(%q) = %v, want %v", tt.pkg, got, tt.want)
+		}
+	}
+}
+
+// TestRunCoderGate_EnvtestJobRunnerInvokedWhenEnvtestPackagesChanged
+// verifies the gate invokes the injected envtestJobRunner when changed
+// envtest packages are present and the in-workspace checks pass.
+func TestRunCoderGate_EnvtestJobRunnerInvokedWhenEnvtestPackagesChanged(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	jobInvoked := false
+	jobPass := true
+	jobFeedback := ""
+
+	envtestRunner := func(_ context.Context) (bool, string) {
+		jobInvoked = true
+		return jobPass, jobFeedback
+	}
+
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "gofmt":
+			return "", nil
+		case name == "go":
+			return "", nil
+		case name == golangciPath:
+			return "", nil
+		case name == "git" && len(args) > 0 && args[0] == "status":
+			return " M internal/controller/model_controller.go\x00", nil
+		case name == "test" && len(args) > 0 && args[0] == "-f":
+			return "", nil // controller-gen exists
+		case name == "make":
+			return "", nil
+		case name == "git" && len(args) > 0 && args[0] == "diff":
+			return "", nil // tree is clean
+		default:
+			return "", nil
+		}
+	}
+
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, envtestRunner)
+	if !jobInvoked {
+		t.Fatal("envtestJobRunner should have been invoked when envtest packages changed")
+	}
+	if !pass {
+		t.Fatalf("gate should pass when envtest job passes; feedback:\n%s", feedback)
+	}
+}
+
+// TestRunCoderGate_EnvtestJobRunnerFailureFoldsIntoGateFailure verifies
+// a Job failure from the envtestJobRunner folds into the gate's not-pass
+// result with feedback.
+func TestRunCoderGate_EnvtestJobRunnerFailureFoldsIntoGateFailure(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	jobFeedback := "make test failed: internal/controller/model_controller_test.go:42: panic"
+
+	envtestRunner := func(_ context.Context) (bool, string) {
+		return false, jobFeedback
+	}
+
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "gofmt":
+			return "", nil
+		case name == "go":
+			return "", nil
+		case name == golangciPath:
+			return "", nil
+		case name == "git" && len(args) > 0 && args[0] == "status":
+			return " M internal/controller/model_controller.go\x00", nil
+		case name == "test" && len(args) > 0 && args[0] == "-f":
+			return "", nil
+		case name == "make":
+			return "", nil
+		case name == "git" && len(args) > 0 && args[0] == "diff":
+			return "", nil
+		default:
+			return "", nil
+		}
+	}
+
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, envtestRunner)
+	if pass {
+		t.Fatal("gate should fail when envtest job fails")
+	}
+	if !strings.Contains(feedback, "envtest gate job") {
+		t.Errorf("feedback should cite envtest gate job; got:\n%s", feedback)
+	}
+	if !strings.Contains(feedback, jobFeedback) {
+		t.Errorf("feedback should include job feedback; got:\n%s", feedback)
+	}
+}
+
+// TestRunCoderGate_EnvtestJobRunnerNotInvokedWhenNoEnvtestPackagesChanged
+// verifies the Job runner is NOT invoked when no envtest packages changed.
+func TestRunCoderGate_EnvtestJobRunnerNotInvokedWhenNoEnvtestPackagesChanged(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	jobInvoked := false
+
+	envtestRunner := func(_ context.Context) (bool, string) {
+		jobInvoked = true
+		return true, ""
+	}
+
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "gofmt":
+			return "", nil
+		case name == "go":
+			return "", nil
+		case name == golangciPath:
+			return "", nil
+		case name == "git" && len(args) > 0 && args[0] == "status":
+			return " M pkg/cli/cache_inspect.go\x00", nil // non-envtest only
+		case name == "test" && len(args) > 0 && args[0] == "-f":
+			return "", nil
+		case name == "make":
+			return "", nil
+		case name == "git" && len(args) > 0 && args[0] == "diff":
+			return "", nil
+		default:
+			return "", nil
+		}
+	}
+
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, envtestRunner)
+	if jobInvoked {
+		t.Fatal("envtestJobRunner should NOT have been invoked when no envtest packages changed")
+	}
+	if !pass {
+		t.Fatalf("gate should pass; feedback:\n%s", feedback)
+	}
+}
+
+// TestRunCoderGate_EnvtestJobRunnerNotInvokedWhenInWorkspaceChecksFail
+// verifies the Job runner is NOT invoked when in-workspace checks fail,
+// since the gate already failed and the model needs to fix those first.
+func TestRunCoderGate_EnvtestJobRunnerNotInvokedWhenInWorkspaceChecksFail(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	jobInvoked := false
+
+	envtestRunner := func(_ context.Context) (bool, string) {
+		jobInvoked = true
+		return true, ""
+	}
+
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "gofmt":
+			return "pkg/cli/cache_inspect.go\n", nil // gofmt failure
+		case name == "go":
+			return "", nil
+		case name == golangciPath:
+			return "", nil
+		case name == "git" && len(args) > 0 && args[0] == "status":
+			return " M internal/controller/model_controller.go\x00", nil
+		case name == "test" && len(args) > 0 && args[0] == "-f":
+			return "", nil
+		case name == "make":
+			return "", nil
+		case name == "git" && len(args) > 0 && args[0] == "diff":
+			return "", nil
+		default:
+			return "", nil
+		}
+	}
+
+	pass, _ := RunCoderGate(context.Background(), "/work", golangciPath, run, envtestRunner)
+	if jobInvoked {
+		t.Fatal("envtestJobRunner should NOT have been invoked when in-workspace checks fail")
+	}
+	if pass {
+		t.Fatal("gate should fail due to gofmt failure")
 	}
 }

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -604,7 +604,7 @@ func makeCoderGateVerifier(workspace string, log logr.Logger, profile *foremanv1
 				return true, "", err
 			}
 		}
-		pass, feedback := RunCoderGate(ctx, workspace, lintPath, execCommandRunner)
+		pass, feedback := RunCoderGate(ctx, workspace, lintPath, execCommandRunner, nil)
 		if !pass {
 			log.Info("coder gate: fast checks failed; returning feedback to the loop for a fix")
 		}


### PR DESCRIPTION
Part 1 of #859: the tested detection + delegation seam. Part 2 (a follow-up) wires the real Job submitter in `executor_native`.

## What

Adds, to the fast coder gate (`RunCoderGate`), detection of changed **envtest-backed** packages and an injectable seam to delegate their verification to a clean-room gate Job. The seam is in place and unit-tested; the executor passes `nil` for now, so the delegation is inert until Part 2 wires a real submitter.

## Why

`RunCoderGate`'s in-workspace unit-test tier deliberately excludes `envtestPackagePrefixes` (the coder workspace has no `KUBEBUILDER_ASSETS`), and the single-coder GO flow never invokes the clean-room gate Job that *does* run `make test`. So a controller-only change can reach GO with its tests run nowhere in the coder loop. This was demonstrated end to end on #855 / PR #858, where six gate-GO runs all shipped controller-test breakage that only CI caught. Part of #859.

## How

- Extracts a shared `changedPackages` helper and an `isEnvtestPackage` predicate; rebuilds `changedTestPackages` on top (excludes envtest packages) and adds the inverse `changedEnvtestPackages` (returns only envtest packages). DRY: both tiers share one git-status parse.
- Adds an `envtestJobRunner` seam (a `func(ctx) (pass bool, feedback string)`), threaded through `RunCoderGate`. New step 7: when the in-workspace checks otherwise pass and changed envtest packages exist, invoke the runner and fold a failure into the gate's not-pass result (feedback cites `envtest gate job`), so it flows through the existing `VerifyTerminal` retry loop.
- `executor_native` passes `nil` for now (Part 2 wires a real submitter that reuses the `run_gate_job` machinery to run `make test` under envtest for the changed packages only).

## Checklist

- [x] `go build`, `go vet`, `gofmt`, `golangci-lint` clean
- [x] Unit tests in `pkg/foreman/agent` (which is not envtest-backed, so they run in the fast gate): inverse detection + disjoint sets; predicate classification; runner invoked when envtest packages changed; failure folds into the gate; runner NOT invoked when none changed or when fast checks already failed
- [ ] Part 2: wire a real `envtestJobRunner` in `executor_native` (submits a scoped clean-room gate Job); tracked under #859

## Notes

This intentionally does not close #859 (`Part of`, not `Fixes`): the gap is closed in production only once Part 2 wires the runner.
