### PR TITLE
feat(foreman): make the verify gate optional in the issue-batch decomposition

### DIFF
--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -43,11 +43,12 @@ const (
 //     one AgenticTask owner-ref'd to this Workload. The reconciler
 //     rewrites step-local DependsOn names to absolute task names. Used
 //     for full control over a hand-authored pipeline.
-//  2. Issue-batch shortcut (Issues non-empty + CoderAgentRef +
-//     VerifierAgentRef set): emit one code+verify pair per issue. The
-//     most common shape for v0.1. When ReviewerAgentRefs is also set
-//     (v0.2), each issue additionally fans out one parallel review
-//     task per listed reviewer Agent, depending on the verify task.
+//  2. Issue-batch shortcut (Issues non-empty + CoderAgentRef set): emit
+//     one code step per issue, plus a verify step when VerifierAgentRef
+//     is set. The most common shape for v0.1. When ReviewerAgentRefs is
+//     also set (v0.2), each issue additionally fans out one parallel
+//     review task per listed reviewer Agent, depending on the verify
+//     task (or directly on the code task when no verifier is set).
 //     When EscalationReviewerAgentRefs is also set, a second reviewer
 //     tier is emitted per issue only after a base reviewer returns
 //     NO-GO.
@@ -105,9 +106,13 @@ type WorkloadSpec struct {
 	// +optional
 	CoderAgentRef *corev1.LocalObjectReference `json:"coderAgentRef,omitempty"`
 
-	// VerifierAgentRef is required when Issues is set: names the same-
-	// namespace Agent the verify-<N> steps reference. Ignored in explicit
-	// Pipeline mode.
+	// VerifierAgentRef names the same-namespace Agent the verify-<N>
+	// steps reference. Optional in the issue-batch shortcut: when unset,
+	// no deterministic verify gate is emitted and each issue's pipeline
+	// is code -> review (reviews depend directly on the code step);
+	// verification then rests on the coder's own test run and the
+	// repository's CI on the opened PR. Ignored in explicit Pipeline
+	// mode.
 	// +optional
 	VerifierAgentRef *corev1.LocalObjectReference `json:"verifierAgentRef,omitempty"`
 

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -771,9 +771,13 @@ spec:
                 type: object
               verifierAgentRef:
                 description: |-
-                  VerifierAgentRef is required when Issues is set: names the same-
-                  namespace Agent the verify-<N> steps reference. Ignored in explicit
-                  Pipeline mode.
+                  VerifierAgentRef names the same-namespace Agent the verify-<N>
+                  steps reference. Optional in the issue-batch shortcut: when unset,
+                  no deterministic verify gate is emitted and each issue's pipeline
+                  is code -> review (reviews depend directly on the code step);
+                  verification then rests on the coder's own test run and the
+                  repository's CI on the opened PR. Ignored in explicit Pipeline
+                  mode.
                 properties:
                   name:
                     default: ""

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -240,7 +240,6 @@ func coderEscalationSteps(
 	w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
 ) (steps []foremanv1alpha1.PipelineStep, escalated []int32, reason string) {
 	if w.Spec.EscalationCoderAgentRef == nil ||
-		w.Spec.VerifierAgentRef == nil ||
 		len(w.Spec.Issues) == 0 {
 		return nil, nil, ""
 	}
@@ -303,7 +302,14 @@ func coderEscalationSteps(
 					PromptPrefix: escalationHintPrompt(coderSummary(base)),
 				},
 			},
-			foremanv1alpha1.PipelineStep{
+		)
+		// Gateless Workloads (no VerifierAgentRef) skip the escalated
+		// verify step; the escalated reviews hang directly off the
+		// escalated code step, mirroring the base round's shape.
+		escReviewDep := escCodeStep
+		if w.Spec.VerifierAgentRef != nil {
+			escReviewDep = escVerifyStep
+			steps = append(steps, foremanv1alpha1.PipelineStep{
 				Name:      escVerifyStep,
 				Kind:      foremanv1alpha1.AgenticTaskKindVerify,
 				AgentRef:  *w.Spec.VerifierAgentRef,
@@ -313,8 +319,8 @@ func coderEscalationSteps(
 					Issue:  n,
 					Branch: branch,
 				},
-			},
-		)
+			})
+		}
 		// Reviewer fan-out on the escalated branch: without it the
 		// escalated coder can GO and gate-pass but nothing produces a
 		// verdict or (post-#956) the openPullRequest carrier, so the
