### PR TITLE
fix(foreman): gate Job downloads the go.mod toolchain (GOTOOLCHAIN=auto)

### DIFF
--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -160,6 +160,14 @@ spec:
               value: "{{ .Branch }}"
             - name: BASE_BRANCH
               value: "{{ .BaseBranch }}"
+            # The base image (golang:1.26) bakes GOTOOLCHAIN=local, which
+            # refuses to run when go.mod's toolchain floor is newer than the
+            # image's Go (e.g. go.mod requires 1.26.5 but the cached
+            # golang:1.26 tag is still 1.26.4). Force `auto` so the gate
+            # downloads whatever toolchain go.mod requires into the persistent
+            # GOMODCACHE below, keeping the gate immune to go.mod patch bumps.
+            - name: GOTOOLCHAIN
+              value: auto
             - name: GOMODCACHE
               value: /cache/gomod
             - name: GOCACHE


### PR DESCRIPTION
## What

Set `GOTOOLCHAIN=auto` in the clean-room gate Job env (`gate_job_template.yaml`).

## Why

The gate runs `make fmt`/`vet`/`lint` on `golang:1.26`, which bakes `GOTOOLCHAIN=local`. After the `go.mod` toolchain floor rose to `go >= 1.26.5` (#1016, GO-2026-5856), the gate node's `IfNotPresent`-cached `golang:1.26` (1.26.4) could no longer satisfy it, so every gate check failed:

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

This blocked **every coder GO** at the gate, regardless of the change — an examples-only diff (#699) GATE-FAILed identically because the gate runs `go fmt ./...` over the whole module.

## How

`GOTOOLCHAIN=auto` lets the gate download whatever toolchain `go.mod` requires into the existing persistent `GOMODCACHE` PVC (one-time per version). The Job already has egress (it downloads golangci-lint). This is immune to future `go.mod` patch bumps and needs no base-image chasing.

## Testing

- `go build` + `go test ./pkg/foreman/agent/tools/...` (gate template render) pass.
- Root-caused from a live lab gate failure on `0.9.1-main.gaa969ed` (logTail showed the toolchain refusal on an examples-only change).

## Checklist

- [x] One-line env change; no behavior change beyond toolchain resolution
- [x] Uses the existing `GOMODCACHE` PVC (no new persistence)
- [x] AI assistance disclosed below

Fixes #1018

---

Assisted-by: Claude Code (root-caused the gate toolchain failure from lab logs and wrote the fix; human-reviewed and DCO-signed by the maintainer)