### PR TITLE
fix(runtime): bind inference servers to :: for IPv6-only clusters

### DIFF
--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -3660,12 +3660,12 @@ var _ = Describe("RuntimeBackend interface", func() {
 			// deprecated and intentionally omitted.
 			Expect(args[0]).To(Equal("/models/llama3"))
 			Expect(args).NotTo(ContainElement("--model"))
-			Expect(args).To(ContainElements("--host", "0.0.0.0"))
+			Expect(args).To(ContainElements("--host", "::"))
 			Expect(args).To(ContainElements("--port", "8000"))
 			// --enable-metrics is always set so vLLM pods expose /metrics for
 			// PodMonitor scraping (#409).
 			Expect(args).To(ContainElement("--enable-metrics"))
-			// Six elements: <model> --host 0.0.0.0 --port 8000 --enable-metrics.
+			// Six elements: <model> --host :: --port 8000 --enable-metrics.
 			Expect(args).To(HaveLen(6))
 		})
 

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -4206,7 +4206,7 @@ var _ = Describe("constructDeployment Regression Tests", func() {
 			Expect(container.Ports[0].Name).To(Equal("http"))
 
 			By("verifying base args")
-			Expect(container.Args).To(ContainElements("--model", "--host", "0.0.0.0", "--port", "8080"))
+			Expect(container.Args).To(ContainElements("--model", "--host", "::", "--port", "8080"))
 			Expect(container.Args).To(ContainElement("--metrics"))
 
 			By("verifying no GPU args")

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -43,7 +43,12 @@ func (b *LlamaCppBackend) DefaultHPAMetric() string { return "llamacpp:requests_
 func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, modelPath string, port int32) []string {
 	args := []string{
 		"--model", modelPath,
-		"--host", "0.0.0.0",
+		// Bind the dual-stack wildcard so pods are reachable on IPv6-only
+		// clusters (#972). With the default net.ipv6.bindv6only=0, :: also
+		// accepts IPv4, so IPv4-only and dual-stack clusters keep working.
+		// On IPv6-disabled nodes, override via extraArgs ("--host", "0.0.0.0");
+		// llama.cpp keeps the last occurrence of a repeated flag.
+		"--host", "::",
 		"--port", fmt.Sprintf("%d", port),
 	}
 

--- a/internal/controller/runtime_llamacpp_test.go
+++ b/internal/controller/runtime_llamacpp_test.go
@@ -58,6 +58,19 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			notContains: []string{"--ctx-size", "--parallel", "--flash-attn", "--jinja", "--cache-type-k", "--cpu-moe", "--n-cpu-moe", "--no-kv-offload", "--override-tensor", "--override-kv", "--batch-size", "--ubatch-size", "--no-warmup", "--reasoning-budget", "--reasoning-budget-message", "--mmproj"},
 		},
 		{
+			// #972: bind the dual-stack wildcard (::), not 0.0.0.0, so pods are
+			// reachable on IPv6-only clusters. :: still accepts IPv4 (default
+			// bindv6only=0), so IPv4-only clusters are unaffected.
+			model: model,
+			name:  "binds dual-stack wildcard :: for IPv6-only clusters",
+			spec: &inferencev1alpha1.InferenceServiceSpec{
+				Runtime:  "llama",
+				ModelRef: "test-model",
+			},
+			contains:    []FlagCheck{{"--host", "::"}},
+			notContains: []string{"0.0.0.0"},
+		},
+		{
 			model: model,
 			name:  "contextSize set emits flag",
 			spec: &inferencev1alpha1.InferenceServiceSpec{

--- a/internal/controller/runtime_tgi.go
+++ b/internal/controller/runtime_tgi.go
@@ -27,7 +27,10 @@ func (b *TGIBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model *
 
 	args := []string{
 		"--model-id", source,
-		"--hostname", "0.0.0.0",
+		// Bind the dual-stack wildcard so pods are reachable on IPv6-only
+		// clusters (#972). With the default net.ipv6.bindv6only=0, :: also
+		// accepts IPv4, so IPv4-only and dual-stack clusters keep working.
+		"--hostname", "::",
 		"--port", fmt.Sprintf("%d", port),
 	}
 

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -66,7 +66,12 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 	// accept) and v0.20+ (no deprecation warning).
 	args := []string{
 		source,
-		"--host", "0.0.0.0",
+		// Bind the dual-stack wildcard so pods are reachable on IPv6-only
+		// clusters (#972). With the default net.ipv6.bindv6only=0, :: also
+		// accepts IPv4, so IPv4-only and dual-stack clusters keep working.
+		// On IPv6-disabled nodes, override via extraArgs ("--host", "0.0.0.0"),
+		// which are appended last so the user flag wins.
+		"--host", "::",
 		"--port", fmt.Sprintf("%d", port),
 		"--enable-metrics",
 	}

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -68,7 +68,7 @@ func TestVLLMBuildArgs(t *testing.T) {
 			},
 			// vLLM v0.20+ deprecated --model in favor of a positional argument.
 			// The bare model path appears as args[0]; --model itself must NOT appear.
-			contains: []FlagCheck{{"--host", "0.0.0.0"}, {"--port", "8000"}},
+			contains: []FlagCheck{{"--host", "::"}, {"--port", "8000"}},
 			notContains: []string{
 				"--attention-backend",
 				"--cpu-offload-gb",


### PR DESCRIPTION
## What

Change the inference-server bind address from `0.0.0.0` (IPv4 wildcard) to `::` (dual-stack wildcard) in the llama.cpp, vLLM, and TGI runtimes.

## Why

Fixes #972. On an IPv6-only cluster (reported on Talos + AMD APU), the pod IP is IPv6. The runtimes hardcoded `--host` / `--hostname 0.0.0.0`, so llama-server only listened on IPv4. The kubelet health probe targets the pod IP (IPv6), nothing answers there, and the pod never becomes Ready.

## How

- `internal/controller/runtime_llamacpp.go`, `runtime_vllm.go`, `runtime_tgi.go`: bind `::` instead of `0.0.0.0`.
- `::` with the default `net.ipv6.bindv6only=0` also accepts IPv4 via v4-mapped addresses, so **IPv4-only and dual-stack clusters are unaffected** (no regression for existing users).
- **Escape hatch for the rare IPv6-disabled node:** llama.cpp and vLLM append `extraArgs` last, and all three parsers keep the last occurrence of a repeated flag (verified: llama.cpp logs "only last value will be used"; vLLM argparse; TGI clap). So `extraArgs: ["--host", "0.0.0.0"]` overrides it. (TGI does not currently consume `extraArgs`; a small parity follow-up could add that if needed.)
- Added a llama.cpp regression test asserting `--host ::` and no `0.0.0.0`; updated the vLLM arg assertions.

## Checklist

- [x] `gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint` (0 issues)
- [x] Unit tests pass (`TestLlamaCppBuildArgs`, `TestVLLMBuildArgs`); the one envtest-suite assertion is updated and runs in CI
- [x] No API/CRD change (no `make manifests`/`generate` needed)
- [x] No RBAC marker change

Thanks to @dekarl for the clear, reproducible report and for verifying the `::` fix.

---
Developed with AI assistance (Claude) per LLMKube's AI-assisted contribution policy (band 3).