### PR TITLE
feat(foreman): coder-tier escalation, re-dispatch a failed coder to a larger model

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -300,6 +300,15 @@ type AgenticTaskPayload struct {
 	// +optional
 	Prompt string `json:"prompt,omitempty"`
 
+	// PromptPrefix is prepended to the assembled user prompt for an
+	// issue-fix task, BEFORE the fetched issue body. Unlike Prompt
+	// (which, when set, suppresses the issue-body fetch), PromptPrefix
+	// leaves the issue-body fetch intact, so the agent sees both this
+	// hint and the issue's acceptance criteria. Used by the coder
+	// escalation tier to carry the prior model's diagnosis.
+	// +optional
+	PromptPrefix string `json:"promptPrefix,omitempty"`
+
 	// Agent is the named agent to invoke. Required for freeform; defaults
 	// to "issue-fixer" for issue-fix and "verify" for verify.
 	// +optional

--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -175,6 +175,28 @@ type WorkloadSpec struct {
 	// +optional
 	OpenPullRequest *bool `json:"openPullRequest,omitempty"`
 
+	// EscalationCoderAgentRef is the optional coder escalation tier: a
+	// single, typically larger/denser coder Agent that re-attempts an
+	// issue when the base CoderAgentRef fails at its model's ceiling.
+	// Issue-batch mode only. For each issue N, if the base code-<N> task
+	// is terminal with a capability failure (verdict NO-GO from the
+	// model, or outcome CODER-GATE-FAILED), the WorkloadReconciler emits
+	// an escalation code+verify(+review) set (code-<N>-esc /
+	// verify-<N>-esc / review-<N>-esc-<i>) against this Agent, on a fresh
+	// branch foreman/<w>/issue-<N>-esc, with the failed model's summary
+	// passed as a prompt hint.
+	//
+	// Singular (unlike EscalationReviewerAgentRefs, which fans out N
+	// reviewers in parallel): coders are sequential, so N parallel
+	// escalation coders would produce N competing branches. Exactly one
+	// escalation tier; an escalation task that itself fails is terminal.
+	//
+	// Does NOT trigger on STUCK-LOOP-DETECTED, a model-decided
+	// INCOMPLETE, or ERROR: those are scope/harness failures a larger,
+	// slower model will not fix. Leave unset to disable escalation.
+	// +optional
+	EscalationCoderAgentRef *corev1.LocalObjectReference `json:"escalationCoderAgentRef,omitempty"`
+
 	// AllowOverwrite lets this Workload's coder replace a stale remote
 	// ref for its own foreman/* branch (force-with-lease compare-and-swap)
 	// instead of failing non-fast-forward. Opt-in — #573 deliberately

--- a/api/foreman/v1alpha1/zz_generated.deepcopy.go
+++ b/api/foreman/v1alpha1/zz_generated.deepcopy.go
@@ -997,6 +997,16 @@ func (in *WorkloadSpec) DeepCopyInto(out *WorkloadSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.OpenPullRequest != nil {
+		in, out := &in.OpenPullRequest, &out.OpenPullRequest
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EscalationCoderAgentRef != nil {
+		in, out := &in.EscalationCoderAgentRef, &out.EscalationCoderAgentRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	if in.MaxReviewIterations != nil {
 		in, out := &in.MaxReviewIterations, &out.MaxReviewIterations
 		*out = new(int32)

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -235,6 +235,15 @@ spec:
                   prompt:
                     description: Prompt is the agent input. Required for freeform.
                     type: string
+                  promptPrefix:
+                    description: |-
+                      PromptPrefix is prepended to the assembled user prompt for an
+                      issue-fix task, BEFORE the fetched issue body. Unlike Prompt
+                      (which, when set, suppresses the issue-body fetch), PromptPrefix
+                      leaves the issue-body fetch intact, so the agent sees both this
+                      hint and the issue's acceptance criteria. Used by the coder
+                      escalation tier to carry the prior model's diagnosis.
+                    type: string
                   repo:
                     description: Repo is the "owner/name" GitHub repo. Required for
                       issue-fix and verify.

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -112,6 +112,39 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              escalationCoderAgentRef:
+                description: |-
+                  EscalationCoderAgentRef is the optional coder escalation tier: a
+                  single, typically larger/denser coder Agent that re-attempts an
+                  issue when the base CoderAgentRef fails at its model's ceiling.
+                  Issue-batch mode only. For each issue N, if the base code-<N> task
+                  is terminal with a capability failure (verdict NO-GO from the
+                  model, or outcome CODER-GATE-FAILED), the WorkloadReconciler emits
+                  an escalation code+verify(+review) set (code-<N>-esc /
+                  verify-<N>-esc / review-<N>-esc-<i>) against this Agent, on a fresh
+                  branch foreman/<w>/issue-<N>-esc, with the failed model's summary
+                  passed as a prompt hint.
+
+                  Singular (unlike EscalationReviewerAgentRefs, which fans out N
+                  reviewers in parallel): coders are sequential, so N parallel
+                  escalation coders would produce N competing branches. Exactly one
+                  escalation tier; an escalation task that itself fails is terminal.
+
+                  Does NOT trigger on STUCK-LOOP-DETECTED, a model-decided
+                  INCOMPLETE, or ERROR: those are scope/harness failures a larger,
+                  slower model will not fix. Leave unset to disable escalation.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               escalationReviewerAgentRefs:
                 description: |-
                   EscalationReviewerAgentRefs is the optional second reviewer tier
@@ -469,6 +502,15 @@ spec:
                           type: boolean
                         prompt:
                           description: Prompt is the agent input. Required for freeform.
+                          type: string
+                        promptPrefix:
+                          description: |-
+                            PromptPrefix is prepended to the assembled user prompt for an
+                            issue-fix task, BEFORE the fetched issue body. Unlike Prompt
+                            (which, when set, suppresses the issue-body fetch), PromptPrefix
+                            leaves the issue-body fetch intact, so the agent sees both this
+                            hint and the issue's acceptance criteria. Used by the coder
+                            escalation tier to carry the prior model's diagnosis.
                           type: string
                         repo:
                           description: Repo is the "owner/name" GitHub repo. Required

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -235,6 +235,15 @@ spec:
                   prompt:
                     description: Prompt is the agent input. Required for freeform.
                     type: string
+                  promptPrefix:
+                    description: |-
+                      PromptPrefix is prepended to the assembled user prompt for an
+                      issue-fix task, BEFORE the fetched issue body. Unlike Prompt
+                      (which, when set, suppresses the issue-body fetch), PromptPrefix
+                      leaves the issue-body fetch intact, so the agent sees both this
+                      hint and the issue's acceptance criteria. Used by the coder
+                      escalation tier to carry the prior model's diagnosis.
+                    type: string
                   repo:
                     description: Repo is the "owner/name" GitHub repo. Required for
                       issue-fix and verify.

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -112,6 +112,39 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              escalationCoderAgentRef:
+                description: |-
+                  EscalationCoderAgentRef is the optional coder escalation tier: a
+                  single, typically larger/denser coder Agent that re-attempts an
+                  issue when the base CoderAgentRef fails at its model's ceiling.
+                  Issue-batch mode only. For each issue N, if the base code-<N> task
+                  is terminal with a capability failure (verdict NO-GO from the
+                  model, or outcome CODER-GATE-FAILED), the WorkloadReconciler emits
+                  an escalation code+verify(+review) set (code-<N>-esc /
+                  verify-<N>-esc / review-<N>-esc-<i>) against this Agent, on a fresh
+                  branch foreman/<w>/issue-<N>-esc, with the failed model's summary
+                  passed as a prompt hint.
+
+                  Singular (unlike EscalationReviewerAgentRefs, which fans out N
+                  reviewers in parallel): coders are sequential, so N parallel
+                  escalation coders would produce N competing branches. Exactly one
+                  escalation tier; an escalation task that itself fails is terminal.
+
+                  Does NOT trigger on STUCK-LOOP-DETECTED, a model-decided
+                  INCOMPLETE, or ERROR: those are scope/harness failures a larger,
+                  slower model will not fix. Leave unset to disable escalation.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               escalationReviewerAgentRefs:
                 description: |-
                   EscalationReviewerAgentRefs is the optional second reviewer tier
@@ -469,6 +502,15 @@ spec:
                           type: boolean
                         prompt:
                           description: Prompt is the agent input. Required for freeform.
+                          type: string
+                        promptPrefix:
+                          description: |-
+                            PromptPrefix is prepended to the assembled user prompt for an
+                            issue-fix task, BEFORE the fetched issue body. Unlike Prompt
+                            (which, when set, suppresses the issue-body fetch), PromptPrefix
+                            leaves the issue-body fetch intact, so the agent sees both this
+                            hint and the issue's acceptance criteria. Used by the coder
+                            escalation tier to carry the prior model's diagnosis.
                           type: string
                         repo:
                           description: Repo is the "owner/name" GitHub repo. Required

--- a/docs/site/foreman/README.md
+++ b/docs/site/foreman/README.md
@@ -156,6 +156,69 @@ upstream PR or queue more issues into the Workload.
 For the full reviewer-ensemble shape:
 `examples/foreman/workload-v04-default.yaml` in this repo.
 
+## Coder escalation tier
+
+Setting `Workload.spec.escalationCoderAgentRef` opts the Workload
+into a coder escalation tier. When the base coder fails an issue at
+its model's ceiling, Foreman re-runs that one issue on the named
+larger-model coder Agent, carrying the failed model's own diagnosis
+forward as a prompt hint. The idea is a routing hop, not a retry
+storm: a fast, capable model takes the first pass, and only the
+issues it genuinely can't close get a second, heavier attempt.
+
+Escalation fires **only on capability failures**, where a bigger
+model plausibly helps:
+
+- a model-decided **NO-GO** (the coder concluded it could not solve
+  the issue), or
+- a **coder-gate failure** (`CODER-GATE-FAILED`).
+
+It deliberately does **not** fire on:
+
+- a model-decided **INCOMPLETE** (the model gave up or ran out of
+  turns),
+- a **stuck-loop** detection, or
+- an **error**.
+
+A larger, slower model won't fix a give-up or a loop and is more
+likely to blow the turn budget, so those outcomes are left as-is.
+
+`escalationCoderAgentRef` is a singular field: one escalation tier,
+run sequentially after the base coder. It applies to issue-batch
+mode only, alongside `coderAgentRef` and `verifierAgentRef`, and is
+ignored for explicit Pipeline-mode Workloads. Unset (the default)
+means the tier is disabled.
+
+**Recommended deployment.** Run the base and escalation coders as a
+dual-box pair with both models hot, for example a fast MoE coder on
+one accelerator and a larger dense coder on another, so escalation
+is a routing hop rather than a cold model load. The operator is
+responsible for ensuring the escalation Agent's model is reachable;
+the controller schedules against it but does not manage serving.
+
+```yaml
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Workload
+metadata:
+  name: fix-a-batch
+  namespace: default
+spec:
+  intent: "Clear the edit-fidelity backlog"
+  repo: defilantech/LLMKube
+  issues: [944, 911, 921]
+  coderAgentRef:
+    name: qwen36-35b-carnice-mtp-coder
+  verifierAgentRef:
+    name: shadowstack-gate
+  escalationCoderAgentRef:
+    name: qwopus-27b-dense-coder
+```
+
+Issues that the base coder closes never touch the escalation Agent.
+An issue whose base coder returns NO-GO or trips the coder gate is
+re-dispatched once to `qwopus-27b-dense-coder`, with the base
+model's failure summary threaded into the prompt.
+
 ## What v0.1 deliberately doesn't ship
 
 Foreman v0.1 is the foundation, not the finished platform. A few

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// coderResultEnvelope is the subset of an AgenticTask's status.result we
+// need to classify a coder failure. The executor writes the machine
+// outcome at extra.outcome (top-level; "MODEL-DECIDED" for a model-
+// terminated run) and, for a coder-gate failure, at extra.modelExtra.
+// outcome ("CODER-GATE-FAILED"). Summary is the model's own one-liner.
+type coderResultEnvelope struct {
+	Summary string `json:"summary"`
+	Extra   struct {
+		Outcome    string `json:"outcome"`
+		ModelExtra struct {
+			Outcome string `json:"outcome"`
+		} `json:"modelExtra"`
+	} `json:"extra"`
+}
+
+// coderTerminalOutcome extracts the fields that decide escalation from a
+// terminal coder task: the typed verdict plus the two outcome strings in
+// the result envelope. A missing/unparseable result yields empty
+// outcome strings (treated as non-escalating).
+func coderTerminalOutcome(task *foremanv1alpha1.AgenticTask) (
+	verdict foremanv1alpha1.AgenticTaskVerdict, topOutcome, modelOutcome string,
+) {
+	verdict = task.Status.Verdict
+	if task.Status.Result == nil || len(task.Status.Result.Raw) == 0 {
+		return verdict, "", ""
+	}
+	var env coderResultEnvelope
+	if err := json.Unmarshal(task.Status.Result.Raw, &env); err != nil {
+		return verdict, "", ""
+	}
+	return verdict, env.Extra.Outcome, env.Extra.ModelExtra.Outcome
+}
+
+// coderSummary returns the model's own terminal summary for the hint, or
+// "" if unavailable.
+func coderSummary(task *foremanv1alpha1.AgenticTask) string {
+	if task.Status.Result == nil || len(task.Status.Result.Raw) == 0 {
+		return ""
+	}
+	var env coderResultEnvelope
+	if err := json.Unmarshal(task.Status.Result.Raw, &env); err != nil {
+		return ""
+	}
+	return env.Summary
+}
+
+// shouldEscalateCoder is the escalation trigger: escalate only on
+// capability failures. A model-decided NO-GO (the honest "I could not
+// solve this" bail) or a coder-gate failure (wrote code, could not pass
+// the gate) escalate; a model-decided INCOMPLETE (gave up / ran out of
+// turns), a harness STUCK-LOOP-DETECTED, a trivial NO-CHANGES NO-GO, an
+// ERROR, or a GO do not.
+func shouldEscalateCoder(
+	verdict foremanv1alpha1.AgenticTaskVerdict, topOutcome, modelOutcome string,
+) bool {
+	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == "MODEL-DECIDED" {
+		return true
+	}
+	if modelOutcome == "CODER-GATE-FAILED" {
+		return true
+	}
+	return false
+}
+
+// escalationHintPrompt renders the PromptPrefix given to the escalation
+// coder. It carries the prior model's summary as a hint, framed so the
+// larger model does not treat the failed attempt's conclusions as
+// authoritative.
+func escalationHintPrompt(priorSummary string) string {
+	var b strings.Builder
+	b.WriteString("A previous attempt to fix this issue with a smaller model did not succeed.")
+	if strings.TrimSpace(priorSummary) != "" {
+		b.WriteString(" Its own summary was:\n\n\"")
+		b.WriteString(strings.TrimSpace(priorSummary))
+		b.WriteString("\"\n\n")
+	} else {
+		b.WriteString("\n\n")
+	}
+	b.WriteString("Approach the issue fresh. Do not assume the previous attempt's ")
+	b.WriteString("conclusions are correct; use the summary only as a hint about ")
+	b.WriteString("what proved difficult.")
+	return b.String()
+}
+
+// coderEscalationSteps decides which code-<N>-esc / verify-<N>-esc steps
+// to emit NOW (mirrors escalationSteps for reviewers, #546). For each
+// issue N the trigger is: the base code-<N> task is terminal (Phase
+// Succeeded or Failed) AND shouldEscalateCoder is true for it. Steps
+// whose code-<N>-esc child already exists are skipped, so a partial
+// create failure is repaired on the next reconcile. The escalation
+// tasks themselves (step suffix "-esc") are never scanned as base tasks,
+// so the tier is exactly one level deep.
+//
+// Pure: no API calls, no status writes. The caller owns MaxTasks
+// accounting, sovereignty filtering, and creation. Issue-batch mode
+// only (the caller guards against explicit Pipeline mode).
+func coderEscalationSteps(
+	w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
+) (steps []foremanv1alpha1.PipelineStep, escalated []int32) {
+	if w.Spec.EscalationCoderAgentRef == nil ||
+		w.Spec.VerifierAgentRef == nil ||
+		len(w.Spec.Issues) == 0 {
+		return nil, nil
+	}
+
+	// Index base code tasks and existing -esc tasks by step label.
+	baseCode := map[string]*foremanv1alpha1.AgenticTask{}
+	existingEsc := map[string]struct{}{}
+	for i := range children {
+		step := children[i].Labels[labelStep]
+		switch {
+		case strings.HasSuffix(step, "-esc"):
+			existingEsc[step] = struct{}{}
+		case strings.HasPrefix(step, "code-"):
+			baseCode[step] = &children[i]
+		}
+	}
+
+	for _, n := range w.Spec.Issues {
+		codeStep := fmt.Sprintf("code-%d", n)
+		escCodeStep := fmt.Sprintf("code-%d-esc", n)
+		escVerifyStep := fmt.Sprintf("verify-%d-esc", n)
+
+		base, ok := baseCode[codeStep]
+		if !ok {
+			continue
+		}
+		phase := base.Status.Phase
+		if phase != foremanv1alpha1.AgenticTaskPhaseSucceeded &&
+			phase != foremanv1alpha1.AgenticTaskPhaseFailed {
+			continue // not terminal yet
+		}
+		verdict, topOutcome, modelOutcome := coderTerminalOutcome(base)
+		if !shouldEscalateCoder(verdict, topOutcome, modelOutcome) {
+			continue
+		}
+		if _, exists := existingEsc[escCodeStep]; exists {
+			continue // already escalated this issue
+		}
+
+		branch := fmt.Sprintf("foreman/%s/issue-%d-esc", w.Name, n)
+		steps = append(steps,
+			foremanv1alpha1.PipelineStep{
+				Name:     escCodeStep,
+				Kind:     foremanv1alpha1.AgenticTaskKindIssueFix,
+				AgentRef: *w.Spec.EscalationCoderAgentRef,
+				Payload: foremanv1alpha1.AgenticTaskPayload{
+					Repo:         w.Spec.Repo,
+					Issue:        n,
+					Branch:       branch,
+					PromptPrefix: escalationHintPrompt(coderSummary(base)),
+				},
+			},
+			foremanv1alpha1.PipelineStep{
+				Name:      escVerifyStep,
+				Kind:      foremanv1alpha1.AgenticTaskKindVerify,
+				AgentRef:  *w.Spec.VerifierAgentRef,
+				DependsOn: []string{escCodeStep},
+				Payload: foremanv1alpha1.AgenticTaskPayload{
+					Repo:   w.Spec.Repo,
+					Issue:  n,
+					Branch: branch,
+				},
+			},
+		)
+		escalated = append(escalated, n)
+	}
+	return steps, escalated
+}

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -315,9 +315,12 @@ func (r *WorkloadReconciler) emitCoderEscalations(
 		return children, createErr
 	}
 
-	// Rollup must see the new tasks as in-flight in this same pass; a
-	// cache-backed List could miss tasks created microseconds ago, so
-	// synthesize placeholders (a zero-value phase counts as in-flight).
+	// Rollup and activeChildren must see the new tasks as in-flight in
+	// this same pass; a cache-backed List could miss tasks created
+	// microseconds ago, so synthesize labeled placeholders (a zero-value
+	// phase counts as in-flight). The step label lets activeChildren
+	// recognize the escalation immediately and supersede the failed base
+	// attempt in the same reconcile (#963), matching emitReviewIterations.
 	existing := make(map[string]struct{}, len(children))
 	for i := range children {
 		existing[children[i].Name] = struct{}{}
@@ -327,7 +330,14 @@ func (r *WorkloadReconciler) emitCoderEscalations(
 			continue
 		}
 		children = append(children, foremanv1alpha1.AgenticTask{
-			ObjectMeta: metav1.ObjectMeta{Name: ref.Name, Namespace: ref.Namespace},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ref.Name,
+				Namespace: ref.Namespace,
+				Labels: map[string]string{
+					labelWorkload: w.Name,
+					labelStep:     strings.TrimPrefix(ref.Name, w.Name+"-"),
+				},
+			},
 		})
 	}
 	return children, nil

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -114,8 +114,11 @@ func escalationHintPrompt(priorSummary string) string {
 	return b.String()
 }
 
-// coderEscalationSteps decides which code-<N>-esc / verify-<N>-esc steps
-// to emit NOW (mirrors escalationSteps for reviewers, #546). For each
+// coderEscalationSteps decides which code-<N>-esc / verify-<N>-esc /
+// review-<N>-esc-<i> steps to emit NOW (mirrors escalationSteps for
+// reviewers, #546). The reviewer fan-out is emitted only when the
+// Workload sets ReviewerAgentRefs, so the escalated branch gets a
+// verdict and a PR carrier rather than ending unreviewed. For each
 // issue N the trigger is: the base code-<N> task is terminal (Phase
 // Succeeded or Failed) AND shouldEscalateCoder is true for it. Steps
 // whose code-<N>-esc child already exists are skipped, so a partial
@@ -195,6 +198,27 @@ func coderEscalationSteps(
 				},
 			},
 		)
+		// Reviewer fan-out on the escalated branch: without it the
+		// escalated coder can GO and gate-pass but nothing produces a
+		// verdict or (post-#956) the openPullRequest carrier, so the
+		// fix ends as a pushed, unreviewed branch with no PR. Mirrors
+		// the base review-<N>-<i> emission in synthesizeIssueBatch. No
+		// reviewers configured means code+verify only (unchanged).
+		openPR := w.Spec.OpenPullRequest == nil || *w.Spec.OpenPullRequest
+		for i, reviewerRef := range w.Spec.ReviewerAgentRefs {
+			steps = append(steps, foremanv1alpha1.PipelineStep{
+				Name:      fmt.Sprintf("review-%d-esc-%d", n, i),
+				Kind:      foremanv1alpha1.AgenticTaskKindReview,
+				AgentRef:  reviewerRef,
+				DependsOn: []string{escVerifyStep},
+				Payload: foremanv1alpha1.AgenticTaskPayload{
+					Repo:            w.Spec.Repo,
+					Issue:           n,
+					Branch:          branch,
+					OpenPullRequest: openPR,
+				},
+			})
+		}
 		escalated = append(escalated, n)
 	}
 	return steps, escalated

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -17,9 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
@@ -192,4 +198,113 @@ func coderEscalationSteps(
 		escalated = append(escalated, n)
 	}
 	return steps, escalated
+}
+
+// emitCoderEscalations is the coder-side second-pass emission hook,
+// called from Reconcile's children-exist branch BEFORE emitEscalations
+// (a coder that did not GO has no branch for reviewers to escalate on).
+// Mirrors emitEscalations: synthesize due code-<N>-esc/verify-<N>-esc
+// steps, apply MaxTasks + sovereignty gates, create, patch status, and
+// synthesize placeholders so rollup counts the new tasks as in-flight.
+// Returns the refreshed children slice; a no-op returns the input.
+func (r *WorkloadReconciler) emitCoderEscalations(
+	ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
+) ([]foremanv1alpha1.AgenticTask, error) {
+	log := logf.FromContext(ctx).WithName("workload").WithValues("workload", client.ObjectKeyFromObject(w))
+
+	if len(w.Spec.Pipeline) > 0 {
+		// Explicit Pipeline mode: escalation is an issue-batch feature.
+		return children, nil
+	}
+	if w.Spec.EscalationCoderAgentRef == nil {
+		return children, nil
+	}
+
+	steps, escalated := coderEscalationSteps(w, children)
+	if len(steps) == 0 {
+		return children, nil
+	}
+
+	patch := client.MergeFrom(w.DeepCopy())
+	now := metav1.Now()
+
+	if w.Spec.MaxTasks > 0 && len(children)+len(steps) > int(w.Spec.MaxTasks) {
+		// No silent cap: report why the coder escalation tier did not run.
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeTruncated,
+			Status:             metav1.ConditionTrue,
+			Reason:             "MaxTasksCoderEscalationCap",
+			Message:            fmt.Sprintf("MaxTasks=%d leaves no room for %d coder escalation task(s)", w.Spec.MaxTasks, len(steps)),
+			LastTransitionTime: now,
+		})
+		if err := r.Status().Patch(ctx, w, patch); err != nil {
+			return children, fmt.Errorf("patch coder-escalation truncation condition: %w", err)
+		}
+		return children, nil
+	}
+
+	steps, suppressed, err := r.filterCloudProviders(ctx, w, steps)
+	if err != nil {
+		return children, fmt.Errorf("filter coder-escalation providers: %w", err)
+	}
+
+	created, createErr := r.renderAndCreate(ctx, w, steps)
+	if createErr != nil {
+		log.Error(createErr, "creating coder escalation AgenticTasks failed mid-way", "createdSoFar", len(created))
+	}
+
+	msg := fmt.Sprintf("issues %s re-dispatched to the escalation coder after a capability failure (%d task(s) created, %d suppressed)",
+		joinInt32(escalated), len(created), len(suppressed))
+
+	// Steady-state short-circuit: coderEscalationSteps re-proposes these
+	// steps until the -esc child exists in cache, so when nothing was
+	// created and the condition already says exactly this, re-patching
+	// would only churn LastTransitionTime.
+	if len(created) == 0 && createErr == nil {
+		if cond := apimeta.FindStatusCondition(w.Status.Conditions, conditionTypeCoderEscalationTriggered); cond != nil &&
+			cond.Status == metav1.ConditionTrue && cond.Message == msg {
+			return children, nil
+		}
+	}
+
+	w.Status.Tasks = appendNewTaskRefs(w.Status.Tasks, created)
+	setCondition(&w.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeCoderEscalationTriggered,
+		Status:             metav1.ConditionTrue,
+		Reason:             "BaseCoderCapabilityFailure",
+		Message:            msg,
+		LastTransitionTime: now,
+	})
+	if len(suppressed) > 0 {
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeCloudReviewersSuppressed,
+			Status:             metav1.ConditionTrue,
+			Reason:             "SovereigntyGate",
+			Message:            fmt.Sprintf("skipped %d cloud-provider Agent(s): %s", len(suppressed), strings.Join(suppressed, "; ")),
+			LastTransitionTime: now,
+		})
+	}
+	if err := r.Status().Patch(ctx, w, patch); err != nil {
+		return children, fmt.Errorf("patch workload status after coder escalation: %w", err)
+	}
+	if createErr != nil {
+		return children, createErr
+	}
+
+	// Rollup must see the new tasks as in-flight in this same pass; a
+	// cache-backed List could miss tasks created microseconds ago, so
+	// synthesize placeholders (a zero-value phase counts as in-flight).
+	existing := make(map[string]struct{}, len(children))
+	for i := range children {
+		existing[children[i].Name] = struct{}{}
+	}
+	for _, ref := range created {
+		if _, ok := existing[ref.Name]; ok {
+			continue
+		}
+		children = append(children, foremanv1alpha1.AgenticTask{
+			ObjectMeta: metav1.ObjectMeta{Name: ref.Name, Namespace: ref.Namespace},
+		})
+	}
+	return children, nil
 }

