### PR TITLE
feat(webhook): admission-time gpuSharing validation (#1196 story 5)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -458,7 +458,10 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Model")
 			os.Exit(1)
 		}
-		if err := controller.SetupInferenceServiceQuotaWebhookWithManager(mgr, gpuSharingVRAMPerDeviceGiB); err != nil {
+		if err := controller.SetupInferenceServiceQuotaWebhookWithManager(mgr, controller.InferenceServiceQuotaWebhookOptions{
+			VRAMPerDeviceGiB:     gpuSharingVRAMPerDeviceGiB,
+			GPUSharingSharedPool: gpuSharingSharedPool,
+		}); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "InferenceServiceQuota")
 			os.Exit(1)
 		}

--- a/internal/controller/gpu_sharing.go
+++ b/internal/controller/gpu_sharing.go
@@ -79,10 +79,11 @@ func gpuSharingMode(isvc *inferencev1alpha1.InferenceService) string {
 // toleration key from the Model spec), so a nil/exclusive gpuSharing changes
 // nothing for existing manifests.
 //
-// Validation performed here is reconcile-time; promoting it to admission
-// time is a planned follow-up (#1196 story 5). CEL on the CRD already
-// enforces the structural rules (profile iff partitioned, memoryLimitGiB
-// only for shared).
+// These rules run at BOTH admission time (the quota webhook's
+// validateGPUSharing, on fleets with multitenancy enabled) and reconcile
+// time (the backstop for installs without the webhook). CEL on the CRD
+// already enforces the structural rules (profile iff partitioned,
+// memoryLimitGiB only for shared).
 func resolveGPUSharing(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, sharedPoolSelector map[string]string) (gpuSharingResolution, error) {
 	exclusive := gpuSharingResolution{
 		resourceName:  gpuResourceNameForSpec(model),
@@ -96,14 +97,22 @@ func resolveGPUSharing(isvc *inferencev1alpha1.InferenceService, model *inferenc
 
 	// Both non-exclusive modes are single-device by definition: a partition
 	// cannot span devices and a shared slot is one seat on one device.
-	if count := resolveGPUCount(isvc, model); count != 1 {
+	// Nil-safe count: at admission time the Model may not exist yet
+	// (resolveGPUCount assumes a non-nil Model).
+	count := int32(0)
+	if model != nil {
+		count = resolveGPUCount(isvc, model)
+	} else if isvc.Spec.Resources != nil {
+		count = isvc.Spec.Resources.GPU
+	}
+	if count != 1 {
 		return gpuSharingResolution{}, fmt.Errorf(
 			"gpuSharing mode %q requires exactly 1 GPU, got %d (tensor parallelism needs mode exclusive)", mode, count)
 	}
 
 	// DRA claims allocate devices out-of-band; combining them with a sharing
 	// mode would leave two owners for the same placement decision.
-	if len(modelResourceClaims(model)) > 0 {
+	if model != nil && len(modelResourceClaims(model)) > 0 {
 		return gpuSharingResolution{}, fmt.Errorf(
 			"gpuSharing mode %q cannot be combined with hardware.gpu.resourceClaims (DRA claims own device placement)", mode)
 	}
@@ -241,6 +250,29 @@ func podVRAMBytes(isvc *inferencev1alpha1.InferenceService, model *inferencev1al
 		}
 		return int64(count) * int64(vramPerDeviceGiB) * bytesPerGiB, true
 	}
+}
+
+// gpuSharingParallelismConflict rejects explicit multi-device parallelism on
+// a non-exclusive sharing mode. resolveGPUSharing already enforces gpu == 1,
+// which keeps the AUTO-derived tensor-parallel size at 1; this catches the
+// remaining hole where vllmConfig/sglangConfig declare an explicit size > 1
+// that the runtime would then try to satisfy inside a single partition or
+// shared seat.
+func gpuSharingParallelismConflict(isvc *inferencev1alpha1.InferenceService) error {
+	mode := gpuSharingMode(isvc)
+	if mode == inferencev1alpha1.GPUSharingModeExclusive {
+		return nil
+	}
+	over := func(v *int32) bool { return v != nil && *v > 1 }
+	if cfg := isvc.Spec.VLLMConfig; cfg != nil && over(cfg.TensorParallelSize) {
+		return fmt.Errorf("gpuSharing mode %q cannot use vllmConfig.tensorParallelSize > 1 (parallelism needs mode exclusive)", mode)
+	}
+	if cfg := isvc.Spec.SGLangConfig; cfg != nil {
+		if over(cfg.TensorParallelSize) || over(cfg.ExpertParallelSize) || over(cfg.DataParallelSize) {
+			return fmt.Errorf("gpuSharing mode %q cannot use sglangConfig tensor/expert/data parallelism > 1 (parallelism needs mode exclusive)", mode)
+		}
+	}
+	return nil
 }
 
 // serviceVRAMBytesFor derives the total VRAM footprint of an

--- a/internal/controller/gpu_sharing_vram_test.go
+++ b/internal/controller/gpu_sharing_vram_test.go
@@ -150,10 +150,14 @@ func TestQuotaVRAMAdmission(t *testing.T) {
 			MemoryLimitGiB: gib32(limitGiB),
 		}
 	}
+	// Story 5 validates the sharing spec at admission before quota logic
+	// runs, so shared-mode subtests need a configured pool to get PAST that
+	// gate and into the VRAM accounting under test here.
+	pool := map[string]string{"llmkube.dev/gpu-pool": "shared"}
 
 	t.Run("shared within the vram cap is admitted", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns).Build()
-		v := &InferenceServiceQuotaValidator{Client: c}
+		v := &InferenceServiceQuotaValidator{Client: c, GPUSharingSharedPool: pool}
 		if _, err := v.ValidateCreate(ctx, vramISvc("s1", "vram-ns", 1, 1, shared(24))); err != nil {
 			t.Fatalf("expected admission, got: %v", err)
 		}
@@ -161,7 +165,7 @@ func TestQuotaVRAMAdmission(t *testing.T) {
 
 	t.Run("shared exceeding the vram cap is denied", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns).Build()
-		v := &InferenceServiceQuotaValidator{Client: c}
+		v := &InferenceServiceQuotaValidator{Client: c, GPUSharingSharedPool: pool}
 		_, err := v.ValidateCreate(ctx, vramISvc("s2", "vram-ns", 1, 1, shared(128)))
 		if err == nil {
 			t.Fatal("expected denial (128GiB > 96GiB cap), got nil")
@@ -174,7 +178,7 @@ func TestQuotaVRAMAdmission(t *testing.T) {
 	t.Run("vram accounts for replicas", func(t *testing.T) {
 		// 24GiB x 5 replicas = 120GiB > 96GiB cap.
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns).Build()
-		v := &InferenceServiceQuotaValidator{Client: c}
+		v := &InferenceServiceQuotaValidator{Client: c, GPUSharingSharedPool: pool}
 		_, err := v.ValidateCreate(ctx, vramISvc("s3", "vram-ns", 1, 5, shared(24)))
 		if err == nil {
 			t.Fatal("expected denial (24*5 > 96), got nil")
@@ -187,7 +191,7 @@ func TestQuotaVRAMAdmission(t *testing.T) {
 	t.Run("stored shared usage counts against the cap", func(t *testing.T) {
 		existing := vramISvc("stored", "vram-ns", 1, 1, shared(80))
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vramQuota(96), ns, existing).Build()
-		v := &InferenceServiceQuotaValidator{Client: c}
+		v := &InferenceServiceQuotaValidator{Client: c, GPUSharingSharedPool: pool}
 		// 80 stored + 24 incoming = 104 > 96.
 		_, err := v.ValidateCreate(ctx, vramISvc("s4", "vram-ns", 1, 1, shared(24)))
 		if err == nil {
@@ -286,4 +290,112 @@ func TestGPUQuotaReconcileVRAM(t *testing.T) {
 	if limit := testutil.ToFloat64(llmkubemetrics.GPUQuotaVRAMBytesLimit.WithLabelValues("vram-gq", "default")); limit != float64(256*bytesPerGiB) {
 		t.Errorf("vram limit gauge = %v, want %v", limit, float64(256*bytesPerGiB))
 	}
+}
+
+// TestGPUSharingAdmission covers #1196 story 5: invalid or unsatisfiable
+// gpuSharing specs are rejected at admission by the quota webhook (same rules
+// as the reconcile-time backstop), including with a Model that does not exist
+// yet, and explicit parallelism config cannot ride a non-exclusive mode.
+func TestGPUSharingAdmission(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+	ctx := context.Background()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "gs-adm-ns"}}
+	// A permissive quota so only the gpuSharing rules can reject.
+	quota := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "gs-adm-quota", Namespace: "gs-adm-ns"},
+		Spec:       inferencev1alpha1.GPUQuotaSpec{NamespaceRef: "gs-adm-ns", GPUCount: 100},
+	}
+	pool := map[string]string{"llmkube.dev/gpu-pool": "shared"}
+
+	newValidator := func(pool map[string]string) *InferenceServiceQuotaValidator {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(quota, ns).Build()
+		return &InferenceServiceQuotaValidator{Client: c, GPUSharingSharedPool: pool}
+	}
+
+	t.Run("partitioned with a nonexistent Model is admitted (NVIDIA default)", func(t *testing.T) {
+		isvc := vramISvc("adm1", "gs-adm-ns", 1, 1, &inferencev1alpha1.GPUSharingSpec{
+			Mode:    inferencev1alpha1.GPUSharingModePartitioned,
+			Profile: "1g.24gb",
+		})
+		if _, err := newValidator(nil).ValidateCreate(ctx, isvc); err != nil {
+			t.Fatalf("expected admission, got: %v", err)
+		}
+	})
+
+	t.Run("partitioned with a bad profile is rejected at admission", func(t *testing.T) {
+		isvc := vramISvc("adm2", "gs-adm-ns", 1, 1, &inferencev1alpha1.GPUSharingSpec{
+			Mode:    inferencev1alpha1.GPUSharingModePartitioned,
+			Profile: "24gb",
+		})
+		_, err := newValidator(nil).ValidateCreate(ctx, isvc)
+		if err == nil || !strings.Contains(err.Error(), "not a valid MIG profile") {
+			t.Fatalf("expected MIG-profile rejection, got: %v", err)
+		}
+	})
+
+	t.Run("shared without a configured pool is rejected at admission", func(t *testing.T) {
+		isvc := vramISvc("adm3", "gs-adm-ns", 1, 1, &inferencev1alpha1.GPUSharingSpec{
+			Mode: inferencev1alpha1.GPUSharingModeShared,
+		})
+		_, err := newValidator(nil).ValidateCreate(ctx, isvc)
+		if err == nil || !strings.Contains(err.Error(), "requires a configured shared pool") {
+			t.Fatalf("expected no-pool rejection, got: %v", err)
+		}
+	})
+
+	t.Run("shared with a pool is admitted", func(t *testing.T) {
+		isvc := vramISvc("adm4", "gs-adm-ns", 1, 1, &inferencev1alpha1.GPUSharingSpec{
+			Mode: inferencev1alpha1.GPUSharingModeShared,
+		})
+		if _, err := newValidator(pool).ValidateCreate(ctx, isvc); err != nil {
+			t.Fatalf("expected admission, got: %v", err)
+		}
+	})
+
+	t.Run("multi-GPU partitioned is rejected at admission", func(t *testing.T) {
+		isvc := vramISvc("adm5", "gs-adm-ns", 4, 1, &inferencev1alpha1.GPUSharingSpec{
+			Mode:    inferencev1alpha1.GPUSharingModePartitioned,
+			Profile: "1g.24gb",
+		})
+		_, err := newValidator(nil).ValidateCreate(ctx, isvc)
+		if err == nil || !strings.Contains(err.Error(), "requires exactly 1 GPU") {
+			t.Fatalf("expected single-GPU rejection, got: %v", err)
+		}
+	})
+
+	t.Run("explicit vLLM tensor parallelism cannot ride a partition", func(t *testing.T) {
+		tp := int32(4)
+		isvc := vramISvc("adm6", "gs-adm-ns", 1, 1, &inferencev1alpha1.GPUSharingSpec{
+			Mode:    inferencev1alpha1.GPUSharingModePartitioned,
+			Profile: "1g.24gb",
+		})
+		isvc.Spec.VLLMConfig = &inferencev1alpha1.VLLMConfig{TensorParallelSize: &tp}
+		_, err := newValidator(nil).ValidateCreate(ctx, isvc)
+		if err == nil || !strings.Contains(err.Error(), "tensorParallelSize > 1") {
+			t.Fatalf("expected TP rejection, got: %v", err)
+		}
+	})
+
+	t.Run("explicit SGLang expert parallelism cannot ride shared", func(t *testing.T) {
+		ep := int32(2)
+		isvc := vramISvc("adm7", "gs-adm-ns", 1, 1, &inferencev1alpha1.GPUSharingSpec{
+			Mode: inferencev1alpha1.GPUSharingModeShared,
+		})
+		isvc.Spec.SGLangConfig = &inferencev1alpha1.SGLangConfig{ExpertParallelSize: &ep}
+		_, err := newValidator(pool).ValidateCreate(ctx, isvc)
+		if err == nil || !strings.Contains(err.Error(), "parallelism > 1") {
+			t.Fatalf("expected parallelism rejection, got: %v", err)
+		}
+	})
+
+	t.Run("exclusive with explicit TP stays admitted", func(t *testing.T) {
+		tp := int32(8)
+		isvc := vramISvc("adm8", "gs-adm-ns", 8, 1, nil)
+		isvc.Spec.VLLMConfig = &inferencev1alpha1.VLLMConfig{TensorParallelSize: &tp}
+		if _, err := newValidator(nil).ValidateCreate(ctx, isvc); err != nil {
+			t.Fatalf("expected admission, got: %v", err)
+		}
+	})
 }

--- a/internal/controller/inferenceservice_quota_webhook.go
+++ b/internal/controller/inferenceservice_quota_webhook.go
@@ -57,6 +57,20 @@ type InferenceServiceQuotaValidator struct {
 	// against a quota that declares a vramBytes cap is denied with an
 	// actionable message rather than silently waved through.
 	VRAMPerDeviceGiB int
+	// GPUSharingSharedPool mirrors the reconciler's shared-pool node
+	// selector (--gpu-sharing-shared-pool-selector) so gpuSharing specs are
+	// validated at admission with the same rules the reconciler applies:
+	// a shared-mode InferenceService on a fleet with no configured pool is
+	// rejected at kubectl apply instead of sitting Phase=Failed (#1196
+	// story 5).
+	GPUSharingSharedPool map[string]string
+}
+
+// InferenceServiceQuotaWebhookOptions carries the fleet-level configuration
+// the quota webhook shares with the reconcilers.
+type InferenceServiceQuotaWebhookOptions struct {
+	VRAMPerDeviceGiB     int
+	GPUSharingSharedPool map[string]string
 }
 
 var _ admission.Validator[*inferencev1alpha1.InferenceService] = &InferenceServiceQuotaValidator{}
@@ -74,11 +88,12 @@ var _ admission.Validator[*inferencev1alpha1.InferenceService] = &InferenceServi
 // failurePolicy=Fail, fail closed on EVERY InferenceService admission whenever
 // multitenancy is enabled. The distinct -quota suffix keeps this webhook from
 // colliding with any future default-path InferenceService webhook.
-func SetupInferenceServiceQuotaWebhookWithManager(mgr ctrl.Manager, vramPerDeviceGiB int) error {
+func SetupInferenceServiceQuotaWebhookWithManager(mgr ctrl.Manager, opts InferenceServiceQuotaWebhookOptions) error {
 	return ctrl.NewWebhookManagedBy(mgr, &inferencev1alpha1.InferenceService{}).
 		WithValidator(&InferenceServiceQuotaValidator{
-			Client:           mgr.GetClient(),
-			VRAMPerDeviceGiB: vramPerDeviceGiB,
+			Client:               mgr.GetClient(),
+			VRAMPerDeviceGiB:     opts.VRAMPerDeviceGiB,
+			GPUSharingSharedPool: opts.GPUSharingSharedPool,
 		}).
 		WithValidatorCustomPath("/validate-inference-llmkube-dev-v1alpha1-inferenceservice-quota").
 		Complete()
@@ -104,6 +119,17 @@ func (v *InferenceServiceQuotaValidator) ValidateDelete(_ context.Context, _ *in
 // validate checks the InferenceService against all applicable GPUQuotas and
 // returns an error if any quota denies the admission.
 func (v *InferenceServiceQuotaValidator) validate(ctx context.Context, isvc *inferencev1alpha1.InferenceService) error {
+	// gpuSharing spec validation first (#1196 story 5): an invalid or
+	// unsatisfiable sharing spec is rejected at admission with the same
+	// rules the reconciler applies, instead of being accepted and then
+	// parked at Phase=Failed. These are spec errors, not quota denials, so
+	// they do not touch the denial counter. The reconcile-time gate stays
+	// as the backstop for installs that run without this webhook
+	// (multitenancy disabled).
+	if err := v.validateGPUSharing(ctx, isvc); err != nil {
+		return fmt.Errorf("invalid gpuSharing spec: %w", err)
+	}
+
 	quotas, err := v.listApplicableQuotas(ctx, isvc)
 	if err != nil {
 		return fmt.Errorf("listing applicable GPUQuotas: %w", err)
@@ -121,6 +147,25 @@ func (v *InferenceServiceQuotaValidator) validate(ctx context.Context, isvc *inf
 	}
 
 	return nil
+}
+
+// validateGPUSharing runs the resolver's sharing rules plus the explicit
+// parallelism cross-checks against the incoming InferenceService. The Model
+// is fetched best-effort: at admission time it may not exist yet, and a nil
+// Model resolves with the NVIDIA-default vendor exactly as the reconciler
+// would on first sight.
+func (v *InferenceServiceQuotaValidator) validateGPUSharing(ctx context.Context, isvc *inferencev1alpha1.InferenceService) error {
+	var model *inferencev1alpha1.Model
+	if isvc.Spec.ModelRef != "" {
+		m := &inferencev1alpha1.Model{}
+		if err := v.Client.Get(ctx, types.NamespacedName{Name: isvc.Spec.ModelRef, Namespace: isvc.Namespace}, m); err == nil {
+			model = m
+		}
+	}
+	if _, err := resolveGPUSharing(isvc, model, v.GPUSharingSharedPool); err != nil {
+		return err
+	}
+	return gpuSharingParallelismConflict(isvc)
 }
 
 // listApplicableQuotas returns all GPUQuotas whose scope covers the given


### PR DESCRIPTION
## What

Story 5 of #1196: invalid or unsatisfiable `gpuSharing` specs are rejected **at admission** by the quota webhook — `kubectl apply` fails immediately with the actionable message, instead of the ISvc being accepted and parked at `Phase=Failed`. The enforcement ladder is now complete:

| Layer | Enforces | When |
|---|---|---|
| CEL | structural rules (profile iff partitioned, memoryLimitGiB iff shared) | always |
| **Webhook (this PR)** | cluster-aware rules (pool configured, vendor, profile shape, single-device, DRA, explicit parallelism) | multitenancy-enabled fleets |
| Reconciler | same rules, unchanged | backstop for installs without the webhook |

Part of #1196 (story 5 of 7; do not auto-close).

## How

- `validateGPUSharing` runs before quota evaluation inside the **existing** quota-validator registration — no new webhook path, so the #1195 custom-path lesson applies exactly once. Sharing-spec rejections are not quota denials and don't touch the denial counter.
- Setup signature refactored to an options struct (`VRAMPerDeviceGiB` + `GPUSharingSharedPool`) to stop parameter creep.
- **Bug fixed en route:** `resolveGPUSharing` deref'd a nil Model (`resolveGPUCount`, `modelResourceClaims`) — the webhook path can legitimately see a Model that doesn't exist yet; it now resolves with the NVIDIA-default vendor, exactly as the reconciler would on first sight. Covered by an explicit nonexistent-Model admission test.
- **New cross-check:** explicit `vllmConfig.tensorParallelSize > 1` / SGLang tensor/expert/data parallelism > 1 cannot ride a non-exclusive mode. The resolver's `gpu == 1` rule only constrained the *auto-derived* TP; an explicit size slipped through and would have asked the runtime to parallelize inside a single partition.

## Validation

- 8 new admission tests + the story-4 VRAM tests updated to configure a pool (the admission gate now runs before the accounting they test — the correct interaction, caught by the full-suite run).
- **All specs pass locally**: 588/588 controller + the full foreman suites. Honest caveat: the local runs end with an environmental `AfterSuite` teardown flake ("timeout waiting for kube-apiserver to stop") that reproduces **on unmodified main on this machine** (macOS security daemons re-assessing envtest binaries; 124 orphaned control planes from earlier interrupted runs were also purged). Zero spec failures anywhere; Linux CI on this PR is the clean arbiter.
- `GOOS=linux golangci-lint` 0 issues; committed bytes verified clean.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (all specs green; see teardown caveat above, reproduced on unmodified main)
- [x] `make lint` passes locally (GOOS=linux cross-arch, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: implemented with AI assistance (human-directed) from the approved gpuSharing design; human owns the review conversation.
- [ ] Documentation updated (operator docs page is story 6)