### PR TITLE
feat(foreman): closest-line fallback when str_replace has no unique anchor

### DIFF
--- a/pkg/foreman/agent/tools/str_replace.go
+++ b/pkg/foreman/agent/tools/str_replace.go
@@ -151,6 +151,15 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 					"The file's actual current text near your edit is below - copy it "+
 					"VERBATIM into old_string and retry:\n%s%s", a.Path, actual, writeFileHint(content))
 			}
+			// No unique verbatim anchor exists. Fall back to the closest line
+			// match so the model always gets real file content to re-anchor on
+			// instead of the bare count error (#944).
+			if closest := closestLineContext(content, a.OldString); closest != "" {
+				return nil, fmt.Errorf("str_replace: old_string not found in %q. "+
+					"No unique anchor line exists; the closest approximate match "+
+					"in the file is below (not verbatim). Copy the actual bytes "+
+					"VERBATIM into old_string and retry:\n%s%s", a.Path, closest, writeFileHint(content))
+			}
 		}
 		return nil, fmt.Errorf("str_replace: old_string found %d times in %q, want %d%s",
 			occurrences, a.Path, want, writeFileHint(content))
@@ -381,4 +390,54 @@ func anchorContext(content, oldString string) (string, bool) {
 		hi = len(contentLines)
 	}
 	return strings.Join(contentLines[lo:hi], "\n"), true
+}
+
+// closestLineContext is the best-effort fallback when anchorContext finds no
+// unique verbatim anchor. It scores every file line against the most
+// distinctive old_string line (longest trimmed line, skipping trivial lines)
+// using boundedLevenshtein and returns the surrounding real lines of the
+// single lowest-distance hit, clearly labeled as approximate. This gives the
+// model actual file bytes to re-anchor on instead of the bare count error.
+func closestLineContext(content, oldString string) string {
+	contentLines := strings.Split(content, "\n")
+	oldLines := strings.Split(oldString, "\n")
+
+	// Pick the most distinctive old_string line (longest trimmed, skip trivial).
+	bestIdx, bestLen := -1, 0
+	for i, ol := range oldLines {
+		trimmed := strings.TrimSpace(ol)
+		if len(trimmed) < 8 {
+			continue
+		}
+		if len(trimmed) > bestLen {
+			bestLen = len(trimmed)
+			bestIdx = i
+		}
+	}
+	if bestIdx < 0 {
+		return ""
+	}
+	probe := strings.TrimSpace(oldLines[bestIdx])
+
+	// Score every content line against the probe; keep the closest hit.
+	minDist := len(probe) + 1 // worse than any real distance
+	closestIdx := 0
+	for i, cl := range contentLines {
+		d := boundedLevenshtein(strings.TrimSpace(cl), probe, minDist)
+		if d < minDist {
+			minDist = d
+			closestIdx = i
+		}
+	}
+
+	span := strings.Count(oldString, "\n") + 1
+	lo := closestIdx - 2
+	if lo < 0 {
+		lo = 0
+	}
+	hi := closestIdx + span + 2
+	if hi > len(contentLines) {
+		hi = len(contentLines)
+	}
+	return strings.Join(contentLines[lo:hi], "\n")
 }

--- a/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
+++ b/pkg/foreman/agent/tools/str_replace_fuzzy_test.go
@@ -347,3 +347,35 @@ func TestStrReplace_IdenticalOldNewRejected(t *testing.T) {
 		t.Errorf("file must be unchanged, got %q", got)
 	}
 }
+
+// When anchorContext finds no unique verbatim anchor (every old_string line
+// appears 0 or 2+ times in the file), the error must still carry real file
+// content via the closestLineContext fallback (#944). The bare count error
+// gives the model nothing to re-anchor on.
+func TestStrReplace_ClosestLineFallbackWhenNoUniqueAnchor(t *testing.T) {
+	ws := makeWorkspace(t)
+	// Build a file where every line of old_string appears 0 or 2+ times,
+	// so anchorContext cannot find a unique verbatim anchor. The old_string
+	// must have 0 occurrences to trigger the recovery ladder.
+	src := "func alpha() int {\n\treturn count\n}\n" +
+		"func alpha() int {\n\treturn count\n}\n"
+	seedFile(t, ws, "g.go", src)
+	// old_string has 0 occurrences (drifted), and every line it contains
+	// appears 2+ times in the file, so anchorContext finds no unique anchor.
+	old := "func alpha() int {\n\treturn total\n}"
+	err := execStrReplace(t, ws, "g.go", old, "x")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Must NOT be the bare count error; must contain real file content.
+	if !strings.Contains(err.Error(), "closest") {
+		t.Errorf("expected closest-line fallback message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "return count") {
+		t.Errorf("expected real file content in the error, got: %v", err)
+	}
+	// File must be untouched.
+	if got := readBack(t, ws, "g.go"); got != src {
+		t.Errorf("file must be unchanged, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

When `str_replace`'s recovery ladder is exhausted and `anchorContext` finds no unique verbatim anchor line, the error now includes a best-effort closest-line match from the file (real bytes, clearly labeled approximate) instead of the bare "old_string found 0 times". This gives the model actual file content to re-anchor on.

## Why

Fixes #944

Previously, exhausting the ladder returned only "old_string found 0 times, want 1" with nothing to correct against, so the coder burned its edit budget re-hallucinating `old_string` until the stuck-loop detector killed the run. This exact failure was observed live in a 2026-07-06 Foreman run on issue #970: the coder implemented the feature but could not update the test files via `str_replace` and bailed INCOMPLETE, discarding otherwise-complete work.

## How

Added `closestLineContext(content, oldString)`: picks the most distinctive `old_string` line (longest trimmed, skipping trivial short lines), scores every file line against it with the existing `boundedLevenshtein`, and returns the surrounding real lines of the single closest hit, labeled as approximate. Wired into the recovery ladder after the unique-anchor attempt and before the bare count error. Feedback only: it never auto-applies, and the unique-window rule for automatic edits is unchanged.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go test ./pkg/foreman/agent/tools/` green)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO, by a human
- [x] AI assistance disclosed below
- [ ] Documentation updated: n/a (internal agent-tool behavior, no user-facing surface)

---

Assisted-by: Foreman, LLMKube's own agentic coder (a local model on the in-cluster Strix node), generated the implementation and tests. The change was verified by the Foreman gate (GATE-PASS) and reviewed by a local Nemotron-49B reviewer (GO). I reviewed the diff, ran `go test` and `golangci-lint` locally, and I am accountable for this change.
