### PR TITLE
fix(foreman): accept workspace-internal absolute paths in resolveInside

### DIFF
--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -177,8 +177,19 @@ func TestResolveInside_Cases(t *testing.T) {
 		}
 	})
 
-	t.Run("absolute rejected", func(t *testing.T) {
-		_, err := resolveInside(ws, filepath.Join(ws, "ok.txt"))
+	t.Run("absolute inside workspace accepted", func(t *testing.T) {
+		abs := filepath.Join(ws, "ok.txt")
+		got, err := resolveInside(ws, abs)
+		if err != nil {
+			t.Fatalf("resolveInside absolute inside: %v", err)
+		}
+		if got != abs {
+			t.Errorf("absolute inside: got %q want %q", got, abs)
+		}
+	})
+
+	t.Run("absolute outside workspace rejected", func(t *testing.T) {
+		_, err := resolveInside(ws, "/etc/passwd")
 		if !errors.Is(err, ErrPathEscapesWorkspace) {
 			t.Errorf("expected ErrPathEscapesWorkspace, got %v", err)
 		}

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -218,6 +218,46 @@ func TestResolveInside_Cases(t *testing.T) {
 		}
 	})
 
+	// Prefix-collision: a sibling directory whose name has the workspace path
+	// as a string prefix (ws + "-evil") must NOT be treated as inside. This
+	// pins the guarantee that containment uses filepath.Rel (a real path
+	// relationship), not a naive strings.HasPrefix on the cleaned path.
+	t.Run("absolute prefix-collision sibling rejected", func(t *testing.T) {
+		evil := ws + "-evil"
+		if err := os.MkdirAll(evil, 0o755); err != nil {
+			t.Fatalf("mkdir sibling: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(evil) })
+		secret := filepath.Join(evil, "secret.txt")
+		if err := os.WriteFile(secret, []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed sibling secret: %v", err)
+		}
+		if _, err := resolveInside(ws, secret); !errors.Is(err, ErrPathEscapesWorkspace) {
+			t.Errorf("prefix-collision sibling must be rejected, got %v", err)
+		}
+	})
+
+	// Absolute + symlink escape: the new absolute-path branch must still be
+	// caught by the terminal symlink-resolution check. An in-workspace symlink
+	// to an outside dir, referenced by its ABSOLUTE path, must be rejected.
+	t.Run("absolute path through escaping symlink rejected", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink semantics differ on windows")
+		}
+		outside := t.TempDir()
+		if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed outside secret: %v", err)
+		}
+		link := filepath.Join(ws, "abs-escape-link")
+		if err := os.Symlink(outside, link); err != nil {
+			t.Fatalf("symlink: %v", err)
+		}
+		abs := filepath.Join(ws, "abs-escape-link", "secret.txt")
+		if _, err := resolveInside(ws, abs); !errors.Is(err, ErrPathEscapesWorkspace) {
+			t.Errorf("absolute path through escaping symlink must be rejected, got %v", err)
+		}
+	})
+
 	t.Run("nonexistent path ok for write_file", func(t *testing.T) {
 		_, err := resolveInside(ws, "subdir/new.txt")
 		if err != nil {

--- a/pkg/foreman/agent/tools/workspace.go
+++ b/pkg/foreman/agent/tools/workspace.go
@@ -43,10 +43,6 @@ var ErrPathEscapesWorkspace = errors.New("path escapes workspace")
 // is skipped. The workspace itself is EvalSymlinks-resolved so a
 // symlinked workspace is treated as its real path.
 func resolveInside(workspace, p string) (string, error) {
-	if filepath.IsAbs(p) {
-		return "", fmt.Errorf("%w: %q is absolute", ErrPathEscapesWorkspace, p)
-	}
-
 	wsAbs, err := filepath.Abs(workspace)
 	if err != nil {
 		return "", fmt.Errorf("workspace abs(%s): %w", workspace, err)
@@ -56,13 +52,29 @@ func resolveInside(workspace, p string) (string, error) {
 		return "", fmt.Errorf("workspace evalsymlinks(%s): %w", wsAbs, err)
 	}
 
+	// Accept absolute paths that live under the workspace root. Strip the
+	// workspace prefix and continue with the same containment checks as
+	// for a relative path. Absolute paths outside the workspace are still
+	// rejected so the model learns the rule.
+	if filepath.IsAbs(p) {
+		cleaned := filepath.Clean(p)
+		rel, relErr := filepath.Rel(wsResolved, cleaned)
+		if relErr != nil {
+			return "", fmt.Errorf("rel(%s,%s): %w", wsResolved, cleaned, relErr)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return "", fmt.Errorf("%w: absolute paths must be inside the workspace", ErrPathEscapesWorkspace)
+		}
+		p = rel
+	}
+
 	joined := filepath.Clean(filepath.Join(wsResolved, p))
 	rel, err := filepath.Rel(wsResolved, joined)
 	if err != nil {
 		return "", fmt.Errorf("rel(%s,%s): %w", wsResolved, joined, err)
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("%w: %q", ErrPathEscapesWorkspace, p)
+		return "", fmt.Errorf("%w: paths must be workspace-relative", ErrPathEscapesWorkspace)
 	}
 
 	// Only check symlink escape if the path actually exists. Unborn paths

--- a/pkg/foreman/agent/tools/workspace.go
+++ b/pkg/foreman/agent/tools/workspace.go
@@ -33,7 +33,10 @@ var ErrPathEscapesWorkspace = errors.New("path escapes workspace")
 // resolveInside returns the absolute path of p resolved against the
 // workspace dir, after enforcing:
 //
-//  1. p is not absolute.
+//  1. If p is absolute, it must resolve inside the workspace (an
+//     absolute path pointing outside is rejected); it is then treated as
+//     the equivalent workspace-relative path. Relative paths are used
+//     as-is.
 //  2. After Clean+Join, the result is still under the workspace.
 //  3. Following symlinks (if the path exists) does not escape the
 //     workspace.
@@ -74,7 +77,7 @@ func resolveInside(workspace, p string) (string, error) {
 		return "", fmt.Errorf("rel(%s,%s): %w", wsResolved, joined, err)
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("%w: paths must be workspace-relative", ErrPathEscapesWorkspace)
+		return "", fmt.Errorf("%w: %q resolves outside workspace", ErrPathEscapesWorkspace, p)
 	}
 
 	// Only check symlink escape if the path actually exists. Unborn paths


### PR DESCRIPTION
## What

Widens `resolveInside` (the path-containment boundary for every file tool) to accept absolute paths that resolve *inside* the workspace, instead of rejecting all absolute paths outright. External absolute paths are still rejected, now with a clearer message.

## Why

Fixes #945

Local coder models constantly quote absolute paths from their own bash output (`find`, `ls`, `git status` against `$WORKSPACE_ROOT`) and paste them into edit tools. The blanket rejection cost a full turn on each — fatal under the 3-turn restricted-edit budget of an aggressive stuck-loop profile. Observed live twice on the fleet (the #942/#943 validation runs).

## How

When the input is absolute, compute `filepath.Rel(wsResolved, filepath.Clean(p))`; reject if the result escapes (`..`), otherwise strip the prefix and fall through to the **unchanged** relative-path containment path (Join → Rel check → terminal `Lstat`+`EvalSymlinks` symlink-escape check). Containment is computed with `filepath.Rel` (a real path relationship), never a naive string prefix, so a sibling like `<ws>-evil` is correctly rejected.

Adversarially verified: prefix-collision, absolute traversal, non-existent-path lexical escape, and absolute-path-through-an-escaping-symlink (with real on-disk symlinks) all reject; only the accepted *spelling* of already-inside paths widens. The two highest-value cases (prefix-collision, absolute+symlink escape) are pinned as regression tests so a future refactor can't reintroduce a `strings.HasPrefix` bug.

Authored by **Foreman**, LLMKube's agentic coder harness (local model on the lab fleet); reviewed adversarially and hardened with the two extra containment tests by the maintainer, who takes responsibility for the change per the AI-assisted contribution policy.

## Checklist

- [x] Tests added/updated - `TestResolveInside_Cases` gains absolute-inside/outside, prefix-collision, and absolute-symlink-escape subtests
- [x] `make test` passes locally
- [x] `make lint` passes locally (+ `GOOS=linux golangci-lint`, 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - not user-facing (internal tool boundary)
