### PR TITLE
docs: document strict-taint model caches

### DIFF
--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -285,15 +285,18 @@ modelCache:
   #     schedules to. Use this as the opt-in escape hatch for multi-node clusters
   #     that do NOT have an RWX storage class: the cache co-locates with the
   #     workload instead of pinning to one node (#728). The tradeoff is no
-  #     cross-isvc dedup (each InferenceService downloads its own copy) and
-  #     `cache list` is not per-isvc aware yet.
+  #     cross-isvc dedup (each InferenceService downloads its own copy).
+  #     `llmkube cache list` discovers operator-managed per-service cache PVCs;
+  #     user-managed `spec.modelCache.claimName` PVCs are outside that discovery
+  #     contract.
   mode: shared
   # Storage size for each model cache PVC
   size: 100Gi
   # Storage class (leave empty for the cluster default). For shared on a
   # multi-node cluster use an RWX class; for perService the default class should
   # use volumeBindingMode WaitForFirstConsumer so the PVC binds on the serving
-  # node.
+  # node. On a hard-tainted node, the storage provisioner's helper path must also
+  # tolerate the taint; otherwise use a pre-provisioned claim.
   storageClass: ""
   # Access mode for the shared cache PVC (only used when mode=shared):
   # ReadWriteOnce (single-node) or ReadWriteMany (multi-node with NFS/EFS).

--- a/docs/MODEL-CACHE.md
+++ b/docs/MODEL-CACHE.md
@@ -95,6 +95,13 @@ modelCache:
   # Enable persistent model cache (default: true)
   enabled: true
 
+  # Provisioning mode: shared or perService.
+  # shared (default): a single cluster-wide PVC that all InferenceServices share.
+  # perService: operator-managed per-InferenceService PVC that binds on the node
+  #   where the inference pod schedules. A separate user-managed override is
+  #   available via spec.modelCache.claimName on individual InferenceServices.
+  mode: shared
+
   # Storage size for model cache
   size: 100Gi
 
@@ -145,6 +152,24 @@ modelCache:
   accessMode: ReadWriteMany
 ```
 
+#### Strictly tainted GPU nodes
+
+When a GPU node carries a hard `NoSchedule` taint, dynamic provisioning can fail for reasons unrelated to the inference pod's tolerations. The safest approach is to pre-provision a PVC bound to the tainted node and reference it through `spec.modelCache.claimName`.
+
+The inference pod already receives the GPU toleration derived from the Model's `hardware.gpu` configuration. The `model-downloader` runs as an init container in that same pod, so a pre-existing PVC does not require a separate download Job.
+
+The claim must already exist and be node-aligned by the cluster administrator's storage setup. `claimName` is user-owned: LLMKube mounts it through the same prep and download init containers as the built-in cache, but never creates, mutates, or deletes it. If the named PVC is missing, the InferenceService is marked Degraded rather than silently falling back to the shared cache.
+
+**Note:** `claimName` is ignored for `pvc://` model sources because those weights are already staged on the cluster and mounted read-only; no download occurs.
+
+Some dynamic provisioners create a per-node helper pod to provision volumes. This helper pod is separate from the LLMKube inference pod and typically carries only the default not-ready/unreachable tolerations. When a GPU node has a hard `NoSchedule` taint, the helper pod may remain Pending with an untolerated-taint event — even though the inference pod itself has the correct GPU toleration.
+
+Strict-taint choices:
+
+- Pre-provision a static, node-aligned claim and use `claimName`.
+- Use a provisioner whose helper configuration supports the taint.
+- Apply a narrowly scoped cluster-level policy maintained by the cluster administrator.
+
 ### Per-InferenceService Cache PVC (Bring Your Own)
 
 The cache backend above is an operator-global choice. To point a *single*
@@ -188,8 +213,11 @@ Behavior:
   `nodeSelector` so the pod lands where the PVC binds (a
   `WaitForFirstConsumer` local class binds on the first consumer; a pre-bound
   RWO PVC pins the pod).
