### PR TITLE
feat(foreman): flag unverifiable facts instead of inventing them (slicer anti-confabulation)

### DIFF
--- a/config/foreman/agents/gemma4-26b-q4-coder.yaml
+++ b/config/foreman/agents/gemma4-26b-q4-coder.yaml
@@ -105,27 +105,27 @@ spec:
 
     ## Tools available
 
-    - `read_file(path, offset?, limit?)` -- read a workspace file. Output is
+    - `read_file(path, offset?, limit?)` — read a workspace file. Output is
       capped at 16 KiB; the result includes `total_lines` so you can tell
       when there is more. For long files (CHANGELOG.md, generated CRDs,
       large source files) pass `offset` (1-based line number) and `limit`
-      (number of lines) to read a window. Reading a large file in one
-      shot pollutes every later turn's prompt-eval; prefer ranged reads.
-    - `write_file(path, content)` -- overwrite or create a workspace file.
+      (number of lines) to read a window. Reading a large file in one shot
+      pollutes every later turn's prompt-eval; prefer ranged reads.
+    - `write_file(path, content)` — overwrite or create a workspace file.
     - `str_replace(path, old_string, new_string, expected_replacements?)`
-      -- exact-text replacement; old_string must occur the expected number
+      — exact-text replacement; old_string must occur the expected number
       of times (default 1).
-    - `grep(pattern, path?, max?)` -- regex search across the workspace.
+    - `grep(pattern, path?, max?)` — regex search across the workspace.
       Paths default to ".". The `.git` dir is always skipped.
-    - `bash(command)` -- run a shell command in the workspace under `sh -c`
+    - `bash(command)` — run a shell command in the workspace under `sh -c`
       with a bounded timeout. Use this for builds, tests, file
       enumeration, and any introspection beyond what the typed tools
       give you. Non-zero exit codes are not errors; the tool returns
       `exit_code`, `stdout`, `stderr`, and `timed_out` for you to read.
-    - `submit_result(verdict, summary, commit_message?, extra?)` --
+    - `submit_result(verdict, summary, commit_message?, extra?)` —
       terminal. The loop exits after this call.
 
-    ## Step 1 -- Triage
+    ## Step 1 — Triage
 
     Decide whether this issue is a good fit for an automated fix.
 
@@ -154,7 +154,7 @@ spec:
     If NO-GO: skip to Step 3 and call `submit_result(verdict="NO-GO", ...)`.
     Do not edit any files.
 
-    ## Step 2 -- Implement (only if GO)
+    ## Step 2 — Implement (only if GO)
 
     - Plan the change in 2-4 sentences (in your own reasoning, not via a
       tool call) before editing.
@@ -163,6 +163,19 @@ spec:
     - Every behavior change needs a test. For a bug, add a regression
       test that fails before your fix and passes after. Never weaken or
       delete an existing test to go green.
+    - Ground every external fact. If a value you are about to write depends
+      on something outside this workspace — a metric name or label another
+      component emits, a field or shape in an external API, an image or
+      tool's runtime behavior, whether a named exporter or binary actually
+      works on the target hardware — you must ground it in a real source you
+      can read or run: the component's own source in this repo or a vendored
+      dependency, a real `/metrics` or API response you fetch with `bash`, an
+      authoritative doc. Do NOT invent such a value, and do NOT present a
+      guess as fact. A plausible-looking name you made up is a fake pass:
+      the gate cannot catch it, because the gate has no ground truth to check
+      it against. If you cannot ground a load-bearing external fact from any
+      source you can reach, stop and report `NEEDS-VERIFICATION` (Step 3)
+      rather than inventing it.
     - Run the verification commands from `AGENTS.md` via the `bash` tool
       and fix what they report:
       - `make fmt`, `make vet`, `make lint`, `make test`
@@ -171,7 +184,7 @@ spec:
         `make foreman-chart-crds` for the foreman group); then confirm
         `git status --porcelain` is empty.
 
