### PR TITLE
feat(foreman): verdict-from-findings rail (promote GO with a grounded blocker)

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -627,6 +627,14 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// still get their turn to re-flag it for a real, computed reason.
 			verdict = enforceReviewerGroundedFindings(log, loopRes.Terminal.Extra, verdict,
 				reviewerGroundedChangedLines(ctx, log, workspace, reviewDiff, reviewDiffErr))
+			// Verdict-from-findings rail: the mirror of the demote rail. A GO
+			// carrying a grounded blocking finding is a found-it-but-approved
+			// inconsistency; promote it to NO-GO so it routes to escalation
+			// instead of opening a PR. Runs after the demote rail and before
+			// scope-overlap, so the two grounding rails jointly make the
+			// verdict NO-GO iff a grounded blocking finding exists.
+			verdict = enforceReviewerVerdictFromFindings(log, loopRes.Terminal.Extra, verdict,
+				reviewerGroundedChangedLines(ctx, log, workspace, reviewDiff, reviewDiffErr))
 			// Computable scope-overlap check (#647): when the issue names
 			// concrete files and the diff touches none of them, demote a
 			// GO deterministically. Runs before issueAsk enforcement so

--- a/pkg/foreman/agent/grounded_finding_gate.go
+++ b/pkg/foreman/agent/grounded_finding_gate.go
@@ -49,6 +49,39 @@ func groundedFindingsDisabled() bool {
 	return os.Getenv("FOREMAN_GROUNDED_FINDINGS") == "0"
 }
 
+// groundedBlockingFindings partitions the blocking findings (severity blocker
+// or major; minor is advisory and excluded) into those grounded in a changed
+// line and those not. A finding is grounded iff File is non-empty, Line > 0,
+// and Line is in changedLines(File) (a new-file line inside a diff hunk).
+// changedLines results are cached per file since it may shell out to git.
+// Both the grounded-finding demote rail and the verdict-from-findings promote
+// rail key on this partition, so they share one grounding definition.
+func groundedBlockingFindings(
+	findings []reviewer.Finding,
+	changedLines func(file string) map[int]bool,
+) (grounded, ungrounded []reviewer.Finding) {
+	cache := map[string]map[int]bool{}
+	lines := func(f string) map[int]bool {
+		if m, ok := cache[f]; ok {
+			return m
+		}
+		m := changedLines(f)
+		cache[f] = m
+		return m
+	}
+	for _, f := range findings {
+		if f.Severity != reviewer.SeverityBlocker && f.Severity != reviewer.SeverityMajor {
+			continue // minor is advisory, never blocking
+		}
+		if f.File != "" && f.Line > 0 && lines(f.File)[f.Line] {
+			grounded = append(grounded, f)
+		} else {
+			ungrounded = append(ungrounded, f)
+		}
+	}
+	return grounded, ungrounded
+}
+
 // enforceReviewerGroundedFindings demotes a model NO-GO to GO when none of its
 // blocking findings cite a changed line. Returns the (possibly demoted)
 // verdict. It is a no-op on any non-NO-GO verdict, when disabled, or when
@@ -72,31 +105,7 @@ func enforceReviewerGroundedFindings(
 	}
 
 	findings, _ := reviewer.ParseFindings(extra)
-
-	// Cache per-file changed lines: a NO-GO can carry several findings on the
-	// same file, and changedLines() may shell out to git per call.
-	cache := map[string]map[int]bool{}
-	lines := func(f string) map[int]bool {
-		if m, ok := cache[f]; ok {
-			return m
-		}
-		m := changedLines(f)
-		cache[f] = m
-		return m
-	}
-
-	var blocking, grounded, ungrounded []reviewer.Finding
-	for _, f := range findings {
-		if f.Severity != reviewer.SeverityBlocker && f.Severity != reviewer.SeverityMajor {
-			continue // minor is advisory, never sustains a NO-GO
-		}
-		blocking = append(blocking, f)
-		if f.File != "" && f.Line > 0 && lines(f.File)[f.Line] {
-			grounded = append(grounded, f)
-		} else {
-			ungrounded = append(ungrounded, f)
-		}
-	}
+	grounded, ungrounded := groundedBlockingFindings(findings, changedLines)
 
 	if len(grounded) >= 1 {
 		return verdict // rejection earned; NO-GO stands
@@ -104,11 +113,12 @@ func enforceReviewerGroundedFindings(
 
 	// Zero grounded blocking findings: the rejection is ungrounded. Demote to
 	// GO and archive, mirroring the filesTouchedClaimed transparency pattern.
+	blockingCount := len(grounded) + len(ungrounded)
 	extra["groundedFindingDemotion"] = true
 	extra["ungroundedFindings"] = ungrounded
 	extra["groundedFindingReason"] = fmt.Sprintf(
-		"NO-GO demoted to GO: 0 of %d blocking finding(s) cite a changed line", len(blocking))
+		"NO-GO demoted to GO: 0 of %d blocking finding(s) cite a changed line", blockingCount)
 	log.Info("reviewer grounded-finding: NO-GO demoted to GO; no blocking finding cites a changed line",
-		"blockingCount", len(blocking))
+		"blockingCount", blockingCount)
 	return foremanv1alpha1.AgenticTaskVerdictGo
 }

