### PR TITLE
feat(foreman): scope-overlap guard catches wrong-subsystem coder drift

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -18,10 +18,13 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/repomap"
 )
 
 // envtestPackagePrefixes are workspace-relative package path prefixes whose
@@ -81,18 +84,21 @@ type checkFailure struct {
 // it names the failing check(s) and includes their output so the model
 // can fix the issue and resubmit. golangciPath is the path to the
 // golangci-lint binary (e.g. "./bin/golangci-lint"). run is the command
-// runner (production callers pass execCommandRunner).
+// runner (production callers pass execCommandRunner). issueText is the
+// query the scope-overlap check ranks files against; an empty string
+// disables that check (backward compatible).
 //
-// The gate runs six deterministic checks in order: gofmt, go vet,
+// The gate runs seven deterministic checks in order: gofmt, go vet,
 // go build, golangci-lint, a fast unit-test tier on changed packages,
-// and a codegen-drift check. Heavy envtest or integration tests are
-// intentionally out of scope; they run in a separate post-push gate Job.
-// All checks run regardless of earlier failures so the feedback reports
-// everything wrong at once.
+// a codegen-drift check, and a scope-overlap check. Heavy envtest or
+// integration tests are intentionally out of scope; they run in a separate
+// post-push gate Job. All checks run regardless of earlier failures so the
+// feedback reports everything wrong at once.
 func RunCoderGate(
 	ctx context.Context,
 	workspace, golangciPath string,
 	run commandRunner,
+	issueText string,
 ) (pass bool, feedback string) {
 	var failures []checkFailure
 
@@ -145,6 +151,17 @@ func RunCoderGate(
 	// controller-gen is unavailable. (Originally a hard drift check, #775.)
 	if failed, out := resolveCodegenDrift(ctx, workspace, run); failed {
 		failures = append(failures, checkFailure{name: "codegen drift", output: out})
+	}
+
+	// 7. Scope-overlap check: flag a coder whose changed Go files have zero
+	// overlap with the files the issue implies are relevant, which catches a
+	// drift to an unrelated subsystem that every other check happily
+	// green-lights (e.g. refactoring pkg/cli/cache.go for a pkg/agent issue).
+	// Conservative by design: it only judges non-test Go changes, only fires
+	// on near-zero overlap, and stays silent when the issue gives no Go signal
+	// (#782).
+	if drift, out := checkScopeOverlap(ctx, workspace, run, issueText); drift {
+		failures = append(failures, checkFailure{name: "scope overlap", output: out})
 	}
 
 	if len(failures) == 0 {
@@ -375,4 +392,100 @@ func truncateOutput(output string) string {
 		return output
 	}
 	return "...(truncated)...\n" + output[len(output)-maxCheckOutputBytes:]
+}
+
+// scopeRelevantTopK bounds how many of the highest-scored files count as
+// "relevant" for the scope-overlap check. Generous on purpose: a larger set
+// means the check only fires on a clear drift (a change touching none of the
+// most-relevant files), keeping false positives low as #782 asks.
+const scopeRelevantTopK = 50
+
+// maxRelevantShown caps how many relevant files the scope feedback lists.
+const maxRelevantShown = 10
+
+// scopeRelevantFiles returns the workspace's Go files most relevant to
+// issueText: up to scopeRelevantTopK files with a positive relevance score
+// (the repomap scorer ranks descending, so a non-positive score ends the
+// set), as both an ordered slice and a membership set. Injectable so tests
+// can supply a canned relevant set without walking the real filesystem.
+var scopeRelevantFiles = func(workspace, issueText string) (paths []string, set map[string]bool) {
+	files, err := repomap.Walk(workspace, nil)
+	if err != nil {
+		return nil, nil
+	}
+	scored := repomap.ScoreFiles(files, issueText)
+	set = make(map[string]bool)
+	for _, sf := range scored {
+		if sf.Score <= 0 || len(paths) >= scopeRelevantTopK {
+			break
+		}
+		paths = append(paths, sf.Path)
+		set[sf.Path] = true
+	}
+	return paths, set
+}
+
+// checkScopeOverlap reports whether the coder's diff drifted to an unrelated
+// subsystem: its changed non-test Go files have zero overlap with the files
+// the issue implies are relevant. It returns (drift, feedback).
+//
+// It is deliberately conservative to avoid false positives (#782):
+//   - issueText empty -> skip (no signal).
+//   - no non-test Go files changed -> skip (a yaml/docs-only change is not
+//     judged by the Go-aware repomap).
+//   - the issue produces no positively-scored Go files -> skip (no Go signal
+//     to compare against).
+//   - any changed Go file is in the top-K relevant set -> in scope, pass.
+//
+// Only when there is a real Go signal AND the changed Go files miss it
+// entirely is the submit flagged, with feedback naming what changed vs. what
+// the issue points at.
+func checkScopeOverlap(
+	ctx context.Context, workspace string, run commandRunner, issueText string,
+) (drift bool, feedback string) {
+	if strings.TrimSpace(issueText) == "" {
+		return false, ""
+	}
+
+	var changedGo []string
+	for path := range dirtyPathSet(ctx, workspace, run) {
+		if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+			changedGo = append(changedGo, path)
+		}
+	}
+	if len(changedGo) == 0 {
+		return false, ""
+	}
+
+	relevantPaths, relevantSet := scopeRelevantFiles(workspace, issueText)
+	if len(relevantSet) == 0 {
+		return false, ""
+	}
+	for _, p := range changedGo {
+		if relevantSet[p] {
+			return false, ""
+		}
+	}
+
+	sort.Strings(changedGo)
+	var b strings.Builder
+	b.WriteString("Your changed Go files do not overlap with any of the files this issue points at. ")
+	b.WriteString("This usually means the change drifted to the wrong subsystem. ")
+	b.WriteString("Re-read the issue and edit the relevant files, or explain why these are correct.\n\n")
+	b.WriteString("Changed (non-test) Go files:\n")
+	for _, c := range changedGo {
+		b.WriteString("  - " + c + "\n")
+	}
+	b.WriteString("\nFiles most relevant to the issue:\n")
+	shown := relevantPaths
+	if len(shown) > maxRelevantShown {
+		shown = shown[:maxRelevantShown]
+	}
+	for _, r := range shown {
+		b.WriteString("  - " + r + "\n")
+	}
+	if len(relevantPaths) > len(shown) {
+		b.WriteString(fmt.Sprintf("  ... and %d more\n", len(relevantPaths)-len(shown)))
+	}
+	return true, b.String()
 }

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -112,7 +112,7 @@ func TestRunCoderGate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			run, _ := newFakeRunner(tt.responses)
-			pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+			pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 
 			if pass != tt.wantPass {
 				t.Fatalf("pass = %v, want %v (feedback: %q)", pass, tt.wantPass, feedback)
@@ -144,7 +144,7 @@ func TestRunCoderGateLintEnv(t *testing.T) {
 		golangciPath: {},
 	})
 
-	RunCoderGate(context.Background(), "/work", golangciPath, run)
+	RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 
 	var lintCall *recordedCall
 	for i := range *calls {
@@ -192,7 +192,7 @@ func TestRunCoderGateLintCacheScopedToWorkspace(t *testing.T) {
 		golangciPath: {},
 	})
 
-	RunCoderGate(context.Background(), "/work", golangciPath, run)
+	RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 
 	var lintCall *recordedCall
 	for i := range *calls {
@@ -266,7 +266,7 @@ func TestRunCoderGate_FailsOnChangedPackageUnitTest(t *testing.T) {
 			return "", nil // golangci-lint
 		}
 	}
-	pass, feedback := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run, "")
 	if pass {
 		t.Fatal("gate should fail when a changed package's unit test fails")
 	}
@@ -285,7 +285,7 @@ func TestRunCoderGate_SkipsTestTierWhenNoChangedPackages(t *testing.T) {
 		}
 		return "", nil // git status empty, all checks clean
 	}
