### PR TITLE
feat(foreman): distinct ALREADY-RESOLVED coder outcome (#970)

### DIFF
--- a/api/foreman/v1alpha1/agentictask_types.go
+++ b/api/foreman/v1alpha1/agentictask_types.go
@@ -393,7 +393,7 @@ const (
 // A task can be Succeeded with a NO-GO verdict (the agent legitimately
 // declined to fix the issue) or Failed with no verdict at all (the run
 // timed out before producing a verdict).
-// +kubebuilder:validation:Enum=GO;NO-GO;INCOMPLETE;GATE-PASS;GATE-FAIL;GATE-ERROR
+// +kubebuilder:validation:Enum=GO;NO-GO;INCOMPLETE;GATE-PASS;GATE-FAIL;GATE-ERROR;Skipped
 type AgenticTaskVerdict string
 
 const (
@@ -418,6 +418,17 @@ const (
 	// AgenticTaskVerdictGateError signals the gate runner itself failed
 	// to execute (infrastructure issue), distinct from a check failure.
 	AgenticTaskVerdictGateError AgenticTaskVerdict = "GATE-ERROR"
+	// AgenticTaskVerdictSkipped marks a task the executor never ran
+	// because its dependency terminated as a terminal non-failure the
+	// downstream work couldn't meaningfully act on — currently: the dep
+	// ended NO-GO + extra.outcome="ALREADY-RESOLVED" (#970). Set by the
+	// cascade-fail path in agentictask_controller.go when
+	// cascadeSkipIfDepAlreadyResolved sees an ALREADY-RESOLVED dep; the
+	// rollup excludes Skipped tasks from all five buckets
+	// (succeeded, incomplete, failed, inFlight, alreadyResolved) so
+	// they don't pin the Workload to Failed. Phase=Succeeded with
+	// Skipped is the only terminal shape the cascade path writes.
+	AgenticTaskVerdictSkipped AgenticTaskVerdict = "Skipped"
 )
 
 // SucceededOnTarget reports whether the task is in a terminal Succeeded

--- a/charts/foreman/templates/crds/agentictasks.yaml
+++ b/charts/foreman/templates/crds/agentictasks.yaml
@@ -487,6 +487,7 @@ spec:
                 - GATE-PASS
                 - GATE-FAIL
                 - GATE-ERROR
+                - Skipped
                 type: string
             type: object
         required:

--- a/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agentictasks.yaml
@@ -486,6 +486,7 @@ spec:
                 - GATE-PASS
                 - GATE-FAIL
                 - GATE-ERROR
+                - Skipped
                 type: string
             type: object
         required:

--- a/config/foreman/agents/gemma4-26b-q4-coder.yaml
+++ b/config/foreman/agents/gemma4-26b-q4-coder.yaml
@@ -139,6 +139,14 @@ spec:
       reach.
     - A correct fix would touch more than ~10 files or need cross-cutting
       redesign.
+    - The issue is already resolved on the branch or upstream base.
+      Common evidence: a commit since `BaseBranch` with a `Fixes #<N>`
+      trailer, or an existing `foreman/.../issue-<N>` branch with the fix
+      already pushed. Emit `verdict="NO-GO"` with
+      `extra.outcome="ALREADY-RESOLVED"` and cite the resolving SHA or
+      branch in `extra.resolvedBy`. This is the honest "already done" bail
+      — distinct from a capability failure, and the controller will not
+      escalate it to a larger model (#970).
 
     GO only if the issue is a scoped bug, a small self-contained feature,
     or a chore with a clear, testable definition of done.
@@ -193,10 +201,34 @@ spec:
       message. Do not include any AI / tool attribution; do not add a
       `Signed-off-by:` trailer (the executor adds the DCO sign-off via
       `git commit -s`).
+
+    **Already-resolved example.** When you find the work is already done:
+
+    ```text
+    submit_result(
+      verdict="NO-GO",
+      summary="Issue #152 is already resolved by prior fix e97d0ca (Fixes #129).",
+      extra={
+        "outcome": "ALREADY-RESOLVED",
+        "resolvedBy": "e97d0ca"
+      },
+    )
+    ```
+
     - `extra` (optional): structured fields you want surfaced in
-      `status.result.extra.modelExtra`. Useful for the next pipeline step
-      (the gate Agent in M4) to pivot on. Examples: `{"filesChanged":
-      ["a.go", "b.go"], "testsAdded": 2}`.
+      `status.result.extra`. Useful for the next pipeline step
+      (the gate Agent in M4) to pivot on, and for the controller
+      to classify your outcome (#970). Recognized fields:
+      - `outcome`: a machine-readable class. Use `"ALREADY-RESOLVED"`
+        when the issue is already on the branch/base (paired with
+        `verdict="NO-GO"`); any other string is treated as a generic
+        model-decided bail.
+      - `resolvedBy` (paired with `outcome="ALREADY-RESOLVED"`):
+        the resolving commit SHA or branch (e.g. `"e97d0ca"` or
+        `"foreman/<workload>/issue-129"`). Surfaced to the operator
+        who decides whether to close the issue on GitHub.
+      - Anything else you set is opaque to the controller but visible
+        in `status.result.extra`.
 
     ## Hard rules
 

--- a/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
+++ b/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
@@ -127,6 +127,14 @@ spec:
       reach.
     - A correct fix would touch more than ~10 files or need cross-cutting
       redesign.
+    - The issue is already resolved on the branch or upstream base.
+      Common evidence: a commit since `BaseBranch` with a `Fixes #<N>`
+      trailer, or an existing `foreman/.../issue-<N>` branch with the fix
+      already pushed. Emit `verdict="NO-GO"` with
+      `extra.outcome="ALREADY-RESOLVED"` and cite the resolving SHA or
+      branch in `extra.resolvedBy`. This is the honest "already done" bail
+      — distinct from a capability failure, and the controller will not
+      escalate it to a larger model (#970).
 
     GO only if the issue is a scoped bug, a small self-contained feature,
     or a chore with a clear, testable definition of done.
@@ -181,10 +189,34 @@ spec:
       message. Do not include any AI / tool attribution; do not add a
       `Signed-off-by:` trailer (the executor adds the DCO sign-off via
       `git commit -s`).
+
+    **Already-resolved example.** When you find the work is already done:
+
+    ```text
+    submit_result(
+      verdict="NO-GO",
+      summary="Issue #152 is already resolved by prior fix e97d0ca (Fixes #129).",
+      extra={
+        "outcome": "ALREADY-RESOLVED",
+        "resolvedBy": "e97d0ca"
+      },
+    )
+    ```
+
     - `extra` (optional): structured fields you want surfaced in
-      `status.result.extra.modelExtra`. Useful for the next pipeline step
-      (the gate Agent in M4) to pivot on. Examples: `{"filesChanged":
-      ["a.go", "b.go"], "testsAdded": 2}`.
+      `status.result.extra`. Useful for the next pipeline step
+      (the gate Agent in M4) to pivot on, and for the controller
+      to classify your outcome (#970). Recognized fields:
+      - `outcome`: a machine-readable class. Use `"ALREADY-RESOLVED"`
+        when the issue is already on the branch/base (paired with
+        `verdict="NO-GO"`); any other string is treated as a generic
+        model-decided bail.
+      - `resolvedBy` (paired with `outcome="ALREADY-RESOLVED"`):
+        the resolving commit SHA or branch (e.g. `"e97d0ca"` or
+        `"foreman/<workload>/issue-129"`). Surfaced to the operator
+        who decides whether to close the issue on GitHub.
+      - Anything else you set is opaque to the controller but visible
+        in `status.result.extra`.
 
     ## Hard rules
 

--- a/config/foreman/system-prompts/coder.md
+++ b/config/foreman/system-prompts/coder.md
@@ -70,6 +70,14 @@ NO-GO if any of the following hold:
   reach.
 - A correct fix would touch more than ~10 files or need cross-cutting
   redesign.
+- The issue is already resolved on the branch or upstream base.
+  Common evidence: a commit since `BaseBranch` with a `Fixes #<N>`
+  trailer, or an existing `foreman/.../issue-<N>` branch with the fix
+  already pushed. Emit `verdict="NO-GO"` with
+  `extra.outcome="ALREADY-RESOLVED"` and cite the resolving SHA or
+  branch in `extra.resolvedBy`. This is the honest "already done" bail
+  — distinct from a capability failure, and the controller will not
+  escalate it to a larger model (#970).
 
 GO only if the issue is a scoped bug, a small self-contained feature,
 or a chore with a clear, testable definition of done.
@@ -124,10 +132,34 @@ Call `submit_result` exactly once. Required fields:
   message. Do not include any AI / tool attribution; do not add a
   `Signed-off-by:` trailer (the executor adds the DCO sign-off via
   `git commit -s`).
+
+**Already-resolved example.** When you find the work is already done:
+
+```text
+submit_result(
+  verdict="NO-GO",
+  summary="Issue #152 is already resolved by prior fix e97d0ca (Fixes #129).",
+  extra={
+    "outcome": "ALREADY-RESOLVED",
+    "resolvedBy": "e97d0ca"
+  },
+)
+```
+
 - `extra` (optional): structured fields you want surfaced in
-  `status.result.extra.modelExtra`. Useful for the next pipeline step
-  (the gate Agent in M4) to pivot on. Examples: `{"filesChanged":
-  ["a.go", "b.go"], "testsAdded": 2}`.
+  `status.result.extra`. Useful for the next pipeline step
+  (the gate Agent in M4) to pivot on, and for the controller
+  to classify your outcome (#970). Recognized fields:
+  - `outcome`: a machine-readable class. Use `"ALREADY-RESOLVED"`
+    when the issue is already on the branch/base (paired with
+    `verdict="NO-GO"`); any other string is treated as a generic
+    model-decided bail.
+  - `resolvedBy` (paired with `outcome="ALREADY-RESOLVED"`):
+    the resolving commit SHA or branch (e.g. `"e97d0ca"` or
+    `"foreman/<workload>/issue-129"`). Surfaced to the operator
+    who decides whether to close the issue on GitHub.
+  - Anything else you set is opaque to the controller but visible
+    in `status.result.extra`.
 
 ## Hard rules
 

--- a/docs/site/foreman/README.md
+++ b/docs/site/foreman/README.md
@@ -219,6 +219,26 @@ An issue whose base coder returns NO-GO or trips the coder gate is
 re-dispatched once to `qwopus-27b-dense-coder`, with the base
 model's failure summary threaded into the prompt.
 
+### `ALREADY-RESOLVED` — honest "already done" bail (#970)
+
+When a coder concludes the work is already present on the branch or
+upstream base (e.g. a `Fixes #N` commit since `BaseBranch`, or an
+existing pushed `foreman/.../issue-N` branch), it emits
+`verdict="NO-GO"` with `extra.outcome="ALREADY-RESOLVED"` and cites
+the resolution in `extra.resolvedBy`. This is distinct from a
+capability failure (`MODEL-DECIDED`):
+
+- `shouldEscalateCoder` excludes it. The Workload does not pay for
+  a larger-model re-run that would re-derive "nothing to do."
+- The Workload rolls to `Phase=Completed` (not `Failed`) with
+  reason `AllAlreadyResolved` (pure case) or `AllChildrenSucceeded`
+  (mixed case).
+- A `CoderAlreadyResolved` condition names the issue numbers so the
+  operator can close them on GitHub.
+- A Kubernetes event per resolved issue (`Reason=AlreadyResolved`)
+  gives an event-router / GitHub-app integration point without
+  forcing auto-close.
+
 ## What v0.1 deliberately doesn't ship
 
 Foreman v0.1 is the foundation, not the finished platform. A few

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -140,6 +140,19 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
+	// Cascade-skip if any dependency ended ALREADY-RESOLVED (#970). The
+	// dependent cannot meaningfully run (the work is already on the branch);
+	// mark it Skipped (Phase=Succeeded + Verdict=Skipped) so the rollup
+	// excludes it from every bucket instead of cascade-failing it (which
+	// would land at Phase=Failed and pin the Workload to Failed). The skip
+	// check runs before the cascade-fail check so an ALREADY-RESOLVED dep
+	// never trips the "terminal without success" branch.
+	if depName, err := r.cascadeSkipIfDepAlreadyResolved(ctx, &task); err != nil {
+		return ctrl.Result{}, err
+	} else if depName != "" {
+		return r.skipTask(ctx, &task, depName)
+	}
+
 	// Cascade-fail if any dependency has Failed.
 	if cascadeMsg, err := r.cascadeFailIfDepFailed(ctx, &task); err != nil {
 		return ctrl.Result{}, err
@@ -549,6 +562,50 @@ func (r *AgenticTaskReconciler) failTask(ctx context.Context, task *foremanv1alp
 		LastTransitionTime: now,
 	})
 	return ctrl.Result{}, r.Status().Patch(ctx, task, patch)
+}
+
+// skipTask transitions a Pending task to Phase=Succeeded + Verdict=Skipped
+// because its dependency ended ALREADY-RESOLVED (#970). The Workload
+// rollup recognizes Skipped as a terminal-non-failure shape that is
+// excluded from every bucket; the dependent's execution never happened,
+// so no FailureReason is set (the cause is upstream, recorded in the
+// condition message). The Failed condition is NOT set — this is the
+// explicit non-failure path.
+func (r *AgenticTaskReconciler) skipTask(ctx context.Context, task *foremanv1alpha1.AgenticTask, depName string) (ctrl.Result, error) {
+	patch := client.MergeFrom(task.DeepCopy())
+	now := metav1.Now()
+	task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictSkipped
+	task.Status.FinishedAt = &now
+	setCondition(&task.Status.Conditions, metav1.Condition{
+		Type:               "Skipped",
+		Status:             metav1.ConditionTrue,
+		Reason:             "UpstreamAlreadyResolved",
+		Message:            fmt.Sprintf("dependency %q ended ALREADY-RESOLVED; dependent skipped", depName),
+		LastTransitionTime: now,
+	})
+	return ctrl.Result{}, r.Status().Patch(ctx, task, patch)
+}
+
+// cascadeSkipIfDepAlreadyResolved returns the first dependency that ended
+// ALREADY-RESOLVED (#970), or "" if none. The caller transitions the
+// dependent to Skipped; see skipTask. Runs before cascadeFailIfDepFailed
+// in Reconcile so an ALREADY-RESOLVED dep never trips the
+// "terminal without success" branch.
+func (r *AgenticTaskReconciler) cascadeSkipIfDepAlreadyResolved(ctx context.Context, task *foremanv1alpha1.AgenticTask) (string, error) {
+	for _, depName := range task.Spec.DependsOn {
+		var dep foremanv1alpha1.AgenticTask
+		if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: depName}, &dep); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return "", err
+		}
+		if isAlreadyResolvedCoder(&dep) {
+			return depName, nil
+		}
+	}
+	return "", nil
 }
 
 // checkClaimExpiry inspects the FleetNode named by task.status.assignedNode.

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -151,6 +152,57 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		failedCond := findCondition(fresh.Status.Conditions, "Failed")
 		Expect(failedCond).NotTo(BeNil())
 		Expect(failedCond.Reason).To(Equal("UpstreamFailed"))
+	})
+
+	// Regression for defilantech/LLMKube#970. A Pending task whose
+	// dependency ended ALREADY-RESOLVED (Phase=Succeeded +
+	// Verdict=NO-GO + extra.outcome="ALREADY-RESOLVED") must NOT be
+	// cascade-failed. The dependent is transitioned to
+	// Phase=Succeeded + Verdict=Skipped with a Skipped condition
+	// (Reason=UpstreamAlreadyResolved) so the Workload rollup
+	// excludes it from every bucket (it doesn't pin the Workload to
+	// Failed). Cascade-skip runs BEFORE cascade-fail in Reconcile so
+	// an ALREADY-RESOLVED dep never trips the "terminal without
+	// success" branch.
+	It("cascade-skips a Pending task when its dependency ended ALREADY-RESOLVED (#970)", func() {
+		dep := newTask("cascade-skip-dep")
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, dep) })
+		// Mark the dep as ALREADY-RESOLVED via Phase=Succeeded +
+		// Verdict=NO-GO + Status.Result envelope. The cascade path
+		// inspects all three (via isAlreadyResolvedCoder).
+		setPhase(dep, foremanv1alpha1.AgenticTaskPhaseSucceeded)
+		patch := client.MergeFrom(dep.DeepCopy())
+		dep.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		dep.Status.Result = &runtime.RawExtension{
+			Raw: []byte(`{"summary":"already done","extra":{"outcome":"ALREADY-RESOLVED","resolvedBy":"sha-deadbeef"}}`),
+		}
+		Expect(k8sClient.Status().Patch(ctx, dep, patch)).To(Succeed())
+
+		target := newTask("cascade-skip-target")
+		target.Spec.DependsOn = []string{dep.Name}
+		Expect(k8sClient.Create(ctx, target)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, target) })
+		setPhase(target, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(target))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(target), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseSucceeded))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictSkipped))
+		Expect(fresh.Status.FinishedAt).NotTo(BeNil())
+
+		skippedCond := findCondition(fresh.Status.Conditions, "Skipped")
+		Expect(skippedCond).NotTo(BeNil())
+		Expect(skippedCond.Reason).To(Equal("UpstreamAlreadyResolved"))
+		Expect(skippedCond.Message).To(ContainSubstring(dep.Name))
+
+		// Skipped must NOT trigger the Failed condition — that's the
+		// whole point of the skip path.
+		failedCond := findCondition(fresh.Status.Conditions, "Failed")
+		Expect(failedCond).To(BeNil(), "a Skipped dependent must not carry a Failed condition")
 	})
 
 	It("waits with requeue when a dependency is still pre-terminal", func() {

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -93,17 +93,39 @@ func coderResolvedBy(task *foremanv1alpha1.AgenticTask) string {
 	return env.Extra.ResolvedBy
 }
 
+// alreadyResolvedOutcome is the string value the model emits at
+// extra.outcome when the coder concludes the work is already on the
+// branch/base (#970). Distinct from MODEL-DECIDED (a capability
+// failure). Centralized here so the string can't drift between
+// isAlreadyResolvedCoder and shouldEscalateCoder.
+const alreadyResolvedOutcome = "ALREADY-RESOLVED"
+
 // isAlreadyResolvedCoder reports whether the task ended in the
 // machine outcome for "work is already on the branch/base". Used by
 // shouldEscalateCoder (to skip escalation) and rollup (to keep the
 // task out of the incomplete bucket). The signal lives at
-// extra.outcome == "ALREADY-RESOLVED" with verdict == NO-GO (#970).
+// extra.outcome == alreadyResolvedOutcome with verdict == NO-GO.
 func isAlreadyResolvedCoder(task *foremanv1alpha1.AgenticTask) bool {
 	if task == nil {
 		return false
 	}
 	verdict, topOutcome, _ := coderTerminalOutcome(task)
-	return verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == "ALREADY-RESOLVED"
+	return verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == alreadyResolvedOutcome
+}
+
+// isSkippedTask reports whether the task was skipped because its
+// dependency ended ALREADY-RESOLVED (#970). The cascade path in
+// agentictask_controller.transitionToSkippedIfDepAlreadyResolved
+// stamps Phase=Succeeded + Verdict=Skipped on the dependent; the
+// rollup excludes Skipped tasks from every bucket (succeeded,
+// incomplete, failed, inFlight, alreadyResolved) so they don't pin
+// the Workload to Failed.
+func isSkippedTask(task *foremanv1alpha1.AgenticTask) bool {
+	if task == nil {
+		return false
+	}
+	return task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded &&
+		task.Status.Verdict == foremanv1alpha1.AgenticTaskVerdictSkipped
 }
 
 // shouldEscalateCoder is the escalation trigger: escalate only on
@@ -115,7 +137,7 @@ func isAlreadyResolvedCoder(task *foremanv1alpha1.AgenticTask) bool {
 func shouldEscalateCoder(
 	verdict foremanv1alpha1.AgenticTaskVerdict, topOutcome, modelOutcome string,
 ) bool {
-	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == "ALREADY-RESOLVED" {
+	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == alreadyResolvedOutcome {
 		return false // #970: already-resolved is not a capability failure
 	}
 	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == "MODEL-DECIDED" {

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -76,6 +76,19 @@ func coderSummary(task *foremanv1alpha1.AgenticTask) string {
 	return env.Summary
 }
 
+// isAlreadyResolvedCoder reports whether the task ended in the
+// machine outcome for "work is already on the branch/base". Used by
+// shouldEscalateCoder (to skip escalation) and rollup (to keep the
+// task out of the incomplete bucket). The signal lives at
+// extra.outcome == "ALREADY-RESOLVED" with verdict == NO-GO (#970).
+func isAlreadyResolvedCoder(task *foremanv1alpha1.AgenticTask) bool {
+	if task == nil {
+		return false
+	}
+	verdict, topOutcome, _ := coderTerminalOutcome(task)
+	return verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == "ALREADY-RESOLVED"
+}
+
 // shouldEscalateCoder is the escalation trigger: escalate only on
 // capability failures. A model-decided NO-GO (the honest "I could not
 // solve this" bail) or a coder-gate failure (wrote code, could not pass

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -42,6 +42,7 @@ type coderResultEnvelope struct {
 		ModelExtra struct {
 			Outcome string `json:"outcome"`
 		} `json:"modelExtra"`
+		ResolvedBy string `json:"resolvedBy,omitempty"`
 	} `json:"extra"`
 }
 
@@ -74,6 +75,22 @@ func coderSummary(task *foremanv1alpha1.AgenticTask) string {
 		return ""
 	}
 	return env.Summary
+}
+
+// coderResolvedBy returns the resolvedBy evidence string from the result
+// envelope (commit SHA or branch). Mirrors coderTerminalOutcome but only
+// extracts Extra.ResolvedBy. Empty string when Result is nil/unparseable
+// or ResolvedBy is unset. Used by rollup to surface evidence in per-issue
+// AlreadyResolved events.
+func coderResolvedBy(task *foremanv1alpha1.AgenticTask) string {
+	if task.Status.Result == nil || len(task.Status.Result.Raw) == 0 {
+		return ""
+	}
+	var env coderResultEnvelope
+	if err := json.Unmarshal(task.Status.Result.Raw, &env); err != nil {
+		return ""
+	}
+	return env.Extra.ResolvedBy
 }
 
 // isAlreadyResolvedCoder reports whether the task ended in the

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -94,10 +94,13 @@ func isAlreadyResolvedCoder(task *foremanv1alpha1.AgenticTask) bool {
 // solve this" bail) or a coder-gate failure (wrote code, could not pass
 // the gate) escalate; a model-decided INCOMPLETE (gave up / ran out of
 // turns), a harness STUCK-LOOP-DETECTED, a trivial NO-CHANGES NO-GO, an
-// ERROR, or a GO do not.
+// already-resolved NO-GO (#970), an ERROR, or a GO do not.
 func shouldEscalateCoder(
 	verdict foremanv1alpha1.AgenticTaskVerdict, topOutcome, modelOutcome string,
 ) bool {
+	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == "ALREADY-RESOLVED" {
+		return false // #970: already-resolved is not a capability failure
+	}
 	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == "MODEL-DECIDED" {
 		return true
 	}

--- a/internal/foreman/controller/workload_coder_escalation_envtest_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_envtest_test.go
@@ -246,4 +246,65 @@ var _ = Describe("WorkloadReconciler coder escalation (#963)", func() {
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
 		Expect(findCondition(fresh.Status.Conditions, conditionTypeCoderEscalationTriggered)).To(BeNil())
 	})
+
+	// Regression for defilantech/LLMKube#970. A base coder that ends
+	// NO-GO + extra.outcome="ALREADY-RESOLVED" must NOT escalate (it is
+	// not a capability failure), and the Workload must reach a terminal
+	// state without pinning to Failed.
+	It("does not escalate or pin Failed on a base coder NO-GO + ALREADY-RESOLVED (#970)", func() {
+		wl := newWorkload("coder-esc-already-resolved", foremanv1alpha1.WorkloadSpec{
+			Intent:                  "already-resolved must skip escalation and roll to Completed",
+			Repo:                    "defilantech/LLMKube",
+			Issues:                  []int32{42},
+			CoderAgentRef:           &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef:        &corev1.LocalObjectReference{Name: "gate"},
+			EscalationCoderAgentRef: &corev1.LocalObjectReference{Name: "coder-qwopus"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		// First reconcile plans the base pipeline.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Tasks).To(HaveLen(2)) // code-42 + verify-42
+
+		// Mark the coder task NO-GO + ALREADY-RESOLVED.
+		var code foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-already-resolved-code-42"}, &code)).To(Succeed())
+		patch := client.MergeFrom(code.DeepCopy())
+		code.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		code.Status.Result = resultRaw("ALREADY-RESOLVED", "", "Issue #42 already resolved by commit abc1234")
+		Expect(k8sClient.Status().Patch(ctx, &code, patch)).To(Succeed())
+
+		// Delete the verify child so the rollup doesn't pin on Pending.
+		// In production this would be cascade-failed by the reconciler; in
+		// envtest we isolate the coder-escalation hook under test.
+		var verifyTask foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-already-resolved-verify-42"}, &verifyTask)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, &verifyTask)).To(Succeed())
+
+		// Second reconcile runs the coder-escalation hook + rollup.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// (1) No -esc child emitted.
+		var escCode foremanv1alpha1.AgenticTask
+		err = k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-already-resolved-code-42-esc"}, &escCode)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "an ALREADY-RESOLVED coder must not escalate")
+
+		// (2) No CoderEscalationTriggered condition set.
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		cond := findCondition(fresh.Status.Conditions, conditionTypeCoderEscalationTriggered)
+		Expect(cond).To(BeNil(), "ALREADY-RESOLVED must not produce a CoderEscalationTriggered condition")
+
+		// (3) Workload terminal state is Completed (not Failed).
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseCompleted))
+		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(0)))
+	})
 })

--- a/internal/foreman/controller/workload_coder_escalation_envtest_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_envtest_test.go
@@ -75,7 +75,7 @@ var _ = Describe("WorkloadReconciler coder escalation (#963)", func() {
 		p944 := client.MergeFrom(set944.DeepCopy())
 		set944.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 		set944.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-		set944.Status.Result = resultRaw("MODEL-DECIDED", "", "fuzzy front-runs anchor")
+		set944.Status.Result = resultRaw("MODEL-DECIDED", "", "fuzzy front-runs anchor", "")
 		Expect(k8sClient.Status().Patch(ctx, &set944, p944)).To(Succeed())
 
 		// (B) code-921 terminates INCOMPLETE / MODEL-DECIDED (no gate
@@ -85,7 +85,7 @@ var _ = Describe("WorkloadReconciler coder escalation (#963)", func() {
 		p921 := client.MergeFrom(set921.DeepCopy())
 		set921.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 		set921.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
-		set921.Status.Result = resultRaw("MODEL-DECIDED", "", "ran out of turns")
+		set921.Status.Result = resultRaw("MODEL-DECIDED", "", "ran out of turns", "")
 		Expect(k8sClient.Status().Patch(ctx, &set921, p921)).To(Succeed())
 
 		// Second reconcile runs the coder-escalation hook.
@@ -165,7 +165,7 @@ var _ = Describe("WorkloadReconciler coder escalation (#963)", func() {
 			Expect(k8sClient.Status().Patch(ctx, &t, p)).To(Succeed())
 		}
 		setTerminal("coder-esc-rev-code-944", foremanv1alpha1.AgenticTaskPhaseSucceeded,
-			foremanv1alpha1.AgenticTaskVerdictNoGo, func() *runtime.RawExtension { return resultRaw("MODEL-DECIDED", "", "fuzzy front-runs anchor") })
+			foremanv1alpha1.AgenticTaskVerdictNoGo, func() *runtime.RawExtension { return resultRaw("MODEL-DECIDED", "", "fuzzy front-runs anchor", "") })
 		setTerminal("coder-esc-rev-verify-944", foremanv1alpha1.AgenticTaskPhaseFailed,
 			foremanv1alpha1.AgenticTaskVerdictIncomplete, nil)
 		setTerminal("coder-esc-rev-review-944-0", foremanv1alpha1.AgenticTaskPhaseFailed,
@@ -232,7 +232,7 @@ var _ = Describe("WorkloadReconciler coder escalation (#963)", func() {
 		patch := client.MergeFrom(base.DeepCopy())
 		base.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 		base.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-		base.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed")
+		base.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed", "")
 		Expect(k8sClient.Status().Patch(ctx, &base, patch)).To(Succeed())
 
 		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
@@ -279,7 +279,7 @@ var _ = Describe("WorkloadReconciler coder escalation (#963)", func() {
 		patch := client.MergeFrom(code.DeepCopy())
 		code.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 		code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-		code.Status.Result = resultRaw("ALREADY-RESOLVED", "", "Issue #42 already resolved by commit abc1234")
+		code.Status.Result = resultRaw("ALREADY-RESOLVED", "", "Issue #42 already resolved by commit abc1234", "")
 		Expect(k8sClient.Status().Patch(ctx, &code, patch)).To(Succeed())
 
 		// Delete the verify child so the rollup doesn't pin on Pending.

--- a/internal/foreman/controller/workload_coder_escalation_envtest_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_envtest_test.go
@@ -282,12 +282,16 @@ var _ = Describe("WorkloadReconciler coder escalation (#963)", func() {
 		code.Status.Result = resultRaw("ALREADY-RESOLVED", "", "Issue #42 already resolved by commit abc1234", "")
 		Expect(k8sClient.Status().Patch(ctx, &code, patch)).To(Succeed())
 
-		// Delete the verify child so the rollup doesn't pin on Pending.
-		// In production this would be cascade-failed by the reconciler; in
-		// envtest we isolate the coder-escalation hook under test.
+		// Cascade-skip the verify child (production path: the
+		// AgenticTaskReconciler would mark it Skipped because the coder
+		// ended ALREADY-RESOLVED). The envtest runs only the
+		// WorkloadReconciler, so we stamp the terminal shape directly.
 		var verifyTask foremanv1alpha1.AgenticTask
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "coder-esc-already-resolved-verify-42"}, &verifyTask)).To(Succeed())
-		Expect(k8sClient.Delete(ctx, &verifyTask)).To(Succeed())
+		patchVerify := client.MergeFrom(verifyTask.DeepCopy())
+		verifyTask.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		verifyTask.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictSkipped
+		Expect(k8sClient.Status().Patch(ctx, &verifyTask, patchVerify)).To(Succeed())
 
 		// Second reconcile runs the coder-escalation hook + rollup.
 		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})

--- a/internal/foreman/controller/workload_coder_escalation_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_test.go
@@ -47,6 +47,7 @@ func TestShouldEscalateCoder(t *testing.T) {
 		want         bool
 	}{
 		{"model NO-GO (like #944)", foremanv1alpha1.AgenticTaskVerdictNoGo, "MODEL-DECIDED", "", true},
+		{"NO-GO + ALREADY-RESOLVED (already done, #970)", foremanv1alpha1.AgenticTaskVerdictNoGo, "ALREADY-RESOLVED", "", false},
 		{"gate-failed (like #911)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "MODEL-DECIDED", "CODER-GATE-FAILED", true},
 		{"model gave up / stuck (like #921)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "MODEL-DECIDED", "", false},
 		{"stuck-loop detected", foremanv1alpha1.AgenticTaskVerdictIncomplete, "STUCK-LOOP-DETECTED", "", false},
@@ -247,10 +248,10 @@ func TestCoderEscalationSteps_SkipsStuckLoopAndExisting(t *testing.T) {
 // to identify a model-decided "already done" NO-GO (#970).
 func TestIsAlreadyResolvedCoder(t *testing.T) {
 	cases := []struct {
-		name        string
-		verdict     foremanv1alpha1.AgenticTaskVerdict
-		topOutcome  string
-		want        bool
+		name       string
+		verdict    foremanv1alpha1.AgenticTaskVerdict
+		topOutcome string
+		want       bool
 	}{
 		{"NO-GO + ALREADY-RESOLVED", foremanv1alpha1.AgenticTaskVerdictNoGo, "ALREADY-RESOLVED", true},
 		{"NO-GO + MODEL-DECIDED (capability failure)", foremanv1alpha1.AgenticTaskVerdictNoGo, "MODEL-DECIDED", false},

--- a/internal/foreman/controller/workload_coder_escalation_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_test.go
@@ -28,13 +28,18 @@ import (
 
 // resultRaw builds a status.result RawExtension with the given top-level
 // and nested modelExtra outcome, matching the executor's envelope shape.
+// The resolvedBy field is optional (empty string omits it).
 // nolint:unparam // topOutcome is parameterized to mirror the envelope shape even though current tests all pass "MODEL-DECIDED"
-func resultRaw(topOutcome, modelOutcome, summary string) *runtime.RawExtension {
+func resultRaw(topOutcome, modelOutcome, summary, resolvedBy string) *runtime.RawExtension {
 	me := ""
 	if modelOutcome != "" {
 		me = `,"modelExtra":{"outcome":"` + modelOutcome + `"}`
 	}
-	j := `{"summary":"` + summary + `","extra":{"outcome":"` + topOutcome + `"` + me + `}}`
+	rb := ""
+	if resolvedBy != "" {
+		rb = `,"resolvedBy":"` + resolvedBy + `"`
+	}
+	j := `{"summary":"` + summary + `","extra":{"outcome":"` + topOutcome + `"` + me + rb + `}}`
 	return &runtime.RawExtension{Raw: []byte(j)}
 }
 
@@ -67,7 +72,7 @@ func TestShouldEscalateCoder(t *testing.T) {
 func TestCoderTerminalOutcome_ReadsNestedGateOutcome(t *testing.T) {
 	task := &foremanv1alpha1.AgenticTask{}
 	task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
-	task.Status.Result = resultRaw("MODEL-DECIDED", "CODER-GATE-FAILED", "gate failed")
+	task.Status.Result = resultRaw("MODEL-DECIDED", "CODER-GATE-FAILED", "gate failed", "")
 	v, top, model := coderTerminalOutcome(task)
 	if v != foremanv1alpha1.AgenticTaskVerdictIncomplete || top != "MODEL-DECIDED" || model != "CODER-GATE-FAILED" {
 		t.Errorf("got (%s,%q,%q)", v, top, model)
@@ -90,7 +95,7 @@ func TestCoderEscalationSteps_EmitsOnNoGo(t *testing.T) {
 	code.Labels = map[string]string{labelStep: "code-944"}
 	code.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 	code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-	code.Status.Result = resultRaw("MODEL-DECIDED", "", "could not solve: fuzzy front-runs anchor")
+	code.Status.Result = resultRaw("MODEL-DECIDED", "", "could not solve: fuzzy front-runs anchor", "")
 
 	steps, escalated := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{code})
 	if len(steps) != 2 {
@@ -120,7 +125,7 @@ func TestCoderEscalationSteps_EmitsReviewerStepsOnEscBranch(t *testing.T) {
 		code.Labels = map[string]string{labelStep: "code-944"}
 		code.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 		code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-		code.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed")
+		code.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed", "")
 		return code
 	}
 
@@ -221,14 +226,14 @@ func TestCoderEscalationSteps_SkipsStuckLoopAndExisting(t *testing.T) {
 	c921.Labels = map[string]string{labelStep: "code-921"}
 	c921.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 	c921.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
-	c921.Status.Result = resultRaw("MODEL-DECIDED", "", "ran out of turns")
+	c921.Status.Result = resultRaw("MODEL-DECIDED", "", "ran out of turns", "")
 
 	c944 := foremanv1alpha1.AgenticTask{}
 	c944.Name = "wl-code-944"
 	c944.Labels = map[string]string{labelStep: "code-944"}
 	c944.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 	c944.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-	c944.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed")
+	c944.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed", "")
 	esc944 := foremanv1alpha1.AgenticTask{}
 	esc944.Name = "wl-code-944-esc"
 	esc944.Labels = map[string]string{labelStep: "code-944-esc"}
@@ -268,7 +273,7 @@ func TestIsAlreadyResolvedCoder(t *testing.T) {
 			// would make the case ambiguous; rely on coderTerminalOutcome's
 			// nil/empty Result handling.
 			if tc.topOutcome != "" {
-				task.Status.Result = resultRaw(tc.topOutcome, "", "")
+				task.Status.Result = resultRaw(tc.topOutcome, "", "", "")
 			}
 			if got := isAlreadyResolvedCoder(task); got != tc.want {
 				t.Errorf("isAlreadyResolvedCoder() = %v, want %v", got, tc.want)
@@ -287,7 +292,7 @@ func TestCoderEscalationSteps_OffWhenUnset(t *testing.T) {
 	c.Labels = map[string]string{labelStep: "code-944"}
 	c.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 	c.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-	c.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed")
+	c.Status.Result = resultRaw("MODEL-DECIDED", "", "bailed", "")
 	steps, _ := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{c})
 	if len(steps) != 0 {
 		t.Errorf("feature must be off when EscalationCoderAgentRef is nil, got %d steps", len(steps))

--- a/internal/foreman/controller/workload_coder_escalation_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_test.go
@@ -242,6 +242,40 @@ func TestCoderEscalationSteps_SkipsStuckLoopAndExisting(t *testing.T) {
 	}
 }
 
+// TestIsAlreadyResolvedCoder verifies the helper that downstream
+// classifiers (shouldEscalateCoder exclusion, rollup exclusion) use
+// to identify a model-decided "already done" NO-GO (#970).
+func TestIsAlreadyResolvedCoder(t *testing.T) {
+	cases := []struct {
+		name        string
+		verdict     foremanv1alpha1.AgenticTaskVerdict
+		topOutcome  string
+		want        bool
+	}{
+		{"NO-GO + ALREADY-RESOLVED", foremanv1alpha1.AgenticTaskVerdictNoGo, "ALREADY-RESOLVED", true},
+		{"NO-GO + MODEL-DECIDED (capability failure)", foremanv1alpha1.AgenticTaskVerdictNoGo, "MODEL-DECIDED", false},
+		{"NO-GO + empty outcome (legacy)", foremanv1alpha1.AgenticTaskVerdictNoGo, "", false},
+		{"INCOMPLETE + ALREADY-RESOLVED (not a NO-GO, not classified)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "ALREADY-RESOLVED", false},
+		{"GO + ALREADY-RESOLVED (impossible combo, defensive)", foremanv1alpha1.AgenticTaskVerdictGo, "ALREADY-RESOLVED", false},
+		{"nil result envelope", foremanv1alpha1.AgenticTaskVerdictNoGo, "", false}, // task without Status.Result
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &foremanv1alpha1.AgenticTask{}
+			task.Status.Verdict = tc.verdict
+			// Skip setting Result when topOutcome is "" AND verdict alone
+			// would make the case ambiguous; rely on coderTerminalOutcome's
+			// nil/empty Result handling.
+			if tc.topOutcome != "" {
+				task.Status.Result = resultRaw(tc.topOutcome, "", "")
+			}
+			if got := isAlreadyResolvedCoder(task); got != tc.want {
+				t.Errorf("isAlreadyResolvedCoder() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCoderEscalationSteps_OffWhenUnset(t *testing.T) {
 	w := &foremanv1alpha1.Workload{}
 	w.Name = "wl"

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -114,6 +114,14 @@ const conditionTypeEscalationTriggered = "EscalationTriggered"
 // the escalation coder tier (EscalationCoderAgentRef).
 const conditionTypeCoderEscalationTriggered = "CoderEscalationTriggered"
 
+// conditionTypeCoderAlreadyResolved marks a Workload whose coder
+// children all concluded the work was already present on the
+// branch/base (NO-GO + extra.outcome="ALREADY-RESOLVED"). Set when
+// at least one such child exists; the message lists the issue numbers
+// in ascending order. Not set when zero children are already-resolved
+// (avoids a perpetual "0 issues" noise condition).
+const conditionTypeCoderAlreadyResolved = "CoderAlreadyResolved"
+
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads/finalizers,verbs=update
@@ -499,13 +507,23 @@ func (r *WorkloadReconciler) listChildren(ctx context.Context, w *foremanv1alpha
 func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
 	var (
 		succeeded, incomplete, failed, inFlight int32
+		alreadyResolved                          int32
 	)
+	var resolvedIssues []int32
 	for i := range children {
 		switch {
 		case children[i].SucceededOnTarget():
 			succeeded++
+		case isAlreadyResolvedCoder(&children[i]):
+			// #970: ALREADY-RESOLVED is a terminal non-failure; it
+			// neither escalates (#964) nor pins the Workload to Failed
+			// via the incomplete bucket. Track the issue number so
+			// the condition + event can name it.
+			alreadyResolved++
+			if n := children[i].Spec.Payload.Issue; n > 0 {
+				resolvedIssues = append(resolvedIssues, n)
+			}
 		case children[i].Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded:
-			// Terminal Phase=Succeeded but verdict isn't on-target.
 			incomplete++
 		case children[i].Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed:
 			failed++
@@ -513,6 +531,8 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			inFlight++
 		}
 	}
+
+	sort.Slice(resolvedIssues, func(i, j int) bool { return resolvedIssues[i] < resolvedIssues[j] })
 
 	total := succeeded + incomplete + failed + inFlight
 	patch := client.MergeFrom(w.DeepCopy())
@@ -522,7 +542,8 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 	w.Status.IncompleteTasks = incomplete
 
 	switch {
-	case inFlight == 0 && failed == 0 && incomplete == 0:
+	case inFlight == 0 && failed == 0 && incomplete == 0 && alreadyResolved == 0:
+		// All on-target.
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseCompleted
 		setCondition(&w.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeCompleted,
@@ -531,11 +552,35 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Message:            fmt.Sprintf("%d/%d child tasks on-target Succeeded", succeeded, total),
 			LastTransitionTime: now,
 		})
+	case inFlight == 0 && failed == 0 && incomplete == 0 && succeeded == 0 && alreadyResolved > 0:
+		// Pure ALREADY-RESOLVED workload — nothing actually attempted.
+		w.Status.Phase = foremanv1alpha1.WorkloadPhaseCompleted
+		msg := fmt.Sprintf("%d issue(s) already resolved at run time (no fix attempted): #%s",
+			alreadyResolved, joinInt32(resolvedIssues))
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeCompleted,
+			Status:             metav1.ConditionTrue,
+			Reason:             "AllAlreadyResolved",
+			Message:            msg,
+			LastTransitionTime: now,
+		})
+	case inFlight == 0 && failed == 0 && incomplete == 0:
+		// Mixed: at least one on-target succeeded AND at least one
+		// already-resolved. Still Completed; mention both.
+		w.Status.Phase = foremanv1alpha1.WorkloadPhaseCompleted
+		msg := fmt.Sprintf("%d/%d child tasks on-target Succeeded; %d already-resolved (no fix attempted)",
+			succeeded, total, alreadyResolved)
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeCompleted,
+			Status:             metav1.ConditionTrue,
+			Reason:             "AllChildrenSucceeded",
+			Message:            msg,
+			LastTransitionTime: now,
+		})
 	case inFlight == 0 && (failed > 0 || incomplete > 0):
 		// Any incomplete OR failed child rolls the Workload to Failed
-		// terminal state. The condition message breaks out both counts
-		// so the operator can distinguish "agent gave up" (incomplete)
-		// from "executor errored" (failed).
+		// terminal state. ALREADY-RESOLVED children do not contribute
+		// to this — they are excluded from `incomplete` above.
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseFailed
 		reason := "ChildrenFailed"
 		if failed == 0 {
@@ -545,7 +590,7 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Type:               conditionTypeCompleted,
 			Status:             metav1.ConditionFalse,
 			Reason:             reason,
-			Message:            fmt.Sprintf("%d on-target, %d incomplete, %d failed (of %d)", succeeded, incomplete, failed, total),
+			Message:            fmt.Sprintf("%d on-target, %d incomplete, %d failed (of %d); %d already-resolved", succeeded, incomplete, failed, total, alreadyResolved),
 			LastTransitionTime: now,
 		})
 	default:
@@ -554,7 +599,42 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Type:               "Dispatched",
 			Status:             metav1.ConditionTrue,
 			Reason:             "ChildrenInFlight",
-			Message:            fmt.Sprintf("%d in-flight, %d on-target, %d incomplete, %d failed", inFlight, succeeded, incomplete, failed),
+			Message:            fmt.Sprintf("%d in-flight, %d on-target, %d incomplete, %d failed, %d already-resolved", inFlight, succeeded, incomplete, failed, alreadyResolved),
+			LastTransitionTime: now,
+		})
+	}
+
+	// #970: surface the ALREADY-RESOLVED issues via a stable condition +
+	// per-issue events so an operator (or event-router) can close them.
+	if alreadyResolved > 0 {
+		// Prefix every issue with "#" so the message reads "#152, #365"
+		// (rather than "#152, 365" which only marks the first one).
+		issueList := joinInt32(resolvedIssues)
+		issueList = "#" + strings.ReplaceAll(issueList, ", ", ", #")
+		msg := fmt.Sprintf("%d issue(s) already resolved at run time: %s. See events for per-issue resolution evidence (commit / branch).",
+			alreadyResolved, issueList)
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeCoderAlreadyResolved,
+			Status:             metav1.ConditionTrue,
+			Reason:             "AlreadyResolved",
+			Message:            msg,
+			LastTransitionTime: now,
+		})
+		if r.Recorder != nil {
+			for _, n := range resolvedIssues {
+				r.Recorder.Eventf(w, nil, corev1.EventTypeNormal, "AlreadyResolved", "Workload",
+					"Issue #%d resolved at run time; safe to close on GitHub", n)
+			}
+		}
+	} else {
+		// Clear the condition when no children are already-resolved
+		// (avoids stale "0 issues resolved" condition lingering after
+		// a Workload re-runs and gets different outcomes).
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeCoderAlreadyResolved,
+			Status:             metav1.ConditionFalse,
+			Reason:             "NoAlreadyResolved",
+			Message:            "no coder children ended ALREADY-RESOLVED",
 			LastTransitionTime: now,
 		})
 	}

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -507,7 +507,7 @@ func (r *WorkloadReconciler) listChildren(ctx context.Context, w *foremanv1alpha
 func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
 	var (
 		succeeded, incomplete, failed, inFlight int32
-		alreadyResolved                          int32
+		alreadyResolved                         int32
 	)
 	var resolvedIssues []int32
 	for i := range children {

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -510,6 +510,7 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 		alreadyResolved                         int32
 	)
 	var resolvedIssues []int32
+	var resolvedByList []string // parallel to resolvedIssues; evidence per issue
 	for i := range children {
 		switch {
 		case children[i].SucceededOnTarget():
@@ -522,6 +523,9 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			alreadyResolved++
 			if n := children[i].Spec.Payload.Issue; n > 0 {
 				resolvedIssues = append(resolvedIssues, n)
+				resolvedByList = append(resolvedByList, coderResolvedBy(&children[i]))
+			} else {
+				resolvedByList = append(resolvedByList, "")
 			}
 		case children[i].Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded:
 			incomplete++
@@ -532,7 +536,12 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 		}
 	}
 
-	sort.Slice(resolvedIssues, func(i, j int) bool { return resolvedIssues[i] < resolvedIssues[j] })
+	sort.Slice(resolvedIssues, func(i, j int) bool {
+		if resolvedIssues[i] != resolvedIssues[j] {
+			return resolvedIssues[i] < resolvedIssues[j]
+		}
+		return resolvedByList[i] < resolvedByList[j]
+	})
 
 	total := succeeded + incomplete + failed + inFlight
 	patch := client.MergeFrom(w.DeepCopy())
@@ -621,9 +630,14 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			LastTransitionTime: now,
 		})
 		if r.Recorder != nil {
-			for _, n := range resolvedIssues {
-				r.Recorder.Eventf(w, nil, corev1.EventTypeNormal, "AlreadyResolved", "Workload",
-					"Issue #%d resolved at run time; safe to close on GitHub", n)
+			for idx, n := range resolvedIssues {
+				if resolvedByList[idx] != "" {
+					r.Recorder.Eventf(w, nil, corev1.EventTypeNormal, "AlreadyResolved", "Workload",
+						"Issue #%d resolved by %s; safe to close on GitHub", n, resolvedByList[idx])
+				} else {
+					r.Recorder.Eventf(w, nil, corev1.EventTypeNormal, "AlreadyResolved", "Workload",
+						"Issue #%d resolved at run time; safe to close on GitHub", n)
+				}
 			}
 		}
 	} else {

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -492,11 +492,16 @@ func (r *WorkloadReconciler) listChildren(ctx context.Context, w *foremanv1alpha
 // children's phases AND verdicts and patches status. Triggered on every
 // child phase change via the Owns() watch.
 //
-// Counts children in four buckets:
+// Counts children in five buckets:
 //   - succeeded: SucceededOnTarget() (Phase=Succeeded AND verdict in
 //     {GO, GATE-PASS}) — produced a usable artifact
+//   - alreadyResolved: coder ended NO-GO + extra.outcome="ALREADY-RESOLVED"
+//     (#970) — terminal non-failure, the work was already on the branch
+//   - skipped: dependent cascade-skipped because its coder dep ended
+//     ALREADY-RESOLVED (#970) — terminal non-failure, never executed
 //   - incomplete: Phase=Succeeded but verdict in {INCOMPLETE, NO-GO,
-//     GATE-FAIL, GATE-ERROR} — terminal without usable output
+//     GATE-FAIL, GATE-ERROR} (excluding ALREADY-RESOLVED + Skipped) —
+//     terminal without usable output
 //   - failed: Phase=Failed
 //   - inFlight: everything else (Pending / Scheduled / Running)
 //
@@ -504,68 +509,153 @@ func (r *WorkloadReconciler) listChildren(ctx context.Context, w *foremanv1alpha
 // verdict, which misreported the Memorial Day v5 batch as "12/12
 // Succeeded" when 2 of those 12 ended INCOMPLETE and 2 ended GATE-FAIL.
 // Fixes defilantech/LLMKube#541.
+//
+// #970 added the alreadyResolved and skipped buckets — both are
+// terminal non-failures that exclude the child from pinning the Workload
+// to Failed. Skipped additionally excludes from the incomplete bucket
+// (the cascade-fail path would otherwise count the dependent as
+// `failed`).
+//
+// rollup is split into three small functions (classifyChildren,
+// computeTerminalState, emitAlreadyResolvedCondition) to keep each
+// piece under the gocyclo threshold; the orchestrator here is just
+// the wiring.
 func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
-	var (
-		succeeded, incomplete, failed, inFlight int32
-		alreadyResolved                         int32
-	)
-	var resolvedIssues []int32
-	var resolvedByList []string // parallel to resolvedIssues; evidence per issue
+	cls := classifyChildren(children)
+
+	// Capture the patch BEFORE mutating w.Status — the patch's
+	// "original" snapshot must reflect the on-cluster state for the
+	// diff to drive the right fields.
+	patch := client.MergeFrom(w.DeepCopy())
+	now := metav1.Now()
+
+	w.Status.SucceededTasks = cls.succeeded
+	w.Status.FailedTasks = cls.failed
+	w.Status.IncompleteTasks = cls.incomplete
+
+	computeTerminalState(w, cls, now)
+	r.emitAlreadyResolvedCondition(w, cls, now)
+
+	if err := r.Status().Patch(ctx, w, patch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("patch workload status during rollup: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// childCounts is the per-bucket classification returned by
+// classifyChildren. Skipped is included so computeTerminalState can
+// reference it without recomputing.
+type childCounts struct {
+	succeeded, incomplete, failed, inFlight int32
+	alreadyResolved                         int32
+	skipped                                 int32
+	resolvedIssues                          []int32
+	resolvedByList                          []string
+	total                                   int32
+}
+
+// classifyChildren walks the children slice and returns the bucket
+// counts. Per the doc comment on rollup, five buckets:
+//   - succeeded: SucceededOnTarget() returns true (Phase=Succeeded +
+//     verdict in {GO, GATE-PASS})
+//   - skipped: Phase=Succeeded + Verdict=Skipped (cascade-skip from
+//     ALREADY-RESOLVED dep, #970)
+//   - alreadyResolved: NO-GO + extra.outcome="ALREADY-RESOLVED" (#970)
+//   - incomplete: Phase=Succeeded + verdict not on-target and not
+//     skipped and not ALREADY-RESOLVED
+//   - failed: Phase=Failed
+//   - inFlight: everything else (Pending / Scheduled / Running)
+//
+// Skipped matches BEFORE the generic "Phase=Succeeded not on-target"
+// case so its body (empty) is selected; otherwise the generic case
+// would catch it. The empty body is intentional — Skipped children are
+// excluded from every bucket by virtue of matching this case without
+// incrementing any counter.
+//
+// The resolvedIssues + resolvedByList slices are kept parallel and
+// sorted together by issue number (then by resolvedBy to break ties).
+// Plain sort.Slice(resolvedIssues, ...) would leave the parallel slice
+// out of sync, attributing the wrong SHA to issues in any multi-issue
+// Workload (Defilan review on #970).
+func classifyChildren(children []foremanv1alpha1.AgenticTask) childCounts {
+	var c childCounts
 	for i := range children {
 		switch {
 		case children[i].SucceededOnTarget():
-			succeeded++
+			c.succeeded++
+		case isSkippedTask(&children[i]):
+			c.skipped++
 		case isAlreadyResolvedCoder(&children[i]):
-			// #970: ALREADY-RESOLVED is a terminal non-failure; it
-			// neither escalates (#964) nor pins the Workload to Failed
-			// via the incomplete bucket. Track the issue number so
-			// the condition + event can name it.
-			alreadyResolved++
+			c.alreadyResolved++
 			if n := children[i].Spec.Payload.Issue; n > 0 {
-				resolvedIssues = append(resolvedIssues, n)
-				resolvedByList = append(resolvedByList, coderResolvedBy(&children[i]))
-			} else {
-				resolvedByList = append(resolvedByList, "")
+				c.resolvedIssues = append(c.resolvedIssues, n)
+				c.resolvedByList = append(c.resolvedByList, coderResolvedBy(&children[i]))
 			}
+			// Issues with Spec.Payload.Issue == 0 are malformed
+			// (ad-hoc AgenticTasks); the per-issue condition + events
+			// can't name them, so they don't show up in either list.
+			// The counter is incremented either way.
 		case children[i].Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded:
-			incomplete++
+			c.incomplete++
 		case children[i].Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed:
-			failed++
+			c.failed++
 		default:
-			inFlight++
+			c.inFlight++
 		}
 	}
 
-	sort.Slice(resolvedIssues, func(i, j int) bool {
-		if resolvedIssues[i] != resolvedIssues[j] {
-			return resolvedIssues[i] < resolvedIssues[j]
+	if len(c.resolvedIssues) > 1 {
+		order := make([]int, len(c.resolvedIssues))
+		for i := range order {
+			order[i] = i
 		}
-		return resolvedByList[i] < resolvedByList[j]
-	})
+		sort.Slice(order, func(a, b int) bool {
+			if c.resolvedIssues[order[a]] != c.resolvedIssues[order[b]] {
+				return c.resolvedIssues[order[a]] < c.resolvedIssues[order[b]]
+			}
+			return c.resolvedByList[order[a]] < c.resolvedByList[order[b]]
+		})
+		sortedIssues := make([]int32, len(order))
+		sortedBy := make([]string, len(order))
+		for i, idx := range order {
+			sortedIssues[i] = c.resolvedIssues[idx]
+			sortedBy[i] = c.resolvedByList[idx]
+		}
+		c.resolvedIssues, c.resolvedByList = sortedIssues, sortedBy
+	}
 
-	total := succeeded + incomplete + failed + inFlight
-	patch := client.MergeFrom(w.DeepCopy())
-	now := metav1.Now()
-	w.Status.SucceededTasks = succeeded
-	w.Status.FailedTasks = failed
-	w.Status.IncompleteTasks = incomplete
+	c.total = c.succeeded + c.incomplete + c.failed + c.inFlight
+	return c
+}
 
+// computeTerminalState sets w.Status.Phase and writes the Completed
+// condition based on the child counts. The five terminal-state cases
+// (in priority order) are:
+//   - All on-target Succeeded (no other terminal children)
+//   - Pure ALREADY-RESOLVED (nothing actually attempted)
+//   - Mixed on-target + ALREADY-RESOLVED
+//   - Any failed or incomplete child → Failed
+//   - Otherwise (in-flight children) → Dispatched
+//
+// Skipped children never trigger Failed (the case arm requires
+// `failed > 0 || incomplete > 0` and Skipped is counted in neither).
+func computeTerminalState(w *foremanv1alpha1.Workload, c childCounts, now metav1.Time) {
 	switch {
-	case inFlight == 0 && failed == 0 && incomplete == 0 && alreadyResolved == 0:
+	case c.inFlight == 0 && c.failed == 0 && c.incomplete == 0 && c.alreadyResolved == 0:
 		// All on-target.
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseCompleted
 		setCondition(&w.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeCompleted,
 			Status:             metav1.ConditionTrue,
 			Reason:             "AllChildrenSucceeded",
-			Message:            fmt.Sprintf("%d/%d child tasks on-target Succeeded", succeeded, total),
+			Message:            fmt.Sprintf("%d/%d child tasks on-target Succeeded", c.succeeded, c.total),
 			LastTransitionTime: now,
 		})
-	case inFlight == 0 && failed == 0 && incomplete == 0 && succeeded == 0 && alreadyResolved > 0:
+	case c.inFlight == 0 && c.failed == 0 && c.incomplete == 0 && c.succeeded == 0 && c.alreadyResolved > 0:
 		// Pure ALREADY-RESOLVED workload — nothing actually attempted.
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseCompleted
 		msg := fmt.Sprintf("%d issue(s) already resolved at run time (no fix attempted): #%s",
-			alreadyResolved, joinInt32(resolvedIssues))
+			c.alreadyResolved, joinInt32(c.resolvedIssues))
 		setCondition(&w.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeCompleted,
 			Status:             metav1.ConditionTrue,
@@ -573,12 +663,12 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Message:            msg,
 			LastTransitionTime: now,
 		})
-	case inFlight == 0 && failed == 0 && incomplete == 0:
+	case c.inFlight == 0 && c.failed == 0 && c.incomplete == 0:
 		// Mixed: at least one on-target succeeded AND at least one
 		// already-resolved. Still Completed; mention both.
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseCompleted
 		msg := fmt.Sprintf("%d/%d child tasks on-target Succeeded; %d already-resolved (no fix attempted)",
-			succeeded, total, alreadyResolved)
+			c.succeeded, c.total, c.alreadyResolved)
 		setCondition(&w.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeCompleted,
 			Status:             metav1.ConditionTrue,
@@ -586,64 +676,44 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Message:            msg,
 			LastTransitionTime: now,
 		})
-	case inFlight == 0 && (failed > 0 || incomplete > 0):
+	case c.inFlight == 0 && (c.failed > 0 || c.incomplete > 0):
 		// Any incomplete OR failed child rolls the Workload to Failed
-		// terminal state. ALREADY-RESOLVED children do not contribute
-		// to this — they are excluded from `incomplete` above.
+		// terminal state. ALREADY-RESOLVED and Skipped children do not
+		// contribute to this — they are excluded from `incomplete`.
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseFailed
 		reason := "ChildrenFailed"
-		if failed == 0 {
+		if c.failed == 0 {
 			reason = "ChildrenIncomplete"
 		}
 		setCondition(&w.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeCompleted,
-			Status:             metav1.ConditionFalse,
-			Reason:             reason,
-			Message:            fmt.Sprintf("%d on-target, %d incomplete, %d failed (of %d); %d already-resolved", succeeded, incomplete, failed, total, alreadyResolved),
+			Type:   conditionTypeCompleted,
+			Status: metav1.ConditionFalse,
+			Reason: reason,
+			Message: fmt.Sprintf("%d on-target, %d incomplete, %d failed (of %d); %d already-resolved",
+				c.succeeded, c.incomplete, c.failed, c.total, c.alreadyResolved),
 			LastTransitionTime: now,
 		})
 	default:
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseDispatched
 		setCondition(&w.Status.Conditions, metav1.Condition{
-			Type:               "Dispatched",
-			Status:             metav1.ConditionTrue,
-			Reason:             "ChildrenInFlight",
-			Message:            fmt.Sprintf("%d in-flight, %d on-target, %d incomplete, %d failed, %d already-resolved", inFlight, succeeded, incomplete, failed, alreadyResolved),
+			Type:   "Dispatched",
+			Status: metav1.ConditionTrue,
+			Reason: "ChildrenInFlight",
+			Message: fmt.Sprintf("%d in-flight, %d on-target, %d incomplete, %d failed, %d already-resolved",
+				c.inFlight, c.succeeded, c.incomplete, c.failed, c.alreadyResolved),
 			LastTransitionTime: now,
 		})
 	}
+}
 
-	// #970: surface the ALREADY-RESOLVED issues via a stable condition +
-	// per-issue events so an operator (or event-router) can close them.
-	if alreadyResolved > 0 {
-		// Prefix every issue with "#" so the message reads "#152, #365"
-		// (rather than "#152, 365" which only marks the first one).
-		issueList := joinInt32(resolvedIssues)
-		issueList = "#" + strings.ReplaceAll(issueList, ", ", ", #")
-		msg := fmt.Sprintf("%d issue(s) already resolved at run time: %s. See events for per-issue resolution evidence (commit / branch).",
-			alreadyResolved, issueList)
-		setCondition(&w.Status.Conditions, metav1.Condition{
-			Type:               conditionTypeCoderAlreadyResolved,
-			Status:             metav1.ConditionTrue,
-			Reason:             "AlreadyResolved",
-			Message:            msg,
-			LastTransitionTime: now,
-		})
-		if r.Recorder != nil {
-			for idx, n := range resolvedIssues {
-				if resolvedByList[idx] != "" {
-					r.Recorder.Eventf(w, nil, corev1.EventTypeNormal, "AlreadyResolved", "Workload",
-						"Issue #%d resolved by %s; safe to close on GitHub", n, resolvedByList[idx])
-				} else {
-					r.Recorder.Eventf(w, nil, corev1.EventTypeNormal, "AlreadyResolved", "Workload",
-						"Issue #%d resolved at run time; safe to close on GitHub", n)
-				}
-			}
-		}
-	} else {
-		// Clear the condition when no children are already-resolved
-		// (avoids stale "0 issues resolved" condition lingering after
-		// a Workload re-runs and gets different outcomes).
+// emitAlreadyResolvedCondition sets the CoderAlreadyResolved condition
+// (#970) and fires per-issue Kubernetes events so an operator (or
+// event-router) can close the issues on GitHub. When alreadyResolved
+// is zero, the condition is set to False (an anti-stale guard — a
+// stale True condition would mislead operators reading later
+// reconciles). Events fire only when alreadyResolved > 0.
+func (r *WorkloadReconciler) emitAlreadyResolvedCondition(w *foremanv1alpha1.Workload, c childCounts, now metav1.Time) {
+	if c.alreadyResolved == 0 {
 		setCondition(&w.Status.Conditions, metav1.Condition{
 			Type:               conditionTypeCoderAlreadyResolved,
 			Status:             metav1.ConditionFalse,
@@ -651,12 +721,34 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 			Message:            "no coder children ended ALREADY-RESOLVED",
 			LastTransitionTime: now,
 		})
+		return
 	}
 
-	if err := r.Status().Patch(ctx, w, patch); err != nil {
-		return ctrl.Result{}, fmt.Errorf("patch workload status during rollup: %w", err)
+	// Prefix every issue with "#" so the message reads "#152, #365"
+	// (rather than "#152, 365" which only marks the first one).
+	issueList := joinInt32(c.resolvedIssues)
+	issueList = "#" + strings.ReplaceAll(issueList, ", ", ", #")
+	msg := fmt.Sprintf("%d issue(s) already resolved at run time: %s. See events for per-issue resolution evidence (commit / branch).",
+		c.alreadyResolved, issueList)
+	setCondition(&w.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeCoderAlreadyResolved,
+		Status:             metav1.ConditionTrue,
+		Reason:             "AlreadyResolved",
+		Message:            msg,
+		LastTransitionTime: now,
+	})
+	if r.Recorder == nil {
+		return
 	}
-	return ctrl.Result{}, nil
+	for idx, n := range c.resolvedIssues {
+		if c.resolvedByList[idx] != "" {
+			r.Recorder.Eventf(w, nil, corev1.EventTypeNormal, "AlreadyResolved", "Workload",
+				"Issue #%d resolved by %s; safe to close on GitHub", n, c.resolvedByList[idx])
+		} else {
+			r.Recorder.Eventf(w, nil, corev1.EventTypeNormal, "AlreadyResolved", "Workload",
+				"Issue #%d resolved at run time; safe to close on GitHub", n)
+		}
+	}
 }
 
 // markPlanning patches phase=Planning the first time we touch the

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -561,6 +562,190 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		completed := findCondition(fresh.Status.Conditions, conditionTypeCompleted)
 		Expect(completed).NotTo(BeNil())
 		Expect(completed.Reason).To(Equal("ChildrenIncomplete"))
+	})
+
+	// Regression for defilantech/LLMKube#970. A coder that ends
+	// Phase=Succeeded + Verdict=NO-GO with extra.outcome="ALREADY-RESOLVED"
+	// must NOT count as incomplete and must NOT pin the Workload to
+	// Failed. The Workload rolls to Completed with reason
+	// AllAlreadyResolved, and a CoderAlreadyResolved condition surfaces
+	// the issue numbers so the operator can close them.
+	It("rolls up ALREADY-RESOLVED children to Completed with AllAlreadyResolved (#970)", func() {
+		wl := newWorkload("rollup-already-resolved", foremanv1alpha1.WorkloadSpec{
+			Intent:           "already-resolved at run time",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{152, 365},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Both coder children end NO-GO + ALREADY-RESOLVED. In production
+		// the cascade-fail logic in AgenticTaskReconciler would fail the
+		// verify children (Phase=Failed via cascadeFailIfDepFailed) — the
+		// envtest here runs only the WorkloadReconciler, so the verify
+		// children would stay Pending and pin the rollup to Dispatched.
+		// To isolate the rollup behavior under test, delete the verify
+		// children explicitly. The production cascade-fail interaction
+		// with ALREADY-RESOLVED is a known gap tracked for follow-up.
+		for _, n := range []string{"rollup-already-resolved-code-152", "rollup-already-resolved-code-365"} {
+			var t foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: n}, &t)).To(Succeed())
+			patch := client.MergeFrom(t.DeepCopy())
+			t.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+			t.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+			t.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already resolved by prior fix")
+			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
+		}
+		for _, n := range []string{"rollup-already-resolved-verify-152", "rollup-already-resolved-verify-365"} {
+			var t foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: n}, &t)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, &t)).To(Succeed())
+		}
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseCompleted))
+		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(0)))
+		Expect(fresh.Status.FailedTasks).To(Equal(int32(0)))
+		completed := findCondition(fresh.Status.Conditions, conditionTypeCompleted)
+		Expect(completed).NotTo(BeNil())
+		Expect(completed.Reason).To(Equal("AllAlreadyResolved"))
+		Expect(completed.Message).To(ContainSubstring("152"))
+		Expect(completed.Message).To(ContainSubstring("365"))
+
+		resolved := findCondition(fresh.Status.Conditions, conditionTypeCoderAlreadyResolved)
+		Expect(resolved).NotTo(BeNil())
+		Expect(resolved.Status).To(Equal(metav1.ConditionTrue))
+		Expect(resolved.Reason).To(Equal("AlreadyResolved"))
+		Expect(resolved.Message).To(ContainSubstring("#152"))
+		Expect(resolved.Message).To(ContainSubstring("#365"))
+	})
+
+	// Mixed-case for #970: one issue gets a real fix (coder GO +
+	// verify GATE-PASS), one is ALREADY-RESOLVED at run time. The
+	// Workload rolls to Completed with reason AllChildrenSucceeded and
+	// the message names both buckets.
+	It("rolls up a mixed already-resolved + succeeded Workload to Completed (#970)", func() {
+		wl := newWorkload("rollup-mixed-ar", foremanv1alpha1.WorkloadSpec{
+			Intent:           "mixed already-resolved + succeeded",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{11, 22},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Issue 11: real fix path.
+		for _, u := range []struct {
+			name    string
+			phase   foremanv1alpha1.AgenticTaskPhase
+			verdict foremanv1alpha1.AgenticTaskVerdict
+		}{
+			{"rollup-mixed-ar-code-11", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGo},
+			{"rollup-mixed-ar-verify-11", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGatePass},
+		} {
+			var t foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: u.name}, &t)).To(Succeed())
+			patch := client.MergeFrom(t.DeepCopy())
+			t.Status.Phase = u.phase
+			t.Status.Verdict = u.verdict
+			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
+		}
+
+		// Issue 22: ALREADY-RESOLVED. Same cascade-fail isolation as above —
+// delete the verify-22 child so the rollup sees only the resolved coder.
+		var ar foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-mixed-ar-code-22"}, &ar)).To(Succeed())
+		patch := client.MergeFrom(ar.DeepCopy())
+		ar.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		ar.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		ar.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done")
+		Expect(k8sClient.Status().Patch(ctx, &ar, patch)).To(Succeed())
+		var v22 foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-mixed-ar-verify-22"}, &v22)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, &v22)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseCompleted))
+		Expect(fresh.Status.SucceededTasks).To(Equal(int32(2)))
+		Expect(fresh.Status.IncompleteTasks).To(Equal(int32(0)))
+		completed := findCondition(fresh.Status.Conditions, conditionTypeCompleted)
+		Expect(completed).NotTo(BeNil())
+		Expect(completed.Reason).To(Equal("AllChildrenSucceeded"))
+		Expect(completed.Message).To(ContainSubstring("already-resolved"))
+
+		resolved := findCondition(fresh.Status.Conditions, conditionTypeCoderAlreadyResolved)
+		Expect(resolved).NotTo(BeNil())
+		Expect(resolved.Message).To(ContainSubstring("#22"))
+		Expect(resolved.Message).NotTo(ContainSubstring("#11"))
+	})
+
+	It("emits a per-issue AlreadyResolved event via the Recorder (#970)", func() {
+		recorder := &events.FakeRecorder{Events: make(chan string, 16)}
+		rec := &WorkloadReconciler{
+			Client:              k8sClient,
+			Scheme:              k8sClient.Scheme(),
+			Recorder:            recorder,
+			AllowCloudProviders: true,
+		}
+		wl := newWorkload("rollup-ar-events", foremanv1alpha1.WorkloadSpec{
+			Intent:           "already-resolved events",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{777},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var c foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-ar-events-code-777"}, &c)).To(Succeed())
+		patch := client.MergeFrom(c.DeepCopy())
+		c.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		c.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		c.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done")
+		Expect(k8sClient.Status().Patch(ctx, &c, patch)).To(Succeed())
+		// Same cascade-fail isolation: delete the verify child.
+		var v777 foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-ar-events-verify-777"}, &v777)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, &v777)).To(Succeed())
+
+		_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// One event per resolved issue. Async via channel, so read with timeout.
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring("AlreadyResolved"),
+			ContainSubstring("#777"),
+		)))
 	})
 
 	It("fails the Workload when gate passes but any reviewer emits NO-GO (#575)", func() {

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -587,14 +590,13 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Both coder children end NO-GO + ALREADY-RESOLVED. In production
-		// the cascade-fail logic in AgenticTaskReconciler would fail the
-		// verify children (Phase=Failed via cascadeFailIfDepFailed) — the
-		// envtest here runs only the WorkloadReconciler, so the verify
-		// children would stay Pending and pin the rollup to Dispatched.
-		// To isolate the rollup behavior under test, delete the verify
-		// children explicitly. The production cascade-fail interaction
-		// with ALREADY-RESOLVED is a known gap tracked for follow-up.
+		// Both coder children end NO-GO + ALREADY-RESOLVED. The envtest
+		// runs only the WorkloadReconciler, so the cascade-skip path
+		// in AgenticTaskReconciler (which would mark the verify
+		// children Skipped) isn't exercised here directly. Instead, we
+		// stamp the verify children with the same Skipped terminal
+		// shape via markVerifySkipped below, which is what
+		// cascadeSkipIfDepAlreadyResolved writes in production.
 		for _, n := range []string{"rollup-already-resolved-code-152", "rollup-already-resolved-code-365"} {
 			var t foremanv1alpha1.AgenticTask
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: n}, &t)).To(Succeed())
@@ -604,11 +606,12 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 			t.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already resolved by prior fix", "")
 			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
 		}
-		for _, n := range []string{"rollup-already-resolved-verify-152", "rollup-already-resolved-verify-365"} {
-			var t foremanv1alpha1.AgenticTask
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: n}, &t)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, &t)).To(Succeed())
-		}
+		// Cascade-skip the verify children (production path: AgenticTaskReconciler
+		// would mark them Skipped because their coder ended ALREADY-RESOLVED).
+		// This replaces the previous "delete the verify child" isolation
+		// approach now that the cascade-skip path is implemented.
+		markVerifySkipped("rollup-already-resolved", 152)
+		markVerifySkipped("rollup-already-resolved", 365)
 
 		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
 		Expect(err).NotTo(HaveOccurred())
@@ -679,9 +682,8 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		ar.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
 		ar.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done", "")
 		Expect(k8sClient.Status().Patch(ctx, &ar, patch)).To(Succeed())
-		var v22 foremanv1alpha1.AgenticTask
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-mixed-ar-verify-22"}, &v22)).To(Succeed())
-		Expect(k8sClient.Delete(ctx, &v22)).To(Succeed())
+		// Cascade-skip the verify child (production path).
+		markVerifySkipped("rollup-mixed-ar", 22)
 
 		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
 		Expect(err).NotTo(HaveOccurred())
@@ -733,10 +735,9 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		c.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
 		c.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done", "abc123def")
 		Expect(k8sClient.Status().Patch(ctx, &c, patch)).To(Succeed())
-		// Same cascade-fail isolation: delete the verify child.
-		var v777 foremanv1alpha1.AgenticTask
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-ar-events-verify-777"}, &v777)).To(Succeed())
-		Expect(k8sClient.Delete(ctx, &v777)).To(Succeed())
+		// Cascade-skip the verify child (production path: AgenticTaskReconciler
+		// would mark it Skipped because the coder ended ALREADY-RESOLVED).
+		markVerifySkipped("rollup-ar-events", 777)
 
 		_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
 		Expect(err).NotTo(HaveOccurred())
@@ -780,9 +781,7 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		c.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
 		c.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done", "")
 		Expect(k8sClient.Status().Patch(ctx, &c, patch)).To(Succeed())
-		var v888 foremanv1alpha1.AgenticTask
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-ar-events-no-rb-verify-888"}, &v888)).To(Succeed())
-		Expect(k8sClient.Delete(ctx, &v888)).To(Succeed())
+		markVerifySkipped("rollup-ar-events-no-rb", 888)
 
 		_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
 		Expect(err).NotTo(HaveOccurred())
@@ -792,6 +791,83 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 			ContainSubstring("#888"),
 			ContainSubstring("resolved at run time"),
 		)))
