### PR TITLE
fix(foreman): preserve the in-pod outcome envelope across the coder Job hop (#1077)

### DIFF
--- a/internal/foreman/controller/coder_envelope_integration_test.go
+++ b/internal/foreman/controller/coder_envelope_integration_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// Integration-shaped regression tests for #1077: drive a REAL agent-package
+// Result envelope (marshaled exactly as the watcher stores it in
+// status.result) into this package's escalation classifiers, instead of
+// hand-building synthetic JSON. This is the cross-package contract the
+// original bug slipped through: the executor nested the machine outcome
+// under modelExtra while the classifiers read the top level, and every
+// existing test constructed its own envelope on the side it was testing.
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+)
+
+// realEnvelopeTask marshals an actual agent.Result into an AgenticTask the
+// way the watcher persists it, so the classifiers read the true wire shape.
+func realEnvelopeTask(t *testing.T, r *foremanagent.Result) *foremanv1alpha1.AgenticTask {
+	t.Helper()
+	raw, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal real envelope: %v", err)
+	}
+	task := &foremanv1alpha1.AgenticTask{}
+	task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	task.Status.Verdict = r.Verdict
+	task.Status.Result = &runtime.RawExtension{Raw: raw}
+	return task
+}
+
+func TestRealAgentEnvelope_DrivesClassifiers(t *testing.T) {
+	t.Run("promoted ALREADY-RESOLVED stands escalation down", func(t *testing.T) {
+		r := foremanagent.NewResult("issue-fix", foremanv1alpha1.AgenticTaskVerdictNoGo,
+			"already fixed by abc1234", 5*time.Second)
+		// The shape modelDecidedResult + promoteTerminalOutcome (and, post
+		// #1077, coderJobResultToResult) produce for this outcome.
+		r.Extra = map[string]any{
+			"outcome":    "ALREADY-RESOLVED",
+			"resolvedBy": "abc1234",
+			"modelExtra": map[string]any{"outcome": "ALREADY-RESOLVED", "resolvedBy": "abc1234"},
+		}
+		task := realEnvelopeTask(t, r)
+		if !isAlreadyResolvedCoder(task) {
+			t.Fatal("real ALREADY-RESOLVED envelope not recognized by isAlreadyResolvedCoder")
+		}
+		v, top, model := coderTerminalOutcome(task)
+		if shouldEscalateCoder(v, top, model) {
+			t.Fatal("ALREADY-RESOLVED must not escalate")
+		}
+	})
+
+	t.Run("promoted NEEDS-VERIFICATION stands escalation down", func(t *testing.T) {
+		r := foremanagent.NewResult("issue-fix", foremanv1alpha1.AgenticTaskVerdictNoGo,
+			"claims unverified", 5*time.Second)
+		r.Extra = map[string]any{
+			"outcome":    "NEEDS-VERIFICATION",
+			"unverified": []any{"claim A"},
+			"modelExtra": map[string]any{"outcome": "NEEDS-VERIFICATION"},
+		}
+		task := realEnvelopeTask(t, r)
+		if !isNeedsVerificationCoder(task) {
+			t.Fatal("real NEEDS-VERIFICATION envelope not recognized")
+		}
+		v, top, model := coderTerminalOutcome(task)
+		if shouldEscalateCoder(v, top, model) {
+			t.Fatal("NEEDS-VERIFICATION must not escalate")
+		}
+	})
+
+	t.Run("nested-only outcome (the #1077 bug shape) escalates: regression canary", func(t *testing.T) {
+		// If a future producer regresses to nesting the outcome without
+		// promotion, the classifiers must treat it as a generic NO-GO and
+		// escalate. This pins the reason the promotion must exist at the
+		// producer, and fails loudly if someone "fixes" the classifiers to
+		// read modelExtra instead (the documented contract is top-level).
+		r := foremanagent.NewResult("issue-fix", foremanv1alpha1.AgenticTaskVerdictNoGo,
+			"already fixed", 5*time.Second)
+		r.Extra = map[string]any{
+			"outcome":    "MODEL-DECIDED",
+			"modelExtra": map[string]any{"outcome": "ALREADY-RESOLVED"},
+		}
+		task := realEnvelopeTask(t, r)
+		if isAlreadyResolvedCoder(task) {
+			t.Fatal("nested-only outcome must NOT classify as already-resolved (top-level is the contract)")
+		}
+		v, top, model := coderTerminalOutcome(task)
+		if !shouldEscalateCoder(v, top, model) {
+			t.Fatal("generic MODEL-DECIDED NO-GO should escalate")
+		}
+	})
+}

