### PR TITLE
feat(foreman): ship default integrate/reconcile Agents for sliced workloads

### DIFF
--- a/config/foreman/agents/integrate.yaml
+++ b/config/foreman/agents/integrate.yaml
@@ -1,0 +1,38 @@
+# Foreman integrate Agent: the integrate step of a Sliced Workload (#1033).
+# Deterministic (no inferenceServiceRef, no LLM in the loop); the executor's
+# executeDeterministic() branch dispatches its single tool, run_integrate,
+# with the task payload as JSON arguments. run_integrate unions the disjoint
+# slice branches onto the current base and pushes the integration branch.
+#
+# Apply into the namespace where sliced Workloads run:
+#
+#   kubectl apply -f config/foreman/agents/integrate.yaml
+#
+# Like config/foreman/agents/gate.yaml, this ships with the foreman chart but
+# is NOT a chart template; the chart installs the controller, the Agent CR is
+# workload-data. Apply once per cluster + namespace.
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: integrate
+  namespace: default
+  labels:
+    app.kubernetes.io/part-of: foreman
+    foreman.llmkube.dev/role: verifier
+spec:
+  role: verifier
+  # Deterministic: inferenceServiceRef and systemPrompt are omitted (there is
+  # no model to prompt); the empty .name routes through executeDeterministic().
+  tools:
+    - run_integrate
+  requiredCapability:
+    # run_integrate does a LOCAL git clone/union in the agent workspace, so it
+    # must schedule onto a node whose foreman-agent has --git-remote-url set
+    # (the coder-capable nodes), not the verifier node that runs remote Jobs.
+    # Adjust to match your fleet's FleetNode roles.
+    roles:
+      - coder
+  # Bounds run_integrate's own retry on transient git/apiserver errors.
+  maxRetries: 3
+  # The union + fetch/push are quick; bound the whole step.
+  requestTimeoutSeconds: 900

--- a/config/foreman/agents/reconcile.yaml
+++ b/config/foreman/agents/reconcile.yaml
@@ -1,0 +1,38 @@
+# Foreman reconcile Agent: the reconcile step of a Sliced Workload (#1033).
+# Deterministic (no inferenceServiceRef, no LLM in the loop); the executor's
+# executeDeterministic() branch dispatches its single tool, run_reconcile,
+# with the task payload as JSON arguments. run_reconcile checks the integrated
+# union against the plan's pinned shared identifiers for cross-slice drift.
+#
+# Apply into the namespace where sliced Workloads run:
+#
+#   kubectl apply -f config/foreman/agents/reconcile.yaml
+#
+# Like config/foreman/agents/gate.yaml, this ships with the foreman chart but
+# is NOT a chart template; the chart installs the controller, the Agent CR is
+# workload-data. Apply once per cluster + namespace.
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: reconcile
+  namespace: default
+  labels:
+    app.kubernetes.io/part-of: foreman
+    foreman.llmkube.dev/role: verifier
+spec:
+  role: verifier
+  # Deterministic: inferenceServiceRef and systemPrompt are omitted (there is
+  # no model to prompt); the empty .name routes through executeDeterministic().
+  tools:
+    - run_reconcile
+  requiredCapability:
+    # run_reconcile does a LOCAL git checkout + file read in the agent workspace, so it
+    # must schedule onto a node whose foreman-agent has --git-remote-url set
+    # (the coder-capable nodes), not the verifier node that runs remote Jobs.
+    # Adjust to match your fleet's FleetNode roles.
+    roles:
+      - coder
+  # Bounds run_reconcile's own retry on transient git/apiserver errors.
+  maxRetries: 3
+  # The fetch + pinned check are quick; bound the whole step.
+  requestTimeoutSeconds: 900


### PR DESCRIPTION
## What

Add default `integrate` and `reconcile` Agent manifests under `config/foreman/agents/`, so a Sliced Workload (#1033) runs out of the box.

## Why

The sliced pipeline dispatches an `integrate` step (`run_integrate` tool) and a `reconcile` step (`run_reconcile` tool). Both are deterministic Agents (no `inferenceServiceRef`, tool-only), but none were shipped, so a rendered sliced Workload failed at those steps with "agent not found." Every other pipeline role already has a checked-in reference manifest here (`gate.yaml`, coders, reviewers); these two were the gap.

## How

Mirror `config/foreman/agents/gate.yaml`:
- `role: verifier`, deterministic (no `inferenceServiceRef`/`systemPrompt`),
- `tools: [run_integrate]` / `[run_reconcile]`,
- `requiredCapability.roles: [coder]` — unlike the gate (remote Job on a verifier node), integrate/reconcile do a **local** git clone/union/read in the agent workspace, so they must land on a node whose foreman-agent has `--git-remote-url` set. Operators adjust to match their fleet's FleetNode roles.

Per `gate.yaml`'s own convention, these are checked-in workload-data applied with `kubectl apply -f`, not chart templates (the chart installs the controller). Chart-templating default agents is noted as a follow-up in #1051.

## Testing

Both parse as valid `Agent` CRs (kind/role/tools present). Not covered by a codegen or sync check (`sync-reviewer-prompts` only touches `*-reviewer.yaml`).

## Checklist

- [x] Deterministic Agent shape mirrors gate.yaml
- [x] Routing note for local-git scheduling
- [x] DCO sign-off

Fixes #1051

---

Assisted-by: Claude Code (Opus 4.8); reviewed and verified by the author.
