### PR TITLE
fix(foreman): honor GateProfile source extensions in scope-overlap issue-ref extraction

### DIFF
--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -31,10 +31,35 @@ import (
 // small: under-extracting is safe (no refs means the scope check stays
 // observe-only) while over-extracting risks false drift flags, so
 // identifiers, commands, and API groups must not slip through.
+//
+// This is the language-agnostic base: docs, config, and Go's own source
+// extension (LLMKube's home turf). A repo's PRIMARY source language is
+// declared per-task via GateProfile.SourceExtensions and unioned in at
+// extraction time (see extractIssuePathRefs), so a Godot repo's `.gd`
+// files or a Rust repo's `.rs` files are recognized as issue refs
+// exactly as the diff-side hasSourceFile guard already recognizes them.
+// Without that union the extractor was blind to every non-Go language,
+// so the scope-overlap vouch (#744) never fired for the polyglot fleet.
 var pathRefExtensions = map[string]bool{
 	"go": true, "md": true, "yaml": true, "yml": true, "sh": true,
 	"json": true, "mod": true, "sum": true, "tmpl": true, "proto": true,
 	"toml": true, "mk": true,
+}
+
+// extensionSet normalizes a GateProfile SourceExtensions list (".gd",
+// ".TS") into the dotless-lowercase keys isPathRef compares against.
+// Returns nil for an empty list so callers can cheaply skip the union.
+func extensionSet(exts []string) map[string]bool {
+	if len(exts) == 0 {
+		return nil
+	}
+	m := make(map[string]bool, len(exts))
+	for _, e := range exts {
+		if e = strings.ToLower(strings.TrimPrefix(e, ".")); e != "" {
+			m[e] = true
+		}
+	}
+	return m
 }
 
 // extractIssuePathRefs pulls concrete file references out of an issue
@@ -46,10 +71,16 @@ var pathRefExtensions = map[string]bool{
 // Escaped backticks (as returned by the GitHub API) are normalized
 // away before tokenizing. Results are deduplicated in first-occurrence
 // order.
-func extractIssuePathRefs(body string) []string {
+//
+// sourceExtensions is the task's declared GateProfile source language
+// (e.g. [".gd"] for Godot); those extensions are unioned with the
+// language-agnostic pathRefExtensions so the extractor sees the repo's
+// primary source files, not only Go and docs.
+func extractIssuePathRefs(body string, sourceExtensions []string) []string {
 	if body == "" {
 		return nil
 	}
+	extraExts := extensionSet(sourceExtensions)
 	normalized := strings.ReplaceAll(body, "\\`", "`")
 	normalized = strings.NewReplacer("`", " ", "(", " ", ")", " ", "[", " ", "]", " ",
 		"{", " ", "}", " ", "\"", " ", "'", " ", ",", " ", ";", " ").Replace(normalized)
@@ -61,7 +92,7 @@ func extractIssuePathRefs(body string) []string {
 		if tok == "" || seen[tok] {
 			continue
 		}
-		if isPathRef(tok) {
+		if isPathRef(tok, extraExts) {
 			seen[tok] = true
 			refs = append(refs, tok)
 		}
@@ -87,10 +118,13 @@ func hasSourceFile(paths []string, exts []string) bool {
 }
 
 // isPathRef reports whether a single cleaned token is a concrete file
-// reference per the rules documented on extractIssuePathRefs.
-func isPathRef(tok string) bool {
+// reference per the rules documented on extractIssuePathRefs. extraExts
+// carries the task's declared source extensions (dotless-lowercase, via
+// extensionSet) so a repo's primary language is recognized alongside the
+// language-agnostic pathRefExtensions base.
+func isPathRef(tok string, extraExts map[string]bool) bool {
 	ext := strings.ToLower(strings.TrimPrefix(path.Ext(tok), "."))
-	if !pathRefExtensions[ext] {
+	if !pathRefExtensions[ext] && !extraExts[ext] {
 		return false
 	}
 	for _, seg := range strings.Split(tok, "/") {
@@ -134,7 +168,7 @@ func enforceReviewerScopeOverlap(
 	if extra == nil || issueBody == "" || len(diffFiles) == 0 {
 		return verdict
 	}
-	refs := extractIssuePathRefs(issueBody)
+	refs := extractIssuePathRefs(issueBody, sourceExtensions)
 	if len(refs) == 0 {
 		return verdict
 	}

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -63,7 +63,7 @@ const issue510Body = "## Feature Description\n\n" +
 	"doc costs almost nothing and saves a CI round\n"
 
 func TestExtractIssuePathRefs_Issue379(t *testing.T) {
-	got := extractIssuePathRefs(issue379Body)
+	got := extractIssuePathRefs(issue379Body, nil)
 	want := []string{
 		"config/rbac/role.yaml",
 		"charts/llmkube/templates/clusterrole.yaml",
@@ -77,7 +77,7 @@ func TestExtractIssuePathRefs_Issue379(t *testing.T) {
 }
 
 func TestExtractIssuePathRefs_Issue510BareFilenames(t *testing.T) {
-	got := extractIssuePathRefs(issue510Body)
+	got := extractIssuePathRefs(issue510Body, nil)
 	want := []string{"AGENTS.md", "CONTRIBUTING.md"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("extractIssuePathRefs(#510) = %v, want %v", got, want)
@@ -87,14 +87,96 @@ func TestExtractIssuePathRefs_Issue510BareFilenames(t *testing.T) {
 func TestExtractIssuePathRefs_IgnoresCommandsAndAPIGroups(t *testing.T) {
 	body := "Run `make manifests` then check `core/endpoints` and `kubebuilder:rbac` " +
 		"plus `discovery.k8s.io/v1.EndpointSlice` and plain words."
-	if got := extractIssuePathRefs(body); len(got) != 0 {
+	if got := extractIssuePathRefs(body, nil); len(got) != 0 {
 		t.Errorf("commands, API groups, and identifiers must not extract as path refs; got %v", got)
 	}
 }
 
 func TestExtractIssuePathRefs_EmptyBody(t *testing.T) {
-	if got := extractIssuePathRefs(""); len(got) != 0 {
+	if got := extractIssuePathRefs("", nil); len(got) != 0 {
 		t.Errorf("empty body should yield no refs; got %v", got)
+	}
+}
+
+// godotIssueBody mirrors misospace/windowstead#234: a Godot issue that
+// names `.gd` source files. `.gd` is not in the language-agnostic base
+// set, so extraction depends entirely on the task declaring its source
+// language via GateProfile.SourceExtensions.
+const godotIssueBody = "## Problem\n\n" +
+	"`_on_tick()` in `scripts/main.gd` (line 1360) fires before the world is\n" +
+	"ready, so the first tick reads an empty reservation table.\n\n" +
+	"## Fix\n\n" +
+	"Guard the early call and add coverage in `tests/test_tick_integration.gd`\n" +
+	"alongside the existing `tests/test_e2e.gd` suite.\n"
+
+// TestExtractIssuePathRefs_GodotExtensionsFromGateProfile is the
+// windowstead-234 regression: without the task's source extensions the
+// extractor is blind to `.gd`, so the scope-overlap vouch never fires
+// and an honest GO gets demoted by the stochastic issueAsk rail. With
+// sourceExtensions=[".gd"] the named files extract as refs.
+func TestExtractIssuePathRefs_GodotExtensionsFromGateProfile(t *testing.T) {
+	if got := extractIssuePathRefs(godotIssueBody, nil); len(got) != 0 {
+		t.Errorf("without .gd in the source extensions, no .gd refs should extract; got %v", got)
+	}
+	got := extractIssuePathRefs(godotIssueBody, []string{".gd"})
+	want := []string{
+		"scripts/main.gd",
+		"tests/test_tick_integration.gd",
+		"tests/test_e2e.gd",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("extractIssuePathRefs(godot, [.gd]) = %v, want %v", got, want)
+	}
+}
+
+// TestExtractIssuePathRefs_SourceExtensionsUnionWithBase verifies the
+// declared extensions are unioned with, not substituted for, the
+// language-agnostic base: a Godot issue that also names a `.md` doc
+// yields both once `.gd` is declared.
+func TestExtractIssuePathRefs_SourceExtensionsUnionWithBase(t *testing.T) {
+	body := "See `scripts/main.gd` and update `README.md` accordingly."
+	got := extractIssuePathRefs(body, []string{".gd"})
+	want := []string{"scripts/main.gd", "README.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("union extraction = %v, want %v", got, want)
+	}
+}
+
+// TestEnforceReviewerScopeOverlap_GodotRefMatchVouches is the end-to-end
+// windowstead-234 case: the diff touches two files the issue names, so
+// scope overlap is non-empty, drift is false, the GO stands, and
+// scopeMatched is populated for the issueAsk vouch to consume.
+func TestEnforceReviewerScopeOverlap_GodotRefMatchVouches(t *testing.T) {
+	diff := []string{"scripts/main.gd", "tests/test_tick_integration.gd"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, godotIssueBody, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".gd"})
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("a diff touching issue-named .gd files must not demote; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); v {
+		t.Errorf("scopeDriftDetected should be false when .gd refs match")
+	}
+	matched, _ := extra["scopeMatched"].([]string)
+	if !reflect.DeepEqual(matched, []string{"scripts/main.gd", "tests/test_tick_integration.gd"}) {
+		t.Errorf("scopeMatched = %v, want the two touched .gd files", matched)
+	}
+}
+
+// TestEnforceReviewerScopeOverlap_GodotBlindWithoutExtensions locks in
+// the pre-fix failure mode: with no declared extensions the same Godot
+// diff produces zero refs, so the check stays observe-only and writes
+// no scope annotations — leaving the issueAsk vouch nothing to consume.
+func TestEnforceReviewerScopeOverlap_GodotBlindWithoutExtensions(t *testing.T) {
+	diff := []string{"scripts/main.gd", "tests/test_tick_integration.gd"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, godotIssueBody, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("no refs must pass through; got %v", got)
+	}
+	if _, present := extra["scopeMatched"]; present {
+		t.Errorf("no refs should add no scope annotations; got %v", extra)
 	}
 }
 


### PR DESCRIPTION
## What

Thread the task's `GateProfile.SourceExtensions` into the reviewer scope-overlap issue-body extractor (`extractIssuePathRefs`), unioned with the language-agnostic base allow-list.

## Why

Fixes #1119

The scope-overlap check (#647) extracts file refs from the issue body via a hardcoded, Go/infra-centric extension set (`go, md, yaml, sh, json, …`). It never consulted the task's declared `SourceExtensions`, so for any non-Go language the extractor returned zero refs and the check silently stayed observe-only — leaving `scopeMatched` empty.

That empty `scopeMatched` defeats the issueAsk vouch (#744): a GO whose `issueAsk` fails verbatim verification is only rescued when scope overlap vouches (`!scopeDriftDetected && len(scopeMatched) > 0`). On `misospace/windowstead#234` a reviewer GO on a diff touching two files the issue explicitly named (`scripts/main.gd`, `tests/test_tick_integration.gd`) was demoted to NO-GO anyway, because `.gd` is invisible to the extractor. The vouch rail — the deterministic guard against stochastic issueAsk demotion — is effectively disabled for the whole polyglot fleet.

## How

- `extractIssuePathRefs(body, sourceExtensions)` and `isPathRef(tok, extraExts)` now accept the task's source extensions; a new `extensionSet` helper normalizes them (`.gd` / `.TS` → dotless-lowercase) and they're unioned with `pathRefExtensions`.
- `enforceReviewerScopeOverlap` passes its already-resolved `sourceExtensions` to the extractor — the same value it already hands `hasSourceFile`. So the language is declared once (in the gate profile) and both sides of the scope check honor it.
- Fully backward compatible: empty/`nil` extensions → base set only (unchanged); the Go preset's `.go` is already in the base.

Design note for the maintainer: this wires the fix to the existing per-task `SourceExtensions`, which means a `generic`-language repo must declare its extensions (e.g. `sourceExtensions: [".gd"]`). The alternative is broadening the hardcoded base list to cover common languages for zero-config behavior, at the documented cost of a slightly wider over-extraction surface. Wired it this way to keep one source of truth per repo; easy to switch if you'd prefer the broader base.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance (if any) is disclosed above — authored with Claude Code
- [ ] Documentation updated (if user-facing change) — n/a (internal reviewer rail)