--- a/pkg/foreman/agent/executor_coderjob.go
+++ b/pkg/foreman/agent/executor_coderjob.go
@@ -81,6 +81,10 @@ type CoderJobResult struct {
 	FailureReason string
 	LogTail       string
 	JobName       string
+	// ResultExtra is the in-pod executor Result's full Extra map (already
+	// outcome-promoted by the native executor); see the field of the same
+	// name on tools.CoderJobResult (#1077).
+	ResultExtra map[string]any
 }
 
 // useCoderJobPath reports whether Execute should dispatch this task to a
@@ -153,28 +157,53 @@ func (e *NativeAgentLoopExecutor) executeCoderJob(
 // failure result carrying an infrastructure FailureReason and the log
 // tail, so downstream retry policy treats it like any other run failure
 // rather than a successful model decision.
+// jobExtra seeds a Result Extra map from the in-pod envelope's Extra when
+// the Job carried one, so fields the controller and rollups read (the
+// promoted top-level outcome, resolvedBy, unverified, modelExtra,
+// transcriptRef, turnCount) survive the Job hop instead of being
+// re-synthesized flat (#1077). Job-supervisor fields are stamped on top and
+// win over any same-named envelope key.
+func jobExtra(cjr CoderJobResult, supervisor map[string]any) map[string]any {
+	extra := make(map[string]any, len(cjr.ResultExtra)+len(supervisor))
+	for k, v := range cjr.ResultExtra {
+		extra[k] = v
+	}
+	for k, v := range supervisor {
+		extra[k] = v
+	}
+	return extra
+}
+
 func coderJobResultToResult(kind string, start time.Time, cjr CoderJobResult) *Result {
 	switch cjr.Verdict {
 	case string(foremanv1alpha1.AgenticTaskVerdictGo):
 		r := NewResult(kind, foremanv1alpha1.AgenticTaskVerdictGo, cjr.Summary, time.Since(start))
-		r.Extra = map[string]any{
-			"outcome":       "",
+		r.Extra = jobExtra(cjr, map[string]any{
 			"branch":        cjr.Branch,
 			"commitSHA":     cjr.CommitSHA,
 			"commitMessage": cjr.CommitMessage,
 			"executionMode": "Job",
 			"jobName":       cjr.JobName,
 			"logTail":       cjr.LogTail,
+		})
+		if _, ok := r.Extra["outcome"]; !ok {
+			r.Extra["outcome"] = ""
 		}
 		return r
 	case string(foremanv1alpha1.AgenticTaskVerdictNoGo):
 		r := NewResult(kind, foremanv1alpha1.AgenticTaskVerdictNoGo, cjr.Summary, time.Since(start))
-		r.Extra = map[string]any{
-			"outcome":        "MODEL-NO-GO",
+		r.Extra = jobExtra(cjr, map[string]any{
 			"intendedBranch": cjr.Branch,
 			"executionMode":  "Job",
 			"jobName":        cjr.JobName,
 			"logTail":        cjr.LogTail,
+		})
+		// Preserve the envelope's promoted outcome (ALREADY-RESOLVED /
+		// NEEDS-VERIFICATION / MODEL-DECIDED, plus paired resolvedBy or
+		// unverified fields already in the map); only a Job with no
+		// envelope outcome falls back to the legacy generic tag.
+		if outcome, _ := r.Extra["outcome"].(string); outcome == "" {
+			r.Extra["outcome"] = "MODEL-NO-GO"
 		}
 		return r
 	case string(foremanv1alpha1.AgenticTaskVerdictIncomplete):

--- a/pkg/foreman/agent/executor_coderjob_envelope_test.go
+++ b/pkg/foreman/agent/executor_coderjob_envelope_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+// Unit tests for the Job-mode envelope preservation (#1077):
+// coderJobResultToResult must carry the in-pod executor's promoted
+// outcome (and paired fields) to the top level of the supervisor's
+// Result instead of re-synthesizing a generic MODEL-NO-GO and
+// discarding the model's extra.
+
+import (
+	"testing"
+	"time"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func TestCoderJobResultToResult_PreservesPromotedOutcome(t *testing.T) {
+	start := time.Now()
+
+	t.Run("ALREADY-RESOLVED envelope survives the Job hop", func(t *testing.T) {
+		cjr := CoderJobResult{
+			Verdict: string(foremanv1alpha1.AgenticTaskVerdictNoGo),
+			Summary: "already fixed by abc1234",
+			Branch:  "foreman/wl/issue-970",
+			JobName: "coder-job-1",
+			ResultExtra: map[string]any{
+				"outcome":    "ALREADY-RESOLVED",
+				"resolvedBy": "abc1234",
+				"turnCount":  7,
+				"modelExtra": map[string]any{"outcome": "ALREADY-RESOLVED"},
+			},
+		}
+		r := coderJobResultToResult("issue-fix", start, cjr)
+		if r.Extra["outcome"] != "ALREADY-RESOLVED" {
+			t.Errorf("outcome: want ALREADY-RESOLVED got %v", r.Extra["outcome"])
+		}
+		if r.Extra["resolvedBy"] != "abc1234" {
+			t.Errorf("resolvedBy lost in the Job hop: %v", r.Extra["resolvedBy"])
+		}
+		if r.Extra["turnCount"] != 7 {
+			t.Errorf("turnCount lost: %v", r.Extra["turnCount"])
+		}
+		// Supervisor stamps still present and authoritative.
+		if r.Extra["executionMode"] != "Job" || r.Extra["jobName"] != "coder-job-1" {
+			t.Errorf("supervisor fields missing: %v", r.Extra)
+		}
+		if r.Extra["intendedBranch"] != "foreman/wl/issue-970" {
+			t.Errorf("intendedBranch missing: %v", r.Extra)
+		}
+	})
+
+	t.Run("NEEDS-VERIFICATION envelope survives with unverified", func(t *testing.T) {
+		cjr := CoderJobResult{
+			Verdict: string(foremanv1alpha1.AgenticTaskVerdictNoGo),
+			ResultExtra: map[string]any{
+				"outcome":    "NEEDS-VERIFICATION",
+				"unverified": []any{"claim A"},
+			},
+		}
+		r := coderJobResultToResult("issue-fix", start, cjr)
+		if r.Extra["outcome"] != "NEEDS-VERIFICATION" {
+			t.Errorf("outcome: want NEEDS-VERIFICATION got %v", r.Extra["outcome"])
+		}
+		if r.Extra["unverified"] == nil {
+			t.Errorf("unverified lost in the Job hop")
+		}
+	})
+
+	t.Run("no envelope falls back to the legacy generic outcome", func(t *testing.T) {
+		cjr := CoderJobResult{Verdict: string(foremanv1alpha1.AgenticTaskVerdictNoGo)}
+		r := coderJobResultToResult("issue-fix", start, cjr)
+		if r.Extra["outcome"] != "MODEL-NO-GO" {
+			t.Errorf("fallback outcome: want MODEL-NO-GO got %v", r.Extra["outcome"])
+		}
+	})
+
+	t.Run("envelope with empty outcome also falls back", func(t *testing.T) {
+		cjr := CoderJobResult{
+			Verdict:     string(foremanv1alpha1.AgenticTaskVerdictNoGo),
+			ResultExtra: map[string]any{"outcome": "", "turnCount": 3},
+		}
+		r := coderJobResultToResult("issue-fix", start, cjr)
+		if r.Extra["outcome"] != "MODEL-NO-GO" {
+			t.Errorf("fallback outcome: want MODEL-NO-GO got %v", r.Extra["outcome"])
+		}
+		if r.Extra["turnCount"] != 3 {
+			t.Errorf("envelope fields should still carry: %v", r.Extra)
+		}
+	})
+
+	t.Run("GO keeps envelope fields and stamps supervisor keys over collisions", func(t *testing.T) {
+		cjr := CoderJobResult{
+			Verdict:   string(foremanv1alpha1.AgenticTaskVerdictGo),
+			Branch:    "foreman/wl/issue-1",
+			CommitSHA: "def5678",
+			JobName:   "coder-job-2",
+			ResultExtra: map[string]any{
+				"outcome":   "",
+				"turnCount": 12,
+				"branch":    "stale-in-pod-branch",
+			},
+		}
+		r := coderJobResultToResult("issue-fix", start, cjr)
+		if r.Extra["branch"] != "foreman/wl/issue-1" {
+			t.Errorf("supervisor branch must win over envelope: %v", r.Extra["branch"])
+		}
+		if r.Extra["turnCount"] != 12 {
+			t.Errorf("turnCount lost on GO: %v", r.Extra)
+		}
+		if r.Extra["commitSHA"] != "def5678" {
+			t.Errorf("commitSHA missing: %v", r.Extra)
+		}
+	})
+}

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -2005,3 +2005,63 @@ func gitWriteFile(t *testing.T, dir, path, content string) {
 		t.Fatalf("gitWriteFile: %v", err)
 	}
 }
+
+// TestNativeExecutor_ModelNoGoAlreadyResolved_PromotesOutcome drives a REAL
+// executor run whose model emits NO-GO with extra.outcome=ALREADY-RESOLVED
+// and asserts the promotion contract (#1077): the outcome and its paired
+// resolvedBy surface at the TOP level of the Result's Extra (where the
+// controller's escalation classifiers read), not only under modelExtra.
+func TestNativeExecutor_ModelNoGoAlreadyResolved_PromotesOutcome(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitNoGoBody})
+
+	agent, task := taskAndAgent("nogo-resolved")
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true, Verdict: "NO-GO",
+				Summary: "already fixed by abc1234",
+				Extra: map[string]any{
+					"outcome":    "ALREADY-RESOLVED",
+					"resolvedBy": "abc1234",
+				},
+			},
+		},
+	}
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "B", Email: "b@x"},
+		CommitCommitter:          repo.Identity{Name: "B", Email: "b@x"},
+		RegistryFactory: func(
+			_ context.Context, _ string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("verdict: want NO-GO got %s", res.Verdict)
+	}
+	if got := res.Extra["outcome"]; got != "ALREADY-RESOLVED" {
+		t.Errorf("top-level outcome: want ALREADY-RESOLVED got %v", got)
+	}
+	if got := res.Extra["resolvedBy"]; got != "abc1234" {
+		t.Errorf("top-level resolvedBy: want abc1234 got %v", got)
+	}
+	me, ok := res.Extra["modelExtra"].(map[string]any)
+	if !ok || me["outcome"] != "ALREADY-RESOLVED" {
+		t.Errorf("modelExtra should keep the nested outcome for observability, got %v", res.Extra["modelExtra"])
+	}
+}

