### PR TITLE
feat(controller): add InferenceService hardware-labels info metric (#1121)

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -174,7 +174,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// from before the allowlist was introduced (or tightened).
 	if valErr := validateLocalSourceAllowed(model.Spec.Source, r.AllowedHostPathRoots); valErr != nil {
 		log.Error(valErr, "rejected local model source by host-path allowlist", "model", model.Name, "source", model.Spec.Source)
-		blockResult, updateErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, PhaseFailed, modelReady, 0, 0, "",
+		blockResult, updateErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, model, PhaseFailed, modelReady, 0, 0, "",
 			valErr.Error(), nil)
 		return blockResult, updateErr
 	}
@@ -187,7 +187,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if effectiveModelCacheKey(model) != "" && r.ModelCachePath != "" {
 		if err := r.ensureModelCachePVC(ctx, inferenceService); err != nil {
 			log.Error(err, "Failed to ensure model cache PVC exists", "namespace", inferenceService.Namespace)
-			return r.updateStatusWithSchedulingInfo(ctx, inferenceService, PhaseFailed, modelReady, 0, desiredReplicas, "",
+			return r.updateStatusWithSchedulingInfo(ctx, inferenceService, model, PhaseFailed, modelReady, 0, desiredReplicas, "",
 				fmt.Sprintf("Failed to ensure model cache PVC: %v", err), nil)
 		}
 	}
@@ -214,7 +214,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	service, result, err := r.reconcileService(ctx, inferenceService, modelReady, desiredReplicas, isMetal)
+	service, result, err := r.reconcileService(ctx, inferenceService, model, modelReady, desiredReplicas, isMetal)
 	if err != nil || result != nil {
 		if result != nil {
 			return *result, err
@@ -229,7 +229,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	endpoint := r.constructEndpoint(inferenceService, service)
 	phase, schedulingInfo := r.determinePhase(ctx, inferenceService, readyReplicas, desiredReplicas, isMetal, deployment, metalSnap)
 
-	finalResult, statusErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, phase, modelReady, readyReplicas, desiredReplicas, endpoint, "", schedulingInfo)
+	finalResult, statusErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, model, phase, modelReady, readyReplicas, desiredReplicas, endpoint, "", schedulingInfo)
 	if statusErr != nil {
 		return finalResult, statusErr
 	}
@@ -265,7 +265,7 @@ func (r *InferenceServiceReconciler) getModelForInferenceService(ctx context.Con
 	if err := r.Get(ctx, modelName, model); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Referenced Model not found", "model", isvc.Spec.ModelRef)
-			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, false, 0, 0, "", "Model not found", nil)
+			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, nil, PhaseFailed, false, 0, 0, "", "Model not found", nil)
 			return nil, false, &result, updateErr
 		}
 		log.Error(err, "Failed to get Model")
@@ -275,7 +275,7 @@ func (r *InferenceServiceReconciler) getModelForInferenceService(ctx context.Con
 	modelReady := model.Status.Phase == PhaseReady
 	if !modelReady {
 		log.Info("Model not ready yet", "model", model.Name, "phase", model.Status.Phase)
-		result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, "Pending", false, 0, 0, "", "Waiting for Model to be Ready", nil)
+		result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, model, "Pending", false, 0, 0, "", "Waiting for Model to be Ready", nil)
 		return nil, false, &result, updateErr
 	}
 
@@ -322,7 +322,7 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 		deployment.Annotations[AnnotationDesiredTemplateHash] = tmplHash
 		if err := r.Create(ctx, deployment); err != nil {
 			log.Error(err, "Failed to create Deployment")
-			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create Deployment", nil)
+			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, model, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create Deployment", nil)
 			return nil, 0, nil, &result, updateErr
 		}
 		return deployment, 0, nil, nil, nil
@@ -461,7 +461,7 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	return deployment, existingDeployment.Status.ReadyReplicas, nil, nil, nil
 }
 
