### PR TITLE
fix(metrics): remove dead metrics + phantom PrometheusRule error-rate rule

### DIFF
--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -128,5 +128,11 @@ spec:
             container=~"llamacpp|vllm|tgi|personaplex|llm-server"
           }[5m])
         )
+
+    # TTFT p95 over 5m. vLLM-only; llama.cpp has no first-token histogram.
+    - record: llmkube:inference:ttft_seconds:p95_5m
+      expr: histogram_quantile(0.95, sum by (service, namespace, runtime, le) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+      labels:
+        latency_kind: ttft
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## What

Remove dead operator-layer metrics and a PrometheusRule recording rule that referenced a non-existent vLLM metric; keep the one valid TTFT recording rule.

## Why

Fixes #409

`InferenceTTFTSeconds` and `InferenceRequestErrorsTotal` were registered but never observed — the operator process is not in the inference request path, so they can never be populated. TTFT and per-request errors come from the serving pod (vLLM, scraped via the existing PodMonitor) or the router (`RouterFirstTokenSeconds`, already observed in the proxy). The error-rate recording rule sourced `vllm:request_failure_total{status_class}`, a metric/label vLLM does not emit, so it produced no series.

## How

Delete the two dead metrics and their self-observing tests. Remove the phantom error-rate rule. Keep the valid TTFT p95 rule over `vllm:time_to_first_token_seconds_bucket`, and fix its comment to state it is vLLM-only (llama.cpp has no first-token histogram). `--enable-metrics` on vLLM pods was already present, so no runtime change was needed.

## Checklist

- [x] Tests updated (removed the self-observing tests for the deleted metrics)
- [x] `make test` passes locally (`go build ./...` + package tests green)
- [x] `make lint` passes locally (`golangci-lint`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO, by a human
- [x] AI assistance disclosed below

---

Assisted-by: Foreman, LLMKube's own agentic coder (local model on the in-cluster Strix node), generated the original attempt; an independent review found the metrics were dead and the rule sourced a phantom metric, and Foreman then produced this corrected version in a revision cycle. Gate-verified and re-reviewed by hand before I opened it. I reviewed the diff, ran the build/tests and `golangci-lint`, and I am accountable for this change.
