### PR TITLE
feat(foreman): add a goreleaser-config check to the coder gate

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -88,12 +88,13 @@ type checkFailure struct {
 // query the scope-overlap check ranks files against; an empty string
 // disables that check (backward compatible).
 //
-// The gate runs seven deterministic checks in order: gofmt, go vet,
+// The gate runs eight deterministic checks in order: gofmt, go vet,
 // go build, golangci-lint, a fast unit-test tier on changed packages,
-// a codegen-drift check, and a scope-overlap check. Heavy envtest or
-// integration tests are intentionally out of scope; they run in a separate
-// post-push gate Job. All checks run regardless of earlier failures so the
-// feedback reports everything wrong at once.
+// a codegen-drift check, a goreleaser-config check (path-scoped), and
+// a scope-overlap check. Heavy envtest or integration tests are
+// intentionally out of scope; they run in a separate post-push gate
+// Job. All checks run regardless of earlier failures so the feedback
+// reports everything wrong at once.
 func RunCoderGate(
 	ctx context.Context,
 	workspace, golangciPath string,
@@ -153,7 +154,17 @@ func RunCoderGate(
 		failures = append(failures, checkFailure{name: "codegen drift", output: out})
 	}
 
-	// 7. Scope-overlap check: flag a coder whose changed Go files have zero
+	// 7. Goreleaser config check: when .goreleaser.yaml or any
+	// Dockerfile*.goreleaser is changed, run `goreleaser check` to
+	// validate the release config schema. This catches broken release
+	// configs before they reach a GO (see #854 / #868). Path-scoped so
+	// it adds no latency to the common (Go-only) change. Skipped
+	// gracefully if goreleaser is not available.
+	if failed, out := checkGoreleaserConfig(ctx, workspace, run); failed {
+		failures = append(failures, checkFailure{name: "goreleaser check", output: out})
+	}
+
+	// 8. Scope-overlap check: flag a coder whose changed Go files have zero
 	// overlap with the files the issue implies are relevant, which catches a
 	// drift to an unrelated subsystem that every other check happily
 	// green-lights (e.g. refactoring pkg/cli/cache.go for a pkg/agent issue).
@@ -368,6 +379,41 @@ func isGeneratedArtifact(path string) bool {
 		return true
 	}
 	return false
+}
+
+// releaseConfigChanged reports whether any release-config file is in the
+// dirty set: .goreleaser.yaml or any Dockerfile*.goreleaser.
+func releaseConfigChanged(dirty map[string]bool) bool {
+	for path := range dirty {
+		if path == ".goreleaser.yaml" {
+			return true
+		}
+		if strings.HasPrefix(path, "Dockerfile.") && strings.HasSuffix(path, ".goreleaser") {
+			return true
+		}
+	}
+	return false
+}
+
+// checkGoreleaserConfig runs `goreleaser check` when release-config files
+// are changed, returning (failed, output). It is skipped gracefully if
+// goreleaser is not available (command not found).
+func checkGoreleaserConfig(ctx context.Context, workspace string, run commandRunner) (failed bool, output string) {
+	dirty := dirtyPathSet(ctx, workspace, run)
+	if !releaseConfigChanged(dirty) {
+		return false, ""
+	}
+
+	// Check if goreleaser is available; skip gracefully if not.
+	if _, err := run(ctx, workspace, nil, "which", "goreleaser"); err != nil {
+		return false, ""
+	}
+
+	out, err := run(ctx, workspace, nil, "goreleaser", "check")
+	if err != nil {
+		return true, "goreleaser check failed:\n" + out
+	}
+	return false, ""
 }
 
 // buildFeedback renders the directive and a per-check section for every

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -730,3 +730,172 @@ func TestRunCoderGate_ScopeDisabledWhenIssueTextEmpty(t *testing.T) {
 		t.Fatalf("empty issueText should disable the scope check; gate should pass. feedback:\n%s", fb)
 	}
 }
