### PR TITLE
feat(foreman): executor-owned revise-from-branch restore for revision tasks

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -273,6 +273,19 @@ type AgenticTaskPayload struct {
 	// +optional
 	BranchPrefix string `json:"branchPrefix,omitempty"`
 
+	// ReviseFromBranch names a ref on the push remote that the executor
+	// cuts the working branch FROM instead of from BaseBranch, so a
+	// revision task starts with its prior attempt's files present
+	// (#951). Issue-fix only. The WorkloadReconciler stamps this on fix-
+	// iteration coder tasks (the prior attempt lives at the task's own
+	// branch name on the push remote). The executor owns the git restore
+	// — no prompt-driven fetch/checkout. If the ref does not exist on
+	// the remote (e.g. pruned, or the prior attempt never pushed), the
+	// executor logs and falls back to branching from BaseBranch rather
+	// than failing.
+	// +optional
+	ReviseFromBranch string `json:"reviseFromBranch,omitempty"`
+
 	// Prompt is the agent input. Required for freeform.
 	// +optional
 	Prompt string `json:"prompt,omitempty"`

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -229,6 +229,19 @@ spec:
                     description: Repo is the "owner/name" GitHub repo. Required for
                       issue-fix and verify.
                     type: string
+                  reviseFromBranch:
+                    description: |-
+                      ReviseFromBranch names a ref on the push remote that the executor
+                      cuts the working branch FROM instead of from BaseBranch, so a
+                      revision task starts with its prior attempt's files present
+                      (#951). Issue-fix only. The WorkloadReconciler stamps this on fix-
+                      iteration coder tasks (the prior attempt lives at the task's own
+                      branch name on the push remote). The executor owns the git restore
+                      — no prompt-driven fetch/checkout. If the ref does not exist on
+                      the remote (e.g. pruned, or the prior attempt never pushed), the
+                      executor logs and falls back to branching from BaseBranch rather
+                      than failing.
+                    type: string
                 type: object
               priority:
                 description: |-

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -428,6 +428,19 @@ spec:
                           description: Repo is the "owner/name" GitHub repo. Required
                             for issue-fix and verify.
                           type: string
+                        reviseFromBranch:
+                          description: |-
+                            ReviseFromBranch names a ref on the push remote that the executor
+                            cuts the working branch FROM instead of from BaseBranch, so a
+                            revision task starts with its prior attempt's files present
+                            (#951). Issue-fix only. The WorkloadReconciler stamps this on fix-
+                            iteration coder tasks (the prior attempt lives at the task's own
+                            branch name on the push remote). The executor owns the git restore
+                            — no prompt-driven fetch/checkout. If the ref does not exist on
+                            the remote (e.g. pruned, or the prior attempt never pushed), the
+                            executor logs and falls back to branching from BaseBranch rather
+                            than failing.
+                          type: string
                       type: object
                     priority:
                       description: |-

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -229,6 +229,19 @@ spec:
                     description: Repo is the "owner/name" GitHub repo. Required for
                       issue-fix and verify.
                     type: string
+                  reviseFromBranch:
+                    description: |-
+                      ReviseFromBranch names a ref on the push remote that the executor
+                      cuts the working branch FROM instead of from BaseBranch, so a
+                      revision task starts with its prior attempt's files present
+                      (#951). Issue-fix only. The WorkloadReconciler stamps this on fix-
+                      iteration coder tasks (the prior attempt lives at the task's own
+                      branch name on the push remote). The executor owns the git restore
+                      — no prompt-driven fetch/checkout. If the ref does not exist on
+                      the remote (e.g. pruned, or the prior attempt never pushed), the
+                      executor logs and falls back to branching from BaseBranch rather
+                      than failing.
+                    type: string
                 type: object
               priority:
                 description: |-

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -428,6 +428,19 @@ spec:
                           description: Repo is the "owner/name" GitHub repo. Required
                             for issue-fix and verify.
                           type: string
+                        reviseFromBranch:
+                          description: |-
+                            ReviseFromBranch names a ref on the push remote that the executor
+                            cuts the working branch FROM instead of from BaseBranch, so a
+                            revision task starts with its prior attempt's files present
+                            (#951). Issue-fix only. The WorkloadReconciler stamps this on fix-
+                            iteration coder tasks (the prior attempt lives at the task's own
+                            branch name on the push remote). The executor owns the git restore
+                            — no prompt-driven fetch/checkout. If the ref does not exist on
+                            the remote (e.g. pruned, or the prior attempt never pushed), the
+                            executor logs and falls back to branching from BaseBranch rather
+                            than failing.
+                          type: string
                       type: object
                     priority:
                       description: |-

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -300,33 +300,12 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 		return e.failResult(start, foremanv1alpha1.FailureCloneFailed, err.Error()), nil
 	}
 
-	// 4. Branch off the CURRENT upstream base (#813). The clone above is the
-	// fork (origin = push target); cutting the task branch from the fork's
-	// default branch produces a stale-base branch whenever the fork lags
-	// upstream. When the task carries an upstream repo slug (payload.repo),
-	// fetch its base ref and branch from that instead. Origin stays the fork,
-	// so the branch still pushes there for the PR. Freeform tasks without a
-	// repo slug fall back to branching from the cloned fork HEAD. When the
-	// clone target was itself derived from payload.repo (#915), origin and
-	// upstream resolve to the same URL — branching off the base is then a
-	// no-op-equivalent that still yields a current-base branch.
+	// 4. Cut the task branch (see setupTaskBranch: revise-from-branch
+	// restore (#951), then upstream base fetch (#813), then clone-HEAD
+	// fallback). Failures bucket with CloneFailed for the retry policy.
 	branch := branchNameForTask(task)
 	baseBranch := baseBranchOrDefault(task.Spec.Payload.BaseBranch)
-	if upstreamURL := resolveUpstream(task.Spec.Payload.Repo); upstreamURL != "" {
-		if err := repo.CreateBranchFromUpstream(ctx, repo.UpstreamBranchOptions{
-			Workspace:   workspace,
-			Branch:      branch,
-			UpstreamURL: upstreamURL,
-			BaseBranch:  baseBranch,
-			Auth:        auth,
-		}); err != nil {
-			// Fail loud rather than silently branching from the stale fork
-			// base; bucket with CloneFailed for the retry policy.
-			return e.failResult(start, foremanv1alpha1.FailureCloneFailed, err.Error()), nil
-		}
-	} else if err := repo.CreateAndCheckoutBranch(ctx, workspace, branch); err != nil {
-		// Branch checkout is part of workspace prep; bucket with
-		// CloneFailed so downstream retry policy treats them the same.
+	if err := setupTaskBranch(ctx, task, workspace, branch, baseBranch, resolveUpstream, auth, log); err != nil {
 		return e.failResult(start, foremanv1alpha1.FailureCloneFailed, err.Error()), nil
 	}
 
@@ -352,6 +331,65 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	// cyclomatic-complexity threshold. runLLMPath owns OAI + loop +
 	// transcript + commit/push.
 	return e.runLLMPath(ctx, task, &agent, endpoint, workspace, branch, registry, auth, start)
+}
+
+// setupTaskBranch cuts the task's working branch in the freshly cloned
+// workspace. Precedence:
+//
+//  1. payload.reviseFromBranch on an issue-fix task (#951): restore the
+//     prior attempt by fetching that ref from the push remote ("origin",
+//     the clone the branch pushes back to) and branching from it, so a
+//     revision task starts with its prior attempt's files present. The
+//     executor owns this restore — prompt-driven git proved fragile
+//     under stuck-loop forcing windows. When the ref is gone from the
+//     remote (pruned, or the prior attempt never pushed) it logs and
+//     falls through to (2) rather than failing.
+//  2. Upstream base fetch (#813): when the task carries a repo slug,
+//     fetch the base ref from the upstream project and branch from
+//     that, so a stale fork default branch cannot produce a stale-base
+//     branch. Origin stays the fork; the branch still pushes there.
+//  3. Clone-HEAD checkout for freeform tasks without a repo slug.
+func setupTaskBranch(
+	ctx context.Context,
+	task *foremanv1alpha1.AgenticTask,
+	workspace, branch, baseBranch string,
+	resolveUpstream func(string) string,
+	auth *repo.Auth,
+	log logr.Logger,
+) error {
+	if ref := task.Spec.Payload.ReviseFromBranch; ref != "" &&
+		task.Spec.Kind == foremanv1alpha1.AgenticTaskKindIssueFix {
+		found, err := repo.CreateBranchFromRemoteRef(ctx, repo.RemoteRefBranchOptions{
+			Workspace: workspace,
+			Branch:    branch,
+			Remote:    "origin",
+			Ref:       ref,
+			Auth:      auth,
+		})
+		if err != nil {
+			// Transport/auth failure: fail loud rather than silently
+			// rebuilding from base and force-overwriting the prior attempt.
+			return err
+		}
+		if found {
+			log.Info("restored prior attempt for revision",
+				"reviseFromBranch", ref, "branch", branch)
+			return nil
+		}
+		log.Info("reviseFromBranch ref not found on push remote; falling back to base branch",
+			"reviseFromBranch", ref, "baseBranch", baseBranch)
+	}
+
+	if upstreamURL := resolveUpstream(task.Spec.Payload.Repo); upstreamURL != "" {
+		return repo.CreateBranchFromUpstream(ctx, repo.UpstreamBranchOptions{
+			Workspace:   workspace,
+			Branch:      branch,
+			UpstreamURL: upstreamURL,
+			BaseBranch:  baseBranch,
+			Auth:        auth,
+		})
+	}
+	return repo.CreateAndCheckoutBranch(ctx, workspace, branch)
 }
 
 // runLLMPath is the model-in-the-loop continuation of Execute. Called
@@ -1770,13 +1808,21 @@ func logReviewerFindings(log logr.Logger, extra map[string]any) {
 }
 
 // fetchIssueBodyIfNeeded populates task.Spec.Payload.Prompt from the
-// GitHub issue body when the task is an issue-fix with an empty
-// prompt. The M6 stub planner does not pull issue bodies at synthesis
+// GitHub issue body when the task is an issue-fix that names an
+// issue. The M6 stub planner does not pull issue bodies at synthesis
 // time; this lazy fetch makes a coder Agent's first turn actually
 // useful instead of being told "fix #510" with no context (#571).
 //
+// Revision tasks (payload.reviseFromBranch set, #951) are the
+// exception to the "non-empty prompt suppresses the fetch" rule: their
+// prompt is the review feedback, and a retry handed only the feedback
+// loses the original ask and acceptance criteria. For those, the issue
+// body is APPENDED under an "## Original issue (#N)" heading. Non-
+// revision tasks with a prompt (bridge-composed, hand-authored
+// pipelines) stay untouched, as before.
+//
 // Best-effort: no fetcher, no auth token, malformed repo, or HTTP
-// failure all yield a log line and leave the payload prompt empty,
+// failure all yield a log line and leave the payload prompt as-is,
 // preserving the pre-#571 behavior. The model can still grep the repo
 // for clues; the goal here is to give it a much better starting
 // point when GitHub is reachable.
@@ -1797,7 +1843,9 @@ func fetchIssueBodyIfNeeded(
 	if task.Spec.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
 		return
 	}
-	if task.Spec.Payload.Prompt != "" {
+	if task.Spec.Payload.Prompt != "" && task.Spec.Payload.ReviseFromBranch == "" {
+		// Pre-#951 contract: a composed prompt owns the task context.
+		// Only revision tasks append the issue behind their feedback.
 		return
 	}
 	if task.Spec.Payload.Issue <= 0 {
@@ -1818,13 +1866,13 @@ func fetchIssueBodyIfNeeded(
 		var herr *githubissue.HTTPError
 		switch {
 		case errors.As(err, &herr) && herr.IsNotFound():
-			log.Info("issue fetch: not found; continuing with empty body",
+			log.Info("issue fetch: not found; continuing without issue body",
 				"issue", task.Spec.Payload.Issue, "repo", task.Spec.Payload.Repo)
 		case errors.As(err, &herr) && herr.IsUnauthorized():
 			log.Info("issue fetch: unauthorized; check GITHUB_TOKEN",
 				"issue", task.Spec.Payload.Issue, "repo", task.Spec.Payload.Repo)
 		default:
-			log.Info("issue fetch failed; continuing with empty body",
+			log.Info("issue fetch failed; continuing without issue body",
 				"err", err.Error(),
 				"issue", task.Spec.Payload.Issue, "repo", task.Spec.Payload.Repo)
 		}
@@ -1836,7 +1884,16 @@ func fetchIssueBodyIfNeeded(
 	// the labels (helps with triage). Body is the longest part and
 	// goes last so the structured fields stay near the top.
 	var b strings.Builder
-	fmt.Fprintf(&b, "# Issue #%d: %s\n\n", iss.Number, iss.Title)
+	appended := task.Spec.Payload.Prompt != ""
+	if appended {
+		// Revision task: the review-feedback prompt stays first; the
+		// issue rides behind it under its own heading so the model sees
+		// both the retry context and the original ask.
+		b.WriteString(task.Spec.Payload.Prompt)
+		fmt.Fprintf(&b, "\n\n## Original issue (#%d): %s\n\n", iss.Number, iss.Title)
+	} else {
+		fmt.Fprintf(&b, "# Issue #%d: %s\n\n", iss.Number, iss.Title)
+	}
 	fmt.Fprintf(&b, "State: %s\n", iss.State)
 	if len(iss.Labels) > 0 {
 		fmt.Fprintf(&b, "Labels: %s\n", strings.Join(iss.Labels, ", "))
@@ -1845,7 +1902,7 @@ func fetchIssueBodyIfNeeded(
 	b.WriteString(iss.Body)
 	task.Spec.Payload.Prompt = b.String()
 	log.Info("issue body fetched",
-		"issue", iss.Number, "state", iss.State, "bodyLen", len(iss.Body))
+		"issue", iss.Number, "state", iss.State, "bodyLen", len(iss.Body), "appended", appended)
 }
 
 // progressConfigFromAgent maps the Agent CR's stuckLoopDetection field

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -44,6 +44,7 @@ import (
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
 )
 
@@ -1830,5 +1831,248 @@ func TestBuildUserPrompt_ReviewerOmitsAdvisoryBlockWhenNone(t *testing.T) {
 	// Must still produce a non-empty, useful prompt.
 	if !strings.Contains(got, "reviewing the branch") {
 		t.Errorf("reviewer prompt missing base content; got:\n%s", got)
+	}
+}
+
+// stubIssueFetcher is a minimal whitebox Fetcher: it returns the
+// canned issue and counts calls. The blackbox fakeIssueFetcher in
+// executor_native_test.go drives the end-to-end path; this one pins
+// fetchIssueBodyIfNeeded's prompt-composition logic in isolation.
+type stubIssueFetcher struct {
+	issue *githubissue.Issue
+	calls int
+}
+
+func (s *stubIssueFetcher) Fetch(context.Context, string, string, int, string) (*githubissue.Issue, error) {
+	s.calls++
+	return s.issue, nil
+}
+
+// TestFetchIssueBodyIfNeeded_AppendsIssueOnRevisionTask covers the
+// revision path (#951): on a task with reviseFromBranch set, the
+// review-feedback prompt must not suppress the issue fetch — the
+// original ask is APPENDED under an "## Original issue" heading so the
+// retry sees both the feedback and what it is actually fixing.
+func TestFetchIssueBodyIfNeeded_AppendsIssueOnRevisionTask(t *testing.T) {
+	fetcher := &stubIssueFetcher{issue: &githubissue.Issue{
+		Number: 641,
+		Title:  "Widget breaks on input X",
+		Body:   "The widget panics when given X. Acceptance: no panic.",
+		State:  "open",
+		Labels: []string{"bug"},
+	}}
+	const feedback = "The reviewer rejected your previous attempt at issue #641 (verdict NO-GO)."
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:             "defilantech/LLMKube",
+				Issue:            641,
+				Branch:           "foreman/wl/issue-641",
+				ReviseFromBranch: "foreman/wl/issue-641",
+				Prompt:           feedback,
+			},
+		},
+	}
+
+	fetchIssueBodyIfNeeded(context.Background(), fetcher, task, nil, logr.Discard())
+
+	if fetcher.calls != 1 {
+		t.Fatalf("fetcher calls = %d, want 1", fetcher.calls)
+	}
+	got := task.Spec.Payload.Prompt
+	if !strings.HasPrefix(got, feedback) {
+		t.Errorf("existing prompt must stay first; got:\n%s", got)
+	}
+	for _, want := range []string{
+		"## Original issue (#641): Widget breaks on input X",
+		"State: open",
+		"Labels: bug",
+		"The widget panics when given X. Acceptance: no panic.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("appended prompt missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "# Issue #641:") {
+		t.Errorf("append path must use the Original-issue heading, not the empty-prompt H1; got:\n%s", got)
+	}
+}
+
+// TestFetchIssueBodyIfNeeded_NoIssueNumberIsNoOp pins the Issue==0
+// contract: without an issue number there is nothing to fetch, and an
+// existing prompt must pass through untouched.
+func TestFetchIssueBodyIfNeeded_NoIssueNumberIsNoOp(t *testing.T) {
+	fetcher := &stubIssueFetcher{issue: &githubissue.Issue{Number: 1, Title: "unused"}}
+	const prompt = "hand-authored task prompt with no issue reference"
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Prompt: prompt,
+			},
+		},
+	}
+
+	fetchIssueBodyIfNeeded(context.Background(), fetcher, task, nil, logr.Discard())
+
+	if fetcher.calls != 0 {
+		t.Errorf("fetcher must not be called when Issue is 0; calls = %d", fetcher.calls)
+	}
+	if task.Spec.Payload.Prompt != prompt {
+		t.Errorf("prompt must be untouched; got %q", task.Spec.Payload.Prompt)
+	}
+}
+
+// TestFetchIssueBodyIfNeeded_ComposedPromptWithoutRevisionUntouched
+// pins the pre-#951 contract for NON-revision tasks: a composed prompt
+// (bridge- or hand-authored) owns the task context, so the fetch is
+// suppressed even though an issue number is present.
+func TestFetchIssueBodyIfNeeded_ComposedPromptWithoutRevisionUntouched(t *testing.T) {
+	fetcher := &stubIssueFetcher{issue: &githubissue.Issue{Number: 641, Title: "unused"}}
+	const prompt = "bridge-composed prompt that already embeds the issue text"
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Issue:  641,
+				Prompt: prompt,
+			},
+		},
+	}
+
+	fetchIssueBodyIfNeeded(context.Background(), fetcher, task, nil, logr.Discard())
+
+	if fetcher.calls != 0 {
+		t.Errorf("fetcher must not be called for a composed prompt without reviseFromBranch; calls = %d", fetcher.calls)
+	}
+	if task.Spec.Payload.Prompt != prompt {
+		t.Errorf("prompt must be untouched; got %q", task.Spec.Payload.Prompt)
+	}
+}
+
+// ---- setupTaskBranch (#951 revise-from-branch restore) ----
+
+// gitIn runs git in dir with a hermetic identity, failing the test on
+// error and returning trimmed stdout.
+func gitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// seededRemote creates a bare remote with one commit on main and
+// returns its path plus the main tip SHA.
+func seededRemote(t *testing.T, dir string) (bare, mainSHA string) {
+	t.Helper()
+	bare = filepath.Join(dir, "origin.git")
+	gitIn(t, "", "init", "--bare", "-b", "main", bare)
+	seed := filepath.Join(dir, "seed")
+	gitIn(t, "", "clone", bare, seed)
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("# seed\n"), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	gitIn(t, seed, "add", "README.md")
+	gitIn(t, seed, "commit", "-m", "seed")
+	gitIn(t, seed, "push", "origin", "main")
+	return bare, gitIn(t, seed, "rev-parse", "HEAD")
+}
+
+func revisionTask(branch string) *foremanv1alpha1.AgenticTask {
+	return &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:             "defilantech/LLMKube",
+				Issue:            641,
+				Branch:           branch,
+				ReviseFromBranch: branch,
+			},
+		},
+	}
+}
+
+// TestSetupTaskBranch_RestoresPriorAttempt drives the executor-owned
+// restore (#951): with reviseFromBranch set and the ref present on the
+// push remote, the working branch starts at the prior attempt's tip
+// (files present), NOT at a fresh fetch of the base branch.
+func TestSetupTaskBranch_RestoresPriorAttempt(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, _ := seededRemote(t, dir)
+	const branch = "foreman/wl/issue-641"
+
+	// Prior attempt pushed to the remote.
+	prior := filepath.Join(dir, "prior")
+	gitIn(t, "", "clone", bare, prior)
+	gitIn(t, prior, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(prior, "fix.txt"), []byte("attempt 1\n"), 0o644); err != nil {
+		t.Fatalf("write fix.txt: %v", err)
+	}
+	gitIn(t, prior, "add", "fix.txt")
+	gitIn(t, prior, "commit", "-m", "attempt 1")
+	gitIn(t, prior, "push", "origin", branch)
+	priorSHA := gitIn(t, prior, "rev-parse", "HEAD")
+
+	// Fresh executor-style workspace clone.
+	ws := filepath.Join(dir, "ws")
+	gitIn(t, "", "clone", bare, ws)
+
+	err := setupTaskBranch(context.Background(), revisionTask(branch), ws, branch, "main",
+		func(string) string { return bare }, nil, logr.Discard())
+	if err != nil {
+		t.Fatalf("setupTaskBranch: %v", err)
+	}
+	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != priorSHA {
+		t.Errorf("HEAD = %s, want prior attempt tip %s (restore must not rebuild from base)", got, priorSHA)
+	}
+	if _, err := os.Stat(filepath.Join(ws, "fix.txt")); err != nil {
+		t.Errorf("prior attempt's file must be present: %v", err)
+	}
+	if got := gitIn(t, ws, "branch", "--show-current"); got != branch {
+		t.Errorf("current branch = %q, want %q", got, branch)
+	}
+}
+
+// TestSetupTaskBranch_MissingRefFallsBackToBase pins the degradation
+// contract: when the reviseFromBranch ref is gone from the remote the
+// task still runs — branched from the upstream base — instead of
+// failing.
+func TestSetupTaskBranch_MissingRefFallsBackToBase(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, mainSHA := seededRemote(t, dir)
+	const branch = "foreman/wl/issue-641"
+
+	ws := filepath.Join(dir, "ws")
+	gitIn(t, "", "clone", bare, ws)
+
+	err := setupTaskBranch(context.Background(), revisionTask(branch), ws, branch, "main",
+		func(string) string { return bare }, nil, logr.Discard())
+	if err != nil {
+		t.Fatalf("setupTaskBranch must fall back, not fail: %v", err)
+	}
+	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != mainSHA {
+		t.Errorf("HEAD = %s, want base tip %s (fallback branches from base)", got, mainSHA)
+	}
+	if got := gitIn(t, ws, "branch", "--show-current"); got != branch {
+		t.Errorf("current branch = %q, want %q", got, branch)
 	}
 }

