### PR TITLE
feat(runtime): Blackwell-ready image pins, NVIDIA llama.cpp divert, runtimeImages overrides, platform floors (#1197)

### DIFF
--- a/charts/llmkube/templates/NOTES.txt
+++ b/charts/llmkube/templates/NOTES.txt
@@ -84,6 +84,25 @@ Pyrra ServiceLevelObjective. Pyrra must be installed separately:
   https://github.com/pyrra-dev/pyrra (tested with v0.10.1)
 {{- end }}
 
+{{- if and .Values.platformFloors .Values.platformFloors.show }}
+---
+PLATFORM FLOORS (NVIDIA Blackwell / B200-class serving):
+
+  These are informational minimums for the GPU nodes; the operator does not
+  enforce them. First deploys on Blackwell silicon should verify:
+
+  - NVIDIA driver:  {{ .Values.platformFloors.nvidiaDriver }}
+  - CUDA toolkit:   {{ .Values.platformFloors.cudaToolkit }}
+  - NCCL:           {{ .Values.platformFloors.nccl }}
+  - GPU Operator:   {{ .Values.platformFloors.gpuOperator }}
+
+  Runtime notes: prefer vLLM or SGLang on Blackwell. TGI is archived upstream
+  (final release 3.3.7) with no stated Blackwell support. llama.cpp prebuilt
+  CUDA images carry no native sm_100 codegen (PTX JIT only); build with
+  CUDA_DOCKER_ARCH=100a-real for peak B200 performance and point
+  runtimeImages.llamacpp at the result.
+{{- end }}
+
 ---
 DOCUMENTATION:
 

--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -66,6 +66,12 @@ spec:
         # only when non-empty; the flag's empty default disables such sources.
         - --allowed-host-path-roots={{ join "," . }}
         {{- end }}
+        {{- $ri := .Values.runtimeImages | default dict }}
+        {{- $pairs := list }}
+        {{- range $k, $v := $ri }}{{- if $v }}{{- $pairs = append $pairs (printf "%s=%s" $k $v) }}{{- end }}{{- end }}
+        {{- if $pairs }}
+        - --runtime-images={{ join "," $pairs }}
+        {{- end }}
         {{- with .Values.modelSource.allowedRemoteHosts }}
         # SECURITY (GHSA-jw3m-8q7m-f35r): hostnames/CIDRs the controller-side
         # SSRF guard re-permits as remote (http/https) model sources despite

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -405,6 +405,29 @@
       "properties": {
         "enabled": { "type": "boolean" }
       }
+    },
+    "runtimeImages": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Fleet-wide runtime image overrides; empty string means the operator's pinned default.",
+      "properties": {
+        "llamacpp": { "type": "string" },
+        "vllm": { "type": "string" },
+        "sglang": { "type": "string" },
+        "tgi": { "type": "string" }
+      }
+    },
+    "platformFloors": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Informational Blackwell platform floors rendered into NOTES.txt; not enforced.",
+      "properties": {
+        "show": { "type": "boolean" },
+        "nvidiaDriver": { "type": "string" },
+        "cudaToolkit": { "type": "string" },
+        "nccl": { "type": "string" },
+        "gpuOperator": { "type": "string" }
+      }
     }
   }
 }

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -409,3 +409,30 @@ multitenancy:
 networkPolicies:
   enabled: false
   additionalEgressCIDRs: []
