### PR TITLE
feat(foreman): coder clones/pushes each task's own repo when no static remote

### DIFF
--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -216,22 +216,20 @@ agent:
   # the deterministic gate Agent's workspace prep step.
   workspaceDir: /workspace
 
-  # Git remote the executor (both native LLM-driven coder and the
-  # deterministic gate, which clones the upstream coder's branch from
-  # the fork) reads from and pushes branches to. Required for ALL
-  # native-mode nodes including verifier-only nodes:
+  # Git remote the executor reads from and pushes branches to. OPTIONAL
+  # as of #915:
   #
-  #   - coder-role nodes (M5 Max running the Carnice Agent) need it to
-  #     push the resulting branch.
-  #   - verifier-role nodes (ShadowStack running the M4 gate Agent)
-  #     need it because run_gate_job clones the branch the coder pushed
-  #     to the fork, not the upstream repo where the branch does not
-  #     yet exist.
+  #   - Set: pins every coder task to this one fork/repo (the single-repo
+  #     fork-PR model). The coder pushes the branch here and the gate
+  #     clones it from here.
+  #   - Empty: each coder task clones and pushes its OWN payload.repo
+  #     (github.com/<owner>/<name>), so a single agent serves many repos.
+  #     The gate then constructs the same clone URL from payload.repo, so
+  #     it still finds the branch the coder pushed.
   #
