### PR TITLE
fix(foreman): edits disarm a nudged RepeatedToolCall hash (#1215)

### DIFF
--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -154,8 +154,11 @@ type LoopProgressMonitor struct {
 	// escalates to ForceTerminate. For RepeatedToolCall we track the
 	// specific hash that nudged so a model that changes course on the
 	// next turn isn't punished for the historical buffer; the
-	// nudged-hash recurring even ONCE post-nudge escalates immediately.
-	// For the other signals a bool is enough.
+	// nudged-hash recurring post-nudge escalates immediately UNLESS a
+	// mutating call landed in between (#1215): an edit disarms the hash,
+	// because re-running the flagged command after changing the
+	// workspace is verification, not spin. For the other signals a bool
+	// is enough.
 	nudgedRepeatedToolHash string // "" means not yet nudged
 	nudgedEditFree         bool
 	nudgedContextSoft      bool
@@ -196,6 +199,18 @@ const (
 // model that immediately submits without editing (legitimate for
 // review-only roles or "nothing to fix" cases) does not get
 // false-flagged.
+// hasEditProducingCall reports whether any call in the slice is one of the
+// editProducingTools. Used by the RepeatedToolCall disarm (#1215) and kept
+// beside the map it reads.
+func hasEditProducingCall(calls []oai.ToolCall) bool {
+	for _, tc := range calls {
+		if _, ok := editProducingTools[tc.Function.Name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 var editProducingTools = map[string]struct{}{
 	"write_file":    {},
 	"str_replace":   {},
@@ -338,6 +353,16 @@ func (m *LoopProgressMonitor) Observe(turn int, calls []oai.ToolCall, transcript
 	m.recordCalls(calls)
 	m.updateEditFreeStreak(calls)
 	m.contextTokens = approxTokens(transcript)
+
+	// A mutating call disarms a nudged RepeatedToolCall hash (#1215): the
+	// workspace changed, so re-running the previously-flagged command is
+	// verification of the new edit, not a continuation of the old spin.
+	// True defiance (the armed hash recurring with NO intervening edit)
+	// still escalates below, and renewed spinning after the edit has to
+	// re-earn the threshold from a buffer that was reset at nudge time.
+	if m.nudgedRepeatedToolHash != "" && hasEditProducingCall(calls) {
+		m.nudgedRepeatedToolHash = ""
+	}
 
 	// 2. Evaluate each signal in priority order: hard cap first
 	// (deadliest), then soft cap, then edit-free, then repeated tool.

--- a/pkg/foreman/agent/progress_test.go
+++ b/pkg/foreman/agent/progress_test.go
@@ -100,11 +100,11 @@ func TestProgressMonitor_RepeatedToolNudgesThenTerminates(t *testing.T) {
 // chance: if the nudge is heeded (different call on the next turn),
 // the monitor does NOT escalate to ForceTerminate.
 //
-// Note: the RepeatedToolCall nudge flag stays set for the remainder
-// of the run (we don't re-arm it after a recovery); the model has
-// already shown the pattern once and we want any future re-emergence
-// of the same pattern to escalate immediately rather than starting
-// the nudge ladder over.
+// Note: after an edit-free recovery the RepeatedToolCall nudge flag
+// stays set, so an edit-free re-emergence of the same pattern
+// escalates immediately rather than restarting the ladder. (An
+// intervening EDIT is the one thing that disarms it; see
+// TestProgressMonitor_EditDisarmsNudgedRepeatedTool and #1215.)
 func TestProgressMonitor_RecoveryAfterNudge(t *testing.T) {
 	mon := NewLoopProgressMonitor(ProgressConfig{
 		RepeatedToolThreshold: 3,
@@ -654,5 +654,53 @@ func TestFilterForcedEditSchemas_RestrictReads(t *testing.T) {
 	want = []string{"str_replace", "submit_result"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("restrictReads=true: got %v want %v", got, want)
+	}
+}
+
+// TestProgressMonitor_EditDisarmsNudgedRepeatedTool is the #1215 regression:
+// a model that spins, gets nudged, corrects course with a real edit, and
+// then re-runs the flagged command to VERIFY that edit must not be killed.
+// The exact shape comes from the strreplace-tiers-941 transcript: five
+// identical successful builds, nudge, write_file, rebuild, kill (wrong).
+// Renewed spinning after the edit must re-earn the threshold and re-enter
+// the ladder at Nudge, and edit-free defiance must still terminate.
+func TestProgressMonitor_EditDisarmsNudgedRepeatedTool(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{
+		RepeatedToolThreshold: 3,
+	})
+	transcript := []oai.Message{}
+	buildArgs := `{"command":"go build ./pkg/foreman/agent/tools/..."}`
+
+	// Spin to the nudge.
+	_ = mon.Observe(1, []oai.ToolCall{makeCall("a", "bash", buildArgs)}, transcript)
+	_ = mon.Observe(2, []oai.ToolCall{makeCall("b", "bash", buildArgs)}, transcript)
+	d := mon.Observe(3, []oai.ToolCall{makeCall("c", "bash", buildArgs)}, transcript)
+	if d.Action != ProgressNudge {
+		t.Fatalf("expected Nudge at turn 3; got %+v", d)
+	}
+
+	// The model heeds the nudge with a real edit.
+	d = mon.Observe(4, []oai.ToolCall{makeCall("d", "write_file", `{"path":"x_test.go","content":"pkg"}`)}, transcript)
+	if d.Action != ProgressContinue {
+		t.Fatalf("edit turn should Continue; got %+v", d)
+	}
+
+	// Post-edit verification re-runs the flagged command: must NOT be killed.
+	d = mon.Observe(5, []oai.ToolCall{makeCall("e", "bash", buildArgs)}, transcript)
+	if d.Action != ProgressContinue {
+		t.Fatalf("post-edit verification build must not terminate (#1215); got %+v", d)
+	}
+
+	// Renewed spinning re-earns the threshold and re-enters at Nudge, not kill.
+	_ = mon.Observe(6, []oai.ToolCall{makeCall("f", "bash", buildArgs)}, transcript)
+	d = mon.Observe(7, []oai.ToolCall{makeCall("g", "bash", buildArgs)}, transcript)
+	if d.Action != ProgressNudge {
+		t.Fatalf("renewed spin should re-Nudge; got %+v", d)
+	}
+
+	// Edit-free defiance after the second nudge still terminates.
+	d = mon.Observe(8, []oai.ToolCall{makeCall("h", "bash", buildArgs)}, transcript)
+	if d.Action != ProgressForceTerminate {
+		t.Fatalf("edit-free defiance must still terminate; got %+v", d)
 	}
 }


### PR DESCRIPTION
## What

Fixes #1215

One-condition change to the progress monitor: an edit-producing tool call (write_file / str_replace) disarms a nudged RepeatedToolCall hash. Re-running a previously-flagged command **after changing the workspace** is verification, not spin.

## Why

Forensics on last night's two INCOMPLETE runs split cleanly:

- **model-prefetch-904**: model submitted GO, the in-loop gate bounced it on gocyclo, and the model re-read the same 60 lines six times with an explicit warning and **zero intervening progress**. Kill was correct. (Unchanged by this PR — locked in the regression test.)
- **strreplace-tiers-941**: five identical *successful* builds (real spin, nudge deserved) → model **heeded the nudge** and wrote a new test file → re-ran the build to verify its edit → killed on the armed hash. The nudge worked; the termination undid it.

## How

At state-update time in `Observe`, a turn containing an `editProducingTools` call clears `nudgedRepeatedToolHash`. The ladder is preserved: renewed spinning after the edit must re-earn the full threshold and re-enters at **Nudge**, and edit-free defiance still force-terminates immediately. Doc comments on the field and the existing recovery test updated to state the one exception.

## Validation

- New `TestProgressMonitor_EditDisarmsNudgedRepeatedTool` walks the exact 941 transcript shape: spin → nudge → edit → verification build (must continue) → renewed spin (re-nudge, not kill) → edit-free defiance (still terminates).
- Existing ladder tests (`RepeatedToolNudgesThenTerminates`, `RecoveryAfterNudge`) pass unchanged.
- Full `pkg/foreman/agent` suite green; `GOOS=linux golangci-lint` 0 issues.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (agent package suite)
- [x] `make lint` passes locally (GOOS=linux cross-arch, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: human-directed fix, root-caused from the two run transcripts; human owns the review conversation.
- [ ] Documentation updated (n/a: behavior comments updated in-code)