+
+func TestReleaseConfigChanged(t *testing.T) {
+	tests := []struct {
+		name  string
+		dirty map[string]bool
+		want  bool
+	}{
+		{
+			name:  "no release config changed",
+			dirty: map[string]bool{"pkg/cli/cache.go": true},
+			want:  false,
+		},
+		{
+			name:  ".goreleaser.yaml changed",
+			dirty: map[string]bool{".goreleaser.yaml": true},
+			want:  true,
+		},
+		{
+			name:  "Dockerfile.goreleaser changed",
+			dirty: map[string]bool{"Dockerfile.goreleaser": true},
+			want:  true,
+		},
+		{
+			name:  "Dockerfile.foreman-agent.goreleaser changed",
+			dirty: map[string]bool{"Dockerfile.foreman-agent.goreleaser": true},
+			want:  true,
+		},
+		{
+			name:  "Dockerfile.router-proxy.goreleaser changed",
+			dirty: map[string]bool{"Dockerfile.router-proxy.goreleaser": true},
+			want:  true,
+		},
+		{
+			name:  "Dockerfile.goreleaser and .goreleaser.yaml both changed",
+			dirty: map[string]bool{".goreleaser.yaml": true, "Dockerfile.goreleaser": true},
+			want:  true,
+		},
+		{
+			name:  "Dockerfile.goreleaser not matched by plain Dockerfile",
+			dirty: map[string]bool{"Dockerfile": true},
+			want:  false,
+		},
+		{
+			name:  "Dockerfile.goreleaser not matched by Dockerfile with other suffix",
+			dirty: map[string]bool{"Dockerfile.manager": true},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := releaseConfigChanged(tt.dirty); got != tt.want {
+				t.Errorf("releaseConfigChanged(%v) = %v, want %v", tt.dirty, got, tt.want)
+			}
+		})
+	}
+}
+
+// goreleaserFake builds a commandRunner for the goreleaser-config tier.
+// All other gate checks pass. The goreleaserAvailable flag controls whether
+// `which goreleaser` succeeds. goreleaserCheckErr controls the result of
+// `goreleaser check`. goreleaserPorcelain controls the dirty set for the
+// goreleaser check (the codegen tier is skipped by returning an error from
+// `test -f`).
+func goreleaserFake(
+	goreleaserAvailable bool,
+	goreleaserCheckErr error,
+	goreleaserCheckOutput string,
+	goreleaserPorcelain string,
+) commandRunner {
+	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "gofmt", name == "go", name == gateLintPath:
+			return "", nil
+		case name == "test" && len(args) > 0 && args[0] == "-f":
+			return "", errors.New("no controller-gen") // skip codegen tier
+		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "-z":
+			return "", nil // no changed test packages
+		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain":
+			return goreleaserPorcelain, nil
+		case name == "which" && len(args) > 0 && args[0] == "goreleaser":
+			if goreleaserAvailable {
+				return "/usr/local/bin/goreleaser", nil
+			}
+			return "", errors.New("exit status 1")
+		case name == "goreleaser" && len(args) > 0 && args[0] == "check":
+			return goreleaserCheckOutput, goreleaserCheckErr
+		default:
+			return "", nil
+		}
+	}
+}
+
+func TestCheckGoreleaserConfig_SkippedWhenNoReleaseConfigChanged(t *testing.T) {
+	run := goreleaserFake(true, nil, "", "")
+	failed, out := checkGoreleaserConfig(context.Background(), "/work", run)
+	if failed {
+		t.Fatal("should not fail when no release config files changed")
+	}
+	if out != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestCheckGoreleaserConfig_SkippedWhenGoreleaserNotAvailable(t *testing.T) {
+	run := goreleaserFake(false, nil, "", " M .goreleaser.yaml\n")
+	failed, out := checkGoreleaserConfig(context.Background(), "/work", run)
+	if failed {
+		t.Fatal("should not fail when goreleaser is not available")
+	}
+	if out != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestCheckGoreleaserConfig_PassesWhenCheckSucceeds(t *testing.T) {
+	run := goreleaserFake(true, nil, "", " M .goreleaser.yaml\n")
+	failed, out := checkGoreleaserConfig(context.Background(), "/work", run)
+	if failed {
+		t.Fatalf("should not fail when goreleaser check passes; output: %q", out)
+	}
+}
+
+func TestCheckGoreleaserConfig_FailsWhenCheckFails(t *testing.T) {
+	checkErr := errors.New("exit status 1")
+	checkOutput := "error: invalid key 'dockers_v2'\n"
+	run := goreleaserFake(true, checkErr, checkOutput, " M .goreleaser.yaml\n")
+	failed, out := checkGoreleaserConfig(context.Background(), "/work", run)
+	if !failed {
+		t.Fatal("should fail when goreleaser check fails")
+	}
+	if !strings.Contains(out, "goreleaser check failed") {
+		t.Errorf("output should mention 'goreleaser check failed'; got: %q", out)
+	}
+	if !strings.Contains(out, "invalid key") {
+		t.Errorf("output should include goreleaser error; got: %q", out)
+	}
+}
+
+func TestRunCoderGate_GoreleaserCheckFailsGate(t *testing.T) {
+	checkErr := errors.New("exit status 1")
+	checkOutput := "error: invalid key 'dockers_v2'\n"
+	run := goreleaserFake(true, checkErr, checkOutput, " M .goreleaser.yaml\n")
+	pass, fb := RunCoderGate(context.Background(), "/work", gateLintPath, run, "")
+	if pass {
+		t.Fatal("gate should fail when goreleaser check fails")
+	}
+	if !strings.Contains(fb, "goreleaser check") {
+		t.Errorf("feedback should cite 'goreleaser check'; got:\n%s", fb)
+	}
+}
+
+func TestRunCoderGate_GoreleaserCheckPassesGate(t *testing.T) {
+	run := goreleaserFake(true, nil, "", " M .goreleaser.yaml\n")
+	pass, fb := RunCoderGate(context.Background(), "/work", gateLintPath, run, "")
+	if !pass {
+		t.Fatalf("gate should pass when goreleaser check passes; feedback:\n%s", fb)
+	}
+	if fb != "" {
+		t.Errorf("expected empty feedback, got %q", fb)
+	}
+}
+
+func TestRunCoderGate_GoreleaserCheckSkippedWhenNoReleaseConfigChanged(t *testing.T) {
+	run := goreleaserFake(true, nil, "", "")
+	pass, fb := RunCoderGate(context.Background(), "/work", gateLintPath, run, "")
+	if !pass {
+		t.Fatalf("gate should pass when no release config changed; feedback:\n%s", fb)
+	}
+}


### PR DESCRIPTION
## What

Add an eighth deterministic check to the coder gate (`pkg/foreman/agent/coder_gate.go`): when a coder changes `.goreleaser.yaml` or any `Dockerfile*.goreleaser`, run `goreleaser check` to validate the release-config schema before the run can reach GO.

## Why

Fixes #870

Release-config breakage (e.g. the `dockers_v2` migration in #854 / #868) passes every existing gate check — `go build`/`vet`/`lint`/`test` don't touch the goreleaser config — so a coder could reach GO with a broken release config that only fails later in the release pipeline. This closes that gap at the gate.

## How

- New `checkGoreleaserConfig`: path-scoped via `releaseConfigChanged` (only runs when a release-config file is in the dirty set), so it adds zero latency to the common Go-only change. Skips gracefully if `goreleaser` is not on PATH (`which goreleaser`).
- Wired in as check #8, between codegen-drift and scope-overlap; like the other checks it runs regardless of earlier failures so the feedback reports everything at once. Doc comment updated (7 → 8 checks).
- Tests: `TestReleaseConfigChanged` (table, incl. edge cases like plain `Dockerfile` not matching), `checkGoreleaserConfig` unit tests (skip-when-unavailable / pass / fail-with-output), and three `RunCoderGate`-level tests (fails-gate / passes-gate / skipped-when-no-release-config).

## Checklist

- [x] Tests pass (`go test ./pkg/foreman/agent/` — verified locally)
- [x] Lint passes (coder fast-gate: gofmt/vet/build/golangci-lint/changed-pkg-test)
- [x] No CRD/RBAC changes
- [x] Commit signed off (DCO)

Generated by the Foreman coder agent (model: `qwopus-coder-mtp`, in-cluster executor) during the #829 dual-box validation; human-reviewed before opening. Assisted-by: Foreman coder agent (qwopus-coder-mtp); reviewed and verified by the maintainer.