### PR TITLE
feat(quota): VRAM-based GPUQuota accounting from the gpuSharing tier (#1196 story 4)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,6 +113,7 @@ func main() {
 	var allowedHostPathRoots string
 	var allowedRemoteHosts string
 	var gpuSharingSharedPoolSelector string
+	var gpuSharingVRAMPerDeviceGiB int
 	var modelRevalidateInterval time.Duration
 	var caCertConfigMap string
 	var initContainerImage string
@@ -140,6 +142,11 @@ func main() {
 		"Node selector (key=value[,key=value]) for the shared-GPU pool that gpuSharing mode "+
 			"shared schedules onto. Empty (default) means no shared pool exists and mode shared "+
 			"is rejected.")
+	flag.IntVar(&gpuSharingVRAMPerDeviceGiB, "gpu-sharing-vram-per-device-gib", 0,
+		"Device memory (GiB) of one whole GPU in this fleet, used to derive the VRAM footprint "+
+			"of exclusive-mode InferenceServices for GPUQuota vramBytes accounting. 0 (default) "+
+			"means exclusive footprints are unknown; quotas with a vramBytes cap then deny such "+
+			"admissions with an actionable message.")
 	flag.StringVar(&allowedRemoteHosts, "allowed-remote-hosts", "",
 		"Comma-separated hostnames/CIDRs permitted as remote (http/https) Model sources even if "+
 			"they resolve to private/link-local/loopback ranges. Public hosts are always allowed; "+
@@ -223,6 +230,15 @@ func main() {
 	gpuSharingSharedPool, err := controller.ParseGPUSharingSharedPoolSelector(gpuSharingSharedPoolSelector)
 	if err != nil {
 		setupLog.Error(err, "invalid --gpu-sharing-shared-pool-selector")
+		os.Exit(1)
+	}
+
+	// Bound the per-device VRAM figure. 1 PiB of device memory per GPU is
+	// far beyond any real hardware, so anything outside [0, 2^20] is a typo,
+	// not a fleet.
+	if gpuSharingVRAMPerDeviceGiB < 0 || gpuSharingVRAMPerDeviceGiB > 1<<20 {
+		setupLog.Error(fmt.Errorf("value %d out of range [0, %d]", gpuSharingVRAMPerDeviceGiB, 1<<20),
+			"invalid --gpu-sharing-vram-per-device-gib")
 		os.Exit(1)
 	}
 
@@ -406,8 +422,9 @@ func main() {
 	// InferenceServices in the quota's scope. It never rejects anything or
 	// owns external resources.
 	if err := (&controller.GPUQuotaReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		VRAMPerDeviceGiB: gpuSharingVRAMPerDeviceGiB,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GPUQuota")
 		os.Exit(1)
@@ -428,7 +445,7 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Model")
 			os.Exit(1)
 		}
-		if err := controller.SetupInferenceServiceQuotaWebhookWithManager(mgr); err != nil {
+		if err := controller.SetupInferenceServiceQuotaWebhookWithManager(mgr, gpuSharingVRAMPerDeviceGiB); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "InferenceServiceQuota")
 			os.Exit(1)
 		}

--- a/docs/grafana/llmkube-quota.json
+++ b/docs/grafana/llmkube-quota.json
@@ -190,6 +190,98 @@
       ],
       "title": "Cumulative admission denials",
       "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 18},
+      "id": 102,
+      "panels": [],
+      "title": "VRAM utilization",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "fraction of cap",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.7},
+              {"color": "red", "value": 0.9}
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 19},
+      "id": 5,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube_gpuquota_used_vram_bytes / llmkube_gpuquota_vram_bytes_limit",
+          "legendFormat": "{{gpuquota}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "VRAM utilization per quota (usedVRAMBytes / vramBytes)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "device memory",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null}
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 19},
+      "id": 6,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube_gpuquota_used_vram_bytes",
+          "legendFormat": "{{gpuquota}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Used VRAM per quota",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/internal/controller/gpu_sharing.go
+++ b/internal/controller/gpu_sharing.go
@@ -17,11 +17,16 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -171,6 +176,98 @@ func resolveShared(model *inferencev1alpha1.Model, exclusive gpuSharingResolutio
 	resolved := exclusive
 	resolved.nodeSelector = sharedPoolSelector
 	return resolved, nil
+}
+
+// migProfileVRAMPattern extracts the memory portion of a MIG profile name:
+// "1g.24gb" -> 24 GiB. Same shape as migProfilePattern with a capture group.
+var migProfileVRAMPattern = regexp.MustCompile(`^[0-9]+g\.([0-9]+)gb$`)
+
+const bytesPerGiB = int64(1) << 30
+
+// podVRAMBytes derives the device-memory footprint of ONE pod of the given
+// InferenceService, for GPUQuota vramBytes accounting. The second return
+// reports whether the footprint is knowable at all; the caller decides what
+// unknown means (the admission webhook denies when the governing quota
+// declares a vramBytes cap; the status reconciler counts unknown as zero,
+// since stored objects cannot be retroactively rejected).
+//
+// Derivation by sharing mode:
+//   - partitioned: parsed from the MIG profile name (1g.24gb -> 24 GiB); the
+//     partition size IS the hard footprint.
+//   - shared: memoryLimitGiB when declared, else the Model's
+//     hardware.gpu.memory quantity, else unknown.
+//   - exclusive: gpu count x vramPerDeviceGiB (operator fleet config,
+//     --gpu-sharing-vram-per-device-gib); zero/unset means unknown.
+func podVRAMBytes(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, vramPerDeviceGiB int) (int64, bool) {
+	switch gpuSharingMode(isvc) {
+	case inferencev1alpha1.GPUSharingModePartitioned:
+		profile := strings.TrimSpace(isvc.Spec.Resources.GPUSharing.Profile)
+		if m := migProfileVRAMPattern.FindStringSubmatch(profile); m != nil {
+			gib, err := strconv.ParseInt(m[1], 10, 32)
+			if err == nil && gib > 0 {
+				return gib * bytesPerGiB, true
+			}
+		}
+		return 0, false
+
+	case inferencev1alpha1.GPUSharingModeShared:
+		if limit := isvc.Spec.Resources.GPUSharing.MemoryLimitGiB; limit != nil && *limit > 0 {
+			return int64(*limit) * bytesPerGiB, true
+		}
+		if model != nil && model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil {
+			if mem := strings.TrimSpace(model.Spec.Hardware.GPU.Memory); mem != "" {
+				if q, err := resource.ParseQuantity(mem); err == nil && q.Value() > 0 {
+					return q.Value(), true
+				}
+			}
+		}
+		return 0, false
+
+	default: // exclusive
+		if vramPerDeviceGiB <= 0 {
+			return 0, false
+		}
+		// Nil-safe GPU count: the Model may not exist yet at admission time
+		// (resolveGPUCount assumes a non-nil Model).
+		count := int32(0)
+		if model != nil {
+			count = resolveGPUCount(isvc, model)
+		} else if isvc.Spec.Resources != nil {
+			count = isvc.Spec.Resources.GPU
+		}
+		if count <= 0 {
+			// No GPU requested: zero footprint is exact, not unknown.
+			return 0, true
+		}
+		return int64(count) * int64(vramPerDeviceGiB) * bytesPerGiB, true
+	}
+}
+
+// serviceVRAMBytesFor derives the total VRAM footprint of an
+// InferenceService (per-pod footprint x replicas), fetching its Model for the
+// shared-mode hardware.gpu.memory fallback. A missing Model is not an error:
+// derivation simply falls through to the remaining sources. Shared by the
+// GPUQuota admission webhook and the GPUQuota status reconciler so admission
+// and observed usage can never disagree on the same object.
+func serviceVRAMBytesFor(ctx context.Context, c client.Client, isvc *inferencev1alpha1.InferenceService, vramPerDeviceGiB int) (int64, bool) {
+	var model *inferencev1alpha1.Model
+	if isvc.Spec.ModelRef != "" {
+		m := &inferencev1alpha1.Model{}
+		if err := c.Get(ctx, types.NamespacedName{Name: isvc.Spec.ModelRef, Namespace: isvc.Namespace}, m); err == nil {
+			model = m
+		}
+	}
+
+	perPod, known := podVRAMBytes(isvc, model, vramPerDeviceGiB)
+	if !known {
+		return 0, false
+	}
+
+	replicas := int64(1)
+	if isvc.Spec.Replicas != nil {
+		replicas = int64(*isvc.Spec.Replicas)
+	}
+	return perPod * replicas, true
 }
 
 // ParseGPUSharingSharedPoolSelector parses the

