### PR TITLE
fix(controller): drop invalid --enable-metrics flag from vLLM runtime

### DIFF
--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -3662,11 +3662,12 @@ var _ = Describe("RuntimeBackend interface", func() {
 			Expect(args).NotTo(ContainElement("--model"))
 			Expect(args).To(ContainElements("--host", "::"))
 			Expect(args).To(ContainElements("--port", "8000"))
-			// --enable-metrics is always set so vLLM pods expose /metrics for
-			// PodMonitor scraping (#409).
-			Expect(args).To(ContainElement("--enable-metrics"))
-			// Six elements: <model> --host :: --port 8000 --enable-metrics.
-			Expect(args).To(HaveLen(6))
+			// vLLM has no --enable-metrics flag; it always exposes /metrics.
+			// Emitting the flag makes vLLM reject the command and the pod never
+			// starts (#1030), so it must never appear.
+			Expect(args).NotTo(ContainElement("--enable-metrics"))
+			// Five elements: <model> --host :: --port 8000.
+			Expect(args).To(HaveLen(5))
 		})
 
 		It("should append extraArgs after typed flags", func() {

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -73,8 +73,11 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 		// which are appended last so the user flag wins.
 		"--host", "::",
 		"--port", fmt.Sprintf("%d", port),
-		"--enable-metrics",
 	}
+	// NOTE: vLLM has no --enable-metrics flag. Its OpenAI server always exposes
+	// Prometheus metrics at /metrics, so there is nothing to enable; passing the
+	// flag makes vLLM's argument parser reject the whole command and the pod
+	// never starts (#1030). The PodMonitor scrapes /metrics unconditionally.
 
 	var err error
 


### PR DESCRIPTION
## What

Remove the `--enable-metrics` flag from the vLLM runtime's generated server arguments, and flip the unit test to assert the flag is absent.

## Why

`--enable-metrics` is not a valid vLLM flag. vLLM's OpenAI server always exposes Prometheus metrics at `/metrics`, so there is nothing to enable. Passing the flag makes vLLM's argument parser reject the whole command, so **every** vLLM `InferenceService` pod crashes on startup:

```
vllm: error: unrecognized arguments: --enable-metrics
```

Reported in #1030 (thanks @kaechele) against v0.9.2 on K3s/A10. The flag was introduced in #769 on the assumption vLLM had a llama.cpp-style metrics toggle; it does not. The existing unit test asserted the bad flag was *present*, so the suite stayed green while the runtime was broken end to end (a "test asserts implementation, not behavior" case, cf. #378).

## How

- `internal/controller/runtime_vllm.go`: drop the `--enable-metrics` element from `BuildArgs`; add a NOTE explaining why the flag must not come back. Metrics are unaffected: the PodMonitor already scrapes `/metrics`, which vLLM serves by default.
- `internal/controller/inferenceservice_deployment_test.go`: replace the `ContainElement("--enable-metrics")` assertion with `NotTo(ContainElement("--enable-metrics"))` and update the arg count (`HaveLen(6)` -> `HaveLen(5)`), so the regression cannot silently return.

## Testing

- `go build ./...` clean.
- `go test ./internal/controller/ -run TestControllers` focused on the vLLM `BuildArgs` specs: `Ran 1 of 522 Specs, 1 Passed`.

## Checklist

- [x] Root cause identified and fixed at the source (not the symptom)
- [x] Unit test updated to guard against regression
- [x] No change to metrics behavior (`/metrics` still exposed and scraped)
- [x] DCO sign-off

Fixes #1030

---

Assisted-by: Claude Code (Opus 4.8); reviewed and verified by the author.
