### PR TITLE
fix(foreman): warn when an MCP allowlist entry matches no server tool

### DIFF
--- a/pkg/foreman/agent/mcp/allowlist_warn_test.go
+++ b/pkg/foreman/agent/mcp/allowlist_warn_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+)
+
+// TestUnmatchedAllowlistEntries pins the drift-detection helper: an explicit
+// allowlist entry that matches no discovered tool is reported, so a stale or
+// mistyped tool name (the context7 get-library-docs vs query-docs bug, #1183)
+// is surfaced instead of silently dropping the tool.
+func TestUnmatchedAllowlistEntries(t *testing.T) {
+	tests := []struct {
+		name       string
+		allow      []string
+		discovered []string
+		want       []string
+	}{
+		{"all match", []string{"echo", "boom"}, []string{"echo", "boom"}, nil},
+		{"one stale", []string{"echo", "ghost"}, []string{"echo", "boom"}, []string{"ghost"}},
+		{"two stale", []string{"a", "b"}, []string{"echo"}, []string{"a", "b"}},
+		{"empty allowlist means allow-all", nil, []string{"echo"}, nil},
+		{"wildcard means allow-all", []string{"*"}, []string{"echo"}, nil},
+		{"wildcard suppresses unmatched", []string{"*", "ghost"}, []string{"echo"}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := unmatchedAllowlistEntries(tc.allow, tc.discovered)
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("unmatchedAllowlistEntries(%v, %v) = %v, want %v", tc.allow, tc.discovered, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConnect_WarnsOnUnmatchedAllowlist pins the end-to-end behavior: when a
+// server's allowlist names a tool the server does not expose, Connect logs a
+// warning naming the unmatched entry, while still registering the tools that
+// do match.
+func TestConnect_WarnsOnUnmatchedAllowlist(t *testing.T) {
+	base := startFakeMCP(t) // exposes "echo" and "boom"
+	var logs []string
+	log := funcr.New(func(prefix, args string) { logs = append(logs, args) }, funcr.Options{})
+
+	servers := []ServerConfig{{Name: "fake", URL: base, AllowedTools: []string{"echo", "ghost"}}}
+	toolz, closer, err := Connect(context.Background(), log, servers, Options{}, func(mcpCallRecord) {})
+	if closer != nil {
+		defer func() { _ = closer() }()
+	}
+	if err != nil {
+		t.Fatalf("Connect err = %v", err)
+	}
+	// "echo" still registers; "ghost" does not exist.
+	if len(toolz) != 1 || toolz[0].Name() != "mcp/fake/echo" {
+		names := make([]string, 0, len(toolz))
+		for _, tl := range toolz {
+			names = append(names, tl.Name())
+		}
+		t.Fatalf("want only mcp/fake/echo registered, got %v", names)
+	}
+	// A warning must name the unmatched entry "ghost".
+	joined := strings.Join(logs, "\n")
+	if !strings.Contains(joined, "ghost") || !strings.Contains(strings.ToLower(joined), "allowlist") {
+		t.Errorf("expected a warning naming the unmatched allowlist entry 'ghost'; logs:\n%s", joined)
+	}
+}

--- a/pkg/foreman/agent/mcp/config.go
+++ b/pkg/foreman/agent/mcp/config.go
@@ -35,3 +35,31 @@ func allowed(tool string, allow []string) bool {
 	}
 	return false
 }
+
+// unmatchedAllowlistEntries returns the explicit allowlist entries that match
+// none of the discovered tool names. An empty allowlist, or one containing
+// "*", means allow-all, so there is nothing to flag (returns nil). This
+// surfaces a stale or mistyped tool name that the allowlist would otherwise
+// drop silently (#1183: context7's tool was renamed get-library-docs ->
+// query-docs, and the crippled server went unnoticed for weeks).
+func unmatchedAllowlistEntries(allow, discovered []string) []string {
+	if len(allow) == 0 {
+		return nil
+	}
+	for _, a := range allow {
+		if a == "*" {
+			return nil
+		}
+	}
+	have := make(map[string]struct{}, len(discovered))
+	for _, d := range discovered {
+		have[d] = struct{}{}
+	}
+	var unmatched []string
+	for _, a := range allow {
+		if _, ok := have[a]; !ok {
+			unmatched = append(unmatched, a)
+		}
+	}
+	return unmatched
+}

--- a/pkg/foreman/agent/mcp/session.go
+++ b/pkg/foreman/agent/mcp/session.go
@@ -71,10 +71,20 @@ func Connect(
 		sessions = append(sessions, s)
 
 		filtered := make([]toolDesc, 0, len(discovered))
-		for _, d := range discovered {
+		discoveredNames := make([]string, len(discovered))
+		for i, d := range discovered {
+			discoveredNames[i] = d.Name
 			if allowed(d.Name, server.AllowedTools) {
 				filtered = append(filtered, d)
 			}
+		}
+
+		// Surface stale/mistyped allowlist entries (#1183): an allowlist name
+		// that matches no discovered tool is dropped silently, so warn with the
+		// tools the server actually exposes.
+		if unmatched := unmatchedAllowlistEntries(server.AllowedTools, discoveredNames); len(unmatched) > 0 {
+			log.Info("mcp: allowlist names a tool the server does not expose; it is dropped (stale/mistyped?)",
+				"server", server.Name, "unmatched", unmatched, "available", discoveredNames)
 		}
 
 		aggregated = append(aggregated, newTools(s, server, filtered, opts, record)...)


### PR DESCRIPTION
## What

Warn when an MCP `allowedTools` allowlist entry names a tool the server does not expose, instead of silently dropping it.

## Why

The allowlist filter (`allowed()` in `Connect`) only checks discovered-tool -> allowlist. It never checks the reverse, so an allowlist entry that matches no server tool is silently ignored and the intended tool never reaches the model's schema. That masked a real, weeks-long failure: the coder agents' context7 allowlist listed `get-library-docs` (context7's old tool name) while context7 now exposes it as `query-docs`, so context7 was crippled (only the useless `resolve-library-id` survived) in every run — including the MCP smoke test — with no diagnostic anywhere.

Fixes #1183

## How

- `unmatchedAllowlistEntries(allow, discovered)` returns the explicit allowlist entries that match no discovered tool. `*` or an empty allowlist means allow-all and returns nil (nothing to flag).
- `Connect` computes the discovered tool names alongside filtering and, when there are unmatched entries, logs `mcp: allowlist names a tool the server does not expose ...` with the unmatched entry and the tools the server actually exposes.
- Non-blocking: the run continues; this is a visibility fix.

## Checklist

- [x] Tests added/updated (`TestUnmatchedAllowlistEntries` table + `TestConnect_WarnsOnUnmatchedAllowlist` against the in-process fake MCP server, asserting the warning fires and matching tools still register)
- [x] `go test ./pkg/foreman/agent/mcp/...` passes locally
- [x] `make lint` passes locally (golangci-lint GOOS=linux, 0 issues)
- [x] All commits signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed below
- [ ] Documentation updated (internal diagnostic log line; no user-facing docs)

## AI assistance

AI-assisted (band 3 per CONTRIBUTING.md): root-caused and implemented with an agentic tool (the same debugging session that found the context7 breakage); a human reviewed the diff and tests, ran build/test/lint, and owns this submission.
