### PR TITLE
docs(cachekey): note the metal literal mirrors acceleratorMetal

### DIFF
--- a/pkg/cachekey/cachekey.go
+++ b/pkg/cachekey/cachekey.go
@@ -64,6 +64,11 @@ func EffectiveKey(model *inferencev1alpha1.Model) string {
 		return model.Status.CacheKey
 	}
 	multiFile := len(model.Spec.Files) > 0 || model.Spec.Mmproj != ""
+	// The "metal" literal mirrors internal/controller.acceleratorMetal; it is
+	// duplicated here rather than imported because cachekey is a low-level
+	// utility that must not depend on the controller package. Keep the two in
+	// sync: if the accelerator value is ever renamed, update this literal too,
+	// or metal models will silently start deriving (and caching under) a key.
 	metal := model.Spec.Hardware != nil && model.Spec.Hardware.Accelerator == "metal"
 	if multiFile && !metal {
 		return Compute(model.Spec.Source)


### PR DESCRIPTION
## What

A one-line-of-intent doc comment at the `"metal"` literal in `cachekey.EffectiveKey`, noting it mirrors `internal/controller.acceleratorMetal` and must be kept in sync.

## Why

Fast-follow to #985. In that review @joryirving flagged a real (if low) coupling risk: `EffectiveKey` hard-codes `Accelerator == "metal"` rather than importing `acceleratorMetal`, so if the accelerator value were ever renamed, metal models would silently start deriving (and caching under) a key the controller never intended. The literal is duplicated deliberately — `cachekey` is a low-level utility that must not depend on the controller package — so a compile-time link isn't available; the next best guard is documenting the coupling at the point of risk.

## How

- Comment on the `metal :=` line in `pkg/cachekey/cachekey.go`.
- No behavior change; doc-only.

Note: a runtime drift-guard test would have to live in `internal/controller` (the only package that sees both `acceleratorMetal` and `cachekey.EffectiveKey`), which would drag that package's envtest setup into a pure unit test — more friction than the risk warrants, so the doc note is the proportionate fix.

## Checklist

- [x] Doc-only, no behavior change
- [x] `go build` + `gofmt` clean
- [x] DCO signed off
- [x] No AI-generated code (one human-written comment)