### PR TITLE
fix(foreman): raise coder agent memory limit default to 8Gi

### DIFF
--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -232,13 +232,20 @@ agent:
   commitAuthorName: ""    # defaults to "Foreman Bot" inside the binary
   commitAuthorEmail: ""
 
+  # The memory LIMIT is a cap, not a reservation (requests stays lean), so a
+  # reviewer/scheduler/worker agent still uses ~256Mi -- the high cap only
+  # matters for a coder-role agent. A coder's in-workspace self-gate runs
+  # golangci-lint + go build + go test over the whole target module, which
+  # spikes well past 2Gi and OOMKills the pod at the old default (#880). 8Gi
+  # gives that gate headroom while costing non-coder agents nothing. Lower the
+  # limit if you only run reviewer/scheduler roles on memory-tight nodes.
   resources:
     requests:
       cpu: 200m
       memory: 256Mi
     limits:
       cpu: "2"
-      memory: 2Gi
+      memory: 8Gi
 
   podSecurityContext:
     runAsNonRoot: true


### PR DESCRIPTION
## What

Raise the default `agent.resources.limits.memory` in `charts/foreman` from 2Gi to 8Gi, with a comment explaining why.

## Why

Fixes #880

A `coder`-role agent's in-workspace self-gate runs `golangci-lint` + `go build` + `go test` over the whole target module, which spikes past 2Gi and OOMKills the pod (exit 137). The AgenticTask then orphan-recovers and re-dispatches on every restart, never converging (an OOM loop). Hit live while running the in-cluster coder during the #829 dual-box validation; bumping the live cluster to 8Gi let the loop converge.

The memory **limit is a cap, not a reservation** (`requests` stays at 256Mi), so raising it costs reviewer/scheduler/worker agents nothing: they still use ~256Mi and only a coder gate ever approaches the cap.

## How

- `charts/foreman/values.yaml`: `agent.resources.limits.memory` 2Gi -> 8Gi, with a comment noting the cap-not-reservation rationale and that memory-tight reviewer/scheduler-only deployments can lower it.

## Checklist

- [x] `helm lint charts/foreman` passes
- [x] No code / CRD / RBAC changes (values default only)
- [x] Commit signed off (DCO)