### PR TITLE
fix(agent): inject current date into issue-fix prompt and anchor research queries (#1202)

### DIFF
--- a/config/foreman/system-prompts/coder.md
+++ b/config/foreman/system-prompts/coder.md
@@ -59,7 +59,10 @@ when you call the terminal `submit_result` tool.
 Research tools: your tool list may include `mcp/*` tools: `mcp/context7/*` for
 exact library APIs and `mcp/perplexity/perplexity_ask` / `perplexity_search`
 for web-grounded facts. See "Verify external facts" in Step 2 for when to use
-them.
+them. When asking research tools about versions or "latest" anything, phrase
+queries as "as of today" or "the current latest" — never name a specific year
+from memory. Treat the date given in the task prompt as the current date;
+your internal knowledge-cutoff clock is not authoritative.
 
 ## Step 1 — Triage
 

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -2298,6 +2298,11 @@ func workloadOwnerName(task *foremanv1alpha1.AgenticTask) string {
 }
 
 // buildUserPrompt assembles the prompt the loop sends as the first user
+// nowFunc returns the current time; a seam so tests can pin the date line
+// buildUserPrompt renders (#1202).
+var nowFunc = time.Now
+
+// buildUserPrompt assembles the prompt the loop sends as the first user
 // message. v0.1 is straightforward: for issue-fix, drop the issue
 // number + repo + prompt body into a small template; for freeform,
 // pass the prompt through unchanged.
@@ -2307,6 +2312,9 @@ func buildUserPrompt(task *foremanv1alpha1.AgenticTask) string {
 	switch task.Spec.Kind {
 	case foremanv1alpha1.AgenticTaskKindIssueFix:
 		fmt.Fprintf(&b, "You are working on issue #%d of repository %s.\n\n", p.Issue, p.Repo)
+		b.WriteString("Today's date is ")
+		b.WriteString(nowFunc().UTC().Format("2006-01-02"))
+		b.WriteString(". Treat this date as authoritative over your internal sense of time.\n\n")
 		if p.PromptPrefix != "" {
 			fmt.Fprintf(&b, "%s\n\n", p.PromptPrefix)
 		}

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1942,6 +1942,33 @@ func TestBuildUserPrompt_IssueFix_RendersPromptPrefix(t *testing.T) {
 	}
 }
 
+// TestBuildUserPrompt_IssueFix_ContainsDateLine verifies that the issue-fix
+// prompt includes the current date so the model can anchor time-sensitive
+// research queries (#1202).
+func TestBuildUserPrompt_IssueFix_ContainsDateLine(t *testing.T) {
+	fixed := time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC)
+	orig := nowFunc
+	nowFunc = func() time.Time { return fixed }
+	defer func() { nowFunc = orig }()
+
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:  "defilantech/LLMKube",
+				Issue: 1202,
+			},
+		},
+	}
+	got := buildUserPrompt(task)
+	if !strings.Contains(got, "Today's date is 2026-07-22") {
+		t.Fatalf("date line missing from prompt:\n%s", got)
+	}
+	if !strings.Contains(got, "authoritative over your internal sense of time") {
+		t.Fatalf("date authority clause missing from prompt:\n%s", got)
+	}
+}
+
 // TestBuildUserPrompt_ReviewerAppendsAdvisories verifies that gate advisories
 // wired into the payload by the reconciler are included in the reviewer's
 // first user message so the model is prompted to confirm or dismiss each one.


### PR DESCRIPTION
## What

Fixes #1202

Two-part fix for research queries being anchored to the model's knowledge-cutoff clock ("as of mid-2025" perplexity queries observed in July 2026):

1. **Prompt injection** — `buildUserPrompt` now opens every issue-fix prompt with `Today's date is YYYY-MM-DD` (UTC) plus an explicit authority clause ("treat this date as authoritative over your internal sense of time"), via a `nowFunc` seam so the unit test pins a fixed date.
2. **Guidance** — `coder.md`'s research section now instructs: phrase version/"latest" queries as *"as of today / the current latest"*, never name a year from memory, and treat the task-prompt date as current.

## Provenance

**Authored by a Foreman coder agent** from the issue + a scoping intent — notable because this is Foreman fixing its own research-grounding bug, discovered in its own transcript two runs ago. GO in 19 turns / 6.2 min; deterministic verify gate GATE-PASS; branch based on current main head; scope held to exactly the three intended files. Second consecutive intent-scoped success since #1203.

Human review per the AI-assisted contribution policy: verified the diff, ran the agent package suite (all green) and `GOOS=linux golangci-lint` (0 issues), and made one cosmetic fix — the `nowFunc` var had been inserted between `buildUserPrompt`'s godoc and the function, breaking the doc association; moved it above with its own comment.

## Validation

- New `TestBuildUserPrompt_IssueFix_ContainsDateLine` (fixed-date via the seam, asserts both the date line and the authority clause), plus the full `pkg/foreman/agent` suite green.
- Deploy note: takes effect on the m5max agent at its next binary update; until then operators keep the "as of TODAY" line in Workload intents (documented in the internal runbook).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (agent package suite)
- [x] `make lint` passes locally (GOOS=linux cross-arch, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance disclosed above (Foreman-authored, human-reviewed)
- [ ] Documentation updated (n/a: coder.md change is itself the behavior doc)