### PR TITLE
docs: register the Karpenter GPU autoscaling guide in nav.yaml

### DIFF
--- a/docs/site/_meta/nav.yaml
+++ b/docs/site/_meta/nav.yaml
@@ -79,6 +79,9 @@ sections:
       - label: Metrics-driven autoscaling
         slug: guides/metrics-driven-autoscaling
         file: guides/metrics-driven-autoscaling.md
+      - label: Karpenter GPU autoscaling
+        slug: guides/karpenter-gpu-autoscaling
+        file: guides/karpenter-gpu-autoscaling.md
 
   - title: Operations
     items:


### PR DESCRIPTION
## What

Registers the existing Karpenter GPU autoscaling guide (`docs/site/guides/karpenter-gpu-autoscaling.md`) in the docs nav manifest so llmkube-web publishes it.

## Why

Fixes #658 (the guide was authored in #825 but never listed in `nav.yaml`, so the site never rendered it as a page).

This is currently **breaking the site build**: the metrics-driven autoscaling guide (#952) links to `/docs/guides/karpenter-gpu-autoscaling`, and the SvelteKit prerender fails on the resulting 404:

```
Error: 404 /docs/guides/karpenter-gpu-autoscaling (linked from /docs/guides/metrics-driven-autoscaling)
```

## How

One nav entry under Guides, next to its companion metrics-driven guide. Verified every internal doc link in the newly-published karpenter guide resolves to an existing nav slug (air-gapped, metrics-driven-autoscaling, concepts/crds, getting-started, memory-pressure-protection — the last three are served as stub pages), so publishing it introduces no new broken links.

## Checklist

- [x] Tests added/updated - not applicable (docs manifest only)
- [x] `make test` passes locally - not applicable (no code change)
- [x] `make lint` passes locally - not applicable
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions) - authored by the maintainer
- [x] Documentation updated (if user-facing change) - this is the docs manifest
