### PR TITLE
feat(controller): add GPUQuota status reconciler

### DIFF
--- a/charts/llmkube/templates/clusterrole.yaml
+++ b/charts/llmkube/templates/clusterrole.yaml
@@ -30,6 +30,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - nodes
   - pods
   - secrets
@@ -91,6 +92,7 @@ rules:
 - apiGroups:
   - inference.llmkube.dev
   resources:
+  - gpuquotas
   - inferenceservices
   - modelrouters
   - models
@@ -113,6 +115,7 @@ rules:
 - apiGroups:
   - inference.llmkube.dev
   resources:
+  - gpuquotas/status
   - inferenceservices/status
   - modelrouters/status
   - models/status

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -361,6 +361,16 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "ModelRouterGateway")
 		os.Exit(1)
 	}
+	// GPUQuota reconciles the status-only aggregation of GPU usage from
+	// InferenceServices in the quota's scope. It never rejects anything or
+	// owns external resources.
+	if err := (&controller.GPUQuotaReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "GPUQuota")
+		os.Exit(1)
+	}
 
 	// Register the ModelRouter validating webhook ONLY when the serving cert is
 	// actually present in the configured cert dir. The webhook server crashes the

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - nodes
   - pods
   - secrets
@@ -163,6 +164,27 @@ rules:
 - apiGroups:
   - inference.llmkube.dev
   resources:
+  - gpuquotas
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
+  - gpuquotas/status
+  - inferenceservices/status
+  - modelrouters/status
+  - models/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - inference.llmkube.dev
+  resources:
   - inferenceservices
   - modelrouters
   - models
@@ -181,16 +203,6 @@ rules:
   - modelrouters/finalizers
   - models/finalizers
   verbs:
-  - update
-- apiGroups:
-  - inference.llmkube.dev
-  resources:
-  - inferenceservices/status
-  - modelrouters/status
-  - models/status
-  verbs:
-  - get
-  - patch
   - update
 - apiGroups:
   - resource.k8s.io

