### PR TITLE
feat(foreman): bounded fix iteration on reviewer NO-GO instead of terminal failure

### DIFF
--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -185,6 +185,27 @@ type WorkloadSpec struct {
 	// +optional
 	AllowOverwrite bool `json:"allowOverwrite,omitempty"`
 
+	// MaxReviewIterations bounds how many fix iterations the
+	// WorkloadReconciler may append per issue after a reviewer NO-GO
+	// (#946). On a NO-GO, instead of failing the Workload, the
+	// reconciler emits a new coder task ("code-<N>-r<k>", same
+	// CoderAgentRef, same branch, payload.allowOverwrite=true) whose
+	// payload.prompt carries the reviewer's structured findings and
+	// summary, then chains a fresh verify + reviewer fan-out behind
+	// it ("verify-<N>-r<k>", "review-<N>-<i>-r<k>"). Superseded
+	// iterations stop counting toward the rollup; the Workload
+	// completes when the final iteration's reviewers say GO and
+	// fails (today's behavior) when the last allowed iteration is
+	// still NO-GO.
+	//
+	// nil (unset) defaults to 1 iteration. An explicit 0 disables
+	// iteration and restores the fail-on-first-NO-GO behavior.
+	// Issue-batch mode only; ignored in explicit Pipeline mode.
+	// Iteration tasks count against MaxTasks.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxReviewIterations *int32 `json:"maxReviewIterations,omitempty"`
+
 	// AllowCloudReviewers gates whether reviewer Agents whose
 	// spec.provider is "cloud-proxy" (or any non-"local" value) may be
 	// dispatched for this Workload. Three-valued via the *bool:
@@ -303,6 +324,15 @@ type WorkloadStatus struct {
 	// branch didn't pass the checks."
 	// +optional
 	IncompleteTasks int32 `json:"incompleteTasks,omitempty"`
+
+	// ReviewIterations counts the fix iterations the reconciler has
+	// emitted after reviewer NO-GO verdicts (#946), summed across
+	// issues. Zero (or absent) means no reviewer ever bounced a
+	// branch back to the coder; operators watch this to distinguish
+	// convergence (small counts) from thrash (counts near
+	// issues * maxReviewIterations).
+	// +optional
+	ReviewIterations int32 `json:"reviewIterations,omitempty"`
 
 	// PlannerModel records which frontier model the planner actually used
 	// for this workload. Set after the planner runs.

--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -188,11 +188,14 @@ type WorkloadSpec struct {
 	// MaxReviewIterations bounds how many fix iterations the
 	// WorkloadReconciler may append per issue after a reviewer NO-GO
 	// (#946). On a NO-GO, instead of failing the Workload, the
-	// reconciler emits a new coder task ("code-<N>-r<k>", same
-	// CoderAgentRef, same branch, payload.allowOverwrite=true) whose
-	// payload.prompt carries the reviewer's structured findings and
-	// summary, then chains a fresh verify + reviewer fan-out behind
-	// it ("verify-<N>-r<k>", "review-<N>-<i>-r<k>"). Superseded
+	// reconciler emits a new coder task ("code-<N>-r<k>", using
+	// RevisionCoderAgentRef when set and CoderAgentRef otherwise, same
+	// branch, payload.reviseFromBranch naming that branch so the
+	// executor restores the prior attempt (#951), and
+	// payload.allowOverwrite=true) whose payload.prompt carries the
+	// reviewer's structured findings and summary, then chains a fresh
+	// verify + reviewer fan-out behind it ("verify-<N>-r<k>",
+	// "review-<N>-<i>-r<k>"). Superseded
 	// iterations stop counting toward the rollup; the Workload
 	// completes when the final iteration's reviewers say GO and
 	// fails (today's behavior) when the last allowed iteration is
@@ -205,6 +208,20 @@ type WorkloadSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MaxReviewIterations *int32 `json:"maxReviewIterations,omitempty"`
+
+	// RevisionCoderAgentRef optionally names the same-namespace Agent
+	// the fix-iteration coder steps ("code-<N>-r<k>") reference instead
+	// of CoderAgentRef. A revision task amends its restored prior
+	// attempt (payload.reviseFromBranch, #951) rather than building a
+	// fix from scratch, and the issue-fix Agent's forcing profile is
+	// tuned for the latter — #951's live validation showed a revision
+	// task collapsing under the issue-fix profile's forcing windows.
+	// When unset, iteration coder steps fall back to CoderAgentRef and
+	// the reconciler emits a Warning event on the Workload (reason
+	// RevisionUnderIssueFixProfile). Issue-batch mode only; ignored in
+	// explicit Pipeline mode.
+	// +optional
+	RevisionCoderAgentRef *corev1.LocalObjectReference `json:"revisionCoderAgentRef,omitempty"`
 
 	// AllowCloudReviewers gates whether reviewer Agents whose
 	// spec.provider is "cloud-proxy" (or any non-"local" value) may be

--- a/api/foreman/v1alpha1/zz_generated.deepcopy.go
+++ b/api/foreman/v1alpha1/zz_generated.deepcopy.go
@@ -1002,6 +1002,11 @@ func (in *WorkloadSpec) DeepCopyInto(out *WorkloadSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RevisionCoderAgentRef != nil {
+		in, out := &in.RevisionCoderAgentRef, &out.RevisionCoderAgentRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	if in.AllowCloudReviewers != nil {
 		in, out := &in.AllowCloudReviewers, &out.AllowCloudReviewers
 		*out = new(bool)

--- a/api/foreman/v1alpha1/zz_generated.deepcopy.go
+++ b/api/foreman/v1alpha1/zz_generated.deepcopy.go
@@ -997,6 +997,11 @@ func (in *WorkloadSpec) DeepCopyInto(out *WorkloadSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxReviewIterations != nil {
+		in, out := &in.MaxReviewIterations, &out.MaxReviewIterations
+		*out = new(int32)
+		**out = **in
+	}
 	if in.AllowCloudReviewers != nil {
 		in, out := &in.AllowCloudReviewers, &out.AllowCloudReviewers
 		*out = new(bool)

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -229,6 +229,28 @@ spec:
                   format: int32
                   type: integer
                 type: array
+              maxReviewIterations:
+                description: |-
+                  MaxReviewIterations bounds how many fix iterations the
+                  WorkloadReconciler may append per issue after a reviewer NO-GO
+                  (#946). On a NO-GO, instead of failing the Workload, the
+                  reconciler emits a new coder task ("code-<N>-r<k>", same
+                  CoderAgentRef, same branch, payload.allowOverwrite=true) whose
+                  payload.prompt carries the reviewer's structured findings and
+                  summary, then chains a fresh verify + reviewer fan-out behind
+                  it ("verify-<N>-r<k>", "review-<N>-<i>-r<k>"). Superseded
+                  iterations stop counting toward the rollup; the Workload
+                  completes when the final iteration's reviewers say GO and
+                  fails (today's behavior) when the last allowed iteration is
+                  still NO-GO.
+
+                  nil (unset) defaults to 1 iteration. An explicit 0 disables
+                  iteration and restores the fail-on-first-NO-GO behavior.
+                  Issue-batch mode only; ignored in explicit Pipeline mode.
+                  Iteration tasks count against MaxTasks.
+                format: int32
+                minimum: 0
+                type: integer
               maxTasks:
                 description: |-
                   MaxTasks caps how many AgenticTasks may be emitted. Zero means no
@@ -653,6 +675,16 @@ spec:
                   PlannerModel records which frontier model the planner actually used
                   for this workload. Set after the planner runs.
                 type: string
+              reviewIterations:
+                description: |-
+                  ReviewIterations counts the fix iterations the reconciler has
+                  emitted after reviewer NO-GO verdicts (#946), summed across
+                  issues. Zero (or absent) means no reviewer ever bounced a
+                  branch back to the coder; operators watch this to distinguish
+                  convergence (small counts) from thrash (counts near
+                  issues * maxReviewIterations).
+                format: int32
+                type: integer
               succeededTasks:
                 description: |-
                   SucceededTasks counts child tasks that reached a positive terminal

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -234,11 +234,14 @@ spec:
                   MaxReviewIterations bounds how many fix iterations the
                   WorkloadReconciler may append per issue after a reviewer NO-GO
                   (#946). On a NO-GO, instead of failing the Workload, the
-                  reconciler emits a new coder task ("code-<N>-r<k>", same
-                  CoderAgentRef, same branch, payload.allowOverwrite=true) whose
-                  payload.prompt carries the reviewer's structured findings and
-                  summary, then chains a fresh verify + reviewer fan-out behind
-                  it ("verify-<N>-r<k>", "review-<N>-<i>-r<k>"). Superseded
+                  reconciler emits a new coder task ("code-<N>-r<k>", using
+                  RevisionCoderAgentRef when set and CoderAgentRef otherwise, same
+                  branch, payload.reviseFromBranch naming that branch so the
+                  executor restores the prior attempt (#951), and
+                  payload.allowOverwrite=true) whose payload.prompt carries the
+                  reviewer's structured findings and summary, then chains a fresh
+                  verify + reviewer fan-out behind it ("verify-<N>-r<k>",
+                  "review-<N>-<i>-r<k>"). Superseded
                   iterations stop counting toward the rollup; the Workload
                   completes when the final iteration's reviewers say GO and
                   fails (today's behavior) when the last allowed iteration is
@@ -563,6 +566,31 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              revisionCoderAgentRef:
+                description: |-
+                  RevisionCoderAgentRef optionally names the same-namespace Agent
+                  the fix-iteration coder steps ("code-<N>-r<k>") reference instead
+                  of CoderAgentRef. A revision task amends its restored prior
+                  attempt (payload.reviseFromBranch, #951) rather than building a
+                  fix from scratch, and the issue-fix Agent's forcing profile is
+                  tuned for the latter — #951's live validation showed a revision
+                  task collapsing under the issue-fix profile's forcing windows.
+                  When unset, iteration coder steps fall back to CoderAgentRef and
+                  the reconciler emits a Warning event on the Workload (reason
+                  RevisionUnderIssueFixProfile). Issue-batch mode only; ignored in
+                  explicit Pipeline mode.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               verifierAgentRef:
                 description: |-
                   VerifierAgentRef is required when Issues is set: names the same-

--- a/charts/foreman/templates/operator-rbac.yaml
+++ b/charts/foreman/templates/operator-rbac.yaml
@@ -71,6 +71,11 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  # The WorkloadReconciler's EventRecorder (client-go tools/events)
+  # writes events.k8s.io/v1 Events.
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/cmd/foreman-operator/main.go
+++ b/cmd/foreman-operator/main.go
@@ -127,6 +127,7 @@ func main() {
 	if err := (&foremancontroller.WorkloadReconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),
+		Recorder:            mgr.GetEventRecorder("workload-controller"),
 		AllowCloudProviders: allowCloudProviders,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Workload")

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -229,6 +229,28 @@ spec:
                   format: int32
                   type: integer
                 type: array
+              maxReviewIterations:
+                description: |-
+                  MaxReviewIterations bounds how many fix iterations the
+                  WorkloadReconciler may append per issue after a reviewer NO-GO
+                  (#946). On a NO-GO, instead of failing the Workload, the
+                  reconciler emits a new coder task ("code-<N>-r<k>", same
+                  CoderAgentRef, same branch, payload.allowOverwrite=true) whose
+                  payload.prompt carries the reviewer's structured findings and
+                  summary, then chains a fresh verify + reviewer fan-out behind
+                  it ("verify-<N>-r<k>", "review-<N>-<i>-r<k>"). Superseded
+                  iterations stop counting toward the rollup; the Workload
+                  completes when the final iteration's reviewers say GO and
+                  fails (today's behavior) when the last allowed iteration is
+                  still NO-GO.
+
+                  nil (unset) defaults to 1 iteration. An explicit 0 disables
+                  iteration and restores the fail-on-first-NO-GO behavior.
+                  Issue-batch mode only; ignored in explicit Pipeline mode.
+                  Iteration tasks count against MaxTasks.
+                format: int32
+                minimum: 0
+                type: integer
               maxTasks:
                 description: |-
                   MaxTasks caps how many AgenticTasks may be emitted. Zero means no
@@ -653,6 +675,16 @@ spec:
                   PlannerModel records which frontier model the planner actually used
                   for this workload. Set after the planner runs.
                 type: string
+              reviewIterations:
+                description: |-
+                  ReviewIterations counts the fix iterations the reconciler has
+                  emitted after reviewer NO-GO verdicts (#946), summed across
+                  issues. Zero (or absent) means no reviewer ever bounced a
+                  branch back to the coder; operators watch this to distinguish
+                  convergence (small counts) from thrash (counts near
+                  issues * maxReviewIterations).
+                format: int32
+                type: integer
               succeededTasks:
                 description: |-
                   SucceededTasks counts child tasks that reached a positive terminal

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -234,11 +234,14 @@ spec:
                   MaxReviewIterations bounds how many fix iterations the
                   WorkloadReconciler may append per issue after a reviewer NO-GO
                   (#946). On a NO-GO, instead of failing the Workload, the
-                  reconciler emits a new coder task ("code-<N>-r<k>", same
-                  CoderAgentRef, same branch, payload.allowOverwrite=true) whose
-                  payload.prompt carries the reviewer's structured findings and
-                  summary, then chains a fresh verify + reviewer fan-out behind
-                  it ("verify-<N>-r<k>", "review-<N>-<i>-r<k>"). Superseded
+                  reconciler emits a new coder task ("code-<N>-r<k>", using
+                  RevisionCoderAgentRef when set and CoderAgentRef otherwise, same
+                  branch, payload.reviseFromBranch naming that branch so the
+                  executor restores the prior attempt (#951), and
+                  payload.allowOverwrite=true) whose payload.prompt carries the
+                  reviewer's structured findings and summary, then chains a fresh
+                  verify + reviewer fan-out behind it ("verify-<N>-r<k>",
+                  "review-<N>-<i>-r<k>"). Superseded
                   iterations stop counting toward the rollup; the Workload
                   completes when the final iteration's reviewers say GO and
                   fails (today's behavior) when the last allowed iteration is
@@ -563,6 +566,31 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              revisionCoderAgentRef:
+                description: |-
+                  RevisionCoderAgentRef optionally names the same-namespace Agent
+                  the fix-iteration coder steps ("code-<N>-r<k>") reference instead
+                  of CoderAgentRef. A revision task amends its restored prior
+                  attempt (payload.reviseFromBranch, #951) rather than building a
+                  fix from scratch, and the issue-fix Agent's forcing profile is
+                  tuned for the latter — #951's live validation showed a revision
+                  task collapsing under the issue-fix profile's forcing windows.
+                  When unset, iteration coder steps fall back to CoderAgentRef and
+                  the reconciler emits a Warning event on the Workload (reason
+                  RevisionUnderIssueFixProfile). Issue-batch mode only; ignored in
+                  explicit Pipeline mode.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               verifierAgentRef:
                 description: |-
                   VerifierAgentRef is required when Issues is set: names the same-

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -140,6 +140,22 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// review tasks so the reviewer's prompt can surface them.
 		r.patchReviewAdvisories(ctx, &workload, children)
 
+		// Fix-iteration emission (#946): a reviewer NO-GO re-dispatches
+		// the coder with the review feedback instead of failing the
+		// Workload, bounded by spec.maxReviewIterations. Runs before
+		// escalation so a fresh round defers the escalation tier until
+		// the iterations settle.
+		children, err = r.emitReviewIterations(ctx, &workload, children)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("emit review iterations: %w", err)
+		}
+
+		// Downstream consumers judge each issue by its LATEST fix
+		// iteration: a superseded round's terminal NO-GO must neither
+		// re-fire escalation nor pin the rollup at Failed after a later
+		// round converged.
+		children = activeChildren(&workload, children)
+
 		// Second-pass emission (#546): escalation reviewers fire here,
 		// after base reviewer verdicts land, before status rollup.
 		children, err = r.emitEscalations(ctx, &workload, children)

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -54,6 +55,12 @@ import (
 type WorkloadReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	// Recorder feeds operator-facing Kubernetes events on Workloads
+	// (e.g. Warning RevisionUnderIssueFixProfile when a fix iteration
+	// falls back to the issue-fix coder profile, #951). Optional: nil
+	// (as in most tests) disables event emission.
+	Recorder events.EventRecorder
 
 	// AllowCloudProviders is the operator-level sovereignty kill
 	// switch. True (default) lets reviewer Agents with
@@ -107,6 +114,8 @@ const conditionTypeEscalationTriggered = "EscalationTriggered"
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads/finalizers,verbs=update
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=agentictasks,verbs=create;get;list;watch
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=agents,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile drives a Workload through Planning -> Planned -> Dispatched ->
 // Completed | Failed.

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -579,6 +580,9 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 			ReviewerAgentRefs: []corev1.LocalObjectReference{
 				{Name: "reviewer"},
 			},
+			// Explicit 0 opts out of the #946 fix iteration so this
+			// test keeps pinning the immediate fail-on-NO-GO terminal.
+			MaxReviewIterations: ptr.To(int32(0)),
 		})
 		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
 		DeferCleanup(func() {
@@ -640,6 +644,9 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 			EscalationReviewerAgentRefs: []corev1.LocalObjectReference{
 				{Name: "big-reviewer"},
 			},
+			// Opt out of the #946 fix iteration: this test pins the
+			// #546 escalate-on-first-NO-GO semantics in isolation.
+			MaxReviewIterations: ptr.To(int32(0)),
 		})
 		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
 		DeferCleanup(func() {
@@ -770,6 +777,9 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 			EscalationReviewerAgentRefs: []corev1.LocalObjectReference{
 				{Name: "esc-cloud-big"},
 			},
+			// Opt out of the #946 fix iteration: this test pins the
+			// #546 escalate-on-first-NO-GO semantics in isolation.
+			MaxReviewIterations: ptr.To(int32(0)),
 		})
 		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
 		DeferCleanup(func() {
@@ -832,6 +842,9 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 			EscalationReviewerAgentRefs: []corev1.LocalObjectReference{
 				{Name: "big-reviewer"},
 			},
+			// Opt out of the #946 fix iteration: this test pins the
+			// #546 escalate-on-first-NO-GO semantics in isolation.
+			MaxReviewIterations: ptr.To(int32(0)),
 		})
 		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
 		DeferCleanup(func() {

--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -1,0 +1,556 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
+)
+
+// conditionTypeReviewIterationTriggered reports that at least one
+// issue's reviewer round went terminal with a NO-GO and a bounded fix
+// iteration was appended (#946): a new coder task carrying the review
+// feedback in payload.prompt, plus a fresh verify + reviewer fan-out
+// chained behind it.
+const conditionTypeReviewIterationTriggered = "ReviewIterationTriggered"
+
+// defaultMaxReviewIterations is the per-issue fix-iteration bound when
+// Workload.spec.maxReviewIterations is unset. One iteration mirrors
+// what a human does with a single request-changes round; an explicit 0
+// opts back into the pre-#946 fail-on-first-NO-GO behavior.
+const defaultMaxReviewIterations = 1
+
+// effectiveMaxReviewIterations resolves the *int32 three-state:
+// nil defaults, explicit values (including 0) win.
+func effectiveMaxReviewIterations(w *foremanv1alpha1.Workload) int {
+	if w.Spec.MaxReviewIterations == nil {
+		return defaultMaxReviewIterations
+	}
+	return int(*w.Spec.MaxReviewIterations)
+}
+
+// iterationSuffixed renders the step name for fix iteration k: the
+// base name for the initial round (k=0), "<base>-r<k>" for k >= 1.
+func iterationSuffixed(base string, k int) string {
+	if k == 0 {
+		return base
+	}
+	return fmt.Sprintf("%s-r%d", base, k)
+}
+
+func codeStepName(n int32, k int) string {
+	return iterationSuffixed(fmt.Sprintf("code-%d", n), k)
+}
+
+func verifyStepName(n int32, k int) string {
+	return iterationSuffixed(fmt.Sprintf("verify-%d", n), k)
+}
+
+func reviewStepName(n int32, i, k int) string {
+	return iterationSuffixed(fmt.Sprintf("review-%d-%d", n, i), k)
+}
+
+// parseIterationTail matches "<base>" (iteration 0) or "<base>-r<k>"
+// (iteration k >= 1). Returns ok=false for anything else, including
+// longer names that merely share the base as a prefix (code-64 must
+// not match code-641).
+func parseIterationTail(step, base string) (int, bool) {
+	if step == base {
+		return 0, true
+	}
+	tail, found := strings.CutPrefix(step, base+"-r")
+	if !found {
+		return 0, false
+	}
+	k, err := strconv.Atoi(tail)
+	if err != nil || k < 1 {
+		return 0, false
+	}
+	return k, true
+}
+
+// reviewIterationOf parses a reviewer fan-out step name for issue n
+// ("review-<n>-<i>" or "review-<n>-<i>-r<k>") and returns its fix
+// iteration. The reviewer index digits are validated so issue 64
+// never cross-matches review-641-0.
+func reviewIterationOf(step string, n int32) (int, bool) {
+	rest, found := strings.CutPrefix(step, fmt.Sprintf("review-%d-", n))
+	if !found {
+		return 0, false
+	}
+	idx, tail, hasIter := strings.Cut(rest, "-r")
+	if idx == "" {
+		return 0, false
+	}
+	for _, c := range idx {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+	}
+	if !hasIter {
+		return 0, true
+	}
+	k, err := strconv.Atoi(tail)
+	if err != nil || k < 1 {
+		return 0, false
+	}
+	return k, true
+}
+
+// issueStepIteration classifies a synthesized issue-batch step name
+// (code / verify / review, any iteration) for issue n. Escalation
+// steps and foreign names return ok=false.
+func issueStepIteration(step string, n int32) (int, bool) {
+	if k, ok := parseIterationTail(step, fmt.Sprintf("code-%d", n)); ok {
+		return k, true
+	}
+	if k, ok := parseIterationTail(step, fmt.Sprintf("verify-%d", n)); ok {
+		return k, true
+	}
+	return reviewIterationOf(step, n)
+}
+
+// noGoReviewRound inspects issue n's reviewer fan-out for fix
+// iteration k. It returns the NO-GO review tasks when the round is
+// complete — at least one review child exists, every one is terminal
+// (Phase Succeeded or Failed), and at least one carries verdict=NO-GO
+// — and nil otherwise. A cascade INCOMPLETE after GATE-FAIL (#548) is
+// terminal but not a NO-GO, so a branch the gate rejected never
+// triggers a fix iteration. Scanning what exists (rather than the
+// expected reviewer count) keeps cloud-suppressed reviewers from
+// permanently blocking the trigger, mirroring escalationSteps.
+func noGoReviewRound(
+	children []foremanv1alpha1.AgenticTask, n int32, k int,
+) []*foremanv1alpha1.AgenticTask {
+	var total, terminal int
+	var noGo []*foremanv1alpha1.AgenticTask
+	for i := range children {
+		iter, ok := reviewIterationOf(children[i].Labels[labelStep], n)
+		if !ok || iter != k {
+			continue
+		}
+		total++
+		phase := children[i].Status.Phase
+		if phase == foremanv1alpha1.AgenticTaskPhaseSucceeded ||
+			phase == foremanv1alpha1.AgenticTaskPhaseFailed {
+			terminal++
+		}
+		if children[i].Status.Verdict == foremanv1alpha1.AgenticTaskVerdictNoGo {
+			noGo = append(noGo, &children[i])
+		}
+	}
+	if total == 0 || terminal < total || len(noGo) == 0 {
+		return nil
+	}
+	return noGo
+}
+
+// reviewIterationSteps decides which code-<n>-r<k> / verify-<n>-r<k> /
+// review-<n>-<i>-r<k> steps to emit NOW, given the Workload spec and
+// its current children (#946).
+//
+// For each issue n it walks the fix iterations in order: iteration k
+// (1..maxReviewIterations) is due once iteration k-1's reviewer round
+// is terminal with at least one NO-GO. Steps whose child already
+// exists are skipped individually, so a partial create failure is
+// repaired on the next reconcile instead of stranding the tail of the
+// iteration — the same idempotency-by-existence contract as
+// escalationSteps. The walk stops at the first round that is still in
+// flight, converged (no NO-GO), or past the bound, so exhausting
+// maxReviewIterations leaves the terminal NO-GO for rollup to fail on
+// as before #946.
+//
+// The iteration's coder step re-targets the SAME branch: the payload
+// sets allowOverwrite so the coder can replace its own prior attempt
+// (force-with-lease push, #573/#934), and payload.prompt carries the
+// distilled review feedback so the retry is not blind.
+//
+// Pure function: no API calls, no status writes. The caller owns
+// MaxTasks accounting, sovereignty filtering, and creation, and must
+// restrict invocation to issue-batch mode (user-authored Pipeline step
+// names could false-match the synthesized naming scheme).
+func reviewIterationSteps(
+	w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
+) (steps []foremanv1alpha1.PipelineStep, iterated []int32) {
+	maxIter := effectiveMaxReviewIterations(w)
+	if maxIter <= 0 ||
+		len(w.Spec.ReviewerAgentRefs) == 0 ||
+		len(w.Spec.Issues) == 0 ||
+		w.Spec.CoderAgentRef == nil ||
+		w.Spec.VerifierAgentRef == nil {
+		return nil, nil
+	}
+
+	existing := make(map[string]struct{}, len(children))
+	for i := range children {
+		if step := children[i].Labels[labelStep]; step != "" {
+			existing[step] = struct{}{}
+		}
+	}
+
+	for _, n := range w.Spec.Issues {
+		branch := fmt.Sprintf("foreman/%s/issue-%d", w.Name, n)
+		issueIterated := false
+		for k := 1; k <= maxIter; k++ {
+			noGo := noGoReviewRound(children, n, k-1)
+			if len(noGo) == 0 {
+				break
+			}
+			codeName := codeStepName(n, k)
+			verifyName := verifyStepName(n, k)
+			if _, ok := existing[codeName]; !ok {
+				steps = append(steps, foremanv1alpha1.PipelineStep{
+					Name:     codeName,
+					Kind:     foremanv1alpha1.AgenticTaskKindIssueFix,
+					AgentRef: *w.Spec.CoderAgentRef,
+					Payload: foremanv1alpha1.AgenticTaskPayload{
+						Repo:           w.Spec.Repo,
+						Issue:          n,
+						Branch:         branch,
+						AllowOverwrite: true,
+						Prompt:         reviewFeedbackPrompt(noGo),
+					},
+				})
+				issueIterated = true
+			}
+			if _, ok := existing[verifyName]; !ok {
+				steps = append(steps, foremanv1alpha1.PipelineStep{
+					Name:      verifyName,
+					Kind:      foremanv1alpha1.AgenticTaskKindVerify,
+					AgentRef:  *w.Spec.VerifierAgentRef,
+					DependsOn: []string{codeName},
+					Payload: foremanv1alpha1.AgenticTaskPayload{
+						Repo:   w.Spec.Repo,
+						Issue:  n,
+						Branch: branch,
+					},
+				})
+				issueIterated = true
+			}
+			for i, reviewerRef := range w.Spec.ReviewerAgentRefs {
+				name := reviewStepName(n, i, k)
+				if _, ok := existing[name]; ok {
+					continue
+				}
+				steps = append(steps, foremanv1alpha1.PipelineStep{
+					Name:      name,
+					Kind:      foremanv1alpha1.AgenticTaskKindReview,
+					AgentRef:  reviewerRef,
+					DependsOn: []string{verifyName},
+					Payload: foremanv1alpha1.AgenticTaskPayload{
+						Repo:   w.Spec.Repo,
+						Issue:  n,
+						Branch: branch,
+					},
+				})
+				issueIterated = true
+			}
+		}
+		if issueIterated {
+			iterated = append(iterated, n)
+		}
+	}
+	return steps, iterated
+}
+
+// reviewFeedbackPrompt distills the NO-GO reviewers' structured
+// results into the fix iteration's coder prompt. The executor's
+// buildUserPrompt drops this text into the "Issue context" slot of the
+// issue-fix template, so the retry runs with the rejection in front of
+// it instead of blind (#946: 4 production issues burned 3 attempts
+// each reproducing the same rejected patch).
+func reviewFeedbackPrompt(noGo []*foremanv1alpha1.AgenticTask) string {
+	var b strings.Builder
+	b.WriteString("The reviewer rejected the previous attempt on this issue (verdict NO-GO).\n")
+	b.WriteString("Your previous attempt is already pushed on this task's branch; produce a corrected\n")
+	b.WriteString("fix that addresses every point below, then push to the same branch.\n")
+	for _, t := range noGo {
+		b.WriteString("\n")
+		b.WriteString(reviewFeedbackSection(t))
+	}
+	b.WriteString("\nAddress this feedback.\n")
+	return b.String()
+}
+
+// reviewFeedbackSection renders one NO-GO reviewer's summary +
+// findings. The structured findings live in the review task's
+// status.result at extra.modelExtra (the reviewer's submit_result
+// extra; see pkg/foreman/agent/reviewer). Rendering is best-effort:
+// findings that fail the strict schema fall back to their raw JSON so
+// legacy map-shaped findings ("scope_creep" + "*_details" keys) still
+// reach the coder, and a result-less task degrades to a one-liner.
+func reviewFeedbackSection(t *foremanv1alpha1.AgenticTask) string {
+	label := t.Labels[labelStep]
+	if label == "" {
+		label = t.Name
+	}
+
+	var envelope struct {
+		Summary string `json:"summary"`
+		Extra   struct {
+			ModelExtra map[string]any `json:"modelExtra"`
+		} `json:"extra"`
+	}
+	if t.Status.Result != nil && len(t.Status.Result.Raw) > 0 {
+		// Best-effort: malformed JSON leaves the envelope zero-valued.
+		_ = json.Unmarshal(t.Status.Result.Raw, &envelope)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Reviewer %s", label)
+	if envelope.Summary != "" {
+		fmt.Fprintf(&b, ": %s", envelope.Summary)
+	}
+	b.WriteString("\n")
+
+	findings, _ := reviewer.ParseFindings(envelope.Extra.ModelExtra)
+	if len(findings) > 0 {
+		for _, f := range findings {
+			fmt.Fprintf(&b, "- [%s/%s] %s", f.Severity, f.Area, f.Message)
+			if f.File != "" {
+				fmt.Fprintf(&b, " (%s", f.File)
+				if f.Line > 0 {
+					fmt.Fprintf(&b, ":%d", f.Line)
+				}
+				b.WriteString(")")
+			}
+			if f.Suggestion != "" {
+				fmt.Fprintf(&b, "; suggested fix: %s", f.Suggestion)
+			}
+			b.WriteString("\n")
+		}
+		return b.String()
+	}
+
+	// Schema-strict parse yielded nothing; pass raw findings through so
+	// non-conforming shapes still inform the retry.
+	if raw, ok := envelope.Extra.ModelExtra["findings"]; ok {
+		if buf, err := json.Marshal(raw); err == nil && len(buf) > 0 && string(buf) != "null" {
+			fmt.Fprintf(&b, "- findings: %s\n", buf)
+		}
+	}
+	return b.String()
+}
+
+// activeChildren filters out children that a later fix iteration
+// superseded, so rollup and the escalation trigger judge each issue by
+// its LATEST attempt only. Without this, iteration 0's terminal NO-GO
+// review would keep IncompleteTasks non-zero forever and a converged
+// r1 round could never complete the Workload. A superseded iteration
+// is by construction fully terminal (the k+1 trigger requires it), so
+// nothing in flight is ever hidden from rollup. Escalation steps and
+// anything else that does not parse as a synthesized issue step are
+// always kept. Issue-batch only; explicit Pipeline mode returns the
+// input unchanged.
+func activeChildren(
+	w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
+) []foremanv1alpha1.AgenticTask {
+	if len(w.Spec.Pipeline) > 0 || len(w.Spec.Issues) == 0 {
+		return children
+	}
+
+	latest := make(map[int32]int, len(w.Spec.Issues))
+	for i := range children {
+		step := children[i].Labels[labelStep]
+		for _, n := range w.Spec.Issues {
+			if k, ok := issueStepIteration(step, n); ok {
+				if k > latest[n] {
+					latest[n] = k
+				}
+				break
+			}
+		}
+	}
+
+	active := make([]foremanv1alpha1.AgenticTask, 0, len(children))
+	for i := range children {
+		step := children[i].Labels[labelStep]
+		superseded := false
+		for _, n := range w.Spec.Issues {
+			if k, ok := issueStepIteration(step, n); ok {
+				superseded = k < latest[n]
+				break
+			}
+		}
+		if !superseded {
+			active = append(active, children[i])
+		}
+	}
+	return active
+}
+
+// countReviewIterations sums the latest fix-iteration index per issue
+// over the given step names, for status.reviewIterations. Recomputed
+// from observed state (not incremented) so reconcile echoes cannot
+// inflate it.
+func countReviewIterations(w *foremanv1alpha1.Workload, stepNames map[string]struct{}) int32 {
+	var total int32
+	for _, n := range w.Spec.Issues {
+		best := 0
+		for step := range stepNames {
+			if k, ok := issueStepIteration(step, n); ok && k > best {
+				best = k
+			}
+		}
+		total += int32(best)
+	}
+	return total
+}
+
+// emitReviewIterations is the fix-iteration emission hook (#946):
+// called from Reconcile's children-exist branch after the advisory
+// wiring and before escalation + rollup. Synthesizes the due
+// code/verify/review -r<k> steps, applies MaxTasks accounting and the
+// sovereignty gates, creates the tasks, and patches status (Tasks
+// list + reviewIterations + ReviewIterationTriggered +
+// CloudReviewersSuppressed / Truncated as applicable). Returns the
+// refreshed children slice so escalation and rollup see the new tasks
+// as in-flight; on a no-op it returns the input slice.
+func (r *WorkloadReconciler) emitReviewIterations(
+	ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
+) ([]foremanv1alpha1.AgenticTask, error) {
+	log := logf.FromContext(ctx).WithName("workload").WithValues("workload", client.ObjectKeyFromObject(w))
+
+	if len(w.Spec.Pipeline) > 0 {
+		// Explicit Pipeline mode: user-authored step names could
+		// false-match the synthesized code/verify/review-<n> naming the
+		// iteration walker scans. Iteration is an issue-batch feature.
+		return children, nil
+	}
+
+	steps, iterated := reviewIterationSteps(w, children)
+	if len(steps) == 0 {
+		return children, nil
+	}
+
+	patch := client.MergeFrom(w.DeepCopy())
+	now := metav1.Now()
+
+	if w.Spec.MaxTasks > 0 && len(children)+len(steps) > int(w.Spec.MaxTasks) {
+		// No silent cap: report why the fix iteration did not run. The
+		// terminal NO-GO then rolls the Workload to Failed as before.
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeTruncated,
+			Status:             metav1.ConditionTrue,
+			Reason:             "MaxTasksIterationCap",
+			Message:            fmt.Sprintf("MaxTasks=%d leaves no room for %d fix-iteration task(s)", w.Spec.MaxTasks, len(steps)),
+			LastTransitionTime: now,
+		})
+		if err := r.Status().Patch(ctx, w, patch); err != nil {
+			return children, fmt.Errorf("patch iteration truncation condition: %w", err)
+		}
+		return children, nil
+	}
+
+	steps, suppressed, err := r.filterCloudProviders(ctx, w, steps)
+	if err != nil {
+		return children, fmt.Errorf("filter iteration providers: %w", err)
+	}
+
+	created, createErr := r.renderAndCreate(ctx, w, steps)
+	if createErr != nil {
+		log.Error(createErr, "creating fix-iteration AgenticTasks failed mid-way", "createdSoFar", len(created))
+	}
+
+	msg := fmt.Sprintf("issues %s re-dispatched to the coder after reviewer NO-GO (%d task(s) created, %d suppressed)",
+		joinInt32(iterated), len(created), len(suppressed))
+
+	// Steady-state short-circuit: when nothing was created (e.g. the
+	// only missing steps are cloud-suppressed reviewers) and the
+	// condition already says exactly this, re-patching every rollup
+	// would only churn LastTransitionTime.
+	if len(created) == 0 && createErr == nil {
+		if cond := apimeta.FindStatusCondition(w.Status.Conditions, conditionTypeReviewIterationTriggered); cond != nil &&
+			cond.Status == metav1.ConditionTrue && cond.Message == msg {
+			return children, nil
+		}
+	}
+
+	stepNames := make(map[string]struct{}, len(children)+len(created))
+	for i := range children {
+		if step := children[i].Labels[labelStep]; step != "" {
+			stepNames[step] = struct{}{}
+		}
+	}
+	for _, ref := range created {
+		stepNames[strings.TrimPrefix(ref.Name, w.Name+"-")] = struct{}{}
+	}
+
+	w.Status.Tasks = appendNewTaskRefs(w.Status.Tasks, created)
+	w.Status.ReviewIterations = countReviewIterations(w, stepNames)
+	setCondition(&w.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeReviewIterationTriggered,
+		Status:             metav1.ConditionTrue,
+		Reason:             "ReviewerNoGo",
+		Message:            msg,
+		LastTransitionTime: now,
+	})
+	if len(suppressed) > 0 {
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeCloudReviewersSuppressed,
+			Status:             metav1.ConditionTrue,
+			Reason:             "SovereigntyGate",
+			Message:            fmt.Sprintf("skipped %d cloud-provider Agent(s): %s", len(suppressed), strings.Join(suppressed, "; ")),
+			LastTransitionTime: now,
+		})
+	}
+	if err := r.Status().Patch(ctx, w, patch); err != nil {
+		return children, fmt.Errorf("patch workload status after iteration emission: %w", err)
+	}
+	if createErr != nil {
+		return children, createErr
+	}
+
+	// Escalation + rollup must see the new tasks as in-flight in this
+	// same pass. A cache-backed List here could miss tasks created
+	// microseconds ago (informer lag), so synthesize labeled
+	// placeholders instead: a zero-value phase counts as in-flight, and
+	// the step label lets activeChildren + the escalation trigger
+	// recognize the new round immediately (without it, the superseded
+	// round's terminal NO-GO would fire escalation one pass early).
+	existing := make(map[string]struct{}, len(children))
+	for i := range children {
+		existing[children[i].Name] = struct{}{}
+	}
+	for _, ref := range created {
+		if _, ok := existing[ref.Name]; ok {
+			continue
+		}
+		children = append(children, foremanv1alpha1.AgenticTask{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ref.Name,
+				Namespace: ref.Namespace,
+				Labels: map[string]string{
+					labelWorkload: w.Name,
+					labelStep:     strings.TrimPrefix(ref.Name, w.Name+"-"),
+				},
+			},
+		})
+	}
+	return children, nil
+}

--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -186,9 +187,15 @@ func noGoReviewRound(
 // as before #946.
 //
 // The iteration's coder step re-targets the SAME branch: the payload
-// sets allowOverwrite so the coder can replace its own prior attempt
+// sets reviseFromBranch to the task's own branch name so the executor
+// restores the prior attempt from the push remote before the model
+// runs (#951), allowOverwrite so the coder can replace that attempt
 // (force-with-lease push, #573/#934), and payload.prompt carries the
-// distilled review feedback so the retry is not blind.
+// distilled review feedback so the retry is not blind. The coder step
+// references spec.revisionCoderAgentRef when set — a revision amends
+// existing work and wants a revision-tuned profile, not the issue-fix
+// forcing profile — and falls back to spec.coderAgentRef otherwise
+// (the caller emits the RevisionUnderIssueFixProfile warning).
 //
 // Pure function: no API calls, no status writes. The caller owns
 // MaxTasks accounting, sovereignty filtering, and creation, and must
@@ -213,6 +220,11 @@ func reviewIterationSteps(
 		}
 	}
 
+	coderRef := w.Spec.CoderAgentRef
+	if w.Spec.RevisionCoderAgentRef != nil {
+		coderRef = w.Spec.RevisionCoderAgentRef
+	}
+
 	for _, n := range w.Spec.Issues {
 		branch := fmt.Sprintf("foreman/%s/issue-%d", w.Name, n)
 		issueIterated := false
@@ -227,13 +239,17 @@ func reviewIterationSteps(
 				steps = append(steps, foremanv1alpha1.PipelineStep{
 					Name:     codeName,
 					Kind:     foremanv1alpha1.AgenticTaskKindIssueFix,
-					AgentRef: *w.Spec.CoderAgentRef,
+					AgentRef: *coderRef,
 					Payload: foremanv1alpha1.AgenticTaskPayload{
-						Repo:           w.Spec.Repo,
-						Issue:          n,
-						Branch:         branch,
-						AllowOverwrite: true,
-						Prompt:         reviewFeedbackPrompt(noGo),
+						Repo:   w.Spec.Repo,
+						Issue:  n,
+						Branch: branch,
+						// The prior attempt lives at the task's own
+						// branch name on the push remote; the executor
+						// restores it before the model runs (#951).
+						ReviseFromBranch: branch,
+						AllowOverwrite:   true,
+						Prompt:           reviewFeedbackPrompt(noGo),
 					},
 				})
 				issueIterated = true
@@ -284,11 +300,19 @@ func reviewIterationSteps(
 // issue-fix template, so the retry runs with the rejection in front of
 // it instead of blind (#946: 4 production issues burned 3 attempts
 // each reproducing the same rejected patch).
+//
+// The wording matches the executor's revise-from-branch restore
+// (#951): because the step's payload stamps reviseFromBranch, the
+// workspace really does start from the prior attempt's files, so the
+// prompt directs the model to amend that work as a delta rather than
+// rebuild the fix from scratch.
 func reviewFeedbackPrompt(noGo []*foremanv1alpha1.AgenticTask) string {
 	var b strings.Builder
 	b.WriteString("The reviewer rejected the previous attempt on this issue (verdict NO-GO).\n")
-	b.WriteString("Your previous attempt is already pushed on this task's branch; produce a corrected\n")
-	b.WriteString("fix that addresses every point below, then push to the same branch.\n")
+	b.WriteString("Your workspace already contains that previous attempt: the working branch was\n")
+	b.WriteString("restored from this task's branch on the remote, so its files and history are\n")
+	b.WriteString("present. Do not rebuild the fix from scratch. Amend the existing work with the\n")
+	b.WriteString("smallest changes that address every point below, then push to the same branch.\n")
 	for _, t := range noGo {
 		b.WriteString("\n")
 		b.WriteString(reviewFeedbackSection(t))
@@ -470,6 +494,24 @@ func (r *WorkloadReconciler) emitReviewIterations(
 	steps, suppressed, err := r.filterCloudProviders(ctx, w, steps)
 	if err != nil {
 		return children, fmt.Errorf("filter iteration providers: %w", err)
+	}
+
+	// Revision-vs-profile pairing (#951): a fix-iteration coder task
+	// amends its restored prior attempt, and the issue-fix Agent's
+	// forcing profile is tuned for building a fix from scratch — the
+	// documented #951 failure mode is a revision task collapsing under
+	// it. Warn (once per emission pass) when the fallback is in play so
+	// the operator knows to set spec.revisionCoderAgentRef.
+	if r.Recorder != nil && w.Spec.RevisionCoderAgentRef == nil {
+		for _, s := range steps {
+			if s.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
+				continue
+			}
+			r.Recorder.Eventf(w, nil, corev1.EventTypeWarning, "RevisionUnderIssueFixProfile", "Reconcile",
+				"fix-iteration coder step %s falls back to the issue-fix Agent %q; a revision task amends its restored prior attempt and can collapse under the issue-fix forcing profile (#951) — set spec.revisionCoderAgentRef to pair iterations with a revision-tuned profile",
+				s.Name, w.Spec.CoderAgentRef.Name)
+			break
+		}
 	}
 
 	created, createErr := r.renderAndCreate(ctx, w, steps)

--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -268,6 +268,9 @@ func reviewIterationSteps(
 				})
 				issueIterated = true
 			}
+			// Mirrors the base-round stamp (#937): an iterated-then-approved
+			// issue must still open its PR.
+			openPR := w.Spec.OpenPullRequest == nil || *w.Spec.OpenPullRequest
 			for i, reviewerRef := range w.Spec.ReviewerAgentRefs {
 				name := reviewStepName(n, i, k)
 				if _, ok := existing[name]; ok {
@@ -279,9 +282,10 @@ func reviewIterationSteps(
 					AgentRef:  reviewerRef,
 					DependsOn: []string{verifyName},
 					Payload: foremanv1alpha1.AgenticTaskPayload{
-						Repo:   w.Spec.Repo,
-						Issue:  n,
-						Branch: branch,
+						Repo:            w.Spec.Repo,
+						Issue:           n,
+						Branch:          branch,
+						OpenPullRequest: openPR,
 					},
 				})
 				issueIterated = true

--- a/internal/foreman/controller/workload_iteration_envtest_test.go
+++ b/internal/foreman/controller/workload_iteration_envtest_test.go
@@ -136,6 +136,8 @@ var _ = Describe("WorkloadReconciler review fix iteration (#946)", func() {
 		var review foremanv1alpha1.AgenticTask
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-happy-review-750-0-r1"}, &review)).To(Succeed())
 		Expect(review.Spec.DependsOn).To(ConsistOf("iterate-happy-verify-750-r1"))
+		Expect(review.Spec.Payload.OpenPullRequest).To(BeTrue(),
+			"iteration review steps must carry the base-round openPullRequest stamp (#937)")
 
 		var fresh foremanv1alpha1.Workload
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())

--- a/internal/foreman/controller/workload_iteration_envtest_test.go
+++ b/internal/foreman/controller/workload_iteration_envtest_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,11 +39,14 @@ import (
 // spec.maxReviewIterations is exhausted.
 var _ = Describe("WorkloadReconciler review fix iteration (#946)", func() {
 	var reconciler *WorkloadReconciler
+	var recorder *events.FakeRecorder
 
 	BeforeEach(func() {
+		recorder = &events.FakeRecorder{Events: make(chan string, 16)}
 		reconciler = &WorkloadReconciler{
 			Client:              k8sClient,
 			Scheme:              k8sClient.Scheme(),
+			Recorder:            recorder,
 			AllowCloudProviders: true,
 		}
 	})
@@ -101,16 +105,29 @@ var _ = Describe("WorkloadReconciler review fix iteration (#946)", func() {
 		var code foremanv1alpha1.AgenticTask
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-happy-code-750-r1"}, &code)).To(Succeed())
 		Expect(code.Spec.Kind).To(Equal(foremanv1alpha1.AgenticTaskKindIssueFix))
-		Expect(code.Spec.AgentRef.Name).To(Equal("coder"), "iteration reuses the same coder Agent")
+		Expect(code.Spec.AgentRef.Name).To(Equal("coder"),
+			"no revisionCoderAgentRef: iteration falls back to the issue-fix coder Agent")
 		Expect(code.Spec.Payload.Issue).To(Equal(int32(750)))
 		Expect(code.Spec.Payload.Branch).To(Equal("foreman/iterate-happy/issue-750"),
 			"the retry amends the SAME branch, not a fresh one")
 		Expect(code.Spec.Payload.AllowOverwrite).To(BeTrue(),
 			"amending its own prior attempt needs the force-with-lease push")
+		Expect(code.Spec.Payload.ReviseFromBranch).To(Equal("foreman/iterate-happy/issue-750"),
+			"the executor must restore the prior attempt from the push remote (#951)")
 		Expect(code.Spec.Payload.Prompt).To(ContainSubstring("NO-GO"))
+		Expect(code.Spec.Payload.Prompt).To(ContainSubstring("Do not rebuild the fix from scratch"),
+			"the prompt must direct a delta on the restored attempt")
 		Expect(code.Spec.Payload.Prompt).To(ContainSubstring("scope creep beyond the issue ask"))
 		Expect(code.Spec.Payload.Prompt).To(ContainSubstring("reduces ACCESS_TOKEN_EXPIRE_MINUTES from 10080 to 30"))
 		Expect(code.Spec.DependsOn).To(BeEmpty())
+
+		// No revisionCoderAgentRef: the fallback to the issue-fix coder
+		// profile is the documented #951 failure mode, so it must warn.
+		Expect(recorder.Events).To(Receive(And(
+			ContainSubstring("Warning"),
+			ContainSubstring("RevisionUnderIssueFixProfile"),
+			ContainSubstring("revisionCoderAgentRef"),
+		)))
 
 		var verify foremanv1alpha1.AgenticTask
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-happy-verify-750-r1"}, &verify)).To(Succeed())
@@ -152,6 +169,54 @@ var _ = Describe("WorkloadReconciler review fix iteration (#946)", func() {
 		Expect(fresh.Status.SucceededTasks).To(Equal(int32(3)), "only the latest round is counted")
 		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(0)))
 		Expect(fresh.Status.ReviewIterations).To(Equal(int32(1)))
+	})
+
+	It("pairs iteration coder tasks with the revision coder Agent when configured (#951)", func() {
+		wl := newWorkload("iterate-revision", foremanv1alpha1.WorkloadSpec{
+			Intent:                "revision profile pairing",
+			Repo:                  "defilantech/LLMKube",
+			Issues:                []int32{753},
+			CoderAgentRef:         &corev1.LocalObjectReference{Name: "coder"},
+			RevisionCoderAgentRef: &corev1.LocalObjectReference{Name: "revision-coder"},
+			VerifierAgentRef:      &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "reviewer"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		reconcile(wl)
+
+		// The base round still uses the issue-fix coder profile.
+		var base foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-revision-code-753"}, &base)).To(Succeed())
+		Expect(base.Spec.AgentRef.Name).To(Equal("coder"))
+		Expect(base.Spec.Payload.ReviseFromBranch).To(BeEmpty(),
+			"the base attempt has nothing to restore")
+
+		markTerminal("iterate-revision-code-753", foremanv1alpha1.AgenticTaskVerdictGo, "")
+		markTerminal("iterate-revision-verify-753", foremanv1alpha1.AgenticTaskVerdictGatePass, "")
+		markTerminal("iterate-revision-review-753-0", foremanv1alpha1.AgenticTaskVerdictNoGo, noGoResult)
+		reconcile(wl)
+
+		var code foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-revision-code-753-r1"}, &code)).To(Succeed())
+		Expect(code.Spec.AgentRef.Name).To(Equal("revision-coder"),
+			"the fix iteration must run under the revision-tuned profile")
+		Expect(code.Spec.Payload.ReviseFromBranch).To(Equal("foreman/iterate-revision/issue-753"))
+
+		// Verify + review keep their own refs.
+		var verify foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-revision-verify-753-r1"}, &verify)).To(Succeed())
+		Expect(verify.Spec.AgentRef.Name).To(Equal("gate"))
+
+		// A configured revision profile is the intended pairing: no
+		// RevisionUnderIssueFixProfile warning.
+		Expect(recorder.Events).NotTo(Receive())
 	})
 
 	It("fails the Workload once the iteration budget is exhausted (today's terminal behavior)", func() {

--- a/internal/foreman/controller/workload_iteration_envtest_test.go
+++ b/internal/foreman/controller/workload_iteration_envtest_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// Reviewer NO-GO fix iteration (#946): instead of terminally failing
+// the Workload, the reconciler re-dispatches the coder on the same
+// branch with the review findings in payload.prompt, chains a fresh
+// verify + review round behind it, and only fails once
+// spec.maxReviewIterations is exhausted.
+var _ = Describe("WorkloadReconciler review fix iteration (#946)", func() {
+	var reconciler *WorkloadReconciler
+
+	BeforeEach(func() {
+		reconciler = &WorkloadReconciler{
+			Client:              k8sClient,
+			Scheme:              k8sClient.Scheme(),
+			AllowCloudProviders: true,
+		}
+	})
+
+	// markTerminal drives a child task to a terminal phase + verdict,
+	// optionally attaching a structured result payload.
+	markTerminal := func(name string, verdict foremanv1alpha1.AgenticTaskVerdict, resultJSON string) {
+		var task foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: name}, &task)).To(Succeed())
+		patch := client.MergeFrom(task.DeepCopy())
+		task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		task.Status.Verdict = verdict
+		if resultJSON != "" {
+			task.Status.Result = &runtime.RawExtension{Raw: []byte(resultJSON)}
+		}
+		Expect(k8sClient.Status().Patch(ctx, &task, patch)).To(Succeed())
+	}
+
+	reconcile := func(wl *foremanv1alpha1.Workload) {
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	noGoResult := `{"schemaVersion":"foreman.v1","kind":"review","verdict":"NO-GO",` +
+		`"summary":"scope creep beyond the issue ask","extra":{"outcome":"MODEL-DECIDED","modelExtra":{"findings":` +
+		`[{"severity":"blocker","area":"scope","message":"reduces ACCESS_TOKEN_EXPIRE_MINUTES from 10080 to 30",` +
+		`"file":"config/auth.py","line":12,"suggestion":"revert the unrelated change"}]}}}`
+
+	It("re-dispatches the coder with the review feedback on NO-GO and completes when the retry converges", func() {
+		wl := newWorkload("iterate-happy", foremanv1alpha1.WorkloadSpec{
+			Intent:           "fix iteration happy path",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{750},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "reviewer"},
+			},
+			// maxReviewIterations unset: defaults to 1 iteration.
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		// Plan the base round, then drive it to a reviewer NO-GO.
+		reconcile(wl)
+		markTerminal("iterate-happy-code-750", foremanv1alpha1.AgenticTaskVerdictGo, "")
+		markTerminal("iterate-happy-verify-750", foremanv1alpha1.AgenticTaskVerdictGatePass, "")
+		markTerminal("iterate-happy-review-750-0", foremanv1alpha1.AgenticTaskVerdictNoGo, noGoResult)
+
+		// The rollup pass must append the r1 iteration instead of failing.
+		reconcile(wl)
+
+		var code foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-happy-code-750-r1"}, &code)).To(Succeed())
+		Expect(code.Spec.Kind).To(Equal(foremanv1alpha1.AgenticTaskKindIssueFix))
+		Expect(code.Spec.AgentRef.Name).To(Equal("coder"), "iteration reuses the same coder Agent")
+		Expect(code.Spec.Payload.Issue).To(Equal(int32(750)))
+		Expect(code.Spec.Payload.Branch).To(Equal("foreman/iterate-happy/issue-750"),
+			"the retry amends the SAME branch, not a fresh one")
+		Expect(code.Spec.Payload.AllowOverwrite).To(BeTrue(),
+			"amending its own prior attempt needs the force-with-lease push")
+		Expect(code.Spec.Payload.Prompt).To(ContainSubstring("NO-GO"))
+		Expect(code.Spec.Payload.Prompt).To(ContainSubstring("scope creep beyond the issue ask"))
+		Expect(code.Spec.Payload.Prompt).To(ContainSubstring("reduces ACCESS_TOKEN_EXPIRE_MINUTES from 10080 to 30"))
+		Expect(code.Spec.DependsOn).To(BeEmpty())
+
+		var verify foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-happy-verify-750-r1"}, &verify)).To(Succeed())
+		Expect(verify.Spec.DependsOn).To(ConsistOf("iterate-happy-code-750-r1"))
+
+		var review foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-happy-review-750-0-r1"}, &review)).To(Succeed())
+		Expect(review.Spec.DependsOn).To(ConsistOf("iterate-happy-verify-750-r1"))
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseDispatched),
+			"workload must stay in flight while the fix iteration runs")
+		Expect(fresh.Status.Tasks).To(HaveLen(6))
+		Expect(fresh.Status.ReviewIterations).To(Equal(int32(1)))
+		cond := findCondition(fresh.Status.Conditions, conditionTypeReviewIterationTriggered)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Message).To(ContainSubstring("750"))
+
+		// A further reconcile must NOT double-emit (idempotency by step
+		// name existence, like escalation).
+		reconcile(wl)
+		var tasks foremanv1alpha1.AgenticTaskList
+		Expect(k8sClient.List(ctx, &tasks, client.InNamespace("default"),
+			client.MatchingLabels{labelWorkload: "iterate-happy"})).To(Succeed())
+		Expect(tasks.Items).To(HaveLen(6))
+
+		// Converge the retry: the superseded NO-GO round must no longer
+		// pin the rollup at Failed.
+		markTerminal("iterate-happy-code-750-r1", foremanv1alpha1.AgenticTaskVerdictGo, "")
+		markTerminal("iterate-happy-verify-750-r1", foremanv1alpha1.AgenticTaskVerdictGatePass, "")
+		markTerminal("iterate-happy-review-750-0-r1", foremanv1alpha1.AgenticTaskVerdictGo, "")
+		reconcile(wl)
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseCompleted),
+			"a converged fix iteration completes the Workload")
+		Expect(fresh.Status.SucceededTasks).To(Equal(int32(3)), "only the latest round is counted")
+		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(0)))
+		Expect(fresh.Status.ReviewIterations).To(Equal(int32(1)))
+	})
+
+	It("fails the Workload once the iteration budget is exhausted (today's terminal behavior)", func() {
+		wl := newWorkload("iterate-exhausted", foremanv1alpha1.WorkloadSpec{
+			Intent:           "fix iteration exhaustion",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{751},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "reviewer"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		reconcile(wl)
+		markTerminal("iterate-exhausted-code-751", foremanv1alpha1.AgenticTaskVerdictGo, "")
+		markTerminal("iterate-exhausted-verify-751", foremanv1alpha1.AgenticTaskVerdictGatePass, "")
+		markTerminal("iterate-exhausted-review-751-0", foremanv1alpha1.AgenticTaskVerdictNoGo, noGoResult)
+		reconcile(wl)
+
+		// The r1 round exists; reject it too.
+		markTerminal("iterate-exhausted-code-751-r1", foremanv1alpha1.AgenticTaskVerdictGo, "")
+		markTerminal("iterate-exhausted-verify-751-r1", foremanv1alpha1.AgenticTaskVerdictGatePass, "")
+		markTerminal("iterate-exhausted-review-751-0-r1", foremanv1alpha1.AgenticTaskVerdictNoGo, noGoResult)
+		reconcile(wl)
+
+		// No r2: the default budget of 1 is spent.
+		var r2 foremanv1alpha1.AgenticTask
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-exhausted-code-751-r2"}, &r2)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "exhausted budget must not emit another iteration")
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseFailed),
+			"a NO-GO on the last allowed iteration fails the Workload as before #946")
+		completed := findCondition(fresh.Status.Conditions, conditionTypeCompleted)
+		Expect(completed).NotTo(BeNil())
+		Expect(completed.Reason).To(Equal("ChildrenIncomplete"))
+		Expect(fresh.Status.ReviewIterations).To(Equal(int32(1)))
+	})
+
+	It("does not iterate when the reviewer says GO", func() {
+		wl := newWorkload("iterate-go", foremanv1alpha1.WorkloadSpec{
+			Intent:           "no iteration on GO",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{752},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "reviewer"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		reconcile(wl)
+		markTerminal("iterate-go-code-752", foremanv1alpha1.AgenticTaskVerdictGo, "")
+		markTerminal("iterate-go-verify-752", foremanv1alpha1.AgenticTaskVerdictGatePass, "")
+		markTerminal("iterate-go-review-752-0", foremanv1alpha1.AgenticTaskVerdictGo, "")
+		reconcile(wl)
+
+		var r1 foremanv1alpha1.AgenticTask
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-go-code-752-r1"}, &r1)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "GO must not trigger a fix iteration")
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseCompleted))
+		Expect(fresh.Status.ReviewIterations).To(Equal(int32(0)))
+		Expect(findCondition(fresh.Status.Conditions, conditionTypeReviewIterationTriggered)).To(BeNil())
+	})
+})

--- a/internal/foreman/controller/workload_iteration_test.go
+++ b/internal/foreman/controller/workload_iteration_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// iterationWorkload builds the issue-batch spec reviewIterationSteps
+// consumes: coder + verifier refs plus `reviewers` base reviewer refs.
+func iterationWorkload(issues []int32, reviewers int, maxIter *int32) *foremanv1alpha1.Workload {
+	spec := foremanv1alpha1.WorkloadSpec{
+		Intent:              "iteration unit test",
+		Repo:                "defilantech/LLMKube",
+		Issues:              issues,
+		CoderAgentRef:       &corev1.LocalObjectReference{Name: "coder"},
+		VerifierAgentRef:    &corev1.LocalObjectReference{Name: "gate"},
+		MaxReviewIterations: maxIter,
+	}
+	for i := 0; i < reviewers; i++ {
+		spec.ReviewerAgentRefs = append(spec.ReviewerAgentRefs, corev1.LocalObjectReference{Name: "reviewer"})
+	}
+	w := &foremanv1alpha1.Workload{Spec: spec}
+	w.Name = "wl"
+	return w
+}
+
+// noGoChild is a terminal NO-GO review child carrying a structured
+// review result so the feedback-prompt path is exercised end to end.
+func noGoChild(step, summary, findingsJSON string) foremanv1alpha1.AgenticTask {
+	c := child(step, foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo)
+	raw := `{"schemaVersion":"foreman.v1","kind":"review","verdict":"NO-GO","summary":"` + summary + `",` +
+		`"extra":{"outcome":"MODEL-DECIDED","modelExtra":{"findings":` + findingsJSON + `}}}`
+	c.Status.Result = &runtime.RawExtension{Raw: []byte(raw)}
+	return c
+}
+
+func TestReviewIterationSteps(t *testing.T) {
+	succeeded := foremanv1alpha1.AgenticTaskPhaseSucceeded
+	running := foremanv1alpha1.AgenticTaskPhaseRunning
+	noGo := foremanv1alpha1.AgenticTaskVerdictNoGo
+	gateFail := foremanv1alpha1.AgenticTaskVerdictGateFail
+	incomplete := foremanv1alpha1.AgenticTaskVerdictIncomplete
+	gatePass := foremanv1alpha1.AgenticTaskVerdictGatePass
+	goVerdict := foremanv1alpha1.AgenticTaskVerdictGo
+
+	baseRound := func(reviewVerdict foremanv1alpha1.AgenticTaskVerdict) []foremanv1alpha1.AgenticTask {
+		return []foremanv1alpha1.AgenticTask{
+			child("code-641", succeeded, goVerdict),
+			child("verify-641", succeeded, gatePass),
+			child("review-641-0", succeeded, reviewVerdict),
+		}
+	}
+
+	cases := []struct {
+		name         string
+		w            *foremanv1alpha1.Workload
+		children     []foremanv1alpha1.AgenticTask
+		wantSteps    []string // expected step names, in order
+		wantIterated []int32
+	}{
+		{
+			name:         "reviewer NO-GO triggers the full r1 triple",
+			w:            iterationWorkload([]int32{641}, 1, nil),
+			children:     baseRound(noGo),
+			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
+			wantIterated: []int32{641},
+		},
+		{
+			name:     "reviewer GO converges: no iteration",
+			w:        iterationWorkload([]int32{641}, 1, nil),
+			children: baseRound(goVerdict),
+		},
+		{
+			name: "waits for every reviewer in the round to be terminal",
+			w:    iterationWorkload([]int32{641}, 2, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+				child("review-641-1", running, ""),
+			},
+		},
+		{
+			name: "cascade INCOMPLETE after GATE-FAIL does not iterate",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("verify-641", succeeded, gateFail),
+				child("review-641-0", succeeded, incomplete),
+			},
+		},
+		{
+			name: "existing r1 children block re-emission (idempotency)",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: append(baseRound(noGo),
+				child("code-641-r1", running, ""),
+				child("verify-641-r1", "", ""),
+				child("review-641-0-r1", "", ""),
+			),
+		},
+		{
+			name: "partial create failure repaired: only the missing r1 steps re-emit",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: append(baseRound(noGo),
+				child("code-641-r1", running, ""),
+			),
+			wantSteps:    []string{"verify-641-r1", "review-641-0-r1"},
+			wantIterated: []int32{641},
+		},
+		{
+			name: "r1 NO-GO with budget left chains r2",
+			w:    iterationWorkload([]int32{641}, 1, ptr.To(int32(2))),
+			children: append(baseRound(noGo),
+				child("code-641-r1", succeeded, goVerdict),
+				child("verify-641-r1", succeeded, gatePass),
+				child("review-641-0-r1", succeeded, noGo),
+			),
+			wantSteps:    []string{"code-641-r2", "verify-641-r2", "review-641-0-r2"},
+			wantIterated: []int32{641},
+		},
+		{
+			name: "r1 NO-GO with budget exhausted emits nothing (fails as today)",
+			w:    iterationWorkload([]int32{641}, 1, nil), // nil -> 1 iteration
+			children: append(baseRound(noGo),
+				child("code-641-r1", succeeded, goVerdict),
+				child("verify-641-r1", succeeded, gatePass),
+				child("review-641-0-r1", succeeded, noGo),
+			),
+		},
+		{
+			name:     "explicit 0 disables iteration",
+			w:        iterationWorkload([]int32{641}, 1, ptr.To(int32(0))),
+			children: baseRound(noGo),
+		},
+		{
+			name: "per-issue isolation: only the NO-GO issue iterates",
+			w:    iterationWorkload([]int32{641, 642}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+				child("review-642-0", succeeded, goVerdict),
+			},
+			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
+			wantIterated: []int32{641},
+		},
+		{
+			name: "issue number prefixes do not cross-match (64 vs 641)",
+			w:    iterationWorkload([]int32{64}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-0", succeeded, noGo),
+			},
+		},
+		{
+			name: "no reviewers configured is inert",
+			w:    iterationWorkload([]int32{641}, 0, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			steps, iterated := reviewIterationSteps(tc.w, tc.children)
+
+			var gotNames []string
+			for _, s := range steps {
+				gotNames = append(gotNames, s.Name)
+			}
+			if len(gotNames) != len(tc.wantSteps) {
+				t.Fatalf("steps = %v, want %v", gotNames, tc.wantSteps)
+			}
+			for i := range tc.wantSteps {
+				if gotNames[i] != tc.wantSteps[i] {
+					t.Fatalf("steps = %v, want %v", gotNames, tc.wantSteps)
+				}
+			}
+			if len(iterated) != len(tc.wantIterated) {
+				t.Fatalf("iterated = %v, want %v", iterated, tc.wantIterated)
+			}
+			for i := range tc.wantIterated {
+				if iterated[i] != tc.wantIterated[i] {
+					t.Fatalf("iterated = %v, want %v", iterated, tc.wantIterated)
+				}
+			}
+
+			// Every emitted coder step must re-target the same branch
+			// with allowOverwrite + a non-empty feedback prompt; verify
+			// and review steps chain behind it within the iteration.
+			for _, s := range steps {
+				if s.Payload.Branch == "" || !strings.HasPrefix(s.Payload.Branch, "foreman/wl/issue-") {
+					t.Errorf("step %s branch = %q, want the original issue branch", s.Name, s.Payload.Branch)
+				}
+				switch s.Kind {
+				case foremanv1alpha1.AgenticTaskKindIssueFix:
+					if !s.Payload.AllowOverwrite {
+						t.Errorf("step %s must set allowOverwrite to amend its own branch", s.Name)
+					}
+					if !strings.Contains(s.Payload.Prompt, "NO-GO") {
+						t.Errorf("step %s prompt must carry the review feedback, got %q", s.Name, s.Payload.Prompt)
+					}
+					if len(s.DependsOn) != 0 {
+						t.Errorf("step %s dependsOn = %v, want none (prior round is terminal)", s.Name, s.DependsOn)
+					}
+				case foremanv1alpha1.AgenticTaskKindVerify, foremanv1alpha1.AgenticTaskKindReview:
+					if len(s.DependsOn) != 1 {
+						t.Errorf("step %s dependsOn = %v, want exactly one upstream", s.Name, s.DependsOn)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestReviewFeedbackPrompt(t *testing.T) {
+	structured := noGoChild("review-641-0", "scope creep beyond the issue ask",
+		`[{"severity":"blocker","area":"scope","message":"reduces ACCESS_TOKEN_EXPIRE_MINUTES from 10080 to 30, unrelated to the issue","file":"config/auth.py","line":12,"suggestion":"revert the unrelated change"}]`)
+	prompt := reviewFeedbackPrompt([]*foremanv1alpha1.AgenticTask{&structured})
+	for _, want := range []string{
+		"rejected the previous attempt",
+		"NO-GO",
+		"scope creep beyond the issue ask",
+		"[blocker/scope] reduces ACCESS_TOKEN_EXPIRE_MINUTES from 10080 to 30",
+		"config/auth.py:12",
+		"revert the unrelated change",
+		"Address this feedback",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+
+	// Legacy map-shaped findings (the boolean + *_details shape from the
+	// issue report) fail the strict schema and must fall back to raw JSON
+	// rather than vanishing.
+	legacy := noGoChild("review-641-0", "missing tests",
+		`{"missing_tests":true,"missing_tests_details":"no unit test covers the new branch"}`)
+	prompt = reviewFeedbackPrompt([]*foremanv1alpha1.AgenticTask{&legacy})
+	if !strings.Contains(prompt, "no unit test covers the new branch") {
+		t.Errorf("legacy findings must surface via the raw-JSON fallback:\n%s", prompt)
+	}
+
+	// A result-less NO-GO still yields a usable prompt.
+	bare := child("review-641-1", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo)
+	prompt = reviewFeedbackPrompt([]*foremanv1alpha1.AgenticTask{&bare})
+	if !strings.Contains(prompt, "Reviewer review-641-1") {
+		t.Errorf("result-less reviewer must still be named:\n%s", prompt)
+	}
+}
+
+func TestActiveChildren(t *testing.T) {
+	succeeded := foremanv1alpha1.AgenticTaskPhaseSucceeded
+	w := iterationWorkload([]int32{641}, 1, nil)
+
+	children := []foremanv1alpha1.AgenticTask{
+		child("code-641", succeeded, foremanv1alpha1.AgenticTaskVerdictGo),
+		child("verify-641", succeeded, foremanv1alpha1.AgenticTaskVerdictGatePass),
+		child("review-641-0", succeeded, foremanv1alpha1.AgenticTaskVerdictNoGo),
+		child("code-641-r1", succeeded, foremanv1alpha1.AgenticTaskVerdictGo),
+		child("verify-641-r1", succeeded, foremanv1alpha1.AgenticTaskVerdictGatePass),
+		child("review-641-0-r1", succeeded, foremanv1alpha1.AgenticTaskVerdictGo),
+		child("escalate-641-0", succeeded, foremanv1alpha1.AgenticTaskVerdictGo),
+	}
+
+	active := activeChildren(w, children)
+	names := make([]string, 0, len(active))
+	for i := range active {
+		names = append(names, active[i].Labels[labelStep])
+	}
+	want := []string{"code-641-r1", "verify-641-r1", "review-641-0-r1", "escalate-641-0"}
+	if len(names) != len(want) {
+		t.Fatalf("active = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("active = %v, want %v", names, want)
+		}
+	}
+
+	// Without a later iteration nothing is filtered.
+	base := children[:3]
+	if got := activeChildren(w, base); len(got) != 3 {
+		t.Fatalf("no-iteration input must pass through, got %d children", len(got))
+	}
+
+	// Explicit Pipeline mode passes through untouched even when names
+	// resemble the synthesized scheme.
+	pw := iterationWorkload([]int32{641}, 1, nil)
+	pw.Spec.Pipeline = []foremanv1alpha1.PipelineStep{{Name: "code-641"}}
+	if got := activeChildren(pw, children); len(got) != len(children) {
+		t.Fatalf("pipeline mode must not filter, got %d of %d", len(got), len(children))
+	}
+}

--- a/internal/foreman/controller/workload_iteration_test.go
+++ b/internal/foreman/controller/workload_iteration_test.go
@@ -214,6 +214,10 @@ func TestReviewIterationSteps(t *testing.T) {
 					if !s.Payload.AllowOverwrite {
 						t.Errorf("step %s must set allowOverwrite to amend its own branch", s.Name)
 					}
+					if s.Payload.ReviseFromBranch != s.Payload.Branch {
+						t.Errorf("step %s reviseFromBranch = %q, want %q so the executor restores the prior attempt (#951)",
+							s.Name, s.Payload.ReviseFromBranch, s.Payload.Branch)
+					}
 					if !strings.Contains(s.Payload.Prompt, "NO-GO") {
 						t.Errorf("step %s prompt must carry the review feedback, got %q", s.Name, s.Payload.Prompt)
 					}
@@ -230,6 +234,49 @@ func TestReviewIterationSteps(t *testing.T) {
 	}
 }
 
+// TestReviewIterationCoderRef covers the revision profile pairing
+// (#951): iteration coder steps reference spec.revisionCoderAgentRef
+// when set (a revision amends restored work and wants a revision-tuned
+// profile) and fall back to spec.coderAgentRef otherwise. Verify and
+// review steps keep their own refs either way.
+func TestReviewIterationCoderRef(t *testing.T) {
+	noGoRound := []foremanv1alpha1.AgenticTask{
+		child("code-641", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGo),
+		child("verify-641", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGatePass),
+		child("review-641-0", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo),
+	}
+
+	cases := []struct {
+		name          string
+		revisionRef   *corev1.LocalObjectReference
+		wantCoderName string
+	}{
+		{"revisionCoderAgentRef set selects the revision coder", &corev1.LocalObjectReference{Name: "revision-coder"}, "revision-coder"},
+		{"unset falls back to coderAgentRef", nil, "coder"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := iterationWorkload([]int32{641}, 1, nil)
+			w.Spec.RevisionCoderAgentRef = tc.revisionRef
+
+			steps, _ := reviewIterationSteps(w, noGoRound)
+			refs := map[string]string{}
+			for _, s := range steps {
+				refs[s.Name] = s.AgentRef.Name
+			}
+			if got := refs["code-641-r1"]; got != tc.wantCoderName {
+				t.Errorf("code-641-r1 agentRef = %q, want %q", got, tc.wantCoderName)
+			}
+			if got := refs["verify-641-r1"]; got != "gate" {
+				t.Errorf("verify-641-r1 agentRef = %q, want %q", got, "gate")
+			}
+			if got := refs["review-641-0-r1"]; got != "reviewer" {
+				t.Errorf("review-641-0-r1 agentRef = %q, want %q", got, "reviewer")
+			}
+		})
+	}
+}
+
 func TestReviewFeedbackPrompt(t *testing.T) {
 	structured := noGoChild("review-641-0", "scope creep beyond the issue ask",
 		`[{"severity":"blocker","area":"scope","message":"reduces ACCESS_TOKEN_EXPIRE_MINUTES from 10080 to 30, unrelated to the issue","file":"config/auth.py","line":12,"suggestion":"revert the unrelated change"}]`)
@@ -237,6 +284,12 @@ func TestReviewFeedbackPrompt(t *testing.T) {
 	for _, want := range []string{
 		"rejected the previous attempt",
 		"NO-GO",
+		// The executor's revise-from-branch restore (#951) means the
+		// workspace really does start from the prior attempt; the prompt
+		// must direct a delta, not a rebuild.
+		"restored from this task's branch",
+		"Do not rebuild the fix from scratch",
+		"Amend the existing work",
 		"scope creep beyond the issue ask",
 		"[blocker/scope] reduces ACCESS_TOKEN_EXPIRE_MINUTES from 10080 to 30",
 		"config/auth.py:12",

--- a/internal/foreman/controller/workload_review_advisories.go
+++ b/internal/foreman/controller/workload_review_advisories.go
@@ -34,10 +34,15 @@ import (
 // task's GateAdvisories field is non-empty the patch is skipped.
 //
 // For each issue N in the issue-batch pipeline:
-//  1. Find the "code-N" child whose status.result carries gateAdvisories.
+//  1. Find the coder child whose status.result carries gateAdvisories.
+//     A base-round review ("review-N-<i>") reads "code-N"; a fix
+//     iteration's review ("review-N-<i>-r<k>", #946) reads its own
+//     round's coder ("code-N-r<k>"); an escalation review
+//     ("escalate-N-*") reads the LATEST coder iteration, since it
+//     judges the branch's final state.
 //  2. Unmarshal the JSON array into []foremanv1alpha1.GateAdvisory.
-//  3. For every "review-N-*" or "escalate-N-*" child that is still Pending
-//     and has no GateAdvisories set, patch spec.payload.gateAdvisories.
+//  3. For every such child that is still Pending and has no
+//     GateAdvisories set, patch spec.payload.gateAdvisories.
 //
 // Non-fatal: a single patch failure logs a warning and continues so the
 // remaining review tasks still receive their advisories. This mirrors the
@@ -64,26 +69,35 @@ func (r *WorkloadReconciler) patchReviewAdvisories(
 	}
 
 	for _, n := range w.Spec.Issues {
-		codeStep := fmt.Sprintf("code-%d", n)
-		codeTask, ok := byStep[codeStep]
-		if !ok {
-			continue
+		// The escalation tier reviews the branch's final state, so its
+		// advisories come from the latest fix iteration's coder task.
+		latestCode := 0
+		for step := range byStep {
+			if k, ok := parseIterationTail(step, fmt.Sprintf("code-%d", n)); ok && k > latestCode {
+				latestCode = k
+			}
 		}
 
-		advisories := extractGateAdvisories(codeTask)
-		if len(advisories) == 0 {
-			continue
-		}
-
-		// Patch every review/escalation task for this issue that is still
-		// Pending and does not yet carry advisories.
-		reviewPrefix := fmt.Sprintf("review-%d-", n)
 		escalatePrefix := fmt.Sprintf("escalate-%d-", n)
 		for i := range children {
 			step := children[i].Labels[labelStep]
-			if !strings.HasPrefix(step, reviewPrefix) && !strings.HasPrefix(step, escalatePrefix) {
+			var codeStep string
+			if k, ok := reviewIterationOf(step, n); ok {
+				codeStep = codeStepName(n, k)
+			} else if strings.HasPrefix(step, escalatePrefix) {
+				codeStep = codeStepName(n, latestCode)
+			} else {
 				continue
 			}
+			codeTask, ok := byStep[codeStep]
+			if !ok {
+				continue
+			}
+			advisories := extractGateAdvisories(codeTask)
+			if len(advisories) == 0 {
+				continue
+			}
+
 			reviewTask := &children[i]
 			if reviewTask.Status.Phase != foremanv1alpha1.AgenticTaskPhasePending &&
 				reviewTask.Status.Phase != "" {


### PR DESCRIPTION
> **Depends on #967** (`feat/revise-from-branch`, the executor restore extracted from #951). This branch is rebased on top of it, so the diff includes #967's commit until it merges; after that it shrinks to just the iteration loop.

## What

On a reviewer NO-GO the WorkloadReconciler now appends a bounded fix iteration instead of terminally failing the Workload: a new coder step `code-<n>-r<k>` on the same branch whose `payload.prompt` carries the reviewer's summary + structured findings, chained to fresh `verify-<n>-r<k>` + `review-<n>-<i>-r<k>` steps. Bounded by new `Workload.spec.maxReviewIterations` (`*int32`; unset defaults to 1, explicit 0 restores fail-on-first-NO-GO). `status.reviewIterations` records the emitted count and a `ReviewIterationTriggered` condition names the re-dispatched issues.

Rework after the hold-for-#951 review — the retry now amends the prior attempt instead of rebuilding from main:

- Iteration coder payloads stamp `reviseFromBranch` = the task's own branch (alongside `allowOverwrite`), so the executor (#967) restores the r0 attempt from the push remote before the model runs. The feedback prompt now states the real semantics: the workspace starts from the prior attempt, apply the findings as a delta, don't rebuild.
- New `Workload.spec.revisionCoderAgentRef` implements the profile-pairing piece of #951: iteration coder steps use it when set, pairing revisions with a revision-tuned profile instead of the issue-fix forcing profile. When unset they fall back to `coderAgentRef` and the reconciler emits a Warning event (`RevisionUnderIssueFixProfile`) on the Workload.
- `maxReviewIterations` default stays 1: with the restore in place, an on-by-default iteration can no longer destroy a passing base attempt.

## Why

The review result carries exactly what a fix needs (findings + summary + branch), but a NO-GO discarded it; external retry systems could only delete + recreate the Workload and re-run the coder blind, reproducing the same rejected patch.

Fixes #946. With #967, closes #951.

## How

- `internal/foreman/controller/workload_iteration.go`: emission modeled on `emitEscalations` — pure step-synthesis function (`reviewIterationSteps`), idempotency by step-name existence (partial creates repaired next reconcile), MaxTasks accounting (`MaxTasksIterationCap`), sovereignty gates on iteration reviewers, steady-state condition short-circuit, labeled in-flight placeholders so rollup/escalation see the new round in the same pass.
- Feedback prompt distills the review task's `status.result.extra.modelExtra` via `pkg/foreman/agent/reviewer.ParseFindings`, with a raw-JSON fallback for non-conforming (legacy map-shaped) findings.
- Rollup and the escalation trigger now judge each issue by its latest iteration only (`activeChildren`): a converged retry completes the Workload, a superseded round's NO-GO no longer pins it at Failed, and the escalation tier defers until iterations settle. Escalation semantics are unchanged for workloads that opt out (existing #546 tests now set `maxReviewIterations: 0` since the default changed to 1).
- `patchReviewAdvisories` wires each iteration's reviews to their own round's coder task (escalate reads the latest) instead of always `code-<n>`.
- `WorkloadReconciler` gains the operator-standard `events.EventRecorder` (nil-safe for tests), wired in `cmd/foreman-operator/main.go`; operator chart RBAC gains `events.k8s.io` create/patch.
- CRD manifests + chart CRDs regenerated.

Notable default change: unset `maxReviewIterations` means one fix iteration, so a NO-GO now fails the Workload one round later than before.

Verification: `KUBEBUILDER_ASSETS=... go test ./internal/foreman/controller/ -count=1` (envtest specs for NO-GO-with-budget → r1 steps with feedback prompt + `reviseFromBranch` + `allowOverwrite` and the fallback Warning event, `revisionCoderAgentRef` selected when set with no warning, exhausted budget → Failed/ChildrenIncomplete, GO → no iteration, iteration count in status, idempotency; plus table tests for step synthesis, coder-ref selection, prompt rendering, and superseded-round filtering); `go test ./pkg/foreman/...` ok; `golangci-lint run ./internal/... ./pkg/... ./api/...` 0 issues.

AI assistance: authored by Claude (Opus 4.8) operating under the maintainer's direction; reviewed before submitting.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)