-- `llmkube cache list` / `cache clear` inspect the shared cache only; they do
-  not see bring-your-own cache PVCs.
+- `llmkube cache list` discovers the shared cache and operator-managed
+  per-service cache PVCs. A user-managed `spec.modelCache.claimName` PVC is
+  outside the operator's cache label/discovery contract and may not appear in
+  the listing. Cache inspection may need a running pod or a transient inspector
+  pod for Pending `WaitForFirstConsumer` claims.
 
 ## CLI Commands
 

--- a/docs/model-storage.md
+++ b/docs/model-storage.md
@@ -30,6 +30,7 @@ For multi-node clusters **without** an RWX storage class. Each InferenceService 
 - **RWO**, no explicit StorageClass, so it binds `WaitForFirstConsumer` — on whatever node the inference pod is scheduled to.
 - The pod's **init container downloads the model into that PVC**, so the download and the server land on the same node by construction.
 - Owner-referenced to the InferenceService, so it is garbage-collected when the service is deleted.
+- This mode requires the external provisioner to schedule its helper path on the selected node. On a strictly tainted node where the helper cannot tolerate the taint, use `spec.modelCache.claimName` with a pre-provisioned claim instead (see below).
 
 This makes **heterogeneous, multi-node clusters work without RWX**: an InferenceService whose accelerator is on node B (e.g. an AMD/Vulkan node distinct from the operator's node) schedules on node B and caches its model there (see #728).
 
@@ -38,7 +39,15 @@ modelCache:
   mode: perService
 ```
 
-Trade-offs: models are **not deduplicated across InferenceServices** (each service downloads and stores its own copy), and `llmkube cache list` is not per-isvc cache aware yet. Prefer `shared` + an RWX storage class on multi-node clusters that have one.
+Trade-offs: models are **not deduplicated across InferenceServices** (each service downloads and stores its own copy). Prefer `shared` + an RWX storage class on multi-node clusters that have one.
+
+### Pre-provisioned claim (`spec.modelCache.claimName`)
+
+Strict-taint users can use `spec.modelCache.claimName` with a pre-provisioned, node-aligned PVC. This path does not depend on dynamic helper scheduling: the claim already exists and is bound, so no external provisioner helper pod needs to land on the tainted node. The inference pod's init containers handle the download into the existing claim.
+
+### Cache inspection
+
+`llmkube cache list` discovers the shared cache and operator-managed per-service cache PVCs. A user-managed `spec.modelCache.claimName` PVC is outside the operator's cache label/discovery contract and may not appear in the listing.
 
 ## Choosing a mode
 

--- a/docs/site/_meta/nav.yaml
+++ b/docs/site/_meta/nav.yaml
@@ -75,7 +75,6 @@ sections:
       - label: Model cache
         slug: guides/model-cache
         file: guides/model-cache.md
-        status: stub
       - label: Metrics-driven autoscaling
         slug: guides/metrics-driven-autoscaling
         file: guides/metrics-driven-autoscaling.md

--- a/docs/site/guides/model-cache.md
+++ b/docs/site/guides/model-cache.md
@@ -1,0 +1,159 @@
+---
+title: Model cache and node-local storage
+description: Choose shared, per-service, or pre-provisioned model storage, including strict-taint GPU nodes.
+---
+
+# Model cache and node-local storage
+
+LLMKube downloads a remote Model through the `model-downloader` init
+container in the inference pod. Persistent caching controls which PVC that
+init container and the serving container mount.
+
+## Cache modes
+
+| Cluster/storage topology | Configuration |
+| --- | --- |
+| Single node | `shared` with the default RWO storage |
+| Multi-node with RWX | `shared` with `accessMode: ReadWriteMany` and an RWX StorageClass |
+| Multi-node without RWX, compatible topology-aware provisioner | `perService` |
+| Strictly tainted node with unsuitable dynamic provisioner | Pre-provision a node-aligned PVC and set `spec.modelCache.claimName` |
+
+`shared` is the default. A single cluster-wide PVC named `llmkube-model-cache`
+is created (or reused if it already exists). When using an RWO storage class,
+the shared claim binds to one node, so all inference pods scheduling onto that
+PVC must land on the same node.
+
+`perService` creates a dedicated PVC named `<inferenceservice>-model-cache` for
+each InferenceService. Each per-service PVC uses RWO semantics and relies on the
+StorageClass's `WaitForFirstConsumer` volume binding behavior to bind on the
+node where the inference pod schedules. This avoids cross-node shared-RWO
+affinity but does not affect external provisioner helper pods (see below).
+
+## Strictly tainted GPU nodes
+
+When a GPU node carries a hard `NoSchedule` taint, dynamic provisioning can
+fail for reasons unrelated to the inference pod's tolerations. The safest
+approach is to pre-provision a PVC bound to the tainted node and reference it
+through `spec.modelCache.claimName`.
+
+The inference pod already receives the GPU toleration derived from the Model's
+`hardware.gpu` configuration. The `model-downloader` runs as an init container
+in that same pod, so a pre-existing PVC does not require a separate download
+Job.
+
+The claim must already exist and be node-aligned by the cluster administrator's
+storage setup. `claimName` is user-owned: LLMKube mounts it through the same
+prep and download init containers as the built-in cache, but never creates,
+mutates, or deletes it. If the named PVC is missing, the InferenceService is
+marked Degraded rather than silently falling back to the shared cache.
+
+Example with an AMD GPU node:
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: amd-vulkan-model
+spec:
+  source: https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf
+  format: gguf
+  hardware:
+    gpu:
+      enabled: true
+      count: 1
+      vendor: amd
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: amd-vulkan-service
+spec:
+  modelRef: amd-vulkan-model
+  modelCache:
+    claimName: gpu-node-model-cache
+  resources:
+    gpu: 1
+```
+
+The `source` URL above is an example. Replace it with an allowlisted, reachable
+model source for your environment. This manifest does not create the PVC — the
+PVC named `gpu-node-model-cache` must be pre-provisioned by the cluster
+administrator and bound to a node that matches the GPU taint topology.
+
+**Note:** `claimName` is ignored for `pvc://` model sources because those
+weights are already staged on the cluster and mounted read-only; no download
+occurs.
+
+### Verification
+
+After applying the Model and InferenceService, confirm the PVC is bound and
+the inference pod lands on the expected node:
+
+```bash
+kubectl get pvc gpu-node-model-cache
+kubectl get pod -l app=amd-vulkan-service \
+  -o custom-columns=NAME:.metadata.name,NODE:.spec.nodeName
+kubectl describe pod -l app=amd-vulkan-service
+```
+
+The PVC should show `Bound`, the pod should report the tainted GPU node, and
+`describe` should list the correct toleration and volume mount.
+
+### Why a tolerated inference pod may still have a Pending PVC
+
+Some dynamic provisioners create a per-node helper pod to provision volumes.
+For example, MicroK8s hostpath deploys a `hostpath-provisioner-<node>-*` pod
+on each node. This helper pod is separate from the LLMKube inference pod and
+typically carries only the default not-ready/unreachable tolerations.
+
+When a GPU node has a hard `NoSchedule` taint, the helper pod may remain
+Pending with an untolerated-taint event — even though the inference pod itself
+has the correct GPU toleration. A PVC has no pod `nodeSelector` or
+`tolerations` field for LLMKube to set, and LLMKube does not manage the
+external helper pod.
+
+Strict-taint choices:
+
+- Pre-provision a static, node-aligned claim and use `claimName`.
+- Use a provisioner whose helper configuration supports the taint.
+- Apply a narrowly scoped cluster-level policy maintained by the cluster
+  administrator.
+
+Global `perService` mode only avoids cross-node shared-RWO affinity. It cannot
+make an untolerated external helper pod schedule on a tainted node.
+
+## Troubleshooting
+
+### Pending PVC with `hostpath-provisioner-<node>-*` showing `untolerated taint`
+
+The external provisioner's helper pod cannot schedule on the tainted node.
+This is a limitation of the provisioner, not LLMKube. Use one of the
+strict-taint choices above: pre-provision a static claim with `claimName`,
+switch to a provisioner whose helpers tolerate the taint, or apply a
+cluster-level policy.
+
+### `volume node affinity conflict`
+
+A shared RWO PVC is bound to a different node than where the inference pod is
+trying to schedule. Options:
+
+- Use an RWX StorageClass with the `shared` mode.
+- Switch to `perService` so each InferenceService gets its own RWO PVC that
+  binds via `WaitForFirstConsumer`.
+- Pre-provision a node-aligned PVC and reference it with `claimName`.
+
+### Cache inspection with `llmkube cache list`
+
+The operator-managed shared and labeled per-service cache PVCs are discoverable
+through the `app.kubernetes.io/component=model-cache` label. A user-managed
+`claimName` PVC is not necessarily labeled as an operator cache; it remains
+the user's responsibility to manage its lifecycle.
+
+### Relaxing the taint
+
+As an alternative to pre-provisioning, changing a GPU node's taint from
+`NoSchedule` to `PreferNoSchedule` allows both the inference pod and the
+external provisioner's helper pod to schedule with a scheduling penalty rather
+than a hard block. This is a cluster-level trade-off: it increases scheduling
+flexibility but reduces the guarantee that only tolerated workloads land on
+GPU nodes.

--- a/docs/superpowers/specs/2026-07-14-issue-850-strict-taint-model-cache-design.md
+++ b/docs/superpowers/specs/2026-07-14-issue-850-strict-taint-model-cache-design.md
@@ -1,0 +1,117 @@
+# Issue #850: strict-taint node-local model caches
+
+**Date:** 2026-07-14
+**Status:** Design approved; spec under user review.
+**Issue:** https://github.com/defilantech/LLMKube/issues/850
+
+## Problem
+
+A GPU node protected by a hard `NoSchedule` taint can run LLMKube inference
+pods because the controller renders the matching GPU toleration. A dynamically
+provisioned MicroK8s hostpath cache can still remain Pending: the external
+provisioner creates an owner-less helper pod on the selected node without the
+GPU toleration. LLMKube cannot add pod scheduling fields to a PVC or mutate a
+third-party helper pod through that PVC.
+
+There is a second, independent failure on heterogeneous multi-node clusters.
+The default shared RWO cache binds to one node, so an inference pod selected for
+a different GPU node gets a volume node-affinity conflict. The existing global
+`modelCache.mode: perService` avoids that conflict when the storage provisioner
+can create a volume on the serving node.
+
+LLMKube already supports the strict-taint path needed by users who pre-provision
+storage. `InferenceService.spec.modelCache.claimName` selects a pre-existing,
+user-managed PVC for one service. The normal downloader init container writes a
+remote Model into that claim, and the serving container reads the same claim.
+Because both containers are in the inference pod, they use its existing node
+selection and GPU toleration. For a model already staged in a PVC, a `pvc://`
+Model source is the read-only alternative and `claimName` is intentionally
+ignored.
+
+The current documentation does not connect these facts into a complete
+strict-`NoSchedule` workflow. It also contains stale statements that
+`llmkube cache list` cannot inspect operator-managed per-service cache PVCs.
+
+## Design
+
+Make the existing Model cache guide on the public documentation site real and
+use it as the user-facing source of truth. The guide will distinguish storage
+placement from pod scheduling and document three complete topologies:
+
+1. `shared` plus RWX storage for multi-node clusters where the cache must be
+   reachable from every serving node.
+2. Operator-managed `perService` RWO caches with a `WaitForFirstConsumer`
+   provisioner whose volume-creation path can run on the selected node.
+3. A pre-provisioned, node-aligned PVC selected with
+   `spec.modelCache.claimName`, which is the LLMKube path for a strict-tainted
+   GPU node when dynamic provisioning is unsuitable.
+
+The strict-taint section will show a remote-URL `Model` and an
+`InferenceService` that selects an existing cache claim. It will explain that
+the downloader remains part of the inference pod; no separate staging Job is
+required. A companion section will show when to use `pvc://` for weights that
+are already staged.
+
+Troubleshooting will separate the two observable failures:
+
+- A Pending `hostpath-provisioner-<node>-*` helper with an untolerated taint is a
+  provisioner limitation. Preserving strict `NoSchedule` requires a
+  pre-provisioned/static claim, a provisioner whose helper path supports the
+  taint, or a narrowly scoped cluster-level mutation policy. Merely tolerating
+  the inference pod or using global `perService` mode cannot fix that helper.
+- `volume node affinity conflict` with the shared RWO cache means the cache is
+  bound to another node. Use shared RWX storage, an operator-managed
+  `perService` cache on a compatible provisioner, or a node-aligned
+  `claimName`.
+
+`PreferNoSchedule` may be mentioned as an explicit relaxation, not as the
+recommended solution or a requirement. The guide will not provide an
+unverified third-party mutation-policy manifest.
+
+## Documentation changes
+
+| File | Change |
+|------|--------|
+| `docs/site/guides/model-cache.md` | Replace the stub with the public Model-cache guide, including strict-taint workflow and troubleshooting |
+| `docs/site/_meta/nav.yaml` | Mark the Model cache guide as live by removing `status: stub` |
+| `docs/MODEL-CACHE.md` | Align the repository guide with cache modes, `claimName`, strict-taint troubleshooting, and current cache inspection behavior |
+| `docs/model-storage.md` | Correct stale cache-list text and add the external-helper caveat to the mode-selection guidance |
+| `charts/llmkube/values.yaml` | Correct stale `cache list` comments and clarify the provisioner requirement for `perService` on hard-tainted nodes |
+
+The public and repository guides may organize the material differently, but
+they must describe the same behavior and recommendations.
+
+## Validation
+
+- Cross-check every behavioral statement against the current controller and
+  CLI implementation:
+  - `ModelCacheSpec.ClaimName` and user-owned claim handling;
+  - `ensureModelCachePVC` shared/per-service behavior;
+  - inference-pod node selection and GPU toleration rendering;
+  - cache PVC discovery in `llmkube cache list`.
+- Search the changed documentation for stale claims that per-service caches are
+  not inspectable.
+- Run formatting/lint/test gates required by the repository and record any
+  documentation-only limitations explicitly in the PR checklist.
+- Review the final diff for provider-specific claims that are not supported by
+  the issue's observed evidence or an upstream source.
+
+## Pull request
+
+Use `.github/PULL_REQUEST_TEMPLATE.md` without removing its `What`, `Why`,
+`How`, or checklist sections. The PR will include `Fixes #850` and disclose AI
+assistance in the body as required by `CONTRIBUTING.md`. Commits will use a
+conventional `docs:` subject and DCO sign-off.
+
+## Non-goals
+
+- Adding another InferenceService cache-selection API; `claimName` already
+  provides the required per-service user-managed cache.
+- Making LLMKube mutate or manage MicroK8s hostpath helper pods.
+- Claiming that global `perService` mode alone fixes hard-taint provisioning.
+- Changing the default cache mode.
+- Implementing Model prefetch or a standalone staging Job; that belongs to
+  issue #904.
+- Adding generic Pending-PVC status conditions without a reliable way to
+  identify the external helper-pod failure.
+- Recommending that users weaken strict GPU isolation as the primary fix.


### PR DESCRIPTION
## What

Document strict-`NoSchedule` model-cache workflows for GPU nodes, including pre-provisioned per-InferenceService PVCs via `spec.modelCache.claimName`, dynamic provisioner limitations, and cache-mode selection.

## Why

Dynamic MicroK8s hostpath helper pods do not inherit the GPU toleration, while shared RWO caches can bind to the wrong node on heterogeneous clusters. LLMKube already supports the strict-taint workaround through user-managed cache claims, but the workflow was not documented clearly.

Refs #850

## How

Made the public Model-cache guide live, added the strict-taint claim workflow and troubleshooting guidance, and aligned the repository guide and Helm comments. This deliberately does not weaken `NoSchedule` or attempt to mutate third-party provisioner helper pods.

Verification passed: `make fmt`, `make vet`, `make lint`, `make test`, and `make lint-all`.

AI assistance: OpenAI coding agent investigated the issue, drafted the documentation and verification plan, and reviewed the branch diff; the required checks were run locally before submission.

## Checklist

- [ ] Tests added/updated (documentation-only change)
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance is disclosed above
- [x] Documentation updated