### PR TITLE
feat: expose oMLX TurboQuant KV cache quantization settings

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -359,6 +359,17 @@ type InferenceServiceSpec struct {
 	// +optional
 	ExtraArgs []string `json:"extraArgs,omitempty"`
 
+	// TurboQuantBits sets the KV cache quantization bit width for the oMLX
+	// runtime (3, 6, or 8). Maps to oMLX --kv-cache-quant. When set, the
+	// oMLX daemon uses TurboQuant to compress the KV cache, reducing memory
+	// usage by up to 67% with minimal speed impact (~7% overhead). Only
+	// meaningful for the omlx runtime; ignored by llamacpp and other runtimes.
+	// Requires oMLX v0.3.4+ (which introduced 3-bit TurboQuant) or a later
+	// dev build (6-bit and 8-bit options).
+	// +kubebuilder:validation:Enum=3;6;8
+	// +optional
+	TurboQuantBits *int32 `json:"turboQuantBits,omitempty"`
+
 	// Command overrides the container entrypoint.
 	// Only used when Runtime is "generic" or for advanced customization.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -587,6 +587,11 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.TurboQuantBits != nil {
+		in, out := &in.TurboQuantBits, &out.TurboQuantBits
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Command != nil {
 		in, out := &in.Command, &out.Command
 		*out = make([]string, len(*in))

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -2944,6 +2944,21 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+              turboQuantBits:
+                description: |-
+                  TurboQuantBits sets the KV cache quantization bit width for the oMLX
+                  runtime (3, 6, or 8). Maps to oMLX --kv-cache-quant. When set, the
+                  oMLX daemon uses TurboQuant to compress the KV cache, reducing memory
+                  usage by up to 67% with minimal speed impact (~7% overhead). Only
+                  meaningful for the omlx runtime; ignored by llamacpp and other runtimes.
+                  Requires oMLX v0.3.4+ (which introduced 3-bit TurboQuant) or a later
+                  dev build (6-bit and 8-bit options).
+                enum:
+                - 3
+                - 6
+                - 8
+                format: int32
+                type: integer
               uBatchSize:
                 description: |-
                   UBatchSize sets the micro-batch size for decoding.

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -2940,6 +2940,21 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+              turboQuantBits:
+                description: |-
+                  TurboQuantBits sets the KV cache quantization bit width for the oMLX
+                  runtime (3, 6, or 8). Maps to oMLX --kv-cache-quant. When set, the
+                  oMLX daemon uses TurboQuant to compress the KV cache, reducing memory
+                  usage by up to 67% with minimal speed impact (~7% overhead). Only
+                  meaningful for the omlx runtime; ignored by llamacpp and other runtimes.
+                  Requires oMLX v0.3.4+ (which introduced 3-bit TurboQuant) or a later
+                  dev build (6-bit and 8-bit options).
+                enum:
+                - 3
+                - 6
+                - 8
+                format: int32
+                type: integer
               uBatchSize:
                 description: |-
                   UBatchSize sets the micro-batch size for decoding.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -627,6 +627,7 @@ func buildExecutorConfig(
 		ReasoningBudgetMessage: isvc.Spec.ReasoningBudgetMessage,
 		Mode:                   isvc.Spec.Mode,
 		ExtraArgs:              isvc.Spec.ExtraArgs,
+		TurboQuantBits:         derefInt32(isvc.Spec.TurboQuantBits),
 	}
 }
 

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -118,6 +118,16 @@ type ExecutorConfig struct {
 	// ExtraArgs are appended to the command line as-is, last, so they can
 	// override any earlier flag llama-server emitted (last-wins).
 	ExtraArgs []string
+
+	// TurboQuantBits sets the KV cache quantization bit width for the oMLX
+	// runtime (3, 6, or 8). Maps to oMLX --kv-cache-quant. When set, the
+	// oMLX daemon uses TurboQuant to compress the KV cache, reducing memory
+	// usage by up to 67% with minimal speed impact (~7% overhead). Only
+	// meaningful for the omlx runtime; ignored by llamacpp and other runtimes.
+	// Requires oMLX v0.3.4+ (which introduced 3-bit TurboQuant) or a later
+	// dev build (6-bit and 8-bit options).
+	// +optional
+	TurboQuantBits int
 }
 
 // ProcessExecutor is the interface that both llama-server and oMLX executors

--- a/pkg/agent/executor_omlx.go
+++ b/pkg/agent/executor_omlx.go
@@ -51,6 +51,10 @@ type OMLXExecutor struct {
 	logger         *zap.SugaredLogger
 	httpClient     *http.Client
 	startupTimeout time.Duration
+	// turboQuantBits is the KV cache quantization bit width for the oMLX
+	// daemon (--kv-cache-quant). Set once when the daemon starts; shared
+	// across all models served by this daemon. Zero means no TurboQuant.
+	turboQuantBits int
 }
 
 // NewOMLXExecutor creates an executor that manages models via the oMLX daemon.
@@ -107,6 +111,12 @@ func (e *OMLXExecutor) StartProcess(ctx context.Context, config ExecutorConfig) 
 	}
 
 	e.logger.Infow("starting oMLX model", "modelID", modelID, "modelPath", modelPath)
