### PR TITLE
fix(foreman): defer generic self-gate when runtime is missing from coder image

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -701,7 +701,16 @@ func makeCoderGateVerifier(
 		// resolved commands. The Go path below is left byte-identical: a nil,
 		// empty-language, or explicit-"go" profile takes it unchanged.
 		if usesGenericGate(profile) {
-			pass, feedback := RunGenericGate(ctx, workspace, profile.Resolve(), execCommandRunner)
+			pass, feedback, advisories := RunGenericGate(ctx, workspace, profile.Resolve(), execCommandRunner)
+			if acc != nil {
+				*acc = append(*acc, advisories...)
+			}
+			for _, a := range advisories {
+				// A missing runtime in the coder image (#929) defers the check
+				// to the clean-room verify Job instead of failing the GO.
+				log.Info("coder gate (generic): check deferred; verify Job is the backstop",
+					"language", string(profile.Language), "check", a.Check, "detail", a.Detail)
+			}
 			if !pass {
 				log.Info("coder gate (generic): fast checks failed; returning feedback to the loop for a fix",
 					"language", string(profile.Language))

--- a/pkg/foreman/agent/generic_gate.go
+++ b/pkg/foreman/agent/generic_gate.go
@@ -18,6 +18,9 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os/exec"
 	"strings"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
@@ -34,11 +37,58 @@ func usesGenericGate(profile *foremanv1alpha1.GateProfile) bool {
 		profile.Language != foremanv1alpha1.GateLanguageGo
 }
 
+// genericGateDeferredCheck names the advisory emitted when a self-gate
+// command is deferred to the clean-room verify Job because its runtime is
+// missing from the coder image.
+const genericGateDeferredCheck = "self-gate-deferred"
+
+// missingRuntimeExitCode is the POSIX shell exit status for "command not
+// found": the interpreter the gate command needs is absent from the image,
+// not that the gate ran and genuinely failed.
+const missingRuntimeExitCode = 127
+
+// exitCoder matches errors that expose a process exit code (notably
+// *exec.ExitError). Declared as an interface so table-driven tests can
+// supply a fake without shelling out.
+type exitCoder interface{ ExitCode() int }
+
+// isMissingRuntime reports whether a gate command failed because the
+// runtime/binary it needs is absent from the pod image (exit 127 from the
+// shell, an exec ENOENT, or the shell's "command not found" / ": not found"
+// message) rather than because the gate ran and genuinely failed. err is the
+// commandRunner error and output the command's combined stdout+stderr. The
+// output match is deliberately narrow — the exact shell phrasings — so a
+// test failure whose output merely mentions "not found" is not misread as a
+// missing runtime.
+func isMissingRuntime(err error, output string) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	var ec exitCoder
+	if errors.As(err, &ec) && ec.ExitCode() == missingRuntimeExitCode {
+		return true
+	}
+	combined := strings.ToLower(output + "\n" + err.Error())
+	return strings.Contains(combined, "command not found") ||
+		strings.Contains(combined, ": not found")
+}
+
 // RunGenericGate runs a language-agnostic fast gate by executing the
 // resolved profile's commands in the workspace via `sh -c`. Each non-empty
 // command (format, lint, build, test, codegen) is one check, and a non-zero
 // exit is a failure. Like RunCoderGate, every check runs regardless of
 // earlier failures so the feedback reports everything wrong at once.
+//
+// A command that cannot run because its runtime/binary is missing from the
+// coder image (see isMissingRuntime) does NOT fail the gate: the published
+// coder image is Go-only, so a node/python gate command would otherwise hit
+// "command not found" and spuriously downgrade a correct GO (#929). Such a
+// check is skipped with a deferral advisory — the clean-room verify Job,
+// which runs in gateProfile.image, remains the authoritative gate for it.
+// A command that ran and genuinely failed still fails as before.
 //
 // Non-Go GateProfiles use this path. The Go profile keeps the specialized
 // RunCoderGate, which carries the Go-specific semantics (gofmt's
@@ -50,7 +100,7 @@ func RunGenericGate(
 	workspace string,
 	gate foremanv1alpha1.ResolvedGate,
 	run commandRunner,
-) (pass bool, feedback string) {
+) (pass bool, feedback string, advisories []advisory) {
 	checks := []struct {
 		name string
 		cmd  string
@@ -68,13 +118,25 @@ func RunGenericGate(
 		if cmd == "" {
 			continue
 		}
-		if out, err := run(ctx, workspace, nil, "sh", "-c", cmd); err != nil {
-			failures = append(failures, checkFailure{name: c.name + ": " + cmd, output: out})
+		out, err := run(ctx, workspace, nil, "sh", "-c", cmd)
+		if err == nil {
+			continue
 		}
+		if isMissingRuntime(err, out) {
+			advisories = append(advisories, advisory{
+				Check: genericGateDeferredCheck,
+				Detail: fmt.Sprintf(
+					"self-gate deferred: runtime missing in the coder image for %s command %q; "+
+						"the clean-room verify Job (gateProfile.image) is the authoritative gate for this check",
+					c.name, cmd),
+			})
+			continue
+		}
+		failures = append(failures, checkFailure{name: c.name + ": " + cmd, output: out})
 	}
 
 	if len(failures) == 0 {
-		return true, ""
+		return true, "", advisories
 	}
-	return false, buildFeedback(failures)
+	return false, buildFeedback(failures), advisories
 }

--- a/pkg/foreman/agent/generic_gate_test.go
+++ b/pkg/foreman/agent/generic_gate_test.go
@@ -10,6 +10,8 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -54,9 +56,12 @@ func TestRunGenericGateAllPassRunsEachViaShC(t *testing.T) {
 		Build:  "python -m compileall .",
 		Test:   "pytest -q",
 	}
-	pass, fb := RunGenericGate(context.Background(), "/ws", gate, run)
+	pass, fb, advisories := RunGenericGate(context.Background(), "/ws", gate, run)
 	if !pass || fb != "" {
 		t.Fatalf("want pass with empty feedback; got pass=%v feedback=%q", pass, fb)
+	}
+	if len(advisories) != 0 {
+		t.Fatalf("want no advisories on a clean pass, got %+v", advisories)
 	}
 	if len(calls) != 4 {
 		t.Fatalf("want 4 commands run (empty codegen skipped), got %d: %+v", len(calls), calls)
@@ -81,11 +86,147 @@ func TestRunGenericGateSkipsEmptyAndCollectsFailures(t *testing.T) {
 		Lint: "ruff check .",
 		Test: "pytest -q",
 	}
-	pass, fb := RunGenericGate(context.Background(), "/ws", gate, run)
+	pass, fb, advisories := RunGenericGate(context.Background(), "/ws", gate, run)
 	if pass {
 		t.Fatal("want fail when lint and test fail")
 	}
 	if !strings.Contains(fb, "ruff check") || !strings.Contains(fb, "pytest") {
 		t.Errorf("feedback should name both failing checks; got %q", fb)
 	}
+	if len(advisories) != 0 {
+		t.Fatalf("real command failures must not produce deferral advisories, got %+v", advisories)
+	}
+}
+
+// fakeExitErr is an error exposing an exit code, standing in for
+// *exec.ExitError in table-driven tests without shelling out.
+type fakeExitErr struct{ code int }
+
+func (e fakeExitErr) Error() string { return fmt.Sprintf("exit status %d", e.code) }
+func (e fakeExitErr) ExitCode() int { return e.code }
+
+func TestIsMissingRuntime(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		output string
+		want   bool
+	}{
+		{"nil error never defers", nil, "sh: npm: not found", false},
+		{"exit 127 defers", fakeExitErr{127}, "", true},
+		{"exec.ErrNotFound defers", exec.ErrNotFound, "", true},
+		{"wrapped exec.ErrNotFound defers", fmt.Errorf("run: %w", exec.ErrNotFound), "", true},
+		{"bash-style command not found defers", errors.New("exit status 127"),
+			"sh: npm: command not found\n", true},
+		{"dash-style not found defers", fakeExitErr{2}, "sh: 1: python3: not found\n", true},
+		{"plain test failure does not defer", fakeExitErr{1}, "FAIL tests/test_api.py\n", false},
+		{"pytest fixture not found does not defer", fakeExitErr{1},
+			"E fixture 'db' not found\n", false},
+		{"http 404 output does not defer", fakeExitErr{1}, "npm ERR! 404 Not Found\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMissingRuntime(tc.err, tc.output); got != tc.want {
+				t.Errorf("isMissingRuntime(%v, %q) = %v, want %v", tc.err, tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunGenericGateMissingRuntimeDefersNotFails(t *testing.T) {
+	// npm is absent from the (Go-only) coder image: the shell exits 127.
+	run := func(_ context.Context, _ string, _ []string, _ string, args ...string) (string, error) {
+		if strings.Contains(strings.Join(args, " "), "npm") {
+			return "sh: npm: not found\n", fakeExitErr{127}
+		}
+		return "", nil
+	}
+	gate := foremanv1alpha1.ResolvedGate{
+		Lint: "eslint .",
+		Test: "npm ci && npm test",
+	}
+	pass, fb, advisories := RunGenericGate(context.Background(), "/ws", gate, run)
+	if !pass || fb != "" {
+		t.Fatalf("missing runtime must not fail the self-gate; got pass=%v feedback=%q", pass, fb)
+	}
+	if len(advisories) != 1 {
+		t.Fatalf("want 1 deferral advisory, got %+v", advisories)
+	}
+	if advisories[0].Check != genericGateDeferredCheck {
+		t.Errorf("advisory check = %q, want %q", advisories[0].Check, genericGateDeferredCheck)
+	}
+	if !strings.Contains(advisories[0].Detail, "self-gate deferred: runtime missing") ||
+		!strings.Contains(advisories[0].Detail, "npm ci && npm test") {
+		t.Errorf("advisory should say the runtime is missing and name the command; got %q", advisories[0].Detail)
+	}
+}
+
+func TestRunGenericGateMixedDeferralAndRealFailure(t *testing.T) {
+	run := func(_ context.Context, _ string, _ []string, _ string, args ...string) (string, error) {
+		cmd := strings.Join(args, " ")
+		switch {
+		case strings.Contains(cmd, "npm"):
+			return "sh: npm: command not found\n", fakeExitErr{127}
+		case strings.Contains(cmd, "ruff"):
+			return "would reformat app.py\n", fakeExitErr{1}
+		}
+		return "", nil
+	}
+	gate := foremanv1alpha1.ResolvedGate{
+		Format: "ruff format --check .",
+		Test:   "npm test",
+	}
+	pass, fb, advisories := RunGenericGate(context.Background(), "/ws", gate, run)
+	if pass {
+		t.Fatal("a real failure must still fail the gate even when another check deferred")
+	}
+	if !strings.Contains(fb, "ruff format") {
+		t.Errorf("feedback should name the real failure; got %q", fb)
+	}
+	if strings.Contains(fb, "npm test") {
+		t.Errorf("feedback must not report the deferred check as a failure; got %q", fb)
+	}
+	if len(advisories) != 1 || !strings.Contains(advisories[0].Detail, "npm test") {
+		t.Errorf("want one deferral advisory naming the npm command, got %+v", advisories)
+	}
+}
+
+// TestRunGenericGateRealExec exercises the production execCommandRunner:
+// a genuinely absent binary defers, a command that runs and fails still
+// fails, and a passing command passes.
+func TestRunGenericGateRealExec(t *testing.T) {
+	ws := t.TempDir()
+
+	t.Run("missing binary defers", func(t *testing.T) {
+		gate := foremanv1alpha1.ResolvedGate{Test: "llmkube-no-such-binary-929 --version"}
+		pass, fb, advisories := RunGenericGate(context.Background(), ws, gate, execCommandRunner)
+		if !pass || fb != "" {
+			t.Fatalf("want deferral (pass, no feedback); got pass=%v feedback=%q", pass, fb)
+		}
+		if len(advisories) != 1 || !strings.Contains(advisories[0].Detail, "runtime missing") {
+			t.Fatalf("want a runtime-missing advisory, got %+v", advisories)
+		}
+	})
+
+	t.Run("real failure still fails", func(t *testing.T) {
+		gate := foremanv1alpha1.ResolvedGate{Test: "echo tests failed; exit 1"}
+		pass, fb, advisories := RunGenericGate(context.Background(), ws, gate, execCommandRunner)
+		if pass {
+			t.Fatal("a command that runs and exits non-zero must fail the gate")
+		}
+		if !strings.Contains(fb, "tests failed") {
+			t.Errorf("feedback should carry the command output; got %q", fb)
+		}
+		if len(advisories) != 0 {
+			t.Errorf("want no advisories for a real failure, got %+v", advisories)
+		}
+	})
+
+	t.Run("passing command passes", func(t *testing.T) {
+		gate := foremanv1alpha1.ResolvedGate{Test: "true"}
+		pass, fb, advisories := RunGenericGate(context.Background(), ws, gate, execCommandRunner)
+		if !pass || fb != "" || len(advisories) != 0 {
+			t.Fatalf("want clean pass; got pass=%v feedback=%q advisories=%+v", pass, fb, advisories)
+		}
+	})
 }


### PR DESCRIPTION
## What

When a generic (non-Go) self-gate command cannot run because its runtime/binary is missing from the coder image (exit 127 / exec ENOENT / shell "command not found"), skip the check with a "self-gate deferred: runtime missing" advisory instead of failing the gate. A command that ran and genuinely failed still fails as before; the Go gate path is untouched.

## Why

Fixes #929

The published coder image is Go-only, so a correct node/python `gateProfile` command fails "command not found" in the in-pod fast self-gate, gets retried 3 times, and downgrades the GO to INCOMPLETE — the clean-room verify Job (which runs in `gateProfile.image` and would pass) never gets a branch to verify.

AI assistance: authored by Claude (Opus 4.8) operating under the maintainer's direction; reviewed before submitting.

## How

- `RunGenericGate` classifies each command error via a new `isMissingRuntime` (exit 127, `exec.ErrNotFound`, or the shell's "command not found" / ": not found" message — matched narrowly so a test failure that merely mentions "not found" is not misread) and returns deferrals as advisories alongside pass/feedback.
- `makeCoderGateVerifier` appends those advisories to the existing `gateAdvisories` accumulator, so the deferral surfaces to the reviewer via `Result.Extra["gateAdvisories"]`, and logs each deferral.
- Tests: table-driven `isMissingRuntime` cases (incl. non-deferring false positives), fake-runner gate tests (127 → deferred, real failure → still fails, mixed), and a real-exec test through `execCommandRunner` (missing binary defers, `exit 1` fails, `true` passes).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go test ./pkg/foreman/... -count=1` green)
- [x] `make lint` passes locally (`golangci-lint run ./pkg/foreman/...` — 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)