### PR TITLE
fix(inference): warn when modelCache.claimName is silently ignored

### DIFF
--- a/docs/MODEL-CACHE.md
+++ b/docs/MODEL-CACHE.md
@@ -175,9 +175,15 @@ Behavior:
   garbage-collects `<isvc>-model-cache`). If the claim does not exist, the
   InferenceService is marked `Degraded` with a `ModelCachePVCNotFound` event
   instead of silently falling back to the shared cache.
-- `claimName` targets the download path, so it is ignored for pre-staged
-  `pvc://` model sources (mounted read-only, no download); a warning event is
-  emitted if both are set.
+- `claimName` targets the download path, so it is ignored — with a
+  `ModelCacheClaimIgnored` warning event — for pre-staged `pvc://` model
+  sources (mounted read-only, no download), and whenever caching is inactive
+  (chart `modelCache.enabled: false`, a local `file://` source, or a remote
+  model not yet fingerprinted); in the inactive-caching cases the pod falls
+  back to an ephemeral emptyDir and re-downloads on every restart.
+- `claimName` is mutable: changing it rolls the Deployment onto the new claim,
+  but the old claim (and the weights on it) is **not** garbage-collected —
+  clean it up yourself if it is no longer needed.
 - Node alignment is your responsibility: for an RWO or node-local claim, use
   `nodeSelector` so the pod lands where the PVC binds (a
   `WaitForFirstConsumer` local class binds on the first consumer; a pre-bound

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -173,15 +173,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	// spec.modelCache.claimName targets the download path, so it is meaningless
-	// for a pre-staged pvc:// source (mounted read-only, no download). The
-	// claimName is ignored in that case; surface a Warning so the conflict is
-	// visible instead of silently dropped.
-	if r.Recorder != nil && userModelCacheClaimName(inferenceService) != "" && isPVCSource(model.Spec.Source) {
-		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "ModelCacheClaimIgnored", "Reconcile",
-			"spec.modelCache.claimName is ignored: model source %q is a pre-staged pvc:// volume (read-only, no download)",
-			model.Spec.Source)
-	}
+	r.warnIgnoredModelCacheClaim(inferenceService, model)
 
 	isMetal := isMetalModel(model)
 

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -25,10 +25,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/events"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("buildCachedStorageConfig", func() {
@@ -925,6 +929,162 @@ var _ = Describe("ensureModelCachePVC (user claimName, #928)", func() {
 		perISVC := &corev1.PersistentVolumeClaim{}
 		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: isvc.Name + "-model-cache", Namespace: "default"}, perISVC)
 		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+})
+
+var _ = Describe("ModelCacheClaimIgnored warning events (#928)", func() {
+	const namespace = "default"
+	const userClaim = "byo-event-cache"
+
+	var recorder *events.FakeRecorder
+	var modelName, isvcName string
+
+	// drainEvents empties the FakeRecorder channel into a slice.
+	drainEvents := func() []string {
+		var out []string
+		for {
+			select {
+			case e := <-recorder.Events:
+				out = append(out, e)
+			default:
+				return out
+			}
+		}
+	}
+
+	newReconciler := func(cachePath string) *InferenceServiceReconciler {
+		return &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			Recorder:           recorder,
+			ModelCachePath:     cachePath,
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+	}
+
+	// createModel creates a Model and marks it Ready (with the given cache
+	// key, possibly empty) so Reconcile proceeds past the model-ready gate.
+	createModel := func(source, cacheKey string) *inferencev1alpha1.Model {
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: namespace},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:       source,
+				Format:       "gguf",
+				Quantization: "Q4_K_M",
+				Hardware:     &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				Resources:    &inferencev1alpha1.ResourceRequirements{CPU: "1", Memory: "1Gi"},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), model)).To(Succeed())
+		model.Status.Phase = PhaseReady
+		model.Status.CacheKey = cacheKey
+		Expect(k8sClient.Status().Update(context.Background(), model)).To(Succeed())
+		return model
+	}
+
+	createISVC := func() {
+		replicas := int32(1)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:   modelName,
+				Replicas:   &replicas,
+				Image:      "ghcr.io/ggml-org/llama.cpp:server",
+				ModelCache: &inferencev1alpha1.ModelCacheSpec{ClaimName: userClaim},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
+	}
+
+	reconcileOnce := func(r *InferenceServiceReconciler) {
+		_, err := r.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: namespace},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	deleteIfExists := func(obj client.Object) {
+		err := k8sClient.Delete(context.Background(), obj)
+		if err != nil {
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		}
+	}
+
+	BeforeEach(func() {
+		recorder = events.NewFakeRecorder(20)
+		suffix := rand.String(5)
+		modelName = "claim-ignored-model-" + suffix
+		isvcName = "claim-ignored-isvc-" + suffix
+	})
+
+	AfterEach(func() {
+		deleteIfExists(&inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace}})
+		deleteIfExists(&inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: namespace}})
+		deleteIfExists(&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: userClaim, Namespace: namespace}})
+	})
+
+	It("warns when claimName is set but the model source is a pre-staged pvc:// volume", func() {
+		createModel("pvc://staged-models/llama/model.gguf", "")
+		createISVC()
+
+		reconcileOnce(newReconciler("/models"))
+
+		Expect(drainEvents()).To(ContainElement(SatisfyAll(
+			ContainSubstring("ModelCacheClaimIgnored"),
+			ContainSubstring("pre-staged pvc:// volume"),
+		)))
+	})
+
+	It("warns when claimName is set but caching is disabled on the operator", func() {
+		createModel("https://example.com/model.gguf", "abc123def456")
+		createISVC()
+
+		// ModelCachePath == "" is how the chart's modelCache.enabled=false
+		// reaches the reconciler.
+		reconcileOnce(newReconciler(""))
+
+		Expect(drainEvents()).To(ContainElement(SatisfyAll(
+			ContainSubstring("ModelCacheClaimIgnored"),
+			ContainSubstring("caching is disabled"),
+			ContainSubstring("emptyDir"),
+		)))
+	})
+
+	It("warns when claimName is set but the model has no effective cache key", func() {
+		// Remote source whose fingerprint has not landed in Status.CacheKey yet.
+		createModel("https://example.com/model.gguf", "")
+		createISVC()
+
+		reconcileOnce(newReconciler("/models"))
+
+		Expect(drainEvents()).To(ContainElement(SatisfyAll(
+			ContainSubstring("ModelCacheClaimIgnored"),
+			ContainSubstring("no cache key"),
+			ContainSubstring("emptyDir"),
+		)))
+	})
+
+	It("does not warn when the cache path is active and the user PVC exists", func() {
+		createModel("https://example.com/model.gguf", "abc123def456")
+		createISVC()
+
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: userClaim, Namespace: namespace},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), pvc)).To(Succeed())
+
+		reconcileOnce(newReconciler("/models"))
+
+		Expect(drainEvents()).NotTo(ContainElement(ContainSubstring("ModelCacheClaimIgnored")))
 	})
 })
 

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -80,6 +80,42 @@ func userModelCacheClaimName(isvc *inferencev1alpha1.InferenceService) string {
 	return isvc.Spec.ModelCache.ClaimName
 }
 