--- a/internal/controller/gpuquota_controller.go
+++ b/internal/controller/gpuquota_controller.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
+)
+
+const (
+	gpuQuotaControllerName = "gpuquota"
+)
+
+// GPUQuotaReconciler reconciles the GPUQuota CRD. It aggregates GPU usage
+// from InferenceServices in the quota's scope and writes the total to
+// Status.UsedGPUCount. This is a status-only reconciler: it never rejects
+// anything or owns external resources.
+type GPUQuotaReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=inference.llmkube.dev,resources=gpuquotas,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=inference.llmkube.dev,resources=gpuquotas/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=inference.llmkube.dev,resources=inferenceservices,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+
+func (r *GPUQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	reconcileStart := time.Now()
+	defer func() {
+		llmkubemetrics.ReconcileDuration.WithLabelValues(gpuQuotaControllerName).
+			Observe(time.Since(reconcileStart).Seconds())
+	}()
+
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling GPUQuota", "name", req.Name, "namespace", req.Namespace)
+
+	gq := &inferencev1alpha1.GPUQuota{}
+	if err := r.Get(ctx, req.NamespacedName, gq); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "failed to get GPUQuota")
+		return ctrl.Result{}, err
+	}
+
+	// Resolve scope: which namespaces are in-scope for this quota?
+	var inScopeNamespaces []string
+	switch {
+	case gq.Spec.NamespaceRef != "":
+		// NamespaceRef set: single namespace scope.
+		inScopeNamespaces = []string{gq.Spec.NamespaceRef}
+	case gq.Spec.Selector != nil:
+		// Selector set: label-selector scope across multiple namespaces.
+		sel, err := metav1.LabelSelectorAsSelector(gq.Spec.Selector)
+		if err != nil {
+			logger.Error(err, "failed to convert GPUQuota selector")
+			return ctrl.Result{}, err
+		}
+		nsList := &corev1.NamespaceList{}
+		if err := r.List(ctx, nsList, client.MatchingLabelsSelector{Selector: sel}); err != nil {
+			logger.Error(err, "failed to list namespaces for selector")
+			return ctrl.Result{}, err
+		}
+		for _, ns := range nsList.Items {
+			inScopeNamespaces = append(inScopeNamespaces, ns.Name)
+		}
+	default:
+		// Both/neither set: no in-scope namespaces. The CEL rule already
+		// enforces exactly-one, so this is defensive.
+		return ctrl.Result{}, nil
+	}
+
+	// Aggregate GPU usage from InferenceServices in the in-scope namespaces.
+	var usedGPUCount int32
+	for _, nsName := range inScopeNamespaces {
+		isvcList := &inferencev1alpha1.InferenceServiceList{}
+		if err := r.List(ctx, isvcList, client.InNamespace(nsName)); err != nil {
+			logger.Error(err, "failed to list InferenceServices", "namespace", nsName)
+			return ctrl.Result{}, err
+		}
+		for _, isvc := range isvcList.Items {
+			// GPU count per pod: nil resources means 0.
+			gpuPerPod := int32(0)
+			if isvc.Spec.Resources != nil && isvc.Spec.Resources.GPU > 0 {
+				gpuPerPod = isvc.Spec.Resources.GPU
+			}
+			// Replicas: nil means 1.
+			replicas := int32(1)
+			if isvc.Spec.Replicas != nil {
+				replicas = *isvc.Spec.Replicas
+			}
+			usedGPUCount += gpuPerPod * replicas
+		}
+	}
+
+	// VRAM aggregation is a DOCUMENTED, INTENTIONAL DEFERRAL: InferenceService
+	// exposes no VRAM field, so UsedVRAMBytes stays 0 until either
+	// InferenceService gains a VRAM field or it is derived from the Model size;
+	// the admission webhook already treats vramBytes 0 as "no cap", so the
+	// VRAM half of the quota is simply inert until then.
+	usedVRAMBytes := int64(0)
+
+	// Write status.
+	desired := gq.DeepCopy()
+	desired.Status.UsedGPUCount = usedGPUCount
+	desired.Status.UsedVRAMBytes = usedVRAMBytes
+
+	if err := r.Status().Patch(ctx, desired, client.MergeFrom(gq)); err != nil {
+		logger.Error(err, "failed to update GPUQuota status")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager wires up the GPUQuota primary watch and the secondary
+// watch on InferenceService so a changed InferenceService triggers
+// re-aggregation of all GPUQuotas whose scope covers the changed service's
+// namespace.
+func (r *GPUQuotaReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&inferencev1alpha1.GPUQuota{}).
+		Watches(
+			&inferencev1alpha1.InferenceService{},
+			handler.EnqueueRequestsFromMapFunc(r.findGPUQuotasForInferenceService),
+		).
+		Named(gpuQuotaControllerName).
+		Complete(r)
+}
+
+// findGPUQuotasForInferenceService returns reconcile requests for every
+// GPUQuota whose scope covers the given InferenceService's namespace.
+// Mirrors the pattern used by ModelRouterReconciler.findModelRoutersForInferenceService.
+func (r *GPUQuotaReconciler) findGPUQuotasForInferenceService(ctx context.Context, obj client.Object) []reconcile.Request {
+	isvc, ok := obj.(*inferencev1alpha1.InferenceService)
+	if !ok {
+		return nil
+	}
+
+	gqList := &inferencev1alpha1.GPUQuotaList{}
+	if err := r.List(ctx, gqList); err != nil {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for _, gq := range gqList.Items {
+		if gpuQuotaCoversNamespace(r.Client, &gq, isvc.Namespace) {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      gq.Name,
+					Namespace: gq.Namespace,
+				},
+			})
+		}
+	}
+	return requests
+}
+
+// gpuQuotaCoversNamespace reports whether the GPUQuota's scope includes the
+// given namespace. A quota covers a namespace when:
+//   - spec.namespaceRef matches the namespace name, or
+//   - spec.selector matches the namespace's labels.
+func gpuQuotaCoversNamespace(r client.Client, gq *inferencev1alpha1.GPUQuota, nsName string) bool {
+	switch {
+	case gq.Spec.NamespaceRef != "":
+		return gq.Spec.NamespaceRef == nsName
+	case gq.Spec.Selector != nil:
+		sel, err := metav1.LabelSelectorAsSelector(gq.Spec.Selector)
+		if err != nil {
+			return false
+		}
+		ns := &corev1.Namespace{}
+		if err := r.Get(context.Background(), types.NamespacedName{Name: nsName}, ns); err != nil {
+			return false
+		}
+		return sel.Matches(labels.Set(ns.Labels))
+	}
+	return false
+}

