### PR TITLE
feat(foreman): in-executor envtest gate feedback loop (#768)

### DIFF
--- a/api/foreman/v1alpha1/agent_types.go
+++ b/api/foreman/v1alpha1/agent_types.go
@@ -220,6 +220,18 @@ type AgentSpec struct {
 	// +optional
 	MaxTurns int32 `json:"maxTurns,omitempty"`
 
+	// MaxEnvtestIterations bounds how many times the executor re-runs a
+	// coder after the post-push envtest gate fails, feeding the gate
+	// output back so the coder fixes the failure and the branch is
+	// re-gated (#768). Three-valued: nil defaults to 1; an explicit 0
+	// restores the pre-#768 behavior (a failing gate downgrades to
+	// INCOMPLETE on the first failure); N allows up to N retries before
+	// the downgrade. Applies only to coder issue-fix tasks whose change
+	// touches an envtest-backed package and whose gate runner is wired.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxEnvtestIterations *int32 `json:"maxEnvtestIterations,omitempty"`
+
 	// MaxRetries bounds how many times the loop retries a single turn on
 	// recoverable errors (notably llama.cpp #22072 truncated tool_call
 	// argument JSON). Bounded exponential backoff with jitter.

--- a/api/foreman/v1alpha1/zz_generated.deepcopy.go
+++ b/api/foreman/v1alpha1/zz_generated.deepcopy.go
@@ -276,6 +276,11 @@ func (in *AgentSpec) DeepCopyInto(out *AgentSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MaxEnvtestIterations != nil {
+		in, out := &in.MaxEnvtestIterations, &out.MaxEnvtestIterations
+		*out = new(int32)
+		**out = **in
+	}
 	if in.StuckLoopDetection != nil {
 		in, out := &in.StuckLoopDetection, &out.StuckLoopDetection
 		*out = new(StuckLoopDetectionSpec)

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -220,6 +220,19 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              maxEnvtestIterations:
+                description: |-
+                  MaxEnvtestIterations bounds how many times the executor re-runs a
+                  coder after the post-push envtest gate fails, feeding the gate
+                  output back so the coder fixes the failure and the branch is
+                  re-gated (#768). Three-valued: nil defaults to 1; an explicit 0
+                  restores the pre-#768 behavior (a failing gate downgrades to
+                  INCOMPLETE on the first failure); N allows up to N retries before
+                  the downgrade. Applies only to coder issue-fix tasks whose change
+                  touches an envtest-backed package and whose gate runner is wired.
+                format: int32
+                minimum: 0
+                type: integer
               maxRetries:
                 default: 3
                 description: |-

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -219,6 +219,19 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              maxEnvtestIterations:
+                description: |-
+                  MaxEnvtestIterations bounds how many times the executor re-runs a
+                  coder after the post-push envtest gate fails, feeding the gate
+                  output back so the coder fixes the failure and the branch is
+                  re-gated (#768). Three-valued: nil defaults to 1; an explicit 0
+                  restores the pre-#768 behavior (a failing gate downgrades to
+                  INCOMPLETE on the first failure); N allows up to N retries before
+                  the downgrade. Applies only to coder issue-fix tasks whose change
+                  touches an envtest-backed package and whose gate runner is wired.
+                format: int32
+                minimum: 0
+                type: integer
               maxRetries:
                 default: 3
                 description: |-

--- a/docs/proposals/768-envtest-feedback-loop.md
+++ b/docs/proposals/768-envtest-feedback-loop.md
@@ -120,11 +120,11 @@ until it returns), so each retry amends the prior attempt's files in place.
   prompt, `VerifyTerminal` fast gate, model profile, budgets) is unchanged, so
   the retry still runs behind the fast gate and the coder is not blind.
 
-- **`runLoop` seam.** A field on `NativeAgentLoopExecutor`,
-  `runLoop func(context.Context, LoopConfig) (*LoopResult, error)`, defaulting to
-  `loop.Run`. The initial call at line ~583 and the retry call both route through
-  it. This is the only loop-adjacent change and exists purely so tests can inject
-  a fake loop. No behavior change to `loop.Run` itself.
+- **Retry implementation and testing.** The retry re-uses the same per-task `loop`
+  instance and calls `loop.Run` directly at both the initial and retry call sites;
+  no new production seam. The retry is tested end-to-end through the existing
+  `scriptedOAI` (scripted chat-completions) + `RegistryFactory`/fake `EnvtestJobRunner`
+  harness, which serves successive responses across the initial and retry `loop.Run` calls.
 
 ## Data flow
 

--- a/docs/proposals/768-envtest-feedback-loop.md
+++ b/docs/proposals/768-envtest-feedback-loop.md
@@ -140,8 +140,19 @@ next focused loop. On cap exhaustion the final `feedback` still flows into
 - **Coder NO-GO / MaxTurns on a retry:** return that terminal directly. The
   executor never pushes work the coder itself did not GO. Bounded by the cap and
   by each loop's own MaxTurns, so no unbounded spin.
-- **Gate could-not-run (`ran=false`):** unchanged. `evaluatePostPushEnvtest`
-  returns `failed=false`, the GO stands, no retry is spent on an infra hiccup.
+- **Gate could-not-run (`ran=false`):** attempt-dependent. On attempt 0 the GO
+  stands (the pre-#768 could-not-verify behavior, no prior evidence of failure).
+  On a **retry** it does NOT: a prior attempt already failed the gate, so an
+  unverifiable re-gate cannot confirm the fix and the executor downgrades to
+  INCOMPLETE rather than emit a false GO. `evaluatePostPushEnvtest` returns a
+  tri-state (`envtestGateOK` / `envtestGateFailed` / `envtestGateUnverified`) so
+  the loop can distinguish "passed" from "could-not-verify" by attempt number.
+  (Cluster validation caught the original single-state version landing a failing
+  branch as GO: the retry's gate Job name collided with the prior attempt's
+  because the trailing `-<unix-ms>` disambiguator was truncated past the 63-char
+  k8s limit for a long task name, so the re-gate could not run. Fixed jointly by
+  the semantic guard above and a `gateJobName` helper that truncates the task
+  portion, never the uniqueness suffix.)
 - **Non-coder / non-issue-fix tasks:** `maxEnvtestIterations` is consulted only
   where the envtest gate already runs (coder role, envtest-touched change).
   Every other role/kind path is untouched.
@@ -161,8 +172,13 @@ Unit tests inject a fake `runLoop` and a fake `EnvtestJobRunner`:
    after exactly `maxEnvtestIterations` retries, and no more.
 3. **NO-GO on retry:** the retry loop returns NO-GO -> that terminal surfaces,
    no further push.
-4. **Could-not-run:** `ran=false` -> GO stands, zero retries.
-5. **Cap resolution:** nil -> 1, explicit 0 -> no retry, N honored.
+4. **Could-not-run on attempt 0:** `ran=false` -> GO stands, zero retries.
+5. **Could-not-run on a retry:** attempt 0 fails, the re-gate returns
+   `ran=false` -> INCOMPLETE, never a false GO (regression for the cluster
+   validation finding).
+6. **Gate Job naming:** a long task name keeps the `-<unix-ms>` suffix within
+   the 63-char limit so a retry's gate Job does not collide with the prior one.
+7. **Cap resolution:** nil -> 1, explicit 0 -> no retry, N honored.
 
 Existing envtest-gate and executor tests must continue to pass unchanged for the
 attempt-0 path.

--- a/docs/proposals/768-envtest-feedback-loop.md
+++ b/docs/proposals/768-envtest-feedback-loop.md
@@ -1,0 +1,168 @@
+# Foreman envtest feedback loop (in-executor)
+
+**Issue:** #768 (envtest half of the cluster-backed gate feedback loop)
+**Date:** 2026-07-15
+**Status:** Approved design, pre-implementation
+
+## Problem
+
+The Foreman coder gate has two tiers. The fast in-workspace tier (fmt / vet /
+build / lint / unit tests, #749/#762) feeds failures back to the coder loop via
+the `VerifyTerminal` hook, so a coder iterates until those checks pass. The
+heavyweight tier, the post-push envtest gate (#859/#864), runs `make test`
+(envtest, `KUBEBUILDER_ASSETS`) in a clean-room Kubernetes Job on the pushed
+branch. That tier is **terminal**: `evaluatePostPushEnvtest` captures the gate
+failure output as `feedback`, but `envtestGateFailedResult` only downgrades the
+GO to INCOMPLETE (outcome `ENVTEST-GATE-FAILED`). The feedback goes nowhere.
+
+The consequence is structural. The coder cannot run envtest in its workspace
+(no cluster; the envtest trap of #734 shows it hangs), so on any change whose
+behavior only manifests against envtest-backed reconcile code, the coder gets
+exactly one blind shot: it writes the change, cannot verify it, submits GO, and
+the post-push gate fails with no path to iterate. Landing such a change today
+requires a human to re-dispatch the coder by hand with the gate output pasted
+in (observed repeatedly while landing the #1110 HF-revision slice).
+
+The re-dispatch machinery already exists but only for a different trigger:
+`workload_iteration.go` (#946) re-dispatches a coder on **reviewer NO-GO**, with
+the feedback distilled into `payload.prompt` and the prior attempt restored via
+`ReviseFromBranch`, bounded by `maxReviewIterations` (default 1). The envtest
+gate simply never feeds into it.
+
+## Goal
+
+Automate the manual loop: when the post-push envtest gate fails, feed the gate
+output back to the coder and let it iterate, bounded by a cap, before falling
+back to today's INCOMPLETE. Coverage is **universal** — it must work for every
+coder issue-fix task (issue-batch Workloads, hand-authored Pipeline Workloads,
+and bare AgenticTasks), not just the reconciler-synthesized issue-batch
+pipeline. That requirement places the loop in the executor, not the Workload
+controller.
+
+Non-goals (deferred to separate cycles): the e2e/kind gate tier (`make
+test-e2e` in a privileged Job); seed-transcript conversation continuity; a
+Workload-level override of the cap.
+
+## Approach
+
+An outer retry loop in `runLLMPath` (executor_native.go) wraps the existing
+commit -> push -> envtest-gate sequence. Attempt 0 is exactly today's behavior.
+On a gate failure with budget remaining, the executor re-runs a focused coder
+loop against the same still-live workspace with the gate output injected into
+the user prompt, then re-commits, force-pushes (force-with-lease), and re-gates.
+When the cap is exhausted it falls back to today's `envtestGateFailedResult`
+(INCOMPLETE). This inlines the proven #946 re-dispatch semantics so they apply
+to every Workload shape, at the cost of one small executor test seam.
+
+Rejected alternatives:
+- **Extend `VerifyTerminal` to run the envtest gate in-loop.** The verifier runs
+  pre-commit/pre-push in-workspace; the envtest gate needs a pushed branch
+  (the Job clones `repository@branch`). Unifying would move commit+push
+  ownership into the verify hook and force a push on every candidate terminal:
+  a large, risky refactor.
+- **Seed-transcript continuation.** Continue the same conversation across
+  retries for full context. Adds conversation-continuation plumbing to
+  `loop.Run` and cross-retry context-window management for little gain: the
+  live workspace plus the injected feedback already carry the state, which is
+  exactly what the proven reviewer re-dispatch provides.
+
+## Control flow
+
+`runLLMPath` currently runs, in sequence: `loop.Run` -> `repo.Commit` ->
+`repo.Push` -> `evaluatePostPushEnvtest` -> (fail) `envtestGateFailedResult`.
+The commit -> push -> gate span becomes a bounded loop:
+
+```
+attempt := 0
+for {
+    sha = repo.Commit(...)
+    repo.Push(..., ReplaceOnReject: attempt > 0 || payload.AllowOverwrite)
+    failed, feedback := evaluatePostPushEnvtest(...)
+    if !failed {
+        break                                  // GO path continues as today
+    }
+    if attempt >= maxEnvtestIterations {
+        return envtestGateFailedResult(..., feedback)   // INCOMPLETE, as today
+    }
+    attempt++
+    loopRes, loopErr = e.runLoop(ctx, retryCfg(cfg, feedback))  // focused re-run, same workspace
+    if loopErr != nil || !isGO(loopRes) {
+        return terminalFor(loopRes, loopErr)   // coder gave up / NO-GO; do not push failing work
+    }
+    // loop back: re-commit -> re-push -> re-gate
+}
+// on break: goResult + advisories + applyWorkClassPolicyForTask, unchanged
+```
+
+The coder-grounding and no-functional-change advisories and
+`applyWorkClassPolicyForTask` run once, after the loop settles on a GO, exactly
+as today. The workspace is not torn down between attempts (the executor owns it
+until it returns), so each retry amends the prior attempt's files in place.
+
+## Components
+
+- **Cap knob — `Agent.spec.maxEnvtestIterations *int32`.** Three-valued: nil ->
+  default 1; explicit 0 -> today's fail-on-first-gate-failure; N -> up to N
+  retries. Mirrors `Workload.spec.maxReviewIterations`. Agent-level (every task
+  has an Agent, including bare AgenticTasks) as required by universal coverage.
+  Requires `make manifests` + `make foreman-chart-crds` (and, per repo
+  convention, the CRD sync check).
+
+- **`envtestFeedbackPrompt(feedback string) string`.** Sibling to
+  `reviewFeedbackPrompt`. States that the envtest gate failed on the pushed
+  branch, that the prior work is already present in the workspace, that the coder
+  should amend it minimally to fix exactly the reported failures, followed by the
+  truncated gate log tail (reusing the existing gate-output truncation).
+
+- **`retryCfg(cfg LoopConfig, feedback string) LoopConfig`.** Returns a copy of
+  the resolved loop config with `UserPrompt` rebuilt as the original issue
+  context plus the `envtestFeedbackPrompt` section. Every other field (system
+  prompt, `VerifyTerminal` fast gate, model profile, budgets) is unchanged, so
+  the retry still runs behind the fast gate and the coder is not blind.
+
+- **`runLoop` seam.** A field on `NativeAgentLoopExecutor`,
+  `runLoop func(context.Context, LoopConfig) (*LoopResult, error)`, defaulting to
+  `loop.Run`. The initial call at line ~583 and the retry call both route through
+  it. This is the only loop-adjacent change and exists purely so tests can inject
+  a fake loop. No behavior change to `loop.Run` itself.
+
+## Data flow
+
+The gate output originates in the `EnvtestJobRunner.Run` return (`feedback`,
+the failing `make test` log tail), surfaces through `evaluatePostPushEnvtest`,
+is truncated and embedded into the retry's `UserPrompt` by `retryCfg` /
+`envtestFeedbackPrompt`, and reaches the model as the issue-context slot of the
+next focused loop. On cap exhaustion the final `feedback` still flows into
+`envtestGateFailedResult`'s status extra exactly as today.
+
+## Error handling and edges
+
+- **Coder NO-GO / MaxTurns on a retry:** return that terminal directly. The
+  executor never pushes work the coder itself did not GO. Bounded by the cap and
+  by each loop's own MaxTurns, so no unbounded spin.
+- **Gate could-not-run (`ran=false`):** unchanged. `evaluatePostPushEnvtest`
+  returns `failed=false`, the GO stands, no retry is spent on an infra hiccup.
+- **Non-coder / non-issue-fix tasks:** `maxEnvtestIterations` is consulted only
+  where the envtest gate already runs (coder role, envtest-touched change).
+  Every other role/kind path is untouched.
+- **Force-push safety:** retries push to the task's own branch with
+  `ReplaceOnReject` (force-with-lease), the same compare-and-swap the reviewer
+  re-dispatch uses; no unrelated ref is at risk.
+- **Transcript:** each attempt's transcript is persisted (WriteTranscript per
+  iteration). The returned result references the final attempt; earlier attempts
+  remain for audit.
+
+## Testing
+
+Unit tests inject a fake `runLoop` and a fake `EnvtestJobRunner`:
+
+1. **Converges:** gate fails once then passes -> exactly one retry, result GO.
+2. **Cap exhausted:** gate fails forever -> INCOMPLETE (`ENVTEST-GATE-FAILED`)
+   after exactly `maxEnvtestIterations` retries, and no more.
+3. **NO-GO on retry:** the retry loop returns NO-GO -> that terminal surfaces,
+   no further push.
+4. **Could-not-run:** `ran=false` -> GO stands, zero retries.
+5. **Cap resolution:** nil -> 1, explicit 0 -> no retry, N honored.
+
+Existing envtest-gate and executor tests must continue to pass unchanged for the
+attempt-0 path.

--- a/pkg/foreman/agent/envtest_feedback.go
+++ b/pkg/foreman/agent/envtest_feedback.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"fmt"
+
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
 
@@ -17,4 +19,35 @@ func effectiveMaxEnvtestIterations(agent *foremanv1alpha1.Agent) int {
 		return defaultMaxEnvtestIterations
 	}
 	return int(*agent.Spec.MaxEnvtestIterations)
+}
+
+// envtestFeedbackPrompt renders the retry coder prompt after a post-push
+// envtest gate failure (#768). Sibling to reviewFeedbackPrompt: it states
+// that the gate failed on the pushed branch, that the prior work is
+// already present in the workspace, and that the coder should amend it
+// minimally, then appends the truncated gate log tail. It repeats the
+// no-envtest-in-workspace directive because running envtest here hangs.
+func envtestFeedbackPrompt(feedback string) string {
+	return fmt.Sprintf(
+		"The post-push envtest gate failed on your pushed branch (verdict GATE-FAIL).\n"+
+			"Your workspace already contains your previous attempt: its files and history\n"+
+			"are present. Do not rebuild the fix from scratch. Amend the existing work with\n"+
+			"the smallest changes that make the failing envtest checks pass, then finish.\n"+
+			"Do not run envtest, `make test`, or `go test ./internal/controller/...` here\n"+
+			"(this workspace cannot run envtest and it will hang); only `go build ./...`.\n"+
+			"\nGate output:\n%s\n",
+		truncateGateOutput(feedback))
+}
+
+// retryCfg returns a copy of the resolved loop config for a post-push
+// envtest gate retry (#768): the user prompt becomes the original issue
+// context (base.UserPrompt) plus the gate feedback section, so the retry
+// runs with the failure in front of it instead of blind. Every other
+// field (system prompt, VerifyTerminal fast gate, model profile, budgets)
+// is unchanged. The base is copied by value, so the caller's config is not
+// mutated.
+func retryCfg(base LoopConfig, feedback string) LoopConfig {
+	cfg := base
+	cfg.UserPrompt = base.UserPrompt + "\n\n" + envtestFeedbackPrompt(feedback)
+	return cfg
 }

--- a/pkg/foreman/agent/envtest_feedback.go
+++ b/pkg/foreman/agent/envtest_feedback.go
@@ -1,0 +1,20 @@
+package agent
+
+import (
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// defaultMaxEnvtestIterations is the retry bound used when
+// Agent.spec.maxEnvtestIterations is unset. One mirrors a single human
+// "the gate failed, fix it" round; an explicit 0 opts back into the
+// pre-#768 fail-on-first-gate-failure behavior.
+const defaultMaxEnvtestIterations = 1
+
+// effectiveMaxEnvtestIterations resolves the *int32 three-state: nil (or
+// a nil agent) defaults; explicit values (including 0) win.
+func effectiveMaxEnvtestIterations(agent *foremanv1alpha1.Agent) int {
+	if agent == nil || agent.Spec.MaxEnvtestIterations == nil {
+		return defaultMaxEnvtestIterations
+	}
+	return int(*agent.Spec.MaxEnvtestIterations)
+}

--- a/pkg/foreman/agent/envtest_feedback_test.go
+++ b/pkg/foreman/agent/envtest_feedback_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"testing"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func i32p(v int32) *int32 { return &v }
+
+func TestEffectiveMaxEnvtestIterations(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *int32
+		want int
+	}{
+		{"nil defaults to 1", nil, 1},
+		{"explicit 0 opts out", i32p(0), 0},
+		{"explicit N honored", i32p(3), 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &foremanv1alpha1.Agent{}
+			a.Spec.MaxEnvtestIterations = tc.in
+			if got := effectiveMaxEnvtestIterations(a); got != tc.want {
+				t.Fatalf("got %d want %d", got, tc.want)
+			}
+		})
+	}
+	t.Run("nil agent defaults to 1", func(t *testing.T) {
+		if got := effectiveMaxEnvtestIterations(nil); got != 1 {
+			t.Fatalf("got %d want 1", got)
+		}
+	})
+}

--- a/pkg/foreman/agent/envtest_feedback_test.go
+++ b/pkg/foreman/agent/envtest_feedback_test.go
@@ -39,9 +39,9 @@ func TestEnvtestFeedbackPrompt(t *testing.T) {
 	got := envtestFeedbackPrompt("controller_test.go:42 Expected true got false")
 	for _, want := range []string{
 		"envtest gate failed",
-		"already contains",           // points the coder at its prior work
-		"go build ./...",             // the only self-check allowed here
-		"controller_test.go:42",      // the gate output is embedded
+		"already contains",      // points the coder at its prior work
+		"go build ./...",        // the only self-check allowed here
+		"controller_test.go:42", // the gate output is embedded
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("prompt missing %q; got:\n%s", want, got)

--- a/pkg/foreman/agent/envtest_feedback_test.go
+++ b/pkg/foreman/agent/envtest_feedback_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
@@ -32,4 +33,42 @@ func TestEffectiveMaxEnvtestIterations(t *testing.T) {
 			t.Fatalf("got %d want 1", got)
 		}
 	})
+}
+
+func TestEnvtestFeedbackPrompt(t *testing.T) {
+	got := envtestFeedbackPrompt("controller_test.go:42 Expected true got false")
+	for _, want := range []string{
+		"envtest gate failed",
+		"already contains",           // points the coder at its prior work
+		"go build ./...",             // the only self-check allowed here
+		"controller_test.go:42",      // the gate output is embedded
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("prompt missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestRetryCfgAppendsFeedbackAndPreservesFields(t *testing.T) {
+	base := LoopConfig{
+		SystemPrompt:     "sys",
+		UserPrompt:       "ORIGINAL ISSUE CONTEXT",
+		MaxTurns:         50,
+		MaxVerifyRetries: 3,
+	}
+	out := retryCfg(base, "GATE OUTPUT HERE")
+
+	if !strings.HasPrefix(out.UserPrompt, "ORIGINAL ISSUE CONTEXT") {
+		t.Fatalf("retry prompt dropped the original issue context: %q", out.UserPrompt)
+	}
+	if !strings.Contains(out.UserPrompt, "GATE OUTPUT HERE") {
+		t.Fatalf("retry prompt missing the gate feedback")
+	}
+	if out.SystemPrompt != base.SystemPrompt || out.MaxTurns != base.MaxTurns ||
+		out.MaxVerifyRetries != base.MaxVerifyRetries {
+		t.Fatalf("retryCfg mutated a non-prompt field: %+v", out)
+	}
+	if base.UserPrompt != "ORIGINAL ISSUE CONTEXT" {
+		t.Fatalf("retryCfg mutated the base config in place")
+	}
 }

--- a/pkg/foreman/agent/envtest_gate.go
+++ b/pkg/foreman/agent/envtest_gate.go
@@ -26,26 +26,46 @@ type EnvtestJobRunner interface {
 	) (pass bool, ran bool, feedback string)
 }
 
-// evaluatePostPushEnvtest decides whether a pushed GO should be downgraded
-// because its envtest packages fail in the clean-room gate Job. It returns
-// (failed, feedback): failed is true ONLY when the change touched an envtest
-// package, the Job ran, and it did not pass. A nil runner, an untouched
-// change, or a could-not-run (ran=false) never downgrades.
+// envtestGateVerdict is the outcome of one post-push envtest gate attempt.
+type envtestGateVerdict int
+
+const (
+	// envtestGateOK: the gate passed, the change touched no envtest package,
+	// or no runner is wired. The GO may stand.
+	envtestGateOK envtestGateVerdict = iota
+	// envtestGateFailed: the gate ran and at least one check failed. Feed the
+	// output back and retry, or downgrade at the iteration bound.
+	envtestGateFailed
+	// envtestGateUnverified: the change touched an envtest package and a runner
+	// is wired, but the gate could not be run to a verdict (Job submit/poll
+	// error, name collision, timeout). On the FIRST attempt the GO stands (the
+	// pre-#768 could-not-verify behavior). On a retry it must NOT: a prior
+	// attempt already failed the gate, so an unverifiable re-gate cannot confirm
+	// the fix, and letting it stand emits a false GO (#768 validation).
+	envtestGateUnverified
+)
+
+// evaluatePostPushEnvtest classifies the post-push envtest gate for one
+// attempt. It returns (verdict, feedback): envtestGateFailed carries the log
+// tail; envtestGateOK covers pass / untouched / nil-runner; envtestGateUnverified
+// means the gate could not be run to a verdict. The caller decides what an
+// unverified gate means by attempt number (GO stands on attempt 0, not on a
+// retry).
 func evaluatePostPushEnvtest(
 	ctx context.Context,
 	envtestTouched bool,
 	runner EnvtestJobRunner,
 	taskNamespace, taskName, repository, branch, cloneURL string,
-) (failed bool, feedback string) {
+) (envtestGateVerdict, string) {
 	if !envtestTouched || runner == nil {
-		return false, ""
+		return envtestGateOK, ""
 	}
 	pass, ran, fb := runner.Run(ctx, taskNamespace, taskName, repository, branch, cloneURL)
 	if !ran {
-		return false, ""
+		return envtestGateUnverified, ""
 	}
 	if !pass {
-		return true, fb
+		return envtestGateFailed, fb
 	}
-	return false, ""
+	return envtestGateOK, ""
 }

--- a/pkg/foreman/agent/envtest_gate_test.go
+++ b/pkg/foreman/agent/envtest_gate_test.go
@@ -24,38 +24,38 @@ func (f *fakeEnvtestJobRunner) Run(_ context.Context, taskNamespace, taskName, _
 }
 
 func TestEvaluatePostPushEnvtest(t *testing.T) {
-	t.Run("not touched: runner not called, no downgrade", func(t *testing.T) {
+	t.Run("not touched: runner not called, verdict OK", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{}
-		failed, fb := evaluatePostPushEnvtest(context.Background(), false, r, "ns", "task", "repo", "br", "url")
-		if failed || fb != "" || r.called {
-			t.Fatalf("got failed=%v fb=%q called=%v", failed, fb, r.called)
+		v, fb := evaluatePostPushEnvtest(context.Background(), false, r, "ns", "task", "repo", "br", "url")
+		if v != envtestGateOK || fb != "" || r.called {
+			t.Fatalf("got verdict=%v fb=%q called=%v", v, fb, r.called)
 		}
 	})
-	t.Run("nil runner: no downgrade", func(t *testing.T) {
-		failed, fb := evaluatePostPushEnvtest(context.Background(), true, nil, "ns", "task", "repo", "br", "url")
-		if failed || fb != "" {
-			t.Fatalf("got failed=%v fb=%q", failed, fb)
+	t.Run("nil runner: verdict OK", func(t *testing.T) {
+		v, fb := evaluatePostPushEnvtest(context.Background(), true, nil, "ns", "task", "repo", "br", "url")
+		if v != envtestGateOK || fb != "" {
+			t.Fatalf("got verdict=%v fb=%q", v, fb)
 		}
 	})
-	t.Run("touched + pass: no downgrade", func(t *testing.T) {
+	t.Run("touched + pass: verdict OK", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: true, ran: true}
-		failed, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
-		if failed || !r.called {
-			t.Fatalf("got failed=%v called=%v", failed, r.called)
+		v, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
+		if v != envtestGateOK || !r.called {
+			t.Fatalf("got verdict=%v called=%v", v, r.called)
 		}
 	})
-	t.Run("touched + ran + fail: downgrade with feedback", func(t *testing.T) {
+	t.Run("touched + ran + fail: verdict Failed with feedback", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: false, ran: true, feedback: "envtest broke"}
-		failed, fb := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
-		if !failed || fb != "envtest broke" {
-			t.Fatalf("got failed=%v fb=%q", failed, fb)
+		v, fb := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
+		if v != envtestGateFailed || fb != "envtest broke" {
+			t.Fatalf("got verdict=%v fb=%q", v, fb)
 		}
 	})
-	t.Run("touched + could-not-run: no downgrade (GO stands)", func(t *testing.T) {
+	t.Run("touched + could-not-run: verdict Unverified (caller decides by attempt)", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: false, ran: false, feedback: "infra"}
-		failed, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
-		if failed {
-			t.Fatalf("could-not-run should not downgrade; got failed=%v", failed)
+		v, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
+		if v != envtestGateUnverified {
+			t.Fatalf("could-not-run should be Unverified; got verdict=%v", v)
 		}
 	})
 	t.Run("task identity is threaded to the runner (#893)", func(t *testing.T) {

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -586,37 +586,8 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		log.Error(twErr, "transcript write failed; continuing")
 	}
 
-	if loopErr != nil {
-		switch {
-		case errors.Is(loopErr, ErrMaxTurnsExhausted):
-			return e.incompleteResult(start, transcriptRef, loopRes,
-				foremanv1alpha1.FailureMaxTurnsExhausted,
-				"model did not call submit_result within max_turns"), nil
-		case errors.Is(loopErr, ErrAssistantNoToolCalls):
-			return e.incompleteResult(start, transcriptRef, loopRes,
-				foremanv1alpha1.FailureModelMisunderstood,
-				"model returned text without tool_calls; loop cannot make progress"), nil
-		case errors.Is(loopErr, ErrAssistantReasoningOnly):
-			// A thinking model that exhausted its reasoning-only budget
-			// (#650/#651) is a model behavior outcome, not an
-			// infrastructure failure: record INCOMPLETE and persist the
-			// transcript (the reasoning trace is the evidence an
-			// operator needs) instead of bubbling an ExecutorError that
-			// drops both.
-			return e.incompleteResult(start, transcriptRef, loopRes,
-				foremanv1alpha1.FailureModelMisunderstood,
-				"model exhausted its reasoning-only budget without emitting a tool call"), nil
-		case errors.Is(loopErr, context.Canceled), errors.Is(loopErr, context.DeadlineExceeded):
-			return e.incompleteResult(start, transcriptRef, loopRes,
-				foremanv1alpha1.FailureTimeout,
-				loopErr.Error()), nil
-		default:
-			// Anything else is a system / transport failure: bubble up
-			// as an error so the watcher records ExecutorError. The
-			// watcher's execErr path tags this as InfrastructureError
-			// via the FailureReason mapping in patchTerminal.
-			return nil, loopErr
-		}
+	if r, err := e.mapLoopError(start, transcriptRef, loopRes, loopErr); r != nil || err != nil {
+		return r, err
 	}
 
 	if loopRes.Terminal == nil {
@@ -1731,6 +1702,48 @@ func (e *NativeAgentLoopExecutor) envtestGateFailedResult(
 		"turnCount":     lr.Turns,
 	}
 	return r
+}
+
+// mapLoopError converts a loop.Run error into the Result the initial and
+// retry paths both return. It returns (nil, nil) when loopErr is nil (the
+// caller proceeds to inspect the terminal); (result, nil) for a
+// model-behavior outcome recorded as INCOMPLETE; and (nil, loopErr) for a
+// system/transport failure the caller must bubble so the watcher records
+// ExecutorError.
+func (e *NativeAgentLoopExecutor) mapLoopError(
+	start time.Time, tref corev1.ObjectReference, lr *LoopResult, loopErr error,
+) (*Result, error) {
+	if loopErr == nil {
+		return nil, nil
+	}
+	switch {
+	case errors.Is(loopErr, ErrMaxTurnsExhausted):
+		return e.incompleteResult(start, tref, lr,
+			foremanv1alpha1.FailureMaxTurnsExhausted,
+			"model did not call submit_result within max_turns"), nil
+	case errors.Is(loopErr, ErrAssistantNoToolCalls):
+		return e.incompleteResult(start, tref, lr,
+			foremanv1alpha1.FailureModelMisunderstood,
+			"model returned text without tool_calls; loop cannot make progress"), nil
+	case errors.Is(loopErr, ErrAssistantReasoningOnly):
+		// A thinking model that exhausted its reasoning-only budget
+		// (#650/#651) is a model behavior outcome, not an infrastructure
+		// failure: record INCOMPLETE and persist the transcript (the
+		// reasoning trace is the evidence an operator needs) instead of
+		// bubbling an ExecutorError that drops both.
+		return e.incompleteResult(start, tref, lr,
+			foremanv1alpha1.FailureModelMisunderstood,
+			"model exhausted its reasoning-only budget without emitting a tool call"), nil
+	case errors.Is(loopErr, context.Canceled), errors.Is(loopErr, context.DeadlineExceeded):
+		return e.incompleteResult(start, tref, lr,
+			foremanv1alpha1.FailureTimeout, loopErr.Error()), nil
+	default:
+		// Anything else is a system / transport failure: bubble up as an
+		// error so the watcher records ExecutorError. The watcher's execErr
+		// path tags this as InfrastructureError via the FailureReason
+		// mapping in patchTerminal.
+		return nil, loopErr
+	}
 }
 
 // resolveUpstreamForRun mirrors the resolveUpstream selection used at

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -758,7 +758,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// that does not GO its own fix surfaces that terminal without pushing.
 		var loopErr error
 		loopRes, loopErr = loop.Run(ctx, retryCfg(cfg, feedback))
-		transcriptRef, _ = WriteTranscript(ctx, e.Client, task, loopRes)
+		transcriptRef, twErr := WriteTranscript(ctx, e.Client, task, loopRes)
+		if twErr != nil {
+			log.Error(twErr, "transcript write failed; continuing")
+		}
 		if r, err := e.mapLoopError(start, transcriptRef, loopRes, loopErr); r != nil || err != nil {
 			return r, err
 		}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -733,22 +733,18 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		}
 		sha = attemptSHA
 
-		// Post-push envtest gate (#859): verify envtest-backed packages in a
-		// clean-room Job on the now-pushed branch. A gate green, a could-not-run
-		// (ran=false), or an untouched change all leave the GO standing.
-		failed, feedback := evaluatePostPushEnvtest(
-			ctx, envtestTouched, e.EnvtestJobRunner,
-			task.Namespace, task.Name,
-			task.Spec.Payload.Repo, branch, e.GitRemoteURL,
-		)
-		if !failed {
+		// Post-push envtest gate (#859/#768): run the gate and classify this
+		// attempt. settled -> the GO stands; done != nil -> a terminal downgrade
+		// (an unverifiable retry or the bound exhausted); otherwise retry the
+		// coder with feedback.
+		settled, done, feedback := e.postPushGateDecision(
+			ctx, envtestTouched, task, branch, sha, attempt, maxEnvtestIters,
+			start, transcriptRef, loopRes, gateAdvisories)
+		if settled {
 			break
 		}
-		if attempt >= maxEnvtestIters {
-			// Bound exhausted: fall back to the pre-#768 downgrade (#859).
-			r := e.envtestGateFailedResult(start, transcriptRef, loopRes, branch, sha, feedback)
-			attachGateAdvisories(r.Extra, gateAdvisories)
-			return r, nil
+		if done != nil {
+			return done, nil
 		}
 
 		// Retry (#768): re-run the coder against the same workspace with the
@@ -801,6 +797,59 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	attachGateAdvisories(r.Extra, gateAdvisories)
 	r = e.applyWorkClassPolicyForTask(ctx, log, task, agent, workspace, evidenceBaseSHA, loopRes, r)
 	return r, nil
+}
+
+// postPushGateDecision runs the post-push envtest gate for one attempt and
+// classifies the result into exactly one of three outcomes for the #768 retry
+// loop: settle as GO (settled=true), terminate with a downgrade Result
+// (done != nil), or retry the coder (settled=false, done=nil, feedback carries
+// the gate output). Extracted from runLLMPath so it stays under the gocyclo
+// ceiling and the two downgrade sites share one construction.
+//
+// A gate that passed, was skipped (untouched change / no runner), or -- on the
+// FIRST attempt only -- could not be verified settles as GO (attempt 0 is the
+// pre-#768 could-not-verify behavior, byte-identical). A could-not-verify gate
+// on a RETRY does NOT settle: a prior attempt already failed the gate and the
+// coder cannot fix an infra/collision failure, so it downgrades rather than
+// emit a false GO (the #768 validation caught a retry gate Job name collision
+// landing a failing branch as GO). A failed gate retries until the bound, then
+// downgrades.
+func (e *NativeAgentLoopExecutor) postPushGateDecision(
+	ctx context.Context, envtestTouched bool, task *foremanv1alpha1.AgenticTask,
+	branch, sha string, attempt, maxEnvtestIters int,
+	start time.Time, transcriptRef corev1.ObjectReference, loopRes *LoopResult,
+	gateAdvisories *[]advisory,
+) (settled bool, done *Result, feedback string) {
+	gate, fb := evaluatePostPushEnvtest(
+		ctx, envtestTouched, e.EnvtestJobRunner,
+		task.Namespace, task.Name,
+		task.Spec.Payload.Repo, branch, e.GitRemoteURL,
+	)
+	if gate == envtestGateOK || (gate == envtestGateUnverified && attempt == 0) {
+		return true, nil, ""
+	}
+	if gate == envtestGateUnverified {
+		return false, e.envtestGateDowngrade(start, transcriptRef, loopRes, branch, sha,
+			"envtest re-gate could not be run to a verdict; not landing an unverified retry",
+			gateAdvisories), ""
+	}
+	// gate == envtestGateFailed.
+	if attempt >= maxEnvtestIters {
+		return false, e.envtestGateDowngrade(start, transcriptRef, loopRes, branch, sha, fb, gateAdvisories), ""
+	}
+	return false, nil, fb
+}
+
+// envtestGateDowngrade builds the INCOMPLETE / ENVTEST-GATE-FAILED result with
+// gate advisories attached, shared by the unverified-retry and bound-exhausted
+// downgrade sites in postPushGateDecision.
+func (e *NativeAgentLoopExecutor) envtestGateDowngrade(
+	start time.Time, transcriptRef corev1.ObjectReference, loopRes *LoopResult,
+	branch, sha, feedback string, gateAdvisories *[]advisory,
+) *Result {
+	r := e.envtestGateFailedResult(start, transcriptRef, loopRes, branch, sha, feedback)
+	attachGateAdvisories(r.Extra, gateAdvisories)
+	return r
 }
 
 // commitPushAttempt settles the working tree, commits the current terminal's

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -711,60 +711,80 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		return r, nil
 	}
 
-	// 10. GO verdict: check for changes first, then commit + push. If
-	// the model emitted GO but never edited a file, NO-CHANGES is the
-	// honest outcome regardless of whether commit_message was set.
+	// 10. GO verdict: settle the working tree, then commit -> push -> envtest
+	// gate. On a gate failure, re-run the coder against the same live
+	// workspace with the gate output injected and re-commit / re-push /
+	// re-gate, bounded by the resolved iteration count (#768). Attempt 0 is
+	// the pre-#768 behavior byte-for-byte; exhausting the bound falls back to
+	// the pre-#768 ENVTEST-GATE-FAILED downgrade.
 	baseBranch := baseBranchOrDefault(task.Spec.Payload.BaseBranch)
-	hasChanges, hcErr := repo.HasChanges(ctx, workspace)
-	if hcErr != nil {
-		return e.commitRejectedResult(start, transcriptRef, loopRes, branch, hcErr), nil
+	maxEnvtestIters := effectiveMaxEnvtestIterations(agent)
+	var sha string
+	for attempt := 0; ; attempt++ {
+		// Settle the working tree and commit -> push this attempt. A non-nil
+		// done ends the task with the pre-#768 outcome (no-change, commit
+		// rejected, or push failed); it is byte-identical to the linear path
+		// on attempt 0.
+		attemptSHA, envtestTouched, done := e.commitPushAttempt(
+			ctx, log, task, workspace, branch, baseBranch, auth,
+			attempt, task.Spec.Payload.AllowOverwrite, start, transcriptRef, loopRes)
+		if done != nil {
+			return done, nil
+		}
+		sha = attemptSHA
+
+		// Post-push envtest gate (#859): verify envtest-backed packages in a
+		// clean-room Job on the now-pushed branch. A gate green, a could-not-run
+		// (ran=false), or an untouched change all leave the GO standing.
+		failed, feedback := evaluatePostPushEnvtest(
+			ctx, envtestTouched, e.EnvtestJobRunner,
+			task.Namespace, task.Name,
+			task.Spec.Payload.Repo, branch, e.GitRemoteURL,
+		)
+		if !failed {
+			break
+		}
+		if attempt >= maxEnvtestIters {
+			// Bound exhausted: fall back to the pre-#768 downgrade (#859).
+			r := e.envtestGateFailedResult(start, transcriptRef, loopRes, branch, sha, feedback)
+			attachGateAdvisories(r.Extra, gateAdvisories)
+			return r, nil
+		}
+
+		// Retry (#768): re-run the coder against the same workspace with the
+		// gate output injected, persist the new transcript, then loop back to
+		// re-commit / re-push / re-gate. A retry loop that fails structurally
+		// (max turns, no tool call, timeout) surfaces via mapLoopError; a retry
+		// that does not GO its own fix surfaces that terminal without pushing.
+		var loopErr error
+		loopRes, loopErr = loop.Run(ctx, retryCfg(cfg, feedback))
+		transcriptRef, _ = WriteTranscript(ctx, e.Client, task, loopRes)
+		if r, err := e.mapLoopError(start, transcriptRef, loopRes, loopErr); r != nil || err != nil {
+			return r, err
+		}
+		if loopRes.Terminal == nil {
+			return e.incompleteResult(start, transcriptRef, loopRes,
+				foremanv1alpha1.FailureInfrastructureError,
+				"retry loop returned nil error but no terminal result"), nil
+		}
+		verdict, normReason := normalizeModelVerdict(loopRes.Terminal.Verdict)
+		if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+			return e.retryCoderTerminalResult(ctx, log, agent, task,
+				workspace, branch, auth, start, transcriptRef, loopRes, verdict, normReason), nil
+		}
 	}
 
-	// #982: tolerate a model that self-committed its work. If the working tree
-	// is clean but there are commits ahead of the resolved upstream base on
-	// this branch, recover them by soft-resetting into the working tree so
-	// repo.Commit can re-apply with DCO sign-off and executor-owned author
-	// identity. This prevents false NO-GO ("no diff") outcomes when a model
-	// runs git commit before calling submit_result instead of leaving changes
-	// uncommitted for the executor. The base is the upstream tip at the time
-	// the branch was cut (per #813), not a possibly-stale local ref, so we
-	// don't accidentally re-stage intervening upstream commits.
-	if e.recoverSelfCommitsOrNoChange(
-		ctx, log, hasChanges, workspace,
-		e.resolveUpstreamForRun(task), baseBranch,
-	) {
-		return e.noChangesResult(start, transcriptRef, loopRes, branch), nil
-	}
-
-	// Whether the change touches an envtest-backed package, captured before
-	// the commit clears the working-tree status. Used for the post-push gate.
-	envtestTouched := len(changedEnvtestPackages(ctx, workspace, execCommandRunner)) > 0
-
-	sha, commitErr := repo.Commit(ctx, repo.CommitOptions{
-		Workspace: workspace,
-		Message:   loopRes.Terminal.CommitMessage,
-		Author:    e.CommitAuthor,
-		Committer: e.CommitCommitter,
-	})
-	if errors.Is(commitErr, repo.ErrNothingToCommit) {
-		// Model said GO but never edited anything. Honest report: this
-		// is a NO-CHANGES outcome, NOT a GO. The autofix pipeline saw
-		// this often enough to deserve a distinct outcome string.
-		return e.noChangesResult(start, transcriptRef, loopRes, branch), nil
-	}
-	if commitErr != nil {
-		return e.commitRejectedResult(start, transcriptRef, loopRes, branch, commitErr), nil
-	}
-
+	// Loop settled on a GO. The grounding + no-functional-change advisories
+	// and the work-class policy run once against the final committed attempt.
+	//
 	// Coder grounding rail (v1, non-blocking): flag any external metric
 	// identifier the coder wrote that contradicts the context7 docs it
 	// retrieved this run. MUST run after repo.Commit: the rail reads the
-	// committed diff (base...HEAD), and until the commit above the coder's
-	// edits are uncommitted (the #982 self-commit recovery soft-resets them
-	// into the working tree), so a pre-commit base...HEAD is empty and the
-	// rail sees nothing. Records-and-logs onto loopRes.Terminal.Extra (which
-	// goResult/the downgrade results serialize into status extra.modelExtra);
-	// never changes the verdict.
+	// committed diff (base...HEAD); before the commit the coder's edits are
+	// uncommitted (the #982 self-commit recovery soft-resets them into the
+	// working tree), so a pre-commit base...HEAD is empty and the rail sees
+	// nothing. Records-and-logs onto loopRes.Terminal.Extra (which goResult
+	// serializes into status extra.modelExtra); never changes the verdict.
 	applyCoderGroundingRailForTask(ctx, log, task, workspace, loopRes)
 
 	// No-functional-change advisory (non-blocking): flag a GO whose committed
@@ -774,38 +794,111 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// as the grounding rail; records-and-logs, never changes the verdict.
 	applyNoFunctionalChangeForTask(ctx, log, task, workspace, loopRes)
 
-	if err := repo.Push(ctx, repo.PushOptions{
-		Workspace: workspace,
-		Branch:    branch,
-		Auth:      auth,
-		// Opt-in via Workload.spec.allowOverwrite (stamped onto the task
-		// payload): replace a stale ref for this task's own branch
-		// (compare-and-swap via force-with-lease) instead of failing the
-		// re-run non-fast-forward (#934). Off by default per #573 — a
-		// replaced ref can carry a previously-GO'd audit artifact, so
-		// the caller that re-runs Workloads makes that call explicitly.
-		ReplaceOnReject: task.Spec.Payload.AllowOverwrite,
-	}); err != nil {
-		return e.pushFailedResult(start, transcriptRef, loopRes, branch, sha, err), nil
-	}
-
-	// Post-push envtest gate (#859): verify envtest-backed packages in a
-	// clean-room Job on the now-pushed branch. A real failure downgrades the
-	// GO to INCOMPLETE; a could-not-run leaves the GO standing.
-	if failed, feedback := evaluatePostPushEnvtest(
-		ctx, envtestTouched, e.EnvtestJobRunner,
-		task.Namespace, task.Name,
-		task.Spec.Payload.Repo, branch, e.GitRemoteURL,
-	); failed {
-		r := e.envtestGateFailedResult(start, transcriptRef, loopRes, branch, sha, feedback)
-		attachGateAdvisories(r.Extra, gateAdvisories)
-		return r, nil
-	}
-
 	r := e.goResult(start, transcriptRef, loopRes, branch, sha)
 	attachGateAdvisories(r.Extra, gateAdvisories)
 	r = e.applyWorkClassPolicyForTask(ctx, log, task, agent, workspace, evidenceBaseSHA, loopRes, r)
 	return r, nil
+}
+
+// commitPushAttempt settles the working tree, commits the current terminal's
+// change with the executor's identity + DCO sign-off, and pushes the branch.
+// It returns the commit SHA, whether the change touched an envtest-backed
+// package (captured before the commit clears the working-tree status), and a
+// non-nil done Result when the attempt terminates the task early (no diff,
+// commit rejected, or push failed). Extracted from runLLMPath so the #768
+// retry loop stays under the gocyclo ceiling; attempt 0 is byte-identical to
+// the pre-#768 linear commit -> push path (the only new input is attempt,
+// which flips ReplaceOnReject on for a retry that supersedes its predecessor).
+func (e *NativeAgentLoopExecutor) commitPushAttempt(
+	ctx context.Context, log logr.Logger, task *foremanv1alpha1.AgenticTask,
+	workspace, branch, baseBranch string, auth *repo.Auth,
+	attempt int, allowOverwrite bool,
+	start time.Time, tref corev1.ObjectReference, lr *LoopResult,
+) (sha string, envtestTouched bool, done *Result) {
+	// If the model emitted GO but never edited a file, NO-CHANGES is the
+	// honest outcome regardless of whether commit_message was set.
+	hasChanges, hcErr := repo.HasChanges(ctx, workspace)
+	if hcErr != nil {
+		return "", false, e.commitRejectedResult(start, tref, lr, branch, hcErr)
+	}
+
+	// #982: tolerate a model that self-committed its work. If the working
+	// tree is clean but there are commits ahead of the resolved upstream base
+	// on this branch, recover them by soft-resetting into the working tree so
+	// repo.Commit can re-apply with DCO sign-off and executor-owned author
+	// identity. This prevents false NO-GO ("no diff") outcomes when a model
+	// runs git commit before calling submit_result instead of leaving changes
+	// uncommitted for the executor. The base is the upstream tip at the time
+	// the branch was cut (per #813), not a possibly-stale local ref, so we
+	// don't accidentally re-stage intervening upstream commits. On a retry it
+	// also folds the prior attempt's already-committed change back into the
+	// working tree so the re-commit below re-applies it alongside the coder's
+	// amendment.
+	if e.recoverSelfCommitsOrNoChange(
+		ctx, log, hasChanges, workspace,
+		e.resolveUpstreamForRun(task), baseBranch,
+	) {
+		return "", false, e.noChangesResult(start, tref, lr, branch)
+	}
+
+	envtestTouched = len(changedEnvtestPackages(ctx, workspace, execCommandRunner)) > 0
+
+	sha, commitErr := repo.Commit(ctx, repo.CommitOptions{
+		Workspace: workspace,
+		Message:   lr.Terminal.CommitMessage,
+		Author:    e.CommitAuthor,
+		Committer: e.CommitCommitter,
+	})
+	if errors.Is(commitErr, repo.ErrNothingToCommit) {
+		// Model said GO but never edited anything. Honest report: this is a
+		// NO-CHANGES outcome, NOT a GO. The autofix pipeline saw this often
+		// enough to deserve a distinct outcome string.
+		return "", envtestTouched, e.noChangesResult(start, tref, lr, branch)
+	}
+	if commitErr != nil {
+		return "", envtestTouched, e.commitRejectedResult(start, tref, lr, branch, commitErr)
+	}
+
+	if err := repo.Push(ctx, repo.PushOptions{
+		Workspace: workspace,
+		Branch:    branch,
+		Auth:      auth,
+		// A retry replaces this task's own branch (compare-and-swap via
+		// force-with-lease) because it supersedes the attempt it just
+		// re-gated. Attempt 0 honors the caller's opt-in as before: opt-in via
+		// Workload.spec.allowOverwrite (#934), off by default per #573 since a
+		// replaced ref can carry a previously-GO'd audit artifact.
+		ReplaceOnReject: attempt > 0 || allowOverwrite,
+	}); err != nil {
+		return sha, envtestTouched, e.pushFailedResult(start, tref, lr, branch, sha, err)
+	}
+
+	return sha, envtestTouched, nil
+}
+
+// retryCoderTerminalResult builds the Result for a #768 envtest retry whose
+// coder loop did not GO its fix (a NO-GO / INCOMPLETE / ERROR terminal). It
+// never pushes work the coder did not stand behind: it records the model's
+// terminal, preserves a gate-failed branch and (for the reviewer-only PR
+// case) opens a PR under the same rules the initial non-GO path uses, and
+// carries the normalized failure reason through. Coder-role only in
+// practice (the retry loop is unreachable for read-only reviewers), so no
+// reviewer rails run here. Pulled out as a method so runLLMPath stays under
+// the gocyclo ceiling, mirroring applyWorkClassPolicyForTask above.
+func (e *NativeAgentLoopExecutor) retryCoderTerminalResult(
+	ctx context.Context, log logr.Logger,
+	agent *foremanv1alpha1.Agent, task *foremanv1alpha1.AgenticTask,
+	workspace, branch string, auth *repo.Auth,
+	start time.Time, tref corev1.ObjectReference, lr *LoopResult,
+	verdict foremanv1alpha1.AgenticTaskVerdict, normReason foremanv1alpha1.AgenticTaskFailureReason,
+) *Result {
+	r := e.modelDecidedResult(start, tref, lr, verdict)
+	e.maybePreserveGateFailedBranch(ctx, log, agent, task, workspace, branch, auth, lr, r)
+	e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r)
+	if normReason != "" && r.FailureReason == "" {
+		r.FailureReason = normReason
+	}
+	return r
 }
 
 // applyWorkClassPolicyForTask applies the work-class GO/NEEDS-VERIFICATION

--- a/pkg/foreman/agent/executor_native_envtest_loop_test.go
+++ b/pkg/foreman/agent/executor_native_envtest_loop_test.go
@@ -150,35 +150,76 @@ func envtestLoopExecutor(
 	}
 }
 
-// The gate fails on attempt 0; with the default bound (1) the executor
-// re-runs the coder against the same workspace and re-gates, which passes,
-// so the task settles GO after exactly two gate calls.
-func TestNativeExecutor_EnvtestLoop_ConvergesAfterOneRetry(t *testing.T) {
+// envtestLoopCase configures one end-to-end envtest-loop scenario. run drives
+// it to a terminal Result so each test body is just its inputs and assertions.
+type envtestLoopCase struct {
+	name        string
+	maxEnvtest  *int32   // nil -> default bound (1 retry)
+	oaiBodies   []string // scripted chat-completions, in order
+	regVerdicts []string // submit_result verdict per coder pass
+	gate        []envtestGateResult
+}
+
+func (tc envtestLoopCase) run(t *testing.T) (*foremanagent.Result, int) {
+	t.Helper()
 	gitOrSkip(t)
 	root := t.TempDir()
 	bare := initBareWithSeed(t, root)
-	oaiSrv := scriptedOAI(t, []string{submitGoBody}) // GO on every turn
-	agent, task := taskAndAgent("envtest-converge")
-
+	oaiSrv := scriptedOAI(t, tc.oaiBodies)
+	agent, task := taskAndAgent(tc.name)
+	agent.Spec.MaxEnvtestIterations = tc.maxEnvtest
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
 		WithObjects(agent, task).Build()
-
-	reg := &seqEnvtestRegistry{verdicts: []string{"GO"}}
-	runner := &scriptedEnvtestRunner{results: []envtestGateResult{
-		{pass: false, ran: true, feedback: "controller_test.go:1 boom"}, // attempt 0 fails
-		{pass: true, ran: true}, // retry passes
-	}}
-
+	reg := &seqEnvtestRegistry{verdicts: tc.regVerdicts}
+	runner := &scriptedEnvtestRunner{results: tc.gate}
 	e := envtestLoopExecutor(t, root, bare, oaiSrv.URL, c, runner, reg)
 	res, err := e.Execute(context.Background(), task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
+	return res, runner.calls
+}
+
+// The gate fails on attempt 0; with the default bound (1) the executor
+// re-runs the coder against the same workspace and re-gates, which passes,
+// so the task settles GO after exactly two gate calls.
+func TestNativeExecutor_EnvtestLoop_ConvergesAfterOneRetry(t *testing.T) {
+	res, calls := envtestLoopCase{
+		name: "envtest-converge", oaiBodies: []string{submitGoBody},
+		regVerdicts: []string{"GO"},
+		gate: []envtestGateResult{
+			{pass: false, ran: true, feedback: "controller_test.go:1 boom"}, // attempt 0 fails
+			{pass: true, ran: true}, // retry passes
+		},
+	}.run(t)
 	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("verdict: want GO got %s (result=%+v)", res.Verdict, res)
 	}
-	if runner.calls != 2 {
-		t.Fatalf("gate calls: want 2 got %d", runner.calls)
+	if calls != 2 {
+		t.Fatalf("gate calls: want 2 got %d", calls)
+	}
+}
+
+// A retry whose re-gate cannot be run to a verdict (ran=false: e.g. a gate
+// Job name collision with the still-present attempt-0 Job) must NOT land as
+// GO. A prior attempt already failed the gate, so the executor downgrades to
+// INCOMPLETE rather than let an unverified branch through. Regression for the
+// #768 validation false-GO: the pre-fix loop treated could-not-run as "GO
+// stands" on every attempt, so a failing branch landed GO.
+func TestNativeExecutor_EnvtestLoop_UnverifiedRetryDoesNotFalseGo(t *testing.T) {
+	res, calls := envtestLoopCase{
+		name: "envtest-unverified", oaiBodies: []string{submitGoBody},
+		regVerdicts: []string{"GO"},
+		gate: []envtestGateResult{
+			{pass: false, ran: true, feedback: "attempt 0 fails"}, // attempt 0: real gate failure -> retry
+			{pass: false, ran: false},                             // retry: could-not-run (collision/infra)
+		},
+	}.run(t)
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Fatalf("verdict: want INCOMPLETE (unverified retry must not GO) got %s (result=%+v)", res.Verdict, res)
+	}
+	if calls != 2 {
+		t.Fatalf("gate calls: want 2 got %d", calls)
 	}
 }
 
@@ -186,32 +227,17 @@ func TestNativeExecutor_EnvtestLoop_ConvergesAfterOneRetry(t *testing.T) {
 // falls back to the pre-#768 ENVTEST-GATE-FAILED / INCOMPLETE outcome and
 // never re-runs the coder.
 func TestNativeExecutor_EnvtestLoop_IncompleteAfterCapExhausted(t *testing.T) {
-	gitOrSkip(t)
-	root := t.TempDir()
-	bare := initBareWithSeed(t, root)
-	oaiSrv := scriptedOAI(t, []string{submitGoBody})
-	agent, task := taskAndAgent("envtest-cap")
 	zero := int32(0)
-	agent.Spec.MaxEnvtestIterations = &zero // no retries: fail on first gate failure
-
-	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(agent, task).Build()
-
-	reg := &seqEnvtestRegistry{verdicts: []string{"GO"}}
-	runner := &scriptedEnvtestRunner{results: []envtestGateResult{
-		{pass: false, ran: true, feedback: "still broken"},
-	}}
-
-	e := envtestLoopExecutor(t, root, bare, oaiSrv.URL, c, runner, reg)
-	res, err := e.Execute(context.Background(), task)
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
+	res, calls := envtestLoopCase{
+		name: "envtest-cap", maxEnvtest: &zero, oaiBodies: []string{submitGoBody},
+		regVerdicts: []string{"GO"},
+		gate:        []envtestGateResult{{pass: false, ran: true, feedback: "still broken"}},
+	}.run(t)
 	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
 		t.Fatalf("verdict: want INCOMPLETE got %s", res.Verdict)
 	}
-	if runner.calls != 1 {
-		t.Fatalf("gate calls with cap 0: want 1 got %d", runner.calls)
+	if calls != 1 {
+		t.Fatalf("gate calls with cap 0: want 1 got %d", calls)
 	}
 	if got, _ := res.Extra["outcome"].(string); got != "ENVTEST-GATE-FAILED" {
 		t.Fatalf("outcome: want ENVTEST-GATE-FAILED got %q", got)
@@ -221,26 +247,12 @@ func TestNativeExecutor_EnvtestLoop_IncompleteAfterCapExhausted(t *testing.T) {
 // The retry coder returns NO-GO: the executor surfaces that terminal rather
 // than pushing work the coder did not stand behind.
 func TestNativeExecutor_EnvtestLoop_NoGoOnRetrySurfaces(t *testing.T) {
-	gitOrSkip(t)
-	root := t.TempDir()
-	bare := initBareWithSeed(t, root)
-	oaiSrv := scriptedOAI(t, []string{submitGoBody}) // OAI only needs to call submit_result each turn
-	agent, task := taskAndAgent("envtest-nogo")
-
-	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
-		WithObjects(agent, task).Build()
-
-	// GO on attempt 0 (edits committed + pushed), NO-GO on the retry.
-	reg := &seqEnvtestRegistry{verdicts: []string{"GO", "NO-GO"}}
-	runner := &scriptedEnvtestRunner{results: []envtestGateResult{
-		{pass: false, ran: true, feedback: "boom"},
-	}}
-
-	e := envtestLoopExecutor(t, root, bare, oaiSrv.URL, c, runner, reg)
-	res, err := e.Execute(context.Background(), task)
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
+	res, _ := envtestLoopCase{
+		name: "envtest-nogo", oaiBodies: []string{submitGoBody},
+		// GO on attempt 0 (edits committed + pushed), NO-GO on the retry.
+		regVerdicts: []string{"GO", "NO-GO"},
+		gate:        []envtestGateResult{{pass: false, ran: true, feedback: "boom"}},
+	}.run(t)
 	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("verdict: want NO-GO got %s", res.Verdict)
 	}

--- a/pkg/foreman/agent/executor_native_envtest_loop_test.go
+++ b/pkg/foreman/agent/executor_native_envtest_loop_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
+)
+
+// The post-push envtest gate feedback loop (#768) exercises runLLMPath's
+// commit -> push -> gate retry restructure end-to-end.
+//
+// Two harness facts shape these tests:
+//
+//  1. The terminal verdict the loop records comes from the ToolResult the
+//     tool registry returns for submit_result (loop.dispatchToolCalls), not
+//     from the scripted OAI body's tool-call arguments. The shared
+//     fakeRegistry (executor_native_test.go) is keyed by tool name and so
+//     returns one fixed verdict for every submit_result call; it cannot
+//     express "GO on attempt 0, NO-GO on the retry". This file therefore
+//     uses a small sequenced registry (seqEnvtestRegistry) whose verdict is
+//     driven per submit_result call, which the no-go-on-retry case needs.
+//
+//  2. changedEnvtestPackages reads `git status -z`, which reports untracked
+//     files, so writing a new .go file under internal/controller/ before the
+//     commit makes envtestTouched true and arms the post-push gate.
+
+// seqEnvtestRegistry implements foremanagent.ToolRegistry, returning the
+// next scripted verdict for each submit_result call (repeating the final
+// entry after the script runs out, mirroring scriptedOAI's exhaustion
+// rule) and touching a controller file so the change is envtest-backed.
+type seqEnvtestRegistry struct {
+	verdicts  []string
+	calls     int
+	workspace string
+}
+
+func (r *seqEnvtestRegistry) Schemas() []oai.Tool { return nil }
+
+func (r *seqEnvtestRegistry) Dispatch(
+	_ context.Context, name string, _ json.RawMessage,
+) (*foremanagent.ToolResult, error) {
+	if name != "submit_result" {
+		return nil, fmt.Errorf("seqEnvtestRegistry: unexpected tool %q", name)
+	}
+	touchController(r.workspace)
+	i := r.calls
+	if i >= len(r.verdicts) {
+		i = len(r.verdicts) - 1
+	}
+	r.calls++
+	return &foremanagent.ToolResult{
+		Terminal:      true,
+		Verdict:       r.verdicts[i],
+		Summary:       "fix",
+		CommitMessage: "fix: envtest change\n",
+	}, nil
+}
+
+// scriptedEnvtestRunner returns results[i] for gate call i, repeating the
+// final entry after the script runs out.
+type scriptedEnvtestRunner struct {
+	results []envtestGateResult
+	calls   int
+}
+
+type envtestGateResult struct {
+	pass, ran bool
+	feedback  string
+}
+
+func (f *scriptedEnvtestRunner) Run(
+	_ context.Context, _, _, _, _, _ string,
+) (pass bool, ran bool, feedback string) {
+	i := f.calls
+	if i >= len(f.results) {
+		i = len(f.results) - 1
+	}
+	f.calls++
+	r := f.results[i]
+	return r.pass, r.ran, r.feedback
+}
+
+// touchController writes a file under internal/controller/ and stages it so
+// changedEnvtestPackages reports an envtest-backed change. Staging is load
+// bearing: `git status -z` collapses an entirely-untracked new directory to
+// a single "internal/" entry (no .go suffix), which changedEnvtestPackages
+// skips; `git add` surfaces the file as an individual staged ".go" path.
+func touchController(ws string) {
+	dir := filepath.Join(ws, "internal", "controller")
+	_ = os.MkdirAll(dir, 0o755)
+	rel := filepath.Join("internal", "controller", "zz_envtest_touch.go")
+	_ = os.WriteFile(filepath.Join(ws, rel),
+		[]byte("package controller\n\n// touched by the envtest-loop test\n"), 0o644)
+	_ = exec.Command("git", "-C", ws, "add", rel).Run()
+}
+
+// envtestLoopExecutor assembles the same *NativeAgentLoopExecutor literal
+// TestNativeExecutor_HappyPathPushesBranch builds, plus the EnvtestJobRunner
+// under test. reg's workspace is bound inside RegistryFactory so its touch
+// writes into the per-task clone.
+func envtestLoopExecutor(
+	t *testing.T, root, bare, oaiURL string, c client.Client,
+	runner foremanagent.EnvtestJobRunner, reg *seqEnvtestRegistry,
+) *foremanagent.NativeAgentLoopExecutor {
+	t.Helper()
+	return &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiURL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory:      fakeAuth(t),
+		EnvtestJobRunner: runner,
+	}
+}
+
+// The gate fails on attempt 0; with the default bound (1) the executor
+// re-runs the coder against the same workspace and re-gates, which passes,
+// so the task settles GO after exactly two gate calls.
+func TestNativeExecutor_EnvtestLoop_ConvergesAfterOneRetry(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody}) // GO on every turn
+	agent, task := taskAndAgent("envtest-converge")
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(agent, task).Build()
+
+	reg := &seqEnvtestRegistry{verdicts: []string{"GO"}}
+	runner := &scriptedEnvtestRunner{results: []envtestGateResult{
+		{pass: false, ran: true, feedback: "controller_test.go:1 boom"}, // attempt 0 fails
+		{pass: true, ran: true}, // retry passes
+	}}
+
+	e := envtestLoopExecutor(t, root, bare, oaiSrv.URL, c, runner, reg)
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("verdict: want GO got %s (result=%+v)", res.Verdict, res)
+	}
+	if runner.calls != 2 {
+		t.Fatalf("gate calls: want 2 got %d", runner.calls)
+	}
+}
+
+// With the bound set to 0, the first gate failure is terminal: the executor
+// falls back to the pre-#768 ENVTEST-GATE-FAILED / INCOMPLETE outcome and
+// never re-runs the coder.
+func TestNativeExecutor_EnvtestLoop_IncompleteAfterCapExhausted(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+	agent, task := taskAndAgent("envtest-cap")
+	zero := int32(0)
+	agent.Spec.MaxEnvtestIterations = &zero // no retries: fail on first gate failure
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(agent, task).Build()
+
+	reg := &seqEnvtestRegistry{verdicts: []string{"GO"}}
+	runner := &scriptedEnvtestRunner{results: []envtestGateResult{
+		{pass: false, ran: true, feedback: "still broken"},
+	}}
+
+	e := envtestLoopExecutor(t, root, bare, oaiSrv.URL, c, runner, reg)
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Fatalf("verdict: want INCOMPLETE got %s", res.Verdict)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("gate calls with cap 0: want 1 got %d", runner.calls)
+	}
+	if got, _ := res.Extra["outcome"].(string); got != "ENVTEST-GATE-FAILED" {
+		t.Fatalf("outcome: want ENVTEST-GATE-FAILED got %q", got)
+	}
+}
+
+// The retry coder returns NO-GO: the executor surfaces that terminal rather
+// than pushing work the coder did not stand behind.
+func TestNativeExecutor_EnvtestLoop_NoGoOnRetrySurfaces(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody}) // OAI only needs to call submit_result each turn
+	agent, task := taskAndAgent("envtest-nogo")
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(agent, task).Build()
+
+	// GO on attempt 0 (edits committed + pushed), NO-GO on the retry.
+	reg := &seqEnvtestRegistry{verdicts: []string{"GO", "NO-GO"}}
+	runner := &scriptedEnvtestRunner{results: []envtestGateResult{
+		{pass: false, ran: true, feedback: "boom"},
+	}}
+
+	e := envtestLoopExecutor(t, root, bare, oaiSrv.URL, c, runner, reg)
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("verdict: want NO-GO got %s", res.Verdict)
+	}
+}

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -478,17 +478,32 @@ func applyConfigDefaults(c RunGateJobToolConfig) RunGateJobToolConfig {
 	}
 	if c.NameFn == nil {
 		c.NameFn = func(taskName string) string {
-			// foreman-gate-<task>-<unix-ms>; the timestamp suffix is
-			// enough collision avoidance for the 1-job-at-a-time-per-
-			// foreman-agent invariant. Trim to k8s name limits.
-			name := fmt.Sprintf("foreman-gate-%s-%d", sanitizeName(taskName), time.Now().UnixMilli())
-			if len(name) > 63 {
-				name = name[:63]
-			}
-			return name
+			return gateJobName(taskName, time.Now().UnixMilli())
 		}
 	}
 	return c
+}
+
+// gateJobName builds the gate Job name "foreman-gate-<task>-<unix-ms>",
+// trimmed to the 63-char k8s object-name limit by truncating the TASK
+// portion, never the trailing <unix-ms> disambiguator. The #768 retry loop
+// submits a second gate Job for the same task while the prior attempt's Job
+// still exists; the old code trimmed the whole name from the right, cutting
+// off the timestamp for long task names, so the retry's Create collided with
+// the prior Job (AlreadyExists -> GATE-ERROR -> could-not-verify -> GO). Keeping
+// the suffix guarantees each submission gets a distinct name.
+func gateJobName(taskName string, unixMilli int64) string {
+	const prefix = "foreman-gate-"
+	suffix := fmt.Sprintf("-%d", unixMilli)
+	budget := 63 - len(prefix) - len(suffix)
+	if budget < 0 {
+		budget = 0
+	}
+	task := sanitizeName(taskName)
+	if len(task) > budget {
+		task = task[:budget]
+	}
+	return prefix + task + suffix
 }
 
 // defaultJobResources fills in the gate-matching container resource

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -901,3 +901,27 @@ func TestRunGateJob_ImageOverride(t *testing.T) {
 		})
 	}
 }
+
+func TestGateJobNamePreservesUniquenessSuffixWhenTruncated(t *testing.T) {
+	// A long task name whose "foreman-gate-<task>" already exceeds the 63-char
+	// k8s object-name limit. The #768 validation caught a retry's gate Job
+	// colliding with the prior attempt's because the trailing unix-ms
+	// disambiguator was truncated away, so the retry could not re-gate and a
+	// failing branch landed as GO. The suffix must survive truncation.
+	long := "validate-1110-envtestloop-validate-1110-envtestloop"
+	n1 := gateJobName(long, 1784157000000)
+	n2 := gateJobName(long, 1784157000001)
+
+	if len(n1) > 63 {
+		t.Fatalf("name exceeds the 63-char k8s limit: len=%d %q", len(n1), n1)
+	}
+	if !strings.HasPrefix(n1, "foreman-gate-") {
+		t.Fatalf("lost the foreman-gate- prefix: %q", n1)
+	}
+	if !strings.HasSuffix(n1, "-1784157000000") {
+		t.Fatalf("uniqueness suffix was truncated away: %q", n1)
+	}
+	if n1 == n2 {
+		t.Fatalf("two submissions of the same long task name collide: %q", n1)
+	}
+}


### PR DESCRIPTION
## What

Adds an in-executor **envtest feedback loop** to the Foreman coder gate. When a coder's post-push envtest gate fails, the executor now re-runs the coder against the same workspace with the gate output injected, then re-commits, force-with-lease pushes, and re-gates, bounded by a new `Agent.spec.maxEnvtestIterations` (default 1). Exhausting the bound falls back to the existing behavior (downgrade to INCOMPLETE, outcome `ENVTEST-GATE-FAILED`).

## Why

Fixes #768

The post-push envtest gate (#859/#864) was terminal: it captured the failing `make test` output but fed it nowhere, so a coder got exactly one blind shot at any envtest-backed reconcile change (it cannot run envtest in its workspace). Landing such a change required a human to re-dispatch the coder by hand with the gate output pasted in. This is the envtest half of #768's "auto-wire + feedback" item, which the later triage had marked delivered but was not: the gate ran, but its failure never fed back.

## How

An outer retry loop in `NativeAgentLoopExecutor.runLLMPath` wraps the existing commit -> push -> envtest-gate sequence. Attempt 0 is byte-identical to prior behavior; only a gate failure with budget remaining triggers a re-run. Coverage is universal (every coder issue-fix task, any Workload shape), which is why the loop lives in the executor rather than the Workload controller. Design decisions:

- **New knob** `Agent.spec.maxEnvtestIterations *int32`, three-valued (nil -> 1; explicit 0 -> pre-#768 fail-on-first; N -> up to N retries), mirroring `Workload.spec.maxReviewIterations`.
- **Feedback injection** via `envtestFeedbackPrompt` + `retryCfg`, a sibling of the reviewer-NO-GO `reviewFeedbackPrompt`: the retry rebuilds the user prompt as the original issue context plus the gate output, so it iterates against its own workspace rather than blind.
- **Retries force-with-lease** on the task's own branch (`ReplaceOnReject: attempt > 0 || AllowOverwrite`); a coder NO-GO / MaxTurns on a retry surfaces that terminal and pushes nothing new.
- Advisories and the work-class policy run once, after the loop settles on a GO.
- Extracted `mapLoopError` (behavior-preserving) and split `commitPushAttempt` / `retryCoderTerminalResult` to keep `runLLMPath` under the gocyclo ceiling.

Full design in `docs/proposals/768-envtest-feedback-loop.md`. Follow-up (e2e/kind tier) tracked separately per the issue.

Behavior note for reviewers: the default of 1 means every envtest-touched coder GO that fails the gate now gets one automatic retry before INCOMPLETE, where it previously downgraded immediately. Bounded by the cap and each loop's own MaxTurns; `explicit 0` restores the old terminal behavior.

## Checklist

- [x] Tests added/updated (three end-to-end retry-loop tests + resolver/prompt unit tests)
- [x] Affected package suite passes locally (`go test ./pkg/foreman/agent/` green); full `make test` (envtest) runs in CI
- [x] `golangci-lint` passes locally (incl. `GOOS=linux`)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed below
- [x] Documentation updated (design proposal added; CRD field documented)

## AI assistance disclosure

Assisted-by: Claude Code (Claude Opus 4.8), running locally under my direction. I drove a design-then-plan-then-execute flow: the assistant explored the existing gate code, we settled the architecture together (an in-executor retry loop reusing the proven #946 re-dispatch semantics, chosen over two alternatives), and it wrote the committed design proposal and an implementation plan. Execution ran task-by-task with a fresh implementer per task and an independent code-review pass after each, plus a whole-branch review at the end; I reviewed the diffs, confirmed attempt-0 behavior preservation, and adjudicated the review findings. A human (me) is accountable for this change per CONTRIBUTING.md.
