### PR TITLE
fix(foreman): replace stale agent-owned branches on push rejection (force-with-lease)

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -254,6 +254,19 @@ type AgenticTaskPayload struct {
 	// +optional
 	BaseBranch string `json:"baseBranch,omitempty"`
 
+	// AllowOverwrite permits the coder to replace a stale remote ref for
+	// its own branch (force-with-lease pinned to the observed SHA) when a
+	// plain push is rejected non-fast-forward. Opt-in, per the design
+	// decision in #573: silently overwriting published branches is the
+	// wrong default for a system that leaves an audit trail, but
+	// automated retry systems that delete-and-recreate Workloads derive
+	// the same branch name every run and are otherwise permanently
+	// wedged by their predecessor's ref (#934). Stamped from
+	// Workload.spec.allowOverwrite in issue-batch mode; explicit
+	// pipelines set it per step.
+	// +optional
+	AllowOverwrite bool `json:"allowOverwrite,omitempty"`
+
 	// BranchPrefix overrides the branch name prefix on issue-fix tasks
 	// (default derived from the issue's labels via conventional commit
 	// prefixes: fix/, feat/, chore/, etc.).

--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -164,6 +164,16 @@ type WorkloadSpec struct {
 	// +optional
 	EscalationReviewerAgentRefs []corev1.LocalObjectReference `json:"escalationReviewerAgentRefs,omitempty"`
 
+	// AllowOverwrite lets this Workload's coder replace a stale remote
+	// ref for its own foreman/* branch (force-with-lease compare-and-swap)
+	// instead of failing non-fast-forward. Opt-in — #573 deliberately
+	// rejected force-on-collision as a default; retry systems that
+	// re-run Workloads under the same name set this on the re-run, where
+	// the stale ref is their own previous attempt. Copied onto every
+	// synthesized issue-batch task payload.
+	// +optional
+	AllowOverwrite bool `json:"allowOverwrite,omitempty"`
+
 	// AllowCloudReviewers gates whether reviewer Agents whose
 	// spec.provider is "cloud-proxy" (or any non-"local" value) may be
 	// dispatched for this Workload. Three-valued via the *bool:

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -160,6 +160,19 @@ spec:
                       Agent is the named agent to invoke. Required for freeform; defaults
                       to "issue-fixer" for issue-fix and "verify" for verify.
                     type: string
+                  allowOverwrite:
+                    description: |-
+                      AllowOverwrite permits the coder to replace a stale remote ref for
+                      its own branch (force-with-lease pinned to the observed SHA) when a
+                      plain push is rejected non-fast-forward. Opt-in, per the design
+                      decision in #573: silently overwriting published branches is the
+                      wrong default for a system that leaves an audit trail, but
+                      automated retry systems that delete-and-recreate Workloads derive
+                      the same branch name every run and are otherwise permanently
+                      wedged by their predecessor's ref (#934). Stamped from
+                      Workload.spec.allowOverwrite in issue-batch mode; explicit
+                      pipelines set it per step.
+                    type: boolean
                   baseBranch:
                     description: |-
                       BaseBranch is the upstream base ref the coder branch is cut from

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -85,6 +85,16 @@ spec:
                   air-gapped or compliance-restricted environments. Both gates
                   must allow for a cloud reviewer to dispatch.
                 type: boolean
+              allowOverwrite:
+                description: |-
+                  AllowOverwrite lets this Workload's coder replace a stale remote
+                  ref for its own foreman/* branch (force-with-lease compare-and-swap)
+                  instead of failing non-fast-forward. Opt-in — #573 deliberately
+                  rejected force-on-collision as a default; retry systems that
+                  re-run Workloads under the same name set this on the re-run, where
+                  the stale ref is their own previous attempt. Copied onto every
+                  synthesized issue-batch task payload.
+                type: boolean
               coderAgentRef:
                 description: |-
                   CoderAgentRef is required when Issues is set: names the same-
@@ -348,6 +358,19 @@ spec:
                             Agent is the named agent to invoke. Required for freeform; defaults
                             to "issue-fixer" for issue-fix and "verify" for verify.
                           type: string
+                        allowOverwrite:
+                          description: |-
+                            AllowOverwrite permits the coder to replace a stale remote ref for
+                            its own branch (force-with-lease pinned to the observed SHA) when a
+                            plain push is rejected non-fast-forward. Opt-in, per the design
+                            decision in #573: silently overwriting published branches is the
+                            wrong default for a system that leaves an audit trail, but
+                            automated retry systems that delete-and-recreate Workloads derive
+                            the same branch name every run and are otherwise permanently
+                            wedged by their predecessor's ref (#934). Stamped from
+                            Workload.spec.allowOverwrite in issue-batch mode; explicit
+                            pipelines set it per step.
+                          type: boolean
                         baseBranch:
                           description: |-
                             BaseBranch is the upstream base ref the coder branch is cut from

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -160,6 +160,19 @@ spec:
                       Agent is the named agent to invoke. Required for freeform; defaults
                       to "issue-fixer" for issue-fix and "verify" for verify.
                     type: string
+                  allowOverwrite:
+                    description: |-
+                      AllowOverwrite permits the coder to replace a stale remote ref for
+                      its own branch (force-with-lease pinned to the observed SHA) when a
+                      plain push is rejected non-fast-forward. Opt-in, per the design
+                      decision in #573: silently overwriting published branches is the
+                      wrong default for a system that leaves an audit trail, but
+                      automated retry systems that delete-and-recreate Workloads derive
+                      the same branch name every run and are otherwise permanently
+                      wedged by their predecessor's ref (#934). Stamped from
+                      Workload.spec.allowOverwrite in issue-batch mode; explicit
+                      pipelines set it per step.
+                    type: boolean
                   baseBranch:
                     description: |-
                       BaseBranch is the upstream base ref the coder branch is cut from

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -85,6 +85,16 @@ spec:
                   air-gapped or compliance-restricted environments. Both gates
                   must allow for a cloud reviewer to dispatch.
                 type: boolean
+              allowOverwrite:
+                description: |-
+                  AllowOverwrite lets this Workload's coder replace a stale remote
+                  ref for its own foreman/* branch (force-with-lease compare-and-swap)
+                  instead of failing non-fast-forward. Opt-in — #573 deliberately
+                  rejected force-on-collision as a default; retry systems that
+                  re-run Workloads under the same name set this on the re-run, where
+                  the stale ref is their own previous attempt. Copied onto every
+                  synthesized issue-batch task payload.
+                type: boolean
               coderAgentRef:
                 description: |-
                   CoderAgentRef is required when Issues is set: names the same-
@@ -348,6 +358,19 @@ spec:
                             Agent is the named agent to invoke. Required for freeform; defaults
                             to "issue-fixer" for issue-fix and "verify" for verify.
                           type: string
+                        allowOverwrite:
+                          description: |-
+                            AllowOverwrite permits the coder to replace a stale remote ref for
+                            its own branch (force-with-lease pinned to the observed SHA) when a
+                            plain push is rejected non-fast-forward. Opt-in, per the design
+                            decision in #573: silently overwriting published branches is the
+                            wrong default for a system that leaves an audit trail, but
+                            automated retry systems that delete-and-recreate Workloads derive
+                            the same branch name every run and are otherwise permanently
+                            wedged by their predecessor's ref (#934). Stamped from
+                            Workload.spec.allowOverwrite in issue-batch mode; explicit
+                            pipelines set it per step.
+                          type: boolean
                         baseBranch:
                           description: |-
                             BaseBranch is the upstream base ref the coder branch is cut from

--- a/internal/foreman/controller/workload_allowoverwrite_test.go
+++ b/internal/foreman/controller/workload_allowoverwrite_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// Pins the #573-shaped opt-in from #934: Workload.spec.allowOverwrite is
+// stamped onto the synthesized issue-fix payload (and ONLY there — the
+// default stays false so a plain Workload never force-replaces refs).
+var _ = Describe("WorkloadReconciler allowOverwrite stamping", func() {
+	var reconciler *WorkloadReconciler
+
+	BeforeEach(func() {
+		reconciler = &WorkloadReconciler{
+			Client:              k8sClient,
+			Scheme:              k8sClient.Scheme(),
+			AllowCloudProviders: true,
+		}
+	})
+
+	reconcile := func(wl *foremanv1alpha1.Workload) {
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	codeTask := func(name string) foremanv1alpha1.AgenticTask {
+		var t foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, &t)).To(Succeed())
+		return t
+	}
+
+	It("stamps allowOverwrite=true onto the issue-fix payload when set", func() {
+		wl := newWorkload("overwrite-on", foremanv1alpha1.WorkloadSpec{
+			Intent:           "retry",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{7},
+			AllowOverwrite:   true,
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		reconcile(wl)
+		task := codeTask("overwrite-on-code-7")
+		Expect(task.Spec.Payload.AllowOverwrite).To(BeTrue())
+	})
+
+	It("defaults to false when unset", func() {
+		wl := newWorkload("overwrite-off", foremanv1alpha1.WorkloadSpec{
+			Intent:           "fresh",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{8},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		reconcile(wl)
+		task := codeTask("overwrite-off-code-8")
+		Expect(task.Spec.Payload.AllowOverwrite).To(BeFalse())
+	})
+})

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -292,9 +292,10 @@ func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.Pipelin
 				Kind:     foremanv1alpha1.AgenticTaskKindIssueFix,
 				AgentRef: *w.Spec.CoderAgentRef,
 				Payload: foremanv1alpha1.AgenticTaskPayload{
-					Repo:   w.Spec.Repo,
-					Issue:  n,
-					Branch: branch,
+					Repo:           w.Spec.Repo,
+					Issue:          n,
+					Branch:         branch,
+					AllowOverwrite: w.Spec.AllowOverwrite,
 				},
 			},
 			foremanv1alpha1.PipelineStep{

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -645,6 +645,11 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		Workspace: workspace,
 		Branch:    branch,
 		Auth:      auth,
+		// The task's branch lives in the agent-owned foreman/* namespace;
+		// a stale remote ref is a previous run of this same Workload, so
+		// replace it (compare-and-swap via force-with-lease) instead of
+		// failing every re-run with non-fast-forward (#934).
+		ReplaceOnReject: strings.HasPrefix(branch, "foreman/"),
 	}); err != nil {
 		return e.pushFailedResult(start, transcriptRef, loopRes, branch, sha, err), nil
 	}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -645,11 +645,13 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		Workspace: workspace,
 		Branch:    branch,
 		Auth:      auth,
-		// The task's branch lives in the agent-owned foreman/* namespace;
-		// a stale remote ref is a previous run of this same Workload, so
-		// replace it (compare-and-swap via force-with-lease) instead of
-		// failing every re-run with non-fast-forward (#934).
-		ReplaceOnReject: strings.HasPrefix(branch, "foreman/"),
+		// Opt-in via Workload.spec.allowOverwrite (stamped onto the task
+		// payload): replace a stale ref for this task's own branch
+		// (compare-and-swap via force-with-lease) instead of failing the
+		// re-run non-fast-forward (#934). Off by default per #573 — a
+		// replaced ref can carry a previously-GO'd audit artifact, so
+		// the caller that re-runs Workloads makes that call explicitly.
+		ReplaceOnReject: task.Spec.Payload.AllowOverwrite,
 	}); err != nil {
 		return e.pushFailedResult(start, transcriptRef, loopRes, branch, sha, err), nil
 	}

--- a/pkg/foreman/agent/repo/git.go
+++ b/pkg/foreman/agent/repo/git.go
@@ -51,8 +51,11 @@ func runGit(ctx context.Context, workdir string, extraEnv []string, args ...stri
 		if len(errOut) > 4096 {
 			errOut = errOut[:4096] + "...[truncated]"
 		}
-		return "", fmt.Errorf("git %s: %w: %s",
-			strings.Join(args, " "), err, strings.TrimSpace(errOut))
+		return "", &gitError{
+			args:   strings.Join(args, " "),
+			err:    err,
+			stderr: strings.TrimSpace(errOut),
+		}
 	}
 	return strings.TrimRight(stdout.String(), "\n"), nil
 }
@@ -64,3 +67,21 @@ func envOr(key, fallback string) string {
 	}
 	return fallback
 }
+
+// gitError preserves the structured pieces of a failed git invocation.
+// The message keeps the old "git <args>: <err>: <stderr>" shape for
+// logs, while callers that need to classify the failure (e.g. push
+// rejection sniffing) can inspect stderr alone — matching on the full
+// message would also match the ARGS, and branch names embed
+// caller-controlled Workload names.
+type gitError struct {
+	args   string
+	err    error
+	stderr string
+}
+
+func (e *gitError) Error() string {
+	return fmt.Sprintf("git %s: %v: %s", e.args, e.err, e.stderr)
+}
+
+func (e *gitError) Unwrap() error { return e.err }

--- a/pkg/foreman/agent/repo/push.go
+++ b/pkg/foreman/agent/repo/push.go
@@ -39,6 +39,16 @@ type PushOptions struct {
 	// Auth provides the GIT_ASKPASS scaffolding. Required for
 	// authenticated pushes (which is every realistic case).
 	Auth *Auth
+
+	// ReplaceOnReject retries a rejected push with --force-with-lease
+	// pinned to the remote SHA observed via ls-remote — a compare-and-
+	// swap that replaces exactly the ref we saw, and still fails if a
+	// concurrent writer moves it in between. Callers set this ONLY for
+	// branches the agent owns outright (the foreman/<workload>/...
+	// namespace), where the stale ref is a previous run of the same
+	// Workload: without it, every re-run after a delete-and-recreate
+	// retry dies NO-GO / PUSH-FAILED on non-fast-forward (#934).
+	ReplaceOnReject bool
 }
 
 // ErrPushRejected wraps a non-fast-forward / pre-receive rejection
@@ -76,9 +86,43 @@ func Push(ctx context.Context, opts PushOptions) error {
 	// Heuristic: git push prints "[remote rejected]" or "[rejected]"
 	// in stderr on a non-fast-forward / pre-receive rejection. We
 	// captured stderr inside the wrapped error message in runGit.
-	if isPushRejection(err.Error()) {
-		return fmt.Errorf("%w: %w", ErrPushRejected, err)
+	if !isPushRejection(err.Error()) {
+		return err
 	}
+	if opts.ReplaceOnReject {
+		if replaceErr := replaceRemoteBranch(ctx, opts.Workspace, env, remote, opts.Branch); replaceErr == nil {
+			return nil
+		} else if isPushRejection(replaceErr.Error()) {
+			// The lease failed: someone moved the ref between our
+			// ls-remote and the push. Surface the original rejection
+			// semantics so the caller's PUSH-FAILED handling applies.
+			return fmt.Errorf("%w: force-with-lease retry also rejected: %w", ErrPushRejected, replaceErr)
+		} else {
+			return replaceErr
+		}
+	}
+	return fmt.Errorf("%w: %w", ErrPushRejected, err)
+}
+
+// replaceRemoteBranch re-pushes Branch with --force-with-lease pinned to
+// the remote SHA read via ls-remote: replace exactly the ref we observed,
+// fail if it moves concurrently. Used only for agent-owned branch
+// namespaces (see PushOptions.ReplaceOnReject).
+func replaceRemoteBranch(ctx context.Context, workspace string, env []string, remote, branch string) error {
+	ref := "refs/heads/" + branch
+	out, err := runGit(ctx, workspace, env, "ls-remote", remote, ref)
+	if err != nil {
+		return fmt.Errorf("ls-remote before force-with-lease: %w", err)
+	}
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		// The branch vanished between the rejected push and now (e.g. a
+		// human deleted it). A plain push should succeed; keep the lease
+		// against an empty expectation to stay race-safe.
+		fields = []string{""}
+	}
+	lease := fmt.Sprintf("--force-with-lease=%s:%s", ref, fields[0])
+	_, err = runGit(ctx, workspace, env, "push", lease, "--set-upstream", remote, branch)
 	return err
 }
 

--- a/pkg/foreman/agent/repo/push.go
+++ b/pkg/foreman/agent/repo/push.go
@@ -86,13 +86,13 @@ func Push(ctx context.Context, opts PushOptions) error {
 	// Heuristic: git push prints "[remote rejected]" or "[rejected]"
 	// in stderr on a non-fast-forward / pre-receive rejection. We
 	// captured stderr inside the wrapped error message in runGit.
-	if !isPushRejection(err.Error()) {
+	if !isPushRejection(err) {
 		return err
 	}
 	if opts.ReplaceOnReject {
 		if replaceErr := replaceRemoteBranch(ctx, opts.Workspace, env, remote, opts.Branch); replaceErr == nil {
 			return nil
-		} else if isPushRejection(replaceErr.Error()) {
+		} else if isPushRejection(replaceErr) {
 			// The lease failed: someone moved the ref between our
 			// ls-remote and the push. Surface the original rejection
 			// semantics so the caller's PUSH-FAILED handling applies.
@@ -142,11 +142,19 @@ func SetRemote(ctx context.Context, workspace, name, url string) error {
 	return err
 }
 
-// isPushRejection sniffs git's stderr for the canonical rejection
-// markers. Brittle in principle (string-matching on git output) but
-// stable across modern git versions for this specific case.
-func isPushRejection(msg string) bool {
-	lower := strings.ToLower(msg)
+// isPushRejection sniffs the failed invocation's STDERR for the
+// canonical rejection markers. Brittle in principle (string-matching on
+// git output) but stable across modern git versions for this specific
+// case. Only stderr is examined — the full error message also embeds
+// the git args, and branch names carry caller-controlled Workload names
+// (a workload literally named "non-fast-forward" must not classify
+// every push failure as a rejection).
+func isPushRejection(err error) bool {
+	var ge *gitError
+	if !errors.As(err, &ge) {
+		return false
+	}
+	lower := strings.ToLower(ge.stderr)
 	return strings.Contains(lower, "[rejected]") ||
 		strings.Contains(lower, "remote rejected") ||
 		strings.Contains(lower, "non-fast-forward")

--- a/pkg/foreman/agent/repo/push_test.go
+++ b/pkg/foreman/agent/repo/push_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repo
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// pushCollisionFixture builds the #934 scenario: a bare origin whose
+// foreman/<wl>/issue-N branch was pushed by a previous run, and a fresh
+// clone (the retry) with a DIFFERENT commit on the same branch name.
+// Returns the retry workspace.
+func pushCollisionFixture(t *testing.T, branch string) string {
+	t.Helper()
+	dir := t.TempDir()
+	bare := initBareOrigin(t, dir)
+	seedOrigin(t, bare)
+
+	// Previous run: clone, branch, commit "old", push.
+	oldWork := filepath.Join(dir, "old-run")
+	mustGit(t, "", "clone", bare, oldWork)
+	mustGit(t, oldWork, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(oldWork, "old.txt"), []byte("old attempt\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	mustGit(t, oldWork, "-c", "user.email=a@x", "-c", "user.name=a", "add", ".")
+	mustGit(t, oldWork, "-c", "user.email=a@x", "-c", "user.name=a", "commit", "-m", "old attempt")
+	mustGit(t, oldWork, "push", "--set-upstream", "origin", branch)
+
+	// Retry run: fresh clone of main, same branch name, different commit.
+	retryWork := filepath.Join(dir, "retry-run")
+	mustGit(t, "", "clone", bare, retryWork)
+	mustGit(t, retryWork, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(retryWork, "new.txt"), []byte("retry attempt\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	mustGit(t, retryWork, "-c", "user.email=a@x", "-c", "user.name=a", "add", ".")
+	mustGit(t, retryWork, "-c", "user.email=a@x", "-c", "user.name=a", "commit", "-m", "retry attempt")
+	return retryWork
+}
+
+// TestPush_StaleOwnedBranch_RejectedWithoutReplaceOnReject pins the
+// pre-#934 behavior: a retry pushing its own branch name over a previous
+// run's ref is a non-fast-forward rejection.
+func TestPush_StaleOwnedBranch_RejectedWithoutReplaceOnReject(t *testing.T) {
+	branch := "foreman/wl-x-7/issue-7"
+	work := pushCollisionFixture(t, branch)
+
+	err := Push(context.Background(), PushOptions{Workspace: work, Branch: branch})
+	if !errors.Is(err, ErrPushRejected) {
+		t.Fatalf("want ErrPushRejected, got %v", err)
+	}
+}
+
+// TestPush_StaleOwnedBranch_ReplacedWithReplaceOnReject is the #934 fix:
+// with ReplaceOnReject the retry replaces its predecessor's ref via
+// force-with-lease and succeeds.
+func TestPush_StaleOwnedBranch_ReplacedWithReplaceOnReject(t *testing.T) {
+	branch := "foreman/wl-x-7/issue-7"
+	work := pushCollisionFixture(t, branch)
+
+	if err := Push(context.Background(), PushOptions{
+		Workspace:       work,
+		Branch:          branch,
+		ReplaceOnReject: true,
+	}); err != nil {
+		t.Fatalf("Push with ReplaceOnReject: %v", err)
+	}
+
+	// The remote ref must now be the retry's commit (log contains
+	// "retry attempt", not "old attempt").
+	verify := filepath.Join(t.TempDir(), "verify")
+	// Workspace origin is the bare; read its ref log via a fresh clone.
+	out := mustGitOut(t, work, "ls-remote", "origin", "refs/heads/"+branch)
+	local := mustGitOut(t, work, "rev-parse", "HEAD")
+	if len(out) < 40 || out[:40] != local[:40] {
+		t.Fatalf("remote ref not replaced: remote=%q local=%q (verify dir %s)", out, local, verify)
+	}
+}
+
+// TestPush_CleanPush_NeverForces proves ReplaceOnReject is inert on a
+// clean push (no rejection, no lease dance).
+func TestPush_CleanPush_NeverForces(t *testing.T) {
+	dir := t.TempDir()
+	bare := initBareOrigin(t, dir)
+	seedOrigin(t, bare)
+	work := filepath.Join(dir, "work")
+	mustGit(t, "", "clone", bare, work)
+	mustGit(t, work, "checkout", "-b", "foreman/wl-y-1/issue-1")
+	if err := os.WriteFile(filepath.Join(work, "f.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	mustGit(t, work, "-c", "user.email=a@x", "-c", "user.name=a", "add", ".")
+	mustGit(t, work, "-c", "user.email=a@x", "-c", "user.name=a", "commit", "-m", "x")
+
+	if err := Push(context.Background(), PushOptions{
+		Workspace:       work,
+		Branch:          "foreman/wl-y-1/issue-1",
+		ReplaceOnReject: true,
+	}); err != nil {
+		t.Fatalf("clean push: %v", err)
+	}
+}
+
+// mustGitOut runs git and returns trimmed stdout, failing the test on error.
+func mustGitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := runGit(context.Background(), dir, baseEnv(), args...)
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return out
+}


### PR DESCRIPTION
## What

`repo.Push` gains `ReplaceOnReject`: on a non-fast-forward rejection, re-push with `--force-with-lease` pinned to the remote SHA read via `ls-remote` — a compare-and-swap that replaces exactly the ref we observed and still fails if a concurrent writer moves it. Gated by a new opt-in flag, `Workload.spec.allowOverwrite`, stamped onto the synthesized issue-fix payload.

## Why

Fixes #934 (the behavioral half; the "push to fork" wording is left for a cosmetic pass)

Workload re-runs derive the same deterministic branch name as their predecessor, so the retry's push dies non-fast-forward on the previous run's ref: every delete-and-recreate retry ends NO-GO / PUSH-FAILED until a human deletes the branch. Observed in production: 3 of 3 previously-GO'd tasks failed exactly this way on re-run.

**On #573's design rejection** (thanks for the catch — I hadn't traced that history): this now adopts exactly the opt-in shape #573 prescribed ("an opt-in `Workload.spec.allowOverwrite: true` flag could come later if real automated retries need it") rather than superseding it. The default stays false — a plain Workload never force-replaces a published ref, preserving the audit-artifact property #573 protected. Retry systems that re-run Workloads under the same name (the "real automated retries" #573 anticipated — ours exists now) set the flag explicitly on the re-run, where the stale ref is their own previous attempt.

## How

- `isPushRejection` now inspects only the failed invocation's **stderr**, carried on a typed `gitError` from `runGit` (review point 1: the full message embeds the git args, and branch names carry caller-controlled Workload names — a workload literally named `non-fast-forward` must not classify auth/network failures as rejections)
- plain push first; on rejection with `payload.allowOverwrite`: `ls-remote` → `--force-with-lease=refs/heads/<branch>:<sha>`; a vanished ref leases against empty; lease failure re-wraps as `ErrPushRejected`
- `Workload.spec.allowOverwrite` → `synthesizeIssueBatch` stamps `payload.allowOverwrite` on the issue-fix step → executor sets `ReplaceOnReject` from the payload (explicit pipelines set it per step); CRDs + chart CRDs regenerated

Tests: real-git `push_test.go` reproduces the production collision (rejected without the flag / replaced with it, remote ref verified equal to the retry's HEAD / clean push never forces); envtest pins the operator stamping and the false default.

AI assistance: authored by Claude (Opus 4.8) operating under my direction against our production cluster; I reviewed the change and test output before submitting.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (repo + controller suites green)
- [x] `make lint` passes locally (`golangci-lint run` 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — new `allowOverwrite` field documented in the CRD/API comments