--- a/internal/controller/gpuquota_controller_test.go
+++ b/internal/controller/gpuquota_controller_test.go
@@ -1,0 +1,780 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func TestGPUQuotaCoversNamespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		gq       *inferencev1alpha1.GPUQuota
+		nsName   string
+		want     bool
+		nsLabels map[string]string
+	}{
+		{
+			name: "namespaceRef matches",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{
+					NamespaceRef: "my-ns",
+				},
+			},
+			nsName: "my-ns",
+			want:   true,
+		},
+		{
+			name: "namespaceRef does not match",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{
+					NamespaceRef: "my-ns",
+				},
+			},
+			nsName: "other-ns",
+			want:   false,
+		},
+		{
+			name: "selector matches namespace labels",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "production"},
+					},
+				},
+			},
+			nsName:   "prod-ns",
+			nsLabels: map[string]string{"env": "production"},
+			want:     true,
+		},
+		{
+			name: "selector does not match namespace labels",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "production"},
+					},
+				},
+			},
+			nsName:   "dev-ns",
+			nsLabels: map[string]string{"env": "development"},
+			want:     false,
+		},
+		{
+			name: "matchExpressions selector matches",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "env",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"production", "staging"},
+							},
+						},
+					},
+				},
+			},
+			nsName:   "staging-ns",
+			nsLabels: map[string]string{"env": "staging"},
+			want:     true,
+		},
+		{
+			name: "matchExpressions selector does not match",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "env",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"production", "staging"},
+							},
+						},
+					},
+				},
+			},
+			nsName:   "dev-ns",
+			nsLabels: map[string]string{"env": "development"},
+			want:     false,
+		},
+		{
+			name: "matchExpressions with NotIn operator",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "env",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"development"},
+							},
+						},
+					},
+				},
+			},
+			nsName:   "prod-ns",
+			nsLabels: map[string]string{"env": "production"},
+			want:     true,
+		},
+		{
+			name: "matchExpressions with Exists operator",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "team",
+								Operator: metav1.LabelSelectorOpExists,
+							},
+						},
+					},
+				},
+			},
+			nsName:   "team-ns",
+			nsLabels: map[string]string{"team": "platform"},
+			want:     true,
+		},
+		{
+			name: "matchExpressions with DoesNotExist operator",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "deprecated",
+								Operator: metav1.LabelSelectorOpDoesNotExist,
+							},
+						},
+					},
+				},
+			},
+			nsName:   "clean-ns",
+			nsLabels: map[string]string{"env": "production"},
+			want:     true,
+		},
+		{
+			name: "neither set returns false",
+			gq: &inferencev1alpha1.GPUQuota{
+				Spec: inferencev1alpha1.GPUQuotaSpec{},
+			},
+			nsName: "any-ns",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c client.Client
+			if tt.gq.Spec.Selector != nil {
+				// Build a fake client with the namespace for selector tests.
+				scheme := runtime.NewScheme()
+				_ = corev1.AddToScheme(scheme)
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   tt.nsName,
+						Labels: tt.nsLabels,
+					},
+				}
+				c = fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+			}
+
+			got := gpuQuotaCoversNamespace(c, tt.gq, tt.nsName)
+			if got != tt.want {
+				t.Errorf("gpuQuotaCoversNamespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindGPUQuotasForInferenceService(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	// Create a namespace with a label.
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "my-ns",
+			Labels: map[string]string{"env": "production"},
+		},
+	}
+
+	// Create an InferenceService in that namespace.
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-isvc",
+			Namespace: "my-ns",
+		},
+	}
+
+	// Create a GPUQuota with namespaceRef matching the namespace.
+	gqByRef := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gq-ref",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			NamespaceRef: "my-ns",
+		},
+	}
+
+	// Create a GPUQuota with selector matching the namespace labels.
+	gqBySelector := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gq-selector",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "production"},
+			},
+		},
+	}
+
+	// Create a GPUQuota that does NOT cover the namespace.
+	gqNotCovering := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gq-not-covering",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			NamespaceRef: "other-ns",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(ns, isvc, gqByRef, gqBySelector, gqNotCovering).Build()
+
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	requests := r.findGPUQuotasForInferenceService(context.Background(), isvc)
+
+	// Should find gqByRef and gqBySelector, but not gqNotCovering.
+	if len(requests) != 2 {
+		t.Errorf("findGPUQuotasForInferenceService() returned %d requests, want 2", len(requests))
+	}
+
+	requestNames := make(map[string]bool)
+	for _, req := range requests {
+		requestNames[req.Name] = true
+	}
+	if !requestNames["gq-ref"] {
+		t.Error("findGPUQuotasForInferenceService() missing request for gq-ref")
+	}
+	if !requestNames["gq-selector"] {
+		t.Error("findGPUQuotasForInferenceService() missing request for gq-selector")
+	}
+	if requestNames["gq-not-covering"] {
+		t.Error("findGPUQuotasForInferenceService() should not include gq-not-covering")
+	}
+}
+
+func TestFindGPUQuotasForInferenceServiceNonInferenceService(t *testing.T) {
+	r := &GPUQuotaReconciler{}
+
+	// Passing a non-InferenceService object should return nil.
+	requests := r.findGPUQuotasForInferenceService(context.Background(), &corev1.Pod{})
+	if len(requests) != 0 {
+		t.Errorf("findGPUQuotasForInferenceService() returned %d requests for non-InferenceService, want 0", len(requests))
+	}
+}
+
+func TestFindGPUQuotasForInferenceServiceNoQuotas(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-isvc",
+			Namespace: "my-ns",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(isvc).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	requests := r.findGPUQuotasForInferenceService(context.Background(), isvc)
+	if len(requests) != 0 {
+		t.Errorf("findGPUQuotasForInferenceService() returned %d requests, want 0", len(requests))
+	}
+}
+
+func TestFindGPUQuotasForInferenceServiceReturnsReconcileRequests(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "my-ns",
+			Labels: map[string]string{"env": "production"},
+		},
+	}
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-isvc",
+			Namespace: "my-ns",
+		},
+	}
+
+	gq := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gq-ref",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			NamespaceRef: "my-ns",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(ns, isvc, gq).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	requests := r.findGPUQuotasForInferenceService(context.Background(), isvc)
+	if len(requests) != 1 {
+		t.Fatalf("findGPUQuotasForInferenceService() returned %d requests, want 1", len(requests))
+	}
+
+	expectedReq := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "gq-ref",
+			Namespace: "default",
+		},
+	}
+	if requests[0] != expectedReq {
+		t.Errorf("findGPUQuotasForInferenceService() returned %+v, want %+v", requests[0], expectedReq)
+	}
+}
+
+func TestReconcileNamespaceRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	// Create a GPUQuota with namespaceRef.
+	gq := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			NamespaceRef: "my-ns",
+			GPUCount:     10,
+		},
+	}
+
+	// Create an InferenceService in the target namespace with 2 GPUs and 3 replicas.
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-isvc",
+			Namespace: "my-ns",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			Replicas: ptrInt32GPUQuota(3),
+			Resources: &inferencev1alpha1.InferenceResourceRequirements{
+				GPU: 2,
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(gq, isvc).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() returned %+v, want empty Result", result)
+	}
+
+	// Verify status was updated.
+	var updatedGQ inferencev1alpha1.GPUQuota
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "my-gq", Namespace: "default"}, &updatedGQ); err != nil {
+		t.Fatalf("failed to get GPUQuota after reconcile: %v", err)
+	}
+	if updatedGQ.Status.UsedGPUCount != 6 {
+		t.Errorf("Reconcile() status.UsedGPUCount = %d, want 6 (2 GPUs * 3 replicas)", updatedGQ.Status.UsedGPUCount)
+	}
+	if updatedGQ.Status.UsedVRAMBytes != 0 {
+		t.Errorf("Reconcile() status.UsedVRAMBytes = %d, want 0", updatedGQ.Status.UsedVRAMBytes)
+	}
+}
+
+func TestReconcileSelector(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	// Create a namespace with a label.
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "prod-ns",
+			Labels: map[string]string{"env": "production"},
+		},
+	}
+
+	// Create a GPUQuota with selector.
+	gq := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "production"},
+			},
+			GPUCount: 10,
+		},
+	}
+
+	// Create an InferenceService in the target namespace.
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-isvc",
+			Namespace: "prod-ns",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			Replicas: ptrInt32GPUQuota(2),
+			Resources: &inferencev1alpha1.InferenceResourceRequirements{
+				GPU: 4,
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(ns, gq, isvc).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() returned %+v, want empty Result", result)
+	}
+
+	var updatedGQ inferencev1alpha1.GPUQuota
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "my-gq", Namespace: "default"}, &updatedGQ); err != nil {
+		t.Fatalf("failed to get GPUQuota after reconcile: %v", err)
+	}
+	if updatedGQ.Status.UsedGPUCount != 8 {
+		t.Errorf("Reconcile() status.UsedGPUCount = %d, want 8 (4 GPUs * 2 replicas)", updatedGQ.Status.UsedGPUCount)
+	}
+}
+
+func TestReconcileSelectorMatchExpressions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	// Create a namespace with a label that matches a matchExpressions selector.
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "staging-ns",
+			Labels: map[string]string{"env": "staging"},
+		},
+	}
+
+	// Create a GPUQuota with matchExpressions selector.
+	gq := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			Selector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "env",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"production", "staging"},
+					},
+				},
+			},
+			GPUCount: 10,
+		},
+	}
+
+	// Create an InferenceService in the target namespace.
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-isvc",
+			Namespace: "staging-ns",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			Replicas: ptrInt32GPUQuota(3),
+			Resources: &inferencev1alpha1.InferenceResourceRequirements{
+				GPU: 2,
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(ns, gq, isvc).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() returned %+v, want empty Result", result)
+	}
+
+	var updatedGQ inferencev1alpha1.GPUQuota
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "my-gq", Namespace: "default"}, &updatedGQ); err != nil {
+		t.Fatalf("failed to get GPUQuota after reconcile: %v", err)
+	}
+	if updatedGQ.Status.UsedGPUCount != 6 {
+		t.Errorf("Reconcile() status.UsedGPUCount = %d, want 6 (2 GPUs * 3 replicas)", updatedGQ.Status.UsedGPUCount)
+	}
+}
+
+func TestReconcileNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "nonexistent",
+			Namespace: "default",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() returned error for NotFound: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() returned %+v, want empty Result for NotFound", result)
+	}
+}
+
+func TestReconcileNilResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	gq := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			NamespaceRef: "my-ns",
+			GPUCount:     10,
+		},
+	}
+
+	// InferenceService with nil Resources (should count as 0 GPUs).
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-isvc",
+			Namespace: "my-ns",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			Replicas: ptrInt32GPUQuota(1),
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(gq, isvc).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() returned %+v, want empty Result", result)
+	}
+
+	var updatedGQ inferencev1alpha1.GPUQuota
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "my-gq", Namespace: "default"}, &updatedGQ); err != nil {
+		t.Fatalf("failed to get GPUQuota after reconcile: %v", err)
+	}
+	if updatedGQ.Status.UsedGPUCount != 0 {
+		t.Errorf("Reconcile() status.UsedGPUCount = %d, want 0 (nil resources)", updatedGQ.Status.UsedGPUCount)
+	}
+}
+
+func TestReconcileNilReplicas(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	gq := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			NamespaceRef: "my-ns",
+			GPUCount:     10,
+		},
+	}
+
+	// InferenceService with nil Replicas (should count as 1 replica).
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-isvc",
+			Namespace: "my-ns",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			Resources: &inferencev1alpha1.InferenceResourceRequirements{
+				GPU: 2,
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(gq, isvc).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() returned %+v, want empty Result", result)
+	}
+
+	var updatedGQ inferencev1alpha1.GPUQuota
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "my-gq", Namespace: "default"}, &updatedGQ); err != nil {
+		t.Fatalf("failed to get GPUQuota after reconcile: %v", err)
+	}
+	if updatedGQ.Status.UsedGPUCount != 2 {
+		t.Errorf("Reconcile() status.UsedGPUCount = %d, want 2 (2 GPUs * 1 default replica)", updatedGQ.Status.UsedGPUCount)
+	}
+}
+
+func TestReconcileNoScope(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	// GPUQuota with neither namespaceRef nor selector.
+	gq := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			GPUCount: 10,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(gq).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() returned %+v, want empty Result", result)
+	}
+
+	// Status should remain unchanged (UsedGPUCount = 0).
+	var updatedGQ inferencev1alpha1.GPUQuota
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "my-gq", Namespace: "default"}, &updatedGQ); err != nil {
+		t.Fatalf("failed to get GPUQuota after reconcile: %v", err)
+	}
+	if updatedGQ.Status.UsedGPUCount != 0 {
+		t.Errorf("Reconcile() status.UsedGPUCount = %d, want 0 (no scope)", updatedGQ.Status.UsedGPUCount)
+	}
+}
+
+func TestSetupWithManager(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	// SetupWithManager should not return an error with a fake manager.
+	// We can't easily test the full manager setup without envtest,
+	// but we can verify the reconciler is properly initialized.
+	if r.Client == nil {
+		t.Error("SetupWithManager: reconciler Client is nil")
+	}
+	if r.Scheme == nil {
+		t.Error("SetupWithManager: reconciler Scheme is nil")
+	}
+}
+
+func ptrInt32GPUQuota(i int32) *int32 {
+	return &i
+}


