### PR TITLE
ci(foreman-e2e): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/foreman-e2e.yml
+++ b/.github/workflows/foreman-e2e.yml
@@ -47,20 +47,20 @@ jobs:
       TASK_NS: foreman-e2e
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5.0.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.13.0
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: foreman-e2e
 


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

Pin the four actions in `.github/workflows/foreman-e2e.yml` — `checkout`,
`setup-go`, `setup-helm`, and `kind-action` — to their commit SHAs, each
with the resolved version in a trailing comment.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

The foreman-e2e workflow referenced actions by mutable tag (`@v7`, `@v6`, etc.), leaving it exposed to a compromised or force-moved tag. The repo's other workflows (`security.yml`, `test.yml`, `helm-chart.yml`) already pin by SHA; this brings foreman-e2e in line with that convention.

## How

<!-- How was this implemented? Any design decisions worth noting? -->

Resolved each tag to its commit SHA and verified against the GitHub API:

| Action | Pin |
| --- | --- |
| `actions/checkout` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` # v7.0.0 |
| `actions/setup-go` | `924ae3a1cded613372ab5595356fb5720e22ba16` # v6.5.0 |
| `azure/setup-helm` | `9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310` # v5.0.1 |
| `helm/kind-action` | `ef37e7f390d99f746eb8b610417061a60e82a6cc` # v1.14.0 |

## Checklist

- [ ] Tests added/updated
- [ ] `make test` passes locally
- [ ] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)
