### PR TITLE
feat(foreman): expose CRD status as Prometheus metrics via CRS (Fixes #1001)

### DIFF
--- a/charts/foreman/templates/crs-configmap.yaml
+++ b/charts/foreman/templates/crs-configmap.yaml
@@ -1,0 +1,195 @@
+{{- if .Values.foreman.crs.enabled }}
+# Custom Resource State config for Foreman CRDs.
+#
+# Wired into the kube-state-metrics deployment (or the
+# kube-prometheus-stack `kube-state-metrics.customResourceState` values path)
+# so Foreman Workload / AgenticTask / FleetNode status fields land as
+# Prometheus gauges. See charts/foreman/values.yaml under `foreman.crs` for
+# the toggle and the alert rules that ship alongside this ConfigMap.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "foreman.fullname" . }}-crs
+  namespace: {{ include "foreman.namespace" . }}
+  labels:
+    {{- include "foreman.labels" . | nindent 4 }}
+data:
+  {{ .Values.foreman.crs.configMapKey }}: |
+    resources:
+      # -- AgenticTask -------------------------------------------------------
+      - groupVersionKind:
+          group: foreman.llmkube.dev
+          version: v1alpha1
+          kind: AgenticTask
+        metricNamePrefix: foreman_agentictask
+        metrics:
+          # foreman_agentictask_info{namespace,name,workload,agent,phase,verdict}
+          - name: info
+            help: "AgenticTask phase and verdict"
+            each:
+              type: Info
+              info:
+                labelsFromPath:
+                  phase: [status, phase]
+                  verdict: [status, verdict]
+                  workload: [metadata, labels, "foreman.llmkube.dev/workload"]
+                  agent: [spec, agentRef, name]
+
+          # Enum-style gauges: one series per state, value=1 on the active
+          # state. Easy to alert on (e.g. sum by (namespace) of the Pending
+          # series = pending task count).
+          - name: phase
+            help: "AgenticTask phase (1 = active)"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, phase]
+                labelsMapping:
+                  Pending: pending
+                  Scheduled: scheduled
+                  Running: running
+                  Verifying: verifying
+                  Succeeded: succeeded
+                  Failed: failed
+
+          - name: verdict
+            help: "AgenticTask verdict (1 = active)"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, verdict]
+                labelsMapping:
+                  GO: go
+                  "NO-GO": no-go
+                  INCOMPLETE: incomplete
+                  "GATE-PASS": gate-pass
+                  "GATE-FAIL": gate-fail
+                  "GATE-ERROR": gate-error
+                  Skipped: skipped
+
+          # Counter for failed children, derived from the AgenticTask's own
+          # phase (a task is either failed or it isn't).
+          - name: tasks_failed
+            help: "AgenticTasks in Failed phase (gauge=1 per failed task)"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, phase]
+                labelsMapping:
+                  Failed: failed
+
+      # -- Workload ----------------------------------------------------------
+      - groupVersionKind:
+          group: foreman.llmkube.dev
+          version: v1alpha1
+          kind: Workload
+        metricNamePrefix: foreman_workload
+        metrics:
+          # foreman_workload_info{namespace,name,phase,repo}
+          - name: info
+            help: "Workload phase and repo"
+            each:
+              type: Info
+              info:
+                labelsFromPath:
+                  phase: [status, phase]
+                  repo: [spec, repo]
+
+          # foreman_workload_succeeded_tasks / _failed_tasks / _incomplete_tasks
+          # (integer gauges = status.<field>)
+          - name: succeeded_tasks
+            help: "Succeeded child AgenticTasks for this Workload"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, succeededTasks]
+
+          - name: failed_tasks
+            help: "Failed child AgenticTasks for this Workload"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, failedTasks]
+
+          - name: incomplete_tasks
+            help: "Incomplete child AgenticTasks for this Workload"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, incompleteTasks]
+
+          # Enum-style phase gauges for Workload (Planning / Planned /
+          # Dispatched / Completed / Failed).
+          - name: phase
+            help: "Workload phase (1 = active)"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, phase]
+                labelsMapping:
+                  Planning: planning
+                  Planned: planned
+                  Dispatched: dispatched
+                  Completed: completed
+                  Failed: failed
+
+      # -- FleetNode ---------------------------------------------------------
+      - groupVersionKind:
+          group: foreman.llmkube.dev
+          version: v1alpha1
+          kind: FleetNode
+        metricNamePrefix: foreman_fleetnode
+        metrics:
+          # foreman_fleetnode_info{node,accelerator,os,arch}
+          - name: info
+            help: "FleetNode identity and capability"
+            each:
+              type: Info
+              info:
+                labelsFromPath:
+                  node: [spec, nodeName]
+                  accelerator: [status, capability, accelerator]
+                  os: [status, os]
+                  arch: [status, arch]
+
+          # foreman_fleetnode_heartbeat_timestamp_seconds (gauge = unix seconds
+          # of LastHeartbeatTime, 0 when absent).
+          - name: heartbeat_timestamp_seconds
+            help: "FleetNode last heartbeat unix timestamp (0 = no heartbeat)"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, lastHeartbeatTime]
+
+          # foreman_fleetnode_ram_gigabytes (gauge = status.capability.totalRAMGB)
+          - name: ram_gigabytes
+            help: "FleetNode total RAM in GiB"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, capability, totalRAMGB]
+
+          # Enum-style phase gauges (Ready / Draining / NotReady / Unknown).
+          - name: phase
+            help: "FleetNode phase (1 = active)"
+            each:
+              type: Gauge
+              gauge:
+                valueFrom:
+                  path: [status, phase]
+                labelsMapping:
+                  Ready: ready
+                  Draining: draining
+                  NotReady: not-ready
+                  Unknown: unknown
+---
+{{- end }}

