### PR TITLE
fix(foreman): stamp real AgenticTask name on the post-push gate Job (not 'unknown')

### DIFF
--- a/cmd/foreman-agent/envtest_runner_test.go
+++ b/cmd/foreman-agent/envtest_runner_test.go
@@ -1,6 +1,17 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremantools "github.com/defilantech/llmkube/pkg/foreman/agent/tools"
+)
 
 func TestMapGateVerdict(t *testing.T) {
 	cases := []struct {
@@ -17,5 +28,68 @@ func TestMapGateVerdict(t *testing.T) {
 		if pass != c.wantPass || ran != c.wantRan {
 			t.Errorf("mapGateVerdict(%q) = (%v,%v) want (%v,%v)", c.verdict, pass, ran, c.wantPass, c.wantRan)
 		}
+	}
+}
+
+// TestEnvtestJobRunnerStampsTaskName is the #893 regression: the post-push
+// envtest gate Job must carry the originating AgenticTask name in the
+// foreman.llmkube.dev/task-name label, not the "unknown"/"task" default the
+// gate renderer falls back to when no taskRef is threaded through. The runner
+// submits the Job via a fake client; we read the created Job back out and
+// assert the label matches the task name the executor passed in.
+func TestEnvtestJobRunnerStampsTaskName(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := batchv1.AddToScheme(s); err != nil {
+		t.Fatalf("add batchv1 scheme: %v", err)
+	}
+	kc := fake.NewClientBuilder().WithScheme(s).Build()
+
+	const (
+		taskNS   = "foreman-system"
+		taskName = "fix-issue-893"
+		jobName  = "foreman-gate-fix-issue-893-pinned"
+	)
+
+	runner := &envtestJobRunnerImpl{
+		tool: &foremantools.RunGateJobTool{
+			Client: kc,
+			Cfg: foremantools.RunGateJobToolConfig{
+				Namespace:    taskNS,
+				PollInterval: time.Millisecond,
+				// Bound the poll so the test does not block: the fake client
+				// never drives the Job to a terminal phase, so Run returns a
+				// could-not-run GATE-ERROR. We only care that the Job was
+				// created with the right label before polling gives up.
+				PollTimeout: 5 * time.Millisecond,
+				NameFn:      func(string) string { return jobName },
+			},
+		},
+	}
+
+	// The runner does not need to reach a verdict for this assertion; the Job
+	// is created up front, before polling. Run with a short-lived context.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, _, _ = runner.Run(
+		ctx, taskNS, taskName,
+		"defilantech/LLMKube", "foreman/issue-893",
+		"https://github.com/Defilan/LLMKube.git",
+	)
+
+	var job batchv1.Job
+	key := types.NamespacedName{Namespace: taskNS, Name: jobName}
+	if err := kc.Get(context.Background(), key, &job); err != nil {
+		t.Fatalf("gate Job %s was not created: %v", key, err)
+	}
+
+	if got := job.Labels["foreman.llmkube.dev/task-name"]; got != taskName {
+		t.Errorf("gate Job task-name label = %q, want %q", got, taskName)
+	}
+	if got := job.Labels["foreman.llmkube.dev/task-namespace"]; got != taskNS {
+		t.Errorf("gate Job task-namespace label = %q, want %q", got, taskNS)
+	}
+	// Pod template labels must match so a pod can also be traced back.
+	if got := job.Spec.Template.Labels["foreman.llmkube.dev/task-name"]; got != taskName {
+		t.Errorf("gate Job pod template task-name label = %q, want %q", got, taskName)
 	}
 }

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -808,13 +808,21 @@ type envtestJobRunnerImpl struct {
 }
 
 func (e *envtestJobRunnerImpl) Run(
-	ctx context.Context, repository, branch, cloneURL string,
+	ctx context.Context, taskNamespace, taskName, repository, branch, cloneURL string,
 ) (pass bool, ran bool, feedback string) {
 	args, err := json.Marshal(map[string]any{
 		"repo":     repository,
 		"branch":   branch,
 		"checks":   []string{"test"},
 		"cloneURL": cloneURL,
+		// taskRef stamps the gate Job + pod with the originating AgenticTask
+		// identity (foreman.llmkube.dev/task-{namespace,name} labels) so a
+		// gate Job/pod can be traced back to its task (#893). Without it the
+		// renderer falls back to "unknown".
+		"taskRef": map[string]string{
+			"namespace": taskNamespace,
+			"name":      taskName,
+		},
 	})
 	if err != nil {
 		return false, false, "envtest gate: marshal args: " + err.Error()

--- a/pkg/foreman/agent/envtest_gate.go
+++ b/pkg/foreman/agent/envtest_gate.go
@@ -15,7 +15,15 @@ type EnvtestJobRunner interface {
 	// caller treats that as could-not-verify (GO stands). When ran is true,
 	// pass reflects the gate verdict and feedback carries the log tail on
 	// failure.
-	Run(ctx context.Context, repository, branch, cloneURL string) (pass bool, ran bool, feedback string)
+	//
+	// taskNamespace/taskName identify the originating AgenticTask so the
+	// submitted gate Job carries the foreman.llmkube.dev/task-{namespace,name}
+	// labels and a Job/pod can be traced back to its task (#893). They mirror
+	// the coder Job path's TaskNamespace/TaskName.
+	Run(
+		ctx context.Context,
+		taskNamespace, taskName, repository, branch, cloneURL string,
+	) (pass bool, ran bool, feedback string)
 }
 
 // evaluatePostPushEnvtest decides whether a pushed GO should be downgraded
@@ -27,12 +35,12 @@ func evaluatePostPushEnvtest(
 	ctx context.Context,
 	envtestTouched bool,
 	runner EnvtestJobRunner,
-	repository, branch, cloneURL string,
+	taskNamespace, taskName, repository, branch, cloneURL string,
 ) (failed bool, feedback string) {
 	if !envtestTouched || runner == nil {
 		return false, ""
 	}
-	pass, ran, fb := runner.Run(ctx, repository, branch, cloneURL)
+	pass, ran, fb := runner.Run(ctx, taskNamespace, taskName, repository, branch, cloneURL)
 	if !ran {
 		return false, ""
 	}

--- a/pkg/foreman/agent/envtest_gate_test.go
+++ b/pkg/foreman/agent/envtest_gate_test.go
@@ -9,46 +9,62 @@ type fakeEnvtestJobRunner struct {
 	pass, ran bool
 	feedback  string
 	called    bool
+
+	// gotTaskNamespace / gotTaskName capture the task identity the caller
+	// threaded through, so tests can assert it reaches the runner (#893).
+	gotTaskNamespace string
+	gotTaskName      string
 }
 
-func (f *fakeEnvtestJobRunner) Run(_ context.Context, _, _, _ string) (bool, bool, string) {
+func (f *fakeEnvtestJobRunner) Run(_ context.Context, taskNamespace, taskName, _, _, _ string) (bool, bool, string) {
 	f.called = true
+	f.gotTaskNamespace = taskNamespace
+	f.gotTaskName = taskName
 	return f.pass, f.ran, f.feedback
 }
 
 func TestEvaluatePostPushEnvtest(t *testing.T) {
 	t.Run("not touched: runner not called, no downgrade", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{}
-		failed, fb := evaluatePostPushEnvtest(context.Background(), false, r, "repo", "br", "url")
+		failed, fb := evaluatePostPushEnvtest(context.Background(), false, r, "ns", "task", "repo", "br", "url")
 		if failed || fb != "" || r.called {
 			t.Fatalf("got failed=%v fb=%q called=%v", failed, fb, r.called)
 		}
 	})
 	t.Run("nil runner: no downgrade", func(t *testing.T) {
-		failed, fb := evaluatePostPushEnvtest(context.Background(), true, nil, "repo", "br", "url")
+		failed, fb := evaluatePostPushEnvtest(context.Background(), true, nil, "ns", "task", "repo", "br", "url")
 		if failed || fb != "" {
 			t.Fatalf("got failed=%v fb=%q", failed, fb)
 		}
 	})
 	t.Run("touched + pass: no downgrade", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: true, ran: true}
-		failed, _ := evaluatePostPushEnvtest(context.Background(), true, r, "repo", "br", "url")
+		failed, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
 		if failed || !r.called {
 			t.Fatalf("got failed=%v called=%v", failed, r.called)
 		}
 	})
 	t.Run("touched + ran + fail: downgrade with feedback", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: false, ran: true, feedback: "envtest broke"}
-		failed, fb := evaluatePostPushEnvtest(context.Background(), true, r, "repo", "br", "url")
+		failed, fb := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
 		if !failed || fb != "envtest broke" {
 			t.Fatalf("got failed=%v fb=%q", failed, fb)
 		}
 	})
 	t.Run("touched + could-not-run: no downgrade (GO stands)", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: false, ran: false, feedback: "infra"}
