### PR TITLE
feat: add spec.mode to auto-serve embedding and rerank models

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -21,6 +21,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Serving modes for InferenceService spec.mode and status.mode.
+const (
+	ServingModeChat      = "chat"
+	ServingModeEmbedding = "embedding"
+	ServingModeRerank    = "rerank"
+)
+
 // InferenceServiceSpec defines the desired state of InferenceService
 // RopeScalingType selects the RoPE context-extension method. Mirrors
 // llama.cpp's --rope-scaling values.
@@ -88,6 +95,17 @@ type InferenceServiceSpec struct {
 	// +kubebuilder:default=llamacpp
 	// +optional
 	Runtime string `json:"runtime,omitempty"`
+
+	// Mode selects how the model is served: "chat" (default) for
+	// chat/completion, "embedding" for /v1/embeddings, "rerank" for /v1/rerank.
+	// For the llamacpp runtime it auto-appends the required flags (embedding ->
+	// --embedding --pooling last; rerank -> --reranking --embedding --pooling
+	// rank); any flag already set in spec.extraArgs wins. When unset, the mode is
+	// inferred from spec.extraArgs / spec.endpoint.path. The resolved value is
+	// always reported in status.mode.
+	// +kubebuilder:validation:Enum=chat;embedding;rerank
+	// +optional
+	Mode string `json:"mode,omitempty"`
 
 	// Replicas is the desired number of inference pods
 	// +kubebuilder:validation:Minimum=0
@@ -815,6 +833,11 @@ type InferenceServiceStatus struct {
 	// +kubebuilder:validation:Enum=Pending;Creating;Progressing;Ready;WaitingForGPU;Stopped;Failed
 	// +optional
 	Phase string `json:"phase,omitempty"`
+
+	// Mode is the resolved serving mode (chat, embedding, or rerank): spec.mode
+	// when set, otherwise inferred from the runtime flags and endpoint path.
+	// +optional
+	Mode string `json:"mode,omitempty"`
 
 	// Replicas tracks the number of ready vs desired pods
 	// +optional

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -1476,6 +1476,20 @@ spec:
                 items:
                   type: string
                 type: array
+              mode:
+                description: |-
+                  Mode selects how the model is served: "chat" (default) for
+                  chat/completion, "embedding" for /v1/embeddings, "rerank" for /v1/rerank.
+                  For the llamacpp runtime it auto-appends the required flags (embedding ->
+                  --embedding --pooling last; rerank -> --reranking --embedding --pooling
+                  rank); any flag already set in spec.extraArgs wins. When unset, the mode is
+                  inferred from spec.extraArgs / spec.endpoint.path. The resolved value is
+                  always reported in status.mode.
+                enum:
+                - chat
+                - embedding
+                - rerank
+                type: string
               modelRef:
                 description: ModelRef references the Model CR that contains the model
                   to serve
@@ -3246,6 +3260,11 @@ spec:
               lastUpdated:
                 description: LastUpdated is the timestamp of the last status update
                 format: date-time
+                type: string
+              mode:
+                description: |-
+                  Mode is the resolved serving mode (chat, embedding, or rerank): spec.mode
+                  when set, otherwise inferred from the runtime flags and endpoint path.
                 type: string
               modelReady:
                 description: ModelReady indicates if the referenced Model is in Ready

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1472,6 +1472,20 @@ spec:
                 items:
                   type: string
                 type: array
+              mode:
+                description: |-
+                  Mode selects how the model is served: "chat" (default) for
+                  chat/completion, "embedding" for /v1/embeddings, "rerank" for /v1/rerank.
+                  For the llamacpp runtime it auto-appends the required flags (embedding ->
+                  --embedding --pooling last; rerank -> --reranking --embedding --pooling
+                  rank); any flag already set in spec.extraArgs wins. When unset, the mode is
+                  inferred from spec.extraArgs / spec.endpoint.path. The resolved value is
+                  always reported in status.mode.
+                enum:
+                - chat
+                - embedding
+                - rerank
+                type: string
               modelRef:
                 description: ModelRef references the Model CR that contains the model
                   to serve
@@ -3242,6 +3256,11 @@ spec:
               lastUpdated:
                 description: LastUpdated is the timestamp of the last status update
                 format: date-time
+                type: string
+              mode:
+                description: |-
+                  Mode is the resolved serving mode (chat, embedding, or rerank): spec.mode
+                  when set, otherwise inferred from the runtime flags and endpoint path.
                 type: string
               modelReady:
                 description: ModelReady indicates if the referenced Model is in Ready

--- a/internal/controller/runtime_args.go
+++ b/internal/controller/runtime_args.go
@@ -19,6 +19,15 @@ package controller
 import (
 	"fmt"
 	"strings"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Serving modes accepted in spec.mode and reported in status.mode.
+const (
+	servingModeChat      = inferencev1alpha1.ServingModeChat
+	servingModeEmbedding = inferencev1alpha1.ServingModeEmbedding
+	servingModeRerank    = inferencev1alpha1.ServingModeRerank
 )
 
 func hasMatchingExtraArg(extraArgs []string, argName string) bool {
@@ -30,4 +39,29 @@ func hasMatchingExtraArg(extraArgs []string, argName string) bool {
 		}
 	}
 	return false
+}
+
+// resolveServingMode returns spec.mode when set, otherwise infers it from the
+// runtime flags or endpoint path. A reranker passes both --reranking and
+// --embedding, so rerank is checked first. Defaults to chat.
+func resolveServingMode(isvc *inferencev1alpha1.InferenceService) string {
+	if isvc.Spec.Mode != "" {
+		return isvc.Spec.Mode
+	}
+	args := append(append([]string{}, isvc.Spec.ExtraArgs...), isvc.Spec.Args...)
+	switch {
+	case hasMatchingExtraArg(args, "reranking"):
+		return servingModeRerank
+	case hasMatchingExtraArg(args, "embedding"), hasMatchingExtraArg(args, "embeddings"):
+		return servingModeEmbedding
+	}
+	if isvc.Spec.Endpoint != nil {
+		switch {
+		case strings.Contains(isvc.Spec.Endpoint.Path, "/rerank"):
+			return servingModeRerank
+		case strings.Contains(isvc.Spec.Endpoint.Path, "/embeddings"):
+			return servingModeEmbedding
+		}
+	}
+	return servingModeChat
 }

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -116,6 +116,7 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 		}
 	}
 	args = appendMetadataOverrideArgs(args, isvc.Spec.MetadataOverrides)
