### PR TITLE
fix(foreman): require a non-doc scope match for the reviewer issueAsk vouch

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -2473,7 +2473,19 @@ func enforceReviewerIssueAsk(
 	// diff touches at least one of them, the deterministic scope rail
 	// confirms the reviewer was in-scope even though it paraphrased the
 	// issue ask. Keep GO and annotate the outcome (#744).
-	scopeVouches := !scopeDriftDetected && len(scopeMatched) > 0
+	//
+	// The matched ref must include a non-doc file. A GO whose only
+	// in-scope evidence is a touched documentation file is too weak to
+	// override a failed issueAsk verification: when the issue names a
+	// source/config deliverable alongside a doc, a diff touching only the
+	// doc still "matches" scope, yet that match does not confirm the
+	// substantive change was made. Pairing an unverifiable ask with a
+	// doc-only scope match is a low-confidence review that should route to
+	// escalation for a human or stronger reviewer rather than be silently
+	// vouched. Requiring a non-doc match keeps the honest-paraphrase
+	// rescue (#744/#1120) while closing that gap.
+	scopeVouches := !scopeDriftDetected && len(scopeMatched) > 0 &&
+		scopeMatchHasNonDoc(scopeMatched)
 	if scopeVouches {
 		extra["issueAskVerified"] = false
 		extra["scopeVouched"] = true

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1568,6 +1568,43 @@ func TestEnforceReviewerIssueAsk_UnverifiedGoNoScopeVouchDemotes(t *testing.T) {
 	}
 }
 
+// TestEnforceReviewerIssueAsk_DocOnlyScopeMatchDemotes covers the
+// misospace/miso-chat#687 shape: the issue named a config file
+// (package.json) AND a doc (SECURITY_REVIEW.md), the diff touched only the
+// doc, and issueAsk verification failed. Scope-overlap "matched" the doc, so
+// the vouch used to keep the GO. A documentation-only scope match is too weak
+// to rescue an unverifiable GO — demote to NO-GO so it escalates for
+// confirmation.
+func TestEnforceReviewerIssueAsk_DocOnlyScopeMatchDemotes(t *testing.T) {
+	extra := map[string]any{"issueAskVerified": false}
+	got := enforceReviewerIssueAsk(logr.Discard(), extra,
+		foremanv1alpha1.AgenticTaskVerdictGo, false, []string{"SECURITY_REVIEW.md"})
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Errorf("doc-only scope match must not vouch; want NO-GO, got %v", got)
+	}
+	if _, vouched := extra["scopeVouched"]; vouched {
+		t.Errorf("doc-only scope match must not set scopeVouched")
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("demotion must set verdictDemoted=true; got %v", extra["verdictDemoted"])
+	}
+}
+
+// TestEnforceReviewerIssueAsk_MixedScopeMatchVouches verifies the non-doc
+// requirement is "any", not "all": a matched set carrying at least one
+// non-doc file still vouches even alongside a matched doc.
+func TestEnforceReviewerIssueAsk_MixedScopeMatchVouches(t *testing.T) {
+	extra := map[string]any{"issueAskVerified": false}
+	got := enforceReviewerIssueAsk(logr.Discard(), extra,
+		foremanv1alpha1.AgenticTaskVerdictGo, false, []string{"README.md", "pkg/foo.go"})
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("a non-doc match should vouch even alongside docs; want GO, got %v", got)
+	}
+	if v, _ := extra["scopeVouched"].(bool); !v {
+		t.Errorf("scopeVouched should be true when a non-doc file matched")
+	}
+}
+
 // TestEnforceReviewerIssueAsk_UnverifiedGoNoRefsNoVouchDemotes covers the
 // case where the issue has no concrete file refs (scope observe-only) and
 // the model paraphrased the ask. Without scope vouch, must demote.

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -100,6 +100,30 @@ func extractIssuePathRefs(body string, sourceExtensions []string) []string {
 	return refs
 }
 
