### PR TITLE
fix(metal-agent): reap orphaned legacy Endpoints so mirror slices stop blackholing traffic

### DIFF
--- a/charts/foreman/templates/agent-rbac.yaml
+++ b/charts/foreman/templates/agent-rbac.yaml
@@ -56,6 +56,19 @@ rules:
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
 
+  # The metal-agent registers endpoints as discovery.k8s.io EndpointSlices.
+  # Older agents published a legacy core/v1 Endpoints object instead. On
+  # upgrade across that change the stale Endpoints object is orphaned and the
+  # built-in EndpointSliceMirroring controller keeps regenerating a mirror
+  # slice from it, blackholing a share of traffic on the selector-less Service
+  # (#891). RegisterEndpoint best-effort reaps that legacy object, which needs
+  # get + delete on core/endpoints. Scope is intentionally narrow: the agent
+  # only ever touches the Endpoints whose name matches a Service it manages and
+  # that carries its own managed-by label.
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "delete"]
+
   # When an Agent's spec.provider is "cloud-proxy" (v0.2), the
   # native executor reads providerConfig.apiKeySecretRef and dispatches
   # to the upstream HTTP endpoint with a Bearer token from the named

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -196,6 +196,12 @@ func (r *ServiceRegistry) upsertEndpoint(
 		return fmt.Errorf("failed to create/update endpointslice: %w", err)
 	}
 
+	// Best-effort reap of a legacy core/v1 Endpoints object this agent (or a
+	// prior version that predates the EndpointSlice migration, #684) may have
+	// left behind under the same name. Done after the live slice is written so
+	// there is no window where neither the slice nor the legacy object exists.
+	r.reapLegacyEndpoints(ctx, isvc.Namespace, serviceName)
+
 	if ready {
 		r.logger.Infow("registered endpoint",
 			"namespace", isvc.Namespace,
@@ -213,6 +219,55 @@ func (r *ServiceRegistry) upsertEndpoint(
 	}
 
 	return nil
+}
+
+// reapLegacyEndpoints best-effort deletes a legacy core/v1 Endpoints object
+// this agent (or an older version) created before the EndpointSlice migration
+// (#684). When an agent is upgraded across that change the old Endpoints object
+// is orphaned, and Kubernetes' built-in EndpointSliceMirroring controller keeps
+// generating a mirror EndpointSlice from it. On a selector-less Service that
+// stale mirror unions with the agent's live slice, blackholing a share of
+// traffic to a dead host:port and wedging the InferenceService in Progressing
+// (issue #891).
+//
+// The operation is deliberately:
+//   - Idempotent: a NotFound is the normal steady state and is ignored.
+//   - Non-fatal: any error (NotFound, forbidden, transient) is logged at most
+//     as a warning and never propagated, so it cannot fail registration.
+//   - Conservative: only an Endpoints object carrying this agent's own
+//     managed-by label is deleted. A user's unrelated Endpoints that happens to
+//     share the name is left untouched, because the discriminator is the
+//     llmkube.ai/managed-by=metal-agent label that only the agent ever stamps.
+func (r *ServiceRegistry) reapLegacyEndpoints(ctx context.Context, namespace, serviceName string) {
+	//nolint:staticcheck // SA1019: deliberately operating on the legacy core/v1 Endpoints API to reap it.
+	legacy := &corev1.Endpoints{}
+	err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: serviceName}, legacy)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			r.logger.Warnw("failed to look up legacy Endpoints for reaping; skipping",
+				"namespace", namespace, "name", serviceName, "error", err)
+		}
+		return
+	}
+
+	// Only reap the agent's own legacy artifact. Anything else is left alone.
+	if legacy.Labels["llmkube.ai/managed-by"] != "metal-agent" {
+		r.logger.Debugw("Endpoints exists but is not agent-managed; leaving untouched",
+			"namespace", namespace, "name", serviceName,
+			"managed-by", legacy.Labels["llmkube.ai/managed-by"])
+		return
+	}
+
+	if err := r.client.Delete(ctx, legacy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return // raced with another deleter; nothing to do
+		}
+		r.logger.Warnw("failed to delete legacy Endpoints; mirror slice may persist",
+			"namespace", namespace, "name", serviceName, "error", err)
+		return
+	}
+	r.logger.Infow("reaped legacy Endpoints to stop stale mirror EndpointSlice",
+		"namespace", namespace, "name", serviceName)
 }
 
 // RegisterEndpointWithRetry retries RegisterEndpoint with exponential backoff

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -920,3 +920,135 @@ func TestRegisterEndpointWithRetry_ContextCancelled(t *testing.T) {
 		t.Fatalf("want context.Canceled in error chain, got: %v", err)
 	}
 }