--- a/internal/foreman/controller/workload_coder_escalation_envtest_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_envtest_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// These envtests exercise the coder-escalation second-pass hook end to
+// end through Reconcile (mirrors the reviewer-escalation suite). A base
+// code-<N> task that fails with a capability signal is re-dispatched to
+// EscalationCoderAgentRef as code-<N>-esc / verify-<N>-esc.
+var _ = Describe("WorkloadReconciler coder escalation (#963)", func() {
+	var reconciler *WorkloadReconciler
+
+	BeforeEach(func() {
+		reconciler = &WorkloadReconciler{
+			Client:              k8sClient,
+			Scheme:              k8sClient.Scheme(),
+			AllowCloudProviders: true,
+		}
+	})
+
+	It("re-dispatches a base-coder capability failure to the escalation tier and is idempotent", func() {
+		wl := newWorkload("coder-esc-happy", foremanv1alpha1.WorkloadSpec{
+			Intent:                  "escalate a base coder that could not solve the issue",
+			Repo:                    "defilantech/LLMKube",
+			Issues:                  []int32{944, 921},
+			CoderAgentRef:           &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef:        &corev1.LocalObjectReference{Name: "gate"},
+			EscalationCoderAgentRef: &corev1.LocalObjectReference{Name: "coder-qwopus"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		// First reconcile plans the base pipeline: code + verify per issue.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Tasks).To(HaveLen(4)) // (code+verify) x 2 issues
+
+		// (A) code-944 terminates NO-GO / MODEL-DECIDED: a capability
+		//     failure that must escalate.
+		set944 := foremanv1alpha1.AgenticTask{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-happy-code-944"}, &set944)).To(Succeed())
+		p944 := client.MergeFrom(set944.DeepCopy())
+		set944.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		set944.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		set944.Status.Result = resultRaw("MODEL-DECIDED", "", "fuzzy front-runs anchor")
+		Expect(k8sClient.Status().Patch(ctx, &set944, p944)).To(Succeed())
+
+		// (B) code-921 terminates INCOMPLETE / MODEL-DECIDED (no gate
+		//     outcome): the honest "gave up" bail that must NOT escalate.
+		set921 := foremanv1alpha1.AgenticTask{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-happy-code-921"}, &set921)).To(Succeed())
+		p921 := client.MergeFrom(set921.DeepCopy())
+		set921.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		set921.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+		set921.Status.Result = resultRaw("MODEL-DECIDED", "", "ran out of turns")
+		Expect(k8sClient.Status().Patch(ctx, &set921, p921)).To(Succeed())
+
+		// Second reconcile runs the coder-escalation hook.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// (A) the escalation code + verify tasks exist at the esc tier.
+		var escCode foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-happy-code-944-esc"}, &escCode)).To(Succeed())
+		Expect(escCode.Spec.Kind).To(Equal(foremanv1alpha1.AgenticTaskKindIssueFix))
+		Expect(escCode.Spec.AgentRef.Name).To(Equal("coder-qwopus"))
+		Expect(escCode.Spec.Payload.Branch).To(Equal("foreman/coder-esc-happy/issue-944-esc"))
+		Expect(escCode.Spec.Payload.PromptPrefix).To(ContainSubstring("fuzzy front-runs anchor"))
+		Expect(escCode.Labels[labelStep]).To(Equal("code-944-esc"))
+
+		var escVerify foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-happy-verify-944-esc"}, &escVerify)).To(Succeed())
+		Expect(escVerify.Spec.Kind).To(Equal(foremanv1alpha1.AgenticTaskKindVerify))
+		Expect(escVerify.Spec.DependsOn).To(ContainElement("coder-esc-happy-code-944-esc"))
+
+		// (B) issue 921 (INCOMPLETE, not a capability failure) is untouched.
+		var noEsc921 foremanv1alpha1.AgenticTask
+		err = k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-happy-code-921-esc"}, &noEsc921)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "a model-decided INCOMPLETE must not escalate")
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		escCond := findCondition(fresh.Status.Conditions, conditionTypeCoderEscalationTriggered)
+		Expect(escCond).NotTo(BeNil())
+		Expect(escCond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(escCond.Message).To(ContainSubstring("944"))
+
+		// (D) idempotency: a second escalation pass must not re-emit.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		var tasks foremanv1alpha1.AgenticTaskList
+		Expect(k8sClient.List(ctx, &tasks, client.InNamespace("default"),
+			client.MatchingLabels{labelWorkload: "coder-esc-happy", labelStep: "code-944-esc"})).To(Succeed())
+		Expect(tasks.Items).To(HaveLen(1))
+	})
+
+	It("does not escalate when EscalationCoderAgentRef is unset", func() {
+		wl := newWorkload("coder-esc-off", foremanv1alpha1.WorkloadSpec{
+			Intent:           "no escalation tier configured",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{944},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var base foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-off-code-944"}, &base)).To(Succeed())
+		patch := client.MergeFrom(base.DeepCopy())
+		base.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		base.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		base.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed")
+		Expect(k8sClient.Status().Patch(ctx, &base, patch)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var escCode foremanv1alpha1.AgenticTask
+		err = k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-off-code-944-esc"}, &escCode)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "no escalation tier means no -esc tasks")
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(findCondition(fresh.Status.Conditions, conditionTypeCoderEscalationTriggered)).To(BeNil())
+	})
+})

--- a/internal/foreman/controller/workload_coder_escalation_envtest_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_envtest_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -123,6 +124,90 @@ var _ = Describe("WorkloadReconciler coder escalation (#963)", func() {
 		Expect(k8sClient.List(ctx, &tasks, client.InNamespace("default"),
 			client.MatchingLabels{labelWorkload: "coder-esc-happy", labelStep: "code-944-esc"})).To(Succeed())
 		Expect(tasks.Items).To(HaveLen(1))
+	})
+
+	It("fans reviewers out on the escalated branch and lets a successful escalation supersede the failed base attempt", func() {
+		wl := newWorkload("coder-esc-rev", foremanv1alpha1.WorkloadSpec{
+			Intent:                  "escalate then review the escalated branch",
+			Repo:                    "defilantech/LLMKube",
+			Issues:                  []int32{944},
+			CoderAgentRef:           &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef:        &corev1.LocalObjectReference{Name: "gate"},
+			EscalationCoderAgentRef: &corev1.LocalObjectReference{Name: "coder-qwopus"},
+			ReviewerAgentRefs:       []corev1.LocalObjectReference{{Name: "reviewer"}},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		// First reconcile plans the base pipeline: code + verify + one
+		// reviewer per issue.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Tasks).To(HaveLen(3)) // code + verify + review
+
+		// Base code-944 terminates NO-GO / MODEL-DECIDED (a capability
+		// failure that must escalate), and its verify + review cascade to
+		// a terminal Failed phase (the branch the coder never produced).
+		setTerminal := func(name string, phase foremanv1alpha1.AgenticTaskPhase, verdict foremanv1alpha1.AgenticTaskVerdict, result func() *runtime.RawExtension) {
+			var t foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: name}, &t)).To(Succeed())
+			p := client.MergeFrom(t.DeepCopy())
+			t.Status.Phase = phase
+			t.Status.Verdict = verdict
+			if result != nil {
+				t.Status.Result = result()
+			}
+			Expect(k8sClient.Status().Patch(ctx, &t, p)).To(Succeed())
+		}
+		setTerminal("coder-esc-rev-code-944", foremanv1alpha1.AgenticTaskPhaseSucceeded,
+			foremanv1alpha1.AgenticTaskVerdictNoGo, func() *runtime.RawExtension { return resultRaw("MODEL-DECIDED", "", "fuzzy front-runs anchor") })
+		setTerminal("coder-esc-rev-verify-944", foremanv1alpha1.AgenticTaskPhaseFailed,
+			foremanv1alpha1.AgenticTaskVerdictIncomplete, nil)
+		setTerminal("coder-esc-rev-review-944-0", foremanv1alpha1.AgenticTaskPhaseFailed,
+			foremanv1alpha1.AgenticTaskVerdictIncomplete, nil)
+
+		// Second reconcile runs the coder-escalation hook: it emits the
+		// esc code + verify AND the reviewer fan-out on the esc branch.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// (1) the reviewer step exists on the escalated branch.
+		var escReview foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-rev-review-944-esc-0"}, &escReview)).To(Succeed())
+		Expect(escReview.Spec.Kind).To(Equal(foremanv1alpha1.AgenticTaskKindReview))
+		Expect(escReview.Spec.AgentRef.Name).To(Equal("reviewer"))
+		Expect(escReview.Spec.DependsOn).To(ContainElement("coder-esc-rev-verify-944-esc"))
+		Expect(escReview.Spec.Payload.Branch).To(Equal("foreman/coder-esc-rev/issue-944-esc"))
+		Expect(escReview.Spec.Payload.OpenPullRequest).To(BeTrue())
+		Expect(escReview.Labels[labelStep]).To(Equal("review-944-esc-0"))
+
+		// (2) with the escalation in flight the Workload must NOT report
+		//     Failed: the failed base verify/review are superseded, and the
+		//     three in-flight esc tasks hold the rollup at Dispatched.
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseDispatched),
+			"a failed base attempt must not pin the rollup while its escalation is in flight")
+
+		// (3) drive the whole esc attempt to a terminal on-target success;
+		//     the issue is now judged by the esc attempt and the Workload
+		//     rolls up Completed (the superseded base failures are gone).
+		setTerminal("coder-esc-rev-code-944-esc", foremanv1alpha1.AgenticTaskPhaseSucceeded,
+			foremanv1alpha1.AgenticTaskVerdictGo, nil)
+		setTerminal("coder-esc-rev-verify-944-esc", foremanv1alpha1.AgenticTaskPhaseSucceeded,
+			foremanv1alpha1.AgenticTaskVerdictGatePass, nil)
+		setTerminal("coder-esc-rev-review-944-esc-0", foremanv1alpha1.AgenticTaskPhaseSucceeded,
+			foremanv1alpha1.AgenticTaskVerdictGo, nil)
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseCompleted),
+			"a successful escalation must roll the issue up Succeeded despite the superseded base failures")
 	})
 
 	It("does not escalate when EscalationCoderAgentRef is unset", func() {

--- a/internal/foreman/controller/workload_coder_escalation_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_test.go
@@ -28,6 +28,7 @@ import (
 
 // resultRaw builds a status.result RawExtension with the given top-level
 // and nested modelExtra outcome, matching the executor's envelope shape.
+// nolint:unparam // topOutcome is parameterized to mirror the envelope shape even though current tests all pass "MODEL-DECIDED"
 func resultRaw(topOutcome, modelOutcome, summary string) *runtime.RawExtension {
 	me := ""
 	if modelOutcome != "" {

--- a/internal/foreman/controller/workload_coder_escalation_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_test.go
@@ -112,6 +112,100 @@ func TestCoderEscalationSteps_EmitsOnNoGo(t *testing.T) {
 	}
 }
 
+func TestCoderEscalationSteps_EmitsReviewerStepsOnEscBranch(t *testing.T) {
+	newBase := func() foremanv1alpha1.AgenticTask {
+		code := foremanv1alpha1.AgenticTask{}
+		code.Name = "wl-code-944"
+		code.Labels = map[string]string{labelStep: "code-944"}
+		code.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		code.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed")
+		return code
+	}
+
+	// findStep returns the emitted step by name, or a zero step if absent.
+	findStep := func(steps []foremanv1alpha1.PipelineStep, name string) (foremanv1alpha1.PipelineStep, bool) {
+		for _, s := range steps {
+			if s.Name == name {
+				return s, true
+			}
+		}
+		return foremanv1alpha1.PipelineStep{}, false
+	}
+
+	newWorkload := func() *foremanv1alpha1.Workload {
+		w := &foremanv1alpha1.Workload{}
+		w.Name = "wl"
+		w.Spec.Repo = "defilantech/LLMKube"
+		w.Spec.Issues = []int32{944}
+		w.Spec.CoderAgentRef = &corev1.LocalObjectReference{Name: "coder-metal"}
+		w.Spec.VerifierAgentRef = &corev1.LocalObjectReference{Name: "gate"}
+		w.Spec.EscalationCoderAgentRef = &corev1.LocalObjectReference{Name: "coder-qwopus"}
+		return w
+	}
+
+	t.Run("reviewer set, openPullRequest nil -> review-esc step with openPR true", func(t *testing.T) {
+		w := newWorkload()
+		w.Spec.ReviewerAgentRefs = []corev1.LocalObjectReference{{Name: "reviewer-a"}}
+
+		steps, _ := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{newBase()})
+		// code-esc + verify-esc + one review-esc.
+		if len(steps) != 3 {
+			t.Fatalf("want 3 steps (code+verify+review esc), got %d: %+v", len(steps), steps)
+		}
+		rev, ok := findStep(steps, "review-944-esc-0")
+		if !ok {
+			t.Fatalf("review-944-esc-0 not emitted: %+v", steps)
+		}
+		if rev.Kind != foremanv1alpha1.AgenticTaskKindReview {
+			t.Errorf("review-esc kind wrong: %q", rev.Kind)
+		}
+		if rev.AgentRef.Name != "reviewer-a" {
+			t.Errorf("review-esc agentRef wrong: %q", rev.AgentRef.Name)
+		}
+		if len(rev.DependsOn) != 1 || rev.DependsOn[0] != "verify-944-esc" {
+			t.Errorf("review-esc dependsOn wrong: %v", rev.DependsOn)
+		}
+		if rev.Payload.Branch != "foreman/wl/issue-944-esc" {
+			t.Errorf("review-esc branch wrong: %q", rev.Payload.Branch)
+		}
+		if rev.Payload.Issue != 944 {
+			t.Errorf("review-esc issue wrong: %d", rev.Payload.Issue)
+		}
+		if !rev.Payload.OpenPullRequest {
+			t.Errorf("review-esc openPullRequest must default true when spec.openPullRequest is nil")
+		}
+	})
+
+	t.Run("openPullRequest explicit false -> review-esc carries false", func(t *testing.T) {
+		w := newWorkload()
+		w.Spec.ReviewerAgentRefs = []corev1.LocalObjectReference{{Name: "reviewer-a"}}
+		no := false
+		w.Spec.OpenPullRequest = &no
+
+		steps, _ := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{newBase()})
+		rev, ok := findStep(steps, "review-944-esc-0")
+		if !ok {
+			t.Fatalf("review-944-esc-0 not emitted: %+v", steps)
+		}
+		if rev.Payload.OpenPullRequest {
+			t.Errorf("review-esc openPullRequest must honor spec.openPullRequest=false")
+		}
+	})
+
+	t.Run("no reviewers -> code+verify only (backward-compat)", func(t *testing.T) {
+		w := newWorkload() // ReviewerAgentRefs left nil
+
+		steps, _ := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{newBase()})
+		if len(steps) != 2 {
+			t.Fatalf("want 2 steps (code+verify only), got %d: %+v", len(steps), steps)
+		}
+		if _, ok := findStep(steps, "review-944-esc-0"); ok {
+			t.Errorf("no reviewers configured must emit no review-esc step: %+v", steps)
+		}
+	})
+}
+
 func TestCoderEscalationSteps_SkipsStuckLoopAndExisting(t *testing.T) {
 	ref := corev1.LocalObjectReference{Name: "coder-qwopus"}
 	w := &foremanv1alpha1.Workload{}

--- a/internal/foreman/controller/workload_coder_escalation_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// resultRaw builds a status.result RawExtension with the given top-level
+// and nested modelExtra outcome, matching the executor's envelope shape.
+func resultRaw(topOutcome, modelOutcome, summary string) *runtime.RawExtension {
+	me := ""
+	if modelOutcome != "" {
+		me = `,"modelExtra":{"outcome":"` + modelOutcome + `"}`
+	}
+	j := `{"summary":"` + summary + `","extra":{"outcome":"` + topOutcome + `"` + me + `}}`
+	return &runtime.RawExtension{Raw: []byte(j)}
+}
+
+func TestShouldEscalateCoder(t *testing.T) {
+	cases := []struct {
+		name         string
+		verdict      foremanv1alpha1.AgenticTaskVerdict
+		topOutcome   string
+		modelOutcome string
+		want         bool
+	}{
+		{"model NO-GO (like #944)", foremanv1alpha1.AgenticTaskVerdictNoGo, "MODEL-DECIDED", "", true},
+		{"gate-failed (like #911)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "MODEL-DECIDED", "CODER-GATE-FAILED", true},
+		{"model gave up / stuck (like #921)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "MODEL-DECIDED", "", false},
+		{"stuck-loop detected", foremanv1alpha1.AgenticTaskVerdictIncomplete, "STUCK-LOOP-DETECTED", "", false},
+		{"NO-GO but no-changes (trivial)", foremanv1alpha1.AgenticTaskVerdictNoGo, "NO-CHANGES", "", false},
+		{"GO", foremanv1alpha1.AgenticTaskVerdictGo, "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldEscalateCoder(tc.verdict, tc.topOutcome, tc.modelOutcome); got != tc.want {
+				t.Errorf("shouldEscalateCoder(%s,%q,%q)=%v want %v",
+					tc.verdict, tc.topOutcome, tc.modelOutcome, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCoderTerminalOutcome_ReadsNestedGateOutcome(t *testing.T) {
+	task := &foremanv1alpha1.AgenticTask{}
+	task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+	task.Status.Result = resultRaw("MODEL-DECIDED", "CODER-GATE-FAILED", "gate failed")
+	v, top, model := coderTerminalOutcome(task)
+	if v != foremanv1alpha1.AgenticTaskVerdictIncomplete || top != "MODEL-DECIDED" || model != "CODER-GATE-FAILED" {
+		t.Errorf("got (%s,%q,%q)", v, top, model)
+	}
+}
+
+func TestCoderEscalationSteps_EmitsOnNoGo(t *testing.T) {
+	ref := corev1.LocalObjectReference{Name: "coder-qwopus"}
+	verifier := corev1.LocalObjectReference{Name: "gate"}
+	w := &foremanv1alpha1.Workload{}
+	w.Name = "wl"
+	w.Spec.Repo = "defilantech/LLMKube"
+	w.Spec.Issues = []int32{944}
+	w.Spec.CoderAgentRef = &corev1.LocalObjectReference{Name: "coder-metal"}
+	w.Spec.VerifierAgentRef = &verifier
+	w.Spec.EscalationCoderAgentRef = &ref
+
+	code := foremanv1alpha1.AgenticTask{}
+	code.Name = "wl-code-944"
+	code.Labels = map[string]string{labelStep: "code-944"}
+	code.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+	code.Status.Result = resultRaw("MODEL-DECIDED", "", "could not solve: fuzzy front-runs anchor")
+
+	steps, escalated := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{code})
+	if len(steps) != 2 {
+		t.Fatalf("want 2 steps (code-esc+verify-esc), got %d", len(steps))
+	}
+	if steps[0].Name != "code-944-esc" || steps[0].AgentRef.Name != "coder-qwopus" {
+		t.Errorf("code step wrong: %+v", steps[0])
+	}
+	if steps[0].Payload.Branch != "foreman/wl/issue-944-esc" {
+		t.Errorf("branch wrong: %q", steps[0].Payload.Branch)
+	}
+	if !strings.Contains(steps[0].Payload.PromptPrefix, "fuzzy front-runs anchor") {
+		t.Errorf("hint missing prior summary: %q", steps[0].Payload.PromptPrefix)
+	}
+	if steps[1].Name != "verify-944-esc" || len(steps[1].DependsOn) != 1 || steps[1].DependsOn[0] != "code-944-esc" {
+		t.Errorf("verify step wrong: %+v", steps[1])
+	}
+	if len(escalated) != 1 || escalated[0] != 944 {
+		t.Errorf("escalated wrong: %v", escalated)
+	}
+}
+
+func TestCoderEscalationSteps_SkipsStuckLoopAndExisting(t *testing.T) {
+	ref := corev1.LocalObjectReference{Name: "coder-qwopus"}
+	w := &foremanv1alpha1.Workload{}
+	w.Name = "wl"
+	w.Spec.Repo = "defilantech/LLMKube"
+	w.Spec.Issues = []int32{921, 944}
+	w.Spec.VerifierAgentRef = &corev1.LocalObjectReference{Name: "gate"}
+	w.Spec.EscalationCoderAgentRef = &ref
+
+	c921 := foremanv1alpha1.AgenticTask{}
+	c921.Name = "wl-code-921"
+	c921.Labels = map[string]string{labelStep: "code-921"}
+	c921.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	c921.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+	c921.Status.Result = resultRaw("MODEL-DECIDED", "", "ran out of turns")
+
+	c944 := foremanv1alpha1.AgenticTask{}
+	c944.Name = "wl-code-944"
+	c944.Labels = map[string]string{labelStep: "code-944"}
+	c944.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	c944.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+	c944.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed")
+	esc944 := foremanv1alpha1.AgenticTask{}
+	esc944.Name = "wl-code-944-esc"
+	esc944.Labels = map[string]string{labelStep: "code-944-esc"}
+
+	steps, escalated := coderEscalationSteps(w,
+		[]foremanv1alpha1.AgenticTask{c921, c944, esc944})
+	if len(steps) != 0 {
+		t.Errorf("want no steps (921 not eligible, 944 already escalated), got %d: %+v", len(steps), steps)
+	}
+	if len(escalated) != 0 {
+		t.Errorf("want none escalated, got %v", escalated)
+	}
+}
+
+func TestCoderEscalationSteps_OffWhenUnset(t *testing.T) {
+	w := &foremanv1alpha1.Workload{}
+	w.Name = "wl"
+	w.Spec.Issues = []int32{944}
+	w.Spec.VerifierAgentRef = &corev1.LocalObjectReference{Name: "gate"}
+	c := foremanv1alpha1.AgenticTask{}
+	c.Name = "wl-code-944"
+	c.Labels = map[string]string{labelStep: "code-944"}
+	c.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	c.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+	c.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed")
+	steps, _ := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{c})
+	if len(steps) != 0 {
+		t.Errorf("feature must be off when EscalationCoderAgentRef is nil, got %d steps", len(steps))
+	}
+}

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -109,6 +109,11 @@ const conditionTypeCloudReviewersSuppressed = "CloudReviewersSuppressed"
 // without any base reviewers to escalate from.
 const conditionTypeEscalationTriggered = "EscalationTriggered"
 
+// conditionTypeCoderEscalationTriggered reports that at least one issue's
+// base coder failed with a capability failure and was re-dispatched to
+// the escalation coder tier (EscalationCoderAgentRef).
+const conditionTypeCoderEscalationTriggered = "CoderEscalationTriggered"
+
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads/finalizers,verbs=update
@@ -149,11 +154,20 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// review tasks so the reviewer's prompt can surface them.
 		r.patchReviewAdvisories(ctx, &workload, children)
 
+		// Coder escalation (before iteration and reviewer escalation): a
+		// base coder that failed at its ceiling has no branch to review or
+		// iterate, so it is retried on a larger model first. Mutually
+		// exclusive with fix-iteration by construction — this fires on a
+		// coder-terminal NO-GO (reviews never ran); iteration fires on a
+		// reviewer NO-GO (the coder GO'd).
+		children, err = r.emitCoderEscalations(ctx, &workload, children)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("emit coder escalations: %w", err)
+		}
+
 		// Fix-iteration emission (#946): a reviewer NO-GO re-dispatches
 		// the coder with the review feedback instead of failing the
-		// Workload, bounded by spec.maxReviewIterations. Runs before
-		// escalation so a fresh round defers the escalation tier until
-		// the iterations settle.
+		// Workload, bounded by spec.maxReviewIterations.
 		children, err = r.emitReviewIterations(ctx, &workload, children)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("emit review iterations: %w", err)

--- a/internal/foreman/controller/workload_escalation.go
+++ b/internal/foreman/controller/workload_escalation.go
@@ -64,6 +64,13 @@ func escalationSteps(
 		// The trailing dash keeps issue 64 from matching review-641-0.
 		basePrefix := fmt.Sprintf("review-%d-", n)
 		escPrefix := fmt.Sprintf("escalate-%d-", n)
+		// The coder-escalation tier emits its own reviews (review-<N>-esc-<i>)
+		// which also carry basePrefix but belong to the escalated attempt, not
+		// the base reviewer set this tier escalates. Exclude them so the two
+		// tiers compose (they only coexist when both EscalationReviewerAgentRefs
+		// and EscalationCoderAgentRef are set); otherwise their NO-GO would fan
+		// out escalate steps against the wrong (base) branch.
+		coderEscReviewPrefix := fmt.Sprintf("review-%d-esc-", n)
 
 		var baseTotal, baseTerminal, baseNoGo int
 		existingEsc := map[string]struct{}{}
@@ -72,6 +79,8 @@ func escalationSteps(
 			switch {
 			case strings.HasPrefix(step, escPrefix):
 				existingEsc[step] = struct{}{}
+			case strings.HasPrefix(step, coderEscReviewPrefix):
+				// coder-escalation branch review; not part of the base set
 			case strings.HasPrefix(step, basePrefix):
 				baseTotal++
 				phase := children[i].Status.Phase

--- a/internal/foreman/controller/workload_escalation_test.go
+++ b/internal/foreman/controller/workload_escalation_test.go
@@ -85,6 +85,18 @@ func TestEscalationSteps(t *testing.T) {
 			wantEscalated: []int32{641},
 		},
 		{
+			// The coder-escalation tier's own reviews (review-N-esc-i) carry
+			// the review-N- prefix but belong to the escalated attempt; a NO-GO
+			// on one must NOT fan base reviewer escalation onto the base branch.
+			// (activeChildren has already dropped the superseded base reviews,
+			// so only the esc review remains in the slice.)
+			name: "coder-escalation branch reviews are excluded from base escalation",
+			w:    escalationWorkload([]int32{641}, 1, 1),
+			children: []foremanv1alpha1.AgenticTask{
+				child("review-641-esc-0", succeeded, noGo),
+			},
+		},
+		{
 			name: "all base reviewers GO emits nothing",
 			w:    escalationWorkload([]int32{641}, 1, 1),
 			children: []foremanv1alpha1.AgenticTask{

--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -385,13 +385,25 @@ func reviewFeedbackSection(t *foremanv1alpha1.AgenticTask) string {
 	return b.String()
 }
 
-// activeChildren filters out children that a later fix iteration
-// superseded, so rollup and the escalation trigger judge each issue by
-// its LATEST attempt only. Without this, iteration 0's terminal NO-GO
-// review would keep IncompleteTasks non-zero forever and a converged
-// r1 round could never complete the Workload. A superseded iteration
-// is by construction fully terminal (the k+1 trigger requires it), so
-// nothing in flight is ever hidden from rollup. Escalation steps and
+// activeChildren filters out children that a later attempt superseded,
+// so rollup and the escalation trigger judge each issue by its LATEST
+// attempt only. Two supersession rules apply:
+//
+//   - Fix iteration (#946/#959): a later code-<n>-r<k> round supersedes
+//     earlier synthesized steps for issue n. Without this, iteration 0's
+//     terminal NO-GO review would keep IncompleteTasks non-zero forever
+//     and a converged r1 round could never complete the Workload.
+//   - Coder escalation (#963): once a code-<n>-esc task exists, the base
+//     attempt's steps (code-<n>, verify-<n>, review-<n>-<i>, and any
+//     iteration rounds) are dropped so the base coder's terminal NO-GO
+//     and the cascade-failed verify/review it stranded do not pin the
+//     Workload at Failed. The issue is then judged by the ESC attempt.
+//
+// A superseded iteration round is by construction fully terminal (the
+// k+1 trigger requires it); an escalated base attempt is likewise
+// terminal (the escalation trigger requires a terminal base code task),
+// so nothing in flight is ever hidden from rollup. The escalation steps
+// themselves (suffix -esc, which do not parse as base issue steps) and
 // anything else that does not parse as a synthesized issue step are
 // always kept. Issue-batch only; explicit Pipeline mode returns the
 // input unchanged.
@@ -403,9 +415,14 @@ func activeChildren(
 	}
 
 	latest := make(map[int32]int, len(w.Spec.Issues))
+	escalated := make(map[int32]bool, len(w.Spec.Issues))
 	for i := range children {
 		step := children[i].Labels[labelStep]
 		for _, n := range w.Spec.Issues {
+			if step == fmt.Sprintf("code-%d-esc", n) {
+				escalated[n] = true
+				break
+			}
 			if k, ok := issueStepIteration(step, n); ok {
 				if k > latest[n] {
 					latest[n] = k
@@ -421,7 +438,11 @@ func activeChildren(
 		superseded := false
 		for _, n := range w.Spec.Issues {
 			if k, ok := issueStepIteration(step, n); ok {
-				superseded = k < latest[n]
+				// A later fix iteration, or a successful escalation on this
+				// issue, supersedes the base/earlier synthesized attempt.
+				// issueStepIteration never matches the -esc steps, so the
+				// escalation attempt is never dropped by its own rule.
+				superseded = k < latest[n] || escalated[n]
 				break
 			}
 		}

--- a/internal/foreman/controller/workload_iteration_test.go
+++ b/internal/foreman/controller/workload_iteration_test.go
@@ -362,3 +362,58 @@ func TestActiveChildren(t *testing.T) {
 		t.Fatalf("pipeline mode must not filter, got %d of %d", len(got), len(children))
 	}
 }
+
+// TestActiveChildren_EscalationSupersedesBase proves the #963 rule: once
+// a code-<n>-esc task exists, the failed base attempt (code/verify/review
+// -<n>) is dropped from the active slice so its cascade-failure does not
+// pin the rollup at Failed, while the -esc attempt and unescalated issues
+// are untouched.
+func TestActiveChildren_EscalationSupersedesBase(t *testing.T) {
+	succeeded := foremanv1alpha1.AgenticTaskPhaseSucceeded
+	failed := foremanv1alpha1.AgenticTaskPhaseFailed
+	noGo := foremanv1alpha1.AgenticTaskVerdictNoGo
+	gatePass := foremanv1alpha1.AgenticTaskVerdictGatePass
+	goVerdict := foremanv1alpha1.AgenticTaskVerdictGo
+
+	w := iterationWorkload([]int32{944, 921}, 1, nil)
+
+	children := []foremanv1alpha1.AgenticTask{
+		// Issue 944: base coder NO-GO, verify/review cascade-failed, then
+		// escalated. The base triple must be superseded.
+		child("code-944", succeeded, noGo),
+		child("verify-944", failed, ""),
+		child("review-944-0", failed, ""),
+		child("code-944-esc", succeeded, goVerdict),
+		child("verify-944-esc", succeeded, gatePass),
+		child("review-944-esc-0", succeeded, goVerdict),
+		// Issue 921: not escalated, must pass through untouched.
+		child("code-921", succeeded, goVerdict),
+		child("verify-921", succeeded, gatePass),
+		child("review-921-0", succeeded, goVerdict),
+	}
+
+	active := activeChildren(w, children)
+	got := make(map[string]bool, len(active))
+	for i := range active {
+		got[active[i].Labels[labelStep]] = true
+	}
+
+	dropped := []string{"code-944", "verify-944", "review-944-0"}
+	for _, name := range dropped {
+		if got[name] {
+			t.Errorf("base step %q must be superseded by the escalation, but it is still active", name)
+		}
+	}
+	kept := []string{
+		"code-944-esc", "verify-944-esc", "review-944-esc-0",
+		"code-921", "verify-921", "review-921-0",
+	}
+	for _, name := range kept {
+		if !got[name] {
+			t.Errorf("step %q must remain active, but it was filtered", name)
+		}
+	}
+	if len(active) != len(kept) {
+		t.Fatalf("active = %d steps, want %d (%v)", len(active), len(kept), kept)
+	}
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1522,6 +1522,9 @@ func buildUserPrompt(task *foremanv1alpha1.AgenticTask) string {
 	switch task.Spec.Kind {
 	case foremanv1alpha1.AgenticTaskKindIssueFix:
 		fmt.Fprintf(&b, "You are working on issue #%d of repository %s.\n\n", p.Issue, p.Repo)
+		if p.PromptPrefix != "" {
+			fmt.Fprintf(&b, "%s\n\n", p.PromptPrefix)
+		}
 		if p.Prompt != "" {
 			fmt.Fprintf(&b, "Issue context:\n%s\n\n", p.Prompt)
 		}

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1778,6 +1778,33 @@ func TestRenderGateAdvisories_OmittedWhenEmpty(t *testing.T) {
 	}
 }
 
+// TestBuildUserPrompt_IssueFix_RendersPromptPrefix verifies that a
+// PromptPrefix set on an issue-fix payload is rendered before the fetched
+// issue body, so an escalation-tier diagnosis hint coexists with the issue
+// context rather than replacing it.
+func TestBuildUserPrompt_IssueFix_RendersPromptPrefix(t *testing.T) {
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:         "defilantech/LLMKube",
+				Issue:        944,
+				Prompt:       "The issue body.",
+				PromptPrefix: "A previous smaller-model attempt could not resolve this.",
+			},
+		},
+	}
+	got := buildUserPrompt(task)
+	pi := strings.Index(got, "previous smaller-model attempt")
+	bi := strings.Index(got, "The issue body.")
+	if pi < 0 {
+		t.Fatalf("prompt prefix missing from: %q", got)
+	}
+	if bi >= 0 && pi > bi {
+		t.Errorf("prompt prefix must precede the issue body; got prefix@%d body@%d", pi, bi)
+	}
+}
+
 // TestBuildUserPrompt_ReviewerAppendsAdvisories verifies that gate advisories
 // wired into the payload by the reconciler are included in the reviewer's
 // first user message so the model is prompted to confirm or dismiss each one.


### PR DESCRIPTION
## What

Adds an opt-in coder escalation tier to Foreman's Workload controller. When a base coder task fails at its model's ceiling, the WorkloadReconciler re-dispatches that issue once to a larger coder model, carrying the failed model's own diagnosis as a prompt hint. Off by default; enabled per-Workload via a new `escalationCoderAgentRef`. This is the coder-side twin of the existing escalation-reviewer tier (#546).

## Why

Fixes #963

A single coder model is a fixed capability ceiling. In a four-issue batch on one MoE coder, the model cleanly resolved the tractable bug but failed three others at its ceiling in distinct ways. The clearest case: the model produced a correct diagnosis it could not itself execute and honestly returned NO-GO. That is exactly the case a larger, denser model should take over.

Density is not a blanket upgrade, though. It helps the reasoning-limited failures but hurts convergence-heavy refactors, where a slower dense model exhausts its turn budget sooner. So this is a cascade, not a swap: keep the cheap, fast model for the tractable majority and pay for the larger model only on the specific failure modes where its extra reasoning is worth the cost.

## How

- **New `WorkloadSpec.EscalationCoderAgentRef`** (singular, unlike the plural `escalationReviewerAgentRefs`): coders are sequential, so N parallel escalation coders would produce N competing branches. One tier. Unset means the feature is off, fully backward compatible.
- **Trigger is capability failures only.** Escalate iff the terminal base coder is verdict `NO-GO` with top-level outcome `MODEL-DECIDED`, or nested `modelExtra.outcome == CODER-GATE-FAILED`. Do not escalate on a model-decided `INCOMPLETE` (the model gave up / ran out of turns), `STUCK-LOOP-DETECTED`, a trivial no-changes NO-GO, or `ERROR`: those are scope/harness failures a larger, slower model will not fix and may worsen by timing out.
  - The discriminator is the nested `modelExtra.outcome`, not the top-level `extra.outcome`, which is `MODEL-DECIDED` for the NO-GO, gate-fail, and gave-up cases alike. A naive top-level read would wrongly escalate the gave-up case. The unit truth table pins this against three real batch outcomes: a NO-GO / `MODEL-DECIDED` (escalate), an `INCOMPLETE` with nested `CODER-GATE-FAILED` (escalate), and an `INCOMPLETE` with no gate outcome (do not escalate).
- **Context is fresh branch plus diagnosis.** On a triggering failure the reconciler emits a `code-<N>-esc` + `verify-<N>-esc` pair at the escalation Agent on a fresh branch `foreman/<w>/issue-<N>-esc`, carrying the prior model's summary. A fresh branch (not a restore of the failed attempt) keeps the high-signal insight without anchoring the strong model on the weak model's broken code, and makes the feature independent of the branch-restore machinery that is still in flight elsewhere.
- **The hint reaches the coder via a new `AgenticTaskPayload.PromptPrefix`**, rendered before the fetched issue body, so the escalated coder sees both the diagnosis and the issue's acceptance criteria (leaving `Prompt` empty so the issue-body fetch still runs).
- **Second-pass emission hook `emitCoderEscalations`**, a structural twin of `emitEscalations`, wired into Reconcile before reviewer escalation (a coder that did not GO has no branch to review). One tier deep (`-esc` tasks are never re-scanned as base tasks), idempotent (permanent step names, skip when the `-esc` child already exists), MaxTasks- and sovereignty-gated.
- **The controller does not manage serving.** The escalation Agent must point at an already-reachable model, exactly as escalation reviewers do. The recommended deployment is dual-box with both models hot so escalation is a routing hop, not a cold model load. Documented in the Foreman runbook.

**AI-assisted contribution (band 3).** Implemented with AI assistance under human review; human-accountable. Commits are kept clean per the project's no-attribution-in-commits convention, with the disclosure here in the PR body per CONTRIBUTING.md.

## Checklist

- [x] Tests added/updated (unit trigger truth table + step synthesis; envtest for emission, non-escalation of gave-up/stuck, backward-compat unset, idempotency)
- [x] `make test` passes locally (new envtest green; controller coverage 80.2%)
- [x] `make lint` passes locally (0 issues; also `GOOS=linux golangci-lint run ./...` 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed above, per CONTRIBUTING.md
- [x] Documentation updated (`docs/site/foreman/README.md`: coder escalation tier + dual-box serving)