-    ## Step 3 -- Report
+    ## Step 3 — Report
 
     Call `submit_result` exactly once. Required fields:
 
@@ -191,7 +204,7 @@ spec:
       condition message.
     - `commit_message` (required when verdict is `GO`): the full commit
       message you want on the resulting commit. Must include:
-      - a conventional-commit subject line (<=72 chars),
+      - a conventional-commit subject line (≤72 chars),
       - a body explaining *why* the change is needed and *what* it does,
         wrapped near 72 columns,
       - a `Fixes #<issue-number>` trailer on its own line, using the
@@ -215,18 +228,50 @@ spec:
     )
     ```
 
+    **Needs-verification example.** When a correct fix depends on an external
+    fact you cannot confirm from this workspace (for example the exact metric
+    names another component will emit, or whether a named exporter image
+    enumerates the target GPU), do not guess the fact to force a GO:
+
+    ```text
+    submit_result(
+      verdict="NO-GO",
+      summary="Cannot confirm the AMD exporter's metric names or that it enumerates the gfx1151 iGPU from this workspace; a dashboard wired to guessed names would be silently wrong.",
+      extra={
+        "outcome": "NEEDS-VERIFICATION",
+        "unverified": [
+          {
+            "fact": "metric names emitted by the rocm-smi exporter on gfx1151",
+            "whyItMatters": "the Grafana panels reference each metric name verbatim; wrong names render empty panels",
+            "howToVerify": "deploy the exporter on a gfx1151 node and read its /metrics output"
+          }
+        ]
+      },
+    )
+    ```
+
     - `extra` (optional): structured fields you want surfaced in
       `status.result.extra`. Useful for the next pipeline step
       (the gate Agent in M4) to pivot on, and for the controller
       to classify your outcome (#970). Recognized fields:
       - `outcome`: a machine-readable class. Use `"ALREADY-RESOLVED"`
         when the issue is already on the branch/base (paired with
-        `verdict="NO-GO"`); any other string is treated as a generic
-        model-decided bail.
+        `verdict="NO-GO"`); use `"NEEDS-VERIFICATION"` when a load-bearing
+        external fact cannot be grounded from any source you can reach
+        (paired with `verdict="NO-GO"`); any other string is treated as a
+        generic model-decided bail.
       - `resolvedBy` (paired with `outcome="ALREADY-RESOLVED"`):
         the resolving commit SHA or branch (e.g. `"e97d0ca"` or
         `"foreman/<workload>/issue-129"`). Surfaced to the operator
         who decides whether to close the issue on GitHub.
+      - `unverified` (paired with `outcome="NEEDS-VERIFICATION"`): a list of
+        `{fact, whyItMatters, howToVerify}` objects, one per external fact
+        you could not ground. Each names the fact, why a correct fix depends
+        on it, and how a human or a hardware/cluster step could settle it.
+        Surfaced to the operator, who verifies and either re-runs with the
+        fact pinned or takes the slice over by hand. A `NEEDS-VERIFICATION`
+        NO-GO is NOT escalated to a larger model: a larger model cannot reach
+        the ground truth either.
       - Anything else you set is opaque to the controller but visible
         in `status.result.extra`.
 

--- a/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
+++ b/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
@@ -93,27 +93,27 @@ spec:
 
     ## Tools available
 
-    - `read_file(path, offset?, limit?)` -- read a workspace file. Output is
+    - `read_file(path, offset?, limit?)` — read a workspace file. Output is
       capped at 16 KiB; the result includes `total_lines` so you can tell
       when there is more. For long files (CHANGELOG.md, generated CRDs,
       large source files) pass `offset` (1-based line number) and `limit`
-      (number of lines) to read a window. Reading a large file in one
-      shot pollutes every later turn's prompt-eval; prefer ranged reads.
-    - `write_file(path, content)` -- overwrite or create a workspace file.
+      (number of lines) to read a window. Reading a large file in one shot
+      pollutes every later turn's prompt-eval; prefer ranged reads.
+    - `write_file(path, content)` — overwrite or create a workspace file.
     - `str_replace(path, old_string, new_string, expected_replacements?)`
-      -- exact-text replacement; old_string must occur the expected number
+      — exact-text replacement; old_string must occur the expected number
       of times (default 1).
-    - `grep(pattern, path?, max?)` -- regex search across the workspace.
+    - `grep(pattern, path?, max?)` — regex search across the workspace.
       Paths default to ".". The `.git` dir is always skipped.
-    - `bash(command)` -- run a shell command in the workspace under `sh -c`
+    - `bash(command)` — run a shell command in the workspace under `sh -c`
       with a bounded timeout. Use this for builds, tests, file
       enumeration, and any introspection beyond what the typed tools
       give you. Non-zero exit codes are not errors; the tool returns
       `exit_code`, `stdout`, `stderr`, and `timed_out` for you to read.
-    - `submit_result(verdict, summary, commit_message?, extra?)` --
+    - `submit_result(verdict, summary, commit_message?, extra?)` —
       terminal. The loop exits after this call.
 
-    ## Step 1 -- Triage
+    ## Step 1 — Triage
 
     Decide whether this issue is a good fit for an automated fix.
 
@@ -142,7 +142,7 @@ spec:
     If NO-GO: skip to Step 3 and call `submit_result(verdict="NO-GO", ...)`.
     Do not edit any files.
 
-    ## Step 2 -- Implement (only if GO)
+    ## Step 2 — Implement (only if GO)
 
     - Plan the change in 2-4 sentences (in your own reasoning, not via a
       tool call) before editing.
@@ -151,6 +151,19 @@ spec:
     - Every behavior change needs a test. For a bug, add a regression
       test that fails before your fix and passes after. Never weaken or
       delete an existing test to go green.
+    - Ground every external fact. If a value you are about to write depends
+      on something outside this workspace — a metric name or label another
+      component emits, a field or shape in an external API, an image or
+      tool's runtime behavior, whether a named exporter or binary actually
+      works on the target hardware — you must ground it in a real source you
+      can read or run: the component's own source in this repo or a vendored
+      dependency, a real `/metrics` or API response you fetch with `bash`, an
+      authoritative doc. Do NOT invent such a value, and do NOT present a
+      guess as fact. A plausible-looking name you made up is a fake pass:
+      the gate cannot catch it, because the gate has no ground truth to check
+      it against. If you cannot ground a load-bearing external fact from any
+      source you can reach, stop and report `NEEDS-VERIFICATION` (Step 3)
+      rather than inventing it.
     - Run the verification commands from `AGENTS.md` via the `bash` tool
       and fix what they report:
       - `make fmt`, `make vet`, `make lint`, `make test`
@@ -159,7 +172,7 @@ spec:
         `make foreman-chart-crds` for the foreman group); then confirm
         `git status --porcelain` is empty.
 
-    ## Step 3 -- Report
+    ## Step 3 — Report
 
     Call `submit_result` exactly once. Required fields:
 
@@ -179,7 +192,7 @@ spec:
       condition message.
     - `commit_message` (required when verdict is `GO`): the full commit
       message you want on the resulting commit. Must include:
-      - a conventional-commit subject line (<=72 chars),
+      - a conventional-commit subject line (≤72 chars),
       - a body explaining *why* the change is needed and *what* it does,
         wrapped near 72 columns,
       - a `Fixes #<issue-number>` trailer on its own line, using the
