### PR TITLE
ci: unblock CI repo-wide (kubeconform schema caching + Go 1.26.5 for GO-2026-5856)

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -190,16 +190,36 @@ jobs:
           fi
           echo "✅ Template rendering successful"
 
-      - name: Validate Kubernetes Manifests
-        uses: docker://ghcr.io/yannh/kubeconform:v0.7.0
+      - name: Cache kubeconform schemas
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          entrypoint: '/kubeconform'
-          args: >
-            -summary
-            -output json
-            -ignore-missing-schemas
-            -skip CustomResourceDefinition
-            /github/workspace/manifests.yaml
+          path: .cache/kubeconform
+          key: kubeconform-schemas-v1
+
+      - name: Validate Kubernetes Manifests
+        # kubeconform fetches JSON schemas from raw.githubusercontent.com on
+        # demand. Schema-heavy renders trip GitHub-raw rate limits and the job
+        # hard-fails on a transient download error even though the templates
+        # are valid ("invalid": 0). Persist fetched schemas across runs
+        # (actions/cache + -cache) so steady state needs no network, and retry
+        # with backoff to ride out first-population and transient limits.
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.cache/kubeconform"
+          n=0
+          until [ "$n" -ge 3 ]; do
+            docker run --rm \
+              -v "$GITHUB_WORKSPACE:/github/workspace" \
+              ghcr.io/yannh/kubeconform:v0.7.0 \
+              -summary -output json \
+              -ignore-missing-schemas -skip CustomResourceDefinition \
+              -cache /github/workspace/.cache/kubeconform \
+              /github/workspace/manifests.yaml && exit 0
+            n=$((n + 1))
+            echo "::warning::kubeconform schema fetch failed (attempt ${n}/3); backing off"
+            sleep $((n * 20))
+          done
+          echo "::error::kubeconform failed after 3 attempts (schema download)"
+          exit 1
 
   prometheus-integration:
     name: Test Prometheus Integration
@@ -779,13 +799,30 @@ jobs:
           fi
           echo "✅ verifier-node overrides render correctly"
 
-      - name: Validate Kubernetes Manifests
-        uses: docker://ghcr.io/yannh/kubeconform:v0.7.0
+      - name: Cache kubeconform schemas
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          entrypoint: '/kubeconform'
-          args: >
-            -summary
-            -output json
-            -ignore-missing-schemas
-            -skip CustomResourceDefinition
-            /github/workspace/foreman-default.yaml
+          path: .cache/kubeconform
+          key: kubeconform-schemas-v1
+
+      - name: Validate Kubernetes Manifests
+        # See the Template Validation job above: cache fetched schemas and
+        # retry with backoff so a transient raw.githubusercontent.com rate
+        # limit does not hard-fail a render whose templates are valid.
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.cache/kubeconform"
+          n=0
+          until [ "$n" -ge 3 ]; do
+            docker run --rm \
+              -v "$GITHUB_WORKSPACE:/github/workspace" \
+              ghcr.io/yannh/kubeconform:v0.7.0 \
+              -summary -output json \
+              -ignore-missing-schemas -skip CustomResourceDefinition \
+              -cache /github/workspace/.cache/kubeconform \
+              /github/workspace/foreman-default.yaml && exit 0
+            n=$((n + 1))
+            echo "::warning::kubeconform schema fetch failed (attempt ${n}/3); backing off"
+            sleep $((n * 20))
+          done
+          echo "::error::kubeconform failed after 3 attempts (schema download)"
+          exit 1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/defilantech/llmkube
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
> **Scope note:** two independent CI failures currently break *every* open PR (not the PRs' own code). This bundles both fixes so one merge unblocks them all on rebase.
>
> 1. **Helm `kubeconform`** rate-limited by raw.githubusercontent.com (below).
> 2. **govulncheck** `GO-2026-5856` (crypto/tls), fixed in Go 1.26.5: bump the `go` directive so CI (`go-version-file: go.mod`) builds vuln-free. Verified locally: govulncheck reports no vulnerabilities under 1.26.5.

## What

Make the Helm `kubeconform` validation steps resilient to `raw.githubusercontent.com` rate limiting, in both the **Template Validation** matrix job and the **Foreman chart** job:

- Add `actions/cache` for the kubeconform schema cache dir (`.cache/kubeconform`).
- Pass `-cache` to kubeconform so fetched schemas persist across runs.
- Convert the two `docker://` action steps to `docker run` wrapped in a 3x backoff retry loop.

## Why

`kubeconform` fetches Kubernetes and CRD JSON schemas from `raw.githubusercontent.com` on demand. Schema-heavy renders (`production`, `gpu-cluster`) fetch the most schemas and trip GitHub-raw rate limits, hard-failing the job on a transient download error even though the templates are valid: kubeconform reports `"invalid": 0, "errors": N` where every error is `failed downloading schema ... giving up after 3 attempt(s)`.

This is not a chart or PR problem; it recurs on every chart-touching PR and is not reliably cleared by re-running (the rate limit outlives immediate retries, and each cold run re-fetches every schema).

## How

- Steady state: once any run populates the shared `kubeconform-schemas-v1` cache, later runs restore it and validate with no network.
- Cold cache / new kinds: the 3x retry with 20s/40s backoff rides out first-population and transient limits.
- Templates are still validated identically (same flags: `-summary -output json -ignore-missing-schemas -skip CustomResourceDefinition`).

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` parses the workflow.
- `actionlint` reports no findings on the changed steps (one pre-existing, unrelated `pull_request.title` warning on line 118 is left for a separate PR).
- The retry loop returns 0 on first success and exits 1 only after 3 failed attempts.

## Checklist

- [x] Scoped to CI reliability; no chart template or application code changed
- [x] Both `kubeconform` invocations updated consistently
- [x] `actions/cache` pinned by SHA (`5a3ec84` / v4.2.3), matching repo convention
- [x] No untrusted `github.event.*` input used in the new `run:` scripts
- [x] AI assistance is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)

---

Assisted-by: Claude Code (root-caused the raw.githubusercontent.com rate-limit flake, wrote the cache + retry change; human-reviewed and DCO-signed by the maintainer)