--- a/pkg/foreman/agent/repo/branch.go
+++ b/pkg/foreman/agent/repo/branch.go
@@ -167,6 +167,70 @@ func CreateBranchFromUpstream(ctx context.Context, opts UpstreamBranchOptions) e
 	return nil
 }
 
+// RemoteRefBranchOptions configures CreateBranchFromRemoteRef.
+type RemoteRefBranchOptions struct {
+	// Workspace is the cloned working tree to create the branch in.
+	Workspace string
+	// Branch is the new task branch name.
+	Branch string
+	// Remote is the remote the ref is fetched from — the push remote
+	// ("origin" in executor workspaces), where the prior attempt lives.
+	Remote string
+	// Ref is the branch name on Remote to restore from (the prior
+	// attempt's branch).
+	Ref string
+	// Auth, when non-nil, provides the GIT_ASKPASS scaffolding for the
+	// probe + fetch. A public remote can leave it nil.
+	Auth *Auth
+}
+
+// CreateBranchFromRemoteRef fetches Ref from Remote and creates Branch
+// at the fetched tip, so a revision task's workspace starts with the
+// prior attempt's files present (#951: the executor owns git; the
+// restore must not be prompt-driven). Returns found=false with a nil
+// error when Remote has no such ref (prior attempt pruned or never
+// pushed) so the caller can fall back to the base-branch path;
+// transport/auth failures return an error.
+func CreateBranchFromRemoteRef(ctx context.Context, opts RemoteRefBranchOptions) (found bool, err error) {
+	if opts.Workspace == "" {
+		return false, fmt.Errorf("CreateBranchFromRemoteRef: Workspace is required")
+	}
+	if !gitRefSafe(opts.Branch) {
+		return false, fmt.Errorf("CreateBranchFromRemoteRef: invalid branch name %q", opts.Branch)
+	}
+	if !gitRefSafe(opts.Remote) {
+		return false, fmt.Errorf("CreateBranchFromRemoteRef: invalid remote %q", opts.Remote)
+	}
+	if !gitRefSafe(opts.Ref) {
+		return false, fmt.Errorf("CreateBranchFromRemoteRef: invalid ref %q", opts.Ref)
+	}
+
+	env := baseEnv()
+	if opts.Auth != nil {
+		env = append(env, opts.Auth.Env()...)
+	}
+
+	// Probe first: ls-remote exits 0 with empty output for a missing
+	// ref, which cleanly separates "fall back to base" from transport
+	// failures (which error out and should fail the task loudly).
+	out, err := runGit(ctx, opts.Workspace, env, "ls-remote", opts.Remote, "refs/heads/"+opts.Ref)
+	if err != nil {
+		return false, fmt.Errorf("CreateBranchFromRemoteRef: ls-remote %s %s: %w", opts.Remote, opts.Ref, err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return false, nil
+	}
+
+	if _, err := runGit(ctx, opts.Workspace, env, "fetch", opts.Remote, opts.Ref); err != nil {
+		return false, fmt.Errorf("CreateBranchFromRemoteRef: fetch %s %s: %w", opts.Remote, opts.Ref, err)
+	}
+	// -B for idempotency, mirroring CreateBranchFromUpstream.
+	if _, err := runGit(ctx, opts.Workspace, baseEnv(), "checkout", "-B", opts.Branch, "FETCH_HEAD"); err != nil {
+		return false, fmt.Errorf("CreateBranchFromRemoteRef: checkout -B %s FETCH_HEAD: %w", opts.Branch, err)
+	}
+	return true, nil
+}
+
 // baseEnv is the minimal env for read/local-only git ops that do not
 // need GIT_ASKPASS (branch, status, log). HOME is carried through so
 // git can read ~/.gitconfig if present.

--- a/pkg/foreman/agent/repo/branch_test.go
+++ b/pkg/foreman/agent/repo/branch_test.go
@@ -167,3 +167,108 @@ func TestCreateBranchFromUpstream_FetchFailureErrors(t *testing.T) {
 		t.Fatal("expected error when the upstream fetch fails")
 	}
 }
