### PR TITLE
docs(foreman): enable a coder-capable in-cluster agent (image in llmkube-runtimes)

### DIFF
--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -147,6 +147,11 @@ agent:
 
   image:
     # registry: ghcr.io
+    # Default: the lean runtime image (alpine + git). To run a coder-enabled
+    # in-cluster agent, point this at the coder image
+    # (ghcr.io/defilantech/llmkube-foreman-agent-coder, same tag), which ships
+    # the Go toolchain + golangci-lint/controller-gen/make/helm the coder's
+    # fast self-gate needs, and add "coder" to agent.roles below (#835).
     repository: ghcr.io/defilantech/llmkube-foreman-agent
     tag: ""
     digest: ""
@@ -169,7 +174,11 @@ agent:
   # --roles flag passed to the foreman-agent. The scheduler matches
   # AgenticTask.spec.requiredCapability.roles against this set.
   # Conventions: "worker" = "this node can run user-facing
-  # AgenticTasks"; "verifier" = "this node can host the gate Agent".
+  # AgenticTasks"; "verifier" = "this node can host the gate Agent";
+  # "coder" = "this node can run a coder loop end-to-end". Only advertise
+  # "coder" on an agent running the coder image (see agent.image above) and
+  # with coder.gitCredentialsSecret set, so its fast self-gate has the Go
+  # toolchain and it can push the branch (#835).
   roles:
     - worker
 


### PR DESCRIPTION
## What

Document how to run a **coder-capable in-cluster foreman-agent**. The coder toolchain image itself is built and maintained in **llmkube-runtimes** (see that repo's companion PR); this PR is the operator-side enablement + docs.

## Why

Part of #835. The in-cluster `foreman-agent` could claim and execute an `issue-fix` task but couldn't run a coder loop end to end: the lean runtime image (alpine + git) ships no language toolchain, so the coder's in-workspace self-gate fails.

## How

The chart already exposes everything needed (`agent.roles`, an `agent.image` override, and `coder.gitCredentialsSecret`). The missing pieces were a coder-capable image and the docs to wire it:

- The coder toolchain image is **not** baked into the llmkube release. It is language-specific and fat (a full toolchain), so it lives in **llmkube-runtimes** with that repo's owned-image maintenance/update discipline, built multi-arch (amd64 + arm64).
- Enabling coder mode is then **values-only**: point `agent.image` at a coder toolchain image and add `coder` to `agent.roles`. The image just needs the `foreman-agent` binary at `/foreman-agent` plus the **target repo's** gate toolchain, the same per-language choice `GateProfile.image` already makes for the clean-room gate Job.
- For LLMKube's own (Go) repo: `ghcr.io/defilantech/llmkube-foreman-agent-coder` (built in llmkube-runtimes, tag matches the agent version). For a non-Go target repo: bring your own toolchain image (Python/Rust/Node/...). The lean agent image stays the default; behavior is unchanged.

This reframes the original approach (which baked a Go toolchain into the llmkube release image): the agent stays lean and language-agnostic, and coder capability is a per-language BYO image, consistent with the existing gate-image pattern.

## Checklist

- [ ] Tests added/updated (N/A: chart values docs)
- [ ] `make test` passes locally
- [x] `make lint` passes locally (helm lint)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] Documentation updated (values.yaml)

---

**Companion PR:** the coder toolchain image is built in [defilantech/llmkube-runtimes#7](https://github.com/defilantech/llmkube-runtimes/pull/7).