+
+# Fleet-wide runtime image overrides (#1197). When set, a value replaces the
+# operator's built-in default image for that runtime backend, including its
+# vendor-specific divergences. Intended for air-gapped or mirrored registries.
+# An explicit InferenceService spec.image always wins over these. Empty values
+# are ignored (stock defaults apply); the stock defaults are pinned in
+# internal/controller/runtime_*.go and listed in docs/operations/
+# b200-validation-matrix.md.
+runtimeImages:
+  llamacpp: ""
+  vllm: ""
+  sglang: ""
+  tgi: ""
+
+# Informational platform floors for NVIDIA Blackwell (B200-class) serving
+# (#1197). Rendered into NOTES.txt at install time so a first deploy on new
+# silicon fails loudly at the checklist, not cryptically at CUDA init. These
+# do not gate anything; they document what the fleet's nodes must satisfy.
+# Verified 2026-07-21 against the NVIDIA Blackwell Compatibility Guide, the
+# GPU Operator platform-support matrix, and the NCCL release notes.
+platformFloors:
+  # Render the floors block in NOTES.txt.
+  show: true
+  nvidiaDriver: ">= 570.133.20 (R570 branch; R580/CUDA 13 current)"
+  cudaToolkit: ">= 12.8 (first release with sm_100 codegen)"
+  nccl: ">= 2.25.1 (first Blackwell support; 2.27+ recommended)"
+  gpuOperator: ">= v25.3.0 (first HGX B200 support)"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -114,6 +114,7 @@ func main() {
 	var allowedRemoteHosts string
 	var gpuSharingSharedPoolSelector string
 	var gpuSharingVRAMPerDeviceGiB int
+	var runtimeImages string
 	var modelRevalidateInterval time.Duration
 	var caCertConfigMap string
 	var initContainerImage string
@@ -135,6 +136,11 @@ func main() {
 			"(cross-isvc dedup, cache list works; use an RWX class on multi-node clusters); "+
 			"perService gives each InferenceService its own RWO, WaitForFirstConsumer cache PVC "+
 			"that binds on the serving node (opt-in escape hatch for multi-node clusters without RWX).")
+	flag.StringVar(&runtimeImages, "runtime-images", "",
+		"Fleet-wide runtime image overrides as runtime=image[,runtime=image] with runtimes "+
+			"llamacpp|vllm|sglang|tgi (chart value runtimeImages.*). Overrides the built-in "+
+			"defaults and vendor divergences for air-gapped/mirrored registries; an explicit "+
+			"InferenceService spec.image still wins.")
 	flag.StringVar(&allowedHostPathRoots, "allowed-host-path-roots", "",
 		"Comma-separated absolute path prefixes under which local/file:// and hostPath model "+
 			"sources are permitted. Empty (default) disables all local/hostPath sources (GHSA-jw3m-8q7m-f35r).")
@@ -239,6 +245,12 @@ func main() {
 	if gpuSharingVRAMPerDeviceGiB < 0 || gpuSharingVRAMPerDeviceGiB > 1<<20 {
 		setupLog.Error(fmt.Errorf("value %d out of range [0, %d]", gpuSharingVRAMPerDeviceGiB, 1<<20),
 			"invalid --gpu-sharing-vram-per-device-gib")
+		os.Exit(1)
+	}
+
+	runtimeImageOverrides, err := controller.ParseRuntimeImageOverrides(runtimeImages)
+	if err != nil {
+		setupLog.Error(err, "invalid --runtime-images")
 		os.Exit(1)
 	}
 
@@ -347,19 +359,20 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.InferenceServiceReconciler{
-		Client:               mgr.GetClient(),
-		Scheme:               mgr.GetScheme(),
-		Recorder:             mgr.GetEventRecorder("inferenceservice-controller"),
-		ModelCachePath:       modelCachePath,
-		ModelCacheSize:       modelCacheSize,
-		ModelCacheClass:      modelCacheClass,
-		ModelCacheAccessMode: modelCacheAccessMode,
-		ModelCacheMode:       modelCacheMode,
-		CACertConfigMap:      caCertConfigMap,
-		InitContainerImage:   initContainerImage,
-		DefaultFSGroup:       defaultFSGroup,
-		AllowedHostPathRoots: allowedHostPathRootList,
-		GPUSharingSharedPool: gpuSharingSharedPool,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		Recorder:              mgr.GetEventRecorder("inferenceservice-controller"),
+		ModelCachePath:        modelCachePath,
+		ModelCacheSize:        modelCacheSize,
+		ModelCacheClass:       modelCacheClass,
+		ModelCacheAccessMode:  modelCacheAccessMode,
+		ModelCacheMode:        modelCacheMode,
+		CACertConfigMap:       caCertConfigMap,
+		InitContainerImage:    initContainerImage,
+		DefaultFSGroup:        defaultFSGroup,
+		AllowedHostPathRoots:  allowedHostPathRootList,
+		GPUSharingSharedPool:  gpuSharingSharedPool,
+		RuntimeImageOverrides: runtimeImageOverrides,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InferenceService")
 		os.Exit(1)

--- a/docs/operations/b200-validation-matrix.md
+++ b/docs/operations/b200-validation-matrix.md
@@ -82,11 +82,13 @@ These are project changes the LLMKube codebase, Helm chart, or docs need to abso
 
 ### 3. Runtime image bumps + sm_100 codegen
 
-Audit the default images each runtime backend sets:
+**LANDED (#1197, pins verified 2026-07-21).** Current defaults and their Blackwell status:
 
-- `internal/controller/runtime_vllm.go`: `vllm/vllm-openai:v0.20.0` is on the current line (latest released v0.20.1 as of May 2026). Blackwell support landed incrementally starting around **v0.15.x** per [vllm-project/vllm RFC #18153](https://github.com/vllm-project/vllm/issues/18153) (filed May 2025), maturing through v0.16-v0.18. **Practical floor: v0.18+.** Confirm exact tag at validation time and record it in the matrix row.
-- `internal/controller/runtime_llamacpp.go`: `ghcr.io/ggml-org/llama.cpp:server` must be a build that includes `CMAKE_CUDA_ARCHITECTURES="90;100"`. Pin to a tag verified to ship `sm_100` codegen.
-- `internal/controller/runtime_tgi.go`: `ghcr.io/huggingface/text-generation-inference:latest` should pin to a 3.x tag with rebuilt flash-attn for Blackwell.
+- `internal/controller/runtime_vllm.go`: pinned to `vllm/vllm-openai:v0.25.1` (newest stable). Blackwell has been first-class since before the v0.20.0 floor (FA4 default on SM100, MXFP4 CUTLASS MoE per the v0.20.0 release notes); the default build ships CUDA 13 userspace, with a `v0.25.1-cu129` variant for 570-branch drivers (`runtimeImages.vllm` or `spec.image`).
+- `internal/controller/runtime_sglang.go`: pinned to `lmsysorg/sglang:v0.5.15.post1-cu129` (SM100 CuteDSL kernels since v0.5.14; `-cu130` variant for 580-branch fleets).
+- `internal/controller/runtime_tgi.go`: pinned to `:3.3.7`, the FINAL release; upstream archived the repository 2026-03-21 with no stated Blackwell support. Do not use TGI as a B200 default; prefer vLLM/SGLang.
+- `internal/controller/runtime_llamacpp.go` / `deployment_builder.go`: Models declaring an NVIDIA GPU now auto-divert from the CPU-only `:server` default to `ghcr.io/ggml-org/llama.cpp:server-cuda-b10068` (immutable per-build tag). CAVEAT: upstream's prebuilt CUDA images ship no native `sm_100` codegen (ggml defaults cover 50..90-virtual plus consumer 120a/121a only), so B200 runs via PTX JIT from `90-virtual`. For peak llama.cpp-on-B200, build with `CUDA_DOCKER_ARCH=100a-real` and point `runtimeImages.llamacpp` at it. Validate the JIT path on hardware (matrix row 3) before deciding whether an LLMKube-owned sm_100 build is warranted.
+- Fleet-wide overrides for air-gapped/mirrored registries: chart values `runtimeImages.{llamacpp,vllm,sglang,tgi}` flow to the operator's `--runtime-images` flag; an explicit `spec.image` still wins.
 
 ### 4. FP8 / FP4 quantization in the CRD
 

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -44,25 +44,73 @@ import (
 // it for vLLM where the v0.20+ env-var validator turns it into log noise.
 // resolveRuntimeImage returns the container image for the runtime, making the
 // otherwise vendor-blind backend.DefaultImage() vendor- and runtime-aware where
-// it matters. Today there are three divergences:
-//   - LlamaCppBackend with AMD + Vulkan Model → LLMKube's pinned Vulkan image
-//   - LlamaCppBackend with AMD + ROCm Model → LLMKube's pinned ROCm image
-//   - SGLangBackend with AMD (ROCm) Model → SGLang ROCm image
+// it matters. Resolution order:
 //
-// Every other backend/vendor/runtime combination falls through to
-// backend.DefaultImage(). An explicit InferenceService.spec.image still wins
-// over whatever this returns (handled by the caller).
-func resolveRuntimeImage(backend RuntimeBackend, model *inferencev1alpha1.Model) string {
+//  1. A fleet-level override for the backend (--runtime-images, chart value
+//     runtimeImages.{llamacpp,vllm,sglang,tgi}) wins over every built-in
+//     choice below: it exists for air-gapped/mirrored fleets, which must be
+//     able to redirect the registry unconditionally.
+//  2. Built-in vendor/runtime divergences:
+//     - LlamaCppBackend with AMD + Vulkan Model: LLMKube's pinned Vulkan image
+//     - LlamaCppBackend with AMD + ROCm Model: LLMKube's pinned ROCm image
+//     - LlamaCppBackend with an NVIDIA-GPU Model: upstream CUDA image, because
+//     the :server default is CPU-only and an NVIDIA GPU Model on it would
+//     silently serve on CPU (#1197)
+//     - SGLangBackend with AMD (ROCm) Model: SGLang ROCm image
+//  3. backend.DefaultImage().
+//
+// An explicit InferenceService.spec.image still wins over whatever this
+// returns (handled by the caller).
+func resolveRuntimeImage(backend RuntimeBackend, model *inferencev1alpha1.Model, overrides map[string]string) string {
+	if img := overrides[runtimeImageOverrideKey(backend)]; img != "" {
+		return img
+	}
 	if _, ok := backend.(*LlamaCppBackend); ok && isVulkanAMDModel(model) {
 		return llamaCppVulkanImage
 	}
 	if _, ok := backend.(*LlamaCppBackend); ok && isROCmAMDModel(model) {
 		return llamaCppROCmImage
 	}
+	if _, ok := backend.(*LlamaCppBackend); ok && isNVIDIAGPUModel(model) {
+		return llamaCppCUDAImage
+	}
 	if _, ok := backend.(*SGLangBackend); ok && isAMDROCmModel(model) {
 		return sglangROCmImage
 	}
 	return backend.DefaultImage()
+}
+
+// runtimeImageOverrideKey maps a backend to its --runtime-images key. Only
+// backends whose defaults the operator owns are overridable; every other
+// backend (generic requires spec.image by contract) returns "".
+func runtimeImageOverrideKey(backend RuntimeBackend) string {
+	switch backend.(type) {
+	case *LlamaCppBackend:
+		return "llamacpp"
+	case *VLLMBackend:
+		return "vllm"
+	case *SGLangBackend:
+		return "sglang"
+	case *TGIBackend:
+		return "tgi"
+	default:
+		return ""
+	}
+}
+
+// isNVIDIAGPUModel reports whether the Model declares a GPU that resolves to
+// the NVIDIA vendor, explicitly or by the unset-vendor default (mirroring
+// gpuResourceNameForSpec: unset vendor means NVIDIA).
+func isNVIDIAGPUModel(model *inferencev1alpha1.Model) bool {
+	if model == nil || model.Spec.Hardware == nil || model.Spec.Hardware.GPU == nil {
+		return false
+	}
+	gpu := model.Spec.Hardware.GPU
+	if !gpu.Enabled && gpu.Count <= 0 {
+		return false
+	}
+	vendor := strings.ToLower(strings.TrimSpace(gpu.Vendor))
+	return vendor == "" || vendor == "nvidia"
 }
 
 // isAMDROCmModel reports whether the Model requests the AMD vendor. ROCm vs
@@ -274,7 +322,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 		"inference.llmkube.dev/runtime": runtimeNameLabel(isvc),
 	}
 
-	image := resolveRuntimeImage(backend, model)
+	image := resolveRuntimeImage(backend, model, r.RuntimeImageOverrides)
 	if isvc.Spec.Image != "" {
 		image = isvc.Spec.Image
 	}
@@ -520,4 +568,30 @@ func buildContainerResources(isvc *inferencev1alpha1.InferenceService, model *in
 	}
 
 	return res
+}
+
+// ParseRuntimeImageOverrides parses the --runtime-images flag value
+// ("runtime=image[,runtime=image...]", keys llamacpp|vllm|sglang|tgi) into
+// the override map consumed by resolveRuntimeImage. Empty input means no
+// overrides. Exported for cmd/main.go.
+func ParseRuntimeImageOverrides(flagValue string) (map[string]string, error) {
+	flagValue = strings.TrimSpace(flagValue)
+	if flagValue == "" {
+		return nil, nil
+	}
+	valid := map[string]bool{"llamacpp": true, "vllm": true, "sglang": true, "tgi": true}
+	overrides := map[string]string{}
+	for _, pair := range strings.Split(flagValue, ",") {
+		key, img, found := strings.Cut(strings.TrimSpace(pair), "=")
+		key = strings.ToLower(strings.TrimSpace(key))
+		img = strings.TrimSpace(img)
+		if !found || key == "" || img == "" {
+			return nil, fmt.Errorf("invalid --runtime-images entry %q (expected runtime=image)", pair)
+		}
+		if !valid[key] {
+			return nil, fmt.Errorf("invalid --runtime-images runtime %q (valid: llamacpp, vllm, sglang, tgi)", key)
+		}
+		overrides[key] = img
+	}
+	return overrides, nil
 }

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -205,7 +205,7 @@ func TestResolveRuntimeImage(t *testing.T) {
 			expected: stockLlamaCpp,
 		},
 		{
-			name:    "llamacpp nvidia keeps the stock image even with vulkan runtime",
+			name:    "llamacpp nvidia with GPU not enabled keeps the stock image (vulkan runtime string)",
 			backend: &LlamaCppBackend{},
 			model: &inferencev1alpha1.Model{
 				Spec: inferencev1alpha1.ModelSpec{
@@ -217,7 +217,7 @@ func TestResolveRuntimeImage(t *testing.T) {
 			expected: stockLlamaCpp,
 		},
 		{
-			name:    "llamacpp nvidia keeps the stock image even with rocm runtime",
+			name:    "llamacpp nvidia with GPU not enabled keeps the stock image (rocm runtime string)",
 			backend: &LlamaCppBackend{},
 			model: &inferencev1alpha1.Model{
 				Spec: inferencev1alpha1.ModelSpec{
@@ -286,7 +286,7 @@ func TestResolveRuntimeImage(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := resolveRuntimeImage(tc.backend, tc.model); got != tc.expected {
+			if got := resolveRuntimeImage(tc.backend, tc.model, nil); got != tc.expected {
 				t.Fatalf("resolveRuntimeImage() = %q, want %q", got, tc.expected)
 			}
 		})
@@ -601,4 +601,90 @@ func TestServedModelPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResolveRuntimeImageNVIDIAAndOverrides covers the #1197 additions: the
+// NVIDIA-GPU llamacpp divert to the CUDA image (the :server default is
+// CPU-only) and the fleet-level --runtime-images override that wins over
+// every built-in divergence.
+func TestResolveRuntimeImageNVIDIAAndOverrides(t *testing.T) {
+	nvidiaGPUModel := func(vendor string) *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{
+			Spec: inferencev1alpha1.ModelSpec{
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					GPU: &inferencev1alpha1.GPUSpec{Enabled: true, Vendor: vendor},
+				},
+			},
+		}
+	}
+
+	t.Run("llamacpp with an enabled NVIDIA GPU diverts to the CUDA image", func(t *testing.T) {
+		if got := resolveRuntimeImage(&LlamaCppBackend{}, nvidiaGPUModel("nvidia"), nil); got != llamaCppCUDAImage {
+			t.Fatalf("got %q, want %q", got, llamaCppCUDAImage)
+		}
+	})
+
+	t.Run("llamacpp with an enabled vendorless GPU defaults to NVIDIA and diverts", func(t *testing.T) {
+		if got := resolveRuntimeImage(&LlamaCppBackend{}, nvidiaGPUModel(""), nil); got != llamaCppCUDAImage {
+			t.Fatalf("got %q, want %q", got, llamaCppCUDAImage)
+		}
+	})
+
+	t.Run("llamacpp with no GPU section keeps the CPU image", func(t *testing.T) {
+		got := resolveRuntimeImage(&LlamaCppBackend{}, &inferencev1alpha1.Model{}, nil)
+		if got != (&LlamaCppBackend{}).DefaultImage() {
+			t.Fatalf("got %q, want the CPU default", got)
+		}
+	})
+
+	t.Run("override wins over the built-in AMD divert", func(t *testing.T) {
+		overrides := map[string]string{"llamacpp": "mirror.local/llamacpp:airgap"}
+		if got := resolveRuntimeImage(&LlamaCppBackend{}, amdModel("vulkan"), overrides); got != "mirror.local/llamacpp:airgap" {
+			t.Fatalf("got %q, want the override", got)
+		}
+	})
+
+	t.Run("override wins over a backend default", func(t *testing.T) {
+		overrides := map[string]string{"vllm": "mirror.local/vllm:airgap"}
+		if got := resolveRuntimeImage(&VLLMBackend{}, &inferencev1alpha1.Model{}, overrides); got != "mirror.local/vllm:airgap" {
+			t.Fatalf("got %q, want the override", got)
+		}
+	})
+
+	t.Run("an override for a different backend does not leak", func(t *testing.T) {
+		overrides := map[string]string{"vllm": "mirror.local/vllm:airgap"}
+		got := resolveRuntimeImage(&TGIBackend{}, &inferencev1alpha1.Model{}, overrides)
+		if got != (&TGIBackend{}).DefaultImage() {
+			t.Fatalf("got %q, want the TGI default", got)
+		}
+	})
+}
+
+func TestParseRuntimeImageOverrides(t *testing.T) {
+	t.Run("empty means none", func(t *testing.T) {
+		got, err := ParseRuntimeImageOverrides("  ")
+		if err != nil || got != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+	t.Run("parses multiple entries with spaces and case-folds keys", func(t *testing.T) {
+		got, err := ParseRuntimeImageOverrides(" VLLM=a/b:1 , tgi=c/d:2 ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["vllm"] != "a/b:1" || got["tgi"] != "c/d:2" {
+			t.Fatalf("got %v", got)
+		}
+	})
+	t.Run("rejects unknown runtimes and malformed pairs", func(t *testing.T) {
+		if _, err := ParseRuntimeImageOverrides("triton=x"); err == nil {
+			t.Fatal("expected error for unknown runtime")
+		}
+		if _, err := ParseRuntimeImageOverrides("vllm="); err == nil {
+			t.Fatal("expected error for empty image")
+		}
+		if _, err := ParseRuntimeImageOverrides("not-a-pair"); err == nil {
+			t.Fatal("expected error for missing separator")
+		}
+	})
 }

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -78,6 +78,12 @@ type InferenceServiceReconciler struct {
 	// default client with a 5-second timeout is created per request. Primarily
 	// useful in tests to capture requests or control timeouts.
 	HTTPClient *http.Client
+	// RuntimeImageOverrides remaps a runtime backend's default image
+	// fleet-wide (keys: llamacpp, vllm, sglang, tgi). Set via
+	// --runtime-images (chart: runtimeImages.*) for air-gapped/mirrored
+	// registries; wins over the built-in vendor divergences, loses to an
+	// explicit spec.image. Empty means stock defaults.
+	RuntimeImageOverrides map[string]string
 	// RolloutIdleBaseURL overrides the base URL used for idle endpoint checks.
 	// When non-empty, this URL is used directly instead of constructing a
 	// cluster-local service DNS name. Primarily useful in tests where cluster

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -3696,7 +3696,7 @@ var _ = Describe("RuntimeBackend interface", func() {
 
 		It("should return correct defaults", func() {
 			Expect(backend.ContainerName()).To(Equal("vllm"))
-			Expect(backend.DefaultImage()).To(Equal("vllm/vllm-openai:v0.20.0"))
+			Expect(backend.DefaultImage()).To(Equal("vllm/vllm-openai:v0.25.1"))
 			Expect(backend.DefaultPort()).To(Equal(int32(8000)))
 			Expect(backend.NeedsModelInit()).To(BeTrue())
 			Expect(backend.DefaultHPAMetric()).To(Equal("vllm:num_requests_running"))
@@ -3871,7 +3871,7 @@ var _ = Describe("RuntimeBackend interface", func() {
 
 		It("should return correct defaults", func() {
 			Expect(backend.ContainerName()).To(Equal("tgi"))
-			Expect(backend.DefaultImage()).To(Equal("ghcr.io/huggingface/text-generation-inference:latest"))
+			Expect(backend.DefaultImage()).To(Equal("ghcr.io/huggingface/text-generation-inference:3.3.7"))
 			Expect(backend.DefaultPort()).To(Equal(int32(80)))
 			Expect(backend.NeedsModelInit()).To(BeFalse())
 			Expect(backend.DefaultHPAMetric()).To(Equal("tgi:queue_size"))

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -32,6 +32,18 @@ const llamaCppVulkanImage = "ghcr.io/defilantech/llmkube-llama-vulkan@sha256:cba
 // promoter smokes the candidate on real hardware. See #701.
 const llamaCppROCmImage = "ghcr.io/defilantech/llmkube-llama-rocm@sha256:8da16041a18b4f03f0be4de5e064be97ba8937149091d6693ee09711da362849"
 
+// llamaCppCUDAImage is the upstream CUDA llama.cpp server image the operator
+// substitutes for the CPU-only :server default when the Model declares an
+// NVIDIA GPU (see resolveRuntimeImage). Pinned to an immutable per-build tag
+// (verified 2026-07-21 via the GHCR tags API; CUDA 12.8.1 base). CAVEAT for
+// Blackwell: upstream's prebuilt CUDA images ship no native sm_100 codegen
+// (ggml's CMAKE_CUDA_ARCHITECTURES covers 50..90-virtual plus consumer
+// 120a/121a only), so a B200 runs via PTX JIT from the 90-virtual target:
+// functional, with first-run JIT cost and no sm_100-tuned kernels. Fleets
+// serious about llama.cpp-on-B200 should build with CUDA_DOCKER_ARCH=100a-real
+// and point runtimeImages.llamacpp (or spec.image) at it.
+const llamaCppCUDAImage = "ghcr.io/ggml-org/llama.cpp:server-cuda-b10068"
+
 // LlamaCppBackend generates container configuration for the llama.cpp inference server.
 type LlamaCppBackend struct{}
 
@@ -39,6 +51,10 @@ func (b *LlamaCppBackend) ContainerName() string {
 	return "llama-server"
 }
 
+// DefaultImage is the upstream CPU-only tag: correct for CPU serving and for
+// Models with no GPU section. GPU Models never see it: AMD diverts to the
+// hardware-validated Vulkan/ROCm digests and NVIDIA diverts to
+// llamaCppCUDAImage (resolveRuntimeImage).
 func (b *LlamaCppBackend) DefaultImage() string {
 	return "ghcr.io/ggml-org/llama.cpp:server"
 }

--- a/internal/controller/runtime_sglang.go
+++ b/internal/controller/runtime_sglang.go
@@ -48,7 +48,13 @@ const ConditionSGLangSpecValid = "SGLangSpecValid"
 
 // sglangCUDAImage is the pinned default CUDA image. Tag verified at PR time
 // against Docker Hub; bump in a follow-up if a newer SGLang release is required.
-const sglangCUDAImage = "lmsysorg/sglang:v0.5.15-cu129"
+// sglangCUDAImage pins the newest stable SGLang CUDA image (verified
+// 2026-07-21 via github.com/sgl-project/sglang/releases and Docker Hub).
+// Blackwell is a first-class SGLang target (SM100 CuteDSL kernels since
+// v0.5.14, Blackwell MLA backend since v0.5.12). The -cu129 variant matches
+// the 570 driver branch; 580-branch fleets can pin -cu130 via
+// runtimeImages.sglang or spec.image.
+const sglangCUDAImage = "lmsysorg/sglang:v0.5.15.post1-cu129"
 
 // sglangROCmImage is the AMD ROCm variant. Selected by resolveRuntimeImage
 // when model.Spec.Hardware.GPU.Vendor == "amd".

--- a/internal/controller/runtime_tgi.go
+++ b/internal/controller/runtime_tgi.go
@@ -15,8 +15,16 @@ import (
 type TGIBackend struct{}
 
 func (b *TGIBackend) ContainerName() string { return "tgi" }
+
+// DefaultImage pins TGI's FINAL release: upstream archived the repository on
+// 2026-03-21 (maintenance mode; the project itself recommends vLLM/SGLang
+// going forward), so 3.3.7 (2025-12-19) is the last tag there will ever be
+// and :latest must not float. TGI states no Blackwell (sm_100) support in any
+// release notes; do not use it as a B200 default. Verified 2026-07-21 via the
+// GitHub API (archived: true) and a GHCR manifest check (3.3.7 exists; not
+// every older patch tag does).
 func (b *TGIBackend) DefaultImage() string {
-	return "ghcr.io/huggingface/text-generation-inference:latest"
+	return "ghcr.io/huggingface/text-generation-inference:3.3.7"
 }
 func (b *TGIBackend) DefaultPort() int32       { return 80 }
 func (b *TGIBackend) NeedsModelInit() bool     { return false }

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -33,8 +33,16 @@ const (
 
 type VLLMBackend struct{}
 
-func (b *VLLMBackend) ContainerName() string    { return "vllm" }
-func (b *VLLMBackend) DefaultImage() string     { return "vllm/vllm-openai:v0.20.0" }
+func (b *VLLMBackend) ContainerName() string { return "vllm" }
+
+// DefaultImage pins the newest stable vLLM release (verified 2026-07-21 via
+// github.com/vllm-project/vllm/releases and the Docker Hub tag list).
+// Blackwell (sm_100/B200) has been first-class since before v0.20.0 (FA4
+// default on SM100, MXFP4 CUTLASS MoE; see the v0.20.0 release notes), so any
+// tag at or above that floor is B200-safe; v0.25.1 is simply current. The
+// default build ships CUDA 13 userspace; fleets on the 570 driver branch can
+// pin the v0.25.1-cu129 variant via runtimeImages.vllm or spec.image.
+func (b *VLLMBackend) DefaultImage() string     { return "vllm/vllm-openai:v0.25.1" }
 func (b *VLLMBackend) DefaultPort() int32       { return 8000 }
 func (b *VLLMBackend) NeedsModelInit() bool     { return true }
 func (b *VLLMBackend) DefaultHPAMetric() string { return "vllm:num_requests_running" }


### PR DESCRIPTION
## What

Fixes #1197

Four coupled changes, every version fact research-verified on 2026-07-21 against release pages, registry tag lists, and NVIDIA docs (citations live in the code comments and `b200-validation-matrix.md` section 3):

1. **Image pins**
   - vLLM `v0.20.0` → **`v0.25.1`** (newest stable; Blackwell first-class since before the v0.20.0 floor — FA4 default on SM100, MXFP4 CUTLASS MoE). Default build is CUDA 13 userspace; `-cu129` variant documented for 570-branch drivers.
   - SGLang `v0.5.15-cu129` → **`v0.5.15.post1-cu129`** (SM100 CuteDSL kernels since v0.5.14). The hardware-validated ROCm pin is untouched.
   - TGI `:latest` → **`:3.3.7`** — the **final** release: upstream archived the repo 2026-03-21, recommends vLLM/SGLang, and has no stated Blackwell support. A floating `:latest` on an archived project is a time bomb. (Notably: `3.3.5`, which an earlier automated attempt picked from stale research, does not exist on GHCR — 404.)
2. **NVIDIA llama.cpp divert** — Models declaring an NVIDIA GPU now auto-divert from the CPU-only `:server` default to the upstream CUDA image (immutable tag `server-cuda-b10068`), exactly mirroring the existing AMD Vulkan/ROCm divergences. Previously such Models **silently served on CPU** unless `spec.image` was hand-set. Honestly documented caveat: upstream CUDA images ship **no native sm_100 codegen** (ggml's arch list stops at 90-virtual + consumer 120a/121a), so B200 runs via PTX JIT; peak performance needs a `CUDA_DOCKER_ARCH=100a-real` build via the new override.
3. **Fleet overrides** — chart values `runtimeImages.{llamacpp,vllm,sglang,tgi}` → new `--runtime-images` operator flag (validated at startup). Overrides win over built-in vendor divergences (air-gap/mirror fleets must be able to redirect unconditionally) and lose to explicit `spec.image`. Strict values schema updated.
4. **Platform floors** — informational `platformFloors` values (driver ≥ 570.133.20, CUDA ≥ 12.8, NCCL ≥ 2.25.1, GPU Operator ≥ v25.3.0) rendered into NOTES.txt, so a first Blackwell deploy fails loudly at the checklist rather than cryptically at CUDA init. The optional warn-only preflight Job from the issue is omitted as allowed.

## Validation

- New tests: NVIDIA divert matrix (enabled GPU / vendorless default / no-GPU keeps CPU image), override precedence (beats the AMD divert, beats defaults, no cross-backend leakage), flag parsing (case-folding, unknown runtime + malformed pair rejection). Stale image assertions updated.
- Full `make test` green; `GOOS=linux golangci-lint` 0 issues; `helm lint` green; `--runtime-images` renders only when a value is set (verified via `helm template`); NOTES floors verified via `helm install --dry-run`.
- `b200-validation-matrix.md` section 3 flipped from "not-yet-landed" to LANDED with the verified pins.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (GOOS=linux cross-arch, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: implemented with AI assistance (human-directed); version facts verified by live web research with cited 2026 sources rather than model memory. Human owns the review conversation.
- [x] Documentation updated (validation matrix section 3, values.yaml comments, NOTES.txt)