### PR TITLE
feat(foreman): reference-grounding check in the coder gate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,7 @@ linters:
         - G306  # file permissions ≤0600 (0644 is correct for cache/reports)
         - G703  # path traversal via taint (taint-analysis sibling of G304; the
         #         coder gate reads/writes git-reported files in its own workspace)
+        - G122  # WalkDir file read (taint sibling of G304/G703; scanners read trusted repo dirs)
   exclusions:
     generated: lax
     rules:

--- a/docs/site/_meta/nav.yaml
+++ b/docs/site/_meta/nav.yaml
@@ -114,6 +114,9 @@ sections:
       - label: Non-Go projects (language gates)
         slug: foreman/language-gates
         file: foreman/language-gates.md
+      - label: Grounding checks
+        slug: foreman/grounding-checks
+        file: foreman/grounding-checks.md
 
   - title: Reference
     items:

--- a/docs/site/foreman/grounding-checks.md
+++ b/docs/site/foreman/grounding-checks.md
@@ -1,0 +1,115 @@
+# Grounding checks: catching confabulated references
+
+Foreman's verify gate has two layers. The first is the language-configurable
+command tier (format, lint, build, test): see
+[Running Foreman on non-Go projects](./language-gates). The second is a set of
+deeper **semantic** checks that catch failure modes a command can never see.
+Reference grounding is one of them, and this page documents both what it does
+and the model to follow when you want the same protection for your own stack.
+
+The premise is the "harness, not model" one: a capable local model still
+confabulates, and the answer is a harness that verifies, not a bigger model.
+
+## The blind spot: documentation and config
+
+Format, lint, build, and test all operate on code. They never read the prose
+and example manifests a coder adds to `docs/`. So a model can write a tutorial
+that cites an API group, a CRD field, a metric, or a CLI command that does not
+exist, and every command-based check stays green because no code changed.
+
+This is a real, observed failure mode. In one run a coder wrote a perfectly
+formatted autoscaling tutorial whose YAML used the API group `llmkube.io`
+(the real group is `inference.llmkube.dev`) and scraped a Prometheus metric
+that was never registered. The docs compiled into nothing, so the gate passed
+it. A reader who copy-pasted that manifest would get a schema rejection, and a
+dashboard built on that metric would stay empty.
+
+## What the grounding check does
+
+On a coder's candidate GO, the grounding check scans the **added** lines of any
+docs and example YAML and flags references to project-owned symbols that do not
+resolve in the repository:
+
+- an `apiVersion:` naming an LLMKube-owned API group that no CRD defines, and
+- an `llmkube_*` metric token that is registered nowhere in the tree.
+
+A flagged reference fails the gate and feeds the specifics back to the coder,
+the same way a failing test does, so the loop gets a chance to fix the citation
+before a reviewer ever sees it. A correct example like this one passes
+untouched:
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: my-service
+spec:
+  modelRef: my-model
+```
+
+## The model to follow
+
+The shape of the check is general; only the symbol sources are
+project-specific. If you are adapting this to another project or language,
+follow the same four rules. They are what keep it useful without becoming
+noisy.
+
+### 1. Build ground truth from the project's own sources of truth
+
+The check assembles the set of real symbols by reading the repository: API
+groups and kinds from the generated CRDs under `config/crd/bases`, and
+`llmkube_*` metric names from the source. For another stack the sources differ
+but the idea is identical: enumerate the symbols your project actually defines
+from wherever you define them, for example an OpenAPI document, `.proto` files,
+a metrics registry, your package's public API, or your CLI's command list.
+
+### 2. Judge only the symbols you own
+
+The check validates only LLMKube-owned namespaces: groups matching
+`inference.llmkube.dev` (and the project's other owned suffixes) and the
+`llmkube_*` metric prefix. External references such as `apps/v1`,
+`autoscaling/v2`, or a third-party metric are never judged. This is the single
+most important rule: models confabulate *your* symbols, not the wider
+ecosystem's, and validating things you do not own is where false positives come
+from. Scope to your prefixes and namespaces and the check stays quiet on
+correct docs.
+
+### 3. Inspect the working tree, not committed history
+
+The gate runs before the coder's work is committed, so the check diffs the
+staged working tree against the branch point rather than committed history.
+That way it sees exactly the lines the coder added, including brand-new files.
+
+### 4. Hold the line at near-zero false positives
+
+Because a failed check blocks a GO, a false positive blocks legitimate work,
+which is worse than a missed catch. Keep each check to a class you can validate
+as essentially false-positive-free. The group and metric checks were validated
+against the entire committed documentation corpus with zero false positives;
+checks that could not clear that bar (matching CRD field names and `kind:`
+values, which collide with field values and historical release notes) were
+deliberately left out and deferred to a tool-using reviewer that can parse and
+grep rather than pattern-match.
+
+## Bringing grounding to your language
+
+Today the grounding check is wired into the Go gate path and grounds against
+LLMKube's CRDs and metrics. The command tier already travels to any language
+through [`gateProfile`](./language-gates); the semantic checks do not yet, so a
+Python or Rust project gets the command gate but not grounding.
+
+Closing that is additive, not a rewrite. `gateProfile` is the seam: it already
+carries `language`, `sourceExtensions`, and the command set. A
+profile-configurable grounding check would add declared **symbol sources** (an
+OpenAPI path, a proto directory, a metrics manifest, a package's exported API)
+and the owned-namespace patterns, and the same four rules above would then
+protect your docs in your language. If that is something you want, open an issue
+describing your project's symbol sources and we can shape the generalization
+together.
+
+## See also
+
+- [Running Foreman on non-Go projects](./language-gates): the command tier and
+  the `gateProfile` field, with a verified Python example.
+- [Foreman overview](/docs/foreman): the CRDs and the coder / verifier /
+  reviewer pipeline.

--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -577,8 +577,9 @@ func checkScopeOverlap(
 func checkReferenceGrounding(ctx context.Context, workspace string, run commandRunner) (failed bool, output string) {
 	gt, err := grounding.LoadGroundTruth(
 		filepath.Join(workspace, "config/crd/bases"),
-		filepath.Join(workspace, "internal/metrics"),
-		filepath.Join(workspace, "cmd"),
+		workspace, // scan the whole repo for llmkube_* metric literals: the
+		//            metal-agent metrics live in pkg/agent, not internal/metrics.
+		"", // CLI command validation disabled in v1 (prose false-positive risk).
 	)
 	if err != nil {
 		return false, ""

--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -585,7 +585,7 @@ func checkReferenceGrounding(ctx context.Context, workspace string, run commandR
 		return false, ""
 	}
 	added, err := grounding.AddedLines(
-		ctx, workspace, grounding.CommandRunner(run), "main", []string{"*.md", "*.yaml", "*.yml"},
+		ctx, workspace, grounding.CommandRunner(run), "HEAD", []string{"*.md", "*.yaml", "*.yml"},
 	)
 	if err != nil {
 		return false, ""

--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/defilantech/llmkube/pkg/foreman/agent/grounding"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repomap"
 )
 
@@ -88,13 +89,14 @@ type checkFailure struct {
 // query the scope-overlap check ranks files against; an empty string
 // disables that check (backward compatible).
 //
-// The gate runs eight deterministic checks in order: gofmt, go vet,
+// The gate runs eleven deterministic checks in order: gofmt, go vet,
 // go build, golangci-lint, a fast unit-test tier on changed packages,
-// a codegen-drift check, a goreleaser-config check (path-scoped), and
-// a scope-overlap check. Heavy envtest or integration tests are
-// intentionally out of scope; they run in a separate post-push gate
-// Job. All checks run regardless of earlier failures so the feedback
-// reports everything wrong at once.
+// a codegen-drift check, a goreleaser-config check (path-scoped),
+// a scope-overlap check, a test-presence check, a mutation-survival check,
+// and a reference-grounding check on added docs. Heavy envtest or
+// integration tests are intentionally out of scope; they run in a separate
+// post-push gate Job. All checks run regardless of earlier failures so the
+// feedback reports everything wrong at once.
 func RunCoderGate(
 	ctx context.Context,
 	workspace, golangciPath string,
@@ -194,6 +196,17 @@ func RunCoderGate(
 		if failed, out := checkMutationSurvival(ctx, workspace, run); failed {
 			failures = append(failures, checkFailure{name: "mutation survival", output: out})
 		}
+	}
+
+	// 11. Reference grounding: every LLMKube-owned API group / CRD kind /
+	// spec field / metric / CLI command referenced in ADDED doc or example
+	// YAML lines must resolve to a real symbol in the repo. Catches the
+	// "confabulated reference" class (invented API group, field, metric, or
+	// CLI command) that no compiler or linter touches because docs are never
+	// built. LLMKube-owned symbols only; external APIs are never judged.
+	// Fail-open: a ground-truth load or diff error skips the check.
+	if failed, out := checkReferenceGrounding(ctx, workspace, run); failed {
+		failures = append(failures, checkFailure{name: "reference grounding", output: out})
 	}
 
 	if len(failures) == 0 {
@@ -553,6 +566,35 @@ func checkScopeOverlap(
 	}
 	if len(relevantPaths) > len(shown) {
 		b.WriteString(fmt.Sprintf("  ... and %d more\n", len(relevantPaths)-len(shown)))
+	}
+	return true, b.String()
+}
+
+// checkReferenceGrounding loads LLMKube ground truth from the workspace and
+// flags any ungrounded LLMKube-owned reference in added .md/.yaml lines.
+// Fail-open on any load/diff error so the grounding net never blocks a coder
+// on its own failure.
+func checkReferenceGrounding(ctx context.Context, workspace string, run commandRunner) (failed bool, output string) {
+	gt, err := grounding.LoadGroundTruth(
+		filepath.Join(workspace, "config/crd/bases"),
+		filepath.Join(workspace, "internal/metrics"),
+		filepath.Join(workspace, "cmd"),
+	)
+	if err != nil {
+		return false, ""
+	}
+	added, err := grounding.AddedLines(ctx, workspace, grounding.CommandRunner(run), "main", []string{"*.md", "*.yaml", "*.yml"})
+	if err != nil {
+		return false, ""
+	}
+	findings := grounding.DetectUngroundedReferences(added, gt)
+	if len(findings) == 0 {
+		return false, ""
+	}
+	var b strings.Builder
+	b.WriteString("These docs reference LLMKube symbols that do not exist. Fix the reference (or the code) so it resolves:\n")
+	for _, f := range findings {
+		fmt.Fprintf(&b, "  - %s\n", f.String())
 	}
 	return true, b.String()
 }

--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -583,7 +583,9 @@ func checkReferenceGrounding(ctx context.Context, workspace string, run commandR
 	if err != nil {
 		return false, ""
 	}
-	added, err := grounding.AddedLines(ctx, workspace, grounding.CommandRunner(run), "main", []string{"*.md", "*.yaml", "*.yml"})
+	added, err := grounding.AddedLines(
+		ctx, workspace, grounding.CommandRunner(run), "main", []string{"*.md", "*.yaml", "*.yml"},
+	)
 	if err != nil {
 		return false, ""
 	}
@@ -592,7 +594,8 @@ func checkReferenceGrounding(ctx context.Context, workspace string, run commandR
 		return false, ""
 	}
 	var b strings.Builder
-	b.WriteString("These docs reference LLMKube symbols that do not exist. Fix the reference (or the code) so it resolves:\n")
+	b.WriteString("These docs reference LLMKube symbols that do not exist." +
+		" Fix the reference (or the code) so it resolves:\n")
 	for _, f := range findings {
 		fmt.Fprintf(&b, "  - %s\n", f.String())
 	}

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -19,6 +19,8 @@ package agent
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -897,5 +899,37 @@ func TestRunCoderGate_GoreleaserCheckSkippedWhenNoReleaseConfigChanged(t *testin
 	pass, fb := RunCoderGate(context.Background(), "/work", gateLintPath, run, "")
 	if !pass {
 		t.Fatalf("gate should pass when no release config changed; feedback:\n%s", fb)
+	}
+}
+
+// TestRunCoderGate_FailsOnUngroundedReference verifies that check #11 hard-fails
+// the gate when an added doc references an LLMKube API group that does not exist
+// in the repo's CRDs. All other gate checks must pass with this fake runner.
+func TestRunCoderGate_FailsOnUngroundedReference(t *testing.T) {
+	ws := t.TempDir()
+	crd := "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n" +
+		"spec:\n  group: inference.llmkube.dev\n  names:\n    kind: InferenceService\n" +
+		"  versions:\n    - name: v1alpha1\n      schema:\n        openAPIV3Schema:\n" +
+		"          properties:\n            spec:\n              properties:\n                modelRef:\n                  type: string\n"
+	if err := os.MkdirAll(filepath.Join(ws, "config/crd/bases"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "config/crd/bases/is.yaml"), []byte(crd), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run := func(ctx context.Context, dir string, env []string, name string, args ...string) (string, error) {
+		// Check #11: git diff --unified=0 main...HEAD -- *.md *.yaml *.yml
+		if name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--unified=0" {
+			return "+++ b/docs/x.md\n@@ -0,0 +1,1 @@\n+apiVersion: llmkube.io/v1alpha1\n", nil
+		}
+		// All other commands pass silently (gofmt empty, go/lint success, git status empty).
+		return "", nil
+	}
+	pass, feedback := RunCoderGate(context.Background(), ws, "./bin/golangci-lint", run, "")
+	if pass {
+		t.Fatalf("expected gate to fail on ungrounded reference; feedback=%q", feedback)
+	}
+	if !strings.Contains(feedback, "reference grounding") {
+		t.Errorf("feedback should name the check: %q", feedback)
 	}
 }

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -910,7 +910,8 @@ func TestRunCoderGate_FailsOnUngroundedReference(t *testing.T) {
 	crd := "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n" +
 		"spec:\n  group: inference.llmkube.dev\n  names:\n    kind: InferenceService\n" +
 		"  versions:\n    - name: v1alpha1\n      schema:\n        openAPIV3Schema:\n" +
-		"          properties:\n            spec:\n              properties:\n                modelRef:\n                  type: string\n"
+		"          properties:\n            spec:\n              properties:\n" +
+		"                modelRef:\n                  type: string\n"
 	if err := os.MkdirAll(filepath.Join(ws, "config/crd/bases"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -919,11 +919,13 @@ func TestRunCoderGate_FailsOnUngroundedReference(t *testing.T) {
 		t.Fatal(err)
 	}
 	run := func(ctx context.Context, dir string, env []string, name string, args ...string) (string, error) {
-		// Check #11: git diff --unified=0 main...HEAD -- *.md *.yaml *.yml
-		if name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--unified=0" {
+		// Check #11 diffs the staged working tree: git diff --cached --unified=0
+		// --src-prefix=a/ --dst-prefix=b/ HEAD -- *.md *.yaml *.yml
+		if name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--cached" {
 			return "+++ b/docs/x.md\n@@ -0,0 +1,1 @@\n+apiVersion: llmkube.io/v1alpha1\n", nil
 		}
-		// All other commands pass silently (gofmt empty, go/lint success, git status empty).
+		// All other commands pass silently (gofmt empty, go/lint success,
+		// git add/status no-ops).
 		return "", nil
 	}
 	pass, feedback := RunCoderGate(context.Background(), ws, "./bin/golangci-lint", run, "")

--- a/pkg/foreman/agent/grounding/diff.go
+++ b/pkg/foreman/agent/grounding/diff.go
@@ -16,14 +16,36 @@ type AddedLine struct {
 
 var hunkHeader = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
 
-// AddedLines returns the added (+) lines from `git diff --unified=0
-// base...HEAD -- pathspec...`, each attributed to its new-file line number.
-// Header lines (+++), removed lines, and context are ignored. A git error is
-// returned; an empty diff yields nil with no error.
+// AddedLines returns the added (+) lines of a WORKING-TREE diff against base
+// (`git diff --unified=0 <base> -- pathspec`), each attributed to its new-file
+// line number. It first runs `git add -N -- pathspec` (intent-to-add) so newly
+// created, still-untracked files are included: the coder gate runs BEFORE any
+// commit or stage, so the changes under test live in the working tree and new
+// files are untracked. intent-to-add stages no content and is superseded by the
+// executor's later `git add -A`. Pass base="HEAD" to capture exactly the
+// uncommitted changes on the current branch. A git error from the diff is
+// returned; an empty diff yields nil with no error. (Using `<base>...HEAD` here
+// would be a bug: at gate time HEAD has no coder commit yet, so committed
+// history shows none of the working-tree changes.)
 func AddedLines(
 	ctx context.Context, workspace string, run CommandRunner, base string, pathspec []string,
 ) ([]AddedLine, error) {
-	args := append([]string{"diff", "--unified=0", base + "...HEAD", "--"}, pathspec...)
+	// Stage the working-tree changes for these paths so a pre-commit diff
+	// includes new (untracked) files: `git add -N` (intent-to-add) is NOT
+	// reliably shown by `git diff <base>`, so stage for real with `git add -A`.
+	// The executor's later `git add -A` supersedes this, and the workspace is
+	// discarded after the run, so the staging is harmless.
+	addArgs := append([]string{"add", "-A", "--"}, pathspec...)
+	_, _ = run(ctx, workspace, nil, "git", addArgs...) // best-effort
+
+	// Diff the staged changes against base (--cached): new files show as full
+	// additions, modified files show their changes. base="HEAD" yields exactly
+	// the coder's uncommitted changes on the current branch. --src-prefix=a/
+	// --dst-prefix=b/ force the standard a/ b/ path prefixes: `git diff --cached`
+	// otherwise emits mnemonic c/ i/ prefixes, which the +++ b/ parser misses.
+	args := append([]string{
+		"diff", "--cached", "--unified=0", "--src-prefix=a/", "--dst-prefix=b/", base, "--",
+	}, pathspec...)
 	out, err := run(ctx, workspace, nil, "git", args...)
 	if err != nil {
 		return nil, err

--- a/pkg/foreman/agent/grounding/diff.go
+++ b/pkg/foreman/agent/grounding/diff.go
@@ -1,0 +1,48 @@
+package grounding
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// AddedLine is one added line attributed to its new-file path and line number.
+type AddedLine struct {
+	File string
+	Line int
+	Text string
+}
+
+var hunkHeader = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
+
+// AddedLines returns the added (+) lines from `git diff --unified=0
+// base...HEAD -- pathspec...`, each attributed to its new-file line number.
+// Header lines (+++), removed lines, and context are ignored. A git error is
+// returned; an empty diff yields nil with no error.
+func AddedLines(ctx context.Context, workspace string, run CommandRunner, base string, pathspec []string) ([]AddedLine, error) {
+	args := append([]string{"diff", "--unified=0", base + "...HEAD", "--"}, pathspec...)
+	out, err := run(ctx, workspace, nil, "git", args...)
+	if err != nil {
+		return nil, err
+	}
+	var added []AddedLine
+	var curFile string
+	var curLine int
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++ b/"):
+			curFile = strings.TrimPrefix(line, "+++ b/")
+		case strings.HasPrefix(line, "+++ "): // /dev/null etc.
+			curFile = ""
+		case strings.HasPrefix(line, "@@"):
+			if m := hunkHeader.FindStringSubmatch(line); m != nil {
+				curLine, _ = strconv.Atoi(m[1])
+			}
+		case strings.HasPrefix(line, "+") && curFile != "":
+			added = append(added, AddedLine{File: curFile, Line: curLine, Text: strings.TrimPrefix(line, "+")})
+			curLine++
+		}
+	}
+	return added, nil
+}

