### PR TITLE
fix(foreman): don't force-terminate a coder mid-verification after it has edited (#896)

### DIFF
--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -421,15 +421,29 @@ func (m *LoopProgressMonitor) recordCalls(calls []oai.ToolCall) {
 func (m *LoopProgressMonitor) updateEditFreeStreak(calls []oai.ToolCall) {
 	for _, tc := range calls {
 		if _, ok := editProducingTools[tc.Function.Name]; ok {
-			m.editFreeStreak = 0
+			m.resetEditFreeStreak()
 			return
 		}
 		if tc.Function.Name == "bash" && bashCallMutatesWorkspace(tc.Function.Arguments) {
-			m.editFreeStreak = 0
+			m.resetEditFreeStreak()
 			return
 		}
 	}
 	m.editFreeStreak++
+}
+
+// resetEditFreeStreak clears the edit-free streak AND the escalation flag when
+// a real edit lands. Resetting nudgedEditFree is what fixes #896: a productive
+// edit proves the model is not stuck, so a later edit-free streak (e.g. the
+// post-edit go build / go test / git diff verification turns) must earn a fresh
+// nudge -> forcing-phase recovery instead of jumping straight to force-terminate
+// off a stale nudge from earlier exploration. Without this reset, one early
+// explore-nudge poisons the rest of the run: every subsequent streak that hits
+// the limit terminates empty-handed even though edits were made and the branch
+// was never pushed.
+func (m *LoopProgressMonitor) resetEditFreeStreak() {
+	m.editFreeStreak = 0
+	m.nudgedEditFree = false
 }
 
 // fileWritingBashTokens are substrings that indicate a bash command
@@ -459,11 +473,42 @@ func bashCallMutatesWorkspace(arguments string) bool {
 // the shell.
 func bashLikelyMutatesWorkspace(command string) bool {
 	for _, tok := range fileWritingBashTokens {
-		if strings.Contains(command, tok) {
+		if containsTokenAtWordBoundary(command, tok) {
 			return true
 		}
 	}
 	return bashRedirectsToFile(command)
+}
+
+// containsTokenAtWordBoundary reports whether tok occurs in command at a word
+// boundary: either at the start of the string or immediately after a non-word
+// character. Every token in fileWritingBashTokens begins with the command name
+// (dd, mv, cp, tee, ...), so a boundary check on the leading char prevents
+// matching a token embedded inside an unrelated word. Without it, "git add "
+// matches "dd " and "scp x" matches "cp " (#896 secondary).
+func containsTokenAtWordBoundary(command, tok string) bool {
+	from := 0
+	for {
+		i := strings.Index(command[from:], tok)
+		if i < 0 {
+			return false
+		}
+		abs := from + i
+		if abs == 0 || !isWordByte(command[abs-1]) {
+			return true
+		}
+		from = abs + 1
+	}
+}
+
+// isWordByte reports whether b is an ASCII letter, digit, or underscore, i.e.
+// part of a shell word. The boundary check treats anything else (space, &, |,
+// ;, /, quotes, start-of-string) as a separator.
+func isWordByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
 }
 
 // bashRedirectsToFile reports whether the command contains an output

--- a/pkg/foreman/agent/progress_896_test.go
+++ b/pkg/foreman/agent/progress_896_test.go
@@ -1,0 +1,115 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// TestProgressMonitor_896_PostEditStreakNudgesNotTerminates is the #896
+// regression: a coder that has ALREADY made a successful edit must not be
+// force-terminated by EditFreeStreak during post-edit verification. Instead the
+// edit-free streak re-arming after a real edit should NUDGE (recoverable: the
+// loop enters the forcing phase that drops bash and pushes the model toward
+// submit_result), not terminate empty-handed with no branch.
+//
+// It replays the per-turn tool trace captured on the #856 in-cluster run at the
+// ornith profile's editFreeTurnsLimit=4:
+//
+//	read_file   x4   (pre-edit exploration -> first EditFreeStreak nudge)
+//	str_replace x2   (real edits -- streak AND escalation state must reset)
+//	bash        x4   (verification: build/vet/test/diff -- edit-free turns)
+//
+// Before the fix the run force-terminated at the 4th verification turn because
+// nudgedEditFree survived the edits. After the fix the edits reset the
+// escalation state, so the post-edit streak nudges (recoverable) instead.
+func TestProgressMonitor_896_PostEditStreakNudgesNotTerminates(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{EditFreeTurnsLimit: 4})
+	tr := []oai.Message{}
+
+	turn := 0
+	obs := func(name, args string) ProgressDecision {
+		turn++
+		return mon.Observe(turn, []oai.ToolCall{makeCall("c", name, args)}, tr)
+	}
+
+	// Turns 1-4: pre-edit reads. The 4th trips the limit and nudges.
+	var d ProgressDecision
+	for i := 0; i < 4; i++ {
+		d = obs("read_file", `{"path":"pkg/agent/agent.go"}`)
+	}
+	if d.Action != ProgressNudge || d.Signal != signalEditFreeStreak {
+		t.Fatalf("turn 4: expected pre-edit EditFreeStreak nudge, got action=%v signal=%q",
+			d.Action, d.Signal)
+	}
+
+	// Turns 5-6: the real edits. These must reset BOTH the streak and the
+	// escalation state, so the run is no longer "poisoned" by the early nudge.
+	obs("str_replace", `{"path":"pkg/agent/agent.go","old":"a","new":"b"}`)
+	obs("str_replace", `{"path":"pkg/agent/agent.go","old":"c","new":"d"}`)
+
+	// Turns 7-10: post-edit verification. None mutate the workspace (and we
+	// avoid `git add`, whose "dd " substring is a separate false-positive). The
+	// streak climbs 1..4; at the limit it must NUDGE (recoverable), not
+	// force-terminate, because the edits cleared nudgedEditFree.
+	verify := []string{
+		`{"command":"go build ./..."}`,
+		`{"command":"go vet ./..."}`,
+		`{"command":"go test ./pkg/foreman/agent/ -run TestX"}`,
+		`{"command":"git diff --stat HEAD"}`,
+	}
+	for _, cmd := range verify {
+		d = obs("bash", cmd)
+		t.Logf("turn %d (bash verify): action=%v signal=%q streak=%d",
+			turn, d.Action, d.Signal, mon.editFreeStreak)
+	}
+
+	if d.Action == ProgressForceTerminate {
+		t.Fatalf("#896: coder force-terminated during post-edit verification at turn %d "+
+			"after 2 real edits (branch would never push). Want a recoverable nudge.", turn)
+	}
+	if d.Action != ProgressNudge || d.Signal != signalEditFreeStreak {
+		t.Fatalf("turn %d: expected recoverable EditFreeStreak nudge post-edit, got "+
+			"action=%v signal=%q", turn, d.Action, d.Signal)
+	}
+	t.Logf("#896 fixed: post-edit streak nudges (recoverable) at turn %d instead of "+
+		"terminating empty-handed.", turn)
+}
+
+// TestProgressMonitor_896_EditClearsNudgeEscalation is the focused unit for the
+// fix: an edit that resets the streak must also clear nudgedEditFree, so a
+// later streak that re-hits the limit nudges again rather than escalating
+// straight to force-terminate off the stale flag.
+func TestProgressMonitor_896_EditClearsNudgeEscalation(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{EditFreeTurnsLimit: 2})
+	tr := []oai.Message{}
+	turn := 0
+	obs := func(name, args string) ProgressDecision {
+		turn++
+		return mon.Observe(turn, []oai.ToolCall{makeCall("c", name, args)}, tr)
+	}
+
+	// Two edit-free reads trip the limit -> first nudge (sets nudgedEditFree).
+	obs("read_file", `{"path":"f"}`)
+	if d := obs("read_file", `{"path":"f"}`); d.Action != ProgressNudge {
+		t.Fatalf("turn 2: want nudge, got action=%v", d.Action)
+	}
+	if !mon.nudgedEditFree {
+		t.Fatal("nudgedEditFree should be set after the first edit-free nudge")
+	}
+
+	// A real edit lands: streak AND the escalation flag must clear.
+	obs("str_replace", `{"path":"f","old":"a","new":"b"}`)
+	if mon.nudgedEditFree {
+		t.Fatal("#896: nudgedEditFree must reset when an edit resets the streak")
+	}
+
+	// Two more edit-free turns re-hit the limit. Because the flag was cleared,
+	// this is a fresh NUDGE (recoverable), not a force-terminate.
+	obs("read_file", `{"path":"f"}`)
+	d := obs("read_file", `{"path":"f"}`)
+	if d.Action != ProgressNudge || d.Signal != signalEditFreeStreak {
+		t.Fatalf("post-edit streak: want recoverable nudge, got action=%v signal=%q",
+			d.Action, d.Signal)
+	}
+}

