### PR TITLE
feat(foreman): durable FleetNode labels via --node-labels (survive pod restart)

### DIFF
--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -45,6 +45,11 @@ spec:
           args:
             - --agent-mode={{ .Values.agent.mode }}
             - --roles={{ join "," .Values.agent.roles }}
+            {{- if .Values.agent.nodeLabels }}
+            {{- $pairs := list }}
+            {{- range $k, $v := .Values.agent.nodeLabels }}{{ $pairs = append $pairs (printf "%s=%s" $k $v) }}{{- end }}
+            - --node-labels={{ join "," $pairs }}
+            {{- end }}
             {{- if .Values.agent.taskNamespace }}
             - --task-namespace={{ .Values.agent.taskNamespace }}
             {{- end }}

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -182,6 +182,16 @@ agent:
   roles:
     - worker
 
+  # Labels stamped onto this agent's FleetNode metadata on every
+  # registration (via --node-labels), so capability-routing nodeSelectors
+  # (an Agent's requiredCapability.nodeSelector) keep matching across pod
+  # restarts. A hand-applied `kubectl label fleetnode` is lost when the pod
+  # (and its FleetNode, named for the pod) is recreated; these are not (#881).
+  # Example:
+  #   nodeLabels:
+  #     coder-pool: amd
+  nodeLabels: {}
+
   # --task-namespace flag. Empty = watch all namespaces. Pin to a
   # namespace when a single Foreman install serves multiple
   # tenants that should not see each other's tasks.

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -112,6 +112,7 @@ func main() {
 		workspaceDir     string
 		opencodeBin      string
 		rolesFlag        string
+		nodeLabelsFlag   string
 		acceleratorFlag  string
 		installedModels  string
 		heartbeat        time.Duration
@@ -155,6 +156,10 @@ func main() {
 		"Path to the opencode binary. Required for M3+; unused in M1.")
 	flag.StringVar(&rolesFlag, "roles", "worker",
 		"Comma-separated roles this node serves (worker, verifier).")
+	flag.StringVar(&nodeLabelsFlag, "node-labels", "",
+		"Comma-separated key=value labels stamped on this node's FleetNode "+
+			"metadata on every (re)registration (e.g. coder-pool=amd). Survives "+
+			"pod restarts; used for capability-routing nodeSelectors.")
 	flag.StringVar(&acceleratorFlag, "accelerator", "",
 		"Accelerator label override. Defaults to metal on darwin; required on linux in v0.1.")
 	flag.StringVar(&installedModels, "installed-models", "",
@@ -361,6 +366,7 @@ func main() {
 		Client:   kc,
 		NodeName: fleetNodeName,
 		Spec:     spec,
+		Labels:   parseKeyValueCSV(nodeLabelsFlag),
 		Provider: provider,
 		Interval: heartbeat,
 		Version:  Version,
@@ -605,6 +611,29 @@ func splitCSV(s string) []string {
 		// the same as empty input; collapse to nil so callers
 		// (FleetNodeSpec.Roles, CapabilityOptions.InstalledModels) see
 		// a single "absent" representation rather than nil vs []string{}.
+		return nil
+	}
+	return out
+}
+
+// parseKeyValueCSV parses a comma-separated list of key=value pairs (e.g.
+// "coder-pool=amd,zone=lab") into a map. Empty/whitespace keys and malformed
+// segments (no "=") are skipped; empty input returns nil. A bare trailing
+// comma is tolerated.
+func parseKeyValueCSV(s string) map[string]string {
+	out := map[string]string{}
+	for _, pair := range strings.Split(s, ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(pair), "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		out[k] = strings.TrimSpace(v)
+	}
+	if len(out) == 0 {
 		return nil
 	}
 	return out

--- a/cmd/foreman-agent/main_test.go
+++ b/cmd/foreman-agent/main_test.go
@@ -102,3 +102,29 @@ func TestSplitCSV(t *testing.T) {
 		})
 	}
 }
