### PR TITLE
test: add unit tests for cacheTypeBytesPerElement and statusClass

### DIFF
--- a/pkg/agent/clientproxy_test.go
+++ b/pkg/agent/clientproxy_test.go
@@ -74,3 +74,33 @@ func TestClientProxy_503WhenNoBackend(t *testing.T) {
 		t.Errorf("503 body should carry a JSON error, got %q", rec.Body.String())
 	}
 }
+
+func TestStatusClass(t *testing.T) {
+	tests := []struct {
+		code     int
+		expected string
+	}{
+		{100, "other"},
+		{199, "other"},
+		{200, "2xx"},
+		{204, "2xx"},
+		{299, "2xx"},
+		{301, "3xx"},
+		{302, "3xx"},
+		{399, "3xx"},
+		{400, "4xx"},
+		{404, "4xx"},
+		{499, "4xx"},
+		{500, "5xx"},
+		{502, "5xx"},
+		{599, "5xx"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := statusClass(tt.code)
+			if got != tt.expected {
+				t.Errorf("statusClass(%d) = %q, want %q", tt.code, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/agent/memory_test.go
+++ b/pkg/agent/memory_test.go
@@ -599,3 +599,32 @@ func TestEstimateModelMemory_OverflowFallsBack(t *testing.T) {
 		t.Error("fallback estimate should exceed file size")
 	}
 }
+
+func TestCacheTypeBytesPerElement(t *testing.T) {
+	tests := []struct {
+		name      string
+		cacheType string
+		expected  float64
+	}{
+		{"empty defaults to f16", "", 2.0},
+		{"f16", "f16", 2.0},
+		{"f32", "f32", 4.0},
+		{"q8_0", "q8_0", 1.0625},
+		{"q5_0", "q5_0", 0.6875},
+		{"q5_1", "q5_1", 0.75},
+		{"q4_0", "q4_0", 0.5625},
+		{"iq4_nl", "iq4_nl", 0.5625},
+		{"q4_1", "q4_1", 0.625},
+		{"turbo3", "turbo3", 0.40625},
+		{"turbo4", "turbo4", 0.53125},
+		{"unknown falls back to f16", "unknown-type", 2.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cacheTypeBytesPerElement(tt.cacheType)
+			if got != tt.expected {
+				t.Errorf("cacheTypeBytesPerElement(%q) = %f, want %f", tt.cacheType, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Add table-driven unit tests for two previously under-covered pure functions in `pkg/agent`: `cacheTypeBytesPerElement` and `statusClass`.

## Why

Incremental unit-test coverage on critical pure functions, per the coverage push.

Fixes #89

## How

- `cacheTypeBytesPerElement` (was 54.5% covered): 12 cases covering all known cache types (f16, f32, q8_0, q5_0, q5_1, q4_0, iq4_nl, q4_1, turbo3, turbo4) plus the empty-string default and unknown-type fallback.
- `statusClass` (was 33.3% covered): 13 cases covering all HTTP status-code ranges (1xx-5xx) with boundary values.

Generated autonomously by the Foreman coder (M5 Max, local Qwopus); verified through the fast in-workspace gate plus the clean-room bite check (the new tests fail against pre-change production where applicable).

## Checklist

- [x] Tests added/updated
- [ ] `make test` passes locally
- [ ] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (if user-facing change)
