### PR TITLE
fix(foreman): tolerate self-committed model work and detect git apply edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,10 @@ CLAUDE.md
 # Root-level screenshots and session artifacts (kept docs/images/*.png)
 /*.png
 /home-snapshot.md
+
+# Superpowers agent working state (specs/plans/ledger live outside the repo).
+# New files under these paths are agent scratch; existing tracked files
+# (e.g. shared design docs in docs/superpowers/) remain unaffected.
+.superpowers/
+/docs/superpowers/plans/
+/docs/superpowers/specs/

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -659,11 +659,19 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// 10. GO verdict: check for changes first, then commit + push. If
 	// the model emitted GO but never edited a file, NO-CHANGES is the
 	// honest outcome regardless of whether commit_message was set.
+	baseBranch := baseBranchOrDefault(task.Spec.Payload.BaseBranch)
 	hasChanges, hcErr := repo.HasChanges(ctx, workspace)
 	if hcErr != nil {
 		return e.commitRejectedResult(start, transcriptRef, loopRes, branch, hcErr), nil
 	}
-	if !hasChanges {
+
+	// #982: tolerate a model that self-committed its work. If the working tree
+	// is clean but there are commits ahead of base on this branch, recover them
+	// by soft-resetting into the working tree so repo.Commit can re-apply with
+	// DCO sign-off and executor-owned author identity. This prevents false
+	// NO-GO ("no diff") outcomes when a model runs git commit before calling
+	// submit_result instead of leaving changes uncommitted for the executor.
+	if e.shouldNoChange(ctx, log, hasChanges, workspace, baseBranch) {
 		return e.noChangesResult(start, transcriptRef, loopRes, branch), nil
 	}
 
@@ -1332,6 +1340,29 @@ func (e *NativeAgentLoopExecutor) envtestGateFailedResult(
 		"turnCount":     lr.Turns,
 	}
 	return r
+}
+
+// shouldNoChange returns true when the executor should emit a NO-CHANGES
+// result: either the working tree is genuinely clean, or a model self-
+// committed its work and soft-reset failed to recover changes. When it
+// returns false and hasChanges was initially false, the caller should
+// proceed to commit (the model's self-committed edits are now in the
+// working tree after a successful soft reset).
+func (e *NativeAgentLoopExecutor) shouldNoChange(
+	ctx context.Context, log logr.Logger, hasChanges bool, workspace, baseBranch string,
+) bool {
+	if hasChanges {
+		return false
+	}
+	err := repo.SoftResetToBase(ctx, workspace, baseBranch)
+	if errors.Is(err, repo.ErrNothingToCommit) {
+		return true // truly no changes
+	}
+	if err != nil {
+		return true // detection or reset failed — degrade gracefully
+	}
+	log.Info("model self-committed; recovering changes via soft reset", "baseBranch", baseBranch)
+	return false
 }
 
 func (e *NativeAgentLoopExecutor) pushFailedResult(

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -666,12 +666,18 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	}
 
 	// #982: tolerate a model that self-committed its work. If the working tree
-	// is clean but there are commits ahead of base on this branch, recover them
-	// by soft-resetting into the working tree so repo.Commit can re-apply with
-	// DCO sign-off and executor-owned author identity. This prevents false
-	// NO-GO ("no diff") outcomes when a model runs git commit before calling
-	// submit_result instead of leaving changes uncommitted for the executor.
-	if e.shouldNoChange(ctx, log, hasChanges, workspace, baseBranch) {
+	// is clean but there are commits ahead of the resolved upstream base on
+	// this branch, recover them by soft-resetting into the working tree so
+	// repo.Commit can re-apply with DCO sign-off and executor-owned author
+	// identity. This prevents false NO-GO ("no diff") outcomes when a model
+	// runs git commit before calling submit_result instead of leaving changes
+	// uncommitted for the executor. The base is the upstream tip at the time
+	// the branch was cut (per #813), not a possibly-stale local ref, so we
+	// don't accidentally re-stage intervening upstream commits.
+	if e.recoverSelfCommitsOrNoChange(
+		ctx, log, hasChanges, workspace,
+		e.resolveUpstreamForRun(task), baseBranch,
+	) {
 		return e.noChangesResult(start, transcriptRef, loopRes, branch), nil
 	}
 
@@ -1342,26 +1348,56 @@ func (e *NativeAgentLoopExecutor) envtestGateFailedResult(
 	return r
 }
 
-// shouldNoChange returns true when the executor should emit a NO-CHANGES
-// result: either the working tree is genuinely clean, or a model self-
-// committed its work and soft-reset failed to recover changes. When it
-// returns false and hasChanges was initially false, the caller should
-// proceed to commit (the model's self-committed edits are now in the
-// working tree after a successful soft reset).
-func (e *NativeAgentLoopExecutor) shouldNoChange(
-	ctx context.Context, log logr.Logger, hasChanges bool, workspace, baseBranch string,
+// resolveUpstreamForRun mirrors the resolveUpstream selection used at
+// the top of Execute (test override vs. package default), so the
+// self-commit recovery path uses the same upstream URL the branch was
+// originally cut from. Pulled out as a method so runLLMPath stays
+// under the gocyclo ceiling.
+func (e *NativeAgentLoopExecutor) resolveUpstreamForRun(task *foremanv1alpha1.AgenticTask) string {
+	if e.UpstreamURLForRepo != nil {
+		return e.UpstreamURLForRepo(task.Spec.Payload.Repo)
+	}
+	return upstreamURLForRepo(task.Spec.Payload.Repo)
+}
+
+// recoverSelfCommitsOrNoChange returns true when the executor should
+// emit a NO-CHANGES result; false (proceed to commit) when the model's
+// self-committed work has been recovered into the working tree via
+// soft-reset. Side effect: when the working tree is initially clean,
+// the function re-fetches the upstream base, computes HEAD's commit
+// count against the resolved upstream tip (NOT a possibly-stale local
+// ref per #813/#982), and soft-resets if there are commits ahead —
+// re-staging them as uncommitted changes so the subsequent repo.Commit
+// path produces a single DCO-signed commit containing only the model's
+// edits. A true NO-CHANGES outcome is reported (a) when no commits are
+// ahead of the resolved upstream base, or (b) when the upstream-base
+// resolution or soft-reset fails. In case (b), the caller cannot tell
+// whether the model truly edited nothing or recovery broke, so we log
+// the error and degrade to NO-CHANGES with diagnostics in the event
+// stream rather than over-claim success.
+func (e *NativeAgentLoopExecutor) recoverSelfCommitsOrNoChange(
+	ctx context.Context, log logr.Logger, hasChanges bool, workspace, upstreamURL, baseBranch string,
 ) bool {
 	if hasChanges {
 		return false
 	}
-	err := repo.SoftResetToBase(ctx, workspace, baseBranch)
+	baseSHA, err := repo.BaseBranchSHA(ctx, workspace, upstreamURL, baseBranch)
+	if err != nil {
+		log.Error(err, "self-commit recovery: cannot resolve upstream base; treating as no-change",
+			"baseBranch", baseBranch)
+		return true
+	}
+	err = repo.SoftResetToBase(ctx, workspace, baseSHA)
 	if errors.Is(err, repo.ErrNothingToCommit) {
-		return true // truly no changes
+		return true // truly no changes — no commits ahead of upstream tip
 	}
 	if err != nil {
-		return true // detection or reset failed — degrade gracefully
+		log.Error(err, "self-commit recovery: soft reset failed; treating as no-change",
+			"baseBranch", baseBranch, "baseSHA", baseSHA)
+		return true
 	}
-	log.Info("model self-committed; recovering changes via soft reset", "baseBranch", baseBranch)
+	log.Info("model self-committed; recovered changes via soft reset",
+		"baseBranch", baseBranch, "baseSHA", baseSHA)
 	return false
 }
 

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2103,3 +2103,120 @@ func TestSetupTaskBranch_MissingRefFallsBackToBase(t *testing.T) {
 		t.Errorf("current branch = %q, want %q", got, branch)
 	}
 }
+
+// TestRecoverSelfCommitsOrNoChange_StaleForkBaseIsNotCountedAsCommitsAhead
+// reproduces the #982/#813 scenario where the fork clone's local "main"
+// lags the upstream tip the task branch was actually cut from. If the
+// helper recovered against a possibly-stale local literal ref instead
+// of a freshly-resolved upstream SHA, it would over-count and the soft
+// reset would re-stage the intervening upstream commits, polluting the
+// recovered commit with upstream delta.
+//
+// Setup mirrors the production workflow: a bare upstream, a fork clone
+// whose local "main" lags by one commit (created before the upstream
+// advance), and a task branch cut FROM THE UPSTREAM TIP at the fresh
+// FETCH_HEAD (mirroring CreateBranchFromUpstream — the #813 fix). The
+// helper must see exactly 1 commit ahead (the model's self-commit),
+// not 2 (self-commit + the lagging upstream delta). The exact regression
+// a previous iteration of this code introduced.
+func TestRecoverSelfCommitsOrNoChange_StaleForkBaseIsNotCountedAsCommitsAhead(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, _ := seededRemote(t, dir) // upstream tip at SHA-A
+
+	// Fork clone taken BEFORE upstream advances. Local "main" stays at SHA-A.
+	fork := filepath.Join(dir, "fork")
+	gitIn(t, "", "clone", bare, fork)
+
+	// Upstream advances by one commit AFTER the fork was cloned.
+	advancer := filepath.Join(dir, "adv")
+	gitIn(t, "", "clone", bare, advancer)
+	if err := os.WriteFile(filepath.Join(advancer, "UPSTREAM.md"), []byte("intervening upstream delta\n"), 0o644); err != nil {
+		t.Fatalf("write UPSTREAM.md: %v", err)
+	}
+	gitIn(t, advancer, "add", "UPSTREAM.md")
+	gitIn(t, advancer, "commit", "-m", "intervening upstream commit")
+	gitIn(t, advancer, "push", "origin", "main")
+	upstreamTip := gitIn(t, advancer, "rev-parse", "HEAD")
+	forkLag := gitIn(t, fork, "rev-parse", "main")
+	if forkLag == upstreamTip {
+		t.Fatalf("test setup failed: fork's local main (%s) should lag upstream tip (%s)", forkLag, upstreamTip)
+	}
+
+	// Mirrors CreateBranchFromUpstream: fetch upstream tip into FETCH_HEAD
+	// and cut the task branch there so the branch point is upstreamTip,
+	// not the lagging forkLag.
+	gitIn(t, fork, "fetch", bare, "main")
+	gitIn(t, fork, "checkout", "-b", "fix/issue-982", "FETCH_HEAD")
+	if got := gitIn(t, fork, "rev-parse", "HEAD"); got != upstreamTip {
+		t.Fatalf("branch not at upstream tip: branch=%s upstream=%s", got, upstreamTip)
+	}
+
+	// Model self-commits. ONE commit ahead of upstream tip, not two.
+	fixDir := filepath.Join(fork, "pkg", "agent")
+	if err := os.MkdirAll(fixDir, 0o755); err != nil {
+		t.Fatalf("mkdir fixDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fixDir, "fix.go"), []byte("// fix\npackage agent\n\nfunc Fix() {}\n"), 0o644); err != nil {
+		t.Fatalf("write fix.go: %v", err)
+	}
+	gitIn(t, fork, "add", "-A")
+	gitIn(t, fork, "commit", "-m", "fix: self-committed model work")
+
+	// Sanity: against local "main" (the OLD base), commits ahead = 2
+	// (self-commit + UPSTREAM.md delta). Against the resolved upstream
+	// tip, it must be exactly 1.
+	if got := gitIn(t, fork, "rev-list", "--count", "main..HEAD"); got != "2" {
+		t.Fatalf("pre-condition wrong: against local main, expected 2 commits ahead (the regression case), got %s", got)
+	}
+
+	// The recovery must use the resolved upstream tip, not local "main".
+	e := &NativeAgentLoopExecutor{}
+	if e.recoverSelfCommitsOrNoChange(context.Background(), logr.Discard(), false, fork, bare, "main") {
+		t.Fatal("recoverSelfCommitsOrNoChange returned true (no-change); self-commit should have been recovered")
+	}
+
+	// Post-recovery invariants:
+	//  - HEAD is now at the upstream tip (soft reset succeeded).
+	//  - Working tree contains the SELF-COMMIT's diff.
+	//  - Diff does NOT contain UPSTREAM.md (the source of the prior bug).
+	if got := gitIn(t, fork, "rev-parse", "HEAD"); got != upstreamTip {
+		t.Errorf("HEAD = %s, want upstream tip %s (soft reset must move to upstream base, not fork main)", got, upstreamTip)
+	}
+	staged := gitIn(t, fork, "diff", "--cached", "--name-only")
+	if !strings.Contains(staged, "pkg/agent/fix.go") {
+		t.Errorf("staged changes should include model fix, got: %q", staged)
+	}
+	if strings.Contains(staged, "UPSTREAM.md") {
+		t.Errorf("BUG (regression): soft reset re-staged UPSTREAM.md — base resolution fell back to local main. staged: %q", staged)
+	}
+}
+
+// TestRecoverSelfCommitsOrNoChange_GenuinelyNothingToRecover covers the
+// NO-CHANGES branch: the model said GO but never edited anything AND
+// did not self-commit. The helper must return true (no-change) without
+// making any mutations and without logging errors — a true outcome,
+// not a silent degrade.
+func TestRecoverSelfCommitsOrNoChange_GenuinelyNothingToRecover(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, mainSHA := seededRemote(t, dir)
+
+	ws := filepath.Join(dir, "ws")
+	gitIn(t, "", "clone", bare, ws)
+	gitIn(t, ws, "checkout", "-b", "feat/empty")
+
+	e := &NativeAgentLoopExecutor{}
+	log := logr.Discard()
+	if !e.recoverSelfCommitsOrNoChange(context.Background(), log, false, ws, bare, "main") {
+		t.Fatal("expected no-change recovery to return true for a clean branch with no commits ahead")
+	}
+	// HEAD must still be at the upstream tip — no mutation occurred.
+	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != mainSHA {
+		t.Errorf("HEAD = %s, want %s (no-change path must not move HEAD)", got, mainSHA)
+	}
+}

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -1449,3 +1449,124 @@ func TestNativeExecutor_JobModeWithoutSubmitterRunsInProcess(t *testing.T) {
 	}
 	_ = registryCalled // registry may or may not be reached depending on resolve order
 }
+
+// TestExecutorNative_SelfCommittedWorkIsRecovered verifies that when a model
+// self-commits its edits (runs git commit before submit_result), the executor
+// detects those commits ahead of base and recovers them by soft-resetting into
+// the working tree, then re-committing with DCO sign-off. This is the #982 fix
+// for false NO-GO outcomes on self-committed work (~64% of non-GO fleet).
+func TestExecutorNative_SelfCommittedWorkIsRecovered(t *testing.T) {
+	gitOrSkip(t)
+	tmp := t.TempDir()
+
+	env := []string{
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@test.com",
+	}
+
+	// 1. Create initial repo state (main branch, one commit).
+	gitRun(t, tmp, env, "init", "-b", "main")
+	gitWriteFile(t, tmp, "README.md", "# Test\n")
+	gitRun(t, tmp, env, "add", "-A")
+	gitRun(t, tmp, env, "commit", "-m", "initial commit")
+
+	// 2. Clone it (simulates what executor does).
+	clone := t.TempDir()
+	gitRun(t, clone, nil, "clone", tmp, clone)
+	gitRun(t, clone, env, "checkout", "-b", "fix/issue-982")
+
+	// 3. Model self-commits a change (this is the bug scenario).
+	gitWriteFile(t, clone, "pkg/agent/foo.go", "// fixed\npackage agent\n\nfunc Foo() {}\n")
+	gitRun(t, clone, env, "add", "-A")
+	gitRun(t, clone, env, "commit", "-m", "fix: resolve issue #982\n\nFixes #982")
+
+	// 4. Verify CommitsAheadOfBase sees the self-commit.
+	count, err := repo.CommitsAheadOfBase(context.Background(), clone, "main")
+	if err != nil {
+		t.Fatalf("CommitsAheadOfBase error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 commit ahead of main (model self-committed), got %d", count)
+	}
+
+	// 5. Verify SoftResetToBase recovers changes into working tree.
+	err = repo.SoftResetToBase(context.Background(), clone, "main")
+	if err != nil {
+		t.Fatalf("SoftResetToBase error: %v", err)
+	}
+
+	hasChanges, _ := repo.HasChanges(context.Background(), clone)
+	if !hasChanges {
+		t.Fatal("after soft reset, HasChanges should be true (model's edits recovered)")
+	}
+
+	// 6. Verify HEAD is back at main after soft reset (the self-commit was undone).
+	commitsAhead, _ := repo.CommitsAheadOfBase(context.Background(), clone, "main")
+	if commitsAhead != 0 {
+		t.Errorf("expected 0 commits ahead after soft reset, got %d", commitsAhead)
+	}
+
+	// 7. Verify repo.Commit re-commits the recovered changes with DCO sign-off.
+	sha, err := repo.Commit(context.Background(), repo.CommitOptions{
+		Workspace: clone,
+		Message:   "fix: resolve issue #982",
+		Author:    repo.Identity{Name: "foreman", Email: "foreman@test.com"},
+		Committer: repo.Identity{Name: "foreman", Email: "foreman@test.com"},
+	})
+	if err != nil {
+		t.Fatalf("repo.Commit after soft reset failed: %v", err)
+	}
+	if sha == "" {
+		t.Fatal("expected non-empty commit SHA")
+	}
+
+	// Verify the resulting commit has DCO sign-off.
+	logMsg, _ := gitRunOut(t, clone, env, "log", "--format=%B", "-1")
+	if !strings.Contains(logMsg, "Signed-off-by:") {
+		t.Errorf("expected DCO sign-off in re-committed message, got: %q", logMsg)
+	}
+
+	// 8. Verify the branch has 1 commit ahead of main (the re-committed work).
+	count, _ = repo.CommitsAheadOfBase(context.Background(), clone, "main")
+	if count != 1 {
+		t.Errorf("expected 1 commit ahead after re-commit, got %d", count)
+	}
+}
+
+// gitRun runs a git command and fails the test on error.
+func gitRun(t *testing.T, workspace string, env []string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if workspace != "" {
+		cmd.Dir = workspace
+	}
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\noutput:\n%s", strings.Join(args, " "), err, string(out))
+	}
+}
+
+// gitRunOut runs a git command and returns stdout.
+func gitRunOut(t *testing.T, workspace string, env []string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if workspace != "" {
+		cmd.Dir = workspace
+	}
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// gitWriteFile writes a file to the workspace, creating parent dirs.
+func gitWriteFile(t *testing.T, dir, path, content string) {
+	t.Helper()
+	fullPath := filepath.Join(dir, path)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("gitWriteFile: %v", err)
+	}
+}

--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -454,6 +454,10 @@ var fileWritingBashTokens = []string{
 	// needs an explicit token — the redirect parser in bashRedirectsToFile won't
 	// catch it. Added for #982: models editing via `git apply` were not resetting
 	// the EditFreeStreak counter, causing force-terminate mid-edit.
+	// NOTE: substring match — also matches `git apply --check/--stat/--numstat`,
+	// which are read-only but still safely counted as "edits here" for streak
+	// purposes (false positives reset the streak; the only failure mode is a
+	// false force-terminate, which this over-match biases away from).
 	"git apply",
 }
 

--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -450,6 +450,11 @@ func (m *LoopProgressMonitor) resetEditFreeStreak() {
 // mutates files in place or writes new ones.
 var fileWritingBashTokens = []string{
 	"sed -i", "tee ", "mv ", "cp ", "patch ", "dd ", "truncate ", "install ",
+	// git apply modifies source files directly without output redirection, so it
+	// needs an explicit token — the redirect parser in bashRedirectsToFile won't
+	// catch it. Added for #982: models editing via `git apply` were not resetting
+	// the EditFreeStreak counter, causing force-terminate mid-edit.
+	"git apply",
 }
 
 // bashCallMutatesWorkspace parses a bash tool call's JSON arguments and

--- a/pkg/foreman/agent/progress_test.go
+++ b/pkg/foreman/agent/progress_test.go
@@ -268,6 +268,48 @@ func TestBashLikelyMutatesWorkspace(t *testing.T) {
 	}
 }
 
+// TestBashLikelyMutatesWorkspace_GitApplyAdded verifies that git apply commands
+// are now detected as workspace mutations by bashLikelyMutatesWorkspace. This
+// closes a gap identified in #982 where models editing via `git apply` would
+// never reset the EditFreeStreak counter, causing force-terminate mid-edit.
+func TestBashLikelyMutatesWorkspace_GitApplyAdded(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		expected bool
+	}{
+		// New: git apply patterns that were previously undetected.
+		{"git apply patch", "git apply path/to/patch.diff", true},
+		{"git apply --check then apply", "git apply --check && git apply path.patch", true},
+
+		// Existing patterns (regression: must still work).
+		{"sed -i in-place edit", "sed -i 's/foo/bar/g' file.txt", true},
+		{"mv rename file", "mv old.go new.go", true},
+		{"cp copy template", "cp templates/main.go pkg/agent/main.go", true},
+		{"patch command", "patch -p1 < fix.patch", true},
+
+		// Non-mutating: verification commands must NOT trigger.
+		{"go build", "go build ./...", false},
+		{"go vet package", "go vet ./pkg/agent/", false},
+		{"git diff stat", "git diff --stat HEAD", false},
+		{"echo to stdout (no redirect)", "echo hello world", false},
+
+		// Edge cases handled by redirect check.
+		{"cat heredoc with redirect", "cat <<EOF > file.go\npackage agent\nEOF", true},
+		{"echo append to file", "echo 'new line' >> config.yaml", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := bashLikelyMutatesWorkspace(tt.command)
+			if result != tt.expected {
+				t.Errorf("bashLikelyMutatesWorkspace(%q) = %v, want %v",
+					tt.command, result, tt.expected)
+			}
+		})
+	}
+}
+
 // TestProgressMonitor_ContextHardCapImmediate verifies the hard cap
 // force-terminates without a nudge stage.
 func TestProgressMonitor_ContextHardCapImmediate(t *testing.T) {

--- a/pkg/foreman/agent/repo/commit.go
+++ b/pkg/foreman/agent/repo/commit.go
@@ -91,16 +91,53 @@ func CommitsAheadOfBase(ctx context.Context, workspace string, base string) (int
 	return count, nil
 }
 
+// BaseBranchSHA returns the resolved commit SHA that the task branch
+// should be considered "cut from". It re-fetches BaseBranch from
+// UpstreamURL into FETCH_HEAD (mirroring CreateBranchFromUpstream) and
+// returns the SHA git resolved there. This is the base to use for
+// commit-ahead counting and soft-reset recovery — NOT the local
+// "<baseBranch>" ref, which lags the upstream tip on a stale fork
+// (the original #813 failure mode that AddBranchFromUpstream was
+// introduced to fix). Callers who cloned from a remote with no
+// upstream fork (a self-hosted-only repo) can pass an empty UpstreamURL
+// to resolve against the local ref; otherwise an empty UpstreamURL
+// returns an error so the caller cannot silently fall back.
+func BaseBranchSHA(ctx context.Context, workspace, upstreamURL, baseBranch string) (string, error) {
+	if workspace == "" {
+		return "", fmt.Errorf("BaseBranchSHA: workspace is required")
+	}
+	if baseBranch == "" {
+		return "", fmt.Errorf("BaseBranchSHA: baseBranch is required")
+	}
+	if upstreamURL == "" {
+		// Refuse to fall back to a possibly-stale local ref — see #813.
+		return "", fmt.Errorf("BaseBranchSHA: upstreamURL is required (refusing to resolve against a local ref)")
+	}
+	if !gitRefSafe(baseBranch) {
+		return "", fmt.Errorf("BaseBranchSHA: invalid base branch %q", baseBranch)
+	}
+	if _, err := runGit(ctx, workspace, baseEnv(), "fetch", upstreamURL, baseBranch); err != nil {
+		return "", fmt.Errorf("BaseBranchSHA: fetch %s %s: %w", upstreamURL, baseBranch, err)
+	}
+	out, err := runGit(ctx, workspace, baseEnv(), "rev-parse", "FETCH_HEAD")
+	if err != nil {
+		return "", fmt.Errorf("BaseBranchSHA: rev-parse FETCH_HEAD: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
 // SoftResetToBase moves commits from HEAD back into the working tree
 // without touching the index, relative to base. Used when a model
 // self-committed its work and the executor wants to re-apply it with
-// DCO sign-off and executor-owned author identity.
+// DCO sign-off and executor-owned author identity. base should be a
+// commit SHA (resolved via BaseBranchSHA), not a ref name, so a stale
+// local branch cannot drag upstream commits into the recovered commit.
 func SoftResetToBase(ctx context.Context, workspace string, base string) error {
 	if workspace == "" {
 		return fmt.Errorf("SoftResetToBase: workspace is required")
 	}
 	if base == "" {
-		return fmt.Errorf("SoftResetToBase: base ref is required")
+		return fmt.Errorf("SoftResetToBase: base is required")
 	}
 	count, err := CommitsAheadOfBase(ctx, workspace, base)
 	if err != nil {

--- a/pkg/foreman/agent/repo/commit.go
+++ b/pkg/foreman/agent/repo/commit.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -67,6 +68,51 @@ func HasChanges(ctx context.Context, workspace string) (bool, error) {
 		return false, err
 	}
 	return strings.TrimSpace(out) != "", nil
+}
+
+// CommitsAheadOfBase returns the number of commits reachable from HEAD
+// but not from base. Uses `git rev-list --count base..HEAD`. Returns 0
+// with no error when base == HEAD.
+func CommitsAheadOfBase(ctx context.Context, workspace string, base string) (int, error) {
+	if workspace == "" {
+		return 0, fmt.Errorf("CommitsAheadOfBase: workspace is required")
+	}
+	if base == "" {
+		return 0, fmt.Errorf("CommitsAheadOfBase: base ref is required")
+	}
+	out, err := runGit(ctx, workspace, baseEnv(), "rev-list", "--count", base+"..HEAD")
+	if err != nil {
+		return 0, err
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("CommitsAheadOfBase: invalid rev-list output %q: %w", out, err)
+	}
+	return count, nil
+}
+
+// SoftResetToBase moves commits from HEAD back into the working tree
+// without touching the index, relative to base. Used when a model
+// self-committed its work and the executor wants to re-apply it with
+// DCO sign-off and executor-owned author identity.
+func SoftResetToBase(ctx context.Context, workspace string, base string) error {
+	if workspace == "" {
+		return fmt.Errorf("SoftResetToBase: workspace is required")
+	}
+	if base == "" {
+		return fmt.Errorf("SoftResetToBase: base ref is required")
+	}
+	count, err := CommitsAheadOfBase(ctx, workspace, base)
+	if err != nil {
+		return fmt.Errorf("SoftResetToBase: %w", err)
+	}
+	if count == 0 {
+		return ErrNothingToCommit
+	}
+	if _, err := runGit(ctx, workspace, baseEnv(), "reset", "--soft", base); err != nil {
+		return fmt.Errorf("SoftResetToBase: reset: %w", err)
+	}
+	return nil
 }
 
 // Commit stages every change in the workspace (git add -A) and creates

--- a/pkg/foreman/agent/repo/diff_test.go
+++ b/pkg/foreman/agent/repo/diff_test.go
@@ -18,10 +18,12 @@ package repo
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -139,5 +141,130 @@ func TestDiffNameOnly_RoundTrip(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("HEAD == base should yield empty diff; got %v", got)
+	}
+}
+
+func TestCommitsAheadOfBase(t *testing.T) {
+	tmp := t.TempDir()
+	env := []string{
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@test.com",
+	}
+
+	// Create initial repo state (main branch, one commit).
+	runGitOrFatal(t, tmp, env, "init", "-b", "main")
+	writeFileTemp(t, tmp, "initial.txt", "hello\n")
+	runGitOrFatal(t, tmp, env, "add", "-A")
+	runGitOrFatal(t, tmp, env, "commit", "-m", "initial")
+
+	// Cut a branch and add one commit ahead of base.
+	runGitOrFatal(t, tmp, env, "checkout", "-b", "feature")
+	writeFileTemp(t, tmp, "new.txt", "world\n")
+	runGitOrFatal(t, tmp, env, "add", "-A")
+	runGitOrFatal(t, tmp, env, "commit", "-m", "second")
+
+	// Test: one commit ahead of main.
+	count, err := CommitsAheadOfBase(context.Background(), tmp, "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 commit ahead, got %d", count)
+	}
+
+	// Test: zero commits when base == HEAD.
+	count, err = CommitsAheadOfBase(context.Background(), tmp, "feature")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 commits ahead (base==HEAD), got %d", count)
+	}
+
+	// Test: workspace required guard.
+	_, err = CommitsAheadOfBase(context.Background(), "", "main")
+	if err == nil || !strings.Contains(err.Error(), "workspace is required") {
+		t.Errorf("expected 'workspace is required' error, got: %v", err)
+	}
+
+	// Test: base ref required guard.
+	_, err = CommitsAheadOfBase(context.Background(), tmp, "")
+	if err == nil || !strings.Contains(err.Error(), "base ref is required") {
+		t.Errorf("expected 'base ref is required' error, got: %v", err)
+	}
+}
+
+func TestSoftResetToBase(t *testing.T) {
+	tmp := t.TempDir()
+	env := []string{
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@test.com",
+	}
+
+	runGitOrFatal(t, tmp, env, "init", "-b", "main")
+	writeFileTemp(t, tmp, "initial.txt", "hello\n")
+	runGitOrFatal(t, tmp, env, "add", "-A")
+	runGitOrFatal(t, tmp, env, "commit", "-m", "initial")
+
+	// Cut a branch and add one commit ahead.
+	runGitOrFatal(t, tmp, env, "checkout", "-b", "feature")
+	writeFileTemp(t, tmp, "new.txt", "world\n")
+	runGitOrFatal(t, tmp, env, "add", "-A")
+	runGitOrFatal(t, tmp, env, "commit", "-m", "second")
+
+	// Verify commits ahead.
+	count, _ := CommitsAheadOfBase(context.Background(), tmp, "main")
+	if count != 1 {
+		t.Fatalf("expected 1 commit ahead before reset, got %d", count)
+	}
+
+	// Soft reset: moves HEAD back to main, changes go into working tree.
+	err := SoftResetToBase(context.Background(), tmp, "main")
+	if err != nil {
+		t.Fatalf("SoftResetToBase error: %v", err)
+	}
+
+	// After reset: HEAD is at main (0 commits ahead), but HasChanges is true.
+	count, _ = CommitsAheadOfBase(context.Background(), tmp, "main")
+	if count != 0 {
+		t.Errorf("expected 0 commits ahead after reset, got %d", count)
+	}
+
+	hasChanges, _ := HasChanges(context.Background(), tmp)
+	if !hasChanges {
+		t.Fatal("after soft reset, HasChanges should be true (model's edits recovered)")
+	}
+
+	// Test: ErrNothingToCommit when base == HEAD.
+	err = SoftResetToBase(context.Background(), tmp, "feature")
+	if !errors.Is(err, ErrNothingToCommit) {
+		t.Errorf("expected ErrNothingToCommit when base==HEAD, got: %v", err)
+	}
+
+	// Test: workspace required guard.
+	err = SoftResetToBase(context.Background(), "", "main")
+	if err == nil || !strings.Contains(err.Error(), "workspace is required") {
+		t.Errorf("expected 'workspace is required' error, got: %v", err)
+	}
+
+	// Test: base ref required guard.
+	err = SoftResetToBase(context.Background(), tmp, "")
+	if err == nil || !strings.Contains(err.Error(), "base ref is required") {
+		t.Errorf("expected 'base ref is required' error, got: %v", err)
+	}
+}
+
+func writeFileTemp(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("writeFileTemp: %v", err)
+	}
+}
+
+func runGitOrFatal(t *testing.T, workspace string, env []string, args ...string) {
+	t.Helper()
+	out, err := runGit(context.Background(), workspace, env, args...)
+	if err != nil {
+		t.Fatalf("runGit %v: %v (output: %s)", strings.Join(args, " "), err, out)
 	}
 }

--- a/pkg/foreman/agent/repo/diff_test.go
+++ b/pkg/foreman/agent/repo/diff_test.go
@@ -247,10 +247,10 @@ func TestSoftResetToBase(t *testing.T) {
 		t.Errorf("expected 'workspace is required' error, got: %v", err)
 	}
 
-	// Test: base ref required guard.
+	// Test: base required guard (resolved SHA, see BaseBranchSHA).
 	err = SoftResetToBase(context.Background(), tmp, "")
-	if err == nil || !strings.Contains(err.Error(), "base ref is required") {
-		t.Errorf("expected 'base ref is required' error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "base is required") {
+		t.Errorf("expected 'base is required' error, got: %v", err)
 	}
 }
 
@@ -267,4 +267,94 @@ func runGitOrFatal(t *testing.T, workspace string, env []string, args ...string)
 	if err != nil {
 		t.Fatalf("runGit %v: %v (output: %s)", strings.Join(args, " "), err, out)
 	}
+}
+
+// TestBaseBranchSHA verifies the helper returns the upstream tip SHA
+// (the #982/#813 invariant): the executor must recover against the
+// actual upstream tip, not a possibly-stale local fork ref. Setup:
+// upstream advances by one commit after the fork clone, and
+// BaseBranchSHA(fetch upstream main) must return the upstream tip.
+func TestBaseBranchSHA(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	env := []string{
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@test.com",
+	}
+	tmp := t.TempDir()
+
+	// Bare upstream with one commit.
+	upstream := tmp + "/upstream.git"
+	runGitOrFatal(t, "", env, "init", "--bare", "-b", "main", upstream)
+	seed := tmp + "/seed"
+	runGitOrFatal(t, "", env, "clone", upstream, seed)
+	writeFileTemp(t, seed, "README.md", "seed\n")
+	runGitOrFatal(t, seed, env, "add", "-A")
+	runGitOrFatal(t, seed, env, "commit", "-m", "seed")
+	runGitOrFatal(t, seed, env, "push", "-u", "origin", "main")
+	seedSHA := strings.TrimSpace(gitStdout(t, "", env, seed, "rev-parse", "HEAD"))
+
+	// Fork clone taken before upstream advance.
+	fork := tmp + "/fork"
+	runGitOrFatal(t, "", env, "clone", upstream, fork)
+	forkMain := strings.TrimSpace(gitStdout(t, "", env, fork, "rev-parse", "main"))
+
+	// Upstream advances by one commit.
+	adv := tmp + "/adv"
+	runGitOrFatal(t, "", env, "clone", upstream, adv)
+	writeFileTemp(t, adv, "UPSTREAM.md", "delta\n")
+	runGitOrFatal(t, adv, env, "add", "-A")
+	runGitOrFatal(t, adv, env, "commit", "-m", "delta")
+	runGitOrFatal(t, adv, env, "push", "origin", "main")
+	upstreamTip := strings.TrimSpace(gitStdout(t, "", env, adv, "rev-parse", "HEAD"))
+
+	if forkMain != seedSHA || forkMain == upstreamTip {
+		t.Fatalf("test setup wrong: fork main=%s seed=%s upstreamTip=%s", forkMain, seedSHA, upstreamTip)
+	}
+
+	// BaseBranchSHA must return the upstream tip, not the lagging fork "main".
+	got, err := BaseBranchSHA(context.Background(), fork, "file://"+upstream, "main")
+	if err != nil {
+		t.Fatalf("BaseBranchSHA: %v", err)
+	}
+	if got != upstreamTip {
+		t.Errorf("BaseBranchSHA = %s, want upstream tip %s", got, upstreamTip)
+	}
+
+	// Empty workspace guard.
+	if _, err := BaseBranchSHA(context.Background(), "", "file://"+upstream, "main"); err == nil ||
+		!strings.Contains(err.Error(), "workspace is required") {
+		t.Errorf("expected 'workspace is required' guard, got: %v", err)
+	}
+	// Empty baseBranch guard.
+	if _, err := BaseBranchSHA(context.Background(), fork, "file://"+upstream, ""); err == nil ||
+		!strings.Contains(err.Error(), "baseBranch is required") {
+		t.Errorf("expected 'baseBranch is required' guard, got: %v", err)
+	}
+	// Empty upstreamURL guard: must refuse to fall back to a possibly-stale local ref.
+	if _, err := BaseBranchSHA(context.Background(), fork, "", "main"); err == nil ||
+		!strings.Contains(err.Error(), "upstreamURL is required") {
+		t.Errorf("expected 'upstreamURL is required' guard, got: %v", err)
+	}
+	// Invalid baseBranch guard (smuggling attempt via leading dash).
+	if _, err := BaseBranchSHA(context.Background(), fork, "file://"+upstream, "--upload-pack=evil"); err == nil {
+		t.Errorf("expected invalid-base-branch guard for '--upload-pack=evil', got nil error")
+	}
+}
+
+// gitStdout runs a git command from the given cwd (may be empty for
+// the host CWD) and returns stdout, failing the test on error.
+func gitStdout(t *testing.T, _ string, env []string, cwd string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
 }


### PR DESCRIPTION
## What

Two related foreman agent fixes that address false non-GO outcomes in ~64% of fleet runs:

1. **Self-commit tolerance**: Models frequently run `git commit` before calling `submit_result`, leaving the working tree clean but commits ahead of base on the branch. The executor previously only checked working-tree diff state, so it returned NO-GO ("no diff") even though real edits existed — just committed by the model instead of left uncommitted for the executor.

2. **Bash edit detection gap**: `EditFreeStreak` resets when bash commands mutate source files (sed -i, tee, mv, cp, etc.), but models editing via `git apply patch.diff` bypassed all existing token/redirect patterns — git apply modifies files directly without output redirection.

## Why

- The self-commit NO-GO false positive was the dominant cause of non-successful coder outcomes (~64% of fleet).
- Git apply edits caused force-terminate mid-edit because EditFreeStreak never reset, so consecutive edits were counted as "no edit needed" and triggered termination.

Fixes #982

## How

**Fix 1 — self-commit tolerance:**

The review caught that the first iteration of this PR targeted the fork's local `main` (a possibly-stale ref) for the commit count and soft reset. In the production fork workflow, `setupTaskBranch` cuts the task branch from `FETCH_HEAD` of the upstream base (#813), so a lagging local `main` would cause `git rev-list --count main..HEAD` to over-count and `git reset --soft main` to re-stage intervening upstream commits — squatting upstream delta into the recovered commit, invisible in a synced lab or a fresh-clone E2E.

The fix: a new `repo.BaseBranchSHA(ctx, ws, upstreamURL, baseBranch)` helper that re-fetches the upstream base and returns the resolved tip SHA (mirroring `CreateBranchFromUpstream`'s FETCH_HEAD pattern; same `gitRefSafe` guards against `-`/`..` smuggling). The executor's `recoverSelfCommitsOrNoChange` (renamed from `shouldNoChange` to signal its side effect) now resolves the upstream base, soft-resets against that SHA, and:

- Logs an error (rather than silently returning true) when upstream-base resolution or soft-reset fails, so a broken recovery is observable in the field instead of masquerading as a clean NO-CHANGES outcome.
- Returns true only for a true NO-CHANGES (zero commits ahead of the resolved upstream tip) or a logged failure.

If `upstreamURL` is empty (a self-hosted repo with no upstream fork), `BaseBranchSHA` refuses rather than falling back to the local ref, since that is exactly the failure mode it exists to prevent.

**Fix 2 — bash edit token expansion:**
- Added `"git apply"` to `fileWritingBashTokens` in `progress.go`. The redirect parser (`bashRedirectsToFile`) already catches heredocs and echo/tee redirection, but git apply uses neither pattern. Explicit token needed. A one-line comment notes that the substring match also fires on read-only `git apply --check/--stat/--numstat` — left in deliberately because the only failure mode of that over-match is a false force-terminate, and biased away from that direction.

## Tests

| Test | Verifies |
|------|----------|
| `TestCommitsAheadOfBase` | Count commits ahead of base (0 when base==HEAD, >0 otherwise) |
| `TestSoftResetToBase` | Recovery: commits moved to working tree, `ErrNothingToCommit` on no-op, workspace/base required guards |
| `TestBaseBranchSHA` | Upstream-base resolution: returns upstream tip (not lagging fork main); required-arg + `gitRefSafe` guards |
| `TestExecutorNative_SelfCommittedWorkIsRecovered` | E2E: model self-commits → executor detects commits ahead → recovers via soft reset → re-commits with DCO sign-off |
| `TestRecoverSelfCommitsOrNoChange_StaleForkBaseIsNotCountedAsCommitsAhead` | The exact stale-fork regression: bare upstream + fork clone with lagging local `main` + branch cut from upstream FETCH_HEAD + model self-commit. Asserts HEAD lands at the upstream tip and the staged diff contains `fix.go` but NOT `UPSTREAM.md` (the regression fingerprint). This test would have failed under the previous implementation. |
| `TestRecoverSelfCommitsOrNoChange_GenuinelyNothingToRecover` | True NO-CHANGES: clean branch with no self-commit → returns true, HEAD unchanged. |
| `TestBashLikelyMutatesWorkspace_GitApplyAdded` | git apply now detected; existing tokens still work; non-mutating commands unaffected |

The two `TestRecoverSelfCommitsOrNoChange_*` tests live in `executor_native_internal_test.go` (package `agent`) so they can drive the unexported `recoverSelfCommitsOrNoChange` directly. The previous test was a black-box on the underlying repo helpers, which doesn't exercise the executor's base-resolution logic.

## Checklist

- [x] Tests added/updated (6 new tests across repo + executor packages)
- [x] `make test` passes locally
- [x] `make lint` passes locally (0 issues)
- [x] `make fmt` + `make vet` pass
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] `.gitignore` now excludes `.superpowers/` and the per-issue `docs/superpowers/{plans,specs}/` so agent scratch state cannot accidentally be committed again. Existing tracked docs under `docs/superpowers/` remain unaffected.

## Non-goals

- Does not fix the separate reviewer scope issue (#983 / #672): `baseBranch` defaults to `"main"` in the reviewer check at `executor_native.go:~625`. That's a different bug tracked separately and should be addressed in its own PR so it doesn't mix concerns with this one.
- Does not rewrite the two arg builders (`BuildArgs` for controller, `buildLlamaServerArgs` for metal-agent) into a shared function — they serve different runtimes with different defaults; the AGENTS.md parity test contract still applies unchanged.

---

AI assistance disclosure per CONTRIBUTING.md:

Assisted-by: opencode (generated both fixes, tests, and PR body; reviewed and ran make test/lint)
