### PR TITLE
feat(foreman): grounded-finding rail for reviewer NO-GO verdicts

### DIFF
--- a/config/foreman/agents/claude-sonnet-cloud-reviewer.yaml
+++ b/config/foreman/agents/claude-sonnet-cloud-reviewer.yaml
@@ -414,11 +414,21 @@ spec:
                                  identification.)
           - `findings`        :: `[]` of `{severity: "blocker" | "major" |
                                  "minor", area: "scope" | "tests" | "style"
-                                 | "side-effects" | "docs", message: "..."}`
-                                 . Each finding must include enough specifics
-                                 (file path, line number, quoted issue text)
-                                 that a maintainer can act on it without
-                                 re-deriving your reasoning.
+                                 | "side-effects" | "docs", message: "...",
+                                 file: "path", line: N}`. Each finding must
+                                 include enough specifics (file path, line
+                                 number, quoted issue text) that a maintainer
+                                 can act on it without re-deriving your
+                                 reasoning.
+
+                                 Every BLOCKING finding (severity `blocker`
+                                 or `major`) MUST set `file` and `line` to a
+                                 line THIS diff changed (a line inside a
+                                 `git diff main...HEAD` hunk). A blocking
+                                 finding without a `file` + `line` on changed
+                                 code is IGNORED by the harness and cannot
+                                 sustain a REQUEST-CHANGES verdict; minor
+                                 findings may omit `file`/`line`.
           - `issueAsk`        :: a short quote (≤200 chars) capturing the
                                  operative ask of the issue body, taken from
                                  the `fetch_issue` result as closely as you

--- a/config/foreman/agents/devstral-24b-reviewer.yaml
+++ b/config/foreman/agents/devstral-24b-reviewer.yaml
@@ -360,11 +360,21 @@ spec:
                                  identification.)
           - `findings`        :: `[]` of `{severity: "blocker" | "major" |
                                  "minor", area: "scope" | "tests" | "style"
-                                 | "side-effects" | "docs", message: "..."}`
-                                 . Each finding must include enough specifics
-                                 (file path, line number, quoted issue text)
-                                 that a maintainer can act on it without
-                                 re-deriving your reasoning.
+                                 | "side-effects" | "docs", message: "...",
+                                 file: "path", line: N}`. Each finding must
+                                 include enough specifics (file path, line
+                                 number, quoted issue text) that a maintainer
+                                 can act on it without re-deriving your
+                                 reasoning.
+
+                                 Every BLOCKING finding (severity `blocker`
+                                 or `major`) MUST set `file` and `line` to a
+                                 line THIS diff changed (a line inside a
+                                 `git diff main...HEAD` hunk). A blocking
+                                 finding without a `file` + `line` on changed
+                                 code is IGNORED by the harness and cannot
+                                 sustain a REQUEST-CHANGES verdict; minor
+                                 findings may omit `file`/`line`.
           - `issueAsk`        :: a short quote (≤200 chars) capturing the
                                  operative ask of the issue body, taken from
                                  the `fetch_issue` result as closely as you

