### PR TITLE
fix(foreman): reap orphaned Draining FleetNodes so they stop leaking

### DIFF
--- a/api/foreman/v1alpha1/fleetnode_types.go
+++ b/api/foreman/v1alpha1/fleetnode_types.go
@@ -240,15 +240,20 @@ func (n *FleetNode) HeartbeatStale(now time.Time) bool {
 }
 
 // DrainReapable reports whether a Draining node has been silent long enough
-// (past FleetNodeDrainReapTimeout, or never heart-beat) that its agent is gone
-// and the drain will never complete, so the node may be deleted. The caller is
-// responsible for checking that the node is actually in the Draining phase.
+// (past FleetNodeDrainReapTimeout) that its agent is gone and the drain will
+// never complete, so the node may be deleted. The caller is responsible for
+// checking that the node is actually in the Draining phase.
+//
+// A node with no heartbeat at all falls back to its creation time, so even a
+// hand-crafted Draining object gets the same grace window rather than being
+// reaped on first sight (the agent always stamps LastHeartbeatTime in the same
+// patch that sets Draining, so this branch is unreachable via the agent).
 func (n *FleetNode) DrainReapable(now time.Time) bool {
 	if n == nil {
 		return false
 	}
 	if n.Status.LastHeartbeatTime == nil {
-		return true
+		return now.Sub(n.CreationTimestamp.Time) > FleetNodeDrainReapTimeout
 	}
 	return now.Sub(n.Status.LastHeartbeatTime.Time) > FleetNodeDrainReapTimeout
 }

--- a/api/foreman/v1alpha1/fleetnode_types.go
+++ b/api/foreman/v1alpha1/fleetnode_types.go
@@ -28,6 +28,16 @@ import (
 // declared dead.
 const FleetNodeHeartbeatTimeout = 90 * time.Second
 
+// FleetNodeDrainReapTimeout is how long a node may stay Draining without a
+// heartbeat before the controller deletes it. A live agent keeps heartbeating
+// while it finishes its in-flight task, so this only fires for a node whose
+// agent set Draining and then went away (rollout, scale-down, crash) — which
+// otherwise leaks a FleetNode per restart, since the reconciler leaves
+// Draining nodes alone and there is no ownerReference for garbage collection.
+// Set well above the heartbeat timeout so a genuinely draining agent is never
+// reaped out from under an in-flight task.
+const FleetNodeDrainReapTimeout = 10 * time.Minute
+
 // FleetNodePhase is the heartbeat-driven health state of a fleet worker.
 // +kubebuilder:validation:Enum=Ready;Draining;NotReady;Unknown
 type FleetNodePhase string
@@ -227,6 +237,20 @@ func (n *FleetNode) HeartbeatStale(now time.Time) bool {
 		return true
 	}
 	return now.Sub(n.Status.LastHeartbeatTime.Time) > FleetNodeHeartbeatTimeout
+}
+
+// DrainReapable reports whether a Draining node has been silent long enough
+// (past FleetNodeDrainReapTimeout, or never heart-beat) that its agent is gone
+// and the drain will never complete, so the node may be deleted. The caller is
+// responsible for checking that the node is actually in the Draining phase.
+func (n *FleetNode) DrainReapable(now time.Time) bool {
+	if n == nil {
+		return false
+	}
+	if n.Status.LastHeartbeatTime == nil {
+		return true
+	}
+	return now.Sub(n.Status.LastHeartbeatTime.Time) > FleetNodeDrainReapTimeout
 }
 
 // +kubebuilder:object:root=true

