### PR TITLE
feat(foreman): add vulkan to the accelerator routing enum

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -164,7 +164,8 @@ const (
 
 // AgenticTaskAccelerator pins which accelerator family a task needs from the
 // node that runs it. "any" lets the scheduler pick from any Ready FleetNode.
-// +kubebuilder:validation:Enum=metal;cuda;any
+// "vulkan" is the AMD/Vulkan tier (e.g. Strix Halo gfx1151).
+// +kubebuilder:validation:Enum=metal;cuda;vulkan;any
 type AgenticTaskAccelerator string
 
 // RequiredCapability tells the scheduler which FleetNodes can serve this task.

--- a/api/foreman/v1alpha1/fleetnode_types.go
+++ b/api/foreman/v1alpha1/fleetnode_types.go
@@ -40,7 +40,8 @@ const (
 )
 
 // FleetNodeAccelerator names the accelerator family the node hosts.
-// +kubebuilder:validation:Enum=metal;cuda;none
+// "vulkan" is the AMD/Vulkan tier (e.g. Strix Halo gfx1151).
+// +kubebuilder:validation:Enum=metal;cuda;vulkan;none
 type FleetNodeAccelerator string
 
 // FleetNodeCapability is what the FleetAgent advertises about its host so the

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -209,6 +209,7 @@ spec:
                     enum:
                     - metal
                     - cuda
+                    - vulkan
                     - any
                     type: string
                   minContextTokens:

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -373,6 +373,7 @@ spec:
                     enum:
                     - metal
                     - cuda
+                    - vulkan
                     - any
                     type: string
                   minContextTokens:

--- a/charts/foreman/templates/crds/fleetnodes.yaml
+++ b/charts/foreman/templates/crds/fleetnodes.yaml
@@ -121,6 +121,7 @@ spec:
                     enum:
                     - metal
                     - cuda
+                    - vulkan
                     - none
                     type: string
                   availableRAMGB:

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -209,6 +209,7 @@ spec:
                     enum:
                     - metal
                     - cuda
+                    - vulkan
                     - any
                     type: string
                   minContextTokens:

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -373,6 +373,7 @@ spec:
                     enum:
                     - metal
                     - cuda
+                    - vulkan
                     - any
                     type: string
                   minContextTokens:

--- a/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
@@ -121,6 +121,7 @@ spec:
                     enum:
                     - metal
                     - cuda
+                    - vulkan
                     - none
                     type: string
                   availableRAMGB:

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -307,6 +307,44 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		Expect(fresh.Status.AssignedNode).To(Equal(verifierNode.Name))
 	})
 
+	It("schedules a vulkan task onto a vulkan node and not a metal node", func() {
+		// The AMD/Vulkan tier advertises accelerator=vulkan; a task pinned to
+		// vulkan must land on that node and never on a metal node. Creating the
+		// node and task also exercises the CRD enum (envtest validates the
+		// vulkan value on create).
+		metalNode := newFleetNode("metal-box")
+		Expect(k8sClient.Create(ctx, metalNode)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, metalNode) })
+		setNodeReady(metalNode, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:  64, AvailableRAMGB: 48,
+		})
+
+		vulkanNode := newFleetNode("vulkan-box")
+		Expect(k8sClient.Create(ctx, vulkanNode)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, vulkanNode) })
+		setNodeReady(vulkanNode, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("vulkan"),
+			TotalRAMGB:  128, AvailableRAMGB: 100,
+		})
+
+		task := newTask("vulkan-target")
+		task.Spec.RequiredCapability = foremanv1alpha1.RequiredCapability{
+			Accelerator: foremanv1alpha1.AgenticTaskAccelerator("vulkan"),
+		}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(fresh.Status.AssignedNode).To(Equal(vulkanNode.Name))
+	})
+
 	It("does not reschedule a Running task whose assigned node is fresh", func() {
 		// The scheduler must leave Running tasks alone when the FleetNode is
 		// healthy; only claim expiry (stale/absent node) may alter them.


### PR DESCRIPTION
## What

Add `vulkan` as an accelerator value the Foreman scheduler can route on: to `AgenticTaskAccelerator` (what a task or Agent requires) and `FleetNodeAccelerator` (what a node reports), plus the regenerated CRDs and foreman chart CRDs.

## Why

The AMD/Vulkan tier (e.g. Strix Halo `gfx1151`) has no accelerator value today: the enums are `metal;cuda;any` / `metal;cuda;none`. That means a coder loop cannot be pinned to a Vulkan node by capability, only by `nodeSelector` labels. A typed value is the clean primitive for heterogeneous-fleet routing and is one of the remaining pieces of #829 (concurrent coder runs across AMD + Metal); it also helps the broader AMD Strix Halo tier.

Part of #829.

## How

- `api/foreman/v1alpha1/agentictask_types.go`: `AgenticTaskAccelerator` enum `metal;cuda;any` -> `metal;cuda;vulkan;any`.
- `api/foreman/v1alpha1/fleetnode_types.go`: `FleetNodeAccelerator` enum `metal;cuda;none` -> `metal;cuda;vulkan;none`.
- No routing-logic change: the scheduler match (`capabilitySatisfies`, `agentictask_controller.go`) is a plain string compare, and the agent already passes its `--accelerator` flag straight through, so a Strix foreman-agent can advertise `--accelerator=vulkan` and tasks/Agents can require it.
- Regenerated CRDs (`make manifests`) and synced chart CRDs (`make foreman-chart-crds` / `make chart-crds`).
- Added an envtest spec asserting a `vulkan` task schedules onto a `vulkan` node and not a `metal` node (also exercises the CRD enum on create: it was HTTP 422 before the widening, passes after).

## Testing

- `go test ./internal/foreman/controller/ ./api/foreman/v1alpha1/` (envtest) — pass.
- `make lint` and `GOOS=linux ./bin/golangci-lint run ./...` — 0 issues.
- New spec is red before the enum change (CRD rejects `vulkan`, 422) and green after.

## Checklist

- [x] Tests pass (`make test` scope: foreman controller + api)
- [x] Lint passes (default + cross-arch `GOOS=linux`)
- [x] CRDs regenerated and chart CRDs synced (`make manifests` + `make foreman-chart-crds` + `make chart-crds`)
- [x] Commit is signed off (`git commit -s`) per DCO

Assisted-by: Claude Code (wrote the enum change, the envtest spec, and ran the regen/lint/test; I reviewed the design and own the change).