### PR TITLE
docs(samples): add air-gapped local file-path model source example (#1099)

### DIFF
--- a/config/samples/model_local_source.yaml
+++ b/config/samples/model_local_source.yaml
@@ -1,0 +1,56 @@
+# Air-gapped: serve a model from a local file already staged on the GPU node.
+#
+# The controller recognizes a file:// URL or an absolute path as a local source,
+# skips the download step, and hostPath-mounts the artifact into the serving pod.
+# This is the pre-staged / air-gapped path from #53 (Phase 1, #1099): no public
+# egress, and the model loads with no download at deploy time.
+#
+# Security: local/hostPath sources are DISABLED by default. The operator must be
+# started with an allowlist that covers this path's root, e.g.
+#   --allowed-host-path-roots=/mnt/models
+# (Helm: modelSource.allowedHostPathRoots). A source outside every allowed root is
+# rejected so no unbounded HostPathVolumeSource is ever generated
+# (GHSA-jw3m-8q7m-f35r). The path must exist on the node the pod schedules onto.
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-3b-local
+  namespace: default
+  labels:
+    model: llama-3.2
+    size: 3b
+    source: local
+spec:
+  # Absolute path (or file:///mnt/models/...) already present on the node.
+  # Must sit under one of the operator's --allowed-host-path-roots.
+  source: /mnt/models/Llama-3.2-3B-Instruct-Q4_K_M.gguf
+  format: gguf
+  quantization: Q4_K_M
+
+  # CPU/Memory for the init container that stages the local file into the cache.
+  resources:
+    cpu: "2"
+    memory: "4Gi"
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: llama-3b-local-service
+  namespace: default
+  labels:
+    model: llama-3.2
+    size: 3b
+    source: local
+spec:
+  modelRef: llama-3b-local
+  replicas: 1
+  image: ghcr.io/ggml-org/llama.cpp:server
+
+  endpoint:
+    port: 8080
+    path: /v1/chat/completions
+    type: ClusterIP
+
+  resources:
+    cpu: "2"
+    memory: "4Gi"


### PR DESCRIPTION
## What

Adds `config/samples/model_local_source.yaml`: a Model + InferenceService pair that serves a GGUF from a local, on-node file path (the air-gapped / pre-staged path from #53 Phase 1).

## Why

The local file-path source feature described in #1099 is already implemented and tested end-to-end:

- `internal/controller/source.go`: `isLocalSource` (absolute + `file://`, case-folded), `getLocalPath`, `validateLocalSourceAllowed` (host-path allowlist, GHSA-jw3m-8q7m-f35r), and the `isUnrecoverableFetchError` #405 hot-spin guard.
- `internal/controller/model_storage.go`: `buildModelStorageConfig` mounts the local artifact and skips the `model-downloader` init container.
- `internal/controller/model_controller.go`: local-source reconcile branch (`copyLocalModel`, `rejectDisallowedLocalSource`, Ready/Cached status, no phantom download).
- `internal/controller/inferenceservice_controller.go`: admit-time `validateLocalSourceAllowed` against `AllowedHostPathRoots`.
- `pkg/cli/deploy.go`: `--source /path`, `file://`, and `--source-override` for air-gapped, with `isLocalSourcePath` / `validateLocalPath`.

Passing coverage: `TestValidateLocalSourceAllowed` (16 subtests) in the controller package, and `TestIsLocalSourcePath` / `TestValidateLocalPath` in the CLI package.

The only unmet acceptance-criterion from #1099 was a `config/samples` example manifest. This PR lands it and closes out the issue.

## How

- New sample only. No code or CRD changes.
- The Model uses an absolute on-node path; comments call out that the operator must allowlist the path root (`--allowed-host-path-roots` / Helm `modelSource.allowedHostPathRoots`), since local/hostPath sources are default-deny (GHSA-jw3m-8q7m-f35r).
- `make validate-samples` passes (23/23) against the Model and InferenceService CRD schemas.

## Checklist

- [x] `make validate-samples` passes
- [x] Sample applies against the shipped CRD schema
- [x] DCO sign-off
- [x] No functional/CRD changes (docs/sample only)

## AI assistance

Drafted with AI assistance (Claude Code); reviewed and owned by the author. Band-3 disclosure per the project's AI-assisted contribution policy.

Fixes #1099
