### PR TITLE
feat(metrics): emit GPUQuota usage + admission-denial metrics (#416)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/internal/controller/gpuquota_controller.go
+++ b/internal/controller/gpuquota_controller.go
@@ -140,6 +140,11 @@ func (r *GPUQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
+	// Publish per-quota usage and cap gauges (#416) so the multi-tenancy
+	// dashboard can plot utilization = used / limit.
+	llmkubemetrics.GPUQuotaUsedGPUCount.WithLabelValues(gq.Name, gq.Namespace).Set(float64(usedGPUCount))
+	llmkubemetrics.GPUQuotaGPUCountLimit.WithLabelValues(gq.Name, gq.Namespace).Set(float64(gq.Spec.GPUCount))
+
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/gpuquota_controller_test.go
+++ b/internal/controller/gpuquota_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
 )
 
 func TestGPUQuotaCoversNamespace(t *testing.T) {
@@ -433,6 +435,14 @@ func TestReconcileNamespaceRef(t *testing.T) {
 	}
 	if updatedGQ.Status.UsedVRAMBytes != 0 {
 		t.Errorf("Reconcile() status.UsedVRAMBytes = %d, want 0", updatedGQ.Status.UsedVRAMBytes)
+	}
+
+	// #416: the reconcile also publishes per-quota usage and cap gauges.
+	if got := testutil.ToFloat64(llmkubemetrics.GPUQuotaUsedGPUCount.WithLabelValues("my-gq", "default")); got != 6 {
+		t.Errorf("GPUQuotaUsedGPUCount gauge = %v, want 6", got)
+	}
+	if got := testutil.ToFloat64(llmkubemetrics.GPUQuotaGPUCountLimit.WithLabelValues("my-gq", "default")); got != 10 {
+		t.Errorf("GPUQuotaGPUCountLimit gauge = %v, want 10", got)
 	}
 }
 

--- a/internal/controller/inferenceservice_quota_webhook.go
+++ b/internal/controller/inferenceservice_quota_webhook.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
 	"github.com/defilantech/llmkube/internal/webhook/quota"
 )
 
@@ -89,6 +90,10 @@ func (v *InferenceServiceQuotaValidator) validate(ctx context.Context, isvc *inf
 	for _, q := range quotas {
 		allow, reason := v.decide(ctx, q, isvc)
 		if !allow {
+			// Record the denial as a metric (#416): a sideEffects=None
+			// validating webhook cannot mutate the GPUQuota status counter,
+			// so the per-quota denial count is surfaced here instead.
+			llmkubemetrics.GPUQuotaAdmissionDenialsTotal.WithLabelValues(q.Name, q.Namespace).Inc()
 			return fmt.Errorf("GPUQuota %q denied: %s", q.Name, reason)
 		}
 	}

--- a/internal/controller/inferenceservice_quota_webhook_test.go
+++ b/internal/controller/inferenceservice_quota_webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
 )
 
 func TestInferenceServiceQuotaValidator(t *testing.T) {
@@ -101,6 +103,34 @@ func TestInferenceServiceQuotaValidator(t *testing.T) {
 		}
 		if !strContains(err.Error(), "would exceed gpuCount") {
 			t.Fatalf("expected reason to mention gpuCount, got: %v", err)
+		}
+	})
+
+	t.Run("denial increments the metric (#416)", func(t *testing.T) {
+		// Unique quota name/namespace so the counter is not shared with the
+		// other subtests; assert the per-quota delta is exactly 1.
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "metric-quota", Namespace: "quota-ns"},
+			Spec:       inferencev1alpha1.GPUQuotaSpec{NamespaceRef: "default", GPUCount: 1},
+		}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "big-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Replicas:  ptrInt32Val(1),
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 4},
+			},
+		}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&quota, &ns).Build()
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+
+		before := testutil.ToFloat64(llmkubemetrics.GPUQuotaAdmissionDenialsTotal.WithLabelValues("metric-quota", "quota-ns"))
+		if _, err := v.ValidateCreate(ctx, &isvc); err == nil {
+			t.Fatal("expected denial (4 > 1), got nil")
+		}
+		after := testutil.ToFloat64(llmkubemetrics.GPUQuotaAdmissionDenialsTotal.WithLabelValues("metric-quota", "quota-ns"))
+		if after-before != 1 {
+			t.Errorf("admission denials counter delta = %v, want 1", after-before)
 		}
 	})
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -170,10 +170,41 @@ var (
 		},
 		[]string{"router", "scope"},
 	)
