### PR TITLE
fix: add TTL-based retention for audit ConfigMaps

### DIFF
--- a/pkg/foreman/audit/writer.go
+++ b/pkg/foreman/audit/writer.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,14 @@ const (
 	// AuditedAnnotation guards against re-writing a record on every reconcile
 	// of an already-terminal task (which would emit duplicate audit lines).
 	AuditedAnnotation = "foreman.llmkube.dev/audited"
+
+	// TTLAnnotationKey is the annotation key that stores the TTL in seconds
+	// after which the audit ConfigMap should be reaped.
+	TTLAnnotationKey = "foreman.llmkube.dev/audit-ttl-seconds"
+
+	// DefaultTTLSeconds is the default retention period for audit ConfigMaps
+	// (30 days).
+	DefaultTTLSeconds = 30 * 24 * 60 * 60
 )
 
 // AuditConfigMapName returns the ConfigMap name for a task's audit record.
@@ -45,6 +54,8 @@ func AuditConfigMapName(taskName string) string { return auditNamePrefix + taskN
 // reference is deliberate: the record must outlive the AgenticTask so it
 // remains a compliance trail after task garbage-collection. namespace is the
 // audit namespace (caller passes the task namespace when unset upstream).
+// The ConfigMap is annotated with a TTL (DefaultTTLSeconds) so that
+// ReapOldRecords can clean up stale records.
 func WriteRecord(ctx context.Context, c client.Client, namespace string, rec Record, log logr.Logger) error {
 	data, err := json.Marshal(rec)
 	if err != nil {
@@ -58,6 +69,9 @@ func WriteRecord(ctx context.Context, c client.Client, namespace string, rec Rec
 				AuditLabel:                  "true",
 				AuditTaskLabel:              rec.Task.Name,
 				"app.kubernetes.io/part-of": "foreman",
+			},
+			Annotations: map[string]string{
+				TTLAnnotationKey: fmt.Sprintf("%d", DefaultTTLSeconds),
 			},
 			// No OwnerReferences: survives task GC by design.
 		},
@@ -137,4 +151,37 @@ func RecordTerminal(
 		return fmt.Errorf("audit: set audited annotation: %w", err)
 	}
 	return nil
+}
+
+// ReapOldRecords deletes audit ConfigMaps in namespace that are older than
+// their TTL annotation (TTLAnnotationKey). ConfigMaps without the annotation
+// are skipped (they are assumed to be managed by a different process).
+// Returns the number of ConfigMaps deleted.
+func ReapOldRecords(ctx context.Context, c client.Client, namespace string, log logr.Logger) (int, error) {
+	cms := &corev1.ConfigMapList{}
+	if err := c.List(ctx, cms, client.InNamespace(namespace), client.MatchingLabels{AuditLabel: "true"}); err != nil {
+		return 0, fmt.Errorf("audit: list configmaps: %w", err)
+	}
+	var deleted int
+	for i := range cms.Items {
+		cm := &cms.Items[i]
+		ttlStr, ok := cm.Annotations[TTLAnnotationKey]
+		if !ok {
+			continue
+		}
+		var ttlSec int64
+		if _, err := fmt.Sscanf(ttlStr, "%d", &ttlSec); err != nil {
+			log.Info("audit: invalid TTL annotation; skipping", "configmap", cm.Name, "annotation", ttlStr)
+			continue
+		}
+		if cm.CreationTimestamp.Add(time.Duration(ttlSec) * time.Second).After(time.Now()) {
+			continue
+		}
+		if err := c.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
+			return deleted, fmt.Errorf("audit: delete configmap %s: %w", cm.Name, err)
+		}
+		deleted++
+		log.Info("audit: reaped old ConfigMap", "configmap", cm.Name, "ttlSeconds", ttlSec)
+	}
+	return deleted, nil
 }

