### PR TITLE
fix(webhook): serve GPUQuota webhook at its configured path, with e2e coverage (#416)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -47,6 +47,50 @@ jobs:
           go mod tidy
           make test-e2e
 
+  test-e2e-quota:
+    name: Run on Ubuntu (kind, GPUQuota webhook via Helm)
+    runs-on: ubuntu-latest
+    # Best-effort while this Helm-based Context is hardened in CI; the default
+    # kind job above remains the merge gate. The GPUQuota validating webhook
+    # (#416) ships only through the Helm chart (multitenancy.enabled), so unlike
+    # the make-deploy Contexts it needs Helm and a self-contained release
+    # rather than the shared kustomize deploy — hence its own focused job.
+    continue-on-error: true
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Running GPUQuota webhook e2e
+        env:
+          # Runs only the GPUQuota Multi-tenancy Context (test/e2e/quota_e2e_test.go).
+          LLMKUBE_E2E_QUOTA: "true"
+          # The chart self-signs its webhook serving cert (genSignedCert), so
+          # cert-manager is not needed; skip its install to keep the job fast.
+          CERT_MANAGER_INSTALL_SKIP: "true"
+        run: |
+          go mod tidy
+          make setup-test-e2e
+          go test -tags=e2e ./test/e2e/ -v -ginkgo.v \
+            -ginkgo.focus='GPUQuota Multi-tenancy'
+
+      - name: Tear down the kind cluster
+        if: always()
+        run: make cleanup-test-e2e
+
   test-e2e-longhorn:
     name: Run on Ubuntu (kind + Longhorn, restrictive storage)
     runs-on: ubuntu-latest

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -81,10 +81,15 @@ jobs:
           # The chart self-signs its webhook serving cert (genSignedCert), so
           # cert-manager is not needed; skip its install to keep the job fast.
           CERT_MANAGER_INSTALL_SKIP: "true"
+          # Match the cluster name `make setup-test-e2e` creates. BeforeSuite's
+          # image-load reads KIND_CLUSTER (default "kind"); `make test-e2e`
+          # passes this through, but this job runs `go test` directly, so it
+          # must set the var itself or the load targets a nonexistent "kind".
+          KIND_CLUSTER: llmkube-test-e2e
         run: |
           go mod tidy
           make setup-test-e2e
-          go test -tags=e2e ./test/e2e/ -v -ginkgo.v \
+          KIND_CLUSTER=llmkube-test-e2e go test -tags=e2e ./test/e2e/ -v -ginkgo.v \
             -ginkgo.focus='GPUQuota Multi-tenancy'
 
       - name: Tear down the kind cluster

--- a/internal/controller/inferenceservice_quota_webhook.go
+++ b/internal/controller/inferenceservice_quota_webhook.go
@@ -56,9 +56,21 @@ var _ admission.Validator[*inferencev1alpha1.InferenceService] = &InferenceServi
 
 // SetupInferenceServiceQuotaWebhookWithManager registers the InferenceService
 // GPUQuota validating webhook.
+//
+// The custom path is REQUIRED and must match the +kubebuilder:webhook marker
+// above (and therefore config/webhook + the chart's ValidatingWebhookConfiguration).
+// Without it, the builder registers the handler at controller-runtime's default
+// path for InferenceService (/validate-inference-llmkube-dev-v1alpha1-inferenceservice),
+// while the generated webhook config points admission at
+// /validate-inference-llmkube-dev-v1alpha1-inferenceservice-quota. The API
+// server would then call a path the server does not serve and, with
+// failurePolicy=Fail, fail closed on EVERY InferenceService admission whenever
+// multitenancy is enabled. The distinct -quota suffix keeps this webhook from
+// colliding with any future default-path InferenceService webhook.
 func SetupInferenceServiceQuotaWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &inferencev1alpha1.InferenceService{}).
 		WithValidator(&InferenceServiceQuotaValidator{Client: mgr.GetClient()}).
