### PR TITLE
fix(foreman): truncate over-length submit_result summaries instead of rejecting

### DIFF
--- a/pkg/foreman/agent/tools/submit_result.go
+++ b/pkg/foreman/agent/tools/submit_result.go
@@ -30,6 +30,30 @@ import (
 // forcing a one-sentence outcome rather than a wall of text.
 const MaxSubmitSummaryLen = 280
 
+// truncateRuneSafe truncates s to at most maxLen bytes, appending an
+// ellipsis if truncation occurred. It never splits a multi-byte rune:
+// if the byte limit falls inside a rune, the rune is dropped entirely.
+func truncateRuneSafe(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	ellipsis := "…"
+	// Reserve space for the ellipsis.
+	avail := maxLen - len(ellipsis)
+	// Walk runes until we would exceed avail.
+	var b []rune
+	byteLen := 0
+	for _, r := range s {
+		runeBytes := len(string(r))
+		if byteLen+runeBytes > avail {
+			break
+		}
+		b = append(b, r)
+		byteLen += runeBytes
+	}
+	return string(b) + ellipsis
+}
+
 // SubmitResultTool is the terminal tool. When the model calls it, the
 // loop captures the envelope and exits. The fields map directly onto
 // AgenticTaskStatus.Verdict + Status.Result + the commit message the
@@ -84,8 +108,7 @@ func (SubmitResultTool) Execute(_ context.Context, args json.RawMessage) (*agent
 		return nil, fmt.Errorf("submit_result: summary is required")
 	}
 	if len(a.Summary) > MaxSubmitSummaryLen {
-		return nil, fmt.Errorf("submit_result: summary must be %d chars or fewer (got %d)",
-			MaxSubmitSummaryLen, len(a.Summary))
+		a.Summary = truncateRuneSafe(a.Summary, MaxSubmitSummaryLen)
 	}
 	return &agent.ToolResult{
 		Terminal:      true,

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -927,8 +927,75 @@ func TestSubmitResult_SummaryTooLong(t *testing.T) {
 	tool := SubmitResultTool{}
 	long := strings.Repeat("x", MaxSubmitSummaryLen+1)
 	body, _ := json.Marshal(map[string]any{"verdict": "GO", "summary": long})
-	_, err := tool.Execute(context.Background(), body)
-	if err == nil || !strings.Contains(err.Error(), "chars or fewer") {
-		t.Errorf("expected summary-too-long error, got %v", err)
+	res, err := tool.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatalf("Execute should succeed after truncation: %v", err)
+	}
+	if len(res.Summary) > MaxSubmitSummaryLen {
+		t.Errorf("summary not truncated: got %d bytes", len(res.Summary))
+	}
+	if !strings.HasSuffix(res.Summary, "…") {
+		t.Errorf("truncated summary should end with ellipsis, got %q", res.Summary)
+	}
+}
+
+func TestSubmitResult_SummaryTruncationRuneSafe(t *testing.T) {
+	tool := SubmitResultTool{}
+	// Build a summary that is exactly MaxSubmitSummaryLen bytes, then
+	// append a multi-byte rune so the byte limit falls inside it.
+	base := strings.Repeat("x", MaxSubmitSummaryLen-3) // 3 bytes for "…"
+	summary := base + "🔥"                              // 4-byte rune; total > MaxSubmitSummaryLen
+	body, _ := json.Marshal(map[string]any{"verdict": "GO", "summary": summary})
+	res, err := tool.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(res.Summary) > MaxSubmitSummaryLen {
+		t.Errorf("summary exceeds cap: got %d bytes", len(res.Summary))
+	}
+	// The emoji should be dropped entirely, not split.
+	if strings.Contains(res.Summary, "🔥") {
+		t.Errorf("multi-byte rune should be dropped, not split")
+	}
+}
+
+func TestTruncateRuneSafe(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+	}{
+		{
+			name:   "short string unchanged",
+			input:  "hello",
+			maxLen: 10,
+		},
+		{
+			name:   "exact length unchanged",
+			input:  strings.Repeat("x", 10),
+			maxLen: 10,
+		},
+		{
+			name:   "truncate with ellipsis",
+			input:  strings.Repeat("x", 15),
+			maxLen: 10,
+		},
+		{
+			name:   "multi-byte rune dropped not split",
+			input:  strings.Repeat("x", 9) + "🔥",
+			maxLen: 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateRuneSafe(tt.input, tt.maxLen)
+			if len(result) > tt.maxLen {
+				t.Errorf("truncateRuneSafe(%q, %d) = %d bytes, want <= %d",
+					tt.input, tt.maxLen, len(result), tt.maxLen)
+			}
+			if len(tt.input) > tt.maxLen && !strings.HasSuffix(result, "…") {
+				t.Errorf("truncated result should end with ellipsis, got %q", result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

`submit_result` now truncates an over-length summary instead of hard-rejecting it. The summary is clamped to the 280-char cap with a rune-safe truncation (never splits a multi-byte rune) and an ellipsis marks that it was shortened.

## Why

Fixes #961

A summary over the cap was rejected with an error, so the model re-submitted the same over-length summary until the stuck-loop detector force-terminated the run. Because the terminal `submit_result` never succeeded, no GO was recorded and the executor never committed or pushed: a completed implementation was lost over cosmetic characters. Summary length is human-facing metadata (`AgenticTask.status.result.summary`); it has no bearing on correctness, so failing a finished run over it is the wrong tradeoff.

## How

Added `truncateRuneSafe(s, maxLen)`: walks runes up to the byte cap, appends `…`, and drops (never splits) a multi-byte rune that would straddle the limit. The over-length branch clamps instead of erroring. Tests cover the happy path, the rune-safe boundary (a 4-byte emoji at the limit), and a table of `truncateRuneSafe` cases.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go test ./pkg/foreman/agent/tools/` green)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO, by a human
- [x] AI assistance disclosed below
- [ ] Documentation updated: n/a (internal agent-tool behavior, no user-facing surface)

---

Assisted-by: Foreman, LLMKube's own agentic coder (a local model on the in-cluster Strix node), generated the implementation and tests. The change was verified by the Foreman gate (GATE-PASS) and reviewed by a local Nemotron-49B reviewer (GO). I reviewed the diff, ran `go test` and `golangci-lint` locally, and I am accountable for this change.
