### PR TITLE
feat(helm): gate InferenceService quota webhook and tenant RBAC behind multitenancy toggle

### DIFF
--- a/charts/llmkube/templates/rbac/tenant-admin-role.yaml
+++ b/charts/llmkube/templates/rbac/tenant-admin-role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.multitenancy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "llmkube.fullname" . }}-tenant-admin
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["inference.llmkube.dev"]
+  resources: ["models", "inferenceservices"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["inference.llmkube.dev"]
+  resources: ["gpuquotas", "tokenbudgets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["inference.llmkube.dev"]
+  resources: ["usagereports"]
+  verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/llmkube/templates/rbac/tenant-role.yaml
+++ b/charts/llmkube/templates/rbac/tenant-role.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.multitenancy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "llmkube.fullname" . }}-tenant
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["inference.llmkube.dev"]
+  resources: ["models", "inferenceservices"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+# UsageReport/TokenBudget CRDs land in a later story; RBAC on not-yet-installed
+# resources is valid and simply inert until those CRDs exist.
+- apiGroups: ["inference.llmkube.dev"]
+  resources: ["usagereports", "tokenbudgets"]
+  verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/llmkube/templates/webhook.yaml
+++ b/charts/llmkube/templates/webhook.yaml
@@ -59,6 +59,24 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["modelrouters"]
         scope: Namespaced
+  {{- if .Values.multitenancy.enabled }}
+  - name: vinferenceservicequota.inference.llmkube.dev
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    clientConfig:
+      service:
+        name: {{ include "llmkube.webhook.serviceName" . }}
+        namespace: {{ include "llmkube.namespace" . }}
+        path: /validate-inference-llmkube-dev-v1alpha1-inferenceservice-quota
+      caBundle: {{ $certs.ca }}
+    rules:
+      - apiGroups: ["inference.llmkube.dev"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["inferenceservices"]
+        scope: Namespaced
+  {{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -391,6 +391,13 @@
           "minimum": 1
         }
       }
+    },
+    "multitenancy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
     }
   }
 }

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -384,6 +384,15 @@ webhook:
   # force regeneration before expiry).
   certValidityDays: 3650
 
+# multitenancy gates the opt-in multi-tenant admission + RBAC surface (#416).
+# Default off: the InferenceService quota ValidatingWebhookConfiguration entry is
+# NOT rendered (so InferenceService admission is never intercepted) and no tenant
+# ClusterRoles are installed. Enabling it also requires webhook.enabled=true (the
+# quota webhook reuses the same serving cert + Service). It does not change any
+# existing (ModelRouter/Model) webhook.
+multitenancy:
+  enabled: false
+
 # Network policies for the controller manager pod
 networkPolicies:
   enabled: false


### PR DESCRIPTION
## What

Adds the Helm surface for multi-tenancy (#416 story 5): a `multitenancy.enabled` toggle (default **false**, a no-op) that gates the InferenceService **quota** admission webhook and two opinionated tenant RBAC ClusterRoles. This is the piece that actually turns on the quota enforcement shipped in #1118: until this toggle is set, the operator serves the webhook path but no `ValidatingWebhookConfiguration` points at it, so InferenceService admission is never intercepted.

Chart/RBAC YAML only, no Go changes.

## Why

Fixes #1096

The GPUQuota types (#1092), decision function (#1094), status reconciler (#1117), and validating webhook (#1118) are all merged, but inert: nothing installs the webhook configuration or the tenant roles. This story adds the opt-in Helm switch. Default-off means existing installs are completely unaffected by the upgrade.

## How

- `charts/llmkube/values.yaml`: new top-level `multitenancy.enabled: false` block with a doc comment noting it also requires `webhook.enabled=true` (the quota webhook reuses the existing serving cert + Service).
- `charts/llmkube/templates/webhook.yaml`: adds the `vinferenceservicequota.inference.llmkube.dev` entry to the existing `ValidatingWebhookConfiguration`, wrapped in `{{- if .Values.multitenancy.enabled }}` and nested inside the existing `{{- if .Values.webhook.enabled }}` block. It reuses the same `clientConfig` service and `$certs.ca` as the ModelRouter webhook and honors `.Values.webhook.failurePolicy`. Path/rules match the generated `config/webhook/manifests.yaml` from #1118 (`inferenceservices`, CREATE/UPDATE, `v1alpha1`).
- `charts/llmkube/templates/rbac/tenant-role.yaml` (`llmkube-tenant`) and `tenant-admin-role.yaml` (`llmkube-tenant-admin`): two ClusterRole definitions, each gated on `multitenancy.enabled`, intended to be bound per-namespace via a `RoleBinding` (not shipped; the operator binds them per tenant namespace).
- `charts/llmkube/values.schema.json`: registers the new `multitenancy` object (the schema uses `additionalProperties: false`, so without this the new key would fail validation).

**Note on tenant role scope:** the tenant roles grant read on `usagereports`/`tokenbudgets`, whose CRDs land in a later story. RBAC on not-yet-installed resources is valid and simply inert until those CRDs exist; there is an inline comment to that effect.

**Operational note:** with `multitenancy.enabled=true` and the default `webhook.failurePolicy: Fail`, a single-replica controller rollout has the same brief admission-rejection window already documented for the ModelRouter webhook (applies to InferenceService CREATE/UPDATE during the gap). Run 2+ controller replicas or set `failurePolicy: Ignore` if that window matters.

## Testing / verification

Verified locally in an isolated worktree at the branch commit:

- `helm template charts/llmkube` (default): renders **no** `vinferenceservicequota` webhook and **no** tenant ClusterRoles: pure no-op.
- `helm template charts/llmkube --set multitenancy.enabled=true`: renders the webhook entry and both `llmkube-tenant` / `llmkube-tenant-admin` ClusterRoles.
- `helm lint charts/llmkube` and `helm lint --set multitenancy.enabled=true`: both `0 chart(s) failed`.
- `make check-helm-rbac`: passes (`Helm RBAC covers all 194 kubebuilder rules`). The tenant roles are standalone ClusterRoles and do not touch the generated manager `role.yaml`, so the union check stays green.
- `git diff` limited to the five chart files; no Go or generated-manifest churn.

## Notes for the reviewer

Per the issue's own note: the coder gate is blind to non-Go changes (#1072), so the harness GATE-PASS on this PR is hollow. The verification above was run by hand (me) rather than trusting the gate; please give the rendered YAML a human read before merge.

## AI assistance disclosure

Assisted-by: Foreman, the project's local agentic coding harness (coder model qwopus3.6-35B on-prem). Foreman generated the chart YAML from a tightly-scoped spec; it also correctly caught that `values.schema.json` (`additionalProperties: false`) had to be extended for the new key, which was not in the original file list. I reviewed the diff, ran the full `helm template`/`helm lint`/`check-helm-rbac` verification above, and rewrote the commit subject into conventional-commits form. I own this change and the review conversation; per `AGENTS.md` the commit carries no attribution trailer and the DCO sign-off matches my email.

## Checklist

- [x] Tests added/updated (n/a: chart-only; verified via `helm template`/`helm lint` in both toggle states)
- [x] Tests pass locally (`helm lint` clean; `make check-helm-rbac` passes)
- [x] Lint clean for this change (`helm lint` 0 failures both states)
- [x] Commit messages follow conventional commits
- [x] Commit is signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed above
- [x] Documentation updated (values.yaml doc comment; user-facing enable instructions can follow with the first tenant-facing release)