-	if pass, _ := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run); !pass {
+	if pass, _ := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run, ""); !pass {
 		t.Fatal("gate should pass when all checks are clean and nothing changed")
 	}
 	if sawGoTest {
@@ -303,7 +303,7 @@ func TestRunCoderGateTruncation(t *testing.T) {
 		golangciPath: {output: huge, err: errors.New("boom")},
 	})
 
-	_, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	_, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 
 	if !strings.Contains(feedback, "...(truncated)...") {
 		t.Error("expected truncation marker in feedback")
@@ -373,7 +373,7 @@ func TestRunCoderGate_Codegen_AutoResolvesGeneratedDrift(t *testing.T) {
 		" M charts/foreman/templates/crds/agentictasks.yaml\n" +
 		" M api/foreman/v1alpha1/zz_generated.deepcopy.go\n"
 	run := codegenFake("", after, nil, false)
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 	if !pass {
 		t.Fatalf("gate should auto-resolve generated-only drift; feedback:\n%s", feedback)
 	}
@@ -396,7 +396,7 @@ func TestRunCoderGate_Codegen_IgnoresCoderEdits(t *testing.T) {
 		" M charts/foreman/templates/crds/agentictasks.yaml\n" +
 		" M api/foreman/v1alpha1/zz_generated.deepcopy.go\n"
 	run := codegenFake(before, after, nil, false)
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 	if !pass {
 		t.Fatalf("gate should ignore the coder's own edits and resolve generated drift; feedback:\n%s", feedback)
 	}
@@ -414,7 +414,7 @@ func TestRunCoderGate_Codegen_FailsWhenRegenTouchesNonGenerated(t *testing.T) {
 	after := " M charts/foreman/templates/crds/agentictasks.yaml\n" +
 		" M internal/controller/inferenceservice_controller.go\n"
 	run := codegenFake("", after, nil, false)
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 	if pass {
 		t.Fatal("gate should fail when regeneration touches a non-generated file")
 	}
@@ -434,7 +434,7 @@ func TestRunCoderGate_Codegen_FailsWhenRegenTouchesNonGenerated(t *testing.T) {
 func TestRunCoderGate_Codegen_PassesWhenClean(t *testing.T) {
 	const golangciPath = "./bin/golangci-lint"
 	run := codegenFake("", "", nil, false)
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 	if !pass {
 		t.Fatalf("gate should pass when codegen is clean; feedback:\n%s", feedback)
 	}
@@ -448,7 +448,7 @@ func TestRunCoderGate_Codegen_PassesWhenClean(t *testing.T) {
 func TestRunCoderGate_Codegen_SkippedWhenNoControllerGen(t *testing.T) {
 	const golangciPath = "./bin/golangci-lint"
 	run := codegenFake("", "", nil, true)
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 	if !pass {
 		t.Fatalf("gate should pass when controller-gen is unavailable; feedback:\n%s", feedback)
 	}
@@ -462,7 +462,7 @@ func TestRunCoderGate_Codegen_SkippedWhenNoControllerGen(t *testing.T) {
 func TestRunCoderGate_Codegen_FailsWhenMakeFails(t *testing.T) {
 	const golangciPath = "./bin/golangci-lint"
 	run := codegenFake("", "", errors.New("exit status 2"), false)
-	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run)
+	pass, feedback := RunCoderGate(context.Background(), "/work", golangciPath, run, "")
 	if pass {
 		t.Fatal("gate should fail when the regeneration make target fails")
 	}
@@ -608,5 +608,125 @@ func TestIsEnvtestPackage(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("isEnvtestPackage(%q) = %v, want %v", tt.pkg, got, tt.want)
 		}
+	}
+}
+
+// withScopeRelevant overrides the scopeRelevantFiles seam with a canned set
+// for the duration of the test.
+func withScopeRelevant(t *testing.T, paths []string) {
+	t.Helper()
+	orig := scopeRelevantFiles
+	set := map[string]bool{}
+	for _, p := range paths {
+		set[p] = true
+	}
+	scopeRelevantFiles = func(_, _ string) ([]string, map[string]bool) { return paths, set }
+	t.Cleanup(func() { scopeRelevantFiles = orig })
+}
+
+// scopeRunner returns a commandRunner whose `git status --porcelain` reports
+// the given porcelain output; all other commands succeed silently.
+func scopeRunner(porcelain string) commandRunner {
+	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain" {
+			return porcelain, nil
+		}
+		return "", nil
+	}
+}
+
+func TestCheckScopeOverlap_DriftFlagged(t *testing.T) {
+	withScopeRelevant(t, []string{"pkg/agent/endpoint.go", "pkg/agent/health.go"})
+	run := scopeRunner(" M pkg/cli/cache.go\n")
+	drift, fb := checkScopeOverlap(context.Background(), "/work", run, "metal-agent endpoint health")
+	if !drift {
+		t.Fatal("expected drift when the changed Go file is outside the relevant set")
+	}
+	if !strings.Contains(fb, "pkg/cli/cache.go") || !strings.Contains(fb, "pkg/agent/endpoint.go") {
+		t.Errorf("feedback should name changed + relevant files; got:\n%s", fb)
+	}
+}
+
+func TestCheckScopeOverlap_InScopePasses(t *testing.T) {
+	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
+	// Touches a relevant file plus an unrelated one: any overlap is in scope.
+	run := scopeRunner(" M pkg/agent/endpoint.go\n M pkg/cli/cache.go\n")
+	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, "x"); drift {
+		t.Error("expected no drift when a changed file is in the relevant set")
+	}
+}
+
+func TestCheckScopeOverlap_SkipsNonGoOnlyChanges(t *testing.T) {
+	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
+	run := scopeRunner(" M charts/foreman/x.yaml\n M docs/readme.md\n")
+	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, "x"); drift {
+		t.Error("a yaml/docs-only change must not be flagged by the Go-aware guard")
+	}
+}
+
+func TestCheckScopeOverlap_SkipsTestOnlyChanges(t *testing.T) {
+	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
+	run := scopeRunner(" M pkg/cli/cache_test.go\n")
+	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, "x"); drift {
+		t.Error("a test-only change must not be judged")
+	}
+}
+
+func TestCheckScopeOverlap_SkipsWhenNoGoSignal(t *testing.T) {
+	withScopeRelevant(t, nil) // issue produces no positively-scored Go files
+	run := scopeRunner(" M pkg/cli/cache.go\n")
+	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, "x"); drift {
+		t.Error("no Go signal -> observe-only, no flag")
+	}
+}
+
+func TestCheckScopeOverlap_SkipsWhenIssueTextEmpty(t *testing.T) {
+	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
+	run := scopeRunner(" M pkg/cli/cache.go\n")
+	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, ""); drift {
+		t.Error("empty issueText must disable the scope check")
+	}
+}
+
+// gateRunnerAllPassExcept builds a runner where gofmt/vet/build/lint pass,
+// codegen is skipped (no controller-gen), no changed test packages, and
+// `git status --porcelain` reports porcelain (for the scope tier).
+func gateRunnerScope(golangciPath, porcelain string) commandRunner {
+	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "gofmt", name == "go", name == golangciPath:
+			return "", nil
+		case name == "test" && len(args) > 0 && args[0] == "-f":
+			return "", errors.New("no controller-gen") // skip codegen tier
+		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "-z":
+			return "", nil // no changed test packages
+		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain":
+			return porcelain, nil
+		default:
+			return "", nil
+		}
+	}
+}
+
+func TestRunCoderGate_ScopeDriftFailsTheGate(t *testing.T) {
+	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
+	const golangciPath = "./bin/golangci-lint"
+	run := gateRunnerScope(golangciPath, " M pkg/cli/cache.go\n")
+	pass, fb := RunCoderGate(context.Background(), "/work", golangciPath, run, "metal-agent endpoint")
+	if pass {
+		t.Fatal("gate should fail when the coder drifts to an unrelated subsystem")
+	}
+	if !strings.Contains(fb, "scope overlap") {
+		t.Errorf("feedback should cite scope overlap; got:\n%s", fb)
+	}
+}
+
+func TestRunCoderGate_ScopeDisabledWhenIssueTextEmpty(t *testing.T) {
+	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
+	const golangciPath = "./bin/golangci-lint"
+	run := gateRunnerScope(golangciPath, " M pkg/cli/cache.go\n")
+	pass, fb := RunCoderGate(context.Background(), "/work", golangciPath, run, "")
+	if !pass {
+		t.Fatalf("empty issueText should disable the scope check; gate should pass. feedback:\n%s", fb)
 	}
 }

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -399,8 +399,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// failed fetch logs and the loop runs with the pre-#571 behavior.
 	fetchIssueBodyIfNeeded(ctx, e.IssueFetcher, task, auth, log)
 	userPrompt := buildUserPrompt(task)
