### PR TITLE
fix(foreman): bound reasoning-model coder turns with a per-turn token budget

### DIFF
--- a/api/foreman/v1alpha1/agent_types.go
+++ b/api/foreman/v1alpha1/agent_types.go
@@ -241,6 +241,22 @@ type AgentSpec struct {
 	// +optional
 	MaxRetries int32 `json:"maxRetries,omitempty"`
 
+	// MaxOutputTokens caps the tokens the model may generate per turn (the
+	// OAI max_tokens field). Reasoning models (qwen3-family served with
+	// --reasoning-parser) engage heavy <think> only on decision turns; a
+	// decision turn needs enough budget to finish reasoning AND emit the
+	// tool call. With no cap, generation budget defaults to the server's
+	// remaining context (max_model_len - prompt), so on a large-context
+	// serve a decision turn can reason effectively unbounded for hours
+	// before it acts or hits the context limit, which reads as a stalled
+	// task. Set this high enough to complete a <think> plus its tool call,
+	// but well below the served context so vLLM does not reject the request
+	// when prompt + maxOutputTokens exceeds max_model_len. Zero uses the
+	// executor default (8192 tokens).
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxOutputTokens int32 `json:"maxOutputTokens,omitempty"`
+
 	// ContextWindowTokens is the soft token budget for the wire payload
 	// the loop sends on every turn. When the running message list
 	// approximately exceeds this size, older tool result messages are

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -233,6 +233,23 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              maxOutputTokens:
+                description: |-
+                  MaxOutputTokens caps the tokens the model may generate per turn (the
+                  OAI max_tokens field). Reasoning models (qwen3-family served with
+                  --reasoning-parser) engage heavy <think> only on decision turns; a
+                  decision turn needs enough budget to finish reasoning AND emit the
+                  tool call. With no cap, generation budget defaults to the server's
+                  remaining context (max_model_len - prompt), so on a large-context
+                  serve a decision turn can reason effectively unbounded for hours
+                  before it acts or hits the context limit, which reads as a stalled
+                  task. Set this high enough to complete a <think> plus its tool call,
+                  but well below the served context so vLLM does not reject the request
+                  when prompt + maxOutputTokens exceeds max_model_len. Zero uses the
+                  executor default (8192 tokens).
+                format: int32
+                minimum: 0
+                type: integer
               maxRetries:
                 default: 3
                 description: |-

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -232,6 +232,23 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              maxOutputTokens:
+                description: |-
+                  MaxOutputTokens caps the tokens the model may generate per turn (the
+                  OAI max_tokens field). Reasoning models (qwen3-family served with
+                  --reasoning-parser) engage heavy <think> only on decision turns; a
+                  decision turn needs enough budget to finish reasoning AND emit the
+                  tool call. With no cap, generation budget defaults to the server's
+                  remaining context (max_model_len - prompt), so on a large-context
+                  serve a decision turn can reason effectively unbounded for hours
+                  before it acts or hits the context limit, which reads as a stalled
+                  task. Set this high enough to complete a <think> plus its tool call,
+                  but well below the served context so vLLM does not reject the request
+                  when prompt + maxOutputTokens exceeds max_model_len. Zero uses the
+                  executor default (8192 tokens).
+                format: int32
+                minimum: 0
+                type: integer
               maxRetries:
                 default: 3
                 description: |-

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -627,6 +627,12 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// per-request meaning of RequestTimeoutSeconds; the per-request
 		// header timeout now lives on the OAI client above.
 		LoopBudget: durationFromSeconds(agent.Spec.RequestTimeoutSeconds, 3600),
+		// Per-turn generation cap. A reasoning model that does not budget
+		// its decision-turn <think> can run effectively unbounded on a
+		// large-context serve, reading as a stalled task; the cap turns that
+		// into a bounded, recoverable truncation (see ErrAssistantTruncated).
+		// Agent.spec.maxOutputTokens overrides; 0 uses the package default.
+		MaxTokensPerTurn: maxTokensPerTurnForAgent(agent),
 	}
 
 	// Coder gate feedback loop (#749): coders verify their work through a
@@ -1160,6 +1166,25 @@ func resolveAgainstDiff(f string, diff []string) string {
 // fast checks fail gets this many feedback-and-retry cycles before the loop
 // downgrades it to INCOMPLETE.
 const coderGateMaxRetries = 3
+
+// defaultMaxTokensPerTurn is the per-turn generation cap applied when an
+// Agent does not set spec.maxOutputTokens. 8192 tokens is enough headroom
+// for a reasoning model to finish a <think> block AND emit the tool call on
+// a decision turn, while staying well below a typical served context window
+// so a truncated turn recovers via a continuation rather than hanging the
+// task for hours generating unbounded reasoning.
+const defaultMaxTokensPerTurn = 8192
+
+// maxTokensPerTurnForAgent resolves the loop's per-turn generation cap from
+// the Agent CR: spec.maxOutputTokens when set (> 0), else the package
+// default. Kept as a helper so the resolution rule lives in one place and
+// the LoopConfig assembly in runLLMPath stays declarative.
+func maxTokensPerTurnForAgent(agent *foremanv1alpha1.Agent) int {
+	if agent.Spec.MaxOutputTokens > 0 {
+		return int(agent.Spec.MaxOutputTokens)
+	}
+	return defaultMaxTokensPerTurn
+}
 
 // makeCoderGateVerifier returns the TerminalVerifier that runs the fast
 // in-workspace gate on a coder's GO terminal. Non-GO terminals pass through
@@ -1957,6 +1982,16 @@ func (e *NativeAgentLoopExecutor) mapLoopError(
 		return e.incompleteResult(start, tref, lr,
 			foremanv1alpha1.FailureModelMisunderstood,
 			"model exhausted its reasoning-only budget without emitting a tool call"), nil
+	case errors.Is(loopErr, ErrAssistantTruncated):
+		// The per-turn token cap cut the model off before it emitted a tool
+		// call, and the loop's continuation retries were exhausted. Like the
+		// reasoning-only case this is a model/config outcome, not an
+		// infrastructure failure: record INCOMPLETE with an accurate,
+		// actionable message. The fix is a bigger budget, not a retry.
+		return e.incompleteResult(start, tref, lr,
+			foremanv1alpha1.FailureModelMisunderstood,
+			"model output was truncated by the token cap before it emitted a tool call; "+
+				"raise Agent.spec.maxOutputTokens or the served context window"), nil
 	case errors.Is(loopErr, context.Canceled), errors.Is(loopErr, context.DeadlineExceeded):
 		return e.incompleteResult(start, tref, lr,
 			foremanv1alpha1.FailureTimeout, loopErr.Error()), nil

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2614,3 +2614,29 @@ func TestMakeCoderGateVerifier_GenericGate_CleanPassesWithNoClaims(t *testing.T)
 		t.Errorf("expected empty feedback on accept, got: %q", feedback)
 	}
 }
