### PR TITLE
feat(cli): envtest-verify the slicer's integrated branch (Fixes #1137)

### DIFF
--- a/pkg/cli/slice.go
+++ b/pkg/cli/slice.go
@@ -67,6 +67,7 @@ type sliceOptions struct {
 	coderAgent     string
 	integrateAgent string
 	reconcileAgent string
+	verifyAgent    string
 	baseBranch     string
 	dryRun         bool
 }
@@ -82,7 +83,9 @@ planning an issue.
 
 The pipeline is one issue-fix step per disjoint slice, then an integrate step
 that unions the slice branches, then a reconcile step that checks the union
-against the plan's pinned shared identifiers.
+against the plan's pinned shared identifiers, then a verify step that runs the
+clean-room build+envtest gate on the integrated branch (skip with
+--verify-agent "" for non-code slicing).
 
 Two input modes:
   --plan FILE          render from a slice plan the planner already produced.
@@ -115,6 +118,9 @@ Examples:
 	f.StringVar(&opts.coderAgent, "coder-agent", "coder-metal", "Agent that runs each slice's issue-fix step")
 	f.StringVar(&opts.integrateAgent, "integrate-agent", "integrate", "Deterministic agent that runs the integrate step")
 	f.StringVar(&opts.reconcileAgent, "reconcile-agent", "reconcile", "Deterministic agent that runs the reconcile step")
+	f.StringVar(&opts.verifyAgent, "verify-agent", "gate",
+		"Deterministic gate Agent that build+envtest-verifies the integrated branch after reconcile "+
+			"(must exist in the target namespace); empty string skips verify for non-code slicing")
 	f.StringVar(&opts.baseBranch, "base-branch", "main", "Base branch the slices are cut from and unioned onto")
 	f.BoolVar(&opts.dryRun, "dry-run", false, "Print the rendered Workload without applying it")
 	return cmd
@@ -237,7 +243,9 @@ func validateSlicePlan(p slicePlan) error {
 
 // buildSliceWorkload renders the Workload: one issue-fix step per slice, then an
 // integrate step (dependsOn every slice), then a reconcile step (dependsOn
-// integrate). The integration branch and each slice branch follow the
+// integrate), then (unless --verify-agent is empty) a verify step (dependsOn
+// reconcile) that build+envtest-gates the integrated branch (#1137). The
+// integration branch and each slice branch follow the
 // foreman/slicer-<issue>-<runid>/<name> convention, where <runid> is a
 // per-Workload hex segment that makes re-runs of the same issue never collide
 // with branches left on the fork by an earlier run.
@@ -245,7 +253,7 @@ func buildSliceWorkload(p slicePlan, opts *sliceOptions) *foremanv1alpha1.Worklo
 	runID := sliceRunID()
 	integBranch := fmt.Sprintf("foreman/slicer-%d-%s/integ", p.Issue, runID)
 
-	steps := make([]foremanv1alpha1.PipelineStep, 0, len(p.Slices)+2)
+	steps := make([]foremanv1alpha1.PipelineStep, 0, len(p.Slices)+3)
 	sliceNames := make([]string, 0, len(p.Slices))
 	integSlices := make([]foremanv1alpha1.SliceRef, 0, len(p.Slices))
 	reconSlices := make([]foremanv1alpha1.SliceRef, 0, len(p.Slices))
@@ -303,6 +311,30 @@ func buildSliceWorkload(p slicePlan, opts *sliceOptions) *foremanv1alpha1.Worklo
 		},
 		DependsOn: []string{"integrate"},
 	})
