### PR TITLE
fix(foreman): scope-overlap check catches Go files in new directories

### DIFF
--- a/pkg/foreman/agent/caller_impact_gate_test.go
+++ b/pkg/foreman/agent/caller_impact_gate_test.go
@@ -25,7 +25,7 @@ import (
 // callerImpactRunner builds a fake commandRunner keyed on argv patterns for
 // checkCallerImpact tests. It answers three call types:
 //  1. git status -z  -> returns the changedFiles NUL-separated list
-//  2. git diff -U0 -- <file>  -> returns diffOutput for that file
+//  2. git diff -U0 HEAD -- <file>  -> returns diffOutput for that file
 //  3. grep -rn --include=*.go <name> .  -> returns grepOutput for that name
 func callerImpactRunner(changedFiles, diffOutput string, grepOutputs map[string]string) commandRunner {
 	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
@@ -34,8 +34,8 @@ func callerImpactRunner(changedFiles, diffOutput string, grepOutputs map[string]
 			if len(args) >= 2 && args[0] == "status" && args[1] == "-z" {
 				return changedFiles, nil
 			}
-			if len(args) >= 3 && args[0] == "diff" && args[1] == "-U0" {
-				// args[2] is "--", args[3] is the file
+			if len(args) >= 4 && args[0] == "diff" && args[1] == "-U0" && args[2] == "HEAD" {
+				// args[3] is "--", args[4] is the file
 				return diffOutput, nil
 			}
 		case "grep":
@@ -178,19 +178,21 @@ func TestCheckCallerImpact_AddedFuncWithExternalCaller(t *testing.T) {
 			"./pkg/y/consumer.go:42:\tNewThing()\n",
 	}
 
-	// addedFuncNames uses "git diff -- <file>" (without -U0); the fake runner
-	// above answers args[0]=="diff" && args[1]=="-U0" for modifiedFuncNames.
-	// We need a separate branch for the plain "git diff -- <file>" call used by
-	// addedFuncNames.  Extend the runner to handle both.
+	// addedFuncNames uses "git diff HEAD -- <file>" (without -U0); the fake runner
+	// above answers args[0]=="diff" && args[1]=="-U0" && args[2]=="HEAD" for
+	// modifiedFuncNames. Both diff forms now carry HEAD (#907/#962) so the coder's
+	// changes survive an earlier gate's `git add -A` staging; this branch matches
+	// either shape and returns the same diff (addedFuncNames only reads "+func").
 	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
 		switch name {
 		case "git":
 			if len(args) >= 2 && args[0] == "status" && args[1] == "-z" {
 				return changedFiles, nil
 			}
-			if len(args) >= 2 && args[0] == "diff" {
-				// Both -U0 (modifiedFuncNames) and plain (addedFuncNames) paths
-				// return the same diff; addedFuncNames only cares about "+func" lines.
+			if len(args) >= 3 && args[0] == "diff" &&
+				(args[1] == "HEAD" || (args[1] == "-U0" && args[2] == "HEAD")) {
+				// Both -U0 HEAD (modifiedFuncNames) and plain HEAD (addedFuncNames)
+				// paths return the same diff; addedFuncNames only cares about "+func".
 				return diffOutput, nil
 			}
 		case "grep":

--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -676,16 +676,13 @@ func checkReferenceGrounding(ctx context.Context, workspace string, run commandR
 // uncommitted edits rather than committed history (the gate runs before any
 // commit, so `...HEAD` would see nothing). A git error yields nil (the caller
 // treats that as "no changed files" and skips the check).
-//
-// `--src-prefix=a/ --dst-prefix=b/` is forced so the output is a clean path
-// list, not unified-diff path-prefix output (the `c/`/`i/` gotcha).
 func changedWorkingTreeGoFiles(ctx context.Context, workspace string, run commandRunner) ([]string, error) {
 	// Stage everything so untracked new files appear in the diff.
 	if _, err := run(ctx, workspace, nil, "git", "add", "-A"); err != nil {
 		return nil, err
 	}
 	out, err := run(ctx, workspace, nil, "git", "diff", "--name-only",
-		"--cached", "--src-prefix=a/", "--dst-prefix=b/", "HEAD")
+		"--cached", "HEAD")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -571,6 +571,13 @@ var scopeRelevantFiles = func(workspace, issueText string) (paths []string, set 
 // Only when there is a real Go signal AND the changed Go files miss it
 // entirely is the submit flagged, with feedback naming what changed vs. what
 // the issue points at.
+//
+// The check inspects the coder's actual (uncommitted) working-tree changes by
+// staging them (`git add -A`) and diffing against HEAD with `git diff --name-only
+// --cached`. This is necessary because the gate runs as VerifyTerminal before
+// the executor commits, so `git diff base...HEAD` would see no changes (the
+// coder's edits are uncommitted/untracked). Mirrors the fix applied to the
+// reference-grounding check in #906.
 func checkScopeOverlap(
 	ctx context.Context, workspace string, run commandRunner, issueText string,
 ) (drift bool, feedback string) {
@@ -578,11 +585,10 @@ func checkScopeOverlap(
 		return false, ""
 	}
 
-	var changedGo []string
-	for path := range dirtyPathSet(ctx, workspace, run) {
-		if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
-			changedGo = append(changedGo, path)
-		}
+	changedGo, err := changedWorkingTreeGoFiles(ctx, workspace, run)
+	if err != nil {
+		// Fail-open: a git error here is not a drift signal.
+		return false, ""
 	}
 	if len(changedGo) == 0 {
 		return false, ""
@@ -661,4 +667,37 @@ func checkReferenceGrounding(ctx context.Context, workspace string, run commandR
 		fmt.Fprintf(&b, "  - %s\n", f.String())
 	}
 	return true, b.String()
+}
+
+// changedWorkingTreeGoFiles returns the workspace-relative Go file paths that
+// differ from HEAD in the coder's working tree (staged + unstaged), excluding
+// test files. It stages everything with `git add -A` and then runs
+// `git diff --name-only --cached HEAD` so the result reflects the coder's
+// uncommitted edits rather than committed history (the gate runs before any
+// commit, so `...HEAD` would see nothing). A git error yields nil (the caller
+// treats that as "no changed files" and skips the check).
+//
+// `--src-prefix=a/ --dst-prefix=b/` is forced so the output is a clean path
+// list, not unified-diff path-prefix output (the `c/`/`i/` gotcha).
+func changedWorkingTreeGoFiles(ctx context.Context, workspace string, run commandRunner) ([]string, error) {
+	// Stage everything so untracked new files appear in the diff.
+	if _, err := run(ctx, workspace, nil, "git", "add", "-A"); err != nil {
+		return nil, err
+	}
+	out, err := run(ctx, workspace, nil, "git", "diff", "--name-only",
+		"--cached", "--src-prefix=a/", "--dst-prefix=b/", "HEAD")
+	if err != nil {
+		return nil, err
+	}
+	var paths []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasSuffix(line, ".go") && !strings.HasSuffix(line, "_test.go") {
+			paths = append(paths, line)
+		}
+	}
+	return paths, nil
 }

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -626,12 +626,17 @@ func withScopeRelevant(t *testing.T, paths []string) {
 	t.Cleanup(func() { scopeRelevantFiles = orig })
 }
 
-// scopeRunner returns a commandRunner whose `git status --porcelain` reports
-// the given porcelain output; all other commands succeed silently.
-func scopeRunner(porcelain string) commandRunner {
+// diffRunner returns a commandRunner that mocks `git add -A` as a no-op and
+// returns the given name-only diff output for `git diff --name-only --cached`.
+// All other commands succeed silently. This is the seam used by
+// changedWorkingTreeGoFiles (the scope-overlap check's working-tree diff).
+func diffRunner(diffOutput string) commandRunner {
 	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
-		if name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain" {
-			return porcelain, nil
+		if name == "git" && len(args) >= 1 && args[0] == "add" && len(args) >= 2 && args[1] == "-A" {
+			return "", nil
+		}
+		if name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--name-only" && args[2] == "--cached" {
+			return diffOutput, nil
 		}
 		return "", nil
 	}
@@ -639,7 +644,7 @@ func scopeRunner(porcelain string) commandRunner {
 
 func TestCheckScopeOverlap_DriftFlagged(t *testing.T) {
 	withScopeRelevant(t, []string{"pkg/agent/endpoint.go", "pkg/agent/health.go"})
-	run := scopeRunner(" M pkg/cli/cache.go\n")
+	run := diffRunner("pkg/cli/cache.go\n")
 	drift, fb := checkScopeOverlap(context.Background(), "/work", run, "metal-agent endpoint health")
 	if !drift {
 		t.Fatal("expected drift when the changed Go file is outside the relevant set")
@@ -652,7 +657,7 @@ func TestCheckScopeOverlap_DriftFlagged(t *testing.T) {
 func TestCheckScopeOverlap_InScopePasses(t *testing.T) {
 	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
 	// Touches a relevant file plus an unrelated one: any overlap is in scope.
-	run := scopeRunner(" M pkg/agent/endpoint.go\n M pkg/cli/cache.go\n")
+	run := diffRunner("pkg/agent/endpoint.go\npkg/cli/cache.go\n")
 	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, "x"); drift {
 		t.Error("expected no drift when a changed file is in the relevant set")
 	}
@@ -660,7 +665,7 @@ func TestCheckScopeOverlap_InScopePasses(t *testing.T) {
 
 func TestCheckScopeOverlap_SkipsNonGoOnlyChanges(t *testing.T) {
 	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
-	run := scopeRunner(" M charts/foreman/x.yaml\n M docs/readme.md\n")
+	run := diffRunner("charts/foreman/x.yaml\ndocs/readme.md\n")
 	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, "x"); drift {
 		t.Error("a yaml/docs-only change must not be flagged by the Go-aware guard")
 	}
@@ -668,7 +673,7 @@ func TestCheckScopeOverlap_SkipsNonGoOnlyChanges(t *testing.T) {
 
 func TestCheckScopeOverlap_SkipsTestOnlyChanges(t *testing.T) {
 	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
-	run := scopeRunner(" M pkg/cli/cache_test.go\n")
+	run := diffRunner("pkg/cli/cache_test.go\n")
 	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, "x"); drift {
 		t.Error("a test-only change must not be judged")
 	}
@@ -676,7 +681,7 @@ func TestCheckScopeOverlap_SkipsTestOnlyChanges(t *testing.T) {
 
 func TestCheckScopeOverlap_SkipsWhenNoGoSignal(t *testing.T) {
 	withScopeRelevant(t, nil) // issue produces no positively-scored Go files
-	run := scopeRunner(" M pkg/cli/cache.go\n")
+	run := diffRunner("pkg/cli/cache.go\n")
 	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, "x"); drift {
 		t.Error("no Go signal -> observe-only, no flag")
 	}
@@ -684,15 +689,30 @@ func TestCheckScopeOverlap_SkipsWhenNoGoSignal(t *testing.T) {
 
 func TestCheckScopeOverlap_SkipsWhenIssueTextEmpty(t *testing.T) {
 	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
-	run := scopeRunner(" M pkg/cli/cache.go\n")
+	run := diffRunner("pkg/cli/cache.go\n")
 	if drift, _ := checkScopeOverlap(context.Background(), "/work", run, ""); drift {
 		t.Error("empty issueText must disable the scope check")
 	}
 }
 
+func TestCheckScopeOverlap_CatchesUntrackedNewFile(t *testing.T) {
+	// Regression for #907: the scope-overlap check must see untracked new
+	// files (which `git diff ...HEAD` would miss because they are not in
+	// committed history). `git add -A` stages them; `git diff --cached` shows
+	// them.
+	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
+	run := diffRunner("pkg/agent/new_thing.go\n")
+	drift, _ := checkScopeOverlap(context.Background(), "/work", run, "metal-agent endpoint health")
+	if !drift {
+		t.Error("expected drift when an untracked new Go file is outside the relevant set")
+	}
+}
+
 // gateRunnerAllPassExcept builds a runner where gofmt/vet/build/lint pass,
 // codegen is skipped (no controller-gen), no changed test packages, and
-// `git status --porcelain` reports porcelain (for the scope tier).
+// `git add -A` + `git diff --name-only --cached` report the given porcelain
+// (for the scope tier). The porcelain string is a newline-separated list of
+// workspace-relative paths, matching `git diff --name-only` output.
 func gateRunnerScope(golangciPath, porcelain string) commandRunner {
 	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
 		switch {
@@ -702,7 +722,9 @@ func gateRunnerScope(golangciPath, porcelain string) commandRunner {
 			return "", errors.New("no controller-gen") // skip codegen tier
 		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "-z":
 			return "", nil // no changed test packages
-		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain":
+		case name == "git" && len(args) >= 1 && args[0] == "add" && len(args) >= 2 && args[1] == "-A":
+			return "", nil // stage everything (no-op in tests)
+		case name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--name-only" && args[2] == "--cached":
 			return porcelain, nil
 		default:
 			return "", nil

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -695,16 +695,20 @@ func TestCheckScopeOverlap_SkipsWhenIssueTextEmpty(t *testing.T) {
 	}
 }
 
-func TestCheckScopeOverlap_CatchesUntrackedNewFile(t *testing.T) {
-	// Regression for #907: the scope-overlap check must see untracked new
-	// files (which `git diff ...HEAD` would miss because they are not in
-	// committed history). `git add -A` stages them; `git diff --cached` shows
-	// them.
+func TestCheckScopeOverlap_CatchesGoFileInNewDirectory(t *testing.T) {
+	// Regression for #907. The prior `git status --porcelain` path already
+	// listed untracked files in *tracked* directories, but collapsed a
+	// brand-new untracked directory to a single "newdir/" entry, which fails
+	// the .go suffix filter -- so an out-of-scope Go file created in a new
+	// directory slipped past scope-overlap. Staging (`git add -A`) then
+	// `git diff --name-only --cached HEAD` lists each new file individually,
+	// closing that gap. This test guards the working-tree-diff command seam:
+	// the mocked diff reports a Go file in a new directory, which must drift.
 	withScopeRelevant(t, []string{"pkg/agent/endpoint.go"})
-	run := diffRunner("pkg/agent/new_thing.go\n")
+	run := diffRunner("newpkg/thing.go\n")
 	drift, _ := checkScopeOverlap(context.Background(), "/work", run, "metal-agent endpoint health")
 	if !drift {
-		t.Error("expected drift when an untracked new Go file is outside the relevant set")
+		t.Error("expected drift when an out-of-scope Go file in a new directory is changed")
 	}
 }
 

--- a/pkg/foreman/agent/gate_fixtures_test.go
+++ b/pkg/foreman/agent/gate_fixtures_test.go
@@ -504,3 +504,65 @@ func Solo() string {
 		}
 	})
 }
+
+// TestGateFixtures_StagingDoesNotBlindDownstream is the #907/#962 regression.
+//
+// RunCoderGate runs checkScopeOverlap (step 8) BEFORE checkTestPresence (step 9)
+// and checkMutationSurvival (step 10). #962 changed checkScopeOverlap to stage
+// the whole working tree with `git add -A` (so Go files in NEW directories show
+// up in its name-only diff). But the downstream mutation gates read the coder's
+// changes via `git diff` for a file. Before this fix that diff had no revision
+// argument, so after step 8 staged everything (working tree == index) it
+// returned EMPTY: checkTestPresence saw zero net-new funcs and could not flag a
+// missing test, silently going green on the GO path. The per-check unit tests
+// mock `run` in isolation, so none caught the staging leaking across checks.
+//
+// This test drives the two checks in the real gate order against a REAL git
+// repo (execCommandRunner via materializeFixture, no mocked runner) and asserts
+// test-presence still FIRES after checkScopeOverlap stages. It FAILS on the old
+// `git diff -- <file>` helper (blinded by staging) and PASSES on the
+// `git diff HEAD -- <file>` fix.
+func TestGateFixtures_StagingDoesNotBlindDownstream(t *testing.T) {
+	// Simulate the coder: a NEW exported func in a NEW directory, with NO test.
+	newSrc := `package newthing
+
+// DoNewThing is new, exported, and shipped without a test.
+func DoNewThing() string {
+	return "new"
+}
+`
+	ws, run := materializeFixture(t, []fixtureFile{
+		{relPath: "pkg/newthing/newthing.go", base: "", current: newSrc},
+	})
+
+	ctx := context.Background()
+
+	// Baseline: before any staging, test-presence already fires for the
+	// untested new func (proves the fixture is set up correctly).
+	if failed, _ := checkTestPresence(ctx, ws, run); !failed {
+		t.Fatal("baseline: test-presence should fire for an untested new func")
+	}
+
+	// Step 8: checkScopeOverlap stages the entire tree via `git add -A`. A
+	// non-empty issueText is required so the check reaches the staging step
+	// (it early-returns on empty issueText before staging).
+	_, _ = checkScopeOverlap(ctx, ws, run, "add DoNewThing to pkg/newthing")
+
+	// Precondition that used to blind the downstream gates: with everything
+	// staged, a plain (unstaged) `git diff` is now empty.
+	if plain, _ := run(ctx, ws, nil, "git", "diff"); strings.TrimSpace(plain) != "" {
+		t.Fatalf("precondition: expected an empty unstaged diff after `git add -A`, got:\n%s", plain)
+	}
+
+	// Step 9: test-presence must STILL fire against the staged tree. On the
+	// pre-fix `git diff -- <file>` helper this returned passed=false (the bug),
+	// because the unstaged diff was empty and no net-new func was seen.
+	failed, out := checkTestPresence(ctx, ws, run)
+	if !failed {
+		t.Fatal("regression #907: test-presence was blinded by checkScopeOverlap's " +
+			"`git add -A` staging; the downstream diff must be taken against HEAD")
+	}
+	if !strings.Contains(out, "DoNewThing") {
+		t.Errorf("test-presence output should name DoNewThing; got: %s", out)
+	}
+}

--- a/pkg/foreman/agent/mutation_gate.go
+++ b/pkg/foreman/agent/mutation_gate.go
@@ -111,11 +111,19 @@ func mutationGateDisabled() bool {
 var addedFuncRe = regexp.MustCompile(`^\+\s*func\b[^/]*\(`)
 
 // addedFuncNames returns the names of functions/methods introduced by added
-// lines in `git diff` for the given file. Heuristic and intentionally simple:
-// it keys the presence check on NET-NEW functions so behavior-preserving edits
-// to existing funcs do not require a new test.
+// lines in `git diff HEAD` for the given file. Heuristic and intentionally
+// simple: it keys the presence check on NET-NEW functions so behavior-preserving
+// edits to existing funcs do not require a new test.
+//
+// The diff is taken against HEAD (not the plain working-tree diff) so it is
+// independent of whether an earlier gate staged the tree. checkScopeOverlap
+// runs `git add -A` before this check (#906/#962); a plain `git diff` would then
+// see an empty (working-tree == index) diff and report zero new funcs, silently
+// blinding checkTestPresence/checkMutationSurvival on the GO path (#907). Since
+// the coder's work is uncommitted, HEAD is the pre-work base, so `git diff HEAD`
+// is exactly "the coder's changes" whether or not they are staged.
 func addedFuncNames(ctx context.Context, workspace, file string, run commandRunner) []string {
-	out, err := run(ctx, workspace, nil, "git", "diff", "--", file)
+	out, err := run(ctx, workspace, nil, "git", "diff", "HEAD", "--", file)
 	if err != nil {
 		return nil
 	}
@@ -192,12 +200,18 @@ var hunkFuncRe = regexp.MustCompile(`@@[^@]*@@\s+func\b.*`)
 
 // modifiedFuncNames returns the names of functions whose bodies were touched
 // (but not necessarily introduced) by the diff of the given file. It parses
-// `git diff -U0 -- <file>` and extracts the enclosing function name from the
+// `git diff -U0 HEAD -- <file>` and extracts the enclosing function name from the
 // hunk header trailing context that Go emits when the hunk falls inside a
 // function. Functions already captured by addedFuncNames (net-new +func lines)
 // are included here too; the caller deduplicates via a union set.
+//
+// The diff is taken against HEAD (not the plain working-tree diff) so it is
+// independent of whether an earlier gate staged the tree: checkScopeOverlap runs
+// `git add -A` before this check (#906/#962), which would make a plain
+// `git diff` empty and blind checkTestPresence/checkMutationSurvival (#907).
+// The coder's work is uncommitted, so HEAD is the pre-work base.
 func modifiedFuncNames(ctx context.Context, workspace, file string, run commandRunner) []string {
-	out, err := run(ctx, workspace, nil, "git", "diff", "-U0", "--", file)
+	out, err := run(ctx, workspace, nil, "git", "diff", "-U0", "HEAD", "--", file)
 	if err != nil {
 		return nil
 	}
@@ -341,10 +355,16 @@ func checkTestPresence(ctx context.Context, workspace string, run commandRunner)
 // hunk header: "@@ -a,b +c,d @@".
 var hunkHeaderRe = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
 
-// changedNewLines parses `git diff -U0 -- <file>` and returns the set of
+// changedNewLines parses `git diff -U0 HEAD -- <file>` and returns the set of
 // new-file line numbers touched by added lines.
+//
+// The diff is taken against HEAD (not the plain working-tree diff) so it is
+// independent of whether an earlier gate staged the tree: checkScopeOverlap runs
+// `git add -A` before checkMutationSurvival (#906/#962), which would make a plain
+// `git diff` empty and leave nothing to neuter, auto-passing the survival check
+// (#907). The coder's work is uncommitted, so HEAD is the pre-work base.
 func changedNewLines(ctx context.Context, workspace, file string, run commandRunner) map[int]bool {
-	out, err := run(ctx, workspace, nil, "git", "diff", "-U0", "--", file)
+	out, err := run(ctx, workspace, nil, "git", "diff", "-U0", "HEAD", "--", file)
 	if err != nil {
 		return nil
 	}

--- a/pkg/foreman/agent/mutation_gate_test.go
+++ b/pkg/foreman/agent/mutation_gate_test.go
@@ -80,7 +80,7 @@ func TestCheckTestPresence(t *testing.T) {
 		if name == "git" && len(args) > 0 && args[0] == "status" {
 			return statusOut, nil
 		}
-		if name == "git" && len(args) > 0 && args[0] == "diff" {
+		if name == "git" && len(args) > 1 && args[0] == "diff" && (args[1] == "HEAD" || args[1] == "-U0") {
 			return diffOut, nil
 		}
 		return "", nil
@@ -109,17 +109,17 @@ func TestCheckTestPresence_PassesWhenTestChanged(t *testing.T) { //nolint:dupl
 	_ = os.WriteFile(filepath.Join(ws, "pkg/x/x_test.go"),
 		[]byte("package x\nimport \"testing\"\nfunc TestNew(t *testing.T) { New() }\n"), 0o644)
 	statusOut := " M pkg/x/x.go\x00 M pkg/x/x_test.go\x00"
-	// git diff -- file: plain diff (no -U0 flag) — used by addedFuncNames
+	// git diff HEAD -- file: plain diff (no -U0 flag) — used by addedFuncNames
 	diffOut := "@@ -0,0 +1,1 @@\n+func New() {}\n"
-	// git diff -U0 -- file: used by modifiedFuncNames (no hunk-context func here)
+	// git diff -U0 HEAD -- file: used by modifiedFuncNames (no hunk-context func here)
 	diffU0Out := "@@ -0,0 +1,1 @@\n+func New() {}\n"
 	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
 		switch {
 		case name == "git" && args[0] == "status":
 			return statusOut, nil
-		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "-U0":
+		case name == "git" && args[0] == "diff" && len(args) > 2 && args[1] == "-U0" && args[2] == "HEAD":
 			return diffU0Out, nil
-		case name == "git" && args[0] == "diff":
+		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "HEAD":
 			return diffOut, nil
 		}
 		return "", nil
@@ -143,19 +143,19 @@ func TestCheckTestPresence_UnrelatedTestDoesNotExempt(t *testing.T) {
 		[]byte("package controller\nfunc TestBar(t interface{}) { _ = Bar }\n"), 0o644)
 
 	statusOut := " M internal/controller/x.go\x00 M internal/controller/y_test.go\x00"
-	// git diff -- x.go: plain diff, adds func Foo
+	// git diff HEAD -- x.go: plain diff, adds func Foo
 	diffOut := "diff --git a/internal/controller/x.go b/internal/controller/x.go\n" +
 		"@@ -0,0 +1,2 @@\n+package controller\n+func Foo() {}\n"
-	// git diff -U0 -- x.go: -U0 diff, no trailing func context on this hunk
+	// git diff -U0 HEAD -- x.go: -U0 diff, no trailing func context on this hunk
 	diffU0Out := "@@ -0,0 +1,2 @@\n+package controller\n+func Foo() {}\n"
 
 	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
 		switch {
 		case name == "git" && args[0] == "status":
 			return statusOut, nil
-		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "-U0":
+		case name == "git" && args[0] == "diff" && len(args) > 2 && args[1] == "-U0" && args[2] == "HEAD":
 			return diffU0Out, nil
-		case name == "git" && args[0] == "diff":
+		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "HEAD":
 			return diffOut, nil
 		}
 		return "", nil
@@ -186,9 +186,9 @@ func TestCheckTestPresence_ReferencingTestPasses(t *testing.T) { //nolint:dupl
 		switch {
 		case name == "git" && args[0] == "status":
 			return statusOut, nil
-		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "-U0":
+		case name == "git" && args[0] == "diff" && len(args) > 2 && args[1] == "-U0" && args[2] == "HEAD":
 			return diffU0Out, nil
-		case name == "git" && args[0] == "diff":
+		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "HEAD":
 			return diffOut, nil
 		}
 		return "", nil
@@ -211,19 +211,19 @@ func TestCheckTestPresence_ModifiedFuncNeedsTest(t *testing.T) {
 	// No changed _test.go at all.
 
 	statusOut := " M pkg/diff/diff.go\x00"
-	// git diff -- diff.go: body changed but no +func line
+	// git diff HEAD -- diff.go: body changed but no +func line
 	diffOut := "diff --git a/pkg/diff/diff.go b/pkg/diff/diff.go\n" +
 		"@@ -1,2 +1,2 @@ func DiffNameOnly() string {\n-\treturn \"old\"\n+\treturn \"new\"\n"
-	// git diff -U0 -- diff.go: hunk header carries the enclosing func name
+	// git diff -U0 HEAD -- diff.go: hunk header carries the enclosing func name
 	diffU0Out := "@@ -1,1 +1,1 @@ func DiffNameOnly() string {\n-\treturn \"old\"\n+\treturn \"new\"\n"
 
 	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
 		switch {
 		case name == "git" && args[0] == "status":
 			return statusOut, nil
-		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "-U0":
+		case name == "git" && args[0] == "diff" && len(args) > 2 && args[1] == "-U0" && args[2] == "HEAD":
 			return diffU0Out, nil
-		case name == "git" && args[0] == "diff":
+		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "HEAD":
 			return diffOut, nil
 		}
 		return "", nil
@@ -271,7 +271,7 @@ func TestCheckMutationSurvival_FlagsSurvivor(t *testing.T) {
 		switch {
 		case name == "git" && args[0] == "status":
 			return " M pkg/x/x.go\x00 M pkg/x/x_test.go\x00", nil
-		case name == "git" && args[0] == "diff":
+		case name == "git" && args[0] == "diff" && len(args) > 2 && args[1] == "-U0" && args[2] == "HEAD":
 			return "@@ -0,0 +3 @@\n+func Add(a, b int) int { return a + b }\n", nil
 		case name == "go" && args[0] == "test":
 			return "ok", nil // weak test passes even with the body neutered -> SURVIVOR
@@ -299,7 +299,7 @@ func TestCheckMutationSurvival_PassesWhenTestsBite(t *testing.T) {
 		switch {
 		case name == "git" && args[0] == "status":
 			return " M pkg/x/x.go\x00 M pkg/x/x_test.go\x00", nil
-		case name == "git" && args[0] == "diff":
+		case name == "git" && args[0] == "diff" && len(args) > 2 && args[1] == "-U0" && args[2] == "HEAD":
 			return "@@ -0,0 +3 @@\n+func Add(a, b int) int { return a + b }\n", nil
 		case name == "go" && args[0] == "test":
 			return "FAIL", context.DeadlineExceeded // non-nil -> tests failed under neuter -> they bite


### PR DESCRIPTION
## What

Fixes the coder gate's scope-overlap check so it sees a Go file created in a **brand-new untracked directory**.

## Why

Fixes #907

The scope-overlap check enumerated the coder's changed Go files via `git status --porcelain`. Porcelain lists untracked files in already-tracked directories fine, but it **collapses a brand-new untracked directory to a single `newdir/` entry** — which fails the `.go` suffix filter, so an out-of-scope Go file created in a new directory slipped past the check.

(Note: the original issue described this as the check "diffing committed history" / being "blind pre-commit." On inspection the pre-change code was `git status --porcelain`, not a `base...HEAD` diff, so it did see most uncommitted changes — the real, narrower gap is the new-directory collapse above. The fix is the same either way.)

## How

Replace the porcelain scan with `git add -A` followed by `git diff --name-only --cached HEAD`, which lists each new file individually (including files in new directories). This mirrors the established working-tree-diff approach used by the reference-grounding check (#906).

Safety of `git add -A` inside the gate: it runs pre-commit, but the executor's commit path (`repo.Commit`) runs its own `git add -A` immediately before `git commit -s`, so the committed file set is identical regardless of what the gate staged — no junk inclusion, no interference. This is the same documented-safe pattern as #906.

The regression test models the actual fixed case (a Go file in a new directory) and the diff drops two flags (`--src-prefix`/`--dst-prefix`) that are inert with `--name-only`.

Authored by **Foreman**, LLMKube's agentic coder harness (local model on the lab fleet); the maintainer adversarially reviewed the git-side-effect safety, corrected the diagnosis/test, and takes responsibility per the AI-assisted contribution policy.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (+ `GOOS=linux golangci-lint`, 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - internal gate check, no user-facing surface
