### PR TITLE
fix: grant events.k8s.io to the operator event recorder

### DIFF
--- a/charts/llmkube/templates/clusterrole.yaml
+++ b/charts/llmkube/templates/clusterrole.yaml
@@ -21,6 +21,14 @@ rules:
   - watch
 - apiGroups:
   - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
   resources:
   - nodes
   - pods

--- a/charts/llmkube/templates/role.yaml
+++ b/charts/llmkube/templates/role.yaml
@@ -33,6 +33,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,13 +20,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   - pods
   - secrets
@@ -45,6 +38,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - aigateway.envoyproxy.io
   resources:

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -119,6 +119,7 @@ func initContainerSecurityContext(isvc *inferencev1alpha1.InferenceService) *cor
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims,verbs=get;list;watch
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaimtemplates,verbs=get;list;watch
 


### PR DESCRIPTION
## What

Grant the operator's event recorder permission on the `events.k8s.io` API group, at the kubebuilder source of truth and in both Helm chart roles.

## Why

Fixes #910

The controller's client-go event broadcaster (`tools/events`) records into `events.k8s.io`, but RBAC only granted `events` in the core (`""`) group, and the cluster-scoped operator ClusterRole granted **no** events permission at all. Every event the operator emitted was denied:

```
events.events.k8s.io is forbidden: User "system:serviceaccount:<ns>:llmkube-controller-manager"
cannot create resource "events" in API group "events.k8s.io" in the namespace "<ns>"
```

## How

- Add a second kubebuilder RBAC marker for `groups=events.k8s.io,resources=events,verbs=create;patch` (the source of truth) and regenerate `config/rbac/role.yaml` via `make manifests`.
- Mirror it in both hand-maintained chart roles:
  - **ClusterRole** (`clusterrole.yaml`): add an events rule (`["", "events.k8s.io"]`, `create`/`patch`). It had none, so the cluster-scoped operator could not emit events in any watched namespace. This is the load-bearing part of the fix.
  - **Role** (`role.yaml`): add `events.k8s.io` to the existing core events rule.
- `make check-helm-rbac` passes (chart union covers all 183 generated rules); `helm template` confirms both roles now render `groups: ["", "events.k8s.io"]`.

## AI assistance

Assisted by an AI coding agent under human review (band 3 per CONTRIBUTING.md). The author reviewed, tested, and is accountable for all changes.

## Checklist

- [x] Tests added/updated (RBAC verified via `make check-helm-rbac` + `helm template`)
- [x] `make test` not affected (RBAC-only change; build passes)
- [x] `make lint` passes locally
- [x] `make check-helm-rbac` passes
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed above
- [ ] Documentation updated (no user-facing doc surface)