### PR TITLE
fix(foreman): reviewer diffs against the upstream base, not stale local fork main

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -606,7 +606,13 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// calls returned correct data; the server-side rewrite makes
 			// the model's claim a debugging artifact and the diff the
 			// authoritative answer.
-			reconcileReviewerFilesTouched(ctx, log, workspace, loopRes.Terminal.Extra)
+			// Resolve the branch's true base ONCE for every reviewer diff below:
+			// the upstream base tip it was cut from (#813), freshly fetched. The
+			// reviewer clones the fork, whose local `main` lags upstream, so
+			// diffing against local `main` sweeps in the whole intervening
+			// upstream delta and neuters every rail (#1005).
+			reviewBase := e.reviewerDiffBase(ctx, log, task, workspace)
+			reconcileReviewerFilesTouched(ctx, log, workspace, reviewBase, loopRes.Terminal.Extra)
 			// Ground-truth issueAsk against the fetch_issue tool result
 			// the model already had in its context. Devstral on the same
 			// post-#584 batch confabulated issueAsk on every multi-file
@@ -618,7 +624,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			reconcileReviewerIssueAsk(log, loopRes.Transcript, loopRes.Terminal.Extra)
 			// Ground-truth the branch diff ONCE for the two computable rails
 			// below (grounded-finding + scope-overlap).
-			reviewDiff, reviewDiffErr := repo.DiffNameOnly(ctx, workspace, "main")
+			reviewDiff, reviewDiffErr := repo.DiffNameOnly(ctx, workspace, reviewBase)
 			// Grounded-finding rail: a NO-GO must be earned by >=1 blocking
 			// finding citing a line the diff changed; otherwise demote it to GO
 			// and archive the rejected findings. Mirror of scope-overlap, in the
@@ -626,7 +632,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// ungrounded rejection becomes GO and then scope-overlap / issueAsk
 			// still get their turn to re-flag it for a real, computed reason.
 			verdict = enforceReviewerGroundedFindings(log, loopRes.Terminal.Extra, verdict,
-				reviewerGroundedChangedLines(ctx, log, workspace, reviewDiff, reviewDiffErr))
+				reviewerGroundedChangedLines(ctx, log, workspace, reviewBase, reviewDiff, reviewDiffErr))
 			// Verdict-from-findings rail: the mirror of the demote rail. A GO
 			// carrying a grounded blocking finding is a found-it-but-approved
 			// inconsistency; promote it to NO-GO so it routes to escalation
@@ -634,7 +640,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// scope-overlap, so the two grounding rails jointly make the
 			// verdict NO-GO iff a grounded blocking finding exists.
 			verdict = enforceReviewerVerdictFromFindings(log, loopRes.Terminal.Extra, verdict,
-				reviewerGroundedChangedLines(ctx, log, workspace, reviewDiff, reviewDiffErr))
+				reviewerGroundedChangedLines(ctx, log, workspace, reviewBase, reviewDiff, reviewDiffErr))
 			// Computable scope-overlap check (#647): when the issue names
 			// concrete files and the diff touches none of them, demote a
 			// GO deterministically. Runs before issueAsk enforcement so