--- a/pkg/foreman/agent/tools/run_coder_job.go
+++ b/pkg/foreman/agent/tools/run_coder_job.go
@@ -197,6 +197,15 @@ type CoderJobResult struct {
 	// LogTail is the captured pod log tail, for operator triage.
 	LogTail string
 
+	// ResultExtra is the full Extra map of the in-pod executor's Result
+	// envelope, parsed from the FOREMAN-RESULT line. The in-pod native
+	// executor already promotes terminal machine outcomes
+	// (ALREADY-RESOLVED / NEEDS-VERIFICATION) to its top-level
+	// extra.outcome; carrying the map through lets the Job-mode
+	// supervisor preserve that promotion instead of re-synthesizing a
+	// generic outcome and discarding resolvedBy/unverified (#1077).
+	ResultExtra map[string]any
+
 	// JobName / Namespace identify the submitted Job.
 	JobName   string
 	Namespace string
@@ -263,6 +272,7 @@ func (r *RunCoderJob) Submit(ctx context.Context, req agent.CoderJobRequest) (ag
 		FailureReason: res.FailureReason,
 		LogTail:       res.LogTail,
 		JobName:       res.JobName,
+		ResultExtra:   res.ResultExtra,
 	}, nil
 }
 
@@ -357,6 +367,11 @@ func (r *RunCoderJob) Run(ctx context.Context, args RunCoderJobArgs) (CoderJobRe
 	// verdicts carrying FailureModelReportedError from an in-pod model ERROR.
 	if parsed.Result != nil && parsed.Result.FailureReason != "" {
 		res.FailureReason = string(parsed.Result.FailureReason)
+	}
+	// Same lift for the envelope's Extra: the in-pod executor already
+	// promoted any terminal machine outcome to its top level (#1077).
+	if parsed.Result != nil && parsed.Result.Extra != nil {
+		res.ResultExtra = parsed.Result.Extra
 	}
 	if res.Verdict == "" {
 		// Succeeded Job but no recognizable result line: treat as a


### PR DESCRIPTION
## What

Fixes #1077

Completes the outcome-envelope contract. Investigation found the issue **half-stale**: the in-process path was already fixed by #1075's `promoteTerminalOutcome` (verified here with a new end-to-end test). The **Job-mode path** was still broken exactly as filed: `coderJobResultToResult` hardcoded `MODEL-NO-GO` and discarded the model's extra, so `resolvedBy`/`unverified` were lost and the controller escalated the very verdicts #970/#1033 exist to stand down on.

## How

The data was never missing — the `FOREMAN-RESULT` envelope carries the full in-pod `Result`, whose `Extra` the in-pod executor has *already* promoted. The loss was purely in the flat mapping layers. Fix mirrors the existing `FailureReason` lift:

- `tools.CoderJobResult` + `agent.CoderJobResult` gain `ResultExtra` (the in-pod envelope's Extra), populated at the same parse site as the FailureReason lift.
- `coderJobResultToResult` seeds the supervisor Result's Extra from the envelope (promoted outcome, `resolvedBy`, `unverified`, `modelExtra`, `turnCount`, `transcriptRef` all survive) with supervisor fields stamped on top (they win collisions). No envelope outcome → legacy `MODEL-NO-GO` fallback, so old runners degrade to today's behavior.

## Validation — three layers, closing the issue's stated test gap

1. **End-to-end native**: scripted executor run whose model submits NO-GO with `outcome=ALREADY-RESOLVED` → asserts top-level promotion on the **real** envelope (proves the in-process half and pins it).
2. **Job-hop table**: promoted outcomes survive with paired fields; supervisor keys win collisions; no-envelope and empty-outcome fall back.
3. **Cross-package integration** (the issue's explicit ask): a real `agent.Result`, marshaled exactly as the watcher stores it, drives `coderTerminalOutcome` + the classifiers — including a **regression canary**: a nested-only outcome (the original bug shape) must still escalate, pinning the top-level contract at the producer so nobody "fixes" the classifiers sideways later.

Full `pkg/foreman/...` + `internal/foreman/...` suites green; `GOOS=linux golangci-lint` 0 issues.

## Context

Qwopus attempted this twice via Foreman and hit the stuck-loop detector both times (2,400-line executor files are its documented wall), so it was taken directly per the one-retry-then-escalate rule.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (both foreman trees)
- [x] `make lint` passes locally (GOOS=linux cross-arch, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: implemented with AI assistance (human-directed); human owns the review conversation.
- [ ] Documentation updated (n/a: behavior now matches the existing contract comments)