### PR TITLE
feat(foreman): preserve a coder's gate-failed branch instead of discarding it

### DIFF
--- a/pkg/foreman/agent/executor_gate_preserve_test.go
+++ b/pkg/foreman/agent/executor_gate_preserve_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
+)
+
+func gpGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=seed", "GIT_AUTHOR_EMAIL=seed@example.com",
+		"GIT_COMMITTER_NAME=seed", "GIT_COMMITTER_EMAIL=seed@example.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// gpSetupWorkspace builds a bare origin seeded with `main` and a workspace clone
+// checked out on `branch`; when withChange is true the workspace carries one
+// uncommitted file. Returns the workspace path and the bare origin path.
+func gpSetupWorkspace(t *testing.T, branch string, withChange bool) (ws, origin string) {
+	t.Helper()
+	root := t.TempDir()
+	origin = filepath.Join(root, "origin.git")
+	gpGit(t, root, "init", "--bare", origin)
+
+	seed := filepath.Join(root, "seed")
+	gpGit(t, root, "clone", origin, seed)
+	gpGit(t, seed, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gpGit(t, seed, "add", ".")
+	gpGit(t, seed, "commit", "-m", "seed")
+	gpGit(t, seed, "push", "-u", "origin", "main")
+
+	ws = filepath.Join(root, "ws")
+	gpGit(t, root, "clone", origin, ws)
+	gpGit(t, ws, "checkout", "-b", branch)
+	if withChange {
+		if err := os.WriteFile(filepath.Join(ws, "coder.go"), []byte("package coder\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ws, origin
+}
+
+func gpOriginHasBranch(t *testing.T, origin, branch string) bool {
+	t.Helper()
+	out, err := exec.Command("git", "-C", origin, "branch", "--list", branch).CombinedOutput()
+	if err != nil {
+		t.Fatalf("origin branch --list: %v\n%s", err, out)
+	}
+	return strings.Contains(string(out), branch)
+}
+
+func gpAgent(role foremanv1alpha1.AgentRole) *foremanv1alpha1.Agent {
+	return &foremanv1alpha1.Agent{Spec: foremanv1alpha1.AgentSpec{Role: role}}
+}
+
+func gpLoopResult(outcome string) *LoopResult {
+	return &LoopResult{Terminal: &ToolResult{
+		Terminal: true,
+		Verdict:  "INCOMPLETE",
+		Extra:    map[string]any{outcomeKey: outcome},
+	}}
+}
+
+func TestMaybePreserveGateFailedBranch(t *testing.T) {
+	ident := repo.Identity{Name: "Foreman Bot", Email: "bot@example.com"}
+	newExec := func() *NativeAgentLoopExecutor {
+		return &NativeAgentLoopExecutor{CommitAuthor: ident, CommitCommitter: ident}
+	}
+	newTask := func(branch string) *foremanv1alpha1.AgenticTask {
+		return &foremanv1alpha1.AgenticTask{
+			Spec: foremanv1alpha1.AgenticTaskSpec{
+				Payload: foremanv1alpha1.AgenticTaskPayload{Issue: 1109, Branch: branch},
+			},
+		}
+	}
+
+	t.Run("coder CODER-GATE-FAILED with changes preserves the branch", func(t *testing.T) {
+		const branch = "foreman/gp/preserve"
+		ws, origin := gpSetupWorkspace(t, branch, true)
+		r := &Result{Extra: map[string]any{}}
+		newExec().maybePreserveGateFailedBranch(context.Background(), logr.Discard(),
+			gpAgent(foremanv1alpha1.AgentRoleCoder), newTask(branch), ws, branch, nil,
+			gpLoopResult(CoderGateFailedOutcome), r)
+
+		if !gpOriginHasBranch(t, origin, branch) {
+			t.Fatalf("expected branch %q pushed to origin", branch)
+		}
+		if r.Extra["gateFailedBranch"] != branch {
+			t.Errorf("gateFailedBranch = %v; want %q", r.Extra["gateFailedBranch"], branch)
+		}
+		if _, ok := r.Extra["commitSHA"].(string); !ok {
+			t.Errorf("commitSHA not recorded (got %v)", r.Extra["commitSHA"])
+		}
+	})
+
+	t.Run("non-gate INCOMPLETE outcome is not preserved", func(t *testing.T) {
+		const branch = "foreman/gp/nongate"
+		ws, origin := gpSetupWorkspace(t, branch, true)
+		r := &Result{Extra: map[string]any{}}
+		newExec().maybePreserveGateFailedBranch(context.Background(), logr.Discard(),
+			gpAgent(foremanv1alpha1.AgentRoleCoder), newTask(branch), ws, branch, nil,
+			gpLoopResult("STUCK-LOOP-DETECTED"), r)
+
+		if gpOriginHasBranch(t, origin, branch) {
+			t.Error("branch pushed for a non-gate outcome; should not preserve")
+		}
+		if _, ok := r.Extra["gateFailedBranch"]; ok {
+			t.Error("gateFailedBranch recorded for a non-gate outcome")
+		}
+	})
+
+	t.Run("reviewer role is not preserved", func(t *testing.T) {
+		const branch = "foreman/gp/reviewer"
+		ws, origin := gpSetupWorkspace(t, branch, true)
+		r := &Result{Extra: map[string]any{}}
+		newExec().maybePreserveGateFailedBranch(context.Background(), logr.Discard(),
+			gpAgent(foremanv1alpha1.AgentRoleReviewer), newTask(branch), ws, branch, nil,
+			gpLoopResult(CoderGateFailedOutcome), r)
+
+		if gpOriginHasBranch(t, origin, branch) {
+			t.Error("branch pushed for a reviewer; reviewers are read-only")
+		}
+	})
+
+	t.Run("coder gate-failed but no changes is not preserved", func(t *testing.T) {
+		const branch = "foreman/gp/nochange"
+		ws, origin := gpSetupWorkspace(t, branch, false)
+		r := &Result{Extra: map[string]any{}}
+		newExec().maybePreserveGateFailedBranch(context.Background(), logr.Discard(),
+			gpAgent(foremanv1alpha1.AgentRoleCoder), newTask(branch), ws, branch, nil,
+			gpLoopResult(CoderGateFailedOutcome), r)
+
+		if gpOriginHasBranch(t, origin, branch) {
+			t.Error("branch pushed with no changes")
+		}
+		if _, ok := r.Extra["gateFailedBranch"]; ok {
+			t.Error("gateFailedBranch recorded with no changes")
+		}
+	})
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -719,6 +719,13 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
 		r := e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
+		// #1109: preserve a coder's near-complete work when its in-loop
+		// verification gate never passed. A CODER-GATE-FAILED terminal builds
+		// and only trips the fast gate (fmt/vet/build/lint); without this the
+		// branch is discarded and the work is unrecoverable. The verdict stays
+		// INCOMPLETE (this is NOT a GO); we only commit + push the branch and
+		// record it under r.Extra. Coder-role only (reviewers are read-only).
+		e.maybePreserveGateFailedBranch(ctx, log, agent, task, workspace, branch, auth, loopRes, r)
 		e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r)
 		// Attach the normalized failure reason from the model-to-CRD
 		// mapping (e.g. ERROR→INCOMPLETE + ModelReportedError for #649). Only
@@ -1546,6 +1553,83 @@ func (e *NativeAgentLoopExecutor) openPullRequest(
 		return "", err
 	}
 	return res.URL, nil
+}
+
+// maybePreserveGateFailedBranch commits and pushes a coder's branch when its
+// in-loop verification gate never passed (#749/#1109). Without it, a
+// CODER-GATE-FAILED terminal is INCOMPLETE with no push, so a change that
+// builds and only fails the fast gate (fmt / vet / build / lint) is discarded
+// and the work is unrecoverable. This does NOT change the verdict: it stays
+// INCOMPLETE, not a GO. It only preserves the branch and records it under
+// r.Extra ("gateFailedBranch" / "commitSHA") so a human can finish the fix.
+//
+// Coder-role only: reviewers are read-only (no write_file / str_replace), so
+// they never have changes to preserve. Only the CODER-GATE-FAILED outcome
+// qualifies; NO-GO, ERROR, and every other INCOMPLETE outcome (stuck-loop,
+// loop-budget, no-tool-call) are genuine "do not land" and are left untouched.
+// Best-effort: any failure (no changes, commit, or push) leaves the original
+// INCOMPLETE result as-is.
+func (e *NativeAgentLoopExecutor) maybePreserveGateFailedBranch(
+	ctx context.Context, log logr.Logger,
+	agent *foremanv1alpha1.Agent, task *foremanv1alpha1.AgenticTask,
+	workspace, branch string, auth *repo.Auth, lr *LoopResult, r *Result,
+) {
+	if agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer {
+		return
+	}
+	if lr == nil || lr.Terminal == nil {
+		return
+	}
+	if outcome, _ := lr.Terminal.Extra[outcomeKey].(string); outcome != CoderGateFailedOutcome {
+		return
+	}
+
+	hasChanges, err := repo.HasChanges(ctx, workspace)
+	if err != nil {
+		log.Error(err, "gate-failed preserve: HasChanges failed; not preserving branch")
+		return
+	}
+	if !hasChanges {
+		// Nothing to preserve (the coder left no uncommitted work); keep the
+		// plain INCOMPLETE result.
+		return
+	}
+
+	// The gate-failed envelope carries no model commit message (the coder never
+	// reached a GO), so synthesize a WIP subject that flags the branch as
+	// unfinished. Refs (not Fixes) the issue so merging this branch alone does
+	// not auto-close it.
+	msg := fmt.Sprintf(
+		"wip(gate-failed): preserve coder attempt for issue #%d\n\n"+
+			"The in-workspace verification gate did not pass after its retry "+
+			"budget, so this branch is preserved (verdict INCOMPLETE, not a GO) "+
+			"for a human to finish. Do not merge as-is.\n\nRefs #%d",
+		task.Spec.Payload.Issue, task.Spec.Payload.Issue)
+	sha, err := repo.Commit(ctx, repo.CommitOptions{
+		Workspace: workspace,
+		Message:   msg,
+		Author:    e.CommitAuthor,
+		Committer: e.CommitCommitter,
+	})
+	if err != nil {
+		log.Error(err, "gate-failed preserve: commit failed; not preserving branch")
+		return
+	}
+	if err := repo.Push(ctx, repo.PushOptions{
+		Workspace:       workspace,
+		Branch:          branch,
+		Auth:            auth,
+		ReplaceOnReject: task.Spec.Payload.AllowOverwrite,
+	}); err != nil {
+		log.Error(err, "gate-failed preserve: push failed; branch not preserved",
+			"branch", branch)
+		return
+	}
+
+	r.Extra["gateFailedBranch"] = branch
+	r.Extra["commitSHA"] = sha
+	log.Info("gate-failed preserve: pushed branch for human finish",
+		"branch", branch, "sha", sha, "issue", task.Spec.Payload.Issue)
 }
 
 func (e *NativeAgentLoopExecutor) modelDecidedResult(


### PR DESCRIPTION
## What

When a coder's in-loop verification gate (#749) never passes within its retry budget, the loop returns a `CODER-GATE-FAILED` INCOMPLETE terminal. Today the executor discards that work: a non-GO verdict means no commit and no push (`executor_native.go`, "Non-GO verdicts: no commit, no push"). This PR preserves the branch instead.

The executor now commits and pushes a coder's branch on a `CODER-GATE-FAILED` terminal that left uncommitted changes, recording the pushed branch and SHA under the result `Extra` (`gateFailedBranch` / `commitSHA`). The verdict stays INCOMPLETE (this is not a GO); only the branch is preserved so a human can finish it.

## Why

Fixes #1109

A mid-size coder frequently produces a change that builds and only trips the fast gate (fmt / vet / build / lint), then runs out of gate-retry budget before clearing the last lint nit. Discarding that branch throws away otherwise-correct work and forces a full re-run for what is usually a mechanical fix. Preserving the branch turns "lost 45 minutes" into "finish a 3-line fix."

This came straight out of the #1093 GPUQuota-reconciler runs, where three coder attempts each produced a building reconciler and each was discarded over trivial lint (errcheck, then gofmt / ginkgolinter / unparam). See #1109 for the evidence.

## How

- `maybePreserveGateFailedBranch` (new, `executor_native.go`): guarded on coder-role + `CoderGateFailedOutcome` + uncommitted changes, it commits a WIP `Refs #<issue>` message (the gate-failed envelope carries no model commit message) and pushes via the same `repo.Commit` / `repo.Push` path a GO uses, then records `gateFailedBranch` / `commitSHA` on the result.
- Scope guards: reviewers are skipped (read-only); only `CODER-GATE-FAILED` qualifies. `NO-GO`, `ERROR`, and other INCOMPLETE outcomes (stuck-loop, loop-budget) are genuine do-not-land and are untouched. Best-effort: any failure leaves the original INCOMPLETE result unchanged.

Out of scope for this PR (follow-ups on #1109 if wanted): auto-`gofmt` before the gate lints, and the `errcheck`-defer guidance in `AGENTS.md`.

## Testing / verification

- New `executor_gate_preserve_test.go` (4 cases against a real temp git repo + bare origin): coder gate-failed with changes preserves and records the branch; a non-gate INCOMPLETE, a reviewer, and a gate-failed-with-no-changes each do not push.
- `go build ./...`, `go vet ./pkg/foreman/agent/...`, `gofmt` clean.
- Full `go test ./pkg/foreman/agent/` passes (no regressions).
- `golangci-lint --new-from-rev`: 0 new issues.

## AI assistance disclosure

Assisted-by: Claude Code (Anthropic). This change was hand-written and tested with Claude after Foreman's own coder could not land it: across three runs (two models) the coder produced correct-looking implementations that were each discarded by the lint gate, which is exactly the gap this PR closes. I own the change and the review conversation; the commit carries no attribution trailer and the DCO sign-off is mine.

## Checklist

- [x] Tests added/updated
- [x] `go test ./pkg/foreman/agent/` passes locally
- [x] Lint clean for this change (`golangci-lint --new-from-rev` 0 new issues; `gofmt` clean)
- [x] Commit messages follow conventional commits
- [x] Commit is signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed above
- [ ] Documentation updated (n/a: internal executor behavior)
