### PR TITLE
feat(foreman): deterministically resolve codegen drift in the coder gate

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -135,12 +136,14 @@ func RunCoderGate(
 		}
 	}
 
-	// 6. Codegen-drift check: regenerate manifests/CRDs and fail if the
-	// tree is dirty. This catches changes to API types, kubebuilder
-	// markers, or field doc comments that alter generated CRDs or
-	// role.yaml before they reach CI (#775). Skipped gracefully if
-	// controller-gen is unavailable.
-	if drifted, out := checkCodegenDrift(ctx, workspace, run); drifted {
+	// 6. Codegen drift: regenerate manifests/CRDs/deepcopy and deterministically
+	// resolve any drift confined to generated artifacts, rather than failing the
+	// coder on a mechanical step it was already told to run (#851). Regenerated
+	// generated files are left in the workspace and committed by the executor's
+	// `git add -A` (repo.Commit). Only a make error, or regeneration touching a
+	// NON-generated file, is reported as a failure. Skipped gracefully if
+	// controller-gen is unavailable. (Originally a hard drift check, #775.)
+	if failed, out := resolveCodegenDrift(ctx, workspace, run); failed {
 		failures = append(failures, checkFailure{name: "codegen drift", output: out})
 	}
 
@@ -237,34 +240,117 @@ func isEnvtestPackage(pkg string) bool {
 	return false
 }
 
-// checkCodegenDrift regenerates manifests and CRDs, then checks whether
-// the workspace tree is dirty. It returns (drifted, output) where output
-// lists the drifted files. Skipped (returns false, "") if
+// resolveCodegenDrift runs the full code-generation set and deterministically
+// resolves codegen drift instead of asking the model to (#851). It regenerates
+// manifests, deepcopy, and the Helm chart CRDs; any resulting changes confined
+// to generated artifacts are left in the workspace for the executor's
+// `git add -A` commit to absorb, so an API change lands with its generated
+// files in sync without burning gate-fix attempts on a mechanical step.
+//
+// It returns (failed, output). failed is true only when `make` itself errors,
+// or when regeneration changed a NON-generated file (an anomaly worth
+// surfacing, e.g. a hand-edit to a generated file or a generator that rewrote
+// source). Drift confined to generated artifacts returns (false, "").
+//
+// To distinguish what regeneration changed from the coder's own uncommitted
+// edits, it snapshots the dirty set before and after `make`: only paths newly
+// dirtied by `make` are evaluated. Skipped (returns false, "") if
 // bin/controller-gen is not present in the workspace.
-func checkCodegenDrift(ctx context.Context, workspace string, run commandRunner) (drifted bool, output string) {
+func resolveCodegenDrift(ctx context.Context, workspace string, run commandRunner) (failed bool, output string) {
 	controllerGen := filepath.Join(workspace, "bin", "controller-gen")
 	if _, err := run(ctx, workspace, nil, "test", "-f", controllerGen); err != nil {
 		// controller-gen not available; skip gracefully.
 		return false, ""
 	}
 
-	// Regenerate manifests, CRDs, and sync to Helm charts.
-	if out, err := run(ctx, workspace, nil, "make", "manifests", "chart-crds", "foreman-chart-crds"); err != nil {
-		// If make itself fails, report it as a drift failure.
-		return true, "make manifests chart-crds foreman-chart-crds failed:\n" + out
+	before := dirtyPathSet(ctx, workspace, run)
+
+	// Regenerate manifests, deepcopy, and sync CRDs to both Helm charts. The
+	// foreman CRDs need the separate foreman-chart-crds target; `generate`
+	// (deepcopy) is included so an API change that only alters zz_generated
+	// does not slip through to CI.
+	out, err := run(ctx, workspace, nil,
+		"make", "manifests", "generate", "chart-crds", "foreman-chart-crds")
+	if err != nil {
+		return true, "make manifests generate chart-crds foreman-chart-crds failed:\n" + out
 	}
 
-	// Check whether the tree is dirty after regeneration.
-	if _, err := run(ctx, workspace, nil, "git", "diff", "--quiet"); err == nil {
-		return false, ""
+	after := dirtyPathSet(ctx, workspace, run)
+
+	// Files newly dirtied by regeneration (not part of the coder's own edits).
+	var unexpected []string
+	for path := range after {
+		if before[path] {
+			continue
+		}
+		if !isGeneratedArtifact(path) {
+			unexpected = append(unexpected, path)
+		}
 	}
 
-	// Tree is dirty; collect the list of drifted files.
-	out, _ := run(ctx, workspace, nil, "git", "diff", "--name-only")
-	msg := "Generated files drifted after regeneration. " +
-		"Run 'make manifests chart-crds foreman-chart-crds' and commit the changes.\n\n" +
-		"Drifted files:\n"
-	return true, msg + out
+	if len(unexpected) > 0 {
+		sort.Strings(unexpected)
+		msg := "Regeneration changed files that are not generated artifacts. This usually " +
+			"means a generated file was hand-edited, or a source change needs review. " +
+			"Inspect and resolve these, then resubmit:\n\n" +
+			strings.Join(unexpected, "\n") + "\n"
+		return true, msg
+	}
+
+	// Any drift was confined to generated artifacts: regenerated files stay in
+	// the workspace and are committed by the executor's `git add -A`. Nothing
+	// for the model to do.
+	return false, ""
+}
+
+// dirtyPathSet returns the set of workspace-relative paths reported dirty by
+// `git status --porcelain` (modified, untracked, or staged). Rename entries
+// ("orig -> new") resolve to the new path. A git error yields an empty set so
+// the caller degrades to "no drift detected" rather than failing spuriously.
+func dirtyPathSet(ctx context.Context, workspace string, run commandRunner) map[string]bool {
+	out, err := run(ctx, workspace, nil, "git", "status", "--porcelain")
+	if err != nil {
+		return map[string]bool{}
+	}
+	set := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		// porcelain v1 lines are "XY <path>": 2 status chars + a space, then
+		// the path. Shorter lines (e.g. a trailing empty line) are skipped.
+		if len(line) < 4 {
+			continue
+		}
+		path := line[3:]
+		if i := strings.Index(path, " -> "); i >= 0 {
+			path = path[i+len(" -> "):]
+		}
+		if path = strings.TrimSpace(path); path != "" {
+			set[path] = true
+		}
+	}
+	return set
+}
+
+// isGeneratedArtifact reports whether a workspace-relative path is a
+// code-generation output produced by `make manifests generate chart-crds
+// foreman-chart-crds` (controller-gen CRDs/RBAC, deepcopy, and the synced Helm
+// chart CRDs). The allowlist is deliberately tight so that regeneration
+// touching anything outside it is surfaced rather than silently absorbed.
+func isGeneratedArtifact(path string) bool {
+	switch {
+	case strings.HasPrefix(path, "config/crd/"):
+		return true
+	case path == "config/rbac/role.yaml":
+		return true
+	case strings.HasPrefix(path, "config/webhook/"):
+		return true
+	case strings.HasPrefix(path, "charts/llmkube/templates/crds/"):
+		return true
+	case strings.HasPrefix(path, "charts/foreman/templates/crds/"):
+		return true
+	case strings.Contains(path, "zz_generated."):
+		return true
+	}
+	return false
 }
 
 // buildFeedback renders the directive and a per-check section for every

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -320,69 +320,120 @@ func TestRunCoderGateTruncation(t *testing.T) {
 	}
 }
 
-// TestRunCoderGate_CodegenDrift_FailsWhenDrifted verifies the gate fails
-// when regenerated manifests/CRDs differ from the committed tree (#775).
-func TestRunCoderGate_CodegenDrift_FailsWhenDrifted(t *testing.T) {
-	const golangciPath = "./bin/golangci-lint"
-	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+// codegenFake builds a commandRunner for the codegen-drift tier. All of the
+// other gate checks (gofmt/vet/build/lint, test tier) pass. controller-gen is
+// present unless noControllerGen is set. The two `git status --porcelain`
+// calls (the before/after snapshots around make) return porcelainBefore then
+// porcelainAfter; make returns makeErr.
+// gateLintPath is the golangci-lint path the codegen gate tests pass to
+// RunCoderGate and that codegenFake matches as a passing lint invocation.
+const gateLintPath = "./bin/golangci-lint"
+
+func codegenFake(
+	porcelainBefore, porcelainAfter string,
+	makeErr error,
+	noControllerGen bool,
+) commandRunner {
+	porcelainCalls := 0
+	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
 		switch {
-		case name == "gofmt":
+		case name == "gofmt", name == "go", name == gateLintPath:
 			return "", nil
-		case name == "go":
-			return "", nil
-		case name == golangciPath:
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "status":
-			return "", nil // no changed packages for test tier
 		case name == "test" && len(args) > 0 && args[0] == "-f":
+			if noControllerGen {
+				return "", errors.New("exit status 1")
+			}
 			return "", nil // controller-gen exists
 		case name == "make":
-			return "", nil // make manifests chart-crds foreman-chart-crds succeeds
-		case name == "git" && len(args) > 0 && args[0] == "diff":
-			if len(args) > 1 && args[1] == "--quiet" {
-				return "", errors.New("exit status 1") // tree is dirty
+			if makeErr != nil {
+				return "Error: controller-gen: exit status 1\n", makeErr
 			}
-			return "config/crd/bases/inference.llmkube.dev_models.yaml\nrole.yaml\n", nil
+			return "", nil
+		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "-z":
+			return "", nil // changedTestPackages: no changed packages
+		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain":
+			porcelainCalls++
+			if porcelainCalls == 1 {
+				return porcelainBefore, nil
+			}
+			return porcelainAfter, nil
 		default:
 			return "", nil
 		}
 	}
+}
+
+// TestRunCoderGate_Codegen_AutoResolvesGeneratedDrift verifies the gate passes
+// (deterministic resolution, #851) when regeneration only dirties generated
+// artifacts: the executor's `git add -A` commits them, so the coder is not
+// asked to re-run a mechanical step.
+func TestRunCoderGate_Codegen_AutoResolvesGeneratedDrift(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	after := " M config/crd/bases/foreman.llmkube.dev_agentictasks.yaml\n" +
+		" M charts/foreman/templates/crds/agentictasks.yaml\n" +
+		" M api/foreman/v1alpha1/zz_generated.deepcopy.go\n"
+	run := codegenFake("", after, nil, false)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	if !pass {
+		t.Fatalf("gate should auto-resolve generated-only drift; feedback:\n%s", feedback)
+	}
+	if feedback != "" {
+		t.Errorf("expected empty feedback on auto-resolve, got %q", feedback)
+	}
+}
+
+// TestRunCoderGate_Codegen_IgnoresCoderEdits is the #851/#813 case: the coder
+// changed an API type (and other source) but did not run the full codegen
+// sync. The coder's own edits are present before make; regeneration adds the
+// missing foreman chart CRD + deepcopy. Only make-induced drift is evaluated,
+// it is all generated, so the gate passes instead of failing on the
+// mechanical step.
+func TestRunCoderGate_Codegen_IgnoresCoderEdits(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	before := " M api/foreman/v1alpha1/agentictask_types.go\n" +
+		" M pkg/foreman/agent/executor_native.go\n"
+	after := before +
+		" M charts/foreman/templates/crds/agentictasks.yaml\n" +
+		" M api/foreman/v1alpha1/zz_generated.deepcopy.go\n"
+	run := codegenFake(before, after, nil, false)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	if !pass {
+		t.Fatalf("gate should ignore the coder's own edits and resolve generated drift; feedback:\n%s", feedback)
+	}
+	if feedback != "" {
+		t.Errorf("expected empty feedback, got %q", feedback)
+	}
+}
+
+// TestRunCoderGate_Codegen_FailsWhenRegenTouchesNonGenerated verifies the gate
+// still fails when regeneration changes a file that is NOT a generated
+// artifact (an anomaly: a hand-edited generated file or a generator rewriting
+// source), and surfaces that file.
+func TestRunCoderGate_Codegen_FailsWhenRegenTouchesNonGenerated(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	after := " M charts/foreman/templates/crds/agentictasks.yaml\n" +
+		" M internal/controller/inferenceservice_controller.go\n"
+	run := codegenFake("", after, nil, false)
 	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 	if pass {
-		t.Fatal("gate should fail when codegen drift is detected")
+		t.Fatal("gate should fail when regeneration touches a non-generated file")
 	}
 	if !strings.Contains(feedback, "codegen drift") {
 		t.Errorf("feedback should cite codegen drift; got:\n%s", feedback)
 	}
-	if !strings.Contains(feedback, "config/crd/bases/inference.llmkube.dev_models.yaml") {
-		t.Errorf("feedback should list drifted CRD file; got:\n%s", feedback)
+	if !strings.Contains(feedback, "internal/controller/inferenceservice_controller.go") {
+		t.Errorf("feedback should list the non-generated file; got:\n%s", feedback)
+	}
+	if strings.Contains(feedback, "charts/foreman/templates/crds/agentictasks.yaml") {
+		t.Errorf("feedback should not list generated artifacts; got:\n%s", feedback)
 	}
 }
 
-// TestRunCoderGate_CodegenDrift_PassesWhenClean verifies the gate passes
-// when regenerated manifests/CRDs match the committed tree (#775).
-func TestRunCoderGate_CodegenDrift_PassesWhenClean(t *testing.T) {
+// TestRunCoderGate_Codegen_PassesWhenClean verifies the gate passes when
+// regeneration produces no new drift.
+func TestRunCoderGate_Codegen_PassesWhenClean(t *testing.T) {
 	const golangciPath = "./bin/golangci-lint"
-	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
-		switch {
-		case name == "gofmt":
-			return "", nil
-		case name == "go":
-			return "", nil
-		case name == golangciPath:
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "status":
-			return "", nil // no changed packages for test tier
-		case name == "test" && len(args) > 0 && args[0] == "-f":
-			return "", nil // controller-gen exists
-		case name == "make":
-			return "", nil // make manifests chart-crds foreman-chart-crds succeeds
-		case name == "git" && len(args) > 0 && args[0] == "diff":
-			return "", nil // tree is clean
-		default:
-			return "", nil
-		}
-	}
+	run := codegenFake("", "", nil, false)
 	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 	if !pass {
 		t.Fatalf("gate should pass when codegen is clean; feedback:\n%s", feedback)
@@ -392,27 +443,11 @@ func TestRunCoderGate_CodegenDrift_PassesWhenClean(t *testing.T) {
 	}
 }
 
-// TestRunCoderGate_CodegenDrift_SkippedWhenNoControllerGen verifies the
-// codegen-drift check is skipped gracefully when controller-gen is not
-// available in the workspace (#775).
-func TestRunCoderGate_CodegenDrift_SkippedWhenNoControllerGen(t *testing.T) {
+// TestRunCoderGate_Codegen_SkippedWhenNoControllerGen verifies the codegen
+// tier is skipped gracefully when controller-gen is not available.
+func TestRunCoderGate_Codegen_SkippedWhenNoControllerGen(t *testing.T) {
 	const golangciPath = "./bin/golangci-lint"
-	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
-		switch {
-		case name == "gofmt":
-			return "", nil
-		case name == "go":
-			return "", nil
-		case name == golangciPath:
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "status":
-			return "", nil // no changed packages for test tier
-		case name == "test" && len(args) > 0 && args[0] == "-f":
-			return "", errors.New("exit status 1") // controller-gen not found
-		default:
-			return "", nil
-		}
-	}
+	run := codegenFake("", "", nil, true)
 	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 	if !pass {
 		t.Fatalf("gate should pass when controller-gen is unavailable; feedback:\n%s", feedback)
@@ -422,34 +457,79 @@ func TestRunCoderGate_CodegenDrift_SkippedWhenNoControllerGen(t *testing.T) {
 	}
 }
 
-// TestRunCoderGate_CodegenDrift_FailsWhenMakeFails verifies the gate fails
-// when make manifests chart-crds foreman-chart-crds itself errors (#775).
-func TestRunCoderGate_CodegenDrift_FailsWhenMakeFails(t *testing.T) {
+// TestRunCoderGate_Codegen_FailsWhenMakeFails verifies the gate fails when the
+// regeneration make target itself errors.
+func TestRunCoderGate_Codegen_FailsWhenMakeFails(t *testing.T) {
 	const golangciPath = "./bin/golangci-lint"
-	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
-		switch {
-		case name == "gofmt":
-			return "", nil
-		case name == "go":
-			return "", nil
-		case name == golangciPath:
-			return "", nil
-		case name == "git" && len(args) > 0 && args[0] == "status":
-			return "", nil // no changed packages for test tier
-		case name == "test" && len(args) > 0 && args[0] == "-f":
-			return "", nil // controller-gen exists
-		case name == "make":
-			return "Error: controller-gen: exit status 1\n", errors.New("exit status 2")
-		default:
-			return "", nil
-		}
-	}
+	run := codegenFake("", "", errors.New("exit status 2"), false)
 	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
 	if pass {
-		t.Fatal("gate should fail when make manifests fails")
+		t.Fatal("gate should fail when the regeneration make target fails")
 	}
 	if !strings.Contains(feedback, "codegen drift") {
 		t.Errorf("feedback should cite codegen drift; got:\n%s", feedback)
+	}
+}
+
+func TestIsGeneratedArtifact(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"config/crd/bases/foreman.llmkube.dev_agentictasks.yaml", true},
+		{"config/rbac/role.yaml", true},
+		{"config/webhook/manifests.yaml", true},
+		{"charts/llmkube/templates/crds/inferenceservices.yaml", true},
+		{"charts/foreman/templates/crds/agentictasks.yaml", true},
+		{"api/foreman/v1alpha1/zz_generated.deepcopy.go", true},
+		{"api/v1alpha1/inferenceservice_types.go", false},
+		{"pkg/foreman/agent/executor_native.go", false},
+		{"config/rbac/kustomization.yaml", false},
+		{"charts/foreman/templates/operator-rbac.yaml", false},
+		{"internal/controller/model_controller.go", false},
+	}
+	for _, tc := range cases {
+		if got := isGeneratedArtifact(tc.path); got != tc.want {
+			t.Errorf("isGeneratedArtifact(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestDirtyPathSet(t *testing.T) {
+	const porcelain = " M api/foreman/v1alpha1/agentictask_types.go\n" +
+		"?? charts/foreman/templates/crds/agentictasks.yaml\n" +
+		"R  old/path.go -> pkg/foreman/agent/renamed.go\n" +
+		"\n"
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain" {
+			return porcelain, nil
+		}
+		return "", nil
+	}
+	got := dirtyPathSet(context.Background(), "/work", run)
+	want := []string{
+		"api/foreman/v1alpha1/agentictask_types.go",
+		"charts/foreman/templates/crds/agentictasks.yaml",
+		"pkg/foreman/agent/renamed.go",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("dirtyPathSet returned %d paths, want %d: %v", len(got), len(want), got)
+	}
+	for _, p := range want {
+		if !got[p] {
+			t.Errorf("dirtyPathSet missing %q; got %v", p, got)
+		}
+	}
+}
+
+// TestDirtyPathSet_GitErrorYieldsEmpty verifies a git error degrades to an
+// empty set so the codegen tier does not fail spuriously.
+func TestDirtyPathSet_GitErrorYieldsEmpty(t *testing.T) {
+	run := func(_ context.Context, _ string, _ []string, _ string, _ ...string) (string, error) {
+		return "", errors.New("not a git repo")
+	}
+	if got := dirtyPathSet(context.Background(), "/work", run); len(got) != 0 {
+		t.Errorf("expected empty set on git error, got %v", got)
 	}
 }
 


### PR DESCRIPTION
## What

Make the fast coder gate **deterministically resolve codegen drift** instead of failing the coder on a mechanical regeneration step. Rewrites the gate's codegen tier (`pkg/foreman/agent/coder_gate.go`).

## Why

Fixes #851. Capable coders kept reaching the verify gate with regenerated CRDs/deepcopy out of sync and burning all gate-fix attempts (often INCOMPLETE) on a purely mechanical step they were already instructed to run. Observed on the #813 entrance exam: a 35B coder converged through build, lint, and tests but its final blocker across 3 gate-fix attempts was codegen drift (`charts/foreman/templates/crds/*` + `config/crd/bases/*` not fully synced). The gate correctly detected it, but detection-only turns a mechanical step into a model-judgment gamble.

## How

The codegen tier (`resolveCodegenDrift`):

- Runs the **full** codegen set: `make manifests generate chart-crds foreman-chart-crds`. `generate` (deepcopy) was previously missing, so an API change that only altered `zz_generated.*` would slip past the fast gate to CI.
- **Isolates** what regeneration changed from the coder's own uncommitted edits by snapshotting the dirty set (`git status --porcelain`) before and after `make`. Only newly-dirtied paths are evaluated, so the coder's source edits do not confound the check.
- **Auto-resolves** drift confined to generated artifacts (`config/crd/`, `config/rbac/role.yaml`, `config/webhook/`, `charts/{llmkube,foreman}/templates/crds/`, `zz_generated.*`): the regenerated files are left in the workspace and committed by the executor's existing `git add -A` (`repo.Commit`), so the API change lands with its generated files in sync. No model action required.
- **Still fails** when `make` itself errors, or when regeneration touches a NON-generated file (an anomaly: a hand-edited generated file or a generator rewriting source), surfacing the specific files.

The allowlist (`isGeneratedArtifact`) is deliberately tight so anything outside it is surfaced rather than silently absorbed.

## Checklist

- [x] Tests added/updated (auto-resolve, coder-edit isolation, non-generated anomaly, make-error, clean, skip-when-no-controller-gen; plus unit tests for `isGeneratedArtifact` and `dirtyPathSet`)
- [x] `make test` passes locally (`pkg/foreman/agent`)
- [x] `make lint` passes locally (incl. `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (no user-facing change; internal harness behavior)
