### PR TITLE
feat: Support pinned multi-file Hugging Face models (#1110)

### DIFF
--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -251,7 +251,7 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 		env := config.initContainers[1].Env
 		source := getEnvVar(env, "MODEL_SOURCE")
-		Expect(source).To(Equal("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF"))
+		Expect(source).To(Equal("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF/resolve/main/"))
 	})
 
 	It("includes custom CA cert volume in multi-file cached storage", func() {
@@ -394,12 +394,25 @@ var _ = Describe("buildMultiFileInitCommand", func() {
 		Expect(cmd).To(ContainSubstring("case"))
 		Expect(cmd).To(ContainSubstring("esac"))
 	})
+
+	It("preserves slash between resolve base and filename in per-file URL (regression test for #1110)", func() {
+		// The bug: url="${SOURCE%/}$rel" strips trailing slash from SOURCE (which ends in /)
+		// and glues filename directly, producing ".../resolve/main" + "a.gguf" = ".../resolve/maina.gguf"
+		// The fix: url="${SOURCE%/}/$rel" adds the slash back, producing ".../resolve/main/a.gguf"
+		cmd := buildMultiFileInitCommand(true, RefreshPolicyIfNotPresent)
+		Expect(cmd).To(ContainSubstring(`url="${SOURCE%/}/$rel"`))
+	})
+
+	It("preserves slash between resolve base and filename in OnChange policy (regression test for #1110)", func() {
+		cmd := buildMultiFileInitCommand(true, RefreshPolicyOnChange)
+		Expect(cmd).To(ContainSubstring(`url="${SOURCE%/}/$rel"`))
+	})
 })
 
 var _ = Describe("multiFileInitEnvVars", func() {
 	It("sets MODEL_FILES as newline-delimited list", func() {
 		env := multiFileInitEnvVars("hf://org/repo", "/models/abc", []string{"a.gguf", "b.gguf"})
-		Expect(getEnvVar(env, "MODEL_SOURCE")).To(Equal("https://huggingface.co/org/repo"))
+		Expect(getEnvVar(env, "MODEL_SOURCE")).To(Equal("https://huggingface.co/org/repo/resolve/main/"))
 		Expect(getEnvVar(env, "CACHE_DIR")).To(Equal("/models/abc"))
 		Expect(getEnvVar(env, "MODEL_FILES")).To(Equal("a.gguf\nb.gguf"))
 	})
@@ -501,7 +514,7 @@ var _ = Describe("buildCachedStorageConfig cache key fallback", func() {
 
 var _ = Describe("resolveHFSourceURL", func() {
 	It("converts hf:// to https://huggingface.co/", func() {
-		Expect(resolveHFSourceURL("hf://unsloth/gemma-4-31B-it-GGUF")).To(Equal("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF"))
+		Expect(resolveHFSourceURL("hf://unsloth/gemma-4-31B-it-GGUF")).To(Equal("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF/resolve/main/"))
 	})
 
 	It("passes through https URLs unchanged", func() {

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -1582,7 +1582,7 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 		Expect(hasInvalidFileSet).To(BeTrue())
 	})
 
-	It("should fail with InvalidFileSet when hf source contains @rev", func() {
+	It("should accept hf source with @rev for multi-file staging", func() {
 		modelName := "model-hf-at-rev"
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
@@ -1608,11 +1608,11 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
 		})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result.RequeueAfter).To(Equal(5 * time.Minute))
+		Expect(result).To(Equal(reconcile.Result{}))
 
 		updated := &inferencev1alpha1.Model{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
-		Expect(updated.Status.Phase).To(Equal(PhaseFailed))
+		Expect(updated.Status.Phase).To(Equal(PhaseReady))
 
 		var hasInvalidFileSet bool
 		for _, cond := range updated.Status.Conditions {
@@ -1620,7 +1620,7 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 				hasInvalidFileSet = true
 			}
 		}
-		Expect(hasInvalidFileSet).To(BeTrue())
+		Expect(hasInvalidFileSet).To(BeFalse(), "hf source with @rev should be accepted")
 	})
 })
 

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -249,12 +249,9 @@ func modelEnvFrom(model *inferencev1alpha1.Model) []corev1.EnvFromSource {
 
 // resolveHFSourceURL converts hf://repo-id sources to their huggingface.co
 // HTTPS equivalent for init container env vars. Non-hf:// sources pass through unchanged.
+// This is now a thin wrapper around normalizeHFSource for backward compatibility.
 func resolveHFSourceURL(source string) string {
-	if strings.HasPrefix(source, "hf://") {
-		repo := strings.TrimPrefix(source, "hf://")
-		return "https://huggingface.co/" + repo
-	}
-	return source
+	return normalizeHFSource(source)
 }
 
 // hasMultiFileStaging reports whether the model uses multi-file staging via
@@ -386,7 +383,7 @@ func buildMultiFileInitCommand(useCache bool, refreshPolicy string) string {
 		prefix = `mkdir -p /models && `
 	}
 
-	normalizeFn := `normalize_hf_source() { case "$1" in hf://*) echo "https://huggingface.co/${1#hf://}" ;; *) echo "$1" ;; esac; }` + " && "
+	normalizeFn := `normalize_hf_source() { case "$1" in hf://*) src="${1#hf://}"; rev="${src#*@}"; if [ "$rev" != "$src" ]; then echo "https://huggingface.co/${src%%@*}/resolve/$rev/"; else echo "https://huggingface.co/$src/resolve/main/"; fi ;; *) echo "$1" ;; esac; }` + " && "
 
 	if refreshPolicy == RefreshPolicyOnChange {
 		body := normalizeFn +
@@ -395,7 +392,7 @@ func buildMultiFileInitCommand(useCache bool, refreshPolicy string) string {
 			`[ -n "$rel" ] || continue; ` +
 			`dest="$CACHE_DIR/$rel"; ` +
 			`mkdir -p "$(dirname "$dest")"; ` +
-			`url="${SOURCE%/}/resolve/main/$rel"; ` +
+			`url="${SOURCE%/}/$rel"; ` +
 			`etag="$(dirname "$dest")/.$(basename "$dest").etag"; ` +
 			`if curl -fsSL --etag-compare "$etag" --etag-save "$etag" -o "$dest" "$url"; then ` +
 			`echo "Model artifact $rel revalidated"; ` +
@@ -411,7 +408,7 @@ func buildMultiFileInitCommand(useCache bool, refreshPolicy string) string {
 		`[ -n "$rel" ] || continue; ` +
 		`dest="$CACHE_DIR/$rel"; ` +
 		`mkdir -p "$(dirname "$dest")"; ` +
-		`url="${SOURCE%/}/resolve/main/$rel"; ` +
+		`url="${SOURCE%/}/$rel"; ` +
 		`if [ ! -f "$dest" ]; then ` +
 		`echo "Downloading model artifact $rel..."; ` +
 		`curl -f -L -o "$dest" "$url" || { echo "ERROR: failed to download $rel"; exit 1; }; ` +

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -225,22 +225,69 @@ func isRemoteHTTPSource(source string) bool {
 	return hasSchemeFold(source, "https://") || hasSchemeFold(source, "http://")
 }
 
-// normalizeHFSource strips the hf:// scheme prefix if present, returning the
-// bare repo ID (e.g., "hf://org/repo" -> "org/repo", "org/repo" -> "org/repo").
+// parseHFSource splits an HF source into repo ID and optional revision.
+// Accepts both "hf://org/repo@rev" and "org/repo@rev" forms.
+// Returns (repoID, revision, error) where revision is "" if not specified.
+func parseHFSource(source string) (repoID, revision string, err error) {
+	normalized := strings.TrimPrefix(source, "hf://")
+	if normalized == "" {
+		return "", "", fmt.Errorf("empty hf repo source: %s", source)
+	}
+
+	// Split on @ to extract revision
+	atIdx := strings.Index(normalized, "@")
+	if atIdx >= 0 {
+		repoID = normalized[:atIdx]
+		revision = normalized[atIdx+1:]
+		if repoID == "" {
+			return "", "", fmt.Errorf("empty repo ID in hf source: %s", source)
+		}
+		if revision == "" {
+			return "", "", fmt.Errorf("empty revision in hf source: %s", source)
+		}
+		// Reject whitespace in revision (common user error)
+		if strings.ContainsAny(revision, " \t\n\r") {
+			return "", "", fmt.Errorf("hf revision must not contain whitespace: %s", source)
+		}
+		return repoID, revision, nil
+	}
+
+	// No @rev specified
+	repoID = normalized
+	if repoID == "" {
+		return "", "", fmt.Errorf("empty repo ID in hf source: %s", source)
+	}
+	return repoID, "", nil
+}
+
+// normalizeHFSource converts an HF source to its full HTTPS resolve URL.
+// For hf://org/repo@rev, returns "https://huggingface.co/org/repo/resolve/rev/".
+// For hf://org/repo (no rev), returns "https://huggingface.co/org/repo/resolve/main/".
+// Non-hf sources pass through unchanged.
 func normalizeHFSource(source string) string {
-	return strings.TrimPrefix(source, "hf://")
+	if !strings.HasPrefix(strings.ToLower(source), "hf://") {
+		return source
+	}
+	repoID, revision, err := parseHFSource(source)
+	if err != nil {
+		// On parse error, return the original source; validation will catch it.
+		return source
+	}
+	if revision == "" {
+		revision = "main"
+	}
+	return fmt.Sprintf("https://huggingface.co/%s/resolve/%s/", repoID, revision)
 }
 
 // validateHFRepoSource checks for common HF source mistakes and returns an
-// error if the source is malformed. Currently rejects @rev syntax, which
-// users sometimes add from Git or HF CLI habits but which the operator does
-// not support.
+// error if the source is malformed. Now accepts @rev syntax and validates
+// the revision is well-formed.
 func validateHFRepoSource(source string) error {
-	normalized := normalizeHFSource(source)
-	if strings.Contains(normalized, "@") {
-		return fmt.Errorf("hf repo source must not contain @rev syntax: %s", source)
+	if !strings.HasPrefix(strings.ToLower(source), "hf://") {
+		return nil
 	}
-	return nil
+	_, _, err := parseHFSource(source)
+	return err
 }
 
 // isHFRepoSource reports whether source looks like a HuggingFace repo ID
@@ -272,20 +319,21 @@ func isHFRepoSource(source string) bool {
 	if isRemoteHTTPSource(source) {
 		return false
 	}
-	normalized := normalizeHFSource(source)
-	if !strings.Contains(normalized, "/") {
+	// Strip hf:// prefix if present for validation
+	checkSource := strings.TrimPrefix(strings.ToLower(source), "hf://")
+	if !strings.Contains(checkSource, "/") {
 		return false
 	}
 	// Match HF's permitted character set: alphanumeric, hyphens, underscores,
-	// dots, and forward slashes. Must start with alphanumeric.
-	for i, c := range normalized {
+	// dots, forward slashes, and @ (for revision). Must start with alphanumeric.
+	for i, c := range checkSource {
 		if i == 0 {
 			if !isAlphaNum(c) {
 				return false
 			}
 			continue
 		}
-		if !isAlphaNum(c) && c != '-' && c != '_' && c != '.' && c != '/' {
+		if !isAlphaNum(c) && c != '-' && c != '_' && c != '.' && c != '/' && c != '@' {
 			return false
 		}
 	}

--- a/internal/controller/source_test.go
+++ b/internal/controller/source_test.go
@@ -179,6 +179,59 @@ var _ = Describe("isHFRepoSource (source.go)", func() {
 	})
 })
 
+var _ = Describe("parseHFSource (source.go)", func() {
+	It("should parse hf://org/repo without revision", func() {
+		repoID, revision, err := parseHFSource("hf://org/repo")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("org/repo"))
+		Expect(revision).To(Equal(""))
+	})
+	It("should parse bare org/repo without revision", func() {
+		repoID, revision, err := parseHFSource("org/repo")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("org/repo"))
+		Expect(revision).To(Equal(""))
+	})
+	It("should parse hf://org/repo@main with revision", func() {
+		repoID, revision, err := parseHFSource("hf://org/repo@main")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("org/repo"))
+		Expect(revision).To(Equal("main"))
+	})
+	It("should parse bare org/repo@v1.0 with revision", func() {
+		repoID, revision, err := parseHFSource("org/repo@v1.0")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("org/repo"))
+		Expect(revision).To(Equal("v1.0"))
+	})
+	It("should parse with commit hash revision", func() {
+		repoID, revision, err := parseHFSource("hf://org/repo@abc123def456")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("org/repo"))
+		Expect(revision).To(Equal("abc123def456"))
+	})
+	It("should error on empty hf source", func() {
+		_, _, err := parseHFSource("hf://")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("empty hf repo source"))
+	})
+	It("should error on empty repo ID", func() {
+		_, _, err := parseHFSource("hf://@main")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("empty repo ID"))
+	})
+	It("should error on empty revision", func() {
+		_, _, err := parseHFSource("hf://org/repo@")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("empty revision"))
+	})
+	It("should error on whitespace in revision", func() {
+		_, _, err := parseHFSource("hf://org/repo@main branch")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("whitespace"))
+	})
+})
+
 var _ = Describe("validateHFRepoSource (source.go)", func() {
 	It("should return nil for valid bare repo ID", func() {
 		Expect(validateHFRepoSource("org/repo")).To(Succeed())
@@ -186,24 +239,41 @@ var _ = Describe("validateHFRepoSource (source.go)", func() {
 	It("should return nil for valid hf:// prefixed repo ID", func() {
 		Expect(validateHFRepoSource("hf://org/repo")).To(Succeed())
 	})
-	It("should return error for hf:// with @rev", func() {
-		err := validateHFRepoSource("hf://org/repo@main")
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("@rev"))
+	It("should accept hf:// with @rev", func() {
+		Expect(validateHFRepoSource("hf://org/repo@main")).To(Succeed())
 	})
-	It("should return error for bare repo ID with @rev", func() {
-		err := validateHFRepoSource("org/repo@v1.0")
+	It("should accept bare repo ID with @rev", func() {
+		Expect(validateHFRepoSource("org/repo@v1.0")).To(Succeed())
+	})
+	It("should error on empty hf source", func() {
+		err := validateHFRepoSource("hf://")
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("@rev"))
+		Expect(err.Error()).To(ContainSubstring("empty"))
+	})
+	It("should error on empty repo ID", func() {
+		err := validateHFRepoSource("hf://@main")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("empty repo ID"))
+	})
+	It("should error on whitespace in revision", func() {
+		err := validateHFRepoSource("hf://org/repo@main branch")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("whitespace"))
 	})
 })
 
 var _ = Describe("normalizeHFSource (source.go)", func() {
-	It("should strip hf:// prefix", func() {
-		Expect(normalizeHFSource("hf://org/repo")).To(Equal("org/repo"))
+	It("should convert hf://org/repo to resolve URL with main", func() {
+		Expect(normalizeHFSource("hf://org/repo")).To(Equal("https://huggingface.co/org/repo/resolve/main/"))
 	})
-	It("should leave bare repo ID unchanged", func() {
+	It("should convert bare org/repo unchanged (non-hf)", func() {
 		Expect(normalizeHFSource("org/repo")).To(Equal("org/repo"))
+	})
+	It("should convert hf://org/repo@main to resolve URL with revision", func() {
+		Expect(normalizeHFSource("hf://org/repo@main")).To(Equal("https://huggingface.co/org/repo/resolve/main/"))
+	})
+	It("should convert hf://org/repo@v1.0 to resolve URL with revision", func() {
+		Expect(normalizeHFSource("hf://org/repo@v1.0")).To(Equal("https://huggingface.co/org/repo/resolve/v1.0/"))
 	})
 	It("should leave non-hf source unchanged", func() {
 		Expect(normalizeHFSource("https://example.com/model.gguf")).To(Equal("https://example.com/model.gguf"))


### PR DESCRIPTION
## What

Accept a revision-pinned Hugging Face source `hf://org/repo@<revision>` and thread the revision through the model download path, so a `Model` can pin an exact HF commit/tag/branch instead of always resolving `main`.

## Why

Fixes #1110

Previously `validateHFRepoSource` rejected `@rev` outright and the multi-file staging URL hardcoded `/resolve/main/`, so there was no way to pin a HF revision.

## How

- `parseHFSource(source)` splits an optional `@<revision>` off an hf source and validates it (rejects an empty repo id, an empty revision, or whitespace in the revision).
- `validateHFRepoSource` now accepts `@<revision>` (delegating to `parseHFSource`), and `isHFRepoSource` allows `@` in the recognized character set.
- `normalizeHFSource` now returns the full HF resolve base URL including the revision: `hf://org/repo@abc` -> `https://huggingface.co/org/repo/resolve/abc/`, and `hf://org/repo` (no rev) -> `.../resolve/main/`. `resolveHFSourceURL` becomes a thin wrapper over it.
- `model_storage.go`'s single- and multi-file HF init-command builders source `MODEL_SOURCE` from the normalized base and build each file URL as `${SOURCE%/}/$rel` (the hardcoded `/resolve/main/` is gone); the shell `normalize_hf_source` helper handles `@rev` too.
- Tests updated across `source_test.go`, `model_controller_test.go`, and the downstream assertions in `inferenceservice_storage_test.go`, plus regression tests pinning the per-file URL keeps its slash.

## Checklist

- [x] Tests added/updated (parse/validate/normalize coverage + URL-slash regression tests)
- [x] Affected controller suites pass (`internal/controller` + `internal/foreman/controller` envtest, ground-truthed locally); full `make test` runs in CI
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed below

## AI assistance disclosure

Assisted-by: Foreman (LLMKube's own agentic-coding harness), coder model **GLM-4.7-REAP-218B-A32B** served locally on the AMD Strix Halo node. Foreman produced the implementation from the issue. I (the human) then did a PR-level review and caught a runtime defect the envtest gate had missed: the multi-file download URL dropped the slash between the resolve base and the filename (`${SOURCE%/}$rel` -> `.../resolve/maina.gguf`), which would 404 and regress existing multi-file HF downloads. I fed that finding back through one Foreman revision cycle, which fixed the slash in both builder branches and added regression tests pinning it. I then ground-truthed the result against the real envtest suite before opening this PR. A human (me) is accountable for the change per CONTRIBUTING.md.