--- a/pkg/foreman/audit/writer_test.go
+++ b/pkg/foreman/audit/writer_test.go
@@ -11,10 +11,12 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -106,5 +108,109 @@ func TestRecordTerminalWritesOnceAndSetsAnnotation(t *testing.T) {
 	err := c.Get(ctx, types.NamespacedName{Namespace: "default", Name: "foreman-audit-coder-89"}, &corev1.ConfigMap{})
 	if !apierrors.IsNotFound(err) {
 		t.Errorf("already-audited task must not re-write the record; got err=%v", err)
+	}
+}
+
+func TestReapOldRecordsDeletesExpiredConfigMaps(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+	ctx := context.Background()
+
+	// Create an expired audit ConfigMap (TTL=1s, created 10s ago).
+	expired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreman-audit-expired-task",
+			Namespace: "default",
+			Labels: map[string]string{
+				AuditLabel:     "true",
+				AuditTaskLabel: "expired-task",
+			},
+			Annotations: map[string]string{
+				TTLAnnotationKey: "1",
+			},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+		},
+		Data: map[string]string{auditDataKey: "{}"},
+	}
+	if err := c.Create(ctx, expired); err != nil {
+		t.Fatalf("create expired CM: %v", err)
+	}
+
+	// Create a fresh audit ConfigMap (TTL=3600s, created just now).
+	fresh := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreman-audit-fresh-task",
+			Namespace: "default",
+			Labels: map[string]string{
+				AuditLabel:     "true",
+				AuditTaskLabel: "fresh-task",
+			},
+			Annotations: map[string]string{
+				TTLAnnotationKey: "3600",
+			},
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Data: map[string]string{auditDataKey: "{}"},
+	}
+	if err := c.Create(ctx, fresh); err != nil {
+		t.Fatalf("create fresh CM: %v", err)
+	}
+
+	// Create an audit ConfigMap without TTL annotation (should be skipped).
+	noTTL := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreman-audit-nottl-task",
+			Namespace: "default",
+			Labels: map[string]string{
+				AuditLabel:     "true",
+				AuditTaskLabel: "nottl-task",
+			},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+		},
+		Data: map[string]string{auditDataKey: "{}"},
+	}
+	if err := c.Create(ctx, noTTL); err != nil {
+		t.Fatalf("create no-TTL CM: %v", err)
+	}
+
+	deleted, err := ReapOldRecords(ctx, c, "default", logr.Discard())
+	if err != nil {
+		t.Fatalf("ReapOldRecords: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", deleted)
+	}
+
+	// Expired CM should be gone.
+	expKey := types.NamespacedName{Namespace: "default", Name: "foreman-audit-expired-task"}
+	if err := c.Get(ctx, expKey, &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
+		t.Errorf("expired CM should have been deleted, got err=%v", err)
+	}
+	// Fresh CM should still exist.
+	freshKey := types.NamespacedName{Namespace: "default", Name: "foreman-audit-fresh-task"}
+	if err := c.Get(ctx, freshKey, &corev1.ConfigMap{}); err != nil {
+		t.Errorf("fresh CM should still exist: %v", err)
+	}
+	// No-TTL CM should still exist.
+	noTTLKey := types.NamespacedName{Namespace: "default", Name: "foreman-audit-nottl-task"}
+	if err := c.Get(ctx, noTTLKey, &corev1.ConfigMap{}); err != nil {
+		t.Errorf("no-TTL CM should still exist: %v", err)
+	}
+}
+
+func TestWriteRecordSetsTTLAnnotation(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+	rec := Record{SchemaVersion: SchemaVersion, Task: TaskRef{Name: "coder-89", Namespace: "default"}, Verdict: "GO"}
+
+	if err := WriteRecord(context.Background(), c, "default", rec, logr.Discard()); err != nil {
+		t.Fatalf("WriteRecord: %v", err)
+	}
+
+	var cm corev1.ConfigMap
+	key := types.NamespacedName{Namespace: "default", Name: "foreman-audit-coder-89"}
+	if err := c.Get(context.Background(), key, &cm); err != nil {
+		t.Fatalf("audit ConfigMap not created: %v", err)
+	}
+	if cm.Annotations[TTLAnnotationKey] != "2592000" {
+		t.Errorf("TTL annotation not set correctly, got %q", cm.Annotations[TTLAnnotationKey])
 	}
 }


### PR DESCRIPTION
Fix adds TTL reaper for audit ConfigMaps but lacks documentation updates for the new annotation

Fixes #990

_Opened by foreman on review GO (workload run-20260706-131421)._