### PR TITLE
feat(foreman): make the EditFreeStreak guard grounding-aware

### DIFF
--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -136,7 +136,13 @@ type LoopProgressMonitor struct {
 	// observing a wide-enough window to detect the pattern.
 	recentCallHashes []string
 	editFreeStreak   int // turns since last edit/submit
-	contextTokens    int // approximate wire token count after most recent turn
+	// groundedFiles is the set of distinct files read_file'd since the last
+	// edit. Each distinct file beyond the first raises the effective edit-free
+	// limit (grounding-aware guard, #1066): reading real source to ground the
+	// next edit (the anti-confab rule, #1062) earns tolerance, while a search
+	// loop or a re-read of the same file reads no NEW file and earns none.
+	groundedFiles map[string]struct{}
+	contextTokens int // approximate wire token count after most recent turn
 
 	// Nudge state. Once a signal has fired, the next-turn trigger
 	// escalates to ForceTerminate. For RepeatedToolCall we track the
@@ -188,6 +194,43 @@ var editProducingTools = map[string]struct{}{
 	"write_file":    {},
 	"str_replace":   {},
 	"submit_result": {},
+}
+
+// groundingReadBonusCap bounds the edit-free tolerance a model earns by reading
+// real source to ground its next edit (#1066). Each distinct file read since the
+// last edit, beyond the first, adds one turn to the effective EditFreeTurnsLimit,
+// up to this cap, so grounding is rewarded but a pure-read loop still terminates
+// at base+cap rather than reading forever.
+const groundingReadBonusCap = 8
+
+// editFreeLimit is the effective edit-free trip threshold: the base limit plus
+// one turn of tolerance per distinct file the model read to ground its next edit
+// since the last edit, beyond the first, capped at groundingReadBonusCap. The
+// first distinct read is the file the model is about to edit (base behavior);
+// additional distinct files are grounding. A grep/bash search loop or a re-read
+// of the same file reads no new file, earns no bonus, and still trips at the base
+// limit (#1066).
+func (m *LoopProgressMonitor) editFreeLimit() int {
+	bonus := len(m.groundedFiles) - 1
+	if bonus < 0 {
+		bonus = 0
+	}
+	if bonus > groundingReadBonusCap {
+		bonus = groundingReadBonusCap
+	}
+	return m.cfg.EditFreeTurnsLimit + bonus
+}
+
+// readFilePath extracts the path argument from a read_file tool call's JSON
+// arguments, or "" if the argument is absent or unparseable.
+func readFilePath(arguments string) string {
+	var args struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &args); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(args.Path)
 }
 
 // explorationTools are the open-ended search tools removed from the
@@ -326,8 +369,10 @@ func (m *LoopProgressMonitor) Observe(turn int, calls []oai.ToolCall, transcript
 		}
 	}
 
