### PR TITLE
fix: bump boilerplate copyright year 2025 -> 2026 (#1162)

### DIFF
--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2025.
+Copyright 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What

Bump the copyright year in `hack/boilerplate.go.txt` from `2025` to `2026`, so newly scaffolded/generated Go files carry the current year.

## Why

The controller-gen boilerplate header (`object:headerFile="hack/boilerplate.go.txt"` in the Makefile) still referenced 2025. Fixes #1162.

## How

One-line change to the template. Existing `*.go` files keep their original-year headers — a file's copyright reflects when it was written — so this only affects files generated/scaffolded from now on. No generated output or code changes.

## Testing

No code change; the Go build is unaffected. Existing source and generated files are intentionally untouched.

## Checklist

- [x] Scoped to the boilerplate template only
- [x] No existing headers retroactively rewritten
- [x] `Fixes #1162`
