### PR TITLE
fix(foreman): recover str_replace from near-miss old_string

### DIFF
--- a/pkg/foreman/agent/tools/str_replace.go
+++ b/pkg/foreman/agent/tools/str_replace.go
@@ -51,7 +51,11 @@ func (t *StrReplaceTool) Schema() oai.ToolSchemaDef {
 	return oai.ToolSchemaDef{
 		Name: "str_replace",
 		Description: "Replace exact text in a file. Default: old_string must occur " +
-			"exactly once. Set expected_replacements to N to require exactly N matches.",
+			"exactly once. Set expected_replacements to N to require exactly N matches. " +
+			"Copy old_string VERBATIM from a recent read_file; prefer the shortest " +
+			"unique snippet (1-3 lines). Do not retype it from memory. If it does not " +
+			"match, the error shows the file's actual current text near your edit; " +
+			"copy that exactly and retry.",
 		Parameters: json.RawMessage(`{
 "type": "object",
 "properties": {
@@ -90,6 +94,28 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 	}
 	occurrences := strings.Count(content, a.OldString)
 	if occurrences != want {
+		// Recovery is only attempted for the default single-replace case where
+		// the model's old_string did not match at all. This is the dominant
+		// failure mode for models that retype old_string from memory instead of
+		// copying it verbatim (whitespace drift, or a fabricated near-miss).
+		if want == 1 && occurrences == 0 {
+			if recovered, note, ok := t.applyWhitespaceMatch(content, a.OldString, a.NewString); ok {
+				if err := os.WriteFile(full, []byte(recovered), 0o644); err != nil { //nolint:gosec // G306: workspace file
+					return nil, fmt.Errorf("str_replace: write %q: %w", a.Path, err)
+				}
+				return &agent.ToolResult{
+					Output: map[string]any{"path": a.Path, "replacements": 1, "note": note},
+				}, nil
+			}
+			// Could not safely locate the edit. Surface the file's ACTUAL current
+			// text near the model's intended anchor so it can retry against
+			// truth instead of re-hallucinating old_string.
+			if actual, ok := anchorContext(content, a.OldString); ok {
+				return nil, fmt.Errorf("str_replace: old_string not found in %q. "+
+					"The file's actual current text near your edit is below - copy it "+
+					"VERBATIM into old_string and retry:\n%s", a.Path, actual)
+			}
+		}
 		return nil, fmt.Errorf("str_replace: old_string found %d times in %q, want %d", occurrences, a.Path, want)
 	}
 	next := strings.ReplaceAll(content, a.OldString, a.NewString)
@@ -102,4 +128,87 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 			"replacements": occurrences,
 		},
 	}, nil
+}
+
+// normWS collapses every run of horizontal whitespace to a single space and
+// trims the ends, so tab-vs-space and trailing-space drift compare equal.
+func normWS(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+// applyWhitespaceMatch handles the common case where the model reproduced the
+// right lines but with wrong indentation (spaces instead of the file's tabs) or
+// trailing-whitespace drift. It matches old_string against the file line-by-line
+// under whitespace normalization; if exactly one window matches, it replaces
+// that real byte span with new_string. It refuses to act on an ambiguous
+// (multi-window) match so it can never edit the wrong location.
+func (t *StrReplaceTool) applyWhitespaceMatch(content, oldString, newString string) (result, note string, ok bool) {
+	contentLines := strings.Split(content, "\n")
+	oldLines := strings.Split(oldString, "\n")
+	if len(oldLines) == 0 || len(oldLines) > len(contentLines) {
+		return "", "", false
+	}
+	normOld := make([]string, len(oldLines))
+	for i, l := range oldLines {
+		normOld[i] = normWS(l)
+	}
+	start, matches := -1, 0
+	for i := 0; i+len(oldLines) <= len(contentLines); i++ {
+		hit := true
+		for j := range oldLines {
+			if normWS(contentLines[i+j]) != normOld[j] {
+				hit = false
+				break
+			}
+		}
+		if hit {
+			start = i
+			matches++
+		}
+	}
+	if matches != 1 {
+		return "", "", false
+	}
+	merged := make([]string, 0, len(contentLines))
+	merged = append(merged, contentLines[:start]...)
+	merged = append(merged, strings.Split(newString, "\n")...)
+	merged = append(merged, contentLines[start+len(oldLines):]...)
+	return strings.Join(merged, "\n"), "matched via whitespace-normalized fallback", true
+}
+
+// anchorContext finds the most distinctive line of old_string that appears
+// verbatim (trimmed) exactly once in the file, and returns the real surrounding
+// content so the model can copy the actual bytes. Returns ok=false when no
+// unique anchor line exists.
+func anchorContext(content, oldString string) (string, bool) {
+	contentLines := strings.Split(content, "\n")
+	anchorIdx, anchorLen := -1, 0
+	for _, ol := range strings.Split(oldString, "\n") {
+		trimmed := strings.TrimSpace(ol)
+		if len(trimmed) < 8 { // skip trivial lines like "}" or "return"
+			continue
+		}
+		count, idx := 0, -1
+		for i, cl := range contentLines {
+			if strings.TrimSpace(cl) == trimmed {
+				count++
+				idx = i
+			}
+		}
+		if count == 1 && len(trimmed) > anchorLen {
+			anchorLen = len(trimmed)
+			anchorIdx = idx
+		}
+	}
+	if anchorIdx < 0 {
+		return "", false
+	}
+	span := strings.Count(oldString, "\n") + 1
+	lo := anchorIdx - 2
+	if lo < 0 {
+		lo = 0
+	}
+	hi := anchorIdx + span + 2
+	if hi > len(contentLines) {
+		hi = len(contentLines)
+	}
+	return strings.Join(contentLines[lo:hi], "\n"), true
 }

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -457,6 +457,59 @@ func TestStrReplace_HappyPath_ExactlyOnce(t *testing.T) {
 	}
 }
 
+func TestStrReplace_RecoversFromWhitespaceMismatch(t *testing.T) {
+	ws := makeWorkspace(t)
+	// Real file is tab-indented (as Go source is).
+	src := "func f() {\n\treturn 1\n}\n"
+	if err := os.WriteFile(filepath.Join(ws, "f.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	tool := &StrReplaceTool{Workspace: ws}
+	// Model reproduces the body with SPACES instead of the tab. Exact match
+	// fails, but the whitespace-normalized fallback should locate it and apply
+	// the replacement against the real byte span.
+	wsArgs := map[string]string{
+		"path":       "f.go",
+		"old_string": "func f() {\n    return 1\n}", // spaces, not the file's tab
+		"new_string": "func f() {\n\treturn 2\n}",
+	}
+	wsBuf, _ := json.Marshal(wsArgs)
+	_, err := tool.Execute(context.Background(), wsBuf)
+	if err != nil {
+		t.Fatalf("expected whitespace-normalized recovery, got error: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(ws, "f.go"))
+	if !strings.Contains(string(got), "return 2") {
+		t.Errorf("replacement not applied: %q", string(got))
+	}
+}
+
+func TestStrReplace_ReturnsActualContentOnFabricatedOldString(t *testing.T) {
+	ws := makeWorkspace(t)
+	// Real file: a plain hyphen in the comment, a specific body.
+	src := "// keep this comment - a plain hyphen here\n" +
+		"func compute() string {\n\treturn hash()\n}\n"
+	if err := os.WriteFile(filepath.Join(ws, "f.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	tool := &StrReplaceTool{Workspace: ws}
+	// Model fabricates old_string (em dash + wrong wording + wrong body) but
+	// anchors on the real, verbatim func signature line. The tool must not
+	// match, and must surface the ACTUAL current content so the model can retry
+	// against truth instead of re-hallucinating.
+	old := "// keep this comment — an EM dash and wrong words\n" +
+		"func compute() string {\n\treturn somethingElse()\n}"
+	args := map[string]string{"path": "f.go", "old_string": old, "new_string": "x"}
+	buf, _ := json.Marshal(args)
+	_, err := tool.Execute(context.Background(), buf)
+	if err == nil {
+		t.Fatal("expected error for fabricated old_string")
+	}
+	if !strings.Contains(err.Error(), "a plain hyphen here") || !strings.Contains(err.Error(), "return hash()") {
+		t.Errorf("error should surface real file content near the anchor, got: %v", err)
+	}
+}
+
 func TestStrReplace_CountMismatchIsError(t *testing.T) {
 	ws := makeWorkspace(t)
 	src := "x x x\n"


### PR DESCRIPTION
## What

Make the `str_replace` coder tool recover from a non-matching `old_string` instead of dead-ending, and steer the tool description toward short verbatim snippets.

## Why

Fixes #916

Coder models (local ones especially) retype `old_string` from memory rather than copying it verbatim, so it matches 0 times and the loop re-guesses until `RepeatedToolCall` / `EditFreeStreak` kills it with no edit landed. Observed on #867: the model invented an em dash and duplicated a line in a `computeSpecHash` block; pre-fix Ornith-35B stalled at 12 turns with zero edits.

## How

On a 0-match single replace:
- **Whitespace-normalized fallback:** if the model got the lines right but the indentation wrong (spaces vs the file's tabs, trailing space), locate the unique matching span under whitespace normalization and apply against the real bytes. Refuses ambiguous multi-window matches so it can never edit the wrong place.
- **Actual-content feedback:** otherwise, anchor on the model's most distinctive verbatim line and return the file's real surrounding text, so the model copies the truth and retries.
- Tool description now steers toward short, verbatim `old_string`s.

Unit tests cover both paths (including a repro of the exact #867 em-dash near-miss). `go test ./pkg/foreman/agent/tools/` + `GOOS=linux` lint pass.

Validated end-to-end: with this fix deployed to the metal coder agent, Ornith-35B drove #867 to a gate-passing GO (60 turns, 3-file change) where the pre-fix agent could not land an edit.

## AI assistance

Assisted by an AI coding agent (Claude Code) under human review (band 3 per CONTRIBUTING.md). The author reviewed, tested, and is accountable for all changes.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (tools package)
- [x] `make lint` passes locally (incl. `GOOS=linux`)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed above
- [ ] Documentation updated (tool-internal behavior; none needed)