--- a/internal/controller/gpu_sharing_vram_test.go
+++ b/internal/controller/gpu_sharing_vram_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
+)
+
+func vramISvc(name, ns string, gpu int32, replicas int32, sharing *inferencev1alpha1.GPUSharingSpec) *inferencev1alpha1.InferenceService {
+	return &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "vram-model",
+			Replicas: &replicas,
+			Resources: &inferencev1alpha1.InferenceResourceRequirements{
+				GPU:        gpu,
+				GPUSharing: sharing,
+			},
+		},
+	}
+}
+
+func gib32(v int32) *int32 { return &v }
+
+func TestPodVRAMBytes(t *testing.T) {
+	sharedWithLimit := &inferencev1alpha1.GPUSharingSpec{
+		Mode:           inferencev1alpha1.GPUSharingModeShared,
+		MemoryLimitGiB: gib32(24),
+	}
+	sharedNoLimit := &inferencev1alpha1.GPUSharingSpec{Mode: inferencev1alpha1.GPUSharingModeShared}
+	partitioned := &inferencev1alpha1.GPUSharingSpec{
+		Mode:    inferencev1alpha1.GPUSharingModePartitioned,
+		Profile: "3g.90gb",
+	}
+	modelWithMemory := sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Vendor: "nvidia", Memory: "16Gi"})
+
+	tests := []struct {
+		name      string
+		isvc      *inferencev1alpha1.InferenceService
+		model     *inferencev1alpha1.Model
+		fleetGiB  int
+		wantBytes int64
+		wantKnown bool
+	}{
+		{
+			name:      "partitioned derives from the profile",
+			isvc:      vramISvc("a", "d", 1, 1, partitioned),
+			wantBytes: 90 * bytesPerGiB,
+			wantKnown: true,
+		},
+		{
+			name:      "shared uses memoryLimitGiB",
+			isvc:      vramISvc("b", "d", 1, 1, sharedWithLimit),
+			wantBytes: 24 * bytesPerGiB,
+			wantKnown: true,
+		},
+		{
+			name:      "shared falls back to the Model's gpu memory",
+			isvc:      vramISvc("c", "d", 1, 1, sharedNoLimit),
+			model:     modelWithMemory,
+			wantBytes: 16 * bytesPerGiB,
+			wantKnown: true,
+		},
+		{
+			name:      "shared with neither limit nor model memory is unknown",
+			isvc:      vramISvc("d", "d", 1, 1, sharedNoLimit),
+			wantKnown: false,
+		},
+		{
+			name:      "exclusive multiplies count by the fleet per-device figure",
+			isvc:      vramISvc("e", "d", 2, 1, nil),
+			fleetGiB:  192,
+			wantBytes: 2 * 192 * bytesPerGiB,
+			wantKnown: true,
+		},
+		{
+			name:      "exclusive without fleet config is unknown",
+			isvc:      vramISvc("f", "d", 2, 1, nil),
+			wantKnown: false,
+		},
+		{
+			name:      "exclusive with zero GPUs is exactly zero, not unknown",
+			isvc:      vramISvc("g", "d", 0, 1, nil),
+			fleetGiB:  192,
+			wantBytes: 0,
+			wantKnown: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, known := podVRAMBytes(tt.isvc, tt.model, tt.fleetGiB)
+			if known != tt.wantKnown {
+				t.Fatalf("known = %v, want %v", known, tt.wantKnown)
+			}
+			if known && got != tt.wantBytes {
+				t.Errorf("bytes = %d, want %d", got, tt.wantBytes)
+			}
+		})
+	}
+}
+
+func TestQuotaVRAMAdmission(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	ctx := context.Background()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "vram-ns"}}
+
+	vramQuota := func(capGiB int64) *inferencev1alpha1.GPUQuota {
+		return &inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "vram-quota", Namespace: "vram-ns"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "vram-ns",
+				GPUCount:     100, // GPU-count cap never the binding constraint here
+				VRAMBytes:    capGiB * bytesPerGiB,
+			},
+		}
+	}
+	shared := func(limitGiB int32) *inferencev1alpha1.GPUSharingSpec {
+		return &inferencev1alpha1.GPUSharingSpec{
+			Mode:           inferencev1alpha1.GPUSharingModeShared,
+			MemoryLimitGiB: gib32(limitGiB),
+		}
+	}
+
+	t.Run("shared within the vram cap is admitted", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns).Build()
+		v := &InferenceServiceQuotaValidator{Client: c}
+		if _, err := v.ValidateCreate(ctx, vramISvc("s1", "vram-ns", 1, 1, shared(24))); err != nil {
+			t.Fatalf("expected admission, got: %v", err)
+		}
+	})
+
+	t.Run("shared exceeding the vram cap is denied", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns).Build()
+		v := &InferenceServiceQuotaValidator{Client: c}
+		_, err := v.ValidateCreate(ctx, vramISvc("s2", "vram-ns", 1, 1, shared(128)))
+		if err == nil {
+			t.Fatal("expected denial (128GiB > 96GiB cap), got nil")
+		}
+		if !strings.Contains(err.Error(), "would exceed vramBytes") {
+			t.Fatalf("expected vramBytes reason, got: %v", err)
+		}
+	})
+
+	t.Run("vram accounts for replicas", func(t *testing.T) {
+		// 24GiB x 5 replicas = 120GiB > 96GiB cap.
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns).Build()
+		v := &InferenceServiceQuotaValidator{Client: c}
+		_, err := v.ValidateCreate(ctx, vramISvc("s3", "vram-ns", 1, 5, shared(24)))
+		if err == nil {
+			t.Fatal("expected denial (24*5 > 96), got nil")
+		}
+		if !strings.Contains(err.Error(), "would exceed vramBytes") {
+			t.Fatalf("expected vramBytes reason, got: %v", err)
+		}
+	})
+
+	t.Run("stored shared usage counts against the cap", func(t *testing.T) {
+		existing := vramISvc("stored", "vram-ns", 1, 1, shared(80))
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns, existing).Build()
+		v := &InferenceServiceQuotaValidator{Client: c}
+		// 80 stored + 24 incoming = 104 > 96.
+		_, err := v.ValidateCreate(ctx, vramISvc("s4", "vram-ns", 1, 1, shared(24)))
+		if err == nil {
+			t.Fatal("expected denial (80+24 > 96), got nil")
+		}
+		if !strings.Contains(err.Error(), "would exceed vramBytes") {
+			t.Fatalf("expected vramBytes reason, got: %v", err)
+		}
+	})
+
+	t.Run("unknowable footprint is denied when the quota declares a cap", func(t *testing.T) {
+		// Exclusive workload, no fleet VRAMPerDeviceGiB configured.
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns).Build()
+		v := &InferenceServiceQuotaValidator{Client: c}
+		_, err := v.ValidateCreate(ctx, vramISvc("s5", "vram-ns", 1, 1, nil))
+		if err == nil {
+			t.Fatal("expected denial (unknown footprint vs declared cap), got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot derive the VRAM footprint") {
+			t.Fatalf("expected the actionable unknown-footprint reason, got: %v", err)
+		}
+	})
+
+	t.Run("unknowable footprint is fine when no cap is declared", func(t *testing.T) {
+		q := vramQuota(0) // vramBytes 0 = no cap
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(q, ns).Build()
+		v := &InferenceServiceQuotaValidator{Client: c}
+		if _, err := v.ValidateCreate(ctx, vramISvc("s6", "vram-ns", 1, 1, nil)); err != nil {
+			t.Fatalf("expected admission (no vram cap), got: %v", err)
+		}
+	})
+
+	t.Run("exclusive footprint derives from the fleet per-device figure", func(t *testing.T) {
+		// 1 GPU x 192GiB > 96GiB cap.
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns).Build()
+		v := &InferenceServiceQuotaValidator{Client: c, VRAMPerDeviceGiB: 192}
+		_, err := v.ValidateCreate(ctx, vramISvc("s7", "vram-ns", 1, 1, nil))
+		if err == nil {
+			t.Fatal("expected denial (192 > 96), got nil")
+		}
+		if !strings.Contains(err.Error(), "would exceed vramBytes") {
+			t.Fatalf("expected vramBytes reason, got: %v", err)
+		}
+	})
+}
+
+func TestGPUQuotaReconcileVRAM(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	gq := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "vram-gq", Namespace: "default"},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			NamespaceRef: "vram-agg-ns",
+			GPUCount:     10,
+			VRAMBytes:    256 * bytesPerGiB,
+		},
+	}
+	// 24GiB shared x 2 replicas = 48GiB.
+	sharedISvc := vramISvc("shared-svc", "vram-agg-ns", 1, 2, &inferencev1alpha1.GPUSharingSpec{
+		Mode:           inferencev1alpha1.GPUSharingModeShared,
+		MemoryLimitGiB: gib32(24),
+	})
+	// 90GiB partition x 1 replica.
+	partISvc := vramISvc("part-svc", "vram-agg-ns", 1, 1, &inferencev1alpha1.GPUSharingSpec{
+		Mode:    inferencev1alpha1.GPUSharingModePartitioned,
+		Profile: "3g.90gb",
+	})
+	// Exclusive with no fleet config: unknown, contributes zero.
+	exclISvc := vramISvc("excl-svc", "vram-agg-ns", 2, 1, nil)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).
+		WithObjects(gq, sharedISvc, partISvc, exclISvc).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "vram-gq", Namespace: "default"}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+
+	got := &inferencev1alpha1.GPUQuota{}
+	if err := c.Get(context.Background(), req.NamespacedName, got); err != nil {
+		t.Fatalf("get quota: %v", err)
+	}
+
+	wantVRAM := (2*24 + 90) * bytesPerGiB // 48 shared + 90 partitioned + 0 unknown-exclusive
+	if got.Status.UsedVRAMBytes != wantVRAM {
+		t.Errorf("UsedVRAMBytes = %d, want %d", got.Status.UsedVRAMBytes, wantVRAM)
+	}
+
+	if used := testutil.ToFloat64(llmkubemetrics.GPUQuotaUsedVRAMBytes.WithLabelValues("vram-gq", "default")); used != float64(wantVRAM) {
+		t.Errorf("used vram gauge = %v, want %v", used, float64(wantVRAM))
+	}
+	if limit := testutil.ToFloat64(llmkubemetrics.GPUQuotaVRAMBytesLimit.WithLabelValues("vram-gq", "default")); limit != float64(256*bytesPerGiB) {
+		t.Errorf("vram limit gauge = %v, want %v", limit, float64(256*bytesPerGiB))
+	}
+}

