### PR TITLE
feat(foreman): post-push envtest gate (closes the in-loop timing flaw) (#859)

### DIFF
--- a/cmd/foreman-agent/envtest_runner_test.go
+++ b/cmd/foreman-agent/envtest_runner_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestMapGateVerdict(t *testing.T) {
+	cases := []struct {
+		verdict           string
+		wantPass, wantRan bool
+	}{
+		{"GATE-PASS", true, true},
+		{"GATE-FAIL", false, true},
+		{"GATE-ERROR", false, false},
+		{"", false, false},
+	}
+	for _, c := range cases {
+		pass, ran := mapGateVerdict(c.verdict)
+		if pass != c.wantPass || ran != c.wantRan {
+			t.Errorf("mapGateVerdict(%q) = (%v,%v) want (%v,%v)", c.verdict, pass, ran, c.wantPass, c.wantRan)
+		}
+	}
+}

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -34,6 +34,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -419,6 +420,9 @@ func main() {
 					LogTailFn:         makePodLogTailFn(kcs),
 				},
 			},
+			// EnvtestJobRunner verifies envtest-backed packages post-push in a
+			// clean-room Job (#859).
+			EnvtestJobRunner: makeEnvtestJobRunner(kc, foremanNamespace, makePodLogTailFn(kcs)),
 		}
 	default:
 		setupLog.Error(nil, "unknown --agent-mode", "value", agentMode, "valid", "stub|native")
@@ -733,4 +737,74 @@ func sanitizeName(s string) string {
 		s = strings.TrimRight(s[:63], "-")
 	}
 	return s
+}
+
+// mapGateVerdict maps a RunGateJobTool verdict onto (pass, ran). Only
+// GATE-PASS passes; GATE-ERROR and an empty/unknown verdict mean the Job
+// could not be judged (ran=false -> could-not-verify), so a GO stands.
+func mapGateVerdict(verdict string) (pass bool, ran bool) {
+	switch verdict {
+	case foremantools.VerdictGatePass:
+		return true, true
+	case foremantools.VerdictGateFail:
+		return false, true
+	default: // VerdictGateError, "", unknown
+		return false, false
+	}
+}
+
+// makeEnvtestJobRunner returns an EnvtestJobRunner that submits a clean-room
+// gate Job running `make test` (envtest) for repository@branch, reusing
+// RunGateJobTool scoped to the `test` make target (the fast tier already ran
+// fmt/vet/lint/build).
+func makeEnvtestJobRunner(
+	kc client.Client, foremanNamespace string,
+	logTailFn func(ctx context.Context, namespace, jobName string) string,
+) foremanagent.EnvtestJobRunner {
+	return &envtestJobRunnerImpl{
+		tool: &foremantools.RunGateJobTool{
+			Client: kc,
+			Cfg: foremantools.RunGateJobToolConfig{
+				Namespace:    foremanNamespace,
+				LogTailFn:    logTailFn,
+				PollInterval: 5 * time.Second,
+				PollTimeout:  10 * time.Minute,
+			},
+		},
+	}
+}
+
+type envtestJobRunnerImpl struct {
+	tool *foremantools.RunGateJobTool
+}
+
+func (e *envtestJobRunnerImpl) Run(
+	ctx context.Context, repository, branch, cloneURL string,
+) (pass bool, ran bool, feedback string) {
+	args, err := json.Marshal(map[string]any{
+		"repo":     repository,
+		"branch":   branch,
+		"checks":   []string{"test"},
+		"cloneURL": cloneURL,
+	})
+	if err != nil {
+		return false, false, "envtest gate: marshal args: " + err.Error()
+	}
+	result, err := e.tool.Execute(ctx, args)
+	if err != nil || result == nil {
+		msg := "nil result"
+		if err != nil {
+			msg = err.Error()
+		}
+		return false, false, "envtest gate: " + msg
+	}
+	pass, ran = mapGateVerdict(result.Verdict)
+	if pass {
+		return true, true, ""
+	}
+	fb := result.Summary
+	if lt, ok := result.Extra["logTail"].(string); ok && lt != "" {
+		fb += "\n" + lt
+	}
+	return pass, ran, fb
 }

--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -49,19 +49,6 @@ type commandRunner func(
 	args ...string,
 ) (output string, err error)
 
