### PR TITLE
fix(controller): run model-cache-prep init as root again (0.8.20 regression)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,16 @@ deployment config).
   and `charts/`). Change the source and regenerate.
 - Do not commit secrets, kubeconfigs, or `.env` files.
 - Do not skip the pre-commit checks or the CRD sync step.
+- Do not run an init/main container that performs a privileged syscall (`chown`,
+  `chmod` of an unowned file, `mount`, etc.) non-root with `capabilities.add`
+  when the syscall runs in an exec'd child (`command: ["sh", "-c", "chown ..."]`).
+  A non-root process loses its capabilities across `execve` unless the runtime
+  sets ambient capabilities, which is runtime-dependent (it works on kind but
+  not on every cluster, so envtest and CI will pass while real users hit
+  `EPERM`). Either run the container as root (uid 0, still `Drop: [ALL]` + the
+  minimal caps + no privilege escalation), or do the syscall directly in the
+  container's entrypoint (a small helper binary) so the caps are not cleared.
+  This caused the 0.8.20 `model-cache-prep` regression (#887). Any change to an
+  init/main container `securityContext`, `command`, `image`, or user that affects
+  a privileged syscall must be reasoned about at the runtime level, not just by
+  the rendered-spec envtest.

--- a/docs/MODEL-CACHE.md
+++ b/docs/MODEL-CACHE.md
@@ -315,15 +315,19 @@ This will revert to the legacy behavior where each pod downloads the model via i
 
 ## Security Considerations
 
-### PSA `restricted` incompatibility
+### Automatic shared cache on `fsGroupPolicy: None` backends (CephFS, NFS)
 
-The model cache init container cannot satisfy Pod Security Admission (PSA) `restricted` policy. PSA `restricted` forbids both running as root and adding any capability except `NET_BIND_SERVICE`. Chowning a root-owned mount (which the cache-prep init container does on CSIs with `fsGroupPolicy: None`) requires `CAP_CHOWN`/`CAP_FOWNER`, and the init must run as **root (uid 0)** to use them: it shells out to `chown`, and a non-root process clears its capabilities across `execve` (Kubernetes has no ambient-capability field, and containerd does not set them), so the exec'd `chown` would fail with `EPERM`. The init therefore runs as non-privileged root with only `CHOWN`+`FOWNER`, which cannot satisfy `restricted` no matter how it is tuned. (Running it non-root broke the cache prep in 0.8.20; reverted in 0.8.21.)
+The automatic shared-model-cache workflow is a first-class supported path, **including** on `fsGroupPolicy: None` CSIs such as CephFS and NFS. On those backends Kubernetes does not apply the pod `fsGroup` to the volume, so the PVC root stays `root:root` and the non-root model downloader cannot write to it. The `model-cache-prep` init container fixes the ownership for you so the cache just works. You do not need to pre-stage models or hand-manage a PVC.
 
-This is inherent to the problem: the cache-prep init container exists precisely because `fsGroup` is not applied on `fsGroupPolicy: None` CSIs. On such a CSI in a PSA-`restricted` namespace, the shared cache path is not available. Alternatives:
+The prep is the **compatibility implementation** for these backends, and it runs as **non-privileged root (uid 0)** with `ALL` capabilities dropped and only `CHOWN`+`FOWNER` added (no privilege escalation, read-only rootfs, seccomp `RuntimeDefault`). Root here is a backend-driven requirement, not an avoidable misconfiguration: chowning a root-owned mount needs `CAP_CHOWN`, the prep shells out to `chown`, and a non-root process loses its capabilities across `execve` (Kubernetes has no ambient-capability field), so the exec'd `chown` would fail `EPERM`. Root retains its capabilities across exec. (Running the prep non-root broke the shared cache on these backends in 0.8.20; reverted in 0.8.21. A future change may move the chown into a small dedicated helper that performs the syscall in its own entrypoint, which would let the prep run non-root again without the exec capability loss.)
 
-- Use an `fsGroupPolicy: File` CSI (the default on most clusters) so Kubernetes handles the ownership automatically.
-- Use an `emptyDir` model store (disable the persistent cache).
-- Use a less-strict PSA policy (e.g., `baseline` or `privileged`).
+### PSA `restricted`
+
+Because the prep needs root plus `CHOWN`/`FOWNER`, it cannot satisfy Pod Security Admission `restricted` (which forbids running as root and adding any capability except `NET_BIND_SERVICE`). This is a property of the storage backend, not of the cache feature: it applies only in the narrow intersection of an `fsGroupPolicy: None` backend AND a namespace that enforces `restricted`. If you are in exactly that case, the options are:
+
+- Use an `fsGroupPolicy: File` CSI so Kubernetes applies ownership itself and no prep is needed.
+- Use an `emptyDir` model store (no shared persistent cache).
+- Relax the namespace policy to `baseline`.
 
 ### Shared-cache group-write multi-tenancy
 

--- a/docs/MODEL-CACHE.md
+++ b/docs/MODEL-CACHE.md
@@ -317,7 +317,7 @@ This will revert to the legacy behavior where each pod downloads the model via i
 
 ### PSA `restricted` incompatibility
 
-The model cache init container cannot satisfy Pod Security Admission (PSA) `restricted` policy. PSA `restricted` forbids both running as root and adding any capability except `NET_BIND_SERVICE`. Chowning a root-owned mount (which the cache-prep init container does on CSIs with `fsGroupPolicy: None`) requires either root or `CAP_CHOWN`/`CAP_FOWNER`, so the cache-prep init container cannot satisfy `restricted` no matter how it is tuned.
+The model cache init container cannot satisfy Pod Security Admission (PSA) `restricted` policy. PSA `restricted` forbids both running as root and adding any capability except `NET_BIND_SERVICE`. Chowning a root-owned mount (which the cache-prep init container does on CSIs with `fsGroupPolicy: None`) requires `CAP_CHOWN`/`CAP_FOWNER`, and the init must run as **root (uid 0)** to use them: it shells out to `chown`, and a non-root process clears its capabilities across `execve` (Kubernetes has no ambient-capability field, and containerd does not set them), so the exec'd `chown` would fail with `EPERM`. The init therefore runs as non-privileged root with only `CHOWN`+`FOWNER`, which cannot satisfy `restricted` no matter how it is tuned. (Running it non-root broke the cache prep in 0.8.20; reverted in 0.8.21.)
 
 This is inherent to the problem: the cache-prep init container exists precisely because `fsGroup` is not applied on `fsGroupPolicy: None` CSIs. On such a CSI in a PSA-`restricted` namespace, the shared cache path is not available. Alternatives:
 

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -918,13 +918,17 @@ var _ = Describe("cache prep init container (#855)", func() {
 		Expect(dl.Image).To(Equal("my-registry.io/init:v1.2.3"))
 	})
 
-	It("prep SecurityContext: RunAsUser=100 (non-root), RunAsNonRoot=true, AllowPrivilegeEscalation=false, Capabilities.Drop=[ALL], Capabilities.Add has CHOWN and FOWNER, ReadOnlyRootFilesystem=true, SeccompProfile.Type=RuntimeDefault", func() {
+	It("prep SecurityContext: RunAsUser=0, AllowPrivilegeEscalation=false, Capabilities.Drop=[ALL], Capabilities.Add has CHOWN and FOWNER, ReadOnlyRootFilesystem=true, SeccompProfile.Type=RuntimeDefault", func() {
 		config := buildCachedStorageConfig(cacheModel(), nil, "", "", "curl:8.18.0", 102)
 		prep := config.initContainers[0]
 		sc := prep.SecurityContext
 		Expect(sc).NotTo(BeNil())
-		Expect(*sc.RunAsUser).To(Equal(int64(100)))
-		Expect(*sc.RunAsNonRoot).To(BeTrue())
+		// Regression guard (0.8.20): the prep MUST run as root. Non-root with
+		// capabilities.add does not work -- containerd clears caps when sh
+		// execs chown (no ambient caps), so chown fails EPERM and the init
+		// container errors out on fsGroupPolicy=None CSIs. Do not flip to
+		// non-root without ambient-capability support.
+		Expect(*sc.RunAsUser).To(Equal(int64(0)))
 		Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
 		Expect(*sc.ReadOnlyRootFilesystem).To(BeTrue())
 

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -209,7 +209,7 @@ func invalidFileSetInitContainer(initImage string) corev1.Container {
 	}
 }
 
-// cachePrepInitContainer returns the non-root prep init container that runs
+// cachePrepInitContainer returns the root-run prep init container that runs
 // BEFORE model-downloader in the cache-backed path. CSI drivers with
 // fsGroupPolicy=None (CephFS, NFS) never apply the pod fsGroup to the volume,
 // so the PVC root stays root:root 0755 and the non-root downloader (uid 100)
@@ -221,14 +221,17 @@ func invalidFileSetInitContainer(initImage string) corev1.Container {
 // (fsGroup disabled, e.g. OpenShift) the prep chowns to 100:100 (the
 // downloader's UID/GID) and sets 770 so only the downloader can write.
 //
-// Security: the prep runs as the non-root curl_user (uid 100), drops ALL
-// capabilities, and adds back only CHOWN+FOWNER. CHOWN lets a non-root
-// process change ownership of the root-owned mount arbitrarily, and FOWNER
-// lets it chmod a file it does not own, so the chown/chmod above succeed
-// without running as root. This satisfies Pod Security Admission "baseline"
-// (non-root, no privilege escalation, minimal caps). It cannot satisfy
-// "restricted", which forbids adding any capability except NET_BIND_SERVICE:
-// the chown of an unowned mount fundamentally needs CHOWN. See
+// Security: the prep runs as root (uid 0) with ALL capabilities dropped and
+// only CHOWN+FOWNER added, and is NOT privileged. Root is required, not
+// optional: the container runs `sh -c "chown ... && chmod ..."`, and in
+// containerd a non-root process clears its capabilities across execve (there
+// are no ambient capabilities in the Kubernetes securityContext), so the
+// `chown` the shell execs would run with an empty effective set and fail with
+// EPERM. Root retains its capabilities across exec, so chown/chmod succeed.
+// Running this init non-root broke model-cache-prep on fsGroupPolicy=None CSIs
+// in 0.8.20; see the regression note below. It still cannot satisfy PSA
+// "restricted" (which forbids adding any capability except NET_BIND_SERVICE,
+// and the chown of an unowned mount fundamentally needs CHOWN); see
 // docs/MODEL-CACHE.md "Security Considerations" for the restricted-PSA
 // alternatives (fsGroupPolicy=File CSI, emptyDir store, or a laxer policy).
 //
@@ -249,10 +252,12 @@ func cachePrepInitContainer(initImage string, resolvedFSGroup int64) corev1.Cont
 			{Name: "model-cache", MountPath: "/models"},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			// Non-root (curl_user). CHOWN+FOWNER are sufficient to chown/chmod
-			// the root-owned mount without uid 0; see the doc comment above.
-			RunAsUser:                int64Ptr(100),
-			RunAsNonRoot:             boolPtr(true),
+			// Root (uid 0), required for the exec'd chown to keep CAP_CHOWN.
+			// Non-root + capabilities.add does NOT work here: containerd does
+			// not set ambient caps, so caps are cleared when sh execs chown
+			// (EPERM). Not privileged: ALL caps dropped, only CHOWN+FOWNER
+			// added, no privilege escalation. See the doc comment above.
+			RunAsUser:                int64Ptr(0),
 			AllowPrivilegeEscalation: boolPtr(false),
 			ReadOnlyRootFilesystem:   boolPtr(true),
 			Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
## What

Revert the `model-cache-prep` init container to `RunAsUser: 0`, fixing a crash introduced in 0.8.20.

## Why

Fixes #887 (regression from #883 / 0.8.20).

#883 ran the prep non-root (`RunAsUser: 100`) with `capabilities.add: [CHOWN, FOWNER]`. That does not work in Kubernetes: the container runs `sh -c "chown ... && chmod ..."`, and in containerd a **non-root** process clears its capabilities across `execve` (there is no ambient-capability field in the k8s securityContext, and containerd does not set them). So the `chown` the shell execs runs with an empty effective capability set and fails `EPERM`, crashing the init container on `fsGroupPolicy: None` CSIs (CephFS, NFS) -- the exact case the prep exists for. As **root**, capabilities are retained across exec, so chown succeeds.

This was the precise risk flagged in the #883 review ("envtest validates the spec, not a live chown") that did not get the belt-and-suspenders cluster check.

## How

- `internal/controller/model_storage.go`: `RunAsUser: 100 -> 0`, remove `RunAsNonRoot: true`. Keep `Drop: [ALL]` + `Add: [CHOWN, FOWNER]` + `allowPrivilegeEscalation: false` + read-only rootfs + seccomp (non-privileged root, two minimal caps). Doc comment explains why root is required (cap-on-exec).
- `inferenceservice_storage_test.go`: assert `RunAsUser == 0` with a regression-guard comment ("do not flip non-root without ambient caps").
- `docs/MODEL-CACHE.md`: correct the security note -- non-root + caps cannot work without ambient capabilities; the init runs as non-privileged root.

`privileged` is not required and never was.

## Testing

- Build + vet clean.
- `go test ./internal/controller/` cache-prep suite passes with the `RunAsUser == 0` assertion.
- `make lint`: 0 issues.

## Release

Needs a **0.8.21** patch. Workaround for users on 0.8.20: pin 0.8.19, or use an `fsGroupPolicy: File` CSI / `emptyDir` store.

## Checklist

- [x] Tests pass
- [x] Lint passes
- [x] Commit signed off (DCO)