+		WithValidatorCustomPath("/validate-inference-llmkube-dev-v1alpha1-inferenceservice-quota").
 		Complete()
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -43,6 +43,14 @@ var (
 	//   controller-manager deploy with --enable-pyrra-slo. Needs no image
 	//   build/load here (unlike LLMKUBE_E2E_ROUTER_CLUSTER): Pyrra's
 	//   kubernetes operator image is pulled directly from ghcr.io.
+	// - LLMKUBE_E2E_QUOTA=true: Runs the "GPUQuota Multi-tenancy" Context
+	//   (test/e2e/quota_e2e_test.go), which Helm-installs the chart with
+	//   multitenancy.enabled=true and exercises the InferenceService GPUQuota
+	//   validating webhook (over-quota rejection, in-quota admission, status
+	//   aggregation). Uses Helm rather than the shared make-deploy because the
+	//   webhook ships only via the chart; the chart self-signs its serving
+	//   cert, so no cert-manager is needed. Runs in its own focused CI job
+	//   (test-e2e.yml, test-e2e-quota).
 	// These variables are useful if CertManager is already installed, avoiding
 	// re-installation and conflicts.
 	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"

--- a/test/e2e/quota_e2e_test.go
+++ b/test/e2e/quota_e2e_test.go
@@ -1,0 +1,232 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/defilantech/llmkube/test/utils"
+)
+
+// GPUQuota Multi-tenancy exercises the InferenceService GPUQuota validating
+// webhook against a real API server: an over-quota InferenceService is rejected
+// at admission with the quota's denial message, an in-quota InferenceService is
+// admitted, and the GPUQuota status counter aggregates the admitted usage.
+//
+// envtest (internal/controller/inferenceservice_quota_webhook_test.go) already
+// proves the decision logic (gpuCount/vramBytes/priority branches) against a
+// fake client, but it cannot prove the webhook is actually wired: that the
+// ValidatingWebhookConfiguration ships, that cert-manager injects the CA, and
+// that a real `kubectl apply` is blocked at admission. It also cannot observe
+// the controller's status aggregation across a real reconcile. Hence this
+// Context.
+//
+// Unlike the make-deploy Contexts (Manager, ModelRouter Cluster), this one
+// installs via Helm: the GPUQuota validating webhook ships ONLY in the chart,
+// gated on multitenancy.enabled. config/default (what `make deploy` applies)
+// keeps all webhook + cert-manager sections commented out, so a kustomize
+// deploy would leave the webhook unregistered and every admission would pass.
+// The chart self-signs its serving cert (genSignedCert) and bakes the caBundle
+// straight into the ValidatingWebhookConfiguration, so no cert-manager is
+// needed and the webhook is live the moment the controller pod is Ready.
+//
+// Self-contained like the "Pyrra SLO Integration" and "Catalog E2E Tests"
+// Describes (its own install/uninstall): Ginkgo tears down each top-level
+// container before the next runs, so this Context cannot assume another
+// container's operator is still up. Because it uses Helm rather than the
+// shared kustomize deploy, it runs in its own dedicated CI job (test-e2e.yml,
+// test-e2e-quota) via `-ginkgo.focus='GPUQuota Multi-tenancy'`, not the main
+// make-deploy merge-gate job.
+//
+// Gated on LLMKUBE_E2E_QUOTA=true (see the "Optional Environment Variables"
+// note in e2e_suite_test.go).
+
+var _ = Describe("GPUQuota Multi-tenancy", Ordered, func() {
+	const (
+		quotaTestNs = "e2e-quota-test"
+		quotaName   = "e2e-quota"
+
+		// modelRef value for the test InferenceServices. It need not resolve to
+		// a real Model: the only webhook on InferenceService is the quota
+		// validator, which decides off spec.resources.gpu and never reads the
+		// Model, so admission (the thing under test) does not depend on it.
+		modelName = "quota-test-model"
+		// The over-quota InferenceService requests more GPUs than the quota's
+		// cap, so its admission is always rejected and it is never created.
+		isvcOverName = "quota-over-isvc"
+		// The in-quota InferenceService fits within the cap and is admitted.
+		isvcInName = "quota-in-isvc"
+
+		// The quota caps the namespace at a single GPU. The over-quota ISVC
+		// requests four; the in-quota ISVC requests one.
+		quotaGPUCount = 1
+		overGPUCount  = 4
+		inGPUCount    = 1
+
+		// Substring of the webhook denial the API server surfaces to the
+		// caller. Matches inferenceservice_quota_webhook.go's
+		//   fmt.Errorf("GPUQuota %q denied: %s", ...)
+		// wrapping quota.Decide's "would exceed gpuCount ..." reason.
+		gpuCountDenialSubstr = "denied: would exceed gpuCount"
+	)
+
+	BeforeAll(func() {
+		if os.Getenv("LLMKUBE_E2E_QUOTA") != "true" {
+			Skip("LLMKUBE_E2E_QUOTA not set; GPUQuota multi-tenancy e2e requires " +
+				"the chart installed with multitenancy.enabled=true (Helm)")
+		}
+
+		By("installing LLMKube via Helm with multitenancy (GPUQuota webhook) enabled")
+		// projectImage was built and side-loaded into kind by BeforeSuite;
+		// pullPolicy=Never forces the pod to use that image rather than
+		// pulling. multitenancy.enabled=true adds the GPUQuota validating
+		// webhook (webhook.enabled defaults true). modelCache.enabled=false so
+		// --wait does not block on a PVC bind unrelated to the webhook. Split
+		// projectImage into repository/tag so it stays in sync with
+		// BeforeSuite rather than duplicating the literal.
+		imgParts := strings.SplitN(projectImage, ":", 2)
+		imgRepo, imgTag := imgParts[0], imgParts[1]
+		cmd := exec.Command("helm", "install", "llmkube", "./charts/llmkube",
+			"-n", namespace, "--create-namespace",
+			"--set", "multitenancy.enabled=true",
+			"--set", "controllerManager.image.repository="+imgRepo,
+			"--set", "controllerManager.image.tag="+imgTag,
+			"--set", "controllerManager.image.pullPolicy=Never",
+			"--set", "modelCache.enabled=false",
+			"--wait", "--timeout", "5m")
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install the LLMKube Helm release")
+
+		By("creating the quota test namespace")
+		cmd = exec.Command("kubectl", "create", "ns", quotaTestNs)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create the quota test namespace")
+
+		By("creating a namespace-scoped GPUQuota capping the namespace at one GPU")
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
+kind: GPUQuota
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  namespaceRef: %s
+  gpuCount: %d
+`, quotaName, quotaTestNs, quotaTestNs, quotaGPUCount))
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create GPUQuota")
+	})
+
+	AfterAll(func() {
+		if os.Getenv("LLMKUBE_E2E_QUOTA") != "true" {
+			return
+		}
+
+		By("cleaning up the quota test namespace")
+		cmd := exec.Command("kubectl", "delete", "ns", quotaTestNs, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+
+		By("uninstalling the LLMKube Helm release")
+		cmd = exec.Command("helm", "uninstall", "llmkube", "-n", namespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+
+		By("removing the manager namespace")
+		cmd = exec.Command("kubectl", "delete", "ns", namespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+	})
+
+	It("rejects an InferenceService that would exceed the quota's gpuCount", func() {
+		By("applying an InferenceService requesting more GPUs than the quota allows")
+		// Eventually, not a one-shot: helm --wait returns once the pod is Ready,
+		// but with failurePolicy=Fail the API server rejects every admission
+		// during the brief window before the webhook Service's endpoints are
+		// populated, with a generic webhook-call error rather than the quota
+		// denial. Retrying until the specific quota-denial substring appears
+		// both waits out that warmup and proves the denial is the quota's, not a
+		// transient wiring failure. The request is always rejected (4 > 1), so
+		// no InferenceService is ever created.
+		applyOverQuota := func(g Gomega) {
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  modelRef: %s
+  resources:
+    gpu: %d
+`, isvcOverName, quotaTestNs, modelName, overGPUCount))
+			output, err := utils.Run(cmd)
+			g.Expect(err).To(HaveOccurred(), "expected admission to reject the over-quota InferenceService")
+			g.Expect(output).To(ContainSubstring(gpuCountDenialSubstr),
+				"expected the GPUQuota gpuCount denial message")
+		}
+		Eventually(applyOverQuota, 2*time.Minute, 3*time.Second).Should(Succeed())
+
+		By("confirming the rejected InferenceService was not created")
+		cmd := exec.Command("kubectl", "get", "inferenceservice", isvcOverName,
+			"-n", quotaTestNs, "--ignore-not-found", "-o", "jsonpath={.metadata.name}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(BeEmpty(), "over-quota InferenceService should not exist")
+	})
+
+	It("admits an InferenceService within the quota and aggregates it into status.usedGPUCount", func() {
+		By("applying an InferenceService that fits within the quota")
+		// The webhook is already warm (the previous spec's Eventually observed
+		// a real quota denial), so this should be admitted promptly; Eventually
+		// only guards against the final moments of rollout/injection lag.
+		applyInQuota := func(g Gomega) {
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  modelRef: %s
+  resources:
+    gpu: %d
+`, isvcInName, quotaTestNs, modelName, inGPUCount))
+			_, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred(), "in-quota InferenceService should be admitted")
+		}
+		Eventually(applyInQuota, 1*time.Minute, 3*time.Second).Should(Succeed())
+
+		By("waiting for the GPUQuota reconciler to aggregate the admitted GPU into status.usedGPUCount")
+		verifyUsedGPUCount := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "gpuquota", quotaName,
+				"-n", quotaTestNs, "-o", "jsonpath={.status.usedGPUCount}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(output)).To(Equal(fmt.Sprintf("%d", inGPUCount)),
+				"status.usedGPUCount should reflect the admitted InferenceService")
+		}
+		Eventually(verifyUsedGPUCount, 1*time.Minute, 3*time.Second).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## What

Two coupled changes on the last open thread of #416:

1. **Bug fix** — `SetupInferenceServiceQuotaWebhookWithManager` now serves the webhook at the `-quota` path its config already points to.
2. **The e2e test that caught it** — a new `GPUQuota Multi-tenancy` Context (`test/e2e/quota_e2e_test.go`) plus a dedicated Helm-based CI job (`test-e2e-quota`).

This closes the last acceptance criterion on #416 (*unit + e2e tests pass in CI*).

## The bug

The webhook builder registered the validator without a custom path, so controller-runtime served it at the **default** InferenceService path (`/validate-inference-llmkube-dev-v1alpha1-inferenceservice`). But every generated artifact — `config/webhook/manifests.yaml` and the chart's `ValidatingWebhookConfiguration`, both from the `+kubebuilder:webhook` marker — points admission at the **`-quota`** path. So the API server called a path the webhook server never served and got `could not find the requested resource`. With `failurePolicy=Fail`, that **fail-closed on every InferenceService admission whenever `multitenancy.enabled=true`**, not just over-quota ones.

Fix: add `WithValidatorCustomPath(".../inferenceservice-quota")` so the served path matches the config. No manifest changes — the config was already correct; the code was out of sync. Unit tests are unaffected (they exercise `validate()` directly, not the HTTP path), which is exactly why this slipped through until an e2e existed.

## The e2e test

Two specs against a real API server, `helm install`-ing the chart with `multitenancy.enabled=true` (the only path that ships the webhook; `config/default`/`make deploy` keeps webhooks commented out):

1. **Over-quota rejection** — a GPUQuota caps the namespace at 1 GPU; an InferenceService requesting 4 is rejected at admission with `denied: would exceed gpuCount`, and is never created.
2. **In-quota admission + status** — a 1-GPU InferenceService is admitted, and the reconciler aggregates it into `status.usedGPUCount`.

Design notes:
- The chart self-signs its webhook cert (`genSignedCert`) and bakes the caBundle into the config, so no cert-manager is needed.
- No stub Model: the only webhook on InferenceService is the quota validator, which never reads the Model.
- Its own focused CI job (`-ginkgo.focus='GPUQuota Multi-tenancy'`, Helm installed, `KIND_CLUSTER` matched to `make setup-test-e2e`), `continue-on-error: true` while it hardens — mirroring the Longhorn/OpenShift job precedent. The main kind job stays the merge gate.
- The over-quota spec polls for the specific quota-denial substring, so it distinguishes a real quota denial from a transient wiring/warmup failure — which is precisely how it caught the path bug.

## Why

Fixes #416

## Checklist

- [x] Tests added/updated (this PR is the test, and it caught the fix)
- [ ] `make test` passes locally (webhook unit tests pass; e2e requires kind + Helm, validated in `test-e2e-quota`)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: written with AI assistance (human-directed); the bug was found by the e2e run and root-caused against controller-runtime's path generation. Human owns the review conversation.
- [ ] Documentation updated (n/a: covered by #1194)