--- a/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
+++ b/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
@@ -395,11 +395,21 @@ spec:
                                  identification.)
           - `findings`        :: `[]` of `{severity: "blocker" | "major" |
                                  "minor", area: "scope" | "tests" | "style"
-                                 | "side-effects" | "docs", message: "..."}`
-                                 . Each finding must include enough specifics
-                                 (file path, line number, quoted issue text)
-                                 that a maintainer can act on it without
-                                 re-deriving your reasoning.
+                                 | "side-effects" | "docs", message: "...",
+                                 file: "path", line: N}`. Each finding must
+                                 include enough specifics (file path, line
+                                 number, quoted issue text) that a maintainer
+                                 can act on it without re-deriving your
+                                 reasoning.
+
+                                 Every BLOCKING finding (severity `blocker`
+                                 or `major`) MUST set `file` and `line` to a
+                                 line THIS diff changed (a line inside a
+                                 `git diff main...HEAD` hunk). A blocking
+                                 finding without a `file` + `line` on changed
+                                 code is IGNORED by the harness and cannot
+                                 sustain a REQUEST-CHANGES verdict; minor
+                                 findings may omit `file`/`line`.
           - `issueAsk`        :: a short quote (≤200 chars) capturing the
                                  operative ask of the issue body, taken from
                                  the `fetch_issue` result as closely as you

--- a/config/foreman/system-prompts/reviewer.md
+++ b/config/foreman/system-prompts/reviewer.md
@@ -317,11 +317,21 @@ Call `submit_result` exactly once. Required fields:
                          identification.)
   - `findings`        :: `[]` of `{severity: "blocker" | "major" |
                          "minor", area: "scope" | "tests" | "style"
-                         | "side-effects" | "docs", message: "..."}`
-                         . Each finding must include enough specifics
-                         (file path, line number, quoted issue text)
-                         that a maintainer can act on it without
-                         re-deriving your reasoning.
+                         | "side-effects" | "docs", message: "...",
+                         file: "path", line: N}`. Each finding must
+                         include enough specifics (file path, line
+                         number, quoted issue text) that a maintainer
+                         can act on it without re-deriving your
+                         reasoning.
+
+                         Every BLOCKING finding (severity `blocker`
+                         or `major`) MUST set `file` and `line` to a
+                         line THIS diff changed (a line inside a
+                         `git diff main...HEAD` hunk). A blocking
+                         finding without a `file` + `line` on changed
+                         code is IGNORED by the harness and cannot
+                         sustain a REQUEST-CHANGES verdict; minor
+                         findings may omit `file`/`line`.
   - `issueAsk`        :: a short quote (≤200 chars) capturing the
                          operative ask of the issue body, taken from
                          the `fetch_issue` result as closely as you

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -626,7 +626,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// ungrounded rejection becomes GO and then scope-overlap / issueAsk
 			// still get their turn to re-flag it for a real, computed reason.
 			verdict = enforceReviewerGroundedFindings(log, loopRes.Terminal.Extra, verdict,
-				reviewerGroundedChangedLines(ctx, log, workspace, reviewDiffErr))
+				reviewerGroundedChangedLines(ctx, log, workspace, reviewDiff, reviewDiffErr))
 			// Computable scope-overlap check (#647): when the issue names
 			// concrete files and the diff touches none of them, demote a
 			// GO deterministically. Runs before issueAsk enforcement so
@@ -734,8 +734,8 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 // reviewerGroundedChangedLines builds the changedLines callback the
 // grounded-finding rail (enforceReviewerGroundedFindings) uses to check
 // whether a reviewer finding cites a line the branch diff actually changed.
-// Returns nil (rail becomes a no-op / degrades open) when the ground-truth
-// diff was unavailable, logging why.
+// Returns nil (rail steps aside, verdict left as-is) when the ground-truth
+// branch diff is unavailable (git error) OR empty, logging why.
 //
 // It uses the committed-branch diff (changedBranchLines: git diff main...HEAD),
 // not the working-tree diff (changedNewLines: git diff HEAD). The reviewer
@@ -743,12 +743,23 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 // HEAD and a `git diff HEAD` would be empty, grounding nothing and demoting
 // every NO-GO. The three-dot base matches the scope-overlap check on the line
 // above (repo.DiffNameOnly(ctx, workspace, "main")).
