### PR TITLE
fix(cachekey): unify model cache-key derivation across controller and CLI

### DIFF
--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -42,6 +42,7 @@ import (
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
+	"github.com/defilantech/llmkube/pkg/cachekey"
 	"github.com/defilantech/llmkube/pkg/gguf"
 	"github.com/defilantech/llmkube/pkg/license"
 )
@@ -995,9 +996,13 @@ func formatBytes(bytes int64) string {
 	return fmt.Sprintf("%.1f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }
 
+// computeCacheKey is retained as a thin wrapper around cachekey.Compute for
+// call sites that pre-date the shared package; it exists so the controller
+// package compiles without touching the many `computeCacheKey(source)` sites
+// that only need an unconditional fingerprint. New code should import
+// github.com/defilantech/llmkube/pkg/cachekey directly.
 func computeCacheKey(source string) string {
-	hash := sha256.Sum256([]byte(source))
-	return hex.EncodeToString(hash[:])[:16]
+	return cachekey.Compute(source)
 }
 
 func (r *ModelReconciler) parseGGUFMetadata(path string) (*inferencev1alpha1.GGUFMetadata, error) {

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -30,6 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/cachekey"
 )
 
 // Model storage wiring. The controller has three paths for making a model
@@ -232,31 +233,13 @@ func hasMultiFileStaging(model *inferencev1alpha1.Model) bool {
 	return model != nil && (len(model.Spec.Files) > 0 || model.Spec.Mmproj != "")
 }
 
-// effectiveModelCacheKey returns the key used to namespace a model's files
-// inside the cache PVC, and serves as the single source of truth for whether
-// the in-cluster serving pod should use the cache (non-empty) or an emptyDir
-// (empty). Both the PVC-ensure gate (InferenceService reconcile) and the
-// storage builder MUST consult this so they never disagree about caching.
-//
-// For sources the controller fingerprints (http/https) this is the
-// controller-set Status.CacheKey. The runtime-resolved path (hf:// repo IDs)
-// deliberately leaves Status.CacheKey empty and keeps the Available condition
-// reason "RuntimeResolved", but an hf:// model with multi-file staging still
-// needs the cache PVC: otherwise every file re-downloads into an emptyDir on
-// each pod restart (#909). Derive a stable key from the source in that case.
-// Metal models have no init container and no cache PVC (the host metal-agent
-// loads the files directly), so they never cache here.
+// effectiveModelCacheKey returns the key used to namespace a model's
+// files inside the cache PVC, and is the single source of truth for
+// whether the in-cluster serving pod should use the cache (non-empty)
+// or an emptyDir (empty). It delegates to cachekey.EffectiveKey so the
+// controller and the CLI can never disagree about caching.
 func effectiveModelCacheKey(model *inferencev1alpha1.Model) string {
-	if model == nil {
-		return ""
-	}
-	if model.Status.CacheKey != "" {
-		return model.Status.CacheKey
-	}
-	if hasMultiFileStaging(model) && !isMetalModel(model) {
-		return computeCacheKey(model.Spec.Source)
-	}
-	return ""
+	return cachekey.EffectiveKey(model)
 }
 
 // modelStagingPlan resolves the model's declared files into a staging plan.

--- a/pkg/cachekey/cachekey.go
+++ b/pkg/cachekey/cachekey.go
@@ -19,9 +19,11 @@ limitations under the License.
 // package so `serve`, `cache list`, and `delete --purge-cache` can never
 // disagree about which directory on the cache PVC owns a given model.
 //
-// The controller's effectiveModelCacheKey() additionally scopes the fallback
-// to non-metal multi-file models; that scoping lives in the controller package
-// and delegates to Compute() for the unconditional SHA256 fingerprint.
+// The scoped decision (Status.CacheKey wins; otherwise only a non-metal
+// multi-file model derives a key from its source) lives in EffectiveKey here,
+// so the controller's effectiveModelCacheKey() and the CLI's cache list /
+// delete --purge-cache paths all resolve a model's key the same way. Compute()
+// is the unconditional SHA256 fingerprint the derivation is built on.
 package cachekey
 
 import (

--- a/pkg/cachekey/cachekey.go
+++ b/pkg/cachekey/cachekey.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cachekey provides the single source of truth for deriving a model's
+// cache key from its spec.source. Both the controller and the CLI consult this
+// package so `serve`, `cache list`, and `delete --purge-cache` can never
+// disagree about which directory on the cache PVC owns a given model.
+//
+// The controller's effectiveModelCacheKey() additionally scopes the fallback
+// to non-metal multi-file models; that scoping lives in the controller package
+// and delegates to Compute() for the unconditional SHA256 fingerprint.
+package cachekey
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Compute returns a stable, short fingerprint of source. It is the single
+// function the controller and CLI agree on when they need to derive a cache
+// key from a model source URL (or local path) without consulting status.
+//
+// The output is the first 16 hex characters of SHA-256(source), matching the
+// historical convention used by both the controller and the CLI before this
+// package existed. Keeping the prefix short keeps PVC directory names
+// manageable while the full 64-char digest is still recoverable by callers
+// that need it.
+func Compute(source string) string {
+	hash := sha256.Sum256([]byte(source))
+	return hex.EncodeToString(hash[:])[:16]
+}
+
+// EffectiveKey is the single source of truth for the cache key a model
+// resolves to, shared by the controller and the CLI so serve, cache
+// list, and delete --purge-cache never disagree about whether a model
+// is cached or which directory owns it. Status.CacheKey wins when the
+// controller has set it. Otherwise only a non-metal, multi-file model
+// derives a key from its source (hf:// repo IDs leave Status.CacheKey
+// empty yet still cache; see the controller's effectiveModelCacheKey).
+// Metal models and single-file models are not cached under a derived
+// key and return "".
+func EffectiveKey(model *inferencev1alpha1.Model) string {
+	if model == nil {
+		return ""
+	}
+	if model.Status.CacheKey != "" {
+		return model.Status.CacheKey
+	}
+	multiFile := len(model.Spec.Files) > 0 || model.Spec.Mmproj != ""
+	metal := model.Spec.Hardware != nil && model.Spec.Hardware.Accelerator == "metal"
+	if multiFile && !metal {
+		return Compute(model.Spec.Source)
+	}
+	return ""
+}

--- a/pkg/cachekey/cachekey_test.go
+++ b/pkg/cachekey/cachekey_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cachekey
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func TestComputeLength(t *testing.T) {
+	got := Compute("https://huggingface.co/model.gguf")
+	if len(got) != 16 {
+		t.Errorf("Compute length = %d, want 16", len(got))
+	}
+}
+
+func TestComputeHexChars(t *testing.T) {
+	got := Compute("https://huggingface.co/model.gguf")
+	for i, c := range got {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("Compute char at %d = %q, want hex", i, string(c))
+		}
+	}
+}
+
+func TestComputeDeterministic(t *testing.T) {
+	a := Compute("https://huggingface.co/model.gguf")
+	b := Compute("https://huggingface.co/model.gguf")
+	if a != b {
+		t.Errorf("Compute not deterministic: %q != %q", a, b)
+	}
+}
+
+func TestComputeMatchesSHA256Prefix(t *testing.T) {
+	source := "https://huggingface.co/TheBloke/Llama-2-7B-GGUF/resolve/main/llama-2-7b.Q4_K_M.gguf"
+	want := sha256.Sum256([]byte(source))
+	wantStr := hex.EncodeToString(want[:])[:16]
+	got := Compute(source)
+	if got != wantStr {
+		t.Errorf("Compute = %q, want %q", got, wantStr)
+	}
+}
+
+func TestComputeEmptySource(t *testing.T) {
+	got := Compute("")
+	if len(got) != 16 {
+		t.Errorf("Compute empty length = %d, want 16", len(got))
+	}
+	// Empty string still produces a valid 16-char hex digest.
+	want := sha256.Sum256([]byte(""))
+	wantStr := hex.EncodeToString(want[:])[:16]
+	if got != wantStr {
+		t.Errorf("Compute empty = %q, want %q", got, wantStr)
+	}
+}
+
+func TestEffectiveKeyNilModel(t *testing.T) {
+	if got := EffectiveKey(nil); got != "" {
+		t.Errorf("EffectiveKey(nil) = %q, want empty", got)
+	}
+}
+
+func TestEffectiveKeyStatusCacheKeyWins(t *testing.T) {
+	model := &inferencev1alpha1.Model{
+		Spec: inferencev1alpha1.ModelSpec{
+			Source: "https://huggingface.co/example/model.gguf",
+		},
+		Status: inferencev1alpha1.ModelStatus{
+			CacheKey: "status-wins",
+		},
+	}
+	got := EffectiveKey(model)
+	if got != "status-wins" {
+		t.Errorf("EffectiveKey with Status.CacheKey set = %q, want status-wins", got)
+	}
+}
+
+func TestEffectiveKeyMultiFileNonMetal(t *testing.T) {
+	model := &inferencev1alpha1.Model{
+		Spec: inferencev1alpha1.ModelSpec{
+			Source: "hf://example/model",
+			Files:  []string{"model.gguf", "mmproj.gguf"},
+		},
+	}
+	want := Compute("hf://example/model")
+	got := EffectiveKey(model)
+	if got != want {
+		t.Errorf("EffectiveKey multi-file non-metal = %q, want %q", got, want)
+	}
+}
+
+func TestEffectiveKeyMetalMultiFile(t *testing.T) {
+	model := &inferencev1alpha1.Model{
+		Spec: inferencev1alpha1.ModelSpec{
+			Source: "hf://example/model",
+			Files:  []string{"model.gguf"},
+			Hardware: &inferencev1alpha1.HardwareSpec{
+				Accelerator: "metal",
+			},
+		},
+	}
+	got := EffectiveKey(model)
+	if got != "" {
+		t.Errorf("EffectiveKey metal multi-file = %q, want empty", got)
+	}
+}
+
+func TestEffectiveKeySingleFile(t *testing.T) {
+	model := &inferencev1alpha1.Model{
+		Spec: inferencev1alpha1.ModelSpec{
+			Source: "https://huggingface.co/example/model.gguf",
+		},
+	}
+	got := EffectiveKey(model)
+	if got != "" {
+		t.Errorf("EffectiveKey single-file = %q, want empty", got)
+	}
+}

--- a/pkg/cli/cache.go
+++ b/pkg/cli/cache.go
@@ -18,8 +18,6 @@ package cli
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -33,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/cachekey"
 )
 
 const (
@@ -196,9 +195,12 @@ func runCacheList(namespace string, allNamespaces bool, orphanedOnly bool) error
 
 	cacheEntries := make(map[string]*CacheEntry)
 	for _, model := range modelList.Items {
-		cacheKey := model.Status.CacheKey
+		cacheKey := cachekey.EffectiveKey(&model)
 		if cacheKey == "" {
-			cacheKey = computeCacheKey(model.Spec.Source)
+			// metal / single-file runtime-resolved models are never cached
+			// under a derived key; skip them so they do not show up as
+			// phantom entries.
+			continue
 		}
 
 		entry, exists := cacheEntries[cacheKey]
@@ -500,10 +502,4 @@ func runCachePreload(modelID, namespace string) error {
 			}
 		}
 	}
-}
-
-// computeCacheKey generates a SHA256 hash of the source URL (same as controller)
-func computeCacheKey(source string) string {
-	hash := sha256.Sum256([]byte(source))
-	return hex.EncodeToString(hash[:])[:16]
 }