-// envtestJobRunner is the seam between the coder gate and the clean-room
-// gate Job machinery. When changed envtest packages exist, the gate
-// delegates their verification to a Kubernetes Job that runs `make test`
-// under envtest (with KUBEBUILDER_ASSETS). The Job's outcome is folded
-// into the gate's pass/fail result.
-//
-// The dependency direction is the reason it lives here: the tools package
-// imports the agent package (for ToolResult), so the agent package cannot
-// import tools without a cycle. cmd/foreman-agent wires a closure over
-// the gate Job submitter into the executor, which then passes it to the
-// gate via RunCoderGateConfig.
-type envtestJobRunner func(ctx context.Context) (pass bool, feedback string)
-
 // execCommandRunner is the production commandRunner backed by os/exec. It
 // appends extraEnv to the inherited process environment and captures
 // combined stdout+stderr. Wired into the coder agent loop via
@@ -98,19 +85,13 @@ type checkFailure struct {
 // The gate runs six deterministic checks in order: gofmt, go vet,
 // go build, golangci-lint, a fast unit-test tier on changed packages,
 // and a codegen-drift check. Heavy envtest or integration tests are
-// intentionally out of scope; they run in a separate clean-room
-// Kubernetes Job. All checks run regardless of earlier failures so the
-// feedback reports everything wrong at once.
-//
-// When envtestJobRunner is non-nil and changed envtest packages exist,
-// the gate delegates verification of those packages to a clean-room
-// gate Job after the in-workspace checks pass. A Job failure folds into
-// the gate's not-pass result with feedback.
+// intentionally out of scope; they run in a separate post-push gate Job.
+// All checks run regardless of earlier failures so the feedback reports
+// everything wrong at once.
 func RunCoderGate(
 	ctx context.Context,
 	workspace, golangciPath string,
 	run commandRunner,
-	envtestJobRunner envtestJobRunner,
 ) (pass bool, feedback string) {
 	var failures []checkFailure
 
@@ -161,20 +142,6 @@ func RunCoderGate(
 	// controller-gen is unavailable.
 	if drifted, out := checkCodegenDrift(ctx, workspace, run); drifted {
 		failures = append(failures, checkFailure{name: "codegen drift", output: out})
-	}
-
-	// 7. Envtest package verification: when changed envtest packages exist
-	// and the in-workspace checks otherwise pass, delegate verification
-	// of those packages to a clean-room gate Job that runs `make test`
-	// under envtest (with KUBEBUILDER_ASSETS). A Job failure folds into
-	// the gate's not-pass result with feedback.
-	if len(failures) == 0 && envtestJobRunner != nil {
-		if pkgs := changedEnvtestPackages(ctx, workspace, run); len(pkgs) > 0 {
-			pass, fb := envtestJobRunner(ctx)
-			if !pass {
-				failures = append(failures, checkFailure{name: "envtest gate job", output: fb})
-			}
-		}
 	}
 
 	if len(failures) == 0 {

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -112,7 +112,7 @@ func TestRunCoderGate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			run, _ := newFakeRunner(tt.responses)
-			pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
+			pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 
 			if pass != tt.wantPass {
 				t.Fatalf("pass = %v, want %v (feedback: %q)", pass, tt.wantPass, feedback)
@@ -144,7 +144,7 @@ func TestRunCoderGateLintEnv(t *testing.T) {
 		golangciPath: {},
 	})
 
-	RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
+	RunCoderGate(context.Background(), "/work", golangciPath, run)
 
 	var lintCall *recordedCall
 	for i := range *calls {
@@ -192,7 +192,7 @@ func TestRunCoderGateLintCacheScopedToWorkspace(t *testing.T) {
 		golangciPath: {},
 	})
 
-	RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
+	RunCoderGate(context.Background(), "/work", golangciPath, run)
 
 	var lintCall *recordedCall
 	for i := range *calls {
@@ -266,7 +266,7 @@ func TestRunCoderGate_FailsOnChangedPackageUnitTest(t *testing.T) {
 			return "", nil // golangci-lint
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run, nil)
+	pass, feedback := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run)
 	if pass {
 		t.Fatal("gate should fail when a changed package's unit test fails")
 	}
@@ -285,7 +285,7 @@ func TestRunCoderGate_SkipsTestTierWhenNoChangedPackages(t *testing.T) {
 		}
 		return "", nil // git status empty, all checks clean
 	}
-	if pass, _ := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run, nil); !pass {
+	if pass, _ := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run); !pass {
 		t.Fatal("gate should pass when all checks are clean and nothing changed")
 	}
 	if sawGoTest {
@@ -303,7 +303,7 @@ func TestRunCoderGateTruncation(t *testing.T) {
 		golangciPath: {output: huge, err: errors.New("boom")},
 	})
 
-	_, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
+	_, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 
 	if !strings.Contains(feedback, "...(truncated)...") {
 		t.Error("expected truncation marker in feedback")
@@ -347,7 +347,7 @@ func TestRunCoderGate_CodegenDrift_FailsWhenDrifted(t *testing.T) {
 			return "", nil
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 	if pass {
 		t.Fatal("gate should fail when codegen drift is detected")
 	}
@@ -383,7 +383,7 @@ func TestRunCoderGate_CodegenDrift_PassesWhenClean(t *testing.T) {
 			return "", nil
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 	if !pass {
 		t.Fatalf("gate should pass when codegen is clean; feedback:\n%s", feedback)
 	}
@@ -413,7 +413,7 @@ func TestRunCoderGate_CodegenDrift_SkippedWhenNoControllerGen(t *testing.T) {
 			return "", nil
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 	if !pass {
 		t.Fatalf("gate should pass when controller-gen is unavailable; feedback:\n%s", feedback)
 	}
@@ -444,7 +444,7 @@ func TestRunCoderGate_CodegenDrift_FailsWhenMakeFails(t *testing.T) {
 			return "", nil
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, nil)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 	if pass {
 		t.Fatal("gate should fail when make manifests fails")
 	}
@@ -528,176 +528,5 @@ func TestIsEnvtestPackage(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("isEnvtestPackage(%q) = %v, want %v", tt.pkg, got, tt.want)
 		}
-	}
-}
-
-// TestRunCoderGate_EnvtestJobRunnerInvokedWhenEnvtestPackagesChanged
-// verifies the gate invokes the injected envtestJobRunner when changed
-// envtest packages are present and the in-workspace checks pass.
-func TestRunCoderGate_EnvtestJobRunnerInvokedWhenEnvtestPackagesChanged(t *testing.T) {
-	const golangciPath = "./bin/golangci-lint"
-	jobInvoked := false
-	jobPass := true
-	jobFeedback := ""
-
-	envtestRunner := func(_ context.Context) (bool, string) {
-		jobInvoked = true
-		return jobPass, jobFeedback
-	}
-
-	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
-		switch {
-		case name == "gofmt":
-			return "", nil
-		case name == "go":
-			return "", nil
-		case name == golangciPath:
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "status":
-			return " M internal/controller/model_controller.go\x00", nil
-		case name == "test" && len(args) > 0 && args[0] == "-f":
-			return "", nil // controller-gen exists
-		case name == "make":
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "diff":
-			return "", nil // tree is clean
-		default:
-			return "", nil
-		}
-	}
-
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, envtestRunner)
-	if !jobInvoked {
-		t.Fatal("envtestJobRunner should have been invoked when envtest packages changed")
-	}
-	if !pass {
-		t.Fatalf("gate should pass when envtest job passes; feedback:\n%s", feedback)
-	}
-}
-
-// TestRunCoderGate_EnvtestJobRunnerFailureFoldsIntoGateFailure verifies
-// a Job failure from the envtestJobRunner folds into the gate's not-pass
-// result with feedback.
-func TestRunCoderGate_EnvtestJobRunnerFailureFoldsIntoGateFailure(t *testing.T) {
-	const golangciPath = "./bin/golangci-lint"
-	jobFeedback := "make test failed: internal/controller/model_controller_test.go:42: panic"
-
-	envtestRunner := func(_ context.Context) (bool, string) {
-		return false, jobFeedback
-	}
-
-	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
-		switch {
-		case name == "gofmt":
-			return "", nil
-		case name == "go":
-			return "", nil
-		case name == golangciPath:
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "status":
-			return " M internal/controller/model_controller.go\x00", nil
-		case name == "test" && len(args) > 0 && args[0] == "-f":
-			return "", nil
-		case name == "make":
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "diff":
-			return "", nil
-		default:
-			return "", nil
-		}
-	}
-
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, envtestRunner)
-	if pass {
-		t.Fatal("gate should fail when envtest job fails")
-	}
-	if !strings.Contains(feedback, "envtest gate job") {
-		t.Errorf("feedback should cite envtest gate job; got:\n%s", feedback)
-	}
-	if !strings.Contains(feedback, jobFeedback) {
-		t.Errorf("feedback should include job feedback; got:\n%s", feedback)
-	}
-}
-
-// TestRunCoderGate_EnvtestJobRunnerNotInvokedWhenNoEnvtestPackagesChanged
-// verifies the Job runner is NOT invoked when no envtest packages changed.
-func TestRunCoderGate_EnvtestJobRunnerNotInvokedWhenNoEnvtestPackagesChanged(t *testing.T) {
-	const golangciPath = "./bin/golangci-lint"
-	jobInvoked := false
-
-	envtestRunner := func(_ context.Context) (bool, string) {
-		jobInvoked = true
-		return true, ""
-	}
-
-	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
-		switch {
-		case name == "gofmt":
-			return "", nil
-		case name == "go":
-			return "", nil
-		case name == golangciPath:
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "status":
-			return " M pkg/cli/cache_inspect.go\x00", nil // non-envtest only
-		case name == "test" && len(args) > 0 && args[0] == "-f":
-			return "", nil
-		case name == "make":
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "diff":
-			return "", nil
-		default:
-			return "", nil
-		}
-	}
-
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, envtestRunner)
-	if jobInvoked {
-		t.Fatal("envtestJobRunner should NOT have been invoked when no envtest packages changed")
-	}
-	if !pass {
-		t.Fatalf("gate should pass; feedback:\n%s", feedback)
-	}
-}
-
-// TestRunCoderGate_EnvtestJobRunnerNotInvokedWhenInWorkspaceChecksFail
-// verifies the Job runner is NOT invoked when in-workspace checks fail,
-// since the gate already failed and the model needs to fix those first.
-func TestRunCoderGate_EnvtestJobRunnerNotInvokedWhenInWorkspaceChecksFail(t *testing.T) {
-	const golangciPath = "./bin/golangci-lint"
-	jobInvoked := false
-
-	envtestRunner := func(_ context.Context) (bool, string) {
-		jobInvoked = true
-		return true, ""
-	}
-
-	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
-		switch {
-		case name == "gofmt":
-			return "pkg/cli/cache_inspect.go\n", nil // gofmt failure
-		case name == "go":
-			return "", nil
-		case name == golangciPath:
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "status":
-			return " M internal/controller/model_controller.go\x00", nil
-		case name == "test" && len(args) > 0 && args[0] == "-f":
-			return "", nil
-		case name == "make":
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "diff":
-			return "", nil
-		default:
-			return "", nil
-		}
-	}
-
-	pass, _ := RunCoderGate(context.Background(), "/work", golangciPath, run, envtestRunner)
-	if jobInvoked {
-		t.Fatal("envtestJobRunner should NOT have been invoked when in-workspace checks fail")
-	}
-	if pass {
-		t.Fatal("gate should fail due to gofmt failure")
 	}
 }

