### PR TITLE
feat(controller): add llamacpp-router runtime for multi-model serving

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -108,12 +108,13 @@ type InferenceServiceSpec struct {
 
 	// Runtime selects the inference server backend.
 	// "llamacpp" (default): llama.cpp server with auto-generated args and /health probes.
+	// "llamacpp-router": llama.cpp server in router mode for multi-model dynamic loading.
 	// "generic": user-provided container with custom command, args, env, and probes.
 	// "personaplex": NVIDIA PersonaPlex (Moshi) speech-to-speech server.
 	// "vllm": vLLM OpenAI-compatible server with PagedAttention.
 	// "tgi": HuggingFace Text Generation Inference server.
 	// "sglang": SGLang OpenAI-compatible server with RadixAttention prefix caching.
-	// +kubebuilder:validation:Enum=llamacpp;personaplex;vllm;tgi;sglang;generic
+	// +kubebuilder:validation:Enum=llamacpp;llamacpp-router;personaplex;vllm;tgi;sglang;generic
 	// +kubebuilder:default=llamacpp
 	// +optional
 	Runtime string `json:"runtime,omitempty"`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -4471,6 +4471,7 @@ spec:
                 description: |-
                   Runtime selects the inference server backend.
                   "llamacpp" (default): llama.cpp server with auto-generated args and /health probes.
+                  "llamacpp-router": llama.cpp server in router mode for multi-model dynamic loading.
                   "generic": user-provided container with custom command, args, env, and probes.
                   "personaplex": NVIDIA PersonaPlex (Moshi) speech-to-speech server.
                   "vllm": vLLM OpenAI-compatible server with PagedAttention.
@@ -4478,6 +4479,7 @@ spec:
                   "sglang": SGLang OpenAI-compatible server with RadixAttention prefix caching.
                 enum:
                 - llamacpp
+                - llamacpp-router
                 - personaplex
                 - vllm
                 - tgi

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -4467,6 +4467,7 @@ spec:
                 description: |-
                   Runtime selects the inference server backend.
                   "llamacpp" (default): llama.cpp server with auto-generated args and /health probes.
+                  "llamacpp-router": llama.cpp server in router mode for multi-model dynamic loading.
                   "generic": user-provided container with custom command, args, env, and probes.
                   "personaplex": NVIDIA PersonaPlex (Moshi) speech-to-speech server.
                   "vllm": vLLM OpenAI-compatible server with PagedAttention.
@@ -4474,6 +4475,7 @@ spec:
                   "sglang": SGLang OpenAI-compatible server with RadixAttention prefix caching.
                 enum:
                 - llamacpp
+                - llamacpp-router
                 - personaplex
                 - vllm
                 - tgi

--- a/internal/controller/runtime.go
+++ b/internal/controller/runtime.go
@@ -80,6 +80,8 @@ func resolveBackend(isvc *inferencev1alpha1.InferenceService) RuntimeBackend {
 		return &PersonaPlexBackend{}
 	case RuntimeVLLM:
 		return &VLLMBackend{}
+	case RuntimeLlamaCppRouter:
+		return &LlamaCppRouterBackend{}
 	case "tgi":
 		return &TGIBackend{}
 	case RuntimeSGLANG:

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -186,6 +186,14 @@ type llamaCPUSlot struct {
 // idle status. All slots must report is_processing == false for the probe to
 // return true. Lifted from the original checkServerIdle in drain_before_rollout.go.
 func (b *LlamaCppBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
+	return llamaCppSlotsIdleProbe(client)
+}
+
+// llamaCppSlotsIdleProbe returns an idle-probe closure that queries the llama.cpp
+// /slots endpoint and reports true only when every slot has is_processing == false.
+// Shared by the single-model (LlamaCppBackend) and router (LlamaCppRouterBackend)
+// llama.cpp runtimes so the /slots logic lives in exactly one place.
+func llamaCppSlotsIdleProbe(client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
 	return func(ctx context.Context, baseURL string) (bool, error) {
 		url := fmt.Sprintf("%s/slots", baseURL)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/internal/controller/runtime_llamacpp_router.go
+++ b/internal/controller/runtime_llamacpp_router.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// llamaCppRouterLog is a package-level logger used for construction-time warnings from
+// BuildArgs.
+var llamaCppRouterLog = logf.Log.WithName("runtime.llamacpp-router")
+
+// RuntimeLlamaCppRouter is the InferenceService.Spec.Runtime value that selects the
+// llama.cpp router backend. Kept as a named constant so callers can cross-check the
+// runtime without duplicating the string literal.
+const RuntimeLlamaCppRouter = "llamacpp-router"
+
+// LlamaCppRouterBackend generates container configuration for the llama.cpp inference
+// server in router mode, which allows one Pod to host multiple models with dynamic
+// loading/unloading.
+//
+// Bring-your-own-models-volume: this runtime does NOT provision or mount the model
+// directory. Because NeedsModelInit returns false, the operator adds no model volume
+// or mount for it, so the model files must already be present at /models. Supply them
+// via spec.ExtraVolumes + spec.ExtraVolumeMounts (for example a PVC of GGUF files
+// mounted at /models).
+type LlamaCppRouterBackend struct{}
+
+func (b *LlamaCppRouterBackend) ContainerName() string {
+	return "llama-server"
+}
+
+func (b *LlamaCppRouterBackend) DefaultImage() string {
+	return "ghcr.io/ggml-org/llama.cpp:server"
+}
+
+func (b *LlamaCppRouterBackend) DefaultPort() int32 {
+	return 8080
+}
+
+func (b *LlamaCppRouterBackend) NeedsModelInit() bool {
+	// Router mode does not need a model init container because models are loaded
+	// dynamically from the models directory at runtime.
+	return false
+}
+
+func (b *LlamaCppRouterBackend) DefaultHPAMetric() string {
+	return "llamacpp:requests_processing"
+}
+
+// BuildArgs generates the llama.cpp server CLI arguments for router mode.
+// Router mode uses --models-dir instead of --model to enable dynamic multi-model
+// loading. Arguments are emitted in a deterministic order:
+//
+//  1. --models-dir (always, pointing at /models)
+//  2. --host, --port (always)
+//  3. --metrics (always; Prometheus endpoint)
+//  4. ExtraArgs (user escape hatch, always last so user flags win)
+//
+// Router mode intentionally emits NO GPU flags (--n-gpu-layers, --tensor-split):
+// different models may need different GPU configs, so those are left to per-model INI
+// presets or user ExtraArgs. When GPU resources are present a warning is logged.
+func (b *LlamaCppRouterBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, modelPath string, port int32) []string {
+	// Router mode uses --models-dir to point at the /models directory. NOTE: unlike the
+	// single-model runtime, router mode does NOT auto-mount /models -- NeedsModelInit is
+	// false, so the operator builds no model volume/mount (see deployment_builder.go,
+	// which only builds storage config when NeedsModelInit is true). The user must supply
+	// the models at /models via spec.ExtraVolumes + spec.ExtraVolumeMounts.
+	args := []string{
+		"--models-dir", "/models",
+		// Bind the dual-stack wildcard so pods are reachable on IPv6-only
+		// clusters (#972). With the default net.ipv6.bindv6only=0, :: also
+		// accepts IPv4, so IPv4-only and dual-stack clusters keep working.
+		// On IPv6-disabled nodes, override via extraArgs ("--host", "0.0.0.0");
+		// llama.cpp keeps the last occurrence of a repeated flag.
+		"--host", "::",
+		"--port", fmt.Sprintf("%d", port),
+	}
+
+	// GPU configuration: router mode still needs GPU flags when GPU resources
+	// are present, but we don't set --n-gpu-layers or sharding since models
+	// are loaded dynamically and each model can have its own GPU configuration
+	// via INI presets or model-specific settings.
+	gpuCount := resolveGPUCount(isvc, model)
+	if gpuCount > 0 {
+		// In router mode, we don't set --n-gpu-layers or --tensor-split because
+		// different models may need different GPU configurations. The user can
+		// specify GPU settings via ExtraArgs if they want to apply them globally,
+		// or use INI presets for model-specific GPU configuration.
+		llamaCppRouterLog.Info(
+			"GPU resources present but GPU sharding flags omitted in router mode; "+
+				"use ExtraArgs or INI presets for model-specific GPU configuration",
+			"inferenceService", isvc.Name,
+			"namespace", isvc.Namespace,
+			"gpuCount", gpuCount,
+		)
+	}
+
+	// Enable Prometheus metrics endpoint on llama.cpp
+	args = append(args, "--metrics")
+
+	// Append user-provided extra args last so they can override defaults
+	if len(isvc.Spec.ExtraArgs) > 0 {
+		args = append(args, isvc.Spec.ExtraArgs...)
+	}
+
+	return args
+}
+
+func (b *LlamaCppRouterBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *corev1.Probe) {
+	startup := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/health",
+				Port: intstr.FromInt32(port),
+			},
+		},
+		PeriodSeconds:    10,
+		TimeoutSeconds:   5,
+		FailureThreshold: 180,
+	}
+	liveness := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/health",
+				Port: intstr.FromInt32(port),
+			},
+		},
+		PeriodSeconds:    15,
+		TimeoutSeconds:   5,
+		FailureThreshold: 3,
+	}
+	readiness := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/health",
+				Port: intstr.FromInt32(port),
+			},
+		},
+		PeriodSeconds:    10,
+		TimeoutSeconds:   5,
+		FailureThreshold: 3,
+	}
+	return startup, liveness, readiness
+}
+
+// IdleProbe returns a probe closure that checks the llama.cpp /slots endpoint for
+// idle status (all slots is_processing == false). Shared with the single-model
+// llamacpp backend via llamaCppSlotsIdleProbe so the logic lives in one place.
+func (b *LlamaCppRouterBackend) IdleProbe(_ *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
+	return llamaCppSlotsIdleProbe(client)
+}

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -58,6 +58,7 @@ func TestRuntimeNameLabel(t *testing.T) {
 		{name: "tgi passes through", runtime: "tgi", expected: "tgi"},
 		{name: "personaplex passes through", runtime: "personaplex", expected: "personaplex"},
 		{name: "generic passes through", runtime: "generic", expected: "generic"},
+		{name: "llamacpp-router passes through", runtime: "llamacpp-router", expected: "llamacpp-router"},
 		// Future runtimes (vllm-swift on metal, etc.) pass through
 		// untouched: the label is the user-declared identifier, not a
 		// validated enum, so new backends do not need to update this map.
@@ -159,6 +160,16 @@ func TestResolveBackend_SGLang(t *testing.T) {
 	backend := resolveBackend(isvc)
 	if _, ok := backend.(*SGLangBackend); !ok {
 		t.Errorf("resolveBackend(sglang) = %T, want *SGLangBackend", backend)
+	}
+}
+
+func TestResolveBackend_LlamaCppRouter(t *testing.T) {
+	isvc := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{Runtime: "llamacpp-router"},
+	}
+	backend := resolveBackend(isvc)
+	if _, ok := backend.(*LlamaCppRouterBackend); !ok {
+		t.Errorf("resolveBackend(llamacpp-router) = %T, want *LlamaCppRouterBackend", backend)
 	}
 }
 