--- a/pkg/cli/cache_inspect.go
+++ b/pkg/cli/cache_inspect.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/defilantech/llmkube/pkg/cachekey"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -266,10 +267,10 @@ func findMountPathForPVC(pod *corev1.Pod, containerName, pvcName string) string 
 // may inspect several PVCs in sequence; a single shared pod name would collide
 // (AlreadyExists) with the previous inspector while it is still terminating,
 // causing every PVC after the first to be skipped. Deriving the name from the
-// PVC keeps it unique per PVC and DNS-1123 safe (computeCacheKey is a 16-char
+// PVC keeps it unique per PVC and DNS-1123 safe (cachekey.Compute is a 16-char
 // hex digest).
 func inspectorPodName(pvcName string) string {
-	return "llmkube-cache-inspector-" + computeCacheKey(pvcName)
+	return "llmkube-cache-inspector-" + cachekey.Compute(pvcName)
 }
 
 func createInspectorPodForPVC(

--- a/pkg/cli/cache_test.go
+++ b/pkg/cli/cache_test.go
@@ -18,6 +18,8 @@ package cli
 
 import (
 	"testing"
+
+	"github.com/defilantech/llmkube/pkg/cachekey"
 )
 
 func TestComputeCacheKey(t *testing.T) {
@@ -33,17 +35,17 @@ func TestComputeCacheKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			key := computeCacheKey(tt.source)
+			key := cachekey.Compute(tt.source)
 
 			// Must be exactly 16 hex characters
 			if len(key) != 16 {
-				t.Errorf("computeCacheKey(%q) length = %d, want 16", tt.source, len(key))
+				t.Errorf("cachekey.Compute(%q) length = %d, want 16", tt.source, len(key))
 			}
 
 			// Must contain only hex characters
 			for _, c := range key {
 				if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
-					t.Errorf("computeCacheKey(%q) contains non-hex char %q", tt.source, string(c))
+					t.Errorf("cachekey.Compute(%q) contains non-hex char %q", tt.source, string(c))
 				}
 			}
 		})
