### PR TITLE
fix(foreman): reset strategy force-pushes its own stale branch

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -351,6 +351,33 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	return e.runLLMPath(ctx, task, &agent, endpoint, workspace, branch, registry, auth, start)
 }
 
+// effectiveBranchStrategy resolves the branch strategy the executor acts on:
+// an explicit payload.branchStrategy wins; otherwise a task naming a prior
+// attempt (payload.reviseFromBranch) defaults to rebase (#1047 — restore-and-
+// rebase is the only sensible intent when a prior attempt is named), and
+// everything else defaults to reset.
+func effectiveBranchStrategy(p foremanv1alpha1.AgenticTaskPayload) foremanv1alpha1.BranchStrategy {
+	if p.BranchStrategy != "" {
+		return p.BranchStrategy
+	}
+	if p.ReviseFromBranch != "" {
+		return foremanv1alpha1.BranchStrategyRebase
+	}
+	return foremanv1alpha1.BranchStrategyReset
+}
+
+// replaceStaleOwnBranch reports whether Push may force-with-lease over the
+// task's OWN branch when a plain push is rejected non-fast-forward. True when
+// the caller opted in (allowOverwrite, #934) OR the effective strategy is reset
+// (#1105): a reset is a fresh retry cut from the current base, so any prior
+// attempt still on the task's branch is stale and safe to overwrite — without
+// this a reset re-dispatch PUSH-FAILs on the diverged remote branch, wedging the
+// retry until the branch is deleted by hand. force-with-lease keeps the
+// compare-and-swap guard against an unexpected concurrent push.
+func replaceStaleOwnBranch(p foremanv1alpha1.AgenticTaskPayload) bool {
+	return p.AllowOverwrite || effectiveBranchStrategy(p) == foremanv1alpha1.BranchStrategyReset
+}
+
 // setupTaskBranch cuts the task's working branch in the freshly cloned
 // workspace, honoring payload.branchStrategy (default "reset"). Precedence:
 //
@@ -377,19 +404,7 @@ func setupTaskBranch(
 	auth *repo.Auth,
 	log logr.Logger,
 ) error {
-	strategy := task.Spec.Payload.BranchStrategy
-	if strategy == "" {
-		// #1047: reviseFromBranch without branchStrategy used to silently no-op
-		// (defaulted to reset, which skips the restore). When reviseFromBranch is
-		// set and the caller did not explicitly choose reset, treat the effective
-		// strategy as rebase — restore-and-rebase is the only sensible intent
-		// when a prior attempt is named. An explicit "reset" still wins.
-		if task.Spec.Payload.ReviseFromBranch != "" {
-			strategy = foremanv1alpha1.BranchStrategyRebase
-		} else {
-			strategy = foremanv1alpha1.BranchStrategyReset
-		}
-	}
+	strategy := effectiveBranchStrategy(task.Spec.Payload)
 
 	// rebase (in-review revision): restore the prior attempt AND rebase it onto
 	// the current base, so its commits replay on top of work merged since rather
@@ -800,13 +815,14 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		Workspace: workspace,
 		Branch:    branch,
 		Auth:      auth,
-		// Opt-in via Workload.spec.allowOverwrite (stamped onto the task
-		// payload): replace a stale ref for this task's own branch
-		// (compare-and-swap via force-with-lease) instead of failing the
-		// re-run non-fast-forward (#934). Off by default per #573 — a
-		// replaced ref can carry a previously-GO'd audit artifact, so
-		// the caller that re-runs Workloads makes that call explicitly.
-		ReplaceOnReject: task.Spec.Payload.AllowOverwrite,
+		// Replace a stale ref for this task's own branch (compare-and-swap via
+		// force-with-lease) instead of failing the re-run non-fast-forward: when
+		// the caller opts in via allowOverwrite (#934), OR under the reset
+		// strategy (#1105) — a fresh retry cut from base owns its branch, so a
+		// stale prior attempt on it must be overwritten or the re-dispatch
+		// PUSH-FAILs. force-with-lease still guards against an unexpected
+		// concurrent push (the #573 no-blind-clobber intent).
+		ReplaceOnReject: replaceStaleOwnBranch(task.Spec.Payload),
 	}); err != nil {
 		return e.pushFailedResult(start, transcriptRef, loopRes, branch, sha, err), nil
 	}

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2613,3 +2613,46 @@ func TestMakeCoderGateVerifier_GenericGate_CleanPassesWithNoClaims(t *testing.T)
 		t.Errorf("expected empty feedback on accept, got: %q", feedback)
 	}
 }