--- a/pkg/foreman/agent/grounded_finding_gate_test.go
+++ b/pkg/foreman/agent/grounded_finding_gate_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
 )
 
 // blockerFinding builds a findings extra map with one finding.
@@ -201,5 +202,28 @@ func TestReviewerGroundedChangedLines_EmptyBranchDiffDegradesClosed(t *testing.T
 	// Non-empty diff: a real closure is returned.
 	if got := reviewerGroundedChangedLines(ctx, log, t.TempDir(), []string{"a.go"}, nil); got == nil {
 		t.Fatal("non-empty branch diff must yield a real closure")
+	}
+}
+
+func TestGroundedBlockingFindings_Partition(t *testing.T) {
+	findings := []reviewer.Finding{
+		// grounded
+		{Severity: reviewer.SeverityBlocker, Area: "scope", Message: "m", File: "a.go", Line: 10},
+		// ungrounded: line not changed
+		{Severity: reviewer.SeverityMajor, Area: "scope", Message: "m", File: "b.go", Line: 99},
+		// ungrounded: no line
+		{Severity: reviewer.SeverityMajor, Area: "scope", Message: "m", File: "c.go", Line: 0},
+		// excluded: minor
+		{Severity: reviewer.SeverityMinor, Area: "style", Message: "m", File: "a.go", Line: 10},
+	}
+	changed := func(f string) map[int]bool {
+		return map[string]map[int]bool{"a.go": {10: true}, "b.go": {5: true}}[f]
+	}
+	grounded, ungrounded := groundedBlockingFindings(findings, changed)
+	if len(grounded) != 1 || grounded[0].File != "a.go" {
+		t.Fatalf("grounded = %+v, want [a.go:10]", grounded)
+	}
+	if len(ungrounded) != 2 {
+		t.Fatalf("ungrounded = %d, want 2 (b.go unchanged line + c.go no line)", len(ungrounded))
 	}
 }

