### PR TITLE
feat(controller): ROCm/HIP runtime tier for AMD nodes (#701)

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -205,12 +205,12 @@ type GPUSpec struct {
 	//   - "rocm": the HIP compute tier (#701). Schedules LLMKube's
 	//     hardware-validated ROCm llama.cpp image and requests the same
 	//     shared `devic.es/dri-render` resource as "vulkan" (unless
-	//     ResourceName overrides it) — the two runtimes contend for the same
+	//     ResourceName overrides it): the two runtimes contend for the same
 	//     physical device on single-GPU AMD nodes, so they share one
 	//     device-plugin resource rather than each claiming their own. "rocm"
 	//     differs from "vulkan" only in the container image it selects.
 	//   - "" (empty): falls through to `amd.com/gpu` with the vendor-neutral
-	//     stock image — back-compatible with pre-#701 behavior, not the same
+	//     stock image, back-compatible with pre-#701 behavior, not the same
 	//     as "rocm".
 	//
 	// Ignored for non-AMD vendors and non-llama.cpp backends.

--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -118,6 +118,11 @@ type HardwareSpec struct {
 	// (gpu.vendor: amd/intel + gpu.runtime: vulkan). When set to
 	// "vulkan" the readiness-check path uses devic.es/dri-render as
 	// the GPU resource name instead of amd.com/gpu or nvidia.com/gpu.
+	// "rocm" is the HIP compute tier for AMD GPUs (LLMKube's own
+	// hardware-validated ROCm llama.cpp image, see #701); like "vulkan"
+	// it resolves to devic.es/dri-render rather than amd.com/gpu, since
+	// the two runtimes share the same physical device on single-GPU AMD
+	// nodes. The tiers differ only in the container image they select.
 	// +kubebuilder:validation:Enum=cpu;metal;cuda;rocm;intel;vulkan
 	// +kubebuilder:default=cpu
 	// +optional
@@ -197,8 +202,16 @@ type GPUSpec struct {
 	//     ResourceName overrides it). The plugin injects /dev/dri; the non-root
 	//     container still needs the host render group, supplied via
 	//     InferenceService.spec.podSecurityContext.supplementalGroups.
-	//   - "rocm": the historical behavior (amd -> amd.com/gpu, stock image).
-	//   - "" (empty): back-compatible, identical to "rocm".
+	//   - "rocm": the HIP compute tier (#701). Schedules LLMKube's
+	//     hardware-validated ROCm llama.cpp image and requests the same
+	//     shared `devic.es/dri-render` resource as "vulkan" (unless
+	//     ResourceName overrides it) — the two runtimes contend for the same
+	//     physical device on single-GPU AMD nodes, so they share one
+	//     device-plugin resource rather than each claiming their own. "rocm"
+	//     differs from "vulkan" only in the container image it selects.
+	//   - "" (empty): falls through to `amd.com/gpu` with the vendor-neutral
+	//     stock image — back-compatible with pre-#701 behavior, not the same
+	//     as "rocm".
 	//
 	// Ignored for non-AMD vendors and non-llama.cpp backends.
 	// +kubebuilder:validation:Enum=vulkan;rocm

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -94,6 +94,11 @@ spec:
                       (gpu.vendor: amd/intel + gpu.runtime: vulkan). When set to
                       "vulkan" the readiness-check path uses devic.es/dri-render as
                       the GPU resource name instead of amd.com/gpu or nvidia.com/gpu.
+                      "rocm" is the HIP compute tier for AMD GPUs (LLMKube's own
+                      hardware-validated ROCm llama.cpp image, see #701); like "vulkan"
+                      it resolves to devic.es/dri-render rather than amd.com/gpu, since
+                      the two runtimes share the same physical device on single-GPU AMD
+                      nodes. The tiers differ only in the container image they select.
                     enum:
                     - cpu
                     - metal
@@ -229,8 +234,16 @@ spec:
                               ResourceName overrides it). The plugin injects /dev/dri; the non-root
                               container still needs the host render group, supplied via
                               InferenceService.spec.podSecurityContext.supplementalGroups.
-                            - "rocm": the historical behavior (amd -> amd.com/gpu, stock image).
-                            - "" (empty): back-compatible, identical to "rocm".
+                            - "rocm": the HIP compute tier (#701). Schedules LLMKube's
+                              hardware-validated ROCm llama.cpp image and requests the same
+                              shared `devic.es/dri-render` resource as "vulkan" (unless
+                              ResourceName overrides it) — the two runtimes contend for the same
+                              physical device on single-GPU AMD nodes, so they share one
+                              device-plugin resource rather than each claiming their own. "rocm"
+                              differs from "vulkan" only in the container image it selects.
+                            - "" (empty): falls through to `amd.com/gpu` with the vendor-neutral
+                              stock image — back-compatible with pre-#701 behavior, not the same
+                              as "rocm".
 
                           Ignored for non-AMD vendors and non-llama.cpp backends.
                         enum:

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -237,12 +237,12 @@ spec:
                             - "rocm": the HIP compute tier (#701). Schedules LLMKube's
                               hardware-validated ROCm llama.cpp image and requests the same
                               shared `devic.es/dri-render` resource as "vulkan" (unless
-                              ResourceName overrides it) — the two runtimes contend for the same
+                              ResourceName overrides it): the two runtimes contend for the same
                               physical device on single-GPU AMD nodes, so they share one
                               device-plugin resource rather than each claiming their own. "rocm"
                               differs from "vulkan" only in the container image it selects.
                             - "" (empty): falls through to `amd.com/gpu` with the vendor-neutral
-                              stock image — back-compatible with pre-#701 behavior, not the same
+                              stock image, back-compatible with pre-#701 behavior, not the same
                               as "rocm".
 
                           Ignored for non-AMD vendors and non-llama.cpp backends.

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -233,12 +233,12 @@ spec:
                             - "rocm": the HIP compute tier (#701). Schedules LLMKube's
                               hardware-validated ROCm llama.cpp image and requests the same
                               shared `devic.es/dri-render` resource as "vulkan" (unless
-                              ResourceName overrides it) — the two runtimes contend for the same
+                              ResourceName overrides it): the two runtimes contend for the same
                               physical device on single-GPU AMD nodes, so they share one
                               device-plugin resource rather than each claiming their own. "rocm"
                               differs from "vulkan" only in the container image it selects.
                             - "" (empty): falls through to `amd.com/gpu` with the vendor-neutral
-                              stock image — back-compatible with pre-#701 behavior, not the same
+                              stock image, back-compatible with pre-#701 behavior, not the same
                               as "rocm".
 
                           Ignored for non-AMD vendors and non-llama.cpp backends.

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -90,6 +90,11 @@ spec:
                       (gpu.vendor: amd/intel + gpu.runtime: vulkan). When set to
                       "vulkan" the readiness-check path uses devic.es/dri-render as
                       the GPU resource name instead of amd.com/gpu or nvidia.com/gpu.
+                      "rocm" is the HIP compute tier for AMD GPUs (LLMKube's own
+                      hardware-validated ROCm llama.cpp image, see #701); like "vulkan"
+                      it resolves to devic.es/dri-render rather than amd.com/gpu, since
+                      the two runtimes share the same physical device on single-GPU AMD
+                      nodes. The tiers differ only in the container image they select.
                     enum:
                     - cpu
                     - metal
@@ -225,8 +230,16 @@ spec:
                               ResourceName overrides it). The plugin injects /dev/dri; the non-root
                               container still needs the host render group, supplied via
                               InferenceService.spec.podSecurityContext.supplementalGroups.
-                            - "rocm": the historical behavior (amd -> amd.com/gpu, stock image).
-                            - "" (empty): back-compatible, identical to "rocm".
+                            - "rocm": the HIP compute tier (#701). Schedules LLMKube's
+                              hardware-validated ROCm llama.cpp image and requests the same
+                              shared `devic.es/dri-render` resource as "vulkan" (unless
+                              ResourceName overrides it) — the two runtimes contend for the same
+                              physical device on single-GPU AMD nodes, so they share one
+                              device-plugin resource rather than each claiming their own. "rocm"
+                              differs from "vulkan" only in the container image it selects.
+                            - "" (empty): falls through to `amd.com/gpu` with the vendor-neutral
+                              stock image — back-compatible with pre-#701 behavior, not the same
+                              as "rocm".
 
                           Ignored for non-AMD vendors and non-llama.cpp backends.
                         enum:

--- a/config/samples/model_amd_rocm_igpu.yaml
+++ b/config/samples/model_amd_rocm_igpu.yaml
@@ -1,0 +1,47 @@
+# Example: AMD APU / iGPU with the llama.cpp ROCm (HIP) backend
+#
+# Per-model opt-in ROCm tier (#701). Vulkan remains the AMD default; choose
+# ROCm when prefill latency, long-context decode, or batched concurrency
+# dominate your workload. The operator schedules this against the same
+# devic.es/dri-render resource as Vulkan (one resource per physical AMD GPU);
+# that resource's group must include /dev/kfd for HIP (see
+# docs/amd-rocm-quickstart.md).
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen36-27b-rocm
+  namespace: default
+spec:
+  source: https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/Qwen3.6-27B-Q6_K.gguf
+  format: gguf
+  quantization: Q6_K
+  hardware:
+    accelerator: rocm
+    gpu:
+      enabled: true
+      vendor: amd
+      runtime: rocm
+      count: 1
+  resources:
+    cpu: "2"
+    memory: 8Gi
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen36-27b-rocm
+  namespace: default
+spec:
+  modelRef: qwen36-27b-rocm
+  replicas: 1
+  contextSize: 32768
+  flashAttention: true
+  resources:
+    cpu: "4"
+    gpu: 1
+    memory: 12Gi
+  endpoint:
+    type: ClusterIP
+    port: 8080
+    path: /v1/chat/completions

--- a/docs/amd-rocm-quickstart.md
+++ b/docs/amd-rocm-quickstart.md
@@ -1,0 +1,315 @@
+# AMD ROCm Quickstart
+
+This guide walks through deploying an LLM on an AMD GPU using the llama.cpp
+ROCm (HIP) backend with LLMKube (issue #701). It is a per-model opt-in tier
+alongside the existing [AMD Vulkan sample](../config/samples/model_amd_vulkan_igpu.yaml):
+Vulkan remains the AMD default, and ROCm is something you choose for specific
+workloads.
+
+## When to Use ROCm vs Vulkan
+
+Be honest with yourself about what ROCm buys you before switching a model
+over. On a single AMD iGPU/APU node:
+
+- ROCm wins on **prefill (prompt processing)**, **long-context decode
+  retention**, and **batched concurrency**. Attention and matmul-heavy
+  workloads benefit from HIP's more mature kernels, and rocWMMA flash
+  attention holds up better as context grows.
+- **Vulkan stays the default.** Short-context decode on these nodes is
+  memory-bandwidth-bound, not compute-bound, so the two backends are close
+  and Vulkan usually wins that specific case. There is no free "ROCm is
+  faster inference" win: pick the backend that matches your workload shape,
+  not the newer-sounding one.
+- In practice: reach for ROCm when you are running long prompts, large
+  context windows, or many concurrent requests against the same model. Stay
+  on Vulkan for short-prompt, low-concurrency chat traffic.
+
+The [Benchmarks](#benchmarks) section below has (or will have) measured
+numbers for a concrete model on this hardware; use them, not vibes, to decide
+per-model.
+
+## Node Prerequisites
+
+- Kubernetes cluster with an AMD GPU node and a generic-device-plugin
+  (for example `squat/generic-device-plugin`) advertising the shared
+  `devic.es/dri-render` resource described below.
+- Linux kernel >= 6.18.4.
+- `linux-firmware` >= 20260110. **20251125 is known-bad**; do not run it on a
+  ROCm-tier node.
+- `amdgpu.lockup_timeout=20000` kernel argument recommended. ROCm's own
+  memory and kernel scheduling behave differently than Vulkan's under
+  sustained load, and the default ~10s GPU reset timeout can trip a false
+  "device lost" on long-context or high-concurrency runs. 20 seconds avoids
+  the false positive without masking a genuine hang.
+- LLMKube operator installed.
+- `kubectl` configured for your cluster.
+
+### Device plugin: one shared resource, not two
+
+ROCm and Vulkan schedule against the **same** device-plugin resource,
+`devic.es/dri-render`. There is no separate `devic.es/amd-rocm` resource.
+The group backing `devic.es/dri-render` must include `/dev/kfd` (HIP's
+device node) alongside `/dev/dri/renderD128` and a globbed
+`/dev/dri/card*` (the card index can move across reboots):
+
+```yaml
+# generic-device-plugin DaemonSet arg (excerpt)
+- --device
+- |
+  name: dri-render
+  groups:
+    - count: 4
+      paths:
+        - path: /dev/kfd
+        - path: /dev/dri/renderD128
+        - path: /dev/dri/card*
+```
+
+This is deliberate, not a shortcut. A node with one physical AMD GPU has
+exactly one render device to hand out, so:
+
+- **Single physical GPU.** There is only one device to advertise. A second
+  resource would just be a second name for the same hardware.
+- **Health-watch collisions.** `generic-device-plugin` runs an independent
+  health check per advertised group. Two groups whose paths overlap
+  (`renderD128`, `card*`) end up polling and locking the same device files
+  from two goroutines, which is a source of spurious unhealthy/flapping
+  device state.
+- **GPU double-count.** If `devic.es/dri-render` and `devic.es/amd-rocm` were
+  both advertised for the same physical GPU, the scheduler would see twice
+  the allocatable GPU capacity that actually exists, and could place a
+  Vulkan pod and a ROCm pod on the same GPU at once, expecting isolation
+  that does not exist.
+
+Verify the node advertises the resource and that `/dev/kfd` is actually
+injected:
+
+```bash
+kubectl get nodes -o custom-columns=NAME:.metadata.name,DRI:.status.allocatable."devic\.es/dri-render"
+```
+
+Expected: a non-zero `devic.es/dri-render` value on the AMD GPU node.
+
+```bash
+kubectl run rocm-probe --rm -i --restart=Never --image=busybox:1.36 \
+  --overrides='{"spec":{"tolerations":[{"key":"devic.es/dri-render","operator":"Exists"}],"containers":[{"name":"p","image":"busybox:1.36","command":["ls","-la","/dev/kfd","/dev/dri"],"resources":{"limits":{"devic.es/dri-render":"1"}}}]}}'
+```
+
+Expected: the listing includes both `/dev/kfd` and `/dev/dri/renderD128`.
+
+## Selecting the ROCm Tier
+
+Select ROCm per-model with `hardware.gpu.vendor: amd` and
+`hardware.gpu.runtime: rocm` (the `llmkube` CLI does not yet expose the GPU
+runtime selector; use a YAML manifest):
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen36-27b-rocm
+  namespace: default
+spec:
+  source: https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/Qwen3.6-27B-Q6_K.gguf
+  format: gguf
+  quantization: Q6_K
+  hardware:
+    accelerator: rocm
+    gpu:
+      enabled: true
+      vendor: amd
+      runtime: rocm
+      count: 1
+  resources:
+    cpu: "2"
+    memory: 8Gi
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen36-27b-rocm
+  namespace: default
+spec:
+  modelRef: qwen36-27b-rocm
+  replicas: 1
+  contextSize: 32768
+  flashAttention: true
+  resources:
+    cpu: "4"
+    gpu: 1
+    memory: 12Gi
+  endpoint:
+    type: ClusterIP
+    port: 8080
+    path: /v1/chat/completions
+```
+
+The full sample lives at
+[`config/samples/model_amd_rocm_igpu.yaml`](../config/samples/model_amd_rocm_igpu.yaml).
+Apply it directly:
+
+```bash
+kubectl apply -f config/samples/model_amd_rocm_igpu.yaml
+```
+
+### Escape hatch: AMD's official device plugin
+
+If your cluster instead runs AMD's official ROCm device plugin (the one that
+advertises `amd.com/gpu`, as covered in the
+[Strix Halo quickstart](strix-halo-onboarding.md)), you are not forced onto
+`devic.es/dri-render`. Set `hardware.gpu.resourceName: amd.com/gpu` on the
+Model explicitly; an explicit `resourceName` always wins over the
+vendor/runtime defaults.
+
+### Behavior change from before #701
+
+Before #701, `vendor: amd` with `runtime: rocm` (or `runtime` left unset)
+fell through to the `amd.com/gpu` resource with the stock (non-HIP) image, so
+it never actually served on ROCm. That fallthrough is **preserved** for an
+unset `runtime` (back-compat with existing manifests targeting AMD's
+official plugin). Setting `runtime: rocm` **explicitly** is what opts a Model
+into the new shared `devic.es/dri-render` resource and LLMKube's ROCm image.
+If you have existing AMD Models with `runtime` unset, they keep working
+exactly as before; nothing changes until you add `runtime: rocm`.
+
+## Verify Scheduling and HIP Offload
+
+```bash
+kubectl get model qwen36-27b-rocm -w
+kubectl get inferenceservice qwen36-27b-rocm -w
+kubectl get pods -l app=qwen36-27b-rocm -o wide
+```
+
+Check the pod requested `devic.es/dri-render` and got the matching
+toleration:
+
+```bash
+kubectl get deploy qwen36-27b-rocm -o jsonpath='{.spec.template.spec.containers[0].resources.limits}{"\n"}{.spec.template.spec.tolerations}{"\n"}'
+```
+
+Confirm HIP/ROCm offload in the logs (llama.cpp's HIP build reuses its CUDA
+backend code path, so the log lines say "ROCm devices" rather than "HIP
+devices"):
+
+```bash
+POD=$(kubectl get pod -l app=qwen36-27b-rocm -o jsonpath='{.items[0].metadata.name}')
+kubectl logs "$POD" -c llama-server --tail=200
+```
+
+Expected log markers:
+
+- `found 1 ROCm devices`
+- `offloaded .../... layers to GPU`
+
+## Measure Token Throughput
+
+```bash
+kubectl port-forward svc/qwen36-27b-rocm 8080:8080
+```
+
+In another terminal:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "messages": [{"role": "user", "content": "Explain Kubernetes in one sentence."}],
+    "max_tokens": 128,
+    "temperature": 0.2,
+    "stream": false
+  }' | jq '.timings.prompt_per_second, .timings.predicted_per_second'
+```
+
+`prompt_per_second` is where ROCm's prefill advantage should show up most;
+`predicted_per_second` (decode) is the bandwidth-bound number where Vulkan
+is often competitive or ahead at short context.
+
+## Large-Model Note: ttm.pages_limit
+
+The default kernel GTT/UMA ceiling caps how much system memory the GPU can
+address at once, which in practice limits GPU-visible memory to roughly
+**62GB** on a Strix Halo-class unified-memory node. The 27B Q6_K example
+above (~22GB of weights plus KV cache) fits comfortably under that ceiling;
+**you do not need to touch `ttm.pages_limit` for it.**
+
+If you deploy a model whose weights plus KV cache exceed that ceiling, raise
+`ttm.pages_limit` (a kernel boot parameter; changing it requires a reboot) to
+opt into a larger GPU-visible allocation. Treat this as an explicit,
+per-node opt-in rather than a default: it trades system RAM headroom for GPU
+addressability, and it is easy to over-commit a UMA node if you raise it
+without also accounting for what else runs there.
+
+Very large MoE models may additionally need a batch-size clamp to control
+memory pressure during prefill; pass it via `extraArgs` on the
+InferenceService, for example:
+
+```yaml
+extraArgs:
+  - "-b"
+  - "256"
+```
+
+## Benchmarks
+
+Placeholder: measured numbers land once the validated ROCm-vs-Vulkan run is
+complete (tracked in LLMKube#701). Do not treat the rows below as real data.
+
+| Metric | Vulkan | ROCm | Notes |
+|---|---|---|---|
+| Prefill (prompt tok/s) | TBD | TBD | measured on Strix Halo gfx1151, llama.cpp b9663 |
+| Decode, short context (tok/s) | TBD | TBD | measured on Strix Halo gfx1151, llama.cpp b9663 |
+| Decode, long context (tok/s) | TBD | TBD | measured on Strix Halo gfx1151, llama.cpp b9663 |
+| Concurrency (N parallel, aggregate tok/s) | TBD | TBD | measured on Strix Halo gfx1151, llama.cpp b9663 |
+
+## Troubleshooting
+
+### Insufficient devic.es/dri-render
+
+The device plugin is not running on the AMD GPU node, or its group config
+does not include the node's render device. Check:
+
+```bash
+kubectl describe pod -l app=qwen36-27b-rocm
+kubectl logs -n kube-system -l app.kubernetes.io/name=amd-dri-device-plugin
+```
+
+### /dev/kfd missing in the container
+
+The `devic.es/dri-render` group config was not updated to include
+`/dev/kfd` alongside the render node paths (see
+[Node Prerequisites](#node-prerequisites)). Confirm with the probe pod shown
+above; if `/dev/kfd` is absent from the listing, fix the device plugin's
+group definition and restart it.
+
+### GPU reset / "device lost" under sustained load
+
+A spurious amdgpu reset kills the inference backend mid-run on long-context
+or high-concurrency ROCm workloads. Raise the GPU lockup timeout with
+`amdgpu.lockup_timeout=20000` and reboot; confirm it is live:
+
+```bash
+cat /proc/cmdline | tr ' ' '\n' | grep lockup_timeout
+```
+
+If resets persist afterward, the workload is genuinely hanging the GPU
+rather than hitting a false timeout; check `dmesg | grep -i amdgpu` for the
+failing ring and reduce context length, concurrency, or (for very large MoE)
+the batch size.
+
+### Model schedules but never reports ready
+
+Confirm you set `runtime: rocm` explicitly rather than leaving it unset
+(see [Behavior change from before #701](#behavior-change-from-before-701)):
+an unset runtime targets `amd.com/gpu`, which is a no-op on a node that only
+advertises `devic.es/dri-render`.
+
+## See also
+
+- [AMD Vulkan sample](../config/samples/model_amd_vulkan_igpu.yaml) and the
+  [AMD/Vulkan runtime image proposal](proposals/697-amd-vulkan-runtime-image.md)
+  the ROCm image build mirrors.
+- [Strix Halo quickstart](strix-halo-onboarding.md): AMD's official
+  ROCm GPU Operator path (`amd.com/gpu`), kernel args, and OOM/GTT guidance
+  that also applies here.
+- [Intel GPU quickstart](intel-gpu-quickstart.md): same per-vendor pattern,
+  different accelerator.

--- a/docs/amd-rocm-quickstart.md
+++ b/docs/amd-rocm-quickstart.md
@@ -8,24 +8,46 @@ workloads.
 
 ## When to Use ROCm vs Vulkan
 
-Be honest with yourself about what ROCm buys you before switching a model
-over. On a single AMD iGPU/APU node:
+Be honest about what ROCm buys you on Strix Halo (gfx1151) before switching a
+model over. We measured both backends on the same node, same llama.cpp build
+(b9663), same models (see [Benchmarks](#benchmarks)). The short version:
 
-- ROCm wins on **prefill (prompt processing)**, **long-context decode
-  retention**, and **batched concurrency**. Attention and matmul-heavy
-  workloads benefit from HIP's more mature kernels, and rocWMMA flash
-  attention holds up better as context grows.
-- **Vulkan stays the default.** Short-context decode on these nodes is
-  memory-bandwidth-bound, not compute-bound, so the two backends are close
-  and Vulkan usually wins that specific case. There is no free "ROCm is
-  faster inference" win: pick the backend that matches your workload shape,
-  not the newer-sounding one.
-- In practice: reach for ROCm when you are running long prompts, large
-  context windows, or many concurrent requests against the same model. Stay
-  on Vulkan for short-prompt, low-concurrency chat traffic.
+**Vulkan is the better default on Strix Halo across every case we measured.**
+It wins raw decode, it degrades far more gracefully as context grows, it
+addresses a much larger memory pool (about 112GB versus ROCm's 64GB carveout
+on this driver stack, which decides whether a large model fits at all), and
+it is competitive-to-faster once speculative decoding is in play. ROCm is
+shipped as a fully supported, validated per-model option, but on this
+hardware today it does not beat Vulkan. There is no free "ROCm is faster
+inference" win on Strix Halo.
 
-The [Benchmarks](#benchmarks) section below has (or will have) measured
-numbers for a concrete model on this hardware; use them, not vibes, to decide
+Where ROCm's numbers are actually stronger:
+
+- **Zero-context prefill** (317 vs 287 tok/s) and, relatedly, raw
+  **draft-verification speed** under speculative decoding. On a prompt where
+  both backends reach the same draft-acceptance rate, ROCm's faster
+  verification pulls ahead.
+
+Where Vulkan wins:
+
+- **Raw decode** at every context depth, and it holds up much better as
+  context grows (32k: 8.72 vs 7.41 tok/s).
+- **Prefill at real context.** ROCm's prefill collapses with depth while
+  RADV's coopmat path scales (32k prefill: 130 vs 51 tok/s).
+- **Memory ceiling.** RADV addresses the full unified pool (~112GB); ROCm/HIP
+  sees only the BIOS VRAM carveout (~64GB) and does not spill into GTT by
+  default. For a model larger than the carveout, Vulkan is the path on this
+  stack (see [Large models](#large-model-note-memory-ceiling)).
+- **Speculative decoding, net.** Decode rate under a draft or MTP is
+  dominated by draft-acceptance, which varies by prompt; Vulkan reached
+  higher acceptance on most prompts we tried (ROCm's TOP_K sampler currently
+  runs on CPU, which appears to cost draft quality), so end to end it is a
+  wash-to-Vulkan.
+
+So: **default to Vulkan.** Choose ROCm when you specifically want the HIP
+stack (to match other AMD/CDNA deployments, or to track ROCm maturity on
+RDNA), and re-measure for your own model and prompt mix rather than assuming a
+win. Use the [Benchmarks](#benchmarks) numbers, not vibes, to decide
 per-model.
 
 ## Node Prerequisites
@@ -220,24 +242,49 @@ curl -s http://127.0.0.1:8080/v1/chat/completions \
   }' | jq '.timings.prompt_per_second, .timings.predicted_per_second'
 ```
 
-`prompt_per_second` is where ROCm's prefill advantage should show up most;
-`predicted_per_second` (decode) is the bandwidth-bound number where Vulkan
-is often competitive or ahead at short context.
+`prompt_per_second` (prefill) is strongest for ROCm at low context but falls
+off with depth; `predicted_per_second` (decode) is the bandwidth-bound number
+where Vulkan is competitive or ahead. See [Benchmarks](#benchmarks) for the
+measured comparison.
 
-## Large-Model Note: ttm.pages_limit
+## Large-Model Note: memory ceiling
 
-The default kernel GTT/UMA ceiling caps how much system memory the GPU can
-address at once, which in practice limits GPU-visible memory to roughly
-**62GB** on a Strix Halo-class unified-memory node. The 27B Q6_K example
-above (~22GB of weights plus KV cache) fits comfortably under that ceiling;
-**you do not need to touch `ttm.pages_limit` for it.**
+This is the one place ROCm is at a real disadvantage on Strix Halo, and it is
+counterintuitive, so measure before you plan a large deployment.
 
-If you deploy a model whose weights plus KV cache exceed that ceiling, raise
-`ttm.pages_limit` (a kernel boot parameter; changing it requires a reboot) to
-opt into a larger GPU-visible allocation. Treat this as an explicit,
-per-node opt-in rather than a default: it trades system RAM headroom for GPU
-addressability, and it is easy to over-commit a UMA node if you raise it
-without also accounting for what else runs there.
+On this driver stack the two backends do **not** see the same amount of
+memory:
+
+- **ROCm/HIP sees only the BIOS VRAM carveout** (about 64GB on our node) and
+  does not spill into the shared GTT/system pool by default. `hipMalloc`
+  stays inside the carveout.
+- **Vulkan/RADV addresses the full unified pool** (about 112GB observed:
+  VRAM carveout plus GTT) automatically.
+
+So on the *same* 128GB machine, a model that needs more than the carveout
+(roughly >60GB of weights plus KV cache) **fits under Vulkan but not under
+ROCm** without extra work. This is why very large models (for example a
+low-quant 218B) run on Strix Halo under Vulkan today. The 27B Q6_K example
+above (~22GB weights plus KV) fits comfortably under either backend.
+
+If you specifically need ROCm to address more than its carveout, it takes a
+reboot and is a per-node opt-in, not a default:
+
+- **Lower the BIOS UMA / VRAM carveout** (e.g. to the minimum) so the OS
+  reclaims most of the 128GB, then raise `amdgpu.gttsize` and
+  `ttm.pages_limit` so the iGPU can map the unified pool. `ttm.pages_limit`
+  is in 4KB pages, so 12582912 pages is ~48GB; size it to the memory you want
+  the GPU to reach, leaving headroom for the OS.
+- Weigh whether it is worth it: for a model that big, Vulkan already reaches
+  the memory today, and (per [Benchmarks](#benchmarks)) Vulkan is the faster
+  backend on this hardware anyway. The ROCm-carveout retune mainly matters if
+  you specifically need the HIP stack for that workload.
+
+Do **not** enable `GGML_CUDA_ENABLE_UNIFIED_MEMORY` to work around the
+carveout. It is presence-checked (any value, including `0`, turns it on), it
+does not improve throughput when the model fits VRAM (we measured it slightly
+slower), and on gfx1151 the managed-memory path can produce incoherent output.
+Leave it unset.
 
 Very large MoE models may additionally need a batch-size clamp to control
 memory pressure during prefill; pass it via `extraArgs` on the
@@ -251,15 +298,53 @@ extraArgs:
 
 ## Benchmarks
 
-Placeholder: measured numbers land once the validated ROCm-vs-Vulkan run is
-complete (tracked in LLMKube#701). Do not treat the rows below as real data.
+Measured on Strix Halo (Radeon 8060S / Ryzen AI Max+ 395, gfx1151),
+llama.cpp b9663, both backends built from the same commit, GPU to itself for
+each run.
 
-| Metric | Vulkan | ROCm | Notes |
-|---|---|---|---|
-| Prefill (prompt tok/s) | TBD | TBD | measured on Strix Halo gfx1151, llama.cpp b9663 |
-| Decode, short context (tok/s) | TBD | TBD | measured on Strix Halo gfx1151, llama.cpp b9663 |
-| Decode, long context (tok/s) | TBD | TBD | measured on Strix Halo gfx1151, llama.cpp b9663 |
-| Concurrency (N parallel, aggregate tok/s) | TBD | TBD | measured on Strix Halo gfx1151, llama.cpp b9663 |
+### Raw throughput
+
+`llama-bench`, Qwen3.6-27B Q6_K, `-fa 1 -ngl 99 -p 512 -n 128 -d 0,8192,32768`,
+tokens/sec:
+
+| Context depth | Metric | ROCm | Vulkan | Winner |
+|---|---|---:|---:|---|
+| 0 | prefill (pp512) | **317** | 287 | ROCm +10% |
+| 0 | decode (tg128) | 9.28 | **9.57** | Vulkan |
+| 8k | prefill | 142 | **243** | Vulkan +71% |
+| 8k | decode | 8.82 | **9.34** | Vulkan |
+| 32k | prefill | 51 | **130** | Vulkan +155% |
+| 32k | decode | 7.41 | **8.72** | Vulkan |
+
+ROCm leads only on zero-context prefill; Vulkan wins decode at every depth and
+its prefill scales far better with context. `GGML_CUDA_ENABLE_UNIFIED_MEMORY`
+made no positive difference (pp512 275 vs 317, decode unchanged), so it is not
+enabled.
+
+### Speculative decoding (draft / MTP)
+
+`llama-server --spec-type draft-mtp --spec-draft-n-max 12`, Qwopus3.6-27B Coder
+MTP Q4, three coding prompts, decode tokens/sec:
+
+| Backend | decode tok/s (range) | mean | draft acceptance |
+|---|---|---:|---|
+| ROCm | 14.4 - 16.5 | 15.3 | 22 - 26% |
+| Vulkan | 11.8 - 21.7 | 16.9 | 21 - 45% |
+
+Speculative decoding roughly doubles decode over the raw ~9 tok/s on both
+backends. The end-to-end rate is dominated by draft-acceptance, which varies
+by prompt. On a prompt where both backends hit the same acceptance, ROCm's
+faster draft-verification wins (14.4 vs 11.8 at ~21% acceptance); but Vulkan
+reached higher acceptance on the other prompts (ROCm's TOP_K sampler runs on
+CPU, which appears to cost draft quality), so on average it is a
+wash-to-Vulkan. If you rely on speculative decoding, benchmark your own draft
+model and prompt mix; do not assume a backend win in either direction.
+
+### Memory
+
+At load, RADV/Vulkan reports ~112GB addressable (unified pool) versus ROCm's
+~64GB (BIOS VRAM carveout). See
+[Large-Model Note](#large-model-note-memory-ceiling).
 
 ## Troubleshooting
 

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -44,8 +44,9 @@ import (
 // it for vLLM where the v0.20+ env-var validator turns it into log noise.
 // resolveRuntimeImage returns the container image for the runtime, making the
 // otherwise vendor-blind backend.DefaultImage() vendor- and runtime-aware where
-// it matters. Today there are two divergences:
+// it matters. Today there are three divergences:
 //   - LlamaCppBackend with AMD + Vulkan Model → LLMKube's pinned Vulkan image
+//   - LlamaCppBackend with AMD + ROCm Model → LLMKube's pinned ROCm image
 //   - SGLangBackend with AMD (ROCm) Model → SGLang ROCm image
 //
 // Every other backend/vendor/runtime combination falls through to
@@ -54,6 +55,9 @@ import (
 func resolveRuntimeImage(backend RuntimeBackend, model *inferencev1alpha1.Model) string {
 	if _, ok := backend.(*LlamaCppBackend); ok && isVulkanAMDModel(model) {
 		return llamaCppVulkanImage
+	}
+	if _, ok := backend.(*LlamaCppBackend); ok && isROCmAMDModel(model) {
+		return llamaCppROCmImage
 	}
 	if _, ok := backend.(*SGLangBackend); ok && isAMDROCmModel(model) {
 		return sglangROCmImage
@@ -78,6 +82,19 @@ func isVulkanAMDModel(model *inferencev1alpha1.Model) bool {
 	}
 	gpu := model.Spec.Hardware.GPU
 	return strings.EqualFold(strings.TrimSpace(gpu.Vendor), "amd") && isVulkanRuntime(gpu.Runtime)
+}
+
+// isROCmAMDModel reports whether the Model requests the AMD vendor with the
+// ROCm/HIP GPU runtime (the per-model opt-in tier from #701). Not to be
+// confused with isAMDROCmModel above, which is the SGLang backend's
+// vendor-only check (SGLang ships only ROCm images for AMD, so it does not
+// need to distinguish runtime=vulkan from runtime=rocm the way llama.cpp does).
+func isROCmAMDModel(model *inferencev1alpha1.Model) bool {
+	if model == nil || model.Spec.Hardware == nil || model.Spec.Hardware.GPU == nil {
+		return false
+	}
+	gpu := model.Spec.Hardware.GPU
+	return strings.EqualFold(strings.TrimSpace(gpu.Vendor), "amd") && isROCmRuntime(gpu.Runtime)
 }
 
 func resolveEnableServiceLinks(backend RuntimeBackend) *bool {

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -187,10 +187,16 @@ func TestResolveRuntimeImage(t *testing.T) {
 			expected: llamaCppVulkanImage,
 		},
 		{
-			name:     "llamacpp amd rocm keeps the stock image",
+			name:     "llamacpp amd rocm resolves the pinned ROCm image",
 			backend:  &LlamaCppBackend{},
 			model:    amdModel("rocm"),
-			expected: stockLlamaCpp,
+			expected: llamaCppROCmImage,
+		},
+		{
+			name:     "llamacpp amd rocm is case-insensitive",
+			backend:  &LlamaCppBackend{},
+			model:    amdModel("ROCm"),
+			expected: llamaCppROCmImage,
 		},
 		{
 			name:     "llamacpp amd empty runtime keeps the stock image",
@@ -205,6 +211,18 @@ func TestResolveRuntimeImage(t *testing.T) {
 				Spec: inferencev1alpha1.ModelSpec{
 					Hardware: &inferencev1alpha1.HardwareSpec{
 						GPU: &inferencev1alpha1.GPUSpec{Vendor: "nvidia", Runtime: "vulkan"},
+					},
+				},
+			},
+			expected: stockLlamaCpp,
+		},
+		{
+			name:    "llamacpp nvidia keeps the stock image even with rocm runtime",
+			backend: &LlamaCppBackend{},
+			model: &inferencev1alpha1.Model{
+				Spec: inferencev1alpha1.ModelSpec{
+					Hardware: &inferencev1alpha1.HardwareSpec{
+						GPU: &inferencev1alpha1.GPUSpec{Vendor: "nvidia", Runtime: "rocm"},
 					},
 				},
 			},

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -66,9 +66,14 @@ func TestGPUResourceNameForSpec(t *testing.T) {
 			expected: nvidiaGPUResourceName,
 		},
 		{
-			name:     "vendor amd with runtime rocm maps to amd.com/gpu",
+			name:     "vendor amd with runtime rocm resolves the shared dri-render resource",
 			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "amd", Runtime: "rocm"},
-			expected: amdGPUResourceName,
+			expected: vulkanDRIResourceName,
+		},
+		{
+			name:     "rocm runtime is case-insensitive",
+			gpu:      &inferencev1alpha1.GPUSpec{Vendor: "AMD", Runtime: " ROCm "},
+			expected: vulkanDRIResourceName,
 		},
 		{
 			name:     "vendor amd with empty runtime maps to amd.com/gpu",
@@ -103,6 +108,15 @@ func TestGPUResourceNameForSpec(t *testing.T) {
 			gpu: &inferencev1alpha1.GPUSpec{
 				Vendor:       "amd",
 				Runtime:      "vulkan",
+				ResourceName: "amd.com/gpu",
+			},
+			expected: amdGPUResourceName,
+		},
+		{
+			name: "explicit ResourceName wins over the rocm default",
+			gpu: &inferencev1alpha1.GPUSpec{
+				Vendor:       "amd",
+				Runtime:      "rocm",
 				ResourceName: "amd.com/gpu",
 			},
 			expected: amdGPUResourceName,

--- a/internal/controller/gpu_resources.go
+++ b/internal/controller/gpu_resources.go
@@ -17,10 +17,22 @@ const (
 )
 
 // gpuRuntimeVulkan selects the Vulkan llama.cpp compute backend (LLMKube's own
-// image + the generic-device-plugin /dev/dri resource). The other accepted
-// enum value, "rocm", needs no constant: it falls through to the historical
-// amd.com/gpu + stock-image path, identical to an empty runtime.
+// image + the generic-device-plugin /dev/dri resource).
 const gpuRuntimeVulkan = "vulkan"
+
+// gpuRuntimeROCm selects the ROCm/HIP llama.cpp compute backend. It shares the
+// AMD GPU device-plugin resource (vulkanDRIResourceName, devic.es/dri-render)
+// with the Vulkan runtime: on a single-GPU AMD node the two runtimes contend
+// for the same physical device, and squat/generic-device-plugin cannot expose
+// one device under two resource names without health-watch collisions. ROCm
+// differs from Vulkan only by the container image (see runtime_llamacpp.go).
+// Before #701 this enum value fell through to amd.com/gpu + the stock image,
+// which has no HIP support and therefore never worked; the resourceName
+// override remains the escape hatch for AMD's official amd.com/gpu plugin.
+const gpuRuntimeROCm = "rocm"
+
+// acceleratorROCm is declared in model_controller.go (Model.Spec.Hardware.
+// Accelerator enum value "rocm"); reused here rather than redeclared.
 
 var (
 	nvidiaGPUResourceName    = corev1.ResourceName("nvidia.com/gpu")
@@ -42,10 +54,11 @@ var (
 //  1. Model.Spec.Hardware.GPU.ResourceName, when set, wins over everything
 //     else. This is the escape hatch for non-default device plugins (e.g. a
 //     custom name like squat.ai/dri-render is just an illustrative override).
-//  2. amd + runtime=vulkan -> devic.es/dri-render (the built-in Vulkan default;
-//     the generic device plugin injects /dev/dri for this resource).
+//  2. amd + runtime=vulkan or runtime=rocm -> devic.es/dri-render (the shared
+//     generic-device-plugin resource; see gpuRuntimeROCm for why ROCm reuses
+//     the Vulkan resource instead of amd.com/gpu).
 //  3. Model.Spec.Hardware.GPU.Vendor maps to the device-plugin default for
-//     that vendor (nvidia -> nvidia.com/gpu, amd -> amd.com/gpu [ROCm],
+//     that vendor (nvidia -> nvidia.com/gpu, amd -> amd.com/gpu,
 //     intel -> gpu.intel.com/i915).
 //  4. Unset / unknown -> nvidia.com/gpu (backwards-compatible default).
 //
@@ -59,6 +72,12 @@ func isVulkanRuntime(runtime string) bool {
 	return strings.EqualFold(strings.TrimSpace(runtime), gpuRuntimeVulkan)
 }
 
+// isROCmRuntime reports whether the GPU runtime selector requests the ROCm
+// compute backend. Case-insensitive, trims surrounding space.
+func isROCmRuntime(runtime string) bool {
+	return strings.EqualFold(strings.TrimSpace(runtime), gpuRuntimeROCm)
+}
+
 func gpuResourceNameForSpec(model *inferencev1alpha1.Model) corev1.ResourceName {
 	if model != nil && model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil {
 		if override := strings.TrimSpace(model.Spec.Hardware.GPU.ResourceName); override != "" {
@@ -67,9 +86,11 @@ func gpuResourceNameForSpec(model *inferencev1alpha1.Model) corev1.ResourceName 
 
 		switch strings.ToLower(strings.TrimSpace(model.Spec.Hardware.GPU.Vendor)) {
 		case "amd":
-			// The Vulkan runtime schedules against the generic-device-plugin
-			// /dev/dri resource, not the ROCm amd.com/gpu resource.
-			if isVulkanRuntime(model.Spec.Hardware.GPU.Runtime) {
+			// Both the Vulkan and ROCm runtimes schedule against the shared
+			// generic-device-plugin /dev/dri resource (vulkanDRIResourceName),
+			// not the amd.com/gpu resource; see gpuRuntimeROCm for why.
+			if isVulkanRuntime(model.Spec.Hardware.GPU.Runtime) ||
+				isROCmRuntime(model.Spec.Hardware.GPU.Runtime) {
 				return vulkanDRIResourceName
 			}
 			return amdGPUResourceName
@@ -107,6 +128,10 @@ func resolveGPUResourceName(model *inferencev1alpha1.Model) corev1.ResourceName 
 		}
 
 		if strings.EqualFold(model.Spec.Hardware.Accelerator, acceleratorVulkan) {
+			return vulkanDRIResourceName
+		}
+
+		if strings.EqualFold(model.Spec.Hardware.Accelerator, acceleratorROCm) {
 			return vulkanDRIResourceName
 		}
 	}

--- a/internal/controller/gpu_resources.go
+++ b/internal/controller/gpu_resources.go
@@ -20,15 +20,15 @@ const (
 // image + the generic-device-plugin /dev/dri resource).
 const gpuRuntimeVulkan = "vulkan"
 
-// gpuRuntimeROCm selects the ROCm/HIP llama.cpp compute backend. It shares the
-// AMD GPU device-plugin resource (vulkanDRIResourceName, devic.es/dri-render)
-// with the Vulkan runtime: on a single-GPU AMD node the two runtimes contend
-// for the same physical device, and squat/generic-device-plugin cannot expose
-// one device under two resource names without health-watch collisions. ROCm
-// differs from Vulkan only by the container image (see runtime_llamacpp.go).
-// Before #701 this enum value fell through to amd.com/gpu + the stock image,
-// which has no HIP support and therefore never worked; the resourceName
-// override remains the escape hatch for AMD's official amd.com/gpu plugin.
+// gpuRuntimeROCm selects the ROCm/HIP llama.cpp compute backend, backed by
+// LLMKube's hardware-validated ROCm image (llamaCppROCmImage, see
+// runtime_llamacpp.go and #701). It shares the AMD GPU device-plugin resource
+// (vulkanDRIResourceName, devic.es/dri-render) with the Vulkan runtime: on a
+// single-GPU AMD node the two runtimes contend for the same physical device,
+// and squat/generic-device-plugin cannot expose one device under two resource
+// names without health-watch collisions. ROCm differs from Vulkan only by the
+// container image. The resourceName override remains the escape hatch for
+// AMD's official amd.com/gpu plugin.
 const gpuRuntimeROCm = "rocm"
 
 // acceleratorROCm is declared in model_controller.go (Model.Spec.Hardware.

--- a/internal/controller/gpu_resources_test.go
+++ b/internal/controller/gpu_resources_test.go
@@ -99,6 +99,20 @@ func TestResolveGPUResourceName(t *testing.T) {
 			t.Fatalf("resolveGPUResourceName() = %q, want %q", got, vulkanDRIResourceName)
 		}
 	})
+
+	t.Run("uses the shared dri-render resource when accelerator is rocm", func(t *testing.T) {
+		model := &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					Accelerator: "rocm",
+				},
+			},
+		}
+
+		if got := resolveGPUResourceName(model); got != vulkanDRIResourceName {
+			t.Fatalf("resolveGPUResourceName() = %q, want %q", got, vulkanDRIResourceName)
+		}
+	})
 }
 
 func TestDetectInsufficientGPUResource(t *testing.T) {

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -4823,7 +4823,7 @@ var _ = Describe("AMD Vulkan Deployment Construction", func() {
 		Expect(container.Image).To(Equal(llamaCppVulkanImage))
 	})
 
-	It("keeps amd.com/gpu and the stock image for runtime=rocm", func() {
+	It("uses the pinned ROCm image and devic.es/dri-render for vendor=amd runtime=rocm", func() {
 		model := vulkanModel()
 		model.Spec.Hardware.GPU.Runtime = "rocm"
 		isvc := &inferencev1alpha1.InferenceService{
@@ -4837,9 +4837,30 @@ var _ = Describe("AMD Vulkan Deployment Construction", func() {
 
 		deployment := reconciler.constructDeployment(isvc, model, 1)
 		container := deployment.Spec.Template.Spec.Containers[0]
-		Expect(container.Image).To(Equal((&LlamaCppBackend{}).DefaultImage()))
-		gpuLimit := container.Resources.Limits[amdGPUResourceName]
+		Expect(container.Image).To(Equal(llamaCppROCmImage))
+		gpuLimit := container.Resources.Limits[vulkanDRIResourceName]
 		Expect(gpuLimit).To(Equal(resource.MustParse("1")))
+		// The two runtimes share the device-plugin resource (#701), so ROCm
+		// must not request the amd.com/gpu resource either.
+		_, hasAMDGPU := container.Resources.Limits[amdGPUResourceName]
+		Expect(hasAMDGPU).To(BeFalse())
+	})
+
+	It("lets spec.image override the pinned ROCm image", func() {
+		model := vulkanModel()
+		model.Spec.Hardware.GPU.Runtime = "rocm"
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "rocm-service-img", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "vulkan-model",
+				Replicas:  &replicas,
+				Image:     "ghcr.io/example/custom-rocm:dev",
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+			},
+		}
+
+		deployment := reconciler.constructDeployment(isvc, model, 1)
+		Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/example/custom-rocm:dev"))
 	})
 })
 

--- a/internal/controller/model_accelerator_test.go
+++ b/internal/controller/model_accelerator_test.go
@@ -126,8 +126,18 @@ func TestCheckAcceleratorAvailability(t *testing.T) {
 			[]client.Object{nodeWithCapacity("cpu1", "cpu", "8")}, false,
 		},
 		{
-			"rocm available when a node advertises amd.com/gpu", "rocm", "",
-			[]client.Object{nodeWithCapacity("amd1", "amd.com/gpu", "1")}, true,
+			// #701: rocm resolves to the shared devic.es/dri-render resource,
+			// not amd.com/gpu (one device-plugin resource per physical AMD GPU
+			// serves both Vulkan and ROCm).
+			"rocm available when a node advertises devic.es/dri-render", "rocm", "",
+			[]client.Object{nodeWithCapacity("amd1", "devic.es/dri-render", "4")}, true,
+		},
+		{
+			// Behavior-change guard: pre-#701 rocm checked amd.com/gpu. A node
+			// that advertises only amd.com/gpu (AMD's official plugin) without
+			// the resourceName override no longer satisfies rocm readiness.
+			"rocm unavailable when only amd.com/gpu (pre-701 resource) exists", "rocm", "",
+			[]client.Object{nodeWithCapacity("amd1", "amd.com/gpu", "1")}, false,
 		},
 		{
 			"rocm unavailable when only an nvidia node exists", "rocm", "",

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -913,12 +913,14 @@ func (r *ModelReconciler) checkAcceleratorAvailability(ctx context.Context, mode
 
 	var resName corev1.ResourceName
 	switch accel {
-	case acceleratorROCm:
-		resName = amdGPUResourceName
 	case acceleratorCUDA:
 		resName = nvidiaGPUResourceName
 	default:
-		// intel (and any other GPU vendor resolveGPUResourceName knows).
+		// rocm, intel, and any other GPU vendor resolveGPUResourceName knows.
+		// rocm resolves to the shared devic.es/dri-render device resource (one
+		// resource per physical AMD GPU serves both the Vulkan and ROCm tiers;
+		// #701), NOT amd.com/gpu, so the readiness check validates the resource
+		// the pod will actually request.
 		resName = resolveGPUResourceName(model)
 	}
 

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -30,7 +30,7 @@ const llamaCppVulkanImage = "ghcr.io/defilantech/llmkube-llama-vulkan@sha256:cba
 // image for AMD nodes (gfx1151-targeted, rocWMMA FlashAttention, hipBLASLt).
 // Digest-pinned like the Vulkan image; bumped via reviewed PR after the
 // promoter smokes the candidate on real hardware. See #701.
-const llamaCppROCmImage = "ghcr.io/defilantech/llmkube-llama-rocm@sha256:8638b6824b6992f31e2bb46e222e2863def26ae3197ebe321739825acb001675"
+const llamaCppROCmImage = "ghcr.io/defilantech/llmkube-llama-rocm@sha256:ea7ada64e94d9c2435d9729bc9e0c8635c830d03dd9c6d3fbc15346bdd762812"
 
 // LlamaCppBackend generates container configuration for the llama.cpp inference server.
 type LlamaCppBackend struct{}

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -26,6 +26,12 @@ var llamaCppLog = logf.Log.WithName("runtime.llamacpp")
 // it via PR when the promoter publishes a new :stable digest.
 const llamaCppVulkanImage = "ghcr.io/defilantech/llmkube-llama-vulkan@sha256:cbab8af682ecac9b5c865d85219d808dc356814326c70346e05b8b20b333e295"
 
+// llamaCppROCmImage is LLMKube's hardware-validated ROCm/HIP llama.cpp server
+// image for AMD nodes (gfx1151-targeted, rocWMMA FlashAttention, hipBLASLt).
+// Digest-pinned like the Vulkan image; bumped via reviewed PR after the
+// promoter smokes the candidate on real hardware. See #701.
+const llamaCppROCmImage = "ghcr.io/defilantech/llmkube-llama-rocm@sha256:8638b6824b6992f31e2bb46e222e2863def26ae3197ebe321739825acb001675"
+
 // LlamaCppBackend generates container configuration for the llama.cpp inference server.
 type LlamaCppBackend struct{}
 

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -30,7 +30,7 @@ const llamaCppVulkanImage = "ghcr.io/defilantech/llmkube-llama-vulkan@sha256:cba
 // image for AMD nodes (gfx1151-targeted, rocWMMA FlashAttention, hipBLASLt).
 // Digest-pinned like the Vulkan image; bumped via reviewed PR after the
 // promoter smokes the candidate on real hardware. See #701.
-const llamaCppROCmImage = "ghcr.io/defilantech/llmkube-llama-rocm@sha256:ea7ada64e94d9c2435d9729bc9e0c8635c830d03dd9c6d3fbc15346bdd762812"
+const llamaCppROCmImage = "ghcr.io/defilantech/llmkube-llama-rocm@sha256:8da16041a18b4f03f0be4de5e064be97ba8937149091d6693ee09711da362849"
 
 // LlamaCppBackend generates container configuration for the llama.cpp inference server.
 type LlamaCppBackend struct{}


### PR DESCRIPTION
## What

Lights up the **ROCm/HIP runtime tier** for AMD nodes as a per-model opt-in, selected with `vendor: amd` + `runtime: rocm`. The operator now resolves that selector to LLMKube's digest-pinned ROCm llama-server image and schedules it against the shared AMD-GPU device resource. Adds a sample and a public node runbook. Part of the first-class AMD accelerator tier.

## Why

Part of #701 (epic #696). The Vulkan tier is the AMD default, but ROCm wins on prefill, long-context decode, and batched concurrency on gfx1151 (Strix Halo). Before this change `runtime: rocm` silently fell through to `amd.com/gpu` + the stock CPU image, which has no HIP support and never actually served a model.

Part of #701

## How

- **Resolver** (`gpu_resources.go`): `runtime: rocm` and `accelerator: rocm` resolve to the existing `vulkanDRIResourceName` (`devic.es/dri-render`). The `gpu.resourceName` override still wins (escape hatch for AMD's official `amd.com/gpu` plugin). New `isROCmRuntime` helper mirrors `isVulkanRuntime`.
- **Image selection** (`deployment_builder.go`, `runtime_llamacpp.go`): a LlamaCpp AMD ROCm model resolves to the new digest-pinned `llamaCppROCmImage` (`ghcr.io/defilantech/llmkube-llama-rocm@sha256:8638b682...`, built + published from defilantech/llmkube-runtimes#17). The ROCm tier differs from Vulkan ONLY by the image.
- **Readiness** (`model_controller.go`): `checkAcceleratorAvailability` routes `rocm` through the resolver instead of hardcoding `amd.com/gpu`, so `acceleratorReady` reflects the resource the pod actually requests.
- **Docs/sample**: `config/samples/model_amd_rocm_igpu.yaml` and `docs/amd-rocm-quickstart.md`.

### Design decision worth noting: one shared device resource, not two

The original design proposed a separate `devic.es/amd-rocm` device-plugin resource. Hardware validation on shadowstrix proved that breaks: `squat/generic-device-plugin` keys device health-watches by file path, so two resources referencing the same `/dev/dri` nodes collide and the second goes permanently Unhealthy (it drove `dri-render` to 0 allocatable live). Two `count=4` resources also double-count a single physical GPU. So ROCm and Vulkan share ONE `devic.es/dri-render` resource whose group bundles `/dev/kfd` + render + card. The node-side manifest change lives in the private lab repo; the runbook documents the required group.

Known follow-up (not blocking): `isROCmAMDModel` (this PR, llama.cpp runtime selector) sits next to a pre-existing `isAMDROCmModel` (SGLang vendor check); the near-anagram is mitigated with a cross-reference comment, rename deferred.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (full controller envtest suite green, 192s)
- [x] `make lint` passes locally (native + `GOOS=linux` cross-arch, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed below
- [x] Documentation updated (sample + runbook)

---

AI-assisted (band-3): implemented with Claude Code under human review, using subagent-driven development with per-task spec + quality review gates and a hardware-validated device-plugin decision. Commits authored clean; the human owns the review conversation.
