### PR TITLE
feat(cli): add --planner-token for gateway-routed planner (Fixes #1053)

### DIFF
--- a/pkg/cli/slice.go
+++ b/pkg/cli/slice.go
@@ -61,6 +61,7 @@ type sliceOptions struct {
 	repo           string
 	plannerURL     string
 	plannerModel   string
+	plannerToken   string
 	repomapFile    string
 	namespace      string
 	coderAgent     string
@@ -107,6 +108,8 @@ Examples:
 	f.StringVar(&opts.plannerURL, "planner-url", "",
 		"OpenAI-compatible base URL of the planner model (required when planning an issue)")
 	f.StringVar(&opts.plannerModel, "planner-model", "", "Planner model name to send in the request")
+	f.StringVar(&opts.plannerToken, "planner-token", "",
+		"Bearer token sent to --planner-url; falls back to PLANNER_TOKEN env. Omit for direct InferenceService")
 	f.StringVar(&opts.repomapFile, "repomap", "", "Path to a repository map file to give the planner")
 	f.StringVar(&opts.namespace, "namespace", "default", "Namespace to create the Workload in")
 	f.StringVar(&opts.coderAgent, "coder-agent", "coder-metal", "Agent that runs each slice's issue-fix step")
@@ -161,7 +164,10 @@ func resolveSlicePlan(ctx context.Context, args []string, opts *sliceOptions) (s
 		if opts.repo == "" || opts.plannerURL == "" {
 			return slicePlan{}, fmt.Errorf("planning an issue requires --repo and --planner-url")
 		}
-		return planIssue(ctx, int32(issue), opts, httpPlannerCall(opts.plannerURL, opts.plannerModel))
+		if opts.plannerToken == "" {
+			opts.plannerToken = os.Getenv("PLANNER_TOKEN")
+		}
+		return planIssue(ctx, int32(issue), opts, httpPlannerCall(opts.plannerURL, opts.plannerModel, opts.plannerToken))
 	}
 	return slicePlan{}, fmt.Errorf("provide --plan FILE or an ISSUE with --repo and --planner-url")
 }

--- a/pkg/cli/slice_planner.go
+++ b/pkg/cli/slice_planner.go
@@ -185,8 +185,10 @@ func parseSlicePlan(raw string) (slicePlan, error) {
 }
 
 // httpPlannerCall posts the prompt to an OpenAI-compatible /v1/chat/completions
-// endpoint and returns the assistant message content.
-func httpPlannerCall(url, model string) PlannerCaller {
+// endpoint and returns the assistant message content. When token is non-empty
+// it is sent as an Authorization: Bearer header so the call can route through
+// a ModelRouter / Envoy AI Gateway that requires JWT auth.
+func httpPlannerCall(url, model, token string) PlannerCaller {
 	return func(ctx context.Context, prompt string) (string, error) {
 		reqBody, _ := json.Marshal(map[string]any{
 			"model":       model,
@@ -200,6 +202,9 @@ func httpPlannerCall(url, model string) PlannerCaller {
 			return "", err
 		}
 		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
 		client := &http.Client{Timeout: 10 * time.Minute}
 		resp, err := client.Do(req)
 		if err != nil {

--- a/pkg/cli/slice_planner_test.go
+++ b/pkg/cli/slice_planner_test.go
@@ -111,7 +111,7 @@ func TestHTTPPlannerCall(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	out, err := httpPlannerCall(srv.URL, "planner")(context.Background(), "prompt")
+	out, err := httpPlannerCall(srv.URL, "planner", "")(context.Background(), "prompt")
 	if err != nil {
 		t.Fatalf("call: %v", err)
 	}
@@ -124,8 +124,40 @@ func TestHTTPPlannerCall(t *testing.T) {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	}))
 	defer bad.Close()
-	if _, err := httpPlannerCall(bad.URL, "m")(context.Background(), "p"); err == nil {
+	if _, err := httpPlannerCall(bad.URL, "m", "")(context.Background(), "p"); err == nil {
 		t.Fatal("want error on non-200")
+	}
+}
+
+func TestHTTPPlannerCall_AuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": "issue: 1\nrepo: a/b\nslices: []"}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	// No token → no Authorization header.
+	caller := httpPlannerCall(srv.URL, "m", "")
+	if _, err := caller(context.Background(), "p"); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("no token: Authorization = %q, want empty", gotAuth)
+	}
+
+	// Token set → Bearer header is sent verbatim.
+	caller = httpPlannerCall(srv.URL, "m", "eyJhbGciOiJIUzI1NiJ9.fake")
+	if _, err := caller(context.Background(), "p"); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	want := "Bearer eyJhbGciOiJIUzI1NiJ9.fake"
+	if gotAuth != want {
+		t.Fatalf("with token: Authorization = %q, want %q", gotAuth, want)
 	}
 }
 


### PR DESCRIPTION
## What
Adds `--planner-token` (with `PLANNER_TOKEN` env fallback) so the slicer planner call can route through a ModelRouter / Envoy AI Gateway.

Fixes #1053

## Why
The planner call hit an InferenceService directly; routing it through the fleet's JWT-gated gateway like every other model call needs a bearer token.

## How
When the token is non-empty, `httpPlannerCall` sets `Authorization: Bearer <token>`. Empty token preserves the current direct-InferenceService behavior (non-breaking). `pkg/cli` only, tested.

## Provenance and review
Generated by Foreman, independently reviewed. The auth mechanism is the standard bearer-JWT pattern the gateway uses (grounded, not invented); backward-compatible; `go test ./pkg/cli/...` passes on main.

## Checklist
- [x] Tests added; cli suite passes
- [x] Conventional + DCO signed
- [x] AI assistance disclosed