--- a/pkg/foreman/agent/verdict_from_findings_gate.go
+++ b/pkg/foreman/agent/verdict_from_findings_gate.go
@@ -41,6 +41,11 @@ import (
 
 // verdictFromFindingsDisabled reports whether the promote rail is off via
 // FOREMAN_VERDICT_FROM_FINDINGS=0. Default (unset) is enabled.
+//
+// This toggle is independent of the grounded (demote) rail's
+// FOREMAN_GROUNDED_FINDINGS: disabling one leaves the other active. The joint
+// invariant (verdict == NO-GO iff a grounded blocking finding exists) therefore
+// holds only when both rails are enabled, which is the default.
 func verdictFromFindingsDisabled() bool {
 	return os.Getenv("FOREMAN_VERDICT_FROM_FINDINGS") == "0"
 }

--- a/pkg/foreman/agent/verdict_from_findings_gate.go
+++ b/pkg/foreman/agent/verdict_from_findings_gate.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Verdict-from-findings rail: the mirror of the grounded-finding demote rail.
+// The demote rail turns an ungrounded NO-GO into GO; this rail turns a GO into
+// NO-GO when the reviewer emitted a GROUNDED blocking finding (severity
+// blocker/major with file+line inside a changed hunk) yet still voted GO.
+// Together the two rails make the reviewer verdict a deterministic function of
+// the grounded blocking findings: NO-GO iff at least one exists, else GO.
+//
+// Motivation (2026-07-06 Nemotron isolation run): the model emitted a correct
+// finding ("CLI cache commands don't replicate controller's metal model
+// scoping") but voted GO. The model's verdict cannot be trusted; the grounded
+// findings can.
+//
+// Disabled by FOREMAN_VERDICT_FROM_FINDINGS=0.
+package agent
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
+)
+
+// verdictFromFindingsDisabled reports whether the promote rail is off via
+// FOREMAN_VERDICT_FROM_FINDINGS=0. Default (unset) is enabled.
+func verdictFromFindingsDisabled() bool {
+	return os.Getenv("FOREMAN_VERDICT_FROM_FINDINGS") == "0"
+}
+
+// enforceReviewerVerdictFromFindings promotes a model GO to NO-GO when it
+// carries at least one grounded blocking finding. No-op on any non-GO verdict,
+// when disabled, or when changedLines is nil (git unavailable -> degrade-open).
+func enforceReviewerVerdictFromFindings(
+	log logr.Logger,
+	extra map[string]any,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+	changedLines func(file string) map[int]bool,
+) foremanv1alpha1.AgenticTaskVerdict {
+	if verdictFromFindingsDisabled() ||
+		verdict != foremanv1alpha1.AgenticTaskVerdictGo ||
+		extra == nil || changedLines == nil {
+		return verdict
+	}
+
+	findings, _ := reviewer.ParseFindings(extra)
+	grounded, _ := groundedBlockingFindings(findings, changedLines)
+	if len(grounded) == 0 {
+		return verdict // no grounded blocker; the GO stands
+	}
+
+	// A grounded blocking finding present under a GO verdict is a
+	// found-it-but-approved inconsistency. Promote to NO-GO and archive the
+	// findings that forced it, mirroring the demote rail's transparency.
+	extra["verdictPromotedFromFindings"] = true
+	extra["promotingFindings"] = grounded
+	extra["verdictFromFindingsReason"] = fmt.Sprintf(
+		"GO promoted to NO-GO: %d grounded blocking finding(s) present", len(grounded))
+	log.Info("reviewer verdict-from-findings: GO promoted to NO-GO; grounded blocking finding present",
+		"groundedCount", len(grounded))
+	return foremanv1alpha1.AgenticTaskVerdictNoGo
+}

