### PR TITLE
feat(foreman): distinct ALREADY-RESOLVED coder outcome

### DIFF
--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -364,6 +364,14 @@ type WorkloadStatus struct {
 	// +optional
 	IncompleteTasks int32 `json:"incompleteTasks,omitempty"`
 
+	// AlreadyResolvedTasks counts child tasks that terminated with the
+	// ALREADY-RESOLVED outcome: the coder determined the issue was already
+	// fixed on the branch/base before any fix attempt. These are terminal
+	// non-failures — not counted as incomplete, and they do not roll the
+	// workload to Failed. The operator can close the issue based on this.
+	// +optional
+	AlreadyResolvedTasks int32 `json:"alreadyResolvedTasks,omitempty"`
+
 	// ReviewIterations counts the fix iterations the reconciler has
 	// emitted after reviewer NO-GO verdicts (#946), summed across
 	// issues. Zero (or absent) means no reviewer ever bounced a

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -656,6 +656,15 @@ spec:
           status:
             description: status is the planner's and scheduler's observed view.
             properties:
+              alreadyResolvedTasks:
+                description: |-
+                  AlreadyResolvedTasks counts child tasks that terminated with the
+                  ALREADY-RESOLVED outcome: the coder determined the issue was already
+                  fixed on the branch/base before any fix attempt. These are terminal
+                  non-failures — not counted as incomplete, and they do not roll the
+                  workload to Failed. The operator can close the issue based on this.
+                format: int32
+                type: integer
               conditions:
                 description: 'Conditions track standard signals: Planned, Dispatched,
                   Completed.'

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -81,10 +81,13 @@ func coderSummary(task *foremanv1alpha1.AgenticTask) string {
 // solve this" bail) or a coder-gate failure (wrote code, could not pass
 // the gate) escalate; a model-decided INCOMPLETE (gave up / ran out of
 // turns), a harness STUCK-LOOP-DETECTED, a trivial NO-CHANGES NO-GO, an
-// ERROR, or a GO do not.
+// ALREADY-RESOLVED (issue already fixed), an ERROR, or a GO do not.
 func shouldEscalateCoder(
 	verdict foremanv1alpha1.AgenticTaskVerdict, topOutcome, modelOutcome string,
 ) bool {
+	if topOutcome == "ALREADY-RESOLVED" {
+		return false
+	}
 	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == "MODEL-DECIDED" {
 		return true
 	}

--- a/internal/foreman/controller/workload_coder_escalation_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_test.go
@@ -52,6 +52,8 @@ func TestShouldEscalateCoder(t *testing.T) {
 		{"stuck-loop detected", foremanv1alpha1.AgenticTaskVerdictIncomplete, "STUCK-LOOP-DETECTED", "", false},
 		{"NO-GO but no-changes (trivial)", foremanv1alpha1.AgenticTaskVerdictNoGo, "NO-CHANGES", "", false},
 		{"GO", foremanv1alpha1.AgenticTaskVerdictGo, "", "", false},
+		{"already resolved (like #970)", foremanv1alpha1.AgenticTaskVerdictNoGo, "ALREADY-RESOLVED", "", false},
+		{"already resolved + gate-failed (resolved wins)", foremanv1alpha1.AgenticTaskVerdictNoGo, "ALREADY-RESOLVED", "CODER-GATE-FAILED", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -256,5 +258,31 @@ func TestCoderEscalationSteps_OffWhenUnset(t *testing.T) {
 	steps, _ := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{c})
 	if len(steps) != 0 {
 		t.Errorf("feature must be off when EscalationCoderAgentRef is nil, got %d steps", len(steps))
+	}
+}
+
+func TestCoderEscalationSteps_SkipsAlreadyResolved(t *testing.T) {
+	ref := corev1.LocalObjectReference{Name: "coder-qwopus"}
+	w := &foremanv1alpha1.Workload{}
+	w.Name = "wl"
+	w.Spec.Repo = "defilantech/LLMKube"
+	w.Spec.Issues = []int32{970}
+	w.Spec.CoderAgentRef = &corev1.LocalObjectReference{Name: "coder-metal"}
+	w.Spec.VerifierAgentRef = &corev1.LocalObjectReference{Name: "gate"}
+	w.Spec.EscalationCoderAgentRef = &ref
+
+	code := foremanv1alpha1.AgenticTask{}
+	code.Name = "wl-code-970"
+	code.Labels = map[string]string{labelStep: "code-970"}
+	code.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+	code.Status.Result = resultRaw("ALREADY-RESOLVED", "", "Issue #970 is already resolved by prior fix")
+
+	steps, escalated := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{code})
+	if len(steps) != 0 {
+		t.Errorf("want no steps for ALREADY-RESOLVED, got %d: %+v", len(steps), steps)
+	}
+	if len(escalated) != 0 {
+		t.Errorf("want none escalated for ALREADY-RESOLVED, got %v", escalated)
 	}
 }

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -480,13 +481,28 @@ func (r *WorkloadReconciler) listChildren(ctx context.Context, w *foremanv1alpha
 	return list.Items, nil
 }
 
+// isAlreadyResolvedTask checks if a terminal task carries the ALREADY-RESOLVED
+// outcome in its status.result envelope.
+func isAlreadyResolvedTask(task *foremanv1alpha1.AgenticTask) bool {
+	if task.Status.Result == nil || len(task.Status.Result.Raw) == 0 {
+		return false
+	}
+	var env coderResultEnvelope
+	if err := json.Unmarshal(task.Status.Result.Raw, &env); err != nil {
+		return false
+	}
+	return env.Extra.Outcome == "ALREADY-RESOLVED"
+}
+
 // rollup computes the Workload's terminal-or-in-flight state from its
 // children's phases AND verdicts and patches status. Triggered on every
 // child phase change via the Owns() watch.
 //
-// Counts children in four buckets:
+// Counts children in five buckets:
 //   - succeeded: SucceededOnTarget() (Phase=Succeeded AND verdict in
 //     {GO, GATE-PASS}) — produced a usable artifact
+//   - alreadyResolved: Phase=Succeeded with ALREADY-RESOLVED outcome —
+//     terminal non-failure, issue was already fixed
 //   - incomplete: Phase=Succeeded but verdict in {INCOMPLETE, NO-GO,
 //     GATE-FAIL, GATE-ERROR} — terminal without usable output
 //   - failed: Phase=Failed
@@ -498,12 +514,15 @@ func (r *WorkloadReconciler) listChildren(ctx context.Context, w *foremanv1alpha
 // Fixes defilantech/LLMKube#541.
 func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
 	var (
-		succeeded, incomplete, failed, inFlight int32
+		succeeded, incomplete, failed, inFlight, alreadyResolved int32
 	)
 	for i := range children {
 		switch {
 		case children[i].SucceededOnTarget():
 			succeeded++
+		case children[i].Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded &&
+			isAlreadyResolvedTask(&children[i]):
+			alreadyResolved++
 		case children[i].Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded:
 			// Terminal Phase=Succeeded but verdict isn't on-target.
 			incomplete++
@@ -514,12 +533,13 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 		}
 	}
 
-	total := succeeded + incomplete + failed + inFlight
+	total := succeeded + incomplete + failed + inFlight + alreadyResolved
 	patch := client.MergeFrom(w.DeepCopy())
 	now := metav1.Now()
 	w.Status.SucceededTasks = succeeded
 	w.Status.FailedTasks = failed
 	w.Status.IncompleteTasks = incomplete
+	w.Status.AlreadyResolvedTasks = alreadyResolved
 
 	switch {
 	case inFlight == 0 && failed == 0 && incomplete == 0:
@@ -528,7 +548,7 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Type:               conditionTypeCompleted,
 			Status:             metav1.ConditionTrue,
 			Reason:             "AllChildrenSucceeded",
-			Message:            fmt.Sprintf("%d/%d child tasks on-target Succeeded", succeeded, total),
+			Message:            fmt.Sprintf("%d on-target, %d already resolved (of %d)", succeeded, alreadyResolved, total),
 			LastTransitionTime: now,
 		})
 	case inFlight == 0 && (failed > 0 || incomplete > 0):
@@ -545,7 +565,7 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Type:               conditionTypeCompleted,
 			Status:             metav1.ConditionFalse,
 			Reason:             reason,
-			Message:            fmt.Sprintf("%d on-target, %d incomplete, %d failed (of %d)", succeeded, incomplete, failed, total),
+			Message:            fmt.Sprintf("%d on-target, %d already resolved, %d incomplete, %d failed (of %d)", succeeded, alreadyResolved, incomplete, failed, total),
 			LastTransitionTime: now,
 		})
 	default:
@@ -554,7 +574,7 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Type:               "Dispatched",
 			Status:             metav1.ConditionTrue,
 			Reason:             "ChildrenInFlight",
-			Message:            fmt.Sprintf("%d in-flight, %d on-target, %d incomplete, %d failed", inFlight, succeeded, incomplete, failed),
+			Message:            fmt.Sprintf("%d in-flight, %d on-target, %d already resolved, %d incomplete, %d failed", inFlight, succeeded, alreadyResolved, incomplete, failed),
 			LastTransitionTime: now,
 		})
 	}

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -887,6 +888,62 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		Expect(trunc.Reason).To(Equal("MaxTasksEscalationCap"))
 		// And the workload still terminates Failed on the base NO-GO.
 		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseFailed))