+
+// TestEffectiveBranchStrategy pins the strategy resolution: explicit wins,
+// reviseFromBranch defaults to rebase (#1047), everything else to reset.
+func TestEffectiveBranchStrategy(t *testing.T) {
+	reset := foremanv1alpha1.BranchStrategyReset
+	rebase := foremanv1alpha1.BranchStrategyRebase
+	cases := []struct {
+		name string
+		p    foremanv1alpha1.AgenticTaskPayload
+		want foremanv1alpha1.BranchStrategy
+	}{
+		{"empty defaults reset", foremanv1alpha1.AgenticTaskPayload{}, reset},
+		{"reviseFromBranch defaults rebase", foremanv1alpha1.AgenticTaskPayload{ReviseFromBranch: "b"}, rebase},
+		{"explicit reset wins over reviseFromBranch", foremanv1alpha1.AgenticTaskPayload{BranchStrategy: reset, ReviseFromBranch: "b"}, reset},
+		{"explicit rebase", foremanv1alpha1.AgenticTaskPayload{BranchStrategy: rebase}, rebase},
+	}
+	for _, c := range cases {
+		if got := effectiveBranchStrategy(c.p); got != c.want {
+			t.Errorf("%s: effectiveBranchStrategy = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestReplaceStaleOwnBranch pins the #1105 push decision: reset force-pushes the
+// task's own (stale) branch; rebase/revision only forces via allowOverwrite.
+func TestReplaceStaleOwnBranch(t *testing.T) {
+	cases := []struct {
+		name string
+		p    foremanv1alpha1.AgenticTaskPayload
+		want bool
+	}{
+		{"reset (default) force-pushes own branch", foremanv1alpha1.AgenticTaskPayload{}, true},
+		{"explicit reset", foremanv1alpha1.AgenticTaskPayload{BranchStrategy: foremanv1alpha1.BranchStrategyReset}, true},
+		{"allowOverwrite forces regardless of strategy", foremanv1alpha1.AgenticTaskPayload{BranchStrategy: foremanv1alpha1.BranchStrategyRebase, AllowOverwrite: true}, true},
+		{"revision (reviseFromBranch->rebase) without allowOverwrite does not force", foremanv1alpha1.AgenticTaskPayload{ReviseFromBranch: "b"}, false},
+		{"explicit rebase without allowOverwrite does not force", foremanv1alpha1.AgenticTaskPayload{BranchStrategy: foremanv1alpha1.BranchStrategyRebase}, false},
+	}
+	for _, c := range cases {
+		if got := replaceStaleOwnBranch(c.p); got != c.want {
+			t.Errorf("%s: replaceStaleOwnBranch = %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Make `branchStrategy=reset` force-with-lease over the task's **own** branch when a plain push is rejected non-fast-forward, so a reset re-dispatch no longer PUSH-FAILs on a diverged prior-attempt branch.

## Why

Fixes #1105 — the missing half of #1042.

#1042 made `reset` cut the working branch fresh from the current base (fixing reverted-merged-work, #1029), but the push still gated force-with-lease solely on `payload.allowOverwrite`:

```go
ReplaceOnReject: task.Spec.Payload.AllowOverwrite,
```

On a re-dispatch of an issue whose task branch (`foreman/<wl>/issue-N`) already exists from a prior attempt, `reset` cuts a fresh branch from base that diverges from that remote branch → non-fast-forward push → `PUSH-FAILED` ("push to fork failed") unless `allowOverwrite` is set (bridge-created issue-fix tasks don't set it). So reset retries — and the slicer's future repair re-dispatch (#1033) — stay wedged until the branch is deleted by hand. The maintainer's #1029 review called for exactly this: *"the force-push overwrite is the right call for a fresh retry."*

## How

- Extract the strategy resolution into `effectiveBranchStrategy(payload)` — explicit wins, `reviseFromBranch` ⇒ rebase (#1047), else reset — and use it in both `setupTaskBranch` and the push decision (single source of truth).
- `replaceStaleOwnBranch(payload) = allowOverwrite || effectiveBranchStrategy == reset`, wired into `ReplaceOnReject`. A reset is a fresh retry cut from base, so its own prior task branch is stale and safe to overwrite. `rebase`/revision is unchanged (keeps `allowOverwrite`, which the reconciler already stamps on revisions).
- Stays **force-with-lease** (not `--force`) — the compare-and-swap guard against an unexpected concurrent push (the #573/#934 no-blind-clobber intent) is preserved.

## Checklist

- [x] Tests added/updated — `TestEffectiveBranchStrategy` + `TestReplaceStaleOwnBranch`; the existing `setupTaskBranch` suite (incl. #1047 `ReviseFromBranchDefaultsToRebase`) still passes against the refactor.
- [x] `make test` passes locally (full suite; envtest included)
- [x] `make lint` passes locally (0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed — AI-assisted contribution
- [ ] Documentation updated — N/A (internal push behavior; code comments updated)