+//
+// An EMPTY-but-successful diff (reviewDiff has zero files, reviewDiffErr nil)
+// must degrade CLOSED, exactly like the git-error case: it means the reviewer
+// never established the coder's changes against the base (e.g. it skipped the
+// mandatory Step 1 fetch+checkout, leaving HEAD at main). Returning a live
+// closure there would ground every finding as "unchanged" and demote every
+// NO-GO to GO, opening the PR the reviewer meant to block.
 func reviewerGroundedChangedLines(
-	ctx context.Context, log logr.Logger, workspace string, reviewDiffErr error,
+	ctx context.Context, log logr.Logger, workspace string, reviewDiff []string, reviewDiffErr error,
 ) func(string) map[int]bool {
 	if reviewDiffErr != nil {
 		log.Info("reviewer grounded-finding: ground-truth diff unavailable; skipping",
 			"err", reviewDiffErr.Error())
+		return nil
+	}
+	if len(reviewDiff) == 0 {
+		log.Info("reviewer grounded-finding: branch diff empty; skipping (degrade closed)")
 		return nil
 	}
 	return func(file string) map[int]bool {

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -736,6 +736,13 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 // whether a reviewer finding cites a line the branch diff actually changed.
 // Returns nil (rail becomes a no-op / degrades open) when the ground-truth
 // diff was unavailable, logging why.
+//
+// It uses the committed-branch diff (changedBranchLines: git diff main...HEAD),
+// not the working-tree diff (changedNewLines: git diff HEAD). The reviewer
+// checks out the coder's already-committed branch, so the working tree equals
+// HEAD and a `git diff HEAD` would be empty, grounding nothing and demoting
+// every NO-GO. The three-dot base matches the scope-overlap check on the line
+// above (repo.DiffNameOnly(ctx, workspace, "main")).
 func reviewerGroundedChangedLines(
 	ctx context.Context, log logr.Logger, workspace string, reviewDiffErr error,
 ) func(string) map[int]bool {
@@ -745,7 +752,7 @@ func reviewerGroundedChangedLines(
 		return nil
 	}
 	return func(file string) map[int]bool {
-		return changedNewLines(ctx, workspace, file, execCommandRunner)
+		return changedBranchLines(ctx, workspace, "main", file, execCommandRunner)
 	}
 }
 

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -616,21 +616,32 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// #582/filesTouched fix: harness owns the authoritative
 			// field, model's claim is archived under issueAskClaimed.
 			reconcileReviewerIssueAsk(log, loopRes.Transcript, loopRes.Terminal.Extra)
+			// Ground-truth the branch diff ONCE for the two computable rails
+			// below (grounded-finding + scope-overlap).
+			reviewDiff, reviewDiffErr := repo.DiffNameOnly(ctx, workspace, "main")
+			// Grounded-finding rail: a NO-GO must be earned by >=1 blocking
+			// finding citing a line the diff changed; otherwise demote it to GO
+			// and archive the rejected findings. Mirror of scope-overlap, in the
+			// NO-GO->GO direction. Runs BEFORE the GO->NO-GO rails so an
+			// ungrounded rejection becomes GO and then scope-overlap / issueAsk
+			// still get their turn to re-flag it for a real, computed reason.
+			verdict = enforceReviewerGroundedFindings(log, loopRes.Terminal.Extra, verdict,
+				reviewerGroundedChangedLines(ctx, log, workspace, reviewDiffErr))
 			// Computable scope-overlap check (#647): when the issue names
 			// concrete files and the diff touches none of them, demote a
 			// GO deterministically. Runs before issueAsk enforcement so
 			// the scope signal can rescue an honest paraphrase (#744).
 			var scopeDriftDetected bool
 			var scopeMatched []string
-			if scopeDiff, scopeErr := repo.DiffNameOnly(ctx, workspace, "main"); scopeErr == nil {
+			if reviewDiffErr == nil {
 				verdict = enforceReviewerScopeOverlap(log, loopRes.Terminal.Extra,
-					extractFetchIssueBody(loopRes.Transcript), scopeDiff, verdict,
+					extractFetchIssueBody(loopRes.Transcript), reviewDiff, verdict,
 					task.Spec.GateProfile.Resolve().SourceExtensions)
 				scopeDriftDetected, _ = loopRes.Terminal.Extra["scopeDriftDetected"].(bool)
 				scopeMatched, _ = loopRes.Terminal.Extra["scopeMatched"].([]string)
 			} else {
 				log.Info("reviewer scope: ground-truth diff unavailable; skipping scope check",
-					"err", scopeErr.Error())
+					"err", reviewDiffErr.Error())
 			}
 			// Enforce the verification result (#644): an unverifiable
 			// issueAsk demotes a GO to NO-GO so it routes to escalation
@@ -718,6 +729,24 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	r := e.goResult(start, transcriptRef, loopRes, branch, sha)
 	attachGateAdvisories(r.Extra, gateAdvisories)
 	return r, nil
+}
+
+// reviewerGroundedChangedLines builds the changedLines callback the
+// grounded-finding rail (enforceReviewerGroundedFindings) uses to check
+// whether a reviewer finding cites a line the branch diff actually changed.
+// Returns nil (rail becomes a no-op / degrades open) when the ground-truth
+// diff was unavailable, logging why.
+func reviewerGroundedChangedLines(
+	ctx context.Context, log logr.Logger, workspace string, reviewDiffErr error,
+) func(string) map[int]bool {
+	if reviewDiffErr != nil {
+		log.Info("reviewer grounded-finding: ground-truth diff unavailable; skipping",
+			"err", reviewDiffErr.Error())
+		return nil
+	}
+	return func(file string) map[int]bool {
+		return changedNewLines(ctx, workspace, file, execCommandRunner)
+	}
 }
 
 // coderGateMaxRetries bounds the coder gate fix attempts (#749): a GO whose

--- a/pkg/foreman/agent/grounded_finding_gate.go
+++ b/pkg/foreman/agent/grounded_finding_gate.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Grounded-finding rail: the mirror image of the scope-overlap / issueAsk
+// rails. Those demote a too-lenient GO to NO-GO; this demotes an UNGROUNDED
+// NO-GO to GO. A reviewer must EARN a rejection by pointing at code the diff
+// actually changed: at least one blocking finding (severity blocker/major)
+// must cite a File + Line inside a `git diff -U0 main...HEAD` hunk. A NO-GO
+// with zero grounded blocking findings is demoted to GO and the rejected
+// findings are archived under extra["ungroundedFindings"].
+//
+// Motivation (2026-07-06 Nemotron-49B experiments): a checklist prompt
+// false-approved and fabricated a finding citing a file the diff never
+// touched; an adversarial prompt false-rejected citing an invented
+// requirement pinned to a PRE-EXISTING line. Both objections were not
+// anchored to changed code. This rail makes the reviewer TRUSTWORTHY (cannot
+// block on inventions), not smarter (finding the real defect is the
+// stronger-model / panel problem).
+//
+// Disabled by FOREMAN_GROUNDED_FINDINGS=0.
+package agent
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
+)
+
+// groundedFindingsDisabled reports whether the grounded-finding rail is off
+// via FOREMAN_GROUNDED_FINDINGS=0. Default (unset) is enabled.
+func groundedFindingsDisabled() bool {
+	return os.Getenv("FOREMAN_GROUNDED_FINDINGS") == "0"
+}
+
+// enforceReviewerGroundedFindings demotes a model NO-GO to GO when none of its
+// blocking findings cite a changed line. Returns the (possibly demoted)
+// verdict. It is a no-op on any non-NO-GO verdict, when disabled, or when
+// changedLines is nil (git unavailable -> degrade-open).
+//
+// changedLines(file) returns the set of new-file line numbers inside a changed
+// hunk for that file, or an empty/nil map for a file the diff did not change.
+// Because an unchanged file yields an empty set, the single membership test
+// (line in changedLines(file)) subsumes both the fabricated-file case and the
+// unchanged-line-in-a-changed-file case.
+func enforceReviewerGroundedFindings(
+	log logr.Logger,
+	extra map[string]any,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+	changedLines func(file string) map[int]bool,
+) foremanv1alpha1.AgenticTaskVerdict {
+	if groundedFindingsDisabled() ||
+		verdict != foremanv1alpha1.AgenticTaskVerdictNoGo ||
+		extra == nil || changedLines == nil {
+		return verdict
+	}
+
+	findings, _ := reviewer.ParseFindings(extra)
+
+	// Cache per-file changed lines: a NO-GO can carry several findings on the
+	// same file, and changedLines() may shell out to git per call.
+	cache := map[string]map[int]bool{}
+	lines := func(f string) map[int]bool {
+		if m, ok := cache[f]; ok {
+			return m
+		}
+		m := changedLines(f)
+		cache[f] = m
+		return m
+	}
+
+	var blocking, grounded, ungrounded []reviewer.Finding
+	for _, f := range findings {
+		if f.Severity != reviewer.SeverityBlocker && f.Severity != reviewer.SeverityMajor {
+			continue // minor is advisory, never sustains a NO-GO
+		}
+		blocking = append(blocking, f)
+		if f.File != "" && f.Line > 0 && lines(f.File)[f.Line] {
+			grounded = append(grounded, f)
+		} else {
+			ungrounded = append(ungrounded, f)
+		}
+	}
+
+	if len(grounded) >= 1 {
+		return verdict // rejection earned; NO-GO stands
+	}
+
+	// Zero grounded blocking findings: the rejection is ungrounded. Demote to
+	// GO and archive, mirroring the filesTouchedClaimed transparency pattern.
+	extra["groundedFindingDemotion"] = true
+	extra["ungroundedFindings"] = ungrounded
+	extra["groundedFindingReason"] = fmt.Sprintf(
+		"NO-GO demoted to GO: 0 of %d blocking finding(s) cite a changed line", len(blocking))
+	log.Info("reviewer grounded-finding: NO-GO demoted to GO; no blocking finding cites a changed line",
+		"blockingCount", len(blocking))
+	return foremanv1alpha1.AgenticTaskVerdictGo
+}

