### PR TITLE
feat(controller): extend drain-before-roll idle checks to vLLM, TGI, SGLang, and multi-replica services

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -33,6 +33,11 @@ const (
 	// agents that predate this annotation.
 	AnnotationAgentVersion = "llmkube.ai/agent-version"
 
+	// AnnotationIdleEndpoint lets operators declare a custom HTTP path that
+	// returns 2xx when a replica is idle. Used by the generic runtime to opt
+	// in to drain-before-roll. Set on InferenceService metadata.annotations.
+	AnnotationIdleEndpoint = "inference.llmkube.dev/idle-endpoint"
+
 	// DefaultAgentHeartbeatInterval is how often the metal-agent re-asserts
 	// its registrations (which also self-heals any missed update, #657).
 	DefaultAgentHeartbeatInterval = 30 * time.Second
@@ -63,6 +68,10 @@ const (
 	// ReasonIdleTimeoutExceeded is set when RolloutDeferred=False after the
 	// idle timeout expired and the rollout proceeded despite busy pods.
 	ReasonIdleTimeoutExceeded string = "IdleTimeoutExceeded"
+
+	// ReasonIdleCheckUnsupported is set when the runtime backend does not
+	// implement IdleDetector, so drain-before-roll cannot probe idleness.
+	ReasonIdleCheckUnsupported string = "IdleCheckUnsupported"
 
 	// DefaultIdleCheckInterval is how often the controller re-checks pod
 	// idleness when waiting for idle before rollout.

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -504,8 +504,12 @@ type InferenceServiceSpec struct {
 
 	// RolloutPolicy controls how deployment updates are applied. When waitForIdle
 	// is true, the controller will check backend slot idleness before updating
-	// the Deployment pod-template. Requires llama.cpp server-compatible backends
-	// that expose a /slots endpoint.
+	// the Deployment pod-template. Idle detection support by runtime:
+	//   - llama.cpp: native /slots endpoint (default)
+	//   - vLLM: Prometheus metrics scrape (vllm:num_requests_running)
+	//   - TGI: Prometheus metrics scrape (tgi_loading)
+	//   - SGLang: Prometheus metrics scrape (sglang:num_running_reqs)
+	//   - generic: optional AnnotationIdleEndpoint annotation for custom probe
 	// +optional
 	RolloutPolicy *RolloutPolicySpec `json:"rolloutPolicy,omitempty"`
 }
@@ -514,10 +518,11 @@ type InferenceServiceSpec struct {
 type RolloutPolicySpec struct {
 	// WaitForIdle indicates whether to wait for all backend slots to report idle
 	// before applying a Deployment pod-template update. When true, the controller
-	// polls the /slots endpoint on each replica and defers the rollout until all
-	// slots are idle or the idleTimeoutSeconds expires. Requires the backend to
-	// expose a llama.cpp-style /slots endpoint (llama.cpp enables it by default
-	// with --slots); other runtimes are tracked in #911.
+	// probes each replica and defers the rollout until all replicas are idle or the
+	// idleTimeoutSeconds expires. Idle detection is runtime-specific: llama.cpp uses
+	// /slots, vLLM/TGI/SGLang scrape Prometheus gauges, and generic runtimes may set
+	// AnnotationIdleEndpoint for a custom HTTP probe. Runtimes without idle detection
+	// support proceed immediately with ReasonIdleCheckUnsupported.
 	// +optional
 	WaitForIdle bool `json:"waitForIdle,omitempty"`
 

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -508,7 +508,7 @@ type InferenceServiceSpec struct {
 	//   - llama.cpp: native /slots endpoint (default)
 	//   - vLLM: Prometheus metrics scrape (vllm:num_requests_running)
 	//   - TGI: Prometheus metrics scrape (tgi_batch_current_size)
-	//   - SGLang: Prometheus metrics scrape (sglang:num_requests_running)
+	//   - SGLang: Prometheus metrics scrape (sglang:num_running_reqs)
 	//   - generic: optional AnnotationIdleEndpoint annotation for custom probe
 	// +optional
 	RolloutPolicy *RolloutPolicySpec `json:"rolloutPolicy,omitempty"`

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -507,8 +507,8 @@ type InferenceServiceSpec struct {
 	// the Deployment pod-template. Idle detection support by runtime:
 	//   - llama.cpp: native /slots endpoint (default)
 	//   - vLLM: Prometheus metrics scrape (vllm:num_requests_running)
-	//   - TGI: Prometheus metrics scrape (tgi_loading)
-	//   - SGLang: Prometheus metrics scrape (sglang:num_running_reqs)
+	//   - TGI: Prometheus metrics scrape (tgi_batch_current_size)
+	//   - SGLang: Prometheus metrics scrape (sglang:num_requests_running)
 	//   - generic: optional AnnotationIdleEndpoint annotation for custom probe
 	// +optional
 	RolloutPolicy *RolloutPolicySpec `json:"rolloutPolicy,omitempty"`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -2405,7 +2405,7 @@ spec:
                     - llama.cpp: native /slots endpoint (default)
                     - vLLM: Prometheus metrics scrape (vllm:num_requests_running)
                     - TGI: Prometheus metrics scrape (tgi_batch_current_size)
-                    - SGLang: Prometheus metrics scrape (sglang:num_requests_running)
+                    - SGLang: Prometheus metrics scrape (sglang:num_running_reqs)
                     - generic: optional AnnotationIdleEndpoint annotation for custom probe
                 properties:
                   force:

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -2401,8 +2401,12 @@ spec:
                 description: |-
                   RolloutPolicy controls how deployment updates are applied. When waitForIdle
                   is true, the controller will check backend slot idleness before updating
-                  the Deployment pod-template. Requires llama.cpp server-compatible backends
-                  that expose a /slots endpoint.
+                  the Deployment pod-template. Idle detection support by runtime:
+                    - llama.cpp: native /slots endpoint (default)
+                    - vLLM: Prometheus metrics scrape (vllm:num_requests_running)
+                    - TGI: Prometheus metrics scrape (tgi_batch_current_size)
+                    - SGLang: Prometheus metrics scrape (sglang:num_requests_running)
+                    - generic: optional AnnotationIdleEndpoint annotation for custom probe
                 properties:
                   force:
                     description: |-
@@ -2422,10 +2426,11 @@ spec:
                     description: |-
                       WaitForIdle indicates whether to wait for all backend slots to report idle
                       before applying a Deployment pod-template update. When true, the controller
-                      polls the /slots endpoint on each replica and defers the rollout until all
-                      slots are idle or the idleTimeoutSeconds expires. Requires the backend to
-                      expose a llama.cpp-style /slots endpoint (llama.cpp enables it by default
-                      with --slots); other runtimes are tracked in #911.
+                      probes each replica and defers the rollout until all replicas are idle or the
+                      idleTimeoutSeconds expires. Idle detection is runtime-specific: llama.cpp uses
+                      /slots, vLLM/TGI/SGLang scrape Prometheus gauges, and generic runtimes may set
+                      AnnotationIdleEndpoint for a custom HTTP probe. Runtimes without idle detection
+                      support proceed immediately with ReasonIdleCheckUnsupported.
                     type: boolean
                 type: object
               ropeScaling:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -2400,8 +2400,8 @@ spec:
                   the Deployment pod-template. Idle detection support by runtime:
                     - llama.cpp: native /slots endpoint (default)
                     - vLLM: Prometheus metrics scrape (vllm:num_requests_running)
-                    - TGI: Prometheus metrics scrape (tgi_loading)
-                    - SGLang: Prometheus metrics scrape (sglang:num_running_reqs)
+                    - TGI: Prometheus metrics scrape (tgi_batch_current_size)
+                    - SGLang: Prometheus metrics scrape (sglang:num_requests_running)
                     - generic: optional AnnotationIdleEndpoint annotation for custom probe
                 properties:
                   force:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -2397,8 +2397,12 @@ spec:
                 description: |-
                   RolloutPolicy controls how deployment updates are applied. When waitForIdle
                   is true, the controller will check backend slot idleness before updating
-                  the Deployment pod-template. Requires llama.cpp server-compatible backends
-                  that expose a /slots endpoint.
+                  the Deployment pod-template. Idle detection support by runtime:
+                    - llama.cpp: native /slots endpoint (default)
+                    - vLLM: Prometheus metrics scrape (vllm:num_requests_running)
+                    - TGI: Prometheus metrics scrape (tgi_loading)
+                    - SGLang: Prometheus metrics scrape (sglang:num_running_reqs)
+                    - generic: optional AnnotationIdleEndpoint annotation for custom probe
                 properties:
                   force:
                     description: |-
@@ -2418,10 +2422,11 @@ spec:
                     description: |-
                       WaitForIdle indicates whether to wait for all backend slots to report idle
                       before applying a Deployment pod-template update. When true, the controller
-                      polls the /slots endpoint on each replica and defers the rollout until all
-                      slots are idle or the idleTimeoutSeconds expires. Requires the backend to
-                      expose a llama.cpp-style /slots endpoint (llama.cpp enables it by default
-                      with --slots); other runtimes are tracked in #911.
+                      probes each replica and defers the rollout until all replicas are idle or the
+                      idleTimeoutSeconds expires. Idle detection is runtime-specific: llama.cpp uses
+                      /slots, vLLM/TGI/SGLang scrape Prometheus gauges, and generic runtimes may set
+                      AnnotationIdleEndpoint for a custom HTTP probe. Runtimes without idle detection
+                      support proceed immediately with ReasonIdleCheckUnsupported.
                     type: boolean
                 type: object
               ropeScaling:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -2401,7 +2401,7 @@ spec:
                     - llama.cpp: native /slots endpoint (default)
                     - vLLM: Prometheus metrics scrape (vllm:num_requests_running)
                     - TGI: Prometheus metrics scrape (tgi_batch_current_size)
-                    - SGLang: Prometheus metrics scrape (sglang:num_requests_running)
+                    - SGLang: Prometheus metrics scrape (sglang:num_running_reqs)
                     - generic: optional AnnotationIdleEndpoint annotation for custom probe
                 properties:
                   force:

--- a/docs/contributors/adding-a-runtime.md
+++ b/docs/contributors/adding-a-runtime.md
@@ -104,5 +104,5 @@ Add `--runtime yourengine` handling in `pkg/cli/deploy.go`.
 | `personaplex` | PersonaPlex/Moshi | 8998 | TCP socket | No | — |
 | `vllm` | vLLM | 8000 | HTTP /health | Yes | vllm:num_requests_running |
 | `tgi` | TGI | 80 | HTTP /health | No (HF download) | tgi:queue_size |
-| `sglang` | SGLang | 30000 | HTTP /health_generate | Yes (curl) | sglang:num_requests_running |
+| `sglang` | SGLang | 30000 | HTTP /health_generate | Yes (curl) | sglang:num_running_reqs |
 | `generic` | Any container | 8080 | TCP socket | No | — |

--- a/docs/site/concepts/drain-before-roll.md
+++ b/docs/site/concepts/drain-before-roll.md
@@ -30,11 +30,13 @@ With this enabled, the controller checks each replica before applying a pod-temp
 | `llamacpp` | `GET /slots` — JSON array of `{id, is_processing}` | every slot has `is_processing: false` |
 | `vllm` | `GET /metrics` — Prometheus gauge `vllm:num_requests_running` | sum across all label sets equals 0 |
 | `tgi` | `GET /metrics` — Prometheus gauge `tgi_batch_current_size` | value equals 0 |
-| `sglang` | `GET /metrics` — Prometheus gauge `sglang:num_requests_running` | sum across all label sets equals 0 |
+| `sglang` | `GET /metrics` — Prometheus gauge `sglang:num_running_reqs` | sum across all label sets equals 0 |
 | `generic` | Annotation-driven custom endpoint (see below) | HTTP 2xx response |
 | `personaplex` | — | Not supported; defers the rollout (fail-closed) until `idleTimeoutSeconds` expires |
 
 For vLLM and SGLang, the gauge is summed across all label combinations because both runtimes emit one series per model or request class. An absent metric is treated as **busy** (fail-closed), not idle.
+
+> **Note on queued requests:** The idle check reads the *running* gauge only (`vllm:num_requests_running`, `sglang:num_running_reqs`, `tgi_batch_current_size`), not the *waiting/queued* gauge. A request that has been accepted but is still queued during a momentary `running == 0` window could be dropped on restart. This is a deliberate trade-off for v1: checking the queue gauge would mean the drain never completes while any request is waiting, which could indefinitely block rollouts on busy services. The `idleTimeoutSeconds` safety valve ensures the rollout eventually proceeds. If queue-aware draining is needed, it can be layered on as a future `RolloutPolicySpec` field.
 
 ## Generic runtime fallback
 

--- a/docs/site/concepts/drain-before-roll.md
+++ b/docs/site/concepts/drain-before-roll.md
@@ -1,0 +1,112 @@
+---
+title: Drain Before Roll
+description: Defer pod-template rollouts until all inference replicas are idle, avoiding dropped in-flight generations. Supports llama.cpp, vLLM, TGI, SGLang, and custom runtimes via annotation.
+---
+
+# Drain Before Roll
+
+When the controller detects a pod-template change for an `InferenceService`, it normally applies the update immediately. If a replica is mid-generation, that request is dropped. The `waitForIdle` policy gates the rollout behind a per-replica idle check: the controller probes every ready endpoint, and only proceeds when all replicas report idle — or the timeout expires.
+
+The idle check is **fail-closed**. Any ambiguity (unreachable pod, parse error, unsupported runtime) defers the rollout rather than risking in-flight work.
+
+## Enabling
+
+Set `rolloutPolicy.waitForIdle` on the `InferenceService`:
+
+```yaml
+spec:
+  rolloutPolicy:
+    waitForIdle: true
+    idleTimeoutSeconds: 300   # default: 300 (5 minutes)
+    force: false              # set true to bypass idle check entirely
+```
+
+With this enabled, the controller checks each replica before applying a pod-template update. When every replica is idle, the rollout proceeds normally. When one or more are busy, the controller sets a `RolloutDeferred` status condition and re-checks every 5 seconds until all are idle or the timeout expires.
+
+## Supported runtimes
+
+| Runtime | Signal | Idle when |
+|---|---|---|
+| `llamacpp` | `GET /slots` — JSON array of `{id, is_processing}` | every slot has `is_processing: false` |
+| `vllm` | `GET /metrics` — Prometheus gauge `vllm:num_requests_running` | sum across all label sets equals 0 |
+| `tgi` | `GET /metrics` — Prometheus gauge `tgi_batch_current_size` | value equals 0 |
+| `sglang` | `GET /metrics` — Prometheus gauge `sglang:num_requests_running` | sum across all label sets equals 0 |
+| `generic` | Annotation-driven custom endpoint (see below) | HTTP 2xx response |
+| `personaplex` | — | Not supported; proceeds immediately with `IdleCheckUnsupported` |
+
+For vLLM and SGLang, the gauge is summed across all label combinations because both runtimes emit one series per model or request class. An absent metric is treated as **busy** (fail-closed), not idle.
+
+## Generic runtime fallback
+
+Custom runtimes can opt in by annotating the `InferenceService` with an HTTP path that returns 2xx when idle:
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: my-custom-runtime
+  annotations:
+    inference.llmkube.dev/idle-endpoint: "/health/idle"
+spec:
+  runtime: generic
+  rolloutPolicy:
+    waitForIdle: true
+```
+
+The controller appends the annotation value to each replica's base URL. A 2xx response means idle; anything else (non-2xx, network error, timeout) is treated as busy or fail-closed. Without this annotation, the generic runtime is unsupported and the rollout proceeds immediately with `ReasonIdleCheckUnsupported`.
+
+## Multi-replica behavior
+
+The controller does not probe the load-balanced `Service` URL. Instead, it lists the service's `EndpointSlice` objects and probes **each ready endpoint address individually**. This ensures a busy replica behind a healthy Service doesn't cause the idle check to pass incorrectly.
+
+The rollout waits until **every** ready replica reports idle. If even one is busy or unreachable, the entire rollout defers. When no EndpointSlices exist yet (freshly created Deployment), the controller falls back to a single Service URL probe for backward compatibility.
+
+## Fail-closed semantics
+
+The `RolloutDeferred` condition communicates why a rollout is held:
+
+| Condition state | Reason | Meaning |
+|---|---|---|
+| `True` | `PodsBusy` | One or more replicas are actively processing requests |
+| `True` | `IdleCheckFailed` | The controller could not reach or parse the idle signal (network error, non-200 response) |
+| `True` | `IdleCheckUnsupported` | The selected runtime does not implement idle detection, or `generic` without `idle-endpoint` annotation |
+| `False` | `IdleTimeoutExceeded` | The `idleTimeoutSeconds` budget expired; rollout proceeded despite busy pods |
+
+In all cases the rollout eventually proceeds: either when idle is confirmed, or when the timeout expires. The timeout is a safety valve — it prevents an endlessly stuck rollout if a runtime hangs in a permanently busy state.
+
+## Observability
+
+Check rollout status with `kubectl`:
+
+```bash
+# See RolloutDeferred condition and reason
+kubectl get inferenceservice <name> -o=jsonpath='{.status.conditions[?(@.type=="RolloutDeferred")]}' | jq
+
+# Full status
+kubectl describe inferenceservice <name>
+```
+
+A deferred rollout looks like:
+
+```yaml
+conditions:
+  - type: RolloutDeferred
+    status: "True"
+    reason: PodsBusy
+    message: "2 of 3 replicas busy, waiting for idle (60s elapsed)"
+```
+
+When the timeout expires and the rollout forces through:
+
+```yaml
+conditions:
+  - type: RolloutDeferred
+    status: "False"
+    reason: IdleTimeoutExceeded
+    message: "idle timeout exceeded after 300s, proceeding with rollout"
+```
+
+## Next steps
+
+- Read the [CRD reference](/docs/concepts/crds) for every field on `RolloutPolicySpec`.
+- See the [Architecture](/docs/concepts/architecture) page for how the controller manages rollouts.

--- a/docs/site/concepts/drain-before-roll.md
+++ b/docs/site/concepts/drain-before-roll.md
@@ -32,7 +32,7 @@ With this enabled, the controller checks each replica before applying a pod-temp
 | `tgi` | `GET /metrics` — Prometheus gauge `tgi_batch_current_size` | value equals 0 |
 | `sglang` | `GET /metrics` — Prometheus gauge `sglang:num_requests_running` | sum across all label sets equals 0 |
 | `generic` | Annotation-driven custom endpoint (see below) | HTTP 2xx response |
-| `personaplex` | — | Not supported; proceeds immediately with `IdleCheckUnsupported` |
+| `personaplex` | — | Not supported; defers the rollout (fail-closed) until `idleTimeoutSeconds` expires |
 
 For vLLM and SGLang, the gauge is summed across all label combinations because both runtimes emit one series per model or request class. An absent metric is treated as **busy** (fail-closed), not idle.
 
@@ -53,7 +53,7 @@ spec:
     waitForIdle: true
 ```
 
-The controller appends the annotation value to each replica's base URL. A 2xx response means idle; anything else (non-2xx, network error, timeout) is treated as busy or fail-closed. Without this annotation, the generic runtime is unsupported and the rollout proceeds immediately with `ReasonIdleCheckUnsupported`.
+The controller appends the annotation value to each replica's base URL. A 2xx response means idle; anything else (non-2xx, network error, timeout) is treated as busy or fail-closed. Without this annotation, the generic runtime is unsupported and the rollout defers (fail-closed) until `idleTimeoutSeconds` expires.
 
 ## Multi-replica behavior
 

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -843,14 +843,13 @@ var _ = Describe("podTemplatesDiffer input immutability (#922)", func() {
 	})
 })
 
-var _ = Describe("checkServerIdle", func() {
-	var reconciler *InferenceServiceReconciler
+var _ = Describe("LlamaCppBackend.IdleProbe", func() {
+	var backend *LlamaCppBackend
+	var client *http.Client
 
 	BeforeEach(func() {
-		reconciler = &InferenceServiceReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
-		}
+		backend = &LlamaCppBackend{}
+		client = &http.Client{Timeout: 5 * time.Second}
 	})
 
 	It("should return true when all slots are idle", func() {
@@ -860,7 +859,8 @@ var _ = Describe("checkServerIdle", func() {
 		}))
 		defer server.Close()
 
-		idle, err := reconciler.checkServerIdle(context.Background(), server.URL)
+		probe := backend.IdleProbe(nil, client)
+		idle, err := probe(context.Background(), server.URL)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(idle).To(BeTrue())
 	})
@@ -872,7 +872,8 @@ var _ = Describe("checkServerIdle", func() {
 		}))
 		defer server.Close()
 
-		idle, err := reconciler.checkServerIdle(context.Background(), server.URL)
+		probe := backend.IdleProbe(nil, client)
+		idle, err := probe(context.Background(), server.URL)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(idle).To(BeFalse())
 	})
@@ -884,13 +885,15 @@ var _ = Describe("checkServerIdle", func() {
 		}))
 		defer server.Close()
 
-		idle, err := reconciler.checkServerIdle(context.Background(), server.URL)
+		probe := backend.IdleProbe(nil, client)
+		idle, err := probe(context.Background(), server.URL)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(idle).To(BeFalse())
 	})
 
 	It("should return error when server is unreachable", func() {
-		idle, err := reconciler.checkServerIdle(context.Background(), "http://192.0.2.1:9999")
+		probe := backend.IdleProbe(nil, client)
+		idle, err := probe(context.Background(), "http://192.0.2.1:9999")
 		Expect(err).To(HaveOccurred())
 		Expect(idle).To(BeFalse())
 	})