-	// 2c. EditFreeStreak.
-	if m.cfg.EditFreeTurnsLimit > 0 && m.editFreeStreak >= m.cfg.EditFreeTurnsLimit {
+	// 2c. EditFreeStreak. The threshold is the base limit extended by grounding
+	// reads (editFreeLimit, #1066), so reading real source to ground the next
+	// edit is not force-terminated like an open-ended search loop.
+	if m.cfg.EditFreeTurnsLimit > 0 && m.editFreeStreak >= m.editFreeLimit() {
 		if m.nudgedEditFree {
 			return ProgressDecision{
 				Action: ProgressForceTerminate,
@@ -429,6 +474,19 @@ func (m *LoopProgressMonitor) updateEditFreeStreak(calls []oai.ToolCall) {
 			return
 		}
 	}
+	// No edit this turn. Record any distinct files the model read so grounding
+	// reads raise the effective edit-free limit (see editFreeLimit, #1066).
+	for _, tc := range calls {
+		if tc.Function.Name != "read_file" {
+			continue
+		}
+		if p := readFilePath(tc.Function.Arguments); p != "" {
+			if m.groundedFiles == nil {
+				m.groundedFiles = make(map[string]struct{})
+			}
+			m.groundedFiles[p] = struct{}{}
+		}
+	}
 	m.editFreeStreak++
 }
 
@@ -444,6 +502,9 @@ func (m *LoopProgressMonitor) updateEditFreeStreak(calls []oai.ToolCall) {
 func (m *LoopProgressMonitor) resetEditFreeStreak() {
 	m.editFreeStreak = 0
 	m.nudgedEditFree = false
+	// A landed edit ends the current grounding window; the tolerance earned by
+	// reads before it must not carry into a later stuck phase (#1066).
+	m.groundedFiles = nil
 }
 
 // fileWritingBashTokens are substrings that indicate a bash command

--- a/pkg/foreman/agent/progress_test.go
+++ b/pkg/foreman/agent/progress_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package agent
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -156,6 +157,90 @@ func TestProgressMonitor_EditFreeTurnsTriggers(t *testing.T) {
 	d = mon.Observe(6, []oai.ToolCall{makeCall("x", "grep", `{"pattern":"foo"}`)}, transcript)
 	if d.Action != ProgressForceTerminate {
 		t.Fatalf("turn 6: expected ForceTerminate; got %+v", d)
+	}
+}
+
+// TestProgressMonitor_GroundingReadsExtendEditFreeLimit pins #1066: reading
+// DISTINCT files to ground the next edit (the anti-confab rule, #1062) raises
+// the effective edit-free limit, so grounding is not force-terminated like an
+// open-ended search loop. At the base limit (turn 3) the guard must not fire
+// because the distinct reads bought tolerance; the nudge comes later, once a
+// no-new-file streak catches up to the extended limit.
+func TestProgressMonitor_GroundingReadsExtendEditFreeLimit(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{EditFreeTurnsLimit: 3})
+	tr := []oai.Message{}
+
+	for i, f := range []string{"a.go", "b.go", "c.go", "d.go", "e.go"} {
+		d := mon.Observe(i+1, []oai.ToolCall{makeCall("t", "read_file", fmt.Sprintf(`{"path":%q}`, f))}, tr)
+		if d.Action != ProgressContinue {
+			t.Fatalf("turn %d (distinct read %s): grounding should extend the limit, got %+v", i+1, f, d)
+		}
+	}
+
+	// No new files now: the effective limit stops growing and the streak
+	// catches up, so it nudges -- but later than the base limit of 3.
+	nudged := 0
+	for turn := 6; turn <= 14; turn++ {
+		d := mon.Observe(turn, []oai.ToolCall{makeCall("t", "grep", `{"pattern":"x"}`)}, tr)
+		if d.Action == ProgressNudge && d.Signal == signalEditFreeStreak {
+			nudged = turn
+			break
+		}
+	}
+	if nudged == 0 {
+		t.Fatal("expected an EditFreeStreak nudge once the streak caught up to the extended limit")
+	}
+	if nudged <= 3 {
+		t.Fatalf("nudge at turn %d; grounding should have pushed it past the base limit of 3", nudged)
+	}
+}
+
+// TestProgressMonitor_GroundingBonusIsCapped pins #1066: the tolerance earned
+// by distinct reads is bounded, so a pure-read loop still terminates rather
+// than reading forever. Reading one distinct file per turn, the nudge lands at
+// base + groundingReadBonusCap.
+func TestProgressMonitor_GroundingBonusIsCapped(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{EditFreeTurnsLimit: 3})
+	tr := []oai.Message{}
+	nudged := 0
+	for turn := 1; turn <= 30; turn++ {
+		d := mon.Observe(turn, []oai.ToolCall{makeCall("t", "read_file", fmt.Sprintf(`{"path":"f%d.go"}`, turn))}, tr)
+		if d.Action == ProgressNudge {
+			nudged = turn
+			break
+		}
+	}
+	if want := 3 + groundingReadBonusCap; nudged != want {
+		t.Fatalf("nudge at turn %d; want %d (base 3 + cap %d)", nudged, want, groundingReadBonusCap)
+	}
+}
+
+// TestProgressMonitor_EditResetsGroundingBonus pins #1066: an edit clears the
+// grounded-file set along with the streak, so a prior run of grounding reads
+// does not carry tolerance into a later, unrelated stuck phase.
+func TestProgressMonitor_EditResetsGroundingBonus(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{EditFreeTurnsLimit: 3})
+	tr := []oai.Message{}
+
+	for i, f := range []string{"a.go", "b.go", "c.go", "d.go"} {
+		mon.Observe(i+1, []oai.ToolCall{makeCall("t", "read_file", fmt.Sprintf(`{"path":%q}`, f))}, tr)
+	}
+	// An edit resets the streak AND the grounded-file set.
+	mon.Observe(5, []oai.ToolCall{makeCall("t", "write_file", `{"path":"a.go","content":"x"}`)}, tr)
+
+	// A grep loop with no new grounding now trips at the BASE limit: streak
+	// restarts at turn 6, so the nudge is at turn 8 (3 consecutive no-edit
+	// turns), with no carried-over bonus.
+	nudged := 0
+	for turn := 6; turn <= 14; turn++ {
+		d := mon.Observe(turn, []oai.ToolCall{makeCall("t", "grep", `{"pattern":"x"}`)}, tr)
+		if d.Action == ProgressNudge {
+			nudged = turn
+			break
+		}
+	}
+	if nudged != 8 {
+		t.Fatalf("nudge at turn %d; want 8 (base limit 3 from the post-edit restart, no carried bonus)", nudged)
 	}
 }
 