--- a/api/foreman/v1alpha1/fleetnode_types_test.go
+++ b/api/foreman/v1alpha1/fleetnode_types_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DrainReapable gates deletion of orphaned Draining FleetNodes. A live agent
+// keeps heart-beating while it drains, so reaping only fires once the node has
+// been silent past FleetNodeDrainReapTimeout. The nil-heartbeat branch falls
+// back to creationTimestamp so a hand-crafted object still gets the grace
+// window instead of being reaped on first sight.
+func TestDrainReapable(t *testing.T) {
+	now := time.Now()
+	old := metav1.NewTime(now.Add(-2 * FleetNodeDrainReapTimeout))
+	recent := metav1.NewTime(now.Add(-1 * time.Second))
+
+	tests := []struct {
+		name      string
+		heartbeat *metav1.Time
+		created   metav1.Time
+		want      bool
+	}{
+		{"fresh heartbeat is not reapable", &recent, metav1.NewTime(now), false},
+		{"stale heartbeat past the window is reapable", &old, metav1.NewTime(now), true},
+		{"nil heartbeat with recent creation is not reapable", nil, recent, false},
+		{"nil heartbeat with old creation is reapable", nil, old, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &FleetNode{}
+			n.CreationTimestamp = tc.created
+			n.Status.LastHeartbeatTime = tc.heartbeat
+			if got := n.DrainReapable(now); got != tc.want {
+				t.Fatalf("DrainReapable() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A nil receiver is never reapable (defensive; the reconciler always has a
+// live object).
+func TestDrainReapableNilReceiver(t *testing.T) {
+	var n *FleetNode
+	if n.DrainReapable(time.Now()) {
+		t.Fatalf("nil FleetNode must not be reapable")
+	}
+}

--- a/internal/foreman/controller/fleetnode_controller.go
+++ b/internal/foreman/controller/fleetnode_controller.go
@@ -58,9 +58,23 @@ func (r *FleetNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		"currentTask", node.Status.CurrentTask,
 	)
 
-	// A node the agent is intentionally draining is the agent's domain;
-	// the scheduler already treats Draining as ineligible. Don't fight it.
+	// A node the agent is intentionally draining is the agent's domain; the
+	// scheduler already treats Draining as ineligible, so while the agent is
+	// alive (still heart-beating) don't fight it. But an agent that set
+	// Draining and then went away — rollout, scale-down, crash — leaves the
+	// node Draining forever: nothing here transitions it and there is no
+	// ownerReference for garbage collection, so one FleetNode leaks per agent
+	// restart. Reap a Draining node whose heartbeat has been silent past the
+	// drain grace; its drain will never complete.
 	if node.Status.Phase == foremanv1alpha1.FleetNodePhaseDraining {
+		if node.DrainReapable(time.Now()) {
+			log.Info("reaping orphaned Draining FleetNode (agent gone)",
+				"nodeName", node.Spec.NodeName, "lastHeartbeat", node.Status.LastHeartbeatTime)
+			if err := r.Delete(ctx, &node); err != nil {
+				return ctrl.Result{}, client.IgnoreNotFound(err)
+			}
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{RequeueAfter: foremanv1alpha1.FleetNodeHeartbeatTimeout}, nil
 	}
 

--- a/internal/foreman/controller/fleetnode_controller.go
+++ b/internal/foreman/controller/fleetnode_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -70,7 +71,24 @@ func (r *FleetNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if node.DrainReapable(time.Now()) {
 			log.Info("reaping orphaned Draining FleetNode (agent gone)",
 				"nodeName", node.Spec.NodeName, "lastHeartbeat", node.Status.LastHeartbeatTime)
-			if err := r.Delete(ctx, &node); err != nil {
+			// Delete under UID + ResourceVersion preconditions to close the
+			// revival race: a stable-named (launchd) agent that was down > the
+			// reap window and then restarts revives the node with a Ready
+			// heartbeat, but this reconcile reads from a cache that can lag that
+			// write. Without preconditions we would delete the freshly revived
+			// node; the agent only Upserts at startup, so it would then fail
+			// every heartbeat (Get -> NotFound) and never recreate it. With
+			// preconditions, any write since our read makes the delete 409, and
+			// we requeue to re-evaluate on a fresh view (a truly dead node's
+			// ResourceVersion never advances, so the reap still converges).
+			err := r.Delete(ctx, &node, client.Preconditions{
+				UID:             &node.UID,
+				ResourceVersion: &node.ResourceVersion,
+			})
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{RequeueAfter: foremanv1alpha1.FleetNodeHeartbeatTimeout}, nil
+			}
+			if err != nil {
 				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
 			return ctrl.Result{}, nil

--- a/internal/foreman/controller/fleetnode_controller_test.go
+++ b/internal/foreman/controller/fleetnode_controller_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -133,6 +134,65 @@ var _ = Describe("FleetNodeReconciler heartbeat staleness", func() {
 		var got foremanv1alpha1.FleetNode
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "recovered-node"}, &got)).To(Succeed())
 		Expect(got.Status.Phase).To(Equal(foremanv1alpha1.FleetNodePhaseReady))
+	})
+
+	It("reaps a Draining node whose agent heartbeat is long stale", func() {
+		// Regression for the FleetNode leak: an agent that sets Draining and
+		// then dies (rollout/scale-down) leaves the node Draining forever —
+		// nothing transitions it and there is no ownerReference GC. The
+		// reconciler must delete such an orphan.
+		fn := &foremanv1alpha1.FleetNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "orphan-draining"},
+			Spec: foremanv1alpha1.FleetNodeSpec{
+				NodeName: "orphan-draining",
+				Roles:    []string{"worker"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, fn)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, fn) })
+
+		gone := metav1.NewTime(time.Now().Add(-2 * foremanv1alpha1.FleetNodeDrainReapTimeout))
+		fn.Status.Phase = foremanv1alpha1.FleetNodePhaseDraining
+		fn.Status.LastHeartbeatTime = &gone
+		Expect(k8sClient.Status().Update(ctx, fn)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "orphan-draining"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var got foremanv1alpha1.FleetNode
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: "orphan-draining"}, &got)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "orphaned Draining node should be deleted")
+	})
+
+	It("leaves a Draining node with a fresh heartbeat alone", func() {
+		// A live agent draining its in-flight task keeps heartbeating; the
+		// reconciler must not reap it out from under the task.
+		fn := &foremanv1alpha1.FleetNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "active-draining"},
+			Spec: foremanv1alpha1.FleetNodeSpec{
+				NodeName: "active-draining",
+				Roles:    []string{"worker"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, fn)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, fn) })
+
+		fresh := metav1.NewTime(time.Now().Add(-1 * time.Second))
+		fn.Status.Phase = foremanv1alpha1.FleetNodePhaseDraining
+		fn.Status.LastHeartbeatTime = &fresh
+		Expect(k8sClient.Status().Update(ctx, fn)).To(Succeed())
+
+		res, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "active-draining"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		var got foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "active-draining"}, &got)).To(Succeed())
+		Expect(got.Status.Phase).To(Equal(foremanv1alpha1.FleetNodePhaseDraining))
 	})
 
 	It("requeues after the heartbeat timeout so staleness is detected without an external trigger", func() {


### PR DESCRIPTION
## What

Delete orphaned `Draining` FleetNodes so they stop accumulating — one otherwise leaks per `foreman-agent` rollout, scale-down, or crash.

## Why

Fixes #979

An agent marks its FleetNode `Draining` on shutdown. The `FleetNodeReconciler` deliberately leaves Draining nodes alone ("the agent's domain"), and FleetNodes carry no `ownerReference`, so there is no Kubernetes GC. If the pod terminates before deleting its own node, the node stays `Draining` with a frozen heartbeat forever. Observed on v0.8.28: 23 orphaned Draining nodes across ~11 old ReplicaSets against 3 live nodes.

## How

- New `FleetNodeDrainReapTimeout` (10m) and `FleetNode.DrainReapable(now)`.
- In the reconciler's Draining branch, delete a node that has been silent past the reap timeout (its agent is gone and its drain will never complete). The window sits well above the 90s heartbeat timeout, so a live agent draining its in-flight task — which keeps heartbeating — is never reaped. A live-but-draining node still short-circuits with a requeue, unchanged.

No API/CRD schema change (added a const and a method, not a field).

## Checklist

- [x] Tests added/updated (2 envtest cases: long-stale Draining deleted; fresh Draining left intact)
- [x] `make test` passes locally (controller + api suites)
- [x] `make lint` passes locally (`golangci-lint`: 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed (commit trailer + here), per CONTRIBUTING.md
- [ ] Documentation updated (no user-facing doc change)
