### PR TITLE
feat(foreman): guide coders to verify volatile external facts via MCP research tools

### DIFF
--- a/config/foreman/system-prompts/coder.md
+++ b/config/foreman/system-prompts/coder.md
@@ -56,6 +56,11 @@ when you call the terminal `submit_result` tool.
 - `submit_result(verdict, summary, commit_message?, extra?)` —
   terminal. The loop exits after this call.
 
+Research tools: your tool list may include `mcp/*` tools: `mcp/context7/*` for
+exact library APIs and `mcp/perplexity/perplexity_ask` / `perplexity_search`
+for web-grounded facts. See "Verify external facts" in Step 2 for when to use
+them.
+
 ## Step 1 — Triage
 
 Decide whether this issue is a good fit for an automated fix.
@@ -89,6 +94,16 @@ Do not edit any files.
 
 - Plan the change in 2-4 sentences (in your own reasoning, not via a
   tool call) before editing.
+- Verify external facts before you code them. If your change depends on any
+  external specific that is version sensitive or you are not certain is
+  current (a runtime or CLI flag name/value, an API route or wire/URL format,
+  a config key, a tool invocation, a library's current behavior), you MUST
+  confirm it with `mcp/perplexity/perplexity_ask` or `perplexity_search` (or
+  `mcp/context7/*` for exact library APIs) BEFORE writing code or a test that
+  assumes it, and cite what you found. Guessing an external fact and shipping
+  a test that matches your guess is a failure even if the gate goes green.
+  Skip this only for stable, well established specifics you are already
+  confident about; keep it to a couple of focused queries.
 - Make the smallest correct change. Match surrounding code style (see
   `AGENTS.md`).
 - Every behavior change needs a test. For a bug, add a regression


### PR DESCRIPTION
## What

Adds guidance to the coder Agent system prompt (`config/foreman/system-prompts/coder.md`) telling the coder to verify volatile external facts with its MCP research tools before assuming them.

## Why

Coders confidently emit version-specific external details from memory - a runtime/CLI flag name, an API route, a wire/URL format, a tool invocation - and, worse, ship a unit test that asserts the guessed value, so the gate goes green on incorrect code. When MCP research tools are wired to an Agent (context7 for exact library APIs, perplexity for web-grounded facts), the coder should use them to confirm such facts instead of guessing.

## How

- A short pointer in the tools list noting `mcp/*` tools may be present.
- A directive in the **Step 2 (plan/edit)** flow - the decision point - requiring the coder to confirm any version-sensitive external fact with `mcp/perplexity/*` (or `mcp/context7/*` for exact APIs) **before** writing code or a test that assumes it, and to cite what it found.
- An explicit warning: *guessing an external fact and shipping a test that matches your guess is a failure even if the gate goes green.*
- Scoped: skip stable, well-established specifics; keep it to a couple of focused queries (avoids taxing every run or over-researching).

No-op for Agents without MCP tools configured (the guidance is conditioned on the tools being present).

## Checklist

- [x] Prompt-only change (`config/foreman/system-prompts/coder.md`)
- [x] DCO sign-off

## AI assistance

Wording iterated with AI assistance and validated against live coder runs (research behavior improved, external facts came out correct); reviewed and owned by the author.