+
+	// Set TurboQuant KV cache quantization on the daemon. This is a daemon-level
+	// setting applied once when the daemon starts; shared across all models.
+	e.mu.Lock()
+	e.turboQuantBits = config.TurboQuantBits
+	e.mu.Unlock()
 
 	// Ensure the oMLX daemon is running
 	if err := e.ensureOMLXRunning(ctx); err != nil {
@@ -210,6 +220,14 @@ func (e *OMLXExecutor) ensureOMLXRunning(ctx context.Context) error {
 		"--port", fmt.Sprint(e.port),
 		"--host", "0.0.0.0",
 	)
+
+	// TurboQuant KV cache quantization (oMLX v0.3.4+). Maps to --kv-cache-quant
+	// flag. The bits value (3, 6, or 8) is set via StartProcess before this
+	// call. When turboQuantBits is set, the flag is emitted; when omitted,
+	// oMLX uses its default (unquantized).
+	if e.turboQuantBits > 0 {
+		cmd.Args = append(cmd.Args, "--kv-cache-quant", fmt.Sprint(e.turboQuantBits))
+	}
 	cmd.Env = os.Environ()
 
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
## What

Expose oMLX **TurboQuant** KV-cache quantization through a new
`InferenceService.spec.turboQuantBits` field (enum `3` / `6` / `8`), mapped to
the oMLX `--kv-cache-quant` flag on the metal-agent `--runtime omlx` path.

## Why

Fixes #277

oMLX v0.3.4+ ships TurboQuant, which reduces KV-cache memory by up to ~67% for
roughly ~7% speed overhead. On memory-constrained Apple Silicon (for example a
36 GB M4 Max running a 4-bit ~15.7 GB model, leaving ~16 GB for KV cache + OS),
8-bit TurboQuant is the difference between a 32K and a 65K+ context window.
There was previously no way to enable it through the CRD.

## How

- Add `spec.turboQuantBits *int32` (enum 3/6/8) to `InferenceServiceSpec`;
  regenerate deepcopy and both CRD manifests (chart + config) so they stay in
  sync.
- Add `TurboQuantBits` to `ExecutorConfig` and wire it through
  `buildExecutorConfig`.
- `OMLXExecutor` emits `--kv-cache-quant N` when the value is non-zero and the
  runtime is oMLX; other runtimes ignore it. TurboQuant is a daemon-global oMLX
  setting, so the flag is applied at daemon launch.

Verified locally: `gofmt`, `go build ./...`, `go vet`, and `make lint` (0
issues) all clean; `make manifests generate` produces no CRD drift.

Scope note: exercising this end-to-end needs an oMLX-backed metal node. A unit
test asserting the arg emission (mirroring the existing vllm-swift
`--kv-cache-quant` tests) is a sensible follow-up, and the issue's "document
recommended settings per memory tier" sub-item is not included here.

## AI assistance

Assisted-by: Foreman (LLMKube's autonomous coder harness). The change was
generated end-to-end by Foreman running the model
**Jackrong/Qwopus3.6-35B-A3B-Coder-MTP (Q6_K)**, served locally by the LLMKube
metal-agent on an Apple **M5 Max** (Metal). A human reviewed the diff, ran the
checks below, and signs off under the DCO and the AI-assisted contribution
policy.

## Checklist

- [ ] Tests added/updated (arg-emission unit test recommended as follow-up; see scope note)
- [ ] `make test` passes locally (envtest not run locally; build/vet/lint clean, no controller-logic change)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO (human sign-off added)
- [x] AI assistance is disclosed above, per CONTRIBUTING.md
- [ ] Documentation updated (CRD field is self-describing; tier-recommendation docs are a follow-up per the issue)