--- a/pkg/foreman/agent/grounded_finding_gate_test.go
+++ b/pkg/foreman/agent/grounded_finding_gate_test.go
@@ -170,7 +170,8 @@ func TestReviewerGroundedChangedLines_UsesCommittedBranchDiff(t *testing.T) {
 		t.Fatalf("precondition: working tree must be clean, got %q", out)
 	}
 
-	changed := reviewerGroundedChangedLines(context.Background(), logr.Discard(), ws, nil)
+	// The caller passes the ground-truth diff file list (non-empty here).
+	changed := reviewerGroundedChangedLines(context.Background(), logr.Discard(), ws, []string{"foo.go"}, nil)
 	if changed == nil {
 		t.Fatal("closure must be non-nil when the ground-truth diff is available")
 	}
@@ -182,5 +183,23 @@ func TestReviewerGroundedChangedLines_UsesCommittedBranchDiff(t *testing.T) {
 	// `func B() {}` is added at new-file line 5.
 	if !got[5] {
 		t.Errorf("expected added line 5 (func B) in the grounded set, got %v", got)
+	}
+}
+
+// TestReviewerGroundedChangedLines_EmptyBranchDiffDegradesClosed guards the
+// asymmetric-degrade fail-open: a successful-but-empty branch diff (nil error,
+// zero changed files) means the reviewer never established the coder's changes
+// against the base (e.g. it skipped the Step 1 fetch+checkout). The rail must
+// step aside (nil closure) so a NO-GO is not demoted to GO and its PR opened.
+// This must match the git-error degrade, not the happy path.
+func TestReviewerGroundedChangedLines_EmptyBranchDiffDegradesClosed(t *testing.T) {
+	ctx, log := context.Background(), logr.Discard()
+	// Empty diff, no error: must degrade closed (nil closure).
+	if got := reviewerGroundedChangedLines(ctx, log, t.TempDir(), nil, nil); got != nil {
+		t.Fatal("empty branch diff must yield a nil closure (degrade closed), got non-nil")
+	}
+	// Non-empty diff: a real closure is returned.
+	if got := reviewerGroundedChangedLines(ctx, log, t.TempDir(), []string{"a.go"}, nil); got == nil {
+		t.Fatal("non-empty branch diff must yield a real closure")
 	}
 }