+
+	// GPUQuota metrics (#416): per-quota GPU usage vs. cap, and admission
+	// denials. These enable the multi-tenancy dashboard and satisfy the
+	// "record the denial" requirement (a validating webhook, being
+	// sideEffects=None, cannot mutate the GPUQuota status counter).
+	GPUQuotaUsedGPUCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llmkube_gpuquota_used_gpu_count",
+			Help: "GPUs currently used by InferenceServices in a GPUQuota's scope.",
+		},
+		[]string{"gpuquota", "namespace"},
+	)
+
+	GPUQuotaGPUCountLimit = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llmkube_gpuquota_gpu_count_limit",
+			Help: "The GPU cap (spec.gpuCount) declared by a GPUQuota. 0 means no cap.",
+		},
+		[]string{"gpuquota", "namespace"},
+	)
+
+	GPUQuotaAdmissionDenialsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llmkube_gpuquota_admission_denials_total",
+			Help: "InferenceService admissions denied by a GPUQuota, by quota.",
+		},
+		[]string{"gpuquota", "namespace"},
+	)
 )
 
 func init() {
 	ctrlmetrics.Registry.MustRegister(
+		GPUQuotaUsedGPUCount,
+		GPUQuotaGPUCountLimit,
+		GPUQuotaAdmissionDenialsTotal,
 		ModelDownloadDuration,
 		ModelStatus,
 		InferenceServiceReadyDuration,


### PR DESCRIPTION
## What

Emit three GPUQuota metrics and wire them into the controller and webhook, so multi-tenancy is observable and the "record the denial" requirement is satisfied.

Part of #416. **Unblocks #1097** — its dashboard queries these metrics, and its reference-grounding check failed because they didn't exist yet.

## Why

The enforcement path was built (CRD, usage reconciler, validating webhook, RBAC), but nothing was emitted: the controller aggregated `UsedGPUCount` into status only, and the webhook denied over-quota admissions silently. The GPUQuota `AdmissionDenials` status field was never written (a `sideEffects=None` validating webhook can't mutate status), and a dashboard had no series to plot.

## How

- `llmkube_gpuquota_used_gpu_count{gpuquota,namespace}` (gauge) — set by the controller after each status reconcile.
- `llmkube_gpuquota_gpu_count_limit{gpuquota,namespace}` (gauge) — the `spec.gpuCount` cap, so utilization = used / limit.
- `llmkube_gpuquota_admission_denials_total{gpuquota,namespace}` (counter) — incremented by the webhook on each denial; this is the metric-based fulfillment of the denial-count requirement.
- Tests: assert both gauges after a reconcile (2 GPU × 3 replicas = 6, cap 10), and the counter delta = 1 on a denial (unique quota to avoid cross-test accumulation).

## Remaining for #416 (follow-ups)

- Wire `costBudgetRef` → TokenBudget (currently hardcoded `false`).
- e2e suite (two-namespace/two-quota admission, deletion cleanup, webhook-unavailable deny).
- Docs + quota dashboard are #1097's story (now unblocked by these metrics).

## Checklist

- [x] Tests added (controller gauge + webhook counter)
- [x] `go build ./...`, lint (0 issues), `make vulncheck` clean
- [x] No codegen drift
- [x] Signed off (DCO)
- [x] AI assistance disclosed below

## AI assistance

AI-assisted (band 3 per CONTRIBUTING.md): audited the feature against #416's acceptance criteria, implemented the metrics gap, verified build/test/lint/vuln; a human owns this submission.