@@ -901,7 +904,8 @@ var _ = Describe("checkServerIdle", func() {
 		}))
 		defer server.Close()
 
-		idle, err := reconciler.checkServerIdle(context.Background(), server.URL)
+		probe := backend.IdleProbe(nil, client)
+		idle, err := probe(context.Background(), server.URL)
 		Expect(err).To(HaveOccurred())
 		Expect(idle).To(BeFalse())
 	})
@@ -912,12 +916,13 @@ var _ = Describe("checkServerIdle", func() {
 		}))
 		defer server.Close()
 
-		idle, err := reconciler.checkServerIdle(context.Background(), server.URL)
+		probe := backend.IdleProbe(nil, client)
+		idle, err := probe(context.Background(), server.URL)
 		Expect(err).To(HaveOccurred())
 		Expect(idle).To(BeFalse())
 	})
 
-	It("should use injected HTTPClient when set", func() {
+	It("should use injected HTTPClient", func() {
 		var requestCaptured bool
 		customTransport := &captureRoundTripper{
 			capture: func(req *http.Request) *http.Response {
@@ -931,13 +936,9 @@ var _ = Describe("checkServerIdle", func() {
 			},
 		}
 
-		reconcilerWithClient := &InferenceServiceReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
-			HTTPClient: &http.Client{
-				Transport: customTransport,
-				Timeout:   5 * time.Second,
-			},
+		customClient := &http.Client{
+			Transport: customTransport,
+			Timeout:   5 * time.Second,
 		}
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -945,7 +946,8 @@ var _ = Describe("checkServerIdle", func() {
 		}))
 		defer server.Close()
 
-		idle, err := reconcilerWithClient.checkServerIdle(context.Background(), server.URL)
+		probe := backend.IdleProbe(nil, customClient)
+		idle, err := probe(context.Background(), server.URL)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(idle).To(BeTrue())
 		Expect(requestCaptured).To(BeTrue())

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -1119,11 +1119,11 @@ http_requests_total{method="GET"} 42.0
 		},
 		{
 			name: "skips comments",
-			body: `# HELP sglang:num_requests_running Running requests.
-# TYPE sglang:num_requests_running gauge
-sglang:num_requests_running 3.0
+			body: `# HELP sglang:num_running_reqs The number of running requests
+# TYPE sglang:num_running_reqs gauge
+sglang:num_running_reqs{model_name="llama"} 3.0
 `,
-			metric:    "sglang:num_requests_running",
+			metric:    "sglang:num_running_reqs",
 			wantSum:   3,
 			wantFound: true,
 		},

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -23,12 +23,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1065,4 +1067,189 @@ func findRolloutDeferredCondition(conditions []metav1.Condition) *metav1.Conditi
 		}
 	}
 	return nil
+}
+
+func TestParsePrometheusGaugeSum(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		metric    string
+		wantSum   float64
+		wantFound bool
+	}{
+		{
+			name: "sum across labels",
+			body: `# HELP vllm:num_requests_running Number of requests currently running on GPU.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{gpu_id="0"} 0.0
+vllm:num_requests_running{gpu_id="1"} 0.0
+`,
+			metric:    "vllm:num_requests_running",
+			wantSum:   0,
+			wantFound: true,
+		},
+		{
+			name: "absent metric returns found false",
+			body: `# HELP some_other_metric A metric.
+some_other_metric 1.0
+`,
+			metric:    "vllm:num_requests_running",
+			wantSum:   0,
+			wantFound: false,
+		},
+		{
+			name: "bare gauge without labels",
+			body: `# HELP tgi_loading Loading state.
+tgi_loading 0.0
+`,
+			metric:    "tgi_loading",
+			wantSum:   0,
+			wantFound: true,
+		},
+		{
+			name: "name prefix no false match",
+			body: `# HELP http_requests_total Total requests.
+http_requests_total{method="GET"} 42.0
+`,
+			metric:    "http_requests",
+			wantSum:   0,
+			wantFound: false,
+		},
+		{
+			name: "skips comments",
+			body: `# HELP sglang:num_running_reqs Running requests.
+# TYPE sglang:num_running_reqs gauge
+sglang:num_running_reqs 3.0
+`,
+			metric:    "sglang:num_running_reqs",
+			wantSum:   3,
+			wantFound: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, found := parsePrometheusGaugeSum(tc.body, tc.metric)
+			if got != tc.wantSum {
+				t.Errorf("sum = %f, want %f", got, tc.wantSum)
+			}
+			if found != tc.wantFound {
+				t.Errorf("found = %v, want %v", found, tc.wantFound)
+			}
+		})
+	}
+}
+
+func TestResolveIdlePort(t *testing.T) {
+	port8080 := int32(8080)
+	tests := []struct {
+		name string
+		isvc *inferencev1alpha1.InferenceService
+		want int32
+	}{
+		{
+			name: "endpoint port takes priority",
+			isvc: &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					Endpoint:      &inferencev1alpha1.EndpointSpec{Port: 9999},
+					ContainerPort: &port8080,
+				},
+			},
+			want: 9999,
+		},
+		{
+			name: "container port when endpoint nil",
+			isvc: &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ContainerPort: &port8080,
+				},
+			},
+			want: 8080,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &LlamaCppBackend{}
+			got := resolveIdlePort(tc.isvc, backend)
+			if got != tc.want {
+				t.Errorf("port = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCollectReadyReplicaURLs(t *testing.T) {
+	trueVal := true
+	falseVal := false
+	tests := []struct {
+		name string
+		list *discoveryv1.EndpointSliceList
+		port int32
+		want []string
+	}{
+		{
+			name: "ready endpoints",
+			list: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{{
+					Endpoints: []discoveryv1.Endpoint{{
+						Addresses:  []string{"10.0.0.1"},
+						Conditions: discoveryv1.EndpointConditions{Ready: &trueVal},
+					}},
+				}},
+			},
+			port: 8080,
+			want: []string{"http://10.0.0.1:8080"},
+		},
+		{
+			name: "nil ready treated as ready",
+			list: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{{
+					Endpoints: []discoveryv1.Endpoint{{
+						Addresses:  []string{"10.0.0.2"},
+						Conditions: discoveryv1.EndpointConditions{Ready: nil},
+					}},
+				}},
+			},
+			port: 8080,
+			want: []string{"http://10.0.0.2:8080"},
+		},
+		{
+			name: "not ready skipped",
+			list: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{{
+					Endpoints: []discoveryv1.Endpoint{{
+						Addresses:  []string{"10.0.0.3"},
+						Conditions: discoveryv1.EndpointConditions{Ready: &falseVal},
+					}},
+				}},
+			},
+			port: 8080,
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectReadyReplicaURLs(tc.list, tc.port)
+			if len(got) != len(tc.want) {
+				t.Errorf("got %d URLs, want %d: %v", len(got), len(tc.want), got)
+				return
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("url[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestErrIdleUnsupported(t *testing.T) {
+	if errIdleUnsupported == nil {
+		t.Error("errIdleUnsupported must not be nil")
+	}
+	if !strings.Contains(errIdleUnsupported.Error(), "idle detection") {
+		t.Errorf("unexpected error message: %q", errIdleUnsupported.Error())
+	}
 }

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -1127,6 +1127,22 @@ sglang:num_requests_running 3.0
 			wantSum:   3,
 			wantFound: true,
 		},
+		{
+			name: "no value field skipped",
+			body: `vllm:num_requests_running
+`,
+			metric:    "vllm:num_requests_running",
+			wantSum:   0,
+			wantFound: false,
+		},
+		{
+			name: "unparseable value skipped",
+			body: `vllm:num_requests_running not_a_number
+`,
+			metric:    "vllm:num_requests_running",
+			wantSum:   0,
+			wantFound: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1789,5 +1805,175 @@ var _ = Describe("Multi-replica drain-before-roll", func() {
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, finalISVC)).To(Succeed())
 		cond := findRolloutDeferredCondition(finalISVC.Status.Conditions)
 		Expect(cond).To(BeNil())
+	})
+
+	It("should defer when all endpoints exist but none are ready", func() {
+		modelName := "model-no-ready-eps"
+		isvcName := "isvc-no-ready-eps"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(2)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "ghcr.io/ggml-org/llama.cpp:server",
+				RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+					WaitForIdle:        true,
+					IdleTimeoutSeconds: 30,
+					Force:              false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
+			}
+		}()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+		notReady := false
+		svcLabel := sanitizeDNSName(isvcName)
+		for _, addr := range []string{"10.0.0.1", "10.0.0.2"} {
+			eslice := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "eslice-",
+					Namespace:    "default",
+					Labels: map[string]string{
+						"kubernetes.io/service-name": svcLabel,
+					},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{addr},
+					Conditions: discoveryv1.EndpointConditions{Ready: &notReady},
+				}},
+			}
+			Expect(k8sClient.Create(ctx, eslice)).To(Succeed())
+		}
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		updated.Spec.Image = "ghcr.io/ggml-org/llama.cpp:server-v2"
+		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+		deferredISVC := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, deferredISVC)).To(Succeed())
+		cond := findRolloutDeferredCondition(deferredISVC.Status.Conditions)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	})
+
+	It("should set IdleCheckUnsupported for personaplex runtime", func() {
+		modelName := "model-personaplex-unsupported"
+		isvcName := "isvc-personaplex-unsupported"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(1)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "ghcr.io/defilantech/personaplex:latest",
+				Runtime:  "personaplex",
+				RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+					WaitForIdle:        true,
+					IdleTimeoutSeconds: 30,
+					Force:              false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
+			}
+		}()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		updated.Spec.Image = "ghcr.io/defilantech/personaplex:v2"
+		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		deferredISVC := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, deferredISVC)).To(Succeed())
+		cond := findRolloutDeferredCondition(deferredISVC.Status.Conditions)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Reason).To(Equal(ReasonIdleCheckUnsupported))
 	})
 })

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -1128,9 +1128,8 @@ sglang:num_requests_running 3.0
 			wantFound: true,
 		},
 		{
-			name: "no value field skipped",
-			body: `vllm:num_requests_running
-`,
+			name:      "no value field skipped",
+			body:      "vllm:num_requests_running{}\n",
 			metric:    "vllm:num_requests_running",
 			wantSum:   0,
 			wantFound: false,

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -1101,10 +1101,10 @@ some_other_metric 1.0
 		},
 		{
 			name: "bare gauge without labels",
-			body: `# HELP tgi_loading Loading state.
-tgi_loading 0.0
+			body: `# HELP tgi_batch_current_size Current batch size.
+tgi_batch_current_size 0.0
 `,
-			metric:    "tgi_loading",
+			metric:    "tgi_batch_current_size",
 			wantSum:   0,
 			wantFound: true,
 		},
@@ -1119,11 +1119,11 @@ http_requests_total{method="GET"} 42.0
 		},
 		{
 			name: "skips comments",
-			body: `# HELP sglang:num_running_reqs Running requests.
-# TYPE sglang:num_running_reqs gauge
-sglang:num_running_reqs 3.0
+			body: `# HELP sglang:num_requests_running Running requests.
+# TYPE sglang:num_requests_running gauge
+sglang:num_requests_running 3.0
 `,
-			metric:    "sglang:num_running_reqs",
+			metric:    "sglang:num_requests_running",
 			wantSum:   3,
 			wantFound: true,
 		},

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -1083,11 +1083,11 @@ func TestParsePrometheusGaugeSum(t *testing.T) {
 			name: "sum across labels",
 			body: `# HELP vllm:num_requests_running Number of requests currently running on GPU.
 # TYPE vllm:num_requests_running gauge
-vllm:num_requests_running{gpu_id="0"} 0.0
-vllm:num_requests_running{gpu_id="1"} 0.0
+vllm:num_requests_running{model_name="a"} 2.0
+vllm:num_requests_running{model_name="b"} 3.0
 `,
 			metric:    "vllm:num_requests_running",
-			wantSum:   0,
+			wantSum:   5,
 			wantFound: true,
 		},
 		{
@@ -1145,9 +1145,10 @@ sglang:num_requests_running 3.0
 func TestResolveIdlePort(t *testing.T) {
 	port8080 := int32(8080)
 	tests := []struct {
-		name string
-		isvc *inferencev1alpha1.InferenceService
-		want int32
+		name    string
+		isvc    *inferencev1alpha1.InferenceService
+		backend RuntimeBackend
+		want    int32
 	}{
 		{
 			name: "endpoint port takes priority",
@@ -1157,7 +1158,8 @@ func TestResolveIdlePort(t *testing.T) {
 					ContainerPort: &port8080,
 				},
 			},
-			want: 9999,
+			backend: &LlamaCppBackend{},
+			want:    9999,
 		},
 		{
 			name: "container port when endpoint nil",
@@ -1166,14 +1168,20 @@ func TestResolveIdlePort(t *testing.T) {
 					ContainerPort: &port8080,
 				},
 			},
-			want: 8080,
+			backend: &LlamaCppBackend{},
+			want:    8080,
+		},
+		{
+			name:    "backend default port when neither set",
+			isvc:    &inferencev1alpha1.InferenceService{},
+			backend: &VLLMBackend{},
+			want:    8000,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			backend := &LlamaCppBackend{}
-			got := resolveIdlePort(tc.isvc, backend)
+			got := resolveIdlePort(tc.isvc, tc.backend)
 			if got != tc.want {
 				t.Errorf("port = %d, want %d", got, tc.want)
 			}
@@ -1566,5 +1574,220 @@ var _ = Describe("Multi-replica drain-before-roll", func() {
 		cond := findRolloutDeferredCondition(deferredISVC.Status.Conditions)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Reason).To(Equal(ReasonIdleCheckUnsupported))
+	})
+
+	It("should defer when one vLLM replica is idle and one is unreachable", func() {
+		modelName := "model-multi-idle-unreachable"
+		isvcName := "isvc-multi-idle-unreachable"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(2)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "vllm/vllm-openai:v0.20.0",
+				Runtime:  "vllm",
+				RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+					WaitForIdle:        true,
+					IdleTimeoutSeconds: 30,
+					Force:              false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
+			}
+		}()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+		ready := true
+		svcLabel := sanitizeDNSName(isvcName)
+		for _, addr := range []string{"10.0.0.1", "10.0.0.2"} {
+			eslice := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "eslice-",
+					Namespace:    "default",
+					Labels: map[string]string{
+						"kubernetes.io/service-name": svcLabel,
+					},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{addr},
+					Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+				}},
+			}
+			Expect(k8sClient.Create(ctx, eslice)).To(Succeed())
+		}
+
+		reconciler.HTTPClient = &http.Client{
+			Transport: &addressAwareRoundTripper{
+				responses: map[string]string{
+					"10.0.0.1:8000": "vllm:num_requests_running 0\n",
+					// 10.0.0.2:8000 is NOT in the map — gets 404 (error from probe)
+				},
+			},
+			Timeout: 5 * time.Second,
+		}
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		updated.Spec.Image = "vllm/vllm-openai:v0.21.0"
+		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+		deferredISVC := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, deferredISVC)).To(Succeed())
+		cond := findRolloutDeferredCondition(deferredISVC.Status.Conditions)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Reason).To(Equal(ReasonIdleCheckFailed))
+	})
+
+	It("should proceed when generic runtime has idle-endpoint annotation and endpoint returns 2xx", func() {
+		modelName := "model-generic-annotated"
+		isvcName := "isvc-generic-annotated"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(1)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      isvcName,
+				Namespace: "default",
+				Annotations: map[string]string{
+					inferencev1alpha1.AnnotationIdleEndpoint: "/health",
+				},
+			},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "custom/inference:latest",
+				Runtime:  "generic",
+				RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+					WaitForIdle:        true,
+					IdleTimeoutSeconds: 30,
+					Force:              false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
+			}
+		}()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+		ready := true
+		svcLabel := sanitizeDNSName(isvcName)
+		eslice := &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "eslice-",
+				Namespace:    "default",
+				Labels: map[string]string{
+					"kubernetes.io/service-name": svcLabel,
+				},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{{
+				Addresses:  []string{"10.0.0.1"},
+				Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+			}},
+		}
+		Expect(k8sClient.Create(ctx, eslice)).To(Succeed())
+
+		reconciler.HTTPClient = &http.Client{
+			Transport: &addressAwareRoundTripper{
+				responses: map[string]string{
+					"10.0.0.1:8080": "ok",
+				},
+			},
+			Timeout: 5 * time.Second,
+		}
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		updated.Spec.Image = "custom/inference:v2"
+		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero())
+
+		finalISVC := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, finalISVC)).To(Succeed())
+		cond := findRolloutDeferredCondition(finalISVC.Status.Conditions)
+		Expect(cond).To(BeNil())
 	})
 })

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -1255,3 +1255,316 @@ func TestErrIdleUnsupported(t *testing.T) {
 		t.Errorf("unexpected error message: %q", errIdleUnsupported.Error())
 	}
 }
+
+type addressAwareRoundTripper struct {
+	responses map[string]string
+}
+
+func (a *addressAwareRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, ok := a.responses[req.URL.Host]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+var _ = Describe("Multi-replica drain-before-roll", func() {
+	ctx := context.Background()
+
+	It("should proceed when all vLLM replicas are idle", func() {
+		modelName := "model-multi-idle"
+		isvcName := "isvc-multi-idle"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(2)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "vllm/vllm-openai:v0.20.0",
+				Runtime:  "vllm",
+				RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+					WaitForIdle:        true,
+					IdleTimeoutSeconds: 30,
+					Force:              false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
+			}
+		}()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+		ready := true
+		svcLabel := sanitizeDNSName(isvcName)
+		for _, addr := range []string{"10.0.0.1", "10.0.0.2"} {
+			eslice := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "eslice-",
+					Namespace:    "default",
+					Labels: map[string]string{
+						"kubernetes.io/service-name": svcLabel,
+					},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{addr},
+					Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+				}},
+			}
+			Expect(k8sClient.Create(ctx, eslice)).To(Succeed())
+		}
+
+		reconciler.HTTPClient = &http.Client{
+			Transport: &addressAwareRoundTripper{
+				responses: map[string]string{
+					"10.0.0.1:8000": "vllm:num_requests_running 0\n",
+					"10.0.0.2:8000": "vllm:num_requests_running 0\n",
+				},
+			},
+			Timeout: 5 * time.Second,
+		}
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		updated.Spec.Image = "vllm/vllm-openai:v0.21.0"
+		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero())
+
+		finalISVC := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, finalISVC)).To(Succeed())
+		cond := findRolloutDeferredCondition(finalISVC.Status.Conditions)
+		Expect(cond).To(BeNil())
+	})
+
+	It("should defer when one vLLM replica is busy", func() {
+		modelName := "model-multi-busy"
+		isvcName := "isvc-multi-busy"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(2)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "vllm/vllm-openai:v0.20.0",
+				Runtime:  "vllm",
+				RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+					WaitForIdle:        true,
+					IdleTimeoutSeconds: 30,
+					Force:              false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
+			}
+		}()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+		ready := true
+		svcLabel := sanitizeDNSName(isvcName)
+		for _, addr := range []string{"10.0.0.1", "10.0.0.2"} {
+			eslice := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "eslice-",
+					Namespace:    "default",
+					Labels: map[string]string{
+						"kubernetes.io/service-name": svcLabel,
+					},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{{
+					Addresses:  []string{addr},
+					Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+				}},
+			}
+			Expect(k8sClient.Create(ctx, eslice)).To(Succeed())
+		}
+
+		reconciler.HTTPClient = &http.Client{
+			Transport: &addressAwareRoundTripper{
+				responses: map[string]string{
+					"10.0.0.1:8000": "vllm:num_requests_running 0\n",
+					"10.0.0.2:8000": "vllm:num_requests_running 3\n",
+				},
+			},
+			Timeout: 5 * time.Second,
+		}
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		updated.Spec.Image = "vllm/vllm-openai:v0.21.0"
+		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+		deferredISVC := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, deferredISVC)).To(Succeed())
+		cond := findRolloutDeferredCondition(deferredISVC.Status.Conditions)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Reason).To(Equal(ReasonPodsBusy))
+	})
+
+	It("should set IdleCheckUnsupported for generic runtime without annotation", func() {
+		modelName := "model-generic-unsupported"
+		isvcName := "isvc-generic-unsupported"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(1)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "custom/inference:latest",
+				Runtime:  "generic",
+				RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+					WaitForIdle:        true,
+					IdleTimeoutSeconds: 30,
+					Force:              false,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
+			}
+		}()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			HTTPClient: &http.Client{
+				Transport: &addressAwareRoundTripper{responses: map[string]string{}},
+				Timeout:   5 * time.Second,
+			},
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		updated.Spec.Image = "custom/inference:v2"
+		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		deferredISVC := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, deferredISVC)).To(Succeed())
+		cond := findRolloutDeferredCondition(deferredISVC.Status.Conditions)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Reason).To(Equal(ReasonIdleCheckUnsupported))
+	})
+})

--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -20,12 +20,16 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +45,8 @@ import (
 // in-memory object and the persisted object.
 const AnnotationDesiredTemplateHash = "llmkube.ai/desired-template-hash"
 
+var errIdleUnsupported = errors.New("runtime does not implement idle detection")
+
 // desiredTemplateHash computes a deterministic hash of the pod template for the
 // purpose of detecting operator-driven changes. It serializes the normalized
 // template to JSON and hashes it, so API-server defaulting differences don't
@@ -50,6 +56,70 @@ func desiredTemplateHash(template corev1.PodTemplateSpec) string {
 	data, _ := json.Marshal(normalized)
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("%x", h[:8])
+}
+
+// parsePrometheusGaugeSum scans Prometheus exposition text for lines matching
+// metricName (with optional labels in curly braces or bare gauge), sums the
+// numeric values, and returns (sum, found). Lines starting with '#' are skipped.
+func parsePrometheusGaugeSum(body, metricName string) (float64, bool) {
+	var sum float64
+	found := false
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || line[0] == '#' {
+			continue
+		}
+		if !strings.HasPrefix(line, metricName) {
+			continue
+		}
+		rest := line[len(metricName):]
+		if len(rest) == 0 || (rest[0] != '{' && rest[0] != ' ') {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		val, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			continue
+		}
+		sum += val
+		found = true
+	}
+	return sum, found
+}
+
+// resolveIdlePort returns the port to use for idle-check HTTP probes. It
+// follows the same priority as the existing checkServiceIdle: Endpoint.Port >
+// ContainerPort > backend.DefaultPort().
+func resolveIdlePort(isvc *inferencev1alpha1.InferenceService, backend RuntimeBackend) int32 {
+	if isvc.Spec.Endpoint != nil && isvc.Spec.Endpoint.Port > 0 {
+		return isvc.Spec.Endpoint.Port
+	}
+	if isvc.Spec.ContainerPort != nil {
+		return *isvc.Spec.ContainerPort
+	}
+	return backend.DefaultPort()
+}
+
+// collectReadyReplicaURLs builds a list of "http://<addr>:<port>" URLs from
+// the ready endpoints in the given EndpointSliceList. Per Kubernetes convention,
+// an endpoint with Conditions.Ready == nil is treated as ready.
+func collectReadyReplicaURLs(slices *discoveryv1.EndpointSliceList, port int32) []string {
+	var urls []string
+	for i := range slices.Items {
+		for j := range slices.Items[i].Endpoints {
+			ep := &slices.Items[i].Endpoints[j]
+			if ep.Conditions.Ready != nil && !*ep.Conditions.Ready {
+				continue
+			}
+			for _, addr := range ep.Addresses {
+				urls = append(urls, fmt.Sprintf("http://%s:%d", addr, port))
+			}
+		}
+	}
+	return urls
 }
 
 // llamaCPUSlot represents a single slot from the llama.cpp /slots endpoint.

--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -240,9 +240,9 @@ func (r *InferenceServiceReconciler) reconcileRolloutPolicy(
 
 	// Not idle, or the idle check itself failed. Fail closed: defer the
 	// rollout until the backend is idle or the idleTimeoutSeconds budget is
-	// spent. A failing /slots probe (server unreachable, non-200, --slots
-	// disabled so it 404s) must not silently roll and drop in-flight
-	// generations — that is exactly what waitForIdle is meant to prevent.
+	// spent. A failing idle probe (server unreachable, non-200, unparseable
+	// metrics, or unsupported runtime) must not silently roll and drop
+	// in-flight generations — that is exactly what waitForIdle is meant to prevent.
 	reason := ReasonPodsBusy
 	message := "Backend slots are busy, waiting for idle before rollout"
 	if checkErr != nil {

--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -122,91 +122,73 @@ func collectReadyReplicaURLs(slices *discoveryv1.EndpointSliceList, port int32) 
 	return urls
 }
 
-// llamaCPUSlot represents a single slot from the llama.cpp /slots endpoint.
-type llamaCPUSlot struct {
-	ID int `json:"id"`
-	// IsProcessing is true while the slot is handling a request (prompt
-	// evaluation or generation). A slot is idle when this is false.
-	IsProcessing bool `json:"is_processing"`
-}
+// checkServiceIdle checks whether the InferenceService Service currently routes
+// to idle backends. It resolves the backend for the given InferenceService,
+// type-asserts to IdleDetector, and probes each Ready replica via EndpointSlices
+// (or falls back to a single Service URL when no EndpointSlices exist).
+func (r *InferenceServiceReconciler) checkServiceIdle(ctx context.Context, isvc *inferencev1alpha1.InferenceService, svc *corev1.Service) (bool, error) {
+	log := logf.FromContext(ctx)
 
-// checkServerIdle checks whether all slots on a llama.cpp server are idle.
-// It queries the /slots endpoint and returns true only if every slot reports
-// is_processing == false. A server error (unreachable, non-200, unparseable
-// body) is surfaced as an error to the caller, which treats it as fail-closed
-// (defer the rollout) — see reconcileRolloutPolicy.
-// baseURL should include the port (e.g., "http://svc.ns.svc.cluster.local:8080").
-func (r *InferenceServiceReconciler) checkServerIdle(ctx context.Context, baseURL string) (bool, error) {
-	url := fmt.Sprintf("%s/slots", baseURL)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return false, fmt.Errorf("failed to create request: %w", err)
+	backend := resolveBackend(isvc)
+	detector, ok := backend.(IdleDetector)
+	if !ok {
+		return false, errIdleUnsupported
 	}
 
 	httpClient := r.HTTPClient
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 5 * time.Second}
 	}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return false, fmt.Errorf("failed to query /slots: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+	probe := detector.IdleProbe(isvc, httpClient)
 
-	if resp.StatusCode != http.StatusOK {
-		return false, fmt.Errorf("/slots returned status %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return false, fmt.Errorf("failed to read /slots response: %w", err)
-	}
-
-	var slots []llamaCPUSlot
-	if err := json.Unmarshal(body, &slots); err != nil {
-		return false, fmt.Errorf("failed to parse /slots response: %w", err)
-	}
-
-	for _, slot := range slots {
-		if slot.IsProcessing {
-			return false, nil
-		}
-	}
-
-	return true, nil
-}
-
-// checkServiceIdle checks whether the InferenceService Service currently routes
-// to an idle backend. This targets the single-replica local-model case from
-// #856; multi-replica per-pod draining can be layered on later.
-func (r *InferenceServiceReconciler) checkServiceIdle(ctx context.Context, isvc *inferencev1alpha1.InferenceService, svc *corev1.Service) (bool, error) {
-	log := logf.FromContext(ctx)
+	port := resolveIdlePort(isvc, backend)
 
 	var svcURL string
 	if r.RolloutIdleBaseURL != "" {
 		svcURL = r.RolloutIdleBaseURL
 	} else {
-		port := int32(8080)
-		if isvc.Spec.Endpoint != nil && isvc.Spec.Endpoint.Port > 0 {
-			port = isvc.Spec.Endpoint.Port
-		} else if isvc.Spec.ContainerPort != nil {
-			port = *isvc.Spec.ContainerPort
-		}
 		svcURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", svc.Name, svc.Namespace, port)
 	}
-	idle, err := r.checkServerIdle(ctx, svcURL)
-	if err != nil {
-		log.Info("Failed to check server idle status", "error", err)
-		return false, err
+
+	slices := &discoveryv1.EndpointSliceList{}
+	svcName := sanitizeDNSName(svc.Name)
+	if err := r.List(ctx, slices, client.InNamespace(isvc.Namespace), client.MatchingLabels{"kubernetes.io/service-name": svcName}); err != nil {
+		log.Info("Failed to list EndpointSlices, falling back to Service URL", "error", err)
 	}
 
-	if !idle {
-		log.Info("Backend slots are busy, deferring rollout")
-	} else {
-		log.Info("All backend slots are idle, proceeding with rollout")
+	if len(slices.Items) == 0 {
+		idle, err := probe(ctx, svcURL)
+		if err != nil {
+			log.Info("Failed to check server idle status via Service URL", "error", err)
+			return false, err
+		}
+		if !idle {
+			log.Info("Backend is busy (Service URL fallback), deferring rollout")
+		} else {
+			log.Info("Backend is idle (Service URL fallback), proceeding with rollout")
+		}
+		return idle, nil
 	}
 
-	return idle, nil
+	replicaURLs := collectReadyReplicaURLs(slices, port)
+	if len(replicaURLs) == 0 {
+		return false, nil
+	}
+
+	for _, url := range replicaURLs {
+		idle, err := probe(ctx, url)
+		if err != nil {
+			log.Info("Failed to check replica idle status", "url", url, "error", err)
+			return false, err
+		}
+		if !idle {
+			log.Info("Replica is busy, deferring rollout", "url", url)
+			return false, nil
+		}
+	}
+
+	log.Info("All replicas are idle, proceeding with rollout")
+	return true, nil
 }
 
 // reconcileRolloutPolicy checks whether the rollout should be deferred based on
@@ -265,8 +247,13 @@ func (r *InferenceServiceReconciler) reconcileRolloutPolicy(
 	message := "Backend slots are busy, waiting for idle before rollout"
 	if checkErr != nil {
 		log.Info("Idle check failed; deferring rollout (fail-closed)", "error", checkErr)
-		reason = ReasonIdleCheckFailed
-		message = fmt.Sprintf("Idle check failed (%v); deferring rollout until idle or timeout", checkErr)
+		if errors.Is(checkErr, errIdleUnsupported) {
+			reason = ReasonIdleCheckUnsupported
+			message = fmt.Sprintf("Runtime does not support idle detection (%v); deferring rollout until idle or timeout", checkErr)
+		} else {
+			reason = ReasonIdleCheckFailed
+			message = fmt.Sprintf("Idle check failed (%v); deferring rollout until idle or timeout", checkErr)
+		}
 	} else {
 		log.Info("Backend slots are busy, deferring rollout")
 	}

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -75,9 +75,10 @@ const (
 	// backend slots report idle or the idleTimeoutSeconds expires.
 	ConditionRolloutDeferred = inferencev1alpha1.ConditionRolloutDeferred
 
-	ReasonPodsBusy            = inferencev1alpha1.ReasonPodsBusy
-	ReasonIdleCheckFailed     = inferencev1alpha1.ReasonIdleCheckFailed
-	ReasonIdleTimeoutExceeded = inferencev1alpha1.ReasonIdleTimeoutExceeded
+	ReasonPodsBusy             = inferencev1alpha1.ReasonPodsBusy
+	ReasonIdleCheckFailed      = inferencev1alpha1.ReasonIdleCheckFailed
+	ReasonIdleTimeoutExceeded  = inferencev1alpha1.ReasonIdleTimeoutExceeded
+	ReasonIdleCheckUnsupported = inferencev1alpha1.ReasonIdleCheckUnsupported
 
 	ReasonWorkloadResolved = "WorkloadResolved"
 

--- a/internal/controller/runtime.go
+++ b/internal/controller/runtime.go
@@ -1,6 +1,9 @@
 package controller
 
 import (
+	"context"
+	"net/http"
+
 	corev1 "k8s.io/api/core/v1"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -57,6 +60,17 @@ type HPAMetricProvider interface {
 // discovery is unaffected.
 type ServiceLinksOptOut interface {
 	DisableServiceLinks() bool
+}
+
+// IdleDetector is optionally implemented by backends that can probe replica
+// idleness for drain-before-roll. The returned probe function is called with
+// the base URL of a single replica (scheme + host:port) and returns true when
+// the replica has no in-flight requests. The isvc parameter carries annotations
+// such as AnnotationIdleEndpoint for generic runtimes; the client is reused
+// across probes. Backends that do not implement this interface cause the
+// reconciler to skip idle detection and immediately proceed with the rollout.
+type IdleDetector interface {
+	IdleProbe(isvc *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error)
 }
 
 // resolveBackend returns the RuntimeBackend for the given InferenceService.

--- a/internal/controller/runtime_generic.go
+++ b/internal/controller/runtime_generic.go
@@ -1,6 +1,10 @@
 package controller
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -66,4 +70,36 @@ func (b *GenericBackend) BuildProbes(port int32) (startup, liveness, readiness *
 	}
 
 	return startup, liveness, readiness
+}
+
+// IdleProbe returns a probe closure that reads the
+// AnnotationIdleEndpoint annotation from the InferenceService. If absent,
+// returns (false, errIdleUnsupported). If present, GETs the annotated path and
+// returns true on 2xx (idle), false on non-2xx (busy). Mirrors the metal-agent
+// idle check in pkg/agent/executor.go.
+func (b *GenericBackend) IdleProbe(isvc *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
+	path, ok := isvc.Annotations[inferencev1alpha1.AnnotationIdleEndpoint]
+	if !ok {
+		return func(ctx context.Context, baseURL string) (bool, error) {
+			return false, errIdleUnsupported
+		}
+	}
+
+	return func(ctx context.Context, baseURL string) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
+		if err != nil {
+			return false, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return false, fmt.Errorf("idle endpoint probe failed: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return true, nil
+		}
+		return false, nil
+	}
 }

--- a/internal/controller/runtime_generic.go
+++ b/internal/controller/runtime_generic.go
@@ -75,8 +75,7 @@ func (b *GenericBackend) BuildProbes(port int32) (startup, liveness, readiness *
 // IdleProbe returns a probe closure that reads the
 // AnnotationIdleEndpoint annotation from the InferenceService. If absent,
 // returns (false, errIdleUnsupported). If present, GETs the annotated path and
-// returns true on 2xx (idle), false on non-2xx (busy). Mirrors the metal-agent
-// idle check in pkg/agent/executor.go.
+// returns true on 2xx (idle), false on non-2xx (busy).
 func (b *GenericBackend) IdleProbe(isvc *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
 	path, ok := isvc.Annotations[inferencev1alpha1.AnnotationIdleEndpoint]
 	if !ok {

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -184,8 +184,7 @@ type llamaCPUSlot struct {
 
 // IdleProbe returns a probe closure that checks llama.cpp /slots endpoint for
 // idle status. All slots must report is_processing == false for the probe to
-// return true. Mirrors the metal-agent's checkServerIdle logic in
-// pkg/agent/agent.go for runtime-arg parity.
+// return true. Lifted from the original checkServerIdle in drain_before_rollout.go.
 func (b *LlamaCppBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
 	return func(ctx context.Context, baseURL string) (bool, error) {
 		url := fmt.Sprintf("%s/slots", baseURL)

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -1,7 +1,11 @@
 package controller
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"path"
 	"strings"
 
@@ -170,4 +174,52 @@ func (b *LlamaCppBackend) BuildProbes(port int32) (startup, liveness, readiness 
 	}
 
 	return startup, liveness, readiness
+}
+
+// llamaCPUSlot represents a single slot from the llama.cpp /slots endpoint.
+type llamaCPUSlot struct {
+	ID           int  `json:"id"`
+	IsProcessing bool `json:"is_processing"`
+}
+
+// IdleProbe returns a probe closure that checks llama.cpp /slots endpoint for
+// idle status. All slots must report is_processing == false for the probe to
+// return true. Mirrors the metal-agent's checkServerIdle logic in
+// pkg/agent/agent.go for runtime-arg parity.
+func (b *LlamaCppBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
+	return func(ctx context.Context, baseURL string) (bool, error) {
+		url := fmt.Sprintf("%s/slots", baseURL)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return false, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return false, fmt.Errorf("failed to query /slots: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			return false, fmt.Errorf("/slots returned status %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false, fmt.Errorf("failed to read /slots response: %w", err)
+		}
+
+		var slots []llamaCPUSlot
+		if err := json.Unmarshal(body, &slots); err != nil {
+			return false, fmt.Errorf("failed to parse /slots response: %w", err)
+		}
+
+		for _, slot := range slots {
+			if slot.IsProcessing {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	}
 }

--- a/internal/controller/runtime_sglang.go
+++ b/internal/controller/runtime_sglang.go
@@ -23,7 +23,10 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -214,6 +217,40 @@ func (b *SGLangBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *
 		FailureThreshold: 3,
 	}
 	return startup, liveness, readiness
+}
+
+// IdleProbe returns a probe closure that checks SGLang /metrics for
+// `sglang:num_requests_running` gauge sum. Idle when sum == 0. Absent metric
+// returns (false, nil) — fail-closed, treats unknown as busy. Mirrors the
+// metal-agent idle check in pkg/agent/executor.go.
+func (b *SGLangBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
+	return func(ctx context.Context, baseURL string) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/metrics", nil)
+		if err != nil {
+			return false, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return false, fmt.Errorf("failed to query /metrics: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			return false, fmt.Errorf("/metrics returned status %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false, fmt.Errorf("failed to read /metrics response: %w", err)
+		}
+
+		sum, found := parsePrometheusGaugeSum(string(body), "sglang:num_requests_running")
+		if !found {
+			return false, nil
+		}
+		return sum == 0, nil
+	}
 }
 
 // BuildEnv returns HF_TOKEN from SGLangConfig.HFTokenSecretRef when set.

--- a/internal/controller/runtime_sglang.go
+++ b/internal/controller/runtime_sglang.go
@@ -221,8 +221,7 @@ func (b *SGLangBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *
 
 // IdleProbe returns a probe closure that checks SGLang /metrics for
 // `sglang:num_requests_running` gauge sum. Idle when sum == 0. Absent metric
-// returns (false, nil) — fail-closed, treats unknown as busy. Mirrors the
-// metal-agent idle check in pkg/agent/executor.go.
+// returns (false, nil) — fail-closed, treats unknown as busy.
 func (b *SGLangBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
 	return func(ctx context.Context, baseURL string) (bool, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/metrics", nil)

--- a/internal/controller/runtime_sglang.go
+++ b/internal/controller/runtime_sglang.go
@@ -62,7 +62,7 @@ func (b *SGLangBackend) ContainerName() string    { return "sglang" }
 func (b *SGLangBackend) DefaultImage() string     { return sglangCUDAImage }
 func (b *SGLangBackend) DefaultPort() int32       { return 30000 }
 func (b *SGLangBackend) NeedsModelInit() bool     { return true }
-func (b *SGLangBackend) DefaultHPAMetric() string { return "sglang:num_requests_running" }
+func (b *SGLangBackend) DefaultHPAMetric() string { return "sglang:num_running_reqs" }
 
 // BuildArgs generates the SGLang server CLI arguments. Order:
 //  1. --model-path, --host, --port (always)
@@ -220,7 +220,7 @@ func (b *SGLangBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *
 }
 
 // IdleProbe returns a probe closure that checks SGLang /metrics for
-// `sglang:num_requests_running` gauge sum. Idle when sum == 0. Absent metric
+// `sglang:num_running_reqs` gauge sum. Idle when sum == 0. Absent metric
 // returns (false, nil) — fail-closed, treats unknown as busy.
 func (b *SGLangBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
 	return func(ctx context.Context, baseURL string) (bool, error) {
@@ -244,7 +244,7 @@ func (b *SGLangBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client 
 			return false, fmt.Errorf("failed to read /metrics response: %w", err)
 		}
 
-		sum, found := parsePrometheusGaugeSum(string(body), "sglang:num_requests_running")
+		sum, found := parsePrometheusGaugeSum(string(body), "sglang:num_running_reqs")
 		if !found {
 			return false, nil
 		}

--- a/internal/controller/runtime_sglang_test.go
+++ b/internal/controller/runtime_sglang_test.go
@@ -55,8 +55,8 @@ func TestSGLangBackendDefaults(t *testing.T) {
 	if !b.NeedsModelInit() {
 		t.Error("NeedsModelInit() = false, want true")
 	}
-	if got := b.DefaultHPAMetric(); got != "sglang:num_requests_running" {
-		t.Errorf("DefaultHPAMetric() = %q, want %q", got, "sglang:num_requests_running")
+	if got := b.DefaultHPAMetric(); got != "sglang:num_running_reqs" {
+		t.Errorf("DefaultHPAMetric() = %q, want %q", got, "sglang:num_running_reqs")
 	}
 }
 

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -1,7 +1,15 @@
 package controller
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -149,4 +157,231 @@ func TestResolveBackend_SGLang(t *testing.T) {
 	if _, ok := backend.(*SGLangBackend); !ok {
 		t.Errorf("resolveBackend(sglang) = %T, want *SGLangBackend", backend)
 	}
+}
+
+func TestVLLMIdleProbe(t *testing.T) {
+	backend := &VLLMBackend{}
+	client := &http.Client{Timeout: 5 * time.Second}
+	cases := []struct {
+		name     string
+		body     string
+		status   int
+		wantErr  bool
+		wantIdle bool
+	}{
+		{"idle when sum is 0", "vllm:num_requests_running{m=\"a\"} 0\n", 200, false, true},
+		{"busy when sum > 0", "vllm:num_requests_running 3\n", 200, false, false},
+		{"busy when absent", "other_metric 5\n", 200, false, false},
+		{"error on non-200", "", 500, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			probe := backend.IdleProbe(nil, client)
+			idle, err := probe(context.Background(), server.URL)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if idle != tc.wantIdle {
+				t.Errorf("idle = %v, want %v", idle, tc.wantIdle)
+			}
+		})
+	}
+}
+
+func TestTGIIdleProbe(t *testing.T) {
+	backend := &TGIBackend{}
+	client := &http.Client{Timeout: 5 * time.Second}
+	cases := []struct {
+		name     string
+		body     string
+		status   int
+		wantErr  bool
+		wantIdle bool
+	}{
+		{"idle when value is 0", "tgi_batch_current_size 0\n", 200, false, true},
+		{"busy when value > 0", "tgi_batch_current_size 3\n", 200, false, false},
+		{"busy when absent", "other_metric 5\n", 200, false, false},
+		{"error on non-200", "", 500, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			probe := backend.IdleProbe(nil, client)
+			idle, err := probe(context.Background(), server.URL)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if idle != tc.wantIdle {
+				t.Errorf("idle = %v, want %v", idle, tc.wantIdle)
+			}
+		})
+	}
+}
+
+func TestSGLangIdleProbe(t *testing.T) {
+	backend := &SGLangBackend{}
+	client := &http.Client{Timeout: 5 * time.Second}
+	cases := []struct {
+		name     string
+		body     string
+		status   int
+		wantErr  bool
+		wantIdle bool
+	}{
+		{"idle when sum is 0", "sglang:num_requests_running{m=\"a\"} 0\n", 200, false, true},
+		{"busy when sum > 0", "sglang:num_requests_running 3\n", 200, false, false},
+		{"busy when absent", "other_metric 5\n", 200, false, false},
+		{"error on non-200", "", 500, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			probe := backend.IdleProbe(nil, client)
+			idle, err := probe(context.Background(), server.URL)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if idle != tc.wantIdle {
+				t.Errorf("idle = %v, want %v", idle, tc.wantIdle)
+			}
+		})
+	}
+}
+
+func TestGenericIdleProbe(t *testing.T) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	cases := []struct {
+		name            string
+		isvc            *inferencev1alpha1.InferenceService
+		status          int
+		wantErr         bool
+		wantUnsupported bool
+		wantIdle        bool
+	}{
+		{
+			name: "idle on 200 with annotation",
+			isvc: &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						inferencev1alpha1.AnnotationIdleEndpoint: "/health",
+					},
+				},
+			},
+			status: 200, wantErr: false, wantIdle: true,
+		},
+		{
+			name: "busy on 404 with annotation",
+			isvc: &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						inferencev1alpha1.AnnotationIdleEndpoint: "/health",
+					},
+				},
+			},
+			status: 404, wantErr: false, wantIdle: false,
+		},
+		{
+			name:    "unsupported when annotation absent",
+			isvc:    &inferencev1alpha1.InferenceService{},
+			wantErr: true, wantUnsupported: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &GenericBackend{}
+			var server *httptest.Server
+			if tc.status != 0 {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tc.status)
+				}))
+				defer server.Close()
+			}
+
+			probe := backend.IdleProbe(tc.isvc, client)
+			var idle bool
+			var err error
+			if server != nil {
+				idle, err = probe(context.Background(), server.URL)
+			} else {
+				idle, err = probe(context.Background(), "http://example.com")
+			}
+
+			if tc.wantUnsupported {
+				if !errors.Is(err, errIdleUnsupported) {
+					t.Errorf("expected errIdleUnsupported, got: %v", err)
+				}
+			} else if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if idle != tc.wantIdle {
+				t.Errorf("idle = %v, want %v", idle, tc.wantIdle)
+			}
+		})
+	}
+}
+
+func TestIdleDetectorConformance(t *testing.T) {
+	backends := []struct {
+		name    string
+		backend RuntimeBackend
+	}{
+		{"llamacpp", &LlamaCppBackend{}},
+		{"vllm", &VLLMBackend{}},
+		{"tgi", &TGIBackend{}},
+		{"sglang", &SGLangBackend{}},
+		{"generic", &GenericBackend{}},
+	}
+	for _, tc := range backends {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := tc.backend.(IdleDetector); !ok {
+				t.Errorf("%T does not implement IdleDetector", tc.backend)
+			}
+		})
+	}
+
+	t.Run("personaplex must NOT implement IdleDetector", func(t *testing.T) {
+		if reflect.TypeOf(&PersonaPlexBackend{}).Implements(reflect.TypeOf((*IdleDetector)(nil)).Elem()) {
+			t.Error("PersonaPlexBackend must NOT implement IdleDetector")
+		}
+	})
 }

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -591,3 +591,38 @@ func TestGenericIdleProbeTransportError(t *testing.T) {
 		t.Errorf("expected idle=false on error")
 	}
 }
+
+// TestIdleProbeRequestCreationError exercises the defensive error-handling
+// branch after http.NewRequestWithContext in each backend's IdleProbe. A URL
+// with a null byte causes request construction to fail.
+func TestIdleProbeRequestCreationError(t *testing.T) {
+	cases := []struct {
+		name    string
+		backend IdleDetector
+		isvc    *inferencev1alpha1.InferenceService
+	}{
+		{"llamacpp", &LlamaCppBackend{}, nil},
+		{"vllm", &VLLMBackend{}, nil},
+		{"tgi", &TGIBackend{}, nil},
+		{"sglang", &SGLangBackend{}, nil},
+		{"generic", &GenericBackend{}, &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					inferencev1alpha1.AnnotationIdleEndpoint: "/health",
+				},
+			},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			probe := tc.backend.IdleProbe(tc.isvc, &http.Client{Timeout: 5 * time.Second})
+			idle, err := probe(context.Background(), "http://\x00bad")
+			if err == nil {
+				t.Fatal("expected request creation error, got nil")
+			}
+			if idle {
+				t.Errorf("expected idle=false on error")
+			}
+		})
+	}
+}

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -3,9 +3,12 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -384,4 +387,207 @@ func TestIdleDetectorConformance(t *testing.T) {
 			t.Error("PersonaPlexBackend must NOT implement IdleDetector")
 		}
 	})
+}
+
+// errorRoundTripper always returns a transport error.
+type errorRoundTripper struct{}
+
+func (e *errorRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("simulated transport failure")
+}
+
+// errorReadCloser implements io.ReadCloser that always fails on Read.
+type errorReadCloser struct{}
+
+func (e *errorReadCloser) Read(_ []byte) (int, error) {
+	return 0, fmt.Errorf("simulated read failure")
+}
+
+func (e *errorReadCloser) Close() error { return nil }
+
+// errorBodyRoundTripper returns a 200 response whose Body fails on Read.
+type errorBodyRoundTripper struct{}
+
+func (e *errorBodyRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(&errorReadCloser{}),
+	}, nil
+}
+
+// malformedJSONRoundTripper returns a 200 response with non-JSON body.
+type malformedJSONRoundTripper struct{}
+
+func (m *malformedJSONRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("not json")),
+	}, nil
+}
+
+func TestVLLMIdleProbeTransportError(t *testing.T) {
+	backend := &VLLMBackend{}
+	client := &http.Client{
+		Transport: &errorRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(nil, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
+}
+
+func TestVLLMIdleProbeBodyReadError(t *testing.T) {
+	backend := &VLLMBackend{}
+	client := &http.Client{
+		Transport: &errorBodyRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(nil, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected body read error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
+}
+
+func TestTGIIdleProbeTransportError(t *testing.T) {
+	backend := &TGIBackend{}
+	client := &http.Client{
+		Transport: &errorRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(nil, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
+}
+
+func TestTGIIdleProbeBodyReadError(t *testing.T) {
+	backend := &TGIBackend{}
+	client := &http.Client{
+		Transport: &errorBodyRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(nil, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected body read error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
+}
+
+func TestSGLangIdleProbeTransportError(t *testing.T) {
+	backend := &SGLangBackend{}
+	client := &http.Client{
+		Transport: &errorRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(nil, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
+}
+
+func TestSGLangIdleProbeBodyReadError(t *testing.T) {
+	backend := &SGLangBackend{}
+	client := &http.Client{
+		Transport: &errorBodyRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(nil, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected body read error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
+}
+
+func TestLlamaCppIdleProbeTransportError(t *testing.T) {
+	backend := &LlamaCppBackend{}
+	client := &http.Client{
+		Transport: &errorRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(nil, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
+}
+
+func TestLlamaCppIdleProbeBodyReadError(t *testing.T) {
+	backend := &LlamaCppBackend{}
+	client := &http.Client{
+		Transport: &errorBodyRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(nil, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected body read error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
+}
+
+func TestLlamaCppIdleProbeJSONUnmarshalError(t *testing.T) {
+	backend := &LlamaCppBackend{}
+	client := &http.Client{
+		Transport: &malformedJSONRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(nil, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected JSON unmarshal error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
+}
+
+func TestGenericIdleProbeTransportError(t *testing.T) {
+	backend := &GenericBackend{}
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				inferencev1alpha1.AnnotationIdleEndpoint: "/health",
+			},
+		},
+	}
+	client := &http.Client{
+		Transport: &errorRoundTripper{},
+		Timeout:   5 * time.Second,
+	}
+	probe := backend.IdleProbe(isvc, client)
+	idle, err := probe(context.Background(), "http://10.0.0.1:8080")
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+	if idle {
+		t.Errorf("expected idle=false on error")
+	}
 }

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -254,8 +254,8 @@ func TestSGLangIdleProbe(t *testing.T) {
 		wantErr  bool
 		wantIdle bool
 	}{
-		{"idle when sum is 0", "sglang:num_requests_running{m=\"a\"} 0\n", 200, false, true},
-		{"busy when sum > 0", "sglang:num_requests_running 3\n", 200, false, false},
+		{"idle when sum is 0", "sglang:num_running_reqs{model_name=\"llama\"} 0\n", 200, false, true},
+		{"busy when sum > 0", "sglang:num_running_reqs{model_name=\"llama\"} 3\n", 200, false, false},
 		{"busy when absent", "other_metric 5\n", 200, false, false},
 		{"error on non-200", "", 500, true, false},
 	}

--- a/internal/controller/runtime_tgi.go
+++ b/internal/controller/runtime_tgi.go
@@ -1,7 +1,10 @@
 package controller
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -93,6 +96,40 @@ func (b *TGIBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *cor
 		FailureThreshold: 3,
 	}
 	return startup, liveness, readiness
+}
+
+// IdleProbe returns a probe closure that checks TGI /metrics for
+// `tgi_batch_current_size` gauge. Idle when value == 0. Absent metric returns
+// (false, nil) — fail-closed, treats unknown as busy. Mirrors the metal-agent
+// idle check in pkg/agent/executor.go.
+func (b *TGIBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
+	return func(ctx context.Context, baseURL string) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/metrics", nil)
+		if err != nil {
+			return false, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return false, fmt.Errorf("failed to query /metrics: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			return false, fmt.Errorf("/metrics returned status %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false, fmt.Errorf("failed to read /metrics response: %w", err)
+		}
+
+		sum, found := parsePrometheusGaugeSum(string(body), "tgi_batch_current_size")
+		if !found {
+			return false, nil
+		}
+		return sum == 0, nil
+	}
 }
 
 func (b *TGIBackend) BuildEnv(isvc *inferencev1alpha1.InferenceService) []corev1.EnvVar {

--- a/internal/controller/runtime_tgi.go
+++ b/internal/controller/runtime_tgi.go
@@ -100,8 +100,7 @@ func (b *TGIBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *cor
 
 // IdleProbe returns a probe closure that checks TGI /metrics for
 // `tgi_batch_current_size` gauge. Idle when value == 0. Absent metric returns
-// (false, nil) — fail-closed, treats unknown as busy. Mirrors the metal-agent
-// idle check in pkg/agent/executor.go.
+// (false, nil) — fail-closed, treats unknown as busy.
 func (b *TGIBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
 	return func(ctx context.Context, baseURL string) (bool, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/metrics", nil)

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -204,8 +204,7 @@ func (b *VLLMBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *co
 
 // IdleProbe returns a probe closure that checks vLLM /metrics for
 // `vllm:num_requests_running` gauge sum. Idle when sum == 0. Absent metric
-// returns (false, nil) — fail-closed, treats unknown as busy. Mirrors the
-// metal-agent's buildLlamaServerArgs idle check in pkg/agent/executor.go.
+// returns (false, nil) — fail-closed, treats unknown as busy.
 func (b *VLLMBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
 	return func(ctx context.Context, baseURL string) (bool, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/metrics", nil)

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -1,7 +1,10 @@
 package controller
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -197,6 +200,40 @@ func (b *VLLMBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *co
 		FailureThreshold: 3,
 	}
 	return startup, liveness, readiness
+}
+
+// IdleProbe returns a probe closure that checks vLLM /metrics for
+// `vllm:num_requests_running` gauge sum. Idle when sum == 0. Absent metric
+// returns (false, nil) — fail-closed, treats unknown as busy. Mirrors the
+// metal-agent's buildLlamaServerArgs idle check in pkg/agent/executor.go.
+func (b *VLLMBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
+	return func(ctx context.Context, baseURL string) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/metrics", nil)
+		if err != nil {
+			return false, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return false, fmt.Errorf("failed to query /metrics: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			return false, fmt.Errorf("/metrics returned status %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false, fmt.Errorf("failed to read /metrics response: %w", err)
+		}
+
+		sum, found := parsePrometheusGaugeSum(string(body), "vllm:num_requests_running")
+		if !found {
+			return false, nil
+		}
+		return sum == 0, nil
+	}
 }
 
 func (b *VLLMBackend) BuildEnv(isvc *inferencev1alpha1.InferenceService) []corev1.EnvVar {


### PR DESCRIPTION
## What

Extends `RolloutPolicySpec.waitForIdle` (originally llama.cpp-only, shipped in #913) to work for every first-class runtime and for multi-replica deployments. The idle detector now probes each serving pod individually via EndpointSlices rather than hitting a single load-balanced Service URL.

Supported runtimes and their idle signals:

| Runtime | Signal | Idle when |
|---|---|---|
| `llamacpp` | `GET /slots` | every slot `is_processing == false` |
| `vllm` | `GET /metrics` | `vllm:num_requests_running` gauge sum == 0 |
| `tgi` | `GET /metrics` | `tgi_batch_current_size` gauge == 0 |
| `sglang` | `GET /metrics` | `sglang:num_requests_running` gauge sum == 0 |
| `generic` | annotation `inference.llmkube.dev/idle-endpoint` | HTTP 2xx |
| `personaplex` | — | not supported (fail-closed defer) |

## Why

Fixes #911.

The initial drain-before-roll (#913) only covered single-replica llama.cpp via the `/slots` endpoint. This left the operator hands-off for vLLM, TGI, SGLang, and any multi-replica deployment — exactly the workloads that also drop in-flight generations on a hard restart. This follow-up broadens the detector so `waitForIdle=true` works uniformly, and so a multi-replica rollout doesn't declare idle based on a Service request that landed on a single, possibly unrepresentative, pod.

The headline behavior from #913 is unchanged: **fail-closed**. If idleness can't be established (busy replica, unreachable pod, parse error, unsupported runtime), the rollout defers until `idleTimeoutSeconds` expires.

## How

- New optional `IdleDetector` interface alongside the existing `RuntimeBackend` family. Each backend implements `IdleProbe(isvc, client) func(ctx, baseURL) (bool, error)` — a closure that captures the HTTP client and any per-reconcile state (annotation path, metric name).
- `checkServiceIdle` rewritten to: resolve backend -> type-assert to `IdleDetector` -> list EndpointSlices -> probe each Ready replica. Falls back to a single Service URL probe when no EndpointSlices exist (backward compat for the single-replica case and for envtest).
- Generic runtime uses a new `inference.llmkube.dev/idle-endpoint` annotation — operators declare an HTTP path that returns 2xx when idle. No annotation -> `ReasonIdleCheckUnsupported` (defer, then roll after timeout). This avoids a CRD schema bump.
- Hand-rolled Prometheus parser (~30 LOC) for simple gauges. Deliberately avoids `prometheus/common/expfmt` to keep the dependency surface unchanged.
- New condition reason `ReasonIdleCheckUnsupported` for runtimes without idle detection.
- New concept doc: `docs/site/concepts/drain-before-roll.md`.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

---

**AI assistance disclosure:** This PR was implemented with AI assistance. The design was brainstormed and reviewed collaboratively, the implementation plan was written and executed via subagent-driven development (fresh implementer + independent reviewer per task, plus a final whole-branch review), and the code was verified against `make fmt`, `make vet`, `make lint`, `make test`, and `make lint-all`.