### PR TITLE
feat: prefetch Model artifacts into the shared cache without an InferenceService

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -79,6 +79,20 @@ type ModelSpec struct {
 	// +optional
 	RefreshPolicy string `json:"refreshPolicy,omitempty"`
 
+	// Prefetch, when true on a remote (http/https/hf) source, makes the
+	// operator eagerly download the artifact into the namespace's SHARED
+	// model cache PVC (llmkube-model-cache) via an owner-ref'd Job that
+	// reuses the serving init-container download stack, instead of waiting
+	// for the first InferenceService to pull it at serve time. Progress is
+	// reflected in status (Downloading, then Ready with cacheKey set), so
+	// the first serving pod starts from a cache hit. Fleets running
+	// modelCache.mode=perService still download per-service at serve time:
+	// prefetch targets the shared cache only, and staging via a pvc://
+	// source remains the alternative there. Ignored for local and pvc://
+	// sources, which need no remote fetch.
+	// +optional
+	Prefetch bool `json:"prefetch,omitempty"`
+
 	// Format specifies the model file format.
 	// "gguf" is used with the llama-server runtime; "mlx" is used with the oMLX runtime;
 	// "safetensors", "pytorch", and "custom" are used with the generic runtime.

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -325,6 +325,20 @@ spec:
                   Mmproj is an optional multimodal projector file to stage from Source and
                   pass to runtimes that support projector arguments.
                 type: string
+              prefetch:
+                description: |-
+                  Prefetch, when true on a remote (http/https/hf) source, makes the
+                  operator eagerly download the artifact into the namespace's SHARED
+                  model cache PVC (llmkube-model-cache) via an owner-ref'd Job that
+                  reuses the serving init-container download stack, instead of waiting
+                  for the first InferenceService to pull it at serve time. Progress is
+                  reflected in status (Downloading, then Ready with cacheKey set), so
+                  the first serving pod starts from a cache hit. Fleets running
+                  modelCache.mode=perService still download per-service at serve time:
+                  prefetch targets the shared cache only, and staging via a pvc://
+                  source remains the alternative there. Ignored for local and pvc://
+                  sources, which need no remote fetch.
+                type: boolean
               quantization:
                 description: Quantization describes the quantization level (e.g.,
                   Q4_0, Q5_K_M, F16)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -354,6 +354,12 @@ func main() {
 		RevalidateInterval:   modelRevalidateInterval,
 		AllowedHostPathRoots: allowedHostPathRootList,
 		AllowedRemoteHosts:   allowedRemoteHostList,
+		InitContainerImage:   initContainerImage,
+		CACertConfigMap:      caCertConfigMap,
+		DefaultFSGroup:       defaultFSGroup,
+		ModelCacheSize:       modelCacheSize,
+		ModelCacheClass:      modelCacheClass,
+		ModelCacheAccessMode: modelCacheAccessMode,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Model")
 		os.Exit(1)

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -321,6 +321,20 @@ spec:
                   Mmproj is an optional multimodal projector file to stage from Source and
                   pass to runtimes that support projector arguments.
                 type: string
+              prefetch:
+                description: |-
+                  Prefetch, when true on a remote (http/https/hf) source, makes the
+                  operator eagerly download the artifact into the namespace's SHARED
+                  model cache PVC (llmkube-model-cache) via an owner-ref'd Job that
+                  reuses the serving init-container download stack, instead of waiting
+                  for the first InferenceService to pull it at serve time. Progress is
+                  reflected in status (Downloading, then Ready with cacheKey set), so
+                  the first serving pod starts from a cache hit. Fleets running
+                  modelCache.mode=perService still download per-service at serve time:
+                  prefetch targets the shared cache only, and staging via a pvc://
+                  source remains the alternative there. Ignored for local and pvc://
+                  sources, which need no remote fetch.
+                type: boolean
               quantization:
                 description: Quantization describes the quantization level (e.g.,
                   Q4_0, Q5_K_M, F16)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,6 +85,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices

--- a/config/samples/model_prefetch.yaml
+++ b/config/samples/model_prefetch.yaml
@@ -1,0 +1,37 @@
+# Prefetch: pull a remote model into the shared cache ahead of any
+# InferenceService (#904).
+#
+# With spec.prefetch: true the controller runs an owner-ref'd download Job
+# (the same init-container downloader the serving path uses) into the
+# namespace's shared model cache PVC (llmkube-model-cache) as soon as the
+# Model is applied. Status moves Downloading -> Ready; the first
+# InferenceService referencing the Model then starts from a cache hit
+# instead of a cold multi-GB download.
+#
+# Notes:
+# - Prefetch applies to remote sources (https://, hf://). Local paths and
+#   pvc:// sources have nothing to prefetch and ignore the field.
+# - The prefetch targets the SHARED cache. Fleets running perService cache
+#   mode cannot be pre-populated this way; pre-stage with a pvc:// source
+#   instead.
+# - The Job is garbage-collected with the Model (owner reference) and
+#   self-cleans 24h after finishing.
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-3b-prefetch
+  namespace: default
+  labels:
+    model: llama-3.2
+    size: 3b
+spec:
+  source: hf://bartowski/Llama-3.2-3B-Instruct-GGUF/Llama-3.2-3B-Instruct-Q4_K_M.gguf
+  format: gguf
+  quantization: Q4_K_M
+
+  # Pull to the shared cache now; no InferenceService required.
+  prefetch: true
+
+  resources:
+    cpu: "2"
+    memory: "4Gi"

--- a/docs/MODEL-CACHE.md
+++ b/docs/MODEL-CACHE.md
@@ -86,6 +86,43 @@ Cache Key: a3b8c9d4e5f67890
 Path: /models/a3b8c9d4e5f67890/model.gguf
 ```
 
+## Prefetch (Eager Download)
+
+By default a `Model` with a remote source is only a declaration: nothing is
+downloaded until the first `InferenceService` referencing it starts. Set
+`spec.prefetch: true` to have the operator pull the artifact into the shared
+cache immediately:
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-3b-prefetch
+spec:
+  source: hf://bartowski/Llama-3.2-3B-Instruct-GGUF/Llama-3.2-3B-Instruct-Q4_K_M.gguf
+  format: gguf
+  prefetch: true
+```
+
+The controller runs an owner-referenced download Job that reuses the same
+init-container downloader the serving path uses, writing into the
+namespace's shared cache PVC (`llmkube-model-cache`, created on demand).
+`status.phase` moves `Downloading` -> `Ready`; once `Ready`, the first
+`InferenceService` starts from a cache hit instead of a cold download.
+
+Limitations:
+
+- Prefetch applies to remote sources (`https://`, `hf://`). Local paths and
+  `pvc://` sources ignore the field.
+- Prefetch targets the **shared** cache only. `perService` cache PVCs bind
+  at serve time and cannot be pre-populated; pre-stage those fleets with a
+  `pvc://` source instead.
+- A failed prefetch Job sets `status.phase: Failed`; check the Job's pod
+  logs (`<model-name>-prefetch`). The Job self-cleans 24 hours after
+  finishing and is garbage-collected with the Model.
+
+See `config/samples/model_prefetch.yaml` for a complete example.
+
 ## Configuration
 
 ### Helm Values

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -48,11 +48,14 @@ import (
 )
 
 const (
-	PhaseReady    = "Ready"
-	PhaseFailed   = "Failed"
-	PhaseCached   = "Cached"
-	PhaseCreating = "Creating"
-	PhaseStopped  = "Stopped"
+	PhaseReady  = "Ready"
+	PhaseFailed = "Failed"
+	PhaseCached = "Cached"
+	// PhaseDownloading is also written as a raw string by the legacy
+	// download path's progressPhase; the const is the canonical spelling.
+	PhaseDownloading = "Downloading"
+	PhaseCreating    = "Creating"
+	PhaseStopped     = "Stopped"
 	// acceleratorMetal is the Model.Spec.Hardware.Accelerator value for the
 	// host metal-agent path.
 	acceleratorMetal      = "metal"
@@ -115,6 +118,16 @@ type ModelReconciler struct {
 	// newGuardedHTTPClient and GHSA-jw3m-8q7m-f35r.
 	AllowedRemoteHosts []string
 
+	// Prefetch (#904) configuration, mirrored from the InferenceService
+	// reconciler's cache settings so the prefetch Job writes into the same
+	// shared cache PVC the serving path mounts.
+	InitContainerImage   string
+	CACertConfigMap      string
+	DefaultFSGroup       int64
+	ModelCacheSize       string
+	ModelCacheClass      string
+	ModelCacheAccessMode string
+
 	// metadataHTTPClient is the SSRF-guarded client used for all controller-
 	// side requests to Model.spec.source (metadata reads and revalidation
 	// probes). Built lazily from AllowedRemoteHosts; never use
@@ -136,7 +149,8 @@ func (r *ModelReconciler) metadataClient() *http.Client {
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models/finalizers,verbs=update
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 
 func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -173,6 +187,12 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return result, nil
 	}
 
+	// Prefetch (#904): an eligible Model is downloaded into the shared
+	// cache by an owner-ref'd Job before any InferenceService exists.
+	if handled, result, err := r.reconcilePrefetch(ctx, model); handled {
+		return result, err
+	}
+
 	// Sources that need no controller-side download (PVC, HuggingFace repo,
 	// remote HTTP, Metal local-path) are dispatched here. handled=false means
 	// the source is a local path the controller must copy itself.
@@ -195,55 +215,8 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	logger.Info("Using cache key for model", "cacheKey", cacheKey, "dir", modelDir)
 
-	if existingPath, fileInfo, ok := findCachedModelFile(modelDir); ok {
-		// Cadence-gated drift check on the cached file. Under OnChange a drifted
-		// source re-downloads (overwrites); under IfNotPresent it only records
-		// the SourceDrifted condition and keeps serving the cache. Status writes
-		// here merge into the Ready update below (same in-memory object).
-		reDownload, _, err := r.handleRevalidation(ctx, model)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		if !reDownload {
-			logger.Info("Model found in cache, skipping download", "path", existingPath, "size", fileInfo.Size())
-
-			// Parse GGUF metadata first (non-fatal) so we have the metadata-derived
-			// name available for the rename below.
-			if model.Status.GGUF == nil {
-				if ggufMeta, err := r.parseGGUFMetadata(existingPath); err != nil {
-					logger.Info("Failed to parse GGUF metadata (non-fatal)", "error", err)
-				} else {
-					model.Status.GGUF = ggufMeta
-				}
-			}
-
-			finalPath, err := r.migrateModelFilename(existingPath, modelDir, model)
-			if err != nil {
-				logger.Error(err, "Failed to migrate model filename, keeping existing")
-				finalPath = existingPath
-			}
-
-			model.Status.Phase = PhaseReady
-			model.Status.Path = finalPath
-			model.Status.Size = formatBytes(fileInfo.Size())
-			model.Status.CacheKey = cacheKey
-			model.Status.AcceleratorReady = r.checkAcceleratorAvailability(ctx, model)
-			now := metav1.Now()
-			model.Status.LastUpdated = &now
-
-			if err := r.updateStatus(ctx, model, "Available", metav1.ConditionTrue, "ModelCached", "Model found in cache"); err != nil {
-				return ctrl.Result{}, err
-			}
-
-			llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "Cached").Set(1)
-			llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
-			return ctrl.Result{}, nil
-		}
-
-		logger.Info("Source drifted under OnChange; re-downloading over cached file", "dir", modelDir)
-		if err := r.removeCachedFiles(ctx, modelDir); err != nil {
-			return ctrl.Result{}, err
-		}
+	if done, err := r.reconcileCachedModelFile(ctx, model, modelDir, cacheKey); done {
+		return ctrl.Result{}, err
 	}
 
 	if err := os.MkdirAll(modelDir, 0755); err != nil {
@@ -370,6 +343,69 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 // error. The rejection itself yields a nil error (not the validation error):
 // the failure is unrecoverable without a spec or operator-config change, and
 // a spec change re-triggers reconcile, so there is nothing to tight-loop on.
+// reconcileCachedModelFile serves a Model from an existing cached file, or
+// clears a drifted cache under OnChange. done=true means this reconcile is
+// finished (cache hit served, or an error terminal to this pass); done=false
+// means no usable cache remains and the caller should proceed to download.
+func (r *ModelReconciler) reconcileCachedModelFile(ctx context.Context, model *inferencev1alpha1.Model, modelDir, cacheKey string) (done bool, err error) {
+	logger := log.FromContext(ctx)
+
+	existingPath, fileInfo, ok := findCachedModelFile(modelDir)
+	if !ok {
+		return false, nil
+	}
+
+	// Cadence-gated drift check on the cached file. Under OnChange a drifted
+	// source re-downloads (overwrites); under IfNotPresent it only records
+	// the SourceDrifted condition and keeps serving the cache. Status writes
+	// here merge into the Ready update below (same in-memory object).
+	reDownload, _, err := r.handleRevalidation(ctx, model)
+	if err != nil {
+		return true, err
+	}
+	if !reDownload {
+		logger.Info("Model found in cache, skipping download", "path", existingPath, "size", fileInfo.Size())
+
+		// Parse GGUF metadata first (non-fatal) so we have the metadata-derived
+		// name available for the rename below.
+		if model.Status.GGUF == nil {
+			if ggufMeta, err := r.parseGGUFMetadata(existingPath); err != nil {
+				logger.Info("Failed to parse GGUF metadata (non-fatal)", "error", err)
+			} else {
+				model.Status.GGUF = ggufMeta
+			}
+		}
+
+		finalPath, err := r.migrateModelFilename(existingPath, modelDir, model)
+		if err != nil {
+			logger.Error(err, "Failed to migrate model filename, keeping existing")
+			finalPath = existingPath
+		}
+
+		model.Status.Phase = PhaseReady
+		model.Status.Path = finalPath
+		model.Status.Size = formatBytes(fileInfo.Size())
+		model.Status.CacheKey = cacheKey
+		model.Status.AcceleratorReady = r.checkAcceleratorAvailability(ctx, model)
+		now := metav1.Now()
+		model.Status.LastUpdated = &now
+
+		if err := r.updateStatus(ctx, model, "Available", metav1.ConditionTrue, "ModelCached", "Model found in cache"); err != nil {
+			return true, err
+		}
+
+		llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "Cached").Set(1)
+		llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
+		return true, nil
+	}
+
+	logger.Info("Source drifted under OnChange; re-downloading over cached file", "dir", modelDir)
+	if err := r.removeCachedFiles(ctx, modelDir); err != nil {
+		return true, err
+	}
+	return false, nil
+}
+
 func (r *ModelReconciler) rejectDisallowedLocalSource(ctx context.Context, model *inferencev1alpha1.Model) (handled bool, err error) {
 	logger := log.FromContext(ctx)
 

--- a/internal/controller/model_prefetch.go
+++ b/internal/controller/model_prefetch.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Model prefetch (#904): a Model with spec.prefetch=true and a remote source
+// gets its artifact pulled into the namespace's SHARED model cache PVC ahead
+// of any InferenceService, via an owner-ref'd Job whose pod reuses the exact
+// init-container download stack the serving path uses
+// (buildModelStorageConfig with a nil InferenceService): same cache-prep
+// container, same downloader image and ETag handling, same multi-file
+// staging plan, same SourceSecretRef env. The first serving pod then starts
+// from a cache hit instead of a cold download.
+//
+// The prefetch deliberately targets the shared cache
+// (ModelCacheModeShared): perService cache PVCs are created per
+// InferenceService at serve time and cannot be pre-populated for a service
+// that does not exist yet. The field's GoDoc documents that limitation and
+// the pvc:// staging alternative.
+
+// defaultPrefetchImage mirrors the --init-container-image flag default for
+// the no-op completion container when the reconciler is constructed without
+// the field (tests); production wiring always sets InitContainerImage.
+const defaultPrefetchImage = "docker.io/curlimages/curl:8.18.0"
+
+// prefetchJobName returns the deterministic Job name for a Model's prefetch.
+func prefetchJobName(model *inferencev1alpha1.Model) string {
+	return model.Name + "-prefetch"
+}
+
+// seedPrefetchCacheKey populates Status.CacheKey (in memory) when empty so
+// the storage builder targets the shared cache PVC rather than an emptyDir.
+func seedPrefetchCacheKey(model *inferencev1alpha1.Model) {
+	if model.Status.CacheKey == "" {
+		model.Status.CacheKey = computeCacheKey(model.Spec.Source)
+	}
+}
+
+// prefetchEligible reports whether this Model should take the prefetch path:
+// the field is set and the source is a remote artifact the downloader stack
+// can fetch (http/https/hf). Local paths and pvc:// sources have nothing to
+// prefetch.
+func prefetchEligible(model *inferencev1alpha1.Model) bool {
+	if model == nil || !model.Spec.Prefetch {
+		return false
+	}
+	return isRemoteHTTPSource(normalizeHFSource(model.Spec.Source))
+}
+
+// reconcilePrefetch drives the prefetch state machine. handled=true means
+// the prefetch path owns this reconcile and Reconcile should return its
+// result; handled=false means fall through to the normal source dispatch
+// (not eligible, or the prefetch already completed and the model is Ready).
+func (r *ModelReconciler) reconcilePrefetch(ctx context.Context, model *inferencev1alpha1.Model) (bool, ctrl.Result, error) {
+	if !prefetchEligible(model) {
+		return false, ctrl.Result{}, nil
+	}
+
+	// Completed earlier: the cache is warm and status is terminal. Fall
+	// through so the ordinary remote-source reconcile keeps owning Ready
+	// (revalidation, accelerator checks) without re-running the Job.
+	if model.Status.Phase == PhaseReady && model.Status.CacheKey != "" {
+		return false, ctrl.Result{}, nil
+	}
+
+	logger := logf.FromContext(ctx)
+
+	job := &batchv1.Job{}
+	err := r.Get(ctx, types.NamespacedName{Name: prefetchJobName(model), Namespace: model.Namespace}, job)
+	switch {
+	case apierrors.IsNotFound(err):
+		result, startErr := r.startPrefetch(ctx, model)
+		return true, result, startErr
+	case err != nil:
+		return true, ctrl.Result{}, fmt.Errorf("checking prefetch job: %w", err)
+	}
+
+	switch {
+	case jobSucceeded(job):
+		return true, ctrl.Result{}, r.completePrefetch(ctx, model)
+	case jobFailed(job):
+		logger.Info("Prefetch job failed", "job", job.Name)
+		model.Status.Phase = PhaseFailed
+		return true, ctrl.Result{}, r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionFalse,
+			"PrefetchFailed", fmt.Sprintf("prefetch job %q failed; see its pod logs", job.Name))
+	default:
+		// Still running: reflect progress and poll. The Job's completion
+		// does not generate a Model event, so a modest requeue keeps the
+		// status honest without watching Jobs from this controller.
+		if model.Status.Phase != PhaseDownloading {
+			model.Status.Phase = PhaseDownloading
+			seedPrefetchCacheKey(model)
+			if err := r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionTrue,
+				"PrefetchRunning", "Prefetch job downloading model into the shared cache"); err != nil {
+				return true, ctrl.Result{}, err
+			}
+		}
+		return true, ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	}
+}
+
+// startPrefetch ensures the shared cache PVC exists and creates the
+// owner-ref'd prefetch Job.
+func (r *ModelReconciler) startPrefetch(ctx context.Context, model *inferencev1alpha1.Model) (ctrl.Result, error) {
+	logger := logf.FromContext(ctx)
+
+	// Seed the cache key BEFORE building the Job: effectiveModelCacheKey
+	// reads Status.CacheKey for single-file models, and an empty key makes
+	// buildModelStorageConfig fall back to an emptyDir — the prefetch would
+	// download and then discard the artifact. Same derivation as the remote
+	// branch of reconcileBySourceType, so the serving pod later computes the
+	// identical key and takes the cache-hit path.
+	seedPrefetchCacheKey(model)
+
+	if err := ensureSharedModelCachePVC(ctx, r.Client, model.Namespace,
+		r.ModelCacheSize, r.ModelCacheClass, r.ModelCacheAccessMode); err != nil {
+		return ctrl.Result{}, fmt.Errorf("ensuring shared model cache PVC: %w", err)
+	}
+
+	job, err := r.buildPrefetchJob(model)
+	if err != nil {
+		model.Status.Phase = PhaseFailed
+		return ctrl.Result{}, r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionFalse,
+			"PrefetchInvalid", err.Error())
+	}
+	if err := controllerutil.SetControllerReference(model, job, r.Scheme); err != nil {
+		return ctrl.Result{}, fmt.Errorf("owner-ref prefetch job: %w", err)
+	}
+	if err := r.Create(ctx, job); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// Raced with a concurrent reconcile; the poll branch takes over.
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("creating prefetch job: %w", err)
+	}
+
+	logger.Info("Created prefetch job", "job", job.Name)
+	model.Status.Phase = PhaseDownloading
+	if err := r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionTrue,
+		"PrefetchStarted", "Started prefetch job downloading model into the shared cache"); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+}
+
+// completePrefetch marks the Model Ready with its cache key so the first
+// InferenceService takes the cache-hit path.
+func (r *ModelReconciler) completePrefetch(ctx context.Context, model *inferencev1alpha1.Model) error {
+	model.Status.Phase = PhaseReady
+	seedPrefetchCacheKey(model)
+	model.Status.AcceleratorReady = r.checkAcceleratorAvailability(ctx, model)
+	now := metav1.Now()
+	model.Status.LastUpdated = &now
+	return r.updateStatus(ctx, model, "Available", metav1.ConditionTrue,
+		"ModelPrefetched", "Model prefetched into the shared cache")
+}
+
+// buildPrefetchJob assembles the download Job. The pod reuses the serving
+// path's init containers and volumes verbatim (nil InferenceService: the
+// only isvc-derived input is an optional fsGroup override) and adds a no-op
+// completion container, since a Job pod must have at least one non-init
+// container.
+func (r *ModelReconciler) buildPrefetchJob(model *inferencev1alpha1.Model) (*batchv1.Job, error) {
+	if effectiveModelCacheKey(model) == "" {
+		return nil, fmt.Errorf("prefetch: model has no cache key; refusing to build a Job that would download into an emptyDir")
+	}
+	storage := buildModelStorageConfig(model, nil, model.Namespace, true, ModelCacheModeShared,
+		r.CACertConfigMap, r.InitContainerImage, r.DefaultFSGroup, r.AllowedHostPathRoots)
+	if len(storage.initContainers) == 0 {
+		return nil, fmt.Errorf("prefetch: source %q produced no downloader containers", model.Spec.Source)
+	}
+
+	backoff := int32(2)
+	ttl := int32(24 * 60 * 60) // keep a day for log triage, then self-clean
+
+	var podSecurity *corev1.PodSecurityContext
+	if r.DefaultFSGroup > 0 {
+		fs := r.DefaultFSGroup
+		podSecurity = &corev1.PodSecurityContext{FSGroup: &fs}
+	}
+
+	image := r.InitContainerImage
+	if image == "" {
+		image = defaultPrefetchImage
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      prefetchJobName(model),
+			Namespace: model.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "llmkube",
+				"app.kubernetes.io/component":  "model-prefetch",
+				"app.kubernetes.io/managed-by": "llmkube-controller",
+				"inference.llmkube.dev/model":  model.Name,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            &backoff,
+			TTLSecondsAfterFinished: &ttl,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "model-prefetch",
+						"inference.llmkube.dev/model": model.Name,
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy:   corev1.RestartPolicyNever,
+					SecurityContext: podSecurity,
+					InitContainers:  storage.initContainers,
+					Containers: []corev1.Container{{
+						Name:    "prefetch-done",
+						Image:   image,
+						Command: []string{"sh", "-c", "echo prefetch complete"},
+					}},
+					Volumes: storage.volumes,
+				},
+			},
+		},
+	}, nil
+}
+
+// jobSucceeded / jobFailed read the Job's terminal conditions.
+func jobSucceeded(job *batchv1.Job) bool {
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func jobFailed(job *batchv1.Job) bool {
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/model_prefetch_test.go
+++ b/internal/controller/model_prefetch_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+var _ = Describe("Model Prefetch", func() {
+	ctx := context.Background()
+	const ns = "prefetch-test"
+
+	prefetchReconciler := func() *ModelReconciler {
+		return &ModelReconciler{
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			InitContainerImage:   "docker.io/curlimages/curl:8.18.0",
+			DefaultFSGroup:       102,
+			ModelCacheSize:       "10Gi",
+			ModelCacheAccessMode: "ReadWriteOnce",
+		}
+	}
+
+	newPrefetchModel := func(name string) *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/models/llama.gguf",
+				Prefetch: true,
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+		err := k8sClient.Create(ctx, nsObj)
+		if err != nil {
+			Expect(client.IgnoreAlreadyExists(err)).To(Succeed())
+		}
+	})
+
+	Describe("prefetchEligible", func() {
+		It("is false when the field is unset", func() {
+			m := newPrefetchModel("x")
+			m.Spec.Prefetch = false
+			Expect(prefetchEligible(m)).To(BeFalse())
+		})
+
+		It("is false for pvc:// sources even with prefetch set", func() {
+			m := newPrefetchModel("x")
+			m.Spec.Source = "pvc://some-pvc/model.gguf"
+			Expect(prefetchEligible(m)).To(BeFalse())
+		})
+
+		It("is true for hf:// sources (normalized to https)", func() {
+			m := newPrefetchModel("x")
+			m.Spec.Source = "hf://org/repo/model.gguf"
+			Expect(prefetchEligible(m)).To(BeTrue())
+		})
+
+		It("is true for https sources", func() {
+			Expect(prefetchEligible(newPrefetchModel("x"))).To(BeTrue())
+		})
+	})
+
+	Describe("reconcilePrefetch", func() {
+		It("does not handle models without prefetch", func() {
+			m := newPrefetchModel("no-prefetch")
+			m.Spec.Prefetch = false
+			handled, _, err := prefetchReconciler().reconcilePrefetch(ctx, m)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(handled).To(BeFalse())
+		})
+
+		It("creates the Job and shared cache PVC, then completes on Job success", func() {
+			model := newPrefetchModel("model-prefetch-flow")
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			r := prefetchReconciler()
+
+			// First pass: creates PVC + Job, sets Downloading.
+			handled, result, err := r.reconcilePrefetch(ctx, model)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(handled).To(BeTrue())
+			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+
+			job := &batchv1.Job{}
+			jobKey := types.NamespacedName{Name: "model-prefetch-flow-prefetch", Namespace: ns}
+			Expect(k8sClient.Get(ctx, jobKey, job)).To(Succeed())
+			Expect(job.OwnerReferences).To(HaveLen(1))
+			Expect(job.OwnerReferences[0].Kind).To(Equal("Model"))
+			Expect(job.Spec.Template.Spec.InitContainers).NotTo(BeEmpty())
+			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ModelCachePVCName, Namespace: ns}, pvc)).To(Succeed())
+
+			updated := &inferencev1alpha1.Model{}
+			modelKey := types.NamespacedName{Name: model.Name, Namespace: ns}
+			Expect(k8sClient.Get(ctx, modelKey, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(PhaseDownloading))
+			Expect(updated.Status.CacheKey).NotTo(BeEmpty())
+
+			// Second pass with the Job still running: no duplicate, polls again.
+			handled, result, err = r.reconcilePrefetch(ctx, updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(handled).To(BeTrue())
+			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+
+			// Mark the Job complete; next pass promotes the Model to Ready.
+			// k8s >=1.31 validates the Job status subresource: a finished Job
+			// needs startTime/completionTime, and Complete=True requires
+			// SuccessCriteriaMet=True first.
+			Expect(k8sClient.Get(ctx, jobKey, job)).To(Succeed())
+			now := metav1.Now()
+			job.Status.StartTime = &now
+			job.Status.CompletionTime = &now
+			job.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobSuccessCriteriaMet, Status: corev1.ConditionTrue},
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+			}
+			job.Status.Succeeded = 1
+			Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, modelKey, updated)).To(Succeed())
+			handled, _, err = r.reconcilePrefetch(ctx, updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(handled).To(BeTrue())
+
+			Expect(k8sClient.Get(ctx, modelKey, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(PhaseReady))
+			Expect(updated.Status.CacheKey).To(Equal(effectiveModelCacheKey(updated)))
+
+			// Once Ready with a cache key, prefetch steps aside for the
+			// ordinary remote-source reconcile.
+			handled, _, err = r.reconcilePrefetch(ctx, updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(handled).To(BeFalse())
+		})
+
+		It("marks the Model Failed when the Job fails", func() {
+			model := newPrefetchModel("model-prefetch-fail")
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			r := prefetchReconciler()
+			handled, _, err := r.reconcilePrefetch(ctx, model)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(handled).To(BeTrue())
+
+			// Failed=True requires FailureTarget=True and a startTime under
+			// k8s >=1.31 Job status validation.
+			job := &batchv1.Job{}
+			jobKey := types.NamespacedName{Name: "model-prefetch-fail-prefetch", Namespace: ns}
+			Expect(k8sClient.Get(ctx, jobKey, job)).To(Succeed())
+			now := metav1.Now()
+			job.Status.StartTime = &now
+			job.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobFailureTarget, Status: corev1.ConditionTrue, Reason: "PodFailurePolicy", Message: "test"},
+				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "PodFailurePolicy", Message: "test"},
+			}
+			job.Status.Failed = 3
+			Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+
+			updated := &inferencev1alpha1.Model{}
+			modelKey := types.NamespacedName{Name: model.Name, Namespace: ns}
+			Expect(k8sClient.Get(ctx, modelKey, updated)).To(Succeed())
+			handled, _, err = r.reconcilePrefetch(ctx, updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(handled).To(BeTrue())
+
+			Expect(k8sClient.Get(ctx, modelKey, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(PhaseFailed))
+		})
+	})
+
+	Describe("Reconcile integration", func() {
+		It("intercepts a prefetch model before the remote download path", func() {
+			model := newPrefetchModel("model-prefetch-hook")
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			result, err := prefetchReconciler().Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: model.Name, Namespace: ns},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+
+			job := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "model-prefetch-hook-prefetch", Namespace: ns}, job)).To(Succeed())
+
+			updated := &inferencev1alpha1.Model{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: model.Name, Namespace: ns}, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(PhaseDownloading))
+		})
+	})
+})

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -740,6 +741,59 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 // pod schedules to (the GPU node), co-locating download and serve instead of
 // pinning the cache to the operator's node. Use it on multi-node clusters that
 // have no RWX storage class.
