### PR TITLE
fix: cache hf:// multi-file models instead of emptyDir

### DIFF
--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -246,7 +246,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	var storageConfig modelStorageConfig
 	var modelPath string
 	if backend.NeedsModelInit() && !skipInit {
-		useCache := model.Status.CacheKey != "" && r.ModelCachePath != ""
+		useCache := effectiveModelCacheKey(model) != "" && r.ModelCachePath != ""
 		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.ModelCacheMode, r.CACertConfigMap, r.InitContainerImage, r.DefaultFSGroup)
 		modelPath = storageConfig.modelPath
 	}

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -152,7 +152,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		desiredReplicas = *inferenceService.Spec.Replicas
 	}
 
-	if model.Status.CacheKey != "" && r.ModelCachePath != "" {
+	if effectiveModelCacheKey(model) != "" && r.ModelCachePath != "" {
 		if err := r.ensureModelCachePVC(ctx, inferenceService); err != nil {
 			log.Error(err, "Failed to ensure model cache PVC exists", "namespace", inferenceService.Namespace)
 			return r.updateStatusWithSchedulingInfo(ctx, inferenceService, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create model cache PVC", nil)

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -357,6 +357,68 @@ var _ = Describe("hasMultiFileStaging", func() {
 	})
 })
 
+var _ = Describe("effectiveModelCacheKey", func() {
+	It("returns the controller-set Status.CacheKey when present", func() {
+		model := &inferencev1alpha1.Model{
+			Spec:   inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
+			Status: inferencev1alpha1.ModelStatus{CacheKey: "controllerkey"},
+		}
+		Expect(effectiveModelCacheKey(model)).To(Equal("controllerkey"))
+	})
+
+	It("returns empty for a runtime-resolved single-file model with no cache key", func() {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{Source: "hf://unsloth/gemma-4-31B-it-GGUF"},
+		}
+		Expect(effectiveModelCacheKey(model)).To(BeEmpty())
+	})
+
+	It("derives a stable key from the source for an hf:// multi-file model (#909)", func() {
+		// The runtime-resolved path leaves Status.CacheKey empty for hf://
+		// sources, but multi-file staging must still land in the cache PVC.
+		source := "hf://unsloth/gemma-4-31B-it-GGUF"
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: source,
+				Files:  []string{"a.gguf", "MTP/b.gguf"},
+				Mmproj: "mmproj-F16.gguf",
+			},
+		}
+		Expect(effectiveModelCacheKey(model)).To(Equal(computeCacheKey(source)))
+	})
+
+	It("does not cache a metal multi-file model (no init container / cache PVC)", func() {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "hf://unsloth/gemma-4-31B-it-GGUF",
+				Files:    []string{"a.gguf"},
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: acceleratorMetal},
+			},
+		}
+		Expect(effectiveModelCacheKey(model)).To(BeEmpty())
+	})
+})
+
+var _ = Describe("buildCachedStorageConfig cache key fallback", func() {
+	It("uses the derived key in the cache dir for an hf:// multi-file model with no Status.CacheKey (#909)", func() {
+		source := "hf://unsloth/gemma-4-31B-it-GGUF"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "hf-multi"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: source,
+				Files:  []string{"model.gguf"},
+			},
+		}
+		config := buildCachedStorageConfig(model, nil, ModelCacheModeShared, "", "curl:8.18.0", 102)
+
+		// The staged primary must land under the key derived from the source,
+		// never a bare /models/ which would collide across every keyless model.
+		key := computeCacheKey(source)
+		Expect(key).NotTo(BeEmpty())
+		Expect(config.modelPath).To(Equal("/models/" + key + "/model.gguf"))
+	})
+})
+
 var _ = Describe("resolveHFSourceURL", func() {
 	It("converts hf:// to https://huggingface.co/", func() {
 		Expect(resolveHFSourceURL("hf://unsloth/gemma-4-31B-it-GGUF")).To(Equal("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF"))

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -180,6 +180,33 @@ func hasMultiFileStaging(model *inferencev1alpha1.Model) bool {
 	return model != nil && (len(model.Spec.Files) > 0 || model.Spec.Mmproj != "")
 }
 
+// effectiveModelCacheKey returns the key used to namespace a model's files
+// inside the cache PVC, and serves as the single source of truth for whether
+// the in-cluster serving pod should use the cache (non-empty) or an emptyDir
+// (empty). Both the PVC-ensure gate (InferenceService reconcile) and the
+// storage builder MUST consult this so they never disagree about caching.
+//
+// For sources the controller fingerprints (http/https) this is the
+// controller-set Status.CacheKey. The runtime-resolved path (hf:// repo IDs)
+// deliberately leaves Status.CacheKey empty and keeps the Available condition
+// reason "RuntimeResolved", but an hf:// model with multi-file staging still
+// needs the cache PVC: otherwise every file re-downloads into an emptyDir on
+// each pod restart (#909). Derive a stable key from the source in that case.
+// Metal models have no init container and no cache PVC (the host metal-agent
+// loads the files directly), so they never cache here.
+func effectiveModelCacheKey(model *inferencev1alpha1.Model) string {
+	if model == nil {
+		return ""
+	}
+	if model.Status.CacheKey != "" {
+		return model.Status.CacheKey
+	}
+	if hasMultiFileStaging(model) && !isMetalModel(model) {
+		return computeCacheKey(model.Spec.Source)
+	}
+	return ""
+}
+
 // modelStagingPlan resolves the model's declared files into a staging plan.
 // Returns nil when there is no multi-file staging. Returns an error when
 // multi-file fields are set but resolution fails (fail-closed).
@@ -372,7 +399,7 @@ func buildPVCStorageConfig(model *inferencev1alpha1.Model) modelStorageConfig {
 }
 
 func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64) modelStorageConfig {
-	cacheDir := fmt.Sprintf("/models/%s", model.Status.CacheKey)
+	cacheDir := fmt.Sprintf("/models/%s", effectiveModelCacheKey(model))
 
 	// Resolve the fsGroup that the CSI will actually apply to the volume.
 	// When the InferenceService sets its own FSGroup, that wins over the

--- a/pkg/cli/delete.go
+++ b/pkg/cli/delete.go
@@ -102,6 +102,14 @@ func runDelete(opts *deleteOptions) error {
 			fmt.Printf("Warning: failed to get Model for cache purge: %v\n", err)
 		} else {
 			cacheKey = model.Status.CacheKey
+			if cacheKey == "" {
+				// hf:// multi-file models are cached under a key derived from
+				// the source even though the controller leaves Status.CacheKey
+				// empty (see effectiveModelCacheKey). Mirror `cache list`'s
+				// fallback so --purge-cache targets the same dir the serving
+				// pod uses, instead of skipping it and orphaning the cache.
+				cacheKey = computeCacheKey(model.Spec.Source)
+			}
 		}
 	}
 


### PR DESCRIPTION
## What

Make hf:// Models that use `spec.files`/`spec.mmproj` (multi-file staging) use the shared model cache PVC instead of falling back to an `emptyDir` volume.

## Why

Fixes #909

A user reported that all their multi-file hf:// models swapped to `emptyDir`, re-downloading every declared file on each pod restart. Root cause: these models reach `Ready` via the runtime-resolved path, which deliberately leaves `Status.CacheKey` empty and keeps the Available condition reason `RuntimeResolved`. But both the PVC-ensure gate (`InferenceService` reconcile) and the deployment builder (`useCache`) keyed the "use the cache PVC?" decision off `Status.CacheKey` alone, so a keyless-but-multi-file model got an `emptyDir`.

A naive fix that mints a `Status.CacheKey` in the controller breaks the `RuntimeResolved` condition contract (an existing test guards it). This fixes the decision at the storage layer instead, leaving the controller's condition semantics untouched.

## How

- Add `effectiveModelCacheKey(model)` as the single source of truth for the cache decision: returns `Status.CacheKey` when the controller set one, otherwise derives a stable key from the source for **non-metal** multi-file models.
- Route all three deciders through it so they can no longer disagree:
  - `InferenceServiceReconciler` PVC-ensure gate
  - `deployment_builder` `useCache`
  - `buildCachedStorageConfig` cache dir
- Metal models keep no cache PVC (the host metal-agent loads files directly); the controller's `RuntimeResolved` condition is unchanged.
- Tests: unit coverage for `effectiveModelCacheKey` (controller key, runtime-resolved single-file, hf:// multi-file derivation, metal exclusion) and a `buildCachedStorageConfig` case asserting the keyed cache dir. Full `internal/controller` suite (469 specs) green, including the `RuntimeResolved` multi-file test.

## AI assistance

Assisted by an AI coding agent under human review (band 3 per CONTRIBUTING.md). The author reviewed, tested, and is accountable for all changes.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (incl. `GOOS=linux`)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed above
- [ ] Documentation updated (no user-facing surface change)