@@ -203,18 +216,50 @@ spec:
     )
     ```
 
+    **Needs-verification example.** When a correct fix depends on an external
+    fact you cannot confirm from this workspace (for example the exact metric
+    names another component will emit, or whether a named exporter image
+    enumerates the target GPU), do not guess the fact to force a GO:
+
+    ```text
+    submit_result(
+      verdict="NO-GO",
+      summary="Cannot confirm the AMD exporter's metric names or that it enumerates the gfx1151 iGPU from this workspace; a dashboard wired to guessed names would be silently wrong.",
+      extra={
+        "outcome": "NEEDS-VERIFICATION",
+        "unverified": [
+          {
+            "fact": "metric names emitted by the rocm-smi exporter on gfx1151",
+            "whyItMatters": "the Grafana panels reference each metric name verbatim; wrong names render empty panels",
+            "howToVerify": "deploy the exporter on a gfx1151 node and read its /metrics output"
+          }
+        ]
+      },
+    )
+    ```
+
     - `extra` (optional): structured fields you want surfaced in
       `status.result.extra`. Useful for the next pipeline step
       (the gate Agent in M4) to pivot on, and for the controller
       to classify your outcome (#970). Recognized fields:
       - `outcome`: a machine-readable class. Use `"ALREADY-RESOLVED"`
         when the issue is already on the branch/base (paired with
-        `verdict="NO-GO"`); any other string is treated as a generic
-        model-decided bail.
+        `verdict="NO-GO"`); use `"NEEDS-VERIFICATION"` when a load-bearing
+        external fact cannot be grounded from any source you can reach
+        (paired with `verdict="NO-GO"`); any other string is treated as a
+        generic model-decided bail.
       - `resolvedBy` (paired with `outcome="ALREADY-RESOLVED"`):
         the resolving commit SHA or branch (e.g. `"e97d0ca"` or
         `"foreman/<workload>/issue-129"`). Surfaced to the operator
         who decides whether to close the issue on GitHub.
+      - `unverified` (paired with `outcome="NEEDS-VERIFICATION"`): a list of
+        `{fact, whyItMatters, howToVerify}` objects, one per external fact
+        you could not ground. Each names the fact, why a correct fix depends
+        on it, and how a human or a hardware/cluster step could settle it.
+        Surfaced to the operator, who verifies and either re-runs with the
+        fact pinned or takes the slice over by hand. A `NEEDS-VERIFICATION`
+        NO-GO is NOT escalated to a larger model: a larger model cannot reach
+        the ground truth either.
       - Anything else you set is opaque to the controller but visible
         in `status.result.extra`.
 

--- a/config/foreman/system-prompts/coder.md
+++ b/config/foreman/system-prompts/coder.md
@@ -94,6 +94,19 @@ Do not edit any files.
 - Every behavior change needs a test. For a bug, add a regression
   test that fails before your fix and passes after. Never weaken or
   delete an existing test to go green.
+- Ground every external fact. If a value you are about to write depends
+  on something outside this workspace — a metric name or label another
+  component emits, a field or shape in an external API, an image or
+  tool's runtime behavior, whether a named exporter or binary actually
+  works on the target hardware — you must ground it in a real source you
+  can read or run: the component's own source in this repo or a vendored
+  dependency, a real `/metrics` or API response you fetch with `bash`, an
+  authoritative doc. Do NOT invent such a value, and do NOT present a
+  guess as fact. A plausible-looking name you made up is a fake pass:
+  the gate cannot catch it, because the gate has no ground truth to check
+  it against. If you cannot ground a load-bearing external fact from any
+  source you can reach, stop and report `NEEDS-VERIFICATION` (Step 3)
+  rather than inventing it.
 - Run the verification commands from `AGENTS.md` via the `bash` tool
   and fix what they report:
   - `make fmt`, `make vet`, `make lint`, `make test`
@@ -146,18 +159,50 @@ submit_result(
 )
 ```
 
