### PR TITLE
fix(foreman): agent claims tasks depth-first so verify/review don't starve

### DIFF
--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -193,8 +194,39 @@ func (w *AgenticTaskWatcher) resetOrphanedTask(ctx context.Context, t *foremanv1
 	return w.Client.Status().Patch(ctx, t, patch)
 }
 
+// kindClaimPriority orders candidate tasks depth-first by pipeline
+// position: finish in-flight Workloads (review, then verify) before
+// starting new coder work. Claiming in List order instead maximizes
+// WIP — with a deep issue-fix backlog on a one-task-per-node agent,
+// verify/review tasks starve and no Workload ever completes (#936).
+func kindClaimPriority(kind foremanv1alpha1.AgenticTaskKind) int {
+	switch kind {
+	case foremanv1alpha1.AgenticTaskKindReview:
+		return 0
+	case foremanv1alpha1.AgenticTaskKindVerify:
+		return 1
+	case foremanv1alpha1.AgenticTaskKindIssueFix:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// sortTasksDepthFirst orders claim candidates by kindClaimPriority,
+// breaking ties oldest-first so no task starves within its kind.
+func sortTasksDepthFirst(tasks []*foremanv1alpha1.AgenticTask) {
+	sort.SliceStable(tasks, func(i, j int) bool {
+		pi, pj := kindClaimPriority(tasks[i].Spec.Kind), kindClaimPriority(tasks[j].Spec.Kind)
+		if pi != pj {
+			return pi < pj
+		}
+		return tasks[i].CreationTimestamp.Before(&tasks[j].CreationTimestamp)
+	})
+}
+
 // pollOnce runs a single List() pass and dispatches any task assigned to
-// this node that is in phase=Scheduled.
+// this node that is in phase=Scheduled, preferring downstream tasks
+// (review, verify) over new issue-fix work — see sortTasksDepthFirst.
 func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) error {
 	// If a task is already in flight, skip until it completes; v0.1 is
 	// one-task-per-node.
@@ -210,6 +242,7 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 		return fmt.Errorf("list AgenticTasks: %w", err)
 	}
 
+	candidates := make([]*foremanv1alpha1.AgenticTask, 0, len(list.Items))
 	for i := range list.Items {
 		t := &list.Items[i]
 		if t.Status.AssignedNode != w.NodeName {
@@ -218,6 +251,11 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 		if t.Status.Phase != foremanv1alpha1.AgenticTaskPhaseScheduled {
 			continue
 		}
+		candidates = append(candidates, t)
+	}
+	sortTasksDepthFirst(candidates)
+
+	for _, t := range candidates {
 		if err := w.claim(ctx, t); err != nil {
 			// Patch race or transient apiserver error; let the next
 			// poll retry. Do not count toward the stall threshold

--- a/pkg/foreman/agent/watcher_priority_test.go
+++ b/pkg/foreman/agent/watcher_priority_test.go
@@ -89,7 +89,11 @@ func TestPollOnce_ClaimsReviewBeforeOlderIssueFix(t *testing.T) {
 	w := &AgenticTaskWatcher{
 		Client:   c,
 		NodeName: "node-1",
-		Executor: &StubExecutor{SleepDuration: time.Millisecond},
+		// A long sleep keeps the claimed task deterministically in
+		// phase=Running for the assertions below (a short sleep lets the
+		// executor goroutine patch it terminal on a loaded runner). The
+		// goroutine is abandoned when the test ends.
+		Executor: &StubExecutor{SleepDuration: time.Hour},
 	}
 
 	if err := w.pollOnce(context.Background(), "default"); err != nil {

--- a/pkg/foreman/agent/watcher_priority_test.go
+++ b/pkg/foreman/agent/watcher_priority_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func scheduledTask(
+	name, node string, kind foremanv1alpha1.AgenticTaskKind, age time.Duration,
+) *foremanv1alpha1.AgenticTask {
+	return &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+		},
+		Spec: foremanv1alpha1.AgenticTaskSpec{Kind: kind},
+		Status: foremanv1alpha1.AgenticTaskStatus{
+			Phase:        foremanv1alpha1.AgenticTaskPhaseScheduled,
+			AssignedNode: node,
+		},
+	}
+}
+
+// TestSortTasksDepthFirst_KindOrder pins the depth-first claim order:
+// review before verify before issue-fix before everything else (#936).
+// Breadth-first (List-order) claiming starves downstream tasks behind a
+// deep issue-fix backlog, so no Workload ever completes.
+func TestSortTasksDepthFirst_KindOrder(t *testing.T) {
+	tasks := []*foremanv1alpha1.AgenticTask{
+		scheduledTask("free", "n", foremanv1alpha1.AgenticTaskKindFreeform, time.Hour),
+		scheduledTask("code", "n", foremanv1alpha1.AgenticTaskKindIssueFix, time.Hour),
+		scheduledTask("rev", "n", foremanv1alpha1.AgenticTaskKindReview, time.Minute),
+		scheduledTask("ver", "n", foremanv1alpha1.AgenticTaskKindVerify, time.Minute),
+	}
+	sortTasksDepthFirst(tasks)
+	got := []string{tasks[0].Name, tasks[1].Name, tasks[2].Name, tasks[3].Name}
+	want := []string{"rev", "ver", "code", "free"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("depth-first order: want %v got %v", want, got)
+		}
+	}
+}
+
+// TestSortTasksDepthFirst_OldestFirstWithinKind pins the tiebreak: within
+// a kind, the oldest Scheduled task is claimed first so nothing starves.
+func TestSortTasksDepthFirst_OldestFirstWithinKind(t *testing.T) {
+	tasks := []*foremanv1alpha1.AgenticTask{
+		scheduledTask("code-new", "n", foremanv1alpha1.AgenticTaskKindIssueFix, time.Minute),
+		scheduledTask("code-old", "n", foremanv1alpha1.AgenticTaskKindIssueFix, time.Hour),
+	}
+	sortTasksDepthFirst(tasks)
+	if tasks[0].Name != "code-old" {
+		t.Fatalf("want oldest issue-fix first, got %q", tasks[0].Name)
+	}
+}
+
+// TestPollOnce_ClaimsReviewBeforeOlderIssueFix is the end-to-end #936
+// regression: a review task scheduled AFTER a backlog of issue-fix tasks
+// must still be claimed first.
+func TestPollOnce_ClaimsReviewBeforeOlderIssueFix(t *testing.T) {
+	code := scheduledTask("wl-a-code-1", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Hour)
+	review := scheduledTask("wl-b-review-2-0", "node-1", foremanv1alpha1.AgenticTaskKindReview, time.Minute)
+	other := scheduledTask("wl-c-code-3", "other-node", foremanv1alpha1.AgenticTaskKindReview, time.Minute)
+
+	c := newRecoveryClient(t, code, review, other)
+	w := &AgenticTaskWatcher{
+		Client:   c,
+		NodeName: "node-1",
+		Executor: &StubExecutor{SleepDuration: time.Millisecond},
+	}
+
+	if err := w.pollOnce(context.Background(), "default"); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+
+	// The review task must be the one claimed (Running), the older
+	// issue-fix must remain Scheduled.
+	if got := getTask(t, c, "wl-b-review-2-0"); got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseRunning {
+		t.Errorf("review task phase: want Running got %s", got.Status.Phase)
+	}
+	if got := getTask(t, c, "wl-a-code-1"); got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseScheduled {
+		t.Errorf("issue-fix task phase: want Scheduled (not claimed) got %s", got.Status.Phase)
+	}
+	// The other node's task must be untouched.
+	if got := getTask(t, c, "wl-c-code-3"); got.Status.AssignedNode != "other-node" {
+		t.Errorf("other node's task must not be touched")
+	}
+}


### PR DESCRIPTION
## What

`pollOnce` now sorts claim candidates depth-first by pipeline position — review, then verify, then issue-fix, then everything else — with oldest-first within a kind, and attempts claims in that order.

## Why

Fixes #936

The watcher claimed the first `Scheduled` task in List order. With one-task-per-node and a deep issue-fix backlog, downstream verify/review tasks starve indefinitely: coder GOs pile up but no Workload can reach completion. Observed in production with a 13-Workload batch — reviews pending 70+ minutes while the agent worked unrelated code tasks.

## How

- `kindClaimPriority` + `sortTasksDepthFirst` (stable sort, CreationTimestamp tiebreak so nothing starves within a kind)
- candidates collected, then claimed in order; claim-failure fallthrough unchanged
- no API or scheduler changes; single-node behavior becomes "finish Workload A before starting Workload B"

Tests: `TestSortTasksDepthFirst_*` pin the ordering; `TestPollOnce_ClaimsReviewBeforeOlderIssueFix` is the e2e regression (review scheduled after an hour-old issue-fix backlog is claimed first; other nodes' tasks untouched). Review feedback addressed in 5d7f3c7: the stub executor now sleeps long enough that the claimed task deterministically stays Running for the assertion.

AI assistance: authored by Claude (Opus 4.8) operating under my direction against our production cluster; I reviewed the change and test output before submitting.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go test ./pkg/foreman/agent/` green)
- [x] `make lint` passes locally (`golangci-lint run` 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — n/a, internal scheduling behavior