### PR TITLE
docs(strix): document amdgpu.lockup_timeout for device-lost resets

### DIFF
--- a/docs/strix-halo-onboarding.md
+++ b/docs/strix-halo-onboarding.md
@@ -30,12 +30,20 @@ amdgpu.gttsize=126976
 ttm.pages_limit=32505856
 ttm.page_pool_size=25165824
 amdgpu.vm_fragment_size=8
+amdgpu.lockup_timeout=20000
 ```
+
+The first five tune the GTT/UMA memory ceiling. `amdgpu.lockup_timeout=20000`
+raises the GPU lockup/reset timeout to 20s (from the ~10s default): under
+sustained heavy inference on gfx1151 (long-context coder runs, draft/MTP
+decode) the default timeout can trip a spurious GPU reset ("device lost") that
+kills the llama-server backend mid-run. 20s avoids the false positive without
+masking a genuine hang.
 
 Reboot after applying. Confirm they're live:
 
 ```bash
-cat /proc/cmdline | tr ' ' '\n' | grep -E 'gttsize|ttm|amd_iommu'
+cat /proc/cmdline | tr ' ' '\n' | grep -E 'gttsize|ttm|amd_iommu|lockup_timeout'
 ```
 
 For Talos nodes, set these in the machine config `customization.extraKernelArgs` and include the `siderolabs/amdgpu` and `siderolabs/amd-ucode` system extensions. See the [Talos AMD GPU guide](https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/amd-gpu) for the full Talos recipe.
@@ -308,6 +316,16 @@ cat /proc/cmdline | tr ' ' '\n' | grep -E 'gttsize|ttm|amd_iommu'
 ### OOM under load
 
 The amdgpu GTT pins system RAM the kernel OOM-killer can't reclaim. On UMA nodes running multiple GPU pods, the heaviest pod can deadlock the node under sustained memory pressure. Configure a userspace OOM manager to kill the largest pod (by current memory usage) under sustained memory PSI pressure, while keeping system and runtime classes (kubelet, containerd) protected.
+
+### GPU reset / "device lost" under sustained load
+
+A spurious amdgpu reset (ring timeout, "device lost") kills the inference backend mid-run on long or draft/MTP-heavy workloads. Raise the GPU lockup timeout with `amdgpu.lockup_timeout=20000` (see [Step 1](#step-1-verify-host-prerequisites)) and reboot. Confirm it's live:
+
+```bash
+cat /proc/cmdline | tr ' ' '\n' | grep lockup_timeout
+```
+
+If resets persist after the bump, the workload is genuinely hanging the GPU rather than hitting a false timeout; check `dmesg | grep -i amdgpu` for the failing ring and reduce context length or draft depth.
 
 ## See also
 


### PR DESCRIPTION
## What

Add `amdgpu.lockup_timeout=20000` to the Strix Halo onboarding kernel args, with rationale, and a Troubleshooting entry for GPU reset / "device lost" under sustained load.

## Why

On gfx1151 (Strix Halo), sustained heavy inference (long-context coder runs, draft/MTP decode) can trip the default ~10s GPU lockup timeout and trigger a spurious amdgpu reset ("device lost", ring timeout) that kills the llama-server backend mid-run. Raising the timeout to 20s avoids the false positive without masking a genuine hang. This bit us repeatedly bringing up dense/MTP coders on the Strix; documenting it so the next operator doesn't have to rediscover it.

## How

- `docs/strix-halo-onboarding.md`:
  - Step 1 kernel args: add `amdgpu.lockup_timeout=20000` to the block, a short paragraph explaining what it does and why, and `lockup_timeout` to the verify grep.
  - Troubleshooting: new "GPU reset / device lost under sustained load" entry pointing at the param, with a `dmesg | grep -i amdgpu` follow-up for genuine hangs.

## Checklist

- [x] Docs-only change (no code)
- [x] Commit signed off (DCO)