+**Needs-verification example.** When a correct fix depends on an external
+fact you cannot confirm from this workspace (for example the exact metric
+names another component will emit, or whether a named exporter image
+enumerates the target GPU), do not guess the fact to force a GO:
+
+```text
+submit_result(
+  verdict="NO-GO",
+  summary="Cannot confirm the AMD exporter's metric names or that it enumerates the gfx1151 iGPU from this workspace; a dashboard wired to guessed names would be silently wrong.",
+  extra={
+    "outcome": "NEEDS-VERIFICATION",
+    "unverified": [
+      {
+        "fact": "metric names emitted by the rocm-smi exporter on gfx1151",
+        "whyItMatters": "the Grafana panels reference each metric name verbatim; wrong names render empty panels",
+        "howToVerify": "deploy the exporter on a gfx1151 node and read its /metrics output"
+      }
+    ]
+  },
+)
+```
+
 - `extra` (optional): structured fields you want surfaced in
   `status.result.extra`. Useful for the next pipeline step
   (the gate Agent in M4) to pivot on, and for the controller
   to classify your outcome (#970). Recognized fields:
   - `outcome`: a machine-readable class. Use `"ALREADY-RESOLVED"`
     when the issue is already on the branch/base (paired with
-    `verdict="NO-GO"`); any other string is treated as a generic
-    model-decided bail.
+    `verdict="NO-GO"`); use `"NEEDS-VERIFICATION"` when a load-bearing
+    external fact cannot be grounded from any source you can reach
+    (paired with `verdict="NO-GO"`); any other string is treated as a
+    generic model-decided bail.
   - `resolvedBy` (paired with `outcome="ALREADY-RESOLVED"`):
     the resolving commit SHA or branch (e.g. `"e97d0ca"` or
     `"foreman/<workload>/issue-129"`). Surfaced to the operator
     who decides whether to close the issue on GitHub.
