### PR TITLE
fix(foreman): abort orphaned agent loop when its AgenticTask is deleted (Fixes #1136)

### DIFF
--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -45,6 +45,18 @@ const DefaultWatcherInterval = 5 * time.Second
 // watcher returns ErrWatcherStalled. Matches the metal-agent's pattern.
 const DefaultMaxConsecutiveWatcherFailures = 3
 
+// DefaultTaskLivenessInterval is the poll cadence of the per-run watchdog
+// that aborts a run when its AgenticTask is deleted out from under the agent
+// (#1136). 10s bounds the wasted generation past a deletion to ~one interval
+// (vs. up to LoopBudget/8h today) without adding meaningful apiserver load.
+const DefaultTaskLivenessInterval = 10 * time.Second
+
+// maxTaskLivenessMisses is how many consecutive NON-NotFound Get errors the
+// liveness watchdog tolerates before giving up (fail-open: the run continues
+// under its LoopBudget). This keeps a transient apiserver blip or a network
+// partition from being mistaken for a deletion and killing a healthy run.
+const maxTaskLivenessMisses = 3
+
 // ErrWatcherStalled is returned from Run when consecutive List() failures
 // exceed the configured threshold; the supervisor (launchd / systemd /
 // the harness) is expected to recycle the process to rebuild the client.
@@ -79,6 +91,11 @@ type AgenticTaskWatcher struct {
 
 	// Executor runs claimed tasks. Required.
 	Executor Executor
+
+	// TaskLivenessInterval is the poll cadence of the per-run watchdog that
+	// aborts a run whose AgenticTask was deleted (#1136). Zero defaults to
+	// DefaultTaskLivenessInterval.
+	TaskLivenessInterval time.Duration
 
 	// inflightMu guards inflight. Exactly one task at a time in v0.1.
 	inflightMu sync.Mutex
@@ -312,11 +329,87 @@ func (w *AgenticTaskWatcher) launchExecutor(ctx context.Context, t *foremanv1alp
 		execCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
+		// Abort the run if its AgenticTask is deleted out from under us
+		// (e.g. `kubectl delete workload` GC-ing the child task): otherwise
+		// the loop runs on to LoopBudget with no backing task (#1136). The
+		// watchdog shares execCtx, so it exits when the run finishes.
+		go w.watchTaskLiveness(execCtx, cancel, t)
+
 		res, execErr := w.Executor.Execute(execCtx, t)
 		if patchErr := w.patchTerminal(ctx, t, res, execErr); patchErr != nil {
 			log.Error(patchErr, "patching terminal status failed")
 		}
 	}()
+}
+
+// watchTaskLiveness cancels an in-flight run when its AgenticTask is deleted
+// out from under the agent (#1136). Nothing in the run path re-reads the task
+// after it is claimed, and the poll loop goes dormant while a run is inflight,
+// so a `kubectl delete workload` (owner-ref GC-ing the child task) would
+// otherwise leave the loop generating tokens to LoopBudget with no backing
+// task. This watchdog GETs the task on an interval and calls cancel() on a
+// definitive deletion; the cancellation propagates through the already
+// ctx-aware plumbing (the gateway request is bound to the run context, so the
+// model slot is released, and the executor tears down its workspace on
+// return).
+//
+// It fails OPEN: only a definitive NotFound (or a set DeletionTimestamp)
+// aborts. Non-NotFound errors are transient (apiserver blip, partition) and
+// must never be mistaken for a deletion, so they are tolerated up to
+// maxTaskLivenessMisses, after which the watchdog gives up without cancelling
+// and the run continues under its LoopBudget as before.
+func (w *AgenticTaskWatcher) watchTaskLiveness(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	t *foremanv1alpha1.AgenticTask,
+) {
+	log := logf.FromContext(ctx).WithName("task-liveness").WithValues("task", t.Name)
+	key := types.NamespacedName{Namespace: t.Namespace, Name: t.Name}
+
+	interval := w.TaskLivenessInterval
+	if interval <= 0 {
+		interval = DefaultTaskLivenessInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	misses := 0
+	for {
+		select {
+		case <-ctx.Done():
+			// Run finished (or was already cancelled): nothing to watch.
+			return
+		case <-ticker.C:
+			var cur foremanv1alpha1.AgenticTask
+			err := w.Client.Get(ctx, key, &cur)
+			switch {
+			case err == nil:
+				misses = 0
+				if cur.DeletionTimestamp != nil {
+					log.Info("inflight task is terminating; cancelling run (#1136)")
+					cancel()
+					return
+				}
+			case apierrors.IsNotFound(err):
+				log.Info("inflight task deleted; cancelling run (#1136)")
+				cancel()
+				return
+			case ctx.Err() != nil:
+				// The Get failed because the run finished and cancelled ctx;
+				// not a task deletion. Exit quietly.
+				return
+			default:
+				misses++
+				log.Error(err, "task liveness probe failed (transient); not cancelling", "misses", misses)
+				if misses >= maxTaskLivenessMisses {
+					// Fail open: a partition must not look like a deletion.
+					// Stop probing; the run continues under its LoopBudget.
+					log.Info("task liveness probe giving up after transient errors; run continues")
+					return
+				}
+			}
+		}
+	}
 }
 
 // patchTerminal re-fetches the task and writes its final phase, verdict,
@@ -330,6 +423,11 @@ func (w *AgenticTaskWatcher) patchTerminal(
 	var fresh foremanv1alpha1.AgenticTask
 	key := types.NamespacedName{Namespace: t.Namespace, Name: t.Name}
 	if err := w.Client.Get(ctx, key, &fresh); err != nil {
+		if apierrors.IsNotFound(err) {
+			// The task was deleted (e.g. the #1136 abort-on-delete path):
+			// there is nothing to write a terminal status onto.
+			return nil
+		}
 		return fmt.Errorf("refetch %s: %w", key, err)
 	}
 

--- a/pkg/foreman/agent/watcher_liveness_test.go
+++ b/pkg/foreman/agent/watcher_liveness_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// #1136: the per-run liveness watchdog must cancel the executor's context when
+// the inflight AgenticTask is deleted out from under the agent (e.g. a
+// `kubectl delete workload` GC-ing its child task), so the loop stops
+// generating instead of running on to LoopBudget. These tests exercise the
+// watchdog in isolation and its wiring through launchExecutor.
+
+const testLivenessInterval = 20 * time.Millisecond
+
+// TestWatchTaskLiveness_CancelsOnDelete: a definitive NotFound (the task was
+// deleted) must cancel the run.
+func TestWatchTaskLiveness_CancelsOnDelete(t *testing.T) {
+	task := runningTask("live-del", "m5max-coder")
+	c := newRecoveryClient(t, task)
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "m5max-coder",
+		Namespace:            "default",
+		TaskLivenessInterval: testLivenessInterval,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.watchTaskLiveness(ctx, cancel, task)
+
+	if err := c.Delete(context.Background(), task); err != nil {
+		t.Fatalf("delete task: %v", err)
+	}
+	select {
+	case <-ctx.Done():
+		// watchdog cancelled the run: correct.
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not cancel the run after task deletion")
+	}
+}
+
+// TestWatchTaskLiveness_CancelsOnDeletionTimestamp: a finalizer-mediated delete
+// leaves the object present with DeletionTimestamp set; that terminating state
+// must also cancel the run (the task is on its way out).
+func TestWatchTaskLiveness_CancelsOnDeletionTimestamp(t *testing.T) {
+	task := runningTask("live-term", "m5max-coder")
+	task.Finalizers = []string{"llmkube.dev/test-hold"}
+	c := newRecoveryClient(t, task)
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "m5max-coder",
+		Namespace:            "default",
+		TaskLivenessInterval: testLivenessInterval,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.watchTaskLiveness(ctx, cancel, task)
+
+	// Finalizer present, so Delete sets DeletionTimestamp rather than removing.
+	if err := c.Delete(context.Background(), task); err != nil {
+		t.Fatalf("delete task: %v", err)
+	}
+	select {
+	case <-ctx.Done():
+		// watchdog cancelled on the terminating task: correct.
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not cancel the run for a task with DeletionTimestamp")
+	}
+}
+
+// TestWatchTaskLiveness_FailsOpenOnTransientErrors: persistent NON-NotFound
+// errors (a partition, apiserver hiccup) must NOT be mistaken for a deletion.
+// The watchdog gives up after a bounded number of misses WITHOUT cancelling,
+// so the run continues under its LoopBudget as before.
+func TestWatchTaskLiveness_FailsOpenOnTransientErrors(t *testing.T) {
+	task := runningTask("live-transient", "m5max-coder")
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(task).
+		WithStatusSubresource(&foremanv1alpha1.AgenticTask{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errors.New("apiserver unavailable")
+			},
+		}).
+		Build()
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "m5max-coder",
+		Namespace:            "default",
+		TaskLivenessInterval: testLivenessInterval,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() { w.watchTaskLiveness(ctx, cancel, task); close(done) }()
+
+	select {
+	case <-done:
+		// watchdog gave up after the transient-error cap: correct.
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not give up on persistent transient errors")
+	}
+	if ctx.Err() != nil {
+		t.Fatal("watchdog cancelled the run on transient errors; it must fail OPEN")
+	}
+}
+
+// TestLaunchExecutor_AbortsInflightRunOnDelete: end-to-end wiring — a blocking
+// executor is launched, its task is deleted, and the run must unwind (inflight
+// cleared) because the watchdog cancelled the executor context.
+func TestLaunchExecutor_AbortsInflightRunOnDelete(t *testing.T) {
+	task := runningTask("live-wire", "m5max-coder")
+	c := newRecoveryClient(t, task)
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "m5max-coder",
+		Namespace:            "default",
+		TaskLivenessInterval: testLivenessInterval,
+		Executor:             &StubExecutor{SleepDuration: time.Hour}, // blocks until ctx cancelled
+	}
+
+	w.launchExecutor(context.Background(), task)
+
+	// Confirm the run is actually in flight before deleting.
+	if !waitInflight(w, true, time.Second) {
+		t.Fatal("executor never went inflight")
+	}
+	if err := c.Delete(context.Background(), task); err != nil {
+		t.Fatalf("delete task: %v", err)
+	}
+	if !waitInflight(w, false, 3*time.Second) {
+		t.Fatal("inflight run did not unwind after task deletion")
+	}
+}
+
+// waitInflight polls w.inflight (under its mutex) until it matches want or the
+// timeout elapses.
+func waitInflight(w *AgenticTaskWatcher, want bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		w.inflightMu.Lock()
+		got := w.inflight != nil
+		w.inflightMu.Unlock()
+		if got == want {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}


### PR DESCRIPTION
## What

Adds a per-run liveness watchdog to the Foreman agent's `AgenticTaskWatcher` so that deleting a `Workload`/`AgenticTask` promptly aborts the off-cluster agent's in-flight loop, instead of letting it run on to `LoopBudget`.

## Why

Fixes #1136

Deleting a `Workload` (GC-ing its child `AgenticTask`) did **not** abort a loop already running on an off-cluster metal `FleetNode`. Nothing in the run path re-read the task after it was claimed, and the poll loop went dormant while a run was inflight, so the agent kept generating tokens against a task that no longer existed, bounded only by `LoopBudget` (~8h) / `maxTurns`. Observed live: ~111k tokens generated with no backing `AgenticTask`, only stoppable by bouncing the agent. The blast radius grows with the #768 envtest feedback loop (longer-lived retries).

## How

- New `watchTaskLiveness(ctx, cancel, t)` goroutine, launched inside `launchExecutor`'s run goroutine and sharing its `execCtx`/`cancel`. It `GET`s the inflight task every `TaskLivenessInterval` (default 10s) and calls `cancel()` on a **definitive** deletion: a `NotFound`, or a set `DeletionTimestamp` (finalizer-mediated delete).
- Cancellation reuses plumbing that already exists end-to-end: the gateway generation call is bound to the run context (cancel drops the connection → the InferenceService releases the model slot), and workspace teardown is a `defer` inside `Execute`.
- **Fails open:** only a definitive `NotFound`/`DeletionTimestamp` aborts. Non-`NotFound` errors (apiserver blip, partition) are tolerated up to a bounded miss cap, after which the watchdog gives up **without** cancelling and the run continues under its `LoopBudget` — a partition is never mistaken for a deletion.
- Minor: `patchTerminal` now treats a `NotFound` refetch as a clean no-op (the task is gone; nothing to write) instead of logging a spurious error.
- No API/CRD/controller changes; the fix is entirely agent-side detection over existing cancellation plumbing.

Worst-case wasted generation past a delete drops from ~8h to ~one interval (~10s).

## Checklist

- [x] Tests added (`watcher_liveness_test.go`): cancel-on-delete, cancel-on-DeletionTimestamp, fail-open on persistent transient errors, and end-to-end `launchExecutor` abort wiring; pass under `-race`
- [x] `go build ./...`, `go vet`, and `golangci-lint` clean on the changed package
- [x] Commit signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed below

## AI assistance disclosure

Assisted by Claude Code (band-3): the root-cause analysis and implementation were AI-assisted, then human-reviewed. The fix was ground-truthed by an independent adversarial review pass (compiled, run under `-race`, and the fake-client `DeletionTimestamp` semantics verified against controller-runtime source). A human (me) is accountable for the change per CONTRIBUTING.md.