+// docRefExtensions are the extensions treated as documentation for the
+// scope-overlap vouch (enforceReviewerIssueAsk). A review whose ONLY
+// in-scope evidence is a touched doc file is too weak to override a failed
+// issueAsk verification: the substantive named deliverable (source/config)
+// was left untouched. The set is intentionally narrow — prose docs only.
+var docRefExtensions = map[string]bool{
+	"md": true, "markdown": true, "rst": true, "txt": true, "adoc": true,
+}
+
+// scopeMatchHasNonDoc reports whether any matched scope ref is something
+// other than a documentation file. The scope vouch requires this so that
+// matching only a doc the issue happens to mention — while the primary
+// source/config file the issue is actually about goes untouched — does not
+// rescue an otherwise unverifiable GO.
+func scopeMatchHasNonDoc(matched []string) bool {
+	for _, m := range matched {
+		ext := strings.ToLower(strings.TrimPrefix(path.Ext(m), "."))
+		if !docRefExtensions[ext] {
+			return true
+		}
+	}
+	return false
+}
+
 // hasSourceFile reports whether any path in paths ends with one of the
 // extensions in exts. If exts is empty, it defaults to [".go"] so
 // existing behavior is preserved.

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -320,6 +320,29 @@ func TestEnforceReviewerScopeOverlap_NilOrEmptyInputsPassThrough(t *testing.T) {
 	}
 }
 
+func TestScopeMatchHasNonDoc(t *testing.T) {
+	tests := []struct {
+		name    string
+		matched []string
+		want    bool
+	}{
+		{"empty", nil, false},
+		{"doc only (md)", []string{"SECURITY_REVIEW.md"}, false},
+		{"docs only (mixed doc exts)", []string{"README.md", "notes.rst", "changes.txt"}, false},
+		{"source file", []string{"scripts/main.gd"}, true},
+		{"config file", []string{"package.json"}, true},
+		{"mixed doc + source", []string{"README.md", "pkg/foo.go"}, true},
+		{"no extension treated as non-doc", []string{"Makefile"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scopeMatchHasNonDoc(tt.matched); got != tt.want {
+				t.Errorf("scopeMatchHasNonDoc(%v) = %v, want %v", tt.matched, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHasSourceFile(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## What

The reviewer issueAsk vouch now requires a **non-documentation** matched ref to rescue an unverifiable GO.

## Why

Fixes #1142

`enforceReviewerIssueAsk` demotes a GO whose `issueAsk` can't be verified against the issue body, unless scope-overlap vouches (`!scopeDriftDetected && len(scopeMatched) > 0`). That vouch treated any matched ref as full scope coverage — so a diff touching only a documentation file the issue happens to mention still vouched, even when the primary named source/config deliverable was untouched and the reviewer couldn't articulate the ask.

Pairing an unverifiable issueAsk with a doc-only scope match is a low-confidence review: the scope "match" does not confirm any substantive change was made. Rather than silently approving it, demote to NO-GO so it routes to escalation for a human or stronger reviewer.

## How

- New `scopeMatchHasNonDoc(matched)` in `scope_overlap.go` (docs = `md, markdown, rst, txt, adoc`).
- `scopeVouches` now also requires `scopeMatchHasNonDoc(scopeMatched)`.
- Preserves #744 / #1120: an honest review whose diff touches issue-named source files (`.go`, `.gd`, …) still vouches; only a doc-only match stops rescuing an unverifiable GO.

## On the motivating case (honest note)

Surfaced by `misospace/miso-chat#687`. On closer inspection that issue was itself a **false-premise audit** — it claimed a newer `passport-openidconnect` existed ("latest is significantly newer"), but `0.1.2` is genuinely the latest on npm, so the coder's doc-only "verified current" resolution was actually *correct*. It is therefore not an example of a review that shirked work.

It's still the right shape for this guard: an unverifiable issueAsk plus a doc-only scope match is low-confidence regardless of who turned out to be right, and escalating it for confirmation (rather than auto-approving on a doc match) is the desired behavior. The narrow tradeoff — a genuinely docs-only issue whose reviewer *also* failed issueAsk verification now demotes to NO-GO (→ escalation, not a hard fail) — is acceptable.

Alternative considered: gate on `GateProfile.SourceExtensions` instead of a doc denylist — rejected because `generic`-profile repos declare none, which would over-demote legitimate reviews (same dependency footgun as #1120).

## Verification

- New tests: `scopeMatchHasNonDoc` table; `enforceReviewerIssueAsk` doc-only match demotes; mixed doc+source still vouches; existing `.go` vouch test still green.
- `go test ./pkg/foreman/agent/` passes; `go vet`, `gofmt`, `make lint` clean.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`pkg/foreman/agent`)
- [x] `make lint` passes locally
- [x] Conventional commits
- [x] Signed off (DCO)
- [x] AI assistance disclosed — authored with Claude Code
- [ ] Documentation updated — n/a (internal reviewer rail)