+// ensureSharedModelCachePVC creates the namespace's shared llmkube-model-cache
+// PVC if absent. Extracted from the InferenceService reconciler's shared-mode
+// branch so the Model prefetch path (#904) can guarantee the same PVC exists
+// before its download Job mounts it. No owner reference: the shared cache
+// outlives any one consumer.
+func ensureSharedModelCachePVC(ctx context.Context, c client.Client, namespace, size, class, accessModeCfg string) error {
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := c.Get(ctx, types.NamespacedName{Name: ModelCachePVCName, Namespace: namespace}, pvc)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check for existing PVC: %w", err)
+	}
+
+	accessMode := corev1.ReadWriteOnce
+	if accessModeCfg == "ReadWriteMany" {
+		accessMode = corev1.ReadWriteMany
+	}
+	if size == "" {
+		size = "100Gi"
+	}
+	storageSize, err := resource.ParseQuantity(size)
+	if err != nil {
+		return fmt.Errorf("invalid cache size %q: %w", size, err)
+	}
+
+	newPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ModelCachePVCName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "llmkube",
+				"app.kubernetes.io/component":  "model-cache",
+				"app.kubernetes.io/managed-by": "llmkube-controller",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{accessMode},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: storageSize},
+			},
+		},
+	}
+	if class != "" {
+		newPVC.Spec.StorageClassName = &class
+	}
+	if err := c.Create(ctx, newPVC); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create shared model cache PVC: %w", err)
+	}
+	return nil
+}
+
 func (r *InferenceServiceReconciler) ensureModelCachePVC(ctx context.Context, isvc *inferencev1alpha1.InferenceService) error {
 	log := logf.FromContext(ctx)
 


### PR DESCRIPTION
## Description

Adds `spec.prefetch` to the Model CRD (#904): a Model with a remote source (`https://`, `hf://`) and `prefetch: true` is eagerly downloaded into the namespace's shared model cache PVC by an owner-referenced Job, before any InferenceService exists. The first serving pod then starts from a cache hit instead of a cold multi-GB download.

### How it works

- `reconcilePrefetch` (new `internal/controller/model_prefetch.go`) runs ahead of the source-type dispatch in the Model reconcile. Eligible = `prefetch: true` + remote source; local paths and `pvc://` sources ignore the field.
- The prefetch Job's pod reuses the serving path's download stack verbatim: `buildModelStorageConfig(model, nil, ...)` supplies the same cache-prep + `model-downloader` init containers, downloader image, ETag handling, multi-file staging plan, and `SourceSecretRef` env. A no-op `prefetch-done` container completes the Job.
- The cache key is seeded (`computeCacheKey(source)`, same derivation as the remote branch of `reconcileBySourceType`) before the Job is built: for single-file models `effectiveModelCacheKey` reads `Status.CacheKey`, and an empty key makes the storage builder fall back to an emptyDir, which would silently discard the download. `buildPrefetchJob` also hard-refuses to build a Job with an empty effective key.
- Status: `Downloading` while the Job runs (15s poll), then `Ready` + `status.cacheKey` on Job success (same key the serving path computes, so the ISvc cache-hit path lights up), `Failed` if the Job fails (backoffLimit=2). The Job is owner-ref'd to the Model and TTL-cleans after 24h.
- The shared cache PVC (`llmkube-model-cache`) is created on demand via a new package-level `ensureSharedModelCachePVC`, wired from the existing `model-cache-size/-storage-class/-access-mode` flags (six new `ModelReconciler` fields set in `cmd/main.go`).
- Scope: shared cache only. `perService` cache PVCs bind at serve time and cannot be pre-populated; the field GoDoc, CRD description, and docs all state this, with `pvc://` staging as the alternative for those fleets.

### Also in this PR

- `Reconcile` cache-hit block extracted to `reconcileCachedModelFile` (behavior-preserving) to keep gocyclo under the 30 limit after adding the prefetch hook.
- RBAC: `batch/jobs` (get/list/watch/create/delete) and `persistentvolumeclaims` +create markers; `config/rbac/role.yaml` regenerated, `make check-helm-rbac` green.
- Docs: "Prefetch (Eager Download)" section in `docs/MODEL-CACHE.md`; sample `config/samples/model_prefetch.yaml`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit/envtest: new `model_prefetch_test.go` covers eligibility (unset field, `pvc://`, `hf://`, `https`), Job+PVC creation with owner ref, no duplicate Job on requeue, `Downloading` -> `Ready` + cacheKey on Job success, `Failed` on Job failure, and the Reconcile hook intercepting before the remote download path
- [x] Full `internal/controller` suite green; `GOOS=linux golangci-lint` clean
- [x] `make manifests generate chart-crds` + `make check-helm-rbac` clean

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] AI assistance disclosed: implemented with AI assistance (human-directed); human owns the review conversation.

Assisted-by: Claude Code (generated the implementation and envtest suite under direction; I reviewed the design, ran the full controller suite, cross-arch lint, and codegen/RBAC checks before submitting)

Fixes #904