@@ -369,6 +380,7 @@ func TestIdleDetectorConformance(t *testing.T) {
 		backend RuntimeBackend
 	}{
 		{"llamacpp", &LlamaCppBackend{}},
+		{"llamacpp-router", &LlamaCppRouterBackend{}},
 		{"vllm", &VLLMBackend{}},
 		{"tgi", &TGIBackend{}},
 		{"sglang", &SGLangBackend{}},
@@ -602,6 +614,7 @@ func TestIdleProbeRequestCreationError(t *testing.T) {
 		isvc    *inferencev1alpha1.InferenceService
 	}{
 		{"llamacpp", &LlamaCppBackend{}, nil},
+		{"llamacpp-router", &LlamaCppRouterBackend{}, nil},
 		{"vllm", &VLLMBackend{}, nil},
 		{"tgi", &TGIBackend{}, nil},
 		{"sglang", &SGLangBackend{}, nil},
@@ -624,5 +637,120 @@ func TestIdleProbeRequestCreationError(t *testing.T) {
 				t.Errorf("expected idle=false on error")
 			}
 		})
+	}
+}
+
+func TestLlamaCppRouterBackend_BuildArgs(t *testing.T) {
+	backend := &LlamaCppRouterBackend{}
+	isvc := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{},
+	}
+	model := &inferencev1alpha1.Model{}
+	args := backend.BuildArgs(isvc, model, "", 8080)
+
+	// Router mode should use --models-dir instead of --model
+	if !containsArg(args, "--models-dir", "/models") {
+		t.Error("BuildArgs should include --models-dir /models")
+	}
+
+	// Should include standard host and port flags
+	if !containsArg(args, "--host", "::") {
+		t.Error("BuildArgs should include --host ::")
+	}
+	if !containsArg(args, "--port", "8080") {
+		t.Error("BuildArgs should include --port 8080")
+	}
+
+	// Should include metrics flag
+	if !containsArg(args, "--metrics", "") {
+		t.Error("BuildArgs should include --metrics")
+	}
+
+	// Should NOT include --model flag (router mode uses --models-dir)
+	if containsArg(args, "--model", "") {
+		t.Error("BuildArgs should NOT include --model in router mode")
+	}
+}
+
+func TestLlamaCppRouterBackend_NeedsModelInit(t *testing.T) {
+	backend := &LlamaCppRouterBackend{}
+	if backend.NeedsModelInit() {
+		t.Error("LlamaCppRouterBackend should not need model init container")
+	}
+}
+
+func TestLlamaCppRouterBackend_Defaults(t *testing.T) {
+	backend := &LlamaCppRouterBackend{}
+
+	if backend.ContainerName() != "llama-server" {
+		t.Errorf("ContainerName = %q, want \"llama-server\"", backend.ContainerName())
+	}
+
+	if backend.DefaultImage() != "ghcr.io/ggml-org/llama.cpp:server" {
+		t.Errorf("DefaultImage = %q, want \"ghcr.io/ggml-org/llama.cpp:server\"", backend.DefaultImage())
+	}
+
+	if backend.DefaultPort() != 8080 {
+		t.Errorf("DefaultPort = %d, want 8080", backend.DefaultPort())
+	}
+
+	if backend.DefaultHPAMetric() != "llamacpp:requests_processing" {
+		t.Errorf("DefaultHPAMetric = %q, want \"llamacpp:requests_processing\"", backend.DefaultHPAMetric())
+	}
+}
+
+func TestLlamaCppRouterBackend_BuildProbes(t *testing.T) {
+	backend := &LlamaCppRouterBackend{}
+	startup, liveness, readiness := backend.BuildProbes(8080)
+
+	// Verify startup probe
+	if startup == nil {
+		t.Fatal("startup probe should not be nil")
+	}
+	if startup.ProbeHandler.HTTPGet == nil {
+		t.Fatal("startup probe HTTPGet should not be nil")
+	}
+	if startup.ProbeHandler.HTTPGet.Path != "/health" {
+		t.Errorf("startup probe path = %q, want \"/health\"", startup.ProbeHandler.HTTPGet.Path)
+	}
+	if startup.PeriodSeconds != 10 {
+		t.Errorf("startup probe period = %d, want 10", startup.PeriodSeconds)
+	}
+	if startup.FailureThreshold != 180 {
+		t.Errorf("startup probe failure threshold = %d, want 180", startup.FailureThreshold)
+	}
+
+	// Verify liveness probe
+	if liveness == nil {
+		t.Fatal("liveness probe should not be nil")
+	}
+	if liveness.ProbeHandler.HTTPGet == nil {
+		t.Fatal("liveness probe HTTPGet should not be nil")
+	}
+	if liveness.ProbeHandler.HTTPGet.Path != "/health" {
+		t.Errorf("liveness probe path = %q, want \"/health\"", liveness.ProbeHandler.HTTPGet.Path)
+	}
+	if liveness.PeriodSeconds != 15 {
+		t.Errorf("liveness probe period = %d, want 15", liveness.PeriodSeconds)
+	}
+	if liveness.FailureThreshold != 3 {
+		t.Errorf("liveness probe failure threshold = %d, want 3", liveness.FailureThreshold)
+	}
+
+	// Verify readiness probe
+	if readiness == nil {
+		t.Fatal("readiness probe should not be nil")
+	}
+	if readiness.ProbeHandler.HTTPGet == nil {
+		t.Fatal("readiness probe HTTPGet should not be nil")
+	}
+	if readiness.ProbeHandler.HTTPGet.Path != "/health" {
+		t.Errorf("readiness probe path = %q, want \"/health\"", readiness.ProbeHandler.HTTPGet.Path)
+	}
+	if readiness.PeriodSeconds != 10 {
+		t.Errorf("readiness probe period = %d, want 10", readiness.PeriodSeconds)
+	}
+	if readiness.FailureThreshold != 3 {
+		t.Errorf("readiness probe failure threshold = %d, want 3", readiness.FailureThreshold)
 	}
 }