### PR DESCRIPTION
## What

Adds the `GPUQuota` status reconciler (`internal/controller/gpuquota_controller.go`), registers it in `cmd/main.go`, regenerates the RBAC role, and ships fake-client unit tests. Story 2 of the multi-tenancy epic (#416); builds on the CRD types from #1092.

The reconciler resolves each `GPUQuota`'s scope (a single `namespaceRef` or a `selector` matched against namespace labels), lists the InferenceServices in scope, and writes `Status.UsedGPUCount`. It is status-only: it never rejects anything and owns no external resources (admission is #1094/#1095, already merged). It watches both `GPUQuota` and `InferenceService`, so a change to any InferenceService re-aggregates every quota whose scope covers it.

## Why

Fixes #1093

This is the live-usage half of GPUQuota: it keeps `Status.UsedGPUCount` current so operators can see how close a team is to its cap, and so the admission webhook (#1095) has an accurate usage figure to decide against.

## How

`GPUQuotaReconciler` mirrors `ModelRouterReconciler` (primary watch + `EnqueueRequestsFromMapFunc` secondary watch on InferenceService). Per InferenceService, GPU usage is `spec.resources.gpu * spec.replicas` (nil resources = 0, nil replicas = 1). The `selector` path uses `metav1.LabelSelectorAsSelector`, so both `matchLabels` and `matchExpressions` are honored.

**Documented design decision: `UsedVRAMBytes` is deferred and stays `0`.** `InferenceService` exposes no VRAM field, so there is nothing to aggregate for the VRAM half of the quota. Rather than guess, `UsedVRAMBytes` stays `0` with an explicit comment in the reconciler. The admission webhook already treats `vramBytes: 0` as "no cap", so the VRAM half of a quota is simply inert until we either add a VRAM field to `InferenceService` or derive it from the Model's GGUF size (follow-up).

## Testing / verification

Verified locally in an isolated worktree at the branch commit:

- `go build ./...`, `go vet ./internal/controller/... ./cmd/...` clean
- `go test ./internal/controller/` (the GPUQuota fake-client unit tests: scope resolution, GPU aggregation, the InferenceService->GPUQuota map func, and `matchExpressions` selectors) passes
- `make manifests generate chart-crds` then `git status` stable: the RBAC `role.yaml` is regenerated and in sync (CRD-Sync / RBAC-Sync pass)
- `gofmt` clean; `golangci-lint --new-from-rev` 0 new issues

Tests are fake-client unit tests rather than envtest; happy to add an apiserver-level envtest as a follow-up if you want that coverage.

## Notes for the reviewer

- `spec.selector` is implemented as a **namespace** selector (matched against namespace labels), per the epic. #1092's `Selector` doc comment describes it as a pod selector; that comment should be updated to match. Flagging so the contract is consistent.
- `gpuQuotaCoversNamespace` uses `context.Background()` for its one Get; threading the caller's ctx would be marginally better (minor).

## AI assistance disclosure

Assisted-by: Foreman, the project's local agentic coding harness (coder model qwopus3.6-35B on-prem). The controller and tests were generated by Foreman; a review pass I directed then found two real bugs the gate could not catch (a `ReconcileDuration` metric that measured ~0s because the observation ran at the top of `Reconcile`, and a selector that dropped `matchExpressions`), which were fed back to the harness as a revision cycle that fixed both and added `matchExpressions` test cases. I reviewed the result, ran the verification above, and stripped em dashes from comments. I own this change and the review conversation; per `AGENTS.md` the commit carries no attribution trailer and the DCO sign-off is mine.

## Checklist

- [x] Tests added/updated
- [x] Tests pass locally (`go test ./internal/controller/`)
- [x] Lint clean for this change (`golangci-lint --new-from-rev` 0 new issues; `gofmt` clean)
- [x] Commit messages follow conventional commits
- [x] Commit is signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed above
- [ ] Documentation updated (n/a: internal controller; user-facing docs land with the Helm toggle in #1096)