--- a/internal/controller/gpuquota_controller.go
+++ b/internal/controller/gpuquota_controller.go
@@ -40,13 +40,19 @@ const (
 	gpuQuotaControllerName = "gpuquota"
 )
 
-// GPUQuotaReconciler reconciles the GPUQuota CRD. It aggregates GPU usage
-// from InferenceServices in the quota's scope and writes the total to
-// Status.UsedGPUCount. This is a status-only reconciler: it never rejects
-// anything or owns external resources.
+// GPUQuotaReconciler reconciles the GPUQuota CRD. It aggregates GPU and VRAM
+// usage from InferenceServices in the quota's scope and writes the totals to
+// Status.UsedGPUCount / Status.UsedVRAMBytes. This is a status-only
+// reconciler: it never rejects anything or owns external resources.
 type GPUQuotaReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// VRAMPerDeviceGiB mirrors the admission webhook's fleet-level device
+	// memory per whole GPU (--gpu-sharing-vram-per-device-gib) so observed
+	// usage and admission accounting can never disagree about the same
+	// object. Zero means exclusive-mode footprints are unknowable and
+	// contribute zero to UsedVRAMBytes.
+	VRAMPerDeviceGiB int
 }
 
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=gpuquotas,verbs=get;list;watch;update;patch
@@ -100,8 +106,15 @@ func (r *GPUQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
-	// Aggregate GPU usage from InferenceServices in the in-scope namespaces.
+	// Aggregate GPU and VRAM usage from InferenceServices in the in-scope
+	// namespaces. VRAM is derived per service by serviceVRAMBytesFor (the
+	// same helper the admission webhook uses): partition profile, shared
+	// memoryLimitGiB / Model memory, or exclusive count x fleet
+	// VRAMPerDeviceGiB. Services whose footprint cannot be derived
+	// contribute zero; they were admitted before the footprint was
+	// declarable and the webhook ratchets on new admissions instead.
 	var usedGPUCount int32
+	var usedVRAMBytes int64
 	for _, nsName := range inScopeNamespaces {
 		isvcList := &inferencev1alpha1.InferenceServiceList{}
 		if err := r.List(ctx, isvcList, client.InNamespace(nsName)); err != nil {
@@ -120,15 +133,12 @@ func (r *GPUQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				replicas = *isvc.Spec.Replicas
 			}
 			usedGPUCount += gpuPerPod * replicas
+
+			if vram, known := serviceVRAMBytesFor(ctx, r.Client, &isvc, r.VRAMPerDeviceGiB); known {
+				usedVRAMBytes += vram
+			}
 		}
 	}
-
-	// VRAM aggregation is a DOCUMENTED, INTENTIONAL DEFERRAL: InferenceService
-	// exposes no VRAM field, so UsedVRAMBytes stays 0 until either
-	// InferenceService gains a VRAM field or it is derived from the Model size;
-	// the admission webhook already treats vramBytes 0 as "no cap", so the
-	// VRAM half of the quota is simply inert until then.
-	usedVRAMBytes := int64(0)
 
 	// Write status.
 	desired := gq.DeepCopy()
@@ -144,6 +154,8 @@ func (r *GPUQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// dashboard can plot utilization = used / limit.
 	llmkubemetrics.GPUQuotaUsedGPUCount.WithLabelValues(gq.Name, gq.Namespace).Set(float64(usedGPUCount))
 	llmkubemetrics.GPUQuotaGPUCountLimit.WithLabelValues(gq.Name, gq.Namespace).Set(float64(gq.Spec.GPUCount))
+	llmkubemetrics.GPUQuotaUsedVRAMBytes.WithLabelValues(gq.Name, gq.Namespace).Set(float64(usedVRAMBytes))
+	llmkubemetrics.GPUQuotaVRAMBytesLimit.WithLabelValues(gq.Name, gq.Namespace).Set(float64(gq.Spec.VRAMBytes))
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/inferenceservice_quota_webhook.go
+++ b/internal/controller/inferenceservice_quota_webhook.go
@@ -50,6 +50,13 @@ import (
 // a documented follow-up (a metric or a reconciler-observed counter).
 type InferenceServiceQuotaValidator struct {
 	Client client.Client
+	// VRAMPerDeviceGiB is the fleet-level device memory per whole GPU
+	// (--gpu-sharing-vram-per-device-gib), used to derive the VRAM footprint
+	// of exclusive-mode workloads for vramBytes accounting. Zero means
+	// unconfigured: exclusive footprints are then unknowable, and admission
+	// against a quota that declares a vramBytes cap is denied with an
+	// actionable message rather than silently waved through.
+	VRAMPerDeviceGiB int
 }
 
 var _ admission.Validator[*inferencev1alpha1.InferenceService] = &InferenceServiceQuotaValidator{}
@@ -67,9 +74,12 @@ var _ admission.Validator[*inferencev1alpha1.InferenceService] = &InferenceServi
 // failurePolicy=Fail, fail closed on EVERY InferenceService admission whenever
 // multitenancy is enabled. The distinct -quota suffix keeps this webhook from
 // colliding with any future default-path InferenceService webhook.
-func SetupInferenceServiceQuotaWebhookWithManager(mgr ctrl.Manager) error {
+func SetupInferenceServiceQuotaWebhookWithManager(mgr ctrl.Manager, vramPerDeviceGiB int) error {
 	return ctrl.NewWebhookManagedBy(mgr, &inferencev1alpha1.InferenceService{}).
-		WithValidator(&InferenceServiceQuotaValidator{Client: mgr.GetClient()}).
+		WithValidator(&InferenceServiceQuotaValidator{
+			Client:           mgr.GetClient(),
+			VRAMPerDeviceGiB: vramPerDeviceGiB,
+		}).
 		WithValidatorCustomPath("/validate-inference-llmkube-dev-v1alpha1-inferenceservice-quota").
 		Complete()
 }
@@ -155,7 +165,8 @@ func (v *InferenceServiceQuotaValidator) listApplicableQuotas(ctx context.Contex
 
 // decide evaluates a single InferenceService against a single GPUQuota using
 // the pure quota.Decide function. It computes current usage by listing
-// InferenceServices in the quota's scope and summing their GPU allocations.
+// InferenceServices in the quota's scope and summing their GPU and VRAM
+// allocations.
 func (v *InferenceServiceQuotaValidator) decide(ctx context.Context, q inferencev1alpha1.GPUQuota, isvc *inferencev1alpha1.InferenceService) (bool, string) {
 	currentUsage, err := v.currentUsage(ctx, q, isvc)
 	if err != nil {
@@ -163,15 +174,35 @@ func (v *InferenceServiceQuotaValidator) decide(ctx context.Context, q inference
 		return false, fmt.Sprintf("failed to read current usage: %v", err)
 	}
 
+	// Derive the incoming VRAM footprint from the gpuSharing spec (partition
+	// profile / shared memory limit / exclusive fleet config; see
+	// podVRAMBytes). A quota that declares a vramBytes cap cannot admit a
+	// workload whose footprint is unknowable: waving it through would let
+	// undeclared workloads consume the very budget the cap exists to protect.
+	vramBytes, vramKnown := v.serviceVRAMBytes(ctx, isvc)
+	if !vramKnown && q.Spec.VRAMBytes > 0 {
+		return false, fmt.Sprintf(
+			"cannot derive the VRAM footprint required by this quota's vramBytes cap: " +
+				"declare gpuSharing.memoryLimitGiB (shared), a partition profile (partitioned), " +
+				"or configure --gpu-sharing-vram-per-device-gib for exclusive workloads")
+	}
+
 	incoming := quota.Incoming{
 		GPUCount:  gpuCount(isvc),
-		VRAMBytes: 0, // InferenceService has no VRAM field (mirrors #1093).
+		VRAMBytes: vramBytes,
 		Priority:  isvc.Spec.Priority,
 	}
 
 	// CostBudgetRef integration is a documented follow-up; for now we always
 	// pass costBudgetBreached=false.
 	return quota.Decide(q.Spec, currentUsage, incoming, false)
+}
+
+// serviceVRAMBytes derives the total VRAM footprint of an InferenceService
+// for this validator's fleet configuration. Thin wrapper over the shared
+// serviceVRAMBytesFor used by both the webhook and the GPUQuota reconciler.
+func (v *InferenceServiceQuotaValidator) serviceVRAMBytes(ctx context.Context, isvc *inferencev1alpha1.InferenceService) (int64, bool) {
+	return serviceVRAMBytesFor(ctx, v.Client, isvc, v.VRAMPerDeviceGiB)
 }
 
 // currentUsage lists InferenceServices in the quota's scope and sums their
@@ -203,6 +234,13 @@ func (v *InferenceServiceQuotaValidator) currentUsage(ctx context.Context, q inf
 			continue
 		}
 		usage.GPUCount += gpuCount(&i)
+		// Stored objects whose VRAM footprint cannot be derived contribute
+		// zero: they were admitted before the cap (or before their footprint
+		// was declarable) and cannot be retroactively rejected. The cap
+		// ratchets on new admissions instead (see decide's unknown-denial).
+		if vram, known := v.serviceVRAMBytes(ctx, &i); known {
+			usage.VRAMBytes += vram
+		}
 	}
 
 	return usage, nil

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -198,6 +198,22 @@ var (
 		},
 		[]string{"gpuquota", "namespace"},
 	)
+
+	GPUQuotaUsedVRAMBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llmkube_gpuquota_used_vram_bytes",
+			Help: "Device memory (bytes) currently accounted to InferenceServices in a GPUQuota's scope. Workloads whose footprint cannot be derived contribute zero.",
+		},
+		[]string{"gpuquota", "namespace"},
+	)
+
+	GPUQuotaVRAMBytesLimit = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llmkube_gpuquota_vram_bytes_limit",
+			Help: "The device-memory cap (spec.vramBytes) declared by a GPUQuota. 0 means no cap.",
+		},
+		[]string{"gpuquota", "namespace"},
+	)
 )
 
 func init() {
@@ -205,6 +221,8 @@ func init() {
 		GPUQuotaUsedGPUCount,
 		GPUQuotaGPUCountLimit,
 		GPUQuotaAdmissionDenialsTotal,
+		GPUQuotaUsedVRAMBytes,
+		GPUQuotaVRAMBytesLimit,
 		ModelDownloadDuration,
 		ModelStatus,
 		InferenceServiceReadyDuration,


### PR DESCRIPTION
## What

Story 4 of #1196: fills the two VRAM stubs (`Incoming.VRAMBytes: 0` in the admission webhook, `usedVRAMBytes := 0` in the reconciler) so a GPUQuota's `vramBytes` cap actually enforces. **Device memory, not GPU count, becomes the fairness unit for shared fleets** — a 24GiB partition is no longer indistinguishable from a whole 192GiB card.

> **Stacked on #1199** (stories 1+2, all checks green). This diff includes those commits until #1199 merges; the story-4 delta is the top commit (`89b3305`).

Part of #1196 (do not auto-close).

## How

**Derivation** (`podVRAMBytes`, one shared helper used by both the webhook and the reconciler so admission and observed usage can never disagree about the same object):

| Mode | Per-pod footprint |
|---|---|
| `partitioned` | parsed from the MIG profile (`1g.24gb` → 24GiB) — the partition size IS the hard footprint |
| `shared` | `gpuSharing.memoryLimitGiB`, else the Model's `hardware.gpu.memory` quantity, else unknown |
| `exclusive` | gpu count × fleet-level `--gpu-sharing-vram-per-device-gib`, else unknown |

All × replicas, mirroring the existing gpuCount accounting.

**Policy** — the two honest edges:
- A quota that declares a `vramBytes` cap **denies** admissions whose footprint is unknowable, with an actionable message (declare `memoryLimitGiB`, a partition profile, or configure the fleet flag). Waving them through would let undeclared workloads consume the very budget the cap protects.
- **Stored** objects with unknowable footprints contribute zero to usage — they cannot be retroactively rejected; the cap ratchets on new admissions. Documented in code at both sites.

**Observability** — `status.usedVRAMBytes` now real; new gauges `llmkube_gpuquota_used_vram_bytes` / `llmkube_gpuquota_vram_bytes_limit` (same `{gpuquota,namespace}` labels as the #1193 trio); the quota dashboard gains a VRAM row (utilization + absolute used, bytes unit) — style-preserving 92-line addition, all exprs grounded in emitted metrics.

Also fixed en route: a nil-Model dereference in the exclusive path (the Model may not exist at admission time), caught by the new unit tests before it could ship.

## Why

The B200-class fleet will be shared across teams via the tiered gpuSharing modes; GPU-count quota is meaningless when one "GPU" can be a 24GiB slice of a 192GiB card. This is also the piece the single-node shared-pool validation exercises on existing AMD hardware before Blackwell arrives (quota denial at the VRAM cap with co-located small models).

## Validation

- Derivation table: all three modes, both unknown cases, zero-GPU-is-exactly-zero.
- Webhook admission matrix: within/exceeding cap, replicas multiplication, stored usage counted, unknown-vs-cap denied with the actionable reason, unknown-without-cap admitted, exclusive fleet-figure denial.
- Reconciler: `usedVRAMBytes` aggregation across shared+partitioned+unknown-exclusive, plus both gauges asserted via `testutil`.
- Full `make test` green; cross-arch `GOOS=linux golangci-lint` 0 issues (the flag value stays plain `int` end-to-end with a bounds check at parse — no narrowing conversion for gosec to flag); dashboard JSON validates; committed bytes verified clean post-hook.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (GOOS=linux cross-arch, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: implemented with AI assistance (human-directed) from the approved gpuSharing design; human owns the review conversation.
- [ ] Documentation updated (operator docs page is story 6; the dashboard update ships here)