### PR TITLE
feat(foreman): coder grounding rail (flag doc-contradicting metric writes)

### DIFF
--- a/pkg/foreman/agent/coder_grounding_gate.go
+++ b/pkg/foreman/agent/coder_grounding_gate.go
@@ -1,0 +1,197 @@
+package agent
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// metricIdentRe matches Prometheus/vLLM metric-name-shaped identifiers:
+// a namespace, a colon, then the metric path (e.g. vllm:request_failure_total,
+// llmkube:inference:ttft_seconds:p95_5m). v1 checks exactly this class -- the
+// tokens most prone to hallucination and the ones that failed on #409/#850.
+var metricIdentRe = regexp.MustCompile(`[a-z_][a-z0-9_]*:[a-z0-9_:]+`)
+
+// metricIdents returns the metric-name-shaped identifiers in s, EXCLUDING
+// host:port network addresses (whose path after the first colon is all digits,
+// e.g. "vllm:8000") -- those are not Prometheus metrics and must not be flagged.
+func metricIdents(s string) []string {
+	var out []string
+	for _, m := range metricIdentRe.FindAllString(s, -1) {
+		i := strings.IndexByte(m, ':')
+		if i < 0 {
+			continue
+		}
+		path := m[i+1:]
+		if path == "" || isAllDigits(path) {
+			continue // host:port, not a metric
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// isAllDigits returns true if s contains only ASCII digit characters.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// groundingViolation is one written external identifier that contradicts the
+// retrieved docs: its namespace was the subject of a context7 lookup this run,
+// yet the identifier itself does not appear anywhere in the retrieved evidence.
+type groundingViolation struct {
+	Written               string
+	Namespace             string
+	RetrievedAlternatives []string
+}
+
+// context7Evidence gathers the content of every mcp/* tool result in the
+// transcript into an evidence corpus. The tool message's Name is the function
+// name; when a backend leaves Name empty we recover it from the assistant's
+// tool_call by ToolCallID.
+func context7Evidence(transcript []oai.Message) []string {
+	callName := make(map[string]string)
+	for _, m := range transcript {
+		if m.Role == oai.RoleAssistant {
+			for _, tc := range m.ToolCalls {
+				callName[tc.ID] = tc.Function.Name
+			}
+		}
+	}
+	var ev []string
+	for _, m := range transcript {
+		if m.Role != oai.RoleTool {
+			continue
+		}
+		name := m.Name
+		if name == "" {
+			name = callName[m.ToolCallID]
+		}
+		if strings.HasPrefix(name, "mcp/") {
+			ev = append(ev, m.Content)
+		}
+	}
+	return ev
+}
+
+func namespaceOf(ident string) string {
+	if i := strings.IndexByte(ident, ':'); i > 0 {
+		return ident[:i]
+	}
+	return ""
+}
+
+// groundingViolations flags each metric-shaped identifier in addedLines whose
+// namespace appears in the evidence (so context7 was queried about that domain)
+// but whose full identifier does NOT appear verbatim in the evidence -- a
+// likely hallucination the coder wrote despite the docs it fetched.
+func groundingViolations(evidence []string, addedLines []string) []groundingViolation {
+	if len(evidence) == 0 {
+		return nil
+	}
+	corpus := strings.Join(evidence, "\n")
+
+	// All metric identifiers present in the evidence, grouped by namespace.
+	retrievedByNS := make(map[string][]string)
+	retrievedSet := make(map[string]bool)
+	for _, e := range metricIdents(corpus) {
+		if retrievedSet[e] {
+			continue
+		}
+		retrievedSet[e] = true
+		if ns := namespaceOf(e); ns != "" {
+			retrievedByNS[ns] = append(retrievedByNS[ns], e)
+		}
+	}
+
+	var out []groundingViolation
+	seen := make(map[string]bool)
+	for _, line := range addedLines {
+		for _, w := range metricIdents(line) {
+			if seen[w] {
+				continue
+			}
+			ns := namespaceOf(w)
+			// Only check a namespace context7 was actually queried about.
+			if len(retrievedByNS[ns]) == 0 {
+				continue
+			}
+			// Grounded if the exact identifier is in the evidence.
+			if strings.Contains(corpus, w) {
+				continue
+			}
+			seen[w] = true
+			out = append(out, groundingViolation{
+				Written:               w,
+				Namespace:             ns,
+				RetrievedAlternatives: retrievedByNS[ns],
+			})
+		}
+	}
+	return out
+}
+
+// applyCoderGroundingRail records, on the coder's terminal result, any
+// external metric identifier the coder WROTE that contradicts the context7
+// docs it retrieved this run (namespace was queried, but the identifier is
+// absent from the docs). Non-blocking (v1): it surfaces violations under
+// Extra["coderGroundingViolations"] and logs them; the verdict is unchanged.
+// No-op unless there is context7 evidence AND added diff lines. Degrades
+// open: never returns an error, never mutates the verdict.
+func applyCoderGroundingRail(ctx context.Context, log logr.Logger, base, workspace string, loopRes *LoopResult) {
+	if loopRes == nil || loopRes.Terminal == nil {
+		return
+	}
+	evidence := context7Evidence(loopRes.Transcript)
+	if len(evidence) == 0 {
+		return
+	}
+	added := addedDiffLines(ctx, workspace, base, execCommandRunner)
+	if len(added) == 0 {
+		return
+	}
+	violations := groundingViolations(evidence, added)
+	if len(violations) == 0 {
+		return
+	}
+	recs := make([]map[string]any, 0, len(violations))
+	for _, v := range violations {
+		log.Info("coder grounding: wrote an identifier absent from the retrieved docs",
+			"written", v.Written, "namespace", v.Namespace, "retrievedAlternatives", v.RetrievedAlternatives)
+		recs = append(recs, map[string]any{
+			"written":               v.Written,
+			"namespace":             v.Namespace,
+			"retrievedAlternatives": v.RetrievedAlternatives,
+		})
+	}
+	if loopRes.Terminal.Extra == nil {
+		loopRes.Terminal.Extra = map[string]any{}
+	}
+	loopRes.Terminal.Extra["coderGroundingViolations"] = recs
+}
+
+// applyCoderGroundingRailForTask gates applyCoderGroundingRail to issue-fix
+// tasks and resolves the base branch. Extracted out of runLLMPath so the
+// call site there is a single statement rather than a branch, keeping
+// runLLMPath's cyclomatic complexity budget untouched.
+func applyCoderGroundingRailForTask(
+	ctx context.Context, log logr.Logger, task *foremanv1alpha1.AgenticTask, workspace string, loopRes *LoopResult,
+) {
+	if task.Spec.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
+		return
+	}
+	applyCoderGroundingRail(ctx, log, baseBranchOrDefault(task.Spec.Payload.BaseBranch), workspace, loopRes)
+}

--- a/pkg/foreman/agent/coder_grounding_gate_test.go
+++ b/pkg/foreman/agent/coder_grounding_gate_test.go
@@ -1,0 +1,221 @@
+package agent
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+func TestContext7Evidence_CollectsMCPToolResults(t *testing.T) {
+	tr := []oai.Message{
+		{Role: oai.RoleUser, Content: "fix it"},
+		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{
+			{ID: "c1", Type: "function",
+				Function: oai.ToolCallFunction{Name: "mcp/context7/query-docs"}},
+		}},
+		{Role: oai.RoleTool, ToolCallID: "c1", Name: "mcp/context7/query-docs",
+			Content: "vllm:request_success_total{finished_reason}"},
+		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{
+			{ID: "c2", Type: "function", Function: oai.ToolCallFunction{Name: "read_file"}},
+		}},
+		{Role: oai.RoleTool, ToolCallID: "c2", Name: "read_file", Content: "some file"},
+	}
+	got := context7Evidence(tr)
+	want := []string{"vllm:request_success_total{finished_reason}"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("context7Evidence = %v, want %v", got, want)
+	}
+}
+
+// Correlation fallback: some backends leave Name empty on the tool message;
+// the call name must still be recovered via ToolCallID.
+func TestContext7Evidence_CorrelatesByToolCallIDWhenNameEmpty(t *testing.T) {
+	tr := []oai.Message{
+		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{
+			{ID: "c1", Type: "function", Function: oai.ToolCallFunction{Name: "mcp/context7/resolve-library-id"}},
+		}},
+		{Role: oai.RoleTool, ToolCallID: "c1", Content: "/websites/vllm"},
+	}
+	if got := context7Evidence(tr); len(got) != 1 || got[0] != "/websites/vllm" {
+		t.Fatalf("context7Evidence = %v, want [/websites/vllm]", got)
+	}
+}
+
+func TestGroundingViolations_FlagsHallucinatedSameNamespaceMetric(t *testing.T) {
+	evidence := []string{
+		"# HELP vllm:request_success_total ...\nvllm:request_success_total{finished_reason=\"stop\"} 1.0",
+	}
+	added := []string{
+		`- record: llmkube:err`,
+		`  expr: rate(vllm:request_failure_total{status_class="5xx"}[5m])`,
+	}
+	got := groundingViolations(evidence, added)
+	if len(got) != 1 {
+		t.Fatalf("want 1 violation, got %d: %+v", len(got), got)
+	}
+	if got[0].Written != "vllm:request_failure_total" || got[0].Namespace != "vllm" {
+		t.Fatalf("violation = %+v", got[0])
+	}
+	// It should offer the retrieved same-namespace name as the alternative.
+	found := false
+	for _, a := range got[0].RetrievedAlternatives {
+		if a == "vllm:request_success_total" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("alternatives = %v, want to include vllm:request_success_total", got[0].RetrievedAlternatives)
+	}
+}
+
+func TestGroundingViolations_CleanWhenWrittenMetricIsInEvidence(t *testing.T) {
+	evidence := []string{"vllm:request_success_total{finished_reason}"}
+	added := []string{`  expr: rate(vllm:request_success_total[5m])`}
+	if got := groundingViolations(evidence, added); len(got) != 0 {
+		t.Fatalf("want 0 violations, got %+v", got)
+	}
+}
+
+func TestGroundingViolations_IgnoresDifferentNamespace(t *testing.T) {
+	// context7 was queried about vllm; a go_gc_* metric was never grounded, so
+	// it must NOT be flagged even though it is absent from the evidence.
+	evidence := []string{"vllm:request_success_total"}
+	added := []string{`  expr: go_gc_duration_seconds{quantile="0.5"}`}
+	if got := groundingViolations(evidence, added); len(got) != 0 {
+		t.Fatalf("want 0 violations for ungrounded namespace, got %+v", got)
+	}
+}
+
+func TestGroundingViolations_EmptyEvidenceIsNoOp(t *testing.T) {
+	if got := groundingViolations(nil, []string{"vllm:request_failure_total"}); len(got) != 0 {
+		t.Fatalf("empty evidence must yield no violations, got %+v", got)
+	}
+}
+
+func TestGroundingViolations_IgnoresHostPortScrapeTargets(t *testing.T) {
+	// context7 WAS queried about vllm, but a host:port scrape target in the
+	// same namespace must NOT be flagged as a hallucinated metric.
+	evidence := []string{"vllm:request_success_total{finished_reason}"}
+	added := []string{
+		`      - targets: ['vllm:8000']`,
+		`      - targets: ['host.docker.internal:9091']`,
+	}
+	if got := groundingViolations(evidence, added); len(got) != 0 {
+		t.Fatalf("host:port targets must not be flagged, got %+v", got)
+	}
+}
+
+func TestApplyCoderGroundingRail_RecordsViolation(t *testing.T) {
+	orig := execCommandRunner
+	t.Cleanup(func() { execCommandRunner = orig })
+	execCommandRunner = func(_ context.Context, _ string, _ []string, _ string, _ ...string) (string, error) {
+		return "diff --git a/x b/x\n+++ b/x\n@@ @@\n+  expr: rate(vllm:request_failure_total[5m])\n", nil
+	}
+	queryCall := oai.ToolCall{
+		ID: "c1", Type: "function",
+		Function: oai.ToolCallFunction{Name: "mcp/context7/query-docs"},
+	}
+	lr := &LoopResult{
+		Transcript: []oai.Message{
+			{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{queryCall}},
+			{
+				Role: oai.RoleTool, ToolCallID: "c1", Name: "mcp/context7/query-docs",
+				Content: "vllm:request_success_total{finished_reason}",
+			},
+		},
+		Terminal: &ToolResult{Extra: map[string]any{}},
+	}
+	applyCoderGroundingRail(context.Background(), logr.Discard(), "main", "/ws", lr)
+	recs, ok := lr.Terminal.Extra["coderGroundingViolations"].([]map[string]any)
+	if !ok || len(recs) != 1 || recs[0]["written"] != "vllm:request_failure_total" {
+		t.Fatalf("coderGroundingViolations = %v", lr.Terminal.Extra["coderGroundingViolations"])
+	}
+}
+
+func TestApplyCoderGroundingRail_NoEvidenceIsNoOp(t *testing.T) {
+	lr := &LoopResult{Transcript: nil, Terminal: &ToolResult{Extra: map[string]any{}}}
+	applyCoderGroundingRail(context.Background(), logr.Discard(), "main", "/ws", lr)
+	if _, present := lr.Terminal.Extra["coderGroundingViolations"]; present {
+		t.Fatal("no context7 evidence -> rail must be a no-op")
+	}
+}
+
+func TestApplyCoderGroundingRailForTask_GatesOnIssueFixKind(t *testing.T) {
+	orig := execCommandRunner
+	t.Cleanup(func() { execCommandRunner = orig })
+	execCommandRunner = func(_ context.Context, _ string, _ []string, _ string, _ ...string) (string, error) {
+		return "diff --git a/x b/x\n+++ b/x\n@@ @@\n+  expr: rate(vllm:request_failure_total[5m])\n", nil
+	}
+	newLoopRes := func() *LoopResult {
+		return &LoopResult{
+			Transcript: []oai.Message{
+				{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{
+					{ID: "c1", Type: "function", Function: oai.ToolCallFunction{Name: "mcp/context7/query-docs"}},
+				}},
+				{
+					Role: oai.RoleTool, ToolCallID: "c1", Name: "mcp/context7/query-docs",
+					Content: "vllm:request_success_total{finished_reason}",
+				},
+			},
+			Terminal: &ToolResult{Extra: map[string]any{}},
+		}
+	}
+
+	reviewTask := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{Kind: foremanv1alpha1.AgenticTaskKindReview},
+	}
+	lr := newLoopRes()
+	applyCoderGroundingRailForTask(context.Background(), logr.Discard(), reviewTask, "/ws", lr)
+	if _, present := lr.Terminal.Extra["coderGroundingViolations"]; present {
+		t.Fatal("kind != issue-fix -> rail must be a no-op")
+	}
+
+	issueFixTask := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{Kind: foremanv1alpha1.AgenticTaskKindIssueFix},
+	}
+	lr = newLoopRes()
+	applyCoderGroundingRailForTask(context.Background(), logr.Discard(), issueFixTask, "/ws", lr)
+	recs, ok := lr.Terminal.Extra["coderGroundingViolations"].([]map[string]any)
+	if !ok || len(recs) != 1 || recs[0]["written"] != "vllm:request_failure_total" {
+		t.Fatalf("issue-fix kind should apply the rail; got %v", lr.Terminal.Extra["coderGroundingViolations"])
+	}
+}
+
+func TestGroundingViolations_Issue409Fixture(t *testing.T) {
+	// Real 2026-07-08 #409 run: context7 returned vLLM's /metrics output; the
+	// coder wrote the hallucinated failure metric instead of the retrieved
+	// success metric. The rail must flag exactly the hallucinated name.
+	evidence := []string{
+		`# HELP vllm:num_requests_running Number of requests in model execution batches.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{model_name="meta-llama/Llama-3.1-8B-Instruct"} 8.0
+# HELP vllm:request_success_total Count of successfully processed requests.
+# TYPE vllm:request_success_total counter
+vllm:request_success_total{finished_reason="stop",model_name="meta-llama/Llama-3.1-8B-Instruct"} 1.0`,
+	}
+	added := []string{
+		`  - record: llmkube:inference:error_rate:5m`,
+		`    expr: rate(vllm:request_failure_total{status_class="5xx"}[5m])`,
+	}
+	got := groundingViolations(evidence, added)
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 violation, got %d: %+v", len(got), got)
+	}
+	if got[0].Written != "vllm:request_failure_total" {
+		t.Fatalf("violation.Written = %q, want vllm:request_failure_total", got[0].Written)
+	}
+	hasAlt := false
+	for _, a := range got[0].RetrievedAlternatives {
+		if a == "vllm:request_success_total" {
+			hasAlt = true
+		}
+	}
+	if !hasAlt {
+		t.Fatalf("RetrievedAlternatives = %v, want to include vllm:request_success_total", got[0].RetrievedAlternatives)
+	}
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -736,6 +736,17 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		return e.commitRejectedResult(start, transcriptRef, loopRes, branch, commitErr), nil
 	}
 
