### PR TITLE
fix(foreman): populate FleetNode.Status.CurrentTask so the scheduler spreads work

### DIFF
--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -356,7 +356,7 @@ func (r *AgenticTaskReconciler) reserveFirstFitNode(ctx context.Context, task *f
 // clear cannot wedge a node busy forever.
 func (r *AgenticTaskReconciler) reserveNode(ctx context.Context, node *foremanv1alpha1.FleetNode, taskKey string) (bool, error) {
 	if cur := node.Status.CurrentTask; cur != "" && cur != taskKey {
-		live, err := r.taskIsLive(ctx, cur)
+		live, err := r.taskIsLive(ctx, cur, node.Name)
 		if err != nil {
 			return false, err
 		}
@@ -367,18 +367,25 @@ func (r *AgenticTaskReconciler) reserveNode(ctx context.Context, node *foremanv1
 	patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	node.Status.CurrentTask = taskKey
 	if err := r.Status().Patch(ctx, node, patch); err != nil {
-		if apierrors.IsConflict(err) {
-			return false, nil // another reconcile reserved it first
+		// Lost the race: another reconcile reserved it first (Conflict), or the
+		// node was deleted between the List and here (NotFound — e.g. the
+		// Draining-node reaper, #980/#979). Either way, fall through to the next
+		// candidate rather than erroring the whole reconcile.
+		if apierrors.IsConflict(err) || apierrors.IsNotFound(err) {
+			return false, nil
 		}
 		return false, err
 	}
 	return true, nil
 }
 
-// taskIsLive reports whether the namespaced-name key refers to an AgenticTask
-// that still exists and has not reached a terminal phase. A missing or terminal
-// task is not live, so a node whose CurrentTask points at it may be reclaimed.
-func (r *AgenticTaskReconciler) taskIsLive(ctx context.Context, key string) (bool, error) {
+// taskIsLive reports whether the namespaced-name key still occupies nodeName:
+// the task exists, has not reached a terminal phase, and has not been assigned
+// to a different node. A missing, terminal, or reassigned task is not live, so
+// a node whose CurrentTask points at it may be reclaimed. An empty AssignedNode
+// counts as live — that is the legitimate window between reserveNode and
+// scheduleToNode, which must not be stolen.
+func (r *AgenticTaskReconciler) taskIsLive(ctx context.Context, key, nodeName string) (bool, error) {
 	ns, name, ok := splitNamespacedName(key)
 	if !ok {
 		return false, nil // unparseable key: treat as not live so the node frees
@@ -390,8 +397,17 @@ func (r *AgenticTaskReconciler) taskIsLive(ctx context.Context, key string) (boo
 		}
 		return false, err
 	}
-	return t.Status.Phase != foremanv1alpha1.AgenticTaskPhaseSucceeded &&
-		t.Status.Phase != foremanv1alpha1.AgenticTaskPhaseFailed, nil
+	if t.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded ||
+		t.Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed {
+		return false, nil
+	}
+	// A live task that has been scheduled onto a different node no longer holds
+	// this one; the reservation is stale (e.g. a clear that failed log-and-
+	// continue while the task rescheduled elsewhere). Reclaim it.
+	if an := t.Status.AssignedNode; an != "" && an != nodeName {
+		return false, nil
+	}
+	return true, nil
 }
 
 // clearNodeCurrentTask releases the named FleetNode's reservation, but only if
@@ -408,7 +424,12 @@ func (r *AgenticTaskReconciler) clearNodeCurrentTask(ctx context.Context, nodeNa
 	if node.Status.CurrentTask != taskKey {
 		return nil
 	}
-	patch := client.MergeFrom(node.DeepCopy())
+	// Optimistic lock for symmetry with reserveNode: between the Get above and
+	// this patch a concurrent reserve for a different task could land, and an
+	// unlocked merge would stomp that fresh reservation (the double-book class
+	// this fix exists to prevent). On Conflict the caller logs-and-continues and
+	// the stale-reclaim path in reserveNode self-heals.
+	patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	node.Status.CurrentTask = ""
 	return r.Status().Patch(ctx, &node, patch)
 }

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -115,6 +116,13 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if err := audit.RecordTerminal(ctx, r.Client, &task, r.AuditNamespace, log); err != nil {
 			log.Error(err, "audit: failed to record terminal run (continuing)")
 		}
+		// Release the node reservation so the scheduler can dispatch the next
+		// task there. Guarded on taskKey, so a node already reserved for a
+		// different task is untouched.
+		if err := r.clearNodeCurrentTask(ctx, task.Status.AssignedNode, taskKey(&task)); err != nil {
+			log.Error(err, "failed to release node reservation on terminal task",
+				"node", task.Status.AssignedNode, "task", task.Name)
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -161,17 +169,29 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	// Find a FleetNode that satisfies the effective RequiredCapability.
-	nodeName, err := r.firstFitNode(ctx, required, requiredModel, jobMode)
+	// Find a Ready FleetNode that satisfies the effective RequiredCapability
+	// and atomically reserve it. The reservation (stamping the node's
+	// CurrentTask) is what enforces one-task-per-node and spreads work across
+	// the fleet; without it every task funnels onto the first node. See #977.
+	nodeName, err := r.reserveFirstFitNode(ctx, &task, required, requiredModel, jobMode)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	if nodeName == "" {
-		log.Info("no FleetNode matches; will retry", "task", task.Name)
+		log.Info("no free FleetNode matches; will retry", "task", task.Name)
 		return ctrl.Result{RequeueAfter: requeueNoFit}, nil
 	}
 
-	return r.scheduleToNode(ctx, &task, nodeName)
+	if err := r.scheduleToNode(ctx, &task, nodeName); err != nil {
+		// The node is reserved but the task never reached Scheduled. Release the
+		// reservation so the node is not wedged busy with a task it never ran.
+		if clearErr := r.clearNodeCurrentTask(ctx, nodeName, taskKey(&task)); clearErr != nil {
+			log.Error(clearErr, "failed to release reservation after schedule error",
+				"node", nodeName, "task", task.Name)
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 // effectiveRequiredCapability returns the capability the scheduler should
@@ -282,10 +302,19 @@ func (r *AgenticTaskReconciler) allDepsSucceeded(ctx context.Context, task *fore
 	return true, nil
 }
 
-// firstFitNode picks the alphabetically-first Ready FleetNode whose
-// advertised capability satisfies the effective RequiredCapability and
-// that is not already running another task.
-func (r *AgenticTaskReconciler) firstFitNode(ctx context.Context, required foremanv1alpha1.RequiredCapability, requiredModel string, jobMode bool) (string, error) {
+// reserveFirstFitNode picks the alphabetically-first Ready FleetNode whose
+// advertised capability satisfies the effective RequiredCapability and that is
+// not already running another task, and atomically reserves it by stamping the
+// node's Status.CurrentTask. It returns the reserved node's name, or "" when no
+// eligible node is currently free.
+//
+// Reservation is what makes one-task-per-node spread work across the fleet. The
+// node scan reads FleetNodes from a cache that lags writes, so two back-to-back
+// scheduling reconciles can both observe the same node as free. The reservation
+// is an optimistic-lock status patch, so at most one wins; the loser (Conflict,
+// or a node already reserved for a live task) falls through to the next
+// candidate. Without this, every task funnels onto one node. See #977.
+func (r *AgenticTaskReconciler) reserveFirstFitNode(ctx context.Context, task *foremanv1alpha1.AgenticTask, required foremanv1alpha1.RequiredCapability, requiredModel string, jobMode bool) (string, error) {
 	var nodes foremanv1alpha1.FleetNodeList
 	if err := r.List(ctx, &nodes); err != nil {
 		return "", err
@@ -294,20 +323,108 @@ func (r *AgenticTaskReconciler) firstFitNode(ctx context.Context, required forem
 		return nodes.Items[i].Name < nodes.Items[j].Name
 	})
 	now := time.Now()
+	key := taskKey(task)
 	for i := range nodes.Items {
 		n := &nodes.Items[i]
 		if !nodeSchedulable(n, now) {
 			continue
 		}
-		if n.Status.CurrentTask != "" {
-			continue // v0.1: one task per node
-		}
 		if !capabilitySatisfies(required, requiredModel, n, jobMode) {
 			continue
 		}
-		return n.Name, nil
+		reserved, err := r.reserveNode(ctx, n, key)
+		if err != nil {
+			return "", err
+		}
+		if reserved {
+			return n.Name, nil
+		}
+		// Node was busy with a live task, or another reconcile reserved it
+		// first; try the next candidate.
 	}
 	return "", nil
+}
+
+// reserveNode stamps node.Status.CurrentTask with taskKey via an optimistic-
+// lock status patch, claiming the node for a single task. It returns false
+// (try the next node) when the node is already running another live task or
+// when a concurrent writer won the node first (Conflict).
+//
+// A CurrentTask that points at a task which no longer exists or has reached a
+// terminal phase is stale: the node is treated as free and re-reserved. That
+// self-heals a reservation leaked by a task deleted mid-flight, so a missed
+// clear cannot wedge a node busy forever.
+func (r *AgenticTaskReconciler) reserveNode(ctx context.Context, node *foremanv1alpha1.FleetNode, taskKey string) (bool, error) {
+	if cur := node.Status.CurrentTask; cur != "" && cur != taskKey {
+		live, err := r.taskIsLive(ctx, cur)
+		if err != nil {
+			return false, err
+		}
+		if live {
+			return false, nil // genuinely busy
+		}
+	}
+	patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	node.Status.CurrentTask = taskKey
+	if err := r.Status().Patch(ctx, node, patch); err != nil {
+		if apierrors.IsConflict(err) {
+			return false, nil // another reconcile reserved it first
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// taskIsLive reports whether the namespaced-name key refers to an AgenticTask
+// that still exists and has not reached a terminal phase. A missing or terminal
+// task is not live, so a node whose CurrentTask points at it may be reclaimed.
+func (r *AgenticTaskReconciler) taskIsLive(ctx context.Context, key string) (bool, error) {
+	ns, name, ok := splitNamespacedName(key)
+	if !ok {
+		return false, nil // unparseable key: treat as not live so the node frees
+	}
+	var t foremanv1alpha1.AgenticTask
+	if err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &t); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return t.Status.Phase != foremanv1alpha1.AgenticTaskPhaseSucceeded &&
+		t.Status.Phase != foremanv1alpha1.AgenticTaskPhaseFailed, nil
+}
+
+// clearNodeCurrentTask releases the named FleetNode's reservation, but only if
+// it still points at taskKey, so a node already re-reserved for a different
+// task is left untouched. A missing node (or empty name) is a no-op.
+func (r *AgenticTaskReconciler) clearNodeCurrentTask(ctx context.Context, nodeName, taskKey string) error {
+	if nodeName == "" {
+		return nil
+	}
+	var node foremanv1alpha1.FleetNode
+	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, &node); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if node.Status.CurrentTask != taskKey {
+		return nil
+	}
+	patch := client.MergeFrom(node.DeepCopy())
+	node.Status.CurrentTask = ""
+	return r.Status().Patch(ctx, &node, patch)
+}
+
+// taskKey is the "namespace/name" string stored in FleetNode.Status.CurrentTask.
+func taskKey(task *foremanv1alpha1.AgenticTask) string {
+	return types.NamespacedName{Namespace: task.Namespace, Name: task.Name}.String()
+}
+
+// splitNamespacedName parses the "namespace/name" form written by taskKey.
+func splitNamespacedName(key string) (namespace, name string, ok bool) {
+	i := strings.IndexByte(key, '/')
+	if i < 0 {
+		return "", "", false
+	}
+	return key[:i], key[i+1:], true
 }
 
 // nodeSchedulable reports whether the scheduler may dispatch to a node. It
@@ -381,7 +498,7 @@ func capabilitySatisfies(req foremanv1alpha1.RequiredCapability, requiredModel s
 // scheduleToNode patches the task to phase=Scheduled with the chosen
 // FleetNode set on status.assignedNode. The FleetAgent on that node
 // picks it up via its watcher.
-func (r *AgenticTaskReconciler) scheduleToNode(ctx context.Context, task *foremanv1alpha1.AgenticTask, nodeName string) (ctrl.Result, error) {
+func (r *AgenticTaskReconciler) scheduleToNode(ctx context.Context, task *foremanv1alpha1.AgenticTask, nodeName string) error {
 	patch := client.MergeFrom(task.DeepCopy())
 	now := metav1.Now()
 	task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseScheduled
@@ -393,10 +510,7 @@ func (r *AgenticTaskReconciler) scheduleToNode(ctx context.Context, task *forema
 		Message:            fmt.Sprintf("scheduled to FleetNode %q", nodeName),
 		LastTransitionTime: now,
 	})
-	if err := r.Status().Patch(ctx, task, patch); err != nil {
-		return ctrl.Result{}, err
-	}
-	return ctrl.Result{}, nil
+	return r.Status().Patch(ctx, task, patch)
 }
 
 // failTask cascade-fails a Pending task before it reaches an agent.
@@ -555,7 +669,15 @@ func (r *AgenticTaskReconciler) releaseExpiredClaim(ctx context.Context, task *f
 		Message:            fmt.Sprintf("released from node %q: %s", nodeName, heartbeatMsg),
 		LastTransitionTime: now,
 	})
-	return ctrl.Result{}, r.Status().Patch(ctx, &current, patch)
+	if err := r.Status().Patch(ctx, &current, patch); err != nil {
+		return ctrl.Result{}, err
+	}
+	// Free the node so the released task (or another) can be dispatched there.
+	if err := r.clearNodeCurrentTask(ctx, nodeName, taskKey(&current)); err != nil {
+		log.Error(err, "failed to release node reservation on claim expiry",
+			"node", nodeName, "task", current.Name)
+	}
+	return ctrl.Result{}, nil
 }
 
 // terminalFailExpired marks a task Failed after it has exhausted the
@@ -592,7 +714,15 @@ func (r *AgenticTaskReconciler) terminalFailExpired(ctx context.Context, task *f
 			nodeName, priorExpiries+1),
 		LastTransitionTime: now,
 	})
-	return ctrl.Result{}, r.Status().Patch(ctx, &current, patch)
+	if err := r.Status().Patch(ctx, &current, patch); err != nil {
+		return ctrl.Result{}, err
+	}
+	// The task is terminal-failed on this node; release the reservation.
+	if err := r.clearNodeCurrentTask(ctx, nodeName, taskKey(&current)); err != nil {
+		log.Error(err, "failed to release node reservation on expiry terminal-fail",
+			"node", nodeName, "task", current.Name)
+	}
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager wires the reconciler. We also watch FleetNode so a

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -345,6 +345,158 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		Expect(fresh.Status.AssignedNode).To(Equal(vulkanNode.Name))
 	})
 
+	It("spreads two Pending tasks across two Ready nodes (one task per node)", func() {
+		// Regression for defilantech/LLMKube#977: the scheduler must not funnel
+		// every task onto the alphabetically-first node. With two idle nodes,
+		// two Pending tasks must land on different nodes, each node advertising
+		// its reserved task via Status.CurrentTask.
+		nodeA := newFleetNode("spread-a")
+		Expect(k8sClient.Create(ctx, nodeA)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeA) })
+		setNodeReady(nodeA, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+		nodeB := newFleetNode("spread-b")
+		Expect(k8sClient.Create(ctx, nodeB)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeB) })
+		setNodeReady(nodeB, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+
+		t1 := newTask("spread-t1")
+		Expect(k8sClient.Create(ctx, t1)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, t1) })
+		setPhase(t1, foremanv1alpha1.AgenticTaskPhasePending)
+		t2 := newTask("spread-t2")
+		Expect(k8sClient.Create(ctx, t2)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, t2) })
+		setPhase(t2, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(t1))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = reconciler.Reconcile(ctx, reqFor(t2))
+		Expect(err).NotTo(HaveOccurred())
+
+		var f1, f2 foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(t1), &f1)).To(Succeed())
+		Expect(k8sClient.Get(ctx, nn(t2), &f2)).To(Succeed())
+		Expect(f1.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(f2.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(f1.Status.AssignedNode).NotTo(BeEmpty())
+		Expect(f2.Status.AssignedNode).NotTo(BeEmpty())
+		Expect(f1.Status.AssignedNode).NotTo(Equal(f2.Status.AssignedNode))
+
+		var na, nb foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeA.Name}, &na)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeB.Name}, &nb)).To(Succeed())
+		Expect([]string{na.Status.CurrentTask, nb.Status.CurrentTask}).
+			To(ConsistOf("default/spread-t1", "default/spread-t2"))
+	})
+
+	It("leaves a second task Pending when the only matching node is busy", func() {
+		// One node, two tasks: the second must wait (requeue) rather than
+		// double-book the node.
+		node := newFleetNode("solo-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+
+		t1 := newTask("solo-t1")
+		Expect(k8sClient.Create(ctx, t1)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, t1) })
+		setPhase(t1, foremanv1alpha1.AgenticTaskPhasePending)
+		t2 := newTask("solo-t2")
+		Expect(k8sClient.Create(ctx, t2)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, t2) })
+		setPhase(t2, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(t1))
+		Expect(err).NotTo(HaveOccurred())
+		res, err := reconciler.Reconcile(ctx, reqFor(t2))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+
+		var f2 foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(t2), &f2)).To(Succeed())
+		Expect(f2.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		Expect(f2.Status.AssignedNode).To(BeEmpty())
+	})
+
+	It("frees the node when its task terminates, letting the next task schedule there", func() {
+		// The reservation must be released on a terminal task so the freed node
+		// becomes available again.
+		node := newFleetNode("recycle-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+
+		t1 := newTask("recycle-t1")
+		Expect(k8sClient.Create(ctx, t1)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, t1) })
+		setPhase(t1, foremanv1alpha1.AgenticTaskPhasePending)
+		_, err := reconciler.Reconcile(ctx, reqFor(t1))
+		Expect(err).NotTo(HaveOccurred())
+
+		var busy foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, &busy)).To(Succeed())
+		Expect(busy.Status.CurrentTask).To(Equal("default/recycle-t1"))
+
+		// Agent finishes the task; the controller reconcile of the terminal
+		// task must release the node.
+		setPhase(t1, foremanv1alpha1.AgenticTaskPhaseSucceeded)
+		_, err = reconciler.Reconcile(ctx, reqFor(t1))
+		Expect(err).NotTo(HaveOccurred())
+
+		var freed foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, &freed)).To(Succeed())
+		Expect(freed.Status.CurrentTask).To(BeEmpty())
+
+		// A new task now schedules onto the recycled node.
+		t2 := newTask("recycle-t2")
+		Expect(k8sClient.Create(ctx, t2)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, t2) })
+		setPhase(t2, foremanv1alpha1.AgenticTaskPhasePending)
+		_, err = reconciler.Reconcile(ctx, reqFor(t2))
+		Expect(err).NotTo(HaveOccurred())
+
+		var f2 foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(t2), &f2)).To(Succeed())
+		Expect(f2.Status.AssignedNode).To(Equal(node.Name))
+	})
+
+	It("reclaims a node whose CurrentTask points at a task that no longer exists", func() {
+		// Defense against a leaked reservation (a task deleted mid-flight): a
+		// node's stale CurrentTask must not wedge it busy forever.
+		node := newFleetNode("stale-res-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+		patch := client.MergeFrom(node.DeepCopy())
+		node.Status.CurrentTask = "default/ghost-task-that-never-existed"
+		Expect(k8sClient.Status().Patch(ctx, node, patch)).To(Succeed())
+
+		task := newTask("reclaim-task")
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
+
+		var reclaimed foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, &reclaimed)).To(Succeed())
+		Expect(reclaimed.Status.CurrentTask).To(Equal("default/reclaim-task"))
+	})
+
 	It("does not reschedule a Running task whose assigned node is fresh", func() {
 		// The scheduler must leave Running tasks alone when the FleetNode is
 		// healthy; only claim expiry (stale/absent node) may alter them.

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -414,6 +414,13 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 
 		_, err := reconciler.Reconcile(ctx, reqFor(t1))
 		Expect(err).NotTo(HaveOccurred())
+
+		// Anchor the precondition: t1 must actually hold the node, otherwise
+		// this spec passes vacuously when nothing schedules at all.
+		var busy foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, &busy)).To(Succeed())
+		Expect(busy.Status.CurrentTask).To(Equal("default/solo-t1"))
+
 		res, err := reconciler.Reconcile(ctx, reqFor(t2))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.RequeueAfter).To(BeNumerically(">", 0))