--- a/pkg/foreman/agent/grounding/diff.go
+++ b/pkg/foreman/agent/grounding/diff.go
@@ -20,7 +20,9 @@ var hunkHeader = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
 // base...HEAD -- pathspec...`, each attributed to its new-file line number.
 // Header lines (+++), removed lines, and context are ignored. A git error is
 // returned; an empty diff yields nil with no error.
-func AddedLines(ctx context.Context, workspace string, run CommandRunner, base string, pathspec []string) ([]AddedLine, error) {
+func AddedLines(
+	ctx context.Context, workspace string, run CommandRunner, base string, pathspec []string,
+) ([]AddedLine, error) {
 	args := append([]string{"diff", "--unified=0", base + "...HEAD", "--"}, pathspec...)
 	out, err := run(ctx, workspace, nil, "git", args...)
 	if err != nil {

--- a/pkg/foreman/agent/grounding/diff_test.go
+++ b/pkg/foreman/agent/grounding/diff_test.go
@@ -1,0 +1,33 @@
+package grounding
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAddedLines_AttributesLineNumbers(t *testing.T) {
+	diff := "diff --git a/docs/x.md b/docs/x.md\n" +
+		"--- a/docs/x.md\n+++ b/docs/x.md\n" +
+		"@@ -0,0 +1,2 @@\n+first line\n+second line\n" +
+		"@@ -10,0 +20,1 @@\n+twentieth\n"
+	run := func(_ context.Context, _ string, _ []string, _ string, _ ...string) (string, error) {
+		return diff, nil
+	}
+	got, err := AddedLines(context.Background(), "/ws", run, "main", []string{"*.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []AddedLine{
+		{File: "docs/x.md", Line: 1, Text: "first line"},
+		{File: "docs/x.md", Line: 2, Text: "second line"},
+		{File: "docs/x.md", Line: 20, Text: "twentieth"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %+v want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/foreman/agent/grounding/diff_test.go
+++ b/pkg/foreman/agent/grounding/diff_test.go
@@ -5,6 +5,50 @@ import (
 	"testing"
 )
 
+func TestAddedLines_UsesWorkingTreeAndSurfacesUntracked(t *testing.T) {
+	var sawStage bool
+	var diffArgs []string
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name == "git" && len(args) > 0 && args[0] == "add" {
+			sawStage = true // expect: add -A -- <pathspec> (stage so new files show)
+			return "", nil
+		}
+		if name == "git" && len(args) > 0 && args[0] == "diff" {
+			diffArgs = args
+			// Expect a staged working-tree diff vs HEAD: `diff --cached
+			// --unified=0 HEAD -- ...`. A `<base>...HEAD` committed diff would
+			// miss the coder's uncommitted, still-staged changes.
+			if contains(args, "--cached") && contains(args, "HEAD") && !contains(args, "HEAD...HEAD") {
+				return "+++ b/docs/new.md\n@@ -0,0 +1,1 @@\n+apiVersion: llmkube.io/v1alpha1\n", nil
+			}
+			return "", nil
+		}
+		return "", nil
+	}
+	added, err := AddedLines(context.Background(), "/ws", run, "HEAD", []string{"*.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sawStage {
+		t.Error("AddedLines must stage (`git add -A`) so untracked new files appear in the pre-commit diff")
+	}
+	if !contains(diffArgs, "--cached") {
+		t.Errorf("AddedLines must use a staged diff (`git diff --cached <base>`); got %v", diffArgs)
+	}
+	if len(added) != 1 || added[0].Text != "apiVersion: llmkube.io/v1alpha1" {
+		t.Errorf("expected the working-tree added line, got %v", added)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestAddedLines_AttributesLineNumbers(t *testing.T) {
 	diff := "diff --git a/docs/x.md b/docs/x.md\n" +
 		"--- a/docs/x.md\n+++ b/docs/x.md\n" +

--- a/pkg/foreman/agent/grounding/grounding.go
+++ b/pkg/foreman/agent/grounding/grounding.go
@@ -1,0 +1,35 @@
+// Package grounding holds deterministic, model-free checks that verify a
+// coder's diff is grounded in reality: that every LLMKube-owned symbol it
+// references actually exists (reference-grounding) and that every LLMKube
+// annotation key it introduces has a reader (inert-symbol). The detectors are
+// pure functions of a workspace path and an injected command runner so they
+// unit-test without shelling out. Wiring lives in coder_gate.go (Plan 1) and
+// the executor/controller (Plan 2).
+package grounding
+
+import (
+	"context"
+	"fmt"
+)
+
+// CommandRunner runs one command in dir with extra KEY=VALUE env appended,
+// returning combined stdout+stderr and the exec error. It mirrors the
+// commandRunner in coder_gate.go so the gate can pass its production runner
+// straight through.
+type CommandRunner func(ctx context.Context, dir string, extraEnv []string, name string, args ...string) (string, error)
+
+// Finding is one grounding defect. It mirrors the reviewer.Finding shape
+// (severity/area/file/line/message) so Plan 2 can surface gate findings and
+// reviewer findings as one schema on the task status.
+type Finding struct {
+	Severity string // "blocker" | "major" | "minor"
+	Area     string // "doc-consistency" | "wired-up"
+	File     string
+	Line     int
+	Message  string
+}
+
+// String renders a finding as "file:line [severity/area] message".
+func (f Finding) String() string {
+	return fmt.Sprintf("%s:%d [%s/%s] %s", f.File, f.Line, f.Severity, f.Area, f.Message)
+}

--- a/pkg/foreman/agent/grounding/grounding_test.go
+++ b/pkg/foreman/agent/grounding/grounding_test.go
@@ -3,7 +3,11 @@ package grounding
 import "testing"
 
 func TestFindingString_IncludesFileLineAndMessage(t *testing.T) {
-	f := Finding{Severity: "blocker", Area: "doc-consistency", File: "docs/x.md", Line: 12, Message: "unknown API group llmkube.io"}
+	f := Finding{
+		Severity: "blocker", Area: "doc-consistency",
+		File: "docs/x.md", Line: 12,
+		Message: "unknown API group llmkube.io",
+	}
 	got := f.String()
 	want := "docs/x.md:12 [blocker/doc-consistency] unknown API group llmkube.io"
 	if got != want {

--- a/pkg/foreman/agent/grounding/grounding_test.go
+++ b/pkg/foreman/agent/grounding/grounding_test.go
@@ -1,0 +1,12 @@
+package grounding
+
+import "testing"
+
+func TestFindingString_IncludesFileLineAndMessage(t *testing.T) {
+	f := Finding{Severity: "blocker", Area: "doc-consistency", File: "docs/x.md", Line: 12, Message: "unknown API group llmkube.io"}
+	got := f.String()
+	want := "docs/x.md:12 [blocker/doc-consistency] unknown API group llmkube.io"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}

--- a/pkg/foreman/agent/grounding/groundtruth.go
+++ b/pkg/foreman/agent/grounding/groundtruth.go
@@ -3,6 +3,7 @@ package grounding
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -15,6 +16,40 @@ type GroundTruth struct {
 	SpecFields map[string]map[string]bool // kind -> set of spec.<field> names
 	Metrics    map[string]bool            // metric names, e.g. "llmkube_inferenceservice_phase"
 	CLICmds    map[string]bool            // llmkube subcommands, e.g. "deploy"
+}
+
+var (
+	metricNameRe = regexp.MustCompile(`"(llmkube_[a-z0-9_]+)"`)
+	cobraUseRe   = regexp.MustCompile(`Use:\s*"([a-zA-Z][a-zA-Z0-9_-]*)`)
+)
+
+// scanMetrics walks dir for Go files and records llmkube_* metric-name string
+// literals. Best-effort: an unreadable file is skipped.
+func scanMetrics(dir string, gt *GroundTruth) {
+	_ = filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(p, ".go") {
+			return nil
+		}
+		b, _ := os.ReadFile(p)
+		for _, m := range metricNameRe.FindAllStringSubmatch(string(b), -1) {
+			gt.Metrics[m[1]] = true
+		}
+		return nil
+	})
+}
+
+// scanCLICommands walks dir for cobra `Use: "<verb>"` declarations.
+func scanCLICommands(dir string, gt *GroundTruth) {
+	_ = filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(p, ".go") {
+			return nil
+		}
+		b, _ := os.ReadFile(p)
+		for _, m := range cobraUseRe.FindAllStringSubmatch(string(b), -1) {
+			gt.CLICmds[m[1]] = true
+		}
+		return nil
+	})
 }
 
 // crdDoc is the minimal CRD shape we parse.
@@ -77,6 +112,12 @@ func LoadGroundTruth(crdBasesDir, metricsDir, cmdDir string) (*GroundTruth, erro
 				fields[name] = true
 			}
 		}
+	}
+	if metricsDir != "" {
+		scanMetrics(metricsDir, gt)
+	}
+	if cmdDir != "" {
+		scanCLICommands(cmdDir, gt)
 	}
 	return gt, nil
 }

--- a/pkg/foreman/agent/grounding/groundtruth.go
+++ b/pkg/foreman/agent/grounding/groundtruth.go
@@ -23,11 +23,30 @@ var (
 	cobraUseRe   = regexp.MustCompile(`Use:\s*"([a-zA-Z][a-zA-Z0-9_-]*)`)
 )
 
+// skipScanDir skips version-control, vendored, build, and fixture directories
+// so a repo-wide scan stays fast and does not ingest testdata or tool binaries.
+func skipScanDir(name string) bool {
+	switch name {
+	case ".git", "vendor", "node_modules", "testdata", "bin":
+		return true
+	}
+	return false
+}
+
 // scanMetrics walks dir for Go files and records llmkube_* metric-name string
 // literals. Best-effort: an unreadable file is skipped.
 func scanMetrics(dir string, gt *GroundTruth) {
 	_ = filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(p, ".go") {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if skipScanDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(p, ".go") {
 			return nil
 		}
 		b, _ := os.ReadFile(p)
@@ -41,7 +60,16 @@ func scanMetrics(dir string, gt *GroundTruth) {
 // scanCLICommands walks dir for cobra `Use: "<verb>"` declarations.
 func scanCLICommands(dir string, gt *GroundTruth) {
 	_ = filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(p, ".go") {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if skipScanDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(p, ".go") {
 			return nil
 		}
 		b, _ := os.ReadFile(p)

--- a/pkg/foreman/agent/grounding/groundtruth.go
+++ b/pkg/foreman/agent/grounding/groundtruth.go
@@ -1,0 +1,82 @@
+package grounding
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GroundTruth is the set of LLMKube-owned symbols a reference may name.
+type GroundTruth struct {
+	Groups     map[string]bool            // API groups, e.g. "inference.llmkube.dev"
+	Kinds      map[string]bool            // CRD kinds, e.g. "InferenceService"
+	SpecFields map[string]map[string]bool // kind -> set of spec.<field> names
+	Metrics    map[string]bool            // metric names, e.g. "llmkube_inferenceservice_phase"
+	CLICmds    map[string]bool            // llmkube subcommands, e.g. "deploy"
+}
+
+// crdDoc is the minimal CRD shape we parse.
+type crdDoc struct {
+	Spec struct {
+		Group string `yaml:"group"`
+		Names struct {
+			Kind string `yaml:"kind"`
+		} `yaml:"names"`
+		Versions []struct {
+			Schema struct {
+				OpenAPIV3Schema struct {
+					Properties struct {
+						Spec struct {
+							Properties map[string]yaml.Node `yaml:"properties"`
+						} `yaml:"spec"`
+					} `yaml:"properties"`
+				} `yaml:"openAPIV3Schema"`
+			} `yaml:"schema"`
+		} `yaml:"versions"`
+	} `yaml:"spec"`
+}
+
+// LoadGroundTruth scans crdBasesDir for CRD YAMLs and builds the symbol set.
+// metricsDir and cmdDir are scanned in a later task; empty strings skip them.
+func LoadGroundTruth(crdBasesDir, metricsDir, cmdDir string) (*GroundTruth, error) {
+	gt := &GroundTruth{
+		Groups: map[string]bool{}, Kinds: map[string]bool{},
+		SpecFields: map[string]map[string]bool{},
+		Metrics:    map[string]bool{}, CLICmds: map[string]bool{},
+	}
+	entries, err := os.ReadDir(crdBasesDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(crdBasesDir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var doc crdDoc
+		if err := yaml.Unmarshal(b, &doc); err != nil {
+			continue // a non-CRD yaml; skip rather than fail
+		}
+		if doc.Spec.Group == "" || doc.Spec.Names.Kind == "" {
+			continue
+		}
+		gt.Groups[doc.Spec.Group] = true
+		gt.Kinds[doc.Spec.Names.Kind] = true
+		fields := gt.SpecFields[doc.Spec.Names.Kind]
+		if fields == nil {
+			fields = map[string]bool{}
+			gt.SpecFields[doc.Spec.Names.Kind] = fields
+		}
+		for _, v := range doc.Spec.Versions {
+			for name := range v.Schema.OpenAPIV3Schema.Properties.Spec.Properties {
+				fields[name] = true
+			}
+		}
+	}
+	return gt, nil
+}

--- a/pkg/foreman/agent/grounding/groundtruth_test.go
+++ b/pkg/foreman/agent/grounding/groundtruth_test.go
@@ -2,6 +2,19 @@ package grounding
 
 import "testing"
 
+func TestLoadGroundTruth_MetricsAndCLI(t *testing.T) {
+	gt, err := LoadGroundTruth("testdata/crd-bases", "testdata/metrics", "testdata/cmd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gt.Metrics["llmkube_inferenceservice_phase"] {
+		t.Errorf("missing metric; have %v", gt.Metrics)
+	}
+	if !gt.CLICmds["deploy"] {
+		t.Errorf("missing cli command; have %v", gt.CLICmds)
+	}
+}
+
 func TestLoadGroundTruth_FromCRDBases(t *testing.T) {
 	gt, err := LoadGroundTruth("testdata/crd-bases", "", "")
 	if err != nil {

--- a/pkg/foreman/agent/grounding/groundtruth_test.go
+++ b/pkg/foreman/agent/grounding/groundtruth_test.go
@@ -1,6 +1,10 @@
 package grounding
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestLoadGroundTruth_MetricsAndCLI(t *testing.T) {
 	gt, err := LoadGroundTruth("testdata/crd-bases", "testdata/metrics", "testdata/cmd")
@@ -12,6 +16,30 @@ func TestLoadGroundTruth_MetricsAndCLI(t *testing.T) {
 	}
 	if !gt.CLICmds["deploy"] {
 		t.Errorf("missing cli command; have %v", gt.CLICmds)
+	}
+}
+
+// repoRoot resolves the repository root from this package dir
+// (pkg/foreman/agent/grounding -> four levels up).
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", "..", "..", ".."))
+}
+
+func TestLoadGroundTruth_RealRepoMetricsRepoWide(t *testing.T) {
+	root := repoRoot(t)
+	gt, err := LoadGroundTruth(filepath.Join(root, "config/crd/bases"), root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A real metal-agent metric defined in pkg/agent (NOT internal/metrics) must
+	// be in the ground truth, else the gate would false-positive real Metal docs.
+	if !gt.Metrics["llmkube_metal_agent_apple_power_gpu_watts"] {
+		t.Errorf("repo-wide metric scan missed llmkube_metal_agent_apple_power_gpu_watts; have %d metrics", len(gt.Metrics))
 	}
 }
 

--- a/pkg/foreman/agent/grounding/groundtruth_test.go
+++ b/pkg/foreman/agent/grounding/groundtruth_test.go
@@ -1,0 +1,22 @@
+package grounding
+
+import "testing"
+
+func TestLoadGroundTruth_FromCRDBases(t *testing.T) {
+	gt, err := LoadGroundTruth("testdata/crd-bases", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gt.Groups["inference.llmkube.dev"] {
+		t.Errorf("missing group inference.llmkube.dev; have %v", gt.Groups)
+	}
+	if !gt.Kinds["InferenceService"] {
+		t.Errorf("missing kind InferenceService")
+	}
+	if !gt.SpecFields["InferenceService"]["modelRef"] || !gt.SpecFields["InferenceService"]["turboQuantBits"] {
+		t.Errorf("missing spec fields; have %v", gt.SpecFields["InferenceService"])
+	}
+	if gt.SpecFields["InferenceService"]["bogusField"] {
+		t.Errorf("invented field should not be present")
+	}
+}

--- a/pkg/foreman/agent/grounding/inert.go
+++ b/pkg/foreman/agent/grounding/inert.go
@@ -47,8 +47,11 @@ func DetectInertSymbols(ctx context.Context, workspace string, run CommandRunner
 		}
 		if countNonEmptyLines(out) <= 1 {
 			findings = append(findings, Finding{
-				Severity: "major", Area: "wired-up", File: al.File, Line: al.Line,
-				Message: "annotation key " + key + " is written but never read (inert); confirm a consumer exists or the change is a no-op",
+				Severity: "major", Area: "wired-up",
+				File: al.File, Line: al.Line,
+				Message: "annotation key " + key +
+					" is written but never read (inert);" +
+					" confirm a consumer exists or the change is a no-op",
 			})
 		}
 	}

--- a/pkg/foreman/agent/grounding/inert.go
+++ b/pkg/foreman/agent/grounding/inert.go
@@ -1,0 +1,66 @@
+package grounding
+
+import (
+	"context"
+	"regexp"
+	"strings"
+)
+
+// annotationKeyRe matches an LLMKube annotation/label key string literal:
+// a double-quoted token of the form <ns>/<name> where <ns> ends in
+// llmkube.dev or llmkube.io. CLI flags ("--foo") and bare identifiers do not
+// match (no namespace slash, no llmkube domain), which is the #277 guard.
+var annotationKeyRe = regexp.MustCompile(`"([a-z0-9.-]*llmkube\.(?:dev|io)/[a-z0-9._-]+)"`)
+
+// DetectInertSymbols flags newly-added LLMKube annotation/label keys (in
+// non-test .go files) that have no reader: the key literal occurs only at its
+// adding site and nowhere else in the repo. It greps the workspace for each
+// key via run. Posture is escalate-not-fail; the caller (Plan 2) demotes the
+// verdict and hands these to the reviewer. Returns nil on any diff error
+// (fail-open).
+func DetectInertSymbols(ctx context.Context, workspace string, run CommandRunner, base string) []Finding {
+	added, err := AddedLines(ctx, workspace, run, base, []string{"*.go"})
+	if err != nil {
+		return nil
+	}
+	seen := map[string]AddedLine{}
+	var order []string
+	for _, al := range added {
+		if strings.HasSuffix(al.File, "_test.go") {
+			continue
+		}
+		for _, m := range annotationKeyRe.FindAllStringSubmatch(al.Text, -1) {
+			if _, ok := seen[m[1]]; !ok {
+				seen[m[1]] = al
+				order = append(order, m[1])
+			}
+		}
+	}
+	var findings []Finding
+	for _, key := range order {
+		al := seen[key]
+		out, err := run(ctx, workspace, nil, "grep", "-rFn", "--include=*.go", key, ".")
+		if err != nil {
+			// grep exits 1 when there are no matches; that would mean not even
+			// the writer is present -> treat as no reader and skip (defensive).
+			continue
+		}
+		if countNonEmptyLines(out) <= 1 {
+			findings = append(findings, Finding{
+				Severity: "major", Area: "wired-up", File: al.File, Line: al.Line,
+				Message: "annotation key " + key + " is written but never read (inert); confirm a consumer exists or the change is a no-op",
+			})
+		}
+	}
+	return findings
+}
+
+func countNonEmptyLines(s string) int {
+	n := 0
+	for _, l := range strings.Split(s, "\n") {
+		if strings.TrimSpace(l) != "" {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/foreman/agent/grounding/inert_test.go
+++ b/pkg/foreman/agent/grounding/inert_test.go
@@ -1,0 +1,45 @@
+package grounding
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestDetectInertSymbols(t *testing.T) {
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case name == "git" && strings.HasPrefix(joined, "diff"):
+			return "+++ b/internal/controller/model_storage.go\n" +
+				"@@ -0,0 +1,2 @@\n" +
+				"+\tpvc.Annotations[\"llmkube.io/gpu-taints\"] = taints\n" +
+				"+\tpvc.Annotations[\"llmkube.io/wired-key\"] = v\n", nil
+		case name == "grep" && strings.Contains(joined, "llmkube.io/gpu-taints"):
+			return "internal/controller/model_storage.go:\tpvc.Annotations[\"llmkube.io/gpu-taints\"] = taints\n", nil
+		case name == "grep" && strings.Contains(joined, "llmkube.io/wired-key"):
+			return "internal/controller/model_storage.go:\tpvc.Annotations[\"llmkube.io/wired-key\"] = v\n" +
+				"internal/controller/reader.go:\tif v, ok := o.Annotations[\"llmkube.io/wired-key\"]; ok {\n", nil
+		}
+		return "", nil
+	}
+	got := DetectInertSymbols(context.Background(), "/ws", run, "main")
+	if len(got) != 1 {
+		t.Fatalf("want 1 inert finding (gpu-taints), got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0].Message, "llmkube.io/gpu-taints") || got[0].Area != "wired-up" {
+		t.Errorf("unexpected finding: %+v", got[0])
+	}
+}
+
+func TestDetectInertSymbols_277Guard(t *testing.T) {
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name == "git" {
+			return "+++ b/pkg/agent/executor_omlx.go\n@@ -0,0 +1,1 @@\n+\targs = append(args, \"--kv-cache-quant\", n)\n", nil
+		}
+		return "", nil
+	}
+	if got := DetectInertSymbols(context.Background(), "/ws", run, "main"); len(got) != 0 {
+		t.Fatalf("CLI flag must not be flagged as inert: %v", got)
+	}
+}

--- a/pkg/foreman/agent/grounding/reference.go
+++ b/pkg/foreman/agent/grounding/reference.go
@@ -29,6 +29,11 @@ func checkMetricAndCLITokens(al AddedLine, gt *GroundTruth, out *[]Finding) {
 			}
 		}
 	}
+	// WARNING: cliTokenRe also matches ordinary prose ("the llmkube operator",
+	// "each llmkube deployment"). CLI validation is therefore DISABLED in
+	// production (the gate passes cmdDir="" so gt.CLICmds is empty and this block
+	// is inert). Before enabling it, anchor the match to a code context
+	// (backticks, or a following flag/arg).
 	if len(gt.CLICmds) > 0 {
 		for _, m := range cliTokenRe.FindAllStringSubmatch(al.Text, -1) {
 			if !gt.CLICmds[m[1]] {
@@ -69,8 +74,22 @@ func DetectUngroundedReferences(added []AddedLine, gt *GroundTruth) []Finding {
 	curKind := ""
 	specIndent := -1      // indent of the active spec: line; -1 = not in spec subtree
 	specChildIndent := -1 // indent of spec's direct children; -1 = unknown
+	prevFile := ""
+	prevLine := 0
 
 	for _, al := range added {
+		// --unified=0 strips unchanged context, so an apiVersion:/spec: anchor may
+		// be absent from the diff. Trust block context only across CONSECUTIVE
+		// added lines in the same file; a file change or a line-number gap means
+		// suppressed context intervened, so reset rather than judge an unrelated
+		// (possibly external) block against a stale kind.
+		if al.File != prevFile || al.Line != prevLine+1 {
+			llmkubeBlock = false
+			curKind = ""
+			specIndent, specChildIndent = -1, -1
+		}
+		prevFile = al.File
+		prevLine = al.Line
 		checkMetricAndCLITokens(al, gt, &findings)
 		if m := apiVersionLine.FindStringSubmatch(al.Text); m != nil {
 			llmkubeBlock = false

--- a/pkg/foreman/agent/grounding/reference.go
+++ b/pkg/foreman/agent/grounding/reference.go
@@ -9,6 +9,32 @@ import (
 var llmkubeGroup = regexp.MustCompile(`\b([a-z0-9.-]*llmkube\.(?:dev|io))(?:/v[0-9a-z]+)?\b`)
 
 var (
+	metricTokenRe = regexp.MustCompile(`\bllmkube_[a-z0-9_]+\b`)
+	cliTokenRe    = regexp.MustCompile("llmkube\\s+([a-z][a-z0-9-]*)")
+)
+
+// checkMetricAndCLITokens appends findings for llmkube_* metric tokens and
+// `llmkube <subcmd>` references in al that do not resolve. Runs on every added
+// line regardless of YAML block context. Each set is consulted only when
+// populated (empty => that scanner was disabled => skip, fail-open).
+func checkMetricAndCLITokens(al AddedLine, gt *GroundTruth, out *[]Finding) {
+	if len(gt.Metrics) > 0 {
+		for _, m := range metricTokenRe.FindAllString(al.Text, -1) {
+			if !gt.Metrics[m] {
+				*out = append(*out, Finding{Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line, Message: "unknown metric " + m})
+			}
+		}
+	}
+	if len(gt.CLICmds) > 0 {
+		for _, m := range cliTokenRe.FindAllStringSubmatch(al.Text, -1) {
+			if !gt.CLICmds[m[1]] {
+				*out = append(*out, Finding{Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line, Message: "unknown llmkube subcommand " + m[1]})
+			}
+		}
+	}
+}
+
+var (
 	apiVersionLine = regexp.MustCompile(`^\s*apiVersion:\s*(\S+)`)
 	kindLine       = regexp.MustCompile(`^\s*kind:\s*(\S+)`)
 	// fieldLine captures leading indent (group 1) and the key (group 2).
@@ -37,6 +63,7 @@ func DetectUngroundedReferences(added []AddedLine, gt *GroundTruth) []Finding {
 	specChildIndent := -1 // indent of spec's direct children; -1 = unknown
 
 	for _, al := range added {
+		checkMetricAndCLITokens(al, gt, &findings)
 		if m := apiVersionLine.FindStringSubmatch(al.Text); m != nil {
 			llmkubeBlock = false
 			curKind = ""

--- a/pkg/foreman/agent/grounding/reference.go
+++ b/pkg/foreman/agent/grounding/reference.go
@@ -10,7 +10,7 @@ var llmkubeGroup = regexp.MustCompile(`\b([a-z0-9.-]*llmkube\.(?:dev|io))(?:/v[0
 
 var (
 	metricTokenRe = regexp.MustCompile(`\bllmkube_[a-z0-9_]+\b`)
-	cliTokenRe    = regexp.MustCompile("llmkube\\s+([a-z][a-z0-9-]*)")
+	cliTokenRe    = regexp.MustCompile(`llmkube\s+([a-z][a-z0-9-]*)`)
 )
 
 // checkMetricAndCLITokens appends findings for llmkube_* metric tokens and
@@ -21,14 +21,22 @@ func checkMetricAndCLITokens(al AddedLine, gt *GroundTruth, out *[]Finding) {
 	if len(gt.Metrics) > 0 {
 		for _, m := range metricTokenRe.FindAllString(al.Text, -1) {
 			if !gt.Metrics[m] {
-				*out = append(*out, Finding{Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line, Message: "unknown metric " + m})
+				*out = append(*out, Finding{
+					Severity: "blocker", Area: "doc-consistency",
+					File: al.File, Line: al.Line,
+					Message: "unknown metric " + m,
+				})
 			}
 		}
 	}
 	if len(gt.CLICmds) > 0 {
 		for _, m := range cliTokenRe.FindAllStringSubmatch(al.Text, -1) {
 			if !gt.CLICmds[m[1]] {
-				*out = append(*out, Finding{Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line, Message: "unknown llmkube subcommand " + m[1]})
+				*out = append(*out, Finding{
+					Severity: "blocker", Area: "doc-consistency",
+					File: al.File, Line: al.Line,
+					Message: "unknown llmkube subcommand " + m[1],
+				})
 			}
 		}
 	}

--- a/pkg/foreman/agent/grounding/reference.go
+++ b/pkg/foreman/agent/grounding/reference.go
@@ -1,0 +1,126 @@
+package grounding
+
+import (
+	"regexp"
+	"strings"
+)
+
+// llmkubeGroup matches an LLMKube-owned API group, optionally with a /version.
+var llmkubeGroup = regexp.MustCompile(`\b([a-z0-9.-]*llmkube\.(?:dev|io))(?:/v[0-9a-z]+)?\b`)
+
+var (
+	apiVersionLine = regexp.MustCompile(`^\s*apiVersion:\s*(\S+)`)
+	kindLine       = regexp.MustCompile(`^\s*kind:\s*(\S+)`)
+	// fieldLine captures leading indent (group 1) and the key (group 2).
+	fieldLine = regexp.MustCompile(`^(\s*)([a-zA-Z][a-zA-Z0-9]*):`)
+)
+
+// structuralKeys are YAML keys that are never spec fields.
+var structuralKeys = map[string]bool{
+	"apiVersion": true, "kind": true, "metadata": true, "spec": true, "status": true,
+}
+
+// DetectUngroundedReferences flags LLMKube-owned references in added lines that
+// do not resolve in gt. Within an LLMKube object block (opened by an added
+// `apiVersion:` whose group is llmkube-owned) it validates: the API group, the
+// `kind:`, and the direct child fields of an added `spec:` line. Field
+// validation is scoped to the spec subtree by indentation: keys under
+// metadata/status, keys at or above spec's indent, and keys nested deeper than
+// spec's direct children are never flagged. Because the diff is --unified=0, a
+// field is only checked when its `spec:` parent is itself among the added
+// lines. External (non-llmkube) blocks are never judged.
+func DetectUngroundedReferences(added []AddedLine, gt *GroundTruth) []Finding {
+	var findings []Finding
+	llmkubeBlock := false
+	curKind := ""
+	specIndent := -1      // indent of the active spec: line; -1 = not in spec subtree
+	specChildIndent := -1 // indent of spec's direct children; -1 = unknown
+
+	for _, al := range added {
+		if m := apiVersionLine.FindStringSubmatch(al.Text); m != nil {
+			llmkubeBlock = false
+			curKind = ""
+			specIndent, specChildIndent = -1, -1
+			if g := llmkubeGroup.FindStringSubmatch(m[1]); g != nil {
+				llmkubeBlock = true
+				group := strings.SplitN(g[0], "/", 2)[0]
+				if !gt.Groups[group] {
+					findings = append(findings, Finding{
+						Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line,
+						Message: "unknown LLMKube API group " + group,
+					})
+				}
+			}
+			continue
+		}
+		if !llmkubeBlock {
+			continue
+		}
+		if m := kindLine.FindStringSubmatch(al.Text); m != nil {
+			curKind = m[1]
+			if !gt.Kinds[curKind] {
+				findings = append(findings, Finding{
+					Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line,
+					Message: "unknown LLMKube kind " + curKind,
+				})
+			}
+			continue
+		}
+		m := fieldLine.FindStringSubmatch(al.Text)
+		if m == nil {
+			continue
+		}
+		indent := len(m[1])
+		key := m[2]
+		if key == "spec" {
+			specIndent = indent
+			specChildIndent = -1
+			continue
+		}
+		if structuralKeys[key] {
+			// metadata/status open a non-spec subtree; one at spec's indent or
+			// above ends the spec subtree.
+			if specIndent >= 0 && indent <= specIndent {
+				specIndent, specChildIndent = -1, -1
+			}
+			continue
+		}
+		if specIndent < 0 {
+			continue // not inside a spec subtree (e.g. a key under metadata)
+		}
+		if indent <= specIndent {
+			specIndent, specChildIndent = -1, -1 // dedented out of spec
+			continue
+		}
+		if specChildIndent == -1 {
+			specChildIndent = indent
+		}
+		if indent != specChildIndent {
+			continue // nested deeper than a direct spec child
+		}
+		knownFields := gt.SpecFields[curKind]
+		if curKind == "" || knownFields == nil {
+			if len(gt.SpecFields) == 0 {
+				continue
+			}
+			union := map[string]bool{}
+			for _, fields := range gt.SpecFields {
+				for f := range fields {
+					union[f] = true
+				}
+			}
+			knownFields = union
+		}
+		if !knownFields[key] {
+			label := curKind
+			if label == "" {
+				label = "unknown kind"
+			}
+			findings = append(findings, Finding{
+				Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line,
+				Message: "unknown spec field " + key + " on " + label,
+			})
+		}
+	}
+	return findings
+}

--- a/pkg/foreman/agent/grounding/reference.go
+++ b/pkg/foreman/agent/grounding/reference.go
@@ -8,23 +8,61 @@ import (
 // llmkubeGroup matches an LLMKube-owned API group, optionally with a /version.
 var llmkubeGroup = regexp.MustCompile(`\b([a-z0-9.-]*llmkube\.(?:dev|io))(?:/v[0-9a-z]+)?\b`)
 
+var apiVersionLine = regexp.MustCompile(`^\s*apiVersion:\s*(\S+)`)
+
 var (
 	metricTokenRe = regexp.MustCompile(`\bllmkube_[a-z0-9_]+\b`)
 	cliTokenRe    = regexp.MustCompile(`llmkube\s+([a-z][a-z0-9-]*)`)
 )
 
+// DetectUngroundedReferences flags two high-confidence, low-false-positive
+// classes of LLMKube-owned reference in added doc/yaml lines:
+//   - an `apiVersion:` naming an llmkube.dev / llmkube.io API GROUP that does
+//     not exist in the repo, and
+//   - an `llmkube_*` METRIC token that is not registered.
+//
+// CRD-kind and spec-field grounding are intentionally NOT done here. On the real
+// committed doc corpus they false-positive: a `kind:` that is a field value (an
+// AgenticTask's `spec.kind: issue-fix`) rather than a CRD kind, spec fields
+// nested inside a `spec.<list>[]`, and historical release notes describing old
+// schemas. A hard-fail gate must not block legitimate doc edits, so kind/field
+// grounding is deferred to the tool-using reviewer (Plan 2), which can parse
+// YAML and grep for real definitions. The group and metric checks produced zero
+// false positives across the entire committed doc corpus.
+func DetectUngroundedReferences(added []AddedLine, gt *GroundTruth) []Finding {
+	var findings []Finding
+	for _, al := range added {
+		checkMetricAndCLITokens(al, gt, &findings)
+		m := apiVersionLine.FindStringSubmatch(al.Text)
+		if m == nil {
+			continue
+		}
+		g := llmkubeGroup.FindStringSubmatch(m[1])
+		if g == nil {
+			continue // external (non-llmkube) group: never judged
+		}
+		group := strings.SplitN(g[0], "/", 2)[0]
+		if !gt.Groups[group] {
+			findings = append(findings, Finding{
+				Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line,
+				Message: "unknown LLMKube API group " + group,
+			})
+		}
+	}
+	return findings
+}
+
 // checkMetricAndCLITokens appends findings for llmkube_* metric tokens and
 // `llmkube <subcmd>` references in al that do not resolve. Runs on every added
-// line regardless of YAML block context. Each set is consulted only when
-// populated (empty => that scanner was disabled => skip, fail-open).
+// line. Each set is consulted only when populated (empty => that scanner was
+// disabled => skip, fail-open).
 func checkMetricAndCLITokens(al AddedLine, gt *GroundTruth, out *[]Finding) {
 	if len(gt.Metrics) > 0 {
 		for _, m := range metricTokenRe.FindAllString(al.Text, -1) {
 			if !gt.Metrics[m] {
 				*out = append(*out, Finding{
 					Severity: "blocker", Area: "doc-consistency",
-					File: al.File, Line: al.Line,
-					Message: "unknown metric " + m,
+					File: al.File, Line: al.Line, Message: "unknown metric " + m,
 				})
 			}
 		}
@@ -39,142 +77,9 @@ func checkMetricAndCLITokens(al AddedLine, gt *GroundTruth, out *[]Finding) {
 			if !gt.CLICmds[m[1]] {
 				*out = append(*out, Finding{
 					Severity: "blocker", Area: "doc-consistency",
-					File: al.File, Line: al.Line,
-					Message: "unknown llmkube subcommand " + m[1],
+					File: al.File, Line: al.Line, Message: "unknown llmkube subcommand " + m[1],
 				})
 			}
 		}
 	}
-}
-
-var (
-	apiVersionLine = regexp.MustCompile(`^\s*apiVersion:\s*(\S+)`)
-	kindLine       = regexp.MustCompile(`^\s*kind:\s*(\S+)`)
-	// fieldLine captures leading indent (group 1) and the key (group 2).
-	fieldLine = regexp.MustCompile(`^(\s*)([a-zA-Z][a-zA-Z0-9]*):`)
-)
-
-// structuralKeys are YAML keys that are never spec fields.
-var structuralKeys = map[string]bool{
-	"apiVersion": true, "kind": true, "metadata": true, "spec": true, "status": true,
-}
-
-// DetectUngroundedReferences flags LLMKube-owned references in added lines that
-// do not resolve in gt. Within an LLMKube object block (opened by an added
-// `apiVersion:` whose group is llmkube-owned) it validates: the API group, the
-// `kind:`, and the direct child fields of an added `spec:` line. Field
-// validation is scoped to the spec subtree by indentation: keys under
-// metadata/status, keys at or above spec's indent, and keys nested deeper than
-// spec's direct children are never flagged. Because the diff is --unified=0, a
-// field is only checked when its `spec:` parent is itself among the added
-// lines. External (non-llmkube) blocks are never judged.
-func DetectUngroundedReferences(added []AddedLine, gt *GroundTruth) []Finding {
-	var findings []Finding
-	llmkubeBlock := false
-	curKind := ""
-	specIndent := -1      // indent of the active spec: line; -1 = not in spec subtree
-	specChildIndent := -1 // indent of spec's direct children; -1 = unknown
-	prevFile := ""
-	prevLine := 0
-
-	for _, al := range added {
-		// --unified=0 strips unchanged context, so an apiVersion:/spec: anchor may
-		// be absent from the diff. Trust block context only across CONSECUTIVE
-		// added lines in the same file; a file change or a line-number gap means
-		// suppressed context intervened, so reset rather than judge an unrelated
-		// (possibly external) block against a stale kind.
-		if al.File != prevFile || al.Line != prevLine+1 {
-			llmkubeBlock = false
-			curKind = ""
-			specIndent, specChildIndent = -1, -1
-		}
-		prevFile = al.File
-		prevLine = al.Line
-		checkMetricAndCLITokens(al, gt, &findings)
-		if m := apiVersionLine.FindStringSubmatch(al.Text); m != nil {
-			llmkubeBlock = false
-			curKind = ""
-			specIndent, specChildIndent = -1, -1
-			if g := llmkubeGroup.FindStringSubmatch(m[1]); g != nil {
-				llmkubeBlock = true
-				group := strings.SplitN(g[0], "/", 2)[0]
-				if !gt.Groups[group] {
-					findings = append(findings, Finding{
-						Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line,
-						Message: "unknown LLMKube API group " + group,
-					})
-				}
-			}
-			continue
-		}
-		if !llmkubeBlock {
-			continue
-		}
-		if m := kindLine.FindStringSubmatch(al.Text); m != nil {
-			curKind = m[1]
-			if !gt.Kinds[curKind] {
-				findings = append(findings, Finding{
-					Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line,
-					Message: "unknown LLMKube kind " + curKind,
-				})
-			}
-			continue
-		}
-		m := fieldLine.FindStringSubmatch(al.Text)
-		if m == nil {
-			continue
-		}
-		indent := len(m[1])
-		key := m[2]
-		if key == "spec" {
-			specIndent = indent
-			specChildIndent = -1
-			continue
-		}
-		if structuralKeys[key] {
-			// metadata/status open a non-spec subtree; one at spec's indent or
-			// above ends the spec subtree.
-			if specIndent >= 0 && indent <= specIndent {
-				specIndent, specChildIndent = -1, -1
-			}
-			continue
-		}
-		if specIndent < 0 {
-			continue // not inside a spec subtree (e.g. a key under metadata)
-		}
-		if indent <= specIndent {
-			specIndent, specChildIndent = -1, -1 // dedented out of spec
-			continue
-		}
-		if specChildIndent == -1 {
-			specChildIndent = indent
-		}
-		if indent != specChildIndent {
-			continue // nested deeper than a direct spec child
-		}
-		knownFields := gt.SpecFields[curKind]
-		if curKind == "" || knownFields == nil {
-			if len(gt.SpecFields) == 0 {
-				continue
-			}
-			union := map[string]bool{}
-			for _, fields := range gt.SpecFields {
-				for f := range fields {
-					union[f] = true
-				}
-			}
-			knownFields = union
-		}
-		if !knownFields[key] {
-			label := curKind
-			if label == "" {
-				label = "unknown kind"
-			}
-			findings = append(findings, Finding{
-				Severity: "blocker", Area: "doc-consistency", File: al.File, Line: al.Line,
-				Message: "unknown spec field " + key + " on " + label,
-			})
-		}
-	}
-	return findings
 }

--- a/pkg/foreman/agent/grounding/reference_test.go
+++ b/pkg/foreman/agent/grounding/reference_test.go
@@ -59,6 +59,29 @@ func TestDetectUngroundedReferences_MetricAndCLI(t *testing.T) {
 	}
 }
 
+func TestDetectUngroundedReferences_NoCrossHunkLeak(t *testing.T) {
+	gt := &GroundTruth{
+		Groups:     map[string]bool{"inference.llmkube.dev": true},
+		Kinds:      map[string]bool{"InferenceService": true},
+		SpecFields: map[string]map[string]bool{"InferenceService": {"modelRef": true}},
+	}
+	// A freshly-added llmkube example (consecutive lines 1-4), then a line from a
+	// DIFFERENT example added far away (line 80) whose own apiVersion: apps/v1 is
+	// unchanged context (absent under --unified=0). The non-consecutive line must
+	// reset block state so the external field is NOT judged.
+	added := []AddedLine{
+		{File: "x.md", Line: 1, Text: "apiVersion: inference.llmkube.dev/v1alpha1"},
+		{File: "x.md", Line: 2, Text: "kind: InferenceService"},
+		{File: "x.md", Line: 3, Text: "spec:"},
+		{File: "x.md", Line: 4, Text: "  modelRef: foo"},
+		{File: "x.md", Line: 80, Text: "  replicas: 3"},
+	}
+	got := DetectUngroundedReferences(added, gt)
+	if len(got) != 0 {
+		t.Fatalf("expected no findings (line 80 is an unrelated block), got %v", got)
+	}
+}
+
 func TestDetectUngroundedReferences_478Fixture(t *testing.T) {
 	gt := &GroundTruth{
 		Groups: map[string]bool{"inference.llmkube.dev": true},

--- a/pkg/foreman/agent/grounding/reference_test.go
+++ b/pkg/foreman/agent/grounding/reference_test.go
@@ -42,6 +42,23 @@ func TestDetectUngroundedReferences(t *testing.T) {
 	}
 }
 
+func TestDetectUngroundedReferences_MetricAndCLI(t *testing.T) {
+	gt := &GroundTruth{
+		Groups: map[string]bool{}, Kinds: map[string]bool{}, SpecFields: map[string]map[string]bool{},
+		Metrics: map[string]bool{"llmkube_inferenceservice_phase": true},
+		CLICmds: map[string]bool{"deploy": true},
+	}
+	added := []AddedLine{
+		{File: "d.md", Line: 1, Text: "scrape llmkube_inferenceservice_request_rate from /metrics"},
+		{File: "d.md", Line: 2, Text: "run `llmkube load --endpoint ...`"},
+		{File: "d.md", Line: 3, Text: "run `llmkube deploy model.yaml`  # real"},
+	}
+	got := DetectUngroundedReferences(added, gt)
+	if len(got) != 2 {
+		t.Fatalf("want 2 (bad metric + bad cli), got %d: %v", len(got), got)
+	}
+}
+
 func TestDetectUngroundedReferences_478Fixture(t *testing.T) {
 	gt := &GroundTruth{
 		Groups:     map[string]bool{"inference.llmkube.dev": true},

--- a/pkg/foreman/agent/grounding/reference_test.go
+++ b/pkg/foreman/agent/grounding/reference_test.go
@@ -1,0 +1,61 @@
+package grounding
+
+import "testing"
+
+func TestDetectUngroundedReferences(t *testing.T) {
+	gt := &GroundTruth{
+		Groups:     map[string]bool{"inference.llmkube.dev": true},
+		Kinds:      map[string]bool{"InferenceService": true},
+		SpecFields: map[string]map[string]bool{"InferenceService": {"modelRef": true, "turboQuantBits": true}},
+		Metrics:    map[string]bool{}, CLICmds: map[string]bool{},
+	}
+	added := []AddedLine{
+		// good block: correct group, metadata.name must NOT be flagged, real spec field passes
+		{File: "good.md", Line: 1, Text: "apiVersion: inference.llmkube.dev/v1alpha1"},
+		{File: "good.md", Line: 2, Text: "kind: InferenceService"},
+		{File: "good.md", Line: 3, Text: "metadata:"},
+		{File: "good.md", Line: 4, Text: "  name: my-svc"},
+		{File: "good.md", Line: 5, Text: "spec:"},
+		{File: "good.md", Line: 6, Text: "  modelRef: mistral-7b"},
+		// bad block: wrong group (line 5) + invented spec field (line 9); real field (line 8) passes
+		{File: "bad.md", Line: 5, Text: "apiVersion: llmkube.io/v1alpha1"},
+		{File: "bad.md", Line: 6, Text: "kind: InferenceService"},
+		{File: "bad.md", Line: 7, Text: "spec:"},
+		{File: "bad.md", Line: 8, Text: "  turboQuantBits: 8"},
+		{File: "bad.md", Line: 9, Text: "  servingMode: chat"},
+		// external block: never judged
+		{File: "ext.md", Line: 3, Text: "apiVersion: apps/v1"},
+		{File: "ext.md", Line: 4, Text: "spec:"},
+		{File: "ext.md", Line: 5, Text: "  replicas: 3"},
+	}
+	got := DetectUngroundedReferences(added, gt)
+	if len(got) != 2 {
+		t.Fatalf("got %d findings, want 2 (bad group + invented field): %v", len(got), got)
+	}
+	if got[0].Line != 5 || got[1].Line != 9 {
+		t.Errorf("unexpected finding lines (want 5 then 9): %v", got)
+	}
+	for _, f := range got {
+		if f.Area != "doc-consistency" || f.Severity != "blocker" {
+			t.Errorf("wrong severity/area: %+v", f)
+		}
+	}
+}
+
+func TestDetectUngroundedReferences_478Fixture(t *testing.T) {
+	gt := &GroundTruth{
+		Groups:     map[string]bool{"inference.llmkube.dev": true},
+		Kinds:      map[string]bool{"InferenceService": true},
+		SpecFields: map[string]map[string]bool{"InferenceService": {"modelRef": true, "mode": true, "resources": true, "autoscaling": true}},
+	}
+	added := []AddedLine{
+		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 10, Text: "apiVersion: llmkube.io/v1alpha1"},
+		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 11, Text: "kind: InferenceService"},
+		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 12, Text: "spec:"},
+		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 13, Text: "  servingMode: chat"},
+	}
+	got := DetectUngroundedReferences(added, gt)
+	if len(got) < 2 {
+		t.Fatalf("expected the wrong group AND the invented field to be flagged, got %v", got)
+	}
+}

--- a/pkg/foreman/agent/grounding/reference_test.go
+++ b/pkg/foreman/agent/grounding/reference_test.go
@@ -61,9 +61,11 @@ func TestDetectUngroundedReferences_MetricAndCLI(t *testing.T) {
 
 func TestDetectUngroundedReferences_478Fixture(t *testing.T) {
 	gt := &GroundTruth{
-		Groups:     map[string]bool{"inference.llmkube.dev": true},
-		Kinds:      map[string]bool{"InferenceService": true},
-		SpecFields: map[string]map[string]bool{"InferenceService": {"modelRef": true, "mode": true, "resources": true, "autoscaling": true}},
+		Groups: map[string]bool{"inference.llmkube.dev": true},
+		Kinds:  map[string]bool{"InferenceService": true},
+		SpecFields: map[string]map[string]bool{
+			"InferenceService": {"modelRef": true, "mode": true, "resources": true, "autoscaling": true},
+		},
 	}
 	added := []AddedLine{
 		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 10, Text: "apiVersion: llmkube.io/v1alpha1"},

--- a/pkg/foreman/agent/grounding/reference_test.go
+++ b/pkg/foreman/agent/grounding/reference_test.go
@@ -2,43 +2,37 @@ package grounding
 
 import "testing"
 
-func TestDetectUngroundedReferences(t *testing.T) {
-	gt := &GroundTruth{
-		Groups:     map[string]bool{"inference.llmkube.dev": true},
-		Kinds:      map[string]bool{"InferenceService": true},
-		SpecFields: map[string]map[string]bool{"InferenceService": {"modelRef": true, "turboQuantBits": true}},
-		Metrics:    map[string]bool{}, CLICmds: map[string]bool{},
-	}
+func TestDetectUngroundedReferences_Group(t *testing.T) {
+	gt := &GroundTruth{Groups: map[string]bool{"inference.llmkube.dev": true}}
 	added := []AddedLine{
-		// good block: correct group, metadata.name must NOT be flagged, real spec field passes
 		{File: "good.md", Line: 1, Text: "apiVersion: inference.llmkube.dev/v1alpha1"},
-		{File: "good.md", Line: 2, Text: "kind: InferenceService"},
-		{File: "good.md", Line: 3, Text: "metadata:"},
-		{File: "good.md", Line: 4, Text: "  name: my-svc"},
-		{File: "good.md", Line: 5, Text: "spec:"},
-		{File: "good.md", Line: 6, Text: "  modelRef: mistral-7b"},
-		// bad block: wrong group (line 5) + invented spec field (line 9); real field (line 8) passes
 		{File: "bad.md", Line: 5, Text: "apiVersion: llmkube.io/v1alpha1"},
-		{File: "bad.md", Line: 6, Text: "kind: InferenceService"},
-		{File: "bad.md", Line: 7, Text: "spec:"},
-		{File: "bad.md", Line: 8, Text: "  turboQuantBits: 8"},
-		{File: "bad.md", Line: 9, Text: "  servingMode: chat"},
-		// external block: never judged
 		{File: "ext.md", Line: 3, Text: "apiVersion: apps/v1"},
-		{File: "ext.md", Line: 4, Text: "spec:"},
-		{File: "ext.md", Line: 5, Text: "  replicas: 3"},
 	}
 	got := DetectUngroundedReferences(added, gt)
-	if len(got) != 2 {
-		t.Fatalf("got %d findings, want 2 (bad group + invented field): %v", len(got), got)
+	if len(got) != 1 || got[0].Line != 5 {
+		t.Fatalf("want exactly 1 finding at line 5 (unknown llmkube group), got %v", got)
 	}
-	if got[0].Line != 5 || got[1].Line != 9 {
-		t.Errorf("unexpected finding lines (want 5 then 9): %v", got)
+	if got[0].Area != "doc-consistency" || got[0].Severity != "blocker" {
+		t.Errorf("wrong severity/area: %+v", got[0])
 	}
-	for _, f := range got {
-		if f.Area != "doc-consistency" || f.Severity != "blocker" {
-			t.Errorf("wrong severity/area: %+v", f)
-		}
+}
+
+func TestDetectUngroundedReferences_478Fixture(t *testing.T) {
+	gt := &GroundTruth{
+		Groups:  map[string]bool{"inference.llmkube.dev": true},
+		Metrics: map[string]bool{"llmkube_inferenceservice_phase": true},
+	}
+	added := []AddedLine{
+		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 32, Text: "apiVersion: llmkube.io/v1alpha1"},
+		{
+			File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 87,
+			Text: "scrape llmkube_inferenceservice_request_rate from /metrics",
+		},
+	}
+	got := DetectUngroundedReferences(added, gt)
+	if len(got) < 2 {
+		t.Fatalf("expected the wrong group AND the invented metric flagged, got %v", got)
 	}
 }
 
@@ -56,48 +50,5 @@ func TestDetectUngroundedReferences_MetricAndCLI(t *testing.T) {
 	got := DetectUngroundedReferences(added, gt)
 	if len(got) != 2 {
 		t.Fatalf("want 2 (bad metric + bad cli), got %d: %v", len(got), got)
-	}
-}
-
-func TestDetectUngroundedReferences_NoCrossHunkLeak(t *testing.T) {
-	gt := &GroundTruth{
-		Groups:     map[string]bool{"inference.llmkube.dev": true},
-		Kinds:      map[string]bool{"InferenceService": true},
-		SpecFields: map[string]map[string]bool{"InferenceService": {"modelRef": true}},
-	}
-	// A freshly-added llmkube example (consecutive lines 1-4), then a line from a
-	// DIFFERENT example added far away (line 80) whose own apiVersion: apps/v1 is
-	// unchanged context (absent under --unified=0). The non-consecutive line must
-	// reset block state so the external field is NOT judged.
-	added := []AddedLine{
-		{File: "x.md", Line: 1, Text: "apiVersion: inference.llmkube.dev/v1alpha1"},
-		{File: "x.md", Line: 2, Text: "kind: InferenceService"},
-		{File: "x.md", Line: 3, Text: "spec:"},
-		{File: "x.md", Line: 4, Text: "  modelRef: foo"},
-		{File: "x.md", Line: 80, Text: "  replicas: 3"},
-	}
-	got := DetectUngroundedReferences(added, gt)
-	if len(got) != 0 {
-		t.Fatalf("expected no findings (line 80 is an unrelated block), got %v", got)
-	}
-}
-
-func TestDetectUngroundedReferences_478Fixture(t *testing.T) {
-	gt := &GroundTruth{
-		Groups: map[string]bool{"inference.llmkube.dev": true},
-		Kinds:  map[string]bool{"InferenceService": true},
-		SpecFields: map[string]map[string]bool{
-			"InferenceService": {"modelRef": true, "mode": true, "resources": true, "autoscaling": true},
-		},
-	}
-	added := []AddedLine{
-		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 10, Text: "apiVersion: llmkube.io/v1alpha1"},
-		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 11, Text: "kind: InferenceService"},
-		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 12, Text: "spec:"},
-		{File: "docs/site/guides/metrics-driven-autoscaling.md", Line: 13, Text: "  servingMode: chat"},
-	}
-	got := DetectUngroundedReferences(added, gt)
-	if len(got) < 2 {
-		t.Fatalf("expected the wrong group AND the invented field to be flagged, got %v", got)
 	}
 }

--- a/pkg/foreman/agent/grounding/testdata/cmd/deploy.go
+++ b/pkg/foreman/agent/grounding/testdata/cmd/deploy.go
@@ -1,0 +1,3 @@
+package cmd
+
+var deployCmd = &cobra.Command{Use: "deploy [flags]"}

--- a/pkg/foreman/agent/grounding/testdata/crd-bases/inferenceservice.yaml
+++ b/pkg/foreman/agent/grounding/testdata/crd-bases/inferenceservice.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inferenceservices.inference.llmkube.dev
+spec:
+  group: inference.llmkube.dev
+  names:
+    kind: InferenceService
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                modelRef:
+                  type: string
+                contextSize:
+                  type: integer
+                turboQuantBits:
+                  type: integer

--- a/pkg/foreman/agent/grounding/testdata/metrics/metrics.go
+++ b/pkg/foreman/agent/grounding/testdata/metrics/metrics.go
@@ -1,0 +1,3 @@
+package metrics
+
+var phase = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "llmkube_inferenceservice_phase"}, nil)


### PR DESCRIPTION
## What

Add a deterministic, model-free `grounding` package and wire a **reference-grounding** check into the coder gate (`RunCoderGate`, check #11, hard-fail). It flags two high-confidence classes of confabulated LLMKube-owned reference in a coder's added docs/example YAML:

- an `apiVersion:` naming an `*.llmkube.dev` / `llmkube.io` **API group** that does not exist in the repo's CRDs, and
- an `llmkube_*` **metric** token that is not registered anywhere in the tree.

Also lands (unwired, for a follow-up reviewer stage) an **inert-symbol** detector that flags newly-added LLMKube annotation keys with no reader.

## Why

A local-model Foreman coder batch produced changes that passed the fast gate (fmt/vet/build/lint + the mutation/test-presence gate) but were wrong on substance. One failure mode was **confabulated documentation**: an invented API group (`llmkube.io` vs the real `inference.llmkube.dev`), invented CRD fields, an invented metric, and an invented CLI command. Docs are never compiled or linted, so nothing in the gate touched them. This check closes that blind spot for the mechanizable, zero-false-positive cases, blocking a confabulating coder's GO and feeding the specifics back for a fix.

## How

- New leaf package `pkg/foreman/agent/grounding`: `AddedLines` (working-tree diff parser), `LoadGroundTruth` (API groups/kinds/spec-fields from `config/crd/bases`, `llmkube_*` metrics repo-wide, CLI commands), `DetectUngroundedReferences`, `DetectInertSymbols`. Pure functions over an injected command runner, fully unit-tested.
- Wired into `RunCoderGate` as check #11, fail-open on any load/diff error so the net never blocks a coder on its own bug.
- Scope is deliberately narrow: **only LLMKube-owned groups + metrics** are judged (external APIs like `apps/v1`/KEDA are never touched). CRD-kind and spec-field grounding were prototyped but **dropped** because they false-positive on the real doc corpus (a `kind:` field value vs a CRD kind, fields nested in spec lists, historical release notes); those move to a future tool-using reviewer.
- The check diffs the **staged working tree** (`git add -A` + `git diff --cached --unified=0 --src-prefix=a/ --dst-prefix=b/ HEAD`), because the gate runs pre-commit: the coder's edits are uncommitted and new files are untracked, so a committed `main...HEAD` diff would see none of them.

### Validation
- Replayed against the real confabulated branch (catches the invented group + metric) and the **entire 11,725-line committed doc corpus (zero false positives)**.
- A real-git test proving an untracked, pre-commit confab is flagged.
- **Live in-cluster run**: a local-model coder confabulated a tutorial; check #11 fired in the loop and forced a fix to a clean GO.

## AI assistance

Assisted-by: Claude (Claude Code) orchestrating the design, implementation (per-task subagents with TDD + spec/quality review), and in-cluster validation. A human reviewed the diff, ran the checks, and signs off under the DCO and the AI-assisted contribution policy.


## Docs

This PR also adds **[`docs/site/foreman/grounding-checks.md`](docs/site/foreman/grounding-checks.md)**, which documents the check for users and, importantly, frames it as a **model others can follow for their own stack**: what confabulation it catches (with a real example), the four rules that keep it useful and false-positive-free, and how the same shape generalizes to non-Go projects through the `gateProfile` symbol-sources seam. It cross-links the existing [Non-Go projects (language gates)](docs/site/foreman/language-gates.md) page. The doc uses only real, grounded symbols so it does not trip the very check it describes.

## Checklist

- [x] Tests added/updated
- [ ] `make test` passes locally (unit tests for the touched packages pass; full envtest suite not run — no controller logic changed)
- [x] `make lint` passes locally (0 issues, `GOOS=linux`)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed above, per CONTRIBUTING.md
- [x] Documentation updated (new Foreman grounding-checks page + nav)
