### PR TITLE
fix(foreman): do not resynthesize children on a terminating Workload

### DIFF
--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -118,6 +118,16 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// A deleting Workload must not be reconciled: with foreground
+	// deletion, GC removes the child AgenticTasks while the parent
+	// lingers behind its finalizer — reconciling then takes the
+	// "no children yet" path and re-renders the whole pipeline, GC
+	// deletes it again, and the Workload can never finish terminating
+	// (#949). Let GC do its job.
+	if !workload.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	// List children we already own. The label index keeps this fast and
 	// scoped; child status changes re-queue us via Owns().
 	children, err := r.listChildren(ctx, &workload)

--- a/internal/foreman/controller/workload_deletion_test.go
+++ b/internal/foreman/controller/workload_deletion_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// Pins #949: reconciling a Workload that is terminating (foreground
+// deletion: deletionTimestamp set, parent parked behind the
+// foregroundDeletion finalizer while GC removes its children) must NOT
+// re-render the pipeline. Without the guard, the reconciler sees "no
+// children yet", recreates every AgenticTask, GC deletes them again,
+// and the Workload never finishes terminating — external retry systems
+// that delete-and-recreate Workloads hang forever on the delete.
+var _ = Describe("WorkloadReconciler on a deleting Workload (#949)", func() {
+	var reconciler *WorkloadReconciler
+
+	BeforeEach(func() {
+		reconciler = &WorkloadReconciler{
+			Client:              k8sClient,
+			Scheme:              k8sClient.Scheme(),
+			AllowCloudProviders: true,
+		}
+	})
+
+	It("does not re-render children once deletionTimestamp is set", func() {
+		wl := newWorkload("deleting-no-resynth", foremanv1alpha1.WorkloadSpec{
+			Intent:           "fix it",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{7},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		// First reconcile renders the pipeline.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listChildrenNames(wl)).NotTo(BeEmpty())
+
+		// Foreground-delete the Workload: deletionTimestamp is set and
+		// the object is parked behind the foregroundDeletion finalizer
+		// (envtest runs no GC, so we simulate GC by deleting the
+		// children ourselves).
+		propagation := client.PropagationPolicy("Foreground")
+		Expect(k8sClient.Delete(ctx, wl, propagation)).To(Succeed())
+		var deleting foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &deleting)).To(Succeed())
+		Expect(deleting.DeletionTimestamp.IsZero()).To(BeFalse())
+		cleanupChildren(wl)
+		Expect(listChildrenNames(wl)).To(BeEmpty())
+
+		// Reconciling the terminating Workload must NOT resynthesize
+		// the pipeline.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listChildrenNames(wl)).To(BeEmpty())
+	})
+})
+
+// listChildrenNames returns the names of the AgenticTasks labeled as the
+// Workload's children.
+func listChildrenNames(wl *foremanv1alpha1.Workload) []string {
+	var tasks foremanv1alpha1.AgenticTaskList
+	Expect(k8sClient.List(ctx, &tasks,
+		client.InNamespace(wl.Namespace),
+		client.MatchingLabels{labelWorkload: wl.Name},
+	)).To(Succeed())
+	names := make([]string, 0, len(tasks.Items))
+	for i := range tasks.Items {
+		names = append(names, tasks.Items[i].Name)
+	}
+	return names
+}


### PR DESCRIPTION
## What

Early-return from `WorkloadReconciler.Reconcile` when `deletionTimestamp` is set.

## Why

Fixes #949

With foreground deletion, GC removes the child AgenticTasks while the parent is parked behind the `foregroundDeletion` finalizer. The reconciler then sees "no children yet" and re-renders the entire pipeline on the terminating Workload — GC deletes, reconciler recreates (children perpetually 1s old), and the delete never completes. Hit in production: our bridge's delete-and-recreate retry wedged every run on one immortal Workload.

## How

A guard immediately after the Get: `if !workload.DeletionTimestamp.IsZero() { return }` — GC finishes ownership cleanup on its own; the reconciler has no finalizer of its own to run. New envtest (`workload_deletion_test.go`): render pipeline → foreground-delete (deletionTimestamp set, parent parked) → simulate GC by deleting children → reconcile → assert children are NOT re-rendered.

AI assistance: authored by Claude (Opus 4.8) operating under my direction against our production cluster; I reviewed the change and test output before submitting.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (full `./internal/foreman/controller/` envtest suite green)
- [x] `make lint` passes locally (`golangci-lint run` 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — n/a, bug fix