--- a/pkg/foreman/agent/grounded_finding_gate_test.go
+++ b/pkg/foreman/agent/grounded_finding_gate_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// blockerFinding builds a findings extra map with one finding.
+func findingExtra(severity, file string, line int) map[string]any {
+	return map[string]any{
+		"findings": []any{
+			map[string]any{
+				"severity": severity,
+				"area":     "scope",
+				"message":  "m",
+				"file":     file,
+				"line":     line,
+			},
+		},
+	}
+}
+
+// changed returns a changedLines closure for a fixed file->lines fixture.
+func changed(fix map[string]map[int]bool) func(string) map[int]bool {
+	return func(f string) map[int]bool { return fix[f] }
+}
+
+func TestGroundedFindings_GroundedBlockerStaysNoGo(t *testing.T) {
+	extra := findingExtra("blocker", "pkg/cli/cache.go", 42)
+	fix := map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("grounded blocker must keep NO-GO, got %s", got)
+	}
+	if _, demoted := extra["groundedFindingDemotion"]; demoted {
+		t.Fatal("grounded NO-GO must not be marked demoted")
+	}
+}
+
+func TestGroundedFindings_FabricatedFileDemotes(t *testing.T) {
+	// Cites a file the diff never changed (the docs-fabrication case).
+	extra := findingExtra("blocker", "docs/MODEL-CACHE.md", 10)
+	fix := map[string]map[int]bool{"pkg/cli/cache.go": {42: true}} // docs file absent
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("fabricated-file NO-GO must demote to GO, got %s", got)
+	}
+	if extra["groundedFindingDemotion"] != true {
+		t.Fatal("expected groundedFindingDemotion=true")
+	}
+	if extra["ungroundedFindings"] == nil {
+		t.Fatal("expected ungroundedFindings archived")
+	}
+}
+
+func TestGroundedFindings_UnchangedLineInChangedFileDemotes(t *testing.T) {
+	// Cites a changed file but a line OUTSIDE any hunk (the kubectl-exec case).
+	extra := findingExtra("major", "pkg/cli/delete.go", 999)
+	fix := map[string]map[int]bool{"pkg/cli/delete.go": {106: true, 107: true}} // 999 not changed
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("unchanged-line NO-GO must demote to GO, got %s", got)
+	}
+}
+
+func TestGroundedFindings_NoLineDemotes(t *testing.T) {
+	extra := findingExtra("blocker", "pkg/cli/cache.go", 0) // line 0 = not pinned
+	fix := map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("blocking finding with no line must demote to GO, got %s", got)
+	}
+}
+
+func TestGroundedFindings_MinorOnlyDemotes(t *testing.T) {
+	extra := findingExtra("minor", "pkg/cli/cache.go", 42) // minor is not blocking
+	fix := map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("NO-GO with only minor findings must demote to GO, got %s", got)
+	}
+}
+
+func TestGroundedFindings_GoUntouched(t *testing.T) {
+	extra := findingExtra("blocker", "docs/MODEL-CACHE.md", 10) // ungrounded, but verdict is GO
+	fix := map[string]map[int]bool{}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("GO must pass through untouched, got %s", got)
+	}
+	if _, demoted := extra["groundedFindingDemotion"]; demoted {
+		t.Fatal("GO path must not set demotion keys")
+	}
+}
+
+func TestGroundedFindings_ToggleOff(t *testing.T) {
+	t.Setenv("FOREMAN_GROUNDED_FINDINGS", "0")
+	extra := findingExtra("blocker", "docs/MODEL-CACHE.md", 10) // ungrounded
+	fix := map[string]map[int]bool{}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("toggle off must leave NO-GO untouched, got %s", got)
+	}
+}
+
+func TestGroundedFindings_GitUnavailableDegradesOpen(t *testing.T) {
+	extra := findingExtra("blocker", "docs/MODEL-CACHE.md", 10) // ungrounded
+	// changedLines == nil signals git unavailable -> degrade-open (no demotion).
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("nil changedLines must leave verdict untouched, got %s", got)
+	}
+}

