### PR TITLE
fix(release): publish a cross-platform Homebrew formula, not a macOS-only cask

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,6 +67,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
+      - name: Publish Homebrew formula
+        # GoReleaser no longer manages the tap (its cask replacement is
+        # macOS-only). Publish a cross-platform binary formula from the
+        # release checksums so `brew install defilantech/tap/llmkube` works on
+        # macOS and Linux and tracks every release (#1039 / #1040).
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ needs.release-please.outputs.version }}
+        run: ./hack/publish-homebrew-formula.sh "$VERSION" dist/checksums.txt
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -365,31 +365,11 @@ release:
 
     **Full Changelog**: [CHANGELOG.md](https://github.com/defilantech/LLMKube/blob/main/CHANGELOG.md)
 
-# Homebrew tap. brews/formulas were deprecated in GoReleaser v2.16 in favor
-# of homebrew_casks, which uses cask stanzas (binaries) rather than the
-# formula install/test DSL.
-homebrew_casks:
-  - name: llmkube
-    # Only include the CLI archive (not Metal agent)
-    ids:
-      - llmkube-cli
-    binaries:
-      - llmkube
-    repository:
-      owner: defilantech
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Casks
-    description: "GPU-accelerated Kubernetes operator for local LLM inference"
-    homepage: "https://github.com/defilantech/LLMKube"
-    # The released CLI binary is not notarized; strip the quarantine xattr so
-    # Gatekeeper does not block it on first run.
-    hooks:
-      post:
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/llmkube"]
-          end
+# Homebrew tap: NOT configured here. GoReleaser removed `brews` (formulae) in
+# v2.16 and its only replacement, `homebrew_casks`, produces macOS-only casks,
+# which drops Linux Homebrew for a cross-platform CLI (see #1039 / #1040). The
+# release workflow instead runs hack/publish-homebrew-formula.sh to publish a
+# cross-platform binary formula from dist/checksums.txt.
 
 # Metadata
 metadata:

--- a/hack/publish-homebrew-formula.sh
+++ b/hack/publish-homebrew-formula.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Render Formula/llmkube.rb from the release checksums and publish it to the
+# Homebrew tap.
+#
+# Why a hand-maintained formula: GoReleaser removed the `brews` option in v2.16
+# (formulae are meant to build from source, so it steers binary distribution to
+# `homebrew_casks`). But casks are macOS-only, which drops Linux Homebrew for a
+# cross-platform CLI. A binary-download formula selects the right prebuilt
+# archive per OS/arch and works on macOS AND Linux from one artifact and one
+# `brew install defilantech/tap/llmkube`. See defilantech/LLMKube#1039 / #1040.
+#
+# Usage: publish-homebrew-formula.sh <version> [checksums-file]
+#   DRY_RUN=1 prints the rendered formula and exits (no clone, no push).
+set -euo pipefail
+
+VERSION="${1:?usage: publish-homebrew-formula.sh <version> [checksums-file]}"
+CHECKSUMS="${2:-dist/checksums.txt}"
+TAP_SLUG="defilantech/homebrew-tap"
+
+# sha_for prints the sha256 of the CLI archive for the given os_arch, reading
+# GoReleaser's "<sha256>  <filename>" checksums file.
+sha_for() {
+  local arch="$1" line
+  line=$(grep -E "[[:space:]]LLMKube_${VERSION}_${arch}\.tar\.gz\$" "$CHECKSUMS" || true)
+  [ -n "$line" ] || { echo "no checksum for LLMKube_${VERSION}_${arch}.tar.gz in $CHECKSUMS" >&2; exit 1; }
+  echo "${line%% *}"
+}
+
+DARWIN_ARM=$(sha_for darwin_arm64)
+DARWIN_AMD=$(sha_for darwin_amd64)
+LINUX_ARM=$(sha_for linux_arm64)
+LINUX_AMD=$(sha_for linux_amd64)
+
+render() {
+  cat <<EOF
+class Llmkube < Formula
+  desc "GPU-accelerated Kubernetes operator for local LLM inference"
+  homepage "https://github.com/defilantech/LLMKube"
+  version "${VERSION}"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/defilantech/LLMKube/releases/download/v${VERSION}/LLMKube_${VERSION}_darwin_arm64.tar.gz"
+      sha256 "${DARWIN_ARM}"
+    end
+    on_intel do
+      url "https://github.com/defilantech/LLMKube/releases/download/v${VERSION}/LLMKube_${VERSION}_darwin_amd64.tar.gz"
+      sha256 "${DARWIN_AMD}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/defilantech/LLMKube/releases/download/v${VERSION}/LLMKube_${VERSION}_linux_arm64.tar.gz"
+      sha256 "${LINUX_ARM}"
+    end
+    on_intel do
+      url "https://github.com/defilantech/LLMKube/releases/download/v${VERSION}/LLMKube_${VERSION}_linux_amd64.tar.gz"
+      sha256 "${LINUX_AMD}"
+    end
+  end
+
+  def install
+    bin.install "llmkube"
+  end
+
+  test do
+    assert_match "llmkube", shell_output("#{bin}/llmkube version 2>&1")
+  end
+end
+EOF
+}
+
+if [ "${DRY_RUN:-}" = "1" ]; then
+  render
+  exit 0
+fi
+
+: "${HOMEBREW_TAP_TOKEN:?HOMEBREW_TAP_TOKEN is required to push the tap}"
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+git clone --depth 1 "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${TAP_SLUG}.git" "$workdir/tap"
+
+mkdir -p "$workdir/tap/Formula"
+render >"$workdir/tap/Formula/llmkube.rb"
+# Retire the macOS-only cask; the cross-platform formula supersedes it.
+git -C "$workdir/tap" rm -f --ignore-unmatch Casks/llmkube.rb
+git -C "$workdir/tap" add Formula/llmkube.rb
+
+if git -C "$workdir/tap" diff --cached --quiet; then
+  echo "llmkube formula already at v${VERSION}; nothing to publish"
+  exit 0
+fi
+
+git -C "$workdir/tap" \
+  -c user.name="github-actions[bot]" \
+  -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+  commit -m "Update llmkube to v${VERSION} (cross-platform formula)"
+git -C "$workdir/tap" push
+echo "published llmkube formula v${VERSION} to ${TAP_SLUG}"


### PR DESCRIPTION
## What

Replace the macOS-only Homebrew **cask** with a cross-platform **formula**, published from the release workflow.

- Drop the `homebrew_casks` block from `.goreleaser.yaml`.
- Add `hack/publish-homebrew-formula.sh`: renders a binary-download formula (`on_macos`/`on_linux` + `on_arm`/`on_intel`, `bin.install "llmkube"`) from `dist/checksums.txt` and pushes it to `defilantech/homebrew-tap`, retiring `Casks/llmkube.rb`.
- Wire a "Publish Homebrew formula" step into `release-please.yml` after GoReleaser (it has `dist/`, the version output, and `HOMEBREW_TAP_TOKEN`).

## Why

GoReleaser removed `brews` (formulae) in v2.16 — it steers binary distribution to `homebrew_casks`. But **casks are macOS-only**, so when our release crossed v2.16 two things broke:

1. **Linux Homebrew** lost any install path (the old formula was cross-platform). — #1040
2. On macOS, the new cask and the leftover formula shared a name, and Homebrew resolves the bare name to the **formula**, so users were stranded at the last-published formula version, **0.8.19**. — #1039 (already mitigated by removing the orphan formula; this makes the fix durable and correct)

A cask is the wrong artifact for a cross-platform CLI. A binary-download formula selects the right prebuilt archive per OS/arch, works on macOS **and** Linux from one artifact and one `brew install defilantech/tap/llmkube`, and tracks every release.

## How

Third-party taps ship binary-download formulae routinely; `brew audit`'s build-from-source rule only applies to homebrew-core submissions, not our own tap. GoReleaser won't generate one anymore, so we render it ourselves from the checksums it already produces. The publish step gates on the same `release_created` condition as GoReleaser and passes the version via `env:` (not string-interpolated into `run:`).

## Testing

- Rendered the 0.9.3 formula and verified it in an isolated tap: **`brew style` clean, `brew audit` clean, `brew fetch` confirms the URL + sha256**.
- `DRY_RUN=1 hack/publish-homebrew-formula.sh 0.9.3 <checksums>` is **byte-identical** to that verified formula, and correctly ignores the metal-agent archive.
- `shellcheck` (script), `actionlint` (workflow), and `goreleaser check` (config) all clean.

## Checklist

- [x] Script + workflow + config validated (shellcheck / actionlint / goreleaser check)
- [x] Rendered formula passes brew style/audit/fetch
- [x] Cross-platform (macOS + Linux); one `brew install` command
- [x] No untrusted input interpolated into `run:`
- [x] DCO sign-off

Fixes #1040
Related: #1039

---

Assisted-by: Claude Code (Opus 4.8); reviewed and verified by the author.