@@ -327,7 +333,7 @@ func coderEscalationSteps(
 				Name:      fmt.Sprintf("review-%d-esc-%d", n, i),
 				Kind:      foremanv1alpha1.AgenticTaskKindReview,
 				AgentRef:  reviewerRef,
-				DependsOn: []string{escVerifyStep},
+				DependsOn: []string{escReviewDep},
 				Payload: foremanv1alpha1.AgenticTaskPayload{
 					Repo:            w.Spec.Repo,
 					Issue:           n,

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -298,10 +298,10 @@ func (r *WorkloadReconciler) chooseSteps(w *foremanv1alpha1.Workload) (steps []f
 	switch {
 	case len(w.Spec.Pipeline) > 0:
 		steps = append(steps, w.Spec.Pipeline...)
-	case len(w.Spec.Issues) > 0 && w.Spec.CoderAgentRef != nil && w.Spec.VerifierAgentRef != nil:
+	case len(w.Spec.Issues) > 0 && w.Spec.CoderAgentRef != nil:
 		steps = synthesizeIssueBatch(w)
 	case len(w.Spec.Issues) > 0:
-		modeErr = fmt.Errorf("issues set but coderAgentRef and verifierAgentRef are required for the issue-batch shortcut")
+		modeErr = fmt.Errorf("issues set but coderAgentRef is required for the issue-batch shortcut")
 	default:
 		modeErr = fmt.Errorf("workload has no Pipeline or Issues; the LLM-driven planner is deferred to v0.2")
 	}
@@ -317,14 +317,17 @@ func (r *WorkloadReconciler) chooseSteps(w *foremanv1alpha1.Workload) (steps []f
 // slice. Each issue N produces:
 //
 //   - step "code-<N>" (kind issue-fix, agentRef = CoderAgentRef)
-//   - step "verify-<N>" (kind verify, agentRef = VerifierAgentRef,
-//     dependsOn [code-<N>])
+//   - when VerifierAgentRef is set: step "verify-<N>" (kind verify,
+//     agentRef = VerifierAgentRef, dependsOn [code-<N>])
 //   - for each i in 0..len(ReviewerAgentRefs)-1:
 //     step "review-<N>-<i>" (kind review, agentRef = ReviewerAgentRefs[i],
-//     dependsOn [verify-<N>]). Parallel across i; the cascade-on-verdict
+//     dependsOn [verify-<N>], or [code-<N>] when no verifier is
+//     configured). Parallel across i; the cascade-on-verdict
 //     logic from #548 short-circuits these to Incomplete if verify-<N>
 //     lands GATE-FAIL or GATE-ERROR rather than running the reviewer
-//     loop against a branch the gate already rejected.
+//     loop against a branch the gate already rejected. Without a
+//     verifier there is no gate to reject the branch; the cascade
+//     still fails reviews when code-<N> itself fails.
 //
 // Payload.Branch is "foreman/<workload-name>/issue-<N>" in all stages
 // so each task clones the branch the coder produced (the cloneURL
@@ -337,11 +340,13 @@ func (r *WorkloadReconciler) chooseSteps(w *foremanv1alpha1.Workload) (steps []f
 // authored branch) survives even when an earlier run already produced
 // a branch on the same issue. See #573 for the motivating trace.
 func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.PipelineStep {
-	tasksPerIssue := 2 + len(w.Spec.ReviewerAgentRefs)
+	tasksPerIssue := 1 + len(w.Spec.ReviewerAgentRefs)
+	if w.Spec.VerifierAgentRef != nil {
+		tasksPerIssue++
+	}
 	steps := make([]foremanv1alpha1.PipelineStep, 0, len(w.Spec.Issues)*tasksPerIssue)
 	for _, n := range w.Spec.Issues {
 		codeName := fmt.Sprintf("code-%d", n)
-		verifyName := fmt.Sprintf("verify-%d", n)
 		branch := fmt.Sprintf("foreman/%s/issue-%d", w.Name, n)
 		steps = append(steps,
 			foremanv1alpha1.PipelineStep{
@@ -355,7 +360,17 @@ func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.Pipelin
 					AllowOverwrite: w.Spec.AllowOverwrite,
 				},
 			},
-			foremanv1alpha1.PipelineStep{
+		)
+		// Reviews hang off the verify gate when one is configured, and
+		// directly off the code step when the Workload opts out of the
+		// deterministic gate (VerifierAgentRef unset): the coder already
+		// self-verifies inside the issue-fix loop, and the repository's
+		// own CI checks the opened PR.
+		reviewDep := codeName
+		if w.Spec.VerifierAgentRef != nil {
+			verifyName := fmt.Sprintf("verify-%d", n)
+			reviewDep = verifyName
+			steps = append(steps, foremanv1alpha1.PipelineStep{
 				Name:      verifyName,
 				Kind:      foremanv1alpha1.AgenticTaskKindVerify,
 				AgentRef:  *w.Spec.VerifierAgentRef,
@@ -365,8 +380,8 @@ func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.Pipelin
 					Issue:  n,
 					Branch: branch,
 				},
-			},
-		)
+			})
+		}
 		// nil defaults to true: an issue-batch Workload exists to produce
 		// a PR; spec.openPullRequest=false opts out (#937).
 		openPR := w.Spec.OpenPullRequest == nil || *w.Spec.OpenPullRequest
@@ -375,7 +390,7 @@ func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.Pipelin
 				Name:      fmt.Sprintf("review-%d-%d", n, i),
 				Kind:      foremanv1alpha1.AgenticTaskKindReview,
 				AgentRef:  reviewerRef,
-				DependsOn: []string{verifyName},
+				DependsOn: []string{reviewDep},
 				Payload: foremanv1alpha1.AgenticTaskPayload{
 					Repo:            w.Spec.Repo,
 					Issue:           n,

--- a/internal/foreman/controller/workload_gateless_test.go
+++ b/internal/foreman/controller/workload_gateless_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// Unit tests for the optional-verify ("gateless") issue-batch shape
+// (#1151): a Workload with no VerifierAgentRef decomposes to
+// code -> review, with the coder's own verification and the repo's CI
+// standing in for the deterministic gate.
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// TestSynthesizeIssueBatch_GatelessCodeToReview: no VerifierAgentRef
+// emits code-<N> plus the reviewer fan-out only, with each review
+// depending directly on the code step.
+func TestSynthesizeIssueBatch_GatelessCodeToReview(t *testing.T) {
+	w := &foremanv1alpha1.Workload{}
+	w.Name = "wl"
+	w.Spec.Repo = "defilantech/LLMKube"
+	w.Spec.Issues = []int32{7}
+	w.Spec.CoderAgentRef = &corev1.LocalObjectReference{Name: "coder"}
+	w.Spec.ReviewerAgentRefs = []corev1.LocalObjectReference{{Name: "reviewer-a"}, {Name: "reviewer-b"}}
+
+	steps := synthesizeIssueBatch(w)
+	want := []string{"code-7", "review-7-0", "review-7-1"}
+	if len(steps) != len(want) {
+		t.Fatalf("got %d steps, want %d (%v)", len(steps), len(want), want)
+	}
+	for i, name := range want {
+		if steps[i].Name != name {
+			t.Fatalf("step[%d] = %q, want %q", i, steps[i].Name, name)
+		}
+	}
+	for _, s := range steps {
+		if s.Kind == foremanv1alpha1.AgenticTaskKindVerify {
+			t.Fatalf("gateless batch must not emit a verify step, got %q", s.Name)
+		}
+		if s.Kind == foremanv1alpha1.AgenticTaskKindReview {
+			if len(s.DependsOn) != 1 || s.DependsOn[0] != "code-7" {
+				t.Errorf("review %q dependsOn = %v, want [code-7]", s.Name, s.DependsOn)
+			}
+		}
+	}
+}
+
+// TestSynthesizeIssueBatch_VerifierKeepsGate pins the existing shape:
+// with a VerifierAgentRef the verify step remains and reviews depend on
+// it, not on the code step.
+func TestSynthesizeIssueBatch_VerifierKeepsGate(t *testing.T) {
+	w := &foremanv1alpha1.Workload{}
+	w.Name = "wl"
+	w.Spec.Repo = "defilantech/LLMKube"
+	w.Spec.Issues = []int32{7}
+	w.Spec.CoderAgentRef = &corev1.LocalObjectReference{Name: "coder"}
+	w.Spec.VerifierAgentRef = &corev1.LocalObjectReference{Name: "gate"}
+	w.Spec.ReviewerAgentRefs = []corev1.LocalObjectReference{{Name: "reviewer"}}
+
+	steps := synthesizeIssueBatch(w)
+	want := []string{"code-7", "verify-7", "review-7-0"}
+	if len(steps) != len(want) {
+		t.Fatalf("got %d steps, want %d (%v)", len(steps), len(want), want)
+	}
+	for i, name := range want {
+		if steps[i].Name != name {
+			t.Fatalf("step[%d] = %q, want %q", i, steps[i].Name, name)
+		}
+	}
+	if d := steps[2].DependsOn; len(d) != 1 || d[0] != "verify-7" {
+		t.Errorf("review dependsOn = %v, want [verify-7]", d)
+	}
+}
+
+// TestChooseSteps_IssueBatchWithoutVerifier: the issue-batch shortcut
+// accepts a nil VerifierAgentRef and still requires the coder.
+func TestChooseSteps_IssueBatchWithoutVerifier(t *testing.T) {
+	r := &WorkloadReconciler{}
+
+	w := &foremanv1alpha1.Workload{}
+	w.Name = "wl"
+	w.Spec.Repo = "defilantech/LLMKube"
+	w.Spec.Issues = []int32{7}
+	w.Spec.CoderAgentRef = &corev1.LocalObjectReference{Name: "coder"}
+	steps, _, modeErr := r.chooseSteps(w)
+	if modeErr != nil {
+		t.Fatalf("nil verifier must be accepted, got error: %v", modeErr)
+	}
+	if len(steps) != 1 || steps[0].Name != "code-7" {
+		t.Fatalf("steps = %+v, want the single code-7 step", steps)
+	}
+
+	w2 := &foremanv1alpha1.Workload{}
+	w2.Spec.Issues = []int32{7}
+	if _, _, err := r.chooseSteps(w2); err == nil {
+		t.Fatal("nil coder must still error")
+	}
+}
+
+// TestCoderEscalationSteps_GatelessSkipsVerify: with no VerifierAgentRef
+// the escalated tier emits code-<N>-esc plus the reviewer fan-out, with
+// escalated reviews depending directly on the escalated code step.
+func TestCoderEscalationSteps_GatelessSkipsVerify(t *testing.T) {
+	w := &foremanv1alpha1.Workload{}
+	w.Name = "wl"
+	w.Spec.Repo = "defilantech/LLMKube"
+	w.Spec.Issues = []int32{944}
+	w.Spec.CoderAgentRef = &corev1.LocalObjectReference{Name: "coder-metal"}
+	w.Spec.EscalationCoderAgentRef = &corev1.LocalObjectReference{Name: "coder-qwopus"}
+	w.Spec.ReviewerAgentRefs = []corev1.LocalObjectReference{{Name: "reviewer"}}
+
+	code := foremanv1alpha1.AgenticTask{}
+	code.Name = "wl-code-944"
+	code.Labels = map[string]string{labelStep: "code-944"}
+	code.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+	code.Status.Result = resultRaw("MODEL-DECIDED", "", "could not solve", "")
+
+	steps, escalated, _ := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{code})
+	want := []string{"code-944-esc", "review-944-esc-0"}
+	if len(steps) != len(want) {
+		t.Fatalf("got %d steps, want %d (%v)", len(steps), len(want), want)
+	}
+	for i, name := range want {
+		if steps[i].Name != name {
+			t.Fatalf("step[%d] = %q, want %q", i, steps[i].Name, name)
+		}
+	}
+	if d := steps[1].DependsOn; len(d) != 1 || d[0] != "code-944-esc" {
+		t.Errorf("escalated review dependsOn = %v, want [code-944-esc]", d)
+	}
+	if len(escalated) != 1 || escalated[0] != 944 {
+		t.Errorf("escalated = %v, want [944]", escalated)
+	}
+}
+
+// TestReviewIterationSteps_GatelessReviewDependsOnCode: a NO-GO round on
+// a gateless Workload emits the r1 fix iteration as code -> review with
+// no verify step.
+func TestReviewIterationSteps_GatelessReviewDependsOnCode(t *testing.T) {
+	w := iterationWorkload([]int32{641}, 1, nil)
+	w.Spec.VerifierAgentRef = nil
+	children := []foremanv1alpha1.AgenticTask{
+		child("code-641", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGo),
+		child("review-641-0", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo),
+	}
+
+	steps, iterated := reviewIterationSteps(w, children)
+	want := []string{"code-641-r1", "review-641-0-r1"}
+	if len(steps) != len(want) {
+		t.Fatalf("got %d steps, want %d (%v)", len(steps), len(want), want)
+	}
+	for i, name := range want {
+		if steps[i].Name != name {
+			t.Fatalf("step[%d] = %q, want %q", i, steps[i].Name, name)
+		}
+	}
+	if d := steps[1].DependsOn; len(d) != 1 || d[0] != "code-641-r1" {
+		t.Errorf("iterated review dependsOn = %v, want [code-641-r1]", d)
+	}
+	if len(iterated) != 1 || iterated[0] != 641 {
+		t.Errorf("iterated = %v, want [641]", iterated)
+	}
+}

--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -208,8 +208,7 @@ func reviewIterationSteps(
 	if maxIter <= 0 ||
 		len(w.Spec.ReviewerAgentRefs) == 0 ||
 		len(w.Spec.Issues) == 0 ||
-		w.Spec.CoderAgentRef == nil ||
-		w.Spec.VerifierAgentRef == nil {
+		w.Spec.CoderAgentRef == nil {
 		return nil, nil
 	}
 
@@ -257,19 +256,26 @@ func reviewIterationSteps(
 				})
 				issueIterated = true
 			}
-			if _, ok := existing[verifyName]; !ok {
-				steps = append(steps, foremanv1alpha1.PipelineStep{
-					Name:      verifyName,
-					Kind:      foremanv1alpha1.AgenticTaskKindVerify,
-					AgentRef:  *w.Spec.VerifierAgentRef,
-					DependsOn: []string{codeName},
-					Payload: foremanv1alpha1.AgenticTaskPayload{
-						Repo:   w.Spec.Repo,
-						Issue:  n,
-						Branch: branch,
-					},
-				})
-				issueIterated = true
+			// Gateless Workloads (no VerifierAgentRef) skip the verify
+			// step; the iteration's reviews hang directly off the fix
+			// commit, mirroring the base round's shape.
+			reviewDep := codeName
+			if w.Spec.VerifierAgentRef != nil {
+				reviewDep = verifyName
+				if _, ok := existing[verifyName]; !ok {
+					steps = append(steps, foremanv1alpha1.PipelineStep{
+						Name:      verifyName,
+						Kind:      foremanv1alpha1.AgenticTaskKindVerify,
+						AgentRef:  *w.Spec.VerifierAgentRef,
+						DependsOn: []string{codeName},
+						Payload: foremanv1alpha1.AgenticTaskPayload{
+							Repo:   w.Spec.Repo,
+							Issue:  n,
+							Branch: branch,
+						},
+					})
+					issueIterated = true
+				}
 			}
 			// Mirrors the base-round stamp (#937): an iterated-then-approved
 			// issue must still open its PR.
@@ -283,7 +289,7 @@ func reviewIterationSteps(
 					Name:      name,
 					Kind:      foremanv1alpha1.AgenticTaskKindReview,
 					AgentRef:  reviewerRef,
-					DependsOn: []string{verifyName},
+					DependsOn: []string{reviewDep},
 					Payload: foremanv1alpha1.AgenticTaskPayload{
 						Repo:            w.Spec.Repo,
 						Issue:           n,


### PR DESCRIPTION
## What

Make `verifierAgentRef` optional in the issue-batch decomposition: when unset, each issue's pipeline is `code → review` (no deterministic verify gate), across the base round, the #946 review-fix iterations, and the coder-escalation tier.

## Why

Fixes #1151

The shortcut required `VerifierAgentRef` and always emitted a verify step, so every repo needed a `GateProfile` with a real image + command set — the sole remaining per-repo configuration cost in our loop. For operators whose deterministic signal is the repo's own CI on the opened PR (with the coder already self-verifying inside the issue-fix loop, per its task contract), the pre-PR gate is redundant: unmapped repos fall to the imageless `generic` profile and GATE-ERROR, and maintaining per-repo gate commands duplicates what the repo's CI already declares.

Opt-in and fully backward compatible: with `verifierAgentRef` set, the shape is byte-identical to today (`code → verify → review` everywhere), pinned by regression tests.

## How

- `chooseSteps`: the issue-batch case requires only `CoderAgentRef`; the no-coder error message updated accordingly.
- `synthesizeIssueBatch`: emits the verify step only when a verifier is set; reviews `dependsOn` the verify step, or the code step when gateless.
- `reviewIterationSteps` (#946) and `coderEscalationSteps`: previously **disabled themselves entirely** on a nil verifier; now they emit gateless iterations/escalations (`code-rK → review-rK`, `code-esc → review-esc`) so a gateless Workload keeps fix iterations and coder escalation.
- `#548` cascade: no change needed — it keys off declared dependencies, so reviews still cascade-fail when their code dependency fails; there's simply no gate verdict in between. Rollup likewise classifies by phase+verdict generically.
- API doc + CRD description regenerated (`make manifests && make chart-crds`).

## Checklist

- [x] Tests added/updated — `workload_gateless_test.go`: gateless batch shape + review wiring, verifier-set regression pin, `chooseSteps` acceptance, gateless coder-escalation, gateless review-iteration
- [x] `make test` passes locally (controller suite 82.7% coverage)
- [x] `make lint` passes locally (0 issues)
- [x] Conventional commits
- [x] Signed off (DCO)
- [x] AI assistance disclosed — authored with Claude Code
- [x] Documentation updated — API field doc + generated CRD description
