### PR TITLE
feat(cli): add `llmkube foreman dispatch` to fan issues across coder agents

### DIFF
--- a/pkg/cli/dispatch.go
+++ b/pkg/cli/dispatch.go
@@ -1,0 +1,526 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/yaml"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+)
+
+// Labels stamped on every task a single dispatch invocation creates, so the
+// batch can be queried, watched, and cleaned up as a unit.
+const (
+	dispatchRunLabel   = "foreman.llmkube.dev/dispatch-run"
+	dispatchIssueLabel = "foreman.llmkube.dev/issue"
+	dispatchAgentLabel = "foreman.llmkube.dev/agent"
+)
+
+// Best-effort writers for progress/UI output: the destination is the command's
+// stdout (or a test buffer), where a write error is neither actionable nor worth
+// threading through every call site.
+func fprintf(w io.Writer, format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
+func fprintln(w io.Writer, a ...any)               { _, _ = fmt.Fprintln(w, a...) }
+func fprint(w io.Writer, a ...any)                 { _, _ = fmt.Fprint(w, a...) }
+
+// dispatchOptions holds the resolved flags for one `foreman dispatch` run.
+type dispatchOptions struct {
+	repo         string
+	agents       []string
+	namespace    string
+	timeoutSecs  int32
+	baseBranch   string
+	branchPrefix string
+	promptFiles  []string
+	noWait       bool
+	pollInterval time.Duration
+	dryRun       bool
+}
+
+// taskAssignment pairs an issue with the coder Agent that will run it.
+type taskAssignment struct {
+	Issue int
+	Agent string
+}
+
+// taskResult is the terminal outcome of one dispatched task, used for the
+// summary table and the exit code.
+type taskResult struct {
+	Issue    int
+	Agent    string
+	Node     string
+	Phase    foremanv1alpha1.AgenticTaskPhase
+	Verdict  foremanv1alpha1.AgenticTaskVerdict
+	Branch   string
+	Reason   foremanv1alpha1.AgenticTaskFailureReason
+	Duration time.Duration
+}
+
+// NewForemanCommand is the `llmkube foreman` group: operate the Foreman
+// agentic-coding harness from the CLI.
+func NewForemanCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "foreman",
+		Short: "Operate the Foreman agentic-coding harness",
+		Long: `Operate the Foreman agentic-coding harness.
+
+Foreman runs coder and reviewer agents as AgenticTasks against a fleet of
+heterogeneous executors. These subcommands create and watch those tasks.`,
+	}
+	cmd.AddCommand(newDispatchCommand())
+	return cmd
+}
+
+func newDispatchCommand() *cobra.Command {
+	opts := &dispatchOptions{}
+	cmd := &cobra.Command{
+		Use:   "dispatch ISSUE [ISSUE...]",
+		Short: "Fan a batch of issues across coder agents and watch them run",
+		Long: `Create one AgenticTask per issue, round-robined across the named coder
+Agents, then watch them all to completion and print a summary.
+
+Round-robining across Agents bound to different boxes is what runs the batch
+concurrently: each coder Agent is model- and box-specific, so naming two
+Agents spreads the issues across both. Each issue's prompt is fetched from
+GitHub (title + body) unless overridden with --prompt-file.
+
+Examples:
+  # Two issues, one per box, watched to completion:
+  llmkube foreman dispatch --repo defilantech/LLMKube \
+    --agents gateway-coder-amd,coder-metal 813 854
+
+  # Override one issue's prompt; create and detach:
+  llmkube foreman dispatch --repo defilantech/LLMKube --agents coder-metal \
+    --prompt-file 813=/tmp/813.md --no-wait 813 854`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDispatch(cmd.Context(), cmd.OutOrStdout(), args, opts)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&opts.repo, "repo", "", "Target repository as owner/repo (required)")
+	f.StringSliceVar(&opts.agents, "agents", nil, "Comma-separated coder Agent names to round-robin across (required)")
+	f.StringVarP(&opts.namespace, "namespace", "n", "default", "Namespace to create the AgenticTasks in")
+	f.Int32Var(&opts.timeoutSecs, "timeout", 1800, "Per-task timeout in seconds")
+	f.StringVar(&opts.baseBranch, "base-branch", "", "Base branch the coder branches from (payload.baseBranch)")
+	f.StringVar(&opts.branchPrefix, "branch-prefix", "", "Prefix for the coder's working branch (payload.branchPrefix)")
+	f.StringArrayVar(&opts.promptFiles, "prompt-file", nil, "Override an issue's prompt: ISSUE=PATH (repeatable)")
+	f.BoolVar(&opts.noWait, "no-wait", false, "Create the tasks and exit without watching")
+	f.DurationVar(&opts.pollInterval, "poll-interval", 5*time.Second, "How often to poll task status while watching")
+	f.BoolVar(&opts.dryRun, "dry-run", false, "Print the AgenticTasks that would be created and exit")
+	return cmd
+}
+
+// runDispatch wires the live dependencies (kube client + GitHub fetcher) and
+// executes the dispatch. The testable seams (assignment, task build, watch,
+// summary) are exercised directly in unit tests.
+func runDispatch(ctx context.Context, out io.Writer, args []string, opts *dispatchOptions) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	owner, repo, err := githubissue.ParseRepo(opts.repo)
+	if err != nil {
+		return fmt.Errorf("--repo: %w", err)
+	}
+	if len(opts.agents) == 0 {
+		return fmt.Errorf("--agents is required (one or more coder Agent names)")
+	}
+	issues, err := parseIssues(args)
+	if err != nil {
+		return err
+	}
+	overrides, err := parsePromptOverrides(opts.promptFiles)
+	if err != nil {
+		return err
+	}
+
+	// Resolve each issue's prompt: an explicit override wins; otherwise fetch
+	// the title + body from GitHub.
+	fetcher := githubissue.NewClient()
+	token := os.Getenv("GITHUB_TOKEN")
+	prompts := make(map[int]string, len(issues))
+	for _, n := range issues {
+		if p, ok := overrides[n]; ok {
+			prompts[n] = p
+			continue
+		}
+		iss, ferr := fetcher.Fetch(ctx, owner, repo, n, token)
+		if ferr != nil {
+			return fmt.Errorf(
+				"fetch issue #%d from %s/%s: %w (set GITHUB_TOKEN or pass --prompt-file %d=<path>)",
+				n, owner, repo, ferr, n)
+		}
+		prompts[n] = formatIssuePrompt(iss)
+	}
+
+	runID := newRunID()
+	assignments := assignAgents(issues, opts.agents)
+	tasks := make([]*foremanv1alpha1.AgenticTask, 0, len(assignments))
+	for _, a := range assignments {
+		tasks = append(tasks, buildTask(opts.namespace, runID, opts.repo, a, prompts[a.Issue], opts))
+	}
+
+	if opts.dryRun {
+		return printTasksYAML(out, tasks)
+	}
+
+	c, err := newForemanClient()
+	if err != nil {
+		return err
+	}
+	for _, t := range tasks {
+		if err := c.Create(ctx, t); err != nil {
+			return fmt.Errorf("create AgenticTask %s: %w", t.Name, err)
+		}
+		fprintf(out, "created %s (issue #%d -> agent %s)\n", t.Name, t.Spec.Payload.Issue, t.Spec.AgentRef.Name)
+	}
+
+	if opts.noWait {
+		fprintf(out, "\n%d task(s) created with label %s=%s. Watch with:\n  kubectl -n %s get agentictasks -l %s=%s\n",
+			len(tasks), dispatchRunLabel, runID, opts.namespace, dispatchRunLabel, runID)
+		return nil
+	}
+
+	fprintf(out, "\nwatching %d task(s) (Ctrl-C to stop watching; tasks keep running)\n", len(tasks))
+	results, werr := watchTasks(ctx, c, out, opts.namespace, tasks, opts.pollInterval)
+	renderSummary(out, results)
+	if werr != nil {
+		// Interrupted: report what we have, do not mask as success.
+		fprintf(out, "\nstopped watching: %v\n  resume: kubectl -n %s get agentictasks -l %s=%s\n",
+			werr, opts.namespace, dispatchRunLabel, runID)
+		return werr
+	}
+	return exitErrFromResults(results)
+}
+
+// --- pure, unit-tested helpers ---
+
+// parseIssues converts CLI args to positive issue numbers, preserving order and
+// dropping duplicates.
+func parseIssues(args []string) ([]int, error) {
+	seen := map[int]bool{}
+	out := make([]int, 0, len(args))
+	for _, a := range args {
+		n, err := strconv.Atoi(strings.TrimSpace(a))
+		if err != nil || n <= 0 || n > math.MaxInt32 {
+			return nil, fmt.Errorf("invalid issue number %q: must be a positive integer", a)
+		}
+		if seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no issues given")
+	}
+	return out, nil
+}
+
+// assignAgents round-robins issues across agents in order.
+func assignAgents(issues []int, agents []string) []taskAssignment {
+	out := make([]taskAssignment, len(issues))
+	for i, iss := range issues {
+		out[i] = taskAssignment{Issue: iss, Agent: agents[i%len(agents)]}
+	}
+	return out
+}
+
+// parsePromptOverrides reads each ISSUE=PATH spec into a map of issue ->
+// file contents.
+func parsePromptOverrides(specs []string) (map[int]string, error) {
+	out := map[int]string{}
+	for _, s := range specs {
+		key, path, ok := strings.Cut(s, "=")
+		if !ok {
+			return nil, fmt.Errorf("--prompt-file %q: expected ISSUE=PATH", s)
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(key))
+		if err != nil || n <= 0 {
+			return nil, fmt.Errorf("--prompt-file %q: %q is not a valid issue number", s, key)
+		}
+		b, err := os.ReadFile(strings.TrimSpace(path))
+		if err != nil {
+			return nil, fmt.Errorf("--prompt-file %q: %w", s, err)
+		}
+		out[n] = string(b)
+	}
+	return out, nil
+}
+
+// formatIssuePrompt renders a fetched issue into the prompt body the coder
+// triages: the title as a heading followed by the issue body.
+func formatIssuePrompt(iss *githubissue.Issue) string {
+	body := strings.TrimSpace(iss.Body)
+	if body == "" {
+		body = "(no description provided)"
+	}
+	return fmt.Sprintf("# %s\n\n%s\n", strings.TrimSpace(iss.Title), body)
+}
+
+// taskName is the deterministic AgenticTask name for an issue within a run.
+func taskName(issue int, runID string) string {
+	return fmt.Sprintf("dispatch-%d-%s", issue, runID)
+}
+
+// buildTask constructs the AgenticTask for one assignment.
+func buildTask(
+	namespace, runID, repo string, a taskAssignment, prompt string, opts *dispatchOptions,
+) *foremanv1alpha1.AgenticTask {
+	return &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      taskName(a.Issue, runID),
+			Namespace: namespace,
+			Labels: map[string]string{
+				dispatchRunLabel:   runID,
+				dispatchIssueLabel: strconv.Itoa(a.Issue),
+				dispatchAgentLabel: a.Agent,
+			},
+		},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind:           foremanv1alpha1.AgenticTaskKindIssueFix,
+			AgentRef:       &corev1.LocalObjectReference{Name: a.Agent},
+			TimeoutSeconds: opts.timeoutSecs,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:         repo,
+				Issue:        int32(a.Issue), //nolint:gosec // G115: issue numbers are positive and bounded by parseIssues
+				Prompt:       prompt,
+				BaseBranch:   opts.baseBranch,
+				BranchPrefix: opts.branchPrefix,
+				Agent:        a.Agent,
+			},
+		},
+	}
+}
+
+// isTerminalPhase reports whether a task has reached a terminal state.
+func isTerminalPhase(p foremanv1alpha1.AgenticTaskPhase) bool {
+	return p == foremanv1alpha1.AgenticTaskPhaseSucceeded || p == foremanv1alpha1.AgenticTaskPhaseFailed
+}
+
+// taskSucceeded reports whether a terminal task is a clean success: it reached
+// Succeeded with a GO or GATE-PASS verdict. Anything else (Failed, NO-GO,
+// INCOMPLETE, GATE-FAIL, GATE-ERROR) is a failure for exit-code purposes.
+func taskSucceeded(t *foremanv1alpha1.AgenticTask) bool {
+	if t.Status.Phase != foremanv1alpha1.AgenticTaskPhaseSucceeded {
+		return false
+	}
+	switch t.Status.Verdict {
+	case foremanv1alpha1.AgenticTaskVerdictGo, foremanv1alpha1.AgenticTaskVerdictGatePass:
+		return true
+	default:
+		return false
+	}
+}
+
+// resultFromTask snapshots a task's terminal status into a taskResult.
+func resultFromTask(t *foremanv1alpha1.AgenticTask) taskResult {
+	r := taskResult{
+		Issue:   int(t.Spec.Payload.Issue),
+		Node:    t.Status.AssignedNode,
+		Phase:   t.Status.Phase,
+		Verdict: t.Status.Verdict,
+		Branch:  t.Status.Branch,
+		Reason:  t.Status.FailureReason,
+	}
+	if t.Spec.AgentRef != nil {
+		r.Agent = t.Spec.AgentRef.Name
+	}
+	if t.Status.StartedAt != nil && t.Status.FinishedAt != nil {
+		r.Duration = t.Status.FinishedAt.Sub(t.Status.StartedAt.Time)
+	}
+	return r
+}
+
+// exitErrFromResults returns a non-nil error when any task did not cleanly
+// succeed, so the command exits non-zero and is usable in scripts.
+func exitErrFromResults(results []taskResult) error {
+	bad := make([]string, 0, len(results))
+	for _, r := range results {
+		ok := r.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded &&
+			(r.Verdict == foremanv1alpha1.AgenticTaskVerdictGo || r.Verdict == foremanv1alpha1.AgenticTaskVerdictGatePass)
+		if !ok {
+			bad = append(bad, fmt.Sprintf("#%d", r.Issue))
+		}
+	}
+	if len(bad) > 0 {
+		return fmt.Errorf("%d of %d task(s) did not succeed: %s", len(bad), len(results), strings.Join(bad, " "))
+	}
+	return nil
+}
+
+// renderSummary writes the aggregate table, sorted by issue number.
+func renderSummary(out io.Writer, results []taskResult) {
+	sorted := append([]taskResult(nil), results...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Issue < sorted[j].Issue })
+
+	fprintln(out, "\nSummary:")
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fprintln(w, "ISSUE\tAGENT\tNODE\tPHASE\tVERDICT\tBRANCH\tDURATION")
+	for _, r := range sorted {
+		verdict := string(r.Verdict)
+		if verdict == "" {
+			verdict = "-"
+		}
+		if r.Reason != "" {
+			verdict = fmt.Sprintf("%s (%s)", verdict, r.Reason)
+		}
+		branch := r.Branch
+		if branch == "" {
+			branch = "-"
+		}
+		dur := "-"
+		if r.Duration > 0 {
+			dur = r.Duration.Round(time.Second).String()
+		}
+		node := r.Node
+		if node == "" {
+			node = "-"
+		}
+		fprintf(w, "#%d\t%s\t%s\t%s\t%s\t%s\t%s\n", r.Issue, r.Agent, node, r.Phase, verdict, branch, dur)
+	}
+	_ = w.Flush()
+}
+
+// --- live wiring ---
+
+func newRunID() string {
+	// time-based, sortable, unique per invocation; runtime use of time.Now is
+	// fine here (this is the CLI, not a replayable workflow).
+	return time.Now().Format("20060102-150405")
+}
+
+// newForemanClient builds a controller-runtime client with the foreman scheme
+// registered, using the ambient kubeconfig.
+func newForemanClient() (client.Client, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+	if err := foremanv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		return nil, fmt.Errorf("failed to register foreman scheme: %w", err)
+	}
+	return client.New(cfg, client.Options{Scheme: scheme.Scheme})
+}
+
+// watchTasks polls the given tasks until all reach a terminal phase or the
+// context is cancelled. It prints a one-line progress update each poll and
+// returns the terminal results. A non-nil error means the watch was
+// interrupted (ctx cancelled); the returned results are then partial.
+func watchTasks(
+	ctx context.Context, c client.Client, out io.Writer, namespace string,
+	tasks []*foremanv1alpha1.AgenticTask, poll time.Duration,
+) ([]taskResult, error) {
+	if poll <= 0 {
+		poll = 5 * time.Second
+	}
+	names := make([]string, len(tasks))
+	for i, t := range tasks {
+		names[i] = t.Name
+	}
+	for {
+		fetched := make([]*foremanv1alpha1.AgenticTask, 0, len(names))
+		done := 0
+		phases := map[string]int{}
+		for _, name := range names {
+			var t foremanv1alpha1.AgenticTask
+			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &t); err != nil {
+				return nil, fmt.Errorf("get task %s: %w", name, err)
+			}
+			tc := t
+			fetched = append(fetched, &tc)
+			phase := string(t.Status.Phase)
+			if phase == "" {
+				phase = string(foremanv1alpha1.AgenticTaskPhasePending)
+			}
+			phases[phase]++
+			if isTerminalPhase(t.Status.Phase) {
+				done++
+			}
+		}
+		fprintf(out, "\r%-80s", fmt.Sprintf("  %d/%d done  %s", done, len(names), formatPhaseCounts(phases)))
+
+		if done == len(names) {
+			fprintln(out)
+			results := make([]taskResult, 0, len(fetched))
+			for _, t := range fetched {
+				results = append(results, resultFromTask(t))
+			}
+			return results, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			fprintln(out)
+			results := make([]taskResult, 0, len(fetched))
+			for _, t := range fetched {
+				results = append(results, resultFromTask(t))
+			}
+			return results, ctx.Err()
+		case <-time.After(poll):
+		}
+	}
+}
+
+// formatPhaseCounts renders the per-phase tally deterministically.
+func formatPhaseCounts(phases map[string]int) string {
+	keys := make([]string, 0, len(phases))
+	for k := range phases {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", k, phases[k]))
+	}
+	return strings.Join(parts, " ")
+}
+
+// printTasksYAML renders the tasks as a multi-document YAML stream for --dry-run.
+func printTasksYAML(out io.Writer, tasks []*foremanv1alpha1.AgenticTask) error {
+	for i, t := range tasks {
+		t.APIVersion = foremanv1alpha1.GroupVersion.String()
+		t.Kind = "AgenticTask"
+		b, err := yaml.Marshal(t)
+		if err != nil {
+			return fmt.Errorf("marshal task %s: %w", t.Name, err)
+		}
+		if i > 0 {
+			fprintln(out, "---")
+		}
+		fprint(out, string(b))
+	}
+	return nil
+}