-  # Leaving this empty puts the agent into "deterministic-only-without-
-  # network-git" mode: the M4 V3 two-step pipeline fails at the gate's
-  # clone step with "foreman-agent was not started with --git-remote-url;
-  # cannot clone". Stub-mode agents do not need it.
+  # Set this only to force every task onto one remote (a shared fork).
+  # A coder task with neither this NOR a payload.repo fails at the clone
+  # step with GitRemoteNotConfigured. Stub-mode agents ignore it.
   gitRemoteURL: ""
 
   # Git author + committer identity stamped onto commits the coder-

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -273,8 +273,9 @@ func main() {
 		// leaves other tasks unaffected. The flags stay required at
 		// the per-task level, not at startup.
 		if gitRemoteURL == "" {
-			setupLog.Info("--git-remote-url is unset; coder-role tasks will fail with GitRemoteURLNotConfigured. " +
-				"Deterministic Agents (e.g. M4 gate) work fine without it.")
+			setupLog.Info("--git-remote-url is unset; coder-role tasks clone and push " +
+				"each task's own payload.repo (#915). Tasks with no payload.repo fail " +
+				"with GitRemoteURLNotConfigured; deterministic Agents work fine without it.")
 		}
 		if commitAuthorEmail == "" {
 			setupLog.Info("--commit-author-email is unset; coder-role tasks that need to commit will fail. " +

--- a/docs/site/foreman/runbook-m3.md
+++ b/docs/site/foreman/runbook-m3.md
@@ -100,8 +100,10 @@ pkill -f 'llmkube-foreman-agent --agent-mode=stub' || true
 
 Why each native-mode flag:
 
-- `--git-remote-url`: v0.1 clones from and pushes to the same URL (the
-  fork). v0.2 will split clone-from-upstream from push-to-fork.
+- `--git-remote-url`: clones from and pushes to the same URL (the fork).
+  Optional as of #915: leave it unset and each coder task clones and
+  pushes its own `payload.repo` instead, so one agent serves many repos.
+  Set it only to pin every task to a single shared remote.
 - `--inference-base-url-host-override`: required when foreman-agent
   runs on the host (where `*.svc.cluster.local` does not resolve).
   The executor still reads `InferenceService.status.endpoint` for the

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -269,10 +269,28 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	}
 	defer func() { _ = auth.Close() }()
 
+	// resolveUpstream derives a repo's git URL from its payload.repo
+	// "owner/name" slug. It picks the clone target when no static fork
+	// remote is configured (#915) and cuts the task branch from the
+	// upstream base below (#813). The test override lets envtest inject a
+	// local remote.
+	resolveUpstream := upstreamURLForRepo
+	if e.UpstreamURLForRepo != nil {
+		resolveUpstream = e.UpstreamURLForRepo
+	}
+
+	// Clone target: the statically configured fork remote when set,
+	// otherwise the task's own repo (#915). Deriving the clone+push target
+	// from payload.repo lets a single agent serve many repos instead of
+	// being pinned to one --git-remote-url; the branch still pushes to this
+	// clone's origin, which in that case is the task's repo itself.
 	cloneURL := e.GitRemoteURL
 	if cloneURL == "" {
+		cloneURL = resolveUpstream(task.Spec.Payload.Repo)
+	}
+	if cloneURL == "" {
 		return e.failResult(start, foremanv1alpha1.FailureGitRemoteNotConfigured,
-			"foreman-agent was not started with --git-remote-url; cannot clone"), nil
+			"no --git-remote-url configured and task payload.repo is empty or invalid; cannot clone"), nil
 	}
 	if err := repo.Clone(ctx, repo.CloneOptions{
 		RemoteURL: cloneURL,
@@ -288,13 +306,12 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	// upstream. When the task carries an upstream repo slug (payload.repo),
 	// fetch its base ref and branch from that instead. Origin stays the fork,
 	// so the branch still pushes there for the PR. Freeform tasks without a
-	// repo slug fall back to branching from the cloned fork HEAD.
+	// repo slug fall back to branching from the cloned fork HEAD. When the
+	// clone target was itself derived from payload.repo (#915), origin and
+	// upstream resolve to the same URL — branching off the base is then a
+	// no-op-equivalent that still yields a current-base branch.
 	branch := branchNameForTask(task)
 	baseBranch := baseBranchOrDefault(task.Spec.Payload.BaseBranch)
-	resolveUpstream := upstreamURLForRepo
-	if e.UpstreamURLForRepo != nil {
-		resolveUpstream = e.UpstreamURLForRepo
-	}
 	if upstreamURL := resolveUpstream(task.Spec.Payload.Repo); upstreamURL != "" {
 		if err := repo.CreateBranchFromUpstream(ctx, repo.UpstreamBranchOptions{
 			Workspace:   workspace,

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -405,6 +405,113 @@ func TestNativeExecutor_HappyPathPushesBranch(t *testing.T) {
 	}
 }
 
+// --- #915: no static remote -> clone+push the task's own repo -----------
+
+// TestNativeExecutor_MultiRepoClonesTaskRepoWhenNoStaticRemote proves the
+// #915 path: with no static --git-remote-url, the coder clones and pushes
+// the task's own payload.repo, so one agent can serve many repos. Mirrors
+// the happy path but leaves GitRemoteURL empty; the branch must still land
+// on the repo the task names (here, the bare the override resolves to).
+func TestNativeExecutor_MultiRepoClonesTaskRepoWhenNoStaticRemote(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+
+	agent, task := taskAndAgent("multirepo")
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(agent, task).
+		Build()
+
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true, Verdict: "GO", Summary: "fixed",
+				CommitMessage: "fix: trivial change\n",
+			},
+		},
+		touch: func(name string, ws string) {
+			if name == "submit_result" {
+				_ = os.WriteFile(filepath.Join(ws, "fix.txt"), []byte("foreman touched this\n"), 0o644)
+			}
+		},
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:        c,
+		WorkspaceRoot: filepath.Join(root, "ws"),
+		// No static fork remote: payload.repo drives clone + push.
+		GitRemoteURL:             "",
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(ws string, _ *foremanv1alpha1.Agent) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("verdict: want GO got %s; result=%+v", res.Verdict, res)
+	}
+	// Branch pushed to the task's repo (the override target), proving the
+	// clone+push used payload.repo rather than a static --git-remote-url.
+	out, err := exec.Command("git", "-C", bare, "branch", "--list", "foreman/issue-9999").CombinedOutput()
+	if err != nil {
+		t.Fatalf("post-push branch list: %v: %s", err, out)
+	}
+	if !strings.Contains(string(out), "foreman/issue-9999") {
+		t.Errorf("branch not pushed to task repo: %s", out)
+	}
+}
+
+// TestNativeExecutor_NoStaticRemoteAndNoRepoIsHardError covers the #915
+// precondition: no --git-remote-url and no usable payload.repo leaves
+// nothing to clone, so the task fails cleanly with GitRemoteNotConfigured
+// (not a system error).
+func TestNativeExecutor_NoStaticRemoteAndNoRepoIsHardError(t *testing.T) {
+	root := t.TempDir()
+
+	agent, task := taskAndAgent("norepo")
+	task.Spec.Payload.Repo = "" // no slug to derive a remote from
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(agent, task).
+		Build()
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:        c,
+		WorkspaceRoot: filepath.Join(root, "ws"),
+		GitRemoteURL:  "", // and no repo -> cannot clone
+		// Bypass InferenceService lookup so execution reaches the clone
+		// precondition (endpoint resolution runs before the clone step).
+		InferenceBaseURLOverride: "http://127.0.0.1:1/v1",
+		AuthFactory:              fakeAuth(t),
+		// Required precondition; never exercised — the clone fails first.
+		RegistryFactory: func(string, *foremanv1alpha1.Agent) (foremanagent.ToolRegistry, error) {
+			return &fakeRegistry{}, nil
+		},
+	}
+
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned a system error, want a data-shaped fail: %v", err)
+	}
+	if res == nil || res.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Fatalf("verdict: want INCOMPLETE got %+v", res)
+	}
+	if res.FailureReason != foremanv1alpha1.FailureGitRemoteNotConfigured {
+		t.Errorf("FailureReason: want %q got %q", foremanv1alpha1.FailureGitRemoteNotConfigured, res.FailureReason)
+	}
+}
+
 // --- Loop returns no-change GO -> reported as NO-GO/NO-CHANGES -----------
 
 func TestNativeExecutor_ModelEmitsGoButNoChanges(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #915. The coder cloned and pushed the agent's single static `--git-remote-url`, so one agent could only serve one repository — a Workload-driven source feeding issues across many repos had to run one agent per repo.

When `--git-remote-url` is **empty**, the coder now derives its clone + push target from the task's `payload.repo` (`github.com/<owner>/<name>`, via the existing `upstreamURLForRepo` helper). So a **single agent serves every repo** the Workloads name — pair it with `Workload.spec.repo` + `Workload.spec.gateProfile` (#920) and the whole fleet runs off one agent.

## Behavior

- **Static `--git-remote-url` set** → unchanged: every task pins to that one fork/repo (fork-PR model).
- **Empty** → each coder task clones + pushes its own `payload.repo`.
- **Neither set nor a valid `payload.repo`** → fails cleanly with `GitRemoteNotConfigured` (was: same failure, now with an accurate message).

The gate and post-push envtest paths already construct their clone URL from `payload.repo` when the executor URL is empty (`buildDeterministicArgs`, `evaluatePostPushEnvtest`), so they find the branch the coder pushed without any change. Push follows the clone's `origin`, so it already targets the right repo. The branch is still cut from the current upstream base (#813); when the clone was itself derived from `payload.repo`, origin and upstream resolve to the same URL and the base branch is still current.

## Changes

- `executor_native.go`: derive `cloneURL` from `payload.repo` when `GitRemoteURL` is empty (single resolution point; `resolveUpstream` hoisted above the clone).
- `cmd/foreman-agent/main.go`: the startup info-log for an unset `--git-remote-url` now describes the per-task-repo behavior.
- `charts/foreman/values.yaml` + `runbook-m3.md`: `gitRemoteURL` documented as optional.

## Tests

- `TestNativeExecutor_MultiRepoClonesTaskRepoWhenNoStaticRemote` — empty static remote + `payload.repo` → GO with the branch pushed to the task's repo.
- `TestNativeExecutor_NoStaticRemoteAndNoRepoIsHardError` — neither set → `GitRemoteNotConfigured`.
- Full `pkg/foreman/agent` suite green (incl. the unchanged fork-model happy path); `go build`/`go vet` clean.

## Context

Sibling of #919/#920 (Workload `gateProfile` propagation). Together they let one shared agent run the full coder→gate→reviewer pipeline across a heterogeneous, multi-repo fleet via `Workload.spec.{repo,gateProfile}` — no per-repo agent fan-out.