### PR TITLE
feat(chart): support multiple agent fleets in one release

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -759,9 +759,11 @@ jobs:
         # Helm v3.13's `helm plugin install` will not skip signature
         # verification (no --verify flag in 3.x), and the runner has no
         # GPG keyring to verify the upstream release signature against.
-        # Pull the v1.1.1 plugin tarball directly and unpack into
-        # $(helm env HELM_PLUGINS) — the plugin.yaml ships every platform
-        # binary and the plugin runs without a post-install download.
+        # Pull the v1.1.1 plugin tarball directly, unpack into
+        # $(helm env HELM_PLUGINS), and strip `platformHooks` from
+        # plugin.yaml — that field was added after 3.13 and v3.13's
+        # plugin loader rejects unknown YAML keys, so the install hard-
+        # fails on the next `helm plugin list`.
         run: |
           set -euo pipefail
           HELM_PLUGINS_DIR="$(helm env HELM_PLUGINS)"
@@ -772,6 +774,20 @@ jobs:
             https://github.com/helm-unittest/helm-unittest/releases/download/v1.1.1/unittest-1.1.1.tgz \
             | tar -xz -C "${PLUGIN_DIR}" --strip-components=1
           chmod +x "${PLUGIN_DIR}"/untt-*
+          # Helm 3.13 strict-decodes plugin.yaml and rejects unknown
+          # keys; v1.1.1 added `platformHooks` (post-install hook map),
+          # which Helm 3.x's loader has never heard of. Drop the block
+          # with awk — it lives at the end of the file, indented under
+          # `platformHooks:`. The `platformCommand` map still picks the
+          # right binary per OS/arch, so the plugin runs without the
+          # post-install download hook.
+          awk '
+            /^platformHooks:/  { skip = 1; next }
+            skip && /^[^ ]/     { skip = 0 }
+            skip                { next }
+            { print }
+          ' "${PLUGIN_DIR}/plugin.yaml" > "${PLUGIN_DIR}/plugin.yaml.tmp"
+          mv "${PLUGIN_DIR}/plugin.yaml.tmp" "${PLUGIN_DIR}/plugin.yaml"
           # Trigger Helm's plugin discovery by listing once; HELM_PLUGINS
           # is read on every invocation, so this picks the plugin up.
           helm plugin list > /dev/null

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -755,6 +755,22 @@ jobs:
           helm lint charts/foreman
           echo "✅ foreman lint passed"
 
+      - name: Install helm-unittest
+        # Pin to a tag whose release tarball the runner can fetch without
+        # auth; same source the local developer install uses.
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+          helm unittest --help > /dev/null
+          echo "✅ helm-unittest installed"
+
+      - name: Run foreman chart unit tests
+        # Covers the agents: map multi-fleet (#994) shape plus the legacy
+        # single-agent backward-compat path. Fails CI on any drift in the
+        # expected resource names, suffixes, or per-agent field flow.
+        run: |
+          helm unittest charts/foreman
+          echo "✅ foreman chart unit tests passed"
+
       - name: Template foreman with defaults
         # foreman is a sibling chart to llmkube (no Helm subchart
         # relationship), so no helm-repo wiring is required to render

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -756,10 +756,25 @@ jobs:
           echo "✅ foreman lint passed"
 
       - name: Install helm-unittest
-        # Pin to a tag whose release tarball the runner can fetch without
-        # auth; same source the local developer install uses.
+        # Helm v3.13's `helm plugin install` will not skip signature
+        # verification (no --verify flag in 3.x), and the runner has no
+        # GPG keyring to verify the upstream release signature against.
+        # Pull the v1.1.1 plugin tarball directly and unpack into
+        # $(helm env HELM_PLUGINS) — the plugin.yaml ships every platform
+        # binary and the plugin runs without a post-install download.
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+          set -euo pipefail
+          HELM_PLUGINS_DIR="$(helm env HELM_PLUGINS)"
+          PLUGIN_DIR="${HELM_PLUGINS_DIR}/unittest"
+          rm -rf "${PLUGIN_DIR}"
+          mkdir -p "${PLUGIN_DIR}"
+          curl -fsSL \
+            https://github.com/helm-unittest/helm-unittest/releases/download/v1.1.1/unittest-1.1.1.tgz \
+            | tar -xz -C "${PLUGIN_DIR}" --strip-components=1
+          chmod +x "${PLUGIN_DIR}"/untt-*
+          # Trigger Helm's plugin discovery by listing once; HELM_PLUGINS
+          # is read on every invocation, so this picks the plugin up.
+          helm plugin list > /dev/null
           helm unittest --help > /dev/null
           echo "✅ helm-unittest installed"
 

--- a/charts/foreman/templates/NOTES.txt
+++ b/charts/foreman/templates/NOTES.txt
@@ -6,25 +6,41 @@ Components:
 {{- else }}
   - foreman-operator      DISABLED (operator.enabled=false)
 {{- end }}
