### PR TITLE
feat(quota): add GPUQuota admission decision function

### DIFF
--- a/internal/webhook/quota/decision.go
+++ b/internal/webhook/quota/decision.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package quota holds the pure admission-decision logic for GPUQuota.
+// It is intentionally free of Kubernetes or webhook dependencies so the
+// allow/deny rules can be exhaustively unit-tested in isolation. The
+// controller-runtime webhook that calls this lives in internal/controller
+// and is wired up separately.
+package quota
+
+import (
+	"fmt"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// priorityWeights mirrors pkg/agent/priority.go and internal/controller/
+// scheduling.go. The three copies encode the same semantic ordering used
+// for both Kubernetes PriorityClass selection and GPU admission. Keep them
+// in sync; if they ever diverge the ordering is no longer well-defined.
+var priorityWeights = map[string]int32{
+	"critical": 1000000,
+	"high":     100000,
+	"normal":   10000,
+	"low":      1000,
+	"batch":    100,
+}
+
+// priorityWeight returns the numeric weight for the given priority enum
+// value. Unknown or empty strings are treated as "normal" so a malformed
+// CRD value does not accidentally promote a workload above explicitly-set
+// ones.
+func priorityWeight(p string) int32 {
+	if w, ok := priorityWeights[p]; ok {
+		return w
+	}
+	return priorityWeights["normal"]
+}
+
+// Usage is the current state of a quota: how many GPUs and how much VRAM
+// are already allocated.
+type Usage struct {
+	// GPUCount is the number of GPUs currently allocated under the quota.
+	GPUCount int32
+	// VRAMBytes is the total VRAM (bytes) currently allocated under the
+	// quota. Zero means no VRAM has been allocated yet.
+	VRAMBytes int64
+}
+
+// Incoming describes a single admission request against the quota.
+type Incoming struct {
+	// GPUCount is the number of GPUs the requestor wants to allocate.
+	GPUCount int32
+	// VRAMBytes is the VRAM (bytes) the requestor wants to allocate.
+	VRAMBytes int64
+	// Priority is the requestor's declared priority (critical, high,
+	// normal, low, batch).
+	Priority string
+}
+
+// Decide evaluates a single admission request against a GPUQuota and
+// returns whether to allow it plus a human-readable reason. The function
+// is pure: it does not read live state, talk to an API server, or consult
+// any external cost budget. The caller is responsible for passing in the
+// current usage and the cost-budget status.
+//
+// Rules (in order):
+//
+//  1. If CostBudgetRef is set on the spec and costBudgetBreached is true,
+//     deny with a cost-budget reason.
+//  2. If current+incoming GPUCount would exceed spec.GPUCount, deny with
+//     an over-GPU-count reason.
+//  3. If spec.VRAMBytes is non-zero and current+incoming VRAMBytes would
+//     exceed it, deny with an over-VRAM reason.
+//  4. If incoming.Priority is below spec.MinPriority, deny with a
+//     priority reason.
+//
+// If none of the above apply, allow.
+func Decide(spec inferencev1alpha1.GPUQuotaSpec, current Usage, incoming Incoming, costBudgetBreached bool) (allow bool, reason string) {
+	// Cost budget check. The cost budget is the highest-priority gate:
+	// if the dollar budget is exhausted, nothing gets through regardless
+	// of priority or headroom.
+	if spec.CostBudgetRef != "" && costBudgetBreached {
+		return false, fmt.Sprintf("cost budget %q exhausted", spec.CostBudgetRef)
+	}
+
+	// GPU count check. GPUCount is a required field and the hard cap on
+	// GPUs the quota allows; unlike VRAMBytes, zero means "no GPUs allowed"
+	// (not "unlimited"), so the comparison always runs.
+	if current.GPUCount+incoming.GPUCount > spec.GPUCount {
+		return false, fmt.Sprintf("would exceed gpuCount %d (current %d + requested %d)",
+			spec.GPUCount, current.GPUCount, incoming.GPUCount)
+	}
+
+	// VRAM check. VRAMBytes==0 on the spec means "no cap", so skip the
+	// check in that case.
+	if spec.VRAMBytes > 0 {
+		if current.VRAMBytes+incoming.VRAMBytes > spec.VRAMBytes {
+			return false, fmt.Sprintf("would exceed vramBytes %d (current %d + requested %d)",
+				spec.VRAMBytes, current.VRAMBytes, incoming.VRAMBytes)
+		}
+	}
+
+	// Priority check. An empty minPriority on the spec means "no minimum",
+	// so any incoming priority is fine. An empty incoming priority is
+	// treated as "normal" (the default weight) so a malformed request
+	// does not accidentally pass a high bar.
+	if spec.MinPriority != "" {
+		if priorityWeight(incoming.Priority) < priorityWeight(spec.MinPriority) {
+			return false, fmt.Sprintf("priority %q below minimum %q", incoming.Priority, spec.MinPriority)
+		}
+	}
+
+	return true, "allowed"
+}

--- a/internal/webhook/quota/decision_test.go
+++ b/internal/webhook/quota/decision_test.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"testing"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// want is the expected allow value for a Decide call.
+type want struct {
+	allow bool
+}
+
+func TestDecide_InQuotaAllow(t *testing.T) {
+	spec := inferencev1alpha1.GPUQuotaSpec{
+		GPUCount:    8,
+		VRAMBytes:   64 << 30, // 64 GiB
+		MinPriority: "low",
+	}
+	current := Usage{GPUCount: 2, VRAMBytes: 16 << 30}
+	incoming := Incoming{GPUCount: 2, VRAMBytes: 16 << 30, Priority: "high"}
+
+	allow, reason := Decide(spec, current, incoming, false)
+	if !allow {
+		t.Fatalf("expected allow, got deny: %s", reason)
+	}
+}
+
+func TestDecide_OverGPUCount(t *testing.T) {
+	spec := inferencev1alpha1.GPUQuotaSpec{
+		GPUCount:  4,
+		VRAMBytes: 32 << 30,
+	}
+	current := Usage{GPUCount: 3, VRAMBytes: 8 << 30}
+	incoming := Incoming{GPUCount: 2, VRAMBytes: 4 << 30, Priority: "normal"}
+
+	allow, reason := Decide(spec, current, incoming, false)
+	if allow {
+		t.Fatalf("expected deny, got allow")
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty reason")
+	}
+}
+
+func TestDecide_OverVRAMBytes(t *testing.T) {
+	spec := inferencev1alpha1.GPUQuotaSpec{
+		GPUCount:  8,
+		VRAMBytes: 32 << 30, // 32 GiB
+	}
+	current := Usage{GPUCount: 2, VRAMBytes: 28 << 30}
+	incoming := Incoming{GPUCount: 1, VRAMBytes: 8 << 30, Priority: "normal"}
+
+	allow, reason := Decide(spec, current, incoming, false)
+	if allow {
+		t.Fatalf("expected deny, got allow: %s", reason)
+	}
+}
+
+func TestDecide_MinPrioritySatisfied(t *testing.T) {
+	spec := inferencev1alpha1.GPUQuotaSpec{
+		GPUCount:    4,
+		MinPriority: "high",
+	}
+	current := Usage{GPUCount: 0}
+	incoming := Incoming{GPUCount: 1, Priority: "critical"}
+
+	allow, reason := Decide(spec, current, incoming, false)
+	if !allow {
+		t.Fatalf("expected allow, got deny: %s", reason)
+	}
+}
+
+func TestDecide_MinPriorityViolated(t *testing.T) {
+	spec := inferencev1alpha1.GPUQuotaSpec{
+		GPUCount:    4,
+		MinPriority: "high",
+	}
+	current := Usage{GPUCount: 0}
+	incoming := Incoming{GPUCount: 1, Priority: "low"}
+
+	allow, _ := Decide(spec, current, incoming, false)
+	if allow {
+		t.Fatalf("expected deny, got allow")
+	}
+}
+
+func TestDecide_MinPriorityAtEachLevel(t *testing.T) {
+	// Verify the priority ordering critical > high > normal > low > batch
+	// by checking that each level satisfies its own minimum but not the
+	// next-higher minimum.
+	// priorities[0] = critical (highest), priorities[4] = batch (lowest)
+	priorities := []string{"critical", "high", "normal", "low", "batch"}
+	for i, minP := range priorities {
+		t.Run(minP, func(t *testing.T) {
+			spec := inferencev1alpha1.GPUQuotaSpec{
+				GPUCount:    4,
+				MinPriority: minP,
+			}
+			current := Usage{GPUCount: 0}
+
+			// Incoming at or above minP should be allowed.
+			// Since priorities are in descending order, indices 0..i are at or above minP.
+			for j := 0; j <= i; j++ {
+				incP := priorities[j]
+				incoming := Incoming{GPUCount: 1, Priority: incP}
+				allow, reason := Decide(spec, current, incoming, false)
+				if !allow {
+					t.Errorf("priority %q with min %q: expected allow, got deny: %s", incP, minP, reason)
+				}
+			}
+
+			// Incoming below minP should be denied.
+			// Indices i+1..len-1 are below minP.
+			for j := i + 1; j < len(priorities); j++ {
+				incP := priorities[j]
+				incoming := Incoming{GPUCount: 1, Priority: incP}
+				allow, _ := Decide(spec, current, incoming, false)
+				if allow {
+					t.Errorf("priority %q with min %q: expected deny, got allow", incP, minP)
+				}
+			}
+		})
+	}
+}
+
+func TestDecide_CostBudgetBreached(t *testing.T) {
+	spec := inferencev1alpha1.GPUQuotaSpec{
+		GPUCount:      8,
+		CostBudgetRef: "budget-prod",
+	}
+	current := Usage{GPUCount: 0}
+	incoming := Incoming{GPUCount: 1, Priority: "critical"}
+
+	allow, reason := Decide(spec, current, incoming, true)
+	if allow {
+		t.Fatalf("expected deny when cost budget breached, got allow")
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty reason")
+	}
+}
+
+func TestDecide_CostBudgetNotBreached(t *testing.T) {
+	spec := inferencev1alpha1.GPUQuotaSpec{
+		GPUCount:      8,
+		CostBudgetRef: "budget-prod",
+	}
+	current := Usage{GPUCount: 0}
+	incoming := Incoming{GPUCount: 1, Priority: "critical"}
+
+	allow, reason := Decide(spec, current, incoming, false)
+	if !allow {
+		t.Fatalf("expected allow when cost budget not breached, got deny: %s", reason)
+	}
+}
+
+func TestDecide_CostBudgetRefEmpty(t *testing.T) {
+	// When CostBudgetRef is empty, costBudgetBreached should be ignored.
+	spec := inferencev1alpha1.GPUQuotaSpec{
+		GPUCount: 8,
+	}
+	current := Usage{GPUCount: 0}
+	incoming := Incoming{GPUCount: 1, Priority: "critical"}
+
+	allow, reason := Decide(spec, current, incoming, true)
+	if !allow {
+		t.Fatalf("expected allow when CostBudgetRef is empty, got deny: %s", reason)
+	}
+}
+
+func TestDecide_Combinations(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     inferencev1alpha1.GPUQuotaSpec
+		current  Usage
+		incoming Incoming
+		breached bool
+		want     want
+	}{
+		{
+			name: "allow: in quota, priority ok, no cost budget",
+			spec: inferencev1alpha1.GPUQuotaSpec{
+				GPUCount:    4,
+				MinPriority: "normal",
+			},
+			current:  Usage{GPUCount: 1},
+			incoming: Incoming{GPUCount: 1, Priority: "high"},
+			want:     want{allow: true},
+		},
+		{
+			name: "deny: over gpuCount AND below priority",
+			spec: inferencev1alpha1.GPUQuotaSpec{
+				GPUCount:    2,
+				MinPriority: "high",
+			},
+			current:  Usage{GPUCount: 2},
+			incoming: Incoming{GPUCount: 1, Priority: "low"},
+			want:     want{allow: false},
+		},
+		{
+			name: "deny: cost budget breached overrides allow",
+			spec: inferencev1alpha1.GPUQuotaSpec{
+				GPUCount:      8,
+				CostBudgetRef: "budget-prod",
+			},
+			current:  Usage{GPUCount: 0},
+			incoming: Incoming{GPUCount: 1, Priority: "critical"},
+			breached: true,
+			want:     want{allow: false},
+		},
+		{
+			name: "allow: cost budget breached but no ref set",
+			spec: inferencev1alpha1.GPUQuotaSpec{
+				GPUCount: 8,
+			},
+			current:  Usage{GPUCount: 0},
+			incoming: Incoming{GPUCount: 1, Priority: "critical"},
+			breached: true,
+			want:     want{allow: true},
+		},
+		{
+			name: "deny: over vram AND over gpuCount (gpuCount checked first)",
+			spec: inferencev1alpha1.GPUQuotaSpec{
+				GPUCount:  2,
+				VRAMBytes: 16 << 30,
+			},
+			current:  Usage{GPUCount: 2, VRAMBytes: 12 << 30},
+			incoming: Incoming{GPUCount: 1, VRAMBytes: 8 << 30, Priority: "normal"},
+			want:     want{allow: false},
+		},
+		{
+			name: "allow: exactly at quota limit",
+			spec: inferencev1alpha1.GPUQuotaSpec{
+				GPUCount:    4,
+				VRAMBytes:   32 << 30,
+				MinPriority: "batch",
+			},
+			current:  Usage{GPUCount: 2, VRAMBytes: 16 << 30},
+			incoming: Incoming{GPUCount: 2, VRAMBytes: 16 << 30, Priority: "batch"},
+			want:     want{allow: true},
+		},
+		{
+			name: "deny: exactly at quota limit but priority too low",
+			spec: inferencev1alpha1.GPUQuotaSpec{
+				GPUCount:    4,
+				MinPriority: "high",
+			},
+			current:  Usage{GPUCount: 2},
+			incoming: Incoming{GPUCount: 2, Priority: "batch"},
+			want:     want{allow: false},
+		},
+		{
+			name: "deny: gpuCount 0 cap rejects any positive request",
+			spec: inferencev1alpha1.GPUQuotaSpec{
+				GPUCount: 0,
+			},
+			current:  Usage{GPUCount: 0},
+			incoming: Incoming{GPUCount: 1},
+			want:     want{allow: false},
+		},
+		{
+			name: "allow: gpuCount 0 cap accepts a zero-gpu request",
+			spec: inferencev1alpha1.GPUQuotaSpec{
+				GPUCount: 0,
+			},
+			current:  Usage{GPUCount: 0},
+			incoming: Incoming{GPUCount: 0},
+			want:     want{allow: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allow, reason := Decide(tt.spec, tt.current, tt.incoming, tt.breached)
+			if allow != tt.want.allow {
+				t.Errorf("allow = %v, want %v (reason: %s)", allow, tt.want.allow, reason)
+			}
+		})
+	}
+}
+
+func TestPriorityWeight(t *testing.T) {
+	tests := []struct {
+		priority string
+		want     int32
+	}{
+		{"critical", 1000000},
+		{"high", 100000},
+		{"normal", 10000},
+		{"low", 1000},
+		{"batch", 100},
+		{"", 10000},        // unknown defaults to normal
+		{"unknown", 10000}, // unknown defaults to normal
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.priority, func(t *testing.T) {
+			got := priorityWeight(tt.priority)
+			if got != tt.want {
+				t.Errorf("priorityWeight(%q) = %d, want %d", tt.priority, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds the pure GPUQuota admission decision function, `internal/webhook/quota/decision.go`, plus exhaustive table tests. Story 3 of the multi-tenancy epic (#416). The function is deliberately free of Kubernetes and webhook dependencies so the allow/deny rules can be unit-tested in isolation; the validating webhook that calls it lands in #1095.

`Decide(spec, current, incoming, costBudgetBreached)` evaluates, in order: cost-budget breach (highest gate), GPU-count cap, VRAM cap, and minimum-priority floor, returning allow plus a human-readable reason.

## Why

Fixes #1094

This is the reusable core the GPUQuota validating webhook (#1095) will call. Keeping it a pure function means the full allow/deny matrix is covered by fast unit tests, independent of the apiserver.

## How

Standard pure function plus a table-driven test. Priority ordering reuses the same weights as `pkg/agent/priority.go` and `internal/controller/scheduling.go` (documented in the code, kept in sync). `gpuCount` is treated as a hard cap: a value of `0` denies any positive request (it does not mean "unlimited"; only `vramBytes: 0` means "no cap", matching its documented optional semantics).

## Testing / verification

Verified locally in an isolated worktree at the branch commit:

- `go build ./internal/webhook/quota/...` and `go vet` clean
- `go test ./internal/webhook/quota/...` passes, including exactly-at-limit allow, at-limit-but-priority-too-low deny, cost-budget override, over-VRAM-and-GPU ordering, and the two zero-`gpuCount` cases (positive request denied, zero request allowed)
- `gofmt` clean

## AI assistance disclosure

Assisted-by: Foreman, the project's local agentic coding harness (coder model `ornith-35b`, served on-prem), generated the function and tests. A review pass I directed then found a fail-open bug (a `gpuCount: 0` quota skipped enforcement and allowed unlimited GPUs), which was fed back to the harness as a revision cycle that removed the guard and added the two zero-cap tests. I own this change and the review conversation; per `AGENTS.md` the commit carries no attribution trailer and the DCO sign-off is mine.

## Checklist

- [x] Tests added/updated (full allow/deny matrix, including the zero-cap edge)
- [x] Tests pass locally (`go test ./internal/webhook/quota/...`)
- [x] Lint clean for this change (`gofmt` clean; new package, no new lint)
- [x] Commit messages follow conventional commits
- [x] Commit is signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed above
- [ ] Documentation updated (n/a: internal package, no user-facing surface; docs land with the webhook + Helm toggle)