--- a/pkg/foreman/agent/envtest_gate.go
+++ b/pkg/foreman/agent/envtest_gate.go
@@ -1,0 +1,43 @@
+package agent
+
+import "context"
+
+// EnvtestJobRunner submits a clean-room gate Job that runs `make test`
+// (envtest, with KUBEBUILDER_ASSETS) on repository@branch cloned from
+// cloneURL, polls to terminal, and reports the outcome. It lives in this
+// package (not tools) because tools imports agent (for ToolResult), so the
+// agent package cannot import tools without a cycle; cmd/foreman-agent wires
+// a closure over tools.RunGateJobTool into the executor's EnvtestJobRunner
+// field.
+type EnvtestJobRunner interface {
+	// Run reports (pass, ran, feedback). ran is false when the Job could
+	// not be submitted/polled to a verdict (infra error/timeout); the
+	// caller treats that as could-not-verify (GO stands). When ran is true,
+	// pass reflects the gate verdict and feedback carries the log tail on
+	// failure.
+	Run(ctx context.Context, repository, branch, cloneURL string) (pass bool, ran bool, feedback string)
+}
+
+// evaluatePostPushEnvtest decides whether a pushed GO should be downgraded
+// because its envtest packages fail in the clean-room gate Job. It returns
+// (failed, feedback): failed is true ONLY when the change touched an envtest
+// package, the Job ran, and it did not pass. A nil runner, an untouched
+// change, or a could-not-run (ran=false) never downgrades.
+func evaluatePostPushEnvtest(
+	ctx context.Context,
+	envtestTouched bool,
+	runner EnvtestJobRunner,
+	repository, branch, cloneURL string,
+) (failed bool, feedback string) {
+	if !envtestTouched || runner == nil {
+		return false, ""
+	}
+	pass, ran, fb := runner.Run(ctx, repository, branch, cloneURL)
+	if !ran {
+		return false, ""
+	}
+	if !pass {
+		return true, fb
+	}
+	return false, ""
+}