--- a/pkg/cli/dispatch_test.go
+++ b/pkg/cli/dispatch_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+)
+
+// Short aliases keep the table-driven cases under the line-length limit.
+type (
+	aPhase   = foremanv1alpha1.AgenticTaskPhase
+	aVerdict = foremanv1alpha1.AgenticTaskVerdict
+)
+
+const (
+	phSucceeded = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	phFailed    = foremanv1alpha1.AgenticTaskPhaseFailed
+	phRunning   = foremanv1alpha1.AgenticTaskPhaseRunning
+	vGo         = foremanv1alpha1.AgenticTaskVerdictGo
+	vGatePass   = foremanv1alpha1.AgenticTaskVerdictGatePass
+	vNoGo       = foremanv1alpha1.AgenticTaskVerdictNoGo
+	vIncomplete = foremanv1alpha1.AgenticTaskVerdictIncomplete
+)
+
+func TestParseIssues(t *testing.T) {
+	t.Run("valid, ordered, deduped", func(t *testing.T) {
+		got, err := parseIssues([]string{"813", "854", "813", "89"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []int{813, 854, 89}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+		}
+	})
+	for _, bad := range []string{"0", "-3", "abc", "12x"} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			if _, err := parseIssues([]string{bad}); err == nil {
+				t.Fatalf("expected error for %q", bad)
+			}
+		})
+	}
+	t.Run("empty", func(t *testing.T) {
+		if _, err := parseIssues(nil); err == nil {
+			t.Fatal("expected error for empty input")
+		}
+	})
+}
+
+func TestAssignAgents(t *testing.T) {
+	got := assignAgents([]int{813, 854, 89, 90}, []string{"amd", "metal"})
+	want := []taskAssignment{
+		{813, "amd"}, {854, "metal"}, {89, "amd"}, {90, "metal"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("at %d got %+v want %+v", i, got[i], want[i])
+		}
+	}
+
+	// Single agent: every issue lands on it.
+	single := assignAgents([]int{1, 2, 3}, []string{"only"})
+	for _, a := range single {
+		if a.Agent != "only" {
+			t.Fatalf("single-agent assignment got %q", a.Agent)
+		}
+	}
+}
+
+func TestParsePromptOverrides(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "813.md")
+	if err := os.WriteFile(p, []byte("custom body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := parsePromptOverrides([]string{"813=" + p})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got[813] != "custom body" {
+		t.Fatalf("got %q", got[813])
+	}
+
+	for _, bad := range []string{"no-equals", "x=" + p, "813=/does/not/exist"} {
+		if _, err := parsePromptOverrides([]string{bad}); err == nil {
+			t.Fatalf("expected error for %q", bad)
+		}
+	}
+}
+
+func TestFormatIssuePrompt(t *testing.T) {
+	got := formatIssuePrompt(&githubissue.Issue{Title: "Fix the thing", Body: "details here"})
+	if !strings.Contains(got, "# Fix the thing") || !strings.Contains(got, "details here") {
+		t.Fatalf("got %q", got)
+	}
+	empty := formatIssuePrompt(&githubissue.Issue{Title: "T", Body: "  "})
+	if !strings.Contains(empty, "(no description provided)") {
+		t.Fatalf("empty body not handled: %q", empty)
+	}
+}
+
+func TestBuildTask(t *testing.T) {
+	opts := &dispatchOptions{timeoutSecs: 1800, baseBranch: "main", branchPrefix: "foreman/"}
+	task := buildTask("default", "20260628-120000", "defilantech/LLMKube",
+		taskAssignment{Issue: 813, Agent: "coder-amd"}, "the prompt", opts)
+
+	if task.Name != "dispatch-813-20260628-120000" {
+		t.Fatalf("name: %s", task.Name)
+	}
+	if task.Labels[dispatchRunLabel] != "20260628-120000" ||
+		task.Labels[dispatchIssueLabel] != "813" ||
+		task.Labels[dispatchAgentLabel] != "coder-amd" {
+		t.Fatalf("labels: %v", task.Labels)
+	}
+	if task.Spec.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
+		t.Fatalf("kind: %s", task.Spec.Kind)
+	}
+	if task.Spec.AgentRef == nil || task.Spec.AgentRef.Name != "coder-amd" {
+		t.Fatalf("agentRef: %+v", task.Spec.AgentRef)
+	}
+	if task.Spec.TimeoutSeconds != 1800 {
+		t.Fatalf("timeout: %d", task.Spec.TimeoutSeconds)
+	}
+	p := task.Spec.Payload
+	if p.Repo != "defilantech/LLMKube" || p.Issue != 813 || p.Prompt != "the prompt" ||
+		p.BaseBranch != "main" || p.BranchPrefix != "foreman/" || p.Agent != "coder-amd" {
+		t.Fatalf("payload: %+v", p)
+	}
+}
+
+func TestTaskSucceededAndExitErr(t *testing.T) {
+	mk := func(phase aPhase, v aVerdict) *foremanv1alpha1.AgenticTask {
+		return &foremanv1alpha1.AgenticTask{Status: foremanv1alpha1.AgenticTaskStatus{Phase: phase, Verdict: v}}
+	}
+	cases := []struct {
+		name   string
+		task   *foremanv1alpha1.AgenticTask
+		wantOK bool
+	}{
+		{"succeeded GO", mk(phSucceeded, vGo), true},
+		{"succeeded GATE-PASS", mk(phSucceeded, vGatePass), true},
+		{"succeeded NO-GO", mk(phSucceeded, vNoGo), false},
+		{"succeeded INCOMPLETE", mk(phSucceeded, vIncomplete), false},
+		{"failed", mk(phFailed, ""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := taskSucceeded(tc.task); got != tc.wantOK {
+				t.Fatalf("taskSucceeded got %v want %v", got, tc.wantOK)
+			}
+		})
+	}
+
+	// All-good batch -> nil; any bad -> error naming the issue.
+	good := []taskResult{
+		{Issue: 1, Phase: phSucceeded, Verdict: vGo},
+		{Issue: 2, Phase: phSucceeded, Verdict: vGatePass},
+	}
+	if err := exitErrFromResults(good); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	mixed := []taskResult{
+		{Issue: 1, Phase: phSucceeded, Verdict: vGo},
+		{Issue: 3, Phase: phSucceeded, Verdict: vNoGo},
+	}
+	err := exitErrFromResults(mixed)
+	if err == nil || !strings.Contains(err.Error(), "#3") {
+		t.Fatalf("expected error naming #3, got %v", err)
+	}
+}
+
+func TestRenderSummary(t *testing.T) {
+	var sb strings.Builder
+	renderSummary(&sb, []taskResult{
+		{
+			Issue: 854, Agent: "metal", Node: "m5",
+			Phase: phSucceeded, Verdict: vGo,
+			Branch: "foreman/issue-854", Duration: 90 * time.Second,
+		},
+		{
+			Issue: 813, Agent: "amd", Node: "incluster", Phase: phFailed,
+			Reason: foremanv1alpha1.AgenticTaskFailureReason("Timeout"),
+		},
+	})
+	out := sb.String()
+	// Sorted: #813 before #854.
+	if strings.Index(out, "#813") > strings.Index(out, "#854") {
+		t.Fatalf("rows not sorted by issue:\n%s", out)
+	}
+	for _, want := range []string{"ISSUE", "VERDICT", "#813", "#854", "foreman/issue-854", "Timeout", "1m30s"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := foremanv1alpha1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&foremanv1alpha1.AgenticTask{}).
+		Build()
+}
+
+func terminalTask(name string, issue int32, phase aPhase, v aVerdict) *foremanv1alpha1.AgenticTask {
+	start := metav1.NewTime(time.Unix(1_700_000_000, 0))
+	end := metav1.NewTime(time.Unix(1_700_000_090, 0))
+	return &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Payload: foremanv1alpha1.AgenticTaskPayload{Issue: issue},
+		},
+		Status: foremanv1alpha1.AgenticTaskStatus{
+			Phase: phase, Verdict: v, AssignedNode: "node-x",
+			StartedAt: &start, FinishedAt: &end,
+		},
+	}
+}
+
+func TestWatchTasks_AllTerminalReturnsResults(t *testing.T) {
+	t1 := terminalTask("dispatch-813-x", 813, phSucceeded, vGo)
+	t2 := terminalTask("dispatch-854-x", 854, phFailed, "")
+	c := newFakeClient(t, t1, t2)
+
+	var sb strings.Builder
+	results, err := watchTasks(context.Background(), c, &sb, "default",
+		[]*foremanv1alpha1.AgenticTask{t1, t2}, time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	byIssue := map[int]taskResult{}
+	for _, r := range results {
+		byIssue[r.Issue] = r
+	}
+	if byIssue[813].Verdict != vGo || byIssue[813].Duration != 90*time.Second {
+		t.Fatalf("813 result wrong: %+v", byIssue[813])
+	}
+	if byIssue[854].Phase != phFailed {
+		t.Fatalf("854 result wrong: %+v", byIssue[854])
+	}
+}
+
+func TestWatchTasks_ContextCancelledReturnsPartial(t *testing.T) {
+	pending := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "dispatch-1-x", Namespace: "default"},
+		Spec:       foremanv1alpha1.AgenticTaskSpec{Payload: foremanv1alpha1.AgenticTaskPayload{Issue: 1}},
+		Status:     foremanv1alpha1.AgenticTaskStatus{Phase: phRunning},
+	}
+	c := newFakeClient(t, pending)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: the first poll is non-terminal, then ctx.Done fires.
+
+	var sb strings.Builder
+	results, err := watchTasks(ctx, c, &sb, "default",
+		[]*foremanv1alpha1.AgenticTask{pending}, time.Hour)
+	if err == nil {
+		t.Fatal("expected a context error")
+	}
+	if len(results) != 1 || results[0].Phase != phRunning {
+		t.Fatalf("expected partial running result, got %+v", results)
+	}
+}
+
+func TestPrintTasksYAML(t *testing.T) {
+	opts := &dispatchOptions{timeoutSecs: 1800}
+	task := buildTask("default", "run1", "defilantech/LLMKube",
+		taskAssignment{Issue: 813, Agent: "coder-amd"}, "prompt", opts)
+	var sb strings.Builder
+	if err := printTasksYAML(&sb, []*foremanv1alpha1.AgenticTask{task}); err != nil {
+		t.Fatal(err)
+	}
+	out := sb.String()
+	for _, want := range []string{"apiVersion: foreman.llmkube.dev", "kind: AgenticTask", "issue: 813", "coder-amd"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run YAML missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -51,6 +51,7 @@ built-in observability, SLO enforcement, and edge-native capabilities.`,
 	cmd.AddCommand(NewInspectCommand())
 	cmd.AddCommand(NewLicenseCommand())
 	cmd.AddCommand(NewAuditCommand())
+	cmd.AddCommand(NewForemanCommand())
 
 	return cmd
 }


### PR DESCRIPTION
## What

A new `llmkube foreman dispatch` command (under a new `foreman` CLI group) that creates one AgenticTask per issue, round-robined across the named coder Agents, then watches them all to completion and prints an aggregate summary.

```
llmkube foreman dispatch --repo defilantech/LLMKube \
  --agents gateway-coder-amd,coder-metal 813 854 89
```

## Why

This productizes the ad-hoc batch-dispatch driver from #829 (concurrent coder runs across heterogeneous executors). Today a batch means hand-writing one AgenticTask YAML per issue and `kubectl apply`. Round-robining issues across Agents bound to different boxes (each coder Agent is model/box-specific) is exactly what runs the batch concurrently across AMD + Metal, using the existing scheduler.

Part of #829.

## How

- **`pkg/cli/dispatch.go`** — `NewForemanCommand()` (group) + `dispatch` subcommand. Flow: resolve each issue's prompt (fetch title+body from GitHub via the existing `githubissue` fetcher, or `--prompt-file ISSUE=PATH` override) → round-robin issues across `--agents` → create one labelled `AgenticTask` each (`foreman.llmkube.dev/dispatch-run=<runid>`) → watch to terminal with a live phase tally → final summary table (issue, agent, node, verdict, branch, duration).
- **Exit code** is non-zero if any task did not cleanly succeed (Succeeded + GO/GATE-PASS), so it is scriptable. `--no-wait` creates and detaches; `--dry-run` prints the YAML; Ctrl-C stops watching but leaves tasks running and prints a resume hint.
- Reuses the existing `client.New` + scheme pattern; registers the foreman scheme.
- **`pkg/cli/dispatch_test.go`** — the pure helpers (issue parse, round-robin assignment, prompt-override, task build, summary render, exit-code mapping) are table-tested; the watch loop is tested against the controller-runtime fake client (all-terminal and context-cancelled paths). No envtest required.

Deliberately out of scope (YAGNI, future): a separate `status`/`cancel` command, reviewer fan-out, same-node concurrency.

## Testing

- `go test ./pkg/cli/` — pass (new tests + existing).
- `make lint` and `GOOS=linux ./bin/golangci-lint run ./pkg/cli/...` — 0 issues.
- Manual: `--dry-run` produces correct round-robin AgenticTask YAML (813→first agent, 854→second), labels, `kind: issue-fix`, base-branch threaded.

## Checklist

- [x] Tests pass (`pkg/cli`)
- [x] Lint passes (default + cross-arch `GOOS=linux`)
- [x] No CRD/RBAC changes (pure CLI addition)
- [x] Commit is signed off (`git commit -s`) per DCO

Assisted-by: Claude Code (designed via Q&A and implemented the command + tests; I reviewed the design and own the change).