+// warnIgnoredModelCacheClaim emits a ModelCacheClaimIgnored warning event when
+// spec.modelCache.claimName is set but has no effect. The field targets the
+// download-into-cache path, so it is meaningless whenever that path is
+// inactive; warn in each such case instead of silently dropping the field:
+//   - pvc:// sources are pre-staged (mounted read-only, no download);
+//   - with caching disabled on the operator, or a model without an effective
+//     cache key (local file:// source, or a remote model whose fingerprint has
+//     not landed in Status.CacheKey yet), the pod falls back to an ephemeral
+//     emptyDir and re-downloads on every restart (this mirrors the useCache
+//     gate in constructDeployment).
+func (r *InferenceServiceReconciler) warnIgnoredModelCacheClaim(
+	isvc *inferencev1alpha1.InferenceService,
+	model *inferencev1alpha1.Model,
+) {
+	if r.Recorder == nil || userModelCacheClaimName(isvc) == "" {
+		return
+	}
+	switch {
+	case isPVCSource(model.Spec.Source):
+		r.Recorder.Eventf(isvc, nil, corev1.EventTypeWarning, "ModelCacheClaimIgnored", "Reconcile",
+			"spec.modelCache.claimName is ignored: model source %q is a pre-staged pvc:// volume (read-only, no download)",
+			model.Spec.Source)
+	case r.ModelCachePath == "":
+		r.Recorder.Eventf(isvc, nil, corev1.EventTypeWarning, "ModelCacheClaimIgnored", "Reconcile",
+			"spec.modelCache.claimName is ignored: model caching is disabled on the operator "+
+				"(--model-cache-path unset / chart modelCache.enabled=false); "+
+				"the model downloads into an ephemeral emptyDir and re-downloads on every pod restart")
+	case effectiveModelCacheKey(model) == "":
+		r.Recorder.Eventf(isvc, nil, corev1.EventTypeWarning, "ModelCacheClaimIgnored", "Reconcile",
+			"spec.modelCache.claimName is ignored: model %q has no cache key "+
+				"(local source, or fingerprinting has not completed yet); "+
+				"the model downloads into an ephemeral emptyDir and re-downloads on every pod restart",
+			model.Name)
+	}
+}
+
 // modelCachePVCName returns the name of the model cache PVC for the given mode.
 // A per-InferenceService spec.modelCache.claimName override (#928) wins over
 // the operator-global mode: that user-owned PVC becomes the cache volume for


### PR DESCRIPTION
## What

Emit a `ModelCacheClaimIgnored` warning event when `spec.modelCache.claimName` is set but the cache path is inactive — caching disabled on the operator (chart `modelCache.enabled: false` / `--model-cache-path` unset) or the model has no effective cache key (local `file://` source, or a remote model not yet fingerprinted).

## Why

Follow-up from the #960 review: in these cases the pod silently fell back to an emptyDir and re-downloaded the model on every restart, with no event or condition. #960 already warned for the `pvc://`-source conflict; this covers the symmetric case.

Fixes #965

## How

- The check mirrors the `useCache` gate in `constructDeployment`; it lives in a `warnIgnoredModelCacheClaim` helper next to the other claimName logic (extracted rather than inlined because the extra branches pushed `Reconcile` over the gocyclo limit). Event messages say why the claim was ignored and that the pod gets an ephemeral emptyDir.
- Envtest reconcile tests with a `FakeRecorder` assert every `ModelCacheClaimIgnored` variant — including the pre-existing `pvc://` case, which was previously unasserted — plus a no-warning case when caching is active.
- `docs/MODEL-CACHE.md`: updated the ignored-claim bullet and added a note that `claimName` is mutable and the old claim is not garbage-collected.
- Skipped the `ModelCachePVCNotFound` condition-reason nice-to-have: the Degraded reason is hardcoded in the shared `updateStatusWithSchedulingInfo` switch, so a specific reason means plumbing a new parameter through it — happy to do as a separate PR if wanted.

AI assistance: authored by Claude (Fable 5) operating under the maintainer's direction; reviewed before submitting.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go test ./internal/controller/...` with envtest assets, 506/506)
- [x] `make lint` passes locally (`golangci-lint run ./internal/... ./api/...`, 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)
