### PR TITLE
fix(foreman): count identical read_file re-reads as no-progress under the edit-free nudge

### DIFF
--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -142,7 +142,13 @@ type LoopProgressMonitor struct {
 	// next edit (the anti-confab rule, #1062) earns tolerance, while a search
 	// loop or a re-read of the same file reads no NEW file and earns none.
 	groundedFiles map[string]struct{}
-	contextTokens int // approximate wire token count after most recent turn
+	// lastReadFileKey is the path+range key of the most recent read_file call
+	// across all turns. A repeated read_file with the same key is treated as
+	// no progress (#1116): it does not add to groundedFiles and does not
+	// extend the edit-free budget, preventing a model from burning its
+	// forcing-phase turns on identical re-reads.
+	lastReadFileKey string
+	contextTokens   int // approximate wire token count after most recent turn
 
 	// Nudge state. Once a signal has fired, the next-turn trigger
 	// escalates to ForceTerminate. For RepeatedToolCall we track the
@@ -221,16 +227,19 @@ func (m *LoopProgressMonitor) editFreeLimit() int {
 	return m.cfg.EditFreeTurnsLimit + bonus
 }
 
-// readFilePath extracts the path argument from a read_file tool call's JSON
-// arguments, or "" if the argument is absent or unparseable.
-func readFilePath(arguments string) string {
+// readFileKey returns a stable key for a read_file call: "path:offset:limit".
+// Offset and limit default to 0 when absent, so a bare read_file("foo.go")
+// and read_file("foo.go", offset 1, limit 0) produce the same key.
+func readFileKey(arguments string) string {
 	var args struct {
-		Path string `json:"path"`
+		Path   string `json:"path"`
+		Offset int    `json:"offset"`
+		Limit  int    `json:"limit"`
 	}
 	if err := json.Unmarshal([]byte(arguments), &args); err != nil {
 		return ""
 	}
-	return strings.TrimSpace(args.Path)
+	return strings.TrimSpace(args.Path) + ":" + fmt.Sprintf("%d:%d", args.Offset, args.Limit)
 }
 
 // explorationTools are the open-ended search tools removed from the
@@ -476,16 +485,25 @@ func (m *LoopProgressMonitor) updateEditFreeStreak(calls []oai.ToolCall) {
 	}
 	// No edit this turn. Record any distinct files the model read so grounding
 	// reads raise the effective edit-free limit (see editFreeLimit, #1066).
+	// A repeated read_file with the same path+range as the most recent read
+	// is treated as no progress (#1116): it does not add to groundedFiles.
 	for _, tc := range calls {
 		if tc.Function.Name != "read_file" {
 			continue
 		}
-		if p := readFilePath(tc.Function.Arguments); p != "" {
-			if m.groundedFiles == nil {
-				m.groundedFiles = make(map[string]struct{})
-			}
-			m.groundedFiles[p] = struct{}{}
+		key := readFileKey(tc.Function.Arguments)
+		if key == "" {
+			continue
 		}
+		// Skip repeated reads: same path+range as the last read_file call.
+		if key == m.lastReadFileKey {
+			continue
+		}
+		m.lastReadFileKey = key
+		if m.groundedFiles == nil {
+			m.groundedFiles = make(map[string]struct{})
+		}
+		m.groundedFiles[key] = struct{}{}
 	}
 	m.editFreeStreak++
 }
@@ -505,6 +523,7 @@ func (m *LoopProgressMonitor) resetEditFreeStreak() {
 	// A landed edit ends the current grounding window; the tolerance earned by
 	// reads before it must not carry into a later stuck phase (#1066).
 	m.groundedFiles = nil
+	m.lastReadFileKey = ""
 }
 
 // fileWritingBashTokens are substrings that indicate a bash command

--- a/pkg/foreman/agent/progress_test.go
+++ b/pkg/foreman/agent/progress_test.go
@@ -244,6 +244,95 @@ func TestProgressMonitor_EditResetsGroundingBonus(t *testing.T) {
 	}
 }
 
+// TestReadFileKey confirms readFileKey produces stable, distinct keys for
+// different path+range combinations and identical keys for repeated calls.
+func TestReadFileKey(t *testing.T) {
+	tests := []struct {
+		args string
+		want string
+	}{
+		{`{"path":"a.go"}`, "a.go:0:0"},
+		{`{"path":"a.go","offset":100,"limit":50}`, "a.go:100:50"},
+		{`{"path":"b.go"}`, "b.go:0:0"},
+		{`{"path":"a.go","limit":80}`, "a.go:0:80"},
+	}
+	for _, tc := range tests {
+		got := readFileKey(tc.args)
+		if got != tc.want {
+			t.Errorf("readFileKey(%q) = %q, want %q", tc.args, got, tc.want)
+		}
+	}
+}
+
+// TestProgressMonitor_RepeatedReadFileIsNoProgress pins #1116: a read_file
+// with the same path+range as the most recent read_file is treated as no
+// progress — it does not add to groundedFiles and does not extend the
+// edit-free budget. A model that re-reads the same file in the forcing phase
+// should not earn tolerance for it.
+func TestProgressMonitor_RepeatedReadFileIsNoProgress(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{EditFreeTurnsLimit: 3})
+	tr := []oai.Message{}
+
+	// Turn 1: first read of a.go — counts as grounding.
+	d := mon.Observe(1, []oai.ToolCall{makeCall("t", "read_file", `{"path":"a.go"}`)}, tr)
+	if d.Action != ProgressContinue {
+		t.Fatalf("turn 1: want Continue, got %+v", d)
+	}
+
+	// Turn 2: repeated read of a.go (same path+range) — no progress.
+	d = mon.Observe(2, []oai.ToolCall{makeCall("t", "read_file", `{"path":"a.go"}`)}, tr)
+	if d.Action != ProgressContinue {
+		t.Fatalf("turn 2: want Continue, got %+v", d)
+	}
+
+	// Turn 3: repeated read again — no progress, streak = 3, nudge fires.
+	d = mon.Observe(3, []oai.ToolCall{makeCall("t", "read_file", `{"path":"a.go"}`)}, tr)
+	if d.Action != ProgressNudge || d.Signal != signalEditFreeStreak {
+		t.Fatalf("turn 3: want EditFreeStreak nudge, got %+v", d)
+	}
+
+	// Verify groundedFiles only has one entry (the first read), not three.
+	if len(mon.groundedFiles) != 1 {
+		t.Fatalf("groundedFiles: want 1 entry, got %d", len(mon.groundedFiles))
+	}
+}
+
+// TestProgressMonitor_DifferentRangeReadFileIsProgress confirms that a
+// read_file with a different range (offset/limit) is treated as a new read
+// and earns grounding tolerance, unlike an identical re-read.
+func TestProgressMonitor_DifferentRangeReadFileIsProgress(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{EditFreeTurnsLimit: 3})
+	tr := []oai.Message{}
+
+	// Turn 1: read a.go from the start.
+	d := mon.Observe(1, []oai.ToolCall{makeCall("t", "read_file", `{"path":"a.go"}`)}, tr)
+	if d.Action != ProgressContinue {
+		t.Fatalf("turn 1: want Continue, got %+v", d)
+	}
+
+	// Turn 2: read a.go with a different range — counts as new grounding.
+	d = mon.Observe(2, []oai.ToolCall{makeCall("t", "read_file", `{"path":"a.go","offset":100,"limit":50}`)}, tr)
+	if d.Action != ProgressContinue {
+		t.Fatalf("turn 2: want Continue, got %+v", d)
+	}
+
+	// Turn 3: read a.go with yet another range — still new grounding.
+	d = mon.Observe(3, []oai.ToolCall{makeCall("t", "read_file", `{"path":"a.go","offset":200,"limit":50}`)}, tr)
+	if d.Action != ProgressContinue {
+		t.Fatalf("turn 3: want Continue, got %+v", d)
+	}
+
+	// groundedFiles should have 3 entries (distinct path+range keys).
+	if len(mon.groundedFiles) != 3 {
+		t.Fatalf("groundedFiles: want 3 entries, got %d", len(mon.groundedFiles))
+	}
+
+	// The effective limit should be base + 2 (3 distinct reads, bonus = 2).
+	if mon.editFreeLimit() != 5 {
+		t.Fatalf("editFreeLimit: want 5, got %d", mon.editFreeLimit())
+	}
+}
+
 // TestProgressMonitor_EditResetsStreak confirms a write_file (or
 // str_replace, or submit_result) call resets the edit-free counter.
 func TestProgressMonitor_EditResetsStreak(t *testing.T) {


### PR DESCRIPTION
## What

Under the edit-free progress nudge, count an identical `read_file` re-read (same path+range as the most recent read) as no progress, so it no longer extends the edit-free budget.

## Why

The edit-free nudge disables `grep` and `bash` but leaves `read_file` fully enabled, so a cornered model can burn its forced turns re-reading the same file without ever making an edit, never converging to a `write_file` / `str_replace`. Observed in a live #1093 run (EditFreeStreak at turn 41).

Fixes #1116

## How

- `readFilePath` -> `readFileKey`: key a `read_file` call on path+range (`"path:offset:limit"`).
- In `updateEditFreeStreak`, skip a read whose key equals `lastReadFileKey` (the most recent read): it does not add to `groundedFiles`, so it earns no edit-free tolerance.
- A read of a *different* range of the same file still counts as new grounding (design choice: only identical re-reads are no-progress).
- `resetEditFreeStreak` clears `lastReadFileKey`.

## Checklist

- [x] Tests added/updated (`TestReadFileKey`, `TestProgressMonitor_RepeatedReadFileIsNoProgress`, `TestProgressMonitor_DifferentRangeReadFileIsProgress`)
- [x] `make test` passes locally (full envtest suite, 32 packages ok, 0 failures)
- [x] `make lint` passes locally (golangci-lint, 0 issues)
- [x] All commits signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed below
- [ ] Documentation updated (not user-facing; internal loop heuristic)

## AI assistance

AI-assisted (band 3 per CONTRIBUTING.md): the initial implementation was drafted by an agentic coding tool; a human reviewed the diff, ran `make test` and `make lint`, verified the behavior, and owns this submission.