--- a/pkg/foreman/agent/verdict_from_findings_gate_test.go
+++ b/pkg/foreman/agent/verdict_from_findings_gate_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// vffExtra builds a findings extra map with one finding of the given severity,
+// file, and line (reusing the shape reviewer.ParseFindings expects).
+// nolint:unparam // file is parameterized for clarity at call sites even though existing tests all use "a.go"
+func vffExtra(severity, file string, line int) map[string]any {
+	return map[string]any{
+		"findings": []any{
+			map[string]any{"severity": severity, "area": "scope", "message": "m", "file": file, "line": line},
+		},
+	}
+}
+
+func vffChanged(fix map[string]map[int]bool) func(string) map[int]bool {
+	return func(f string) map[int]bool { return fix[f] }
+}
+
+func TestVerdictFromFindings_GroundedBlockerPromotes(t *testing.T) {
+	extra := vffExtra("blocker", "a.go", 10)
+	got := enforceReviewerVerdictFromFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo,
+		vffChanged(map[string]map[int]bool{"a.go": {10: true}}))
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("GO with a grounded blocker must promote to NO-GO, got %s", got)
+	}
+	if extra["verdictPromotedFromFindings"] != true {
+		t.Fatal("expected verdictPromotedFromFindings=true")
+	}
+	if extra["promotingFindings"] == nil {
+		t.Fatal("expected promotingFindings archived")
+	}
+}
+
+func TestVerdictFromFindings_GroundedMajorPromotes(t *testing.T) {
+	extra := vffExtra("major", "a.go", 10)
+	got := enforceReviewerVerdictFromFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo,
+		vffChanged(map[string]map[int]bool{"a.go": {10: true}}))
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("GO with a grounded major must promote to NO-GO, got %s", got)
+	}
+}
+
+func TestVerdictFromFindings_UngroundedBlockerStaysGo(t *testing.T) {
+	// Cites a changed file but an unchanged line -> ungrounded -> no promotion.
+	extra := vffExtra("blocker", "a.go", 999)
+	got := enforceReviewerVerdictFromFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo,
+		vffChanged(map[string]map[int]bool{"a.go": {10: true}}))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("GO with only an ungrounded blocker must stay GO, got %s", got)
+	}
+	if _, promoted := extra["verdictPromotedFromFindings"]; promoted {
+		t.Fatal("ungrounded blocker must not set promotion keys")
+	}
+}
+
+func TestVerdictFromFindings_MinorStaysGo(t *testing.T) {
+	extra := vffExtra("minor", "a.go", 10) // minor on a changed line is not blocking
+	got := enforceReviewerVerdictFromFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo,
+		vffChanged(map[string]map[int]bool{"a.go": {10: true}}))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("GO with only a minor finding must stay GO, got %s", got)
+	}
+}
+
+func TestVerdictFromFindings_NoGoUntouched(t *testing.T) {
+	extra := vffExtra("blocker", "a.go", 10) // grounded, but verdict is already NO-GO
+	got := enforceReviewerVerdictFromFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo,
+		vffChanged(map[string]map[int]bool{"a.go": {10: true}}))
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("rail must only act on GO; NO-GO must pass through, got %s", got)
+	}
+	if _, promoted := extra["verdictPromotedFromFindings"]; promoted {
+		t.Fatal("NO-GO path must not set promotion keys")
+	}
+}
+
+func TestVerdictFromFindings_ToggleOff(t *testing.T) {
+	t.Setenv("FOREMAN_VERDICT_FROM_FINDINGS", "0")
+	extra := vffExtra("blocker", "a.go", 10)
+	got := enforceReviewerVerdictFromFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo,
+		vffChanged(map[string]map[int]bool{"a.go": {10: true}}))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("toggle off must leave GO untouched, got %s", got)
+	}
+}
+
+func TestVerdictFromFindings_GitUnavailableDegradesOpen(t *testing.T) {
+	extra := vffExtra("blocker", "a.go", 10)
+	// changedLines == nil signals git unavailable -> degrade-open (no promotion).
+	got := enforceReviewerVerdictFromFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("nil changedLines must leave verdict untouched, got %s", got)
+	}
+}

--- a/pkg/foreman/agent/verdict_from_findings_gate_test.go
+++ b/pkg/foreman/agent/verdict_from_findings_gate_test.go
@@ -115,3 +115,38 @@ func TestVerdictFromFindings_GitUnavailableDegradesOpen(t *testing.T) {
 		t.Fatalf("nil changedLines must leave verdict untouched, got %s", got)
 	}
 }