+	// Coder grounding rail (v1, non-blocking): flag any external metric
+	// identifier the coder wrote that contradicts the context7 docs it
+	// retrieved this run. MUST run after repo.Commit: the rail reads the
+	// committed diff (base...HEAD), and until the commit above the coder's
+	// edits are uncommitted (the #982 self-commit recovery soft-resets them
+	// into the working tree), so a pre-commit base...HEAD is empty and the
+	// rail sees nothing. Records-and-logs onto loopRes.Terminal.Extra (which
+	// goResult/the downgrade results serialize into status extra.modelExtra);
+	// never changes the verdict.
+	applyCoderGroundingRailForTask(ctx, log, task, workspace, loopRes)
+
 	if err := repo.Push(ctx, repo.PushOptions{
 		Workspace: workspace,
 		Branch:    branch,

--- a/pkg/foreman/agent/mutation_gate.go
+++ b/pkg/foreman/agent/mutation_gate.go
@@ -394,6 +394,24 @@ func changedBranchLines(ctx context.Context, workspace, base, file string, run c
 	return parseAddedLines(out)
 }
 
+// addedDiffLines returns the text of every added line in the coder's branch
+// diff against base (git diff -U0 base...HEAD), excluding the "+++" file
+// headers. Used by the coder grounding rail to scan what the coder wrote for
+// hallucinated external identifiers. Degrades open: any git error -> nil.
+func addedDiffLines(ctx context.Context, workspace, base string, run commandRunner) []string {
+	out, err := run(ctx, workspace, nil, "git", "diff", "-U0", base+"...HEAD")
+	if err != nil {
+		return nil
+	}
+	var lines []string
+	for _, l := range strings.Split(out, "\n") {
+		if strings.HasPrefix(l, "+") && !strings.HasPrefix(l, "+++") {
+			lines = append(lines, l[1:])
+		}
+	}
+	return lines
+}
+
 // parseAddedLines extracts the set of added new-file line numbers from a
 // `git diff -U0` output by tracking each hunk header's new-file start line.
 func parseAddedLines(out string) map[int]bool {

--- a/pkg/foreman/agent/mutation_gate_test.go
+++ b/pkg/foreman/agent/mutation_gate_test.go
@@ -18,8 +18,10 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -343,6 +345,82 @@ func TestNeuterAndTestPackage_RealGoTest(t *testing.T) {
 	weakDir := filepath.Join(ws, "weak")
 	if _, err := execCommandRunner(context.Background(), weakDir, nil, "go", "test", "./..."); err != nil {
 		t.Fatalf("weak test should PASS under neuter (survivor), got err: %v", err)
+	}
+}
+
+func TestAddedDiffLines_ReturnsAddedContentExcludingHeaders(t *testing.T) {
+	diff := "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1,0 +2,2 @@\n" +
+		"+  expr: rate(vllm:request_failure_total[5m])\n" +
+		"+  labels: {}\n"
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		return diff, nil
+	}
+	got := addedDiffLines(context.Background(), "/ws", "main", run)
+	want := []string{"  expr: rate(vllm:request_failure_total[5m])", "  labels: {}"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("addedDiffLines = %#v, want %#v", got, want)
+	}
+}
+
+func TestAddedDiffLines_NilOnGitError(t *testing.T) {
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		return "", errors.New("boom")
+	}
+	if got := addedDiffLines(context.Background(), "/ws", "main", run); got != nil {
+		t.Fatalf("want nil on git error, got %#v", got)
+	}
+}
+
+// TestAddedDiffLines_CommittedVsUncommitted is the regression test for the
+// coder grounding rail's placement bug: addedDiffLines reads the committed
+// diff (base...HEAD), so a NEW file the coder wrote is invisible until it is
+// committed. The rail therefore MUST run after repo.Commit in runLLMPath, not
+// before it (where the earlier no-op-forever bug lived). This exercises real
+// git rather than a stubbed runner, since the stub is what let the bug hide.
+func TestAddedDiffLines_CommittedVsUncommitted(t *testing.T) {
+	ws := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		out, err := execCommandRunner(context.Background(), ws, nil, "git", args...)
+		if err != nil {
+			t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+		}
+		return out
+	}
+	git("init", "-q")
+	git("config", "user.email", "t@t.io")
+	git("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(ws, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-q", "-m", "base")
+	git("branch", "-M", "main")
+	git("checkout", "-q", "-b", "feature")
+
+	// The coder writes a NEW file containing a hallucinated metric identifier.
+	metricLine := "  expr: rate(vllm:request_failure_total[5m])"
+	if err := os.WriteFile(filepath.Join(ws, "alerts.yaml"), []byte(metricLine+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Uncommitted: base...HEAD sees nothing (this is the bug the fix avoids).
+	if got := addedDiffLines(context.Background(), ws, "main", execCommandRunner); len(got) != 0 {
+		t.Fatalf("pre-commit addedDiffLines should be empty (new file untracked), got %#v", got)
+	}
+
+	// After commit: the new file's added line is visible to base...HEAD.
+	git("add", "-A")
+	git("commit", "-q", "-m", "add alerts")
+	got := addedDiffLines(context.Background(), ws, "main", execCommandRunner)
+	found := false
+	for _, l := range got {
+		if strings.Contains(l, "vllm:request_failure_total") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("post-commit addedDiffLines should include the new file's metric line, got %#v", got)
 	}
 }
 


### PR DESCRIPTION
## What

A deterministic, non-blocking post-coder check: after a coder run that used context7 (MCP), compare the committed diff against the docs the coder retrieved this run. If the coder wrote a Prometheus/vLLM-style metric identifier (`namespace:name`) whose namespace was the subject of a context7 query but whose exact identifier is **absent** from the retrieved docs, record it as a grounding violation on `status.result.extra.modelExtra.coderGroundingViolations` (and log it). It never changes the verdict.

The coder analog of the reviewer grounded-finding rails: only flag when there is retrieved same-namespace evidence, so ungrounded code is never touched.

## Why

MCP (#1014) gives the coder doc-lookup tools, but retrieval does not guarantee faithful use: across two models on issue #409, the coder retrieved the correct fact (`vllm:request_success_total`) yet still wrote the hallucinated `vllm:request_failure_total`. This is the known knowledge-conflict / context-unfaithfulness failure. Retrieval is solved; faithfulness needs an enforcement layer.

## How

- `context7Evidence(transcript)` gathers `mcp/context7/*` tool results into an evidence corpus.
- `addedDiffLines` reads the committed diff (`git diff -U0 base...HEAD`).
- `groundingViolations` flags a written `namespace:name` metric whose namespace appears in the evidence but whose identifier is not a substring of it, with the nearest retrieved alternatives.
- Applied in `runLLMPath` **after `repo.Commit`** (issue-fix kind only). This placement is load-bearing: the rail reads the committed diff, and before the commit the coder's edits are uncommitted (the #982 self-commit recovery soft-resets them into the working tree), so a pre-commit `base...HEAD` is empty. A behavior note for reviewers: because it needs a commit to inspect, the rail runs on the GO/commit path only, not on NO-GO/INCOMPLETE runs (which land no diff to guard).

## Testing

- Fixture test locked to the real #409 hallucination (context7 returned `request_success_total`; coder wrote `request_failure_total` → flagged with the alternative).
- Unit tests for evidence extraction, metric-ident parsing (excludes `host:port`), namespace grouping, and the empty-evidence/degrade-open no-op.
- A real-git regression test proving a new file is invisible to `base...HEAD` until committed and visible after (guards the after-commit placement).
- Verified live in a lab cluster: the rail records a violation end to end when the coder calls context7 and commits a contradicting metric.

## Checklist

- [x] Non-blocking (records + logs; never changes the verdict)
- [x] Degrades open (no context7 calls or no metric writes → no-op)
- [x] Builds on go 1.26.5; `go vet` clean; agent package tests pass
- [x] AI assistance disclosed below

---

Assisted-by: Claude Code (implemented the rail, root-caused the after-commit placement, and validated it live; human-reviewed and DCO-signed by the maintainer)