--- a/pkg/foreman/agent/progress_test.go
+++ b/pkg/foreman/agent/progress_test.go
@@ -250,6 +250,16 @@ func TestBashLikelyMutatesWorkspace(t *testing.T) {
 		{"grep -r foo .", false},
 		{"go test ./... > /dev/null 2>&1", false},
 		{"echo done 2>&1", false},
+		// #896 secondary: tokens must match at a word boundary, not as a
+		// substring inside another word. "git add " contains "dd " (the dd
+		// command token); a coder runs `git add` constantly, and a false reset
+		// of the edit-free streak here masks genuine stuck loops.
+		{"git add -A", false},
+		{"git add -A && git commit -m fix", false},
+		{"go build ./cmd/...", false}, // "cmd" must not trip "dd "/"cp "/etc.
+		// True positives at a real word boundary must still match.
+		{"dd if=/dev/zero of=out.bin", true},
+		{"rm -rf x && tee y.txt", true},
 	}
 	for _, c := range cases {
 		if got := bashLikelyMutatesWorkspace(c.cmd); got != c.want {


### PR DESCRIPTION
## What

Stop `EditFreeStreak` from force-terminating a coder during its **post-edit verification** turns. A coder that already made a successful edit, then ran `go build` / `go test` / `git diff` to verify before submitting, was being killed with `INCOMPLETE` and **no branch** — even though real edits were committed locally.

Also fixes a latent false-positive in the same heuristic: `git add` falsely reset the streak.

Fixes #896

## Why

Root cause: a productive edit reset the streak counter but **not** the `nudgedEditFree` escalation flag. One early explore-nudge (from pre-edit `read_file` turns) then poisoned the rest of the run — when the streak re-hit the limit during legitimate post-edit verification, the monitor took the already-nudged branch and jumped straight to force-terminate, skipping the nudge → forcing-phase recovery that converges the model to `submit_result` (which pushes the branch). The outcome was turn-budget / path-speed dependent (slow gateway path failed, fast local path succeeded), not a model-capability or filesystem issue.

Secondary: `fileWritingBashTokens` matched as plain substrings, so `"git add "` contained the `"dd "` token (and `"scp "` contained `"cp "`), falsely resetting the streak on commands a coder runs constantly. That masked genuine stuck loops.

## How

- `resetEditFreeStreak()` now clears **both** `editFreeStreak` and `nudgedEditFree` when an edit (or workspace-mutating bash) lands. A later edit-free streak earns a fresh nudge → forcing phase (which drops `bash` and pushes the model to submit) instead of an instant terminate.
- `bashLikelyMutatesWorkspace` matches mutation tokens at a **word boundary** (`containsTokenAtWordBoundary`) instead of via `strings.Contains`, so `git add` no longer trips `"dd "`.

## Testing

- `go test ./pkg/foreman/agent/` (full package green, ~52s)
- New deterministic regression replaying the #856 trace (`read_file`x4, `str_replace`x2, `bash`x4): asserts a recoverable **nudge** at the limit, not force-terminate.
- Focused unit: the escalation flag clears on edit.
- Matcher cases: `git add` / `go build ./cmd/...` → not mutating; `dd if=...` / `tee` → mutating.
- `gofmt`, `go vet`, `golangci-lint` clean.

## Checklist

- [x] Tests added/updated and passing
- [x] `gofmt` / `go vet` / lint clean
- [x] DCO sign-off
- [x] No CRD/RBAC/manifest changes (pure loop-behavior fix)

## Notes

Live-cluster confirmation (re-run #856 on the in-cluster coder, expect a pushed branch instead of `INCOMPLETE`) requires this to land in a coder image first; will validate post-merge via the runtimes coder image.
