### PR TITLE
fix(slicer): give the union commit an explicit git identity

### DIFF
--- a/pkg/foreman/slicer/integrate.go
+++ b/pkg/foreman/slicer/integrate.go
@@ -154,9 +154,16 @@ func Integrate(ctx context.Context, opts IntegrateOptions) (*IntegrateResult, er
 		}
 	}
 
-	// 4. Commit the union.
+	// 4. Commit the union. Pass the foreman bot identity explicitly via -c:
+	// the integrate agent runs in a pod whose clone has no user.name/
+	// user.email in any git config scope, where a bare `git commit` dies with
+	// "Author identity unknown" (exit 128). This mirrors repo/branch.go, which
+	// sets the same identity for the coder's commits.
 	msg := "integrate: union of " + strings.Join(opts.Slices, " ")
-	if out, err := run(ctx, opts.RepoDir, "commit", "-m", msg); err != nil {
+	if out, err := run(ctx, opts.RepoDir,
+		"-c", "user.name=foreman",
+		"-c", "user.email=foreman@llmkube.dev",
+		"commit", "-m", msg); err != nil {
 		return nil, fmt.Errorf("integrate: commit union: %w: %s", err, strings.TrimSpace(out))
 	}
 

--- a/pkg/foreman/slicer/integrate_test.go
+++ b/pkg/foreman/slicer/integrate_test.go
@@ -157,3 +157,41 @@ func TestIntegrate_MissingOptions(t *testing.T) {
 		t.Fatal("want error for missing RepoDir")
 	}
 }
+
+// TestIntegrate_NoAmbientGitIdentity reproduces the in-cluster foreman-agent
+// pod, where git has no user.name/user.email in any config scope. The slice
+// branches were committed by the coder (with an identity), but the pod that
+// runs Integrate has none, so the union commit must supply its own or it dies
+// with "Author identity unknown" (exit 128). The package's own fixture masks
+// this because initRepo sets a LOCAL identity; here we neutralize global and
+// system config and strip the local identity before the union commit.
+func TestIntegrate_NoAmbientGitIdentity(t *testing.T) {
+	// Point git's global/system config at nonexistent files so no ambient
+	// identity from the dev's ~/.gitconfig can leak in and hide the bug.
+	// t.Setenv makes these process-wide for the test and restores after.
+	empty := t.TempDir()
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(empty, "no-global"))
+	t.Setenv("GIT_CONFIG_SYSTEM", filepath.Join(empty, "no-system"))
+
+	dir := initRepo(t)
+	sliceBranch(t, dir, "slice-a", map[string]string{"a/new.txt": "AAA\n"})
+	// Drop the local identity: now the repo has NO identity from any scope,
+	// exactly like the integrate pod's fresh clone.
+	git(t, dir, "config", "--unset", "user.email")
+	git(t, dir, "config", "--unset", "user.name")
+
+	res, err := Integrate(context.Background(), IntegrateOptions{
+		RepoDir: dir, Base: "main", Branch: "integ", Slices: []string{"slice-a"},
+	})
+	if err != nil {
+		t.Fatalf("integrate without ambient git identity: %v", err)
+	}
+	// The union commit landed, authored by the foreman bot identity.
+	got := strings.TrimSpace(git(t, dir, "log", "-1", "--format=%an <%ae>", "integ"))
+	if !strings.Contains(got, "foreman@llmkube.dev") {
+		t.Fatalf("union commit author = %q, want the foreman bot identity", got)
+	}
+	if res.Branch != "integ" {
+		t.Fatalf("branch = %q, want integ", res.Branch)
+	}
+}


### PR DESCRIPTION
## What

Give the slicer's union commit an explicit git author identity, so `integrate` succeeds in a pod that has no `user.name`/`user.email` configured.

## Why

Fixes #1056. On the first end-to-end lab run where every slice reached GO, `integrate` ran on the in-cluster foreman-agent pod and died at the union commit:

```
integrate: commit union: exit status 128: Author identity unknown
fatal: unable to auto-detect email address (got 'unknown@foreman-agent-<hash>.(none)')
```

`integrate.go` committed the union with a bare `git commit`, relying on ambient git identity the pod's clone does not have. That surfaced as `GATE-ERROR`, cascade-failing `reconcile` even though all slices were green. The coder's own commits avoid this because `repo/branch.go` already sets `GIT_COMMITTER_NAME=foreman` / `GIT_COMMITTER_EMAIL=foreman@llmkube.dev`; the slicer integrate path never got the same treatment. The package's unit tests missed it because the fixture (`initRepo`) configures a local identity, masking the production condition.

## How

- `integrate.go`: pass `git -c user.name=foreman -c user.email=foreman@llmkube.dev commit -m <msg>`, matching the foreman bot identity used for the coder's commits.
- Add `TestIntegrate_NoAmbientGitIdentity`: neutralizes global/system git config, strips the fixture's local identity, runs `Integrate`, and asserts the union commit lands under the foreman bot identity. Fails before the fix (wrong author on a dev box, or the exit-128 error in CI/pod), passes after.

## Testing

- `go test ./pkg/foreman/slicer/` — all pass, including the new regression test.
- `go build ./...`, `go vet ./pkg/foreman/slicer/`, `golangci-lint run ./pkg/foreman/slicer/...` — clean.
- Validated end-to-end in the lab: with the pod given a git identity as a temporary workaround, the same sliced Workload drives `integrate` past the union commit (this PR removes the need for that workaround).

## Checklist

- [x] Tests added/updated
- [x] `go build ./...` passes
- [x] Lint passes
- [x] Commit is DCO signed-off

Assisted-by: Claude (Anthropic) — analysis, regression test, and patch; reviewed by the maintainer.
