### PR TITLE
feat(finalize): gate foreman-finalize on the Foreman verify verdict (#1150)

### DIFF
--- a/scripts/foreman-finalize.sh
+++ b/scripts/foreman-finalize.sh
@@ -24,7 +24,14 @@
 #   --fork <remote>      Remote holding the Foreman branch (default: origin)
 #   --repo <owner/name>  Base repo slug for gh (default: derived from base remote)
 #   --fork-owner <owner> Fork owner for the PR head (default: derived from fork remote)
-#   --full-test          Also run `make test` (envtest) locally
+#   --full-test          Also run `make test` (envtest) locally; when set, this
+#                        local gate is treated as authoritative and the Foreman
+#                        verify-verdict check is skipped
+#   --kube-context <ctx> kube context for the Foreman verify-verdict lookup
+#                        (default: current kubectl context)
+#   --namespace <ns>     namespace for the verify-verdict lookup (default: default)
+#   --force              Skip the Foreman verify-verdict check (for branches you
+#                        have independently gated by hand); prints a warning
 #   --message-file <f>   Use this file as the commit message (overrides derivation)
 #   --pr-body-file <f>   Use this file as the PR body (overrides the template)
 #   --dry-run            Do everything locally through the squash; print the push
@@ -49,6 +56,9 @@ REPO=""
 FORK_OWNER=""
 FULL_TEST=0
 DRY_RUN=0
+FORCE=0
+KUBE_CONTEXT=""
+NAMESPACE="default"
 MESSAGE_FILE=""
 PR_BODY_FILE=""
 
@@ -63,6 +73,43 @@ die() {
 	exit 1
 }
 info() { echo ">> $*"; }
+
+# require_verify_verdict: refuse to finalize unless Foreman's verify stage passed
+# for this branch. The verify stage (kind=verify) fresh-clones the pushed branch and
+# runs the deterministic gate; its GATE-PASS verdict is what makes the branch
+# trustworthy. --force overrides (for branches gated by hand); --full-test defers to
+# the local envtest run performed later in this script.
+require_verify_verdict() {
+	if ((FORCE)); then
+		info "WARNING: --force set; skipping the Foreman verify-verdict check for '$BRANCH'. Confirm the branch was independently gated (envtest) before merging."
+		return 0
+	fi
+	if ((FULL_TEST)); then
+		info "--full-test set; the local envtest run is the authoritative gate (skipping Foreman verify-verdict lookup)"
+		return 0
+	fi
+	command -v kubectl >/dev/null ||
+		die "kubectl is required to check the Foreman verify verdict for '$BRANCH' (or pass --full-test to gate locally, or --force to override)"
+	command -v jq >/dev/null ||
+		die "jq is required to parse the Foreman verify verdict (or pass --full-test / --force)"
+	local ctx_args=()
+	[[ -n "$KUBE_CONTEXT" ]] && ctx_args=(--context "$KUBE_CONTEXT")
+	local verdict
+	verdict="$(kubectl "${ctx_args[@]}" -n "$NAMESPACE" get agentictasks -o json 2>/dev/null |
+		jq -r --arg b "$BRANCH" '
+			[.items[]
+			 | select(.spec.kind == "verify")
+			 | select(((.spec.payload.branch // .status.branch) // "") == $b)]
+			| sort_by(.metadata.creationTimestamp) | last | (.status.verdict // "")')" ||
+		die "failed to query AgenticTasks in namespace '$NAMESPACE' (pass --kube-context / --namespace, or --full-test / --force)"
+	if [[ -z "$verdict" || "$verdict" == "null" ]]; then
+		die "no Foreman verify (kind=verify) task found for branch '$BRANCH' in namespace '$NAMESPACE'; refusing to finalize an unverified branch. Run the verify stage, or pass --full-test to gate locally, or --force to override."
+	fi
+	if [[ "$verdict" != "GATE-PASS" ]]; then
+		die "Foreman verify for '$BRANCH' did not pass (verdict='$verdict'); refusing to finalize. Fix and re-verify, or pass --force to override."
+	fi
+	info "Foreman verify verdict for '$BRANCH': GATE-PASS"
+}
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -101,6 +148,18 @@ while [[ $# -gt 0 ]]; do
 	--full-test)
 		FULL_TEST=1
 		shift
+		;;
+	--force)
+		FORCE=1
+		shift
+		;;
+	--kube-context)
+		KUBE_CONTEXT="${2:-}"
+		shift 2
+		;;
+	--namespace)
+		NAMESPACE="${2:-}"
+		shift 2
 		;;
 	--dry-run)
 		DRY_RUN=1
@@ -188,6 +247,9 @@ ORIG_REF="$(git rev-parse --abbrev-ref HEAD)"
 
 command -v gh >/dev/null || die "gh (GitHub CLI) is required"
 gh auth status >/dev/null 2>&1 || die "gh is not authenticated (run: gh auth login)"
+
+# Refuse to finalize a branch Foreman's verify stage never blessed (#1150).
+require_verify_verdict
 
 # A fully clean tree is required: the assemble step below stages with `git add -A`,
 # so a stray untracked file would otherwise be swept into the finalize commit.

--- a/scripts/foreman-finalize_verify_test.sh
+++ b/scripts/foreman-finalize_verify_test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Regression test for foreman-finalize.sh's verify-verdict gate (#1150).
+#
+# Self-contained: stubs `kubectl` and `gh` on PATH and drives the real script
+# through the preflight verify check, asserting each decision path. Does not
+# touch the network or git remotes (the script dies at the verify check, or is
+# asserted to have passed it, before any fetch).
+#
+# Usage: scripts/foreman-finalize_verify_test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FINALIZE="$SCRIPT_DIR/foreman-finalize.sh"
+[[ -x "$FINALIZE" || -f "$FINALIZE" ]] || { echo "cannot find foreman-finalize.sh"; exit 1; }
+
+STUB="$(mktemp -d)"
+trap 'rm -rf "$STUB"' EXIT
+
+cat >"$STUB/gh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+cat >"$STUB/kubectl" <<'SH'
+#!/usr/bin/env bash
+if [[ -n "${FAKE_VERDICT:-}" ]]; then
+  cat <<JSON
+{"items":[{"metadata":{"creationTimestamp":"2026-07-17T10:00:00Z"},"spec":{"kind":"verify","payload":{"branch":"foreman/t/issue-9"}},"status":{"verdict":"${FAKE_VERDICT}"}}]}
+JSON
+else
+  echo '{"items":[]}'
+fi
+SH
+chmod +x "$STUB/gh" "$STUB/kubectl"
+
+fails=0
+# check <desc> <grep-pattern> <FAKE_VERDICT> [extra script args...]
+check() {
+  local desc="$1" pat="$2" verdict="${3:-}"; shift 3
+  local out
+  out="$(FAKE_VERDICT="$verdict" PATH="$STUB:$PATH" bash "$FINALIZE" \
+    --branch foreman/t/issue-9 --issue 9 "$@" 2>&1 || true)"
+  if grep -qiE "$pat" <<<"$out"; then
+    echo "ok   - $desc"
+  else
+    echo "FAIL - $desc (wanted /$pat/)"; echo "$out" | sed 's/^/       /' | head -4; fails=$((fails+1))
+  fi
+}
+
+check "NO-GO verdict is refused"           "did not pass.*refusing"            NO-GO
+check "no verify task is refused"          "no Foreman verify.*refusing"       ""
+check "GATE-PASS passes the check"         "verify verdict.*GATE-PASS"         GATE-PASS
+check "--force warns and skips"            "force set.*skipping"               NO-GO --force
+check "--full-test defers to local gate"   "full-test set.*authoritative gate" NO-GO --full-test
+
+if ((fails)); then
+  echo "FAILED: $fails case(s)"; exit 1
+fi
+echo "PASS: all verify-gate cases"


### PR DESCRIPTION
## What

Gate `scripts/foreman-finalize.sh` on Foreman's verify verdict. Before opening a PR, it resolves the newest `kind=verify` AgenticTask for the branch and **refuses to finalize unless the verdict is `GATE-PASS`**.

## Why

Finalize previously took a `--branch` the caller *asserted* was GO'd and re-ran only local build/codegen. It never consulted Foreman's verify stage, so it could open a PR on a branch whose verify failed, was INCOMPLETE, or never ran. This closes that hole: an unverified branch cannot be finalized by default.

## How

- New preflight `require_verify_verdict` (runs right after the `gh` auth check, before any fetch): `kubectl get agentictasks -o json | jq` → newest `kind=verify` task whose `payload.branch`/`status.branch` matches `--branch` → require `status.verdict == GATE-PASS`.
- Fallbacks for paths with no Foreman verify task:
  - `--full-test` (existing): the local `make test` (envtest) run is treated as the authoritative gate; the verdict lookup is skipped.
  - `--force` (new): explicit override for hand-verified branches, with a loud warning.
- New `--kube-context` / `--namespace` flags scope the lookup (default: current context, `default` ns).
- `scripts/foreman-finalize_verify_test.sh` stubs `kubectl`/`gh` and asserts all five paths (refuse-on-NO-GO, refuse-when-absent, pass-on-GATE-PASS, `--force`, `--full-test`).

## Scope note

The original #1150 proposed *building* a post-GO clean-room verify stage. On inspection, that already exists: the workload controller auto-emits a `kind=verify` step that fresh-clones the pushed branch and runs the deterministic gate, and the rollup already folds `GATE-PASS` into the workload verdict. So this PR is re-scoped to the one real gap: finalize not consulting that verdict. Surfacing verify-less *raw* pipelines via a controller condition is left as an optional follow-up.

## Testing

- `shellcheck` clean on both scripts.
- `scripts/foreman-finalize_verify_test.sh` passes all five decision paths (no network/git).

## AI assistance

Designed and implemented with AI assistance (Claude); the author reviewed and verified (shellcheck + the script test). Band-3 disclosure per the project's AI-assisted contribution policy.

Fixes #1150
