### PR TITLE
fix(foreman): set fsGroup on the gate pod so non-root gates can write XDG_DATA_HOME

### DIFF
--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -53,6 +53,14 @@ spec:
         foreman.llmkube.dev/task-name: {{ .TaskName }}
     spec:
       restartPolicy: Never
+      # fsGroup makes the RWX gate-cache PVC group-writable so non-root
+      # gate images (e.g. USER 65534) can write under XDG_DATA_HOME=/cache/xdg.
+      # Without it the PVC mounts root:root and any XDG-aware tool crashes
+      # before the real checks run (#1055). 100 matches the gate image's
+      # typical build-group GID; operators pinning a different group should
+      # override via the gate's image build.
+      securityContext:
+        fsGroup: 100
       containers:
         - name: gate
           image: {{ .Image }}

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -430,6 +430,44 @@ func TestRenderGateJob_GenericRunsCommandsNotMakeOrBiteCheck(t *testing.T) {
 	}
 }
 
+// TestRenderGateJob_PodSecurityContextFSGroup asserts the rendered gate Job
+// carries a PodSecurityContext with fsGroup=100 so non-root gate images
+// (e.g. USER 65534) can write under XDG_DATA_HOME=/cache/xdg on the RWX
+// gate-cache PVC. Regression for #1055.
+func TestRenderGateJob_PodSecurityContextFSGroup(t *testing.T) {
+	job, err := renderGateJob(rendererInput{
+		Name:                    "foreman-gate-fsgroup",
+		Namespace:               "foreman-system",
+		Image:                   "golang:1.26",
+		Repo:                    "defilantech/LLMKube",
+		Branch:                  "foreman/issue-1055",
+		Checks:                  []string{"fmt"},
+		PVCName:                 "foreman-gate-cache",
+		ActiveDeadlineSeconds:   1800,
+		TTLSecondsAfterFinished: 86400,
+		CPURequest:              "2",
+		CPULimit:                "4",
+		MemRequest:              "4Gi",
+		MemLimit:                "8Gi",
+		CloneURLBase:            "https://github.com",
+		TaskNamespace:           "default",
+		TaskName:                "gate-1055",
+	})
+	if err != nil {
+		t.Fatalf("renderGateJob: %v", err)
+	}
+	psc := job.Spec.Template.Spec.SecurityContext
+	if psc == nil {
+		t.Fatalf("PodSecurityContext must be set on the gate pod")
+	}
+	if psc.FSGroup == nil {
+		t.Fatalf("PodSecurityContext.FSGroup must be set for non-root gate images to write XDG_DATA_HOME on the RWX PVC")
+	}
+	if *psc.FSGroup != 100 {
+		t.Errorf("PodSecurityContext.FSGroup: want 100 got %d", *psc.FSGroup)
+	}
+}
+
 // TestRenderGateJob_CloneURLOverride asserts the template branches
 // correctly on the CloneURL field: when set, the git clone target is
 // the override URL verbatim; when empty, the historical


### PR DESCRIPTION
## What

Set `securityContext.fsGroup: 100` on the Foreman gate Job pod so a non-root gate image can write under `XDG_DATA_HOME=/cache/xdg` on the RWX gate-cache PVC.

## Why

Fixes #1055. The gate-cache PVC mounts `root:root`, so a non-root gate image (e.g. `USER 65534`) cannot write `XDG_DATA_HOME`, and any XDG-aware tool crashes before the real checks run. Setting `fsGroup: 100` makes Kubernetes chown the volume to group 100 and add GID 100 as a supplemental group to the gate container's process, so the container can write regardless of its built-in group. Operators pinning a different group can override via the gate image build.

## How

- `gate_job_template.yaml`: add a pod-level `securityContext.fsGroup: 100`.
- Regression test `TestRenderGateJob_PodSecurityContextFSGroup` asserts the rendered gate Job carries `PodSecurityContext.FSGroup == 100`.

## Provenance / AI disclosure (band-3)

Produced autonomously by Foreman (LLMKube's agentic harness) on a local mid-size model (Ornith-35B on the Strix, harness on the M5) with context7 MCP grounding, verified by the deterministic clean-room gate (fmt/vet/build/lint/test), and reviewed by the maintainer before opening. Notably, this issue was force-terminated by the EditFreeStreak guard on a prior run; it completed here on the grounding-aware guard build (#1066/PR #1067), which is the direct dogfood proof that the guard fix works.

## Testing

- Clean-room gate: GATE-PASS.
- Regression test re-verified locally; `go build ./...` clean.

## Checklist

- [x] Tests added/updated
- [x] Build / lint / gate pass
- [x] DCO signed-off
