### PR TITLE
fix(foreman): default to rebase when reviseFromBranch is set without branchStrategy

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -378,7 +378,16 @@ func setupTaskBranch(
 ) error {
 	strategy := task.Spec.Payload.BranchStrategy
 	if strategy == "" {
-		strategy = foremanv1alpha1.BranchStrategyReset
+		// #1047: reviseFromBranch without branchStrategy used to silently no-op
+		// (defaulted to reset, which skips the restore). When reviseFromBranch is
+		// set and the caller did not explicitly choose reset, treat the effective
+		// strategy as rebase — restore-and-rebase is the only sensible intent
+		// when a prior attempt is named. An explicit "reset" still wins.
+		if task.Spec.Payload.ReviseFromBranch != "" {
+			strategy = foremanv1alpha1.BranchStrategyRebase
+		} else {
+			strategy = foremanv1alpha1.BranchStrategyReset
+		}
 	}
 
 	// rebase (in-review revision): restore the prior attempt AND rebase it onto

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2358,6 +2358,61 @@ func TestSetupTaskBranch_ResetSkipsPriorAttempt(t *testing.T) {
 	}
 }
 
+// TestSetupTaskBranch_ReviseFromBranchDefaultsToRebase pins #1047: when
+// reviseFromBranch is set but branchStrategy is left empty (the common
+// caller mistake that produced the silent no-op), the effective strategy
+// must be rebase so the prior attempt is restored instead of silently
+// discarded. An explicit reset still wins.
+func TestSetupTaskBranch_ReviseFromBranchDefaultsToRebase(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, _ := seededRemote(t, dir)
+	const branch = "foreman/wl/issue-641"
+
+	// Prior attempt pushed to the remote.
+	prior := filepath.Join(dir, "prior")
+	gitIn(t, "", "clone", bare, prior)
+	gitIn(t, prior, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(prior, "fix.txt"), []byte("attempt 1\n"), 0o644); err != nil {
+		t.Fatalf("write fix.txt: %v", err)
+	}
+	gitIn(t, prior, "add", "fix.txt")
+	gitIn(t, prior, "commit", "-m", "attempt 1")
+	gitIn(t, prior, "push", "origin", branch)
+	priorSHA := gitIn(t, prior, "rev-parse", "HEAD")
+
+	ws := filepath.Join(dir, "ws")
+	gitIn(t, "", "clone", bare, ws)
+
+	// reviseFromBranch set, branchStrategy left empty — the #1047 footgun.
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:             "defilantech/LLMKube",
+				Branch:           branch,
+				ReviseFromBranch: branch,
+				// BranchStrategy intentionally left empty — this is the bug we're
+				// guarding against.
+			},
+		},
+	}
+
+	err := setupTaskBranch(context.Background(), task, ws, branch, "main",
+		func(string) string { return bare }, nil, logr.Discard())
+	if err != nil {
+		t.Fatalf("setupTaskBranch: %v", err)
+	}
+	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != priorSHA {
+		t.Errorf("HEAD = %s, want prior attempt tip %s (empty branchStrategy + reviseFromBranch must default to rebase)", got, priorSHA)
+	}
+	if _, err := os.Stat(filepath.Join(ws, "fix.txt")); err != nil {
+		t.Errorf("prior attempt's file must be present: %v", err)
+	}
+}
+
 // TestRecoverSelfCommitsOrNoChange_StaleForkBaseIsNotCountedAsCommitsAhead
 // reproduces the #982/#813 scenario where the fork clone's local "main"
 // lags the upstream tip the task branch was actually cut from. If the


### PR DESCRIPTION
## What

Default the effective branch strategy to `rebase` when a task sets `reviseFromBranch` but leaves `branchStrategy` empty, so the prior attempt is restored instead of silently discarded.

## Why

Fixes #1047. When `payload.reviseFromBranch` is set but `branchStrategy` is empty, the effective strategy defaulted to `reset`, which skips the restore and cuts a fresh branch, the opposite of the caller's intent. This already bit #1043 (the `--revise-from-branch` CLI flag stamped `reviseFromBranch` but not `branchStrategy`, so the flag became a silent no-op after #1042).

## How

- `setupTaskBranch`: an empty `branchStrategy` combined with a non-empty `reviseFromBranch` is now treated as `rebase`. An explicit `reset` still wins, preserving the Sliced Workloads repair re-dispatch path (#1033).
- Regression test `TestSetupTaskBranch_ReviseFromBranchDefaultsToRebase` pins the contract: a task with `reviseFromBranch` set and no `branchStrategy` must restore the prior attempt from the push remote.

## Provenance / AI disclosure (band-3)

This PR was produced **autonomously by Foreman**, LLMKube's own agentic coding harness, in an overnight batch on a local mid-size model (Ornith-35B) with context7 MCP grounding. It was verified by the deterministic clean-room gate (fmt/vet/build/lint/test) before push, and reviewed by the maintainer before opening. A nice bit of dogfooding: Foreman fixing a Foreman branch-handling footgun it could have hit itself.

## Testing

- Clean-room gate: GATE-PASS.
- New regression test fails before the fix (reset skips the restore) and passes after; re-verified locally.

## Checklist

- [x] Tests added/updated
- [x] Build / lint / gate pass
- [x] DCO signed-off
