### PR TITLE
fix(chart): nil-safe gpuSharing navigation in deployment args

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -89,14 +89,21 @@ spec:
         {{- with .Values.controllerManager.routerProxy.defaultLiteLLMURL }}
         - --default-litellm-url={{ . }}
         {{- end }}
-        {{- $ns := .Values.gpuSharing.pools.shared.nodeSelector | default dict }}
+        {{- /* Nil-safe at every level: with helm upgrade --reuse-values the
+             chart defaults are NOT merged, so a release whose stored values
+             predate the gpuSharing block would nil-pointer on a chained
+             .Values.gpuSharing.pools.shared lookup. */}}
+        {{- $gs := .Values.gpuSharing | default dict }}
+        {{- $gsPools := $gs.pools | default dict }}
+        {{- $gsShared := $gsPools.shared | default dict }}
+        {{- $ns := $gsShared.nodeSelector | default dict }}
         {{- $nsPairs := list }}
         {{- range $k, $v := $ns }}{{- $nsPairs = append $nsPairs (printf "%s=%s" $k $v) }}{{- end }}
         {{- if $nsPairs }}
         - --gpu-sharing-shared-pool-selector={{ join "," $nsPairs }}
         {{- end }}
-        {{- if gt (.Values.gpuSharing.vramPerDeviceGiB | default 0) 0 }}
-        - --gpu-sharing-vram-per-device-gib={{ .Values.gpuSharing.vramPerDeviceGiB }}
+        {{- if gt (int ($gs.vramPerDeviceGiB | default 0)) 0 }}
+        - --gpu-sharing-vram-per-device-gib={{ $gs.vramPerDeviceGiB }}
         {{- end }}
         {{- if .Values.webhook.enabled }}
         # Point the controller-runtime webhook server at the mounted serving


### PR DESCRIPTION
## What

Nil-safe navigation for the gpuSharing block in `templates/deployment.yaml`: default every level (`gpuSharing` → `pools` → `shared` → `nodeSelector`), not just the final segment.

## Why

`helm upgrade --reuse-values` does not merge new chart defaults. A release whose stored values predate #1205's gpuSharing block fails the upgrade with:

```
templates/deployment.yaml:92:26: executing ... at <.Values.gpuSharing.pools.shared.nodeSelector>: nil pointer evaluating interface {}.shared
```

Hit live on the first real-world upgrade of the shadowstack release (stored values from before the block existed; `--set gpuSharing.vramPerDeviceGiB=...` materializes only that leaf). Review-miss disclosure: the #1205 review noted this navigation pattern and accepted it on the grounds that chart defaults guarantee the block's presence — `--reuse-values` is exactly the case where they don't.

## Validation

- The failing shape (`--set gpuSharing.vramPerDeviceGiB=110 --set gpuSharing.pools=null`) now renders the vram flag cleanly instead of erroring.
- Normal cases unchanged: both flags render when set; nothing renders when unset.
- `helm lint` green.

## Checklist

- [ ] Tests added/updated (n/a: chart template; covered by the template-validation CI lanes)
- [x] `make lint` passes locally (helm lint)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance disclosed: human-directed fix for a production upgrade failure; human owns the review conversation.
- [ ] Documentation updated (n/a)