+	})
+
+	// Regression for the parallel-slice desync Defilan caught on the
+	// 1011 review. Three ALREADY-RESOLVED children, deliberately
+	// created out of ascending issue order, with distinct resolvedBy
+	// values. The rollup must sort the parallel issue+evidence slices
+	// together so the per-issue event attributes the correct SHA to
+	// each issue.
+	It("attributes the correct resolvedBy to each issue when ALREADY-RESOLVED children are out of order (#970)", func() {
+		recorder := &events.FakeRecorder{Events: make(chan string, 16)}
+		rec := &WorkloadReconciler{
+			Client:              k8sClient,
+			Scheme:              k8sClient.Scheme(),
+			Recorder:            recorder,
+			AllowCloudProviders: true,
+		}
+		wl := newWorkload("rollup-ar-multi", foremanv1alpha1.WorkloadSpec{
+			Intent:           "already-resolved multi-issue event pairing",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{42, 17, 99},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Mark coder children terminal out of order. Each carries a
+		// distinct resolvedBy that the event must pair with the
+		// matching issue number. Cascade-skip the verify children so
+		// the rollup sees them as Skipped (the production path).
+		markAR := func(issue int32, resolvedBy string) {
+			var t foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: fmt.Sprintf("rollup-ar-multi-code-%d", issue)}, &t)).To(Succeed())
+			patch := client.MergeFrom(t.DeepCopy())
+			t.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+			t.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+			t.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done", resolvedBy)
+			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
+			markVerifySkipped("rollup-ar-multi", issue)
+		}
+		markAR(99, "sha-99") // out of ascending order
+		markAR(17, "sha-17")
+		markAR(42, "sha-42")
+
+		_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Three events; read all of them with Eventually. Each must
+		// pair the correct issue number with the correct SHA.
+		got := map[string]string{}
+		for i := 0; i < 3; i++ {
+			var line string
+			Eventually(recorder.Events).Should(Receive(&line))
+			Expect(line).To(ContainSubstring("AlreadyResolved"))
+			for _, n := range []int32{17, 42, 99} {
+				if strings.Contains(line, fmt.Sprintf("Issue #%d ", n)) {
+					idx := strings.Index(line, "resolved by ")
+					if idx >= 0 {
+						rest := line[idx+len("resolved by "):]
+						end := strings.IndexAny(rest, "; \n")
+						if end < 0 {
+							end = len(rest)
+						}
+						got[fmt.Sprintf("%d", n)] = rest[:end]
+					}
+				}
+			}
+		}
+		Expect(got["17"]).To(Equal("sha-17"))
+		Expect(got["42"]).To(Equal("sha-42"))
+		Expect(got["99"]).To(Equal("sha-99"))
 	})
 
 	It("fails the Workload when gate passes but any reviewer emits NO-GO (#575)", func() {
@@ -1184,4 +1260,26 @@ func cleanupChildren(w *foremanv1alpha1.Workload) {
 	for i := range list.Items {
 		_ = k8sClient.Delete(ctx, &list.Items[i])
 	}
+}
+
+// markVerifySkipped stamps a verify-<issue> child with the terminal
+// shape the AgenticTaskReconciler's cascade-skip path produces when
+// its coder dep ends ALREADY-RESOLVED (#970): Phase=Succeeded +
+// Verdict=Skipped. The rollup's isSkippedTask classifier excludes
+// such children from every bucket. Used by the #970 rollup tests in
+// place of Delete so the test setup mirrors what the AgenticTask
+// cascade path would actually write in production — without needing
+// to drive the AgenticTaskReconciler inside the WorkloadReconcile
+// envtest setup.
+func markVerifySkipped(workloadName string, issue int32) {
+	GinkgoHelper()
+	var v foremanv1alpha1.AgenticTask
+	Expect(k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: "default",
+		Name:      fmt.Sprintf("%s-verify-%d", workloadName, issue),
+	}, &v)).To(Succeed())
+	patch := client.MergeFrom(v.DeepCopy())
+	v.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	v.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictSkipped
+	Expect(k8sClient.Status().Patch(ctx, &v, patch)).To(Succeed())
 }

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -601,7 +601,7 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 			patch := client.MergeFrom(t.DeepCopy())
 			t.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 			t.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-			t.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already resolved by prior fix")
