### PR TITLE
fix(foreman): substitute placeholder for empty assistant replies to avoid poisoning history

### DIFF
--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -792,11 +792,21 @@ func (l *Loop) runOneTurn(
 	// every subsequent turn (#935). Substitute a placeholder so the
 	// transcript stays valid and the loop can recover with a corrective
 	// nudge rather than burning turns until MaxTurns.
+	//
+	// The placeholder is a NEUTRAL factual marker, not an instruction: it
+	// is replayed as assistant content on every later turn, and a
+	// self-addressed "please call a tool" reads to smaller models as the
+	// model instructing itself. The corrective instruction lives in the
+	// user-role NoToolCallNudgeMessage() the no-tool-call path appends
+	// below, which is the right voice for it.
 	if msg.Role == oai.RoleAssistant &&
 		strings.TrimSpace(msg.Content) == "" &&
 		len(msg.ToolCalls) == 0 &&
 		msg.ReasoningContent == "" {
-		msg.Content = "(empty response from model; please call a tool or submit_result to finish)"
+		msg.Content = "(empty response from model)"
+		// Surface chronic empty replies (a backend or chat-template
+		// problem) on the turn span instead of silently absorbing them.
+		span.SetAttributes(attribute.Bool("empty_assistant_reply", true))
 	}
 	res.Transcript = append(res.Transcript, msg)
 

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -784,6 +784,20 @@ func (l *Loop) runOneTurn(
 	if msg.Role == "" {
 		msg.Role = oai.RoleAssistant
 	}
+	// Guard against a completely empty assistant reply (no content, no
+	// tool_calls, no reasoning_content). Stricter backends (llama.cpp via
+	// litellm, Devstral, OpenAI) reject a history that contains such a
+	// message on the next turn with "Assistant message must contain
+	// either 'content' or 'tool_calls'", poisoning the conversation for
+	// every subsequent turn (#935). Substitute a placeholder so the
+	// transcript stays valid and the loop can recover with a corrective
+	// nudge rather than burning turns until MaxTurns.
+	if msg.Role == oai.RoleAssistant &&
+		strings.TrimSpace(msg.Content) == "" &&
+		len(msg.ToolCalls) == 0 &&
+		msg.ReasoningContent == "" {
+		msg.Content = "(empty response from model; please call a tool or submit_result to finish)"
+	}
 	res.Transcript = append(res.Transcript, msg)
 
 	if len(msg.ToolCalls) == 0 {

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -1073,6 +1073,82 @@ func TestRunOneTurn_EmptyAssistantReply_SubstitutesPlaceholder(t *testing.T) {
 	}
 }
 
+// toolCallWithEmptyContent is a chat-completions body where the model
+// returns an assistant message with tool_calls but explicitly empty
+// content — the normal pattern for a tool-calling turn. The guard added
+// in #935 must NOT fire here: the message is structurally valid (it has
+// tool_calls), and clobbering its content with a placeholder would be
+// incorrect.
+const toolCallWithEmptyContent = `{
+  "id": "t6",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "content": "",
+      "tool_calls": [{
+        "id": "tc-rf2",
+        "type": "function",
+        "function": {"name": "read_file", "arguments": "{\"path\":\"README.md\"}"}
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }]
+}`
+
+// TestRunOneTurn_ToolCallTurnNotClobbered proves the #935 empty-content
+// guard does NOT fire when the assistant message carries tool_calls.
+// A tool-call turn with empty content is structurally valid per the OAI
+// spec ("content optional when tool_calls are present"); substituting the
+// placeholder would corrupt the tool_call_id chain and break strict
+// backends. The test mirrors TestRunOneTurn_EmptyAssistantReply_SubstitutesPlaceholder
+// exactly, swapping the fixture for one that includes tool_calls.
+func TestRunOneTurn_ToolCallTurnNotClobbered(t *testing.T) {
+	srv, _ := scriptedOAIServer(t, []string{toolCallWithEmptyContent})
+	reg := &fakeRegistry{
+		results: map[string]*ToolResult{
+			"read_file": {Output: map[string]any{"content": "# README\n"}},
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	res := &LoopResult{
+		Transcript: []oai.Message{
+			{Role: oai.RoleSystem, Content: "sys"},
+			{Role: oai.RoleUser, Content: "go"},
+		},
+	}
+	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res)
+	// A tool-call turn is a normal, successful turn: no error expected.
+	if err != nil {
+		t.Fatalf("runOneTurn: expected nil error for a tool-call turn with empty content, got %v", err)
+	}
+	// Find the assistant message that runOneTurn appended.
+	var assistantMsg *oai.Message
+	for i := range res.Transcript {
+		if res.Transcript[i].Role == oai.RoleAssistant {
+			assistantMsg = &res.Transcript[i]
+		}
+	}
+	if assistantMsg == nil {
+		t.Fatalf("no assistant message found in transcript: %+v", res.Transcript)
+	}
+	// The tool_calls must be preserved intact.
+	if len(assistantMsg.ToolCalls) == 0 {
+		t.Errorf("tool_calls must not be stripped; got empty ToolCalls on assistant message")
+	}
+	// The placeholder must NOT have been injected: content must still be
+	// empty (or at least must not contain the guard's sentinel string).
+	if strings.Contains(assistantMsg.Content, "empty response from model") {
+		t.Errorf(
+			"guard must not fire for a tool-call turn; placeholder was injected: %q",
+			assistantMsg.Content)
+	}
+	// read_file should have been dispatched, confirming the tool call ran.
+	if len(reg.dispatched) == 0 || reg.dispatched[0] != "read_file" {
+		t.Errorf("expected read_file to be dispatched; got %v", reg.dispatched)
+	}
+}
+
 // TestLoop_StrippedReasoningDoesNotProduceEmptyAssistant covers the
 // sibling case: stripReasoningForWire must not leave an empty assistant
 // message on the wire.

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -986,7 +986,97 @@ func TestStripReasoningForWire(t *testing.T) {
 	}
 }
 
-func TestStripReasoningForWire_NeverEmptiesAssistantMessage(t *testing.T) {
+// emptyAssistantReply is a chat-completions body where the model returns
+// an assistant message with neither content nor tool_calls — the shape
+// that triggers #935: the loop appends it to history, the next turn's
+// request is rejected with 400 "Assistant message must contain either
+// 'content' or 'tool_calls'", and the task cascade-fails.
+const emptyAssistantReply = `{"choices":[{"index":0,"message":{"role":"assistant"},"finish_reason":"stop"}]}`
+
+// TestLoop_EmptyAssistantReply_SubstitutesPlaceholder covers #935: when
+// the model returns an assistant message with no content and no
+// tool_calls, the loop must not append it verbatim to the transcript.
+// Instead it substitutes a placeholder so the next turn's request stays
+// valid against strict backends (llama.cpp, Devstral, OpenAI). The loop
+// should then treat the turn as a no-tool-call and apply its existing
+// corrective-nudge path.
+func TestLoop_EmptyAssistantReply_SubstitutesPlaceholder(t *testing.T) {
+	// Turn 1: empty assistant reply. Turn 2: a real submit_result so the
+	// loop can finish cleanly (proving the empty reply did not poison
+	// history).
+	srv, calls := scriptedOAIServer(t, []string{emptyAssistantReply, toolCallSubmitGo})
+	reg := &fakeRegistry{
+		results: map[string]*ToolResult{
+			"submit_result": {Terminal: true, Verdict: "GO", Summary: "ok"},
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", SystemPrompt: "sys", UserPrompt: "go", MaxTurns: 5,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Errorf("expected GO terminal after recovery, got %+v", res.Terminal)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("OAI calls: want 2 (empty reply + submit) got %d", got)
+	}
+	// The empty assistant message must have been replaced with a
+	// placeholder, not left empty.
+	var sawPlaceholder bool
+	for _, m := range res.Transcript {
+		if m.Role == oai.RoleAssistant && m.Content != "" {
+			if strings.Contains(m.Content, "empty response from model") {
+				sawPlaceholder = true
+			}
+		}
+	}
+	if !sawPlaceholder {
+		t.Errorf(
+			"expected placeholder content on the assistant message "+
+				"that was originally empty; transcript=%+v", res.Transcript)
+	}
+}
+
+// TestRunOneTurn_EmptyAssistantReply_SubstitutesPlaceholder exercises
+// runOneTurn directly (the gate requires a test referencing the changed
+// function by name) and asserts the same #935 behavior as the
+// end-to-end TestLoop_EmptyAssistantReply_SubstitutesPlaceholder.
+func TestRunOneTurn_EmptyAssistantReply_SubstitutesPlaceholder(t *testing.T) {
+	srv, _ := scriptedOAIServer(t, []string{emptyAssistantReply})
+	loop := newTestLoop(srv, &fakeRegistry{results: map[string]*ToolResult{}})
+	res := &LoopResult{
+		Transcript: []oai.Message{
+			{Role: oai.RoleSystem, Content: "sys"},
+			{Role: oai.RoleUser, Content: "go"},
+		},
+	}
+	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res)
+	// The placeholder makes the message non-empty, so runOneTurn treats
+	// it as a no-tool-call turn and returns ErrAssistantNoToolCalls.
+	if !errors.Is(err, ErrAssistantNoToolCalls) {
+		t.Fatalf("runOneTurn: expected ErrAssistantNoToolCalls, got %v", err)
+	}
+	// The assistant message appended by runOneTurn must carry the
+	// placeholder, not be empty (the #935 guard).
+	last := res.Transcript[len(res.Transcript)-1]
+	if last.Role != oai.RoleAssistant {
+		t.Fatalf("last message role: want assistant got %q", last.Role)
+	}
+	if strings.TrimSpace(last.Content) == "" {
+		t.Errorf("runOneTurn must substitute placeholder for empty assistant reply; got empty content")
+	}
+	if !strings.Contains(last.Content, "empty response from model") {
+		t.Errorf("placeholder content not found in: %q", last.Content)
+	}
+}
+
+// TestLoop_StrippedReasoningDoesNotProduceEmptyAssistant covers the
+// sibling case: stripReasoningForWire must not leave an empty assistant
+// message on the wire.
+func TestLoop_StrippedReasoningDoesNotProduceEmptyAssistant(t *testing.T) {
 	// Stripping reasoning from a reasoning-only assistant turn must not
 	// leave an empty assistant message on the wire: llama-server rejects
 	// the request with 400 "Assistant message must contain either


### PR DESCRIPTION
## What

Stop an empty assistant reply from poisoning the agent conversation history.

## Why

Fixes #935

When the model returns an assistant message with no content and no tool_calls, appending it to the transcript makes every later turn 400 with "Assistant message must contain either content or tool_calls", stalling the run.

## How

Before the assistant turn is appended to the transcript, if its content is empty (after trim) AND it has no tool_calls AND no reasoning_content, substitute a short placeholder. The guard is conjunctive, so valid tool-call turns are left untouched and reasoning-only turns continue to be handled by the existing `stripReasoningForWire` path. Adds an end-to-end test (empty reply on turn 1, successful submit on turn 2) plus a regression test asserting an empty-content tool-call turn is not clobbered.

## Checklist

- [x] Tests added/updated (e2e + regression)
- [x] `make test` passes locally
- [x] `make lint` passes locally (GOOS=linux, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [x] AI assistance disclosed below
- [ ] Documentation updated (n/a: internal agent-loop fix)
---

Assisted-by: Foreman (LLMKube coder harness, local Ornith-35B on the Strix) generated the change; it passed the post-push clean-room envtest gate and an independent external-contributor review pass before I opened this. I reviewed the result, ran the tests and cross-arch lint, and am accountable for it.