### PR TITLE
fix(foreman): key test-presence gate on net-new functions only

### DIFF
--- a/pkg/foreman/agent/mutation_gate.go
+++ b/pkg/foreman/agent/mutation_gate.go
@@ -18,11 +18,13 @@ limitations under the License.
 // changes which pass the syntactic checks (gofmt/vet/build/lint) but are not
 // actually constrained by a test (the #856 class).
 //
-//   - Layer 1 (checkTestPresence): for each changed package, every new or
-//     body-modified function in hand-written, non-test Go must be referenced
-//     by name in a changed _test.go in that package; unreferenced functions
-//     fail. Pure diff/text inspection, so it covers envtest/controller
-//     packages too.
+//   - Layer 1 (checkTestPresence): for each changed package, every NET-NEW
+//     function in hand-written, non-test Go must be referenced by name in a
+//     changed _test.go in that package; unreferenced new functions fail.
+//     Body-modified functions are exempt (behavior-preserving edits do not
+//     require a new test); they are covered by Layer 2 where package tests
+//     exist and by CI's full suite everywhere. Pure diff/text inspection, so
+//     it covers envtest/controller packages too.
 //   - Layer 2 (checkMutationSurvival): for non-envtest changed packages that DO
 //     have a changed test, blank the changed function bodies on an in-memory
 //     backup, re-run the package tests, and flag any package whose tests still
@@ -276,27 +278,31 @@ func dedupSorted(in []string) []string {
 	return out
 }
 