+	// issueText ranks files for both the repo-map prefix (coder Agents) and the
+	// scope-overlap guard in the coder gate verifier (#782).
+	issueText := repoMapQuery(task)
 	if agent.Spec.Role == foremanv1alpha1.AgentRoleCoder {
-		issueText := repoMapQuery(task)
 		summary, mapErr := repomap.Build(ctx, workspace, issueText, repomap.Options{})
 		switch {
 		case mapErr != nil:
@@ -450,7 +452,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// fast checks is sent back for a fix instead of landing dirty.
 	if agent.Spec.Role == foremanv1alpha1.AgentRoleCoder {
 		cfg.MaxVerifyRetries = coderGateMaxRetries
-		cfg.VerifyTerminal = makeCoderGateVerifier(workspace, log, task.Spec.GateProfile)
+		cfg.VerifyTerminal = makeCoderGateVerifier(workspace, issueText, log, task.Spec.GateProfile)
 	}
 
 	// Layer the model profile onto the resolved config (addendum + stuck-loop
@@ -649,8 +651,10 @@ const coderGateMaxRetries = 3
 // untouched. golangci-lint is bootstrapped into the workspace bin on first
 // use; a bootstrap or run error is reported as could-not-verify so the
 // terminal stands and the clean-room gate Job remains the authoritative
-// backstop.
-func makeCoderGateVerifier(workspace string, log logr.Logger, profile *foremanv1alpha1.GateProfile) TerminalVerifier {
+// backstop. issueText is passed to the gate's scope-overlap check (#782).
+func makeCoderGateVerifier(
+	workspace, issueText string, log logr.Logger, profile *foremanv1alpha1.GateProfile,
+) TerminalVerifier {
 	return func(ctx context.Context, terminal *ToolResult, _ []oai.Message) (bool, string, error) {
 		if terminal == nil {
 			return true, "", nil
@@ -677,7 +681,7 @@ func makeCoderGateVerifier(workspace string, log logr.Logger, profile *foremanv1
 				return true, "", err
 			}
 		}
-		pass, feedback := RunCoderGate(ctx, workspace, lintPath, execCommandRunner)
+		pass, feedback := RunCoderGate(ctx, workspace, lintPath, execCommandRunner, issueText)
 		if !pass {
 			log.Info("coder gate: fast checks failed; returning feedback to the loop for a fix")
 		}

--- a/pkg/foreman/agent/repomap/repomap.go
+++ b/pkg/foreman/agent/repomap/repomap.go
@@ -112,7 +112,7 @@ func Build(_ context.Context, workspace string, issueText string, opts Options) 
 		maxFiles = DefaultMaxFiles
 	}
 
-	files, err := walk(workspace, opts.SkipPatterns)
+	files, err := Walk(workspace, opts.SkipPatterns)
 	if err != nil {
 		return "", fmt.Errorf("repomap walk: %w", err)
 	}
@@ -120,7 +120,7 @@ func Build(_ context.Context, workspace string, issueText string, opts Options) 
 		return "", nil
 	}
 
-	scored := scoreFiles(files, issueText)
+	scored := ScoreFiles(files, issueText)
 	if len(scored) > maxFiles {
 		scored = scored[:maxFiles]
 	}

--- a/pkg/foreman/agent/repomap/score.go
+++ b/pkg/foreman/agent/repomap/score.go
@@ -31,7 +31,7 @@ type scoredFile struct {
 	Score float64
 }
 
-// scoreFiles assigns each file a relevance score relative to issueText.
+// ScoreFiles assigns each file a relevance score relative to issueText.
 // Files are returned sorted by score (descending). The scoring is
 // pure-Go heuristic, no model call; the empirical finding (Aider's
 // repo-map, Agentless) is that a simple bag-of-words intersection +
@@ -43,7 +43,7 @@ type scoredFile struct {
 // "what is this repo" fallback case useful for the deterministic gate
 // step's read of the repo or for a freeform task without a specific
 // issue.
-func scoreFiles(files []indexableFile, issueText string) []scoredFile {
+func ScoreFiles(files []indexableFile, issueText string) []scoredFile {
 	out := make([]scoredFile, len(files))
 	queryTokens := tokenize(issueText)
 	queryPaths := extractPathMentions(issueText)

--- a/pkg/foreman/agent/repomap/walk.go
+++ b/pkg/foreman/agent/repomap/walk.go
@@ -67,12 +67,12 @@ var defaultSkipDirs = map[string]bool{
 	"venv":         true,
 }
 
-// walk traverses workspace and returns every indexable Go file, with
+// Walk traverses workspace and returns every indexable Go file, with
 // its top-level declarations already extracted. Errors on a single
 // file (parse error, unreadable file) are logged via skipped-and-
 // counted but never abort the walk; partial coverage is more useful
 // than a hard failure mid-summary.
-func walk(workspace string, extraSkipPatterns []string) ([]indexableFile, error) {
+func Walk(workspace string, extraSkipPatterns []string) ([]indexableFile, error) {
 	var out []indexableFile
 
 	err := filepath.WalkDir(workspace, func(path string, d fs.DirEntry, walkErr error) error {


### PR DESCRIPTION
## What

Add a **scope-overlap guard** to the fast coder gate: flag a coder whose changed Go files have zero overlap with the files the issue points at, so a confidently-wrong change to the wrong subsystem is caught by the harness instead of by a human.

## Why

Fixes #782. The fast gate green-lights a well-formed change to the *wrong* subsystem, because fmt/vet/build/lint/tests all pass on code that simply isn't the requested fix. Observed twice: a coder with no clear Go target refactored `pkg/cli/cache.go` for issues about `pkg/agent` (#662) and AMD observability (#700), caught only by an ad-hoc out-of-band drift monitor that isn't part of the harness.

## How

A seventh gate check (`checkScopeOverlap`):

- Collects the coder's changed **non-test `.go`** files (reusing the #851 `dirtyPathSet`).
- Ranks the workspace's Go files against the issue text with the existing repomap scorer (`Walk`/`ScoreFiles`, now exported) and takes the top-K positively-scored files as the "relevant" set.
- Flags drift only when **no** changed Go file is in that set, returning loop feedback naming what changed vs. what the issue points at, so the coder corrects.

Conservative by design to keep false positives low (the issue asks for this):

- Only judges non-test Go changes. A yaml/docs-only change (e.g. a legit Helm/dashboard fix) is **not** judged by the Go-aware repomap, so it is never flagged.
- Only fires on near-zero overlap (touch one relevant file and you pass).
- Stays silent when the issue produces no positively-scored Go file, or when `issueText` is empty (which also keeps it off the generic-gate / non-coder paths).

Note: the prior `foreman/issue-782-scope-guard` branch computed "relevant" as *every* walked file, so overlap was nonzero for any Go change and drift was never actually flagged (and it would false-positive on yaml-only changes). This reimplements the overlap correctly against the top-K relevant set.

## Checklist

- [x] Tests added/updated (drift flagged; in-scope passes; skips for non-Go-only, test-only, no-Go-signal, and empty-issueText; full-gate integration both ways)
- [x] `make test` passes locally (`pkg/foreman/agent/...`)
- [x] `make lint` passes locally (incl. `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [ ] Documentation updated (internal harness behavior; no user-facing docs)