### PR DESCRIPTION
## What

Make the coder's EditFreeStreak stuck-loop guard grounding-aware: reading distinct files to ground the next edit raises the effective edit-free limit, so grounding is not force-terminated like an open-ended search loop.

## Why

Fixes #1066. The anti-confabulation grounding rule (#1062) tells the coder to read real source before writing a value it would otherwise guess. The EditFreeStreak guard force-terminates a run that reads too many turns without editing. These two are in direct tension. An overnight Foreman batch made it concrete: at `editFreeTurnsLimit=12`, 2 of 5 issues (#1055, #904) ended INCOMPLETE via EditFreeStreak, force-terminated *mid-grounding* rather than on the merits.

The guard's own design already distinguishes targeted reading from search: the forcing phase keeps `read_file` and only drops grep/bash, because "a model recovering from a failed str_replace must re-read the target." But the streak *counter* punished a targeted `read_file` turn exactly like a grep turn. This makes the counter consistent with that stated philosophy.

## How

- Track the set of distinct files `read_file`'d since the last edit.
- Effective limit = `EditFreeTurnsLimit + min(distinctFiles - 1, groundingReadBonusCap)`. The first distinct read is the file being edited (base behavior preserved); each additional distinct file is grounding and buys one turn of tolerance, capped at 8.
- A grep/bash search loop or a re-read of the same file reads no NEW file, earns no bonus, and still trips at the base limit.
- An edit clears the grounded-file set, so tolerance never carries into a later, unrelated stuck phase.
- Bounded: even a pure-read loop terminates at `base + cap`, so no new infinite-read escape hatch.

## Testing

- `go test ./pkg/foreman/agent/`: pass, including three new tests (grounding reads extend the limit; the bonus is capped; an edit resets it) and the existing edit-free tests unchanged (re-reading one file still trips at the base limit).
- `go build ./...`, `go vet`, `golangci-lint` on the package: clean.

## Checklist

- [x] Tests added/updated
- [x] Build / lint pass
- [x] DCO signed-off

Assisted-by: Claude (Anthropic) — design, implementation, and tests; reviewed by the maintainer.
