### PR TITLE
feat(foreman): str_replace fuzzy recovery for old_string drift + write_file steering

### DIFF
--- a/pkg/foreman/agent/artifact_gate.go
+++ b/pkg/foreman/agent/artifact_gate.go
@@ -19,9 +19,16 @@ limitations under the License.
 //  1. Parses every ```yaml / ```yml fenced block.
 //  2. Validates each block body with sigs.k8s.io/yaml (unmarshal into
 //     map[string]any or []any; only a dual-failure is a real parse error).
-//  3. For blocks that are Kubernetes manifests (have both "apiVersion" and
-//     "kind"), runs `kubectl --dry-run=client -f <tmpfile>` if kubectl is
-//     on PATH.
+//
+// Validation is deliberately structural only. An earlier revision also ran
+// `kubectl --dry-run=client` on blocks that looked like Kubernetes manifests;
+// that was removed after a live batch false-blocked on it. The argv lacked a
+// subcommand (kubectl has no global --dry-run flag, so every manifest failed
+// with "unknown flag"), and even the corrected form cannot work here: client
+// dry-run resolves kinds via discovery, so any doc embedding a CRD that is
+// not installed on whatever cluster the agent's kubeconfig reaches (a
+// karpenter NodePool, or LLMKube's own CRs on a bare cluster) fails with "no
+// matches for kind". Offline, kubectl adds nothing beyond the YAML parse.
 //
 // The check is conservative: only yaml/yml-fenced blocks are examined; no
 // other content is judged. It is fail-open (a git or read error skips the
@@ -32,7 +39,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -54,7 +60,7 @@ func checkEmbeddedArtifacts(ctx context.Context, workspace string, run commandRu
 		if err != nil {
 			continue // fail-open: skip files we cannot read
 		}
-		findings = append(findings, validateMarkdownYAML(ctx, workspace, path, string(data), run)...)
+		findings = append(findings, validateMarkdownYAML(path, string(data))...)
 	}
 
 	if len(findings) == 0 {
@@ -88,8 +94,9 @@ func changedMarkdownFiles(ctx context.Context, workspace string, run commandRunn
 }
 
 // validateMarkdownYAML extracts and validates every yaml/yml fenced block in
-// content. Each finding is a "file:line - reason" string.
-func validateMarkdownYAML(ctx context.Context, workspace, path, content string, run commandRunner) []string {
+// content. Each finding is a "file:line - reason" string. Purely local: it
+// shells out to nothing (see the package comment on why kubectl is not used).
+func validateMarkdownYAML(path, content string) []string {
 	var findings []string
 
 	// Track the current line as we scan through the content.
@@ -155,14 +162,6 @@ func validateMarkdownYAML(ctx context.Context, workspace, path, content string, 
 				findings = append(findings, fmt.Sprintf(
 					"%s:%d - invalid YAML: %s", path, startLine, parseErr.Error(),
 				))
-				continue
-			}
-			// For k8s manifests: if both "apiVersion" and "kind" are present,
-			// run kubectl --dry-run=client if kubectl is available.
-			if isK8sManifest(doc) {
-				if _, err := exec.LookPath("kubectl"); err == nil {
-					findings = append(findings, kubectlDryRun(ctx, workspace, path, startLine, doc, run)...)
-				}
 			}
 		}
 	}
@@ -199,43 +198,6 @@ func validateYAMLDoc(doc string) error {
 	var l []any
 	if err := sigsyaml.Unmarshal([]byte(doc), &l); err != nil {
 		return err
-	}
-	return nil
-}
-
-// isK8sManifest reports whether the YAML document (already validated) looks
-// like a Kubernetes manifest by checking for both "apiVersion" and "kind"
-// keys at the top level.
-func isK8sManifest(doc string) bool {
-	var m map[string]any
-	if err := sigsyaml.Unmarshal([]byte(doc), &m); err != nil {
-		return false
-	}
-	_, hasAPI := m["apiVersion"]
-	_, hasKind := m["kind"]
-	return hasAPI && hasKind
-}
-
-// kubectlDryRun writes the YAML block to a temp file and runs
-// `kubectl --dry-run=client -f <file>`. Returns any findings.
-func kubectlDryRun(ctx context.Context, workspace, path string, startLine int, doc string, run commandRunner) []string {
-	tmp, err := os.CreateTemp("", "artifact-gate-*.yaml")
-	if err != nil {
-		return nil // fail-open
-	}
-	tmpPath := tmp.Name()
-	defer func() { _ = os.Remove(tmpPath) }() // best-effort cleanup; ignore error
-	if _, err := tmp.WriteString(doc); err != nil {
-		_ = tmp.Close()
-		return nil
-	}
-	_ = tmp.Close()
-
-	out, err := run(ctx, workspace, nil, "kubectl", "--dry-run=client", "-f", tmpPath)
-	if err != nil {
-		return []string{fmt.Sprintf(
-			"%s:%d - kubectl client validation failed: %s", path, startLine, strings.TrimSpace(out),
-		)}
 	}
 	return nil
 }

--- a/pkg/foreman/agent/artifact_gate_test.go
+++ b/pkg/foreman/agent/artifact_gate_test.go
@@ -131,3 +131,32 @@ func TestCheckEmbeddedArtifacts_YamldocFenceNotMatched(t *testing.T) {
 		t.Fatalf("yamldoc fence should NOT be treated as yaml, but got failure: %s", out)
 	}
 }