--- a/pkg/foreman/agent/envtest_gate_test.go
+++ b/pkg/foreman/agent/envtest_gate_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeEnvtestJobRunner struct {
+	pass, ran bool
+	feedback  string
+	called    bool
+}
+
+func (f *fakeEnvtestJobRunner) Run(_ context.Context, _, _, _ string) (bool, bool, string) {
+	f.called = true
+	return f.pass, f.ran, f.feedback
+}
+
+func TestEvaluatePostPushEnvtest(t *testing.T) {
+	t.Run("not touched: runner not called, no downgrade", func(t *testing.T) {
+		r := &fakeEnvtestJobRunner{}
+		failed, fb := evaluatePostPushEnvtest(context.Background(), false, r, "repo", "br", "url")
+		if failed || fb != "" || r.called {
+			t.Fatalf("got failed=%v fb=%q called=%v", failed, fb, r.called)
+		}
+	})
+	t.Run("nil runner: no downgrade", func(t *testing.T) {
+		failed, fb := evaluatePostPushEnvtest(context.Background(), true, nil, "repo", "br", "url")
+		if failed || fb != "" {
+			t.Fatalf("got failed=%v fb=%q", failed, fb)
+		}
+	})
+	t.Run("touched + pass: no downgrade", func(t *testing.T) {
+		r := &fakeEnvtestJobRunner{pass: true, ran: true}
+		failed, _ := evaluatePostPushEnvtest(context.Background(), true, r, "repo", "br", "url")
+		if failed || !r.called {
+			t.Fatalf("got failed=%v called=%v", failed, r.called)
+		}
+	})
+	t.Run("touched + ran + fail: downgrade with feedback", func(t *testing.T) {
+		r := &fakeEnvtestJobRunner{pass: false, ran: true, feedback: "envtest broke"}
+		failed, fb := evaluatePostPushEnvtest(context.Background(), true, r, "repo", "br", "url")
+		if !failed || fb != "envtest broke" {
+			t.Fatalf("got failed=%v fb=%q", failed, fb)
+		}
+	})
+	t.Run("touched + could-not-run: no downgrade (GO stands)", func(t *testing.T) {
+		r := &fakeEnvtestJobRunner{pass: false, ran: false, feedback: "infra"}
+		failed, _ := evaluatePostPushEnvtest(context.Background(), true, r, "repo", "br", "url")
+		if failed {
+			t.Fatalf("could-not-run should not downgrade; got failed=%v", failed)
+		}
+	})
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -144,6 +144,13 @@ type NativeAgentLoopExecutor struct {
 	// Job IS the execution; only the watcher's executor (the one this
 	// field is set on) ever submits a Job. See executor_coderjob.go.
 	CoderJobSubmitter CoderJobSubmitter
+
+	// EnvtestJobRunner, when non-nil, verifies envtest-backed packages in a
+	// clean-room Job (`make test`) on the pushed branch after a coder GO
+	// (#859). cmd/foreman-agent wires a closure over tools.RunGateJobTool
+	// here. Nil skips the post-push envtest gate (e.g. the in-process
+	// run-task path, where the clean-room gate Job is the backstop).
+	EnvtestJobRunner EnvtestJobRunner
 }
 
 // Kind identifies this executor in Result.Kind and in logs.
@@ -539,6 +546,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		return e.noChangesResult(start, transcriptRef, loopRes, branch), nil
 	}
 
