### PR TITLE
fix(controller): default Model accelerator from gpu.runtime (Fixes #1074)

### DIFF
--- a/charts/llmkube/templates/webhook.yaml
+++ b/charts/llmkube/templates/webhook.yaml
@@ -59,4 +59,30 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["modelrouters"]
         scope: Namespaced
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "llmkube.webhook.configName" . }}-mutating
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+webhooks:
+  - name: mmodel.inference.llmkube.dev
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    # Ignore: accelerator normalization is cosmetic (#1074); a Model apply must
+    # never be blocked because the defaulter is unreachable.
+    failurePolicy: Ignore
+    clientConfig:
+      service:
+        name: {{ include "llmkube.webhook.serviceName" . }}
+        namespace: {{ include "llmkube.namespace" . }}
+        path: /mutate-inference-llmkube-dev-v1alpha1-model
+      caBundle: {{ $certs.ca }}
+    rules:
+      - apiGroups: ["inference.llmkube.dev"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["models"]
+        scope: Namespaced
 {{- end }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -373,7 +373,11 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ModelRouter")
 			os.Exit(1)
 		}
-		setupLog.Info("validating webhook enabled", "webhook", "ModelRouter", "certDir", webhookCertPath)
+		if err := controller.SetupModelWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Model")
+			os.Exit(1)
+		}
+		setupLog.Info("webhooks enabled", "webhooks", "ModelRouter,Model", "certDir", webhookCertPath)
 	} else if webhookCertPath != "" {
 		setupLog.Info("webhook cert path set but no serving cert found; skipping ModelRouter webhook",
 			"certDir", webhookCertPath)

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,5 +1,31 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-inference-llmkube-dev-v1alpha1-model
+  failurePolicy: Ignore
+  name: mmodel.inference.llmkube.dev
+  rules:
+  - apiGroups:
+    - inference.llmkube.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - models
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/internal/controller/model_webhook.go
+++ b/internal/controller/model_webhook.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// +kubebuilder:webhook:path=/mutate-inference-llmkube-dev-v1alpha1-model,mutating=true,failurePolicy=ignore,sideEffects=None,groups=inference.llmkube.dev,resources=models,verbs=create;update,versions=v1alpha1,name=mmodel.inference.llmkube.dev,admissionReviewVersions=v1
+
+// ModelDefaulter normalizes a Model's hardware.accelerator so it does not
+// contradict its GPU runtime (#1074). The CRD default for accelerator is "cpu",
+// so a Model that sets gpu.runtime=vulkan but leaves accelerator unset prints
+// ACCELERATOR "cpu" in `kubectl get models` even though it runs on the Vulkan
+// GPU. Scheduling already keys off gpu.runtime, so this is a display/consistency
+// fix, not a behavior change: the defaulter only fills in the accelerator the
+// runtime implies, and only when the user left it at the cpu default.
+//
+// failurePolicy is Ignore: a Model apply must never be blocked because the
+// defaulter is unreachable. The value is cosmetic; degrading to "no defaulting"
+// is strictly better than a failed apply.
+type ModelDefaulter struct{}
+
+var _ admission.Defaulter[*inferencev1alpha1.Model] = &ModelDefaulter{}
+
+// SetupModelWebhookWithManager registers the Model defaulting webhook.
+func SetupModelWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &inferencev1alpha1.Model{}).
+		WithDefaulter(&ModelDefaulter{}).
+		Complete()
+}
+
+// Default applies accelerator normalization to a Model at admission.
+func (d *ModelDefaulter) Default(ctx context.Context, m *inferencev1alpha1.Model) error {
+	logf.FromContext(ctx).V(1).Info("defaulting Model", "name", m.Name, "namespace", m.Namespace)
+	normalizeAccelerator(m)
+	return nil
+}
+
+// normalizeAccelerator sets hardware.accelerator to the value the GPU runtime
+// implies when the accelerator was left at the "cpu" default (or empty) on a
+// GPU-enabled Model. It never overrides an explicitly-set non-cpu accelerator,
+// so a deliberate choice is respected, and it only acts on runtimes that name a
+// concrete accelerator (vulkan, rocm); an empty runtime is left untouched
+// because it is back-compatible with the historical default and normalizing it
+// would restate many pre-existing Models.
+func normalizeAccelerator(m *inferencev1alpha1.Model) {
+	h := m.Spec.Hardware
+	if h == nil || h.GPU == nil || !h.GPU.Enabled {
+		return
+	}
+	accel := strings.ToLower(strings.TrimSpace(h.Accelerator))
+	if accel != "" && accel != "cpu" {
+		return
+	}
+	switch h.GPU.Runtime {
+	case "vulkan":
+		h.Accelerator = "vulkan"
+	case "rocm":
+		h.Accelerator = "rocm"
+	}
+}