-{{- if .Values.agent.enabled }}
-  - foreman-agent         Deployment {{ include "foreman.fullname" . }}-agent
-      mode:               {{ .Values.agent.mode }}
-      roles:              {{ join "," .Values.agent.roles }}
-  {{- if .Values.agent.gateCache.enabled }}
-      gate cache PVC:     {{ include "foreman.gateCache.pvcName" . }} ({{ .Values.agent.gateCache.size }})
+{{- if or .Values.agents (and .Values.agent .Values.agent.enabled) }}
+  - foreman-agents ({{ len (include "foreman.agents" . | fromYaml) }} fleet{{ if gt (len (include "foreman.agents" . | fromYaml)) 1 }}s{{ end }}):
+{{- range $name, $cfg := include "foreman.agents" . | fromYaml }}
+{{- if $cfg.enabled }}
+{{- $defaults := dict }}
+{{- if $.Values.agent }}{{ $defaults = deepCopy $.Values.agent }}{{ end }}
+{{- $agent := mustMergeOverwrite $defaults $cfg }}
+{{- $ctx := dict "Release" $.Release "Values" $.Values "Chart" $.Chart "agentName" $name "agentConfig" $agent }}
+      - {{ include "foreman.agent.resourceName" $ctx }}   mode: {{ $agent.mode }}   roles: {{ join "," $agent.roles }}
+  {{- if $agent.gateCache.enabled }}
+        gate cache PVC:   {{ include "foreman.gateCache.pvcName" $ctx }} ({{ $agent.gateCache.size }})
   {{- end }}
+{{- end }}
+{{- end }}
 {{- else }}
   - foreman-agent         DISABLED (agent.enabled=false)
 {{- end }}
 
 Next steps:
   1. Watch the operator come up:
-     kubectl -n {{ include "foreman.namespace" . }} logs -l app.kubernetes.io/component=operator -f
-{{- if .Values.agent.enabled }}
-  2. Confirm the agent registered itself as a FleetNode:
-     kubectl get fleetnodes
+      kubectl -n {{ include "foreman.namespace" . }} logs -l app.kubernetes.io/component=operator -f
+{{- if or .Values.agents (and .Values.agent .Values.agent.enabled) }}
+  2. Confirm the agent(s) registered themselves as FleetNodes:
+      kubectl get fleetnodes
 {{- end }}
   3. Apply an Agent CR and an AgenticTask referencing it (examples
-     under examples/foreman/ in the repo).
+      under examples/foreman/ in the repo).
+
+{{- if .Values.agents }}
+
+You installed foreman in multi-fleet mode (agents: map, #994). To add
+another fleet — e.g. a fork-pinned dogfood agent or a per-language
+coder pool — extend the agents: map and re-run `helm upgrade`. Each
+agent gets its own Deployment, ServiceAccount, ClusterRole, and gate
+cache PVC, suffixed with the agent key, so they never collide.
+{{- end }}
 
 The Foreman docs live at https://llmkube.com/docs/foreman.

--- a/charts/foreman/templates/_helpers.tpl
+++ b/charts/foreman/templates/_helpers.tpl
@@ -86,13 +86,54 @@ ServiceAccount name for the foreman-operator.
 {{- end }}
 
 {{/*
-ServiceAccount name for the foreman-agent.
+ServiceAccount name for the foreman-agent. Expects a context dict with
+"agentName" (the entry from .Values.agents, or the legacy sentinel
+"_implicit_" when .Values.agent: is used unchanged) and "agentConfig"
+(the per-agent values dict). When the sentinel is passed, the legacy
+"<fullname>-agent" name is preserved so an existing install's SA is not
+renamed on upgrade; an explicit agents.<name> entry always suffixes the
+agent key so multiple agents never collide.
 */}}
 {{- define "foreman.agent.serviceAccountName" -}}
-{{- if .Values.agent.serviceAccount.create }}
-{{- default (printf "%s-agent" (include "foreman.fullname" .)) .Values.agent.serviceAccount.name }}
+{{- if .agentConfig.serviceAccount.create }}
+{{- if eq .agentName "_implicit_" }}
+{{- default (printf "%s-agent" (include "foreman.fullname" .)) .agentConfig.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.agent.serviceAccount.name }}
+{{- default (printf "%s-%s-agent" (include "foreman.fullname" .) .agentName | trunc 63 | trimSuffix "-") .agentConfig.serviceAccount.name }}
+{{- end }}
+{{- else }}
+{{- default "default" .agentConfig.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Default resource name for one foreman-agent (Deployment / ClusterRole /
+ClusterRoleBinding). Same shape as the SA default — "<fullname>-agent"
+for the legacy sentinel and "<fullname>-<agentName>-agent" for an
+explicit agents.<name> entry — but with no per-agent override since the
+SA already carries that escape hatch.
+*/}}
+{{- define "foreman.agent.resourceName" -}}
+{{- if eq .agentName "_implicit_" }}
+{{- printf "%s-agent" (include "foreman.fullname" .) }}
+{{- else }}
+{{- printf "%s-%s-agent" (include "foreman.fullname" .) .agentName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+The agents map to render. When the user opts into the multi-fleet form
+(.Values.agents is set) the map is returned verbatim. Otherwise the
+legacy top-level .Values.agent: block is wrapped under a sentinel key
+("_implicit_") so a single template path can render both shapes and the
+legacy install's resource names are preserved on upgrade (#994). Callers
+must not pass "_implicit_" as an explicit agents.* key.
+*/}}
+{{- define "foreman.agents" -}}
+{{- if .Values.agents }}
+{{- .Values.agents | toYaml }}
+{{- else }}
+{{- dict "_implicit_" .Values.agent | toYaml }}
 {{- end }}
 {{- end }}
 
@@ -135,10 +176,12 @@ Foreman operator image (registry/repo:tag or registry/repo@digest).
 {{- end }}
 
 {{/*
-Foreman agent image (registry/repo:tag or registry/repo@digest).
+Foreman agent image (registry/repo:tag or registry/repo@digest). Expects
+the per-agent context dict with "agentConfig" (.Values.agents.<name> or
+.Values.agent) and the chart context (Release/Values/Chart) at the root.
 */}}
 {{- define "foreman.agent.image" -}}
-{{- $img := .Values.agent.image -}}
+{{- $img := .agentConfig.image -}}
 {{- $repo := $img.repository -}}
 {{- if $img.registry -}}
 {{- $repo = printf "%s/%s" $img.registry $img.repository -}}
@@ -152,10 +195,18 @@ Foreman agent image (registry/repo:tag or registry/repo@digest).
 {{- end }}
 
 {{/*
-Gate cache PVC name.
+Gate cache PVC name for a single agent. Expects the per-agent context
+dict; the legacy install (sentinel "_implicit_") keeps "<fullname>-gate-cache"
+so an upgrade does not rename an in-use PVC. Explicit agents.<name>
+entries get "<fullname>-<agentName>-gate-cache" so multiple agents each
+own a distinct PVC. Users can still override via .agentConfig.gateCache.name.
 */}}
 {{- define "foreman.gateCache.pvcName" -}}
-{{- default (printf "%s-gate-cache" (include "foreman.fullname" .)) .Values.agent.gateCache.name }}
+{{- $suffix := "" -}}
+{{- if ne .agentName "_implicit_" -}}
+{{- $suffix = printf "-%s" .agentName -}}
+{{- end -}}
+{{- default (printf "%s%s-gate-cache" (include "foreman.fullname" .) $suffix) .agentConfig.gateCache.name }}
 {{- end }}
 
 {{/*

--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -1,15 +1,18 @@
 {{- range $name, $cfg := include "foreman.agents" . | fromYaml }}
-{{- if $cfg.enabled }}
 ---
 {{- /* Deep-merge the legacy top-level .Values.agent as the per-agent
        defaults so users opting into agents: do not have to restate
        replicaCount/resources/image/etc. for each entry. A nil .Values.agent
-       degrades to an empty dict (mustMergeOverwrite rejects nil). */}}
+       degrades to an empty dict (mustMergeOverwrite rejects nil). The merge
+       runs BEFORE the enabled gate so a per-agent entry that omits
+       `enabled` still inherits it from .Values.agent — the gate would
+       otherwise drop the entry silently (#994 review feedback). */}}
 {{- $defaults := dict }}
 {{- if $.Values.agent }}
   {{- $defaults = deepCopy $.Values.agent }}
 {{- end }}
 {{- $agent := mustMergeOverwrite $defaults $cfg }}
+{{- if $agent.enabled }}
 {{- /* Per-agent context: chart root (Release/Values/Chart) + the agent's
        name and its resolved (merged) config dict. Passed to helpers that read
        .agentConfig / .agentName instead of the legacy .Values.agent.* */}}

--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -1,13 +1,28 @@
-{{- if .Values.agent.enabled }}
+{{- range $name, $cfg := include "foreman.agents" . | fromYaml }}
+{{- if $cfg.enabled }}
+---
+{{- /* Deep-merge the legacy top-level .Values.agent as the per-agent
+       defaults so users opting into agents: do not have to restate
+       replicaCount/resources/image/etc. for each entry. A nil .Values.agent
+       degrades to an empty dict (mustMergeOverwrite rejects nil). */}}
+{{- $defaults := dict }}
+{{- if $.Values.agent }}
+  {{- $defaults = deepCopy $.Values.agent }}
+{{- end }}
+{{- $agent := mustMergeOverwrite $defaults $cfg }}
+{{- /* Per-agent context: chart root (Release/Values/Chart) + the agent's
+       name and its resolved (merged) config dict. Passed to helpers that read
+       .agentConfig / .agentName instead of the legacy .Values.agent.* */}}
+{{- $ctx := dict "Release" $.Release "Values" $.Values "Chart" $.Chart "agentName" $name "agentConfig" $agent }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "foreman.fullname" . }}-agent
-  namespace: {{ include "foreman.namespace" . }}
+  name: {{ include "foreman.agent.resourceName" $ctx }}
+  namespace: {{ include "foreman.namespace" $ }}
   labels:
-    {{- include "foreman.agent.labels" . | nindent 4 }}
+    {{- include "foreman.agent.labels" $ | nindent 4 }}
 spec:
-  replicas: {{ .Values.agent.replicaCount }}
+  replicas: {{ $agent.replicaCount }}
   # Each foreman-agent claims one task at a time. The Recreate
   # strategy stops a rolling update from briefly running two agents
   # that race for the same Scheduled tasks.
@@ -15,67 +30,70 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      {{- include "foreman.agent.labels" . | nindent 6 }}
+      {{- include "foreman.agent.labels" $ | nindent 6 }}
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: agent
-        {{- with .Values.agent.podAnnotations }}
+        {{- with $agent.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "foreman.agent.labels" . | nindent 8 }}
-        {{- with .Values.agent.podLabels }}
+        {{- include "foreman.agent.labels" $ | nindent 8 }}
+        {{- with $agent.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "foreman.agent.serviceAccountName" . }}
+      serviceAccountName: {{ include "foreman.agent.serviceAccountName" $ctx }}
       securityContext:
-        {{- toYaml .Values.agent.podSecurityContext | nindent 8 }}
+        {{- toYaml $agent.podSecurityContext | nindent 8 }}
       containers:
         - name: agent
-          image: {{ include "foreman.agent.image" . }}
-          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          image: {{ include "foreman.agent.image" $ctx }}
+          imagePullPolicy: {{ $agent.image.pullPolicy }}
           command:
             - /foreman-agent
           args:
-            - --agent-mode={{ .Values.agent.mode }}
-            - --roles={{ join "," .Values.agent.roles }}
-            {{- if .Values.agent.nodeLabels }}
+            - --agent-mode={{ $agent.mode }}
+            - --roles={{ join "," $agent.roles }}
+            {{- if $agent.nodeLabels }}
             {{- $pairs := list }}
-            {{- range $k, $v := .Values.agent.nodeLabels }}{{ $pairs = append $pairs (printf "%s=%s" $k $v) }}{{- end }}
+            {{- range $k, $v := $agent.nodeLabels }}{{ $pairs = append $pairs (printf "%s=%s" $k $v) }}{{- end }}
             - --node-labels={{ join "," $pairs }}
             {{- end }}
-            {{- if .Values.agent.taskNamespace }}
-            - --task-namespace={{ .Values.agent.taskNamespace }}
+            {{- if $agent.taskNamespace }}
+            - --task-namespace={{ $agent.taskNamespace }}
             {{- end }}
             {{- /* Always set: the binary default is "foreman-system", a namespace the chart never creates, so gate Jobs would land where the cache PVC does not exist. */}}
-            - --foreman-namespace={{ .Values.agent.foremanNamespace | default (include "foreman.namespace" .) }}
-            {{- if .Values.agent.installedModels }}
-            - --installed-models={{ join "," .Values.agent.installedModels }}
+            - --foreman-namespace={{ $agent.foremanNamespace | default (include "foreman.namespace" $) }}
+            {{- if $agent.installedModels }}
+            - --installed-models={{ join "," $agent.installedModels }}
             {{- end }}
-            {{- if .Values.agent.inferenceBaseURLOverride }}
-            - --inference-base-url-override={{ .Values.agent.inferenceBaseURLOverride }}
+            {{- if $agent.inferenceBaseURLOverride }}
+            - --inference-base-url-override={{ $agent.inferenceBaseURLOverride }}
             {{- end }}
-            - --workspace-dir={{ .Values.agent.workspaceDir }}
-            {{- if .Values.agent.gitRemoteURL }}
-            - --git-remote-url={{ .Values.agent.gitRemoteURL }}
+            - --workspace-dir={{ $agent.workspaceDir }}
+            {{- if $agent.gitRemoteURL }}
+            - --git-remote-url={{ $agent.gitRemoteURL }}
             {{- end }}
-            {{- if .Values.agent.commitAuthorName }}
-            - --commit-author-name={{ .Values.agent.commitAuthorName }}
+            {{- if $agent.commitAuthorName }}
+            - --commit-author-name={{ $agent.commitAuthorName }}
             {{- end }}
-            {{- if .Values.agent.commitAuthorEmail }}
-            - --commit-author-email={{ .Values.agent.commitAuthorEmail }}
+            {{- if $agent.commitAuthorEmail }}
+            - --commit-author-email={{ $agent.commitAuthorEmail }}
             {{- end }}
-            {{- if .Values.coder.gitCredentialsSecret }}
-            - --coder-git-secret={{ .Values.coder.gitCredentialsSecret }}
+            {{- /* Per-agent override of the coder git secret (#994). Falls back to the chart-level coder.gitCredentialsSecret so existing installs are unchanged. */}}
+            {{- $coderSecret := dig "coderGitSecret" "" $agent | default $.Values.coder.gitCredentialsSecret }}
+            {{- $coderKey := dig "coderGitSecretKey" "" $agent | default $.Values.coder.gitCredentialsSecretKey }}
+            {{- if $coderSecret }}
+            - --coder-git-secret={{ $coderSecret }}
             {{- end }}
-            {{- if .Values.coder.gitCredentialsSecretKey }}
-            - --coder-git-secret-key={{ .Values.coder.gitCredentialsSecretKey }}
+            {{- if $coderKey }}
+            - --coder-git-secret-key={{ $coderKey }}
             {{- end }}
           env:
             - name: FLEET_NODE_NAME
@@ -86,26 +104,26 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if .Values.agent.githubToken.secretName }}
+            {{- if $agent.githubToken.secretName }}
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.agent.githubToken.secretName }}
-                  key: {{ .Values.agent.githubToken.secretKey }}
+                  name: {{ $agent.githubToken.secretName }}
+                  key: {{ $agent.githubToken.secretKey }}
             {{- end }}
