### PR TITLE
fix(cli): keep the slicer planner output to YAML only (fixes #1062 regression)

### DIFF
--- a/pkg/cli/slice_planner.go
+++ b/pkg/cli/slice_planner.go
@@ -40,7 +40,12 @@ const plannerPrompt = `You are a planning agent. You are given a GitHub issue an
 Decompose the issue into 2 to 4 slices that can be implemented INDEPENDENTLY and
 combined by concatenation.
 
-Before you decompose, check the premises. A premise is any fact the slices'
+Reason SILENTLY. Do ALL of the analysis below in your own head. Your entire
+reply is the single YAML document specified at the end and NOTHING else: no
+preamble, no prose, no premise analysis, no "Now I'll create the slices",
+nothing before the first YAML key or after the last line.
+
+First, classify the premises (silently). A premise is any fact the slices'
 correctness depends on. Classify each load-bearing premise:
 - settled-in-repo: verifiable from the repository map or the issue itself. Fine.
 - repo-verifiable: the answer lives in the repo or a vendored dependency (does a
@@ -74,7 +79,10 @@ Hard rules:
    (metric name, config key, CRD field, function signature), pin the EXACT string
    in a shared_identifiers list with which slice defines it and which reference
    it. In each slice's task, name the exact identifiers that slice uses, VERBATIM.
-5. Output VALID YAML in exactly this shape and nothing else:
+5. Keep the contract field as plain prose lines only: no markdown headers,
+   bold, or nested bullets, so the YAML block scalar always parses cleanly.
+6. Your whole reply is ONLY this YAML document, nothing before the first key
+   or after the last line, in exactly this shape:
 
 issue: <number>
 repo: <owner/name>
@@ -150,9 +158,14 @@ func parseSlicePlan(raw string) (slicePlan, error) {
 	if m := fenceRE.FindStringSubmatch(body); m != nil {
 		body = strings.TrimSpace(m[1])
 	}
-	if strings.HasPrefix(strings.ToUpper(body), "UNSLICEABLE") {
-		return slicePlan{}, fmt.Errorf("planner refused: %s", firstLine(body))
+	// A chatty local planner can wrap the YAML in prose despite the prompt
+	// (premise analysis, a "Now I'll create the slices:" lead-in, etc).
+	// Surface an UNSLICEABLE refusal on whatever line it lands, then strip any
+	// preamble before the first top-level `issue:` key so the YAML parses.
+	if line, ok := unsliceableLine(body); ok {
+		return slicePlan{}, fmt.Errorf("planner refused: %s", line)
 	}
+	body = stripToYAMLStart(body)
 	var p slicePlan
 	if err := yaml.Unmarshal([]byte(body), &p); err != nil {
 		return slicePlan{}, fmt.Errorf("parse planner output as a slice plan: %w", err)
@@ -206,9 +219,28 @@ func httpPlannerCall(url, model string) PlannerCaller {
 	}
 }
 
-func firstLine(s string) string {
-	if i := strings.IndexByte(s, '\n'); i >= 0 {
-		return s[:i]
+// unsliceableLine returns the first line whose trimmed text begins with
+// "UNSLICEABLE" (case-insensitive), so the planner's refusal is surfaced even
+// when a chatty model prefixes it with prose.
+func unsliceableLine(body string) (string, bool) {
+	for _, l := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(l)
+		if strings.HasPrefix(strings.ToUpper(t), "UNSLICEABLE") {
+			return t, true
+		}
 	}
-	return s
+	return "", false
+}
+
+// stripToYAMLStart drops any preamble before the first line that begins the
+// plan document (a top-level `issue:` key). If the body already starts there,
+// or no such line exists, it is returned unchanged.
+func stripToYAMLStart(body string) string {
+	lines := strings.Split(body, "\n")
+	for i, l := range lines {
+		if strings.HasPrefix(l, "issue:") {
+			return strings.Join(lines[i:], "\n")
+		}
+	}
+	return body
 }

--- a/pkg/cli/slice_planner_test.go
+++ b/pkg/cli/slice_planner_test.go
@@ -70,6 +70,27 @@ func TestParseSlicePlan(t *testing.T) {
 		}
 	})
 
+	t.Run("prose preamble before yaml", func(t *testing.T) {
+		// A chatty local planner prints its reasoning before the document.
+		chatty := "Looking at this issue, let me classify the premises first.\n\n" +
+			"**Premises:**\n1. foo is settled-in-repo\n\nNow I'll create the slices:\n\n" +
+			planYAMLBody
+		p, err := parseSlicePlan(chatty)
+		if err != nil {
+			t.Fatalf("parse with preamble: %v", err)
+		}
+		if len(p.Slices) != 2 {
+			t.Fatalf("preamble parse wrong: %+v", p)
+		}
+	})
+
+	t.Run("unsliceable behind preamble", func(t *testing.T) {
+		_, err := parseSlicePlan("Let me analyze.\n\nUNSLICEABLE: hardware verification required")
+		if err == nil || !strings.Contains(err.Error(), "refused") {
+			t.Fatalf("want refusal error surfaced from a non-prefix line, got %v", err)
+		}
+	})
+
 	t.Run("no slices", func(t *testing.T) {
 		if _, err := parseSlicePlan("issue: 1\nrepo: a/b\n"); err == nil {
 			t.Fatal("want error for a plan with no slices")


### PR DESCRIPTION
## What

Keep the slicer planner's output to a single clean YAML document, and harden the parser against chatty local-model output.

## Why

Fixes #1063. The premise-classification step added in #1062 put the planner into show-your-work mode: on the first live #1021 run it printed a prose analysis preamble ("Now I'll create the slices:") and a markdown-heavy `contract:` block, which broke the strict YAML parse:

```
Error: parse planner output as a slice plan: yaml: line 19: mapping values are not allowed in this context
```

The premise-classification *logic* was correct (it flagged `kubeconform` availability as externally-empirical); only the output formatting regressed.

## How

- **Prompt** (`plannerPrompt`): instruct the planner to reason SILENTLY and emit only the YAML document (no preamble, no analysis, nothing before the first key or after the last line), and keep the `contract` field to plain prose so the YAML block scalar always parses.
- **Parser** (`parseSlicePlan`), defense in depth since chatty local models will keep testing this: surface an `UNSLICEABLE` refusal found on any line (not just a prefix), and strip any preamble before the first top-level `issue:` key before unmarshalling.

## Testing

- `go build ./pkg/cli/...`, `go test ./pkg/cli/`, `golangci-lint`: all clean.
- New `TestParseSlicePlan` subtests: a prose preamble before the YAML parses correctly, and an `UNSLICEABLE` line behind preamble is surfaced as a refusal.
- Verified against the live planner (ornith-35b): with the tightened prompt it emits clean YAML that parses, and the #1021 slice run proceeds.

## Checklist

- [x] Tests added/updated
- [x] `go build ./...` passes
- [x] Lint passes
- [x] Commit is DCO signed-off

Assisted-by: Claude (Anthropic) — diagnosis, prompt tightening, parser guard, and tests; reviewed by the maintainer.
