### PR TITLE
fix: preserve init-container SecurityContext in podTemplatesDiffer (#922)

### DIFF
--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -798,6 +798,49 @@ var _ = Describe("RolloutPolicy drain-before-rollout", func() {
 	})
 })
 
+var _ = Describe("podTemplatesDiffer input immutability (#922)", func() {
+	newPrepTemplate := func() corev1.PodTemplateSpec {
+		root := int64(0)
+		return corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Name:  "model-cache-prep",
+					Image: "curl:8.18.0",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: &root,
+						Capabilities: &corev1.Capabilities{
+							Add:  []corev1.Capability{"CHOWN", "FOWNER"},
+							Drop: []corev1.Capability{"ALL"},
+						},
+					},
+				}},
+			},
+		}
+	}
+
+	It("does not mutate the desired template's init container SecurityContext", func() {
+		desired := newPrepTemplate()
+		existing := newPrepTemplate()
+		// A rollout-worthy difference so the function runs its full
+		// normalization path before returning.
+		existing.Spec.InitContainers[0].Image = "curl:8.17.0"
+
+		changed := podTemplatesDiffer(existing, desired)
+
+		Expect(changed).To(BeTrue(), "an image change should still be detected")
+		sc := desired.Spec.InitContainers[0].SecurityContext
+		Expect(sc).NotTo(BeNil())
+		Expect(sc.RunAsUser).NotTo(BeNil(), "RunAsUser must survive the diff (see #922)")
+		Expect(*sc.RunAsUser).To(Equal(int64(0)))
+		Expect(sc.Capabilities).NotTo(BeNil())
+		Expect(sc.Capabilities.Add).To(ContainElement(corev1.Capability("CHOWN")))
+	})
+
+	It("reports no difference for identical templates", func() {
+		Expect(podTemplatesDiffer(newPrepTemplate(), newPrepTemplate())).To(BeFalse())
+	})
+})
+
 var _ = Describe("checkServerIdle", func() {
 	var reconciler *InferenceServiceReconciler
 

--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -267,6 +267,15 @@ func computePodTemplateForComparison(t corev1.PodTemplateSpec) corev1.PodTemplat
 // scheduling fields) while ignoring API-server-applied defaults like
 // TerminationGracePeriodSeconds that cause false positives on full DeepEqual.
 func podTemplatesDiffer(existing, desired corev1.PodTemplateSpec) bool {
+	// Deep-copy both templates up front. The normalization below mutates
+	// container SecurityContexts and other fields in place, and a shallow
+	// struct copy still shares the underlying slices and pointers with the
+	// caller's templates. Without this, normalizing `desired` for comparison
+	// nils out the real desired template's SecurityContext (e.g. the
+	// model-cache-prep init container's RunAsUser/Capabilities), which then
+	// gets applied to the Deployment. See #922.
+	existing = *existing.DeepCopy()
+	desired = *desired.DeepCopy()
 	if !apiequality.Semantic.DeepEqual(existing.Labels, desired.Labels) {
 		return true
 	}


### PR DESCRIPTION
## What

Deep-copy both pod templates at the top of `podTemplatesDiffer` so the
comparison-time normalization can no longer mutate the caller's `desired`
template.

## Why

Fixes #922.

After 0.8.23, every cache-backed model crashlooped in init with
`model-cache-prep chown: /models: Operation not permitted`. The rendered
Deployment's `model-cache-prep` init container had an empty
`securityContext: {}` (it was `runAsUser: 0` + `CHOWN`/`FOWNER` on 0.8.22),
so the `chown` lost `CAP_CHOWN` and failed with EPERM on `fsGroupPolicy: None`
CSIs.

Root cause is an aliasing bug in `podTemplatesDiffer` (added with the
drain-before-rollout work in #913):

```go
a, b := existing.Spec, desired.Spec   // shallow struct copy
...
normalizeContainers(b.InitContainers) // nils RunAsUser/Capabilities/... in place
```

The struct copy is shallow, so `b.InitContainers` and each
`Container.SecurityContext` pointer are still shared with the caller's
`desired` template. `normalizeContainers` nils `RunAsUser`, `Capabilities`,
etc. for comparison purposes, but does so *through the shared pointers* —
gutting the real desired `model-cache-prep` securityContext to `{}`. The
reconciler then applies that mutated `desired` template to the Deployment
(`reconcileDeployment`), so the init container ships without root/CHOWN. The
same shallow-copy issue also nils the pod-level `SecurityContext.SeccompProfile`.

## How

- `existing = *existing.DeepCopy()` / `desired = *desired.DeepCopy()` at the
  top of `podTemplatesDiffer`, so all in-place normalization operates on copies
  and never leaks into the applied object.

## Testing

- Added a regression spec in `drain_before_roll_test.go` asserting the desired
  init-container `SecurityContext` (`RunAsUser`, `Capabilities`) survives a
  `podTemplatesDiffer` call, that a rollout-worthy change (image) is still
  detected, and that identical templates report no diff.
- Verified the fix + test logic locally by running the `podTemplatesDiffer`
  assertions as a standalone `go test` (bypassing the envtest `BeforeSuite`):
  passes with the fix, and without it fails with
  `desired RunAsUser mutated: ...RunAsUser:nil...`, reproducing the bug.
- `go build ./...`, `go vet ./internal/controller/`, `gofmt` all clean.
- I could not run the full envtest-backed `internal/controller` suite locally
  (the darwin-arm64 1.36.2 envtest control-plane binaries wouldn't exec in my
  environment, so `BeforeSuite` failed and all specs skipped). CI should run
  the Ginkgo suite.

## AI assistance

Assisted by an AI coding agent under human review (band 3 per CONTRIBUTING.md).
The author reviewed, tested, and is accountable for all changes.

## Checklist

- [x] Tests added/updated
- [ ] `make test` passes locally (blocked by local envtest binaries; see Testing)
- [x] `go build` / `go vet` / `gofmt` clean
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed above
- [ ] Documentation updated (no user-facing surface change)
