### PR TITLE
fix(security)!: gate local/hostPath model sources + block controller SSRF (GHSA-jw3m-8q7m-f35r)

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -63,6 +63,13 @@ spec:
         # only when non-empty; the flag's empty default disables such sources.
         - --allowed-host-path-roots={{ join "," . }}
         {{- end }}
+        {{- with .Values.modelSource.allowedRemoteHosts }}
+        # SECURITY (GHSA-jw3m-8q7m-f35r): hostnames/CIDRs the controller-side
+        # SSRF guard re-permits as remote (http/https) model sources despite
+        # resolving to private/link-local/loopback ranges. Rendered only when
+        # non-empty; the flag's empty default blocks all such ranges.
+        - --allowed-remote-hosts={{ join "," . }}
+        {{- end }}
         - --init-container-image={{ include "llmkube.initContainerImage" . }}
         # The default value is set in values.yaml. We do NOT use `| default 102`
         # here because Go template's default treats 0 as missing, which would

--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -57,6 +57,12 @@ spec:
         # Empty path disables caching (the flag defaults to /models otherwise).
         - --model-cache-path=
         {{- end }}
+        {{- with .Values.modelSource.allowedHostPathRoots }}
+        # SECURITY (GHSA-jw3m-8q7m-f35r): absolute path roots under which local
+        # (/abs and file://) and hostPath model sources are permitted. Rendered
+        # only when non-empty; the flag's empty default disables such sources.
+        - --allowed-host-path-roots={{ join "," . }}
+        {{- end }}
         - --init-container-image={{ include "llmkube.initContainerImage" . }}
         # The default value is set in values.yaml. We do NOT use `| default 102`
         # here because Go template's default treats 0 as missing, which would

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -278,6 +278,17 @@
         }
       }
     },
+    "modelSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowedHostPathRoots": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^/" },
+          "default": []
+        }
+      }
+    },
     "priorityClasses": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -286,6 +286,11 @@
           "type": "array",
           "items": { "type": "string", "pattern": "^/" },
           "default": []
+        },
+        "allowedRemoteHosts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
         }
       }
     },

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -312,6 +312,15 @@ modelCache:
 #     - /srv/models
 modelSource:
   allowedHostPathRoots: []
+  # Remote-host allowlist for the controller-side SSRF guard on http/https
+  # model sources. SECURITY (GHSA-jw3m-8q7m-f35r): the controller's metadata
+  # and revalidation requests refuse to connect to private, link-local,
+  # loopback, or unspecified addresses. Public hosts are always allowed; list
+  # hostnames and/or CIDRs here only to re-permit trusted internal hosts, e.g.
+  #   allowedRemoteHosts:
+  #     - models.corp.internal
+  #     - 10.20.0.0/16
+  allowedRemoteHosts: []
 
 # Priority classes for GPU scheduling
 priorityClasses:

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -305,6 +305,14 @@ modelCache:
   # Annotations for the shared PVC (e.g., for backup policies)
   annotations: {}
 
+# Host-path allowlist for local (/abs and file://) and hostPath model sources.
+# SECURITY (GHSA-jw3m-8q7m-f35r): empty list disables all such sources. To serve
+# a model from node-local disk, list the absolute directory roots you trust, e.g.
+#   allowedHostPathRoots:
+#     - /srv/models
+modelSource:
+  allowedHostPathRoots: []
+
 # Priority classes for GPU scheduling
 priorityClasses:
   # Create LLMKube priority classes (critical, high, normal, low, batch)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -108,6 +109,7 @@ func main() {
 	var modelCacheClass string
 	var modelCacheAccessMode string
 	var modelCacheMode string
+	var allowedHostPathRoots string
 	var modelRevalidateInterval time.Duration
 	var caCertConfigMap string
 	var initContainerImage string
@@ -129,6 +131,9 @@ func main() {
 			"(cross-isvc dedup, cache list works; use an RWX class on multi-node clusters); "+
 			"perService gives each InferenceService its own RWO, WaitForFirstConsumer cache PVC "+
 			"that binds on the serving node (opt-in escape hatch for multi-node clusters without RWX).")