+	// Whether the change touches an envtest-backed package, captured before
+	// the commit clears the working-tree status. Used for the post-push gate.
+	envtestTouched := len(changedEnvtestPackages(ctx, workspace, execCommandRunner)) > 0
+
 	sha, commitErr := repo.Commit(ctx, repo.CommitOptions{
 		Workspace: workspace,
 		Message:   loopRes.Terminal.CommitMessage,
@@ -561,6 +572,16 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		Auth:      auth,
 	}); err != nil {
 		return e.pushFailedResult(start, transcriptRef, loopRes, branch, sha, err), nil
+	}
+
+	// Post-push envtest gate (#859): verify envtest-backed packages in a
+	// clean-room Job on the now-pushed branch. A real failure downgrades the
+	// GO to INCOMPLETE; a could-not-run leaves the GO standing.
+	if failed, feedback := evaluatePostPushEnvtest(
+		ctx, envtestTouched, e.EnvtestJobRunner,
+		task.Spec.Payload.Repo, branch, e.GitRemoteURL,
+	); failed {
+		return e.envtestGateFailedResult(start, transcriptRef, loopRes, branch, sha, feedback), nil
 	}
 
 	return e.goResult(start, transcriptRef, loopRes, branch, sha), nil
@@ -1057,6 +1078,26 @@ func (e *NativeAgentLoopExecutor) commitRejectedResult(
 		"error":          cause.Error(),
 		"transcriptRef":  objRefAsMap(tref),
 		"turnCount":      lr.Turns,
+	}
+	return r
+}
+
+// envtestGateFailedResult downgrades a pushed GO to INCOMPLETE when the
+// post-push envtest gate Job (`make test`) failed on the pushed branch
+// (#859). The commit is already pushed (sha); a re-run or a human fixes
+// the failing envtest packages. feedback is the Job's log tail.
+func (e *NativeAgentLoopExecutor) envtestGateFailedResult(
+	start time.Time, tref corev1.ObjectReference, lr *LoopResult, branch, sha, feedback string,
+) *Result {
+	r := NewResult(e.Kind(), foremanv1alpha1.AgenticTaskVerdictIncomplete,
+		"post-push envtest gate failed", time.Since(start))
+	r.Extra = map[string]any{
+		"outcome":       "ENVTEST-GATE-FAILED",
+		"branch":        branch,
+		"commitSHA":     sha,
+		"feedback":      feedback,
+		"transcriptRef": objRefAsMap(tref),
+		"turnCount":     lr.Turns,
 	}
 	return r
 }

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -604,7 +604,7 @@ func makeCoderGateVerifier(workspace string, log logr.Logger, profile *foremanv1
 				return true, "", err
 			}
 		}