+	})
+
+	It("rolls up ALREADY-RESOLVED tasks separately and completes when all children are succeeded or already resolved", func() {
+		wl := newWorkload("rollup-already-resolved", foremanv1alpha1.WorkloadSpec{
+			Intent:           "rollup-already-resolved",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{970},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Coder succeeded on target (GO), verifier Phase=Succeeded with
+		// verdict=NO-GO and ALREADY-RESOLVED outcome (issue was already
+		// fixed before the agent ran).
+		updates := []struct {
+			name    string
+			phase   foremanv1alpha1.AgenticTaskPhase
+			verdict foremanv1alpha1.AgenticTaskVerdict
+			result  *runtime.RawExtension
+		}{
+			{"rollup-already-resolved-code-970", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGo, nil},
+			{"rollup-already-resolved-verify-970", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo, resultRaw("ALREADY-RESOLVED", "", "already fixed")},
+		}
+		for _, u := range updates {
+			var t foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: u.name}, &t)).To(Succeed())
+			patch := client.MergeFrom(t.DeepCopy())
+			t.Status.Phase = u.phase
+			t.Status.Verdict = u.verdict
+			t.Status.Result = u.result
+			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
+		}
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseCompleted),
+			"workload must complete when all children are succeeded or already resolved")
+		Expect(fresh.Status.SucceededTasks).To(Equal(int32(1)))
+		Expect(fresh.Status.AlreadyResolvedTasks).To(Equal(int32(1)))
+		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(0)))
+		Expect(fresh.Status.FailedTasks).To(Equal(int32(0)))
+		completed := findCondition(fresh.Status.Conditions, conditionTypeCompleted)
+		Expect(completed).NotTo(BeNil())
+		Expect(completed.Reason).To(Equal("AllChildrenSucceeded"))
+		Expect(completed.Message).To(ContainSubstring("already resolved"))
 	})
 
 	It("flags escalation refs without base reviewers via EscalationTriggered=False (#546)", func() {

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -660,7 +660,12 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 				scopeDriftDetected, scopeMatched)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
-		r := e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
+		var r *Result
+		if isAlreadyResolved(verdict, loopRes.Terminal) {
+			r = e.alreadyResolvedResult(start, transcriptRef, loopRes, verdict)
+		} else {
+			r = e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
+		}
 		e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r)
 		// Attach the normalized failure reason from the model-to-CRD
 		// mapping (e.g. ERROR→INCOMPLETE + ModelReportedError for #649). Only