-		failed, _ := evaluatePostPushEnvtest(context.Background(), true, r, "repo", "br", "url")
+		failed, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
 		if failed {
 			t.Fatalf("could-not-run should not downgrade; got failed=%v", failed)
+		}
+	})
+	t.Run("task identity is threaded to the runner (#893)", func(t *testing.T) {
+		r := &fakeEnvtestJobRunner{pass: true, ran: true}
+		evaluatePostPushEnvtest(context.Background(), true, r,
+			"foreman-system", "fix-issue-893", "repo", "br", "url")
+		if r.gotTaskNamespace != "foreman-system" || r.gotTaskName != "fix-issue-893" {
+			t.Fatalf("runner got task identity (%q,%q), want (foreman-system,fix-issue-893)",
+				r.gotTaskNamespace, r.gotTaskName)
 		}
 	})
 }

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -633,6 +633,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// GO to INCOMPLETE; a could-not-run leaves the GO standing.
 	if failed, feedback := evaluatePostPushEnvtest(
 		ctx, envtestTouched, e.EnvtestJobRunner,
+		task.Namespace, task.Name,
 		task.Spec.Payload.Repo, branch, e.GitRemoteURL,
 	); failed {
 		return e.envtestGateFailedResult(start, transcriptRef, loopRes, branch, sha, feedback), nil


### PR DESCRIPTION
## What

Thread the originating `AgenticTask`'s namespace/name through the post-push envtest gate so the gate Job is labeled `foreman.llmkube.dev/task-name: <task>` instead of the literal `unknown`.

## Why

Fixes #893. The `EnvtestJobRunner.Run` interface carried no task identity, so `renderGateJob` hit its empty-name fallback and stamped `task-name: unknown` on every post-push gate Job (and a `task` Job-name suffix). That makes a gate Job/pod (e.g. an `Error` pod) impossible to trace back to the task that created it. The sibling coder-Job path already threads the name correctly; this brings the gate path in line.

## How

- Add `taskNamespace, taskName` to the `EnvtestJobRunner.Run` interface and `evaluatePostPushEnvtest`.
- Executor (GO path) passes `task.Namespace, task.Name` down.
- `envtestJobRunnerImpl.Run` includes `taskRef: {namespace, name}` in the marshaled gate args, so `RunGateJobTool` renders the real name.
- Test: `TestEnvtestJobRunnerStampsTaskName` asserts the created Job's `task-name`/`task-namespace`/pod-template labels equal the supplied task (failed to build on the old 3-arg signature, passes after).

## Checklist

- [x] `gofmt`, `go vet ./...`, `go build ./...`, `GOOS=linux go build ./...`
- [x] `go test ./pkg/foreman/agent/... ./cmd/foreman-agent/...`
- [x] `GOOS=linux golangci-lint run` on touched packages (0 issues)
- [x] No CRD/RBAC changes

---
AI-assisted (band-3, human-accountable): implemented with AI assistance; reviewed and verified by me. Commits are clean per the contributor guide.