+			t.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already resolved by prior fix", "")
 			Expect(k8sClient.Status().Patch(ctx, &t, patch)).To(Succeed())
 		}
 		for _, n := range []string{"rollup-already-resolved-verify-152", "rollup-already-resolved-verify-365"} {
@@ -677,7 +677,7 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		patch := client.MergeFrom(ar.DeepCopy())
 		ar.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 		ar.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-		ar.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done")
+		ar.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done", "")
 		Expect(k8sClient.Status().Patch(ctx, &ar, patch)).To(Succeed())
 		var v22 foremanv1alpha1.AgenticTask
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-mixed-ar-verify-22"}, &v22)).To(Succeed())
@@ -731,7 +731,7 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		patch := client.MergeFrom(c.DeepCopy())
 		c.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 		c.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
-		c.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done")
+		c.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done", "abc123def")
 		Expect(k8sClient.Status().Patch(ctx, &c, patch)).To(Succeed())
 		// Same cascade-fail isolation: delete the verify child.
 		var v777 foremanv1alpha1.AgenticTask
@@ -745,6 +745,52 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		Eventually(recorder.Events).Should(Receive(And(
 			ContainSubstring("AlreadyResolved"),
 			ContainSubstring("#777"),
+			ContainSubstring("abc123def"),
+		)))
+	})
+
+	It("emits AlreadyResolved event without resolvedBy when field is empty (#970)", func() {
+		recorder := &events.FakeRecorder{Events: make(chan string, 16)}
+		rec := &WorkloadReconciler{
+			Client:              k8sClient,
+			Scheme:              k8sClient.Scheme(),
+			Recorder:            recorder,
+			AllowCloudProviders: true,
+		}
+		wl := newWorkload("rollup-ar-events-no-rb", foremanv1alpha1.WorkloadSpec{
+			Intent:           "already-resolved events no resolvedBy",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{888},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var c foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-ar-events-no-rb-code-888"}, &c)).To(Succeed())
+		patch := client.MergeFrom(c.DeepCopy())
+		c.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		c.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		c.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done", "")
+		Expect(k8sClient.Status().Patch(ctx, &c, patch)).To(Succeed())
+		var v888 foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-ar-events-no-rb-verify-888"}, &v888)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, &v888)).To(Succeed())
+
+		_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring("AlreadyResolved"),
+			ContainSubstring("#888"),
+			ContainSubstring("resolved at run time"),
 		)))
 	})
 

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -671,7 +671,7 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		}
 
 		// Issue 22: ALREADY-RESOLVED. Same cascade-fail isolation as above —
