### PR TITLE
fix(foreman): exempt REJECT from grounded-finding demotion

### DIFF
--- a/pkg/foreman/agent/grounded_finding_gate.go
+++ b/pkg/foreman/agent/grounded_finding_gate.go
@@ -92,6 +92,12 @@ func groundedBlockingFindings(
 // Because an unchanged file yields an empty set, the single membership test
 // (line in changedLines(file)) subsumes both the fabricated-file case and the
 // unchanged-line-in-a-changed-file case.
+//
+// REJECT (do-not-retry) is exempt from demotion: a wrong-issue rejection
+// typically cannot cite a changed line (the defect is what is absent), so
+// it would be demoted to GO unless scope-overlap or issueAsk independently
+// re-flag it. A do-not-retry rejection should not be overturnable by the
+// absence of a line-grounded finding.
 func enforceReviewerGroundedFindings(
 	log logr.Logger,
 	extra map[string]any,
@@ -101,6 +107,11 @@ func enforceReviewerGroundedFindings(
 	if groundedFindingsDisabled() ||
 		verdict != foremanv1alpha1.AgenticTaskVerdictNoGo ||
 		extra == nil || changedLines == nil {
+		return verdict
+	}
+
+	// REJECT (do-not-retry) is exempt from grounded demotion.
+	if reviewOutcome, ok := extra["reviewOutcome"].(string); ok && reviewOutcome == "REJECT" {
 		return verdict
 	}
 

--- a/pkg/foreman/agent/grounded_finding_gate_test.go
+++ b/pkg/foreman/agent/grounded_finding_gate_test.go
@@ -205,6 +205,45 @@ func TestReviewerGroundedChangedLines_EmptyBranchDiffDegradesClosed(t *testing.T
 	}
 }
 
+func TestGroundedFindings_REJECTExemptFromDemotion(t *testing.T) {
+	// REJECT (do-not-retry) must not be demoted even when no blocking finding
+	// cites a changed line. A wrong-issue rejection typically cannot cite a
+	// changed line (the defect is what is absent), so it would be demoted to
+	// GO unless scope-overlap or issueAsk independently re-flag it.
+	extra := findingExtra("blocker", "docs/MODEL-CACHE.md", 10) // ungrounded
+	extra["reviewOutcome"] = "REJECT"
+	fix := map[string]map[int]bool{} // no changed lines
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("REJECT must not be demoted to GO, got %s", got)
+	}
+	if _, demoted := extra["groundedFindingDemotion"]; demoted {
+		t.Fatal("REJECT must not be marked demoted")
+	}
+}
+
+func TestGroundedFindings_REJECTExemptWithGroundedFindings(t *testing.T) {
+	// REJECT with grounded findings still stays NO-GO (no demotion either way).
+	extra := findingExtra("blocker", "pkg/cli/cache.go", 42)
+	extra["reviewOutcome"] = "REJECT"
+	fix := map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("REJECT with grounded findings must stay NO-GO, got %s", got)
+	}
+}
+
+func TestGroundedFindings_RequestChangesDemotesWhenUngrounded(t *testing.T) {
+	// REQUEST-CHANGES is NOT REJECT; it should still be subject to demotion.
+	extra := findingExtra("blocker", "docs/MODEL-CACHE.md", 10) // ungrounded
+	extra["reviewOutcome"] = "REQUEST-CHANGES"
+	fix := map[string]map[int]bool{} // no changed lines
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("REQUEST-CHANGES with ungrounded findings must demote to GO, got %s", got)
+	}
+}
+
 func TestGroundedBlockingFindings_Partition(t *testing.T) {
 	findings := []reviewer.Finding{
 		// grounded


### PR DESCRIPTION
## What

Exempt REJECT (do-not-retry) from the grounded-finding rail's NO-GO -> GO demotion.

## Why

Fixes #1003

The grounded-finding rail demotes a reviewer NO-GO to GO when no blocking finding cites a changed line. REJECT (the reviewer's "wrong issue / do not retry" outcome) collapses to the top-level NO-GO verdict, so the rail treats it like any NO-GO and can demote it. A wrong-issue rejection typically cannot cite a changed line (the defect is what is absent), so it would be demoted to GO unless scope-overlap or issueAsk independently re-flag it. A do-not-retry rejection should not be overturnable by the absence of a line-grounded finding.

## How

Thread `reviewOutcome` into `enforceReviewerGroundedFindings` and return early (no demotion) when `reviewOutcome == "REJECT"`. Three tests: REJECT + ungrounded stays NO-GO, REJECT + grounded stays NO-GO, and REQUEST-CHANGES + ungrounded still demotes (proving the exemption is REJECT-specific, not a blanket skip).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go test ./pkg/foreman/agent/` green)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO, by a human
- [x] AI assistance disclosed below
- [ ] Documentation updated: n/a (internal reviewer-rail behavior)

---

Assisted-by: Foreman, LLMKube's own agentic coder (a local model on the in-cluster Strix node), generated the fix and tests; it was gate-verified (GATE-PASS) and then adversarially reviewed by an independent reviewer before I opened it. I reviewed the diff, ran `go test` and `golangci-lint` locally, and I am accountable for this change.
