### PR TITLE
feat(controller): run model-cache-prep init non-root + document PSA/multi-tenancy caveats

### DIFF
--- a/docs/MODEL-CACHE.md
+++ b/docs/MODEL-CACHE.md
@@ -312,3 +312,21 @@ modelCache:
 ```
 
 This will revert to the legacy behavior where each pod downloads the model via init container.
+
+## Security Considerations
+
+### PSA `restricted` incompatibility
+
+The model cache init container cannot satisfy Pod Security Admission (PSA) `restricted` policy. PSA `restricted` forbids both running as root and adding any capability except `NET_BIND_SERVICE`. Chowning a root-owned mount (which the cache-prep init container does on CSIs with `fsGroupPolicy: None`) requires either root or `CAP_CHOWN`/`CAP_FOWNER`, so the cache-prep init container cannot satisfy `restricted` no matter how it is tuned.
+
+This is inherent to the problem: the cache-prep init container exists precisely because `fsGroup` is not applied on `fsGroupPolicy: None` CSIs. On such a CSI in a PSA-`restricted` namespace, the shared cache path is not available. Alternatives:
+
+- Use an `fsGroupPolicy: File` CSI (the default on most clusters) so Kubernetes handles the ownership automatically.
+- Use an `emptyDir` model store (disable the persistent cache).
+- Use a less-strict PSA policy (e.g., `baseline` or `privileged`).
+
+### Shared-cache group-write multi-tenancy
+
+In `shared` mode, the cache-prep init container sets `chmod g+rwX /models`, making the cache root writable by any pod in the same `fsGroup`. On a shared cache PVC, multiple InferenceServices share that `fsGroup` and can write to each other's cached model files.
+
+Within one operator's trust domain this is fine. For a multi-tenant cache where distrusting tenants share the same namespace, this is a real consideration. Use per-service caches (`modelCache.mode: perService`) for isolation between distrusting tenants.

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -918,12 +918,13 @@ var _ = Describe("cache prep init container (#855)", func() {
 		Expect(dl.Image).To(Equal("my-registry.io/init:v1.2.3"))
 	})
 
-	It("prep SecurityContext: RunAsUser=0, AllowPrivilegeEscalation=false, Capabilities.Drop=[ALL], Capabilities.Add has CHOWN and FOWNER, ReadOnlyRootFilesystem=true, SeccompProfile.Type=RuntimeDefault", func() {
+	It("prep SecurityContext: RunAsUser=100 (non-root), RunAsNonRoot=true, AllowPrivilegeEscalation=false, Capabilities.Drop=[ALL], Capabilities.Add has CHOWN and FOWNER, ReadOnlyRootFilesystem=true, SeccompProfile.Type=RuntimeDefault", func() {
 		config := buildCachedStorageConfig(cacheModel(), nil, "", "", "curl:8.18.0", 102)
 		prep := config.initContainers[0]
 		sc := prep.SecurityContext
 		Expect(sc).NotTo(BeNil())
-		Expect(*sc.RunAsUser).To(Equal(int64(0)))
+		Expect(*sc.RunAsUser).To(Equal(int64(100)))
+		Expect(*sc.RunAsNonRoot).To(BeTrue())
 		Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
 		Expect(*sc.ReadOnlyRootFilesystem).To(BeTrue())
 

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -209,7 +209,7 @@ func invalidFileSetInitContainer(initImage string) corev1.Container {
 	}
 }
 
-// cachePrepInitContainer returns the root-run prep init container that runs
+// cachePrepInitContainer returns the non-root prep init container that runs
 // BEFORE model-downloader in the cache-backed path. CSI drivers with
 // fsGroupPolicy=None (CephFS, NFS) never apply the pod fsGroup to the volume,
 // so the PVC root stays root:root 0755 and the non-root downloader (uid 100)
@@ -220,6 +220,17 @@ func invalidFileSetInitContainer(initImage string) corev1.Container {
 // rw on existing and future files/dirs (g+rwX). When resolvedFSGroup <= 0
 // (fsGroup disabled, e.g. OpenShift) the prep chowns to 100:100 (the
 // downloader's UID/GID) and sets 770 so only the downloader can write.
+//
+// Security: the prep runs as the non-root curl_user (uid 100), drops ALL
+// capabilities, and adds back only CHOWN+FOWNER. CHOWN lets a non-root
+// process change ownership of the root-owned mount arbitrarily, and FOWNER
+// lets it chmod a file it does not own, so the chown/chmod above succeed
+// without running as root. This satisfies Pod Security Admission "baseline"
+// (non-root, no privilege escalation, minimal caps). It cannot satisfy
+// "restricted", which forbids adding any capability except NET_BIND_SERVICE:
+// the chown of an unowned mount fundamentally needs CHOWN. See
+// docs/MODEL-CACHE.md "Security Considerations" for the restricted-PSA
+// alternatives (fsGroupPolicy=File CSI, emptyDir store, or a laxer policy).
 //
 // The prep reuses the configurable initContainerImage (no hardcoded busybox)
 // so air-gapped clusters that mirror initContainerImage are covered.
@@ -238,7 +249,10 @@ func cachePrepInitContainer(initImage string, resolvedFSGroup int64) corev1.Cont
 			{Name: "model-cache", MountPath: "/models"},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:                int64Ptr(0),
+			// Non-root (curl_user). CHOWN+FOWNER are sufficient to chown/chmod
+			// the root-owned mount without uid 0; see the doc comment above.
+			RunAsUser:                int64Ptr(100),
+			RunAsNonRoot:             boolPtr(true),
 			AllowPrivilegeEscalation: boolPtr(false),
 			ReadOnlyRootFilesystem:   boolPtr(true),
 			Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
## What

Two changes to the model cache, addressing both halves of #865:

1. **Hardening:** run the `model-cache-prep` init container non-root (`RunAsUser: 100` / `RunAsNonRoot: true`) instead of uid 0, keeping the minimal `CHOWN`+`FOWNER` capabilities.
2. **Docs:** add a "Security Considerations" section to `docs/MODEL-CACHE.md` covering PSA `restricted` incompatibility and shared-cache group-write multi-tenancy.

## Why

Fixes #865

The cache-prep init chowns/chmods the PVC root on `fsGroupPolicy: None` CSIs so the non-root downloader can write. It ran as uid 0, but it doesn't need root: `CHOWN` lets a non-root process change ownership of a root-owned path arbitrarily, and `FOWNER` lets it chmod a file it doesn't own. Dropping to the non-root `curl_user` (uid 100) with just those two caps is strictly better defense-in-depth and satisfies PSA **baseline**.

It still cannot satisfy PSA **restricted** — that forbids adding any capability except `NET_BIND_SERVICE`, and the chown of an unowned mount fundamentally needs `CHOWN`. That constraint is real and immutable, so the PR documents it (with the workarounds) rather than pretending it's tunable.

## How

- `internal/controller/model_storage.go`: `cachePrepInitContainer` now sets `RunAsUser: 100` + `RunAsNonRoot: true`; doc comment explains why non-root + `CHOWN`/`FOWNER` is sufficient and why `restricted` remains out of reach.
- `internal/controller/inferenceservice_storage_test.go`: the prep-SecurityContext test now asserts `RunAsUser=100` + `RunAsNonRoot=true`.
- `docs/MODEL-CACHE.md`: new "Security Considerations" section — PSA-`restricted` incompatibility (with three alternatives: `fsGroupPolicy: File` CSI, `emptyDir` store, or a laxer PSA policy) and the `shared`-mode multi-tenancy consideration (recommending `perService` caches between distrusting tenants).

## Checklist

- [x] Tests pass (`go test ./internal/controller/` cache-prep suite, envtest)
- [x] Lint passes (default + cross-arch `GOOS=linux`)
- [x] No CRD/RBAC changes
- [x] Commits signed off (DCO)

The docs commit was generated by the Foreman coder agent (model `coder-m5`, M5 executor) during the #829 dual-box validation; the non-root hardening commit was added during human review (the coder's docs correctly noted `restricted` is unreachable but stopped short of the achievable non-root flip). Assisted-by: Foreman coder agent (coder-m5) + human review.