### PR TITLE
feat(foreman): open the pull request on review GO

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -254,6 +254,16 @@ type AgenticTaskPayload struct {
 	// +optional
 	BaseBranch string `json:"baseBranch,omitempty"`
 
+	// OpenPullRequest instructs the reviewer-role executor to open a
+	// pull request for the task's branch when its review verdict is GO
+	// (idempotent: an existing PR for the branch is reused). Stamped
+	// from Workload.spec.openPullRequest onto review steps in
+	// issue-batch mode; explicit pipelines set it per step. The PR is
+	// the Workload's artifact — without this the pipeline ends at a
+	// reviewed-but-unopened branch (#937).
+	// +optional
+	OpenPullRequest bool `json:"openPullRequest,omitempty"`
+
 	// AllowOverwrite permits the coder to replace a stale remote ref for
 	// its own branch (force-with-lease pinned to the observed SHA) when a
 	// plain push is rejected non-fast-forward. Opt-in, per the design

--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -164,6 +164,17 @@ type WorkloadSpec struct {
 	// +optional
 	EscalationReviewerAgentRefs []corev1.LocalObjectReference `json:"escalationReviewerAgentRefs,omitempty"`
 
+	// OpenPullRequest controls whether a review-GO opens a pull request
+	// for the Workload's branch (the pipeline's end artifact). Three-
+	// valued via the *bool: nil (unset) means true in issue-batch mode —
+	// a Workload built from Issues exists to produce a PR — while *false
+	// opts a Workload out (branch-only consumers). Explicit pipelines
+	// carry the flag per step and ignore this field. Idempotent at the
+	// executor: an existing PR for the branch is reused, never
+	// duplicated (#937).
+	// +optional
+	OpenPullRequest *bool `json:"openPullRequest,omitempty"`
+
 	// AllowOverwrite lets this Workload's coder replace a stale remote
 	// ref for its own foreman/* branch (force-with-lease compare-and-swap)
 	// instead of failing non-fast-forward. Opt-in — #573 deliberately

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -222,6 +222,16 @@ spec:
                     format: int32
                     minimum: 1
                     type: integer
+                  openPullRequest:
+                    description: |-
+                      OpenPullRequest instructs the reviewer-role executor to open a
+                      pull request for the task's branch when its review verdict is GO
+                      (idempotent: an existing PR for the branch is reused). Stamped
+                      from Workload.spec.openPullRequest onto review steps in
+                      issue-batch mode; explicit pipelines set it per step. The PR is
+                      the Workload's artifact — without this the pipeline ends at a
+                      reviewed-but-unopened branch (#937).
+                    type: boolean
                   prompt:
                     description: Prompt is the agent input. Required for freeform.
                     type: string

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -238,6 +238,17 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              openPullRequest:
+                description: |-
+                  OpenPullRequest controls whether a review-GO opens a pull request
+                  for the Workload's branch (the pipeline's end artifact). Three-
+                  valued via the *bool: nil (unset) means true in issue-batch mode —
+                  a Workload built from Issues exists to produce a PR — while *false
+                  opts a Workload out (branch-only consumers). Explicit pipelines
+                  carry the flag per step and ignore this field. Idempotent at the
+                  executor: an existing PR for the branch is reused, never
+                  duplicated (#937).
+                type: boolean
               pipeline:
                 description: |-
                   Pipeline, when set, bypasses the planner and emits AgenticTasks
@@ -421,6 +432,16 @@ spec:
                           format: int32
                           minimum: 1
                           type: integer
+                        openPullRequest:
+                          description: |-
+                            OpenPullRequest instructs the reviewer-role executor to open a
+                            pull request for the task's branch when its review verdict is GO
+                            (idempotent: an existing PR for the branch is reused). Stamped
+                            from Workload.spec.openPullRequest onto review steps in
+                            issue-batch mode; explicit pipelines set it per step. The PR is
+                            the Workload's artifact — without this the pipeline ends at a
+                            reviewed-but-unopened branch (#937).
+                          type: boolean
                         prompt:
                           description: Prompt is the agent input. Required for freeform.
                           type: string

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -67,6 +67,7 @@ import (
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	foremantools "github.com/defilantech/llmkube/pkg/foreman/agent/tools"
 	"github.com/defilantech/llmkube/pkg/selfupdate"
@@ -406,6 +407,7 @@ func main() {
 			KeepWorkspace:   keepWorkspace,
 			RegistryFactory: makeRegistryFactory(kc, kcs, foremanNamespace),
 			IssueFetcher:    githubissue.NewClient(),
+			PREnsurer:       githubpr.NewClient(),
 			// CoderJobSubmitter routes Job-mode Agents to an ephemeral
 			// per-task Job (#620). Wired ONLY on the watcher executor: the
 			// run-task path (which the Job itself runs) builds its executor
@@ -569,6 +571,7 @@ func runTaskCommand(args []string) {
 		KeepWorkspace:                keepWorkspace,
 		RegistryFactory:              makeRegistryFactory(kc, kcs, foremanNamespace),
 		IssueFetcher:                 githubissue.NewClient(),
+		PREnsurer:                    githubpr.NewClient(),
 	})
 	if err != nil {
 		// System / execution failure: the result line + ERROR sentinel

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -222,6 +222,16 @@ spec:
                     format: int32
                     minimum: 1
                     type: integer
+                  openPullRequest:
+                    description: |-
+                      OpenPullRequest instructs the reviewer-role executor to open a
+                      pull request for the task's branch when its review verdict is GO
+                      (idempotent: an existing PR for the branch is reused). Stamped
+                      from Workload.spec.openPullRequest onto review steps in
+                      issue-batch mode; explicit pipelines set it per step. The PR is
+                      the Workload's artifact — without this the pipeline ends at a
+                      reviewed-but-unopened branch (#937).
+                    type: boolean
                   prompt:
                     description: Prompt is the agent input. Required for freeform.
                     type: string

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -238,6 +238,17 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              openPullRequest:
+                description: |-
+                  OpenPullRequest controls whether a review-GO opens a pull request
+                  for the Workload's branch (the pipeline's end artifact). Three-
+                  valued via the *bool: nil (unset) means true in issue-batch mode —
+                  a Workload built from Issues exists to produce a PR — while *false
+                  opts a Workload out (branch-only consumers). Explicit pipelines
+                  carry the flag per step and ignore this field. Idempotent at the
+                  executor: an existing PR for the branch is reused, never
+                  duplicated (#937).
+                type: boolean
               pipeline:
                 description: |-
                   Pipeline, when set, bypasses the planner and emits AgenticTasks
@@ -421,6 +432,16 @@ spec:
                           format: int32
                           minimum: 1
                           type: integer
+                        openPullRequest:
+                          description: |-
+                            OpenPullRequest instructs the reviewer-role executor to open a
+                            pull request for the task's branch when its review verdict is GO
+                            (idempotent: an existing PR for the branch is reused). Stamped
+                            from Workload.spec.openPullRequest onto review steps in
+                            issue-batch mode; explicit pipelines set it per step. The PR is
+                            the Workload's artifact — without this the pipeline ends at a
+                            reviewed-but-unopened branch (#937).
+                          type: boolean
                         prompt:
                           description: Prompt is the agent input. Required for freeform.
                           type: string

--- a/internal/foreman/controller/workload_allowoverwrite_test.go
+++ b/internal/foreman/controller/workload_allowoverwrite_test.go
@@ -83,3 +83,63 @@ var _ = Describe("WorkloadReconciler allowOverwrite stamping", func() {
 		Expect(task.Spec.Payload.AllowOverwrite).To(BeFalse())
 	})
 })
+
+// Pins #937's default: an issue-batch Workload opens a PR on review GO
+// unless spec.openPullRequest is explicitly false.
+var _ = Describe("WorkloadReconciler openPullRequest stamping", func() {
+	var reconciler *WorkloadReconciler
+
+	BeforeEach(func() {
+		reconciler = &WorkloadReconciler{
+			Client:              k8sClient,
+			Scheme:              k8sClient.Scheme(),
+			AllowCloudProviders: true,
+		}
+	})
+
+	reviewTask := func(name string) foremanv1alpha1.AgenticTask {
+		var t foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, &t)).To(Succeed())
+		return t
+	}
+
+	makeWL := func(name string, openPR *bool, issue int32) *foremanv1alpha1.Workload {
+		return newWorkload(name, foremanv1alpha1.WorkloadSpec{
+			Intent:            "fix",
+			Repo:              "defilantech/LLMKube",
+			Issues:            []int32{issue},
+			OpenPullRequest:   openPR,
+			CoderAgentRef:     &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef:  &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{{Name: "reviewer"}},
+		})
+	}
+
+	run := func(wl *foremanv1alpha1.Workload) {
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	It("defaults to true (nil) on review payloads", func() {
+		run(makeWL("openpr-default", nil, 21))
+		Expect(reviewTask("openpr-default-review-21-0").Spec.Payload.OpenPullRequest).To(BeTrue())
+	})
+
+	It("false opts out", func() {
+		f := false
+		run(makeWL("openpr-off", &f, 22))
+		Expect(reviewTask("openpr-off-review-22-0").Spec.Payload.OpenPullRequest).To(BeFalse())
+	})
+
+	It("does not stamp code or verify payloads", func() {
+		run(makeWL("openpr-scope", nil, 23))
+		var t foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "openpr-scope-code-23"}, &t)).To(Succeed())
+		Expect(t.Spec.Payload.OpenPullRequest).To(BeFalse())
+	})
+})

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -320,6 +320,9 @@ func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.Pipelin
 				},
 			},
 		)
