### PR TITLE
chore: add make vulncheck target for local govulncheck scanning (#1100)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,6 +470,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+GOVULNCHECK = $(LOCALBIN)/govulncheck
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
@@ -479,6 +480,7 @@ ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v2.12.2
+GOVULNCHECK_VERSION ?= d1f380186385b4f64e00313f31743df8e4b89a77
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -507,6 +509,15 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: govulncheck
+govulncheck: $(GOVULNCHECK) ## Download govulncheck locally if necessary.
+$(GOVULNCHECK): $(LOCALBIN)
+	$(call go-install-tool,$(GOVULNCHECK),golang.org/x/vuln/cmd/govulncheck,$(GOVULNCHECK_VERSION))
+
+.PHONY: vulncheck
+vulncheck: govulncheck ## Run govulncheck against the module.
+	$(GOVULNCHECK) ./...
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary


### PR DESCRIPTION
## What

Add a `make vulncheck` target that installs a pinned `govulncheck` (v1.1.4, `d1f3801`) and runs `govulncheck ./...`, so the supply-chain scan CI already runs is reproducible locally.

## Why

Fixes #1100 (a slice of the #233 supply-chain epic). CI's `security.yml` already runs govulncheck on push/PR/weekly; the remaining gap was a local, reproducible invocation. This closes it.

## How

Follows the existing tool-target pattern (`golangci-lint`, `controller-gen`): a `$(GOVULNCHECK)` prerequisite that `go-install-tool`s the pinned binary, and a user-facing `vulncheck` target that runs it. `make vulncheck` reports no vulnerabilities on the current tree.

## Checklist

- [x] `make vulncheck` runs clean locally
- [x] Pinned to the same govulncheck version as CI
- [x] Conventional commit, DCO signed
- [x] Fixes #1100

---

AI-assisted (band-3): drafted by an LLMKube Foreman coder agent (qwopus) and reviewed by a human before opening. Clean commit; human owns the review conversation.