-func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc *inferencev1alpha1.InferenceService, modelReady bool, desiredReplicas int32, isMetal bool) (*corev1.Service, *ctrl.Result, error) {
+func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, modelReady bool, desiredReplicas int32, isMetal bool) (*corev1.Service, *ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	if isMetal {
@@ -488,7 +488,7 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 		log.Info("Creating new Service", "name", service.Name)
 		if err := r.Create(ctx, service); err != nil {
 			log.Error(err, "Failed to create Service")
-			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create Service", nil)
+			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, model, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create Service", nil)
 			return nil, &result, updateErr
 		}
 	} else if err != nil {

--- a/internal/controller/inferenceservice_service_test.go
+++ b/internal/controller/inferenceservice_service_test.go
@@ -213,7 +213,7 @@ var _ = Describe("reconcileService Metal path", func() {
 			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "some-model"},
 		}
 
-		svc, result, err := reconciler.reconcileService(context.Background(), isvc, true, 1, true)
+		svc, result, err := reconciler.reconcileService(context.Background(), isvc, nil, true, 1, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(BeNil())
 		Expect(svc).NotTo(BeNil())
@@ -227,7 +227,7 @@ var _ = Describe("reconcileService Metal path", func() {
 			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "some-model"},
 		}
 
-		svc, result, err := reconciler.reconcileService(context.Background(), isvc, true, 1, true)
+		svc, result, err := reconciler.reconcileService(context.Background(), isvc, nil, true, 1, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(BeNil())
 		Expect(svc.Name).To(Equal("llama-3-2-3b"))
@@ -243,7 +243,7 @@ var _ = Describe("reconcileService Metal path", func() {
 			},
 		}
 
-		svc, _, err := reconciler.reconcileService(context.Background(), isvc, true, 1, true)
+		svc, _, err := reconciler.reconcileService(context.Background(), isvc, nil, true, 1, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc.Spec.Ports).To(BeEmpty())
 		Expect(svc.Spec.Type).To(Equal(corev1.ServiceType("")))
@@ -256,7 +256,7 @@ var _ = Describe("reconcileService Metal path", func() {
 			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "some-model"},
 		}
 
-		_, _, err := reconciler.reconcileService(context.Background(), isvc, true, 1, true)
+		_, _, err := reconciler.reconcileService(context.Background(), isvc, nil, true, 1, true)
 		Expect(err).NotTo(HaveOccurred())
 
 		svc := &corev1.Service{}

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -130,6 +130,7 @@ func (r *InferenceServiceReconciler) constructEndpoint(isvc *inferencev1alpha1.I
 func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 	ctx context.Context,
 	isvc *inferencev1alpha1.InferenceService,
+	model *inferencev1alpha1.Model,
 	phase string,
 	modelReady bool,
 	readyReplicas int32,
@@ -158,6 +159,19 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 	if previousPhase != "" && previousPhase != phase {
 		llmkubemetrics.InferenceServicePhase.WithLabelValues(isvc.Name, isvc.Namespace, previousPhase).Set(0)
 	}
+
+	// Emit info metric with hardware labels (accelerator, runtime)
+	accelerator := "cpu"
+	runtime := isvc.Spec.Runtime
+	if model != nil && model.Spec.Hardware != nil {
+		if model.Spec.Hardware.Accelerator != "" {
+			accelerator = model.Spec.Hardware.Accelerator
+		}
+	}
+	if runtime == "" {
+		runtime = "llamacpp"
+	}
+	llmkubemetrics.InferenceServiceInfo.WithLabelValues(isvc.Name, isvc.Namespace, accelerator, runtime).Set(1)
 
 	// Track time-to-ready using creation timestamp
 	if phase == PhaseReady && previousPhase != PhaseReady {

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,6 +172,12 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 	if runtime == "" {
 		runtime = "llamacpp"
 	}
+	// Delete any prior series for this InferenceService so that when the
+	// accelerator or runtime changes in place only one series exists per ISvc.
+	llmkubemetrics.InferenceServiceInfo.DeletePartialMatch(prometheus.Labels{
+		"inferenceservice": isvc.Name,
+		"namespace":        isvc.Namespace,
+	})
 	llmkubemetrics.InferenceServiceInfo.WithLabelValues(isvc.Name, isvc.Namespace, accelerator, runtime).Set(1)
 
 	// Track time-to-ready using creation timestamp

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -60,6 +60,14 @@ var (
 		[]string{"inferenceservice", "namespace", "phase"},
 	)
 
+	InferenceServiceInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llmkube_inferenceservice_info",
+			Help: "Information about inference services. Value is always 1; use accelerator and runtime labels for grouping.",
+		},
+		[]string{"inferenceservice", "namespace", "accelerator", "runtime"},
+	)
+
 	GPUQueueDepth = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "llmkube_gpu_queue_depth",
@@ -170,6 +178,7 @@ func init() {
 		ModelStatus,
 		InferenceServiceReadyDuration,
 		InferenceServicePhase,
+		InferenceServiceInfo,
 		GPUQueueDepth,
 		GPUQueueWaitDuration,
 		ReconcileTotal,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -50,6 +50,7 @@ func TestMetricsRegistered(t *testing.T) {
 		{"llmkube_model_status", ModelStatus},
 		{"llmkube_inferenceservice_ready_duration_seconds", InferenceServiceReadyDuration},
 		{"llmkube_inferenceservice_phase", InferenceServicePhase},
+		{"llmkube_inferenceservice_info", InferenceServiceInfo},
 		{"llmkube_gpu_queue_depth", GPUQueueDepth},
 		{"llmkube_gpu_queue_wait_duration_seconds", GPUQueueWaitDuration},
 		{"llmkube_reconcile_total", ReconcileTotal},
@@ -120,6 +121,37 @@ func TestInferenceServicePhase(t *testing.T) {
 	}
 	if m.GetGauge().GetValue() != 1 {
 		t.Errorf("expected Ready phase to be 1 after transition, got %f", m.GetGauge().GetValue())
+	}
+}
+
+func TestInferenceServiceInfo(t *testing.T) {
+	// Verify the info metric is emitted with accelerator and runtime labels.
+	InferenceServiceInfo.WithLabelValues("info-test", "default", "cuda", "llamacpp").Set(1)
+
+	var m dto.Metric
+	if err := InferenceServiceInfo.WithLabelValues("info-test", "default", "cuda", "llamacpp").Write(&m); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if m.GetGauge().GetValue() != 1 {
+		t.Errorf("expected gauge value 1, got %f", m.GetGauge().GetValue())
+	}
+
+	// Verify a different accelerator label produces a distinct series.
+	InferenceServiceInfo.WithLabelValues("info-test", "default", "rocm", "llamacpp").Set(1)
+
+	if err := InferenceServiceInfo.WithLabelValues("info-test", "default", "rocm", "llamacpp").Write(&m); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if m.GetGauge().GetValue() != 1 {
+		t.Errorf("expected gauge value 1 for rocm, got %f", m.GetGauge().GetValue())
+	}
+
+	// Verify the cuda series is still 1 (not overwritten).
+	if err := InferenceServiceInfo.WithLabelValues("info-test", "default", "cuda", "llamacpp").Write(&m); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if m.GetGauge().GetValue() != 1 {
+		t.Errorf("expected cuda gauge value 1, got %f", m.GetGauge().GetValue())
 	}
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -136,9 +136,14 @@ func TestInferenceServiceInfo(t *testing.T) {
 		t.Errorf("expected gauge value 1, got %f", m.GetGauge().GetValue())
 	}
 
-	// Verify a different accelerator label produces a distinct series.
+	// Simulate an accelerator change: delete the old series and emit the new one.
+	InferenceServiceInfo.DeletePartialMatch(prometheus.Labels{
+		"inferenceservice": "info-test",
+		"namespace":        "default",
+	})
 	InferenceServiceInfo.WithLabelValues("info-test", "default", "rocm", "llamacpp").Set(1)
 
+	// Verify the new accelerator series is 1.
 	if err := InferenceServiceInfo.WithLabelValues("info-test", "default", "rocm", "llamacpp").Write(&m); err != nil {
 		t.Fatalf("failed to write metric: %v", err)
 	}
@@ -146,12 +151,12 @@ func TestInferenceServiceInfo(t *testing.T) {
 		t.Errorf("expected gauge value 1 for rocm, got %f", m.GetGauge().GetValue())
 	}
 
-	// Verify the cuda series is still 1 (not overwritten).
+	// Verify the old cuda series is gone (not present / 0).
 	if err := InferenceServiceInfo.WithLabelValues("info-test", "default", "cuda", "llamacpp").Write(&m); err != nil {
 		t.Fatalf("failed to write metric: %v", err)
 	}
-	if m.GetGauge().GetValue() != 1 {
-		t.Errorf("expected cuda gauge value 1, got %f", m.GetGauge().GetValue())
+	if m.GetGauge().GetValue() != 0 {
+		t.Errorf("expected cuda gauge value 0 after deletion, got %f", m.GetGauge().GetValue())
 	}
 }
 


### PR DESCRIPTION
## What

Add an `llmkube_inferenceservice_info` gauge (value 1) carrying `{inferenceservice, namespace, accelerator, runtime}` so a fleet dashboard can group InferenceServices by hardware family (Metal / AMD / NVIDIA) and serving backend directly from the CR-state metric.

## Why

Fixes #1121. Today `llmkube_inferenceservice_phase` carries only `{inferenceservice, namespace, phase}`, so a fleet-overview dashboard can list models and phases but cannot answer "group my models by Metal vs AMD vs NVIDIA" without joining node-level metrics. This is the Phase-3 hardware-per-model follow-up to the fleet dashboard.

## How

- New `InferenceServiceInfo` gauge in `internal/metrics/metrics.go`, registered once.
- Set in `status_builder.go` from `Model.Spec.Hardware.Accelerator` and `InferenceService.Spec.Runtime` (with the CRD defaults `cpu` / `llamacpp` as fallbacks; empty values guarded). Bounded cardinality (both labels are closed enums).
- **Stale-series cleanup:** `DeletePartialMatch({inferenceservice, namespace})` runs before the `Set(1)` so that when a Model's accelerator or an ISvc's runtime changes in place, exactly one series exists per ISvc (no double-counting on a fleet dashboard).

## Testing

- Metrics-package test asserts the info gauge is emitted with the hardware labels and that a prior label-set is removed when it changes (the old combo reads 0 after `DeletePartialMatch`).
- Full `internal/controller` + `internal/metrics` suites green; `make lint` clean.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes (controller envtest + metrics suites green)
- [x] `make lint` passes (0 issues)
- [x] Conventional commits, DCO signed
- [x] AI assistance disclosed below
- [x] `Fixes #1121`

---

AI-assisted (band-3): implemented by an LLMKube Foreman coder agent (qwopus 35B), then reviewed by a human who caught a stale-series leak; a second Foreman revision cycle applied the `DeletePartialMatch` fix, re-verified before opening. Human owns the review conversation.
