### PR TITLE
fix(foreman): widen coder scope-overlap gate to a bottom-quartile floor

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -591,10 +591,13 @@ func truncateOutput(output string) string {
 	return "...(truncated)...\n" + output[len(output)-maxCheckOutputBytes:]
 }
 
-// scopeRelevantTopK bounds how many of the highest-scored files count as
-// "relevant" for the scope-overlap check. Generous on purpose: a larger set
-// means the check only fires on a clear drift (a change touching none of the
-// most-relevant files), keeping false positives low as #782 asks.
+// scopeRelevantTopK is both the display cap for the scope-overlap feedback
+// (how many of the highest-scored files are listed) and the floor of the
+// in-scope membership set (see inScopeCount). Generous on purpose: a larger
+// in-scope set means the check only fires on a clear drift, keeping false
+// positives low as #782 asks. The in-scope set widens to the top three
+// quartiles for large repos so a relevant-but-lower-ranked fix is not
+// falsely flagged (#1180).
 const scopeRelevantTopK = 50
 
 // maxRelevantShown caps how many relevant files the scope feedback lists.
@@ -611,14 +614,61 @@ var scopeRelevantFiles = func(workspace, issueText string) (paths []string, set 
 		return nil, nil
 	}
 	scored := repomap.ScoreFiles(files, issueText)
-	set = make(map[string]bool)
+	// Collect every positively-scored file in rank order. repomap ranks
+	// descending, so the first non-positive score ends the ranked set.
+	var ranked []string
 	for _, sf := range scored {
-		if sf.Score <= 0 || len(paths) >= scopeRelevantTopK {
+		if sf.Score <= 0 {
 			break
 		}
-		paths = append(paths, sf.Path)
-		set[sf.Path] = true
+		ranked = append(ranked, sf.Path)
 	}
+	return scopeRelevantView(ranked)
+}
+
+// inScopeCount returns how many of the n positively-scored files (ranked
+// descending by relevance) count as in-scope for the scope-overlap check:
+// the larger of scopeRelevantTopK and the top three quartiles (ceil(0.75*n)),
+// capped at n. Keeping scopeRelevantTopK as a floor makes the percentile
+// strictly more permissive than the old top-K-only rule, so it can only
+// remove false positives (#1180). A changed file is flagged as drift only
+// when it lands in the bottom quartile of relevance, not merely below an
+// arbitrary rank cliff over a dense score distribution (repomap routinely
+// scores every file positively, so "outside top-50" was not "unrelated").
+func inScopeCount(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	c := scopeRelevantTopK
+	if q := (3*n + 3) / 4; q > c { // ceil(0.75*n)
+		c = q
+	}
+	if c > n {
+		c = n
+	}
+	return c
+}
+
+// scopeRelevantView splits a ranked list of positively-scored files into the
+// display list (the scopeRelevantTopK most relevant, shown in gate feedback)
+// and the in-scope membership set (the top inScopeCount, used for the drift
+// decision). Returns (nil, nil) for empty input so callers treat "no Go
+// signal" as observe-only. Injected via scopeRelevantFiles in tests.
+func scopeRelevantView(rankedPositive []string) (paths []string, set map[string]bool) {
+	n := len(rankedPositive)
+	if n == 0 {
+		return nil, nil
+	}
+	k := inScopeCount(n)
+	set = make(map[string]bool, k)
+	for i := 0; i < k; i++ {
+		set[rankedPositive[i]] = true
+	}
+	shown := scopeRelevantTopK
+	if shown > n {
+		shown = n
+	}
+	paths = append(paths, rankedPositive[:shown]...)
 	return paths, set
 }
 

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -19,6 +19,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -639,6 +640,55 @@ func diffRunner(diffOutput string) commandRunner {
 			return diffOutput, nil
 		}
 		return "", nil