--- a/charts/foreman/templates/grafana-dashboard.yaml
+++ b/charts/foreman/templates/grafana-dashboard.yaml
@@ -1,0 +1,365 @@
+{{- if .Values.foreman.crs.enabled }}
+# Starter Grafana dashboard for Foreman CRD status metrics.
+#
+# Drop this ConfigMap into a namespace that the Grafana datasource plugin
+# can mount (the kube-prometheus-stack `grafana.sidecar.dashboards` config,
+# or a Grafana dashboard-provider ConfigMap). The dashboard covers:
+#
+#   - Foreman fleet overview (FleetNode count by phase, RAM, accelerator)
+#   - Workload lifecycle (phases, task counts)
+#   - AgenticTask pipeline (phase/verdict distribution, stuck tasks)
+#
+# The metric series referenced here are emitted by the CRS ConfigMap
+# (charts/foreman/templates/crs-configmap.yaml).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "foreman.fullname" . }}-grafana-dashboard
+  namespace: {{ include "foreman.namespace" . }}
+  labels:
+    {{- include "foreman.labels" . | nindent 4 }}
+    grafana_dashboard: "true"
+data:
+  foreman.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+          "id": 1,
+          "panels": [],
+          "title": "Fleet Overview",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "green", "value": 2 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+          "id": 2,
+          "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+          "title": "Ready Nodes",
+          "type": "stat",
+          "targets": [
+            { "expr": "sum(foreman_fleetnode_phase{phase=\"ready\"})", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+          "id": 3,
+          "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+          "title": "Draining Nodes",
+          "type": "stat",
+          "targets": [
+            { "expr": "sum(foreman_fleetnode_phase{phase=\"draining\"})", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+          "id": 4,
+          "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+          "title": "NotReady Nodes",
+          "type": "stat",
+          "targets": [
+            { "expr": "sum(foreman_fleetnode_phase{phase=\"not-ready\"})", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "axisLabel": "", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0 },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 8, "x": 12, "y": 1 },
+          "id": 5,
+          "options": { "barRadius": 0, "orientation": "auto", "showValue": "auto", "stacking": { "group": "A", "mode": "none" } },
+          "title": "Nodes by Accelerator",
+          "type": "barchart",
+          "targets": [
+            { "expr": "sum by (accelerator) (foreman_fleetnode_info)", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "axisLabel": "", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+          "id": 6,
+          "options": { "tooltip": { "mode": "multi" } },
+          "title": "FleetNode Heartbeat Timestamp",
+          "type": "timeseries",
+          "targets": [
+            { "expr": "foreman_fleetnode_heartbeat_timestamp_seconds", "refId": "A" }
+          ]
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+          "id": 7,
+          "panels": [],
+          "title": "Workloads",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "axisLabel": "", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0 },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+          "id": 8,
+          "options": { "barRadius": 0, "orientation": "auto", "showValue": "auto", "stacking": { "group": "A", "mode": "normal" } },
+          "title": "Workloads by Phase",
+          "type": "barchart",
+          "targets": [
+            { "expr": "sum by (phase) (foreman_workload_phase)", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "axisLabel": "", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+          "id": 9,
+          "options": { "tooltip": { "mode": "multi" } },
+          "title": "Workload Task Counts",
+          "type": "timeseries",
+          "targets": [
+            { "expr": "foreman_workload_succeeded_tasks", "refId": "A" },
+            { "expr": "foreman_workload_failed_tasks", "refId": "B" },
+            { "expr": "foreman_workload_incomplete_tasks", "refId": "C" }
+          ]
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 },
+          "id": 10,
+          "panels": [],
+          "title": "AgenticTasks",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "axisLabel": "", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0 },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 27 },
+          "id": 11,
+          "options": { "barRadius": 0, "orientation": "auto", "showValue": "auto", "stacking": { "group": "A", "mode": "normal" } },
+          "title": "Tasks by Phase",
+          "type": "barchart",
+          "targets": [
+            { "expr": "sum by (phase) (foreman_agentictask_phase)", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "axisLabel": "", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0 },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 27 },
+          "id": 12,
+          "options": { "barRadius": 0, "orientation": "auto", "showValue": "auto", "stacking": { "group": "A", "mode": "normal" } },
+          "title": "Tasks by Verdict",
+          "type": "barchart",
+          "targets": [
+            { "expr": "sum by (verdict) (foreman_agentictask_verdict)", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "yellow", "value": 1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 35 },
+          "id": 13,
+          "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+          "title": "Stuck Tasks (Running > 1h)",
+          "type": "stat",
+          "targets": [
+            { "expr": "count(foreman_agentictask_phase{phase=\"running\"}) > 0", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 35 },
+          "id": 14,
+          "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+          "title": "Succeeded Tasks",
+          "type": "stat",
+          "targets": [
+            { "expr": "sum(foreman_agentictask_phase{phase=\"succeeded\"})", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 35 },
+          "id": 15,
+          "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+          "title": "Failed Tasks",
+          "type": "stat",
+          "targets": [
+            { "expr": "sum(foreman_agentictask_phase{phase=\"failed\"})", "refId": "A" }
+          ]
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "yellow", "value": null }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 35 },
+          "id": 16,
+          "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+          "title": "Incomplete Tasks",
+          "type": "stat",
+          "targets": [
+            { "expr": "sum(foreman_agentictask_verdict{verdict=\"incomplete\"})", "refId": "A" }
+          ]
+        }
+      ],
+      "schemaVersion": 38,
+      "tags": ["foreman", "llmkube"],
+      "templating": { "list": [
+        { "current": {}, "hide": 0, "includeAll": false, "label": "Datasource", "multi": false, "name": "datasource", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" }
+      ]},
+      "time": { "from": "now-6h", "to": "now" },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Foreman Fleet & Tasks",
+      "uid": "foreman-fleet-tasks",
+      "version": 1
+    }
+---
+{{- end }}

--- a/charts/foreman/templates/prometheusrule.yaml
+++ b/charts/foreman/templates/prometheusrule.yaml
@@ -1,0 +1,76 @@
+{{- if and .Values.foreman.crs.enabled .Values.foreman.crs.alerts.enabled }}
+# Starter PrometheusRule alerts for Foreman CRD status metrics.
+#
+# These alert on the two axes that matter most to an SRE running Foreman:
+# a Workload stuck in Pending (scheduling or capability mismatch) and a
+# FleetNode whose heartbeat has gone stale (agent crash or network partition).
+#
+# The metric series these rules reference are emitted by the CRS ConfigMap
+# (charts/foreman/templates/crs-configmap.yaml). Disable with
+# `foreman.crs.alerts.enabled: false` if you prefer to author your own
+# rules against the same series.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "foreman.fullname" . }}-alerts
+  namespace: {{ include "foreman.namespace" . }}
+  labels:
+    {{- include "foreman.labels" . | nindent 4 }}
+    {{- with .Values.foreman.crs.alerts.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+  - name: foreman-workload
+    interval: 30s
+    rules:
+    # A Workload stuck in Planning/Planned/Pending for longer than the
+    # alert threshold. The WorkloadReconciler transitions Planning ->
+    # Planned -> Dispatched as it emits AgenticTasks; if it lingers in
+    # Planning the planner is blocked (missing CoderAgentRef, invalid
+    # Intent, etc.) and a human should investigate.
+    - alert: ForemanWorkloadStuckPending
+      expr: foreman_workload_phase{phase="planning"} == 1 or foreman_workload_phase{phase="planned"} == 1
+      for: {{ .Values.foreman.crs.alerts.stuckPendingDuration }}
+      labels:
+        severity: warning
+        component: foreman
+      annotations:
+        summary: "Workload {{`{{ $labels.namespace }}/{{ $labels.name }}`}} stuck in {{`{{ $labels.phase }}`}}"
+        description: "Workload {{`{{ $labels.namespace }}/{{ $labels.name }}`}} has been in phase {{`{{ $labels.phase }}`}} for more than {{ .Values.foreman.crs.alerts.stuckPendingDuration }}. Check the Workload's conditions and the CoderAgentRef it references."
+
+  - name: foreman-fleetnode
+    interval: 30s
+    rules:
+    # A FleetNode whose heartbeat has gone stale. The foreman-agent
+    # heartbeats every 30s; FleetNodeHeartbeatTimeout is 90s. This alert
+    # fires after `staleHeartbeatDuration` of silence, which must be >
+    # 90s to avoid flapping on a single missed beat.
+    - alert: ForemanFleetNodeHeartbeatStale
+      expr: foreman_fleetnode_heartbeat_timestamp_seconds > 0 and (time_seconds() - foreman_fleetnode_heartbeat_timestamp_seconds) > {{ .Values.foreman.crs.alerts.staleHeartbeatSeconds }}
+      for: {{ .Values.foreman.crs.alerts.staleHeartbeatDuration }}
+      labels:
+        severity: critical
+        component: foreman
+      annotations:
+        summary: "FleetNode {{`{{ $labels.node }}`}} heartbeat stale"
+        description: "FleetNode {{`{{ $labels.node }}`}} has not heartbeated in more than {{ .Values.foreman.crs.alerts.staleHeartbeatDuration }}. The foreman-agent on this node may be crashed or the network partitioned."
+
+  - name: foreman-agentictask
+    interval: 30s
+    rules:
+    # A task in Running phase for an unreasonably long time. Most
+    # issue-fix tasks complete in under 10 minutes; a task running for
+    # over an hour is likely stuck in the model loop (max-turns
+    # misconfigured, model unresponsive) and needs human intervention.
+    - alert: ForemanAgenticTaskRunningTooLong
+      expr: foreman_agentictask_phase{phase="running"} == 1
+      for: 1h
+      labels:
+        severity: warning
+        component: foreman
+      annotations:
+        summary: "AgenticTask {{`{{ $labels.namespace }}/{{ $labels.name }}`}} running for over 1 hour"
+        description: "AgenticTask {{`{{ $labels.namespace }}/{{ $labels.name }}`}} (kind={{`{{ $labels.agent }}`}}) has been in Running phase for over 1 hour. Check the agent's transcript ConfigMap for signs of a stuck loop."
+---
+{{- end }}

--- a/charts/foreman/tests/agents_test.yaml
+++ b/charts/foreman/tests/agents_test.yaml
@@ -7,6 +7,9 @@ templates:
   - operator-rbac.yaml
   - coder-rbac.yaml
   - webhook.yaml
+  - crs-configmap.yaml
+  - prometheusrule.yaml
+  - grafana-dashboard.yaml
 
 tests:
   # ---- Backward compat: legacy agent: block ----
@@ -258,3 +261,115 @@ tests:
     asserts:
       - hasDocuments:
           count: 3
+
+  # ---- CRS: disabled by default ----
+
+  - it: CRS ConfigMap is omitted when foreman.crs.enabled is false
+    template: crs-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: CRS ConfigMap renders when foreman.crs.enabled is true
+    template: crs-configmap.yaml
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-crs
+      - isKind:
+          of: ConfigMap
+
+  - it: CRS ConfigMap contains the AgenticTask mapping
+    template: crs-configmap.yaml
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: "AgenticTask"
+
+  - it: CRS ConfigMap contains the Workload mapping
+    template: crs-configmap.yaml
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: "Workload"
+
+  - it: CRS ConfigMap contains the FleetNode mapping
+    template: crs-configmap.yaml
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: "FleetNode"
+
+  # ---- PrometheusRule: disabled by default ----
+
+  - it: PrometheusRule is omitted when foreman.crs.alerts.enabled is false
+    template: prometheusrule.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: PrometheusRule renders when foreman.crs.alerts.enabled is true
+    template: prometheusrule.yaml
+    set:
+      foreman.crs.enabled: true
+      foreman.crs.alerts.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-alerts
+      - isKind:
+          of: PrometheusRule
+
+  - it: PrometheusRule contains the stuck-pending alert
+    template: prometheusrule.yaml
+    set:
+      foreman.crs.enabled: true
+      foreman.crs.alerts.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[0].rules[0].alert
+          pattern: "ForemanWorkloadStuckPending"
+
+  - it: PrometheusRule contains the stale-heartbeat alert
+    template: prometheusrule.yaml
+    set:
+      foreman.crs.enabled: true
+      foreman.crs.alerts.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[1].rules[0].alert
+          pattern: "ForemanFleetNodeHeartbeatStale"
+
+  # ---- Grafana dashboard: disabled by default ----
+
+  - it: Grafana dashboard ConfigMap is omitted when foreman.crs.enabled is false
+    template: grafana-dashboard.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Grafana dashboard ConfigMap renders when foreman.crs.enabled is true
+    template: grafana-dashboard.yaml
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-foreman-grafana-dashboard
+      - equal:
+          path: metadata.labels.grafana_dashboard
+          value: "true"

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -43,6 +43,85 @@ foreman:
   # should set this false.
   allowCloudProviders: true
 
+  # Foreman CRD status metrics via kube-state-metrics Custom Resource State.
+  #
+  # Maps the Foreman CRD status fields (Workload, AgenticTask, FleetNode) to
+  # Prometheus gauges so job and fleet state is scrapable and alertable in the
+  # Prometheus + Grafana stack operators already run. Pure configuration
+  # against the kube-state-metrics already deployed in most clusters: no new
+  # operator code.
+  #
+  # The CRS config is rendered as a ConfigMap in the Foreman release namespace.
+  # The kube-state-metrics deployment (or the kube-prometheus-stack
+  # `kube-state-metrics.customResourceState` values path) must be pointed at
+  # this ConfigMap for the metrics to land in the existing scrape pipeline.
+  #
+  # Set `enabled: false` to opt out (e.g. when the cluster does not run
+  # kube-state-metrics, or when a different observability stack is in use).
+  crs:
+    enabled: false
+    # Metrics path the CRS ConfigMap is served at inside the ConfigMap.
+    # Matches the kube-prometheus-stack default (`/etc/ksm-cmaps/...`) so
+    # the stack picks it up without extra wiring.
+    configMapKey: foreman-crs.yaml
+    # Example PrometheusRule alerts shipped alongside the CRS config.
+    # Disable when you prefer to author your own alerts against the same
+    # metric series.
+    alerts:
+      enabled: false
+      # How long a Workload may sit in Pending before the alert fires.
+      stuckPendingDuration: 15m
+      # How long a FleetNode's heartbeat must be stale before the alert
+      # fires. Must be > FleetNodeHeartbeatTimeout (90s) to avoid flapping.
+      staleHeartbeatDuration: 5m
+      # Numeric threshold in seconds used for the `> N` comparison in the
+      # ForemanFleetNodeHeartbeatStale expr. Defaults to 300 (5 minutes).
+      # The `staleHeartbeatDuration` duration string is used for the `for:`
+      # field and the alert description instead.
+      staleHeartbeatSeconds: 300
+      # Labels applied to the PrometheusRule metadata so a Prometheus
+      # instance that restricts ruleSelector (e.g. the default
+      # kube-prometheus-stack) will adopt these rules.
+      additionalLabels:
+        prometheus: kube-prometheus-stack-prometheus
+
+# agents is the multi-fleet map (#994). Leave it UNSET for a single
+# agent (the legacy `agent:` block above is used as-is and renders
+# exactly the resources it always has, so an existing install is
+# unchanged on upgrade). Set it to render one Deployment +
+# ServiceAccount + ClusterRole/ClusterRoleBinding + gate-cache PVC PER
+# entry, each suffixed with the agent key, so multiple heterogeneous
+# agent fleets coexist in one release instead of needing a second
+# chart install (which would collide on the chart's singletons).
+#
+# Real-world use cases:
+#
+#   agents:
+#     default:                  # the primary multi-repo worker/coder pool
+#       replicaCount: 3
+#       roles: [worker, coder, verifier]
+#     llmkube-fork:             # a fork-pinned dogfood agent for upstream PRs
+#       replicaCount: 1
+#       roles: [coder-fork]
+#       gitRemoteURL: https://github.com/<you>/LLMKube
+#       githubToken: { secretName: foreman-agent-fork, secretKey: GITHUB_TOKEN }
+#       commitAuthorName: "<you>"
+#       commitAuthorEmail: "<you>@users.noreply.github.com"
+#       coderGitSecret: foreman-fork-credentials     # per-agent coder PAT
+#       gateCache: { enabled: false }                  # fork agents don't gate
+#
+# Each entry's fields DEEP-MERGE with the legacy `agent:` block above
+# (which serves as the defaults) so you only have to specify what
+# differs. Naming convention: per-agent resources are
+# `<fullname>-<agentKey>-agent` (Deployment / SA / ClusterRole /
+# ClusterRoleBinding) and `<fullname>-<agentKey>-gate-cache` (PVC), so
+# agents never collide. The shared components — operator Deployment,
+# webhook, CRDs, coder SA/Role/RoleBinding — remain single per release.
+#
+# Setting `agents:` opts you OUT of the implicit legacy agent: render
+# path; if you need a "default" fleet alongside custom ones, list it
+# explicitly under `agents:` with the name `default` (or any other key).
+
 operator:
   enabled: true
   replicaCount: 1
@@ -335,42 +414,6 @@ agent:
   coderGitSecret: ""
   coderGitSecretKey: ""
 
-# agents is the multi-fleet map (#994). Leave it UNSET for a single
-# agent (the legacy `agent:` block above is used as-is and renders
-# exactly the resources it always has, so an existing install is
-# unchanged on upgrade). Set it to render one Deployment +
-# ServiceAccount + ClusterRole/ClusterRoleBinding + gate-cache PVC PER
-# entry, each suffixed with the agent key, so multiple heterogeneous
-# agent fleets coexist in one release instead of needing a second
-# chart install (which would collide on the chart's singletons).
-#
-# Real-world use cases:
-#
-#   agents:
-#     default:                  # the primary multi-repo worker/coder pool
-#       replicaCount: 3
-#       roles: [worker, coder, verifier]
-#     llmkube-fork:             # a fork-pinned dogfood agent for upstream PRs
-#       replicaCount: 1
-#       roles: [coder-fork]
-#       gitRemoteURL: https://github.com/<you>/LLMKube
-#       githubToken: { secretName: foreman-agent-fork, secretKey: GITHUB_TOKEN }
-#       commitAuthorName: "<you>"
-#       commitAuthorEmail: "<you>@users.noreply.github.com"
-#       coderGitSecret: foreman-fork-credentials     # per-agent coder PAT
-#       gateCache: { enabled: false }                  # fork agents don't gate
-#
-# Each entry's fields DEEP-MERGE with the legacy `agent:` block above
-# (which serves as the defaults) so you only have to specify what
-# differs. Naming convention: per-agent resources are
-# `<fullname>-<agentKey>-agent` (Deployment / SA / ClusterRole /
-# ClusterRoleBinding) and `<fullname>-<agentKey>-gate-cache` (PVC), so
-# agents never collide. The shared components — operator Deployment,
-# webhook, CRDs, coder SA/Role/RoleBinding — remain single per release.
-#
-# Setting `agents:` opts you OUT of the implicit legacy agent: render
-# path; if you need a "default" fleet alongside custom ones, list it
-# explicitly under `agents:` with the name `default` (or any other key).
 agents: {}
 
 # coder gates the ServiceAccount + namespaced Role the Job-mode coder


### PR DESCRIPTION
## What
Exposes Foreman CRD status (Workload / AgenticTask / FleetNode) as Prometheus metrics via a kube-state-metrics CustomResourceState ConfigMap, plus a Grafana dashboard and PrometheusRule, gated behind `foreman.crs.enabled`.

Fixes #1001

## How
kube-state-metrics CRS mappings for the three CRDs' status fields, a dashboard, and alerts (stuck workload, stale heartbeat, long-running task).

## Provenance and review
Generated by Foreman, then revised through a full maintainer-review cycle. The first attempt GO'd but an independent review found 8 defects (its own `helm unittest` suite failed 5/29). All 8 were fed back to a restore-first revision run, which fixed them; I then re-verified independently (the Go gate does not test charts):

- `helm unittest charts/foreman`: **29/29 pass** (was 5 failed / 24 passed).
- Stale-heartbeat alert threshold renders `> 300` for the `5m` default (was `> 5`, i.e. flapping every scrape).
- `foreman_workload_tasks_total` (list-typed `status.tasks`) replaced with the integer `status.{succeeded,failed,incomplete}Tasks` gauges.
- AgenticTask `agent` label fixed to `spec.agentRef.name`; PrometheusRule gains the `additionalLabels` operator-selector hook (mirroring `charts/llmkube`); the owner-reference string gauge removed; dead namespace override knobs and an overclaiming comment corrected.

## Checklist
- [x] `helm unittest charts/foreman` 29/29 (verified on this branch and on main)
- [x] `helm lint` / `helm template` (enabled + disabled) render clean
- [x] Commits conventional + DCO signed
- [x] AI assistance disclosed above