+
+func TestParseKeyValueCSV(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{"empty_returns_nil", "", nil},
+		{"single_pair", "coder-pool=amd", map[string]string{"coder-pool": "amd"}},
+		{"two_pairs", "coder-pool=amd,zone=lab", map[string]string{"coder-pool": "amd", "zone": "lab"}},
+		{"whitespace_trimmed", " coder-pool = amd , zone = lab ", map[string]string{"coder-pool": "amd", "zone": "lab"}},
+		{"trailing_comma_tolerated", "coder-pool=amd,", map[string]string{"coder-pool": "amd"}},
+		{"malformed_segment_skipped", "coder-pool=amd,garbage", map[string]string{"coder-pool": "amd"}},
+		{"empty_key_skipped", "=amd,zone=lab", map[string]string{"zone": "lab"}},
+		{"empty_value_allowed", "coder-pool=", map[string]string{"coder-pool": ""}},
+		{"only_separators_returns_nil", ",,,", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseKeyValueCSV(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseKeyValueCSV(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/fleetnode.go
+++ b/pkg/foreman/agent/fleetnode.go
@@ -73,6 +73,14 @@ type Registrar struct {
 	NodeName string
 	Spec     foremanv1alpha1.FleetNodeSpec
 	Provider CapabilityProvider
+
+	// Labels are operator-managed labels (from the agent's --node-labels
+	// flag) stamped onto the FleetNode's metadata on every Upsert. A new
+	// agent pod creates a fresh FleetNode named for the pod, so labels set
+	// here survive pod restarts / rollouts without manual re-labeling, which
+	// a hand-applied `kubectl label fleetnode` does not (#881). Only these
+	// keys are managed; labels added by others are left untouched.
+	Labels   map[string]string
 	Interval time.Duration // zero defaults to DefaultHeartbeatInterval
 
 	// Version is the agent binary's version string (e.g. "v0.8.4").
@@ -103,8 +111,9 @@ type Registrar struct {
 	Updater UpdateApplier
 }
 
-// Upsert creates the FleetNode if missing, otherwise updates its Spec so
-// flag changes between agent restarts take effect immediately.
+// Upsert creates the FleetNode if missing, otherwise updates its Spec and
+// managed Labels so flag changes between agent restarts take effect
+// immediately.
 func (r *Registrar) Upsert(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	key := types.NamespacedName{Name: r.NodeName}
@@ -114,7 +123,7 @@ func (r *Registrar) Upsert(ctx context.Context) error {
 	switch {
 	case apierrors.IsNotFound(err):
 		node := &foremanv1alpha1.FleetNode{
-			ObjectMeta: metav1.ObjectMeta{Name: r.NodeName},
+			ObjectMeta: metav1.ObjectMeta{Name: r.NodeName, Labels: cloneLabels(r.Labels)},
 			Spec:       r.Spec,
 		}
 		if err := r.Client.Create(ctx, node); err != nil {
@@ -126,18 +135,60 @@ func (r *Registrar) Upsert(ctx context.Context) error {
 		return fmt.Errorf("get FleetNode %q: %w", r.NodeName, err)
 	}
 
-	// Update spec only if it actually changed; avoids touch noise on
-	// every restart with identical flags.
-	if specEqual(existing.Spec, r.Spec) {
-		log.Info("FleetNode spec unchanged", "name", r.NodeName)
+	// Reconcile spec and our managed labels. A new agent pod gets a new
+	// FleetNode (named for the pod) via the create path above; this branch
+	// handles in-place container restarts and flag/label changes on an
+	// existing node. Update only when something actually changed to avoid
+	// touch noise on every restart with identical flags.
+	mergedLabels, labelsChanged := mergeManagedLabels(existing.Labels, r.Labels)
+	specChanged := !specEqual(existing.Spec, r.Spec)
+	if !specChanged && !labelsChanged {
+		log.Info("FleetNode spec and labels unchanged", "name", r.NodeName)
 		return nil
 	}
 	existing.Spec = r.Spec
+	existing.Labels = mergedLabels
 	if err := r.Client.Update(ctx, &existing); err != nil {
-		return fmt.Errorf("update FleetNode %q spec: %w", r.NodeName, err)
+		return fmt.Errorf("update FleetNode %q: %w", r.NodeName, err)
 	}
-	log.Info("updated FleetNode spec", "name", r.NodeName)
+	log.Info("updated FleetNode", "name", r.NodeName,
+		"specChanged", specChanged, "labelsChanged", labelsChanged)
 	return nil
+}
+
+// cloneLabels returns a shallow copy of m, or nil when m is empty, so the
+// FleetNode does not alias the Registrar's map.
+func cloneLabels(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// mergeManagedLabels returns existing with every key from managed added or
+// overwritten, plus whether anything changed. Labels not in managed are left
+// untouched: the agent owns only the keys it sets, never the whole label map,
+// so labels added by an operator (or other controllers) survive.
+func mergeManagedLabels(existing, managed map[string]string) (map[string]string, bool) {
+	if len(managed) == 0 {
+		return existing, false
+	}
+	out := make(map[string]string, len(existing)+len(managed))
+	for k, v := range existing {
+		out[k] = v
+	}
+	changed := false
+	for k, v := range managed {
+		if cur, ok := out[k]; !ok || cur != v {
+			out[k] = v
+			changed = true
+		}
+	}
+	return out, changed
 }
 
 // PatchHeartbeat patches the FleetNode's status with a fresh heartbeat

--- a/pkg/foreman/agent/fleetnode_test.go
+++ b/pkg/foreman/agent/fleetnode_test.go
@@ -209,6 +209,116 @@ func TestRegistrar_Upsert_NoopIfSpecUnchanged(t *testing.T) {
 	}
 }
 
+func TestMergeManagedLabels(t *testing.T) {
+	cases := []struct {
+		name        string
+		existing    map[string]string
+		managed     map[string]string
+		wantChanged bool
+		wantKV      map[string]string // subset that must be present
+	}{
+		{
+			name: "no managed labels", existing: map[string]string{"a": "b"},
+			managed: nil, wantChanged: false, wantKV: map[string]string{"a": "b"},
+		},
+		{
+			name: "add to nil existing", existing: nil,
+			managed: map[string]string{"coder-pool": "amd"}, wantChanged: true,
+			wantKV: map[string]string{"coder-pool": "amd"},
+		},
+		{
+			name: "add missing key", existing: map[string]string{"a": "b"},
+			managed: map[string]string{"coder-pool": "amd"}, wantChanged: true,
+			wantKV: map[string]string{"a": "b", "coder-pool": "amd"},
+		},
+		{
+			name: "overwrite changed value", existing: map[string]string{"coder-pool": "metal"},
+			managed: map[string]string{"coder-pool": "amd"}, wantChanged: true,
+			wantKV: map[string]string{"coder-pool": "amd"},
+		},
+		{
+			name: "no change when present+equal", existing: map[string]string{"coder-pool": "amd"},
+			managed: map[string]string{"coder-pool": "amd"}, wantChanged: false,
+			wantKV: map[string]string{"coder-pool": "amd"},
+		},
+		{
+			name: "preserve unmanaged labels", existing: map[string]string{"keep": "me"},
+			managed: map[string]string{"coder-pool": "amd"}, wantChanged: true,
+			wantKV: map[string]string{"keep": "me", "coder-pool": "amd"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := mergeManagedLabels(tc.existing, tc.managed)
+			if changed != tc.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tc.wantChanged)
+			}
+			for k, v := range tc.wantKV {
+				if got[k] != v {
+					t.Errorf("result[%q] = %q, want %q (full: %v)", k, got[k], v, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRegistrar_Upsert_SetsLabelsOnCreate(t *testing.T) {
+	kc := newFakeClient(t)
+	r := &Registrar{
+		Client:   kc,
+		NodeName: "incluster-agent",
+		Spec:     foremanv1alpha1.FleetNodeSpec{NodeName: "incluster-agent", Roles: []string{"worker", "coder"}},
+		Labels:   map[string]string{"coder-pool": "amd"},
+		Provider: &fixedCapability{},
+	}
+	if err := r.Upsert(context.Background()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	var got foremanv1alpha1.FleetNode
+	if err := kc.Get(context.Background(), types.NamespacedName{Name: "incluster-agent"}, &got); err != nil {
+		t.Fatalf("Get after create: %v", err)
+	}
+	if got.Labels["coder-pool"] != "amd" {
+		t.Errorf("Labels = %v, want coder-pool=amd", got.Labels)
+	}
+}
+
+func TestRegistrar_Upsert_ReappliesLabelsOnExisting(t *testing.T) {
+	// Simulate a FleetNode that lost its managed label (e.g. a hand-applied
+	// label dropped on pod recreate) while carrying an unrelated label. Upsert
+	// must re-add the managed label without disturbing the unmanaged one, even
+	// though the spec is unchanged.
+	existing := &foremanv1alpha1.FleetNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "incluster-agent",
+			ResourceVersion: "1",
+			Labels:          map[string]string{"unmanaged": "keep"},
+		},
+		Spec: foremanv1alpha1.FleetNodeSpec{NodeName: "incluster-agent", Roles: []string{"worker", "coder"}},
+	}
+	kc := newFakeClient(t, existing)
+	r := &Registrar{
+		Client:   kc,
+		NodeName: "incluster-agent",
+		Spec:     foremanv1alpha1.FleetNodeSpec{NodeName: "incluster-agent", Roles: []string{"worker", "coder"}},
+		Labels:   map[string]string{"coder-pool": "amd"},
+		Provider: &fixedCapability{},
+	}
+	if err := r.Upsert(context.Background()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	var got foremanv1alpha1.FleetNode
+	if err := kc.Get(context.Background(), types.NamespacedName{Name: "incluster-agent"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Labels["coder-pool"] != "amd" {
+		t.Errorf("managed label not re-applied: %v", got.Labels)
+	}
+	if got.Labels["unmanaged"] != "keep" {
+		t.Errorf("unmanaged label not preserved: %v", got.Labels)
+	}
+}
+
 func TestRegistrar_PatchHeartbeat_WritesPhaseAndCapability(t *testing.T) {
 	existing := &foremanv1alpha1.FleetNode{
 		ObjectMeta: metav1.ObjectMeta{Name: "m5-max"},


### PR DESCRIPTION
## What

Add a `--node-labels key=value,...` flag to `foreman-agent` (wired from `charts/foreman` `agent.nodeLabels`) so capability-routing labels on a FleetNode survive agent pod restarts.

## Why

Fixes #881

Capability routing matches an Agent's `requiredCapability.nodeSelector` against labels on the FleetNode (e.g. `coder-pool: amd`). A FleetNode is named for the agent pod, so every pod recreation (crash, rollout, `helm upgrade`) produces a fresh FleetNode with no label, and a hand-applied `kubectl label fleetnode` is lost. Routing then silently stops matching that node until someone re-labels by hand. Hit live during the #829 dual-box validation: a `helm upgrade` dropped the in-cluster node's `coder-pool: amd` label.

## How

- `cmd/foreman-agent/main.go`: new `--node-labels` flag, parsed by `parseKeyValueCSV` into a map, passed to the Registrar.
- `pkg/foreman/agent/fleetnode.go`: `Registrar.Labels` is stamped onto the FleetNode's metadata in `Upsert` -- set at create time (so a fresh pod's FleetNode is immediately routable) and reconciled on the existing-node path via `mergeManagedLabels`. Only the managed keys are added/overwritten; labels added by an operator or other controllers are preserved.
- `charts/foreman`: `agent.nodeLabels` (default `{}`) renders `--node-labels=k=v,...`; values doc explains the durability vs a hand-applied label.

No RBAC change: the agent already has create/update on `fleetnodes` (it owns its FleetNode spec); labels go through the same path.

## Testing

- `pkg/foreman/agent`: `TestMergeManagedLabels` (add / overwrite / no-op / preserve-unmanaged), `TestRegistrar_Upsert_SetsLabelsOnCreate`, `TestRegistrar_Upsert_ReappliesLabelsOnExisting` (re-adds a dropped managed label, spec unchanged, keeps an unrelated label).
- `cmd/foreman-agent`: `TestParseKeyValueCSV` (trim / trailing comma / malformed / empty-key).
- `helm template ... --set agent.nodeLabels.coder-pool=amd` renders `--node-labels=coder-pool=amd`; `helm lint` clean.
- `make lint` + `GOOS=linux` lint: 0 issues.

## Checklist

- [x] Tests pass
- [x] Lint passes (default + cross-arch)
- [x] No CRD change; no new RBAC (reuses existing fleetnodes create/update)
- [x] Commit signed off (DCO)