+
+// pushPriorAttempt clones bare, commits fname on branch, and pushes the
+// branch — simulating a prior coder attempt living on the push remote.
+// Returns the attempt's tip SHA.
+func pushPriorAttempt(t *testing.T, bare, dir, branch, fname string) string {
+	t.Helper()
+	work := mustClone(t, bare, dir)
+	mustGit(t, work, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(work, fname), []byte("attempt 1\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", fname, err)
+	}
+	mustGit(t, work, "-c", "user.email=u@x", "-c", "user.name=u", "add", fname)
+	mustGit(t, work, "-c", "user.email=u@x", "-c", "user.name=u", "commit", "-m", "attempt 1")
+	mustGit(t, work, "push", "origin", branch)
+	return gitOut(t, work, "rev-parse", "HEAD")
+}
+
+// TestCreateBranchFromRemoteRef verifies the #951 revision restore: the
+// task branch is cut from the prior attempt's ref on the push remote,
+// so the prior attempt's files are simply present in the workspace.
+func TestCreateBranchFromRemoteRef(t *testing.T) {
+	gitOrSkip(t)
+	dir := t.TempDir()
+
+	bare := initBareOrigin(t, filepath.Join(dir, "fork"))
+	seedOrigin(t, bare)
+	const branch = "foreman/wl/issue-641"
+	priorSHA := pushPriorAttempt(t, bare, filepath.Join(dir, "prior"), branch, "fix.txt")
+
+	// Revision workspace: a fresh clone, like the executor makes.
+	workspace := mustClone(t, bare, filepath.Join(dir, "workspace"))
+
+	found, err := CreateBranchFromRemoteRef(context.Background(), RemoteRefBranchOptions{
+		Workspace: workspace,
+		Branch:    branch,
+		Remote:    "origin",
+		Ref:       branch,
+	})
+	if err != nil {
+		t.Fatalf("CreateBranchFromRemoteRef: %v", err)
+	}
+	if !found {
+		t.Fatal("found = false, want true (the ref exists on the remote)")
+	}
+	if got := gitOut(t, workspace, "rev-parse", "HEAD"); got != priorSHA {
+		t.Errorf("HEAD = %s, want the prior attempt tip %s", got, priorSHA)
+	}
+	if got := gitOut(t, workspace, "branch", "--show-current"); got != branch {
+		t.Errorf("current branch = %q, want %q", got, branch)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "fix.txt")); err != nil {
+		t.Errorf("prior attempt's file must be present in the workspace: %v", err)
+	}
+}
+
+// TestCreateBranchFromRemoteRef_MissingRef verifies the fallback
+// contract: a ref absent from the remote (pruned, or the prior attempt
+// never pushed) returns found=false WITHOUT an error and leaves the
+// workspace untouched, so the caller can branch from base instead.
+func TestCreateBranchFromRemoteRef_MissingRef(t *testing.T) {
+	gitOrSkip(t)
+	dir := t.TempDir()
+	bare := initBareOrigin(t, filepath.Join(dir, "fork"))
+	seedOrigin(t, bare)
+	workspace := mustClone(t, bare, filepath.Join(dir, "workspace"))
+
+	found, err := CreateBranchFromRemoteRef(context.Background(), RemoteRefBranchOptions{
+		Workspace: workspace,
+		Branch:    "foreman/wl/issue-999",
+		Remote:    "origin",
+		Ref:       "foreman/wl/issue-999",
+	})
+	if err != nil {
+		t.Fatalf("missing ref must not error: %v", err)
+	}
+	if found {
+		t.Fatal("found = true, want false for a ref the remote does not have")
+	}
+	if got := gitOut(t, workspace, "branch", "--show-current"); got != "main" {
+		t.Errorf("workspace must be untouched on a miss; current branch = %q", got)
+	}
+}
+
+// TestCreateBranchFromRemoteRef_Validation pins the argv-safety guards:
+// option-shaped and traversal-shaped values must be rejected before
+// they reach git.
+func TestCreateBranchFromRemoteRef_Validation(t *testing.T) {
+	cases := []struct {
+		name string
+		opts RemoteRefBranchOptions
+	}{
+		{"empty workspace", RemoteRefBranchOptions{Branch: "b", Remote: "origin", Ref: "r"}},
+		{"option-shaped ref", RemoteRefBranchOptions{Workspace: "w", Branch: "b", Remote: "origin", Ref: "--upload-pack=/x"}},
+		{"traversal ref", RemoteRefBranchOptions{Workspace: "w", Branch: "b", Remote: "origin", Ref: "a..b"}},
+		{"option-shaped remote", RemoteRefBranchOptions{Workspace: "w", Branch: "b", Remote: "--mirror", Ref: "r"}},
+		{"empty branch", RemoteRefBranchOptions{Workspace: "w", Remote: "origin", Ref: "r"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := CreateBranchFromRemoteRef(context.Background(), tc.opts); err == nil {
+				t.Fatalf("expected validation error for %+v", tc.opts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Executor-owned branch restore for revision tasks: new `AgenticTaskPayload.reviseFromBranch` names a ref on the push remote, and the executor cuts the working branch from that ref (fetch + `checkout -B` from `FETCH_HEAD`) instead of from `baseBranch`, so a revision coder starts with its prior attempt's files present. On revision tasks, `fetchIssueBodyIfNeeded` now appends the GitHub issue under an `## Original issue (#N)` heading behind the review-feedback prompt instead of suppressing the fetch.

## Why

Without this, a review-feedback retry runs in a fresh workspace cut from the upstream base: it rebuilds from main, sees only the feedback (losing the original ask), and force-overwrites the prior attempt with a feedback-only diff. #951's live validation showed the prompt-driven alternative (model runs `git fetch`/`checkout` itself) dies under stuck-loop forcing windows — the executor owns git everywhere else and should own the restore too.

Part of #951 (the executor-restore half; revision profile pairing rides with the iteration loop in #959, which stacks on this branch).

## How

- `repo.CreateBranchFromRemoteRef`: `ls-remote` probe, then fetch + `checkout -B <branch> FETCH_HEAD`. A missing ref returns `found=false` without error; transport/auth failures error loudly. Same argv-safety guards as `CreateBranchFromUpstream`.
- Executor `setupTaskBranch` (extracted from `Execute` step 4): issue-fix tasks with `reviseFromBranch` restore from `origin`; a pruned/never-pushed ref logs and falls back to the existing branch-from-upstream-base path (#813) rather than failing. Base-branch and clone-HEAD paths unchanged.
- Issue-body append is gated on `reviseFromBranch` being set, so composed prompts on non-revision tasks (bridge/hand-authored pipelines) keep the pre-existing "non-empty prompt suppresses the fetch" contract.
- CRD manifests + foreman chart CRDs regenerated.

Standalone useful: hand-authored Pipeline Workloads and external retry bridges can set `reviseFromBranch` directly today; the controller starts stamping it in #959.

Verification: `go test ./pkg/foreman/...` (new unit tests: restore from existing ref, missing-ref fallback, argv validation, issue-append on revision tasks, composed-prompt no-op); `KUBEBUILDER_ASSETS=... go test ./internal/foreman/controller/...`; `golangci-lint run ./internal/... ./pkg/... ./api/...` 0 issues; `gofmt -l` clean.

AI assistance: authored by Claude (Fable 5) operating under the maintainer's direction; reviewed before submitting.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)
