### PR TITLE
docs: add Jory Irving as Foreman area maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,10 @@
 # Default owners for all files
 * @Defilan
+
+# Foreman (coder/reviewer harness) — @joryirving co-maintains this area.
+# More specific paths win, so these override the catch-all above.
+/api/foreman/          @Defilan @joryirving
+/internal/foreman/     @Defilan @joryirving
+/pkg/foreman/          @Defilan @joryirving
+/cmd/foreman-agent/    @Defilan @joryirving
+/cmd/foreman-operator/ @Defilan @joryirving

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,24 +4,34 @@ This file lists the maintainers of LLMKube.
 
 ## Current Maintainers
 
-| Maintainer  | GitHub                                 | Areas                          |
-| ----------- | -------------------------------------- | ------------------------------ |
-| Chris Maher | [@Defilan](https://github.com/Defilan) | All: operator, CLI, Helm, docs |
+| Maintainer  | GitHub                                       | Areas                                 |
+| ----------- | -------------------------------------------- | ------------------------------------- |
+| Chris Maher | [@Defilan](https://github.com/Defilan)       | Lead: operator, CLI, Helm, docs       |
+| Jory Irving | [@joryirving](https://github.com/joryirving) | Foreman (coder/reviewer harness)      |
 
-LLMKube is currently maintained by a single person. The maintainer reviews
-and merges pull requests, triages issues, cuts releases, and sets technical
-direction.
+Maintainers review and merge pull requests, triage issues, and help set
+technical direction. Area maintainers focus their review and merge authority
+on their listed areas; the lead maintainer covers the rest, cuts releases, and
+owns overall direction.
 
 ## Becoming a Maintainer
 
-As the contributor community grows, this document will describe the path to
-becoming a maintainer: a track record of quality contributions, issue triage,
-and review participation, followed by an invitation from the existing
-maintainers.
+Maintainership is earned through sustained, high-quality contribution rather
+than a formal application. The path we look for:
 
-If you would like to get more involved, the best starting points are opening
-focused pull requests, helping triage issues, and joining discussions. See
-[CONTRIBUTING.md](CONTRIBUTING.md).
+- A track record of well-scoped, reviewed pull requests in an area of the
+  codebase.
+- Helping triage issues and review others' pull requests.
+- Reliable adherence to the project's process: DCO sign-off, tests alongside
+  changes, and disclosure of AI assistance per
+  [CONTRIBUTING.md](CONTRIBUTING.md).
+
+An existing maintainer then extends an invitation for an area (or the whole
+project), after which the new maintainer is added here and to
+[CODEOWNERS](.github/CODEOWNERS).
+
+The best starting points are opening focused pull requests, helping triage
+issues, and joining discussions. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Security
 


### PR DESCRIPTION
## What

Add Jory Irving (@joryirving) as the maintainer for the Foreman area, formalize the contributor ladder, and give him CODEOWNERS review ownership of the Foreman code paths.

## Why

Jory has driven the recent Foreman work: drain-before-roll (#856/#913), Workload `gateProfile` propagation (#919/#920), the multi-repo coder (#915/#924), and he found and fixed the `podTemplatesDiffer` aliasing regression (#922/#923) that broke 0.8.23. He's already been operating as a de-facto maintainer for that area, and he now has collaborator access.

## How

- **MAINTAINERS.md**: add Jory to the table with area "Foreman (coder/reviewer harness)"; reframe the description for more than one maintainer (area vs lead); replace the placeholder "Becoming a Maintainer" section with a real, concise contributor ladder (track record + triage + review + process adherence, then an invitation).
- **.github/CODEOWNERS**: add area entries so `@joryirving` (with `@Defilan`) is auto-requested on Foreman PRs (`api/foreman/`, `internal/foreman/`, `pkg/foreman/`, `cmd/foreman-agent/`, `cmd/foreman-operator/`). More specific paths override the catch-all.

Docs-only; no code or behavior change.

## Checklist

- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (this is the doc change)