### PR TITLE
chore: migrate .goreleaser.yaml off deprecated v2 keys

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -188,86 +188,82 @@ checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 
+# dockers_v2 builds one multi-arch manifest per image natively (buildx),
+# replacing the old per-arch `dockers` entries + `docker_manifests`. The
+# binaries are staged per platform under $TARGETPLATFORM in the build
+# context, so the Dockerfiles COPY from "$TARGETPLATFORM/<binary>".
 dockers_v2:
-  - image_templates:
-      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}-amd64"
-      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}-arm64"
+  - id: controller
     ids:
       - llmkube-controller
+    images:
+      - "ghcr.io/defilantech/llmkube-controller"
+    tags:
+      - "{{ .Version }}"
     dockerfile: Dockerfile.goreleaser
-    use: buildx
     platforms:
       - linux/amd64
       - linux/arm64
-    build_flag_templates:
-      - "--platform={{ .TargetOS }}/{{ .TargetArch }}"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-    manifest_templates:
-      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}"
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.source: "{{ .GitURL }}"
 
-  - image_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}-amd64"
-      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}-arm64"
+  - id: foreman-operator
     ids:
       - llmkube-foreman-operator
+    images:
+      - "ghcr.io/defilantech/llmkube-foreman-operator"
+    tags:
+      - "{{ .Version }}"
     dockerfile: Dockerfile.foreman-operator.goreleaser
-    use: buildx
     platforms:
       - linux/amd64
       - linux/arm64
-    build_flag_templates:
-      - "--platform={{ .TargetOS }}/{{ .TargetArch }}"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=llmkube-foreman-operator"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-    manifest_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}"
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.title: "llmkube-foreman-operator"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.source: "{{ .GitURL }}"
 
-  - image_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-amd64"
-      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-arm64"
+  - id: foreman-agent
     ids:
       - llmkube-foreman-agent
+    images:
+      - "ghcr.io/defilantech/llmkube-foreman-agent"
+    tags:
+      - "{{ .Version }}"
     dockerfile: Dockerfile.foreman-agent.goreleaser
-    use: buildx
     platforms:
       - linux/amd64
       - linux/arm64
-    build_flag_templates:
-      - "--platform={{ .TargetOS }}/{{ .TargetArch }}"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=llmkube-foreman-agent"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-    manifest_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}"
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.title: "llmkube-foreman-agent"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.source: "{{ .GitURL }}"
 
-  - image_templates:
-      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-amd64"
-      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-arm64"
+  - id: router-proxy
     ids:
       - llmkube-router-proxy
+    images:
+      - "ghcr.io/defilantech/llmkube-router-proxy"
+    tags:
+      - "{{ .Version }}"
     dockerfile: Dockerfile.router-proxy.goreleaser
-    use: buildx
     platforms:
       - linux/amd64
       - linux/arm64