+
+// TestRegisterEndpoint_ReapsLegacyEndpoints verifies that a legacy core/v1
+// Endpoints object the agent (or a prior version) left behind is deleted on
+// registration, so the built-in EndpointSliceMirroring controller stops
+// regenerating a stale mirror slice that blackholes traffic (issue #891).
+func TestRegisterEndpoint_ReapsLegacyEndpoints(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+
+	// A legacy Endpoints object carrying the agent's own managed-by label,
+	// same name as the Service the agent manages.
+	legacy := &corev1.Endpoints{ //nolint:staticcheck // SA1019: simulating a legacy artifact under test
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "default",
+			Labels: map[string]string{
+				"llmkube.ai/managed-by":        "metal-agent",
+				"llmkube.ai/inference-service": "test-model",
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(legacy).
+		Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "test-model"},
+	}
+
+	if err := registry.RegisterEndpoint(context.Background(), isvc, 8080); err != nil {
+		t.Fatalf("RegisterEndpoint returned error: %v", err)
+	}
+
+	// The legacy Endpoints object must be gone.
+	err := k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      "test-model",
+		Namespace: "default",
+	}, &corev1.Endpoints{}) //nolint:staticcheck // SA1019: asserting the legacy artifact is deleted
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("legacy Endpoints should have been deleted; Get returned err=%v", err)
+	}
+
+	// The live EndpointSlice must still be present.
+	slice := &discoveryv1.EndpointSlice{}
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      "test-model",
+		Namespace: "default",
+	}, slice); err != nil {
+		t.Fatalf("EndpointSlice should be present after registration: %v", err)
+	}
+}
+
+// TestRegisterEndpoint_LeavesUnrelatedEndpoints verifies the reaper only
+// deletes the agent's own legacy artifact: an Endpoints object that does not
+// carry the agent's managed-by label (e.g. a user's own selector-less Service
+// endpoints that happens to share the name) must be left untouched.
+func TestRegisterEndpoint_LeavesUnrelatedEndpoints(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+
+	// An Endpoints object NOT managed by the agent.
+	unrelated := &corev1.Endpoints{ //nolint:staticcheck // SA1019: simulating a user-owned object under test
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "someone-else",
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(unrelated).
+		Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "test-model"},
+	}
+
+	if err := registry.RegisterEndpoint(context.Background(), isvc, 8080); err != nil {
+		t.Fatalf("RegisterEndpoint returned error: %v", err)
+	}
+
+	// The unrelated Endpoints object must still exist.
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      "test-model",
+		Namespace: "default",
+	}, &corev1.Endpoints{}); err != nil { //nolint:staticcheck // SA1019: asserting the user object survived
+		t.Errorf("unrelated Endpoints should NOT have been deleted; Get returned err=%v", err)
+	}
+}
+
+// TestRegisterEndpoint_NoLegacyEndpoints verifies that registration with no
+// pre-existing legacy Endpoints object succeeds: a NotFound from the reaper's
+// lookup must be swallowed and never fail registration.
+func TestRegisterEndpoint_NoLegacyEndpoints(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	registry := NewServiceRegistry(k8sClient, "", newNopLogger(), "")
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "test-model"},
+	}
+
+	if err := registry.RegisterEndpoint(context.Background(), isvc, 8080); err != nil {
+		t.Fatalf("RegisterEndpoint with no legacy Endpoints returned error: %v", err)
+	}
+
+	// The EndpointSlice must still be created.
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      "test-model",
+		Namespace: "default",
+	}, &discoveryv1.EndpointSlice{}); err != nil {
+		t.Fatalf("EndpointSlice should be present after registration: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Reap the legacy `core/v1` `Endpoints` object the metal-agent (or a prior version) owns when it (re)asserts a Service+EndpointSlice, so the EndpointSliceMirroring controller stops regenerating a stale mirror slice.

## Why

Fixes #891. Older metal-agents published a legacy `Endpoints` object; newer agents publish `EndpointSlice` directly and orphan the old object. The mirroring controller keeps generating a mirror slice from it, and on a selector-less Service the Service resolves to the UNION of the live slice and the dead mirror, blackholing a share of traffic to a stale `host:port` and pinning the InferenceService in `Progressing` (readyReplicas > desired). Observed in the field: `Endpoints/devstral-24b` frozen for a week kept respawning a dead-port mirror slice until the source object was deleted by hand.

## How

- New `reapLegacyEndpoints` called from `upsertEndpoint` **after** the live slice is written (no gap where neither exists; self-heals on every heartbeat).
- Conservative discriminator: only deletes an `Endpoints` carrying `llmkube.ai/managed-by: metal-agent` (the exact label the old legacy-Endpoints code stamped — verified in git history). An unrelated user `Endpoints` of the same name is left untouched.
- Idempotent + non-fatal: NotFound is the steady state; any error is logged at most as a warning and never fails registration.
- RBAC: add `core/endpoints` `get,delete` to the agent ClusterRole (chart is hand-maintained; `make check-helm-rbac` passes).

## Checklist

- [x] `gofmt`, `go vet ./...`, `go build ./...`, `GOOS=linux go build ./...`
- [x] `go test ./pkg/agent/...` (fail-before/pass-after on the reap; unrelated-Endpoints + NotFound cases covered)
- [x] `GOOS=linux golangci-lint run ./pkg/agent/...` (0 issues)
- [x] `make check-helm-rbac` passes

---
AI-assisted (band-3, human-accountable): implemented with AI assistance; reviewed and verified by me. Commits are clean per the contributor guide.
