### PR TITLE
feat(foreman): str_replace escalates to write_file after repeated failures

### DIFF
--- a/pkg/foreman/agent/tools/str_replace.go
+++ b/pkg/foreman/agent/tools/str_replace.go
@@ -19,6 +19,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -34,6 +35,73 @@ import (
 // N occurrences" and the tool enforces the count.
 type StrReplaceTool struct {
 	Workspace string
+
+	// failures counts consecutive str_replace match-failures per file path
+	// within one run (StrReplaceTool is instantiated per workspace). Once a
+	// file crosses strReplaceEscalateAfter, the failure result escalates to
+	// dumping the full file and ordering a write_file, so a model that keeps
+	// re-hallucinating old_string gets a deterministic escape instead of
+	// looping into RepeatedToolCall (#1025). Reset on a successful edit.
+	failures map[string]int
+}
+
+const (
+	// strReplaceEscalateAfter is the consecutive per-file failure count at
+	// which str_replace stops handing back an anchor snippet and instead
+	// dumps the whole file with a write_file directive.
+	strReplaceEscalateAfter = 2
+	// strReplaceEscalateMaxLines caps how large a file we will inline in the
+	// escalated hint; above it, the model is told to write_file from a fresh
+	// read rather than dumping the whole thing into the transcript.
+	strReplaceEscalateMaxLines = 400
+)
+
+// noteFailure records a match-failure for path and returns the new consecutive
+// count. clearFailures resets it after any successful edit to that path.
+func (t *StrReplaceTool) noteFailure(path string) int {
+	if t.failures == nil {
+		t.failures = map[string]int{}
+	}
+	t.failures[path]++
+	return t.failures[path]
+}
+
+func (t *StrReplaceTool) clearFailures(path string) { delete(t.failures, path) }
+
+// failureResult records a failure for path and returns either the caller's
+// normal hint (early failures) or, once the file has failed
+// strReplaceEscalateAfter times in a row, the escalated write_file hint.
+func (t *StrReplaceTool) failureResult(path, content, normalHint string) error {
+	if n := t.noteFailure(path); n >= strReplaceEscalateAfter {
+		return errors.New(escalatedEditHint(path, content, n))
+	}
+	return errors.New(normalHint)
+}
+
+// escalatedEditHint tells the model to stop retrying str_replace on a file it
+// cannot match and to rewrite it wholesale, inlining the full numbered content
+// for small files so write_file needs no further reads.
+func escalatedEditHint(path, content string, n int) string {
+	head := fmt.Sprintf(
+		"str_replace has failed %d times in a row on %q: your old_string is not matching the "+
+			"actual bytes. STOP calling str_replace on this file. ", n, path)
+	if strings.Count(content, "\n")+1 <= strReplaceEscalateMaxLines {
+		return head + fmt.Sprintf(
+			"Call write_file on %q with the full corrected file. Its complete current content is "+
+				"below, line-numbered for reference (do NOT include the numbers in write_file):\n%s",
+			path, numberLines(content))
+	}
+	return head + "The file is large: do a fresh read_file of the exact region and copy the bytes " +
+		"VERBATIM, or call write_file with the full corrected content. Do not retype old_string from memory."
+}
+
+// numberLines prefixes each line of content with its 1-based number and a tab.
+func numberLines(content string) string {
+	var b strings.Builder
+	for i, l := range strings.Split(content, "\n") {
+		fmt.Fprintf(&b, "%d\t%s\n", i+1, l)
+	}
+	return b.String()
 }
 
 type strReplaceArgs struct {
@@ -125,6 +193,7 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 				if err := os.WriteFile(full, []byte(recovered), 0o644); err != nil { //nolint:gosec // G306: workspace file
 					return nil, fmt.Errorf("str_replace: write %q: %w", a.Path, err)
 				}
+				t.clearFailures(a.Path)
 				return &agent.ToolResult{
 					Output: map[string]any{"path": a.Path, "replacements": 1, "note": note},
 				}, nil
@@ -138,6 +207,7 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 					if err := os.WriteFile(full, []byte(recovered), 0o644); err != nil { //nolint:gosec // G306: workspace file
 						return nil, fmt.Errorf("str_replace: write %q: %w", a.Path, err)
 					}
+					t.clearFailures(a.Path)
 					return &agent.ToolResult{
 						Output: map[string]any{"path": a.Path, "replacements": 1, "note": note},
 					}, nil
@@ -147,27 +217,31 @@ func (t *StrReplaceTool) Execute(_ context.Context, args json.RawMessage) (*agen
 			// text near the model's intended anchor so it can retry against
 			// truth instead of re-hallucinating old_string.
 			if actual, ok := anchorContext(content, a.OldString); ok {
-				return nil, fmt.Errorf("str_replace: old_string not found in %q. "+
-					"The file's actual current text near your edit is below - copy it "+
-					"VERBATIM into old_string and retry:\n%s%s", a.Path, actual, writeFileHint(content))
+				return nil, t.failureResult(a.Path, content, fmt.Sprintf(
+					"str_replace: old_string not found in %q. "+
+						"The file's actual current text near your edit is below - copy it "+
+						"VERBATIM into old_string and retry:\n%s%s", a.Path, actual, writeFileHint(content)))
 			}
 			// No unique verbatim anchor exists. Fall back to the closest line
 			// match so the model always gets real file content to re-anchor on
 			// instead of the bare count error (#944).
 			if closest := closestLineContext(content, a.OldString); closest != "" {
-				return nil, fmt.Errorf("str_replace: old_string not found in %q. "+
-					"No unique anchor line exists; the closest approximate match "+
-					"in the file is below (not verbatim). Copy the actual bytes "+
-					"VERBATIM into old_string and retry:\n%s%s", a.Path, closest, writeFileHint(content))
+				return nil, t.failureResult(a.Path, content, fmt.Sprintf(
+					"str_replace: old_string not found in %q. "+
+						"No unique anchor line exists; the closest approximate match "+
+						"in the file is below (not verbatim). Copy the actual bytes "+
+						"VERBATIM into old_string and retry:\n%s%s", a.Path, closest, writeFileHint(content)))
 			}
 		}
-		return nil, fmt.Errorf("str_replace: old_string found %d times in %q, want %d%s",
-			occurrences, a.Path, want, writeFileHint(content))
+		return nil, t.failureResult(a.Path, content, fmt.Sprintf(
+			"str_replace: old_string found %d times in %q, want %d%s",
+			occurrences, a.Path, want, writeFileHint(content)))
 	}
 	next := strings.ReplaceAll(content, a.OldString, a.NewString)
 	if err := os.WriteFile(full, []byte(next), 0o644); err != nil { //nolint:gosec // G306: workspace file
 		return nil, fmt.Errorf("str_replace: write %q: %w", a.Path, err)
 	}
+	t.clearFailures(a.Path)
 	return &agent.ToolResult{
 		Output: map[string]any{
 			"path":         a.Path,

--- a/pkg/foreman/agent/tools/str_replace_escalate_test.go
+++ b/pkg/foreman/agent/tools/str_replace_escalate_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func strReplaceArgsJSON(t *testing.T, path, oldS, newS string) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{"path": path, "old_string": oldS, "new_string": newS})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	return b
+}
+
+// TestStrReplace_EscalatesAfterRepeatedFailure: the first non-matching edit
+// returns the normal anchor hint; the second consecutive failure on the same
+// file escalates to a STOP directive with the full file inlined and a
+// write_file order (#1025). This is the deterministic escape a model that
+// keeps re-hallucinating old_string needs, so it stops looping into
+// RepeatedToolCall.
+func TestStrReplace_EscalatesAfterRepeatedFailure(t *testing.T) {
+	ws := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ws, "f.go"), []byte("package x\n\nfunc A() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := &StrReplaceTool{Workspace: ws}
+	bad := strReplaceArgsJSON(t, "f.go", "ZZZ_NO_SUCH_LINE_ANYWHERE_ZZZ", "func B() {}")
+
+	_, err1 := tool.Execute(context.Background(), bad)
+	if err1 == nil {
+		t.Fatal("first failing edit should error")
+	}
+	if strings.Contains(err1.Error(), "STOP calling str_replace") {
+		t.Fatalf("first failure should be a normal hint, not escalated: %v", err1)
+	}
+
+	_, err2 := tool.Execute(context.Background(), bad)
+	if err2 == nil {
+		t.Fatal("second failing edit should error")
+	}
+	if !strings.Contains(err2.Error(), "STOP calling str_replace") {
+		t.Errorf("second failure should escalate with a STOP directive; got: %v", err2)
+	}
+	if !strings.Contains(err2.Error(), "write_file") {
+		t.Errorf("escalated hint should order write_file; got: %v", err2)
+	}
+	if !strings.Contains(err2.Error(), "func A()") {
+		t.Errorf("escalated hint should inline the small file's content; got: %v", err2)
+	}
+}
+
+// TestStrReplace_SuccessResetsFailureCounter: a successful edit clears the
+// per-file failure count, so a later failure starts over at the normal hint
+// rather than immediately escalating.
+func TestStrReplace_SuccessResetsFailureCounter(t *testing.T) {
+	ws := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ws, "f.go"), []byte("package x\n\nfunc A() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := &StrReplaceTool{Workspace: ws}
+	bad := strReplaceArgsJSON(t, "f.go", "ZZZ_NO_SUCH_LINE_ANYWHERE_ZZZ", "x")
+	good := strReplaceArgsJSON(t, "f.go", "func A() {}", "func A() { _ = 1 }")
+
+	if _, err := tool.Execute(context.Background(), bad); err == nil {
+		t.Fatal("first edit should fail")
+	}
+	if _, err := tool.Execute(context.Background(), good); err != nil {
+		t.Fatalf("good edit should succeed and reset the counter: %v", err)
+	}
+	// Counter reset: the next failure is a "first" failure again, not escalated.
+	_, err := tool.Execute(context.Background(), bad)
+	if err == nil {
+		t.Fatal("edit should fail")
+	}
+	if strings.Contains(err.Error(), "STOP calling str_replace") {
+		t.Errorf("a success should reset the counter; got escalated: %v", err)
+	}
+}
+
+func TestEscalatedEditHint_LargeFileNotInlined(t *testing.T) {
+	big := strings.Repeat("line\n", strReplaceEscalateMaxLines+50)
+	h := escalatedEditHint("big.txt", big, 2)
+	if strings.Contains(h, numberLines(big)) {
+		t.Error("a large file must not be dumped inline")
+	}
+	if !strings.Contains(h, "read_file") || !strings.Contains(h, "write_file") {
+		t.Errorf("large-file escalation should steer to read_file/write_file; got head: %.120s", h)
+	}
+}
+
+func TestNumberLines(t *testing.T) {
+	if got := numberLines("a\nb"); got != "1\ta\n2\tb\n" {
+		t.Errorf("numberLines = %q", got)
+	}
+}


### PR DESCRIPTION
## What

After a file fails `str_replace` twice in a row, the tool escalates: it tells the model to **stop** calling `str_replace` on that file and, for reasonably-sized files, inlines the **full line-numbered current content** with an order to `write_file` the corrected file. A successful edit resets the per-file counter.

## Why

When `old_string` does not match, `str_replace` already returns an anchor snippet plus a `writeFileHint` (which is *suppressed for large files*). Some models ignore it and hammer `str_replace` until the `RepeatedToolCall` stuck-loop detector force-terminates the run as INCOMPLETE.

Observed live dogfooding **Qwopus3.6-35B-A3B-Coder-MTP** on the Strix: three runs of #850 all INCOMPLETE'd this way (12-30 `str_replace` calls returning "not found"), and **three system-prompt nudges — re-read-before-edit, prefer-write_file, converge-and-submit — did not fix it.** The model ignored the prompt. The escape has to be enforced in the tool, not requested.

This is the highest-leverage lever for the "swap in any better local model" goal: a model weak at surgical edits should still land changes deterministically, without per-model prompt tuning.

## How

`StrReplaceTool` (instantiated per workspace) now tracks consecutive match-failures per file path. `failureResult` routes the three existing failure paths (anchor / closest-line / count-mismatch) through the counter:
- 1st failure → the existing anchor hint (unchanged).
- 2nd+ failure → `escalatedEditHint`: a STOP directive plus the full numbered content for files ≤ `strReplaceEscalateMaxLines` (400), or a read/write directive for larger files (closing the gap where the old hint returned nothing for big files).
- Any successful edit (including whitespace/fuzzy recovery) clears the counter.

## Testing

- `TestStrReplace_EscalatesAfterRepeatedFailure`: 1st failure normal, 2nd escalates with STOP + `write_file` + inlined content.
- `TestStrReplace_SuccessResetsFailureCounter`: a success resets, so a later failure starts over.
- `TestEscalatedEditHint_LargeFileNotInlined`: large files steer to read/write instead of dumping.
- The 6 existing fuzzy/recovery tests still pass (no regression). Full `tools` package green.

## Checklist

- [x] `Fixes #1025`
- [x] Deterministic, tool-enforced (not prompt-dependent)
- [x] No regression to existing recovery paths
- [x] AI assistance disclosed below

---

Assisted-by: Claude Code (root-caused the Qwopus edit-loop failure live on the Strix, designed and wrote the escalation; human-reviewed and DCO-signed by the maintainer).