+	flag.StringVar(&allowedHostPathRoots, "allowed-host-path-roots", "",
+		"Comma-separated absolute path prefixes under which local/file:// and hostPath model "+
+			"sources are permitted. Empty (default) disables all local/hostPath sources (GHSA-jw3m-8q7m-f35r).")
 	flag.DurationVar(&modelRevalidateInterval, "model-revalidate-interval", controller.DefaultRevalidateInterval,
 		"Minimum interval between upstream source revalidation checks for a Model. "+
 			"Bounds the HEAD traffic the controller generates; drift is surfaced via the "+
@@ -176,6 +181,16 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Parse the host-path allowlist for local model sources: split on comma,
+	// trim spaces, drop empties. Empty (the default) disables all local and
+	// hostPath model sources (GHSA-jw3m-8q7m-f35r).
+	var allowedHostPathRootList []string
+	for _, root := range strings.Split(allowedHostPathRoots, ",") {
+		if root = strings.TrimSpace(root); root != "" {
+			allowedHostPathRootList = append(allowedHostPathRootList, root)
+		}
+	}
 
 	// Initialize OpenTelemetry tracing (noop if OTEL_EXPORTER_OTLP_ENDPOINT not set)
 	shutdownTracer := initTracer(context.Background())
@@ -271,10 +286,11 @@ func main() {
 	}
 
 	if err := (&controller.ModelReconciler{
-		Client:             mgr.GetClient(),
-		Scheme:             mgr.GetScheme(),
-		StoragePath:        modelCachePath,
-		RevalidateInterval: modelRevalidateInterval,
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		StoragePath:          modelCachePath,
+		RevalidateInterval:   modelRevalidateInterval,
+		AllowedHostPathRoots: allowedHostPathRootList,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Model")
 		os.Exit(1)
@@ -291,6 +307,7 @@ func main() {
 		CACertConfigMap:      caCertConfigMap,
 		InitContainerImage:   initContainerImage,
 		DefaultFSGroup:       defaultFSGroup,
+		AllowedHostPathRoots: allowedHostPathRootList,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InferenceService")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,6 +110,7 @@ func main() {
 	var modelCacheAccessMode string
 	var modelCacheMode string
 	var allowedHostPathRoots string
+	var allowedRemoteHosts string
 	var modelRevalidateInterval time.Duration
 	var caCertConfigMap string
 	var initContainerImage string
@@ -134,6 +135,10 @@ func main() {
 	flag.StringVar(&allowedHostPathRoots, "allowed-host-path-roots", "",
 		"Comma-separated absolute path prefixes under which local/file:// and hostPath model "+
 			"sources are permitted. Empty (default) disables all local/hostPath sources (GHSA-jw3m-8q7m-f35r).")
+	flag.StringVar(&allowedRemoteHosts, "allowed-remote-hosts", "",
+		"Comma-separated hostnames/CIDRs permitted as remote (http/https) Model sources even if "+
+			"they resolve to private/link-local/loopback ranges. Public hosts are always allowed; "+
+			"this only re-permits internal hosts blocked by the SSRF guard (GHSA-jw3m-8q7m-f35r).")
 	flag.DurationVar(&modelRevalidateInterval, "model-revalidate-interval", controller.DefaultRevalidateInterval,
 		"Minimum interval between upstream source revalidation checks for a Model. "+
 			"Bounds the HEAD traffic the controller generates; drift is surfaced via the "+
@@ -189,6 +194,16 @@ func main() {
 	for _, root := range strings.Split(allowedHostPathRoots, ",") {
 		if root = strings.TrimSpace(root); root != "" {
 			allowedHostPathRootList = append(allowedHostPathRootList, root)
+		}
+	}
+
+	// Parse the remote-host allowlist for the controller-side SSRF guard the
+	// same way: split on comma, trim spaces, drop empties. Empty (the default)
+	// blocks every private/link-local/loopback destination (GHSA-jw3m-8q7m-f35r).
+	var allowedRemoteHostList []string
+	for _, host := range strings.Split(allowedRemoteHosts, ",") {
+		if host = strings.TrimSpace(host); host != "" {
+			allowedRemoteHostList = append(allowedRemoteHostList, host)
 		}
 	}
 
@@ -291,6 +306,7 @@ func main() {
 		StoragePath:          modelCachePath,
 		RevalidateInterval:   modelRevalidateInterval,
 		AllowedHostPathRoots: allowedHostPathRootList,
+		AllowedRemoteHosts:   allowedRemoteHostList,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Model")
 		os.Exit(1)

--- a/docs/MODEL-CACHE.md
+++ b/docs/MODEL-CACHE.md
@@ -361,6 +361,23 @@ This will revert to the legacy behavior where each pod downloads the model via i
 
 ## Security Considerations
 
+### Local and hostPath model sources (host-path allowlist)
+
+Besides remote downloads, the model storage machinery can serve node-local sources: a Model whose `spec.source` is an absolute path (`/srv/models/model.gguf`) or a `file://` URL is mounted into the inference pod via a hostPath volume. As of v0.9.0, these sources are gated by an operator-configured allowlist ([GHSA-jw3m-8q7m-f35r](https://github.com/defilantech/LLMKube/security/advisories/GHSA-jw3m-8q7m-f35r)).
+
+The allowlist is **empty by default**, which disables local and hostPath sources entirely. With the default configuration, a Model with a local source is rejected: it goes to phase `Failed` with a `SourceNotAllowed` condition, nothing is fetched, and no hostPath volume is created. Remote sources (`https://`, `pvc://`, `hf://`) are unaffected.
+
+To keep serving models from node-local disk, list the absolute directory roots you trust:
+
+```yaml
+# values.yaml
+modelSource:
+  allowedHostPathRoots:
+    - /srv/models
+```
+
+The equivalent controller flag is `--allowed-host-path-roots` (comma-separated). A source is permitted only when its cleaned path is within one of the configured roots; `..` escapes are rejected. The check is lexical and does not resolve symlinks, so only allowlist roots whose contents you control.
+
 ### Automatic shared cache on `fsGroupPolicy: None` backends (CephFS, NFS)
 
 The automatic shared-model-cache workflow is a first-class supported path, **including** on `fsGroupPolicy: None` CSIs such as CephFS and NFS. On those backends Kubernetes does not apply the pod `fsGroup` to the volume, so the PVC root stays `root:root` and the non-root model downloader cannot write to it. The `model-cache-prep` init container fixes the ownership for you so the cache just works. You do not need to pre-stage models or hand-manage a PVC.

--- a/docs/air-gapped-quickstart.md
+++ b/docs/air-gapped-quickstart.md
@@ -17,6 +17,24 @@ Deploy LLMKube in environments without internet access. This guide covers deploy
 - Pre-downloaded GGUF model file(s)
 - `llmkube` CLI installed on a workstation with cluster access
 
+## Breaking Change in 0.9.0: Host-Path Allowlist for Local Sources
+
+As of v0.9.0, local model sources (absolute paths and `file://` URLs) are gated by an operator-configured allowlist (GHSA-jw3m-8q7m-f35r). The allowlist is **empty by default**, so with a default install every local source in this guide is rejected: the Model goes to phase `Failed` with a `SourceNotAllowed` condition, nothing is fetched, and no hostPath volume is created. Remote sources (`https://`, `pvc://`, `hf://`) are unaffected.
+
+Before following the local-path examples below, add the directory roots you stage models under to your Helm values:
+
+```yaml
+# values.yaml
+modelSource:
+  allowedHostPathRoots:
+    - /mnt/models
+    - /mnt/nfs/models
+```
+
+Or pass the controller flag directly: `--allowed-host-path-roots=/mnt/models,/mnt/nfs/models`. A source is permitted only when its cleaned path is within a configured root; `..` escapes are rejected. The check is lexical and does not resolve symlinks, so only allowlist roots whose contents you control.
+
+**Upgrading from an earlier release**: a local source that previously caused the controller to hot-spin now fails cleanly with `SourceNotAllowed`. After upgrading, also delete any existing InferenceService whose source now falls outside the allowlist; a pod created before the upgrade keeps its hostPath mount until it is deleted.
+
 ## Quick Start: Deploy from Local Path
 
 ### Step 1: Pre-download the Model
@@ -102,6 +120,7 @@ spec:
 ```
 
 **Requirements:**
+- The path must be inside a root listed in `modelSource.allowedHostPathRoots` (required as of 0.9.0; see the breaking-change section above)
 - Model file must exist at the same path on all nodes where pods may run
 - Use a DaemonSet or node affinity to ensure pods land on nodes with the model
 
@@ -118,6 +137,8 @@ spec:
   source: file:///mnt/models/llama-3.1-8b-q4_k_m.gguf
   format: gguf
 ```
+
+Like absolute paths, `file://` sources require the path to be inside an allowlisted root as of 0.9.0.
 
 ### Option 3: PVC Source (Recommended for Air-Gapped)
 
@@ -303,6 +324,9 @@ spec:
 kubectl describe model my-model
 
 # Common issues:
+# - "SourceNotAllowed" condition - the local source is outside
+#   modelSource.allowedHostPathRoots (empty by default as of 0.9.0;
+#   see the breaking-change section above)
 # - "file does not exist" - Model path is incorrect or not accessible
 # - "permission denied" - File permissions issue
 # - "copy incomplete" - Disk space or I/O error
@@ -372,9 +396,10 @@ kubectl get model my-model -o jsonpath='{.status.sha256}'
 ## Security Considerations
 
 1. **Model Integrity**: Use the `sha256` field to verify model checksums automatically
-2. **File Permissions**: Restrict model file access to necessary users/groups
-3. **Network Segmentation**: Ensure internal model servers are properly firewalled
-4. **Audit Logging**: Track model deployments and access events through the controller's structured logs and Prometheus metrics. For SOC 2 / HIPAA / FedRAMP environments, forward operator logs to your SIEM via Vector, Fluent Bit, or your existing logging stack.
+2. **Host-Path Allowlist**: Keep `modelSource.allowedHostPathRoots` as narrow as possible (dedicated model directories, not `/` or `/mnt`); the allowlist is what stops a Model spec from mounting arbitrary node files into an inference pod
+3. **File Permissions**: Restrict model file access to necessary users/groups
+4. **Network Segmentation**: Ensure internal model servers are properly firewalled
+5. **Audit Logging**: Track model deployments and access events through the controller's structured logs and Prometheus metrics. For SOC 2 / HIPAA / FedRAMP environments, forward operator logs to your SIEM via Vector, Fluent Bit, or your existing logging stack.
 
 ## Next Steps
 

--- a/docs/contributors/model-hf-source-spec.md
+++ b/docs/contributors/model-hf-source-spec.md
@@ -10,6 +10,8 @@ The Model CRD's `source` field regex accepts bare HuggingFace repo IDs like `Tin
 - Local sources (`file://...` or `/absolute/path`) → copy via `io.Copy`
 - Everything else → HTTP download via `http.Get`
 
+Note (post-spec, as of v0.9.0): local sources are additionally gated by the operator's host-path allowlist (`--allowed-host-path-roots` flag, chart value `modelSource.allowedHostPathRoots`, empty by default). A local source outside the allowlist is rejected before the copy path runs; the Model goes to `Failed` with a `SourceNotAllowed` condition (GHSA-jw3m-8q7m-f35r). This gate does not apply to HF repo sources, which are runtime-resolved, nor to `pvc://` or HTTP(S) sources.
+
 When a HuggingFace repo ID falls into "everything else," `http.Get("TinyLlama/TinyLlama-1.1B-Chat-v1.0")` fails with `unsupported protocol scheme ""`. The model phase goes to `Failed` and any referencing InferenceService stays `Pending` forever.
 
 This blocks the intended vLLM workflow: user creates a Model with a bare repo ID, sets `skipModelInit: true` on the InferenceService, vLLM receives the repo ID as `--model` and downloads the weights itself using `HF_TOKEN` at runtime.

--- a/docs/operations/runbooks/controller-hot-spin-on-file-source.md
+++ b/docs/operations/runbooks/controller-hot-spin-on-file-source.md
@@ -2,6 +2,8 @@
 
 The LLMKube controller-manager pod is consuming an entire CPU core continuously and emitting the same error log line every few milliseconds. Running this for hours can pin a kind/k3s cluster's only CPU at 200-300% (multiple cores), trigger liveness probe failures, and starve other reconcilers.
 
+**Scope as of v0.9.0**: local sources are gated by the host-path allowlist (`modelSource.allowedHostPathRoots` / `--allowed-host-path-roots`, GHSA-jw3m-8q7m-f35r). A local source that is NOT inside an allowlisted root never reaches the fetch path; it fails fast with phase `Failed` and a `SourceNotAllowed` Degraded condition, and cannot hot-spin. On v0.9.0+ this runbook therefore only applies to a source that IS allowlisted but points at a file the controller pod cannot see.
+
 ## Trigger
 
 One or more of:
@@ -37,16 +39,26 @@ One or more of:
 
    Look at `spec.source`. The hot-spin reproduces specifically when:
    - `spec.source` is a `file://` URL OR an absolute path
+   - On v0.9.0+: the path is inside a root listed in `modelSource.allowedHostPathRoots` (a non-allowlisted source is rejected up front and cannot hot-spin)
    - The path exists on the **host** that runs the metal-agent (or wherever you want it to run)
    - The path does NOT exist inside the controller-manager pod's filesystem
 
    This is the canonical Mac kind / k3s + out-of-cluster metal-agent topology.
 
+   If instead the Model shows phase `Failed` with a `SourceNotAllowed` Degraded condition, the allowlist rejected the source and there is no hot-spin; this runbook does not apply. Either add the source's root to `modelSource.allowedHostPathRoots` (only if you trust its contents) or fix `spec.source`:
+
+   ```bash
+   kubectl --context <ctx> get model <model-name> \
+     -o jsonpath='{.status.phase} {.status.conditions[?(@.type=="Degraded")].reason}{"\n"}'
+   ```
+
 3. **Confirm fix #405 is deployed.** Run `kubectl --context <ctx> -n llmkube-system get pods -o jsonpath='{.items[*].spec.containers[*].image}'` and confirm the controller image tag is at or after the version in which [PR #412](https://github.com/defilantech/LLMKube/pull/412) merged. If the image predates that PR, the fix is missing and the runbook below applies as historical context only; upgrade the chart instead.
 
 ## Mitigate (immediate, gets CPU off the floor)
 
-1. **Edit `spec.source` to remove the unreachable `file://` reference.** Two safe options:
+1. **(v0.9.0+) Reconsider the allowlist entry.** The spinning source is by definition inside an allowlisted root that the controller pod cannot actually read; the allowlist entry may be wrong or overly broad. If the controller was never meant to serve this path, remove the root from `modelSource.allowedHostPathRoots` (or narrow it) and upgrade the Helm release: the Model then fails fast with `SourceNotAllowed` and stops retrying, which also gets CPU off the floor.
+
+2. **Edit `spec.source` to remove the unreachable `file://` reference.** Two safe options:
    - Replace with the equivalent `https://huggingface.co/.../<file>.gguf` URL. The metal-agent uses `filepath.Base(source)` to compute the local path, so a HTTPS URL with the same filename results in the same on-disk lookup; no re-download.
    - Replace with a `pvc://<claim>/<path>.gguf` source backed by a PVC the controller pod CAN mount.
 
@@ -54,7 +66,7 @@ One or more of:
    kubectl --context <ctx> edit model <model-name>
    ```
 
-2. **Verify CPU drops within 1-2 minutes.**
+3. **Verify CPU drops within 1-2 minutes.**
 
    ```bash
    kubectl --context <ctx> -n llmkube-system top pod \
@@ -66,6 +78,8 @@ One or more of:
 ## Resolve (structural)
 
 The fix landed in [PR #412](https://github.com/defilantech/LLMKube/pull/412): the Model controller now detects `fs.ErrNotExist` and `fs.ErrPermission` and returns `RequeueAfter: 5*time.Minute, nil` instead of an error. This stops the rate-limited workqueue from tight-retrying.
+
+Since v0.9.0 the protection is two-layered: the host-path allowlist rejects non-allowlisted local sources outright (immediate `Failed` / `SourceNotAllowed`, no fetch attempt), and the #412 backoff covers the remaining case of an allowlisted source whose file is missing or unreadable from the controller pod.
 
 If you are observing this on a controller image that includes the fix (post-#412):
 
@@ -98,7 +112,7 @@ If you are observing this on a controller image that includes the fix (post-#412
      -o jsonpath='{.status.phase} {.status.conditions[?(@.type=="Degraded")].reason}{"\n"}'
    ```
 
-   Either `Ready` (if you fixed the source) or `Failed CopyFailed` with `RequeueAfter` showing 5 minutes between reconciles (if you left the Model in its broken state intentionally).
+   Either `Ready` (if you fixed the source), `Failed CopyFailed` with `RequeueAfter` showing 5 minutes between reconciles (if you left the Model in its broken state intentionally), or `Failed SourceNotAllowed` (if you removed the root from the allowlist; this state is stable and does not consume reconcile cycles).
 
 3. **Controller CPU is sane.**
 
@@ -113,5 +127,6 @@ If you are observing this on a controller image that includes the fix (post-#412
 
 - Issue: [#405](https://github.com/defilantech/LLMKube/issues/405) (the bug report from a real-world incident)
 - Fix: [PR #412](https://github.com/defilantech/LLMKube/pull/412)
+- Allowlist: GHSA-jw3m-8q7m-f35r (v0.9.0) added `modelSource.allowedHostPathRoots` / `--allowed-host-path-roots`; empty by default, which disables local/hostPath sources entirely
 - Companion runbook: `model-fetch-failure.md` (HTTPS source failures), `pvc-source-not-bound.md` (PVC source missing)
 - Documentation: `Model.spec.source` GoDoc has the file:// caveat for hybrid topologies

--- a/docs/site/guides/air-gapped.md
+++ b/docs/site/guides/air-gapped.md
@@ -242,6 +242,32 @@ spec:
   format: gguf
 ```
 
+**Breaking change in v0.9.0**: local sources (`file://` and
+absolute paths) are disabled unless the path sits inside an
+operator-configured allowlist of trusted directory roots
+(GHSA-jw3m-8q7m-f35r). The allowlist is empty by default; with a
+default install this option is rejected outright, and the Model
+goes to phase `Failed` with a `SourceNotAllowed` condition (no
+fetch, no hostPath volume). Add the model root to your Helm
+values before using this option:
+
+```yaml
+modelSource:
+  allowedHostPathRoots:
+    - /mnt/models
+```
+
+or at install time with
+`--set 'modelSource.allowedHostPathRoots[0]=/mnt/models'` (the
+underlying controller flag is `--allowed-host-path-roots`,
+comma-separated). The check is lexical: `..` escapes are
+rejected, symlinks are not resolved, so only allowlist roots
+whose contents you control. `https://`, `pvc://`, and `hf://`
+sources are unaffected. If you upgrade with local-source
+workloads already running, delete any InferenceService whose
+source now falls outside the allowlist: a pod created before the
+upgrade keeps its hostPath mount until it is deleted.
+
 Pin the workload to nodes that have the file (via Deployment node
 selector, taint/toleration, or affinity). The operator does not
 distribute the file across nodes; that's the operator's
@@ -348,6 +374,13 @@ the InferenceService's namespace. View the init log:
 The cluster's egress policy is blocking the connection. Confirm
 your `NetworkPolicy` permits the runtime namespace to reach
 `model-server.internal.corp` on port 443.
+
+**Model `Failed` with a `SourceNotAllowed` condition**
+The `file://` or absolute-path source is outside the operator's
+host-path allowlist, which is empty by default as of v0.9.0. Add
+the model root to `modelSource.allowedHostPathRoots` (see Option C
+above) and upgrade the Helm release, or switch the Model to a
+`pvc://` source.
 
 **`pvc://` source reports `PVC <name> not Bound`**
 The PVC exists but no PV satisfies it. Check

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -247,7 +247,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	var modelPath string
 	if backend.NeedsModelInit() && !skipInit {
 		useCache := effectiveModelCacheKey(model) != "" && r.ModelCachePath != ""
-		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.ModelCacheMode, r.CACertConfigMap, r.InitContainerImage, r.DefaultFSGroup)
+		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.ModelCacheMode, r.CACertConfigMap, r.InitContainerImage, r.DefaultFSGroup, r.AllowedHostPathRoots)
 		modelPath = storageConfig.modelPath
 	}
 

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -63,6 +63,12 @@ type InferenceServiceReconciler struct {
 	ModelCacheMode     string
 	CACertConfigMap    string
 	InitContainerImage string
+	// AllowedHostPathRoots is the operator-configured allowlist of absolute
+	// path prefixes under which local (/abs and file://) model sources — and
+	// therefore the HostPathVolumeSource they generate — are permitted. Empty
+	// (the secure default) disables all local/hostPath sources; see
+	// validateLocalSourceAllowed and GHSA-jw3m-8q7m-f35r.
+	AllowedHostPathRoots []string
 	// DefaultFSGroup is applied to the rendered PodSecurityContext when the
 	// user has not supplied one. Values <= 0 disable the default (recommended
 	// on OpenShift, where the restricted-v2 SCC injects fsGroup from the
@@ -158,6 +164,19 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return *result, err
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Host-path allowlist gate (GHSA-jw3m-8q7m-f35r): a local model source
+	// outside the operator-configured roots must never produce a
+	// HostPathVolumeSource in a generated pod. Block the InferenceService
+	// before any Deployment is built. This guards independently of the Model
+	// controller's own gate because a Model may carry a sticky Ready status
+	// from before the allowlist was introduced (or tightened).
+	if valErr := validateLocalSourceAllowed(model.Spec.Source, r.AllowedHostPathRoots); valErr != nil {
+		log.Error(valErr, "rejected local model source by host-path allowlist", "model", model.Name, "source", model.Spec.Source)
+		blockResult, updateErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, PhaseFailed, modelReady, 0, 0, "",
+			valErr.Error(), nil)
+		return blockResult, updateErr
 	}
 
 	desiredReplicas := int32(1)

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -111,6 +111,81 @@ var _ = Describe("buildCachedStorageConfig", func() {
 	})
 })
 
+var _ = Describe("buildModelStorageConfig host-path allowlist (GHSA-jw3m-8q7m-f35r)", func() {
+	newLocalModel := func() *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "local-model", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "file:///mnt/models/test.gguf",
+			},
+			Status: inferencev1alpha1.ModelStatus{
+				CacheKey: "abc123",
+			},
+		}
+	}
+
+	expectNoHostPath := func(config modelStorageConfig) {
+		GinkgoHelper()
+		for _, v := range config.volumes {
+			Expect(v.HostPath).To(BeNil(),
+				"a disallowed local source must never produce a HostPathVolumeSource (volume %q)", v.Name)
+		}
+	}
+
+	It("emits no hostPath volume when no roots are configured (secure default)", func() {
+		config := buildModelStorageConfig(newLocalModel(), nil, "default", true, "", "", "curl:8.18.0", 102, nil)
+
+		expectNoHostPath(config)
+		Expect(config.initContainers).To(HaveLen(1))
+		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("SourceNotAllowed"))
+	})
+
+	It("emits no hostPath volume when the source is outside the allowed roots", func() {
+		config := buildModelStorageConfig(newLocalModel(), nil, "default", true, "", "", "curl:8.18.0", 102,
+			[]string{"/srv/models"})
+
+		expectNoHostPath(config)
+		Expect(config.initContainers).To(HaveLen(1))
+		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("SourceNotAllowed"))
+	})
+
+	It("emits no hostPath volume on the emptyDir (useCache=false) path either", func() {
+		config := buildModelStorageConfig(newLocalModel(), nil, "default", false, "", "", "curl:8.18.0", 102, nil)
+
+		expectNoHostPath(config)
+		Expect(config.initContainers).To(HaveLen(1))
+		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("SourceNotAllowed"))
+	})
+
+	It("emits the host-model hostPath volume for a local source under an allowed root", func() {
+		config := buildModelStorageConfig(newLocalModel(), nil, "default", true, "", "", "curl:8.18.0", 102,
+			[]string{"/mnt/models"})
+
+		var hostPath *corev1.HostPathVolumeSource
+		for _, v := range config.volumes {
+			if v.Name == "host-model" {
+				hostPath = v.HostPath
+			}
+		}
+		Expect(hostPath).NotTo(BeNil(), "an allowed local source keeps the host-model hostPath volume")
+		Expect(hostPath.Path).To(Equal("/mnt/models/test.gguf"))
+	})
+
+	It("leaves non-local sources untouched regardless of roots", func() {
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "remote-model", Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"},
+			Status:     inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
+		}
+		config := buildModelStorageConfig(model, nil, "default", true, "", "", "curl:8.18.0", 102, nil)
+
+		expectNoHostPath(config)
+		Expect(config.initContainers).To(HaveLen(2))
+		Expect(config.initContainers[1].Name).To(Equal("model-downloader"))
+		Expect(config.initContainers[1].Command[2]).NotTo(ContainSubstring("SourceNotAllowed"))
+	})
+})
+
 var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 	It("uses primary staged path and MODEL_FILES env for multi-file model", func() {
 		model := &inferencev1alpha1.Model{
@@ -550,7 +625,7 @@ var _ = Describe("buildModelStorageConfig PVC dispatch", func() {
 			Spec:       inferencev1alpha1.ModelSpec{Source: "pvc://my-claim/model.gguf"},
 			Status:     inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
 		}
-		config := buildModelStorageConfig(model, nil, "default", true, "", "", "curl:8.18.0", 102)
+		config := buildModelStorageConfig(model, nil, "default", true, "", "", "curl:8.18.0", 102, nil)
 
 		// Should use PVC config, not cached config
 		Expect(config.volumes[0].Name).To(Equal("model-source"))

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -100,6 +100,11 @@ type ModelReconciler struct {
 	// RevalidateInterval is the minimum time between upstream revalidation
 	// checks for a Model. Zero means DefaultRevalidateInterval.
 	RevalidateInterval time.Duration
+	// AllowedHostPathRoots is the operator-configured allowlist of absolute
+	// path prefixes under which local (/abs and file://) model sources are
+	// permitted. Empty (the secure default) disables all local sources; see
+	// validateLocalSourceAllowed and GHSA-jw3m-8q7m-f35r.
+	AllowedHostPathRoots []string
 }
 
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models,verbs=get;list;watch;create;update;patch;delete
@@ -128,6 +133,14 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if r.StoragePath == "" {
 		r.StoragePath = DefaultModelCachePath
+	}
+
+	// Host-path allowlist gate (GHSA-jw3m-8q7m-f35r): a local source outside
+	// the operator-configured roots must never reach copyLocalModel/os.Open —
+	// including the metal local-path branch in reconcileBySourceType, so this
+	// runs before any source-type dispatch.
+	if handled, err := r.rejectDisallowedLocalSource(ctx, model); handled {
+		return ctrl.Result{}, err
 	}
 
 	if handled, result := r.validateMultiFileStagingSource(ctx, model); handled {
@@ -322,6 +335,31 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
 	logger.Info("Model ready and cached", "path", finalPath, "size", model.Status.Size, "cacheKey", cacheKey)
 	return ctrl.Result{}, nil
+}
+
+// rejectDisallowedLocalSource enforces the host-path allowlist for local
+// model sources (GHSA-jw3m-8q7m-f35r). handled=true means the source was
+// rejected: the Model is marked Failed with a SourceNotAllowed Degraded
+// condition and the reconcile must return an empty result with the returned
+// error. The rejection itself yields a nil error (not the validation error):
+// the failure is unrecoverable without a spec or operator-config change, and
+// a spec change re-triggers reconcile, so there is nothing to tight-loop on.
+func (r *ModelReconciler) rejectDisallowedLocalSource(ctx context.Context, model *inferencev1alpha1.Model) (handled bool, err error) {
+	logger := log.FromContext(ctx)
+
+	valErr := validateLocalSourceAllowed(model.Spec.Source, r.AllowedHostPathRoots)
+	if valErr == nil {
+		return false, nil
+	}
+
+	logger.Error(valErr, "rejected local model source by host-path allowlist", "source", model.Spec.Source)
+	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "error").Inc()
+	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, PhaseFailed).Set(1)
+	model.Status.Phase = PhaseFailed
+	if statusErr := r.updateStatus(ctx, model, ConditionDegraded, metav1.ConditionTrue, "SourceNotAllowed", valErr.Error()); statusErr != nil {
+		return true, statusErr
+	}
+	return true, nil
 }
 
 func (r *ModelReconciler) validateMultiFileStagingSource(ctx context.Context, model *inferencev1alpha1.Model) (bool, ctrl.Result) {

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -105,6 +106,29 @@ type ModelReconciler struct {
 	// permitted. Empty (the secure default) disables all local sources; see
 	// validateLocalSourceAllowed and GHSA-jw3m-8q7m-f35r.
 	AllowedHostPathRoots []string
+	// AllowedRemoteHosts is the operator-configured allowlist of hostnames
+	// and CIDRs that remote (http/https) Model sources may target even when
+	// they resolve to private/link-local/loopback ranges. Empty (the secure
+	// default) blocks all such ranges; public hosts are always allowed. See
+	// newGuardedHTTPClient and GHSA-jw3m-8q7m-f35r.
+	AllowedRemoteHosts []string
+
+	// metadataHTTPClient is the SSRF-guarded client used for all controller-
+	// side requests to Model.spec.source (metadata reads and revalidation
+	// probes). Built lazily from AllowedRemoteHosts; never use
+	// http.DefaultClient for source-derived URLs.
+	metadataHTTPClient     *http.Client
+	metadataHTTPClientOnce sync.Once
+}
+
+// metadataClient returns the SSRF-guarded HTTP client for source-derived
+// requests, building it on first use.
+func (r *ModelReconciler) metadataClient() *http.Client {
+	r.metadataHTTPClientOnce.Do(func() {
+		r.metadataHTTPClient = newGuardedHTTPClient(
+			parseRemoteHostAllowlist(r.AllowedRemoteHosts), remoteMetadataTimeout)
+	})
+	return r.metadataHTTPClient
 }
 
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models,verbs=get;list;watch;create;update;patch;delete
@@ -750,7 +774,15 @@ func (r *ModelReconciler) downloadModel(ctx context.Context, source, dest string
 	logger := log.FromContext(ctx)
 
 	logger.Info("Downloading model", "source", source, "dest", dest)
-	resp, err := http.Get(source)
+	// Fetch through the SSRF-guarded client, never http.DefaultClient: remote
+	// sources are normally runtime-resolved and do not reach this sink today,
+	// but if a future routing change lets one through, the download must obey
+	// the same private-range guard as the metadata reads (GHSA-jw3m-8q7m-f35r).
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to download: %w", err)
+	}
+	resp, err := r.metadataClient().Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("failed to download: %w", err)
 	}
@@ -1007,7 +1039,7 @@ const remoteMetadataTimeout = 30 * time.Second
 func (r *ModelReconciler) parseRemoteGGUFMetadata(ctx context.Context, source string) (*inferencev1alpha1.GGUFMetadata, int64, error) {
 	ctx, cancel := context.WithTimeout(ctx, remoteMetadataTimeout)
 	defer cancel()
-	parsed, err := gguf.ParseFromURL(ctx, source)
+	parsed, err := gguf.ParseFromURLWithClient(ctx, r.metadataClient(), source)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to parse remote GGUF: %w", err)
 	}
@@ -1025,18 +1057,19 @@ func (r *ModelReconciler) parseRemoteGGUFMetadata(ctx context.Context, source st
 		License:       license.Normalize(parsed.License()),
 	}
 
-	return meta, remoteContentLength(ctx, source), nil
+	return meta, r.remoteContentLength(ctx, source), nil
 }
 
 // remoteContentLength returns the object size from a HEAD request, or 0 when the
 // server does not report a usable Content-Length. Best-effort: any error yields
 // 0 so the caller leaves Status.Size untouched rather than failing the reconcile.
-func remoteContentLength(ctx context.Context, source string) int64 {
+// The request goes through the SSRF-guarded client (GHSA-jw3m-8q7m-f35r).
+func (r *ModelReconciler) remoteContentLength(ctx context.Context, source string) int64 {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, source, nil)
 	if err != nil {
 		return 0
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.metadataClient().Do(req)
 	if err != nil {
 		return 0
 	}

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -776,7 +776,10 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		dest := filepath.Join(tempDir, "model.gguf")
-		reconciler := &ModelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		// Allowlist loopback: this spec exercises download mechanics against a
+		// local httptest server, not the SSRF guard (which is covered by
+		// TestDownloadModelUsesGuardedClient).
+		reconciler := &ModelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), AllowedRemoteHosts: []string{"127.0.0.1"}}
 		_, err = reconciler.downloadModel(context.Background(), server.URL+"/model.gguf", dest)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(SatisfyAny(
@@ -880,7 +883,8 @@ var _ = Describe("downloadModel", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
-		reconciler := &ModelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		// Allowlist loopback so the SSRF guard permits the local httptest server.
+		reconciler := &ModelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), AllowedRemoteHosts: []string{"127.0.0.1"}}
 		size, err := reconciler.downloadModel(context.Background(), server.URL+"/model.gguf", filepath.Join(tempDir, "model.gguf"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(size).To(Equal(int64(len(content))))
@@ -896,7 +900,8 @@ var _ = Describe("downloadModel", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
-		reconciler := &ModelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		// Allowlist loopback so the SSRF guard permits the local httptest server.
+		reconciler := &ModelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), AllowedRemoteHosts: []string{"127.0.0.1"}}
 		_, err = reconciler.downloadModel(context.Background(), server.URL+"/model.gguf", filepath.Join(tempDir, "model.gguf"))
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("bad status"))
@@ -1111,6 +1116,7 @@ var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 			Scheme:               k8sClient.Scheme(),
 			StoragePath:          tempDir,
 			AllowedHostPathRoots: testLocalRoots,
+			AllowedRemoteHosts:   testRemoteHosts,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -2021,11 +2027,14 @@ var _ = Describe("Model Controller remote GGUF metadata (#728, Task 2)", func() 
 		Expect(k8sClient.Create(ctx, model)).To(Succeed())
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
+		// Loopback is a blocked range; the fixture opts it back in via the
+		// allowlist (GHSA-jw3m-8q7m-f35r).
 		reconciler := &ModelReconciler{
 			Client:               k8sClient,
 			Scheme:               k8sClient.Scheme(),
 			StoragePath:          tempDir,
 			AllowedHostPathRoots: testLocalRoots,
+			AllowedRemoteHosts:   testRemoteHosts,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -2056,5 +2065,51 @@ var _ = Describe("Model Controller remote GGUF metadata (#728, Task 2)", func() 
 
 		// And it read far fewer bytes than the full file (header-only).
 		Expect(bytesServed).To(BeNumerically("<", int64(len(ggufBytes))/2))
+	})
+
+	It("refuses to probe private-range sources when no remote host is allowlisted (SSRF guard)", func() {
+		tempDir, err := os.MkdirTemp("", "llmkube-ssrf-guard-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		// Stands in for cloud metadata / in-cluster services: a loopback
+		// server the controller must never connect to by default
+		// (GHSA-jw3m-8q7m-f35r).
+		var hits int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			hits++
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		modelName := "ssrf-guard-default-deny"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec:       inferencev1alpha1.ModelSpec{Source: srv.URL + "/model.gguf", Format: "gguf"},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		// No AllowedRemoteHosts: the secure default.
+		reconciler := &ModelReconciler{
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred(), "a blocked metadata probe is non-fatal")
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+
+		// The model still reaches Ready (workload-resolved), but the controller
+		// never connected: no GGUF metadata, no size, zero requests served.
+		Expect(updated.Status.Phase).To(Equal(PhaseReady))
+		Expect(updated.Status.GGUF).To(BeNil(), "guard must prevent the remote metadata read")
+		Expect(updated.Status.Size).To(Equal("0"))
+		Expect(hits).To(Equal(0), "the SSRF guard must block the connection at dial time")
 	})
 })

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -90,9 +90,10 @@ var _ = Describe("Model Controller", func() {
 			defer func() { _ = os.RemoveAll(tempDir) }()
 
 			controllerReconciler := &ModelReconciler{
-				Client:      k8sClient,
-				Scheme:      k8sClient.Scheme(),
-				StoragePath: tempDir,
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				StoragePath:          tempDir,
+				AllowedHostPathRoots: testLocalRoots,
 			}
 
 			// HTTPS sources are downloaded by the InferenceService Pod's init
@@ -126,9 +127,10 @@ var _ = Describe("Model Controller Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: "nonexistent", Namespace: "default"},
@@ -195,9 +197,10 @@ var _ = Describe("Model Controller Reconcile", func() {
 		}()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -239,9 +242,10 @@ var _ = Describe("Model Controller Reconcile", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -301,9 +305,10 @@ var _ = Describe("Model Controller Reconcile", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -349,9 +354,10 @@ var _ = Describe("Model Controller Reconcile", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -409,9 +415,10 @@ var _ = Describe("Model Controller Reconcile", func() {
 		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -456,9 +463,10 @@ var _ = Describe("Model Controller Reconcile", func() {
 		}()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -497,9 +505,10 @@ var _ = Describe("Model Controller Reconcile", func() {
 		}()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -543,9 +552,10 @@ var _ = Describe("Model Controller Reconcile", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -592,9 +602,10 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		// (fake) GGUF metadata (which fails non-fatally), and migrates the file
 		// to the canonical filename derived from Model.Name.
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -656,9 +667,10 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 
 		// First reconcile: controller downloads the model and marks it Ready.
@@ -721,9 +733,10 @@ var _ = Describe("Model Controller - Cache Bug Fixes", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1005,9 +1018,10 @@ var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1053,9 +1067,10 @@ var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1092,9 +1107,10 @@ var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1142,9 +1158,10 @@ var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1193,9 +1210,10 @@ var _ = Describe("Model Controller - GGUF Filename Migration", func() {
 		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1233,9 +1251,10 @@ var _ = Describe("Runtime-Resolved Source Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1277,9 +1296,10 @@ var _ = Describe("Runtime-Resolved Source Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		// First reconcile to set Ready
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
@@ -1322,9 +1342,10 @@ var _ = Describe("Runtime-Resolved Source Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1362,9 +1383,10 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1407,9 +1429,10 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1447,9 +1470,10 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1487,9 +1511,10 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1527,9 +1552,10 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1567,9 +1593,10 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1629,9 +1656,10 @@ var _ = Describe("SHA256 Verification", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1669,9 +1697,10 @@ var _ = Describe("SHA256 Verification", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1723,9 +1752,10 @@ var _ = Describe("SHA256 Verification", func() {
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1800,9 +1830,10 @@ var _ = Describe("Issue #363 regression — controller / workload cache disconne
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1832,9 +1863,10 @@ var _ = Describe("Issue #363 regression — controller / workload cache disconne
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1885,9 +1917,10 @@ var _ = Describe("Issue #363 regression — controller / workload cache disconne
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
@@ -1989,9 +2022,10 @@ var _ = Describe("Model Controller remote GGUF metadata (#728, Task 2)", func() 
 		defer func() { _ = k8sClient.Delete(ctx, model) }()
 
 		reconciler := &ModelReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			StoragePath: tempDir,
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
 		}
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},

--- a/internal/controller/model_revalidate.go
+++ b/internal/controller/model_revalidate.go
@@ -164,7 +164,7 @@ func (r *ModelReconciler) probeHTTPSource(ctx context.Context, source string) (s
 		return sourceFingerprint{}, false
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.metadataClient().Do(req)
 	if err != nil {
 		logger.Info("HEAD request failed for revalidation (non-fatal)", "source", source, "error", err.Error())
 		return sourceFingerprint{}, false

--- a/internal/controller/model_revalidate_test.go
+++ b/internal/controller/model_revalidate_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Model source revalidation", func() {
 			reconciler := &ModelReconciler{
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Nanosecond,
+				AllowedHostPathRoots: testLocalRoots,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 
@@ -128,6 +129,7 @@ var _ = Describe("Model source revalidation", func() {
 			reconciler := &ModelReconciler{
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Nanosecond,
+				AllowedHostPathRoots: testLocalRoots,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 
@@ -190,6 +192,7 @@ var _ = Describe("Model source revalidation", func() {
 			reconciler := &ModelReconciler{
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Nanosecond,
+				AllowedHostPathRoots: testLocalRoots,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 
@@ -236,6 +239,7 @@ var _ = Describe("Model source revalidation", func() {
 			reconciler := &ModelReconciler{
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Nanosecond,
+				AllowedHostPathRoots: testLocalRoots,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 
@@ -301,6 +305,7 @@ var _ = Describe("Model source revalidation", func() {
 			reconciler := &ModelReconciler{
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Hour,
+				AllowedHostPathRoots: testLocalRoots,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 			_, err = reconciler.Reconcile(ctx, req)

--- a/internal/controller/model_revalidate_test.go
+++ b/internal/controller/model_revalidate_test.go
@@ -75,6 +75,7 @@ var _ = Describe("Model source revalidation", func() {
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Nanosecond,
 				AllowedHostPathRoots: testLocalRoots,
+				AllowedRemoteHosts:   testRemoteHosts,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 
@@ -130,6 +131,7 @@ var _ = Describe("Model source revalidation", func() {
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Nanosecond,
 				AllowedHostPathRoots: testLocalRoots,
+				AllowedRemoteHosts:   testRemoteHosts,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 
@@ -193,6 +195,7 @@ var _ = Describe("Model source revalidation", func() {
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Nanosecond,
 				AllowedHostPathRoots: testLocalRoots,
+				AllowedRemoteHosts:   testRemoteHosts,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 
@@ -240,6 +243,7 @@ var _ = Describe("Model source revalidation", func() {
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Nanosecond,
 				AllowedHostPathRoots: testLocalRoots,
+				AllowedRemoteHosts:   testRemoteHosts,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 
@@ -306,6 +310,7 @@ var _ = Describe("Model source revalidation", func() {
 				Client: k8sClient, Scheme: k8sClient.Scheme(),
 				StoragePath: tempDir, RevalidateInterval: time.Hour,
 				AllowedHostPathRoots: testLocalRoots,
+				AllowedRemoteHosts:   testRemoteHosts,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"}}
 			_, err = reconciler.Reconcile(ctx, req)

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -414,7 +414,15 @@ type modelStorageConfig struct {
 	volumeMounts   []corev1.VolumeMount
 }
 
-func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64) modelStorageConfig {
+func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64, allowedHostPathRoots []string) modelStorageConfig {
+	// Host-path allowlist gate (GHSA-jw3m-8q7m-f35r), belt-and-suspenders to
+	// the upfront check in the InferenceService reconcile: a local source
+	// outside the allowed roots must never yield a HostPathVolumeSource, even
+	// if a future caller forgets the reconcile-time validation. Fail loudly
+	// with an init container that exits instead of silently serving nothing.
+	if err := validateLocalSourceAllowed(model.Spec.Source, allowedHostPathRoots); err != nil {
+		return disallowedLocalSourceStorageConfig(initContainerImage)
+	}
 	if isPVCSource(model.Spec.Source) {
 		return buildPVCStorageConfig(model)
 	}
@@ -422,6 +430,29 @@ func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1al
 		return buildCachedStorageConfig(model, isvc, cacheMode, caCertConfigMap, initContainerImage, defaultFSGroup)
 	}
 	return buildEmptyDirStorageConfig(model, isvc, namespace, caCertConfigMap, initContainerImage)
+}
+
+// disallowedLocalSourceStorageConfig returns a storage config whose init
+// container immediately exits with a clear error, and which mounts no volumes
+// beyond an ephemeral emptyDir. Used when the model's local source fails the
+// host-path allowlist (GHSA-jw3m-8q7m-f35r) so that no HostPathVolumeSource is
+// ever emitted for a disallowed source.
+func disallowedLocalSourceStorageConfig(initImage string) modelStorageConfig {
+	return modelStorageConfig{
+		modelPath: "/models/model.gguf",
+		initContainers: []corev1.Container{
+			{
+				Name:  "model-downloader",
+				Image: initImage,
+				Command: []string{"sh", "-c",
+					`echo "ERROR: SourceNotAllowed - the model's local/hostPath source is not within the operator's --allowed-host-path-roots (GHSA-jw3m-8q7m-f35r)."; exit 1`},
+			},
+		},
+		volumes: []corev1.Volume{
+			{Name: "model-storage", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		},
+		volumeMounts: []corev1.VolumeMount{{Name: "model-storage", MountPath: "/models", ReadOnly: true}},
+	}
 }
 
 // buildPVCStorageConfig mounts the user's PVC directly as a read-only volume.

--- a/internal/controller/safehttp.go
+++ b/internal/controller/safehttp.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"time"
+)
+
+// remoteHostAllowlist permits specific hostnames and CIDRs back through the
+// private-range SSRF guard. Hostnames match the request URL host
+// (case-insensitive); CIDRs match resolved IPs.
+type remoteHostAllowlist struct {
+	hosts    map[string]struct{}
+	prefixes []netip.Prefix
+}
+
+// parseRemoteHostAllowlist builds an allowlist from operator-supplied entries
+// (--allowed-remote-hosts). Each entry is a CIDR (10.20.0.0/16), a bare IP
+// (treated as a single-address prefix), or a hostname. Blank entries are
+// ignored; an unparseable CIDR falls back to hostname matching.
+func parseRemoteHostAllowlist(entries []string) remoteHostAllowlist {
+	al := remoteHostAllowlist{hosts: map[string]struct{}{}}
+	for _, e := range entries {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		if strings.Contains(e, "/") {
+			if p, err := netip.ParsePrefix(e); err == nil {
+				al.prefixes = append(al.prefixes, p)
+				continue
+			}
+			// Not a valid CIDR; fall through and treat it as a host entry.
+		}
+		if ip, err := netip.ParseAddr(e); err == nil {
+			al.prefixes = append(al.prefixes, netip.PrefixFrom(ip, ip.BitLen()))
+			continue
+		}
+		al.hosts[strings.ToLower(e)] = struct{}{}
+	}
+	return al
+}
+
+func (al remoteHostAllowlist) hostAllowed(host string) bool {
+	_, ok := al.hosts[strings.ToLower(host)]
+	return ok
+}
+
+func (al remoteHostAllowlist) ipAllowed(ip netip.Addr) bool {
+	ip = ip.Unmap()
+	for _, p := range al.prefixes {
+		if p.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// blockedPrefixes lists non-public ranges that Go's stdlib classifiers
+// (IsPrivate, IsLoopback, IsLinkLocal*) do NOT cover but that must never be
+// reachable from source-derived URLs unless allowlisted. Parsed once at
+// package init; ipIsBlocked runs on every dial, so no per-call parsing.
+var blockedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("100.64.0.0/10"),  // CGNAT / shared address space (RFC 6598), incl. Tailscale
+	netip.MustParsePrefix("192.0.0.0/24"),   // IETF protocol assignments (RFC 6890)
+	netip.MustParsePrefix("198.18.0.0/15"),  // benchmarking (RFC 2544)
+	netip.MustParsePrefix("192.88.99.0/24"), // 6to4 relay anycast (RFC 3068)
+	netip.MustParsePrefix("64:ff9b::/96"),   // NAT64 well-known prefix (RFC 6052)
+	netip.MustParsePrefix("64:ff9b:1::/48"), // NAT64 local-use (RFC 8215)
+}
+
+// v4CompatPrefix matches deprecated IPv4-compatible IPv6 addresses
+// (::a.b.c.d, RFC 4291 §2.5.5.1). Some stacks route these to the embedded
+// IPv4 target, so they classify by the embedded address, not as IPv6.
+var v4CompatPrefix = netip.MustParsePrefix("::/96")
+
+// ipIsBlocked reports whether an IP is in a range we refuse to connect to
+// unless explicitly allowlisted: loopback, link-local (incl. 169.254.169.254
+// and fe80::/10), RFC-1918 private, ULA (fc00::/7), unspecified, or any of
+// blockedPrefixes (CGNAT, benchmarking, NAT64, ...). Unmap() first so
+// IPv4-in-IPv6 forms (::ffff:127.0.0.1) classify as their IPv4 self;
+// IPv4-compatible forms (::127.0.0.1) recurse on the embedded IPv4 address.
+func ipIsBlocked(ip netip.Addr) bool {
+	ip = ip.Unmap()
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() || ip.IsPrivate() || ip.IsUnspecified() {
+		return true
+	}
+	for _, p := range blockedPrefixes {
+		if p.Contains(ip) {
+			return true
+		}
+	}
+	// IPv4-compatible IPv6: in ::/96 but not :: or ::1 (both already returned
+	// true above). Extract the embedded IPv4 address and classify by it, so
+	// ::169.254.169.254 and ::127.0.0.1 are blocked like their IPv4 selves.
+	// Recursion terminates: the embedded address is Is4 and cannot re-enter
+	// this branch.
+	if ip.Is6() && v4CompatPrefix.Contains(ip) {
+		b := ip.As16()
+		return ipIsBlocked(netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]}))
+	}
+	return false
+}
+
+// newGuardedHTTPClient returns an *http.Client whose dialer refuses to connect
+// to blocked IP ranges unless the target host/IP is allowlisted. The check runs
+// on the RESOLVED IPs and dials only those pinned IPs, so DNS rebinding cannot
+// slip a blocked address in after the check. Every resolved IP must be
+// permitted (a multi-record answer mixing one public and one loopback address
+// is rejected outright). Redirect targets dial through the same guard; hops
+// are capped.
+func newGuardedHTTPClient(allow remoteHostAllowlist, timeout time.Duration) *http.Client {
+	base := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		hostAllowed := allow.hostAllowed(host)
+		var ips []netip.Addr
+		if ip, err := netip.ParseAddr(host); err == nil {
+			ips = []netip.Addr{ip}
+		} else {
+			addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+			if err != nil {
+				return nil, err
+			}
+			ips = addrs
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("no addresses for host %q", host)
+		}
+		// Strict: every resolved IP must be permitted, so a multi-record rebind
+		// (one public + one 127.0.0.1) cannot pass.
+		for _, ip := range ips {
+			permitted := hostAllowed || allow.ipAllowed(ip) || !ipIsBlocked(ip)
+			if !permitted {
+				return nil, fmt.Errorf(
+					"connection to %s (%s) blocked by SSRF guard (GHSA-jw3m-8q7m-f35r); "+
+						"allowlist via modelSource.allowedRemoteHosts", host, ip)
+			}
+		}
+		// Dial the pinned, already-checked IPs in resolver order, falling back
+		// across them (dual-stack hosts may not listen on every address).
+		var dialErr error
+		for _, ip := range ips {
+			conn, err := base.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			dialErr = err
+		}
+		return nil, dialErr
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			DialContext:           dial,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: timeout,
+			MaxIdleConns:          10,
+		},
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("stopped after 5 redirects")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/controller/safehttp_test.go
+++ b/internal/controller/safehttp_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIPIsBlocked(t *testing.T) {
+	cases := []struct {
+		ip      string
+		blocked bool
+	}{
+		// Blocked: loopback, link-local, RFC-1918, ULA, unspecified.
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"::ffff:127.0.0.1", true}, // IPv4-in-IPv6 loopback must not slip through
+		{"169.254.169.254", true},  // cloud metadata
+		{"fe80::1", true},
+		{"10.1.2.3", true},
+		{"172.16.0.1", true},
+		{"192.168.1.1", true},
+		{"fc00::1", true},
+		{"0.0.0.0", true},
+		{"::", true},
+		{"::ffff:10.0.0.1", true}, // IPv4-in-IPv6 RFC-1918
+		// Blocked: ranges IsPrivate() does not cover (GHSA-jw3m-8q7m-f35r).
+		{"100.64.0.1", true},        // CGNAT (RFC 6598)
+		{"100.93.59.11", true},      // CGNAT: Tailscale address in this env
+		{"192.0.0.1", true},         // IETF protocol assignments (RFC 6890)
+		{"198.18.0.1", true},        // benchmarking (RFC 2544)
+		{"198.19.255.1", true},      // benchmarking upper half of the /15
+		{"192.88.99.1", true},       // 6to4 relay anycast (RFC 3068)
+		{"64:ff9b::7f00:1", true},   // NAT64 well-known prefix (RFC 6052)
+		{"64:ff9b:1::a", true},      // NAT64 local-use (RFC 8215)
+		{"::169.254.169.254", true}, // IPv4-compatible IPv6 hiding metadata IP
+		{"::127.0.0.1", true},       // IPv4-compatible IPv6 loopback
+		{"::ffff:100.64.0.1", true}, // IPv4-mapped CGNAT
+		// Not blocked: public addresses (incl. boundary neighbors of the new ranges).
+		{"1.1.1.1", false},
+		{"8.8.8.8", false},
+		{"2606:4700:4700::1111", false},
+		{"100.128.0.1", false}, // just above 100.64.0.0/10
+		{"198.20.0.1", false},  // just above 198.18.0.0/15
+	}
+	for _, tc := range cases {
+		t.Run(tc.ip, func(t *testing.T) {
+			ip := netip.MustParseAddr(tc.ip)
+			if got := ipIsBlocked(ip); got != tc.blocked {
+				t.Errorf("ipIsBlocked(%s) = %v, want %v", tc.ip, got, tc.blocked)
+			}
+		})
+	}
+}
+
+func TestParseRemoteHostAllowlist(t *testing.T) {
+	al := parseRemoteHostAllowlist([]string{
+		"10.20.0.0/16",
+		"10.9.9.9",
+		"Artifact.Corp",
+		"  ",
+		"",
+	})
+
+	ipCases := []struct {
+		ip      string
+		allowed bool
+	}{
+		{"10.20.5.5", true},        // inside CIDR
+		{"10.30.5.5", false},       // outside CIDR
+		{"10.9.9.9", true},         // bare IP became a /32
+		{"10.9.9.10", false},       // adjacent IP not covered by the /32
+		{"::ffff:10.20.5.5", true}, // 4-in-6 form of an allowlisted IPv4
+	}
+	for _, tc := range ipCases {
+		if got := al.ipAllowed(netip.MustParseAddr(tc.ip)); got != tc.allowed {
+			t.Errorf("ipAllowed(%s) = %v, want %v", tc.ip, got, tc.allowed)
+		}
+	}
+
+	hostCases := []struct {
+		host    string
+		allowed bool
+	}{
+		{"artifact.corp", true}, // case-insensitive match
+		{"ARTIFACT.CORP", true},
+		{"other.corp", false},
+		{"", false}, // blank entries were dropped, not registered
+	}
+	for _, tc := range hostCases {
+		if got := al.hostAllowed(tc.host); got != tc.allowed {
+			t.Errorf("hostAllowed(%q) = %v, want %v", tc.host, got, tc.allowed)
+		}
+	}
+}
+
+// TestGuardedClientBlocksLoopback is the end-to-end proof the guard fires: a
+// guarded client with an empty allowlist must refuse to connect to a loopback
+// httptest server (the SSRF-relevant target class), and the same client with
+// 127.0.0.1 allowlisted must succeed.
+func TestGuardedClientBlocksLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	t.Run("empty allowlist refuses loopback", func(t *testing.T) {
+		client := newGuardedHTTPClient(parseRemoteHostAllowlist(nil), 5*time.Second)
+		resp, err := client.Get(srv.URL)
+		if err == nil {
+			_ = resp.Body.Close()
+			t.Fatalf("expected the SSRF guard to block %s, but the request succeeded", srv.URL)
+		}
+		if !strings.Contains(err.Error(), "SSRF guard") {
+			t.Errorf("expected an SSRF-guard error, got: %v", err)
+		}
+	})
+
+	t.Run("allowlisted loopback is permitted", func(t *testing.T) {
+		client := newGuardedHTTPClient(parseRemoteHostAllowlist([]string{"127.0.0.1"}), 5*time.Second)
+		resp, err := client.Get(srv.URL)
+		if err != nil {
+			t.Fatalf("expected allowlisted request to succeed, got: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("reading body: %v", err)
+		}
+		if string(body) != "ok" {
+			t.Errorf("unexpected body %q", body)
+		}
+	})
+
+	t.Run("CIDR allowlist covering loopback is permitted", func(t *testing.T) {
+		client := newGuardedHTTPClient(parseRemoteHostAllowlist([]string{"127.0.0.0/8"}), 5*time.Second)
+		resp, err := client.Get(srv.URL)
+		if err != nil {
+			t.Fatalf("expected CIDR-allowlisted request to succeed, got: %v", err)
+		}
+		_ = resp.Body.Close()
+	})
+}
+
+// TestGuardedClientRedirects verifies redirect hops dial through the same
+// guard: with loopback allowlisted a 302 chain works end-to-end, and the hop
+// count is capped.
+func TestGuardedClientRedirects(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("target"))
+	}))
+	defer target.Close()
+
+	hop := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer hop.Close()
+
+	t.Run("allowlisted redirect chain succeeds", func(t *testing.T) {
+		client := newGuardedHTTPClient(parseRemoteHostAllowlist([]string{"127.0.0.1"}), 5*time.Second)
+		resp, err := client.Get(hop.URL)
+		if err != nil {
+			t.Fatalf("expected allowlisted redirect to succeed, got: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "target" {
+			t.Errorf("expected to land on target, got body %q", body)
+		}
+	})
+
+	t.Run("blocked redirect target is refused at dial", func(t *testing.T) {
+		// Allowlist ONLY the first hop's exact host:port would not be expressible
+		// (allowlist is host-level), so instead prove the guard fires on the hop:
+		// with an empty allowlist even the first loopback hop is refused.
+		client := newGuardedHTTPClient(parseRemoteHostAllowlist(nil), 5*time.Second)
+		resp, err := client.Get(hop.URL)
+		if err == nil {
+			_ = resp.Body.Close()
+			t.Fatal("expected the SSRF guard to block the redirecting server")
+		}
+	})
+
+	t.Run("redirect hops are capped", func(t *testing.T) {
+		var loop *httptest.Server
+		loop = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, loop.URL, http.StatusFound)
+		}))
+		defer loop.Close()
+
+		client := newGuardedHTTPClient(parseRemoteHostAllowlist([]string{"127.0.0.1"}), 5*time.Second)
+		resp, err := client.Get(loop.URL)
+		if err == nil {
+			_ = resp.Body.Close()
+			t.Fatal("expected the redirect loop to be capped")
+		}
+		if !strings.Contains(err.Error(), "redirect") {
+			t.Errorf("expected a redirect-cap error, got: %v", err)
+		}
+	})
+}
+
+// TestGuardedClientHostnameAllowlist proves a hostname entry re-permits a name
+// that resolves to a blocked IP. "localhost" resolves to loopback, so with
+// "localhost" allowlisted the request must succeed even though every resolved
+// IP is blocked.
+func TestGuardedClientHostnameAllowlist(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	// Rewrite 127.0.0.1 -> localhost so the dialer takes the DNS path.
+	url := strings.Replace(srv.URL, "127.0.0.1", "localhost", 1)
+
+	t.Run("hostname not allowlisted is refused", func(t *testing.T) {
+		client := newGuardedHTTPClient(parseRemoteHostAllowlist(nil), 5*time.Second)
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			t.Fatal("expected the SSRF guard to block localhost")
+		}
+	})
+
+	t.Run("hostname allowlisted is permitted", func(t *testing.T) {
+		client := newGuardedHTTPClient(parseRemoteHostAllowlist([]string{"LocalHost"}), 5*time.Second)
+		resp, err := client.Get(url)
+		if err != nil {
+			t.Fatalf("expected hostname-allowlisted request to succeed, got: %v", err)
+		}
+		_ = resp.Body.Close()
+	})
+}
+
+// TestDownloadModelUsesGuardedClient proves the controller-side download sink
+// goes through the SSRF-guarded metadata client (GHSA-jw3m-8q7m-f35r): with no
+// allowlist configured, a source resolving to loopback must be refused before
+// any bytes are fetched, surfacing on the normal download-error path.
+func TestDownloadModelUsesGuardedClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not a real model"))
+	}))
+	defer srv.Close()
+
+	r := &ModelReconciler{} // empty AllowedRemoteHosts: secure default
+	dest := filepath.Join(t.TempDir(), "model.gguf")
+	_, err := r.downloadModel(context.Background(), srv.URL, dest)
+	if err == nil {
+		t.Fatal("expected the SSRF guard to refuse a loopback download source")
+	}
+	if !strings.Contains(err.Error(), "SSRF guard") {
+		t.Errorf("expected an SSRF-guard error, got: %v", err)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Errorf("expected no file written for a blocked download, stat err: %v", statErr)
+	}
+}

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strings"
 )
 
@@ -100,6 +101,59 @@ func getLocalPath(source string) string {
 		return strings.TrimPrefix(source, "file://")
 	}
 	return source
+}
+
+// validateLocalSourceAllowed enforces the host-path allowlist for local model
+// sources. Non-local sources (https, pvc, hf) are validated elsewhere and pass
+// through as nil here. A local source (absolute path or file:// URI) is allowed
+// only when its cleaned absolute path lies within one of allowedRoots. An empty
+// allowedRoots disables local/hostPath sources entirely, which is the secure
+// default (see GHSA-jw3m-8q7m-f35r).
+//
+// The check is lexical (filepath.Clean), so ".." escapes are rejected; it does
+// NOT resolve symlinks, so an operator who allowlists a root is trusting the
+// contents of that root not to symlink elsewhere. Roots that are empty or not
+// absolute are ignored.
+func validateLocalSourceAllowed(source string, allowedRoots []string) error {
+	if !isLocalSource(source) {
+		return nil
+	}
+	p := getLocalPath(source)
+	if !filepath.IsAbs(p) {
+		return fmt.Errorf("local model source must be an absolute path: %q", source)
+	}
+	clean := filepath.Clean(p)
+	allowed := false
+	for _, root := range allowedRoots {
+		if root == "" || !filepath.IsAbs(root) {
+			continue
+		}
+		r := filepath.Clean(root)
+		if clean == r || strings.HasPrefix(clean, r+string(filepath.Separator)) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		if hasNoUsableRoot(allowedRoots) {
+			return fmt.Errorf("local/hostPath model sources are disabled: no allowed roots configured "+
+				"(set modelSource.allowedHostPathRoots); refusing source %q (GHSA-jw3m-8q7m-f35r)", source)
+		}
+		return fmt.Errorf("local model source %q is not within any allowed root %v (GHSA-jw3m-8q7m-f35r)", source, allowedRoots)
+	}
+	return nil
+}
+
+// hasNoUsableRoot reports whether allowedRoots contains no usable (non-empty,
+// absolute) entry, so the error message can distinguish "feature disabled" from
+// "path outside configured roots".
+func hasNoUsableRoot(allowedRoots []string) bool {
+	for _, root := range allowedRoots {
+		if root != "" && filepath.IsAbs(root) {
+			return false
+		}
+	}
+	return true
 }
 
 // isRemoteHTTPSource reports whether source is an http:// or https:// URL.

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -90,15 +90,29 @@ func parsePVCSource(source string) (claimName, path string, err error) {
 	return claimName, path, nil
 }
 
-// isLocalSource returns true if the source is a local file (file:// URL or absolute path).
-func isLocalSource(source string) bool {
-	return strings.HasPrefix(source, "file://") || strings.HasPrefix(source, "/")
+// hasSchemeFold reports whether source starts with the given scheme prefix
+// (e.g. "http://"), matching case-insensitively. URL schemes are
+// case-insensitive per RFC 3986 §3.1 and url.Parse lowercases them, so the
+// source classifiers must agree with the URL parser: a case-sensitive match
+// would let a case-variant scheme ("HTTP://...") dodge its classifier and
+// fall through to a differently-guarded code path (GHSA-jw3m-8q7m-f35r).
+func hasSchemeFold(source, prefix string) bool {
+	return len(source) >= len(prefix) && strings.EqualFold(source[:len(prefix)], prefix)
 }
 
-// getLocalPath extracts the filesystem path from a local source.
+// isLocalSource returns true if the source is a local file (file:// URL or
+// absolute path). The file:// scheme matches case-insensitively so a
+// case-variant local source cannot bypass the hostPath allowlist check in
+// validateLocalSourceAllowed by dodging classification.
+func isLocalSource(source string) bool {
+	return hasSchemeFold(source, "file://") || strings.HasPrefix(source, "/")
+}
+
+// getLocalPath extracts the filesystem path from a local source. The scheme
+// strip is case-insensitive to stay in agreement with isLocalSource.
 func getLocalPath(source string) string {
-	if strings.HasPrefix(source, "file://") {
-		return strings.TrimPrefix(source, "file://")
+	if hasSchemeFold(source, "file://") {
+		return source[len("file://"):]
 	}
 	return source
 }
@@ -162,8 +176,13 @@ func hasNoUsableRoot(allowedRoots []string) bool {
 // the controller's pod writes to the operator-namespace PVC, which is not
 // visible to Pods in user namespaces (PVCs cannot be cross-namespace mounted),
 // so the controller defers the actual fetch to the workload.
+//
+// The scheme matches case-insensitively ("HTTP://..." is remote): url.Parse
+// lowercases schemes, so http.Client would happily fetch a case-variant URL
+// that a case-sensitive classifier had failed to route to the guarded
+// remote-source path (GHSA-jw3m-8q7m-f35r).
 func isRemoteHTTPSource(source string) bool {
-	return strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://")
+	return hasSchemeFold(source, "https://") || hasSchemeFold(source, "http://")
 }
 
 // normalizeHFSource strips the hf:// scheme prefix if present, returning the

--- a/internal/controller/source_test.go
+++ b/internal/controller/source_test.go
@@ -113,6 +113,13 @@ var _ = Describe("isLocalSource (source.go)", func() {
 	It("should return false for empty string", func() {
 		Expect(isLocalSource("")).To(BeFalse())
 	})
+	// URL schemes are case-insensitive (RFC 3986); a case-variant file://
+	// must still classify as local so it cannot dodge the hostPath
+	// allowlist check (GHSA-jw3m-8q7m-f35r).
+	It("should return true for case-variant FILE:// prefix", func() {
+		Expect(isLocalSource("FILE:///mnt/models/test.gguf")).To(BeTrue())
+		Expect(isLocalSource("File:///mnt/models/test.gguf")).To(BeTrue())
+	})
 })
 
 var _ = Describe("getLocalPath (source.go)", func() {
@@ -121,6 +128,9 @@ var _ = Describe("getLocalPath (source.go)", func() {
 	})
 	It("should return absolute path as-is", func() {
 		Expect(getLocalPath("/mnt/models/test.gguf")).To(Equal("/mnt/models/test.gguf"))
+	})
+	It("should strip a case-variant FILE:// prefix, agreeing with isLocalSource", func() {
+		Expect(getLocalPath("FILE:///mnt/models/test.gguf")).To(Equal("/mnt/models/test.gguf"))
 	})
 })
 
@@ -232,6 +242,16 @@ var _ = Describe("isRemoteHTTPSource (source.go)", func() {
 	})
 	It("should return false for ftp:// URL (out of scope for the workload init container)", func() {
 		Expect(isRemoteHTTPSource("ftp://example.com/model.gguf")).To(BeFalse())
+	})
+	// URL schemes are case-insensitive (RFC 3986) and url.Parse lowercases
+	// them, so http.Client happily fetches "HTTP://..." URLs. The classifier
+	// must agree or a case-variant scheme dodges the guarded remote-source
+	// routing (GHSA-jw3m-8q7m-f35r).
+	It("should return true for case-variant HTTP:// scheme", func() {
+		Expect(isRemoteHTTPSource("HTTP://x")).To(BeTrue())
+	})
+	It("should return true for case-variant HtTpS:// scheme", func() {
+		Expect(isRemoteHTTPSource("HtTpS://x")).To(BeTrue())
 	})
 	It("source-type matchers must be mutually exclusive", func() {
 		// Architectural invariant: every reachable source falls into exactly

--- a/internal/controller/sourcevalidation_reconcile_test.go
+++ b/internal/controller/sourcevalidation_reconcile_test.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// GHSA-jw3m-8q7m-f35r: both sinks for an unvalidated local model source must
+// be closed. Sink 1 is os.Open in the Model controller's copyLocalModel; sink
+// 2 is the HostPathVolumeSource in the InferenceService's generated pod. The
+// specs below prove a source that fails validateLocalSourceAllowed reaches
+// neither.
+var _ = Describe("Model controller host-path allowlist (GHSA-jw3m-8q7m-f35r)", func() {
+	It("rejects a local source when no roots are configured and never opens the file", func() {
+		// A real, readable file: the guard must reject it WITHOUT touching it,
+		// proving rejection is policy-based, not fetch-failure-based.
+		srcDir, err := os.MkdirTemp("", "llmkube-ghsa-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "secret.gguf")
+		Expect(os.WriteFile(srcFile, []byte("sensitive-bytes"), 0644)).To(Succeed())
+
+		tempDir, err := os.MkdirTemp("", "llmkube-ghsa-cache-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "model-hostpath-denied"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: fmt.Sprintf("file://%s", srcFile),
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:      k8sClient,
+			Scheme:      k8sClient.Scheme(),
+			StoragePath: tempDir,
+			// Secure default: no roots.
+		}
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred(), "allowlist rejection is unrecoverable; must not feed the rate-limited workqueue")
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseFailed))
+
+		var degraded *metav1.Condition
+		for i, cond := range updated.Status.Conditions {
+			if cond.Type == ConditionDegraded {
+				degraded = &updated.Status.Conditions[i]
+			}
+		}
+		Expect(degraded).NotTo(BeNil())
+		Expect(degraded.Reason).To(Equal("SourceNotAllowed"))
+		Expect(degraded.Message).To(ContainSubstring("GHSA-jw3m-8q7m-f35r"))
+
+		// Sink 1 closed: the controller never copied (never os.Open'ed) the
+		// file — its cache directory stays empty.
+		entries, err := os.ReadDir(tempDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(BeEmpty(), "a rejected local source must never reach copyLocalModel/os.Open")
+	})
+
+	It("rejects a local source outside the configured roots", func() {
+		tempDir, err := os.MkdirTemp("", "llmkube-ghsa-cache-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "model-hostpath-outside-roots"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "/etc/passwd",
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: []string{"/srv/models"},
+		}
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseFailed))
+
+		entries, err := os.ReadDir(tempDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(BeEmpty())
+	})
+
+	It("gates the metal local-path branch too (no Ready for a disallowed source)", func() {
+		modelName := "model-hostpath-metal-denied"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "/Users/someone/models/m.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseFailed), "the metal local branch must not mark a disallowed source Ready")
+	})
+
+	It("copies a local source that lies within an allowed root", func() {
+		srcDir, err := os.MkdirTemp("", "llmkube-ghsa-allowed-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(srcDir) }()
+		srcFile := filepath.Join(srcDir, "allowed.gguf")
+		Expect(os.WriteFile(srcFile, []byte("model-bytes"), 0644)).To(Succeed())
+
+		tempDir, err := os.MkdirTemp("", "llmkube-ghsa-cache-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		modelName := "model-hostpath-allowed"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: fmt.Sprintf("file://%s", srcFile),
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		reconciler := &ModelReconciler{
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: []string{srcDir},
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseReady))
+		Expect(updated.Status.Path).NotTo(BeEmpty())
+		_, err = os.Stat(updated.Status.Path)
+		Expect(err).NotTo(HaveOccurred(), "the allowed source must actually be copied into the cache")
+	})
+})
+
+var _ = Describe("InferenceService controller host-path allowlist (GHSA-jw3m-8q7m-f35r)", func() {
+	It("blocks the InferenceService and creates no Deployment for a disallowed local source", func() {
+		modelName := "model-isvc-hostpath-denied"
+		isvcName := "isvc-hostpath-denied"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "/var/run/secrets/kubernetes.io/serviceaccount/token",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		// Simulate a Model that reached Ready before the allowlist existed
+		// (sticky status): the InferenceService-side gate must still block.
+		model.Status.Phase = PhaseReady
+		model.Status.Path = "/models/somewhere/model.gguf"
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(1)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			// Secure default: no roots.
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseFailed))
+
+		var degraded *metav1.Condition
+		for i, cond := range updated.Status.Conditions {
+			if cond.Type == ConditionDegraded {
+				degraded = &updated.Status.Conditions[i]
+			}
+		}
+		Expect(degraded).NotTo(BeNil())
+		Expect(degraded.Message).To(ContainSubstring("GHSA-jw3m-8q7m-f35r"))
+
+		// Sink 2 closed: no Deployment exists, so no pod spec (and no
+		// HostPathVolumeSource) was ever generated.
+		dep := &appsv1.Deployment{}
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "no Deployment may be created for a disallowed local source")
+	})
+
+	It("creates the Deployment without any hostPath volume when the local source is allowed", func() {
+		modelName := "model-isvc-hostpath-allowed"
+		isvcName := "isvc-hostpath-allowed"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "/srv/models/m.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		model.Status.Phase = PhaseReady
+		model.Status.Path = "/models/somewhere/m.gguf"
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(1)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "ghcr.io/ggml-org/llama.cpp:server",
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+		}()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			InitContainerImage:   "docker.io/curlimages/curl:8.18.0",
+			AllowedHostPathRoots: []string{"/srv/models"},
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+		// Without the cache (no ModelCachePath on the reconciler) the local
+		// source lands on the emptyDir path, which never mounts a hostPath;
+		// the allowlist gate must not have replaced the normal init container
+		// with the fail-loud SourceNotAllowed one.
+		for _, v := range dep.Spec.Template.Spec.Volumes {
+			Expect(v.HostPath).To(BeNil())
+		}
+		Expect(dep.Spec.Template.Spec.InitContainers).NotTo(BeEmpty())
+		Expect(dep.Spec.Template.Spec.InitContainers[0].Command[2]).NotTo(ContainSubstring("SourceNotAllowed"))
+	})
+})

--- a/internal/controller/sourcevalidation_test.go
+++ b/internal/controller/sourcevalidation_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// testLocalRoots is the host-path allowlist handed to envtest reconcilers
+// whose fixtures use local (file://) sources. It spans os.TempDir() (where
+// the MkdirTemp fixtures live) and the fixed fake paths used by the
+// unrecoverable-fetch tests, so pre-allowlist test behavior is preserved
+// while production defaults stay locked down (GHSA-jw3m-8q7m-f35r).
+var testLocalRoots = []string{os.TempDir(), "/nonexistent", "/still", "/models"}
+
+// TestValidateLocalSourceAllowed locks down the host-path allowlist for local
+// model sources (GHSA-jw3m-8q7m-f35r). A local source (absolute path or
+// file:// URI) must be rejected unless it lies within an operator-configured
+// allowed root; the allowlist is empty by default, so local/hostPath sources
+// are disabled until the operator opts in.
+func TestValidateLocalSourceAllowed(t *testing.T) {
+	tests := []struct {
+		name        string
+		source      string
+		roots       []string
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name:   "non-local https passes through with no roots",
+			source: "https://x/m.gguf",
+			roots:  nil,
+		},
+		{
+			name:   "non-local pvc passes through with no roots",
+			source: "pvc://c/m.gguf",
+			roots:  nil,
+		},
+		{
+			name:   "non-local hf passes through with no roots",
+			source: "hf://org/repo",
+			roots:  nil,
+		},
+		{
+			name:   "non-local https passes through even with roots set",
+			source: "https://x/m.gguf",
+			roots:  []string{"/srv/models"},
+		},
+		{
+			name:        "empty roots reject absolute path",
+			source:      "/etc/passwd",
+			roots:       nil,
+			wantErr:     true,
+			wantErrText: "disabled",
+		},
+		{
+			name:        "empty roots reject file:// URI",
+			source:      "file:///etc/passwd",
+			roots:       nil,
+			wantErr:     true,
+			wantErrText: "GHSA-jw3m-8q7m-f35r",
+		},
+		{
+			name:   "path under allowed root is allowed",
+			source: "/srv/models/m.gguf",
+			roots:  []string{"/srv/models"},
+		},
+		{
+			name:   "exact allowed root is allowed",
+			source: "/srv/models",
+			roots:  []string{"/srv/models"},
+		},
+		{
+			name:   "file:// URI under allowed root is allowed",
+			source: "file:///srv/models/m.gguf",
+			roots:  []string{"/srv/models"},
+		},
+		{
+			name:        "path outside allowed root is rejected",
+			source:      "/etc/passwd",
+			roots:       []string{"/srv/models"},
+			wantErr:     true,
+			wantErrText: "not within any allowed root",
+		},
+		{
+			name:        "dot-dot escape out of allowed root is rejected",
+			source:      "/srv/models/../../etc/passwd",
+			roots:       []string{"/srv/models"},
+			wantErr:     true,
+			wantErrText: "GHSA-jw3m-8q7m-f35r",
+		},
+		{
+			name:        "sibling directory sharing the root as a string prefix is rejected",
+			source:      "/models-evil/m.gguf",
+			roots:       []string{"/models"},
+			wantErr:     true,
+			wantErrText: "not within any allowed root",
+		},
+		{
+			name:   "trailing slash on the root is cleaned before matching",
+			source: "/srv/models/m.gguf",
+			roots:  []string{"/srv/models/"},
+		},
+		{
+			name:        "unusable roots (blank, relative) are treated as empty",
+			source:      "/srv/models/m.gguf",
+			roots:       []string{"  ", "relative/path"},
+			wantErr:     true,
+			wantErrText: "disabled",
+		},
+		{
+			name:   "prefix mechanism: SA token path allowed only when under an allowlisted root",
+			source: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+			roots:  []string{"/var/run/secrets/kubernetes.io/serviceaccount"},
+		},
+		{
+			name:        "SA token path rejected when only an unrelated root is allowed",
+			source:      "/var/run/secrets/kubernetes.io/serviceaccount/token",
+			roots:       []string{"/srv/models"},
+			wantErr:     true,
+			wantErrText: "not within any allowed root",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLocalSourceAllowed(tt.source, tt.roots)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("validateLocalSourceAllowed(%q, %v) = nil, want error", tt.source, tt.roots)
+				}
+				if tt.wantErrText != "" && !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("validateLocalSourceAllowed(%q, %v) error %q does not contain %q",
+						tt.source, tt.roots, err.Error(), tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateLocalSourceAllowed(%q, %v) = %v, want nil", tt.source, tt.roots, err)
+			}
+		})
+	}
+}

--- a/internal/controller/sourcevalidation_test.go
+++ b/internal/controller/sourcevalidation_test.go
@@ -29,6 +29,13 @@ import (
 // while production defaults stay locked down (GHSA-jw3m-8q7m-f35r).
 var testLocalRoots = []string{os.TempDir(), "/nonexistent", "/still", "/models"}
 
+// testRemoteHosts is the remote-host allowlist handed to envtest reconcilers
+// whose fixtures serve http sources from loopback httptest servers. The SSRF
+// guard (GHSA-jw3m-8q7m-f35r) blocks loopback by default, so tests that need
+// to reach their fixture server opt loopback back in, mirroring how an
+// operator would allowlist a trusted internal model host.
+var testRemoteHosts = []string{"127.0.0.1", "::1"}
+
 // TestValidateLocalSourceAllowed locks down the host-path allowlist for local
 // model sources (GHSA-jw3m-8q7m-f35r). A local source (absolute path or
 // file:// URI) must be rejected unless it lies within an operator-configured

--- a/pkg/gguf/remote.go
+++ b/pkg/gguf/remote.go
@@ -52,6 +52,14 @@ func ParseFromURL(ctx context.Context, url string) (*GGUFFile, error) {
 	return parseFromURL(ctx, http.DefaultClient, url)
 }
 
+// ParseFromURLWithClient is ParseFromURL with a caller-supplied *http.Client.
+// Callers that fetch attacker-influenced URLs (e.g. the LLMKube controller
+// reading Model.spec.source) use this to route every request — HEAD probe,
+// Range GETs, and the streaming fallback — through an SSRF-guarded client.
+func ParseFromURLWithClient(ctx context.Context, client *http.Client, url string) (*GGUFFile, error) {
+	return parseFromURL(ctx, client, url)
+}
+
 func parseFromURL(ctx context.Context, client *http.Client, url string) (*GGUFFile, error) {
 	size, rangeOK, err := probeURL(ctx, client, url)
 	if err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -634,14 +634,16 @@ spec:
 			Eventually(verifyServiceGone, 1*time.Minute).Should(Succeed())
 		})
 
-		It("should report Failed for Model with unreachable file:// source", func() {
+		It("should report Failed with SourceNotAllowed for a disallowed file:// source", func() {
 			// HTTP(S) sources are validated by the InferenceService Pod's init
 			// container, not by the Model controller (issue #363), so a 404
-			// HTTP source no longer surfaces a Failed Model phase. file://
-			// sources still flow through the controller's in-process path
-			// and surface broken sources as Model.status.phase=Failed with
-			// reason=CopyFailed, which is the controller-side failure
-			// surface we want to keep covered here.
+			// HTTP source no longer surfaces a Failed Model phase. As of the
+			// host-path allowlist (GHSA-jw3m-8q7m-f35r), a local/file:// source
+			// outside modelSource.allowedHostPathRoots (empty by default, and
+			// unset in this e2e deploy) is rejected before the copy runs,
+			// surfacing as Model.status.phase=Failed with
+			// reason=SourceNotAllowed. This is the controller-side failure
+			// surface we keep covered here.
 			By("applying a Model CR with a file:// path that does not exist on the controller pod")
 			cmd := exec.Command("kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
@@ -665,13 +667,13 @@ spec:
 			}
 			Eventually(verifyModelFailed, 2*time.Minute).Should(Succeed())
 
-			By("verifying Degraded condition with CopyFailed reason")
+			By("verifying Degraded condition with SourceNotAllowed reason")
 			cmd = exec.Command("kubectl", "get", "model", "test-model-bad-source",
 				"-n", crTestNs, "-o",
 				`jsonpath={.status.conditions[?(@.type=="Degraded")].reason}`)
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(Equal("CopyFailed"))
+			Expect(output).To(Equal("SourceNotAllowed"))
 		})
 	})
 


### PR DESCRIPTION
## What

Ship the 0.9.0 security fixes for `Model.spec.source`:

1. **Arbitrary file read (GHSA-jw3m-8q7m-f35r, CWE-22, CVSS 7.7):** gate local
   (absolute-path and `file://`) and hostPath model sources behind an
   operator-configured allowlist, empty by default.
2. **Controller-side SSRF:** block the controller's metadata/revalidation
   requests to remote (`http(s)://`) sources from reaching private, link-local,
   loopback, CGNAT, ULA, and NAT64 networks, with an opt-in remote-host allowlist.

Both are secure-by-default.

## Why

`Model.spec.source` accepted arbitrary absolute paths and `file://` URIs and fed
them unsanitized into `os.Open` in the controller pod (`copyLocalModel`) and into a
`HostPathVolumeSource` mounted in the inference pod, letting a namespace user with
`Model`/`InferenceService` write access read the controller's service-account token
or arbitrary files on the scheduling node. Model caching, which arms the hostPath
sink, is enabled by default.

Separately, the controller made metadata and revalidation HTTP requests to remote
sources with no network restriction, so a namespace user could point a source at
cloud metadata (169.254.169.254), loopback, or internal cluster/private-network
services and have the controller connect from its in-cluster network position.

Fixes GHSA-jw3m-8q7m-f35r. Reported by EQSTLab.

## How

- **Shared validator** `validateLocalSourceAllowed` (`internal/controller/source.go`):
  non-local sources pass through; a local source must clean (via `filepath.Clean`, so
  `..` is rejected) to within a configured absolute root; empty allowlist rejects all.
  Enforced before `os.Open` in `ModelReconciler`, and before the `HostPathVolumeSource`
  is built in the InferenceService path (double-gated).
- **Guarded HTTP client** (`internal/controller/safehttp.go`) used by all controller-side
  source fetches: refuses to connect to loopback, link-local (incl. 169.254.169.254),
  RFC-1918, CGNAT (100.64.0.0/10), ULA, and NAT64 ranges on the resolved, pinned IP
  (DNS-rebind safe) with redirect re-validation, unless the host/IP is allowlisted.
- **Config:** `--allowed-host-path-roots` and `--allowed-remote-hosts` flags; Helm
  `modelSource.allowedHostPathRoots` and `modelSource.allowedRemoteHosts` (both `[]`).
- **Docs:** migration guidance in MODEL-CACHE, the air-gapped guides, the source spec,
  and the file-source runbook.
- No CRD schema change; enforcement is at runtime.

**BREAKING CHANGE:** local and `file://` model sources now require
`modelSource.allowedHostPathRoots`; remote sources resolving to private/internal IPs
require `modelSource.allowedRemoteHosts`. Public remote sources are unaffected. See the
release notes for migration. Operators should also delete any existing InferenceService
whose source now falls outside the allowlist (a pre-upgrade pod keeps its mount until
recreated).

Validation: `make test` (envtest controller suite), `make lint` and
`GOOS=linux golangci-lint` both clean, `helm template` renders both flags only when set.
New tests assert the sinks are not reached (empty cache dir; no Deployment; no hostPath
volume; guarded client refuses loopback and private ranges).

AI assistance: implementation and adversarial security review were AI-assisted; all code
and tests were reviewed and verified by the maintainer, per CONTRIBUTING.md.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (migration docs for both breaking changes)
