### PR TITLE
docs(observability): multi-tenancy guide + GPUQuota Grafana dashboard (#1097)

### DIFF
--- a/docs/grafana/llmkube-quota.json
+++ b/docs/grafana/llmkube-quota.json
@@ -1,0 +1,225 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "datasource", "uid": "grafana"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Per-quota GPU utilization and admission denial tracking for LLMKube GPUQuota resources. Surfaces usedGPUCount/gpuCount ratios and denial rates by quota name and namespace.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "GPU utilization",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "GPUs",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.7},
+              {"color": "red", "value": 0.9}
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+      "id": 1,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube_gpuquota_used_gpu_count / llmkube_gpuquota_gpu_count_limit",
+          "legendFormat": "{{gpuquota}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU utilization per quota (usedGPUCount / gpuCount)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "GPUs",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "id": 2,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube_gpuquota_used_gpu_count",
+          "legendFormat": "{{gpuquota}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Used GPUs per quota",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+      "id": 101,
+      "panels": [],
+      "title": "Admission denials",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "denials/s",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "noValue": "0",
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
+      "id": 3,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "rate(llmkube_gpuquota_admission_denials_total[5m])",
+          "legendFormat": "{{gpuquota}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Admission denial rate (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 10},
+              {"color": "red", "value": 50}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube_gpuquota_admission_denials_total",
+          "legendFormat": "{{gpuquota}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Cumulative admission denials",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["llmkube", "quota", "multi-tenancy"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "LLMKube Quota",
+  "uid": "llmkube-quota",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/operations/multi-tenancy.md
+++ b/docs/operations/multi-tenancy.md
@@ -1,0 +1,229 @@
+# Multi-tenancy with GPUQuota
+
+GPUQuota is the LLMKube mechanism for enforcing GPU budgets across multiple
+tenants (namespaces, teams, or label-scoped groups). It works as a validating
+admission webhook on `InferenceService` creation and update, rejecting any
+request that would exceed the declared quota.
+
+## When to use
+
+Use GPUQuota when you need to guarantee that one tenant cannot starve another
+of GPU resources. Common scenarios:
+
+- **Shared GPU cluster with multiple teams**: each team gets a hard cap on
+  how many GPUs their InferenceServices can consume.
+- **Priority-based scheduling**: high-priority workloads (e.g., production
+  inference) are guaranteed admission even when the cluster is saturated,
+  while low-priority workloads (e.g., batch fine-tuning) are denied first.
+- **Cost control**: tie a quota to a `CostBudgetRef` so that dollar spend
+  is capped in addition to GPU count.
+
+## Scoping a quota
+
+A GPUQuota must declare exactly one of `selector` or `namespaceRef`; they are
+mutually exclusive, enforced by a CEL validation rule on the CRD.
+
+### Namespace-scoped quota
+
+Pins the quota to a single namespace. Every InferenceService created in that
+namespace is checked against this quota.
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: GPUQuota
+metadata:
+  name: team-alpha-quota
+  namespace: team-alpha
+spec:
+  namespaceRef: team-alpha
+  gpuCount: 4
+  minPriority: normal
+```
+
+### Label-selector quota
+
+Matches namespaces by label, allowing a single quota to cover multiple
+namespaces. Useful for cross-namespace teams or environments.
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: GPUQuota
+metadata:
+  name: staging-quota
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      environment: staging
+  gpuCount: 8
+  vramBytes: 17179869184  # illustrative value
+```
+
+## RBAC binding examples
+
+The operator's `manager-role` ClusterRole includes `get;list;watch` on
+`gpuquotas` and `get;patch;update` on `gpuquotas/status`. To let a team
+manage their own quota, bind a Role to their namespace:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gpuquota-manager
+  namespace: team-alpha
+rules:
+- apiGroups: ["inference.llmkube.dev"]
+  resources: ["gpuquotas"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["inference.llmkube.dev"]
+  resources: ["gpuquotas/status"]
+  verbs: ["get"]
+```
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: team-alpha-gpuquota
+  namespace: team-alpha
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gpuquota-manager
+subjects:
+- kind: Group
+  name: team-alpha
+  apiGroup: rbac.authorization.k8s.io
+```
+
+For cluster-wide quota management (e.g., a platform team that sets quotas
+for all namespaces), use a ClusterRole:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gpuquota-admin
+rules:
+- apiGroups: ["inference.llmkube.dev"]
+  resources: ["gpuquotas"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["inference.llmkube.dev"]
+  resources: ["gpuquotas/status"]
+  verbs: ["get", "patch", "update"]
+```
+
+## Cost-budget integration
+
+The `costBudgetRef` field on `GPUQuotaSpec` references a `CostBudget` resource
+(future CRD) that caps the dollar cost of GPU usage under the quota. When the
+cost budget is exhausted, the webhook denies **all** admission requests
+regardless of GPU headroom or priority. The cost budget is the highest-
+priority gate.
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: GPUQuota
+metadata:
+  name: team-alpha-quota
+spec:
+  namespaceRef: team-alpha
+  gpuCount: 4
+  costBudgetRef: team-alpha-budget
+```
+
+Cost budget enforcement is a documented follow-up; the field is present on the
+CRD but the webhook currently passes `costBudgetBreached=false` to the
+admission decision. When the `CostBudget` CRD ships, the webhook will query
+it and enforce the cap.
+
+## What happens at quota breach
+
+When an InferenceService is denied by a GPUQuota, the validating webhook
+returns an HTTP 403 with a message like:
+
+```
+GPUQuota "team-alpha-quota" denied: would exceed gpuCount 4 (current 4 + requested 1)
+```
+
+The denial reason encodes which rule was violated:
+
+| Reason | Meaning |
+|---|---|
+| `cost budget "X" exhausted` | The referenced CostBudget has been exceeded. |
+| `would exceed gpuCount N` | GPU count cap reached. |
+| `would exceed vramBytes N` | VRAM cap reached (only when `vramBytes` is set on the quota). |
+| `priority "X" below minimum "Y"` | The InferenceService's priority is lower than the quota's `minPriority`. |
+
+Because the validating webhook is `sideEffects=None`, it cannot mutate the
+GPUQuota status from the admission path. Denials are therefore recorded as a
+Prometheus counter, `llmkube_gpuquota_admission_denials_total{gpuquota,namespace}`,
+incremented on every rejection. The `admissionDenials` and `lastDenial` fields
+on `GPUQuotaStatus` are reserved for a future reconciler-observed counter and
+are not yet populated, so they read as zero. Denials are observable today via
+the counter metric and the Grafana dashboard below.
+
+## Webhook failure-policy behavior
+
+The GPUQuota validating webhook is registered with `failurePolicy: Fail`:
+
+```
++kubebuilder:webhook:path=/validate-inference-llmkube-dev-v1alpha1-inferenceservice-quota,
+  mutating=false,failurePolicy=fail,sideEffects=None,
+  groups=inference.llmkube.dev,resources=inferenceservices,
+  verbs=create;update,versions=v1alpha1,
+  name=vinferenceservicequota.inference.llmkube.dev,
+  admissionReviewVersions=v1
+```
+
+This means:
+
+- **If the webhook is reachable**, it evaluates the quota and returns allow or
+deny. Deny blocks the InferenceService from being created or updated.
+- **If the webhook is unreachable** (network partition, pod restart, etc.), the
+API server rejects the request with a 503. The InferenceService is **not**
+created; the cluster fails closed.
+- **If the webhook returns an internal error** (e.g., it cannot read current
+usage from the API server), it denies the request with a reason like
+`failed to read current usage: ...`. This is a safe default: when in doubt,
+block admission.
+
+This is intentional. A quota that cannot be enforced is worse than no quota;
+it gives a false sense of protection. If you need the cluster to remain
+operational when the webhook is down, you would need to change the
+`failurePolicy` to `Ignore` in the webhook configuration, but this is not
+recommended for production multi-tenant clusters.
+
+## Priority ordering
+
+The `minPriority` field on a quota enforces a minimum scheduling priority.
+Priorities are ordered from highest to lowest:
+
+1. `critical`: highest priority, always admitted if GPU headroom exists
+2. `high`
+3. `normal`: default when no priority is set
+4. `low`
+5. `batch`: lowest priority, denied first when the quota is tight
+
+An InferenceService with priority `low` will be denied by a quota with
+`minPriority: normal`, even if GPU headroom exists. This allows operators to
+reserve capacity for important workloads.
+
+## Observability
+
+The `llmkube-quota.json` Grafana dashboard (in `docs/grafana/`) reads the
+`llmkube_gpuquota_*` metrics emitted by the operator and visualizes:
+
+- **GPU utilization per quota**: `llmkube_gpuquota_used_gpu_count /
+  llmkube_gpuquota_gpu_count_limit`, the fraction of each quota's cap in use.
+- **Used GPUs per quota**: `llmkube_gpuquota_used_gpu_count`, the absolute
+  GPU count the reconciler aggregates from in-scope InferenceServices.
+- **Admission denial rate**:
+  `rate(llmkube_gpuquota_admission_denials_total[5m])`, denials per second
+  over a 5-minute window.
+- **Cumulative admission denials**:
+  `llmkube_gpuquota_admission_denials_total`, the running denial total.
+
+All series are labeled by `gpuquota` and `namespace`. Import the dashboard
+from `docs/grafana/llmkube-quota.json` into your Grafana instance; it reads
+from the same Prometheus datasource used by the other LLMKube dashboards.


### PR DESCRIPTION
## What

Adds the operator documentation and reference Grafana dashboard for multi-tenant GPU quotas. Story 6 of #416.

- `docs/operations/multi-tenancy.md`: when to use GPUQuota, namespace- and selector-scoped examples, RBAC binding examples, cost-budget integration, quota-breach denial reasons, `failurePolicy=Fail` behavior, priority ordering, and observability.
- `docs/grafana/llmkube-quota.json`: 4 panels (GPU utilization per quota, used GPUs per quota, admission denial rate, cumulative admission denials).

## Why

Fixes #1097

GPUQuota shipped its enforcement path (CRD, controller, validating webhook) and its metrics (#1193, merged), but had no operator-facing guide or dashboard. This closes the docs story so operators can actually adopt it.

## How

Every factual claim is grounded against the shipped code, not asserted:

- **CRD fields**: all example YAML fields match `GPUQuotaSpec` verbatim (`selector`, `namespaceRef`, `gpuCount`, `vramBytes`, `minPriority`, `costBudgetRef`).
- **Denial reasons**: the reason table reproduces `quota.Decide`'s strings exactly (`would exceed gpuCount N`, `would exceed vramBytes N`, `priority "X" below minimum "Y"`, `cost budget "X" exhausted`).
- **Priority ordering**: `critical > high > normal > low > batch` matches `priorityWeights`.
- **Metrics**: the dashboard queries the metrics shipped in #1193 (`llmkube_gpuquota_used_gpu_count`, `llmkube_gpuquota_gpu_count_limit`, `llmkube_gpuquota_admission_denials_total`) with the emitted `{gpuquota,namespace}` labels. Corrected the draft's `gpu_count` -> `gpu_count_limit` and legend `{{quota}}` -> `{{gpuquota}}` so panels actually render.
- **Honesty about status**: documents that denials are tracked via the counter metric rather than `GPUQuotaStatus.admissionDenials`, because the `sideEffects=None` webhook cannot write status (the status fields are reserved for a future reconciler-observed counter and read as zero today). This matches the webhook's own code comment.

Grafana JSON validated (imports cleanly, 6 panels including 2 row headers). Doc uses no external/internal markdown links; the two in-repo file references resolve.

No code changes, so `make test`/`make lint` are not affected; this is docs + dashboard JSON only.

## Checklist

- [ ] Tests added/updated (n/a: docs + dashboard JSON)
- [ ] `make test` passes locally (n/a: no code change)
- [ ] `make lint` passes locally (n/a: no code change)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: this PR salvages an agent-drafted (Foreman) doc + dashboard, then was reviewed and corrected by a human-directed AI-assisted pass (metric-name grounding, status-field accuracy, panel/label fixes, house-style). Human owns the review conversation.
- [x] Documentation updated (this PR is the documentation)