### PR TITLE
fix(foreman): inject Workload.spec.intent into coder prompts (#1201)

### DIFF
--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -299,7 +299,7 @@ func coderEscalationSteps(
 					Repo:         w.Spec.Repo,
 					Issue:        n,
 					Branch:       branch,
-					PromptPrefix: escalationHintPrompt(coderSummary(base)),
+					PromptPrefix: joinPromptSections(intentPromptPrefix(w), escalationHintPrompt(coderSummary(base))),
 				},
 			},
 		)

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -339,6 +339,34 @@ func (r *WorkloadReconciler) chooseSteps(w *foremanv1alpha1.Workload) (steps []f
 // fast-forward conflicts, and the empirical artifact (the foreman-
 // authored branch) survives even when an earlier run already produced
 // a branch on the same issue. See #573 for the motivating trace.
+// intentPromptPrefix renders Workload.spec.intent as the operator-scope
+// block prepended to every coder prompt (via AgenticTaskPayload.PromptPrefix,
+// which the executor prints BEFORE the fetched issue body). Before this,
+// intent was a required-but-write-only field: the coder only ever saw the
+// issue body, so operator scoping ("change only these files", "X is out of
+// scope") was silently discarded (#1201).
+func intentPromptPrefix(w *foremanv1alpha1.Workload) string {
+	intent := strings.TrimSpace(w.Spec.Intent)
+	if intent == "" {
+		return ""
+	}
+	return "Operator intent for this run (this scopes the work; where it is " +
+		"narrower than the issue's proposed solution, the intent wins):\n" + intent
+}
+
+// joinPromptSections joins non-empty prompt sections with a blank line, so
+// callers composing PromptPrefix from multiple sources (operator intent,
+// escalation hint) never emit stray separators.
+func joinPromptSections(sections ...string) string {
+	parts := make([]string, 0, len(sections))
+	for _, s := range sections {
+		if s = strings.TrimSpace(s); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
 func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.PipelineStep {
 	tasksPerIssue := 1 + len(w.Spec.ReviewerAgentRefs)
 	if w.Spec.VerifierAgentRef != nil {
@@ -358,6 +386,7 @@ func synthesizeIssueBatch(w *foremanv1alpha1.Workload) []foremanv1alpha1.Pipelin
 					Issue:          n,
 					Branch:         branch,
 					AllowOverwrite: w.Spec.AllowOverwrite,
+					PromptPrefix:   intentPromptPrefix(w),
 				},
 			},
 		)

--- a/internal/foreman/controller/workload_intent_test.go
+++ b/internal/foreman/controller/workload_intent_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// Unit tests for operator-intent injection (#1201): Workload.spec.intent
+// must reach the coder as AgenticTaskPayload.PromptPrefix at every coder
+// task construction site (issue batch, review-driven iteration, coder
+// escalation), instead of being a required-but-write-only field.
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func intentWorkload(intent string) *foremanv1alpha1.Workload {
+	w := &foremanv1alpha1.Workload{}
+	w.Name = "wl-intent"
+	w.Spec.Repo = "defilantech/LLMKube"
+	w.Spec.Issues = []int32{42}
+	w.Spec.Intent = intent
+	w.Spec.CoderAgentRef = &corev1.LocalObjectReference{Name: "coder"}
+	return w
+}
+
+func TestIntentPromptPrefix(t *testing.T) {
+	t.Run("renders the intent under the operator-scope header", func(t *testing.T) {
+		got := intentPromptPrefix(intentWorkload("Change only these 3 files."))
+		if !strings.Contains(got, "Operator intent for this run") {
+			t.Fatalf("missing header: %q", got)
+		}
+		if !strings.Contains(got, "Change only these 3 files.") {
+			t.Fatalf("missing intent body: %q", got)
+		}
+		if !strings.Contains(got, "the intent wins") {
+			t.Fatalf("missing precedence instruction: %q", got)
+		}
+	})
+
+	t.Run("empty and whitespace intents render nothing", func(t *testing.T) {
+		if got := intentPromptPrefix(intentWorkload("")); got != "" {
+			t.Fatalf("empty intent produced %q", got)
+		}
+		if got := intentPromptPrefix(intentWorkload("   \n ")); got != "" {
+			t.Fatalf("whitespace intent produced %q", got)
+		}
+	})
+}
+
+func TestJoinPromptSections(t *testing.T) {
+	if got := joinPromptSections("a", "", "  ", "b"); got != "a\n\nb" {
+		t.Fatalf("got %q, want %q", got, "a\n\nb")
+	}
+	if got := joinPromptSections("", "  "); got != "" {
+		t.Fatalf("all-empty sections produced %q", got)
+	}
+}
+
+func TestSynthesizeIssueBatch_CarriesIntent(t *testing.T) {
+	w := intentWorkload("SCOPED SLICE: only pin the three images.")
+	w.Spec.VerifierAgentRef = &corev1.LocalObjectReference{Name: "gate"}
+
+	steps := synthesizeIssueBatch(w)
+
+	var code *foremanv1alpha1.PipelineStep
+	for i := range steps {
+		if steps[i].Kind == foremanv1alpha1.AgenticTaskKindIssueFix {
+			code = &steps[i]
+		}
+	}
+	if code == nil {
+		t.Fatal("no issue-fix step synthesized")
+	}
+	if !strings.Contains(code.Payload.PromptPrefix, "SCOPED SLICE: only pin the three images.") {
+		t.Fatalf("coder step PromptPrefix missing the intent: %q", code.Payload.PromptPrefix)
+	}
+
+	// The verify step runs the deterministic gate, not a prompt; it must
+	// not grow a PromptPrefix.
+	for _, s := range steps {
+		if s.Kind == foremanv1alpha1.AgenticTaskKindVerify && s.Payload.PromptPrefix != "" {
+			t.Fatalf("verify step unexpectedly carries a PromptPrefix: %q", s.Payload.PromptPrefix)
+		}
+	}
+}
+
+func TestReviewIterationSteps_CarriesIntent(t *testing.T) {
+	w := iterationWorkload([]int32{641}, 1, nil)
+	w.Spec.Intent = "Do not touch the chart."
+	children := []foremanv1alpha1.AgenticTask{
+		child("code-641", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGo),
+		child("verify-641", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGatePass),
+		noGoChild("review-641-0", "needs work", "[]"),
+	}
+
+	steps, _ := reviewIterationSteps(w, children)
+
+	var found bool
+	for _, s := range steps {
+		if s.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
+			continue
+		}
+		found = true
+		if !strings.Contains(s.Payload.PromptPrefix, "Do not touch the chart.") {
+			t.Fatalf("iteration coder step missing intent in PromptPrefix: %q", s.Payload.PromptPrefix)
+		}
+		// The review feedback must still arrive via Prompt: intent must not
+		// displace it.
+		if s.Payload.Prompt == "" {
+			t.Fatal("iteration coder step lost its review-feedback Prompt")
+		}
+	}
+	if !found {
+		t.Fatal("no iteration issue-fix step synthesized")
+	}
+}
+
+func TestCoderEscalationSteps_ComposesIntentWithHint(t *testing.T) {
+	w := intentWorkload("Only fix the parser.")
+	w.Spec.Issues = []int32{944}
+	w.Spec.VerifierAgentRef = &corev1.LocalObjectReference{Name: "gate"}
+	w.Spec.EscalationCoderAgentRef = &corev1.LocalObjectReference{Name: "coder-esc"}
+
+	code := foremanv1alpha1.AgenticTask{}
+	code.Name = "wl-intent-code-944"
+	code.Labels = map[string]string{labelStep: "code-944"}
+	code.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+	code.Status.Result = resultRaw("MODEL-DECIDED", "", "could not solve: anchor drift", "")
+
+	steps, _, _ := coderEscalationSteps(w, []foremanv1alpha1.AgenticTask{code})
+	if len(steps) == 0 {
+		t.Fatal("no escalation steps synthesized")
+	}
+	prefix := steps[0].Payload.PromptPrefix
+	if !strings.Contains(prefix, "Only fix the parser.") {
+		t.Fatalf("escalation PromptPrefix missing the intent: %q", prefix)
+	}
+	if !strings.Contains(prefix, "anchor drift") {
+		t.Fatalf("escalation PromptPrefix lost the prior-attempt hint: %q", prefix)
+	}
+	if strings.Index(prefix, "Only fix the parser.") > strings.Index(prefix, "anchor drift") {
+		t.Fatalf("intent should precede the escalation hint: %q", prefix)
+	}
+}

--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -252,6 +252,7 @@ func reviewIterationSteps(
 						BranchStrategy:   foremanv1alpha1.BranchStrategyRebase,
 						AllowOverwrite:   true,
 						Prompt:           reviewFeedbackPrompt(noGo),
+						PromptPrefix:     intentPromptPrefix(w),
 					},
 				})
 				issueIterated = true