+
+// Regression for the live false-block found by the #943 validation run: a
+// changed doc embedding a VALID manifest (here a third-party CRD kind) must
+// pass on structural validation alone, and kubectl must never be invoked.
+// The old kubectl step was doubly broken: its argv lacked a subcommand
+// (kubectl has no global --dry-run flag, so EVERY manifest failed "unknown
+// flag"), and even corrected, client dry-run needs kind discovery, which
+// false-blocks any doc whose CRDs are not installed on the reachable cluster
+// (karpenter NodePool in the #478 run; LLMKube's own CRs in docs elsewhere).
+func TestCheckEmbeddedArtifacts_ManifestValidatedWithoutKubectl(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "docs/site/guides/autoscale.md",
+		"# Guide\n\n```yaml\napiVersion: karpenter.sh/v1\nkind: NodePool\n"+
+			"metadata:\n  name: gpu\nspec:\n  limits:\n    cpu: \"64\"\n```\n")
+
+	gitOnly := fakeMdRunner(map[string]string{
+		"docs/site/guides/autoscale.md": " M",
+	})
+	run := func(ctx context.Context, dir2 string, env []string, name string, args ...string) (string, error) {
+		if name == "kubectl" {
+			t.Fatalf("kubectl must not be invoked by the artifact gate, got args %v", args)
+		}
+		return gitOnly(ctx, dir2, env, name, args...)
+	}
+	failed, out := checkEmbeddedArtifacts(context.Background(), dir, run)
+	if failed {
+		t.Fatalf("valid manifest must pass structural validation, got: %s", out)
+	}
+}

--- a/pkg/foreman/agent/tools/levenshtein.go
+++ b/pkg/foreman/agent/tools/levenshtein.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+// boundedLevenshtein returns the Levenshtein edit distance between a and b,
+// giving up early once the distance provably exceeds maxDist. When the true
+// distance is greater than maxDist it returns maxDist+1; callers only need
+// "over budget", not the exact value. The two-row DP abandons a row as soon
+// as its minimum exceeds maxDist, so clearly-mismatched inputs are rejected
+// in O(len x maxDist) instead of O(len^2).
+func boundedLevenshtein(a, b string, maxDist int) int {
+	if a == b {
+		return 0
+	}
+	ra, rb := []rune(a), []rune(b)
+	// The distance is at least the rune-length difference.
+	diff := len(ra) - len(rb)
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > maxDist {
+		return maxDist + 1
+	}
+	prev := make([]int, len(rb)+1)
+	curr := make([]int, len(rb)+1)
+	for j := 0; j <= len(rb); j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		rowMin := curr[0]
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			m := prev[j] + 1               // deletion
+			if v := curr[j-1] + 1; v < m { // insertion
+				m = v
+			}
+			if v := prev[j-1] + cost; v < m { // substitution
+				m = v
+			}
+			curr[j] = m
+			if m < rowMin {
+				rowMin = m
+			}
+		}
+		if rowMin > maxDist {
+			return maxDist + 1
+		}
+		prev, curr = curr, prev
+	}
+	if prev[len(rb)] > maxDist {
+		return maxDist + 1
+	}
+	return prev[len(rb)]
+}

--- a/pkg/foreman/agent/tools/levenshtein.go
+++ b/pkg/foreman/agent/tools/levenshtein.go
@@ -21,7 +21,9 @@ package tools
 // distance is greater than maxDist it returns maxDist+1; callers only need
 // "over budget", not the exact value. The two-row DP abandons a row as soon
 // as its minimum exceeds maxDist, so clearly-mismatched inputs are rejected