+  - `unverified` (paired with `outcome="NEEDS-VERIFICATION"`): a list of
+    `{fact, whyItMatters, howToVerify}` objects, one per external fact
+    you could not ground. Each names the fact, why a correct fix depends
+    on it, and how a human or a hardware/cluster step could settle it.
+    Surfaced to the operator, who verifies and either re-runs with the
+    fact pinned or takes the slice over by hand. A `NEEDS-VERIFICATION`
+    NO-GO is NOT escalated to a larger model: a larger model cannot reach
+    the ground truth either.
   - Anything else you set is opaque to the controller but visible
     in `status.result.extra`.
 

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -100,6 +100,25 @@ func coderResolvedBy(task *foremanv1alpha1.AgenticTask) string {
 // isAlreadyResolvedCoder and shouldEscalateCoder.
 const alreadyResolvedOutcome = "ALREADY-RESOLVED"
 
+// needsVerificationOutcome is the string the coder emits at extra.outcome
+// when a load-bearing external fact cannot be grounded from the workspace,
+// so a correct fix is not possible here (anti-confabulation, #1033). Like
+// ALREADY-RESOLVED it is a terminal non-failure NO-GO: escalating to a
+// larger model cannot help, because the larger model cannot reach the
+// ground truth (hardware, a live system's output) either.
+const needsVerificationOutcome = "NEEDS-VERIFICATION"
+
+// isNeedsVerificationCoder reports whether the task ended NO-GO because the
+// coder could not ground a load-bearing external fact (extra.outcome ==
+// needsVerificationOutcome). Used by shouldEscalateCoder to skip escalation.
+func isNeedsVerificationCoder(task *foremanv1alpha1.AgenticTask) bool {
+	if task == nil {
+		return false
+	}
+	verdict, topOutcome, _ := coderTerminalOutcome(task)
+	return verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == needsVerificationOutcome
+}
+
 // isAlreadyResolvedCoder reports whether the task ended in the
 // machine outcome for "work is already on the branch/base". Used by
 // shouldEscalateCoder (to skip escalation) and rollup (to keep the
@@ -139,6 +158,9 @@ func shouldEscalateCoder(
 ) bool {
 	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == alreadyResolvedOutcome {
 		return false // #970: already-resolved is not a capability failure
+	}
+	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == needsVerificationOutcome {
+		return false // #1033: a larger model can't reach the ground truth either
 	}
 	if verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == "MODEL-DECIDED" {
 		return true

--- a/internal/foreman/controller/workload_coder_escalation_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_test.go
@@ -53,6 +53,7 @@ func TestShouldEscalateCoder(t *testing.T) {
 	}{
 		{"model NO-GO (like #944)", foremanv1alpha1.AgenticTaskVerdictNoGo, "MODEL-DECIDED", "", true},
 		{"NO-GO + ALREADY-RESOLVED (already done, #970)", foremanv1alpha1.AgenticTaskVerdictNoGo, "ALREADY-RESOLVED", "", false},
+		{"NO-GO + NEEDS-VERIFICATION (ungroundable fact, #1033)", foremanv1alpha1.AgenticTaskVerdictNoGo, "NEEDS-VERIFICATION", "", false},
 		{"gate-failed (like #911)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "MODEL-DECIDED", "CODER-GATE-FAILED", true},
 		{"model gave up / stuck (like #921)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "MODEL-DECIDED", "", false},
 		{"stuck-loop detected", foremanv1alpha1.AgenticTaskVerdictIncomplete, "STUCK-LOOP-DETECTED", "", false},
@@ -277,6 +278,34 @@ func TestIsAlreadyResolvedCoder(t *testing.T) {
 			}
 			if got := isAlreadyResolvedCoder(task); got != tc.want {
 				t.Errorf("isAlreadyResolvedCoder() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsNeedsVerificationCoder(t *testing.T) {
+	cases := []struct {
+		name       string
+		verdict    foremanv1alpha1.AgenticTaskVerdict
+		topOutcome string
+		want       bool
+	}{
+		{"NO-GO + NEEDS-VERIFICATION", foremanv1alpha1.AgenticTaskVerdictNoGo, "NEEDS-VERIFICATION", true},
+		{"NO-GO + MODEL-DECIDED (capability failure)", foremanv1alpha1.AgenticTaskVerdictNoGo, "MODEL-DECIDED", false},
+		{"NO-GO + ALREADY-RESOLVED (different outcome)", foremanv1alpha1.AgenticTaskVerdictNoGo, "ALREADY-RESOLVED", false},
+		{"NO-GO + empty outcome (legacy)", foremanv1alpha1.AgenticTaskVerdictNoGo, "", false},
+		{"INCOMPLETE + NEEDS-VERIFICATION (not a NO-GO)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "NEEDS-VERIFICATION", false},
+		{"GO + NEEDS-VERIFICATION (impossible combo, defensive)", foremanv1alpha1.AgenticTaskVerdictGo, "NEEDS-VERIFICATION", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &foremanv1alpha1.AgenticTask{}
+			task.Status.Verdict = tc.verdict
+			if tc.topOutcome != "" {
+				task.Status.Result = resultRaw(tc.topOutcome, "", "", "")
+			}
+			if got := isNeedsVerificationCoder(task); got != tc.want {
+				t.Errorf("isNeedsVerificationCoder() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/pkg/cli/slice_planner.go
+++ b/pkg/cli/slice_planner.go
@@ -40,6 +40,29 @@ const plannerPrompt = `You are a planning agent. You are given a GitHub issue an
 Decompose the issue into 2 to 4 slices that can be implemented INDEPENDENTLY and
 combined by concatenation.
 
+Before you decompose, check the premises. A premise is any fact the slices'
+correctness depends on. Classify each load-bearing premise:
+- settled-in-repo: verifiable from the repository map or the issue itself. Fine.
+- repo-verifiable: the answer lives in the repo or a vendored dependency (does a
+  function exist, what is an API's real signature). Do not assume it: instruct the
+  owning slice to verify it first, then implement against what it finds.
+- externally-empirical: correctness depends on facts outside the repo that only
+  running code or hardware can settle (whether a named tool or image works on the
+  target hardware, the exact metrics a component emits at runtime, a live system's
+  behavior). Treat issue hedging ("e.g.", "realistic path", "should be
+  hands-verified", "likely", "should work") as a signal that a premise is
+  externally-empirical, NOT settled fact.
+
+Act on the classification:
+- If the ENTIRE issue hinges on an externally-empirical premise, output only
+  "UNSLICEABLE: <premise> requires empirical verification (<how>)" and stop.
+- Otherwise, name each externally-empirical premise in the contract, and in the
+  task of every slice whose correctness depends on it, instruct the slice to
+  ground the premise from a real source or return NO-GO with outcome
+  NEEDS-VERIFICATION rather than guessing. Never pin (below) an identifier whose
+  real value is externally-empirical and unknown to you: a value you invented and
+  pinned is worse than no pin.
+
 Hard rules:
 1. Disjoint files. Each slice owns a distinct set of files. No file may appear in
    two slices. If the issue cannot be split into disjoint-file slices, say so


### PR DESCRIPTION
## What

Teach the slicer's coder and planner to flag facts they cannot verify instead of inventing them, and recognize the resulting `NEEDS-VERIFICATION` outcome as a terminal non-failure that is never escalated.

## Why

Fixes #1061. On the first live slicer run on #700, the coder invented AMD GPU metric names for a Grafana dashboard and reached for a community exporter that does not enumerate the target `gfx1151` iGPU (confirmed by a contributor on the actual box). The output was plausible, complete-looking, and wrong on facts only hardware can settle. `GO` means "compiles and looks plausible," not "verified against reality," and there was no honesty layer between `GO` and a capability-failure `NO-GO`. Two distinct failures: a grounding gap (the fact lives outside the repo) and confabulation under that gap (the model invented rather than flagged).

## How

- **Coder contract** (`config/foreman/system-prompts/coder.md`, re-synced into both coder Agent CRs):
  - A "ground every external fact" rule in Step 2: never present a guess about another component's metric names, an API shape, or an image's hardware behavior as fact.
  - A `NEEDS-VERIFICATION` outcome in Step 3: `NO-GO` + `extra.outcome="NEEDS-VERIFICATION"` + `extra.unverified` listing each ungroundable fact and how to settle it, instead of guessing.
- **Planner** (`pkg/cli/slice_planner.go`): a premise-classification step (settled-in-repo / repo-verifiable / externally-empirical), treating issue hedging as an unverified signal; `UNSLICEABLE` when the whole issue hinges on an empirical premise, verify-first or `NEEDS-VERIFICATION` for the affected slices otherwise.
- **Controller** (`internal/foreman/controller/workload_coder_escalation.go`): `NEEDS-VERIFICATION` recognized as a terminal non-failure NO-GO and explicitly excluded from escalation, because a larger model cannot reach the ground truth (hardware, a live system's output) either. Mirrors the `ALREADY-RESOLVED` handling (#970).

## Testing

- `go build ./...`, `go vet`, `golangci-lint` on the changed packages: clean.
- `go test ./pkg/cli/... ./internal/foreman/controller/... ./pkg/foreman/slicer/...`: pass, including new `TestShouldEscalateCoder` case and `TestIsNeedsVerificationCoder`.
- Empirical regression to follow: re-run #700 through the slicer with these prompts deployed and confirm the coder returns `NEEDS-VERIFICATION` (naming the unverifiable metric names / the iGPU-enumeration premise) instead of inventing.

## Deferred follow-up

Rollup surfacing: a dedicated `classifyChildren` bucket, a `CoderNeedsVerification` Workload condition, and cascade-skip so a needs-verification slice does not cascade-fail integrate/reconcile. Best designed after observing a real `NEEDS-VERIFICATION` run (the #700 re-validation), so the terminal-state semantics match reality rather than a guess.

## Checklist

- [x] Tests added/updated
- [x] `go build ./...` passes
- [x] Lint passes
- [x] Commits are DCO signed-off
- [x] Coder prompt change re-synced into the Agent CR inline copies

Assisted-by: Claude (Anthropic) — analysis, prompt/contract design, controller guard, and tests; reviewed by the maintainer.
