### PR TITLE
feat(metal-agent): expose oMLX paged SSD cache configuration (#278)

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -392,6 +392,31 @@ type InferenceServiceSpec struct {
 	// +optional
 	TurboQuantBits *int32 `json:"turboQuantBits,omitempty"`
 
+	// PagedSSDCacheDir sets the directory for the oMLX paged SSD cache.
+	// Maps to oMLX --paged-ssd-cache-dir. When set, the oMLX daemon uses
+	// a paged cache backed by the specified directory, allowing models to
+	// exceed available RAM by paging KV cache blocks to SSD. The directory
+	// must exist and be writable by the oMLX process. Only meaningful for
+	// the omlx runtime; ignored by llamacpp and other runtimes.
+	// +optional
+	PagedSSDCacheDir *string `json:"pagedSSDCacheDir,omitempty"`
+
+	// HotCacheMaxSize sets the maximum size of the oMLX hot cache.
+	// Maps to oMLX --hot-cache-max-size. The hot cache holds recently used
+	// KV cache blocks in RAM for fast access. A string value like "100GB"
+	// or "50GB". Only meaningful for the omlx runtime; ignored by llamacpp
+	// and other runtimes.
+	// +optional
+	HotCacheMaxSize *string `json:"hotCacheMaxSize,omitempty"`
+
+	// PagedSSDCacheMaxSize sets the maximum size of the oMLX paged SSD cache.
+	// Maps to oMLX --paged-ssd-cache-max-size. The paged cache holds KV cache
+	// blocks that have been evicted from RAM to SSD. A string value like
+	// "200GB" or "500GB". Only meaningful for the omlx runtime; ignored by
+	// llamacpp and other runtimes.
+	// +optional
+	PagedSSDCacheMaxSize *string `json:"pagedSSDCacheMaxSize,omitempty"`
+
 	// Command overrides the container entrypoint.
 	// Only used when Runtime is "generic" or for advanced customization.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -690,6 +690,21 @@ func (in *InferenceServiceSpec) DeepCopyInto(out *InferenceServiceSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.PagedSSDCacheDir != nil {
+		in, out := &in.PagedSSDCacheDir, &out.PagedSSDCacheDir
+		*out = new(string)
+		**out = **in
+	}
+	if in.HotCacheMaxSize != nil {
+		in, out := &in.HotCacheMaxSize, &out.HotCacheMaxSize
+		*out = new(string)
+		**out = **in
+	}
+	if in.PagedSSDCacheMaxSize != nil {
+		in, out := &in.PagedSSDCacheMaxSize, &out.PagedSSDCacheMaxSize
+		*out = new(string)
+		**out = **in
+	}
 	if in.Command != nil {
 		in, out := &in.Command, &out.Command
 		*out = make([]string, len(*in))

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -3408,6 +3408,14 @@ spec:
                   the ~25% decode degradation observed at long context on Qwen-class
                   models running on M-series chips.
                 type: boolean
+              hotCacheMaxSize:
+                description: |-
+                  HotCacheMaxSize sets the maximum size of the oMLX hot cache.
+                  Maps to oMLX --hot-cache-max-size. The hot cache holds recently used
+                  KV cache blocks in RAM for fast access. A string value like "100GB"
+                  or "50GB". Only meaningful for the omlx runtime; ignored by llamacpp
+                  and other runtimes.
+                type: string
               image:
                 description: |-
                   Image is the container image for the inference runtime.
@@ -3523,6 +3531,23 @@ spec:
                   type: string
                 description: NodeSelector for pod placement (e.g., specific node pools)
                 type: object
+              pagedSSDCacheDir:
+                description: |-
+                  PagedSSDCacheDir sets the directory for the oMLX paged SSD cache.
+                  Maps to oMLX --paged-ssd-cache-dir. When set, the oMLX daemon uses
+                  a paged cache backed by the specified directory, allowing models to
+                  exceed available RAM by paging KV cache blocks to SSD. The directory
+                  must exist and be writable by the oMLX process. Only meaningful for
+                  the omlx runtime; ignored by llamacpp and other runtimes.
+                type: string
+              pagedSSDCacheMaxSize:
+                description: |-
+                  PagedSSDCacheMaxSize sets the maximum size of the oMLX paged SSD cache.
+                  Maps to oMLX --paged-ssd-cache-max-size. The paged cache holds KV cache
+                  blocks that have been evicted from RAM to SSD. A string value like
+                  "200GB" or "500GB". Only meaningful for the omlx runtime; ignored by
+                  llamacpp and other runtimes.
+                type: string
               parallelSlots:
                 description: |-
                   ParallelSlots sets the number of concurrent request slots for the llama.cpp

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -3404,6 +3404,14 @@ spec:
                   the ~25% decode degradation observed at long context on Qwen-class
                   models running on M-series chips.
                 type: boolean
+              hotCacheMaxSize:
+                description: |-
+                  HotCacheMaxSize sets the maximum size of the oMLX hot cache.
+                  Maps to oMLX --hot-cache-max-size. The hot cache holds recently used
+                  KV cache blocks in RAM for fast access. A string value like "100GB"
+                  or "50GB". Only meaningful for the omlx runtime; ignored by llamacpp
+                  and other runtimes.
+                type: string
               image:
                 description: |-
                   Image is the container image for the inference runtime.
@@ -3519,6 +3527,23 @@ spec:
                   type: string
                 description: NodeSelector for pod placement (e.g., specific node pools)
                 type: object
+              pagedSSDCacheDir:
+                description: |-
+                  PagedSSDCacheDir sets the directory for the oMLX paged SSD cache.
+                  Maps to oMLX --paged-ssd-cache-dir. When set, the oMLX daemon uses
+                  a paged cache backed by the specified directory, allowing models to
+                  exceed available RAM by paging KV cache blocks to SSD. The directory
+                  must exist and be writable by the oMLX process. Only meaningful for
+                  the omlx runtime; ignored by llamacpp and other runtimes.
+                type: string
+              pagedSSDCacheMaxSize:
+                description: |-
+                  PagedSSDCacheMaxSize sets the maximum size of the oMLX paged SSD cache.
+                  Maps to oMLX --paged-ssd-cache-max-size. The paged cache holds KV cache
+                  blocks that have been evicted from RAM to SSD. A string value like
+                  "200GB" or "500GB". Only meaningful for the omlx runtime; ignored by
+                  llamacpp and other runtimes.
+                type: string
               parallelSlots:
                 description: |-
                   ParallelSlots sets the number of concurrent request slots for the llama.cpp

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -628,6 +628,9 @@ func buildExecutorConfig(
 		Mode:                   isvc.Spec.Mode,
 		ExtraArgs:              isvc.Spec.ExtraArgs,
 		TurboQuantBits:         derefInt32(isvc.Spec.TurboQuantBits),
+		PagedSSDCacheDir:       derefString(isvc.Spec.PagedSSDCacheDir),
+		HotCacheMaxSize:        derefString(isvc.Spec.HotCacheMaxSize),
+		PagedSSDCacheMaxSize:   derefString(isvc.Spec.PagedSSDCacheMaxSize),
 	}
 }
 
@@ -643,6 +646,13 @@ func derefInt32(p *int32) int {
 		return 0
 	}
 	return int(*p)
+}
+
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 // resolveRuntime returns the effective runtime for an InferenceService.
@@ -1733,6 +1743,10 @@ func computeSpecHash(isvc *inferencev1alpha1.InferenceService) string {
 		Mode                   string
 		Replicas               *int32
 		Runtime                string
+		TurboQuantBits         *int32
+		PagedSSDCacheDir       *string
+		HotCacheMaxSize        *string
+		PagedSSDCacheMaxSize   *string
 	}{
 		ModelRef:               isvc.Spec.ModelRef,
 		ContextSize:            isvc.Spec.ContextSize,
@@ -1757,6 +1771,10 @@ func computeSpecHash(isvc *inferencev1alpha1.InferenceService) string {
 		Mode:                   isvc.Spec.Mode,
 		Replicas:               isvc.Spec.Replicas,
 		Runtime:                isvc.Spec.Runtime,
+		TurboQuantBits:         isvc.Spec.TurboQuantBits,
+		PagedSSDCacheDir:       isvc.Spec.PagedSSDCacheDir,
+		HotCacheMaxSize:        isvc.Spec.HotCacheMaxSize,
+		PagedSSDCacheMaxSize:   isvc.Spec.PagedSSDCacheMaxSize,
 	}
 	b, err := json.Marshal(relevant)
 	if err != nil {

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -128,6 +128,23 @@ type ExecutorConfig struct {
 	// dev build (6-bit and 8-bit options).
 	// +optional
 	TurboQuantBits int
+
+	// PagedSSDCacheDir maps to oMLX --paged-ssd-cache-dir. When non-empty,
+	// the oMLX daemon uses a paged cache backed by the specified directory,
+	// allowing models to exceed available RAM by paging KV cache blocks to
+	// SSD. Only meaningful for the omlx runtime; ignored by llamacpp and
+	// other runtimes.
+	PagedSSDCacheDir string
+
+	// HotCacheMaxSize maps to oMLX --hot-cache-max-size. A string value like
+	// "100GB" or "50GB". Only meaningful for the omlx runtime; ignored by
+	// llamacpp and other runtimes.
+	HotCacheMaxSize string
+
+	// PagedSSDCacheMaxSize maps to oMLX --paged-ssd-cache-max-size. A string
+	// value like "200GB" or "500GB". Only meaningful for the omlx runtime;
+	// ignored by llamacpp and other runtimes.
+	PagedSSDCacheMaxSize string
 }
 
 // ProcessExecutor is the interface that both llama-server and oMLX executors

--- a/pkg/agent/executor_omlx.go
+++ b/pkg/agent/executor_omlx.go
@@ -55,6 +55,18 @@ type OMLXExecutor struct {
 	// daemon (--kv-cache-quant). Set once when the daemon starts; shared
 	// across all models served by this daemon. Zero means no TurboQuant.
 	turboQuantBits int
+	// pagedSSDCacheDir is the directory for the oMLX paged SSD cache
+	// (--paged-ssd-cache-dir). Set once when the daemon starts; shared
+	// across all models served by this daemon. Empty means no paged SSD cache.
+	pagedSSDCacheDir string
+	// hotCacheMaxSize is the maximum size of the oMLX hot cache
+	// (--hot-cache-max-size). Set once when the daemon starts; shared
+	// across all models served by this daemon. Empty means no limit.
+	hotCacheMaxSize string
+	// pagedSSDCacheMaxSize is the maximum size of the oMLX paged SSD cache
+	// (--paged-ssd-cache-max-size). Set once when the daemon starts; shared
+	// across all models served by this daemon. Empty means no limit.
+	pagedSSDCacheMaxSize string
 }
 
 // NewOMLXExecutor creates an executor that manages models via the oMLX daemon.
@@ -116,6 +128,9 @@ func (e *OMLXExecutor) StartProcess(ctx context.Context, config ExecutorConfig) 
 	// setting applied once when the daemon starts; shared across all models.
 	e.mu.Lock()
 	e.turboQuantBits = config.TurboQuantBits
+	e.pagedSSDCacheDir = config.PagedSSDCacheDir
+	e.hotCacheMaxSize = config.HotCacheMaxSize
+	e.pagedSSDCacheMaxSize = config.PagedSSDCacheMaxSize
 	e.mu.Unlock()
 
 	// Ensure the oMLX daemon is running
@@ -202,6 +217,61 @@ func (e *OMLXExecutor) UnloadModel(ctx context.Context, modelID string) error {
 	return nil
 }
 
+// buildOMLXServeArgs constructs the command-line argument vector for the
+// oMLX daemon serve subcommand. It is split out from ensureOMLXRunning so it
+// can be unit tested without spawning a real process. The function is pure:
+// it takes the model directory, port, and a config struct and returns the
+// full arg slice. Conditional flags are emitted only when their corresponding
+// config field is set (non-empty for strings, > 0 for turboQuantBits).
+func buildOMLXServeArgs(modelDir string, port int, cfg omlxServeConfig) []string {
+	args := []string{
+		"serve",
+		"--model-dir", modelDir,
+		"--port", fmt.Sprint(port),
+		"--host", "0.0.0.0",
+	}
+
+	// TurboQuant KV cache quantization (oMLX v0.3.4+). Maps to --kv-cache-quant
+	// flag. The bits value (3, 6, or 8) is set via StartProcess before this
+	// call. When turboQuantBits is set, the flag is emitted; when omitted,
+	// oMLX uses its default (unquantized).
+	if cfg.turboQuantBits > 0 {
+		args = append(args, "--kv-cache-quant", fmt.Sprint(cfg.turboQuantBits))
+	}
+
+	// Paged SSD cache directory. Maps to --paged-ssd-cache-dir. When set,
+	// the oMLX daemon uses a paged cache backed by the specified directory,
+	// allowing models to exceed available RAM by paging KV cache blocks to SSD.
+	if cfg.pagedSSDCacheDir != "" {
+		args = append(args, "--paged-ssd-cache-dir", cfg.pagedSSDCacheDir)
+	}
+
+	// Hot cache max size. Maps to --hot-cache-max-size. A string value like
+	// "100GB" or "50GB". When set, limits the size of the hot cache in RAM.
+	if cfg.hotCacheMaxSize != "" {
+		args = append(args, "--hot-cache-max-size", cfg.hotCacheMaxSize)
+	}
+
+	// Paged SSD cache max size. Maps to --paged-ssd-cache-max-size. A string
+	// value like "200GB" or "500GB". When set, limits the size of the paged
+	// cache on SSD.
+	if cfg.pagedSSDCacheMaxSize != "" {
+		args = append(args, "--paged-ssd-cache-max-size", cfg.pagedSSDCacheMaxSize)
+	}
+
+	return args
+}
+
+// omlxServeConfig holds the daemon-level configuration for the oMLX serve
+// subcommand. It mirrors the fields on OMLXExecutor that are set once when
+// the daemon starts and shared across all models.
+type omlxServeConfig struct {
+	turboQuantBits       int
+	pagedSSDCacheDir     string
+	hotCacheMaxSize      string
+	pagedSSDCacheMaxSize string
+}
+
 // ensureOMLXRunning starts the oMLX daemon if it is not already responding.
 func (e *OMLXExecutor) ensureOMLXRunning(ctx context.Context) error {
 	e.mu.Lock()
@@ -215,19 +285,13 @@ func (e *OMLXExecutor) ensureOMLXRunning(ctx context.Context) error {
 
 	e.logger.Infow("starting oMLX daemon", "bin", e.omlxBin, "modelDir", e.modelDir, "port", e.port)
 
-	cmd := exec.Command(e.omlxBin, "serve",
-		"--model-dir", e.modelDir,
-		"--port", fmt.Sprint(e.port),
-		"--host", "0.0.0.0",
-	)
-
-	// TurboQuant KV cache quantization (oMLX v0.3.4+). Maps to --kv-cache-quant
-	// flag. The bits value (3, 6, or 8) is set via StartProcess before this
-	// call. When turboQuantBits is set, the flag is emitted; when omitted,
-	// oMLX uses its default (unquantized).
-	if e.turboQuantBits > 0 {
-		cmd.Args = append(cmd.Args, "--kv-cache-quant", fmt.Sprint(e.turboQuantBits))
+	cfg := omlxServeConfig{
+		turboQuantBits:       e.turboQuantBits,
+		pagedSSDCacheDir:     e.pagedSSDCacheDir,
+		hotCacheMaxSize:      e.hotCacheMaxSize,
+		pagedSSDCacheMaxSize: e.pagedSSDCacheMaxSize,
 	}
+	cmd := exec.Command(e.omlxBin, buildOMLXServeArgs(e.modelDir, e.port, cfg)...)
 	cmd.Env = os.Environ()
 
 	if err := cmd.Start(); err != nil {

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -838,3 +838,165 @@ func buildExecutorConfigForTest(isvc *inferencev1alpha1.InferenceService) Execut
 		Mode:                   isvc.Spec.Mode,
 	}
 }
+
+// TestDerefString verifies the derefString helper used in buildExecutorConfig.
+func TestDerefString(t *testing.T) {
+	// Nil pointer returns empty string.
+	if got := derefString(nil); got != "" {
+		t.Errorf("derefString(nil) = %q, want %q", got, "")
+	}
+
+	// Non-nil pointer returns the pointed value.
+	s := "hello"
+	if got := derefString(&s); got != "hello" {
+		t.Errorf("derefString(&s) = %q, want %q", got, "hello")
+	}
+}
+
+// TestBuildOMLXServeArgs_Defaults verifies the base arg vector for the oMLX
+// daemon serve subcommand.
+func TestBuildOMLXServeArgs_Defaults(t *testing.T) {
+	cfg := omlxServeConfig{
+		turboQuantBits:       0,
+		pagedSSDCacheDir:     "",
+		hotCacheMaxSize:      "",
+		pagedSSDCacheMaxSize: "",
+	}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	want := map[string]string{
+		"--model-dir": "/models/test",
+		"--port":      "8000",
+		"--host":      "0.0.0.0",
+	}
+	for flag, expected := range want {
+		if got := flagValue(args, flag); got != expected {
+			t.Errorf("%s = %q, want %q (full args: %v)", flag, got, expected, args)
+		}
+	}
+
+	// No optional flags should be present.
+	unwantedFlags := []string{
+		"--kv-cache-quant",
+		"--paged-ssd-cache-dir",
+		"--hot-cache-max-size",
+		"--paged-ssd-cache-max-size",
+	}
+	for _, unwanted := range unwantedFlags {
+		if hasFlag(args, unwanted) {
+			t.Errorf("unexpected flag %q in default args: %v", unwanted, args)
+		}
+	}
+}
+
+// TestBuildOMLXServeArgs_TurboQuant verifies the --kv-cache-quant flag is
+// emitted when turboQuantBits is set.
+func TestBuildOMLXServeArgs_TurboQuant(t *testing.T) {
+	cfg := omlxServeConfig{turboQuantBits: 3}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	if got := flagValue(args, "--kv-cache-quant"); got != "3" {
+		t.Errorf("--kv-cache-quant = %q, want %q (full args: %v)", got, "3", args)
+	}
+}
+
+// TestBuildOMLXServeArgs_TurboQuantOmittedWhenZero verifies the flag is
+// omitted when turboQuantBits is zero.
+func TestBuildOMLXServeArgs_TurboQuantOmittedWhenZero(t *testing.T) {
+	cfg := omlxServeConfig{turboQuantBits: 0}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	if hasFlag(args, "--kv-cache-quant") {
+		t.Errorf("--kv-cache-quant must be omitted when turboQuantBits=0 (full args: %v)", args)
+	}
+}
+
+// TestBuildOMLXServeArgs_PagedSSDCacheDir verifies the --paged-ssd-cache-dir
+// flag is emitted when the directory is set.
+func TestBuildOMLXServeArgs_PagedSSDCacheDir(t *testing.T) {
+	cfg := omlxServeConfig{pagedSSDCacheDir: "/mnt/ssd-cache"}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	if got := flagValue(args, "--paged-ssd-cache-dir"); got != "/mnt/ssd-cache" {
+		t.Errorf("--paged-ssd-cache-dir = %q, want %q (full args: %v)", got, "/mnt/ssd-cache", args)
+	}
+}
+
+// TestBuildOMLXServeArgs_PagedSSDCacheDirOmittedWhenEmpty verifies the flag
+// is omitted when the directory is empty.
+func TestBuildOMLXServeArgs_PagedSSDCacheDirOmittedWhenEmpty(t *testing.T) {
+	cfg := omlxServeConfig{pagedSSDCacheDir: ""}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	if hasFlag(args, "--paged-ssd-cache-dir") {
+		t.Errorf("--paged-ssd-cache-dir must be omitted when pagedSSDCacheDir is empty (full args: %v)", args)
+	}
+}
+
+// TestBuildOMLXServeArgs_HotCacheMaxSize verifies the --hot-cache-max-size
+// flag is emitted when the size is set.
+func TestBuildOMLXServeArgs_HotCacheMaxSize(t *testing.T) {
+	cfg := omlxServeConfig{hotCacheMaxSize: "100GB"}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	if got := flagValue(args, "--hot-cache-max-size"); got != "100GB" {
+		t.Errorf("--hot-cache-max-size = %q, want %q (full args: %v)", got, "100GB", args)
+	}
+}
+
+// TestBuildOMLXServeArgs_HotCacheMaxSizeOmittedWhenEmpty verifies the flag
+// is omitted when the size is empty.
+func TestBuildOMLXServeArgs_HotCacheMaxSizeOmittedWhenEmpty(t *testing.T) {
+	cfg := omlxServeConfig{hotCacheMaxSize: ""}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	if hasFlag(args, "--hot-cache-max-size") {
+		t.Errorf("--hot-cache-max-size must be omitted when hotCacheMaxSize is empty (full args: %v)", args)
+	}
+}
+
+// TestBuildOMLXServeArgs_PagedSSDCacheMaxSize verifies the
+// --paged-ssd-cache-max-size flag is emitted when the size is set.
+func TestBuildOMLXServeArgs_PagedSSDCacheMaxSize(t *testing.T) {
+	cfg := omlxServeConfig{pagedSSDCacheMaxSize: "200GB"}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	if got := flagValue(args, "--paged-ssd-cache-max-size"); got != "200GB" {
+		t.Errorf("--paged-ssd-cache-max-size = %q, want %q (full args: %v)", got, "200GB", args)
+	}
+}
+
+// TestBuildOMLXServeArgs_PagedSSDCacheMaxSizeOmittedWhenEmpty verifies the
+// flag is omitted when the size is empty.
+func TestBuildOMLXServeArgs_PagedSSDCacheMaxSizeOmittedWhenEmpty(t *testing.T) {
+	cfg := omlxServeConfig{pagedSSDCacheMaxSize: ""}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	if hasFlag(args, "--paged-ssd-cache-max-size") {
+		t.Errorf("--paged-ssd-cache-max-size must be omitted when pagedSSDCacheMaxSize is empty (full args: %v)", args)
+	}
+}
+
+// TestBuildOMLXServeArgs_AllFlags verifies all flags are emitted together
+// when all config fields are set.
+func TestBuildOMLXServeArgs_AllFlags(t *testing.T) {
+	cfg := omlxServeConfig{
+		turboQuantBits:       6,
+		pagedSSDCacheDir:     "/mnt/ssd",
+		hotCacheMaxSize:      "100GB",
+		pagedSSDCacheMaxSize: "500GB",
+	}
+	args := buildOMLXServeArgs("/models/test", 8000, cfg)
+
+	want := map[string]string{
+		"--kv-cache-quant":           "6",
+		"--paged-ssd-cache-dir":      "/mnt/ssd",
+		"--hot-cache-max-size":       "100GB",
+		"--paged-ssd-cache-max-size": "500GB",
+	}
+	for flag, expected := range want {
+		if got := flagValue(args, flag); got != expected {
+			t.Errorf("%s = %q, want %q (full args: %v)", flag, got, expected, args)
+		}
+	}
+}


### PR DESCRIPTION
## What

Exposes the oMLX paged SSD cache configuration via typed `InferenceService` fields, passed to the oMLX daemon by the metal-agent.

## Why

oMLX supports a tiered KV cache that spills cold blocks to SSD, letting memory-constrained Apple Silicon (36-48GB) serve longer context than fits in RAM. The metal-agent had no way to configure it.

## How

- Extract a pure `buildOMLXServeArgs(modelDir, port, cfg)` from `ensureOMLXRunning` so the argv is unit-testable (mirrors the llama-server arg builder).
- Add `PagedSSDCacheDir`, `HotCacheMaxSize`, `PagedSSDCacheMaxSize` (`*string`, optional) on the InferenceService spec, wired CRD -> `ExecutorConfig` -> executor exactly like the existing `TurboQuantBits` two-point pattern.
- Emit `--paged-ssd-cache-dir` / `--hot-cache-max-size` / `--paged-ssd-cache-max-size` only when set.
- Arg logic stays in the untagged `executor_omlx.go` so the Linux gate compiles it.

## Testing

- `TestBuildOMLXServeArgs_*` (11 cases): each flag present with its value when set, omitted when empty, plus an all-flags case. `go test ./pkg/agent/...` green (pure unit, no Mac/daemon).
- `go build`, `go vet` clean; CRD regen (`make manifests && make generate && make chart-crds`) produces no drift.
- Runtime validation against a live oMLX daemon on a Mac is manual (out of unit-test scope).

## Checklist

- [x] Unit tests (arg construction)
- [x] CRD regen with no drift
- [x] Compiles under the Linux gate (untagged file)
- [x] DCO sign-off, `Fixes #278`

## AI assistance

Implemented via the Foreman agentic-coding harness (GO), then rebased onto current `main`, verified, and finalized by the author. Band-3 disclosure per the project's AI-assisted contribution policy.

Fixes #278