### PR DESCRIPTION
## What

Populate `FleetNode.Status.CurrentTask` so the Foreman scheduler's one-task-per-node model actually spreads work across the fleet, instead of funneling every task onto a single node.

## Why

Fixes #977

`firstFitNode` skips nodes whose `Status.CurrentTask` is non-empty ("v0.1: one task per node"), but that field was **never written** anywhere in the operator — only declared, read by the guard, and logged. So the guard never tripped and every task was scheduled onto the alphabetically-first Ready node. Extra `foreman-agent` replicas never received work; effective concurrency was 1 regardless of fleet size (observed on v0.8.28 with 3 replicas: one node running, 25 queued on it, 50 Pending, two idle).

## How

- **`reserveFirstFitNode`** replaces `firstFitNode`: it scans candidates (sorted, schedulable, capability-matched) and reserves the first free one by stamping `CurrentTask` via an **optimistic-lock status patch**. The node scan reads FleetNodes from a cache that lags writes, so two back-to-back scheduling reconciles can both see a node as free; the optimistic lock means at most one wins and the loser (`Conflict`) falls through to the next candidate.
- **Stale-reservation recovery:** a `CurrentTask` pointing at a missing or terminal task is treated as free and reclaimed, so a reservation leaked by a task deleted mid-flight can't wedge a node busy forever.
- **`clearNodeCurrentTask`** releases the reservation on terminal tasks and on both claim-expiry paths (`releaseExpiredClaim`, `terminalFailExpired`), guarded on the task key so a node already re-reserved for a different task is untouched.
- `scheduleToNode` now returns only `error` (its `Result` was always the zero value; flagged by `unparam`).

No API/CRD change — `CurrentTask` already exists in the schema.

Design note: with `MaxConcurrentReconciles` at the default (1) the optimistic lock is belt-and-suspenders, but it keeps the fix correct if concurrency is ever raised. Happy to adjust the set/clear split (e.g. move clearing into a level-triggered `FleetNodeReconciler` pass) if you'd prefer that shape.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (envtest; controller suite, 83 specs)
- [x] `make lint` passes locally (`golangci-lint`: 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed (commit trailer + here), per CONTRIBUTING.md
- [ ] Documentation updated (no user-facing doc change)