@@ -1346,6 +1351,49 @@ func (e *NativeAgentLoopExecutor) modelDecidedResult(
 	r := NewResult(e.Kind(), verdict, lr.Terminal.Summary, time.Since(start))
 	r.Extra = map[string]any{
 		"outcome":       "MODEL-DECIDED",
+		"transcriptRef": objRefAsMap(tref),
+		"turnCount":     lr.Turns,
+		"modelExtra":    lr.Terminal.Extra,
+	}
+	return r
+}
+
+// isAlreadyResolved checks if the model signaled that the issue is already
+// resolved via submit_result.extra.already_resolved=true, or via summary
+// keywords as a fallback heuristic. Only returns true for NO-GO verdicts.
+func isAlreadyResolved(verdict foremanv1alpha1.AgenticTaskVerdict, terminal *ToolResult) bool {
+	if verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		return false
+	}
+	if terminal == nil || terminal.Extra == nil {
+		return false
+	}
+	// Explicit signal from the model via already_resolved field.
+	if v, ok := terminal.Extra["already_resolved"]; ok {
+		if b, ok := v.(bool); ok && b {
+			return true
+		}
+	}
+	// Fallback heuristic: summary contains "already" + resolution keyword.
+	summary := strings.ToLower(terminal.Summary)
+	if !strings.Contains(summary, "already") {
+		return false
+	}
+	for _, kw := range []string{"resolved", "fixed", "done", "merged"} {
+		if strings.Contains(summary, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *NativeAgentLoopExecutor) alreadyResolvedResult(
+	start time.Time, tref corev1.ObjectReference, lr *LoopResult,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+) *Result {
+	r := NewResult(e.Kind(), verdict, lr.Terminal.Summary, time.Since(start))
+	r.Extra = map[string]any{
+		"outcome":       "ALREADY-RESOLVED",
 		"transcriptRef": objRefAsMap(tref),
 		"turnCount":     lr.Turns,
 		"modelExtra":    lr.Terminal.Extra,

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2220,3 +2220,112 @@ func TestRecoverSelfCommitsOrNoChange_GenuinelyNothingToRecover(t *testing.T) {
 		t.Errorf("HEAD = %s, want %s (no-change path must not move HEAD)", got, mainSHA)
 	}
 }
+
+func TestIsAlreadyResolved(t *testing.T) {
+	cases := []struct {
+		name     string
+		verdict  foremanv1alpha1.AgenticTaskVerdict
+		terminal *ToolResult
+		want     bool
+	}{
+		{
+			name:     "GO verdict always false",
+			verdict:  foremanv1alpha1.AgenticTaskVerdictGo,
+			terminal: &ToolResult{Extra: map[string]any{"already_resolved": true}},
+			want:     false,
+		},
+		{
+			name:    "NO-GO with explicit already_resolved true",
+			verdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			terminal: &ToolResult{
+				Summary: "could not apply the fix",
+				Extra:   map[string]any{"already_resolved": true},
+			},
+			want: true,
+		},
+		{
+			name:    "NO-GO with already_resolved false",
+			verdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			terminal: &ToolResult{
+				Summary: "could not apply the fix",
+				Extra:   map[string]any{"already_resolved": false},
+			},
+			want: false,
+		},
+		{
+			name:    "NO-GO with no extra field",
+			verdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			terminal: &ToolResult{
+				Summary: "could not apply the fix",
+				Extra:   map[string]any{},
+			},
+			want: false,
+		},
+		{
+			name:    "NO-GO summary already resolved heuristic",
+			verdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			terminal: &ToolResult{
+				Summary: "Issue #152 is already resolved by prior fix e97d0ca",
+				Extra:   map[string]any{},
+			},
+			want: true,
+		},
+		{
+			name:    "NO-GO summary already fixed heuristic",
+			verdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			terminal: &ToolResult{
+				Summary: "This was already fixed in commit abc123",
+				Extra:   map[string]any{},
+			},
+			want: true,
+		},
+		{
+			name:    "NO-GO summary already done heuristic",
+			verdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			terminal: &ToolResult{
+				Summary: "This is already done on main",
+				Extra:   map[string]any{},
+			},
+			want: true,
+		},
+		{
+			name:    "NO-GO summary already merged heuristic",
+			verdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			terminal: &ToolResult{
+				Summary: "PR was already merged upstream",
+				Extra:   map[string]any{},
+			},
+			want: true,
+		},
+		{
+			name:    "NO-GO summary has already but no resolution keyword",
+			verdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			terminal: &ToolResult{
+				Summary: "I already tried three approaches and none worked",
+				Extra:   map[string]any{},
+			},
+			want: false,
+		},
+		{
+			name:     "NO-GO nil terminal",
+			verdict:  foremanv1alpha1.AgenticTaskVerdictNoGo,
+			terminal: nil,
+			want:     false,
+		},
+		{
+			name:     "INCOMPLETE verdict always false",
+			verdict:  foremanv1alpha1.AgenticTaskVerdictIncomplete,
+			terminal: &ToolResult{Extra: map[string]any{"already_resolved": true}},
+			want:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isAlreadyResolved(tc.verdict, tc.terminal)
+			if got != tc.want {
+				t.Errorf("isAlreadyResolved(%s, %+v) = %v, want %v", tc.verdict, tc.terminal, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -258,6 +258,13 @@ const LoopBudgetOutcome = "LOOP-BUDGET-EXHAUSTED"
 // build / lint) still fail never lands as a clean GO.
 const CoderGateFailedOutcome = "CODER-GATE-FAILED"
 
+// AlreadyResolvedOutcome is the value set in LoopResult.Terminal.Extra["outcome"]
+// when the coder determines the issue is already resolved on the branch/base
+// before any fix attempt. This is an honest-bail distinct from MODEL-DECIDED
+// capability failure: the work exists, there is nothing for a larger model to
+// do on escalation. See defilantech/LLMKube#970.
+const AlreadyResolvedOutcome = "ALREADY-RESOLVED"
+
 // outcomeKey is the Terminal.Extra map key the loop stamps with the
 // machine-readable outcome string (LoopBudgetOutcome, CoderGateFailedOutcome,
 // StuckLoopOutcome, ...).

--- a/pkg/foreman/agent/tools/submit_result.go
+++ b/pkg/foreman/agent/tools/submit_result.go
@@ -61,10 +61,11 @@ func truncateRuneSafe(s string, maxLen int) string {
 type SubmitResultTool struct{}
 
 type submitResultArgs struct {
-	Verdict       string         `json:"verdict"`
-	Summary       string         `json:"summary"`
-	CommitMessage string         `json:"commit_message"`
-	Extra         map[string]any `json:"extra"`
+	Verdict         string         `json:"verdict"`
+	Summary         string         `json:"summary"`
+	CommitMessage   string         `json:"commit_message"`
+	AlreadyResolved bool           `json:"already_resolved"`
+	Extra           map[string]any `json:"extra"`
 }
 
 // Name returns the tool name as advertised to the model.
@@ -82,6 +83,8 @@ func (SubmitResultTool) Schema() oai.ToolSchemaDef {
   "summary":        {"type": "string", "description": "One-sentence outcome summary (1-280 chars)."},
   "commit_message": {"type": "string",
     "description": "Full commit message including subject, body, and Fixes #N if applicable."},
+  "already_resolved": {"type": "boolean",
+    "description": "Set true if the issue is already resolved on the branch/base. Distinct from capability failure."},
   "extra": {"type": "object",
     "description": "Structured extra fields the executor may surface in status.result.extra."}
 },
@@ -110,12 +113,17 @@ func (SubmitResultTool) Execute(_ context.Context, args json.RawMessage) (*agent
 	if len(a.Summary) > MaxSubmitSummaryLen {
 		a.Summary = truncateRuneSafe(a.Summary, MaxSubmitSummaryLen)
 	}
+	extra := a.Extra
+	if extra == nil {
+		extra = make(map[string]any)
+	}
+	extra["already_resolved"] = a.AlreadyResolved
 	return &agent.ToolResult{
 		Terminal:      true,
 		Verdict:       a.Verdict,
 		Summary:       a.Summary,
 		CommitMessage: a.CommitMessage,
-		Extra:         a.Extra,
+		Extra:         extra,
 		Output: map[string]any{
 			"accepted": true,
 			"verdict":  a.Verdict,


### PR DESCRIPTION
Add a dedicated terminal outcome for the coder honest-bail case where the model determines the issue is already fixed, separate from `MODEL-DECIDED` capability failure.

**Why:** Running the fleet, 2 of 3 real `NO-GO` / `MODEL-DECIDED` coder outcomes were "already done" — not capability failures. Under #964's escalation trigger both escalate to a larger model which re-derives "nothing to do" at higher cost.

**What changes:**
- New `ALREADY-RESOLVED` outcome constant and `submit_result.already_resolved` schema field
- Executor detects ALREADY-RESOLVED via explicit flag or summary keyword heuristic ("already" + resolved/fixed/done/merged)
- `shouldEscalateCoder` skips ALREADY-RESOLVED — nothing for a larger model to do
- Rollup counts ALREADY-RESOLVED separately (`AlreadyResolvedTasks`), treats as terminal non-failure
- Workload completes when all children are succeeded or already resolved (no incomplete/failed)

Fixes #970.

AI-assisted contribution disclosure applies.