### PR TITLE
fix(foreman): grant coder Job pods get on secrets for cloud-proxy auth

### DIFF
--- a/charts/foreman/templates/coder-rbac.yaml
+++ b/charts/foreman/templates/coder-rbac.yaml
@@ -10,13 +10,18 @@ metadata:
 ---
 {{- end }}
 # Least-privilege Role for the coder Job pods. A Job-mode coder runs
-# `foreman-agent run-task`, which READS the AgenticTask, the referenced
-# Agent, the Agent's InferenceService, and (for cloud-proxy providers) the
-# Secret referenced by `providerConfig.apiKeySecretRef` from the API to
-# resolve the executor's base URL and auth, then runs the native loop
-# in-process. It never writes task status (the foreman-agent watcher
-# polls the Job's log tail and patches status), so this Role is read-only
-# and namespaced to where the chart (and the tasks) live.
+# `foreman-agent run-task`, which:
+#   - READS the AgenticTask, the referenced Agent, and the Agent's
+#     InferenceService from the API to resolve the executor's base URL.
+#   - For cloud-proxy providers, READS the Secret referenced by
+#     `providerConfig.apiKeySecretRef` to resolve the API key.
+#   - WRITES a per-task transcript ConfigMap (foreman-transcript-<task>)
+#     during the run so failing runs can be diagnosed post-hoc; without
+#     this the turn-by-turn transcript is lost and only the summary
+#     audit ConfigMap survives.
+# The foreman-agent watcher (separate process) patches AgenticTask
+# status — the in-Job run-task never writes task status itself. The
+# Role is namespaced to where the chart (and the tasks) live.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -36,6 +41,12 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
+  # Per-task transcript write. `get` + `create`/`update` mirror the
+  # transcript writer's read-then-upsert flow; the writer targets a
+  # single ConfigMap (foreman-transcript-<task-name>) per run.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/foreman/templates/coder-rbac.yaml
+++ b/charts/foreman/templates/coder-rbac.yaml
@@ -11,11 +11,12 @@ metadata:
 {{- end }}
 # Least-privilege Role for the coder Job pods. A Job-mode coder runs
 # `foreman-agent run-task`, which READS the AgenticTask, the referenced
-# Agent, and the Agent's InferenceService from the API to resolve the
-# executor's base URL, then runs the native loop in-process. It never
-# writes task status (the foreman-agent watcher polls the Job's log tail
-# and patches status), so this Role is read-only and namespaced to where
-# the chart (and the tasks) live.
+# Agent, the Agent's InferenceService, and (for cloud-proxy providers) the
+# Secret referenced by `providerConfig.apiKeySecretRef` from the API to
+# resolve the executor's base URL and auth, then runs the native loop
+# in-process. It never writes task status (the foreman-agent watcher
+# polls the Job's log tail and patches status), so this Role is read-only
+# and namespaced to where the chart (and the tasks) live.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -30,6 +31,11 @@ rules:
   - apiGroups: ["inference.llmkube.dev"]
     resources: ["inferenceservices"]
     verbs: ["get", "list", "watch"]
+  # Resolves providerConfig.apiKeySecretRef for cloud-proxy providers.
+  # `get` only — the agent does not list/watch secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## What

Adds two missing rules to the `foreman-coder` Role in the foreman chart:

1. **`secrets: get`** — resolves `providerConfig.apiKeySecretRef` for cloud-proxy providers. The executor's `resolveAuthToken` calls `clientset.CoreV1().Secrets(namespace).Get(...)` to fetch the API key.
2. **`configmaps: get` + `create` + `update`** — writes the per-task transcript ConfigMap (`foreman-transcript-<task-name>`) so failing runs can be diagnosed post-hoc.

The chart mounts `GITHUB_TOKEN` as a Job env, but the API key is resolved dynamically — hence the secrets gap. The transcript writer was always failing silently (the run-task logged `continuing`), but the consequence is invisible: a failing Job-mode coder leaves no recoverable transcript, only the summary audit ConfigMap. That just bit a 52-minute `ModelReportedError` run.

## Why

Fixes #986

Repro from the issue:

```bash
llmkube foreman dispatch --repo defilantech/LLMKube --agents coder-go -n llm 892
# → INCOMPLETE / InferenceServiceUnavailable
# → get Secret llm/foreman-agent for provider auth: secrets "foreman-agent" is forbidden
```

## How

- Two new rules in `charts/foreman/templates/coder-rbac.yaml`:
  - Core API group, `secrets`, `get` only.
  - Core API group, `configmaps`, `get` + `create` + `update`.
- Header comment updated to reflect the new read+write pattern.
- Both grants scoped to the Role's namespace (the chart's namespace) and the minimum verbs needed.

No `values.yaml` toggle — every cloud-proxy Job-mode coder needs the secrets rule, every Job-mode coder run produces a transcript, so granting both by default is the simplest correct posture.

## Checklist

- [ ] Tests added/updated
- [ ] `make test` passes locally
- [ ] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [x] AI assistance disclosed below
- [ ] Documentation updated (n/a — RBAC is internal)

---

Assisted-by: opencode — the assistant located the chart template, drafted the diff and this PR body. I reviewed the change, verified the code paths (`executor_native.go` `resolveAuthToken` → `Secrets().Get`; `WriteTranscript` → ConfigMap read-then-upsert), confirmed the reproductions against the live cluster, and signed off both commits myself.