### PR TITLE
feat(controller): explicit vllm serve entrypoint for image-agnostic vLLM (#1164)

### DIFF
--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -39,6 +39,17 @@ func (b *VLLMBackend) DefaultPort() int32       { return 8000 }
 func (b *VLLMBackend) NeedsModelInit() bool     { return true }
 func (b *VLLMBackend) DefaultHPAMetric() string { return "vllm:num_requests_running" }
 
+// BuildCommand returns the entrypoint for the vLLM container, mirroring
+// SGLangBackend/PersonaPlexBackend. The stock vllm/vllm-openai image already
+// entrypoints on "vllm serve" (the positional-model form BuildArgs emits), so
+// setting it explicitly is behavior-preserving for that image while making the
+// runtime image-agnostic: a custom image (e.g. a community AMD ROCm/gfx1151
+// build) no longer has to match the stock entrypoint or set spec.command to
+// avoid exec'ing the positional model path as the container process.
+func (b *VLLMBackend) BuildCommand() []string {
+	return []string{"vllm", "serve"}
+}
+
 // DisableServiceLinks returns true so the operator emits Pods with
 // `enableServiceLinks: false`. vLLM v0.20+ logs a warning for every K8s
 // service-link env var that matches the `VLLM_*` prefix; in a namespace with

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -526,6 +527,19 @@ func TestVLLMDisableServiceLinks(t *testing.T) {
 	backend := &VLLMBackend{}
 	if !backend.DisableServiceLinks() {
 		t.Error("VLLMBackend.DisableServiceLinks() = false, want true (vLLM v0.20+ env validator noise)")
+	}
+}
+
+// TestVLLMBuildCommand pins the explicit "vllm serve" entrypoint so the runtime
+// is image-agnostic (parity with SGLang): the deployment builder sets
+// container.Command from this, so BuildArgs' positional model path is served by
+// vLLM rather than exec'd as the container process on a non-stock image.
+func TestVLLMBuildCommand(t *testing.T) {
+	b := &VLLMBackend{}
+	want := []string{"vllm", "serve"}
+	got := b.BuildCommand()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("BuildCommand() = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## What

Make `VLLMBackend` set an explicit `vllm serve` container command (via `BuildCommand`), so the vLLM runtime is **image-agnostic** — parity with `SGLangBackend`/`PersonaPlexBackend`, which already do this.

## Why

`VLLMBackend` was the only runtime that relied on the container **image's `ENTRYPOINT`** to launch the server. On a **non-stock image** whose entrypoint isn't `vllm serve`, the operator leaves `container.Command` empty and passes `[<model-path>, --host, ...]` as args, so `arg[0]` (the staged model path) gets exec'd as the container process:

```
StartError: exec: "/models/<hash>/config.json": permission denied
```

Surfaced while validating a community **AMD ROCm / gfx1151** vLLM image on AMD Strix Halo. Fixes #1164.

## How

`VLLMBackend` implements the `CommandBuilder` interface, mirroring `SGLangBackend.BuildCommand()`:

```go
func (b *VLLMBackend) BuildCommand() []string {
    return []string{"vllm", "serve"}
}
```

The stock `vllm/vllm-openai` image already entrypoints on `vllm serve` — confirmed by the fact `BuildArgs` emits the **positional** model form (which `vllm serve` accepts). So this is **behavior-preserving for the default image** and makes custom images first-class without a per-InferenceService `spec.command` override.

## Testing

- `go build ./...`
- Full controller suite via `make test` (envtest) — green.
- New unit test `TestVLLMBuildCommand` (mirrors `TestSGLangBuildCommand`).
- `golangci-lint run ./internal/controller/...` — 0 issues.

## Checklist

- [x] Behavior-preserving for the stock `vllm/vllm-openai` image
- [x] Mirrors the existing SGLang/PersonaPlex `BuildCommand` pattern
- [x] Unit test added; full suite + lint pass
- [x] No CRD/API change

---
AI-assisted (Claude Code) under the project's AI contribution policy; authored and reviewed by @Defilan.
