### PR TITLE
fix(cli): scope slicer branch names by run id (Fixes #1054)

### DIFF
--- a/pkg/cli/slice.go
+++ b/pkg/cli/slice.go
@@ -18,6 +18,8 @@ package cli
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -209,9 +211,12 @@ func validateSlicePlan(p slicePlan) error {
 // buildSliceWorkload renders the Workload: one issue-fix step per slice, then an
 // integrate step (dependsOn every slice), then a reconcile step (dependsOn
 // integrate). The integration branch and each slice branch follow the
-// foreman/slicer-<issue>/<name> convention.
+// foreman/slicer-<issue>-<runid>/<name> convention, where <runid> is a
+// per-Workload hex segment that makes re-runs of the same issue never collide
+// with branches left on the fork by an earlier run.
 func buildSliceWorkload(p slicePlan, opts *sliceOptions) *foremanv1alpha1.Workload {
-	integBranch := fmt.Sprintf("foreman/slicer-%d/integ", p.Issue)
+	runID := sliceRunID()
+	integBranch := fmt.Sprintf("foreman/slicer-%d-%s/integ", p.Issue, runID)
 
 	steps := make([]foremanv1alpha1.PipelineStep, 0, len(p.Slices)+2)
 	sliceNames := make([]string, 0, len(p.Slices))
@@ -219,7 +224,7 @@ func buildSliceWorkload(p slicePlan, opts *sliceOptions) *foremanv1alpha1.Worklo
 	reconSlices := make([]foremanv1alpha1.SliceRef, 0, len(p.Slices))
 
 	for _, s := range p.Slices {
-		branch := fmt.Sprintf("foreman/slicer-%d/%s", p.Issue, s.Name)
+		branch := fmt.Sprintf("foreman/slicer-%d-%s/%s", p.Issue, runID, s.Name)
 		steps = append(steps, foremanv1alpha1.PipelineStep{
 			Name:     s.Name,
 			Kind:     foremanv1alpha1.AgenticTaskKindIssueFix,
@@ -304,4 +309,18 @@ func buildSlicePrompt(p slicePlan, s planSlice) string {
 			"When your slice's files are done and verified once, submit_result GO.",
 		p.Issue, files, p.Contract, s.Task,
 	)
+}
+
+// sliceRunID returns an 8-char hex segment unique per invocation. It scopes
+// slicer branches so re-runs of the same issue never collide with branches
+// left on the fork by an earlier run. Stable across slices of one Workload so
+// integrate/reconcile resolve the same refs.
+func sliceRunID() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failure is essentially impossible; surface it loudly
+		// rather than silently degrading to a collision-prone fallback.
+		panic(fmt.Sprintf("crypto/rand: %v", err))
+	}
+	return hex.EncodeToString(b[:])
 }

--- a/pkg/cli/slice_test.go
+++ b/pkg/cli/slice_test.go
@@ -65,9 +65,11 @@ func TestBuildSliceWorkload_PipelineShape(t *testing.T) {
 		if s.Name != name || s.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
 			t.Fatalf("step %d = %s/%s, want %s/issue-fix", i, s.Name, s.Kind, name)
 		}
-		wantBranch := "foreman/slicer-700/" + name
-		if s.Payload.Branch != wantBranch {
-			t.Errorf("slice %s branch = %q, want %q", name, s.Payload.Branch, wantBranch)
+		// branch is foreman/slicer-<issue>-<runid>/<name>; runid is 8 hex chars.
+		if len(s.Payload.Branch) < 24 ||
+			!strings.HasPrefix(s.Payload.Branch, "foreman/slicer-700-") ||
+			!strings.HasSuffix(s.Payload.Branch, "/"+name) {
+			t.Errorf("slice %s branch = %q, want foreman/slicer-700-<runid>/%s", name, s.Payload.Branch, name)
 		}
 		if s.AgentRef.Name != "coder-metal" {
 			t.Errorf("slice %s agent = %q", name, s.AgentRef.Name)
@@ -85,9 +87,10 @@ func TestBuildSliceWorkload_PipelineShape(t *testing.T) {
 	if got := integ.DependsOn; len(got) != 2 || got[0] != "exporter" || got[1] != "dashboard" {
 		t.Errorf("integrate dependsOn = %v, want [exporter dashboard]", got)
 	}
-	if len(integ.Payload.Slices) != 2 || integ.Payload.Slices[0].Branch != "foreman/slicer-700/exporter" {
+	if len(integ.Payload.Slices) != 2 {
 		t.Errorf("integrate payload slices wrong: %+v", integ.Payload.Slices)
 	}
+	checkRunIDConsistency(t, steps[:2], integ, "integrate")
 
 	// reconcile step
 	rec := steps[3]
@@ -100,12 +103,79 @@ func TestBuildSliceWorkload_PipelineShape(t *testing.T) {
 	if len(rec.Payload.SharedIdentifiers) != 1 || rec.Payload.SharedIdentifiers[0].ID != "rocm_smi_gpu_temp" {
 		t.Errorf("reconcile pins wrong: %+v", rec.Payload.SharedIdentifiers)
 	}
-	if rec.Payload.Contract == "" || rec.Payload.Branch != "foreman/slicer-700/integ" {
-		t.Errorf("reconcile payload missing contract/branch: %+v", rec.Payload)
+	if rec.Payload.Contract == "" {
+		t.Errorf("reconcile payload missing contract: %+v", rec.Payload)
 	}
 	// reconcile carries files (for pinned_check), integrate carries branches.
 	if len(rec.Payload.Slices) != 2 || len(rec.Payload.Slices[0].Files) == 0 {
 		t.Errorf("reconcile payload slices need files: %+v", rec.Payload.Slices)
+	}
+}
+
+// checkRunIDConsistency asserts that every slice step's branch, the integrate
+// step's branch, and the integrate payload's slice refs all share the same
+// run-scoped segment. This is the invariant that lets integrate/reconcile
+// resolve the same branches the coder pushed, even though the runid is
+// generated fresh per Workload.
+func checkRunIDConsistency(
+	t *testing.T,
+	sliceSteps []foremanv1alpha1.PipelineStep,
+	integ foremanv1alpha1.PipelineStep,
+	label string,
+) {
+	t.Helper()
+	integRunID := strings.TrimPrefix(integ.Payload.Slices[0].Branch, "foreman/slicer-700-")
+	integRunID = strings.TrimSuffix(integRunID, "/exporter")
+	for _, s := range sliceSteps {
+		if !strings.Contains(s.Payload.Branch, "-"+integRunID+"/") {
+			t.Errorf("%s slice %s branch %q does not share runid %q", label, s.Name, s.Payload.Branch, integRunID)
+		}
+	}
+	if !strings.Contains(integ.Payload.Slices[0].Branch, "-"+integRunID+"/") {
+		t.Errorf("%s integrate slice ref does not share runid %q", label, integRunID)
+	}
+}
+
+// TestBuildSliceWorkload_RunIDUniquePerWorkload asserts that two independent
+// builds of the same plan produce different run-scoped branch segments, so a
+// re-run of `llmkube foreman slice` on the same issue never collides with
+// branches left on the fork by the prior run (issue #1054).
+func TestBuildSliceWorkload_RunIDUniquePerWorkload(t *testing.T) {
+	plan := samplePlan()
+	opts := defaultOpts()
+
+	wl1 := buildSliceWorkload(plan, opts)
+	wl2 := buildSliceWorkload(plan, opts)
+
+	branch1 := wl1.Spec.Pipeline[0].Payload.Branch
+	branch2 := wl2.Spec.Pipeline[0].Payload.Branch
+	if branch1 == branch2 {
+		t.Errorf("two Workloads for the same plan produced the same branch %q; runid must be unique per invocation", branch1)
+	}
+	// Both must still follow the foreman/slicer-<issue>-<runid>/<name> shape.
+	const wantPrefix = "foreman/slicer-700-"
+	if !strings.HasPrefix(branch1, wantPrefix) || !strings.HasPrefix(branch2, wantPrefix) {
+		t.Errorf("branches must be foreman/slicer-<issue>-<runid>/<name>; got %q, %q", branch1, branch2)
+	}
+}
+
+// TestSliceRunID_Properties exercises sliceRunID directly: it must return an
+// 8-char lowercase-hex string and two calls must differ. This is the unit
+// contract the branch-name change depends on.
+func TestSliceRunID_Properties(t *testing.T) {
+	a := sliceRunID()
+	b := sliceRunID()
+	if len(a) != 8 {
+		t.Errorf("sliceRunID() length = %d, want 8", len(a))
+	}
+	if a == b {
+		t.Errorf("sliceRunID() is not unique across calls: %q", a)
+	}
+	for _, r := range a {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			t.Errorf("sliceRunID() contains non-hex char %q", r)
+			break
+		}
 	}
 }
 


### PR DESCRIPTION
## What
Scopes slicer branch names by a per-Workload `crypto/rand` hex `runID`: `foreman/slicer-<issue>-<runid>/<name>`.

## Why
Re-running the slicer on the same issue reused identical branch names, colliding with branches an earlier run left on the fork and producing a NO-GO on push.

Fixes #1054

## How
One `runID` is generated per Workload build and reused across every slice branch, the integrate branch, and the reconcile payload refs, so they stay internally consistent while being unique across runs. Scoped to `pkg/cli/slice.go` (+25) and `pkg/cli/slice_test.go` (+82).

## Provenance and review
Generated by Foreman (LLMKube's agentic coder) and independently reviewed before opening. Review verdict: APPROVE, mergeable. Non-blocking minors noted for follow-up: `sliceRunID()` panics on a `crypto/rand` failure rather than returning an error (effectively unreachable; loud-fail preferred over a weak ID); a test helper hardcodes the first slice name when deriving the runID.

## Checklist
- [x] Tests added/updated (2 new, verified non-vacuous)
- [x] `make test` scope passes locally (`go test ./pkg/cli/...`)
- [x] Commits conventional + DCO signed
- [x] AI assistance disclosed above