+
+// TestMaxTokensPerTurnForAgent pins the per-turn generation-cap resolution:
+// an Agent that leaves spec.maxOutputTokens unset (0) gets the package
+// default; a set value flows through verbatim. This is the knob that bounds
+// a reasoning model's decision-turn <think> so a truncated turn recovers via
+// a continuation instead of hanging the task.
+func TestMaxTokensPerTurnForAgent(t *testing.T) {
+	cases := []struct {
+		name string
+		spec int32
+		want int
+	}{
+		{name: "unset uses the package default", spec: 0, want: defaultMaxTokensPerTurn},
+		{name: "set flows through as the CR value", spec: 2048, want: 2048},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := &foremanv1alpha1.Agent{
+				Spec: foremanv1alpha1.AgentSpec{MaxOutputTokens: tc.spec},
+			}
+			if got := maxTokensPerTurnForAgent(agent); got != tc.want {
+				t.Errorf("maxTokensPerTurnForAgent=%d want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -411,6 +411,78 @@ func TestNativeExecutor_HappyPathPushesBranch(t *testing.T) {
 	}
 }
 
+// truncatedTurnBody is a reasoning turn the token cap cut off: reasoning
+// present, empty content, no tool_calls, finish_reason=="length". Repeated
+// past MaxTruncationRetries it drives the loop to ErrAssistantTruncated.
+const truncatedTurnBody = `{
+  "id": "trunc",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "reasoning_content": "Designing the edit; I will change the handler to..."
+    },
+    "finish_reason": "length"
+  }]
+}`
+
+// TestNativeExecutor_TruncatedMapsToIncomplete proves the terminal-error
+// mapping: when the model's turns are truncated by the token cap until the
+// loop gives up with ErrAssistantTruncated, the executor records INCOMPLETE
+// (not an infrastructure ExecutorError) with the actionable truncation
+// message pointing the operator at maxOutputTokens / the served context.
+func TestNativeExecutor_TruncatedMapsToIncomplete(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	// DefaultMaxTruncationRetries (3) continuations + the initial turn =
+	// 4 truncated turns before the loop surfaces ErrAssistantTruncated.
+	oaiSrv := scriptedOAI(t, []string{
+		truncatedTurnBody, truncatedTurnBody, truncatedTurnBody, truncatedTurnBody,
+	})
+
+	agent, task := taskAndAgent("truncated")
+	// Room for the initial turn + 3 continuations without tripping the
+	// final-turns force-submit convergence guard prematurely.
+	agent.Spec.MaxTurns = 10
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(agent, task).
+		Build()
+
+	reg := &fakeRegistry{results: map[string]*foremanagent.ToolResult{}}
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned a hard error; truncation must map to INCOMPLETE: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Fatalf("verdict: want INCOMPLETE got %s; result=%+v", res.Verdict, res)
+	}
+	if res.FailureReason != foremanv1alpha1.FailureModelMisunderstood {
+		t.Errorf("FailureReason: want %q got %q", foremanv1alpha1.FailureModelMisunderstood, res.FailureReason)
+	}
+	if !strings.Contains(res.Summary, "truncated by the token cap") {
+		t.Errorf("summary should describe the truncation; got %q", res.Summary)
+	}
+}
+
 // --- #915: no static remote -> clone+push the task's own repo -----------
 
 // TestNativeExecutor_MultiRepoClonesTaskRepoWhenNoStaticRemote proves the

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -167,6 +167,28 @@ type LoopConfig struct {
 	// addition to grep/bash), forcing a thrash-prone model to edit instead
 	// of re-reading. Set from the resolved ModelProfile. Default false.
 	RestrictReadsInForcingPhase bool
+
+	// MaxTokensPerTurn caps the tokens the server generates for a single
+	// turn's completion (the OAI max_tokens field). <= 0 omits max_tokens
+	// on the wire, deferring to the server's own default
+	// (max_model_len - prompt). Reasoning models engage heavy <think> only
+	// on decision turns, by which point the prompt has grown; without a cap
+	// a decision turn runs its reasoning effectively unbounded on a
+	// large-context serve, reading as a stalled task. The executor maps
+	// Agent.spec.maxOutputTokens here (or its default) so a truncated turn
+	// (finish_reason=="length") becomes a bounded, recoverable event rather
+	// than a multi-hour hang. See ErrAssistantTruncated and #650.
+	MaxTokensPerTurn int
+
+	// MaxTruncationRetries bounds the streak of turns truncated by the token
+	// cap (finish_reason=="length") before the loop gives up with
+	// ErrAssistantTruncated. A truncated turn is continued (not restarted):
+	// its partial reasoning is preserved for the immediate next turn so the
+	// model resumes and emits its tool call instead of re-thinking from
+	// scratch. Distinct from MaxReasoningOnlyRetries, which handles a
+	// finish_reason=="stop" model that circled without acting. Resets after
+	// any tool-calling turn. <= 0 falls back to DefaultMaxTruncationRetries.
+	MaxTruncationRetries int
 }
 
 // DefaultContextWindowTokens is the budget used when LoopConfig.ContextWindowTokens
@@ -195,6 +217,15 @@ const DefaultMaxReasoningOnlyRetries = 4
 // is enough for the model to chain a read -> edit -> verify sequence
 // without losing the just-observed file contents.
 const DefaultObservationWindowTurns = 3
+
+// DefaultMaxTruncationRetries is the budget used when
+// LoopConfig.MaxTruncationRetries is <= 0. A per-turn token cap that
+// truncates a reasoning model mid-<think> is recoverable: preserving the
+// partial reasoning and telling the model to stop deliberating usually
+// lands the tool call within a turn or two. Three continuation attempts
+// is enough to converge without letting a model that cannot finish inside
+// the cap spin indefinitely.
+const DefaultMaxTruncationRetries = 3
 
 const (
 	// ContextStrategyWindow applies observation masking bounded by
@@ -453,6 +484,18 @@ var ErrAssistantNoToolCalls = errors.New("loop: assistant turn had no tool_calls
 // model narrated prose" from "the model thought itself in circles."
 var ErrAssistantReasoningOnly = errors.New("loop: assistant turns carried only reasoning, no tool_calls")
 
+// ErrAssistantTruncated is returned when the model's turn hit the token
+// cap (finish_reason=="length") before it emitted a tool call, and the
+// loop exhausted MaxTruncationRetries continuing it. Distinct from
+// ErrAssistantReasoningOnly: a truncated turn was cut off mid-generation
+// by the per-turn budget (MaxTokensPerTurn or the server's max_model_len),
+// NOT a model that finished (finish_reason=="stop") having only reasoned.
+// Conflating the two misfiles a bounded, config-fixable truncation as the
+// #650 "reasoning-only circling" case, whose recovery strips the partial
+// reasoning and makes the model re-think from scratch — the exact opposite
+// of what a truncated turn needs.
+var ErrAssistantTruncated = errors.New("loop: assistant turn truncated (finish_reason=length) before a tool call")
+
 // ReasoningOnlyNudgeMessage is the continuation the loop appends after
 // a reasoning-only turn. Unlike NoToolCallNudgeMessage it does not
 // scold: the model was mid-thought, so the correction is "act on the
@@ -462,6 +505,21 @@ func ReasoningOnlyNudgeMessage() string {
 		"tool call. Continue from that reasoning and emit the tool call " +
 		"for your next action now. If your review or task is complete, " +
 		"call submit_result with your verdict."
+}
+
+// TruncationContinueMessage is the continuation the loop appends after a
+// turn the token cap truncated (finish_reason=="length"). The model was
+// cut off mid-generation, most likely deep in a <think> block before it
+// reached the tool call. Unlike ReasoningOnlyNudgeMessage this is a hard
+// "stop deliberating" directive: the partial reasoning is preserved on the
+// immediate next turn (see the preserveReasoning path in Run), so the
+// model must resume from where it was cut off and emit the tool call now
+// rather than restart. Exported so tests can assert on it.
+func TruncationContinueMessage() string {
+	return "Your previous turn hit the token limit before you finished. Do " +
+		"not restart your reasoning. Stop deliberating now and emit the tool " +
+		"call for your next concrete action. If your work is complete, call " +
+		"submit_result with your verdict."
 }
 
 // NoToolCallNudgeMessage is the corrective the loop appends as a user
@@ -477,6 +535,86 @@ func NoToolCallNudgeMessage() string {
 		"and verified, you MUST call submit_result now with your verdict " +
 		"(GO or NO_GO), a summary, and the commit message. Otherwise call " +
 		"the appropriate tool to continue. Respond with a tool call, not text."
+}
+
+// noProgressStreaks bundles the three bounded retry counters the loop uses to
+// recover a turn that made no forward progress (no tool call), plus the
+// one-shot preserve-reasoning flag the truncation path arms. Grouped so
+// recoverNoProgressTurn owns the streak bookkeeping and Run stays under the
+// gocyclo ceiling. Each streak is independent: a token-cap truncation and a
+// finish_reason=="stop" reasoning-only pause never share a budget.
+type noProgressStreaks struct {
+	// noToolCall counts consecutive prose-only replies (ErrAssistantNoToolCalls).
+	noToolCall int
+	// reasoningOnly counts consecutive reasoning-only pauses (#650).
+	reasoningOnly int
+	// truncation counts consecutive token-cap truncations (ErrAssistantTruncated).
+	truncation int
+	// preserveReasoningNext, when set, tells the NEXT turn's wire build to keep
+	// the reasoning_content on its most-recent assistant message (the
+	// just-truncated turn) so the model resumes its <think> instead of
+	// re-deriving it. Armed only on a truncation retry and cleared after the
+	// single continuation turn it applies to.
+	preserveReasoningNext bool
+}
+
+// resetOnProgress clears the three no-progress streaks after a successful
+// tool-calling turn. preserveReasoningNext is intentionally NOT reset here: it
+// is a one-shot consumed at the top of the next iteration regardless of
+// outcome, so a successful turn cannot strand it set.
+func (s *noProgressStreaks) resetOnProgress() {
+	s.noToolCall = 0
+	s.reasoningOnly = 0
+	s.truncation = 0
+}
+
+// recoverNoProgressTurn handles the three bounded no-progress recoveries a
+// turn error can trigger: a prose-only reply (ErrAssistantNoToolCalls), a
+// token-cap truncation (ErrAssistantTruncated), and a hybrid-thinking pause
+// (ErrAssistantReasoningOnly). Each appends a role-appropriate corrective and
+// retries within its own budget; the failing turn is already in the transcript
+// so the model sees its own output followed by the correction.
+//
+// handled is false when turnErr is none of these (the caller surfaces it).
+// When handled, cont=true means a corrective was appended within budget (the
+// loop should continue) and cont=false means the streak budget is spent (the
+// caller should return turnErr). The truncation path additionally arms
+// preserveReasoningNext so the continuation keeps the partial reasoning — the
+// #650 reasoning-only path deliberately does NOT, since a finish_reason=="stop"
+// pause is a completed turn whose reasoning re-entering the budget is the very
+// circling that path guards against.
+func (l *Loop) recoverNoProgressTurn(
+	res *LoopResult, cfg LoopConfig, turnErr error, s *noProgressStreaks,
+) (handled, cont bool) {
+	switch {
+	case errors.Is(turnErr, ErrAssistantNoToolCalls):
+		return true, appendCorrectiveIfBudget(
+			res, &s.noToolCall, cfg.MaxNoToolCallRetries, NoToolCallNudgeMessage())
+	case errors.Is(turnErr, ErrAssistantTruncated):
+		cont = appendCorrectiveIfBudget(
+			res, &s.truncation, cfg.MaxTruncationRetries, TruncationContinueMessage())
+		if cont {
+			s.preserveReasoningNext = true
+		}
+		return true, cont
+	case errors.Is(turnErr, ErrAssistantReasoningOnly):
+		return true, appendCorrectiveIfBudget(
+			res, &s.reasoningOnly, cfg.MaxReasoningOnlyRetries, ReasoningOnlyNudgeMessage())
+	}
+	return false, false
+}
+
+// appendCorrectiveIfBudget appends a user-role corrective and consumes one
+// unit of a bounded retry budget. Returns true when there was budget (streak
+// incremented, message appended -> the loop should continue) and false when
+// the budget is spent (nothing appended -> the loop should surface the error).
+func appendCorrectiveIfBudget(res *LoopResult, streak *int, maxRetries int, msg string) bool {
+	if *streak >= maxRetries {
+		return false
+	}
+	*streak++
+	res.Transcript = append(res.Transcript, oai.Message{Role: oai.RoleUser, Content: msg})
+	return true
 }
 
 // Loop runs the native agent loop against a single OAI endpoint. It is
@@ -520,6 +658,9 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	}
 	if cfg.MaxReasoningOnlyRetries <= 0 {
 		cfg.MaxReasoningOnlyRetries = DefaultMaxReasoningOnlyRetries
+	}
+	if cfg.MaxTruncationRetries <= 0 {
+		cfg.MaxTruncationRetries = DefaultMaxTruncationRetries
 	}
 	// Loop-wide wall-clock budget (#532). Distinct from the per-request
 	// header timeout baked into the OAI client: this bounds the whole
@@ -572,16 +713,14 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	const forceSubmitFinalTurns = 3
 	forceSubmitAnnounced := false
 
-	// noToolCallStreak counts consecutive turns that returned text without
-	// a tool call. It resets to zero after any successful tool-calling
-	// turn, so only sustained narration exhausts MaxNoToolCallRetries.
-	noToolCallStreak := 0
+	// streaks bundles the three bounded no-progress retry counters (prose
+	// narration, token-cap truncation, reasoning-only pause) plus the
+	// one-shot preserve-reasoning flag; recoverNoProgressTurn owns the
+	// bookkeeping. Each streak resets after any successful tool-calling turn,
+	// so only a sustained no-progress run exhausts its budget.
+	var streaks noProgressStreaks
 	// verifyRetries counts coder-gate fix attempts spent so far (#749).
 	verifyRetries := 0
-	// reasoningOnlyStreak is the sibling counter for reasoning-only
-	// turns (#650); separate so a thinking model's pauses don't consume
-	// the prose-narration budget and vice versa.
-	reasoningOnlyStreak := 0
 
 	for turn := 1; turn <= cfg.MaxTurns; turn++ {
 		res.Turns = turn
@@ -612,8 +751,12 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 		// runOneTurn appends the assistant message + tool messages to
 		// res.Transcript. It returns errTerminalReached on submit_result.
 		// editSucceeded reports whether a write_file/str_replace landed this
-		// turn (gates the forcing phase below).
-		editSucceeded, turnErr := l.runOneTurn(ctx, cfg, activeSchemas, res)
+		// turn (gates the forcing phase below). The preserve-reasoning flag is
+		// consumed here (one-shot): it applies to exactly this turn's wire
+		// payload, so it is cleared immediately regardless of the outcome.
+		preserveReasoning := streaks.preserveReasoningNext
+		streaks.preserveReasoningNext = false
+		editSucceeded, turnErr := l.runOneTurn(ctx, cfg, activeSchemas, res, preserveReasoning)
 		if turnErr != nil {
 			if errors.Is(turnErr, errTerminalReached) {
 				// Coder gate feedback loop (#749): give the gate a chance to
@@ -633,45 +776,21 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 				res.Terminal = LoopBudgetExhaustedEnvelope(turn)
 				return res, nil
 			}
-			// No-tool-call recovery: a prose-only reply makes no forward
-			// progress, but local models sometimes narrate their
-			// conclusion instead of calling submit_result. Append a
-			// forceful corrective and retry, bounded by
-			// MaxNoToolCallRetries, before surfacing the error. The
-			// failing assistant turn is already in the transcript, so the
-			// model sees its own prose followed by the correction.
-			if errors.Is(turnErr, ErrAssistantNoToolCalls) {
-				if noToolCallStreak < cfg.MaxNoToolCallRetries {
-					noToolCallStreak++
-					res.Transcript = append(res.Transcript, oai.Message{
-						Role:    oai.RoleUser,
-						Content: NoToolCallNudgeMessage(),
-					})
-					continue
-				}
-				return res, turnErr
-			}
-			// Reasoning-only recovery (#650): the model was mid-thought,
-			// not narrating. Continue it with a gentler nudge on its own
-			// roomier budget; the reasoning itself is already in the
-			// transcript for archaeology.
-			if errors.Is(turnErr, ErrAssistantReasoningOnly) {
-				if reasoningOnlyStreak < cfg.MaxReasoningOnlyRetries {
-					reasoningOnlyStreak++
-					res.Transcript = append(res.Transcript, oai.Message{
-						Role:    oai.RoleUser,
-						Content: ReasoningOnlyNudgeMessage(),
-					})
-					continue
-				}
-				return res, turnErr
+			// No-progress recovery: a prose-only reply, a token-cap
+			// truncation, or a reasoning-only pause each get a bounded
+			// corrective-and-retry within their own budget (see
+			// recoverNoProgressTurn). handled && cont means a corrective was
+			// appended with budget to spare -> continue; every other case
+			// (budget spent, or an error type this does not handle) falls
+			// through to surface turnErr.
+			if handled, cont := l.recoverNoProgressTurn(res, cfg, turnErr, &streaks); handled && cont {
+				continue
 			}
 			return res, turnErr
 		}
 
-		// A successful tool-calling turn clears both streaks.
-		noToolCallStreak = 0
-		reasoningOnlyStreak = 0
+		// A successful tool-calling turn clears every no-progress streak.
+		streaks.resetOnProgress()
 
 		// Consult the progress monitor. The most recent assistant
 		// message in the transcript has this turn's tool_calls.
@@ -761,7 +880,16 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 // past reasoning never re-enters the context window or the token
 // budget (#650). Copies lazily: if no message carries reasoning, the
 // input slice is returned as-is.
-func stripReasoningForWire(msgs []oai.Message) []oai.Message {
+//
+// preserveTrailingReasoning is the one exception to the strip-everything
+// rule: when true, the reasoning_content on the single most-recent
+// assistant message is kept. This is the continuation of a token-cap
+// truncation (finish_reason=="length"): the model was cut off mid-<think>,
+// so preserving that one message's reasoning lets it resume instead of
+// re-thinking from scratch. The caller scopes this to exactly one turn, so
+// preserved reasoning re-enters the budget only for that continuation and
+// the #650 always-strip behavior holds everywhere else.
+func stripReasoningForWire(msgs []oai.Message, preserveTrailingReasoning bool) []oai.Message {
 	needsCopy := false
 	for i := range msgs {
 		if msgs[i].ReasoningContent != "" {
@@ -772,10 +900,26 @@ func stripReasoningForWire(msgs []oai.Message) []oai.Message {
 	if !needsCopy {
 		return msgs
 	}
+	// Index of the most-recent assistant message, or -1 if none. Only used
+	// when preserveTrailingReasoning is set.
+	keepIdx := -1
+	if preserveTrailingReasoning {
+		for i := len(msgs) - 1; i >= 0; i-- {
+			if msgs[i].Role == oai.RoleAssistant {
+				keepIdx = i
+				break
+			}
+		}
+	}
 	wire := make([]oai.Message, len(msgs))
 	copy(wire, msgs)
 	for i := range wire {
 		if wire[i].ReasoningContent == "" {
+			continue
+		}
+		if i == keepIdx {
+			// Preserve this one message's reasoning so the truncated turn's
+			// partial <think> survives into the continuation request.
 			continue
 		}
 		wire[i].ReasoningContent = ""
@@ -863,8 +1007,17 @@ func (l *Loop) applyTerminalGate(
 // the model invoked the terminal (submit_result) tool. editSucceeded
 // reports whether a write_file/str_replace landed this turn (used by the
 // EditFreeStreak forcing function in Run).
+// preserveTrailingReasoning, when true, keeps the reasoning_content on the
+// single most-recent assistant message in the wire payload. It is set for
+// exactly the one turn that continues a token-cap truncation
+// (finish_reason=="length"): the model was cut off mid-<think>, so it must
+// resume from that reasoning rather than restart. Every other assistant
+// message is still stripped, and the flag is reset by the caller after one
+// use, so the #650 behavior (strip all reasoning on a finish_reason=="stop"
+// reasoning-only turn) is untouched.
 func (l *Loop) runOneTurn(
 	ctx context.Context, cfg LoopConfig, schemas []oai.Tool, res *LoopResult,
+	preserveTrailingReasoning bool,
 ) (editSucceeded bool, err error) {
 	ctx, span := l.tracer.Start(ctx, "foreman.agent.turn",
 		trace.WithAttributes(attribute.Int("turn", res.Turns)))
@@ -874,9 +1027,14 @@ func (l *Loop) runOneTurn(
 	req := oai.ChatRequest{
 		Model: cfg.Model,
 		Messages: stripReasoningForWire(
-			selectWireTranscript(cfg, res.Transcript)),
+			selectWireTranscript(cfg, res.Transcript), preserveTrailingReasoning),
 		Tools:       schemas,
 		Temperature: cfg.Temperature,
+		// Per-turn generation cap (0 omits max_tokens, deferring to the
+		// server). Bounds a reasoning model's decision-turn <think> so an
+		// unbudgeted turn cannot run effectively unbounded on a
+		// large-context serve.
+		MaxTokens: cfg.MaxTokensPerTurn,
 	}
 	resp, err := l.client.Chat(ctx, req)
 	if err != nil {
@@ -890,6 +1048,7 @@ func (l *Loop) runOneTurn(
 	}
 
 	msg := resp.Choices[0].Message
+	finishReason := resp.Choices[0].FinishReason
 	// Some servers omit the role on the assistant reply; the OAI spec
 	// considers role required. Set it defensively so downstream
 	// transcript consumers do not see an empty role.
@@ -923,6 +1082,20 @@ func (l *Loop) runOneTurn(
 	res.Transcript = append(res.Transcript, msg)
 
 	if len(msg.ToolCalls) == 0 {
+		// A turn the token cap cut off mid-generation (finish_reason=="length")
+		// is a truncation, NOT a completed turn. Classify it first and
+		// distinctly: it carries reasoning_content and empty content exactly
+		// like a #650 reasoning-only turn, so without this check it would be
+		// misfiled as reasoning-only circling — whose recovery strips the
+		// partial reasoning and makes the model re-think from scratch, the
+		// opposite of what a truncated turn needs. The truncated assistant
+		// message stays in the transcript so the continuation can resume it.
+		if finishReason == "length" {
+			span.SetAttributes(attribute.Bool("truncated", true))
+			err := fmt.Errorf("turn %d: %w", res.Turns, ErrAssistantTruncated)
+			span.RecordError(err)
+			return false, err
+		}
 		// Distinguish a thinking model mid-reasoning (reasoning_content
 		// present, no prose) from a model narrating its conclusion as
 		// prose. The two get different correctives and budgets (#650).

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1020,13 +1021,174 @@ func TestLoop_ReasoningOnlyExhausted(t *testing.T) {
 	}
 }
 
+// assistantTruncated is a chat-completions body where a reasoning model
+// was cut off by the per-turn token cap: reasoning_content present, empty
+// content, no tool_calls, and finish_reason=="length". It is byte-identical
+// in shape to assistantReasoningOnly EXCEPT the finish_reason ("length" vs
+// "stop") — the single field that distinguishes a budget truncation from a
+// finish_reason=="stop" reasoning-only turn.
+const assistantTruncated = `{
+  "id": "t6",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "reasoning_content": "Let me design the edit. First I will change the function to..."
+    },
+    "finish_reason": "length"
+  }]
+}`
+
+// capturingScriptedServer behaves like scriptedOAIServer but also records
+// the full decoded ChatRequest for every call, so tests can assert on the
+// wire payload (retained reasoning_content, max_tokens, message ordering).
+func capturingScriptedServer(t *testing.T, bodies []string) (*httptest.Server, *[]oai.ChatRequest) {
+	t.Helper()
+	var calls atomic.Int64
+	var mu sync.Mutex
+	captured := make([]oai.ChatRequest, 0, len(bodies))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req oai.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("capturingScriptedServer: decode request: %v", err)
+		}
+		mu.Lock()
+		captured = append(captured, req)
+		mu.Unlock()
+		i := int(calls.Add(1) - 1)
+		if i >= len(bodies) {
+			t.Errorf("capturingScriptedServer: %d-th call exceeds script (%d)", i+1, len(bodies))
+			http.Error(w, "script exhausted", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(chatJSONToSSE(t, bodies[i])))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &captured
+}
+
+// TestLoop_TruncatedTurn_ClassifiedAsTruncatedNotReasoningOnly pins the
+// core taxonomy fix: a turn cut off by the token cap (finish_reason=="length")
+// with only reasoning and no tool call must classify as ErrAssistantTruncated,
+// never as ErrAssistantReasoningOnly (the finish_reason=="stop" circling case).
+// Exhaust the truncation budget so the terminal sentinel surfaces.
+func TestLoop_TruncatedTurn_ClassifiedAsTruncatedNotReasoningOnly(t *testing.T) {
+	srv, calls := scriptedOAIServer(t, []string{assistantTruncated, assistantTruncated})
+	reg := &fakeRegistry{results: map[string]*ToolResult{}}
+	loop := newTestLoop(srv, reg)
+
+	_, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", SystemPrompt: "sys", UserPrompt: "go",
+		MaxTurns: 10, MaxTruncationRetries: 1, MaxTokensPerTurn: 256,
+	})
+	if !errors.Is(err, ErrAssistantTruncated) {
+		t.Fatalf("want ErrAssistantTruncated after budget exhaustion, got %v", err)
+	}
+	if errors.Is(err, ErrAssistantReasoningOnly) {
+		t.Fatalf("a length-truncated turn must NOT be misfiled as reasoning-only")
+	}
+	// One initial turn + one continuation retry (MaxTruncationRetries=1).
+	if calls.Load() != 2 {
+		t.Errorf("calls: want 2 got %d", calls.Load())
+	}
+}
+
+// TestLoop_TruncatedTurn_ContinuationRetainsReasoningAndRecovers proves the
+// preserve-reasoning-on-continuation mechanism end to end: after a truncated
+// turn the loop appends the continuation directive and re-requests WITHOUT
+// stripping the just-produced partial reasoning, so the model resumes and
+// emits its terminal tool call. It also asserts the per-turn max_tokens cap
+// rides on every request.
+func TestLoop_TruncatedTurn_ContinuationRetainsReasoningAndRecovers(t *testing.T) {
+	srv, captured := capturingScriptedServer(t, []string{assistantTruncated, toolCallSubmitGo})
+	reg := &fakeRegistry{results: map[string]*ToolResult{
+		"submit_result": {Terminal: true, Verdict: "GO"},
+	}}
+	loop := newTestLoop(srv, reg)
+
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", SystemPrompt: "sys", UserPrompt: "go",
+		MaxTurns: 5, MaxTokensPerTurn: 4096,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Fatalf("expected GO terminal after recovery, got %+v", res.Terminal)
+	}
+
+	reqs := *captured
+	if len(reqs) != 2 {
+		t.Fatalf("want 2 captured requests, got %d", len(reqs))
+	}
+	// Every turn carries the per-turn generation cap on the wire.
+	for i, rq := range reqs {
+		if rq.MaxTokens != 4096 {
+			t.Errorf("request %d: MaxTokens=%d, want 4096 (cfg.MaxTokensPerTurn)", i, rq.MaxTokens)
+		}
+	}
+	// The continuation request (2nd) must RETAIN the truncated turn's partial
+	// reasoning so the model resumes instead of re-thinking from scratch.
+	var sawRetainedReasoning bool
+	for _, m := range reqs[1].Messages {
+		if m.Role == oai.RoleAssistant && strings.Contains(m.ReasoningContent, "design the edit") {
+			sawRetainedReasoning = true
+		}
+	}
+	if !sawRetainedReasoning {
+		t.Errorf("continuation request must retain the truncated reasoning; got messages=%+v", reqs[1].Messages)
+	}
+	// The continuation directive (not the reasoning-only nudge) was appended.
+	var sawContinue bool
+	for _, m := range res.Transcript {
+		if m.Role == oai.RoleUser && m.Content == TruncationContinueMessage() {
+			sawContinue = true
+		}
+	}
+	if !sawContinue {
+		t.Errorf("transcript should contain the truncation continuation directive")
+	}
+}
+
+// TestLoop_TruncatedTurn_StreakResetsOnToolCall confirms a successful
+// tool-calling turn between truncations resets the streak, so intermittent
+// truncations never accumulate to a spurious ErrAssistantTruncated. The
+// script truncates, recovers with a read_file (resets the streak),
+// truncates again, then submits — four turns with a single-retry budget
+// that would fail if the streak did not reset.
+func TestLoop_TruncatedTurn_StreakResetsOnToolCall(t *testing.T) {
+	srv, calls := scriptedOAIServer(t, []string{
+		assistantTruncated, toolCallReadFile, assistantTruncated, toolCallSubmitGo,
+	})
+	reg := &fakeRegistry{results: map[string]*ToolResult{
+		"read_file":     {Output: map[string]any{"content": "x"}},
+		"submit_result": {Terminal: true, Verdict: "GO"},
+	}}
+	loop := newTestLoop(srv, reg)
+
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", SystemPrompt: "sys", UserPrompt: "go",
+		MaxTurns: 10, MaxTruncationRetries: 1, MaxTokensPerTurn: 512,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Fatalf("expected GO terminal, got %+v", res.Terminal)
+	}
+	if calls.Load() != 4 {
+		t.Errorf("calls: want 4 got %d", calls.Load())
+	}
+}
+
 func TestStripReasoningForWire(t *testing.T) {
 	transcript := []oai.Message{
 		{Role: oai.RoleSystem, Content: "sys"},
 		{Role: oai.RoleAssistant, ReasoningContent: "thinking", Content: "answer"},
 		{Role: oai.RoleUser, Content: "next"},
 	}
-	wire := stripReasoningForWire(transcript)
+	wire := stripReasoningForWire(transcript, false)
 	if wire[1].ReasoningContent != "" {
 		t.Errorf("wire copy must strip reasoning_content, got %q", wire[1].ReasoningContent)
 	}
@@ -1035,6 +1197,42 @@ func TestStripReasoningForWire(t *testing.T) {
 	}
 	if transcript[1].ReasoningContent != "thinking" {
 		t.Errorf("original transcript must be untouched, got %q", transcript[1].ReasoningContent)
+	}
+}
+
+// TestStripReasoningForWire_PreserveTrailing pins the one-shot preserve
+// mechanism: with preserveTrailingReasoning=true, ONLY the most-recent
+// assistant message keeps its reasoning_content (the just-truncated turn);
+// every earlier assistant message is still stripped. This is what lets a
+// token-cap continuation resume the model's <think> without re-admitting
+// all prior reasoning to the budget.
+func TestStripReasoningForWire_PreserveTrailing(t *testing.T) {
+	transcript := []oai.Message{
+		{Role: oai.RoleSystem, Content: "sys"},
+		{Role: oai.RoleAssistant, ReasoningContent: "old thought", Content: "prior"},
+		{Role: oai.RoleTool, Name: "read_file", Content: "{}"},
+		{Role: oai.RoleAssistant, ReasoningContent: "the truncated in-progress thought"},
+		{Role: oai.RoleUser, Content: TruncationContinueMessage()},
+	}
+	wire := stripReasoningForWire(transcript, true)
+
+	// The earlier assistant message is still stripped.
+	if wire[1].ReasoningContent != "" {
+		t.Errorf("earlier assistant reasoning must be stripped, got %q", wire[1].ReasoningContent)
+	}
+	// The most-recent assistant message keeps its reasoning.
+	if wire[3].ReasoningContent != "the truncated in-progress thought" {
+		t.Errorf("trailing assistant reasoning must be preserved, got %q", wire[3].ReasoningContent)
+	}
+	// A stripped reasoning-only assistant becomes non-empty (placeholder) so
+	// the wire stays valid (#935); the preserved one keeps its reasoning and
+	// needs no placeholder.
+	if strings.TrimSpace(wire[3].Content) != "" {
+		t.Errorf("preserved trailing message should not get a placeholder, got content=%q", wire[3].Content)
+	}
+	// Original transcript untouched.
+	if transcript[1].ReasoningContent != "old thought" {
+		t.Errorf("original transcript mutated: %q", transcript[1].ReasoningContent)
 	}
 }
 
@@ -1105,7 +1303,7 @@ func TestRunOneTurn_EmptyAssistantReply_SubstitutesPlaceholder(t *testing.T) {
 			{Role: oai.RoleUser, Content: "go"},
 		},
 	}
-	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res)
+	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res, false)
 	// The placeholder makes the message non-empty, so runOneTurn treats
 	// it as a no-tool-call turn and returns ErrAssistantNoToolCalls.
 	if !errors.Is(err, ErrAssistantNoToolCalls) {
@@ -1169,7 +1367,7 @@ func TestRunOneTurn_ToolCallTurnNotClobbered(t *testing.T) {
 			{Role: oai.RoleUser, Content: "go"},
 		},
 	}
-	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res)
+	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res, false)
 	// A tool-call turn is a normal, successful turn: no error expected.
 	if err != nil {
 		t.Fatalf("runOneTurn: expected nil error for a tool-call turn with empty content, got %v", err)
@@ -1214,7 +1412,7 @@ func TestLoop_StrippedReasoningDoesNotProduceEmptyAssistant(t *testing.T) {
 		{Role: oai.RoleAssistant, ReasoningContent: "thinking only, no action"},
 		{Role: oai.RoleUser, Content: ReasoningOnlyNudgeMessage()},
 	}
-	wire := stripReasoningForWire(transcript)
+	wire := stripReasoningForWire(transcript, false)
 	if wire[0].ReasoningContent != "" {
 		t.Errorf("reasoning must be stripped, got %q", wire[0].ReasoningContent)
 	}

--- a/pkg/foreman/agent/oai/types.go
+++ b/pkg/foreman/agent/oai/types.go
@@ -154,6 +154,16 @@ type ChatRequest struct {
 	Messages    []Message `json:"messages"`
 	Tools       []Tool    `json:"tools,omitempty"`
 	Temperature *float64  `json:"temperature,omitempty"`
+	// MaxTokens bounds the number of tokens the server generates for one
+	// completion (the OpenAI `max_tokens` field). Zero omits the field so
+	// the server falls back to its own default (max_model_len - prompt).
+	// The loop sets this per turn so a reasoning model cannot run its
+	// <think> block effectively unbounded on a large-context serve: an
+	// unbudgeted decision turn generates until it either finally acts or
+	// hits the context limit, which reads as a stalled task. Keep the
+	// caller's value well below (served context - prompt) so the server
+	// does not 400 on prompt + max_tokens > max_model_len.
+	MaxTokens int `json:"max_tokens,omitempty"`
 	// Stream is set by the client just before the wire send; callers
 	// do not need to populate it.
 	Stream bool `json:"stream"`

--- a/pkg/foreman/agent/oai/types_test.go
+++ b/pkg/foreman/agent/oai/types_test.go
@@ -151,6 +151,42 @@ func TestMessageMarshalJSON_AssistantOmitsContentWhenEmpty(t *testing.T) {
 	}
 }
 
+// TestChatRequestMarshalJSON_MaxTokens pins the per-turn generation cap
+// wire contract: max_tokens must appear in the marshaled body when set
+// (> 0) so the server bounds a reasoning model's decision-turn <think>,
+// and must be omitted when zero so the request defers to the server's own
+// default (max_model_len - prompt) rather than pinning it to 0 (which
+// would generate nothing).
+func TestChatRequestMarshalJSON_MaxTokens(t *testing.T) {
+	cases := []struct {
+		name       string
+		maxTokens  int
+		wantHasKey bool
+	}{
+		{name: "positive max_tokens is emitted", maxTokens: 8192, wantHasKey: true},
+		{name: "zero max_tokens is omitted", maxTokens: 0, wantHasKey: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(ChatRequest{
+				Model:     "test",
+				Messages:  []Message{{Role: RoleUser, Content: "go"}},
+				MaxTokens: tc.maxTokens,
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			hasKey := strings.Contains(string(raw), `"max_tokens":`)
+			if hasKey != tc.wantHasKey {
+				t.Errorf("max_tokens present=%v want=%v in %s", hasKey, tc.wantHasKey, raw)
+			}
+			if tc.wantHasKey && !strings.Contains(string(raw), `"max_tokens":8192`) {
+				t.Errorf("expected max_tokens=8192 in %s", raw)
+			}
+		})
+	}
+}
+
 // TestMessageMarshalJSON_RoleAlwaysEmitted is a belt-and-suspenders
 // guard: regardless of which marshal branch a message goes through,
 // the role field must always be on the wire (it's the primary


### PR DESCRIPTION
## What

Makes Foreman coders usable with **reasoning models** (qwen3-family: Qwen3.6-35B-A3B, Ornith-1.0-35B) by (A) sending a bounded, configurable per-turn `max_tokens`, and (B) reading `finish_reason` so a length-truncated turn is handled as *continue-and-act* instead of being misfiled as #650 reasoning-only 'circling' and strip-restarted.

## Why

Fixes #1174. Confirmed via a captured stall transcript: reasoning models only `<think>` on *decision* turns; with no `max_tokens` sent, that reasoning ran effectively unbounded (~2h at ~18 tok/s on a 128K serve), and because the loop never read `finish_reason`, a truncated turn was misclassified as reasoning-only circling. The #650 recovery then stripped the partial reasoning and restarted thinking, reproducing the truncation until the task ended INCOMPLETE with **zero edits**. Non-reasoning coders were unaffected (they don't produce a `<think>` block).

## How

- **A — per-turn budget.** `oai.ChatRequest.MaxTokens` (`max_tokens,omitempty`); `LoopConfig.MaxTokensPerTurn` set in `runOneTurn`; new `AgentSpec.MaxOutputTokens` (`+optional`, `Minimum=0`) mapped in the executor with a `defaultMaxTokensPerTurn = 8192`. A stuck turn now fails fast instead of hanging for hours.
- **B — truncation handling.** `runOneTurn` reads `Choices[0].FinishReason`; a no-tool-call turn with `finish_reason=="length"` returns a new `ErrAssistantTruncated` **before** the reasoning-only classification. `Run` continues it (bounded by `MaxTruncationRetries`, default 3) with a stop-deliberating directive, and a one-shot `preserveTrailingReasoning` flag keeps the truncated turn's partial `<think>` on the wire for exactly that continuation turn — so the model resumes rather than re-derives. The #650 `finish_reason=="stop"` path is untouched.
- The three bounded no-progress recoveries (no-tool-call, truncation, reasoning-only) were consolidated into `recoverNoProgressTurn`; the executor's terminal error mapping into `mapLoopError`, adding an `ErrAssistantTruncated` -> INCOMPLETE case with an accurate message.

## Tests

- `oai/types_test.go`: `max_tokens` present when >0, omitted when 0.
- `loop_test.go`: truncated turn classified as `ErrAssistantTruncated` (not reasoning-only); continuation **retains** the partial reasoning and `req.MaxTokens` is on the wire; streak resets on a tool-calling turn; exhaustion returns `ErrAssistantTruncated`; the existing `finish_reason=="stop"` reasoning-only tests stay green.
- `executor_native_test.go`: `MaxOutputTokens` defaulting (unset->8192, set->CR) and the `ErrAssistantTruncated`->INCOMPLETE mapping.

`go test -race ./pkg/foreman/agent/... ./api/...` green; `go vet` + `golangci-lint` (GOOS=linux) clean; CRDs regenerated via `make manifests generate chart-crds foreman-chart-crds`.

## Checklist

- [x] Tests added/updated
- [x] `make test` (non-envtest agent + api packages) green
- [x] `make lint` clean
- [x] Conventional commit, DCO signed off
- [x] Docs: CRD field doc comment; regenerated CRD + chart

AI-assisted (Claude Code): diagnosed from a captured live stall transcript and implemented under human review.

### Open concern
No runtime clamp of `max_tokens` against the served `max_model_len` (the executor can't reliably know the serve's context). Relies on the conservative 8192 default + a CRD doc warning; a hard guard would need the served context surfaced on InferenceService status.