### PR TITLE
fix(foreman): guard file-less findings + resolve bare/absolute paths in grounding rail

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -791,8 +791,53 @@ func reviewerGroundedChangedLines(
 		return nil
 	}
 	return func(file string) map[int]bool {
-		return changedBranchLines(ctx, workspace, base, file, execCommandRunner)
+		normalized := normalizeFilePath(file)
+		// If the normalized path is in the diff, use it directly. Diff
+		// against the resolved upstream base (#1006), not a hardcoded
+		// "main" which would be the stale local fork tip.
+		if inDiff(normalized, reviewDiff) {
+			return changedBranchLines(ctx, workspace, base, normalized, execCommandRunner)
+		}
+		// Resolve bare basenames and absolute paths against the diff file
+		// list by unique suffix match (#1004). If exactly one diff file
+		// equals or ends with "/"+basename, use that file; if zero or
+		// more than one match (ambiguous), leave the finding ungrounded.
+		if resolved := resolveAgainstDiff(normalized, reviewDiff); resolved != "" {
+			return changedBranchLines(ctx, workspace, base, resolved, execCommandRunner)
+		}
+		return nil
 	}
+}
+
+// inDiff reports whether f is in the diff file list.
+func inDiff(f string, diff []string) bool {
+	for _, d := range diff {
+		if d == f {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveAgainstDiff resolves a bare basename or absolute path against the
+// diff file list by unique suffix match. If exactly one diff file equals or
+// ends with "/"+basename, that file is returned. If zero or more than one
+// match (ambiguous), "" is returned to leave the finding ungrounded.
+func resolveAgainstDiff(f string, diff []string) string {
+	if f == "" {
+		return ""
+	}
+	basename := filepath.Base(f)
+	var matches []string
+	for _, d := range diff {
+		if d == f || strings.HasSuffix(d, "/"+basename) {
+			matches = append(matches, d)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0]
+	}
+	return "" // zero or ambiguous
 }
 
 // coderGateMaxRetries bounds the coder gate fix attempts (#749): a GO whose

--- a/pkg/foreman/agent/grounded_finding_gate.go
+++ b/pkg/foreman/agent/grounded_finding_gate.go
@@ -36,6 +36,8 @@ package agent
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/go-logr/logr"
 
@@ -49,6 +51,21 @@ func groundedFindingsDisabled() bool {
 	return os.Getenv("FOREMAN_GROUNDED_FINDINGS") == "0"
 }
 
+// normalizeFilePath strips leading "./" and leading "/" from a file path so
+// that reviewer-supplied paths (which may be basenames, "./"-prefixed, or
+// absolute) match the repo-root-relative paths used by the git diff.
+// An empty or "." result is returned as "" (no file) so that file-less
+// findings cannot falsely ground against the entire repo diff (#1004).
+func normalizeFilePath(p string) string {
+	p = strings.TrimPrefix(p, "./")
+	p = strings.TrimPrefix(p, "/")
+	p = filepath.Clean(p) // also collapses any redundant separators
+	if p == "" || p == "." {
+		return ""
+	}
+	return p
+}
+
 // groundedBlockingFindings partitions the blocking findings (severity blocker
 // or major; minor is advisory and excluded) into those grounded in a changed
 // line and those not. A finding is grounded iff File is non-empty, Line > 0,
@@ -56,6 +73,10 @@ func groundedFindingsDisabled() bool {
 // changedLines results are cached per file since it may shell out to git.
 // Both the grounded-finding demote rail and the verdict-from-findings promote
 // rail key on this partition, so they share one grounding definition.
+//
+// The finding's File path is normalized (strip "./", strip leading "/",
+// collapse separators) before lookup so that reviewer-supplied paths that are
+// not repo-root-relative still match the diff file list (#1004).
 func groundedBlockingFindings(
 	findings []reviewer.Finding,
 	changedLines func(file string) map[int]bool,
@@ -73,7 +94,8 @@ func groundedBlockingFindings(
 		if f.Severity != reviewer.SeverityBlocker && f.Severity != reviewer.SeverityMajor {
 			continue // minor is advisory, never blocking
 		}
-		if f.File != "" && f.Line > 0 && lines(f.File)[f.Line] {
+		normalizedFile := normalizeFilePath(f.File)
+		if normalizedFile != "" && f.Line > 0 && lines(normalizedFile)[f.Line] {
 			grounded = append(grounded, f)
 		} else {
 			ungrounded = append(ungrounded, f)

--- a/pkg/foreman/agent/grounded_finding_gate_test.go
+++ b/pkg/foreman/agent/grounded_finding_gate_test.go
@@ -266,3 +266,218 @@ func TestGroundedBlockingFindings_Partition(t *testing.T) {
 		t.Fatalf("ungrounded = %d, want 2 (b.go unchanged line + c.go no line)", len(ungrounded))
 	}
 }
+
+func TestNormalizeFilePath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"pkg/cli/cache.go", "pkg/cli/cache.go"},
+		{"./pkg/cli/cache.go", "pkg/cli/cache.go"},
+		{"/workspace/pkg/cli/cache.go", "workspace/pkg/cli/cache.go"},
+		{"pkg//cli/cache.go", "pkg/cli/cache.go"},
+		{"./", ""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := normalizeFilePath(tc.input)
+			if got != tc.expected {
+				t.Errorf("normalizeFilePath(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestGroundedBlockingFindings_EmptyFileDoesNotGround asserts that a
+// blocking finding with File="" and Line=N does NOT ground (stays
+// ungrounded), so the promote rail cannot falsely promote a GO to NO-GO
+// on a file-less finding (#1004).
+func TestGroundedBlockingFindings_EmptyFileDoesNotGround(t *testing.T) {
+	changed := func(f string) map[int]bool {
+		return map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}[f]
+	}
+	findings := []reviewer.Finding{
+		{Severity: reviewer.SeverityBlocker, Area: "scope", Message: "m", File: "", Line: 42},
+	}
+	grounded, ungrounded := groundedBlockingFindings(findings, changed)
+	if len(grounded) != 0 {
+		t.Fatalf("file-less finding must not ground, got %d grounded", len(grounded))
+	}
+	if len(ungrounded) != 1 {
+		t.Fatalf("file-less finding must be ungrounded, got %d ungrounded", len(ungrounded))
+	}
+}
+
+// TestResolveAgainstDiff asserts that bare basenames and absolute paths
+// resolve against the diff file list by unique suffix match (#1004).
+func TestResolveAgainstDiff(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		diff     []string
+		expected string
+	}{
+		{
+			name:     "bare basename unique match",
+			file:     "cache.go",
+			diff:     []string{"pkg/cli/cache.go"},
+			expected: "pkg/cli/cache.go",
+		},
+		{
+			name:     "absolute path resolves",
+			file:     "/workspace/pkg/cli/cache.go",
+			diff:     []string{"pkg/cli/cache.go"},
+			expected: "pkg/cli/cache.go",
+		},
+		{
+			name:     "ambiguous basename stays ungrounded",
+			file:     "cache.go",
+			diff:     []string{"pkg/cli/cache.go", "pkg/foreman/agent/cache.go"},
+			expected: "",
+		},
+		{
+			name:     "no match stays ungrounded",
+			file:     "missing.go",
+			diff:     []string{"pkg/cli/cache.go"},
+			expected: "",
+		},
+		{
+			name:     "empty file stays ungrounded",
+			file:     "",
+			diff:     []string{"pkg/cli/cache.go"},
+			expected: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveAgainstDiff(tc.file, tc.diff)
+			if got != tc.expected {
+				t.Errorf("resolveAgainstDiff(%q, %v) = %q, want %q", tc.file, tc.diff, got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestInDiff asserts the inDiff helper (#1004).
+func TestInDiff(t *testing.T) {
+	diff := []string{"pkg/cli/cache.go", "pkg/foreman/agent/cache.go"}
+	if !inDiff("pkg/cli/cache.go", diff) {
+		t.Error("expected pkg/cli/cache.go in diff")
+	}
+	if inDiff("missing.go", diff) {
+		t.Error("expected missing.go not in diff")
+	}
+}
+
+// TestGroundedBlockingFindings_BareBasenameGrounds asserts that a bare
+// basename in a subdir grounds to the right file when the changedLines
+// callback resolves it (#1004).
+func TestGroundedBlockingFindings_BareBasenameGrounds(t *testing.T) {
+	diff := []string{"pkg/cli/cache.go"}
+	changed := func(f string) map[int]bool {
+		normalized := normalizeFilePath(f)
+		if inDiff(normalized, diff) {
+			return map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}[normalized]
+		}
+		if resolved := resolveAgainstDiff(normalized, diff); resolved != "" {
+			return map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}[resolved]
+		}
+		return nil
+	}
+	findings := []reviewer.Finding{
+		{Severity: reviewer.SeverityBlocker, Area: "scope", Message: "m", File: "cache.go", Line: 42},
+	}
+	grounded, _ := groundedBlockingFindings(findings, changed)
+	if len(grounded) != 1 {
+		t.Fatalf("bare basename must ground when unique, got %d grounded", len(grounded))
+	}
+}
+
+// TestGroundedBlockingFindings_AbsolutePathGrounds asserts that an
+// absolute path grounds when the changedLines callback resolves it (#1004).
+func TestGroundedBlockingFindings_AbsolutePathGrounds(t *testing.T) {
+	diff := []string{"pkg/cli/cache.go"}
+	changed := func(f string) map[int]bool {
+		normalized := normalizeFilePath(f)
+		if inDiff(normalized, diff) {
+			return map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}[normalized]
+		}
+		if resolved := resolveAgainstDiff(normalized, diff); resolved != "" {
+			return map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}[resolved]
+		}
+		return nil
+	}
+	findings := []reviewer.Finding{
+		{Severity: reviewer.SeverityBlocker, Area: "scope", Message: "m", File: "/workspace/pkg/cli/cache.go", Line: 42},
+	}
+	grounded, _ := groundedBlockingFindings(findings, changed)
+	if len(grounded) != 1 {
+		t.Fatalf("absolute path must ground when it resolves, got %d grounded", len(grounded))
+	}
+}
+
+// TestGroundedBlockingFindings_AmbiguousBasenameStaysUngrounded asserts
+// that a bare basename that matches multiple diff files stays ungrounded
+// (#1004).
+func TestGroundedBlockingFindings_AmbiguousBasenameStaysUngrounded(t *testing.T) {
+	diff := []string{"pkg/cli/cache.go", "pkg/foreman/agent/cache.go"}
+	changed := func(f string) map[int]bool {
+		normalized := normalizeFilePath(f)
+		if inDiff(normalized, diff) {
+			return map[string]map[int]bool{
+				"pkg/cli/cache.go":           {42: true},
+				"pkg/foreman/agent/cache.go": {42: true},
+			}[normalized]
+		}
+		if resolved := resolveAgainstDiff(normalized, diff); resolved != "" {
+			return map[string]map[int]bool{
+				"pkg/cli/cache.go":           {42: true},
+				"pkg/foreman/agent/cache.go": {42: true},
+			}[resolved]
+		}
+		return nil
+	}
+	findings := []reviewer.Finding{
+		{Severity: reviewer.SeverityBlocker, Area: "scope", Message: "m", File: "cache.go", Line: 42},
+	}
+	grounded, _ := groundedBlockingFindings(findings, changed)
+	if len(grounded) != 0 {
+		t.Fatalf("ambiguous basename must stay ungrounded, got %d grounded", len(grounded))
+	}
+}
+
+func TestGroundedBlockingFindings_PathNormalization(t *testing.T) {
+	// The diff map only has repo-root-relative paths. A reviewer may emit
+	// "./"-prefixed, absolute, or bare-basename paths. All must normalize
+	// to the same repo-root-relative key (#1004).
+	changed := func(f string) map[int]bool {
+		return map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}[f]
+	}
+
+	tests := []struct {
+		name     string
+		file     string
+		grounded bool
+	}{
+		{"repo-root-relative", "pkg/cli/cache.go", true},
+		{"dot-slash prefix", "./pkg/cli/cache.go", true},
+		{"double slash", "pkg//cli/cache.go", true},
+		{"wrong file", "pkg/cli/other.go", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := []reviewer.Finding{
+				{Severity: reviewer.SeverityBlocker, Area: "scope", Message: "m", File: tc.file, Line: 42},
+			}
+			grounded, _ := groundedBlockingFindings(findings, changed)
+			if tc.grounded && len(grounded) != 1 {
+				t.Errorf("expected grounded, got %d grounded findings", len(grounded))
+			}
+			if !tc.grounded && len(grounded) != 0 {
+				t.Errorf("expected ungrounded, got %d grounded findings", len(grounded))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fix two defects in the reviewer grounding rail's file-path handling: a regression that grounded file-less findings against the whole-repo diff, and the (previously unaddressed) grounding of bare-basename and absolute finding paths.

## Why

Fixes #1004

The grounding rails match `finding.File` against the git-diff file list. `normalizeFilePath("")` returned `"."` (`filepath.Clean("") == "."`), defeating the `!= ""` guard so a blocking finding with `File="" , Line=N` falsely grounded against `git diff -- .` (the entire repo). Separately, the rail never resolved a bare basename (`cache.go`) or absolute path (`/workspace/pkg/cli/cache.go`) against the diff, so those findings failed to ground at all.

## How

`normalizeFilePath` now returns `""` for an empty/`"."` result. `reviewerGroundedChangedLines` resolves non-diff-relative paths against the actual diff file list via `resolveAgainstDiff`: unique-suffix match, and stays ungrounded on zero or ambiguous (>1) matches, so a finding is never grounded to the wrong file. Tests cover the file-less case, subdir-basename grounding, absolute-path grounding, and ambiguous-basename staying ungrounded.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`go test ./pkg/foreman/agent/` green)
- [x] `make lint` passes locally (`golangci-lint`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO, by a human
- [x] AI assistance disclosed below

---

Assisted-by: Foreman, LLMKube's own agentic coder (local model on the in-cluster Strix node), generated the original fix; an independent review found two defects (one a regression), and Foreman then produced this corrected version in a revision cycle. Gate-verified (GATE-PASS) and re-reviewed by hand before I opened it. I reviewed the diff, ran `go test` and `golangci-lint`, and I am accountable for this change.
