### PR TITLE
docs: add AI-assisted contribution policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,5 @@ Fixes #
 - [ ] `make lint` passes locally
 - [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
 - [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
+- [ ] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
 - [ ] Documentation updated (if user-facing change)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,9 +90,14 @@ changelogs and version bumps. Every commit needs one:
 
 Use `feat!:` / `fix!:` for breaking changes.
 
-- Sign off every commit: `git commit -s` (DCO is enforced by CI).
+- Sign off every commit: `git commit -s`. A human is accountable for every
+  commit, however it was produced (DCO is enforced by CI; bot-only sign-offs
+  are not accepted).
 - Subject says *what* changed; body says *why*. No implementation play-by-play.
-- Do not add `Co-Authored-By` trailers or AI/tool attribution to commit messages.
+- Keep commit messages free of attribution trailers (`Co-Authored-By`,
+  `AI-Agent`, `Assisted-by`, etc.). Disclose AI assistance in the PR
+  description instead, per [CONTRIBUTING.md](CONTRIBUTING.md) ("AI-Assisted and
+  Agent Contributions").
 - One logical change per commit.
 
 ## Branches and pull requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing to LLMKube! This project aims to mak
 - [How Can I Contribute?](#how-can-i-contribute)
 - [Development Setup](#development-setup)
 - [Making Changes](#making-changes)
+- [AI-Assisted and Agent Contributions](#ai-assisted-and-agent-contributions)
 - [Pull Request Process](#pull-request-process)
 - [Coding Standards](#coding-standards)
 - [Community](#community)
@@ -257,6 +258,52 @@ make fmt
 make vet
 make test
 ```
+
+## AI-Assisted and Agent Contributions
+
+LLMKube is built by people who use AI coding agents heavily: our own Foreman
+harness opens PRs against this project. So we welcome AI-assisted
+contributions. We hold them to one standard, the same one we hold our own
+agent to: human accountability, not where the code came from.
+
+If any part of your contribution (code, tests, commit messages, PR text) was
+generated or substantially assisted by an AI tool, the following apply.
+
+**A human is accountable.**
+
+- A human signs off every commit with the DCO (`git commit -s`). The sign-off
+  means a person takes responsibility for understanding, testing, and
+  maintaining the change, however it was produced. Bot-only sign-offs are not
+  accepted.
+- A human, not an agent, owns the review conversation. Replies to review
+  feedback come from you, not from an autonomous agent posting on your behalf.
+
+**Disclose the assistance.**
+
+- State in the PR description which tool was used, what it generated, and what
+  you verified before submitting. One line is enough, for example:
+  `Assisted-by: <tool> (generated the tests; I reviewed and ran make test)`.
+- Put the disclosure in the PR body, not the commit message. We keep commit
+  messages free of attribution trailers (see `AGENTS.md`).
+
+**Same bar as any other PR.**
+
+- Tests must exercise real behavior. A test that still passes when the code
+  under test is broken is not coverage.
+- The change must match the scope of the issue it claims to fix: no unrelated
+  edits, no placeholder or fabricated content.
+- Run the gate locally first: `make test`, `make lint`.
+
+**Unsolicited and drive-by PRs.**
+
+- We may close unsolicited AI-generated PRs that were not preceded by an issue
+  or discussion, especially low-effort ones targeting `good-first-issue`
+  labels. To work an issue, comment on it first so a human can confirm it is a
+  good fit and not already in progress.
+
+This is not an anti-AI policy. It is a "stand behind your work" policy. We
+dogfood agentic contribution daily; we just require that a person stay in the
+loop and on the hook.
 
 ## Pull Request Process
 


### PR DESCRIPTION
## What

Add an explicit policy for AI-assisted and agent-submitted contributions:

- `CONTRIBUTING.md`: new "AI-Assisted and Agent Contributions" section.
- `AGENTS.md`: reconcile the commit-attribution rule with the new disclosure expectation.
- `.github/PULL_REQUEST_TEMPLATE.md`: a checklist item to disclose AI assistance.

## Why

Agentic coding has removed the effort backpressure that used to limit low-quality PRs, and projects across OSS are now setting explicit policies (disclosure, human accountability, or outright bans). We dogfood agentic contribution ourselves (Foreman opens PRs against this repo), so a ban would be off-thesis. The stance here is permissive but accountability-first: a human must stand behind the work, AI use is disclosed, and the same quality bar applies. This was prompted by a recent autonomous-agent PR (#871) that disclosed its origin (good) but had no human DCO sign-off and shipped a non-biting test.

## How

- The policy centers on human accountability rather than provenance: a human DCO-signs every commit and owns the review thread; the agent does not post on the contributor's behalf.
- Disclosure lives in the PR description, not the commit. This reconciles the previously flat "no AI attribution in commits" rule in `AGENTS.md` (commits stay clean; disclosure has a home).
- The same gate applies: tests must exercise real behavior, scope must match the issue, unsolicited drive-by PRs may be closed.

## Checklist

- [ ] Tests added/updated (N/A: docs only)
- [ ] `make test` passes locally
- [ ] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)