+	}
+}
+
+// TestInScopeCount pins the percentile floor (#1180): a file is in-scope
+// unless it falls in the bottom quartile of positively-scored files, but the
+// legacy scopeRelevantTopK stays a floor so the change is strictly more
+// permissive than the old top-50-only rule (it can only remove false
+// positives). ceil(0.75*n) wins only once it exceeds scopeRelevantTopK.
+func TestInScopeCount(t *testing.T) {
+	tests := []struct {
+		n    int
+		want int
+	}{
+		{0, 0},
+		{1, 1},
+		{10, 10},   // below the floor: all in scope, never drift for tiny repos
+		{50, 50},   // exactly the floor
+		{60, 50},   // ceil(0.75*60)=45 < 50 floor
+		{68, 51},   // ceil(0.75*68)=51 > 50 floor
+		{100, 75},  // ceil(0.75*100)=75
+		{245, 184}, // the #1116 repo: ceil(0.75*245)=184
+	}
+	for _, tc := range tests {
+		if got := inScopeCount(tc.n); got != tc.want {
+			t.Errorf("inScopeCount(%d) = %d, want %d", tc.n, got, tc.want)
+		}
+	}
+}
+
+// TestScopeRelevantView_BottomQuartileIsDrift pins #1180 end to end at the
+// pure core: a relevant-but-lower-ranked file (rank 91 of 245, the measured
+// #1116 progress.go position) must be in scope, while a bottom-quartile file
+// must not be. The display slice stays capped at scopeRelevantTopK.
+func TestScopeRelevantView_BottomQuartileIsDrift(t *testing.T) {
+	const n = 245
+	ranked := make([]string, n)
+	for i := range ranked {
+		ranked[i] = fmt.Sprintf("f%03d.go", i) // index i == rank i+1
+	}
+	paths, set := scopeRelevantView(ranked)
+
+	if !set["f090.go"] { // rank 91: top 37%, clearly relevant
+		t.Error("rank-91/245 file must be in scope (top 37%), not flagged as drift")
+	}
+	if set["f239.go"] { // rank 240: bottom quartile
+		t.Error("rank-240/245 file (bottom quartile) must be out of scope")
+	}
+	if len(paths) != scopeRelevantTopK {
+		t.Errorf("display list should be capped at %d, got %d", scopeRelevantTopK, len(paths))
 	}
 }
 


### PR DESCRIPTION
## What

Widen the coder gate's scope-overlap check from a fixed "top-50 ranked files" membership to a self-calibrating bottom-quartile floor, so a correct fix in a relevant-but-lower-ranked file is no longer hard-failed as drift.

## Why

`checkScopeOverlap` flagged drift when none of a coder's changed Go files were in the top-50 files `repomap.ScoreFiles` ranked for the issue text. But repomap scores every file positively and densely, so the true fix-site can rank just below the cut. For #1116 the fix belonged in `pkg/foreman/agent/progress.go`, which ranked 91 of 245 (score 6.25, cutoff 6.33). The code built and passed `make test`, but the gate hard-failed it on every attempt with no escape hatch, ending the run INCOMPLETE and blocking a correct change.

Fixes #1180

## How

- `inScopeCount(n)`: in-scope size = `max(scopeRelevantTopK, ceil(0.75*n))`, capped at `n`. Keeping `scopeRelevantTopK` as a floor makes the new rule strictly more permissive than the old top-50-only rule, so it can only remove false positives, never add them.
- `scopeRelevantView(rankedPositive)`: splits the ranked positive-scored files into the display list (top `scopeRelevantTopK`) and the in-scope membership set (top `inScopeCount`). `scopeRelevantFiles` now collects all positively-scored files and delegates to it.
- A changed file is flagged as drift only when it lands in the bottom quartile of relevance. Genuinely unrelated files still rank there and are still caught.

Verified against the real repomap on the #1116 issue text: `progress.go` moves from outside the top-50 into the in-scope set (which grows from 50 to 184), so the exact gate that rejected #1116 now passes it.

## Checklist

- [x] Tests added/updated (`TestInScopeCount`, `TestScopeRelevantView_BottomQuartileIsDrift`; existing scope-overlap tests still pass)
- [x] `make lint` passes locally (golangci-lint, 0 issues)
- [x] `go test ./pkg/foreman/agent/` passes locally
- [x] All commits signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed below
- [ ] Documentation updated (not user-facing; internal gate heuristic)

## AI assistance

AI-assisted (band 3 per CONTRIBUTING.md): diagnosed and implemented with an agentic tool under TDD; a human reviewed the diff, ran the tests and lint, verified the #1116 repro is resolved, and owns this submission.
