### PR TITLE
feat(chart): gpuSharing pool + VRAM values wired to operator flags (#1196 story 3)

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -89,6 +89,15 @@ spec:
         {{- with .Values.controllerManager.routerProxy.defaultLiteLLMURL }}
         - --default-litellm-url={{ . }}
         {{- end }}
+        {{- $ns := .Values.gpuSharing.pools.shared.nodeSelector | default dict }}
+        {{- $nsPairs := list }}
+        {{- range $k, $v := $ns }}{{- $nsPairs = append $nsPairs (printf "%s=%s" $k $v) }}{{- end }}
+        {{- if $nsPairs }}
+        - --gpu-sharing-shared-pool-selector={{ join "," $nsPairs }}
+        {{- end }}
+        {{- if gt (.Values.gpuSharing.vramPerDeviceGiB | default 0) 0 }}
+        - --gpu-sharing-vram-per-device-gib={{ .Values.gpuSharing.vramPerDeviceGiB }}
+        {{- end }}
         {{- if .Values.webhook.enabled }}
         # Point the controller-runtime webhook server at the mounted serving
         # cert. cmd/main.go registers the ModelRouter validating webhook only

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -406,6 +406,34 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "gpuSharing": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "GPU sharing configuration for the operator's gpuSharing feature (#1196).",
+      "properties": {
+        "pools": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "shared": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "nodeSelector": {
+                  "type": "object",
+                  "additionalProperties": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "vramPerDeviceGiB": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Device memory (GiB) of one whole GPU; 0 means unset."
+        }
+      }
+    },
     "runtimeImages": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -410,6 +410,24 @@ networkPolicies:
   enabled: false
   additionalEgressCIDRs: []
 
+# GPU sharing configuration for the operator's gpuSharing feature (#1196).
+# These values are rendered as operator flags; they do not change any CRD.
+gpuSharing:
+  # Pools for gpuSharing mode "shared". When a shared pool is configured,
+  # InferenceServices with gpuSharing.mode=shared are scheduled onto nodes
+  # matching this nodeSelector (the operator passes it as
+  # --gpu-sharing-shared-pool-selector). Empty means no shared pool exists
+  # and mode shared is rejected at admission.
+  pools:
+    shared:
+      nodeSelector: {}
+  # Device memory (GiB) of one whole GPU in this fleet, used to derive the
+  # VRAM footprint of exclusive-mode InferenceServices for GPUQuota
+  # vramBytes accounting. 0 (default) means exclusive footprints are unknown;
+  # quotas with a vramBytes cap then deny such admissions with an actionable
+  # message.
+  vramPerDeviceGiB: 0
+
 # Fleet-wide runtime image overrides (#1197). When set, a value replaces the
 # operator's built-in default image for that runtime backend, including its
 # vendor-specific divergences. Intended for air-gapped or mirrored registries.


### PR DESCRIPTION
## What

Story 3 of #1196: Helm chart plumbing for the two gpuSharing operator flags that landed in stories 2+4.

- `gpuSharing.pools.shared.nodeSelector` (string map) → `--gpu-sharing-shared-pool-selector` (joined `key=value[,key=value]`)
- `gpuSharing.vramPerDeviceGiB` (integer, 0 = unset) → `--gpu-sharing-vram-per-device-gib`

Each arg renders only when its value is set, mirroring the `runtimeImages` pattern from #1204 in the same file. Strict `values.schema.json` entries included.

Part of #1196 (story 3 of 7; do not auto-close).

## Provenance

**Authored by a Foreman coder agent** (dense Qwopus3.6-27B) from the epic issue plus an operator intent scoping it to exactly this story — the first production run after #1203 made `Workload.spec.intent` reach the coder. Scope held perfectly: 3 chart files touched, nothing else. The in-loop gate passed (GATE-PASS) and the branch was based on the then-current main head (including #1204, merged an hour before the run). Human review performed per the AI-assisted contribution policy: verified the diff file-by-file, validated `helm lint` plus `helm template` render/absence behavior against current main, and amended only the commit trailer (`Fixes` → `Part of`, so the epic stays open).

## Validation

- `helm lint` green.
- `helm template --set gpuSharing.vramPerDeviceGiB=192 --set-string 'gpuSharing.pools.shared.nodeSelector...'` renders both flags with correct syntax; an unset chart renders neither.
- Values comments accurately describe the admission behavior (which #1196 story 5, in flight, makes literal).

## Checklist

- [ ] Tests added/updated (n/a: chart-only; the chart CI lanes validate lint/template/schema)
- [ ] `make test` passes locally (n/a: no Go changes)
- [x] `make lint` passes locally (helm lint)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance disclosed above (Foreman-authored, human-reviewed)
- [x] Documentation updated (values.yaml comments)