+	args = appendModeArgs(args, isvc.Spec.Mode, isvc.Spec.ExtraArgs)
 	if len(isvc.Spec.ExtraArgs) > 0 {
 		args = append(args, isvc.Spec.ExtraArgs...)
 	}

--- a/internal/controller/runtime_llamacpp_args.go
+++ b/internal/controller/runtime_llamacpp_args.go
@@ -169,6 +169,33 @@ func appendNoWarmupArgs(args []string, noWarmup *bool) []string {
 	return args
 }
 
+// appendModeArgs wires the llama.cpp flags for embedding and rerank serving.
+// A reranker needs both --reranking and --embedding. Flags already in extraArgs
+// win and are not duplicated, so hand-wired manifests are left untouched; chat
+// (or empty) adds nothing.
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case servingModeRerank:
+		if !hasMatchingExtraArg(extraArgs, "reranking") {
+			args = append(args, "--reranking")
+		}
+		if !hasMatchingExtraArg(extraArgs, "embedding") {
+			args = append(args, "--embedding")
+		}
+		if !hasMatchingExtraArg(extraArgs, "pooling") {
+			args = append(args, "--pooling", "rank")
+		}
+	case servingModeEmbedding:
+		if !hasMatchingExtraArg(extraArgs, "embedding") {
+			args = append(args, "--embedding")
+		}
+		if !hasMatchingExtraArg(extraArgs, "pooling") {
+			args = append(args, "--pooling", "last")
+		}
+	}
+	return args
+}
+
 func appendSpeculativeDecodingArgs(args []string, spec *inferencev1alpha1.SpeculativeDecodingSpec) []string {
 	if spec == nil || spec.Type == "" || spec.Type == "disabled" {
 		return args

--- a/internal/controller/runtime_mode_test.go
+++ b/internal/controller/runtime_mode_test.go
@@ -1,0 +1,76 @@
+package controller
+
+import (
+	"testing"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func TestResolveServingMode(t *testing.T) {
+	cases := []struct {
+		name      string
+		mode      string
+		extraArgs []string
+		args      []string
+		path      string
+		want      string
+	}{
+		{name: "default is chat", want: servingModeChat},
+		{name: "explicit spec.mode wins", mode: servingModeEmbedding, want: servingModeEmbedding},
+		{
+			name:      "explicit spec.mode wins over conflicting flags",
+			mode:      servingModeChat,
+			extraArgs: []string{"--embedding"},
+			want:      servingModeChat,
+		},
+		{name: "inferred from --embedding", extraArgs: []string{"--embedding", "--pooling", "last"}, want: servingModeEmbedding},
+		{
+			name:      "rerank inferred even though reranker also passes --embedding",
+			extraArgs: []string{"--reranking", "--pooling", "rank", "--embedding"},
+			want:      servingModeRerank,
+		},
+		{name: "inferred from generic Args", args: []string{"--embeddings"}, want: servingModeEmbedding},
+		{name: "inferred from endpoint path", path: "/v1/rerank", want: servingModeRerank},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isvc := &inferencev1alpha1.InferenceService{}
+			isvc.Spec.Mode = tc.mode
+			isvc.Spec.ExtraArgs = tc.extraArgs
+			isvc.Spec.Args = tc.args
+			if tc.path != "" {
+				isvc.Spec.Endpoint = &inferencev1alpha1.EndpointSpec{Path: tc.path}
+			}
+			if got := resolveServingMode(isvc); got != tc.want {
+				t.Fatalf("resolveServingMode() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppendModeArgs(t *testing.T) {
+	t.Run("embedding adds --embedding and default pooling", func(t *testing.T) {
+		args := appendModeArgs(nil, servingModeEmbedding, nil)
+		if !containsArg(args, "--embedding", "") || !containsArg(args, "--pooling", "last") {
+			t.Fatalf("missing embedding flags: %v", args)
+		}
+	})
+	t.Run("rerank adds --reranking, --embedding and rank pooling", func(t *testing.T) {
+		args := appendModeArgs(nil, servingModeRerank, nil)
+		if !containsArg(args, "--reranking", "") || !containsArg(args, "--embedding", "") || !containsArg(args, "--pooling", "rank") {
+			t.Fatalf("missing rerank flags: %v", args)
+		}
+	})
+	t.Run("does not duplicate flags already in extraArgs", func(t *testing.T) {
+		extra := []string{"--embedding", "--pooling", "cls"}
+		args := appendModeArgs(nil, servingModeEmbedding, extra)
+		if len(args) != 0 {
+			t.Fatalf("expected no appended flags when extraArgs already set them, got %v", args)
+		}
+	})
+	t.Run("chat adds nothing", func(t *testing.T) {
+		if args := appendModeArgs(nil, servingModeChat, nil); len(args) != 0 {
+			t.Fatalf("chat mode should append nothing, got %v", args)
+		}
+	})
+}

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -109,6 +109,7 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 	now := metav1.Now()
 	previousPhase := isvc.Status.Phase
 	isvc.Status.Phase = phase
+	isvc.Status.Mode = resolveServingMode(isvc)
 	isvc.Status.ModelReady = modelReady
 	isvc.Status.ReadyReplicas = readyReplicas
 	isvc.Status.Replicas = desiredReplicas

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -625,6 +625,7 @@ func buildExecutorConfig(
 		NoWarmup:               derefBool(isvc.Spec.NoWarmup),
 		ReasoningBudget:        derefInt32(isvc.Spec.ReasoningBudget),
 		ReasoningBudgetMessage: isvc.Spec.ReasoningBudgetMessage,
+		Mode:                   isvc.Spec.Mode,
 		ExtraArgs:              isvc.Spec.ExtraArgs,
 	}
 }
@@ -1722,6 +1723,7 @@ func computeSpecHash(isvc *inferencev1alpha1.InferenceService) string {
 		ExtraArgs              []string
 		ReasoningBudget        *int32
 		ReasoningBudgetMessage string
+		Mode                   string
 		Replicas               *int32
 		Runtime                string
 	}{
@@ -1745,6 +1747,7 @@ func computeSpecHash(isvc *inferencev1alpha1.InferenceService) string {
 		ExtraArgs:              isvc.Spec.ExtraArgs,
 		ReasoningBudget:        isvc.Spec.ReasoningBudget,
 		ReasoningBudgetMessage: isvc.Spec.ReasoningBudgetMessage,
+		Mode:                   isvc.Spec.Mode,
 		Replicas:               isvc.Spec.Replicas,
 		Runtime:                isvc.Spec.Runtime,
 	}

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -25,10 +25,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
 	"go.uber.org/zap"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
 
 type ExecutorConfig struct {
@@ -107,6 +110,10 @@ type ExecutorConfig struct {
 	// ReasoningBudgetMessage maps to --reasoning-budget-message. Ignored
 	// unless ReasoningBudget > 0.
 	ReasoningBudgetMessage string
+
+	// Mode is the serving mode (chat, embedding, rerank) resolved from
+	// InferenceService.spec.mode. Empty defaults to chat (no extra flags).
+	Mode string
 
 	// ExtraArgs are appended to the command line as-is, last, so they can
 	// override any earlier flag llama-server emitted (last-wins).
@@ -356,6 +363,47 @@ func (e *MetalExecutor) waitForHealthy(port int, timeout time.Duration) error {
 	}
 }
 
+// hasMatchingExtraArg reports whether extraArgs already carries argName in
+// either the "--name" or "--name=value" form. Mirrors the controller helper so
+// the agent path does not duplicate flags the user set explicitly.
+func hasMatchingExtraArg(extraArgs []string, argName string) bool {
+	arg := fmt.Sprintf("--%s", argName)
+	inlineArg := fmt.Sprintf("--%s=", argName)
+	for _, v := range extraArgs {
+		if v == arg || strings.HasPrefix(v, inlineArg) {
+			return true
+		}
+	}
+	return false
+}
+
+// appendModeArgs wires the llama.cpp flags for embedding and rerank serving,
+// mirroring the controller's runtime_llamacpp arg builder. A reranker needs
+// both --reranking and --embedding; flags already in extraArgs win and are not
+// duplicated. Chat (or empty) adds nothing.
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case inferencev1alpha1.ServingModeRerank:
+		if !hasMatchingExtraArg(extraArgs, "reranking") {
+			args = append(args, "--reranking")
+		}
+		if !hasMatchingExtraArg(extraArgs, "embedding") {
+			args = append(args, "--embedding")
+		}
+		if !hasMatchingExtraArg(extraArgs, "pooling") {
+			args = append(args, "--pooling", "rank")
+		}
+	case inferencev1alpha1.ServingModeEmbedding:
+		if !hasMatchingExtraArg(extraArgs, "embedding") {
+			args = append(args, "--embedding")
+		}
+		if !hasMatchingExtraArg(extraArgs, "pooling") {
+			args = append(args, "--pooling", "last")
+		}
+	}
+	return args
+}
+
 // buildLlamaServerArgs constructs the command-line argument vector for the
 // llama-server child process. It is split out from StartProcess so it can be
 // unit tested without spawning a real process and so the Apple-Silicon-specific
@@ -454,6 +502,8 @@ func buildLlamaServerArgs(modelPath string, port int, config ExecutorConfig) []s
 	if config.Jinja {
 		args = append(args, "--jinja")
 	}
+
+	args = appendModeArgs(args, config.Mode, config.ExtraArgs)
 
 	// ExtraArgs comes last so user-provided overrides actually override.
 	if len(config.ExtraArgs) > 0 {

--- a/pkg/agent/executor_mode_test.go
+++ b/pkg/agent/executor_mode_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import "testing"
+
+func TestBuildLlamaServerArgs_EmbeddingMode(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{ContextSize: 4096, Mode: "embedding"})
+	if !hasFlag(args, "--embedding") {
+		t.Errorf("--embedding must be set for embedding mode (full args: %v)", args)
+	}
+	if got := flagValue(args, "--pooling"); got != "last" {
+		t.Errorf("--pooling = %q, want %q (full args: %v)", got, "last", args)
+	}
+	if hasFlag(args, "--reranking") {
+		t.Errorf("--reranking must not be set for embedding mode (full args: %v)", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_RerankMode(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{ContextSize: 4096, Mode: "rerank"})
+	if !hasFlag(args, "--reranking") || !hasFlag(args, "--embedding") {
+		t.Errorf("rerank mode must set both --reranking and --embedding (full args: %v)", args)
+	}
+	if got := flagValue(args, "--pooling"); got != "rank" {
+		t.Errorf("--pooling = %q, want %q (full args: %v)", got, "rank", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_ModeDoesNotOverrideExtraArgs(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize: 4096,
+		Mode:        "embedding",
+		ExtraArgs:   []string{"--pooling", "cls"},
+	})
+	// Mode must not inject its own --pooling when the user already set one.
+	if got := flagValue(args, "--pooling"); got != "cls" {
+		t.Errorf("--pooling = %q, want user value %q (full args: %v)", got, "cls", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_ChatModeAddsNoModeFlags(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{ContextSize: 4096, Mode: "chat"})
+	if hasFlag(args, "--embedding") || hasFlag(args, "--reranking") {
+		t.Errorf("chat mode must add no serving-mode flags (full args: %v)", args)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `spec.mode` field (`chat` | `embedding` | `rerank`) to `InferenceService` so embedding and reranker models are first-class instead of requiring hand-wired runtime flags. Today, serving an embedding or reranker model means knowing and passing the right llama.cpp flags (`--embedding --pooling last`, `--reranking --pooling rank`, plus the reranker also needs `--embedding`) via `spec.extraArgs`, and nothing surfaces the model's task type to consumers.

## What it does

- **`spec.mode`** (enum `chat|embedding|rerank`, intentionally **undefaulted**): for the `llamacpp` runtime, setting it auto-appends the required flags — `embedding` → `--embedding --pooling last`; `rerank` → `--reranking --embedding --pooling rank`. Any flag already present in `spec.extraArgs` wins and is not duplicated.
- **`status.mode`**: the resolved mode — `spec.mode` when set, otherwise inferred from `spec.extraArgs` / `spec.endpoint.path` — so downstream routers and external operators can key off model type without parsing runtime flags.
- **Backward compatible**: existing manifests that wire `--embedding`/`--reranking` by hand keep working unchanged, and their mode is still inferred and published to `status.mode`. The field is left undefaulted on purpose so a `chat` default cannot clobber that inference.

## Resolution precedence

`spec.mode` → runtime flags (`--reranking` wins over `--embedding`, since rerankers pass both) → `spec.endpoint.path` (`/v1/rerank`, `/v1/embeddings`) → `chat`.

## Tests

`resolveServingMode` and `appendModeArgs` table tests in `internal/controller/runtime_mode_test.go` (default, explicit-wins, explicit-over-conflicting-flags, flag inference, rerank-over-embedding, generic `Args`, endpoint path, no-duplicate, chat-noop). `make manifests generate` regenerated the CRD; build, controller tests, and golangci-lint pass.

## Motivation

This unblocks routing embedding/reranker `InferenceService`s through an OpenAI-compatible proxy (e.g. LiteLLM): `status.mode` maps directly to litellm's `model_info.mode`, so the proxy serves `/v1/embeddings` and `/v1/rerank` correctly instead of treating every model as chat.
