### PR TITLE
fix(foreman): reject no-op str_replace where old_string equals new_string

### DIFF
--- a/pkg/foreman/agent/tools/str_replace.go
+++ b/pkg/foreman/agent/tools/str_replace.go
@@ -81,6 +81,18 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 	if a.Path == "" || a.OldString == "" {
 		return nil, fmt.Errorf("str_replace: path and old_string are required")
 	}
+	// A no-op edit (old_string == new_string) changes nothing, but the match
+	// logic below would still "replace" the string with itself and report
+	// replacements:1 -- a phantom success. A model that sees success on an
+	// unchanged file re-issues the identical call and gets killed by the
+	// RepeatedToolCall stuck-loop detector (#968). Reject it explicitly so the
+	// model corrects new_string or moves on.
+	if a.OldString == a.NewString {
+		return nil, fmt.Errorf("str_replace: old_string and new_string are identical, " +
+			"so this edit would change nothing. If the file already contains the text " +
+			"you want, move on to the next step; otherwise set new_string to the " +
+			"replacement text you intend")
+	}
 	full, err := resolveInside(t.Workspace, a.Path)
 	if err != nil {
 		return nil, fmt.Errorf("str_replace: %w", err)

--- a/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
+++ b/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
@@ -324,3 +324,26 @@ func TestStrReplace_NonexistentFileSteersToWriteFile(t *testing.T) {
 		t.Errorf("expected existence + write_file steering in the error, got: %v", err)
 	}
 }
+
+// Regression for #968: str_replace with old_string == new_string is a no-op.
+// Before the guard the match logic would "find and replace" the string with
+// itself and report replacements:1 -- a phantom success. Models that see
+// success on an unchanged file re-issue the identical call and get killed by
+// the RepeatedToolCall stuck-loop detector. It must be rejected instead.
+func TestStrReplace_IdenticalOldNewRejected(t *testing.T) {
+	ws := makeWorkspace(t)
+	src := "func compute() int {\n\treturn userCount\n}\n"
+	seedFile(t, ws, "f.go", src)
+	// old_string exists in the file, but new_string is identical to it.
+	err := execStrReplace(t, ws, "f.go", "\treturn userCount", "\treturn userCount")
+	if err == nil {
+		t.Fatal("expected an error for identical old_string/new_string, got nil (phantom success)")
+	}
+	if !strings.Contains(err.Error(), "identical") {
+		t.Errorf("expected an 'identical' no-op error, got: %v", err)
+	}
+	// The file must be untouched.
+	if got := readBack(t, ws, "f.go"); got != src {
+		t.Errorf("file must be unchanged, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Reject a no-op `str_replace` where `old_string == new_string` with an actionable error, instead of silently reporting `replacements:1` (a phantom success).

## Why

Fixes #968

A `str_replace` whose `old_string` equals its `new_string` changes nothing, but the tool's match logic still "found and replaced" the string with itself and returned `{"replacements":1}`. A model that sees success on a file that did not actually change concludes the edit did not take, re-issues the identical call, and loops until the `RepeatedToolCall` stuck-loop detector terminates the run INCOMPLETE.

This was found in the wild, not theorized: in live Foreman coder runs on issue #944, two different local models (a 35B-A3B MoE and a coder-tuned sibling) each constructed a byte-identical `old_string`/`new_string` `str_replace`, received the phantom success six times in a row, and were killed by the stuck-loop detector at turn 34. The models even narrated it ("I keep writing the same thing") but could not break out, because the tool kept telling them they had succeeded. The failure is model-independent: it is the tool rewarding a no-op.

## How

A guard at the top of `Execute`, right after the required-args check and before the file is read (a no-op is a pure argument mistake, so there is no reason to touch the file):

```go
if a.OldString == a.NewString {
    return nil, fmt.Errorf("str_replace: old_string and new_string are identical, ...")
}
```

The error steers the model to either move on (if the file already contains the desired text) or correct `new_string`. Behavior for every real edit is unchanged; only the exact-equality no-op is now rejected. Distinct from #942/#943's recovery ladder (which handles `str_replace` *failing to match*); this is `str_replace` *succeeding on a no-op*.

## Checklist

- [x] Tests added/updated (`TestStrReplace_IdenticalOldNewRejected`: asserts the error, the `identical` message, and that the file is untouched; written test-first, watched it fail on the phantom success, then pass)
- [x] `make test` scope: `go test ./pkg/foreman/agent/tools/` passes; `go build ./...` clean
- [x] `make lint` passes locally (0 issues; also `GOOS=linux golangci-lint` 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: implemented with AI assistance (Claude Code) under human review; human-accountable (band 3), commits kept clean per CONTRIBUTING.md
- [x] Documentation updated (n/a: internal tool behavior, no user-facing doc)