### PR DESCRIPTION
## What

Renders `Workload.spec.intent` as an operator-scope block in `AgenticTaskPayload.PromptPrefix` (the mechanism the escalation tier already uses; the executor prints it before the fetched issue body) at all three coder task construction sites: issue batch, review-driven iteration, and coder escalation (composed with the prior-attempt hint, intent first).

## Why

Fixes #1201

`spec.intent` was a **required-but-write-only field**: `grep -rn 'Spec\.Intent'` had zero non-test consumers, so the coder only ever saw the issue body and every operator scoping instruction was silently discarded. Two consecutive runs on #1197 showed the cost: one NO-GO'd on scope the intent had already narrowed ("multi-part epic, ambiguous ACs"); the next ignored an explicit 3-file slice and implemented the full issue.

## How

- `intentPromptPrefix(w)` renders the block with explicit precedence: *"where it is narrower than the issue's proposed solution, the intent wins."* Empty/whitespace intents render nothing.
- `joinPromptSections(...)` composes intent + escalation hint without stray separators.
- Iteration coders keep their review feedback via `Prompt` (unchanged); intent rides `PromptPrefix` beside it.
- Verify steps (deterministic gate, no prompt) grow no prefix — asserted.
- **No API changes**: `PromptPrefix` already exists on the payload, so no CRD regen and no agent-side changes; existing escalation-hint tests keep passing (composition preserves the hint).

## Validation

- 5 new unit tests: prefix rendering + precedence text, empty-intent no-op, section joining, and intent presence at each of the three sites (batch, iteration with Prompt preserved, escalation with intent-before-hint ordering).
- Full `internal/foreman/...` package green (incl. the envtest controller suite); `GOOS=linux golangci-lint` 0 issues.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (foreman packages incl. envtest suite)
- [x] `make lint` passes locally (GOOS=linux cross-arch, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: implemented with AI assistance (human-directed), root-caused from the #1197 workload transcripts; human owns the review conversation.
- [ ] Documentation updated (n/a: behavior now matches the field's existing GoDoc)