@@ -773,7 +779,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 // closure there would ground every finding as "unchanged" and demote every
 // NO-GO to GO, opening the PR the reviewer meant to block.
 func reviewerGroundedChangedLines(
-	ctx context.Context, log logr.Logger, workspace string, reviewDiff []string, reviewDiffErr error,
+	ctx context.Context, log logr.Logger, workspace, base string, reviewDiff []string, reviewDiffErr error,
 ) func(string) map[int]bool {
 	if reviewDiffErr != nil {
 		log.Info("reviewer grounded-finding: ground-truth diff unavailable; skipping",
@@ -785,7 +791,7 @@ func reviewerGroundedChangedLines(
 		return nil
 	}
 	return func(file string) map[int]bool {
-		return changedBranchLines(ctx, workspace, "main", file, execCommandRunner)
+		return changedBranchLines(ctx, workspace, base, file, execCommandRunner)
 	}
 }
 
@@ -1747,12 +1753,12 @@ func buildUserPrompt(task *foremanv1alpha1.AgenticTask) string {
 // with main).
 func reconcileReviewerFilesTouched(
 	ctx context.Context, log logr.Logger,
-	workspace string, extra map[string]any,
+	workspace, base string, extra map[string]any,
 ) {
 	if extra == nil || workspace == "" {
 		return
 	}
-	groundTruth, err := repo.DiffNameOnly(ctx, workspace, "main")
+	groundTruth, err := repo.DiffNameOnly(ctx, workspace, base)
 	if err != nil {
 		log.Info("reviewer filesTouched: ground-truth diff failed; preserving model claim",
 			"err", err.Error())
@@ -1771,6 +1777,29 @@ func reconcileReviewerFilesTouched(
 		)
 	}
 	extra["filesTouched"] = groundTruth
+}
+
+// reviewerDiffBase resolves the ref the reviewer diffs HEAD against: the coder
+// branch's upstream base tip, freshly fetched (repo.BaseBranchSHA, #995). The
+// reviewer clones the contributor's fork, whose local `main` lags the upstream
+// base the branch was cut from (#813), so diffing against local `main` sweeps
+// in the whole intervening upstream delta and neuters every reviewer rail
+// (#1005). Falls back to the local "main" ref only when no upstream is
+// resolvable (freeform tasks), matching the pre-#1005 degrade posture.
+func (e *NativeAgentLoopExecutor) reviewerDiffBase(
+	ctx context.Context, log logr.Logger, task *foremanv1alpha1.AgenticTask, workspace string,
+) string {
+	upstreamURL := e.resolveUpstreamForRun(task)
+	if upstreamURL == "" {
+		return "main"
+	}
+	base, err := repo.BaseBranchSHA(ctx, workspace, upstreamURL, baseBranchOrDefault(task.Spec.Payload.BaseBranch))
+	if err != nil {
+		log.Info("reviewer diff base: upstream base unavailable; falling back to local main",
+			"err", err.Error())
+		return "main"
+	}
+	return base
 }
 
 // fileListsEqual returns true when prev (which is `any` because it

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -978,7 +978,7 @@ func TestReconcileReviewerFilesTouched_OverwritesAndPreservesClaim(t *testing.T)
 		"findings":      []any{},
 	}
 
-	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), ws, extra)
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), ws, "main", extra)
 
 	got, ok := extra["filesTouched"].([]string)
 	if !ok {
@@ -1020,7 +1020,7 @@ func TestReconcileReviewerFilesTouched_HonestClaimNoClaimedFieldAdded(t *testing
 
 	honestClaim := []any{"a.go", "c.go"}
 	extra := map[string]any{"filesTouched": honestClaim}
-	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), ws, extra)
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), ws, "main", extra)
 
 	if _, present := extra["filesTouchedClaimed"]; present {
 		t.Errorf("filesTouchedClaimed should NOT be set when claim matched; got %v",
@@ -1037,8 +1037,8 @@ func TestReconcileReviewerFilesTouched_HonestClaimNoClaimedFieldAdded(t *testing
 }
 
 func TestReconcileReviewerFilesTouched_NilExtraIsNoOp(t *testing.T) {
-	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), "/tmp", nil)
-	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), "", map[string]any{"x": 1})
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), "/tmp", "main", nil)
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), "", "main", map[string]any{"x": 1})
 }
 
 func TestReconcileReviewerFilesTouched_GitFailurePreservesClaim(t *testing.T) {
@@ -1052,7 +1052,7 @@ func TestReconcileReviewerFilesTouched_GitFailurePreservesClaim(t *testing.T) {
 
 	originalClaim := []any{"some-file.go"}
 	extra := map[string]any{"filesTouched": originalClaim}
-	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), ws, extra)
+	reconcileReviewerFilesTouched(context.Background(), logr.Discard(), ws, "main", extra)
 
 	got, ok := extra["filesTouched"].([]any)
 	if !ok {
@@ -2016,6 +2016,74 @@ func seededRemote(t *testing.T, dir string) (bare, mainSHA string) {
 	gitIn(t, seed, "commit", "-m", "seed")
 	gitIn(t, seed, "push", "origin", "main")
 	return bare, gitIn(t, seed, "rev-parse", "HEAD")
+}
+
+// TestReviewerDiffBase_ResolvesUpstreamNotStaleForkMain guards #1005: the
+// reviewer clones the fork, whose local `main` lags the upstream base the
+// coder branch was cut from. Diffing against local `main` sweeps in the whole
+// intervening upstream delta; reviewerDiffBase must instead resolve the fresh
+// upstream base so the diff isolates the coder's change.
+func TestReviewerDiffBase_ResolvesUpstreamNotStaleForkMain(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, _ := seededRemote(t, dir) // upstream main at A
+
+	// Fork clone taken BEFORE upstream advances: local "main" stays at A.
+	fork := filepath.Join(dir, "fork")
+	gitIn(t, "", "clone", bare, fork)
+
+	// Upstream advances by one unrelated commit AFTER the fork was cloned.
+	adv := filepath.Join(dir, "adv")
+	gitIn(t, "", "clone", bare, adv)
+	if err := os.WriteFile(filepath.Join(adv, "UPSTREAM.md"), []byte("intervening upstream delta\n"), 0o644); err != nil {
+		t.Fatalf("write UPSTREAM.md: %v", err)
+	}
+	gitIn(t, adv, "add", "UPSTREAM.md")
+	gitIn(t, adv, "commit", "-m", "intervening upstream commit")
+	gitIn(t, adv, "push", "origin", "main")
+
+	// Coder branch: cut from the CURRENT upstream tip, plus a one-file fix.
+	gitIn(t, fork, "fetch", bare, "main")
+	gitIn(t, fork, "checkout", "-b", "fix/issue-1005", "FETCH_HEAD")
+	fixDir := filepath.Join(fork, "pkg", "agent")
+	if err := os.MkdirAll(fixDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fixDir, "fix.go"), []byte("// fix\npackage agent\n"), 0o644); err != nil {
+		t.Fatalf("write fix.go: %v", err)
+	}
+	gitIn(t, fork, "add", "-A")
+	gitIn(t, fork, "commit", "-m", "fix: the coder change under review")
+
+	// Pre-condition: against the STALE local main, the diff wrongly includes
+	// the upstream delta (the bug this fix removes).
+	if stale := gitIn(t, fork, "diff", "--name-only", "main...HEAD"); !strings.Contains(stale, "UPSTREAM.md") {
+		t.Fatalf("pre-condition wrong: local-main diff should include the upstream delta, got %q", stale)
+	}
+
+	// reviewerDiffBase resolves the fresh upstream base instead of local main.
+	e := &NativeAgentLoopExecutor{UpstreamURLForRepo: func(string) string { return bare }}
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind:    foremanv1alpha1.AgenticTaskKindReview,
+			Payload: foremanv1alpha1.AgenticTaskPayload{Repo: "defilantech/LLMKube", BaseBranch: "main"},
+		},
+	}
+	base := e.reviewerDiffBase(context.Background(), logr.Discard(), task, fork)
+	if base == "main" {
+		t.Fatal("reviewerDiffBase fell back to local main; expected the resolved upstream base SHA")
+	}
+
+	// Diffing against the resolved base isolates the coder's change.
+	got := gitIn(t, fork, "diff", "--name-only", base+"...HEAD")
+	if !strings.Contains(got, "pkg/agent/fix.go") {
+		t.Errorf("diff should include the coder fix, got %q", got)
+	}
+	if strings.Contains(got, "UPSTREAM.md") {
+		t.Errorf("BUG #1005: reviewer diff base still sweeps in the upstream delta, got %q", got)
+	}
 }
 
 func revisionTask(branch string) *foremanv1alpha1.AgenticTask {

--- a/pkg/foreman/agent/grounded_finding_gate_test.go
+++ b/pkg/foreman/agent/grounded_finding_gate_test.go
@@ -172,7 +172,7 @@ func TestReviewerGroundedChangedLines_UsesCommittedBranchDiff(t *testing.T) {
 	}
 
 	// The caller passes the ground-truth diff file list (non-empty here).
-	changed := reviewerGroundedChangedLines(context.Background(), logr.Discard(), ws, []string{"foo.go"}, nil)
+	changed := reviewerGroundedChangedLines(context.Background(), logr.Discard(), ws, "main", []string{"foo.go"}, nil)
 	if changed == nil {
 		t.Fatal("closure must be non-nil when the ground-truth diff is available")
 	}
@@ -196,11 +196,11 @@ func TestReviewerGroundedChangedLines_UsesCommittedBranchDiff(t *testing.T) {
 func TestReviewerGroundedChangedLines_EmptyBranchDiffDegradesClosed(t *testing.T) {
 	ctx, log := context.Background(), logr.Discard()
 	// Empty diff, no error: must degrade closed (nil closure).
-	if got := reviewerGroundedChangedLines(ctx, log, t.TempDir(), nil, nil); got != nil {
+	if got := reviewerGroundedChangedLines(ctx, log, t.TempDir(), "main", nil, nil); got != nil {
 		t.Fatal("empty branch diff must yield a nil closure (degrade closed), got non-nil")
 	}
 	// Non-empty diff: a real closure is returned.
-	if got := reviewerGroundedChangedLines(ctx, log, t.TempDir(), []string{"a.go"}, nil); got == nil {
+	if got := reviewerGroundedChangedLines(ctx, log, t.TempDir(), "main", []string{"a.go"}, nil); got == nil {
 		t.Fatal("non-empty branch diff must yield a real closure")
 	}
 }


### PR DESCRIPTION
## What

The Foreman reviewer now computes its ground-truth branch diff against the coder branch's actual upstream base, not the reviewer clone's stale local `main`.

## Why

Fixes #1005

The reviewer clones the contributor's fork and diffs `git diff main...HEAD`. The fork's `main` lags the upstream base the coder branch was cut from (#813), so the three-dot merge-base resolves to a stale commit and the diff sweeps in the entire intervening upstream delta instead of the coder's change. Reproduced live: a fresh fork clone checked out `main` at the 0.8.26 release while the branch was cut from 0.9.1, so `main...HEAD` returned ~150 files instead of the coder's 2. Every reviewer computable rail (filesTouched #582, scope-overlap #647, grounded-finding #988, verdict-from-findings #992) runs on that diff, so all of them silently operate on the wrong changeset whenever the fork base lags, which is the normal case in the fork workflow. Observed impact in a 2026-07-07 batch: a false NO-GO (#970, which then burned a coder revision round) and a rubber-stamp GO (#1003), both sailing through ungrounded.

## How

Resolve the branch's true base once via `repo.BaseBranchSHA` (#995): fetch the upstream base fresh and diff `<baseSHA>...HEAD` (three-dot, robust to upstream advancing). Thread the resolved base through `reconcileReviewerFilesTouched`, the scope-overlap `DiffNameOnly` call, and `reviewerGroundedChangedLines`. Fall back to local `main` with a logged warning only when no upstream is resolvable (freeform tasks). Add an integration test with a stale fork `main` plus an upstream advance, asserting the resolved base isolates the coder's change and excludes the upstream delta.

## Checklist

- [x] Tests added/updated (new stale-fork integration test; existing reviewer/reconcile/grounded tests updated for the base param)
- [x] `make test` passes locally (`go test ./pkg/foreman/agent/` green)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO, by a human
- [x] AI assistance disclosed below
- [ ] Documentation updated: n/a (internal reviewer behavior, no user-facing surface)

---

Assisted-by: Claude Code generated the fix and tests in-session from a reproduction I ran against the live fleet; I reviewed the diff, ran `go test` and `golangci-lint` locally, and I am accountable for this change.