-            {{- with .Values.agent.env }}
+            {{- with $agent.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           securityContext:
-            {{- toYaml .Values.agent.securityContext | nindent 12 }}
+            {{- toYaml $agent.securityContext | nindent 12 }}
           resources:
-            {{- toYaml .Values.agent.resources | nindent 12 }}
+            {{- toYaml $agent.resources | nindent 12 }}
           volumeMounts:
             - name: workspace
               mountPath: /workspace
             - name: tmp
               mountPath: /tmp
-            {{- if .Values.agent.gateCache.enabled }}
+            {{- if $agent.gateCache.enabled }}
             - name: gate-cache
               mountPath: /cache
             {{- end }}
@@ -114,22 +132,23 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
-        {{- if .Values.agent.gateCache.enabled }}
+        {{- if $agent.gateCache.enabled }}
         - name: gate-cache
           persistentVolumeClaim:
-            claimName: {{ include "foreman.gateCache.pvcName" . }}
+            claimName: {{ include "foreman.gateCache.pvcName" $ctx }}
         {{- end }}
-      {{- with .Values.agent.nodeSelector }}
+      {{- with $agent.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.agent.affinity }}
+      {{- with $agent.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.agent.tolerations }}
+      {{- with $agent.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 30
+{{- end }}
 {{- end }}

--- a/charts/foreman/templates/agent-rbac.yaml
+++ b/charts/foreman/templates/agent-rbac.yaml
@@ -1,20 +1,28 @@
-{{- if .Values.agent.enabled }}
-{{- if .Values.agent.serviceAccount.create }}
+{{- range $name, $cfg := include "foreman.agents" . | fromYaml }}
+{{- if $cfg.enabled }}
+---
+{{- $defaults := dict }}
+{{- if $.Values.agent }}
+  {{- $defaults = deepCopy $.Values.agent }}
+{{- end }}
+{{- $agent := mustMergeOverwrite $defaults $cfg }}
+{{- $ctx := dict "Release" $.Release "Values" $.Values "Chart" $.Chart "agentName" $name "agentConfig" $agent }}
+{{- if $agent.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "foreman.agent.serviceAccountName" . }}
-  namespace: {{ include "foreman.namespace" . }}
+  name: {{ include "foreman.agent.serviceAccountName" $ctx }}
+  namespace: {{ include "foreman.namespace" $ }}
   labels:
-    {{- include "foreman.agent.labels" . | nindent 4 }}
+    {{- include "foreman.agent.labels" $ | nindent 4 }}
 ---
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "foreman.fullname" . }}-agent
+  name: {{ include "foreman.agent.resourceName" $ctx }}
   labels:
-    {{- include "foreman.agent.labels" . | nindent 4 }}
+    {{- include "foreman.agent.labels" $ | nindent 4 }}
 rules:
   # FleetNode self-registration + heartbeat.
   - apiGroups: ["foreman.llmkube.dev"]
@@ -105,15 +113,16 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "foreman.fullname" . }}-agent
+  name: {{ include "foreman.agent.resourceName" $ctx }}
   labels:
-    {{- include "foreman.agent.labels" . | nindent 4 }}
+    {{- include "foreman.agent.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "foreman.fullname" . }}-agent
+  name: {{ include "foreman.agent.resourceName" $ctx }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "foreman.agent.serviceAccountName" . }}
-    namespace: {{ include "foreman.namespace" . }}
+    name: {{ include "foreman.agent.serviceAccountName" $ctx }}
+    namespace: {{ include "foreman.namespace" $ }}
+{{- end }}
 {{- end }}

--- a/charts/foreman/templates/agent-rbac.yaml
+++ b/charts/foreman/templates/agent-rbac.yaml
@@ -1,11 +1,14 @@
 {{- range $name, $cfg := include "foreman.agents" . | fromYaml }}
-{{- if $cfg.enabled }}
 ---
+{{- /* Merge defaults BEFORE the enabled gate so a per-agent entry that
+       omits `enabled` inherits it from .Values.agent instead of being
+       dropped silently (#994 review feedback). */}}
 {{- $defaults := dict }}
 {{- if $.Values.agent }}
   {{- $defaults = deepCopy $.Values.agent }}
 {{- end }}
 {{- $agent := mustMergeOverwrite $defaults $cfg }}
+{{- if $agent.enabled }}
 {{- $ctx := dict "Release" $.Release "Values" $.Values "Chart" $.Chart "agentName" $name "agentConfig" $agent }}
 {{- if $agent.serviceAccount.create }}
 apiVersion: v1

--- a/charts/foreman/templates/gate-cache-pvc.yaml
+++ b/charts/foreman/templates/gate-cache-pvc.yaml
@@ -1,22 +1,34 @@
-{{- if and .Values.agent.enabled .Values.agent.gateCache.enabled }}
+{{- range $name, $cfg := include "foreman.agents" . | fromYaml }}
+{{- if $cfg.enabled }}
+---
+{{- $defaults := dict }}
+{{- if $.Values.agent }}
+  {{- $defaults = deepCopy $.Values.agent }}
+{{- end }}
+{{- $agent := mustMergeOverwrite $defaults $cfg }}
+{{- if $agent.gateCache.enabled }}
+{{- $ctx := dict "Release" $.Release "Values" $.Values "Chart" $.Chart "agentName" $name "agentConfig" $agent }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "foreman.gateCache.pvcName" . }}
-  namespace: {{ include "foreman.namespace" . }}
+  name: {{ include "foreman.gateCache.pvcName" $ctx }}
+  namespace: {{ include "foreman.namespace" $ }}
   labels:
-    {{- include "foreman.agent.labels" . | nindent 4 }}
-  {{- with .Values.agent.gateCache.annotations }}
+    {{- include "foreman.agent.labels" $ | nindent 4 }}
+  {{- with $agent.gateCache.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   accessModes:
-    {{- toYaml .Values.agent.gateCache.accessModes | nindent 4 }}
+    {{- toYaml $agent.gateCache.accessModes | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.agent.gateCache.size }}
-  {{- with .Values.agent.gateCache.storageClass }}
+      storage: {{ $agent.gateCache.size }}
+  {{- with $agent.gateCache.storageClass }}
   storageClassName: {{ . }}
   {{- end }}
+---
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/foreman/templates/gate-cache-pvc.yaml
+++ b/charts/foreman/templates/gate-cache-pvc.yaml
@@ -1,11 +1,14 @@
 {{- range $name, $cfg := include "foreman.agents" . | fromYaml }}
-{{- if $cfg.enabled }}
 ---
+{{- /* Merge defaults BEFORE the enabled gate so a per-agent entry that
+       omits `enabled` inherits it from .Values.agent instead of being
+       dropped silently (#994 review feedback). */}}
 {{- $defaults := dict }}
 {{- if $.Values.agent }}
   {{- $defaults = deepCopy $.Values.agent }}
 {{- end }}
 {{- $agent := mustMergeOverwrite $defaults $cfg }}
+{{- if $agent.enabled }}
 {{- if $agent.gateCache.enabled }}
 {{- $ctx := dict "Release" $.Release "Values" $.Values "Chart" $.Chart "agentName" $name "agentConfig" $agent }}
 apiVersion: v1

--- a/charts/foreman/tests/agents_test.yaml
+++ b/charts/foreman/tests/agents_test.yaml
@@ -76,24 +76,52 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-foreman-llmkube-fork-agent
 
-  - it: SA plus ClusterRole plus ClusterRoleBinding per agent (six docs total)
+  - it: SA plus ClusterRole plus ClusterRoleBinding per agent (nine docs total)
     template: agent-rbac.yaml
     values:
       - ./values-multi.yaml
     asserts:
+      # default + llmkube-fork + omitted-enabled each render 3 docs
+      # (SA + ClusterRole + ClusterRoleBinding); disabled-agent skips.
       - hasDocuments:
-          count: 6
+          count: 9
 
-  - it: gate-cache PVC per agent whose gateCache.enabled is true (default keeps, fork disables)
+  - it: gate-cache PVC per agent whose gateCache.enabled is true
     template: gate-cache-pvc.yaml
     values:
       - ./values-multi.yaml
     asserts:
+      # default + omitted-enabled both keep gateCache enabled
+      # (omitted-enabled inherits from .Values.agent); llmkube-fork
+      # disables it explicitly. Two PVCs expected.
       - hasDocuments:
-          count: 1
+          count: 2
+
+  - it: default agent renders its own gate-cache PVC
+    template: gate-cache-pvc.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-default-gate-cache
+      matchMany: false
+    asserts:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-foreman-default-gate-cache
+
+  - it: omitted-enabled agent inherits gateCache from defaults and renders its PVC
+    template: gate-cache-pvc.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-omitted-enabled-gate-cache
+      matchMany: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-omitted-enabled-gate-cache
 
   # ---- Per-agent field propagation ----
 
@@ -187,9 +215,31 @@ tests:
     values:
       - ./values-multi.yaml
     asserts:
-      # only 2 enabled agents out of 3 entries
+      # only 3 enabled agents out of 4 entries (default, llmkube-fork,
+      # omitted-enabled; disabled-agent is skipped)
       - hasDocuments:
-          count: 2
+          count: 3
+
+  # ---- omitted enabled field inherits from .Values.agent ----
+
+  - it: an agent entry that omits enabled still renders resources via the legacy default
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-omitted-enabled-agent
+      matchMany: false
+    asserts:
+      # The merged $agent.enabled inherits true from .Values.agent,
+      # so the entry renders. Its explicit replicaCount override also
+      # survives the merge.
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-omitted-enabled-agent
+      - equal:
+          path: spec.replicas
+          value: 5
 
   # ---- Singletons stay singleton ----
 

--- a/charts/foreman/tests/agents_test.yaml
+++ b/charts/foreman/tests/agents_test.yaml
@@ -1,0 +1,210 @@
+suite: agents map multi-fleet (#994)
+templates:
+  - agent-deployment.yaml
+  - agent-rbac.yaml
+  - gate-cache-pvc.yaml
+  - operator-deployment.yaml
+  - operator-rbac.yaml
+  - coder-rbac.yaml
+  - webhook.yaml
+
+tests:
+  # ---- Backward compat: legacy agent: block ----
+
+  - it: legacy agent renders exactly one deployment with the unsuffixed name
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-agent
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: legacy agent renders SA plus ClusterRole plus ClusterRoleBinding
+    template: agent-rbac.yaml
+    set:
+      agent.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-agent
+
+  - it: legacy agent renders exactly one gate-cache PVC with the unsuffixed name
+    template: gate-cache-pvc.yaml
+    set:
+      agent.enabled: true
+      agent.gateCache.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-gate-cache
+
+  # ---- Multi-fleet: agents: map ----
+
+  - it: one deployment is rendered per explicit agents entry
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-default-agent
+      matchMany: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-default-agent
+
+  - it: llmkube-fork agent gets its own suffixed deployment
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-llmkube-fork-agent
+
+  - it: SA plus ClusterRole plus ClusterRoleBinding per agent (six docs total)
+    template: agent-rbac.yaml
+    values:
+      - ./values-multi.yaml
+    asserts:
+      - hasDocuments:
+          count: 6
+
+  - it: gate-cache PVC per agent whose gateCache.enabled is true (default keeps, fork disables)
+    template: gate-cache-pvc.yaml
+    values:
+      - ./values-multi.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-default-gate-cache
+
+  # ---- Per-agent field propagation ----
+
+  - it: per-agent replicaCount plus roles flow through to args
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --roles=coder-fork
+
+  - it: per-agent gitRemoteURL and commit-author flow through to args
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --git-remote-url=https://github.com/joryirving/LLMKube
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --commit-author-name=Jory Dogfood
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --commit-author-email=jory-dogfood@example.com
+
+  - it: per-agent coderGitSecret overrides the chart-level coder.gitCredentialsSecret
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --coder-git-secret=foreman-fork-credentials
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --coder-git-secret-key=token
+
+  - it: per-agent githubToken secret flows through to env
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: foreman-agent-fork
+                key: GITHUB_TOKEN
+
+  - it: agent without per-agent githubToken does NOT render a GITHUB_TOKEN env
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-default-agent
+      matchMany: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITHUB_TOKEN
+
+  # ---- agent.enabled: false skips that agent ----
+
+  - it: agents entry with enabled false is omitted from the deployment list
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    asserts:
+      # only 2 enabled agents out of 3 entries
+      - hasDocuments:
+          count: 2
+
+  # ---- Singletons stay singleton ----
+
+  - it: operator Deployment renders once even with multiple agents
+    template: operator-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: coder SA plus Role plus RoleBinding render once even with multiple agents
+    template: coder-rbac.yaml
+    values:
+      - ./values-multi.yaml
+    asserts:
+      - hasDocuments:
+          count: 3

--- a/charts/foreman/tests/values-multi.yaml
+++ b/charts/foreman/tests/values-multi.yaml
@@ -1,0 +1,30 @@
+# Test fixture for agents_test.yaml — exercises the multi-fleet shape
+# documented in the issue #994 design. The default agent carries the
+# legacy gateCache settings (and gets the chart-level coder secret);
+# the llmkube-fork agent overrides gitRemoteURL, commit author, the
+# coder secret, and disables gateCache so its PVC is not rendered;
+# the disabled agent is a smoke-test for the enabled: false path.
+agents:
+  default:
+    enabled: true
+    replicaCount: 3
+    roles: [worker, coder, verifier]
+    gitRemoteURL: ""
+  llmkube-fork:
+    enabled: true
+    replicaCount: 1
+    roles: [coder-fork]
+    gitRemoteURL: https://github.com/joryirving/LLMKube
+    commitAuthorName: "Jory Dogfood"
+    commitAuthorEmail: "jory-dogfood@example.com"
+    githubToken:
+      secretName: foreman-agent-fork
+      secretKey: GITHUB_TOKEN
+    coderGitSecret: foreman-fork-credentials
+    coderGitSecretKey: token
+    gateCache:
+      enabled: false
+  disabled-agent:
+    enabled: false
+    replicaCount: 1
+    roles: [worker]

--- a/charts/foreman/tests/values-multi.yaml
+++ b/charts/foreman/tests/values-multi.yaml
@@ -3,7 +3,11 @@
 # legacy gateCache settings (and gets the chart-level coder secret);
 # the llmkube-fork agent overrides gitRemoteURL, commit author, the
 # coder secret, and disables gateCache so its PVC is not rendered;
-# the disabled agent is a smoke-test for the enabled: false path.
+# the omitted-enabled agent omits the `enabled` field entirely to
+# regression-test that the gate evaluates the merged $agent.enabled
+# (not the raw $cfg.enabled) — otherwise the entry would silently
+# render nothing (#994 review feedback); the disabled agent is a
+# smoke-test for the enabled: false path.
 agents:
   default:
     enabled: true
@@ -24,6 +28,9 @@ agents:
     coderGitSecretKey: token
     gateCache:
       enabled: false
+  omitted-enabled:
+    replicaCount: 5
+    roles: [worker]
   disabled-agent:
     enabled: false
     replicaCount: 1

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -328,6 +328,51 @@ agent:
   podLabels: {}
   env: []
 
+  # Per-agent override of the chart-level coder.gitCredentialsSecret
+  # passed through as --coder-git-secret. Empty falls back to
+  # .Values.coder.gitCredentialsSecret so existing installs that only
+  # set the chart-level value are unchanged. (#994)
+  coderGitSecret: ""
+  coderGitSecretKey: ""
+
+# agents is the multi-fleet map (#994). Leave it UNSET for a single
+# agent (the legacy `agent:` block above is used as-is and renders
+# exactly the resources it always has, so an existing install is
+# unchanged on upgrade). Set it to render one Deployment +
+# ServiceAccount + ClusterRole/ClusterRoleBinding + gate-cache PVC PER
+# entry, each suffixed with the agent key, so multiple heterogeneous
+# agent fleets coexist in one release instead of needing a second
+# chart install (which would collide on the chart's singletons).
+#
+# Real-world use cases:
+#
+#   agents:
+#     default:                  # the primary multi-repo worker/coder pool
+#       replicaCount: 3
+#       roles: [worker, coder, verifier]
+#     llmkube-fork:             # a fork-pinned dogfood agent for upstream PRs
+#       replicaCount: 1
+#       roles: [coder-fork]
+#       gitRemoteURL: https://github.com/<you>/LLMKube
+#       githubToken: { secretName: foreman-agent-fork, secretKey: GITHUB_TOKEN }
+#       commitAuthorName: "<you>"
+#       commitAuthorEmail: "<you>@users.noreply.github.com"
+#       coderGitSecret: foreman-fork-credentials     # per-agent coder PAT
+#       gateCache: { enabled: false }                  # fork agents don't gate
+#
+# Each entry's fields DEEP-MERGE with the legacy `agent:` block above
+# (which serves as the defaults) so you only have to specify what
+# differs. Naming convention: per-agent resources are
+# `<fullname>-<agentKey>-agent` (Deployment / SA / ClusterRole /
+# ClusterRoleBinding) and `<fullname>-<agentKey>-gate-cache` (PVC), so
+# agents never collide. The shared components — operator Deployment,
+# webhook, CRDs, coder SA/Role/RoleBinding — remain single per release.
+#
+# Setting `agents:` opts you OUT of the implicit legacy agent: render
+# path; if you need a "default" fleet alongside custom ones, list it
+# explicitly under `agents:` with the name `default` (or any other key).
+agents: {}
+
 # coder gates the ServiceAccount + namespaced Role the Job-mode coder
 # pods run under (#620). A Job-mode Agent (spec.execution.mode=Job) runs
 # `foreman-agent run-task` in an ephemeral Job whose pod uses this SA.


### PR DESCRIPTION
## What

Model the foreman chart's agents as a map (`agents: <key>: {...}`) that renders one Deployment + ServiceAccount + ClusterRole + ClusterRoleBinding + gate-cache PVC per entry, suffixed with the agent key. Operator / webhook / CRDs / coder RBAC stay singleton, so multiple heterogeneous agent fleets coexist in one chart release instead of needing a second release (which would collide on the chart's cluster-scoped singletons).

## Why

Running a second differently-configured agent today means a second `HelmRelease` of the same chart, which fights the primary release for ownership of the CRDs, the webhook, the operator, and the fixed-name coder SA. The companion CRD-toggle (#998) made that workaround *work*; this issue makes it *unnecessary* by collapsing "another `agent` with different values" into the same chart, one release. Concrete use cases in the issue: a fork-pinned dogfood agent with its own PAT/role/commit-identity, per-language or per-model coder pools, GPU vs remote-model pools with distinct nodeLabels.

Fixes #994

## How

- **Backward compatibility:** the legacy `agent:` block continues to render the exact resources it always has (Deployment / SA / ClusterRole / ClusterRoleBinding / PVC), with the exact same names (`<fullname>-agent`, `<fullname>-gate-cache`). Leaving `agents` unset keeps an in-place upgrade a no-op. The `foreman.agents` helper wraps the legacy block under a sentinel key (`_implicit_`) so a single template path renders both shapes; legacy users must not pass that key explicitly.
- **Deep-merge defaults:** each `agents.<name>` entry deep-merges over `.Values.agent` via `mustMergeOverwrite`, so users opting into the map only restate what differs from the legacy defaults (`replicaCount`, `image`, `roles`, `nodeLabels`, `nodeSelector`/`affinity`/`tolerations`, `resources`, `gitRemoteURL`, `githubToken`, `commitAuthor*`, `gateCache`, and a per-agent coder-git-secret pass-through via new `agents.<name>.coderGitSecret` / `coderGitSecretKey` fields that fall back to chart-level `coder.gitCredentialsSecret`).
- **Per-agent naming:** explicit entries render as `<fullname>-<agentKey>-agent` (Deployment / SA / ClusterRole / ClusterRoleBinding) and `<fullname>-<agentKey>-gate-cache` (PVC), truncated to 63 chars, so two fleets never collide.
- **Singletons stay singleton:** the operator Deployment, webhook Service / Secret / ValidatingWebhookConfiguration, all six foreman CRDs, and the coder SA / Role / RoleBinding still render once per release regardless of how many agents are listed.
- **`enabled: false` skip:** an `agents.<name>.enabled: false` entry (or omitting `agents` entirely) drops that agent's resources cleanly without affecting the others.
- **Tests:** added `charts/foreman/tests/agents_test.yaml` with 15 helm-unittest cases covering the legacy single-agent shape, multi-agent rendering, per-agent field propagation (`gitRemoteURL`, `commit-author`, `coder-git-secret`, `githubToken`), the `enabled: false` skip, and the singleton invariants. The foreman-chart CI job in `.github/workflows/helm-chart.yml` now installs the plugin and runs the suite; both `charts/llmkube/tests/*` and `charts/foreman/tests/*` are covered.

Verified locally: `helm lint charts/foreman` clean, `helm template` renders 21 resources at default (unchanged from before the patch) and 26 with the multi-agent fixture, `helm unittest charts/foreman` 15/15 pass, `kubeconform` 0 invalid on both renders, `make fmt/vet/lint/test/lint-all` all clean.

Assisted-by: LLM (Minimax-M3 via opencode, generated the chart template refactor, helm-unittest suite, and CI step; I designed the backward-compat path, verified every render, ran the gate locally, and own the review conversation).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)