--- a/internal/controller/model_webhook_test.go
+++ b/internal/controller/model_webhook_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func TestNormalizeAccelerator(t *testing.T) {
+	gpu := func(enabled bool, runtime string) *inferencev1alpha1.GPUSpec {
+		return &inferencev1alpha1.GPUSpec{Enabled: enabled, Runtime: runtime}
+	}
+	cases := []struct {
+		name     string
+		hardware *inferencev1alpha1.HardwareSpec
+		want     string // expected accelerator after normalization
+	}{
+		{"vulkan runtime + cpu default -> vulkan (#1074)",
+			&inferencev1alpha1.HardwareSpec{Accelerator: "cpu", GPU: gpu(true, "vulkan")}, "vulkan"},
+		{"vulkan runtime + empty accelerator -> vulkan",
+			&inferencev1alpha1.HardwareSpec{Accelerator: "", GPU: gpu(true, "vulkan")}, "vulkan"},
+		{"rocm runtime + cpu default -> rocm",
+			&inferencev1alpha1.HardwareSpec{Accelerator: "cpu", GPU: gpu(true, "rocm")}, "rocm"},
+		{"explicit non-cpu accelerator is respected",
+			&inferencev1alpha1.HardwareSpec{Accelerator: "cuda", GPU: gpu(true, "vulkan")}, "cuda"},
+		{"gpu disabled -> accelerator untouched",
+			&inferencev1alpha1.HardwareSpec{Accelerator: "cpu", GPU: gpu(false, "vulkan")}, "cpu"},
+		{"no gpu block -> cpu stays cpu",
+			&inferencev1alpha1.HardwareSpec{Accelerator: "cpu"}, "cpu"},
+		{"empty runtime is not normalized (back-compat)",
+			&inferencev1alpha1.HardwareSpec{Accelerator: "cpu", GPU: gpu(true, "")}, "cpu"},
+		{"nil hardware is a no-op",
+			nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &inferencev1alpha1.Model{}
+			m.Spec.Hardware = tc.hardware
+			normalizeAccelerator(m)
+			got := ""
+			if m.Spec.Hardware != nil {
+				got = m.Spec.Hardware.Accelerator
+			}
+			if got != tc.want {
+				t.Errorf("accelerator = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModelDefaulter_Default(t *testing.T) {
+	d := &ModelDefaulter{}
+	m := &inferencev1alpha1.Model{}
+	m.Spec.Hardware = &inferencev1alpha1.HardwareSpec{
+		Accelerator: "cpu",
+		GPU:         &inferencev1alpha1.GPUSpec{Enabled: true, Runtime: "vulkan"},
+	}
+	if err := d.Default(context.Background(), m); err != nil {
+		t.Fatalf("Default returned error: %v", err)
+	}
+	if m.Spec.Hardware.Accelerator != "vulkan" {
+		t.Errorf("Default did not normalize accelerator: got %q", m.Spec.Hardware.Accelerator)
+	}
+}


### PR DESCRIPTION
## What
Adds a `Model` defaulting (mutating) webhook that normalizes `spec.hardware.accelerator` to the value the GPU runtime implies (`vulkan` or `rocm`) when it was left at the `cpu` default on a GPU-enabled Model.

Fixes #1074

## Why
A Model that sets `gpu.runtime: vulkan` but omits `accelerator` inherits the CRD default `cpu`, so `kubectl get models` prints `ACCELERATOR cpu` for every AMD/Vulkan model even though it is running on the Vulkan GPU. Scheduling already keys off `gpu.runtime` (the dri-render device is requested regardless), so this was a cosmetic/consistency wart, not a functional bug — but the label directly contradicts the GPU config and misleads any operator reading it.

## How
`ModelDefaulter.Default` calls a pure `normalizeAccelerator`: on a `gpu.enabled` Model whose `accelerator` is empty or `cpu`, it sets the accelerator from `gpu.runtime` (`vulkan` → `vulkan`, `rocm` → `rocm`). It never overrides an explicitly-set non-cpu accelerator, and it leaves an empty runtime untouched (back-compat). The webhook reuses the already-deployed webhook server, cert Secret, and Service; the new `MutatingWebhookConfiguration` uses `failurePolicy: Ignore` so a Model apply is never blocked because the defaulter is unreachable (the value is cosmetic; degrading to "no defaulting" beats a failed apply). Registered in `cmd/main.go` behind the same cert-present guard as the ModelRouter webhook.

Existing Models keep their current label until re-applied (admission only fires on write); the immediate in-cluster manifests are corrected separately.

## Verification
- New `TestNormalizeAccelerator` (8 cases) + `TestModelDefaulter_Default`.
- `make test` (full envtest): pass; `internal/controller` suite green with the webhook.
- `make manifests`/`generate`/`chart-crds`/`foreman-chart-crds`: clean, only intended files changed.
- `make check-helm-rbac`: all 183 kubebuilder rules covered.
- `golangci-lint` on the changed files (cross-arch): 0 issues. (`make lint` surfaces only pre-existing findings in generated `zz_generated` files and an external workspace clone, none in this change.)

## Checklist
- [x] Tests added (unit; envtest suite green)
- [x] `make test` passes locally
- [x] Manifests/chart regenerated and in sync
- [x] Commits conventional + DCO signed
- [x] AI assistance disclosed (implemented with an AI coding assistant; design, verification, and sign-off are mine)