+		// nil defaults to true: an issue-batch Workload exists to produce
+		// a PR; spec.openPullRequest=false opts out (#937).
+		openPR := w.Spec.OpenPullRequest == nil || *w.Spec.OpenPullRequest
 		for i, reviewerRef := range w.Spec.ReviewerAgentRefs {
 			steps = append(steps, foremanv1alpha1.PipelineStep{
 				Name:      fmt.Sprintf("review-%d-%d", n, i),
@@ -327,9 +330,10 @@ func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.Pipelin
 				AgentRef:  reviewerRef,
 				DependsOn: []string{verifyName},
 				Payload: foremanv1alpha1.AgenticTaskPayload{
-					Repo:   w.Spec.Repo,
-					Issue:  n,
-					Branch: branch,
+					Repo:            w.Spec.Repo,
+					Issue:           n,
+					Branch:          branch,
+					OpenPullRequest: openPR,
 				},
 			})
 		}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1172,6 +1172,15 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 // from the branch head's commit subject (fallback "Fix #<n>"), base
 // from payload.baseBranch (default main), body linking the issue. The
 // same token the coder pushed with authenticates the API calls.
+//
+// The coder pushed the branch to the configured git remote, which may be
+// a fork of payload.repo (--git-remote-url names the fork while
+// payload.repo names the upstream the PR targets). When the remote's
+// owner differs from payload.repo's owner, the PR is cross-fork: the
+// head must be qualified "forkOwner:branch" and the head commit read
+// from the fork, where the ref actually exists. A remote with the same
+// owner — or one that is not an owner/repo-shaped URL at all (local
+// paths in tests) — keeps the same-repo shape.
 func (e *NativeAgentLoopExecutor) openPullRequest(
 	ctx context.Context, task *foremanv1alpha1.AgenticTask, auth *repo.Auth,
 ) (string, error) {
@@ -1184,13 +1193,20 @@ func (e *NativeAgentLoopExecutor) openPullRequest(
 	if auth != nil {
 		token = auth.Token
 	}
-	title := e.PREnsurer.HeadCommitSubject(ctx, owner, name, p.Branch, token)
+	head := p.Branch
+	headOwner, headRepo := owner, name
+	if forkOwner, forkRepo := gitRemoteOwnerRepo(e.GitRemoteURL); forkOwner != "" &&
+		!strings.EqualFold(forkOwner, owner) {
+		head = forkOwner + ":" + p.Branch
+		headOwner, headRepo = forkOwner, forkRepo
+	}
+	title := e.PREnsurer.HeadCommitSubject(ctx, headOwner, headRepo, p.Branch, token)
 	if title == "" {
 		title = fmt.Sprintf("Fix #%d", p.Issue)
 	}
 	body := fmt.Sprintf("Fixes #%d\n\nOpened by foreman on review GO (workload %s).",
 		p.Issue, task.Labels["foreman.llmkube.dev/workload"])
-	res, err := e.PREnsurer.EnsurePR(ctx, owner, name, p.Branch,
+	res, err := e.PREnsurer.EnsurePR(ctx, owner, name, head,
 		baseBranchOrDefault(p.BaseBranch), title, body, token)
 	if err != nil {
 		return "", err
@@ -1381,6 +1397,41 @@ func upstreamURLForRepo(repoSlug string) string {
 // limited to git/GitHub-safe characters and exactly one slash is allowed, so
 // "..", multiple path segments, and whitespace are rejected.
 var repoSlugPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`)
+
+// gitRemoteOwnerRepo extracts the owner and repository name from a git
+// remote URL, so openPullRequest can tell whether --git-remote-url is a
+// fork of payload.repo. Understood forms: http(s)://host/owner/repo,
+// ssh://git@host/owner/repo, and scp-like git@host:owner/repo — each
+// with or without the .git suffix. Anything else (local paths, file://
+// remotes used in tests, bare hosts) yields "", "" so callers fall back
+// to same-repo behavior.
+func gitRemoteOwnerRepo(remoteURL string) (owner, name string) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	var path string
+	switch {
+	case strings.HasPrefix(remoteURL, "https://"),
+		strings.HasPrefix(remoteURL, "http://"),
+		strings.HasPrefix(remoteURL, "ssh://"):
+		u, err := url.Parse(remoteURL)
+		if err != nil {
+			return "", ""
+		}
+		path = strings.Trim(u.Path, "/")
+	case strings.Contains(remoteURL, "@") && strings.Contains(remoteURL, ":") &&
+		!strings.Contains(remoteURL, "://"):
+		// scp-like syntax: git@github.com:owner/repo.git
+		_, after, _ := strings.Cut(remoteURL, ":")
+		path = strings.Trim(after, "/")
+	default:
+		return "", ""
+	}
+	path = strings.TrimSuffix(path, ".git")
+	if !repoSlugPattern.MatchString(path) {
+		return "", ""
+	}
+	o, n, _ := strings.Cut(path, "/")
+	return o, n
+}
 
 // 4. Everything else falls back to foreman/<task-name>.
 func branchNameForTask(task *foremanv1alpha1.AgenticTask) string {

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -41,6 +41,7 @@ import (
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repomap"
@@ -138,6 +139,12 @@ type NativeAgentLoopExecutor struct {
 	// preserving backward compatibility. Tests inject a fake; production
 	// wires githubissue.NewClient() in cmd/foreman-agent.
 	IssueFetcher githubissue.Fetcher
+
+	// PREnsurer opens (idempotently) the pull request for a branch whose
+	// review verdict is GO, when the task payload carries
+	// openPullRequest (#937). nil disables PR opening entirely;
+	// cmd/foreman-agent wires githubpr.NewClient().
+	PREnsurer githubpr.Ensurer
 
 	// CoderJobSubmitter, when non-nil, routes Job-mode Agents
 	// (spec.execution.mode == Job) to an ephemeral per-task Kubernetes Job
@@ -597,6 +604,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
 		r := e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
+		e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r)
 		// Attach the normalized failure reason from the model-to-CRD
 		// mapping (e.g. ERROR→INCOMPLETE + ModelReportedError for #649). Only
 		// set when the normalizer produced a reason AND the result does
@@ -1130,6 +1138,64 @@ func (e *NativeAgentLoopExecutor) incompleteResult(
 		"turnCount":     lr.Turns,
 	}
 	return r
+}
+
+// maybeOpenPullRequest opens the Workload's PR after a reviewer GO
+// (#937). A reviewer GO is APPROVE — the Workload's artifact is a pull
+// request. Best-effort: the approval stands even if GitHub is down; the
+// failure is surfaced in result extra for operators. Idempotent at the
+// client, so multiple reviewer tasks GOing on the same branch cannot
+// duplicate the PR.
+func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
+	ctx context.Context, log logr.Logger,
+	task *foremanv1alpha1.AgenticTask, auth *repo.Auth,
+	verdict foremanv1alpha1.AgenticTaskVerdict, r *Result,
+) {
+	if verdict != foremanv1alpha1.AgenticTaskVerdictGo ||
+		task.Spec.Kind != foremanv1alpha1.AgenticTaskKindReview ||
+		!task.Spec.Payload.OpenPullRequest ||
+		e.PREnsurer == nil {
+		return
+	}
+	if prURL, prErr := e.openPullRequest(ctx, task, auth); prErr != nil {
+		log.Error(prErr, "review GO: opening pull request failed",
+			"repo", task.Spec.Payload.Repo, "branch", task.Spec.Payload.Branch)
+		r.Extra["pullRequestError"] = prErr.Error()
+	} else {
+		log.Info("review GO: pull request ensured",
+			"repo", task.Spec.Payload.Repo, "pr", prURL)
+		r.Extra["pullRequestURL"] = prURL
+	}
+}
+
+// openPullRequest ensures the PR for the task's branch exists: title
+// from the branch head's commit subject (fallback "Fix #<n>"), base
+// from payload.baseBranch (default main), body linking the issue. The
+// same token the coder pushed with authenticates the API calls.
+func (e *NativeAgentLoopExecutor) openPullRequest(
+	ctx context.Context, task *foremanv1alpha1.AgenticTask, auth *repo.Auth,
+) (string, error) {
+	p := task.Spec.Payload
+	owner, name, ok := strings.Cut(p.Repo, "/")
+	if !ok || owner == "" || name == "" {
+		return "", fmt.Errorf("openPullRequest: payload.repo %q is not owner/name", p.Repo)
+	}
+	token := ""
+	if auth != nil {
+		token = auth.Token
+	}
+	title := e.PREnsurer.HeadCommitSubject(ctx, owner, name, p.Branch, token)
+	if title == "" {
+		title = fmt.Sprintf("Fix #%d", p.Issue)
+	}
+	body := fmt.Sprintf("Fixes #%d\n\nOpened by foreman on review GO (workload %s).",
+		p.Issue, task.Labels["foreman.llmkube.dev/workload"])
+	res, err := e.PREnsurer.EnsurePR(ctx, owner, name, p.Branch,
+		baseBranchOrDefault(p.BaseBranch), title, body, token)
+	if err != nil {
+		return "", err
+	}
+	return res.URL, nil
 }
 
 func (e *NativeAgentLoopExecutor) modelDecidedResult(

--- a/pkg/foreman/agent/executor_pr_test.go
+++ b/pkg/foreman/agent/executor_pr_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
+)
+
+// prEnsureCall records one EnsurePR invocation on the fake.
+type prEnsureCall struct {
+	owner, repo, head, base, title string
+}
+
+// prSubjectCall records one HeadCommitSubject invocation on the fake.
+type prSubjectCall struct {
+	owner, repo, ref string
+}
+
+// fakePREnsurer is a recording githubpr.Ensurer for executor wiring
+// tests: it captures the arguments the executor derives (base owner,
+// qualified head, fork owner for the subject lookup) without any HTTP.
+type fakePREnsurer struct {
+	ensures  []prEnsureCall
+	subjects []prSubjectCall
+	subject  string
+	url      string
+	err      error
+}
+
+func (f *fakePREnsurer) EnsurePR(
+	_ context.Context, owner, repo, head, base, title, _, _ string,
+) (*githubpr.Result, error) {
+	f.ensures = append(f.ensures, prEnsureCall{owner, repo, head, base, title})
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &githubpr.Result{URL: f.url, Created: true}, nil
+}
+
+func (f *fakePREnsurer) HeadCommitSubject(_ context.Context, owner, repo, ref, _ string) string {
+	f.subjects = append(f.subjects, prSubjectCall{owner, repo, ref})
+	return f.subject
+}
+
+// reviewTaskForPR builds the minimal review-kind AgenticTask that
+// maybeOpenPullRequest inspects.
+func reviewTaskForPR(kind foremanv1alpha1.AgenticTaskKind, openPR bool) *foremanv1alpha1.AgenticTask {
+	return &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "review-pr", Namespace: "default",
+			Labels: map[string]string{"foreman.llmkube.dev/workload": "wl-x"},
+		},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: kind,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:            "defilantech/LLMKube",
+				Issue:           7,
+				Branch:          "foreman/wl-x/issue-7",
+				OpenPullRequest: openPR,
+			},
+		},
+	}
+}
+
+// TestMaybeOpenPullRequest_Gating pins the wiring the #937 feature hangs
+// on: the ensurer runs only for verdict GO + kind review +
+// payload.openPullRequest, and never otherwise.
+func TestMaybeOpenPullRequest_Gating(t *testing.T) {
+	cases := []struct {
+		name       string
+		verdict    foremanv1alpha1.AgenticTaskVerdict
+		kind       foremanv1alpha1.AgenticTaskKind
+		openPR     bool
+		wantCalled bool
+	}{
+		{"go review flag on opens", foremanv1alpha1.AgenticTaskVerdictGo,
+			foremanv1alpha1.AgenticTaskKindReview, true, true},
+		{"no-go review never opens", foremanv1alpha1.AgenticTaskVerdictNoGo,
+			foremanv1alpha1.AgenticTaskKindReview, true, false},
+		{"go review flag off never opens", foremanv1alpha1.AgenticTaskVerdictGo,
+			foremanv1alpha1.AgenticTaskKindReview, false, false},
+		{"go non-review never opens", foremanv1alpha1.AgenticTaskVerdictGo,
+			foremanv1alpha1.AgenticTaskKindIssueFix, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fe := &fakePREnsurer{url: "https://github.com/defilantech/LLMKube/pull/1"}
+			e := &NativeAgentLoopExecutor{PREnsurer: fe}
+			task := reviewTaskForPR(tc.kind, tc.openPR)
+			r := &Result{Extra: map[string]any{}}
+
+			e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil, tc.verdict, r)
+
+			if called := len(fe.ensures) > 0; called != tc.wantCalled {
+				t.Fatalf("EnsurePR called=%v, want %v (calls=%+v)", called, tc.wantCalled, fe.ensures)
+			}
+			if _, hasURL := r.Extra["pullRequestURL"]; hasURL != tc.wantCalled {
+				t.Errorf("pullRequestURL present=%v, want %v; extra=%+v", hasURL, tc.wantCalled, r.Extra)
+			}
+		})
+	}
+}
+
+// TestMaybeOpenPullRequest_NilEnsurerIsDisabled: nil PREnsurer disables
+// PR opening entirely (cmd wiring may leave it unset) without panicking.
+func TestMaybeOpenPullRequest_NilEnsurerIsDisabled(t *testing.T) {
+	e := &NativeAgentLoopExecutor{}
+	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
+	r := &Result{Extra: map[string]any{}}
+	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+		foremanv1alpha1.AgenticTaskVerdictGo, r)
+	if len(r.Extra) != 0 {
+		t.Fatalf("nil ensurer must be a no-op; extra=%+v", r.Extra)
+	}
+}
+
+// TestMaybeOpenPullRequest_ForkRemoteQualifiesHead is the #956 review
+// fix: the coder pushes to the fork named by --git-remote-url while
+// payload.repo names the upstream, so the PR must be cross-fork — head
+// "Defilan:branch" against base repo defilantech/LLMKube, and the title
+// commit read from the fork where the ref exists.
+func TestMaybeOpenPullRequest_ForkRemoteQualifiesHead(t *testing.T) {
+	fe := &fakePREnsurer{
+		subject: "fix: the thing",
+		url:     "https://github.com/defilantech/LLMKube/pull/2",
+	}
+	e := &NativeAgentLoopExecutor{
+		PREnsurer:    fe,
+		GitRemoteURL: "https://github.com/Defilan/LLMKube.git",
+	}
+	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
+	r := &Result{Extra: map[string]any{}}
+
+	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+		foremanv1alpha1.AgenticTaskVerdictGo, r)
+
+	if len(fe.ensures) != 1 {
+		t.Fatalf("want 1 EnsurePR call, got %+v", fe.ensures)
+	}
+	got := fe.ensures[0]
+	want := prEnsureCall{
+		owner: "defilantech", repo: "LLMKube",
+		head: "Defilan:foreman/wl-x/issue-7", base: "main", title: "fix: the thing",
+	}
+	if got != want {
+		t.Errorf("EnsurePR args:\n got %+v\nwant %+v", got, want)
+	}
+	if len(fe.subjects) != 1 {
+		t.Fatalf("want 1 HeadCommitSubject call, got %+v", fe.subjects)
+	}
+	if s := fe.subjects[0]; s.owner != "Defilan" || s.repo != "LLMKube" || s.ref != "foreman/wl-x/issue-7" {
+		t.Errorf("HeadCommitSubject must read from the fork; got %+v", s)
+	}
+	if r.Extra["pullRequestURL"] != fe.url {
+		t.Errorf("pullRequestURL: got %v", r.Extra["pullRequestURL"])
+	}
+}
+
+// TestMaybeOpenPullRequest_SameRepoRemoteKeepsBareHead: a remote whose
+// owner matches payload.repo (case-insensitively, GitHub owners are
+// case-insensitive) is not a fork — same-repo behavior stands.
+func TestMaybeOpenPullRequest_SameRepoRemoteKeepsBareHead(t *testing.T) {
+	for _, remote := range []string{
+		"https://github.com/defilantech/LLMKube.git",
+		"https://github.com/DefilanTech/LLMKube", // owner case differs only
+		"",                                       // no static remote configured (#915 multi-repo mode)
+		"/tmp/seed/bare.git",                     // local path (tests, air-gapped mirrors)
+		"file:///srv/bare.git",                   // not owner/repo-shaped
+	} {
+		fe := &fakePREnsurer{subject: "fix: same repo", url: "https://github.com/defilantech/LLMKube/pull/3"}
+		e := &NativeAgentLoopExecutor{PREnsurer: fe, GitRemoteURL: remote}
+		task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
+		r := &Result{Extra: map[string]any{}}
+
+		e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+			foremanv1alpha1.AgenticTaskVerdictGo, r)
+
+		if len(fe.ensures) != 1 {
+			t.Fatalf("remote %q: want 1 EnsurePR call, got %+v", remote, fe.ensures)
+		}
+		if got := fe.ensures[0].head; got != "foreman/wl-x/issue-7" {
+			t.Errorf("remote %q: head got %q, want bare branch", remote, got)
+		}
+		if s := fe.subjects[0]; s.owner != "defilantech" || s.repo != "LLMKube" {
+			t.Errorf("remote %q: subject read from %s/%s, want base repo", remote, s.owner, s.repo)
+		}
+	}
+}
+
+// TestGitRemoteOwnerRepo pins the tolerant URL forms the fork-owner
+// derivation must understand, and the non-GitHub-shaped remotes it must
+// decline to parse.
+func TestGitRemoteOwnerRepo(t *testing.T) {
+	cases := []struct {
+		url         string
+		owner, name string
+	}{
+		{"https://github.com/Defilan/LLMKube.git", "Defilan", "LLMKube"},
+		{"https://github.com/Defilan/LLMKube", "Defilan", "LLMKube"},
+		{"https://github.com/Defilan/LLMKube/", "Defilan", "LLMKube"},
+		{"http://ghes.corp/Defilan/LLMKube.git", "Defilan", "LLMKube"},
+		{"https://x-access-token:tok@github.com/Defilan/LLMKube.git", "Defilan", "LLMKube"},
+		{"git@github.com:Defilan/LLMKube.git", "Defilan", "LLMKube"},
+		{"git@github.com:Defilan/LLMKube", "Defilan", "LLMKube"},
+		{"ssh://git@github.com/Defilan/LLMKube.git", "Defilan", "LLMKube"},
+		{"", "", ""},
+		{"/tmp/seed/bare.git", "", ""},
+		{"file:///srv/git/bare.git", "", ""},
+		{"https://github.com/onlyowner", "", ""},
+		{"https://github.com/a/b/c", "", ""},
+	}
+	for _, tc := range cases {
+		owner, name := gitRemoteOwnerRepo(tc.url)
+		if owner != tc.owner || name != tc.name {
+			t.Errorf("gitRemoteOwnerRepo(%q) = %q, %q; want %q, %q",
+				tc.url, owner, name, tc.owner, tc.name)
+		}
+	}
+}

--- a/pkg/foreman/agent/githubpr/ensure.go
+++ b/pkg/foreman/agent/githubpr/ensure.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package githubpr opens the pull request a completed Workload earned.
+// The pipeline used to end one hop short of its artifact: a coder-GO,
+// gate-PASS, review-GO branch sat on the remote, reviewed and unopened,
+// until a human found it (#937). EnsurePR closes that hop, idempotently.
+package githubpr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultTimeout bounds each API call.
+const DefaultTimeout = 10 * time.Second
+
+// Result reports what EnsurePR did.
+type Result struct {
+	// URL is the pull request's html_url (existing or just created).
+	URL string
+	// Created is false when a PR for the head branch already existed
+	// (including losing a create race to a concurrent reviewer task).
+	Created bool
+}
+
+// Ensurer is the interface the executor consumes; tests substitute it.
+type Ensurer interface {
+	EnsurePR(ctx context.Context, owner, repo, head, base, title, body, token string) (*Result, error)
+	// HeadCommitSubject returns the branch head's commit subject for use
+	// as the PR title; "" on any failure (callers fall back).
+	HeadCommitSubject(ctx context.Context, owner, repo, ref, token string) string
+}
+
+// Client is the production Ensurer. BaseURL is overridable so tests can
+// point at an httptest server; production leaves it empty and the
+// client uses https://api.github.com.
+type Client struct {
+	HTTPClient *http.Client
+	BaseURL    string // empty defaults to https://api.github.com
+}
+
+// NewClient constructs a Client with a 10s timeout.
+func NewClient() *Client {
+	return &Client{HTTPClient: &http.Client{Timeout: DefaultTimeout}}
+}
+
+// EnsurePR makes sure a pull request exists for head → base, creating
+// it if absent. Idempotent: an existing PR (any state) for the head
+// branch is returned rather than duplicated, and losing a create race
+// (GitHub 422 "already exists") resolves to the winner's PR.
+func (c *Client) EnsurePR(
+	ctx context.Context, owner, repo, head, base, title, body, token string,
+) (*Result, error) {
+	if owner == "" || repo == "" || head == "" || base == "" {
+		return nil, fmt.Errorf("githubpr: owner, repo, head, and base are required")
+	}
+	if title == "" {
+		return nil, fmt.Errorf("githubpr: title is required")
+	}
+
+	if existing, err := c.findByHead(ctx, owner, repo, head, token); err != nil {
+		return nil, err
+	} else if existing != "" {
+		return &Result{URL: existing, Created: false}, nil
+	}
+
+	created, err := c.create(ctx, owner, repo, head, base, title, body, token)
+	if err == nil {
+		return &Result{URL: created, Created: true}, nil
+	}
+	// Create race: a concurrent reviewer task (multiple reviewers GO on
+	// the same Workload) created it between our list and our POST.
+	// GitHub answers 422; resolve to the winner's PR.
+	var httpErr *HTTPError
+	if isAlreadyExists(err, &httpErr) {
+		if existing, findErr := c.findByHead(ctx, owner, repo, head, token); findErr == nil && existing != "" {
+			return &Result{URL: existing, Created: false}, nil
+		}
+	}
+	return nil, err
+}
+
+// HeadCommitSubject returns the first line of the branch head's commit
+// message — the natural PR title (the coder writes a conventional
+// subject). Empty on any failure so callers can fall back.
+func (c *Client) HeadCommitSubject(ctx context.Context, owner, repo, ref, token string) string {
+	target := fmt.Sprintf("%s/repos/%s/%s/commits/%s", c.base(), owner, repo, ref)
+	var out struct {
+		Commit struct {
+			Message string `json:"message"`
+		} `json:"commit"`
+	}
+	if err := c.getJSON(ctx, target, token, &out); err != nil {
+		return ""
+	}
+	subject, _, _ := strings.Cut(out.Commit.Message, "\n")
+	return strings.TrimSpace(subject)
+}
+
+func (c *Client) base() string {
+	if c.BaseURL != "" {
+		return c.BaseURL
+	}
+	return "https://api.github.com"
+}
+
+func (c *Client) findByHead(ctx context.Context, owner, repo, head, token string) (string, error) {
+	target := fmt.Sprintf("%s/repos/%s/%s/pulls?state=all&head=%s",
+		c.base(), owner, repo, url.QueryEscape(owner+":"+head))
+	var prs []struct {
+		HTMLURL string `json:"html_url"`
+	}
+	if err := c.getJSON(ctx, target, token, &prs); err != nil {
+		return "", fmt.Errorf("githubpr: list by head: %w", err)
+	}
+	if len(prs) == 0 {
+		return "", nil
+	}
+	return prs[0].HTMLURL, nil
+}
+
+func (c *Client) create(ctx context.Context, owner, repo, head, base, title, body, token string) (string, error) {
+	target := fmt.Sprintf("%s/repos/%s/%s/pulls", c.base(), owner, repo)
+	payload, err := json.Marshal(map[string]string{
+		"title": title, "head": head, "base": base, "body": body,
+	})
+	if err != nil {
+		return "", fmt.Errorf("githubpr: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("githubpr: build request: %w", err)
+	}
+	c.headers(req, token)
+	resp, err := c.client().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("githubpr: http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return "", fmt.Errorf("githubpr: read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return "", &HTTPError{StatusCode: resp.StatusCode, Body: string(raw)}
+	}
+	var pr struct {
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.Unmarshal(raw, &pr); err != nil {
+		return "", fmt.Errorf("githubpr: decode created PR: %w", err)
+	}
+	return pr.HTMLURL, nil
+}
+
+func (c *Client) getJSON(ctx context.Context, target, token string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	c.headers(req, token)
+	resp, err := c.client().Do(req)
+	if err != nil {
+		return fmt.Errorf("http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return &HTTPError{StatusCode: resp.StatusCode, Body: string(raw)}
+	}
+	return json.Unmarshal(raw, out)
+}
+
+func (c *Client) headers(req *http.Request, token string) {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if req.Method == http.MethodPost {
+		req.Header.Set("Content-Type", "application/json")
+	}
+}
+
+func (c *Client) client() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+// HTTPError carries a non-2xx response so callers can distinguish
+// validation failures (422) from auth (401/403) and transport errors.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("githubpr: HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// isAlreadyExists reports whether err is GitHub's 422 for "a pull
+// request already exists" (the create race).
+func isAlreadyExists(err error, target **HTTPError) bool {
+	if !asHTTPError(err, target) {
+		return false
+	}
+	return (*target).StatusCode == http.StatusUnprocessableEntity &&
+		strings.Contains(strings.ToLower((*target).Body), "already exists")
+}
+
+func asHTTPError(err error, target **HTTPError) bool {
+	e, ok := err.(*HTTPError) //nolint:errorlint // constructed locally, never wrapped
+	if ok {
+		*target = e
+	}
+	return ok
+}

--- a/pkg/foreman/agent/githubpr/ensure.go
+++ b/pkg/foreman/agent/githubpr/ensure.go
@@ -46,6 +46,9 @@ type Result struct {
 
 // Ensurer is the interface the executor consumes; tests substitute it.
 type Ensurer interface {
+	// EnsurePR's head is a bare branch name for a same-repo PR, or a
+	// "forkOwner:branch" qualified head for a cross-fork PR (the coder
+	// pushed to a fork of owner/repo). owner/repo always name the base.
 	EnsurePR(ctx context.Context, owner, repo, head, base, title, body, token string) (*Result, error)
 	// HeadCommitSubject returns the branch head's commit subject for use
 	// as the PR title; "" on any failure (callers fall back).
@@ -126,13 +129,28 @@ func (c *Client) base() string {
 }
 
 func (c *Client) findByHead(ctx context.Context, owner, repo, head, token string) (string, error) {
+	// A cross-fork head arrives pre-qualified ("forkOwner:branch") and is
+	// used verbatim; a same-repo head is qualified with the base owner so
+	// the filter cannot match another fork's identically-named branch.
+	filter := head
+	if !strings.Contains(head, ":") {
+		filter = owner + ":" + head
+	}
 	target := fmt.Sprintf("%s/repos/%s/%s/pulls?state=all&head=%s",
-		c.base(), owner, repo, url.QueryEscape(owner+":"+head))
+		c.base(), owner, repo, url.QueryEscape(filter))
 	var prs []struct {
 		HTMLURL string `json:"html_url"`
+		State   string `json:"state"`
 	}
 	if err := c.getJSON(ctx, target, token, &prs); err != nil {
 		return "", fmt.Errorf("githubpr: list by head: %w", err)
+	}
+	// state=all carries no open-first ordering guarantee; when a closed
+	// PR and an open one share the head, the open one is the artifact.
+	for _, pr := range prs {
+		if pr.State == "open" {
+			return pr.HTMLURL, nil
+		}
 	}
 	if len(prs) == 0 {
 		return "", nil

--- a/pkg/foreman/agent/githubpr/ensure_test.go
+++ b/pkg/foreman/agent/githubpr/ensure_test.go
@@ -91,6 +91,85 @@ func TestEnsurePR_ReusesExisting(t *testing.T) {
 	}
 }
 
+// TestEnsurePR_ForkQualifiedHeadUsedVerbatim covers the cross-fork shape
+// (#956 review): the coder pushed the branch to a fork, so the head
+// arrives pre-qualified as "forker:branch". The list filter must use it
+// verbatim — not re-prefix the base owner — and the create body must
+// carry the qualified head, or GitHub 422s because the bare branch does
+// not exist in the base repo.
+func TestEnsurePR_ForkQualifiedHeadUsedVerbatim(t *testing.T) {
+	var posts []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("head"); got != "forker:foreman/wl-x/issue-7" {
+			t.Errorf("head filter: got %q, want fork-qualified", got)
+		}
+		_, _ = w.Write([]byte("[]"))
+	})
+	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		b, _ := json.Marshal(req)
+		posts = append(posts, string(b))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"html_url":"https://github.com/o/r/pull/12"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+
+	res, err := c.EnsurePR(context.Background(), "o", "r",
+		"forker:foreman/wl-x/issue-7", "main", "t", "b", "tok")
+	if err != nil {
+		t.Fatalf("EnsurePR: %v", err)
+	}
+	if !res.Created || res.URL != "https://github.com/o/r/pull/12" {
+		t.Fatalf("want created PR 12, got %+v", res)
+	}
+	if len(posts) != 1 {
+		t.Fatalf("want 1 create POST, got %d", len(posts))
+	}
+	var req map[string]string
+	_ = json.Unmarshal([]byte(posts[0]), &req)
+	if req["head"] != "forker:foreman/wl-x/issue-7" {
+		t.Errorf("create head: got %q, want fork-qualified", req["head"])
+	}
+}
+
+// TestEnsurePR_FindByHeadPrefersOpen: state=all carries no open-first
+// ordering guarantee; when a closed PR and an open one share the head,
+// the open one is the artifact to link.
+func TestEnsurePR_FindByHeadPrefersOpen(t *testing.T) {
+	var posts int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"html_url":"https://github.com/o/r/pull/3","state":"closed"},
+			{"html_url":"https://github.com/o/r/pull/8","state":"open"}
+		]`))
+	})
+	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		posts++
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+
+	res, err := c.EnsurePR(context.Background(), "o", "r",
+		"foreman/wl-x/issue-7", "main", "t", "b", "tok")
+	if err != nil {
+		t.Fatalf("EnsurePR: %v", err)
+	}
+	if res.Created || res.URL != "https://github.com/o/r/pull/8" {
+		t.Fatalf("want open PR 8 preferred over closed PR 3, got %+v", res)
+	}
+	if posts != 0 {
+		t.Fatalf("must not POST when a PR exists; got %d posts", posts)
+	}
+}
+
 func TestEnsurePR_ResolvesCreateRace(t *testing.T) {
 	// List says absent, create 422s "already exists" (a concurrent
 	// reviewer won), second list finds the winner.
@@ -151,6 +230,26 @@ func TestHeadCommitSubject(t *testing.T) {
 	// matches the unescaped path.
 	got := c.HeadCommitSubject(context.Background(), "o", "r", "foreman/wl-x/issue-7", "tok")
 	if got != "feat: add the thing" {
+		t.Fatalf("subject: got %q", got)
+	}
+}
+
+// TestHeadCommitSubject_ReadsFromForkRepo pins the cross-fork contract:
+// the branch ref only exists in the fork, so the caller passes the fork
+// owner/repo and the commit URL must target /repos/<fork>/<repo>/…, not
+// the base repo.
+func TestHeadCommitSubject_ReadsFromForkRepo(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/forker/r/commits/foreman/wl-x/issue-7",
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"commit":{"message":"fix: fork-side subject"}}`))
+		})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+
+	got := c.HeadCommitSubject(context.Background(), "forker", "r", "foreman/wl-x/issue-7", "tok")
+	if got != "fix: fork-side subject" {
 		t.Fatalf("subject: got %q", got)
 	}
 }

--- a/pkg/foreman/agent/githubpr/ensure_test.go
+++ b/pkg/foreman/agent/githubpr/ensure_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package githubpr
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// prServer scripts the two endpoints EnsurePR touches: the head-filtered
+// list and the create. existing controls the list response; createStatus
+// and createBody script the POST.
+func prServer(t *testing.T, existing []string, createStatus int, createBody string) (*Client, *[]string) {
+	t.Helper()
+	var posts []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("head") != "o:foreman/wl-x/issue-7" {
+			t.Errorf("head filter: got %q", r.URL.Query().Get("head"))
+		}
+		items := make([]map[string]string, 0, len(existing))
+		for _, u := range existing {
+			items = append(items, map[string]string{"html_url": u})
+		}
+		_ = json.NewEncoder(w).Encode(items)
+	})
+	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		b, _ := json.Marshal(req)
+		posts = append(posts, string(b))
+		w.WriteHeader(createStatus)
+		_, _ = w.Write([]byte(createBody))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}, &posts
+}
+
+func TestEnsurePR_CreatesWhenAbsent(t *testing.T) {
+	c, posts := prServer(t, nil, http.StatusCreated, `{"html_url":"https://github.com/o/r/pull/9"}`)
+
+	res, err := c.EnsurePR(context.Background(), "o", "r",
+		"foreman/wl-x/issue-7", "main", "Fix the thing", "Fixes #7", "tok")
+	if err != nil {
+		t.Fatalf("EnsurePR: %v", err)
+	}
+	if !res.Created || res.URL != "https://github.com/o/r/pull/9" {
+		t.Fatalf("want created PR 9, got %+v", res)
+	}
+	if len(*posts) != 1 {
+		t.Fatalf("want 1 create POST, got %d", len(*posts))
+	}
+	var req map[string]string
+	_ = json.Unmarshal([]byte((*posts)[0]), &req)
+	if req["head"] != "foreman/wl-x/issue-7" || req["base"] != "main" || req["title"] != "Fix the thing" {
+		t.Errorf("create payload wrong: %v", req)
+	}
+}
+
+func TestEnsurePR_ReusesExisting(t *testing.T) {
+	c, posts := prServer(t, []string{"https://github.com/o/r/pull/4"}, http.StatusCreated, `{}`)
+
+	res, err := c.EnsurePR(context.Background(), "o", "r",
+		"foreman/wl-x/issue-7", "main", "t", "b", "tok")
+	if err != nil {
+		t.Fatalf("EnsurePR: %v", err)
+	}
+	if res.Created || res.URL != "https://github.com/o/r/pull/4" {
+		t.Fatalf("want existing PR 4 reused, got %+v", res)
+	}
+	if len(*posts) != 0 {
+		t.Fatalf("must not POST when a PR exists; got %d posts", len(*posts))
+	}
+}
+
+func TestEnsurePR_ResolvesCreateRace(t *testing.T) {
+	// List says absent, create 422s "already exists" (a concurrent
+	// reviewer won), second list finds the winner.
+	var listCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		listCalls++
+		if listCalls == 1 {
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		_, _ = w.Write([]byte(`[{"html_url":"https://github.com/o/r/pull/11"}]`))
+	})
+	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"A pull request already exists for o:foreman/wl-x/issue-7."}]}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+
+	res, err := c.EnsurePR(context.Background(), "o", "r",
+		"foreman/wl-x/issue-7", "main", "t", "b", "tok")
+	if err != nil {
+		t.Fatalf("EnsurePR after race: %v", err)
+	}
+	if res.Created || res.URL != "https://github.com/o/r/pull/11" {
+		t.Fatalf("want race resolved to PR 11, got %+v", res)
+	}
+}
+
+func TestEnsurePR_SurfacesAuthFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Resource not accessible"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+
+	_, err := c.EnsurePR(context.Background(), "o", "r", "h", "main", "t", "b", "tok")
+	if err == nil {
+		t.Fatal("want error on 403")
+	}
+}
+
+func TestHeadCommitSubject(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/commits/foreman/wl-x/issue-7", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"commit":{"message":"feat: add the thing\n\nLonger body.\nFixes #7"}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+
+	// Note: the ref is path-escaped by the client; httptest's mux
+	// matches the unescaped path.
+	got := c.HeadCommitSubject(context.Background(), "o", "r", "foreman/wl-x/issue-7", "tok")
+	if got != "feat: add the thing" {
+		t.Fatalf("subject: got %q", got)
+	}
+}
+
+func TestHeadCommitSubject_EmptyOnFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	if got := c.HeadCommitSubject(context.Background(), "o", "r", "b", "t"); got != "" {
+		t.Fatalf("want empty on 404, got %q", got)
+	}
+}

--- a/pkg/foreman/agent/runtask.go
+++ b/pkg/foreman/agent/runtask.go
@@ -29,6 +29,7 @@ import (
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 )
 
@@ -130,6 +131,9 @@ type RunTaskConfig struct {
 	// default (env / file token lookup).
 	AuthFactory func() (*repo.Auth, error)
 
+	// PREnsurer opens the PR on a review GO (#937). nil disables.
+	PREnsurer githubpr.Ensurer
+
 	// IssueFetcher pulls the GitHub issue body for issue-fix tasks with
 	// an empty payload prompt. Optional; nil preserves the empty-body
 	// behavior.
@@ -206,6 +210,7 @@ func RunTask(ctx context.Context, cfg RunTaskConfig) (RunTaskResult, error) {
 		RegistryFactory:              cfg.RegistryFactory,
 		AuthFactory:                  cfg.AuthFactory,
 		IssueFetcher:                 cfg.IssueFetcher,
+		PREnsurer:                    cfg.PREnsurer,
 	}
 
 	res, execErr := exec.Execute(ctx, &task)


### PR DESCRIPTION
## What

A reviewer GO now opens the Workload's pull request — idempotently — instead of leaving a reviewed branch unopened on the remote. New `githubpr` package (mirrors `githubissue`); `Workload.spec.openPullRequest` gates it (nil = **true** in issue-batch mode, `false` opts out; explicit pipelines set `payload.openPullRequest` per step).

## Why

Fixes #937

The pipeline ended one hop short of its artifact: coder GO → gate PASS → review GO → …a branch sitting on the remote until a human noticed. We have hand-opened 12 PRs for completed Workloads in production since filing #937.

## How

- `githubpr.EnsurePR`: list-by-head first (any state → reuse), then create; a 422 create race (two reviewer tasks GOing concurrently) resolves to the winner's PR. Title = branch head's commit subject (fallback `Fix #<n>`), base = `payload.baseBranch` (default main), body = `Fixes #<n>` + workload provenance.
- Executor: after the reviewer enforcement passes settle a GO, `maybeOpenPullRequest` runs best-effort with the same token the coder pushed with — the approval stands if GitHub is down; `pullRequestURL`/`pullRequestError` surface in result extra.
- Operator: `synthesizeIssueBatch` stamps `payload.openPullRequest` on review steps from the spec field (three-valued `*bool`, default true — an issue-batch Workload exists to produce a PR). CRDs + chart CRDs regenerated.
- `PREnsurer` is injected (like `IssueFetcher`); nil disables the feature entirely.

Follow-up candidates kept out of scope: draft PR on NO-GO carrying review findings (noted in #937), GHES base-URL config.

AI assistance: authored by Claude (Opus 4.8) operating under my direction; I reviewed the change and test output before submitting.

## Checklist

- [x] Tests added/updated (httptest client suite: create / reuse / 422 race / auth failure / title fallback; envtest: default-true, opt-out, review-step-only stamping)
- [x] `make test` passes locally (agent + controller suites green)
- [x] `make lint` passes locally (`golangci-lint run` 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — new fields documented in CRD/API comments