-    build_flag_templates:
-      - "--platform={{ .TargetOS }}/{{ .TargetArch }}"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=llmkube-router-proxy"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-    manifest_templates:
-      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}"
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.title: "llmkube-router-proxy"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.source: "{{ .GitURL }}"
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
@@ -369,28 +365,31 @@ release:
 
     **Full Changelog**: [CHANGELOG.md](https://github.com/defilantech/LLMKube/blob/main/CHANGELOG.md)
 
-# Homebrew tap
+# Homebrew tap. brews/formulas were deprecated in GoReleaser v2.16 in favor
+# of homebrew_casks, which uses cask stanzas (binaries) rather than the
+# formula install/test DSL.
 homebrew_casks:
   - name: llmkube
     # Only include the CLI archive (not Metal agent)
     ids:
       - llmkube-cli
+    binaries:
+      - llmkube
     repository:
       owner: defilantech
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
+    directory: Casks
     description: "GPU-accelerated Kubernetes operator for local LLM inference"
     homepage: "https://github.com/defilantech/LLMKube"
-    license: "Apache-2.0"
-
-    # Install instructions
-    install: |
-      bin.install "llmkube"
-
-    # Test the installation
-    test: |
-      system "#{bin}/llmkube", "version"
+    # The released CLI binary is not notarized; strip the quarantine xattr so
+    # Gatekeeper does not block it on first run.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/llmkube"]
+          end
 
 # Metadata
 metadata:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -135,7 +135,7 @@ builds:
 
 archives:
   - id: llmkube-cli
-    builds:
+    ids:
       - llmkube-cli
 
     # Archive name template
@@ -151,10 +151,11 @@ archives:
     # Format by OS
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
   - id: llmkube-metal-agent
-    builds:
+    ids:
       - llmkube-metal-agent
 
     # Archive name template
@@ -168,12 +169,12 @@ archives:
       - deployment/macos/*
 
   - id: llmkube-foreman-agent
-    builds:
+    ids:
       - llmkube-foreman-agent
 
     # Archive name template. Produces darwin (Mac native agents) and linux
     # (edge nodes) archives; the linux foreman-agent Pod still ships as a
-    # ghcr image via the dockers section below.
+    # ghcr image via the dockers_v2 section below.
     name_template: "{{ .ProjectName }}-foreman-agent_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
     # Files to include
@@ -187,163 +188,86 @@ checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 
-dockers:
-  - id: controller-amd64
-    goos: linux
-    goarch: amd64
+dockers_v2:
+  - image_templates:
+      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}-amd64"
+      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}-arm64"
     ids:
       - llmkube-controller
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}-amd64"
     dockerfile: Dockerfile.goreleaser
     use: buildx
+    platforms:
+      - linux/amd64
+      - linux/arm64
     build_flag_templates:
-      - "--platform=linux/amd64"
+      - "--platform={{ .TargetOS }}/{{ .TargetArch }}"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
+    manifest_templates:
+      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}"
 
-  - id: controller-arm64
-    goos: linux
-    goarch: arm64
-    ids:
-      - llmkube-controller
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}-arm64"
-    dockerfile: Dockerfile.goreleaser
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-
-  - id: foreman-operator-amd64
-    goos: linux
-    goarch: amd64
+  - image_templates:
+      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}-amd64"
+      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}-arm64"
     ids:
       - llmkube-foreman-operator
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}-amd64"
     dockerfile: Dockerfile.foreman-operator.goreleaser
     use: buildx
+    platforms:
+      - linux/amd64
+      - linux/arm64
     build_flag_templates:
-      - "--platform=linux/amd64"
+      - "--platform={{ .TargetOS }}/{{ .TargetArch }}"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title=llmkube-foreman-operator"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
+    manifest_templates:
+      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}"
 
-  - id: foreman-operator-arm64
-    goos: linux
-    goarch: arm64
-    ids:
-      - llmkube-foreman-operator
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}-arm64"
-    dockerfile: Dockerfile.foreman-operator.goreleaser
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=llmkube-foreman-operator"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-
-  - id: foreman-agent-amd64
-    goos: linux
-    goarch: amd64
+  - image_templates:
+      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-amd64"
+      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-arm64"
     ids:
       - llmkube-foreman-agent
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-amd64"
     dockerfile: Dockerfile.foreman-agent.goreleaser
     use: buildx
+    platforms:
+      - linux/amd64
+      - linux/arm64
     build_flag_templates:
-      - "--platform=linux/amd64"
+      - "--platform={{ .TargetOS }}/{{ .TargetArch }}"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title=llmkube-foreman-agent"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
+    manifest_templates:
+      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}"
 
-  - id: foreman-agent-arm64
-    goos: linux
-    goarch: arm64
-    ids:
-      - llmkube-foreman-agent
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-arm64"
-    dockerfile: Dockerfile.foreman-agent.goreleaser
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=llmkube-foreman-agent"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-
-  - id: router-proxy-amd64
-    goos: linux
-    goarch: amd64
+  - image_templates:
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-amd64"
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-arm64"
     ids:
       - llmkube-router-proxy
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-amd64"
     dockerfile: Dockerfile.router-proxy.goreleaser
     use: buildx
+    platforms:
+      - linux/amd64
+      - linux/arm64
     build_flag_templates:
-      - "--platform=linux/amd64"
+      - "--platform={{ .TargetOS }}/{{ .TargetArch }}"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title=llmkube-router-proxy"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
-
-  - id: router-proxy-arm64
-    goos: linux
-    goarch: arm64
-    ids:
-      - llmkube-router-proxy
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-arm64"
-    dockerfile: Dockerfile.router-proxy.goreleaser
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title=llmkube-router-proxy"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-
-docker_manifests:
-  - name_template: "ghcr.io/defilantech/llmkube-controller:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}-amd64"
-      - "ghcr.io/defilantech/llmkube-controller:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}-amd64"
-      - "ghcr.io/defilantech/llmkube-foreman-operator:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-amd64"
-      - "ghcr.io/defilantech/llmkube-foreman-agent:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-amd64"
-      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}-arm64"
+    manifest_templates:
+      - "ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}"
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
@@ -446,7 +370,7 @@ release:
     **Full Changelog**: [CHANGELOG.md](https://github.com/defilantech/LLMKube/blob/main/CHANGELOG.md)
 
 # Homebrew tap
-brews:
+homebrew_casks:
   - name: llmkube
     # Only include the CLI archive (not Metal agent)
     ids:

--- a/Dockerfile.foreman-agent.goreleaser
+++ b/Dockerfile.foreman-agent.goreleaser
@@ -1,15 +1,17 @@
-# Dockerfile for GoReleaser builds of the foreman-agent. Expects a
-# pre-built binary at the build context root.
+# Dockerfile for GoReleaser builds of the foreman-agent. dockers_v2 stages
+# the pre-built binary per platform under $TARGETPLATFORM in the build
+# context.
 #
 # The foreman-agent shells out to `git` for clone / commit / push from
 # its repo helpers, so the runtime image swaps distroless static for
 # alpine + git. nonroot uid 65532 stays.
 FROM alpine:3.24
+ARG TARGETPLATFORM
 RUN apk add --no-cache git ca-certificates \
     && addgroup -S -g 65532 nonroot \
     && adduser -S -u 65532 -G nonroot nonroot
 WORKDIR /
-COPY foreman-agent /foreman-agent
+COPY $TARGETPLATFORM/foreman-agent /foreman-agent
 USER 65532:65532
 
 ENTRYPOINT ["/foreman-agent"]

--- a/Dockerfile.foreman-operator.goreleaser
+++ b/Dockerfile.foreman-operator.goreleaser
@@ -1,9 +1,10 @@
-# Dockerfile for GoReleaser builds of the foreman-operator. Expects a
-# pre-built binary at the build context root; GoReleaser stages one
-# per (goos, goarch) into the docker build directory.
+# Dockerfile for GoReleaser builds of the foreman-operator. dockers_v2
+# stages the pre-built binary per platform under $TARGETPLATFORM in the
+# build context.
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETPLATFORM
 WORKDIR /
-COPY foreman-operator /foreman-operator
+COPY $TARGETPLATFORM/foreman-operator /foreman-operator
 USER 65532:65532
 
 ENTRYPOINT ["/foreman-operator"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,10 +1,11 @@
 # Dockerfile for GoReleaser builds
-# This Dockerfile expects a pre-built binary in the build context
-# and simply packages it into a distroless container image.
+# dockers_v2 stages the pre-built binary per platform under
+# $TARGETPLATFORM in the build context; package it into a distroless image.
 
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETPLATFORM
 WORKDIR /
-COPY manager .
+COPY $TARGETPLATFORM/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile.router-proxy.goreleaser
+++ b/Dockerfile.router-proxy.goreleaser
@@ -1,11 +1,12 @@
-# Dockerfile for GoReleaser builds of the router-proxy. Expects a pre-built
-# binary at the build context root; GoReleaser stages one per (goos, goarch)
-# into the docker build directory. Mirrors Dockerfile.router-proxy's runtime
-# (distroless, non-root, port 8080) but skips the in-image Go build since
-# GoReleaser already produced the binary.
+# Dockerfile for GoReleaser builds of the router-proxy. dockers_v2 stages
+# the pre-built binary per platform under $TARGETPLATFORM in the build
+# context. Mirrors Dockerfile.router-proxy's runtime (distroless, non-root,
+# port 8080) but skips the in-image Go build since GoReleaser already
+# produced the binary.
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETPLATFORM
 WORKDIR /
-COPY router-proxy /usr/local/bin/router-proxy
+COPY $TARGETPLATFORM/router-proxy /usr/local/bin/router-proxy
 
 # Default HTTP port; the binary's --listen flag overrides.
 EXPOSE 8080


### PR DESCRIPTION
## What

Migrate `.goreleaser.yaml` off four deprecated v2 key classes that GoReleaser v2.16.0 emits DEPRECATED warnings for.

## Why

The deprecated keys will be removed in a future GoReleaser release, which would break the release pipeline. Migrating proactively keeps the release path unblocked and clears the warnings.

Fixes #854

## How

- `archives.builds` -> `archives.ids` (3 occurrences)
- `format_overrides.format` -> `format_overrides.formats` (list form)
- `dockers` + `docker_manifests` -> `dockers_v2` with `platforms` and `manifest_templates` (collapses 8 docker + 4 manifest entries into 4 `dockers_v2` entries)
- `brews` -> `homebrew_casks`

Generated autonomously by the Foreman coder (M5 Max, local Qwopus) and reviewed by a maintainer. Note: the in-workspace gate does not run `goreleaser check`, so the config is being reviewed by hand on this PR.

## Checklist

- [ ] Tests added/updated (N/A: release config only)
- [ ] `make test` passes locally
- [ ] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change)