### PR DESCRIPTION
## What

Adds a new `runtime: llamacpp-router` option on `InferenceService.spec` that runs the llama.cpp server in router mode: one Pod hosts multiple models with dynamic load/unload via `--models-dir` instead of `--model`. Purely additive — the single-model `llamacpp` path and the `ModelRouter` CRD are unchanged.

## Why

On constrained/edge nodes (single GPU, low-VRAM mini-PCs), giving each model its own Pod wastes VRAM. Router mode lets one endpoint serve N models with on-demand load/unload, fronted transparently by an existing `ModelRouter`.

## How

- New `LlamaCppRouterBackend` (`internal/controller/runtime_llamacpp_router.go`) implementing the `RuntimeBackend` interface; registered in `resolveBackend()`.
- `Runtime` enum + kubebuilder validation extended with `llamacpp-router`; CRDs regenerated in both `config/crd` and the Helm chart.
- `NeedsModelInit() == false` (no init container). Router mode is **bring-your-own `/models` volume** — the operator mounts nothing; the user supplies models at `/models` via `spec.ExtraVolumes` + `spec.ExtraVolumeMounts` (documented on the type).
- Router mode emits no GPU-sharding flags (per-model configs go via INI presets / `ExtraArgs`); a warning is logged when GPU resources are present.
- `/slots` idle detection is shared with the single-model backend via a common `llamaCppSlotsIdleProbe` helper (no duplication).

## Testing

- `go build` / `go vet` clean; `make validate-samples` passes.
- CRD/codegen regeneration (manifests, generate, chart-crds, foreman-chart-crds) produces no drift.
- Full envtest suite (`internal/controller`, `internal/foreman/controller`) passes — verified independently on a clean checkout after rebase, not only in the coder's workspace.
- New unit tests cover arg-building (`--models-dir` present, `--model` absent), backend resolution, `NeedsModelInit`, defaults, and probes.

## Checklist

- [x] Additive; no breaking changes
- [x] CRDs regenerated and in sync (config/crd + chart)
- [x] Tests added and passing (unit + envtest)
- [x] `Fixes #516`

## AI assistance

Implemented via the Foreman agentic-coding harness (GLM-4.7-REAP-218B) and code-reviewed; the review findings (docs correction + idle-probe de-duplication) were then applied, the branch rebased onto current `main`, and independently re-verified (build + full envtest gate) by the author. Band-3 disclosure per the project's AI-assisted contribution policy; the author owns the review conversation.