+
+	// verify step: a clean-room build + envtest gate on the integrated branch,
+	// so a sliced Workload cannot reach terminal PASS while the merged union
+	// fails to build or fails envtest (#1137). integrate (git union) and
+	// reconcile (static pinned-identifier check) validate the merge and the
+	// interface, but neither compiles the code; per-slice envtest is no
+	// substitute because coupled slices cannot build in isolation, so the
+	// union is the only meaningful thing to test. dependsOn reconcile so it
+	// runs only after the merge and pins check out. An empty --verify-agent
+	// opts out (non-code slicing has nothing to build).
+	if opts.verifyAgent != "" {
+		steps = append(steps, foremanv1alpha1.PipelineStep{
+			Name:     "verify",
+			Kind:     foremanv1alpha1.AgenticTaskKindVerify,
+			AgentRef: corev1.LocalObjectReference{Name: opts.verifyAgent},
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:       p.Repo,
+				Issue:      p.Issue,
+				Branch:     integBranch,
+				BaseBranch: opts.baseBranch,
+			},
+			DependsOn: []string{"reconcile"},
+		})
+	}
 
 	return &foremanv1alpha1.Workload{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/cli/slice_test.go
+++ b/pkg/cli/slice_test.go
@@ -44,7 +44,8 @@ func samplePlan() slicePlan {
 func defaultOpts() *sliceOptions {
 	return &sliceOptions{
 		namespace: "default", coderAgent: "coder-metal",
-		integrateAgent: "integrate", reconcileAgent: "reconcile", baseBranch: "main",
+		integrateAgent: "integrate", reconcileAgent: "reconcile",
+		verifyAgent: "gate", baseBranch: "main",
 	}
 }
 
@@ -55,8 +56,8 @@ func TestBuildSliceWorkload_PipelineShape(t *testing.T) {
 		t.Fatalf("meta = %s/%s", wl.Namespace, wl.Name)
 	}
 	steps := wl.Spec.Pipeline
-	if len(steps) != 4 {
-		t.Fatalf("want 4 steps (2 slices + integrate + reconcile), got %d", len(steps))
+	if len(steps) != 5 {
+		t.Fatalf("want 5 steps (2 slices + integrate + reconcile + verify), got %d", len(steps))
 	}
 
 	// slice steps
@@ -109,6 +110,52 @@ func TestBuildSliceWorkload_PipelineShape(t *testing.T) {
 	// reconcile carries files (for pinned_check), integrate carries branches.
 	if len(rec.Payload.Slices) != 2 || len(rec.Payload.Slices[0].Files) == 0 {
 		t.Errorf("reconcile payload slices need files: %+v", rec.Payload.Slices)
+	}
+
+	// verify step: envtest gate on the integrated branch (#1137). It runs
+	// after reconcile and targets the SAME integration branch reconcile does,
+	// so a build/envtest failure of the merged union blocks terminal PASS.
+	assertVerifyStep(t, steps[4], rec)
+}
+
+// assertVerifyStep checks the slicer's trailing verify step: it gates the same
+// integration branch reconcile targets, depends on reconcile, uses the verify
+// agent, and carries a bare make-target payload (no slice refs / pins / contract).
+func assertVerifyStep(t *testing.T, ver, rec foremanv1alpha1.PipelineStep) {
+	t.Helper()
+	if ver.Name != "verify" || ver.Kind != foremanv1alpha1.AgenticTaskKindVerify {
+		t.Fatalf("verify step = %s/%s, want verify/verify", ver.Name, ver.Kind)
+	}
+	if len(ver.DependsOn) != 1 || ver.DependsOn[0] != "reconcile" {
+		t.Errorf("verify dependsOn = %v, want [reconcile]", ver.DependsOn)
+	}
+	if ver.AgentRef.Name != "gate" {
+		t.Errorf("verify agent = %q, want gate", ver.AgentRef.Name)
+	}
+	if ver.Payload.Branch != rec.Payload.Branch {
+		t.Errorf("verify branch %q != reconcile/integ branch %q", ver.Payload.Branch, rec.Payload.Branch)
+	}
+	if ver.Payload.BaseBranch != "main" {
+		t.Errorf("verify baseBranch = %q, want main", ver.Payload.BaseBranch)
+	}
+	if len(ver.Payload.Slices) != 0 || len(ver.Payload.SharedIdentifiers) != 0 || ver.Payload.Contract != "" {
+		t.Errorf("verify payload should be bare (repo/issue/branch/base only): %+v", ver.Payload)
+	}
+}
+
+// TestBuildSliceWorkload_VerifyOptOut: an empty --verify-agent drops the
+// verify step, leaving the legacy 4-step pipeline for non-code slicing.
+func TestBuildSliceWorkload_VerifyOptOut(t *testing.T) {
+	opts := defaultOpts()
+	opts.verifyAgent = ""
+	steps := buildSliceWorkload(samplePlan(), opts).Spec.Pipeline
+	if len(steps) != 4 {
+		t.Fatalf("opt-out want 4 steps (no verify), got %d", len(steps))
+	}
+	for _, s := range steps {
+		if s.Kind == foremanv1alpha1.AgenticTaskKindVerify {
+			t.Errorf("verify step present despite empty --verify-agent: %+v", s)
+		}
 	}
 }
 
@@ -253,7 +300,10 @@ slices:
 		t.Fatalf("runSlice: %v", err)
 	}
 	out := buf.String()
-	wants := []string{"kind: Workload", "name: slicer-700", "kind: integrate", "kind: reconcile", "rocm_smi_gpu_temp"}
+	wants := []string{
+		"kind: Workload", "name: slicer-700", "kind: integrate",
+		"kind: reconcile", "kind: verify", "rocm_smi_gpu_temp",
+	}
 	for _, want := range wants {
 		if !strings.Contains(out, want) {
 			t.Errorf("dry-run output missing %q:\n%s", want, out)


### PR DESCRIPTION
## What

Appends a `verify` step to the `llmkube foreman slice` pipeline, after `reconcile`, that runs the clean-room build+envtest gate on the integrated branch. Wired via a new `--verify-agent` flag (default `gate`); `--verify-agent ""` opts out.

## Why

Fixes #1137

The sliced-Workload pipeline was `N slices → integrate → reconcile`. `integrate` is a git-union check and `reconcile` is a static pinned-identifier token check — **neither compiles or envtests the merged code**, so a sliced Workload could reach a terminal PASS while the integrated branch does not build or fails envtest. Per-slice envtest is not a substitute: a coupled slice (e.g. `model_storage.go` consuming `normalizeHFSource` defined in a *different* slice) cannot build in isolation, so the integrated union is the only meaningful thing to test. This is the same false-confidence class as the #768 post-push gate, and it's exactly what the #1110 slicing exercise hit.

## How

- `buildSliceWorkload` now appends a `verify` step (`Kind: AgenticTaskKindVerify`, `DependsOn: [reconcile]`) targeting `integBranch` — the same integration branch `reconcile` checks and `integrate` already pushes to the fork.
- New `--verify-agent` flag defaults to `gate`, the existing deterministic verifier Agent whose `run_gate_job` tool runs the `make fmt/vet/lint/test` clean-room gate (the same gate the issue-fix flow uses). No API/executor/gate changes — a `verify` task already runs this path.
- The verify payload is bare (`Repo`/`Issue`/`Branch`/`BaseBranch`) — no slice refs, shared identifiers, or contract — since verify is the make-target gate path, not integrate/reconcile. `BaseBranch` is threaded so the gate's bite check diffs against the slicer's `--base-branch`.
- `--verify-agent ""` opts out (non-code slicing has nothing to build), preserving the legacy 4-step pipeline.
- Mirrors the existing issue-batch verify step (`synthesizeIssueBatch` in `workload_controller.go`).

Note: the `gate` Agent must exist in the target namespace (it is applied per-cluster, not chart-templated); a missing agent fails the verify task at execute time. This is called out in the flag help.

## Checklist

- [x] Tests updated (`pkg/cli/slice_test.go`): pipeline is now 5 steps with verify asserted (kind, `dependsOn: [reconcile]`, `gate` agent, gates the same integ branch as reconcile, bare payload); opt-out test; dry-run YAML asserts `kind: verify`
- [x] `go build ./...`, `go vet`, `golangci-lint` clean; `--help` renders the new flag
- [x] Commit signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed below

## AI assistance disclosure

Assisted by Claude Code (band-3): the change was AI-assisted from the issue's proposed solution and human-reviewed, with the render mirrored on the existing issue-batch verify pattern. A human (me) is accountable for the change per CONTRIBUTING.md.
