### PR TITLE
fix(foreman): stop the coder from running envtest it cannot run

### DIFF
--- a/config/foreman/agents/gemma4-26b-q4-coder.yaml
+++ b/config/foreman/agents/gemma4-26b-q4-coder.yaml
@@ -176,13 +176,20 @@ spec:
       it against. If you cannot ground a load-bearing external fact from any
       source you can reach, stop and report `NEEDS-VERIFICATION` (Step 3)
       rather than inventing it.
-    - Run the verification commands from `AGENTS.md` via the `bash` tool
-      and fix what they report:
-      - `make fmt`, `make vet`, `make lint`, `make test`
-      - If you changed `api/v1alpha1/` or `api/foreman/v1alpha1/`, also
+    - Verify your edit compiles: run `go build ./...` via the `bash` tool and
+      fix any build error. Do NOT run `make test`, `go test`, `golangci-lint`,
+      or `go vet` yourself. The coder workspace cannot run envtest
+      (KUBEBUILDER_ASSETS is unavailable), so `make test` hangs on the
+      envtest-backed controller packages (`internal/controller`,
+      `internal/foreman/controller`) and burns your turn budget for no result.
+      The deterministic clean-room gate runs `fmt`, `vet`, `lint`, and the full
+      `test` suite AFTER you submit GO and returns any failures for you to fix,
+      so a single `go build ./...` is the only self-check you need.
+      - If you changed `api/v1alpha1/` or `api/foreman/v1alpha1/`, also run
         `make manifests`, `make generate`, and `make chart-crds` (or
         `make foreman-chart-crds` for the foreman group); then confirm
-        `git status --porcelain` is empty.
+        `git status --porcelain` is empty. (These regenerate CRDs and do not
+        need envtest.)
 
     ## Step 3 — Report
 

--- a/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
+++ b/config/foreman/agents/qwen36-35b-carnice-mtp-coder.yaml
@@ -164,13 +164,20 @@ spec:
       it against. If you cannot ground a load-bearing external fact from any
       source you can reach, stop and report `NEEDS-VERIFICATION` (Step 3)
       rather than inventing it.
-    - Run the verification commands from `AGENTS.md` via the `bash` tool
-      and fix what they report:
-      - `make fmt`, `make vet`, `make lint`, `make test`
-      - If you changed `api/v1alpha1/` or `api/foreman/v1alpha1/`, also
+    - Verify your edit compiles: run `go build ./...` via the `bash` tool and
+      fix any build error. Do NOT run `make test`, `go test`, `golangci-lint`,
+      or `go vet` yourself. The coder workspace cannot run envtest
+      (KUBEBUILDER_ASSETS is unavailable), so `make test` hangs on the
+      envtest-backed controller packages (`internal/controller`,
+      `internal/foreman/controller`) and burns your turn budget for no result.
+      The deterministic clean-room gate runs `fmt`, `vet`, `lint`, and the full
+      `test` suite AFTER you submit GO and returns any failures for you to fix,
+      so a single `go build ./...` is the only self-check you need.
+      - If you changed `api/v1alpha1/` or `api/foreman/v1alpha1/`, also run
         `make manifests`, `make generate`, and `make chart-crds` (or
         `make foreman-chart-crds` for the foreman group); then confirm
-        `git status --porcelain` is empty.
+        `git status --porcelain` is empty. (These regenerate CRDs and do not
+        need envtest.)
 
     ## Step 3 — Report
 

--- a/config/foreman/system-prompts/coder.md
+++ b/config/foreman/system-prompts/coder.md
@@ -107,13 +107,20 @@ Do not edit any files.
   it against. If you cannot ground a load-bearing external fact from any
   source you can reach, stop and report `NEEDS-VERIFICATION` (Step 3)
   rather than inventing it.
-- Run the verification commands from `AGENTS.md` via the `bash` tool
-  and fix what they report:
-  - `make fmt`, `make vet`, `make lint`, `make test`
-  - If you changed `api/v1alpha1/` or `api/foreman/v1alpha1/`, also
+- Verify your edit compiles: run `go build ./...` via the `bash` tool and
+  fix any build error. Do NOT run `make test`, `go test`, `golangci-lint`,
+  or `go vet` yourself. The coder workspace cannot run envtest
+  (KUBEBUILDER_ASSETS is unavailable), so `make test` hangs on the
+  envtest-backed controller packages (`internal/controller`,
+  `internal/foreman/controller`) and burns your turn budget for no result.
+  The deterministic clean-room gate runs `fmt`, `vet`, `lint`, and the full
+  `test` suite AFTER you submit GO and returns any failures for you to fix,
+  so a single `go build ./...` is the only self-check you need.
+  - If you changed `api/v1alpha1/` or `api/foreman/v1alpha1/`, also run
     `make manifests`, `make generate`, and `make chart-crds` (or
     `make foreman-chart-crds` for the foreman group); then confirm
-    `git status --porcelain` is empty.
+    `git status --porcelain` is empty. (These regenerate CRDs and do not
+    need envtest.)
 
 ## Step 3 — Report
 


### PR DESCRIPTION
## What

Stop the coder from running `make test` (which hangs on envtest in the coder workspace) and make `go build ./...` its only self-check. The clean-room gate already runs the full fmt/vet/lint/test suite after the coder submits.

## Why

Fixes #1069. The coder workspace cannot run envtest (KUBEBUILDER_ASSETS unavailable), so `make test` hangs on the envtest-backed controller packages (`internal/controller`, `internal/foreman/controller`). Any fix that lives in a controller package could not be self-verified, so the coder burned turns on a hung `make test` and reported INCOMPLETE.

Observed on #904 (the grounding-guard re-run): the coder completed the whole prefetch feature (Prefetch field, Cached phase, `reconcilePrefetchSource`, tests) but reported *"the envtest suite is timing out on unrelated gateway tests, preventing verification"*, a complete, plausibly-correct feature blocked from GO by a self-check that cannot run in the workspace.

The deployed `coder-metal` prompt historically carried the correct "don't run envtest, `go build` only" guidance; a regenerate-from-`coder.md` patch overwrote it because `coder.md` had drifted and lacked that guidance. This restores it in the source of truth.

## How

- `config/foreman/system-prompts/coder.md`: replace the `make fmt/vet/lint/test` self-check with `go build ./...` only, and state explicitly that the workspace cannot run envtest and the clean-room gate runs the full suite after submit. `make manifests/generate/chart-crds` for API changes is retained (it does not need envtest).
- Re-synced into both coder Agent CRs (`qwen36-35b-carnice-mtp-coder`, `gemma4-26b-q4-coder`).

## Testing

- Prompt-only change; both Agent CRs re-parse as valid YAML with the corrected guidance.
- Empirical validation to follow: re-run #904 with the corrected prompt deployed and confirm the coder `go build`s and submits GO (the clean-room gate then verifies the envtest-backed tests) instead of hanging.

## Follow-up (separate, noted in #1069)

A drift guard for the coder prompt (like the reviewer prompt's `check-reviewer-prompts` CI gate) and a source-controlled home for the `coder-metal` Agent CR, so `coder.md` and the deployed prompt cannot silently diverge again.

## Checklist

- [x] Coder prompt + Agent CRs updated in lockstep
- [x] DCO signed-off

Assisted-by: Claude (Anthropic) — root-cause investigation and fix; reviewed by the maintainer.
