### PR TITLE
feat(foreman): provider-neutral CodeHost/WorkItems/ChangePolicy seams (#1158)

### DIFF
--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -68,11 +68,14 @@ import (
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/changepolicy"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/mcp"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	foremantools "github.com/defilantech/llmkube/pkg/foreman/agent/tools"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/worktracker"
 	"github.com/defilantech/llmkube/pkg/selfupdate"
 )
 
@@ -87,6 +90,22 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
+
+// githubCodeHost builds the GitHub-backed CodeHost seam (#1158), wrapping the
+// githubpr client with the same token source (env / file) as the git auth so
+// PR creation and head-commit reads stay authenticated.
+func githubCodeHost() codehost.CodeHost {
+	token, _ := repo.TokenFromEnvOrFile()
+	return &codehost.GitHubCodeHost{Ensurer: githubpr.NewClient(), Token: token}
+}
+
+// githubWorkItems builds the GitHub-backed WorkItems seam (#1158), wrapping the
+// githubissue client with the same token source as the git auth so issue-body
+// fetches stay authenticated.
+func githubWorkItems() worktracker.WorkItems {
+	token, _ := repo.TokenFromEnvOrFile()
+	return &worktracker.GitHubWorkItems{Fetcher: githubissue.NewClient(), Token: token}
+}
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -409,8 +428,9 @@ func main() {
 			},
 			KeepWorkspace:   keepWorkspace,
 			RegistryFactory: makeRegistryFactory(kc, kcs, foremanNamespace),
-			IssueFetcher:    githubissue.NewClient(),
-			PREnsurer:       githubpr.NewClient(),
+			CodeHost:        githubCodeHost(),
+			WorkItems:       githubWorkItems(),
+			ChangePolicy:    changepolicy.NewDefaultPolicy(),
 			// CoderJobSubmitter routes Job-mode Agents to an ephemeral
 			// per-task Job (#620). Wired ONLY on the watcher executor: the
 			// run-task path (which the Job itself runs) builds its executor
@@ -573,8 +593,9 @@ func runTaskCommand(args []string) {
 		CommitCommitter:              repo.Identity{Name: commitAuthorName, Email: commitAuthorEmail},
 		KeepWorkspace:                keepWorkspace,
 		RegistryFactory:              makeRegistryFactory(kc, kcs, foremanNamespace),
-		IssueFetcher:                 githubissue.NewClient(),
-		PREnsurer:                    githubpr.NewClient(),
+		CodeHost:                     githubCodeHost(),
+		WorkItems:                    githubWorkItems(),
+		ChangePolicy:                 changepolicy.NewDefaultPolicy(),
 	})
 	if err != nil {
 		// System / execution failure: the result line + ERROR sentinel

--- a/pkg/foreman/agent/changepolicy/changepolicy.go
+++ b/pkg/foreman/agent/changepolicy/changepolicy.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package changepolicy provides a provider-neutral work-class classification
+// and human-review gate for AgenticTask verdicts. It mirrors the GitHub-specific
+// logic in workclass.go and verdict_policy.go, extracted behind an interface
+// so future providers (Forgejo, Linear, etc.) can supply their own policies.
+package changepolicy
+
+import "path/filepath"
+
+// WorkClass buckets a changed file into the honest-verdict policy classes
+// (proposal 1075, section 3.1).
+type WorkClass string
+
+const (
+	workClassCIPolicy      WorkClass = "ci-policy"
+	workClassReleasePolicy WorkClass = "release-policy"
+	workClassPackaging     WorkClass = "packaging"
+	workClassDocs          WorkClass = "docs"
+	workClassConfig        WorkClass = "config"
+	workClassCodeFix       WorkClass = "code-fix"
+	workClassMixed         WorkClass = "mixed"
+)
+
+// footprintDominance is the changed-line share a class must reach for the
+// diff to take that class; below it the footprint is mixed.
+const footprintDominance = 0.70
+
+type classRule struct {
+	globs []string
+	class WorkClass
+}
+
+// classRules is evaluated in order; first matching glob wins. Globs match
+// with path.Match against the full slash path and against the base name,
+// plus a prefix form for directory trees (dir/**).
+var classRules = []classRule{
+	{[]string{".github/workflows/**", ".github/actions/**"}, workClassCIPolicy},
+	{[]string{".goreleaser*", "release-please*"}, workClassReleasePolicy},
+	{[]string{"Formula/**", "Dockerfile*", "charts/**", "*.spec",
+		"hack/publish-*"}, workClassPackaging},
+	{[]string{"*.md", "docs/**", "examples/**"}, workClassDocs},
+	{[]string{"*.yaml", "*.yml", "*.toml", "*.json"}, workClassConfig},
+}
+
+func matchGlob(glob, path string) bool {
+	if ok, _ := filepath.Match(glob, path); ok {
+		return true
+	}
+	if ok, _ := filepath.Match(glob, filepath.Base(path)); ok {
+		return true
+	}
+	// dir/** prefix form: filepath.Match does not cross separators.
+	if len(glob) > 3 && glob[len(glob)-3:] == "/**" {
+		prefix := glob[:len(glob)-2]
+		return len(path) > len(prefix) && path[:len(prefix)] == prefix
+	}
+	return false
+}
+
+func classifyFile(path string) WorkClass {
+	for _, r := range classRules {
+		for _, g := range r.globs {
+			if matchGlob(g, path) {
+				return r.class
+			}
+		}
+	}
+	return workClassCodeFix
+}
+
+func classifyFootprint(changed map[string]int) WorkClass {
+	if len(changed) == 0 {
+		return workClassCodeFix
+	}
+	total, byClass := 0, map[WorkClass]int{}
+	for f, n := range changed {
+		total += n
+		byClass[classifyFile(f)] += n
+	}
+	// Zero-line diffs (rename-only, permission-only) must not nondeterministically
+	// classify as a self-GO-able class; mixed is the safe fallback.
+	if total == 0 {
+		return workClassMixed
+	}
+	for class, n := range byClass {
+		if float64(n) >= footprintDominance*float64(total) {
+			return class
+		}
+	}
+	return workClassMixed
+}
+
+// ChangePolicy classifies changed paths into work classes and gates
+// human review when a change falls outside the self-GO allowlist.
+type ChangePolicy interface {
+	// Classify returns the dominant work class for a set of changed paths
+	// with their added+deleted line counts.
+	Classify(changed map[string]int) WorkClass
+	// RequiresHumanReview returns true when any changed path classifies
+	// to a class NOT in the provided selfGO list.
+	RequiresHumanReview(changedPaths []string, selfGO []string) bool
+}
+
+// NewDefaultPolicy returns the default ChangePolicy, which mirrors the
+// GitHub-specific classification in workclass.go and the human-review
+// gate in verdict_policy.go.
+func NewDefaultPolicy() ChangePolicy {
+	return defaultPolicy{}
+}
+
+// defaultPolicy is the default implementation that mirrors the
+// workclass.go/verdict_policy.go logic.
+type defaultPolicy struct{}
+
+// Classify implements ChangePolicy.Classify.
+func (defaultPolicy) Classify(changed map[string]int) WorkClass {
+	return classifyFootprint(changed)
+}
+
+// RequiresHumanReview implements ChangePolicy.RequiresHumanReview.
+func (defaultPolicy) RequiresHumanReview(changedPaths []string, selfGO []string) bool {
+	// Build the footprint map from the path list (each path counts as 1
+	// line for the purpose of this gate; the caller may pass a richer
+	// map via Classify when line counts are available).
+	changed := map[string]int{}
+	for _, p := range changedPaths {
+		changed[p] = 1
+	}
+	class := classifyFootprint(changed)
+	return !workClassInList(class, selfGO)
+}
+
+// workClassInList reports whether class's string form appears in list.
+// list is small (a handful of policy classes at most) so a linear scan
+// is simplest; called at most a few times per GO verdict.
+func workClassInList(class WorkClass, list []string) bool {
+	for _, c := range list {
+		if c == string(class) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/foreman/agent/changepolicy/changepolicy_test.go
+++ b/pkg/foreman/agent/changepolicy/changepolicy_test.go
@@ -1,0 +1,493 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package changepolicy
+
+import (
+	"testing"
+)
+
+func TestClassify(t *testing.T) {
+	policy := defaultPolicy{}
+
+	tests := []struct {
+		name    string
+		changed map[string]int
+		want    WorkClass
+	}{
+		{
+			name:    "ci-policy: .github/workflows",
+			changed: map[string]int{".github/workflows/ci.yml": 10},
+			want:    workClassCIPolicy,
+		},
+		{
+			name:    "ci-policy: .github/actions",
+			changed: map[string]int{".github/actions/lint/action.yml": 5},
+			want:    workClassCIPolicy,
+		},
+		{
+			name:    "release-policy: .goreleaser",
+			changed: map[string]int{".goreleaser.yaml": 8},
+			want:    workClassReleasePolicy,
+		},
+		{
+			name:    "release-policy: release-please",
+			changed: map[string]int{"release-please-config.json": 3},
+			want:    workClassReleasePolicy,
+		},
+		{
+			name:    "packaging: Formula",
+			changed: map[string]int{"Formula/llmkube.rb": 12},
+			want:    workClassPackaging,
+		},
+		{
+			name:    "packaging: Dockerfile",
+			changed: map[string]int{"Dockerfile": 20},
+			want:    workClassPackaging,
+		},
+		{
+			name:    "packaging: charts",
+			changed: map[string]int{"charts/llmkube/values.yaml": 15},
+			want:    workClassPackaging,
+		},
+		{
+			name:    "packaging: *.spec",
+			changed: map[string]int{"pkg/llmkube.spec": 6},
+			want:    workClassPackaging,
+		},
+		{
+			name:    "packaging: hack/publish-*",
+			changed: map[string]int{"hack/publish-release.sh": 9},
+			want:    workClassPackaging,
+		},
+		{
+			name:    "docs: *.md",
+			changed: map[string]int{"README.md": 7},
+			want:    workClassDocs,
+		},
+		{
+			name:    "docs: docs/**",
+			changed: map[string]int{"docs/guides/install.md": 11},
+			want:    workClassDocs,
+		},
+		{
+			name:    "docs: examples/**",
+			changed: map[string]int{"examples/basic.yaml": 4},
+			want:    workClassDocs,
+		},
+		{
+			name:    "config: *.yaml",
+			changed: map[string]int{"config/rbac/role.yaml": 14},
+			want:    workClassConfig,
+		},
+		{
+			name:    "config: *.yml",
+			changed: map[string]int{"config/kustomization.yml": 2},
+			want:    workClassConfig,
+		},
+		{
+			name:    "config: *.toml",
+			changed: map[string]int{"config/settings.toml": 3},
+			want:    workClassConfig,
+		},
+		{
+			name:    "config: *.json",
+			changed: map[string]int{"config/config.json": 5},
+			want:    workClassConfig,
+		},
+		{
+			name:    "code-fix: Go source",
+			changed: map[string]int{"pkg/agent/loop.go": 25},
+			want:    workClassCodeFix,
+		},
+		{
+			name:    "code-fix: empty changed",
+			changed: map[string]int{},
+			want:    workClassCodeFix,
+		},
+		{
+			name: "mixed: no dominant class",
+			changed: map[string]int{
+				"pkg/agent/loop.go": 10,
+				"README.md":         10,
+			},
+			want: workClassMixed,
+		},
+		{
+			name: "mixed: zero-line diffs",
+			changed: map[string]int{
+				"pkg/agent/loop.go": 0,
+				"README.md":         0,
+			},
+			want: workClassMixed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := policy.Classify(tt.changed)
+			if got != tt.want {
+				t.Errorf("Classify() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequiresHumanReview(t *testing.T) {
+	policy := defaultPolicy{}
+
+	tests := []struct {
+		name         string
+		changedPaths []string
+		selfGO       []string
+		want         bool
+	}{
+		{
+			name:         "ci-policy change with selfGO missing ci-policy",
+			changedPaths: []string{".github/workflows/ci.yml"},
+			selfGO:       []string{"code-fix", "docs", "config"},
+			want:         true,
+		},
+		{
+			name:         "ci-policy change with selfGO including ci-policy",
+			changedPaths: []string{".github/workflows/ci.yml"},
+			selfGO:       []string{"ci-policy", "code-fix", "docs", "config"},
+			want:         false,
+		},
+		{
+			name:         "release-policy change with selfGO missing release-policy",
+			changedPaths: []string{".goreleaser.yaml"},
+			selfGO:       []string{"code-fix", "docs", "config"},
+			want:         true,
+		},
+		{
+			name:         "release-policy change with selfGO including release-policy",
+			changedPaths: []string{".goreleaser.yaml"},
+			selfGO:       []string{"release-policy", "code-fix", "docs", "config"},
+			want:         false,
+		},
+		{
+			name:         "code-fix change with selfGO including code-fix",
+			changedPaths: []string{"pkg/agent/loop.go"},
+			selfGO:       []string{"code-fix", "docs", "config"},
+			want:         false,
+		},
+		{
+			name:         "code-fix change with selfGO missing code-fix",
+			changedPaths: []string{"pkg/agent/loop.go"},
+			selfGO:       []string{"docs", "config"},
+			want:         true,
+		},
+		{
+			name:         "docs change with selfGO including docs",
+			changedPaths: []string{"README.md"},
+			selfGO:       []string{"code-fix", "docs", "config"},
+			want:         false,
+		},
+		{
+			name:         "docs change with selfGO missing docs",
+			changedPaths: []string{"README.md"},
+			selfGO:       []string{"code-fix", "config"},
+			want:         true,
+		},
+		{
+			name:         "mixed change with selfGO missing mixed",
+			changedPaths: []string{"pkg/agent/loop.go", "README.md"},
+			selfGO:       []string{"code-fix", "docs", "config"},
+			want:         true,
+		},
+		{
+			name:         "mixed change with selfGO including mixed",
+			changedPaths: []string{"pkg/agent/loop.go", "README.md"},
+			selfGO:       []string{"mixed", "code-fix", "docs", "config"},
+			want:         false,
+		},
+		{
+			name:         "empty changed paths",
+			changedPaths: []string{},
+			selfGO:       []string{"code-fix"},
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := policy.RequiresHumanReview(tt.changedPaths, tt.selfGO)
+			if got != tt.want {
+				t.Errorf("RequiresHumanReview() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyCiPolicy(t *testing.T) {
+	// Regression test: .github/workflows must classify as ci-policy.
+	policy := defaultPolicy{}
+	got := policy.Classify(map[string]int{".github/workflows/ci.yml": 10})
+	if got != workClassCIPolicy {
+		t.Errorf("Classify(ci.yml) = %q, want %q", got, workClassCIPolicy)
+	}
+}
+
+func TestClassifyCiPolicyActions(t *testing.T) {
+	// Regression test: .github/actions must classify as ci-policy.
+	policy := defaultPolicy{}
+	got := policy.Classify(map[string]int{".github/actions/lint/action.yml": 5})
+	if got != workClassCIPolicy {
+		t.Errorf("Classify(actions/lint/action.yml) = %q, want %q", got, workClassCIPolicy)
+	}
+}
+
+func TestRequiresHumanReviewCiPolicyGate(t *testing.T) {
+	// Regression test: RequiresHumanReview returns true when
+	// a ci-policy change is not in the selfGO list.
+	policy := defaultPolicy{}
+	got := policy.RequiresHumanReview(
+		[]string{".github/workflows/ci.yml"},
+		[]string{"code-fix", "docs", "config"},
+	)
+	if !got {
+		t.Error("RequiresHumanReview(ci.yml) = false, want true")
+	}
+}
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		name string
+		glob string
+		path string
+		want bool
+	}{
+		{
+			name: "exact match",
+			glob: ".goreleaser.yaml",
+			path: ".goreleaser.yaml",
+			want: true,
+		},
+		{
+			name: "base name match",
+			glob: ".goreleaser*",
+			path: ".goreleaser.yaml",
+			want: true,
+		},
+		{
+			name: "prefix /** match",
+			glob: ".github/workflows/**",
+			path: ".github/workflows/ci.yml",
+			want: true,
+		},
+		{
+			name: "prefix /** no match",
+			glob: ".github/workflows/**",
+			path: ".github/actions/lint/action.yml",
+			want: false,
+		},
+		{
+			name: "no match",
+			glob: "*.yaml",
+			path: "pkg/agent/loop.go",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchGlob(tt.glob, tt.path)
+			if got != tt.want {
+				t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.glob, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyFile(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want WorkClass
+	}{
+		{
+			name: "ci-policy: .github/workflows/ci.yml",
+			path: ".github/workflows/ci.yml",
+			want: workClassCIPolicy,
+		},
+		{
+			name: "ci-policy: .github/actions/lint/action.yml",
+			path: ".github/actions/lint/action.yml",
+			want: workClassCIPolicy,
+		},
+		{
+			name: "release-policy: .goreleaser.yaml",
+			path: ".goreleaser.yaml",
+			want: workClassReleasePolicy,
+		},
+		{
+			name: "release-policy: release-please-config.json",
+			path: "release-please-config.json",
+			want: workClassReleasePolicy,
+		},
+		{
+			name: "packaging: Formula/llmkube.rb",
+			path: "Formula/llmkube.rb",
+			want: workClassPackaging,
+		},
+		{
+			name: "packaging: Dockerfile",
+			path: "Dockerfile",
+			want: workClassPackaging,
+		},
+		{
+			name: "packaging: charts/llmkube/values.yaml",
+			path: "charts/llmkube/values.yaml",
+			want: workClassPackaging,
+		},
+		{
+			name: "packaging: pkg/llmkube.spec",
+			path: "pkg/llmkube.spec",
+			want: workClassPackaging,
+		},
+		{
+			name: "packaging: hack/publish-release.sh",
+			path: "hack/publish-release.sh",
+			want: workClassPackaging,
+		},
+		{
+			name: "docs: README.md",
+			path: "README.md",
+			want: workClassDocs,
+		},
+		{
+			name: "docs: docs/guides/install.md",
+			path: "docs/guides/install.md",
+			want: workClassDocs,
+		},
+		{
+			name: "docs: examples/basic.yaml",
+			path: "examples/basic.yaml",
+			want: workClassDocs,
+		},
+		{
+			name: "config: config/rbac/role.yaml",
+			path: "config/rbac/role.yaml",
+			want: workClassConfig,
+		},
+		{
+			name: "config: config/kustomization.yml",
+			path: "config/kustomization.yml",
+			want: workClassConfig,
+		},
+		{
+			name: "config: config/settings.toml",
+			path: "config/settings.toml",
+			want: workClassConfig,
+		},
+		{
+			name: "config: config/config.json",
+			path: "config/config.json",
+			want: workClassConfig,
+		},
+		{
+			name: "code-fix: pkg/agent/loop.go",
+			path: "pkg/agent/loop.go",
+			want: workClassCodeFix,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyFile(tt.path)
+			if got != tt.want {
+				t.Errorf("classifyFile(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyFootprint(t *testing.T) {
+	tests := []struct {
+		name    string
+		changed map[string]int
+		want    WorkClass
+	}{
+		{
+			name:    "single ci-policy file",
+			changed: map[string]int{".github/workflows/ci.yml": 10},
+			want:    workClassCIPolicy,
+		},
+		{
+			name:    "single code-fix file",
+			changed: map[string]int{"pkg/agent/loop.go": 25},
+			want:    workClassCodeFix,
+		},
+		{
+			name:    "mixed: no dominant class",
+			changed: map[string]int{"pkg/agent/loop.go": 10, "README.md": 10},
+			want:    workClassMixed,
+		},
+		{
+			name:    "mixed: zero-line diffs",
+			changed: map[string]int{"pkg/agent/loop.go": 0, "README.md": 0},
+			want:    workClassMixed,
+		},
+		{
+			name:    "empty changed",
+			changed: map[string]int{},
+			want:    workClassCodeFix,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyFootprint(tt.changed)
+			if got != tt.want {
+				t.Errorf("classifyFootprint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkClassInList(t *testing.T) {
+	tests := []struct {
+		name  string
+		class WorkClass
+		list  []string
+		want  bool
+	}{
+		{
+			name:  "ci-policy in list",
+			class: workClassCIPolicy,
+			list:  []string{"ci-policy", "code-fix"},
+			want:  true,
+		},
+		{
+			name:  "ci-policy not in list",
+			class: workClassCIPolicy,
+			list:  []string{"code-fix", "docs"},
+			want:  false,
+		},
+		{
+			name:  "empty list",
+			class: workClassCodeFix,
+			list:  []string{},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := workClassInList(tt.class, tt.list)
+			if got != tt.want {
+				t.Errorf("workClassInList(%q, %v) = %v, want %v", tt.class, tt.list, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/codehost/codehost.go
+++ b/pkg/foreman/agent/codehost/codehost.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package codehost provides a provider-neutral seam for code-host
+// operations (clone URLs, pull request management, commit metadata).
+// The GitHub adapter lives in this package so the rest of the agent
+// ecosystem never imports githubpr or githubissue directly.
+package codehost
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
+)
+
+// repoSlugPattern matches a single "owner/name" GitHub slug. Each segment
+// is limited to git/GitHub-safe characters and exactly one slash is allowed,
+// so "..", multiple path segments, and whitespace are rejected.
+var repoSlugPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`)
+
+// CodeHost is the provider-neutral seam for code-host operations.
+// Implementations wrap a specific platform (GitHub, Forgejo, etc.) and
+// expose operations the executor needs without leaking platform details.
+type CodeHost interface {
+	// ResolveCloneURL derives the HTTPS git clone URL from a repo slug
+	// like "owner/name". Returns "" for an empty or malformed slug so
+	// callers fall back to the cloned fork's HEAD.
+	ResolveCloneURL(repoSlug string) string
+
+	// EnsureChangeRequest ensures a pull request exists for head → base,
+	// creating it if absent. Returns the PR URL and whether it was
+	// created (true) or already existed (false).
+	EnsureChangeRequest(ctx context.Context, repoSlug, headBranch,
+		baseBranch, title, body string) (url string, created bool, err error)
+
+	// HeadCommitSubject returns the first line of the branch head's commit
+	// message — the natural PR title (the coder writes a conventional
+	// subject). Empty on any failure so callers can fall back.
+	HeadCommitSubject(ctx context.Context, repoSlug, headBranch string) (string, error)
+}
+
+// GitHubCodeHost wraps a githubpr.Ensurer and provides the CodeHost
+// interface backed by GitHub. The Ensurer is injected so tests can
+// substitute a fake.
+type GitHubCodeHost struct {
+	Ensurer githubpr.Ensurer
+	// Token authenticates the GitHub API calls (PR create, head-commit
+	// read). Empty means unauthenticated; PR creation needs a real token,
+	// so main wires it from the same source as the git auth.
+	Token string
+}
+
+// NewGitHubCodeHost constructs a GitHubCodeHost from a githubpr.Ensurer.
+func NewGitHubCodeHost(ensurer githubpr.Ensurer) *GitHubCodeHost {
+	return &GitHubCodeHost{Ensurer: ensurer}
+}
+
+// ResolveCloneURL derives the upstream project's HTTPS git URL from a
+// payload.repo "owner/name" slug (the GitHub convention LLMKube uses).
+// It returns "" for an empty or malformed slug so callers fall back to
+// the cloned fork's HEAD (e.g. freeform tasks that carry no repo slug).
+func (g *GitHubCodeHost) ResolveCloneURL(repoSlug string) string {
+	repoSlug = strings.TrimSpace(repoSlug)
+	if !repoSlugPattern.MatchString(repoSlug) {
+		return ""
+	}
+	return "https://github.com/" + repoSlug + ".git"
+}
+
+// EnsureChangeRequest ensures a pull request exists for head → base,
+// creating it if absent. Returns the PR URL and whether it was created.
+func (g *GitHubCodeHost) EnsureChangeRequest(
+	ctx context.Context, repoSlug, headBranch, baseBranch, title, body string,
+) (string, bool, error) {
+	owner, name, ok := strings.Cut(repoSlug, "/")
+	if !ok || owner == "" || name == "" {
+		return "", false, nil
+	}
+	res, err := g.Ensurer.EnsurePR(ctx, owner, name, headBranch, baseBranch, title, body, g.Token)
+	if err != nil {
+		return "", false, err
+	}
+	return res.URL, res.Created, nil
+}
+
+// HeadCommitSubject returns the first line of the branch head's commit
+// message — the natural PR title (the coder writes a conventional
+// subject). Empty on any failure so callers can fall back.
+func (g *GitHubCodeHost) HeadCommitSubject(ctx context.Context, repoSlug, headBranch string) (string, error) {
+	owner, name, ok := strings.Cut(repoSlug, "/")
+	if !ok || owner == "" || name == "" {
+		return "", nil
+	}
+	return g.Ensurer.HeadCommitSubject(ctx, owner, name, headBranch, g.Token), nil
+}

--- a/pkg/foreman/agent/codehost/codehost_test.go
+++ b/pkg/foreman/agent/codehost/codehost_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codehost
+
+import (
+	"context"
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
+)
+
+// fakeEnsurer is a minimal githubpr.Ensurer implementation for tests.
+type fakeEnsurer struct {
+	ensurePRFunc func(ctx context.Context, owner, repo, head, base, title, body, token string) (*githubpr.Result, error)
+	commitFunc   func(ctx context.Context, owner, repo, ref, token string) string
+}
+
+func (f *fakeEnsurer) EnsurePR(ctx context.Context, owner, repo, head,
+	base, title, body, token string) (*githubpr.Result, error) {
+	if f.ensurePRFunc != nil {
+		return f.ensurePRFunc(ctx, owner, repo, head, base, title, body, token)
+	}
+	return nil, nil
+}
+
+func (f *fakeEnsurer) HeadCommitSubject(ctx context.Context, owner, repo, ref, token string) string {
+	if f.commitFunc != nil {
+		return f.commitFunc(ctx, owner, repo, ref, token)
+	}
+	return ""
+}
+
+func TestNewGitHubCodeHost(t *testing.T) {
+	fake := &fakeEnsurer{}
+	g := NewGitHubCodeHost(fake)
+	if g == nil {
+		t.Fatal("NewGitHubCodeHost returned nil")
+	}
+	if g.Ensurer != fake {
+		t.Errorf("NewGitHubCodeHost.Ensurer = %v, want %v", g.Ensurer, fake)
+	}
+}
+
+func TestResolveCloneURL(t *testing.T) {
+	g := &GitHubCodeHost{}
+
+	tests := []struct {
+		name string
+		slug string
+		want string
+	}{
+		{
+			name: "valid slug",
+			slug: "defilantech/llmkube",
+			want: "https://github.com/defilantech/llmkube.git",
+		},
+		{
+			name: "valid slug with dots and hyphens",
+			slug: "my-org/my-repo-name",
+			want: "https://github.com/my-org/my-repo-name.git",
+		},
+		{
+			name: "empty slug",
+			slug: "",
+			want: "",
+		},
+		{
+			name: "malformed slug - no slash",
+			slug: "defilantech",
+			want: "",
+		},
+		{
+			name: "malformed slug - extra slash",
+			slug: "defilantech/llmkube/extra",
+			want: "",
+		},
+		{
+			name: "slug with trailing whitespace is trimmed",
+			slug: "defilantech/llmkube ",
+			want: "https://github.com/defilantech/llmkube.git",
+		},
+		{
+			name: "slug with leading whitespace",
+			slug: "  defilantech/llmkube",
+			want: "https://github.com/defilantech/llmkube.git",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := g.ResolveCloneURL(tc.slug)
+			if got != tc.want {
+				t.Errorf("ResolveCloneURL(%q) = %q, want %q", tc.slug, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEnsureChangeRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		repoSlug    string
+		headBranch  string
+		baseBranch  string
+		title       string
+		body        string
+		ensurePR    func(ctx context.Context, owner, repo, head, base, title, body, token string) (*githubpr.Result, error)
+		wantURL     string
+		wantCreated bool
+		wantErr     bool
+	}{
+		{
+			name:       "creates new PR",
+			repoSlug:   "defilantech/llmkube",
+			headBranch: "foreman/wl-x/issue-7",
+			baseBranch: "main",
+			title:      "Fix the thing",
+			body:       "Fixes #7",
+			ensurePR: func(ctx context.Context, owner, repo, head, base, title, body, token string) (*githubpr.Result, error) {
+				return &githubpr.Result{URL: "https://github.com/defilantech/llmkube/pull/9", Created: true}, nil
+			},
+			wantURL:     "https://github.com/defilantech/llmkube/pull/9",
+			wantCreated: true,
+		},
+		{
+			name:       "reuses existing PR",
+			repoSlug:   "defilantech/llmkube",
+			headBranch: "foreman/wl-x/issue-7",
+			baseBranch: "main",
+			title:      "Fix the thing",
+			body:       "Fixes #7",
+			ensurePR: func(ctx context.Context, owner, repo, head, base, title, body, token string) (*githubpr.Result, error) {
+				return &githubpr.Result{URL: "https://github.com/defilantech/llmkube/pull/4", Created: false}, nil
+			},
+			wantURL:     "https://github.com/defilantech/llmkube/pull/4",
+			wantCreated: false,
+		},
+		{
+			name:        "malformed repo slug returns empty",
+			repoSlug:    "bad-slug",
+			headBranch:  "foreman/wl-x/issue-7",
+			baseBranch:  "main",
+			title:       "Fix the thing",
+			body:        "Fixes #7",
+			ensurePR:    nil,
+			wantURL:     "",
+			wantCreated: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &GitHubCodeHost{
+				Ensurer: &fakeEnsurer{
+					ensurePRFunc: tc.ensurePR,
+				},
+			}
+
+			url, created, err := g.EnsureChangeRequest(
+				context.Background(), tc.repoSlug, tc.headBranch,
+				tc.baseBranch, tc.title, tc.body)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("EnsureChangeRequest() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if url != tc.wantURL {
+				t.Errorf("EnsureChangeRequest() url = %q, want %q", url, tc.wantURL)
+			}
+			if created != tc.wantCreated {
+				t.Errorf("EnsureChangeRequest() created = %v, want %v", created, tc.wantCreated)
+			}
+		})
+	}
+}
+
+func TestHeadCommitSubject(t *testing.T) {
+	tests := []struct {
+		name        string
+		repoSlug    string
+		headBranch  string
+		commitFunc  func(ctx context.Context, owner, repo, ref, token string) string
+		wantSubject string
+	}{
+		{
+			name:       "valid subject",
+			repoSlug:   "defilantech/llmkube",
+			headBranch: "foreman/wl-x/issue-7",
+			commitFunc: func(ctx context.Context, owner, repo, ref, token string) string {
+				return "feat: add the thing"
+			},
+			wantSubject: "feat: add the thing",
+		},
+		{
+			name:       "empty subject on failure",
+			repoSlug:   "defilantech/llmkube",
+			headBranch: "foreman/wl-x/issue-7",
+			commitFunc: func(ctx context.Context, owner, repo, ref, token string) string {
+				return ""
+			},
+			wantSubject: "",
+		},
+		{
+			name:        "malformed repo slug returns empty",
+			repoSlug:    "bad-slug",
+			headBranch:  "foreman/wl-x/issue-7",
+			commitFunc:  nil,
+			wantSubject: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &GitHubCodeHost{
+				Ensurer: &fakeEnsurer{
+					commitFunc: tc.commitFunc,
+				},
+			}
+
+			subject, err := g.HeadCommitSubject(context.Background(), tc.repoSlug, tc.headBranch)
+			if err != nil {
+				t.Errorf("HeadCommitSubject() error = %v", err)
+				return
+			}
+			if subject != tc.wantSubject {
+				t.Errorf("HeadCommitSubject() = %q, want %q", subject, tc.wantSubject)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -40,6 +40,8 @@ import (
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/changepolicy"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/grounding"
@@ -47,6 +49,7 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repomap"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/worktracker"
 )
 
 // NativeAgentLoopExecutor is the M3 production executor. It resolves an
@@ -155,7 +158,30 @@ type NativeAgentLoopExecutor struct {
 	// review verdict is GO, when the task payload carries
 	// openPullRequest (#937). nil disables PR opening entirely;
 	// cmd/foreman-agent wires githubpr.NewClient().
+	//
+	// Deprecated for direct use: the executor now reaches PR + clone-URL
+	// operations through the provider-neutral CodeHost seam (#1158). This
+	// field remains as a fallback the codeHost() accessor wraps when
+	// CodeHost is nil, so existing callers/tests that inject a githubpr
+	// fake keep working.
 	PREnsurer githubpr.Ensurer
+
+	// CodeHost is the provider-neutral seam for code-host operations (PR
+	// creation, clone-URL resolution, head-commit subject) introduced by
+	// #1158. Production wires a codehost.GitHubCodeHost; when nil the
+	// codeHost() accessor falls back to wrapping PREnsurer.
+	CodeHost codehost.CodeHost
+
+	// WorkItems is the provider-neutral seam for fetching work items
+	// (issues) by ID (#1158). Production wires a worktracker.GitHubWorkItems;
+	// when nil the workItems() accessor falls back to wrapping IssueFetcher.
+	WorkItems worktracker.WorkItems
+
+	// ChangePolicy is the provider-neutral seam for classifying changed
+	// paths into work classes and gating human review (#1158). Production
+	// wires changepolicy.NewDefaultPolicy(); when nil the changePolicy()
+	// accessor falls back to that same default.
+	ChangePolicy changepolicy.ChangePolicy
 
 	// CoderJobSubmitter, when non-nil, routes Job-mode Agents
 	// (spec.execution.mode == Job) to an ephemeral per-task Kubernetes Job
@@ -178,6 +204,58 @@ type NativeAgentLoopExecutor struct {
 	// here. Nil skips the post-push envtest gate (e.g. the in-process
 	// run-task path, where the clean-room gate Job is the backstop).
 	EnvtestJobRunner EnvtestJobRunner
+}
+
+// codeHost returns the effective CodeHost seam: the injected CodeHost when
+// set, else a GitHubCodeHost wrapping the legacy PREnsurer (nil when neither
+// is configured, which disables PR opening exactly as before). token is the
+// run's git-auth token, threaded onto the legacy wrap so it authenticates the
+// GitHub API calls exactly as the pre-#1158 code did; it is ignored when
+// CodeHost is injected directly (production bakes its own token in).
+func (e *NativeAgentLoopExecutor) codeHost(token string) codehost.CodeHost {
+	if e.CodeHost != nil {
+		return e.CodeHost
+	}
+	if e.PREnsurer != nil {
+		return &codehost.GitHubCodeHost{Ensurer: e.PREnsurer, Token: token}
+	}
+	return nil
+}
+
+// workItems returns the effective WorkItems seam: the injected WorkItems
+// when set, else a GitHubWorkItems wrapping the legacy IssueFetcher (nil
+// when neither is configured, which preserves the empty-issue-body
+// behavior). token is the run's git-auth token, threaded onto the legacy
+// wrap so the issue fetch stays authenticated exactly as before; it is
+// ignored when WorkItems is injected directly.
+func (e *NativeAgentLoopExecutor) workItems(token string) worktracker.WorkItems {
+	if e.WorkItems != nil {
+		return e.WorkItems
+	}
+	if e.IssueFetcher != nil {
+		return &worktracker.GitHubWorkItems{Fetcher: e.IssueFetcher, Token: token}
+	}
+	return nil
+}
+
+// authToken returns the token carried by auth, or "" when auth is nil. It
+// bridges the run's repo.Auth to the token the CodeHost/WorkItems legacy
+// wraps need.
+func authToken(auth *repo.Auth) string {
+	if auth != nil {
+		return auth.Token
+	}
+	return ""
+}
+
+// changePolicy returns the effective ChangePolicy seam: the injected
+// ChangePolicy when set, else the default policy (which mirrors the
+// workclass.go/verdict_policy.go behavior).
+func (e *NativeAgentLoopExecutor) changePolicy() changepolicy.ChangePolicy {
+	if e.ChangePolicy != nil {
+		return e.ChangePolicy
+	}
+	return changepolicy.NewDefaultPolicy()
 }
 
 // Kind identifies this executor in Result.Kind and in logs.
@@ -503,7 +581,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// the prompt empty; without this fetch the model is asked to fix
 	// "#510" with no knowledge of what #510 is about. Best-effort: a
 	// failed fetch logs and the loop runs with the pre-#571 behavior.
-	fetchIssueBodyIfNeeded(ctx, e.IssueFetcher, task, auth, log)
+	fetchIssueBodyIfNeeded(ctx, e.workItems(authToken(auth)), task, log)
 	userPrompt := buildUserPrompt(task)
 	// issueText ranks files for both the repo-map prefix (coder Agents) and the
 	// scope-overlap guard in the coder gate verifier (#782).
@@ -994,7 +1072,7 @@ func (e *NativeAgentLoopExecutor) applyWorkClassPolicyForTask(
 		r.Extra["workClassUnknown"] = true
 		return r
 	}
-	return applyVerdictPolicy(r, changed, task.Spec.VerdictPolicy.Resolve())
+	return applyVerdictPolicy(r, changed, task.Spec.VerdictPolicy.Resolve(), e.changePolicy())
 }
 
 // reviewerGroundedChangedLines builds the changedLines callback the
@@ -1602,7 +1680,7 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 	if verdict != foremanv1alpha1.AgenticTaskVerdictGo ||
 		task.Spec.Kind != foremanv1alpha1.AgenticTaskKindReview ||
 		!task.Spec.Payload.OpenPullRequest ||
-		e.PREnsurer == nil {
+		e.codeHost(authToken(auth)) == nil {
 		return
 	}
 	if prURL, prErr := e.openPullRequest(ctx, task, auth, r.Summary); prErr != nil {
@@ -1637,18 +1715,18 @@ func (e *NativeAgentLoopExecutor) openPullRequest(
 	if !ok || owner == "" || name == "" {
 		return "", fmt.Errorf("openPullRequest: payload.repo %q is not owner/name", p.Repo)
 	}
-	token := ""
-	if auth != nil {
-		token = auth.Token
-	}
+	ch := e.codeHost(authToken(auth))
+	// The coder pushed the branch to e.GitRemoteURL, which may be a fork of
+	// payload.repo. For a cross-fork PR the head is qualified "forkOwner:branch"
+	// and the head commit is read from the fork (headSlug), where the ref lives.
 	head := p.Branch
-	headOwner, headRepo := owner, name
+	headSlug := p.Repo
 	if forkOwner, forkRepo := gitRemoteOwnerRepo(e.GitRemoteURL); forkOwner != "" &&
 		!strings.EqualFold(forkOwner, owner) {
 		head = forkOwner + ":" + p.Branch
-		headOwner, headRepo = forkOwner, forkRepo
+		headSlug = forkOwner + "/" + forkRepo
 	}
-	title := e.PREnsurer.HeadCommitSubject(ctx, headOwner, headRepo, p.Branch, token)
+	title, _ := ch.HeadCommitSubject(ctx, headSlug, p.Branch)
 	if title == "" {
 		title = fmt.Sprintf("Fix #%d", p.Issue)
 	}
@@ -1663,12 +1741,12 @@ func (e *NativeAgentLoopExecutor) openPullRequest(
 	fmt.Fprintf(&bodyB, "Fixes #%d\n\n_Opened by foreman on review GO (workload %s)._",
 		p.Issue, task.Labels["foreman.llmkube.dev/workload"])
 	body := bodyB.String()
-	res, err := e.PREnsurer.EnsurePR(ctx, owner, name, head,
-		baseBranchOrDefault(p.BaseBranch), title, body, token)
+	prURL, _, err := ch.EnsureChangeRequest(ctx, p.Repo, head,
+		baseBranchOrDefault(p.BaseBranch), title, body)
 	if err != nil {
 		return "", err
 	}
-	return res.URL, nil
+	return prURL, nil
 }
 
 // maybePreserveGateFailedBranch commits and pushes a coder's branch when its
@@ -2102,12 +2180,15 @@ func baseBranchOrDefault(baseBranch string) string {
 // validated against a strict "owner/name" allowlist so it cannot inject path
 // traversal, spaces, or extra path segments into the derived URL.
 func upstreamURLForRepo(repoSlug string) string {
-	repoSlug = strings.TrimSpace(repoSlug)
-	if !repoSlugPattern.MatchString(repoSlug) {
-		return ""
-	}
-	return "https://github.com/" + repoSlug + ".git"
+	return cloneURLResolver.ResolveCloneURL(repoSlug)
 }
+
+// cloneURLResolver is the provider-neutral clone-URL resolver backing
+// upstreamURLForRepo. Wiring it through codehost.CodeHost (#1158) keeps the
+// github.com URL template in one place (the GitHub adapter) instead of
+// duplicated here. The Ensurer is nil because ResolveCloneURL is pure and
+// never touches it.
+var cloneURLResolver codehost.CodeHost = codehost.NewGitHubCodeHost(nil)
 
 // repoSlugPattern matches a single "owner/name" GitHub slug. Each segment is
 // limited to git/GitHub-safe characters and exactly one slash is allowed, so
@@ -2775,12 +2856,11 @@ func logReviewerFindings(log logr.Logger, extra map[string]any) {
 // being asked to do before reading the longer body.
 func fetchIssueBodyIfNeeded(
 	ctx context.Context,
-	fetcher githubissue.Fetcher,
+	items worktracker.WorkItems,
 	task *foremanv1alpha1.AgenticTask,
-	auth *repo.Auth,
 	log logr.Logger,
 ) {
-	if fetcher == nil {
+	if items == nil {
 		return
 	}
 	if task.Spec.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
@@ -2794,16 +2874,7 @@ func fetchIssueBodyIfNeeded(
 	if task.Spec.Payload.Issue <= 0 {
 		return
 	}
-	owner, repoName, err := githubissue.ParseRepo(task.Spec.Payload.Repo)
-	if err != nil {
-		log.Info("issue fetch skipped: bad repo string", "repo", task.Spec.Payload.Repo, "err", err.Error())
-		return
-	}
-	token := ""
-	if auth != nil {
-		token = auth.Token
-	}
-	iss, err := fetcher.Fetch(ctx, owner, repoName, int(task.Spec.Payload.Issue), token)
+	wi, err := items.Get(ctx, task.Spec.Payload.Repo, strconv.Itoa(int(task.Spec.Payload.Issue)))
 	if err != nil {
 		// Distinguish the common cases so the log line is actionable.
 		var herr *githubissue.HTTPError
@@ -2833,19 +2904,19 @@ func fetchIssueBodyIfNeeded(
 		// issue rides behind it under its own heading so the model sees
 		// both the retry context and the original ask.
 		b.WriteString(task.Spec.Payload.Prompt)
-		fmt.Fprintf(&b, "\n\n## Original issue (#%d): %s\n\n", iss.Number, iss.Title)
+		fmt.Fprintf(&b, "\n\n## Original issue (#%d): %s\n\n", task.Spec.Payload.Issue, wi.Title)
 	} else {
-		fmt.Fprintf(&b, "# Issue #%d: %s\n\n", iss.Number, iss.Title)
+		fmt.Fprintf(&b, "# Issue #%d: %s\n\n", task.Spec.Payload.Issue, wi.Title)
 	}
-	fmt.Fprintf(&b, "State: %s\n", iss.State)
-	if len(iss.Labels) > 0 {
-		fmt.Fprintf(&b, "Labels: %s\n", strings.Join(iss.Labels, ", "))
+	fmt.Fprintf(&b, "State: %s\n", wi.State)
+	if len(wi.Labels) > 0 {
+		fmt.Fprintf(&b, "Labels: %s\n", strings.Join(wi.Labels, ", "))
 	}
 	b.WriteString("\n")
-	b.WriteString(iss.Body)
+	b.WriteString(wi.Body)
 	task.Spec.Payload.Prompt = b.String()
 	log.Info("issue body fetched",
-		"issue", iss.Number, "state", iss.State, "bodyLen", len(iss.Body), "appended", appended)
+		"issue", task.Spec.Payload.Issue, "state", wi.State, "bodyLen", len(wi.Body), "appended", appended)
 }
 
 // progressConfigFromAgent maps the Agent CR's stuckLoopDetection field

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -46,6 +46,7 @@ import (
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/worktracker"
 )
 
 // TestBranchNameForTask covers the precedence rule between explicit
@@ -2038,7 +2039,7 @@ func TestFetchIssueBodyIfNeeded_AppendsIssueOnRevisionTask(t *testing.T) {
 		},
 	}
 
-	fetchIssueBodyIfNeeded(context.Background(), fetcher, task, nil, logr.Discard())
+	fetchIssueBodyIfNeeded(context.Background(), &worktracker.GitHubWorkItems{Fetcher: fetcher}, task, logr.Discard())
 
 	if fetcher.calls != 1 {
 		t.Fatalf("fetcher calls = %d, want 1", fetcher.calls)
@@ -2078,7 +2079,7 @@ func TestFetchIssueBodyIfNeeded_NoIssueNumberIsNoOp(t *testing.T) {
 		},
 	}
 
-	fetchIssueBodyIfNeeded(context.Background(), fetcher, task, nil, logr.Discard())
+	fetchIssueBodyIfNeeded(context.Background(), &worktracker.GitHubWorkItems{Fetcher: fetcher}, task, logr.Discard())
 
 	if fetcher.calls != 0 {
 		t.Errorf("fetcher must not be called when Issue is 0; calls = %d", fetcher.calls)
@@ -2106,7 +2107,7 @@ func TestFetchIssueBodyIfNeeded_ComposedPromptWithoutRevisionUntouched(t *testin
 		},
 	}
 
-	fetchIssueBodyIfNeeded(context.Background(), fetcher, task, nil, logr.Discard())
+	fetchIssueBodyIfNeeded(context.Background(), &worktracker.GitHubWorkItems{Fetcher: fetcher}, task, logr.Discard())
 
 	if fetcher.calls != 0 {
 		t.Errorf("fetcher must not be called for a composed prompt without reviseFromBranch; calls = %d", fetcher.calls)

--- a/pkg/foreman/agent/runtask.go
+++ b/pkg/foreman/agent/runtask.go
@@ -28,9 +28,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/changepolicy"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/worktracker"
 )
 
 // RunTask is the standalone single-task runner: it executes ONE
@@ -143,6 +146,14 @@ type RunTaskConfig struct {
 	// behavior.
 	IssueFetcher githubissue.Fetcher
 
+	// CodeHost, WorkItems, and ChangePolicy are the provider-neutral seams
+	// (#1158). When set they take precedence over the PREnsurer /
+	// IssueFetcher fallbacks in NativeAgentLoopExecutor; cmd/foreman-agent
+	// wires the GitHub-backed implementations.
+	CodeHost     codehost.CodeHost
+	WorkItems    worktracker.WorkItems
+	ChangePolicy changepolicy.ChangePolicy
+
 	// UpstreamURLForRepo overrides how the task's payload.repo slug
 	// resolves to the upstream project's git URL (mirrors
 	// NativeAgentLoopExecutor.UpstreamURLForRepo). nil falls back to the
@@ -223,6 +234,9 @@ func RunTask(ctx context.Context, cfg RunTaskConfig) (RunTaskResult, error) {
 		AuthFactory:                  cfg.AuthFactory,
 		IssueFetcher:                 cfg.IssueFetcher,
 		PREnsurer:                    cfg.PREnsurer,
+		CodeHost:                     cfg.CodeHost,
+		WorkItems:                    cfg.WorkItems,
+		ChangePolicy:                 cfg.ChangePolicy,
 		UpstreamURLForRepo:           cfg.UpstreamURLForRepo,
 	}
 

--- a/pkg/foreman/agent/verdict_policy.go
+++ b/pkg/foreman/agent/verdict_policy.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/changepolicy"
 )
 
 // needsVerificationOutcome mirrors
@@ -135,7 +136,9 @@ func unverifiedPolicyEntry(class workClass) map[string]string {
 // Extra["unverified"] entry explaining why; a declared/actual mismatch
 // where BOTH classes are self-GO-able does not downgrade but records
 // Extra["workClassMismatch"] = true so the discrepancy stays visible.
-func applyVerdictPolicy(res *Result, changed map[string]int, selfGO []string) *Result {
+func applyVerdictPolicy(
+	res *Result, changed map[string]int, selfGO []string, policy changepolicy.ChangePolicy,
+) *Result {
 	if res == nil || res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
 		return res
 	}
@@ -143,7 +146,7 @@ func applyVerdictPolicy(res *Result, changed map[string]int, selfGO []string) *R
 		res.Extra = map[string]any{}
 	}
 
-	class := classifyFootprint(changed)
+	class := workClass(policy.Classify(changed))
 	res.Extra["actualWorkClass"] = string(class)
 
 	declared, hasDeclared := res.Extra["workClass"].(string)

--- a/pkg/foreman/agent/verdict_policy_test.go
+++ b/pkg/foreman/agent/verdict_policy_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/changepolicy"
 )
 
 func TestApplyVerdictPolicy(t *testing.T) {
@@ -31,7 +32,7 @@ func TestApplyVerdictPolicy(t *testing.T) {
 	}
 	t.Run("ci-policy footprint downgrades GO", func(t *testing.T) {
 		res := applyVerdictPolicy(goResult(),
-			map[string]int{".github/workflows/release.yml": 40}, defaultSelfGO)
+			map[string]int{".github/workflows/release.yml": 40}, defaultSelfGO, changepolicy.NewDefaultPolicy())
 		if res.Verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
 			t.Fatalf("verdict = %v, want NO-GO", res.Verdict)
 		}
@@ -54,7 +55,7 @@ func TestApplyVerdictPolicy(t *testing.T) {
 	})
 	t.Run("code-fix GO stands", func(t *testing.T) {
 		res := applyVerdictPolicy(goResult(),
-			map[string]int{"pkg/foreman/agent/loop.go": 40}, defaultSelfGO)
+			map[string]int{"pkg/foreman/agent/loop.go": 40}, defaultSelfGO, changepolicy.NewDefaultPolicy())
 		if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
 			t.Fatalf("verdict = %v, want GO", res.Verdict)
 		}
@@ -62,27 +63,28 @@ func TestApplyVerdictPolicy(t *testing.T) {
 	t.Run("operator opt-in allows ci-policy", func(t *testing.T) {
 		res := applyVerdictPolicy(goResult(),
 			map[string]int{".github/workflows/release.yml": 40},
-			append(defaultSelfGO, "ci-policy"))
+			append(defaultSelfGO, "ci-policy"), changepolicy.NewDefaultPolicy())
 		if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
 			t.Fatalf("verdict = %v, want GO with opt-in", res.Verdict)
 		}
 	})
 	t.Run("NO-GO passes through untouched", func(t *testing.T) {
 		res := &Result{Verdict: foremanv1alpha1.AgenticTaskVerdictNoGo}
-		if got := applyVerdictPolicy(res, nil, defaultSelfGO); got.Verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		got := applyVerdictPolicy(res, nil, defaultSelfGO, changepolicy.NewDefaultPolicy())
+		if got.Verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
 			t.Fatal("non-GO must pass through")
 		}
 	})
 	t.Run("actualWorkClass always recorded even when it stands", func(t *testing.T) {
 		res := applyVerdictPolicy(goResult(),
-			map[string]int{"pkg/foreman/agent/loop.go": 40}, defaultSelfGO)
+			map[string]int{"pkg/foreman/agent/loop.go": 40}, defaultSelfGO, changepolicy.NewDefaultPolicy())
 		if res.Extra["actualWorkClass"] != "code-fix" {
 			t.Errorf("actualWorkClass = %v", res.Extra["actualWorkClass"])
 		}
 	})
 	t.Run("declared work class is recorded when the coder set one", func(t *testing.T) {
 		res := applyVerdictPolicy(goResult(),
-			map[string]int{"pkg/foreman/agent/loop.go": 40}, defaultSelfGO)
+			map[string]int{"pkg/foreman/agent/loop.go": 40}, defaultSelfGO, changepolicy.NewDefaultPolicy())
 		if res.Extra["declaredWorkClass"] != "code-fix" {
 			t.Errorf("declaredWorkClass = %v", res.Extra["declaredWorkClass"])
 		}
@@ -90,7 +92,8 @@ func TestApplyVerdictPolicy(t *testing.T) {
 	t.Run("declared-vs-actual mismatch between two self-GO classes flags without downgrading", func(t *testing.T) {
 		res := &Result{Verdict: foremanv1alpha1.AgenticTaskVerdictGo,
 			Extra: map[string]any{"workClass": "docs"}}
-		res = applyVerdictPolicy(res, map[string]int{"pkg/foreman/agent/loop.go": 40}, defaultSelfGO)
+		res = applyVerdictPolicy(res, map[string]int{"pkg/foreman/agent/loop.go": 40},
+			defaultSelfGO, changepolicy.NewDefaultPolicy())
 		if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
 			t.Fatalf("verdict = %v, want GO to stand despite the mismatch", res.Verdict)
 		}
@@ -101,14 +104,14 @@ func TestApplyVerdictPolicy(t *testing.T) {
 	t.Run("no declared class means no mismatch flag", func(t *testing.T) {
 		res := applyVerdictPolicy(
 			&Result{Verdict: foremanv1alpha1.AgenticTaskVerdictGo, Extra: map[string]any{}},
-			map[string]int{"pkg/foreman/agent/loop.go": 40}, defaultSelfGO)
+			map[string]int{"pkg/foreman/agent/loop.go": 40}, defaultSelfGO, changepolicy.NewDefaultPolicy())
 		if _, ok := res.Extra["workClassMismatch"]; ok {
 			t.Errorf("workClassMismatch should be absent, got %v", res.Extra["workClassMismatch"])
 		}
 	})
 	t.Run("nil Extra on a GO result does not panic", func(t *testing.T) {
 		res := applyVerdictPolicy(&Result{Verdict: foremanv1alpha1.AgenticTaskVerdictGo},
-			map[string]int{".github/workflows/release.yml": 40}, defaultSelfGO)
+			map[string]int{".github/workflows/release.yml": 40}, defaultSelfGO, changepolicy.NewDefaultPolicy())
 		if res.Extra["outcome"] != "NEEDS-VERIFICATION" {
 			t.Errorf("outcome = %v", res.Extra["outcome"])
 		}

--- a/pkg/foreman/agent/worktracker/worktracker.go
+++ b/pkg/foreman/agent/worktracker/worktracker.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package worktracker provides a generic interface for retrieving
+// work items (e.g. GitHub issues) by ID, and a GitHub-backed
+// implementation that delegates to the githubissue.Fetcher.
+package worktracker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+)
+
+// WorkItem represents a single unit of work, such as a GitHub issue.
+type WorkItem struct {
+	ID     string
+	Title  string
+	Body   string
+	State  string
+	URL    string
+	Labels []string
+}
+
+// WorkItems is the interface for retrieving work items by ID.
+type WorkItems interface {
+	Get(ctx context.Context, repoSlug, id string) (*WorkItem, error)
+}
+
+// GitHubWorkItems implements WorkItems using the GitHub API via
+// githubissue.Fetcher. The repoSlug is "owner/repo" and the id is
+// the issue number as a string.
+type GitHubWorkItems struct {
+	Fetcher githubissue.Fetcher
+	// Token authenticates the GitHub API calls. Empty means an
+	// unauthenticated request (public repos, subject to rate limits),
+	// matching the executor's prior best-effort issue fetch.
+	Token string
+}
+
+// Get fetches a single work item by repo slug and ID. The ID is
+// parsed as an integer and passed to the Fetcher. The returned
+// githubissue.Issue is mapped to a WorkItem.
+func (g *GitHubWorkItems) Get(ctx context.Context, repoSlug, id string) (*WorkItem, error) {
+	owner, repo, err := githubissue.ParseRepo(repoSlug)
+	if err != nil {
+		return nil, fmt.Errorf("worktracker: parse repo slug: %w", err)
+	}
+
+	num, err := strconv.Atoi(id)
+	if err != nil {
+		return nil, fmt.Errorf("worktracker: parse id %q as int: %w", id, err)
+	}
+
+	issue, err := g.Fetcher.Fetch(ctx, owner, repo, num, g.Token)
+	if err != nil {
+		return nil, fmt.Errorf("worktracker: fetch issue %d: %w", num, err)
+	}
+
+	return &WorkItem{
+		ID:     strconv.Itoa(issue.Number),
+		Title:  issue.Title,
+		Body:   issue.Body,
+		State:  issue.State,
+		URL:    "",
+		Labels: issue.Labels,
+	}, nil
+}

--- a/pkg/foreman/agent/worktracker/worktracker_test.go
+++ b/pkg/foreman/agent/worktracker/worktracker_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package worktracker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+)
+
+// fakeFetcher implements githubissue.Fetcher for testing.
+type fakeFetcher struct {
+	Issue *githubissue.Issue
+	Err   error
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, _, _ string, _ int, _ string) (*githubissue.Issue, error) {
+	return f.Issue, f.Err
+}
+
+func TestGitHubWorkItems_Get(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		repoSlug   string
+		id         string
+		fetcher    *fakeFetcher
+		wantItem   *WorkItem
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:     "happy path",
+			repoSlug: "defilantech/llmkube",
+			id:       "42",
+			fetcher: &fakeFetcher{
+				Issue: &githubissue.Issue{
+					Number: 42,
+					Title:  "Fix memory leak in agent",
+					Body:   "The agent leaks goroutines on shutdown.",
+					State:  "open",
+					Labels: []string{"bug", "agent"},
+				},
+			},
+			wantItem: &WorkItem{
+				ID:     "42",
+				Title:  "Fix memory leak in agent",
+				Body:   "The agent leaks goroutines on shutdown.",
+				State:  "open",
+				URL:    "",
+				Labels: []string{"bug", "agent"},
+			},
+		},
+		{
+			name:     "closed issue",
+			repoSlug: "defilantech/llmkube",
+			id:       "7",
+			fetcher: &fakeFetcher{
+				Issue: &githubissue.Issue{
+					Number: 7,
+					Title:  "Add CI badge",
+					Body:   "Add a CI badge to the README.",
+					State:  "closed",
+					Labels: []string{"docs"},
+				},
+			},
+			wantItem: &WorkItem{
+				ID:     "7",
+				Title:  "Add CI badge",
+				Body:   "Add a CI badge to the README.",
+				State:  "closed",
+				URL:    "",
+				Labels: []string{"docs"},
+			},
+		},
+		{
+			name:     "issue with no labels",
+			repoSlug: "defilantech/llmkube",
+			id:       "1",
+			fetcher: &fakeFetcher{
+				Issue: &githubissue.Issue{
+					Number: 1,
+					Title:  "Initial issue",
+					Body:   "First issue ever.",
+					State:  "open",
+					Labels: nil,
+				},
+			},
+			wantItem: &WorkItem{
+				ID:     "1",
+				Title:  "Initial issue",
+				Body:   "First issue ever.",
+				State:  "open",
+				URL:    "",
+				Labels: nil,
+			},
+		},
+		{
+			name:       "invalid repo slug",
+			repoSlug:   "bad-slug",
+			id:         "1",
+			fetcher:    &fakeFetcher{},
+			wantErr:    true,
+			errContain: "parse repo slug",
+		},
+		{
+			name:       "invalid id",
+			repoSlug:   "defilantech/llmkube",
+			id:         "not-a-number",
+			fetcher:    &fakeFetcher{},
+			wantErr:    true,
+			errContain: "parse id",
+		},
+		{
+			name:     "fetcher returns error",
+			repoSlug: "defilantech/llmkube",
+			id:       "99",
+			fetcher: &fakeFetcher{
+				Err: &githubissue.HTTPError{StatusCode: 404},
+			},
+			wantErr:    true,
+			errContain: "fetch issue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gw := &GitHubWorkItems{Fetcher: tt.fetcher}
+			item, err := gw.Get(context.Background(), tt.repoSlug, tt.id)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Get() expected error containing %q, got nil", tt.errContain)
+				}
+				if tt.errContain != "" && !contains(err.Error(), tt.errContain) {
+					t.Fatalf("Get() error = %q, want to contain %q", err, tt.errContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Get() unexpected error: %v", err)
+			}
+
+			if item == nil {
+				t.Fatal("Get() returned nil WorkItem")
+			}
+
+			if item.ID != tt.wantItem.ID {
+				t.Errorf("ID = %q, want %q", item.ID, tt.wantItem.ID)
+			}
+			if item.Title != tt.wantItem.Title {
+				t.Errorf("Title = %q, want %q", item.Title, tt.wantItem.Title)
+			}
+			if item.Body != tt.wantItem.Body {
+				t.Errorf("Body = %q, want %q", item.Body, tt.wantItem.Body)
+			}
+			if item.State != tt.wantItem.State {
+				t.Errorf("State = %q, want %q", item.State, tt.wantItem.State)
+			}
+			if item.URL != tt.wantItem.URL {
+				t.Errorf("URL = %q, want %q", item.URL, tt.wantItem.URL)
+			}
+			if len(item.Labels) != len(tt.wantItem.Labels) {
+				t.Errorf("Labels length = %d, want %d", len(item.Labels), len(tt.wantItem.Labels))
+			}
+			for i := range item.Labels {
+				if item.Labels[i] != tt.wantItem.Labels[i] {
+					t.Errorf("Labels[%d] = %q, want %q", i, item.Labels[i], tt.wantItem.Labels[i])
+				}
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	if len(s) < len(substr) {
+		return false
+	}
+	if s == substr {
+		return true
+	}
+	return findSubstring(s, substr)
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Introduce three provider-neutral interfaces in `pkg/foreman/agent` — `codehost.CodeHost`, `worktracker.WorkItems`, and `changepolicy.ChangePolicy` — and route the agent executor through them instead of calling the GitHub packages directly. GitHub remains the only implementation; no behavior change.

## Why

Foreman's node-side agent is hard-wired to GitHub across three concerns: code hosting (repo/PR), work tracking (issues), and change policy (path classification for human review). Decoupling these behind interfaces is the enabling refactor for non-GitHub setups (e.g. Forgejo + Linear + Woodpecker). Part of #1158.

## How

- `codehost.CodeHost` — clone-URL resolution, change-request (PR) creation, and head-commit subject. `GitHubCodeHost` wraps `githubpr.Ensurer` and the github.com clone-URL template.
- `worktracker.WorkItems` — fetch a work item by string ID. `GitHubWorkItems` wraps `githubissue.Fetcher`, mapping the issue number to/from a string ID at the adapter boundary.
- `changepolicy.ChangePolicy` — classify changed paths into work classes and gate human review; mirrors `workclass.go` / `verdict_policy.go`.
- The executor reaches each seam via accessor methods that prefer the injected interface and otherwise wrap the legacy `IssueFetcher` / `PREnsurer` fields (threading the run's git-auth token), so existing callers and tests keep working. `upstreamURLForRepo` now delegates to `codehost.ResolveCloneURL` and `applyVerdictPolicy` classifies via `changepolicy`, so all three packages are live. `cmd/foreman-agent` wires the GitHub-backed implementations.

**Scope: Phase 1 = interface extraction only.** The CRD work-item ID `int`→`string` migration and the Forgejo/Linear implementations are separate follow-ups; that migration ripples across the controller, CLI, audit, and generated CRDs, so it is kept out here to bound the blast radius. The `AgenticTaskPayload.Issue` field stays `int32` (converted to a string at the `worktracker` boundary).

## Testing

- `go build ./...` — clean on `GOOS=darwin` and `GOOS=linux`.
- `golangci-lint run` (repo-pinned v2.12.2) on the touched packages — 0 issues, darwin and linux.
- `go test ./pkg/foreman/agent/...` including the three new packages — passing. Behavior is preserved: the existing executor PR, issue-fetch, and verdict-policy tests pass with only the mechanical signature updates.

## Checklist

- [x] Behavior preserved (GitHub-only; no functional change)
- [x] Build + lint clean on darwin and linux
- [x] Tests pass
- [x] No CRD change in this phase

---
AI-assisted (Claude Code) under the project's AI contribution policy; authored and reviewed by @Defilan.