+
+// TestGroundingRailsComposition runs the demote rail then the promote rail in
+// executor order and asserts the net invariant: after both, verdict == NO-GO
+// iff at least one grounded blocking finding is present, regardless of the
+// model's stated verdict. This guards the two-rail composition against future
+// reordering (the per-rail tests cover each rail in isolation).
+func TestGroundingRailsComposition(t *testing.T) {
+	gogo := foremanv1alpha1.AgenticTaskVerdictGo
+	nogo := foremanv1alpha1.AgenticTaskVerdictNoGo
+	changed := vffChanged(map[string]map[int]bool{"a.go": {10: true}})
+	blk := func() map[string]any { return vffExtra("blocker", "a.go", 10) } // grounded blocker
+	non := func() map[string]any { return vffExtra("minor", "a.go", 10) }   // not blocking
+
+	cases := []struct {
+		name  string
+		model foremanv1alpha1.AgenticTaskVerdict
+		extra map[string]any
+		want  foremanv1alpha1.AgenticTaskVerdict
+	}{
+		{"GO+blocker->NoGo", gogo, blk(), nogo},
+		{"NoGo+blocker->NoGo", nogo, blk(), nogo},
+		{"GO+none->GO", gogo, non(), gogo},
+		{"NoGo+none->GO", nogo, non(), gogo},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := tc.model
+			v = enforceReviewerGroundedFindings(logr.Discard(), tc.extra, v, changed)
+			v = enforceReviewerVerdictFromFindings(logr.Discard(), tc.extra, v, changed)
+			if v != tc.want {
+				t.Fatalf("net verdict = %s, want %s", v, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/verdict_from_findings_gate_test.go
+++ b/pkg/foreman/agent/verdict_from_findings_gate_test.go
@@ -125,8 +125,9 @@ func TestGroundingRailsComposition(t *testing.T) {
 	gogo := foremanv1alpha1.AgenticTaskVerdictGo
 	nogo := foremanv1alpha1.AgenticTaskVerdictNoGo
 	changed := vffChanged(map[string]map[int]bool{"a.go": {10: true}})
-	blk := func() map[string]any { return vffExtra("blocker", "a.go", 10) } // grounded blocker
-	non := func() map[string]any { return vffExtra("minor", "a.go", 10) }   // not blocking
+	blk := func() map[string]any { return vffExtra("blocker", "a.go", 10) }  // grounded blocker
+	ublk := func() map[string]any { return vffExtra("blocker", "a.go", 99) } // ungrounded blocker (line unchanged)
+	non := func() map[string]any { return vffExtra("minor", "a.go", 10) }    // not blocking (severity)
 
 	cases := []struct {
 		name  string
@@ -136,6 +137,10 @@ func TestGroundingRailsComposition(t *testing.T) {
 	}{
 		{"GO+blocker->NoGo", gogo, blk(), nogo},
 		{"NoGo+blocker->NoGo", nogo, blk(), nogo},
+		// Ungrounded BLOCKER (the #526-style false NO-GO the demote rail exists
+		// for): the blocker cites an unchanged line, so it is not grounded.
+		{"GO+ungrounded-blocker->GO", gogo, ublk(), gogo},
+		{"NoGo+ungrounded-blocker->GO", nogo, ublk(), gogo},
 		{"GO+none->GO", gogo, non(), gogo},
 		{"NoGo+none->GO", nogo, non(), gogo},
 	}


### PR DESCRIPTION
## What

The mirror of the grounded-finding rail (#988). When a reviewer votes GO but emitted a grounded blocking finding (severity blocker/major with file+line inside a changed hunk), the verdict is promoted to NO-GO and the promoting findings archived under `extra.promotingFindings`. Together with #988's demotion, the reviewer verdict becomes a deterministic function of the grounded blocking findings: **NO-GO iff at least one exists**, regardless of the model's stated verdict.

## Why

#988 stops a reviewer blocking on inventions (false positives). This stops the opposite failure: a reviewer that finds a real defect but votes GO anyway. In a 2026-07-06 Nemotron isolation run the model emitted a correct finding ("CLI cache commands don't replicate controller's metal model scoping") and then voted GO. The model's verdict cannot be trusted; the grounded findings can.

## How

- Extract `groundedBlockingFindings` (the blocking-findings grounded/ungrounded partition) from #988's demote rail into a shared helper; the demote rail is refactored to use it (behavior unchanged, its 8 tests still pass).
- New `enforceReviewerVerdictFromFindings` (pure function, injected `changedLines` closure, unit-tested): promotes GO->NO-GO on >=1 grounded blocking finding; degrade-open on git error; `FOREMAN_VERDICT_FROM_FINDINGS=0` toggle.
- Wired into the reviewer block right after the demote rail, before scope-overlap.
- A composition test exercises both rails in executor order across all four (model-verdict x grounded-blocker) cases, asserting the deterministic invariant.
- No prompt change (the file+line requirement #988 added is what makes findings groundable).

Interaction: a promoted NO-GO routes to escalation and does NOT open a PR, the correct effect for a found defect (the exact opposite of #988's demoted-GO-can-open-a-PR note).

> Stacked on #988 (branch `feat/reviewer-grounded-finding-rail`). This PR's diff includes #988's commits until #988 merges; rebase after.

## Checklist

- [x] Tests added (helper partition test, 7 rail cases, + a 4-case composition test proving the net invariant)
- [x] #988's grounded-finding tests still pass after the helper refactor
- [x] make lint clean (darwin + GOOS=linux)
- [x] No API/CRD changes

## AI assistance disclosure

Assisted-by: Claude Code (Claude Opus 4.8). Generated the implementation, tests, and PR text from a design I approved; I reviewed the diff, ran the gate locally (go test, make lint on darwin and GOOS=linux), and ran an adversarial whole-branch review (which added the composition test) before submitting.