### PR TITLE
feat(controller): pass staged model directory to vLLM/SGLang for multi-file models (#1157)

### DIFF
--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -229,6 +229,20 @@ func buildPodAnnotations(isvc *inferencev1alpha1.InferenceService) map[string]st
 	return annotations
 }
 
+// servedModelPath picks the path handed to the runtime. For a multi-file model
+// (stagedDir set) on a directory-oriented runtime (vLLM/SGLang) whose format is
+// not GGUF, that is the staged directory (the full Hugging Face model tree);
+// otherwise it is the primary file, preserving GGUF and llama.cpp behavior.
+// (#1157)
+func servedModelPath(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, sc modelStorageConfig) string {
+	if sc.stagedDir != "" &&
+		directoryOrientedRuntime(isvc.Spec.Runtime) &&
+		model.Spec.Format != "" && model.Spec.Format != "gguf" {
+		return sc.stagedDir
+	}
+	return sc.modelPath
+}
+
 func (r *InferenceServiceReconciler) constructDeployment(
 	isvc *inferencev1alpha1.InferenceService,
 	model *inferencev1alpha1.Model,
@@ -262,7 +276,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	if backend.NeedsModelInit() && !skipInit {
 		useCache := effectiveModelCacheKey(model) != "" && r.ModelCachePath != ""
 		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.ModelCacheMode, r.CACertConfigMap, r.InitContainerImage, r.DefaultFSGroup, r.AllowedHostPathRoots)
-		modelPath = storageConfig.modelPath
+		modelPath = servedModelPath(isvc, model, storageConfig)
 	}
 
 	args := backend.BuildArgs(isvc, model, modelPath, port)

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -524,3 +524,49 @@ func TestGPUTolerationKeyForSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestDirectoryOrientedRuntime(t *testing.T) {
+	cases := map[string]bool{
+		RuntimeVLLM: true, RuntimeSGLANG: true,
+		"": false, "tgi": false, "generic": false, "personaplex": false,
+	}
+	for rt, want := range cases {
+		if got := directoryOrientedRuntime(rt); got != want {
+			t.Errorf("directoryOrientedRuntime(%q) = %v, want %v", rt, got, want)
+		}
+	}
+}
+
+func TestServedModelPath(t *testing.T) {
+	sf := func(format string) *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Format: format}}
+	}
+	isvcRT := func(rt string) *inferencev1alpha1.InferenceService {
+		return &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{Runtime: rt}}
+	}
+	dirSC := modelStorageConfig{modelPath: "/models/k/model.safetensors", stagedDir: "/models/k"}
+	fileSC := modelStorageConfig{modelPath: "/models/k/model.gguf"} // single-file: stagedDir empty
+
+	cases := []struct {
+		name     string
+		isvc     *inferencev1alpha1.InferenceService
+		model    *inferencev1alpha1.Model
+		sc       modelStorageConfig
+		expected string
+	}{
+		{"sglang + safetensors + multi-file -> directory", isvcRT(RuntimeSGLANG), sf("safetensors"), dirSC, "/models/k"},
+		{"vllm + safetensors + multi-file -> directory", isvcRT(RuntimeVLLM), sf("safetensors"), dirSC, "/models/k"},
+		{"vllm + pytorch + multi-file -> directory", isvcRT(RuntimeVLLM), sf("pytorch"), dirSC, "/models/k"},
+		{"sglang + gguf + multi-file -> primary file", isvcRT(RuntimeSGLANG), sf("gguf"), dirSC, "/models/k/model.safetensors"},
+		{"sglang + unset format + multi-file -> primary file", isvcRT(RuntimeSGLANG), sf(""), dirSC, "/models/k/model.safetensors"},
+		{"llamacpp + safetensors + multi-file -> primary file", isvcRT(""), sf("safetensors"), dirSC, "/models/k/model.safetensors"},
+		{"sglang + safetensors + single-file -> primary file", isvcRT(RuntimeSGLANG), sf("safetensors"), fileSC, "/models/k/model.gguf"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := servedModelPath(tc.isvc, tc.model, tc.sc); got != tc.expected {
+				t.Errorf("servedModelPath = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -48,6 +48,7 @@ var _ = Describe("buildCachedStorageConfig", func() {
 		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 
 		Expect(config.modelPath).To(Equal("/models/abc123def456/model.gguf"))
+		Expect(config.stagedDir).To(BeEmpty())
 		Expect(config.volumes).To(HaveLen(1))
 		Expect(config.volumes[0].Name).To(Equal("model-cache"))
 		Expect(config.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal(ModelCachePVCName))
@@ -216,6 +217,22 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 		Expect(modelFiles).To(ContainSubstring("mmproj-F16.gguf"))
 	})
 
+	It("sets stagedDir to the cache directory for multi-file staging", func() {
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "gemma", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "hf://unsloth/gemma-4-31B-it-GGUF",
+				Files:  []string{"a.gguf", "MTP/b.gguf"},
+			},
+			Status: inferencev1alpha1.ModelStatus{CacheKey: "abc123"},
+		}
+
+		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
+
+		Expect(config.stagedDir).To(Equal("/models/abc123"))
+		Expect(config.modelPath).To(Equal("/models/abc123/a.gguf"))
+	})
+
 	It("preserves subdirectories in multi-file staging", func() {
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: "multi", Namespace: "default"},
@@ -333,6 +350,21 @@ var _ = Describe("buildEmptyDirStorageConfig multi-file staging", func() {
 		env := config.initContainers[0].Env
 		modelFiles := getEnvVar(env, "MODEL_FILES")
 		Expect(modelFiles).To(ContainSubstring("extra.gguf"))
+	})
+
+	It("sets stagedDir to the emptyDir staging directory for multi-file staging", func() {
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "empty-model", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "hf://org/repo",
+				Files:  []string{"model.gguf", "extra.gguf"},
+			},
+		}
+
+		config := buildEmptyDirStorageConfig(model, nil, "default", "", "curl:8.18.0")
+
+		Expect(config.stagedDir).To(Equal("/models/default-empty-model"))
+		Expect(config.modelPath).To(Equal("/models/default-empty-model/model.gguf"))
 	})
 
 	It("uses OnChange per-file etag revalidation in emptyDir storage", func() {

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -419,6 +419,7 @@ func buildMultiFileInitCommand(useCache bool, refreshPolicy string) string {
 
 type modelStorageConfig struct {
 	modelPath      string
+	stagedDir      string // staged model directory for multi-file staging; empty for single-file/GGUF
 	initContainers []corev1.Container
 	volumes        []corev1.Volume
 	volumeMounts   []corev1.VolumeMount
@@ -564,6 +565,7 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1a
 
 		return modelStorageConfig{
 			modelPath:      modelPath,
+			stagedDir:      cacheDir,
 			initContainers: initContainers,
 			volumes:        volumes,
 			volumeMounts:   []corev1.VolumeMount{{Name: "model-cache", MountPath: "/models", ReadOnly: true}},
@@ -657,9 +659,10 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 		}
 	}
 	if plan != nil {
-		modelPath := fmt.Sprintf("/models/%s-%s/%s", namespace, model.Name, plan.Primary)
+		stagedDir := fmt.Sprintf("/models/%s-%s", namespace, model.Name)
+		modelPath := fmt.Sprintf("%s/%s", stagedDir, plan.Primary)
 		cmd := buildMultiFileInitCommand(false, model.Spec.RefreshPolicy)
-		env := multiFileInitEnvVars(model.Spec.Source, fmt.Sprintf("/models/%s-%s", namespace, model.Name), plan.Files)
+		env := multiFileInitEnvVars(model.Spec.Source, stagedDir, plan.Files)
 
 		initVolumeMounts := []corev1.VolumeMount{{Name: "model-storage", MountPath: "/models"}}
 		volumes := []corev1.Volume{
@@ -673,6 +676,7 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 
 		return modelStorageConfig{
 			modelPath: modelPath,
+			stagedDir: stagedDir,
 			initContainers: []corev1.Container{{
 				Name:            "model-downloader",
 				Image:           initContainerImage,

--- a/internal/controller/runtime.go
+++ b/internal/controller/runtime.go
@@ -91,6 +91,19 @@ func resolveBackend(isvc *inferencev1alpha1.InferenceService) RuntimeBackend {
 	}
 }
 
+// directoryOrientedRuntime reports whether a runtime loads a model from a
+// directory (the full Hugging Face model tree) rather than a single weights
+// file. Used to decide whether to hand a multi-file model its staged directory
+// instead of the primary file (#1157).
+func directoryOrientedRuntime(runtime string) bool {
+	switch runtime {
+	case RuntimeVLLM, RuntimeSGLANG:
+		return true
+	default:
+		return false
+	}
+}
+
 // runtimeNameLabel returns a stable, lowercase identifier for the runtime
 // selected by isvc.Spec.Runtime. The returned value is used as the
 // `inference.llmkube.dev/runtime` pod label so Prometheus scrapes can attach a


### PR DESCRIPTION
## What

For a multi-file Hugging Face model served on a directory-oriented runtime (SGLang / vLLM), pass the staged model **directory** as the model path instead of the resolved primary file. GGUF and llama.cpp (including multi-file MTP) keep their primary-file behavior.

## Why

Fixes #1157 (thanks @Tanguille). v0.9.7 downloads and caches all files of a revision-pinned multi-file HF source, but the controller still set `modelPath` to `/models/<cache-key>/<plan.Primary>`. SGLang (`--model-path`) and vLLM (positional model arg) need the **directory** containing the full model tree (Safetensors shards + config/tokenizer/generation files), not one file.

## How

Approach A (centralized selection), no CRD change, runtime backends untouched:

1. **`modelStorageConfig.stagedDir`** — new field, populated only in the two multi-file storage branches (cached: the cache directory; emptyDir: `/models/<ns>-<name>`), empty for single-file / GGUF. Both builders already computed this directory and discarded it.
2. **`directoryOrientedRuntime(runtime)`** — classifies `vllm` / `sglang` (matches `resolveBackend`'s switch style).
3. **`servedModelPath(isvc, model, sc)`** — selects dir-vs-file once at the `deployment_builder` choke point before `BuildArgs`. Gate: `stagedDir` set **and** directory-oriented runtime **and** `Format != gguf`. Everything else keeps the primary-file path.

The runtime gate alone already excludes multi-file GGUF/MTP (always llama.cpp); the `Format != gguf` check is a safety belt (e.g. a hypothetical `runtime: vllm` + GGUF). `safetensors` / `pytorch` / `mlx` directories all work.

## Testing

- `buildCachedStorageConfig` and `buildEmptyDirStorageConfig` set `stagedDir` for multi-file (identically); single-file leaves it empty.
- `TestServedModelPath` (7 cases): SGLang/vLLM + safetensors/pytorch → directory; GGUF, unset format, llama.cpp, single-file → primary file.
- `TestDirectoryOrientedRuntime`: vllm/sglang true, others false.
- Full `internal/controller` envtest suite green; `make lint` clean.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (controller envtest suite green)
- [x] `make lint` passes locally (0 issues)
- [x] Conventional commits, DCO signed
- [x] AI assistance disclosed below
- [x] `Fixes #1157`

---

AI-assisted (band-3): designed and implemented with Claude Code (brainstorm → spec → plan → TDD) under human review; commits authored clean. Human owns the review conversation. @Tanguille, happy to have you test this against your multi-file Safetensors + SGLang/vLLM setup.