-// delete the verify-22 child so the rollup sees only the resolved coder.
+		// delete the verify-22 child so the rollup sees only the resolved coder.
 		var ar foremanv1alpha1.AgenticTask
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-mixed-ar-code-22"}, &ar)).To(Succeed())
 		patch := client.MergeFrom(ar.DeepCopy())

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -648,6 +648,53 @@ func TestNativeExecutor_ModelEmitsNoGo(t *testing.T) {
 	}
 }
 
+// TestSubmitResultEnvelopePreservesAlreadyResolved verifies that
+// the executor passes model-supplied extra.outcome values through
+// verbatim. The "ALREADY-RESOLVED" outcome (#970) is emitted by the
+// model, not the executor, so any rewriting of the envelope would
+// silently break the controller's escalation + rollup classifiers.
+// This is a regression guard, not a behavior change in the executor.
+func TestSubmitResultEnvelopePreservesAlreadyResolved(t *testing.T) {
+	// Construct the JSON the model would produce via submit_result.
+	submitted := map[string]any{
+		"schemaVersion": "foreman.v1",
+		"kind":          "issue-fix",
+		"verdict":       "NO-GO",
+		"summary":       "Issue #152 is already resolved by prior fix e97d0ca (Fixes #129)",
+		"extra": map[string]any{
+			"outcome":    "ALREADY-RESOLVED",
+			"resolvedBy": "e97d0ca",
+		},
+	}
+	raw, err := json.Marshal(submitted)
+	if err != nil {
+		t.Fatalf("marshal submitted envelope: %v", err)
+	}
+
+	// The executor's job here is "no rewriting." We assert the shape
+	// the controller later parses (coderResultEnvelope in
+	// workload_coder_escalation.go) is intact.
+	var env struct {
+		Summary string `json:"summary"`
+		Extra   struct {
+			Outcome    string `json:"outcome"`
+			ResolvedBy string `json:"resolvedBy"`
+		} `json:"extra"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if env.Extra.Outcome != "ALREADY-RESOLVED" {
+		t.Errorf("outcome: want ALREADY-RESOLVED, got %q", env.Extra.Outcome)
+	}
+	if env.Extra.ResolvedBy != "e97d0ca" {
+		t.Errorf("resolvedBy: want e97d0ca, got %q", env.Extra.ResolvedBy)
+	}
+	if !strings.Contains(env.Summary, "already resolved") {
+		t.Errorf("summary: want to contain 'already resolved', got %q", env.Summary)
+	}
+}
+
 // --- Reviewer-role Agent: GO means APPROVE, not commit + push ------------
 
 // reviewerTaskAndAgent builds a reviewer-role Agent and a freeform

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -648,13 +648,28 @@ func TestNativeExecutor_ModelEmitsNoGo(t *testing.T) {
 	}
 }
 
-// TestSubmitResultEnvelopePreservesAlreadyResolved verifies that
-// the executor passes model-supplied extra.outcome values through
-// verbatim. The "ALREADY-RESOLVED" outcome (#970) is emitted by the
-// model, not the executor, so any rewriting of the envelope would
-// silently break the controller's escalation + rollup classifiers.
-// This is a regression guard, not a behavior change in the executor.
-func TestSubmitResultEnvelopePreservesAlreadyResolved(t *testing.T) {
+// TestAlreadyResolvedEnvelopeShape is a schema-shape regression guard
+// for the #970 ALREADY-RESOLVED machine outcome. The model emits a
+// submit_result envelope with `extra.outcome="ALREADY-RESOLVED"` and
+// (optionally) `extra.resolvedBy=<sha|branch>`. The controller's
+// coderResultEnvelope parser in
+// internal/foreman/controller/workload_coder_escalation.go reads
+// exactly these fields. This test locks the JSON contract: any change
+// to the field names or nesting would break the parser.
+//
+// What this test does NOT cover: the executor's actual pass-through
+// behavior (model JSON in → Status.Result.Raw out). A future change
+// to the executor that rewrites the envelope mid-pipeline would
+// silently break the controller's classifier and this test would
+// still pass. The real pass-through is exercised by the existing
+// TestNativeExecutor_ModelEmitsNoGo and the other ModelEmits* tests
+// in this file (which drive the executor end-to-end with a scripted
+// OAI server). For #970 specifically, no new executor behavior is
+// introduced; the executor passes the model's extra map through
+// verbatim, and the controller does the rest. If a future PR adds
+// executor-side ALREADY-RESOLVED detection or rewriting, add a new
+// TestNativeExecutor_<that-behavior> test here.
+func TestAlreadyResolvedEnvelopeShape(t *testing.T) {
 	// Construct the JSON the model would produce via submit_result.
 	submitted := map[string]any{
 		"schemaVersion": "foreman.v1",
@@ -671,9 +686,9 @@ func TestSubmitResultEnvelopePreservesAlreadyResolved(t *testing.T) {
 		t.Fatalf("marshal submitted envelope: %v", err)
 	}
 
-	// The executor's job here is "no rewriting." We assert the shape
-	// the controller later parses (coderResultEnvelope in
-	// workload_coder_escalation.go) is intact.
+	// Parse the shape the controller later reads (mirrors
+	// coderResultEnvelope.Extra in
+	// internal/foreman/controller/workload_coder_escalation.go).
 	var env struct {
 		Summary string `json:"summary"`
 		Extra   struct {


### PR DESCRIPTION
## What

Foreman: distinct `ALREADY-RESOLVED` coder outcome — the controller no longer escalates or pins the Workload to Failed when the coder concludes the work is already on the branch/base.

## Why

2 of 3 live `NO-GO` / `MODEL-DECIDED` coder outcomes on the fleet are honest "already done" bails (e.g. `misospace/KubeTix#152`, `misospace/pr-reviewer-action#365`), not capability failures. Today both escalate to the larger model — which will re-derive "nothing to do" at higher cost — and both pin the parent Workload to `Phase=Failed` with reason `ChildrenIncomplete`. Splitting the class lets the controller skip the escalation run and roll to `Completed` instead.

Fixes #970, Fixes #1012

## How

- New outcome string `ALREADY-RESOLVED` at `extra.outcome`, parallel to `MODEL-DECIDED`. `verdict` stays `NO-GO`. No CRD enum bump.
- `shouldEscalateCoder` (#964) excludes it — no escalation.
- `rollup` gets a fifth classification bucket: `alreadyResolved`. Children are excluded from the `incomplete` bucket, so the Workload doesn't pin to `Phase=Failed`.
- New `CoderAlreadyResolved` condition surfaces the issue numbers (sorted, `#`-prefixed). One condition per Workload; messages refer the operator to events for per-issue resolution evidence.
- Per-issue Kubernetes event (`Reason=AlreadyResolved`, `EventType=Normal`) gives an event-router / GitHub-app integration point without forcing auto-close.
- Pure case rolls with reason `AllAlreadyResolved`; mixed (some succeeded, some already-resolved) rolls with reason `AllChildrenSucceeded` and an `"; M already-resolved"` appendix in the message.
- Coder prompt (`config/foreman/system-prompts/coder.md` + 2 Agent CRs) teaches the model the new contract: emit `verdict="NO-GO", extra={"outcome":"ALREADY-RESOLVED", "resolvedBy":"<sha|branch>"}` when the work is already present, citing the resolution in `summary`.

**Known follow-up (out of scope):** `cascadeFailIfDepFailed` in `internal/foreman/controller/agentictask_controller.go` cascade-fails the verify child when its coder ends Phase=Succeeded + Verdict=NO-GO. In production today, those cascade-failed verify children (Phase=Failed) would count in the `failed` rollup bucket and pin the Workload to `Phase=Failed` despite the rollup change. Tracked as a follow-up; the new envtests work because they explicitly delete the verify children to isolate the rollup behavior under test. The spec's promise is met for the controller's classifier; the cascade interaction is a separate fix.

## Checklist

- [x] Tests added/updated (1 helper table test, 1 escalation-trigger table case, 4 envtest cases, 1 executor envelope regression guard)
- [x] `make test` passes locally
- [x] `make lint` passes locally (darwin + linux, via `make lint-all`)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed: implemented with AI assistance under the repo's CONTRIBUTING.md policy
- [x] Documentation updated (`docs/site/foreman/README.md`)