### PR TITLE
feat(foreman): append actionable steers to structural-lint gate feedback

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -503,6 +504,10 @@ func checkGoreleaserConfig(ctx context.Context, workspace string, run commandRun
 
 // buildFeedback renders the directive and a per-check section for every
 // failing check, truncating each check's output to maxCheckOutputBytes.
+// Structural-lint failures additionally get a one-line steer (see
+// lintAdvisories): the raw linter dump alone is not actionable for
+// mid-size coders, which re-submit the same shape until the attempt
+// budget is gone (#982 run: gocyclo 31 > 30, three identical attempts).
 func buildFeedback(failures []checkFailure) string {
 	var b strings.Builder
 	b.WriteString("The verification gate failed. Fix the issues below and resubmit.\n")
@@ -512,8 +517,51 @@ func buildFeedback(failures []checkFailure) string {
 		b.WriteString("\n")
 		b.WriteString(truncateOutput(f.output))
 		b.WriteString("\n")
+		for _, steer := range lintAdvisories(f.output) {
+			b.WriteString(steer)
+			b.WriteString("\n")
+		}
 	}
 	return b.String()
+}
+
+// maxLintAdvisories caps the steers appended per failing check so a
+// sprawling lint report cannot bloat the feedback prompt.
+const maxLintAdvisories = 3
+
+// gocycloFuncRe captures the backticked function name from a gocyclo
+// failure line, e.g.
+// "cyclomatic complexity 31 of func `(*T).runLLMPath` is high (> 30) (gocyclo)".
+var gocycloFuncRe = regexp.MustCompile("cyclomatic complexity \\d+ of func `([^`]+)`")
+
+// lintAdvisories maps structural-lint failure output to one-line steers a
+// coder model can follow mechanically. Deterministic string inspection, no
+// LLM involved; unknown failure classes yield no advisory. Every steer is
+// prefixed "Advice:" so tests and readers can tell steers from raw output.
+func lintAdvisories(output string) []string {
+	var steers []string
+	seen := map[string]bool{}
+	for _, m := range gocycloFuncRe.FindAllStringSubmatch(output, -1) {
+		fn := m[1]
+		if seen[fn] {
+			continue
+		}
+		seen[fn] = true
+		steers = append(steers, fmt.Sprintf(
+			"Advice: Do not add more branches to `%s`. Extract your new logic into a small "+
+				"named helper function and call it from `%s`.",
+			fn, fn))
+	}
+	if strings.Contains(output, "(dupl)") {
+		steers = append(steers, "Advice: Extract the duplicated block into one shared helper instead of copying it.")
+	}
+	if strings.Contains(output, "(funlen)") {
+		steers = append(steers, "Advice: The function is too long. Move your addition into a new helper function.")
+	}
+	if len(steers) > maxLintAdvisories {
+		steers = steers[:maxLintAdvisories]
+	}
+	return steers
 }
 
 // truncateOutput caps output at maxCheckOutputBytes, keeping the tail

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -1014,3 +1014,59 @@ func TestCheckReferenceGrounding_IgnoresExporterMetricTokens(t *testing.T) {
 			"got failed=true output=%q", output)
 	}
 }