--- a/pkg/foreman/agent/grounded_finding_gate_test.go
+++ b/pkg/foreman/agent/grounded_finding_gate_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package agent
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -128,5 +132,55 @@ func TestGroundedFindings_GitUnavailableDegradesOpen(t *testing.T) {
 	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("nil changedLines must leave verdict untouched, got %s", got)
+	}
+}
+
+// TestReviewerGroundedChangedLines_UsesCommittedBranchDiff is the integration
+// guard the synthetic-closure unit tests above miss: it drives the real git
+// wiring in a reviewer-shaped workspace, where the coder's work is already
+// committed and the working tree is clean. `git diff HEAD` is empty there, so
+// the rail must diff the branch against its merge-base with main (main...HEAD).
+// Otherwise every blocking finding is classified ungrounded and every NO-GO is
+// demoted to GO unconditionally.
+func TestReviewerGroundedChangedLines_UsesCommittedBranchDiff(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ws := t.TempDir()
+	foo := filepath.Join(ws, "foo.go")
+	gitIn(t, "", "init", "-b", "main", ws)
+	if err := os.WriteFile(foo, []byte("package p\n\nfunc A() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-m", "base")
+
+	// The coder's work: a committed change on a branch, then checked out so the
+	// working tree is clean, exactly what the reviewer sees after checkout.
+	gitIn(t, ws, "checkout", "-b", "fix/x")
+	if err := os.WriteFile(foo, []byte("package p\n\nfunc A() {}\n\nfunc B() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-m", "add B")
+
+	// Precondition: the work is committed, so `git diff HEAD` (the old base) is
+	// empty. This is the exact condition that made the rail a no-op.
+	if out := gitIn(t, ws, "diff", "--name-only", "HEAD"); out != "" {
+		t.Fatalf("precondition: working tree must be clean, got %q", out)
+	}
+
+	changed := reviewerGroundedChangedLines(context.Background(), logr.Discard(), ws, nil)
+	if changed == nil {
+		t.Fatal("closure must be non-nil when the ground-truth diff is available")
+	}
+	got := changed("foo.go")
+	if len(got) == 0 {
+		t.Fatal("no changed lines for a committed branch: the rail is a no-op " +
+			"(git diff HEAD is empty when work is committed); must diff main...HEAD")
+	}
+	// `func B() {}` is added at new-file line 5.
+	if !got[5] {
+		t.Errorf("expected added line 5 (func B) in the grounded set, got %v", got)
 	}
 }

--- a/pkg/foreman/agent/mutation_gate.go
+++ b/pkg/foreman/agent/mutation_gate.go
@@ -368,6 +368,29 @@ func changedNewLines(ctx context.Context, workspace, file string, run commandRun
 	if err != nil {
 		return nil
 	}
+	return parseAddedLines(out)
+}
+
+// changedBranchLines parses `git diff -U0 <base>...HEAD -- <file>` and returns
+// the set of new-file line numbers touched by added lines relative to the
+// branch's merge-base with base.
+//
+// This is the committed-branch view the reviewer grounded-finding rail needs:
+// the reviewer checks out the coder's already-committed branch, so the working
+// tree equals HEAD and the `git diff HEAD` view (changedNewLines) is empty and
+// would ground nothing. The three-dot base mirrors the scope-overlap check
+// (repo.DiffNameOnly), so both reviewer rails agree on what the branch changed.
+func changedBranchLines(ctx context.Context, workspace, base, file string, run commandRunner) map[int]bool {
+	out, err := run(ctx, workspace, nil, "git", "diff", "-U0", base+"...HEAD", "--", file)
+	if err != nil {
+		return nil
+	}
+	return parseAddedLines(out)
+}
+
+// parseAddedLines extracts the set of added new-file line numbers from a
+// `git diff -U0` output by tracking each hunk header's new-file start line.
+func parseAddedLines(out string) map[int]bool {
 	lines := map[int]bool{}
 	cur := 0
 	for _, ln := range strings.Split(out, "\n") {

--- a/pkg/foreman/agent/reviewer/findings.go
+++ b/pkg/foreman/agent/reviewer/findings.go
@@ -63,6 +63,28 @@ var validSeverities = map[Severity]struct{}{
 	SeverityMinor:   {},
 }
 
+// severitySynonyms maps common non-canonical severity labels local reviewer
+// models emit onto the canonical set. Without this, a real blocker labeled
+// e.g. "critical" or "high" fails validSeverities and is dropped by
+// normalize(); the grounded-finding rail then sees zero blocking findings and
+// demotes a genuine NO-GO to GO. Only unambiguous synonyms are mapped;
+// genuinely ambiguous labels (e.g. "medium") still fail validation.
+var severitySynonyms = map[Severity]Severity{
+	"critical": SeverityBlocker,
+	"crit":     SeverityBlocker,
+	"fatal":    SeverityBlocker,
+	"severe":   SeverityBlocker,
+	"blocking": SeverityBlocker,
+	"high":     SeverityMajor,
+	"error":    SeverityMajor,
+	"warning":  SeverityMinor,
+	"warn":     SeverityMinor,
+	"low":      SeverityMinor,
+	"info":     SeverityMinor,
+	"nit":      SeverityMinor,
+	"trivial":  SeverityMinor,
+}
+
 // Area names the review-checklist section the finding belongs to.
 // Tracks the section headers in reviewer.md (A. Scope alignment, B.
 // Change is minimal and idiomatic, etc.) so downstream filtering /
@@ -174,6 +196,9 @@ func ParseFindings(extra map[string]any) ([]Finding, []string) {
 // indicate the model did not understand the schema.
 func (f *Finding) normalize() (ok bool, reason string) {
 	f.Severity = Severity(strings.ToLower(strings.TrimSpace(string(f.Severity))))
+	if canon, ok := severitySynonyms[f.Severity]; ok {
+		f.Severity = canon
+	}
 	f.Area = Area(strings.ToLower(strings.TrimSpace(string(f.Area))))
 	f.Message = strings.TrimSpace(f.Message)
 

--- a/pkg/foreman/agent/reviewer/findings_test.go
+++ b/pkg/foreman/agent/reviewer/findings_test.go
@@ -80,7 +80,7 @@ func TestParseFindings_DropsInvalidLenient(t *testing.T) {
 	extra := jsonExtra(t, `{
 		"findings": [
 			{"severity":"BLOCKER","area":"SCOPE","message":"loud caps still ok"},
-			{"severity":"critical","area":"scope","message":"unknown severity dropped"},
+			{"severity":"bogus","area":"scope","message":"unknown severity dropped"},
 			{"severity":"major","area":"security","message":"unknown area dropped"},
 			{"severity":"minor","area":"docs","message":""},
 			{"severity":"major","area":"tests","message":"valid one"}
@@ -96,6 +96,36 @@ func TestParseFindings_DropsInvalidLenient(t *testing.T) {
 	// Loud-caps row was normalized successfully.
 	if got[0].Severity != SeverityBlocker || got[0].Area != AreaScope {
 		t.Errorf("normalize did not lowercase: %+v", got[0])
+	}
+}
+
+// TestParseFindings_SeveritySynonymsNormalized verifies that common
+// non-canonical severity labels (critical/high/warning) are mapped onto the
+// canonical set instead of being dropped, so a real blocker labeled "critical"
+// still reaches the grounded-finding rail as a blocking finding.
+func TestParseFindings_SeveritySynonymsNormalized(t *testing.T) {
+	extra := jsonExtra(t, `{
+		"findings": [
+			{"severity":"critical","area":"scope","message":"crit -> blocker"},
+			{"severity":"HIGH","area":"tests","message":"high -> major"},
+			{"severity":"warning","area":"style","message":"warning -> minor"}
+		]
+	}`)
+	got, warnings := ParseFindings(extra)
+	if len(warnings) != 0 {
+		t.Fatalf("synonyms must not warn/drop; got %d: %v", len(warnings), warnings)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 findings; got %d (%+v)", len(got), got)
+	}
+	if got[0].Severity != SeverityBlocker {
+		t.Errorf("critical must map to blocker, got %q", got[0].Severity)
+	}
+	if got[1].Severity != SeverityMajor {
+		t.Errorf("high must map to major, got %q", got[1].Severity)
+	}
+	if got[2].Severity != SeverityMinor {
+		t.Errorf("warning must map to minor, got %q", got[2].Severity)
 	}
 }
 


### PR DESCRIPTION
## What

A deterministic rail that demotes a reviewer NO-GO to GO when none of its blocking findings (severity blocker/major) cite a line the diff actually changed. The rejected findings are archived under `extra.ungroundedFindings`. Mirror of the existing scope-overlap / issueAsk rails, in the opposite direction.

## Why

Every existing reviewer rail guards the false-negative direction (a too-lenient GO). Nothing guarded the false-positive direction: a NO-GO whose blocking findings cite fabricated or out-of-scope code. In reviewer experiments a model blocked a branch on a fabricated file (`docs/MODEL-CACHE.md`, never in the diff) and on a pre-existing out-of-scope line (a `kubectl exec` print unchanged since the prior release). Both are objections not anchored to changed code. This rail makes the reviewer trustworthy: it can no longer block on inventions.

## How

- New `enforceReviewerGroundedFindings` (pure function, injected `changedLines(file)` closure, unit-tested): line-level grounding via the diff-hunk parsing already in the package; degrade-open on git error; `FOREMAN_GROUNDED_FINDINGS=0` toggle.
- Wired into the reviewer executor block before the GO->NO-GO rails, hoisting the diff ground-truth to one `repo.DiffNameOnly` call (fed to both rails). The closure is built in a small helper `reviewerGroundedChangedLines` to keep `runLLMPath` under the gocyclo cap.
- Reviewer prompt (`config/foreman/system-prompts/reviewer.md`) now requires `file`+`line` on blocking findings.

Scope note: this makes the reviewer trustworthy, not smarter. On a subtly-flawed branch where the reviewer never found the real defect, an ungrounded NO-GO correctly demotes to GO. Catching subtle gaps is a separate (stronger-model / panel) track.

## Interaction note

Demoting NO-GO->GO puts the branch on the normal review-GO path, so if a review task sets `Payload.OpenPullRequest`, a demoted GO that also clears scope-overlap AND issueAsk will auto-open a PR. This is design-consistent (an ungrounded NO-GO is treated as APPROVE) and double-gated by the two GO->NO-GO rails. The "real defect, wrong citation" case is covered by the stronger-reviewer / panel track, not this rail.

## Checklist

- [x] Tests added (8 table-driven cases: grounded, fabricated-file, unchanged-line, no-line, minor-only, GO-untouched, toggle-off, git-degrade-open)
- [x] make lint clean (darwin + GOOS=linux)
- [x] go test ./pkg/foreman/agent/... passes
- [x] No API/CRD changes

## AI assistance disclosure

Assisted-by: Claude Code (Claude Opus 4.8). Generated the implementation, tests, and PR text from a design I approved; I reviewed the diff, ran the gate locally (go test, make lint on darwin and GOOS=linux), and adversarially reviewed the whole branch before submitting.