-// checkTestPresence fails when a changed package has new or body-modified
-// functions in hand-written, non-test Go that are not referenced by name in
-// any changed _test.go in that package. Pure inspection -- no test execution
-// -- so it covers envtest/controller packages the fast unit-test tier cannot
-// run. Returns (failed, feedback).
+// checkTestPresence fails when a changed package has NET-NEW functions in
+// hand-written, non-test Go that are not referenced by name in any changed
+// _test.go in that package. Body-modified functions are exempt: Layer 2
+// (mutation survival) covers them where the package has a changed test, and
+// CI's full suite covers them everywhere. Pure inspection -- no test
+// execution -- so it covers envtest/controller packages the fast unit-test
+// tier cannot run. Returns (failed, feedback).
 func checkTestPresence(ctx context.Context, workspace string, run commandRunner) (bool, string) {
 	changed := changedNonTestGoFiles(ctx, workspace, run)
 	if len(changed) == 0 {
 		return false, ""
 	}
 
-	// changedFuncs maps pkgDir -> deduplicated set of function names that are
-	// either net-new (+func line) or body-modified (hunk inside an existing
-	// func, captured via the hunk-header trailing context).
+	// changedFuncs maps pkgDir -> deduplicated set of NET-NEW function names
+	// (+func lines in the diff). Body-modified functions are deliberately
+	// excluded: demanding a named test for every touched call site made
+	// refactors un-landable for mid-size coders (the #921 run burned all
+	// three gate attempts on it, partly inside envtest packages whose tests
+	// the coder workspace cannot run). Modified functions stay covered by
+	// Layer 2 (mutation survival) where the package has a changed test, and
+	// by the full suite in CI.
 	changedFuncs := map[string]map[string]bool{}
 	for _, f := range changed {
 		dir := filepath.Dir(f)
-		added := addedFuncNames(ctx, workspace, f, run)
-		modified := modifiedFuncNames(ctx, workspace, f, run)
-		all := append(added, modified...) //nolint:gocritic // intentional extend
-		for _, name := range all {
+		for _, name := range addedFuncNames(ctx, workspace, f, run) {
 			if name == "" {
 				continue
 			}

--- a/pkg/foreman/agent/mutation_gate_test.go
+++ b/pkg/foreman/agent/mutation_gate_test.go
@@ -200,10 +200,15 @@ func TestCheckTestPresence_ReferencingTestPasses(t *testing.T) { //nolint:dupl
 	}
 }
 
-// TestCheckTestPresence_ModifiedFuncNeedsTest verifies that a body-modified
-// function (no net-new +func line) is flagged when no changed test references
-// it by name.
-func TestCheckTestPresence_ModifiedFuncNeedsTest(t *testing.T) {
+// TestCheckTestPresence_ModifiedFuncDoesNotNeedTest verifies that a
+// body-modified function (no net-new +func line) does NOT demand a named
+// test. Behavior-preserving edits to existing functions are covered by
+// Layer 2 (mutation survival) where package tests exist, and by CI's full
+// suite everywhere; demanding a fresh named test for every touched call
+// site made refactors un-landable for mid-size coders (the #921 run burned
+// all three gate attempts on envtest-package tests the coder workspace
+// cannot even run).
+func TestCheckTestPresence_ModifiedFuncDoesNotNeedTest(t *testing.T) {
 	ws := t.TempDir()
 	_ = os.MkdirAll(filepath.Join(ws, "pkg/diff"), 0o755)
 	_ = os.WriteFile(filepath.Join(ws, "pkg/diff/diff.go"),
@@ -211,27 +216,27 @@ func TestCheckTestPresence_ModifiedFuncNeedsTest(t *testing.T) {
 	// No changed _test.go at all.
 
 	statusOut := " M pkg/diff/diff.go\x00"
-	// git diff HEAD -- diff.go: body changed but no +func line
+	// git diff -- diff.go: body changed but no +func line
 	diffOut := "diff --git a/pkg/diff/diff.go b/pkg/diff/diff.go\n" +
 		"@@ -1,2 +1,2 @@ func DiffNameOnly() string {\n-\treturn \"old\"\n+\treturn \"new\"\n"
-	// git diff -U0 HEAD -- diff.go: hunk header carries the enclosing func name
+	// git diff -U0 -- diff.go: hunk header carries the enclosing func name
 	diffU0Out := "@@ -1,1 +1,1 @@ func DiffNameOnly() string {\n-\treturn \"old\"\n+\treturn \"new\"\n"
 
 	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
 		switch {
 		case name == "git" && args[0] == "status":
 			return statusOut, nil
-		case name == "git" && args[0] == "diff" && len(args) > 2 && args[1] == "-U0" && args[2] == "HEAD":
+		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "-U0":
 			return diffU0Out, nil
-		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "HEAD":
+		case name == "git" && args[0] == "diff":
 			return diffOut, nil
 		}
 		return "", nil
 	}
 
 	failed, out := checkTestPresence(context.Background(), ws, runner)
-	if !failed || !strings.Contains(out, "DiffNameOnly") {
-		t.Fatalf("want failure naming DiffNameOnly, got failed=%v out=%q", failed, out)
+	if failed {
+		t.Fatalf("body-modified func must not demand a test; got failure:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## What

The coder gate's test-presence check (mutation gate Layer 1) now demands a named test only for net-new functions (+func lines in the diff). Body-modified functions no longer trigger the demand.

## Why

The check's own doc comment states the intent: key on net-new functions "so behavior-preserving edits to existing funcs do not require a new test." The implementation additionally unioned in every function whose body a hunk touched. On refactor-class issues this demands one named test per touched call site, including in envtest-backed packages whose tests the coder workspace cannot run. Live evidence: the #921 coder run burned all 3 gate attempts (112 turns) on exactly this, with the gate demanding tests for 8 call-site functions across internal/controller/ and pkg/cli/.

Coverage for body-modified functions is unchanged where it is enforceable: Layer 2 (mutation survival) still neuters any function intersecting changed lines when the package has a changed test, and CI runs the full suite on every PR.

## How

- checkTestPresence builds its demand set from addedFuncNames only; modifiedFuncNames is no longer unioned in.
- modifiedFuncNames itself stays (the caller-impact gate consumes it).
- Package and function doc comments updated to match.
- TestCheckTestPresence_ModifiedFuncNeedsTest rewritten as TestCheckTestPresence_ModifiedFuncDoesNotNeedTest, pinning the corrected contract.

## Checklist

- [x] Tests added/updated
- [x] make lint clean (darwin + GOOS=linux)
- [x] go test ./pkg/foreman/agent/... passes
- [x] No API/CRD changes

## AI assistance disclosure

Assisted-by: Claude Code (Claude Opus 4.8). Generated the implementation, tests, and PR text from a design I approved; I reviewed the diff, ran the gate locally (go test ./pkg/foreman/agent/..., make lint on darwin and GOOS=linux), and validated the change live on the lab fleet before submitting.