+
+// TestBuildFeedback_GocycloAdvisory pins the steer appended when golangci-lint
+// reports gocyclo. The raw dump alone burned all three gate attempts on the
+// #982 run: the model re-submitted the same over-complex function each time.
+func TestBuildFeedback_GocycloAdvisory(t *testing.T) {
+	out := buildFeedback([]checkFailure{{
+		name: "golangci-lint run ./...",
+		output: "pkg/foreman/agent/executor_native.go:407:1: cyclomatic complexity 31 " +
+			"of func `(*NativeAgentLoopExecutor).runLLMPath` is high (> 30) (gocyclo)",
+	}})
+	want := "Do not add more branches to `(*NativeAgentLoopExecutor).runLLMPath`."
+	if !strings.Contains(out, want) {
+		t.Fatalf("feedback missing gocyclo steer %q; got:\n%s", want, out)
+	}
+	if !strings.Contains(out, "helper function") {
+		t.Fatalf("steer should tell the model to extract a helper; got:\n%s", out)
+	}
+}
+
+func TestBuildFeedback_NoAdvisoryForUnknownFailure(t *testing.T) {
+	out := buildFeedback([]checkFailure{{
+		name:   "test presence",
+		output: "Package pkg/x/ changed functions (Foo) have no test referencing them by name.",
+	}})
+	if strings.Contains(out, "Advice:") {
+		t.Fatalf("non-structural failure must get no advisory; got:\n%s", out)
+	}
+}
+
+func TestLintAdvisories_DuplAndFunlen(t *testing.T) {
+	steers := lintAdvisories("a.go:1: 20-40 lines are duplicate of `b.go:5-25` (dupl)\n" +
+		"c.go:9: Function 'bigOne' is too long (75 > 60) (funlen)\n")
+	if len(steers) != 2 {
+		t.Fatalf("want 2 steers (dupl + funlen), got %d: %v", len(steers), steers)
+	}
+	if !strings.Contains(steers[0], "duplicated block") || !strings.Contains(steers[1], "too long") {
+		t.Fatalf("unexpected steer content: %v", steers)
+	}
+}
+
+func TestLintAdvisories_DedupesAndCaps(t *testing.T) {
+	line := "x.go:1:1: cyclomatic complexity 31 of func `Alpha` is high (> 30) (gocyclo)\n"
+	// Same func twice -> one steer; four distinct funcs -> capped at 3.
+	steers := lintAdvisories(line + line)
+	if len(steers) != 1 {
+		t.Fatalf("duplicate gocyclo func must dedupe to 1 steer, got %d", len(steers))
+	}
+	many := "x.go:1:1: cyclomatic complexity 31 of func `A` is high (> 30) (gocyclo)\n" +
+		"x.go:2:1: cyclomatic complexity 31 of func `B` is high (> 30) (gocyclo)\n" +
+		"x.go:3:1: cyclomatic complexity 31 of func `C` is high (> 30) (gocyclo)\n" +
+		"x.go:4:1: cyclomatic complexity 31 of func `D` is high (> 30) (gocyclo)\n"
+	steers = lintAdvisories(many)
+	if len(steers) != maxLintAdvisories {
+		t.Fatalf("advisories must cap at %d, got %d", maxLintAdvisories, len(steers))
+	}
+}


### PR DESCRIPTION
## What

The coder gate's failure feedback gains deterministic one-line steers for structural lint classes: gocyclo (named function, "extract a helper"), dupl, and funlen. Unknown failure classes are untouched.

## Why

A raw linter dump is not actionable for mid-size coder models. Live evidence: on the #982 run the coder implemented a correct fix, then re-submitted the same over-complex function on all 3 gate attempts because the only feedback was "cyclomatic complexity 31 of func runLLMPath is high (> 30)". Telling the model the mechanical remedy (do not add branches; extract a named helper) is a steer this model class demonstrably follows.

## How

- New package-private lintAdvisories(output) []string: regex-captures gocyclo function names (deduped), substring-detects (dupl) and (funlen), caps at 3 steers per failing check, prefixes each with "Advice:".
- buildFeedback appends the steers under each failing check's section.
- Table-driven tests: gocyclo steer content and function naming, no advisory for non-structural failures, dupl+funlen coverage, dedupe and cap.

## Checklist

- [x] Tests added/updated
- [x] make lint clean (darwin + GOOS=linux)
- [x] go test ./pkg/foreman/agent/... passes
- [x] No API/CRD changes

## AI assistance disclosure

Assisted-by: Claude Code (Claude Opus 4.8). Generated the implementation, tests, and PR text from a design I approved; I reviewed the diff, ran the gate locally (go test ./pkg/foreman/agent/..., make lint on darwin and GOOS=linux), and validated the change live on the lab fleet before submitting.