-		pass, feedback := RunCoderGate(ctx, workspace, lintPath, execCommandRunner, nil)
+		pass, feedback := RunCoderGate(ctx, workspace, lintPath, execCommandRunner)
 		if !pass {
 			log.Info("coder gate: fast checks failed; returning feedback to the loop for a fix")
 		}


### PR DESCRIPTION
## What

Verifies envtest-backed controller packages in a clean-room Job (`make test`) **after** the coder pushes its branch, downgrading a GO to INCOMPLETE when envtest fails. Supersedes the parked in-loop attempt on `foreman/issue-859-part2`.

## Why

#859 wants a controller change that breaks envtest to not reach a trustworthy GO. The in-loop approach (delegating to the gate Job from inside the `VerifyTerminal` loop) can't work: the coder's branch is created locally (`CreateAndCheckoutBranch`) and the only `Push` happens *after* the loop, so an in-loop Job would clone a branch that isn't on the remote yet and falsely fail every run. The gate Job is a post-push tool by design. Fixes #859.

## How

- **Revert #860's inert in-loop seam**: `RunCoderGate` drops the `envtestJobRunner` param + the in-loop step; the fast gate is workspace-only again. The detection helpers (`changedEnvtestPackages`, `isEnvtestPackage`) are kept and reused.
- **Post-push step in the executor GO path**: after the coder commits + pushes on GO, if the change touched an envtest package (`changedEnvtestPackages`, captured pre-commit), run a clean-room gate Job scoped to the `test` target on the pushed branch. A pure `evaluatePostPushEnvtest` helper holds the decision: real FAIL → INCOMPLETE (`envtestGateFailedResult`, outcome `ENVTEST-GATE-FAILED`, the commit is already pushed); could-not-run (infra error/timeout) → GO stands (the clean-room gate Job remains the backstop); PASS or untouched → GO.
- **`EnvtestJobRunner` seam**: interface in `pkg/foreman/agent` (dodges the agent↔tools import cycle); `cmd/foreman-agent` wires a `RunGateJobTool` closure (passing `cloneURL` so the Job clones the fork branch the coder pushed to), with a `mapGateVerdict` that treats `GATE-ERROR`/unknown as could-not-verify.

## Checklist

- [x] `go build ./...`, `go vet`, `gofmt`, `GOOS=linux golangci-lint` clean (0 issues on changed packages)
- [x] Unit tests: `evaluatePostPushEnvtest` (5 cases: untouched/nil/pass/real-fail/could-not-run) and `mapGateVerdict` (GATE-PASS/FAIL/ERROR/empty); both in non-envtest packages so the fast gate runs them
- [x] #860's now-inert in-loop seam + its tests removed
- [ ] Manual: a coder run that breaks a controller test pushes, the post-push Job runs `make test`, fails, and the run is INCOMPLETE/ENVTEST-GATE-FAILED (follow-up on a real cluster)
