### PR TITLE
fix(foreman): chart exposes --foreman-namespace so gate Jobs land with the cache PVC

### DIFF
--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -53,6 +53,7 @@ spec:
             {{- if .Values.agent.taskNamespace }}
             - --task-namespace={{ .Values.agent.taskNamespace }}
             {{- end }}
+            - --foreman-namespace={{ .Values.agent.foremanNamespace | default (include "foreman.namespace" .) }}
             {{- if .Values.agent.installedModels }}
             - --installed-models={{ join "," .Values.agent.installedModels }}
             {{- end }}

--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -53,6 +53,7 @@ spec:
             {{- if .Values.agent.taskNamespace }}
             - --task-namespace={{ .Values.agent.taskNamespace }}
             {{- end }}
+            {{- /* Always set: the binary default is "foreman-system", a namespace the chart never creates, so gate Jobs would land where the cache PVC does not exist. */}}
             - --foreman-namespace={{ .Values.agent.foremanNamespace | default (include "foreman.namespace" .) }}
             {{- if .Values.agent.installedModels }}
             - --installed-models={{ join "," .Values.agent.installedModels }}

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -197,6 +197,12 @@ agent:
   # tenants that should not see each other's tasks.
   taskNamespace: ""
 
+  # --foreman-namespace flag. Namespace the agent submits gate Jobs
+  # into. Defaults to the release namespace, which is where the chart
+  # creates the foreman-gate-cache PVC. Override only when the PVC
+  # and the agent live in different namespaces.
+  foremanNamespace: ""
+
   # Models the foreman-agent advertises in its FleetNode.spec
   # heartbeat. Use kebab-case slugs (e.g. "qwen36-35b-carnice-mtp").
   installedModels: []


### PR DESCRIPTION
## What

Expose the agent's `--foreman-namespace` flag in the foreman Helm chart, defaulting to the release namespace.

## Why

Fixes #933

The agent binary defaults `--foreman-namespace` to `foreman-system`, a namespace the chart never creates. Any install not named `foreman-system` lands gate Jobs where the gate-cache PVC does not exist, so every verify task GATE-ERRORs.

## How

Adds `agent.foremanNamespace` to values.yaml (empty default resolves via the `foreman.namespace` helper to `.Release.Namespace`) and wires it unconditionally into the agent Deployment args, so gate Jobs always share the namespace of the cache PVC (which uses the same helper). Verified default and override paths with `helm lint` and `helm template`.

## Checklist

- [x] Tested (helm lint + helm template on default and override paths)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [x] AI assistance disclosed below
- [x] Documentation updated (values.yaml documents the new key)
---

Assisted-by: Foreman (LLMKube coder harness, local Ornith-35B on the Strix) generated the change; it passed the post-push clean-room envtest gate and an independent external-contributor review pass before I opened this. I reviewed the result, ran the tests and cross-arch lint, and am accountable for it.


---

**Upgrade note (for release notes):** operators who applied the `--foreman-namespace=<release-ns>` postRenderer workaround from #933 will briefly have the flag set twice after upgrading to this chart (chart-rendered + patch, same value, last-wins — harmless). They should drop the postRenderer patch once on this version. (Thanks @joryirving for flagging.)