-// in O(len x maxDist) instead of O(len^2).
+// in O(len x maxDist) instead of O(len^2). maxDist must be >= 0; a negative
+// cap still reports over-budget for unequal inputs but the returned value is
+// meaningless as a distance.
 func boundedLevenshtein(a, b string, maxDist int) int {
 	if a == b {
 		return 0

--- a/pkg/foreman/agent/tools/levenshtein_test.go
+++ b/pkg/foreman/agent/tools/levenshtein_test.go
@@ -32,6 +32,7 @@ func TestBoundedLevenshtein(t *testing.T) {
 		{"over cap returns cap+1", "abc", "xyz", 1, 2},
 		{"length screen over cap", "abcdefgh", "a", 3, 4},
 		{"exact at cap", "kitten", "sitting", 3, 3},
+		{"unequal at cap 0", "abc", "abd", 0, 1},
 		{"multibyte runes", "héllo", "hello", 2, 1},
 		{"empty vs nonempty", "abc", "", 5, 3},
 	}

--- a/pkg/foreman/agent/tools/levenshtein_test.go
+++ b/pkg/foreman/agent/tools/levenshtein_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import "testing"
+
+func TestBoundedLevenshtein(t *testing.T) {
+	cases := []struct {
+		name    string
+		a, b    string
+		maxDist int
+		want    int
+	}{
+		{"both empty", "", "", 5, 0},
+		{"identical", "abc", "abc", 0, 0},
+		{"classic kitten/sitting", "kitten", "sitting", 10, 3},
+		{"single deletion", "userCount", "usrCount", 4, 1},
+		{"over cap returns cap+1", "abc", "xyz", 1, 2},
+		{"length screen over cap", "abcdefgh", "a", 3, 4},
+		{"exact at cap", "kitten", "sitting", 3, 3},
+		{"multibyte runes", "héllo", "hello", 2, 1},
+		{"empty vs nonempty", "abc", "", 5, 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := boundedLevenshtein(tc.a, tc.b, tc.maxDist); got != tc.want {
+				t.Errorf("boundedLevenshtein(%q, %q, %d) = %d, want %d",
+					tc.a, tc.b, tc.maxDist, got, tc.want)
+			}
+			// Distance is symmetric; the cap contract must hold both ways.
+			if got := boundedLevenshtein(tc.b, tc.a, tc.maxDist); got != tc.want {
+				t.Errorf("boundedLevenshtein(%q, %q, %d) = %d, want %d (symmetry)",
+					tc.b, tc.a, tc.maxDist, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/tools/str_replace.go
+++ b/pkg/foreman/agent/tools/str_replace.go
@@ -87,6 +87,14 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 	}
 	raw, err := os.ReadFile(full) //nolint:gosec // G304: path is resolveInside-validated
 	if err != nil {
+		// The most literal wrong-tool case: editing a file that does not
+		// exist. Seen live burning a coder's whole restricted-edit budget on
+		// bare ENOENT retries against a hallucinated path; steer to
+		// write_file instead (#942 Part B).
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("str_replace: %q does not exist. "+
+				"To create a new file, call write_file with the full contents instead", a.Path)
+		}
 		return nil, fmt.Errorf("str_replace: read %q: %w", a.Path, err)
 	}
 	content := string(raw)

--- a/pkg/foreman/agent/tools/str_replace.go
+++ b/pkg/foreman/agent/tools/str_replace.go
@@ -107,6 +107,20 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 					Output: map[string]any{"path": a.Path, "replacements": 1, "note": note},
 				}, nil
 			}
+			// Whitespace normalization only equalizes whitespace; a drifted
+			// TOKEN (renamed identifier, paraphrased comment) falls through to
+			// here. The fuzzy window recovers the unique near-miss case that
+			// otherwise stalls local coder models into EditFreeStreak (#942).
+			if fuzzyEnabled() {
+				if recovered, note, ok := t.applyFuzzyMatch(content, a.OldString, a.NewString); ok {
+					if err := os.WriteFile(full, []byte(recovered), 0o644); err != nil { //nolint:gosec // G306: workspace file
+						return nil, fmt.Errorf("str_replace: write %q: %w", a.Path, err)
+					}
+					return &agent.ToolResult{
+						Output: map[string]any{"path": a.Path, "replacements": 1, "note": note},
+					}, nil
+				}
+			}
 			// Could not safely locate the edit. Surface the file's ACTUAL current
 			// text near the model's intended anchor so it can retry against
 			// truth instead of re-hallucinating old_string.
@@ -172,6 +186,98 @@ func (t *StrReplaceTool) applyWhitespaceMatch(content, oldString, newString stri
 	merged = append(merged, strings.Split(newString, "\n")...)
 	merged = append(merged, contentLines[start+len(oldLines):]...)
 	return strings.Join(merged, "\n"), "matched via whitespace-normalized fallback", true
+}
+
+// Fuzzy thresholds (see the #942 design doc). A candidate window must have
+// every line within fuzzyPerLineThreshold normalized edit distance of the
+// corresponding old_string line; windows of 2+ lines must additionally keep
+// their aggregate drift under fuzzyWindowThreshold. The aggregate bound is
+// deliberately NOT applied to single-line windows: there the aggregate ratio
+// equals the per-line ratio, and stacking both would silently tighten the
+// effective threshold to 0.15 and reject the primary drift case (one small
+// token typo on one line).
+const (
+	fuzzyPerLineThreshold = 0.25
+	fuzzyWindowThreshold  = 0.15
+)
+
+// fuzzyEnabled reports whether the fuzzy line-window fallback is active.
+// FOREMAN_STRREPLACE_FUZZY=0 reverts str_replace to the pre-#942 behavior
+// (whitespace fallback + anchor hint only), mirroring the per-check
+// FOREMAN_<NAME>_GATE kill-switch convention.
+func fuzzyEnabled() bool { return os.Getenv("FOREMAN_STRREPLACE_FUZZY") != "0" }
+
+// applyFuzzyMatch handles the drift case applyWhitespaceMatch cannot: the
+// model reproduced the right block but mutated a token (renamed identifier,
+// paraphrased comment). It scores every old_string-sized line window under
+// whitespace normalization plus bounded per-line edit distance, and applies
+// only when exactly one window qualifies. Zero or 2+ candidates return
+// ok=false so the caller falls through to the anchorContext truth hint; the
+// unique-window requirement means this can never edit the wrong location.
+func (t *StrReplaceTool) applyFuzzyMatch(content, oldString, newString string) (result, note string, ok bool) {
+	contentLines := strings.Split(content, "\n")
+	oldLines := strings.Split(oldString, "\n")
+	if len(oldLines) == 0 || len(oldLines) > len(contentLines) {
+		return "", "", false
+	}
+	normOld := make([]string, len(oldLines))
+	for i, l := range oldLines {
+		normOld[i] = normWS(l)
+	}
+	start, matches := -1, 0
+	for i := 0; i+len(oldLines) <= len(contentLines); i++ {
+		if windowWithinFuzzyBudget(contentLines[i:i+len(oldLines)], normOld) {
+			start = i
+			matches++
+			if matches > 1 {
+				return "", "", false
+			}
+		}
+	}
+	if matches != 1 {
+		return "", "", false
+	}
+	merged := make([]string, 0, len(contentLines))
+	merged = append(merged, contentLines[:start]...)
+	merged = append(merged, strings.Split(newString, "\n")...)
+	merged = append(merged, contentLines[start+len(oldLines):]...)
+	return strings.Join(merged, "\n"),
+		"matched via fuzzy line-window fallback (old_string drifted from the file's actual text)",
+		true
+}
+
+// windowWithinFuzzyBudget scores one candidate window against the
+// whitespace-normalized old_string lines. Every line must clear the per-line
+// budget; multi-line windows must also clear the aggregate budget so drift
+// cannot accumulate across many near-threshold lines. An all-blank window is
+// never a match (it would otherwise match everywhere).
+func windowWithinFuzzyBudget(window, normOld []string) bool {
+	totalDist, totalLen := 0, 0
+	for j, ol := range normOld {
+		cl := normWS(window[j])
+		maxLen := len([]rune(cl))
+		if l := len([]rune(ol)); l > maxLen {
+			maxLen = l
+		}
+		if maxLen == 0 {
+			continue // both blank after normalization: identical
+		}
+		budget := int(fuzzyPerLineThreshold * float64(maxLen))
+		d := boundedLevenshtein(cl, ol, budget)
+		if d > budget {
+			return false
+		}
+		totalDist += d
+		totalLen += maxLen
+	}
+	if totalLen == 0 {
+		return false
+	}
+	if len(normOld) > 1 &&
+		float64(totalDist)/float64(totalLen) > fuzzyWindowThreshold {
+		return false
+	}
+	return true
 }
 
 // anchorContext finds the most distinctive line of old_string that appears

--- a/pkg/foreman/agent/tools/str_replace.go
+++ b/pkg/foreman/agent/tools/str_replace.go
@@ -55,7 +55,9 @@ func (t *StrReplaceTool) Schema() oai.ToolSchemaDef {
 			"Copy old_string VERBATIM from a recent read_file; prefer the shortest " +
 			"unique snippet (1-3 lines). Do not retype it from memory. If it does not " +
 			"match, the error shows the file's actual current text near your edit; " +
-			"copy that exactly and retry.",
+			"copy that exactly and retry. For a NEW file or a full-file rewrite, use " +
+			"write_file instead: str_replace requires old_string to already exist in " +
+			"the file.",
 		Parameters: json.RawMessage(`{
 "type": "object",
 "properties": {
@@ -127,10 +129,11 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 			if actual, ok := anchorContext(content, a.OldString); ok {
 				return nil, fmt.Errorf("str_replace: old_string not found in %q. "+
 					"The file's actual current text near your edit is below - copy it "+
-					"VERBATIM into old_string and retry:\n%s", a.Path, actual)
+					"VERBATIM into old_string and retry:\n%s%s", a.Path, actual, writeFileHint(content))
 			}
 		}
-		return nil, fmt.Errorf("str_replace: old_string found %d times in %q, want %d", occurrences, a.Path, want)
+		return nil, fmt.Errorf("str_replace: old_string found %d times in %q, want %d%s",
+			occurrences, a.Path, want, writeFileHint(content))
 	}
 	next := strings.ReplaceAll(content, a.OldString, a.NewString)
 	if err := os.WriteFile(full, []byte(next), 0o644); err != nil { //nolint:gosec // G306: workspace file
@@ -303,6 +306,22 @@ func windowWithinFuzzyBudget(normWindow, normOld []string) bool {
 		return false
 	}
 	return true
+}
+
+// writeFileHintMaxLines bounds the "did you mean write_file?" steering hint
+// to small files. On a large file a failed match means old_string drift and
+// the anchor hint is the right feedback; on a small (often brand-new or stub)
+// file it frequently means the model picked the wrong tool for creating or
+// rewriting the file outright (#478).
+const writeFileHintMaxLines = 40
+
+// writeFileHint returns the steering line appended to a failed-recovery
+// error for small files, or "" for larger ones.
+func writeFileHint(content string) string {
+	if strings.Count(content, "\n")+1 <= writeFileHintMaxLines {
+		return "\nIf you are creating or rewriting this file, call write_file with the full contents instead."
+	}
+	return ""
 }
 
 // anchorContext finds the most distinctive line of old_string that appears

--- a/pkg/foreman/agent/tools/str_replace.go
+++ b/pkg/foreman/agent/tools/str_replace.go
@@ -201,6 +201,17 @@ const (
 	fuzzyWindowThreshold  = 0.15
 )
 
+// fuzzyPerLineMaxDist caps the per-line budget in absolute terms. The
+// percentage threshold alone lets long lines (120+ runes) absorb 30+ edits,
+// enough to alias two genuinely different logger.Info calls; real old_string
+// drift is a token or two, never dozens of runes.
+const fuzzyPerLineMaxDist = 6
+
+// fuzzyMaxOldLines bounds the window scan. The tool's schema tells models to
+// use 1-3 line snippets; a huge old_string against a large file is O(minutes)
+// of CPU in a single tool call and is never legitimate drift recovery.
+const fuzzyMaxOldLines = 40
+
 // fuzzyEnabled reports whether the fuzzy line-window fallback is active.
 // FOREMAN_STRREPLACE_FUZZY=0 reverts str_replace to the pre-#942 behavior
 // (whitespace fallback + anchor hint only), mirroring the per-check
@@ -212,21 +223,29 @@ func fuzzyEnabled() bool { return os.Getenv("FOREMAN_STRREPLACE_FUZZY") != "0" }
 // paraphrased comment). It scores every old_string-sized line window under
 // whitespace normalization plus bounded per-line edit distance, and applies
 // only when exactly one window qualifies. Zero or 2+ candidates return
-// ok=false so the caller falls through to the anchorContext truth hint; the
-// unique-window requirement means this can never edit the wrong location.
+// ok=false so the caller falls through to the anchorContext truth hint. The
+// unique-window requirement guarantees it never edits an AMBIGUOUS location;
+// a unique near-miss can still be an unintended target (a semantic twin
+// within threshold), which is why the note reports exactly what was replaced
+// and where, so the model and transcript reader can catch a wrong-target
+// edit.
 func (t *StrReplaceTool) applyFuzzyMatch(content, oldString, newString string) (result, note string, ok bool) {
 	contentLines := strings.Split(content, "\n")
 	oldLines := strings.Split(oldString, "\n")
-	if len(oldLines) == 0 || len(oldLines) > len(contentLines) {
+	if len(oldLines) == 0 || len(oldLines) > fuzzyMaxOldLines || len(oldLines) > len(contentLines) {
 		return "", "", false
 	}
 	normOld := make([]string, len(oldLines))
 	for i, l := range oldLines {
 		normOld[i] = normWS(l)
 	}
+	normContent := make([]string, len(contentLines))
+	for i, l := range contentLines {
+		normContent[i] = normWS(l)
+	}
 	start, matches := -1, 0
 	for i := 0; i+len(oldLines) <= len(contentLines); i++ {
-		if windowWithinFuzzyBudget(contentLines[i:i+len(oldLines)], normOld) {
+		if windowWithinFuzzyBudget(normContent[i:i+len(oldLines)], normOld) {
 			start = i
 			matches++
 			if matches > 1 {
@@ -241,20 +260,23 @@ func (t *StrReplaceTool) applyFuzzyMatch(content, oldString, newString string) (
 	merged = append(merged, contentLines[:start]...)
 	merged = append(merged, strings.Split(newString, "\n")...)
 	merged = append(merged, contentLines[start+len(oldLines):]...)
-	return strings.Join(merged, "\n"),
-		"matched via fuzzy line-window fallback (old_string drifted from the file's actual text)",
-		true
+	original := strings.Join(contentLines[start:start+len(oldLines)], "\n")
+	note = fmt.Sprintf(
+		"matched via fuzzy line-window fallback at line %d (old_string drifted from the file's actual text); replaced: %q",
+		start+1, original)
+	return strings.Join(merged, "\n"), note, true
 }
 
-// windowWithinFuzzyBudget scores one candidate window against the
-// whitespace-normalized old_string lines. Every line must clear the per-line
-// budget; multi-line windows must also clear the aggregate budget so drift
-// cannot accumulate across many near-threshold lines. An all-blank window is
-// never a match (it would otherwise match everywhere).
-func windowWithinFuzzyBudget(window, normOld []string) bool {
+// windowWithinFuzzyBudget scores one candidate window (already
+// whitespace-normalized by the caller) against the whitespace-normalized
+// old_string lines. Every line must clear the per-line budget; multi-line
+// windows must also clear the aggregate budget so drift cannot accumulate
+// across many near-threshold lines. An all-blank window is never a match (it
+// would otherwise match everywhere).
+func windowWithinFuzzyBudget(normWindow, normOld []string) bool {
 	totalDist, totalLen := 0, 0
 	for j, ol := range normOld {
-		cl := normWS(window[j])
+		cl := normWindow[j]
 		maxLen := len([]rune(cl))
 		if l := len([]rune(ol)); l > maxLen {
 			maxLen = l
@@ -263,6 +285,9 @@ func windowWithinFuzzyBudget(window, normOld []string) bool {
 			continue // both blank after normalization: identical
 		}
 		budget := int(fuzzyPerLineThreshold * float64(maxLen))
+		if budget > fuzzyPerLineMaxDist {
+			budget = fuzzyPerLineMaxDist
+		}
 		d := boundedLevenshtein(cl, ol, budget)
 		if d > budget {
 			return false

--- a/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
+++ b/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
@@ -19,6 +19,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -218,6 +219,52 @@ func TestStrReplace_FuzzyRefusesLongLineAliasing(t *testing.T) {
 	}
 	if got := readBack(t, ws, "f.go"); got != src {
 		t.Errorf("file must be unchanged, got %q", got)
+	}
+}
+
+// --- write_file steering (#942 Part B) --------------------------------------
+
+// A failed match on a small file appends the write_file steering hint: the
+// model may actually be trying to create or rewrite the file (#478).
+func TestStrReplace_WriteFileHintOnSmallFile(t *testing.T) {
+	ws := makeWorkspace(t)
+	seedFile(t, ws, "stub.go", "package main\n")
+	err := execStrReplace(t, ws, "stub.go", "func main() {\n\tprintln(1)\n}", "x")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "write_file") {
+		t.Errorf("expected write_file steering hint on a small file, got: %v", err)
+	}
+}
+
+// The hint must NOT fire on large files, where a failed match means drift,
+// not wrong-tool choice, and the anchor hint alone is the right feedback.
+func TestStrReplace_NoWriteFileHintOnLargeFile(t *testing.T) {
+	ws := makeWorkspace(t)
+	var b strings.Builder
+	b.WriteString("package main\n\n")
+	for i := 0; i < 60; i++ {
+		fmt.Fprintf(&b, "// filler line %d keeps this file over the hint threshold\n", i)
+	}
+	b.WriteString("func compute() int {\n\treturn userCount\n}\n")
+	seedFile(t, ws, "big.go", b.String())
+	// A block that matches nothing, fuzzy or otherwise.
+	err := execStrReplace(t, ws, "big.go", "class Widget:\n    def render(self):\n        pass", "x")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if strings.Contains(err.Error(), "write_file") {
+		t.Errorf("write_file hint must not fire on a large file, got: %v", err)
+	}
+}
+
+// The tool advertisement itself must steer new-file work to write_file.
+func TestStrReplace_SchemaSteersToWriteFile(t *testing.T) {
+	tool := &StrReplaceTool{}
+	if !strings.Contains(tool.Schema().Description, "write_file") {
+		t.Errorf("schema description should mention write_file for new files, got: %q",
+			tool.Schema().Description)
 	}
 }
 

--- a/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
+++ b/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
@@ -309,3 +309,18 @@ func TestStrReplace_FuzzyNeverFiresForMultiReplace(t *testing.T) {
 		t.Errorf("file must be unchanged, got %q", got)
 	}
 }
+
+// The most literal wrong-tool case, hit live in the #478 rerun: str_replace
+// against a file that does not exist burned the model's whole restricted-edit
+// budget on bare ENOENT errors. The read error must steer to write_file.
+func TestStrReplace_NonexistentFileSteersToWriteFile(t *testing.T) {
+	ws := makeWorkspace(t)
+	err := execStrReplace(t, ws, "missing.go", "old text", "new text")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not exist") ||
+		!strings.Contains(err.Error(), "write_file") {
+		t.Errorf("expected existence + write_file steering in the error, got: %v", err)
+	}
+}

--- a/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
+++ b/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
@@ -259,6 +259,28 @@ func TestStrReplace_NoWriteFileHintOnLargeFile(t *testing.T) {
 	}
 }
 
+// When a unique anchor line exists on a small file, the error must carry
+// BOTH feedback channels: the anchorContext truth snippet (so the model can
+// copy real bytes) and the write_file steering hint (in case it is actually
+// trying to rewrite the file).
+func TestStrReplace_WriteFileHintRidesAnchorContext(t *testing.T) {
+	ws := makeWorkspace(t)
+	src := "package main\n\nfunc computeTotals() int {\n\treturn 42\n}\n"
+	seedFile(t, ws, "small.go", src)
+	// Line 1 anchors verbatim; line 2 is beyond any fuzzy budget.
+	old := "func computeTotals() int {\n\treturn somethingCompletelyDifferentHere()"
+	err := execStrReplace(t, ws, "small.go", old, "x")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "return 42") {
+		t.Errorf("expected anchorContext to surface the real file text, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "write_file") {
+		t.Errorf("expected write_file hint alongside the anchor snippet, got: %v", err)
+	}
+}
+
 // The tool advertisement itself must steer new-file work to write_file.
 func TestStrReplace_SchemaSteersToWriteFile(t *testing.T) {
 	tool := &StrReplaceTool{}

--- a/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
+++ b/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
@@ -162,12 +162,12 @@ func TestStrReplace_FuzzyKillSwitch(t *testing.T) {
 	t.Setenv("FOREMAN_STRREPLACE_FUZZY", "0")
 	ws := makeWorkspace(t)
 	src := "func compute() int {\n\treturn userCount\n}\n"
-	seedFile(t, ws, "f.go", src)
-	err := execStrReplace(t, ws, "f.go", "\treturn usrCount", "\treturn userCount + 1")
+	seedFile(t, ws, "g.go", src)
+	err := execStrReplace(t, ws, "g.go", "\treturn usrCount", "\treturn userCount + 1")
 	if err == nil {
 		t.Fatal("expected error with fuzzy disabled, got nil")
 	}
-	if got := readBack(t, ws, "f.go"); got != src {
+	if got := readBack(t, ws, "g.go"); got != src {
 		t.Errorf("file must be unchanged with fuzzy disabled, got %q", got)
 	}
 }
@@ -192,5 +192,51 @@ func TestStrReplace_FuzzyReportsNote(t *testing.T) {
 	note, _ := out["note"].(string)
 	if !strings.Contains(note, "fuzzy") {
 		t.Errorf("expected fuzzy recovery note, got %q", note)
+	}
+	if !strings.Contains(note, "at line 2") {
+		t.Errorf("expected note to report the applied line, got %q", note)
+	}
+	if !strings.Contains(note, "return userCount") {
+		t.Errorf("expected note to report the replaced text, got %q", note)
+	}
+}
+
+// Regression for the uncapped-budget wrong-line rewrite: two genuinely
+// different logger.Info calls are 25 edits apart, within 25% of a 120-rune
+// line but far beyond any real old_string drift. The absolute per-line cap
+// must refuse.
+func TestStrReplace_FuzzyRefusesLongLineAliasing(t *testing.T) {
+	ws := makeWorkspace(t)
+	src := "func reconcile() {\n" +
+		"\tlogger.Info(\"reconciling inference service\", \"name\", svc.Name, \"generation\", svc.Generation)\n" +
+		"}\n"
+	seedFile(t, ws, "f.go", src)
+	old := "\tlogger.Info(\"reconciling model download\", \"name\", mod.Name, \"revision\", mod.Generation)"
+	err := execStrReplace(t, ws, "f.go", old, "\tlogger.Info(\"x\")")
+	if err == nil {
+		t.Fatal("expected refusal: a genuinely different long line must not fuzzy-match")
+	}
+	if got := readBack(t, ws, "f.go"); got != src {
+		t.Errorf("file must be unchanged, got %q", got)
+	}
+}
+
+// The recovery gate is want==1 only: expected_replacements > 1 with zero
+// occurrences must never invoke fuzzy recovery.
+func TestStrReplace_FuzzyNeverFiresForMultiReplace(t *testing.T) {
+	ws := makeWorkspace(t)
+	src := "func compute() int {\n\treturn userCount\n}\n"
+	seedFile(t, ws, "f.go", src)
+	tool := &StrReplaceTool{Workspace: ws}
+	buf, _ := json.Marshal(map[string]any{
+		"path": "f.go", "old_string": "\treturn usrCount", "new_string": "x",
+		"expected_replacements": 2,
+	})
+	_, err := tool.Execute(context.Background(), buf)
+	if err == nil {
+		t.Fatal("expected count-mismatch error for multi-replace, got nil")
+	}
+	if got := readBack(t, ws, "f.go"); got != src {
+		t.Errorf("file must be unchanged, got %q", got)
 	}
 }

--- a/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
+++ b/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// execStrReplace marshals the args and runs the tool against ws.
+func execStrReplace(t *testing.T, ws, path, oldString, newString string) error {
+	t.Helper()
+	tool := &StrReplaceTool{Workspace: ws}
+	buf, err := json.Marshal(map[string]string{
+		"path": path, "old_string": oldString, "new_string": newString,
+	})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	_, err = tool.Execute(context.Background(), buf)
+	return err
+}
+
+func seedFile(t *testing.T, ws, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(ws, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("seed %s: %v", name, err)
+	}
+}
+
+func readBack(t *testing.T, ws, name string) string {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(ws, name))
+	if err != nil {
+		t.Fatalf("readback %s: %v", name, err)
+	}
+	return string(got)
+}
+
+// The primary #907 failure mode: the model read the file, then retyped
+// old_string from memory with one identifier drifted. Exact match and the
+// whitespace fallback both miss; the fuzzy window must locate the unique
+// near-match and apply against the file's real bytes.
+func TestStrReplace_FuzzyRecoversSingleLineTokenDrift(t *testing.T) {
+	ws := makeWorkspace(t)
+	src := "func compute() int {\n\treturn userCount\n}\n"
+	seedFile(t, ws, "f.go", src)
+	// Model drifted userCount -> usrCount (distance 1).
+	err := execStrReplace(t, ws, "f.go", "\treturn usrCount", "\treturn userCount + 1")
+	if err != nil {
+		t.Fatalf("expected fuzzy recovery, got error: %v", err)
+	}
+	got := readBack(t, ws, "f.go")
+	if !strings.Contains(got, "return userCount + 1") {
+		t.Errorf("replacement not applied: %q", got)
+	}
+	if strings.Contains(got, "usrCount") {
+		t.Errorf("drifted token leaked into the file: %q", got)
+	}
+}
+
+// Multi-line drift: a paraphrased comment above an otherwise-verbatim block.
+// Every line clears the per-line threshold and the window aggregate stays
+// small, so the unique window applies.
+func TestStrReplace_FuzzyRecoversMultiLineCommentDrift(t *testing.T) {
+	ws := makeWorkspace(t)
+	src := "// recordHeartbeat stamps the node's lastSeen time.\n" +
+		"func (r *Registrar) recordHeartbeat(now time.Time) {\n" +
+		"\tr.node.Status.LastSeen = now\n" +
+		"}\n"
+	seedFile(t, ws, "f.go", src)
+	old := "// recordHeartbeat stamps the node's lastSeen timestamp.\n" +
+		"func (r *Registrar) recordHeartbeat(now time.Time) {\n" +
+		"\tr.node.Status.LastSeen = now\n" +
+		"}"
+	repl := "// recordHeartbeat stamps the node's lastSeen time.\n" +
+		"func (r *Registrar) recordHeartbeat(now time.Time) {\n" +
+		"\tr.node.Status.LastSeen = now.UTC()\n" +
+		"}"
+	if err := execStrReplace(t, ws, "f.go", old, repl); err != nil {
+		t.Fatalf("expected fuzzy recovery, got error: %v", err)
+	}
+	got := readBack(t, ws, "f.go")
+	if !strings.Contains(got, "now.UTC()") {
+		t.Errorf("replacement not applied: %q", got)
+	}
+}
+
+// Two near-identical blocks: the fuzzy window sees two candidates and MUST
+// refuse rather than guess. The file must be untouched.
+func TestStrReplace_FuzzyRefusesAmbiguousWindows(t *testing.T) {
+	ws := makeWorkspace(t)
+	src := "func alpha() int {\n\treturn count\n}\n" +
+		"func beta() int {\n\treturn count\n}\n"
+	seedFile(t, ws, "f.go", src)
+	err := execStrReplace(t, ws, "f.go", "\treturn cnt", "\treturn total")
+	if err == nil {
+		t.Fatal("expected refusal on ambiguous fuzzy match, got nil error")
+	}
+	if got := readBack(t, ws, "f.go"); got != src {
+		t.Errorf("file must be unchanged on refusal, got %q", got)
+	}
+}
+
+// A genuinely different block of the same line count must not match: the
+// per-line threshold rejects it and the tool falls through to an error.
+func TestStrReplace_FuzzyRefusesGenuinelyDifferentBlock(t *testing.T) {
+	ws := makeWorkspace(t)
+	src := "func parse(raw []byte) (Config, error) {\n" +
+		"\tvar c Config\n" +
+		"\treturn c, yaml.Unmarshal(raw, &c)\n" +
+		"}\n"
+	seedFile(t, ws, "f.go", src)
+	old := "func render(w io.Writer) error {\n" +
+		"\ttpl := template.Must(template.New(\"x\").Parse(body))\n" +
+		"\treturn tpl.Execute(w, nil)\n" +
+		"}"
+	err := execStrReplace(t, ws, "f.go", old, "x")
+	if err == nil {
+		t.Fatal("expected error for a genuinely different block, got nil")
+	}
+	if got := readBack(t, ws, "f.go"); got != src {
+		t.Errorf("file must be unchanged, got %q", got)
+	}
+}
+
+// An all-blank window (every line empty after whitespace normalization) must
+// never fuzzy-match: it would otherwise qualify everywhere blank lines
+// cluster. Tested via applyFuzzyMatch directly because Execute's earlier
+// whitespace fallback intercepts the unique-blank-window case (pre-existing
+// #917 behavior, unchanged here); the fuzzy layer must still refuse on its
+// own so the defense does not depend on call order.
+func TestApplyFuzzyMatch_RefusesAllBlankWindow(t *testing.T) {
+	tool := &StrReplaceTool{}
+	// The middle window ("   ", "\t") normalizes to two empty lines.
+	if _, _, ok := tool.applyFuzzyMatch("x\n   \n\t\ny", " \n ", "INJECTED"); ok {
+		t.Fatal("all-blank window must never fuzzy-match")
+	}
+}
+
+// FOREMAN_STRREPLACE_FUZZY=0 reverts to pre-#942 behavior: the drift case
+// that Test...SingleLineTokenDrift recovers must now fail.
+func TestStrReplace_FuzzyKillSwitch(t *testing.T) {
+	t.Setenv("FOREMAN_STRREPLACE_FUZZY", "0")
+	ws := makeWorkspace(t)
+	src := "func compute() int {\n\treturn userCount\n}\n"
+	seedFile(t, ws, "f.go", src)
+	err := execStrReplace(t, ws, "f.go", "\treturn usrCount", "\treturn userCount + 1")
+	if err == nil {
+		t.Fatal("expected error with fuzzy disabled, got nil")
+	}
+	if got := readBack(t, ws, "f.go"); got != src {
+		t.Errorf("file must be unchanged with fuzzy disabled, got %q", got)
+	}
+}
+
+// The fuzzy result must report the recovery note so transcripts show the
+// harness stepped in (mirrors the whitespace-fallback note contract).
+func TestStrReplace_FuzzyReportsNote(t *testing.T) {
+	ws := makeWorkspace(t)
+	seedFile(t, ws, "f.go", "func compute() int {\n\treturn userCount\n}\n")
+	tool := &StrReplaceTool{Workspace: ws}
+	buf, _ := json.Marshal(map[string]string{
+		"path": "f.go", "old_string": "\treturn usrCount", "new_string": "\treturn 0",
+	})
+	res, err := tool.Execute(context.Background(), buf)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out, ok := res.Output.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected output type %T", res.Output)
+	}
+	note, _ := out["note"].(string)
+	if !strings.Contains(note, "fuzzy") {
+		t.Errorf("expected fuzzy recovery note, got %q", note)
+	}
+}


### PR DESCRIPTION
## What

Makes the Foreman `str_replace` tool resilient to local-model `old_string` drift, and steers models toward `write_file` when they misuse `str_replace` on new or rewritten files.

The recovery ladder for the not-found case (`want == 1 && occurrences == 0`) is now: exact match -> whitespace-normalized fallback (#917) -> **fuzzy line-window fallback (new)** -> `anchorContext` truth hint.

## Why

Fixes #942

Local coder models (35B-class and smaller) routinely retype `old_string` from memory and drift a token, even immediately after reading the file. In a recent batch re-run, two of five tasks force-terminated via `EditFreeStreak` on exactly this failure mode: one model read the target file nine times and still submitted an `old_string` with a mutated identifier. The whitespace fallback cannot catch token drift, so those loops stall until the harness kills them. A separate stall came from calling `str_replace` where `write_file` was the right tool for a new file.

## How

**Fuzzy line-window recovery** (`applyFuzzyMatch`), conservative by construction:

- Scores every `old_string`-sized line window with a bounded Levenshtein distance under whitespace normalization.
- Per-line budget: 25% of the line's rune length, hard-capped at 6 edits (the cap prevents long, similar lines such as two `logger.Info(...)` calls from aliasing each other).
- Multi-line windows must also keep aggregate drift under 15%, so drift cannot accumulate across many near-threshold lines.
- Auto-applies **only when exactly one window qualifies**; 0 or 2+ candidates fall through to the existing `anchorContext` hint. It never edits an ambiguous location.
- The recovery note reports the 1-based line number and the exact text replaced, so a wrong-target edit is visible in the transcript instead of silent.
- Window scan capped at 40 `old_string` lines; content lines are normalized once (worst-case pathological input measured ~11ms, down from minutes uncapped).
- Kill switch: `FOREMAN_STRREPLACE_FUZZY=0` reverts to the pre-change behavior.

**write_file steering**, entirely in-tool (no progress-monitor changes):

- The tool description now states that new files and full rewrites belong to `write_file`.
- A failed match on a small (<=40 line) file appends a one-line steering hint to the error.
- A str_replace against a file that does not exist returns the steering line directly from the read path (found live: a coder burned its whole restricted-edit budget on bare ENOENT retries against a hallucinated path). The hint deliberately rides every not-found/count-mismatch error on small files (including the case where no anchor line exists at all, i.e. a brand-new file), which is the truest wrong-tool shape.

New tests: bounded-Levenshtein table (10 cases, symmetric), 12 `str_replace` behavior tests covering the drift-recovery cases, ambiguity refusal, long-line aliasing refusal (regression for the cap), the multi-replace gate, the kill switch, note contents, and both hint paths. Existing exact-match and multi-replace behavior is unchanged and still covered by the pre-existing tests.

AI assistance disclosure: implemented with AI assistance (Claude); design, review, and final verification by the maintainer.

### Also in this PR: embedded-artifact gate kubectl false-block (found by validating this PR)

Live fleet validation of this PR (dev build `0.8.26-pr943.g6f6d2e2`, five-issue batch) surfaced a bug in the 0.8.26 gate suite that only became reachable once the fuzzy recovery got coders past the edit phase: the embedded-artifact check invoked `kubectl --dry-run=client -f <file>` with no subcommand, so every embedded manifest failed with `unknown flag: --dry-run` and one task burned all three gate-fix attempts on an unfixable error. The corrected invocation would still false-block (client dry-run needs kind discovery, which fails for any CRD not installed on the reachable cluster, e.g. karpenter or LLMKube's own CRs in docs). The check now validates YAML structurally only, with a regression test pinning that the gate never shells out to kubectl.

Validation summary for the recovery itself: one confirmed fuzzy recovery in the batch transcripts ("matched via fuzzy line-window fallback at line 79"), zero wrong-target edits, and the two issues that previously stalled in EditFreeStreak on old_string drift both progressed into the gate-fix loop instead. Drift beyond the conservative threshold correctly fell through to the anchor-context hint (3 occurrences, no guesses). Single-run, stochastic; not a controlled benchmark.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (plus `GOOS=linux golangci-lint run ./...`, 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - not user-facing; behavior documented in code and the tool schema