@@ -52,8 +54,8 @@ func TestComputeCacheKey(t *testing.T) {
 
 func TestComputeCacheKeyDeterministic(t *testing.T) {
 	source := "https://huggingface.co/TheBloke/model.gguf"
-	key1 := computeCacheKey(source)
-	key2 := computeCacheKey(source)
+	key1 := cachekey.Compute(source)
+	key2 := cachekey.Compute(source)
 
 	if key1 != key2 {
 		t.Errorf("computeCacheKey is not deterministic: %q != %q", key1, key2)
@@ -70,7 +72,7 @@ func TestComputeCacheKeyUniqueness(t *testing.T) {
 
 	keys := make(map[string]string)
 	for _, source := range sources {
-		key := computeCacheKey(source)
+		key := cachekey.Compute(source)
 		if prev, exists := keys[key]; exists {
 			t.Errorf("Cache key collision: %q and %q both produce %q", prev, source, key)
 		}
@@ -82,10 +84,10 @@ func TestComputeCacheKeyMatchesController(t *testing.T) {
 	// The controller uses the same algorithm: SHA256(source)[:16]
 	// Verify known hash values to catch algorithm drift
 	source := "https://huggingface.co/TheBloke/Llama-2-7B-GGUF/resolve/main/llama-2-7b.Q4_K_M.gguf"
-	key := computeCacheKey(source)
+	key := cachekey.Compute(source)
 
 	// Re-compute with the same algorithm to verify
-	expected := computeCacheKey(source)
+	expected := cachekey.Compute(source)
 	if key != expected {
 		t.Errorf("computeCacheKey result changed between calls: %q != %q", key, expected)
 	}
@@ -174,9 +176,9 @@ func TestComputeCacheKeyForDeploySources(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			key := computeCacheKey(tt.source)
+			key := cachekey.Compute(tt.source)
 			if len(key) != 16 {
-				t.Errorf("computeCacheKey(%q) length = %d, want 16", tt.source, len(key))
+				t.Errorf("cachekey.Compute(%q) length = %d, want 16", tt.source, len(key))
 			}
 		})
 	}
@@ -185,8 +187,8 @@ func TestComputeCacheKeyForDeploySources(t *testing.T) {
 func TestComputeCacheKeySameSourceSameKey(t *testing.T) {
 	// Same source should always produce the same cache key
 	source := "https://huggingface.co/model.gguf"
-	key1 := computeCacheKey(source)
-	key2 := computeCacheKey(source)
+	key1 := cachekey.Compute(source)
+	key2 := cachekey.Compute(source)
 	if key1 != key2 {
 		t.Errorf("Same source produced different keys: %q != %q", key1, key2)
 	}
@@ -194,8 +196,8 @@ func TestComputeCacheKeySameSourceSameKey(t *testing.T) {
 
 func TestComputeCacheKeyDifferentSourceDifferentKey(t *testing.T) {
 	// Different sources should produce different cache keys
-	key1 := computeCacheKey("https://huggingface.co/model-a.gguf")
-	key2 := computeCacheKey("https://huggingface.co/model-b.gguf")
+	key1 := cachekey.Compute("https://huggingface.co/model-a.gguf")
+	key2 := cachekey.Compute("https://huggingface.co/model-b.gguf")
 	if key1 == key2 {
 		t.Errorf("Different sources produced same key: %q", key1)
 	}

--- a/pkg/cli/delete.go
+++ b/pkg/cli/delete.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/cachekey"
 )
 
 type deleteOptions struct {
@@ -101,15 +102,7 @@ func runDelete(opts *deleteOptions) error {
 		if err := k8sClient.Get(ctx, client.ObjectKey{Name: opts.name, Namespace: opts.namespace}, model); err != nil {
 			fmt.Printf("Warning: failed to get Model for cache purge: %v\n", err)
 		} else {
-			cacheKey = model.Status.CacheKey
-			if cacheKey == "" {
-				// hf:// multi-file models are cached under a key derived from
-				// the source even though the controller leaves Status.CacheKey
-				// empty (see effectiveModelCacheKey). Mirror `cache list`'s
-				// fallback so --purge-cache targets the same dir the serving
-				// pod uses, instead of skipping it and orphaning the cache.
-				cacheKey = computeCacheKey(model.Spec.Source)
-			}
+			cacheKey = cachekey.EffectiveKey(model)
 		}
 	}
 

--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/cachekey"
 )
 
 const defaultGPUVendor = "nvidia"
@@ -269,10 +270,10 @@ func runDeploy(opts *deployOptions) error {
 		return fmt.Errorf("--skip-cache and --from-cache are mutually exclusive")
 	}
 	if opts.skipCache {
-		cacheKey := computeCacheKey(opts.modelSource)
+		cacheKey := cachekey.Compute(opts.modelSource)
 		fmt.Printf("⚠️  Skipping model cache (cache key: %s); model will be re-downloaded\n", cacheKey)
 	} else if opts.fromCache {
-		cacheKey := computeCacheKey(opts.modelSource)
+		cacheKey := cachekey.Compute(opts.modelSource)
 		fmt.Printf("📦 Deploying from model cache (cache key: %s)\n", cacheKey)
 	}
 

--- a/pkg/cli/deploy_test.go
+++ b/pkg/cli/deploy_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/cachekey"
 )
 
 const testDefaultNamespace = "default"
@@ -875,7 +876,7 @@ func TestNewDeployCommand_CacheFlags(t *testing.T) {
 }
 
 func TestComputeCacheKeyUsedByDeploy(t *testing.T) {
-	// Verify that computeCacheKey is available and produces consistent results
+	// Verify that cachekey.Compute produces consistent results
 	// when used with model sources that would be passed to deploy
 	sources := []string{
 		"https://huggingface.co/model.gguf",
@@ -884,14 +885,14 @@ func TestComputeCacheKeyUsedByDeploy(t *testing.T) {
 	}
 
 	for _, source := range sources {
-		key := computeCacheKey(source)
+		key := cachekey.Compute(source)
 		if len(key) != 16 {
-			t.Errorf("computeCacheKey(%q) length = %d, want 16", source, len(key))
+			t.Errorf("cachekey.Compute(%q) length = %d, want 16", source, len(key))
 		}
 		// Verify determinism
-		key2 := computeCacheKey(source)
+		key2 := cachekey.Compute(source)
 		if key != key2 {
-			t.Errorf("computeCacheKey not deterministic for %q", source)
+			t.Errorf("cachekey.Compute not deterministic for %q", source)
 		}
 	}
 }


### PR DESCRIPTION
## What

Introduces `pkg/cachekey` as the single source of truth for a model's cache key, and routes the controller and all CLI sites through it. Two functions:

- `Compute(source)`: the raw SHA-256[:16] fingerprint (was duplicated in `internal/controller` and `pkg/cli`).
- `EffectiveKey(model)`: the scoped decision. `Status.CacheKey` wins; otherwise only a non-metal, multi-file model derives a key from its source; metal and single-file models return `""`.

The controller's `effectiveModelCacheKey` now delegates to `cachekey.EffectiveKey`; `cache list` and `delete --purge-cache` use it too.

## Why

Fixes #921. There were three sites deciding a model's cache key. The controller scoped the fallback to non-metal multi-file models, but the two CLI sites applied it unconditionally. So `cache list` showed phantom entries and `delete --purge-cache` targeted directories the serving pod never used, for metal and single-file models. Sharing only the raw fingerprint would not fix that; the scoped *decision* has to be shared, which is what `EffectiveKey` does. `cache list` now skips models with no derived key instead of inventing one, and `--purge-cache` no-ops on them.

## How

- New `pkg/cachekey` package: `Compute` (byte-for-byte parity with both prior implementations) and `EffectiveKey` (mirrors the controller's prior scoping semantics exactly).
- `internal/controller`: `effectiveModelCacheKey` delegates to `cachekey.EffectiveKey`; the local `computeCacheKey` becomes a thin wrapper for the many existing call sites. `hasMultiFileStaging` / `isMetalModel` stay in the controller (used widely there for non-cache reasons).
- `pkg/cli`: `cache.go`, `cache_inspect.go`, `delete.go`, `deploy.go` route through the shared package; the duplicate CLI `computeCacheKey` is removed.
- Tests: `pkg/cachekey` covers `Compute` (length, hex, determinism, SHA-256 parity) and `EffectiveKey` (nil, Status wins, multi-file non-metal derives, metal → "", single-file → ""). Existing CLI tests migrated to the shared package.

## Checklist

- [x] Tests added and exercise real behavior (the `EffectiveKey` cases fail if the scoping regresses)
- [x] `make test` / `make lint` pass (darwin and GOOS=linux)
- [x] No API/CRD changes
- [x] Scope matches the issue; no unrelated edits

## AI assistance disclosure

Assisted-by: Foreman (LLMKube's own agentic-coding harness), coder model Ornith-35B running locally on Apple Silicon. Foreman produced the implementation and tests from the issue; I reviewed the first attempt, found it under-delivered on the scoping fix and carried a duplicated doc comment, and fed those two findings back through a Foreman revision cycle that produced this branch. I then reviewed the result, ran the gate locally, and added one doc-comment commit by hand. A human (me) is accountable for the change per CONTRIBUTING.md.