### PR TITLE
feat(metrics): publish operator state metrics from observed state

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -157,15 +157,24 @@ func initContainerSecurityContext(isvc *inferencev1alpha1.InferenceService) *cor
 
 func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reconcileStart := time.Now()
+	inferenceService := &inferencev1alpha1.InferenceService{}
+	// Assigned by getModelForInferenceService below; declared here so the
+	// deferred publish can label the info series with the Model's accelerator.
+	var model *inferencev1alpha1.Model
 	defer func() {
 		llmkubemetrics.ReconcileDuration.WithLabelValues("inferenceservice").Observe(time.Since(reconcileStart).Seconds())
+		// Republish from observed state: a pass that returns before
+		// updateStatusWithSchedulingInfo publishes nothing at the call site.
+		// A live cluster hit this via #1225 — two Ready, serving services
+		// failed reconcileDeployment every pass and exported no series at all.
+		publishInferenceServiceState(inferenceService, model)
 	}()
 
 	log := logf.FromContext(ctx)
 
-	inferenceService := &inferencev1alpha1.InferenceService{}
 	if err := r.Get(ctx, req.NamespacedName, inferenceService); err != nil {
 		if apierrors.IsNotFound(err) {
+			llmkubemetrics.DeleteInferenceServiceSeries(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		log.Error(err, "Failed to get InferenceService")
@@ -188,7 +197,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// from before the allowlist was introduced (or tightened).
 	if valErr := validateLocalSourceAllowed(model.Spec.Source, r.AllowedHostPathRoots); valErr != nil {
 		log.Error(valErr, "rejected local model source by host-path allowlist", "model", model.Name, "source", model.Spec.Source)
-		blockResult, updateErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, model, PhaseFailed, modelReady, 0, 0, "",
+		blockResult, updateErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, PhaseFailed, modelReady, 0, 0, "",
 			valErr.Error(), nil)
 		return blockResult, updateErr
 	}
@@ -201,7 +210,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if effectiveModelCacheKey(model) != "" && r.ModelCachePath != "" {
 		if err := r.ensureModelCachePVC(ctx, inferenceService); err != nil {
 			log.Error(err, "Failed to ensure model cache PVC exists", "namespace", inferenceService.Namespace)
-			return r.updateStatusWithSchedulingInfo(ctx, inferenceService, model, PhaseFailed, modelReady, 0, desiredReplicas, "",
+			return r.updateStatusWithSchedulingInfo(ctx, inferenceService, PhaseFailed, modelReady, 0, desiredReplicas, "",
 				fmt.Sprintf("Failed to ensure model cache PVC: %v", err), nil)
 		}
 	}
@@ -228,7 +237,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	service, result, err := r.reconcileService(ctx, inferenceService, model, modelReady, desiredReplicas, isMetal)
+	service, result, err := r.reconcileService(ctx, inferenceService, modelReady, desiredReplicas, isMetal)
 	if err != nil || result != nil {
 		if result != nil {
 			return *result, err
@@ -243,7 +252,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	endpoint := r.constructEndpoint(inferenceService, service)
 	phase, schedulingInfo := r.determinePhase(ctx, inferenceService, readyReplicas, desiredReplicas, isMetal, deployment, metalSnap)
 
-	finalResult, statusErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, model, phase, modelReady, readyReplicas, desiredReplicas, endpoint, "", schedulingInfo)
+	finalResult, statusErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, phase, modelReady, readyReplicas, desiredReplicas, endpoint, "", schedulingInfo)
 	if statusErr != nil {
 		return finalResult, statusErr
 	}
@@ -279,7 +288,7 @@ func (r *InferenceServiceReconciler) getModelForInferenceService(ctx context.Con
 	if err := r.Get(ctx, modelName, model); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Referenced Model not found", "model", isvc.Spec.ModelRef)
-			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, nil, PhaseFailed, false, 0, 0, "", "Model not found", nil)
+			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, false, 0, 0, "", "Model not found", nil)
 			return nil, false, &result, updateErr
 		}
 		log.Error(err, "Failed to get Model")
@@ -289,7 +298,7 @@ func (r *InferenceServiceReconciler) getModelForInferenceService(ctx context.Con
 	modelReady := model.Status.Phase == PhaseReady
 	if !modelReady {
 		log.Info("Model not ready yet", "model", model.Name, "phase", model.Status.Phase)
-		result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, model, "Pending", false, 0, 0, "", "Waiting for Model to be Ready", nil)
+		result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, "Pending", false, 0, 0, "", "Waiting for Model to be Ready", nil)
 		return nil, false, &result, updateErr
 	}
 
@@ -325,7 +334,7 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	// message; admission-time rejection is the follow-up (#1196 story 5).
 	if _, err := resolveGPUSharing(isvc, model, r.GPUSharingSharedPool); err != nil {
 		log.Info("Rejecting InferenceService with invalid gpuSharing spec", "reason", err.Error())
-		result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, model, PhaseFailed, modelReady, 0, desiredReplicas, "", fmt.Sprintf("Invalid gpuSharing: %v", err), nil)
+		result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, modelReady, 0, desiredReplicas, "", fmt.Sprintf("Invalid gpuSharing: %v", err), nil)
 		return nil, 0, nil, &result, updateErr
 	}
 
@@ -347,7 +356,7 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 		deployment.Annotations[AnnotationDesiredTemplateHash] = tmplHash
 		if err := r.Create(ctx, deployment); err != nil {
 			log.Error(err, "Failed to create Deployment")
-			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, model, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create Deployment", nil)
+			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create Deployment", nil)
 			return nil, 0, nil, &result, updateErr
 		}
 		return deployment, 0, nil, nil, nil
@@ -486,7 +495,7 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	return deployment, existingDeployment.Status.ReadyReplicas, nil, nil, nil
 }
 
-func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, modelReady bool, desiredReplicas int32, isMetal bool) (*corev1.Service, *ctrl.Result, error) {
+func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc *inferencev1alpha1.InferenceService, modelReady bool, desiredReplicas int32, isMetal bool) (*corev1.Service, *ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	if isMetal {
@@ -513,7 +522,7 @@ func (r *InferenceServiceReconciler) reconcileService(ctx context.Context, isvc 
 		log.Info("Creating new Service", "name", service.Name)
 		if err := r.Create(ctx, service); err != nil {
 			log.Error(err, "Failed to create Service")
-			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, model, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create Service", nil)
+			result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, modelReady, 0, desiredReplicas, "", "Failed to create Service", nil)
 			return nil, &result, updateErr
 		}
 	} else if err != nil {

--- a/internal/controller/inferenceservice_service_test.go
+++ b/internal/controller/inferenceservice_service_test.go
@@ -213,7 +213,7 @@ var _ = Describe("reconcileService Metal path", func() {
 			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "some-model"},
 		}
 
-		svc, result, err := reconciler.reconcileService(context.Background(), isvc, nil, true, 1, true)
+		svc, result, err := reconciler.reconcileService(context.Background(), isvc, true, 1, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(BeNil())
 		Expect(svc).NotTo(BeNil())
@@ -227,7 +227,7 @@ var _ = Describe("reconcileService Metal path", func() {
 			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "some-model"},
 		}
 
-		svc, result, err := reconciler.reconcileService(context.Background(), isvc, nil, true, 1, true)
+		svc, result, err := reconciler.reconcileService(context.Background(), isvc, true, 1, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(BeNil())
 		Expect(svc.Name).To(Equal("llama-3-2-3b"))
@@ -243,7 +243,7 @@ var _ = Describe("reconcileService Metal path", func() {
 			},
 		}
 
-		svc, _, err := reconciler.reconcileService(context.Background(), isvc, nil, true, 1, true)
+		svc, _, err := reconciler.reconcileService(context.Background(), isvc, true, 1, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc.Spec.Ports).To(BeEmpty())
 		Expect(svc.Spec.Type).To(Equal(corev1.ServiceType("")))
@@ -256,7 +256,7 @@ var _ = Describe("reconcileService Metal path", func() {
 			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "some-model"},
 		}
 
-		_, _, err := reconciler.reconcileService(context.Background(), isvc, nil, true, 1, true)
+		_, _, err := reconciler.reconcileService(context.Background(), isvc, true, 1, true)
 		Expect(err).NotTo(HaveOccurred())
 
 		svc := &corev1.Service{}

--- a/internal/controller/metrics_lifecycle_test.go
+++ b/internal/controller/metrics_lifecycle_test.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
+)
+
+// Series counts come from DeletePartialMatch's return value; clearing as we
+// count also keeps these specs out of the registry the rest of the suite
+// shares. Read any gauge VALUE first — WithLabelValues resurrects a deleted
+// series at 0 rather than reporting it missing. The llmkubemetrics.Delete*
+// helpers are used where the intent is "clean up this object" rather than
+// "count one vec".
+
+func modelLabels(name string) prometheus.Labels {
+	return prometheus.Labels{"model": name, "namespace": "default"}
+}
+
+func isvcLabels(name string) prometheus.Labels {
+	return prometheus.Labels{"inferenceservice": name, "namespace": "default"}
+}
+
+var _ = Describe("Operator state metrics lifecycle", func() {
+	ctx := context.Background()
+
+	Describe("Model phase gauge", func() {
+		var reconciler *ModelReconciler
+
+		BeforeEach(func() {
+			reconciler = &ModelReconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				StoragePath:          GinkgoT().TempDir(),
+				AllowedHostPathRoots: testLocalRoots,
+			}
+		})
+
+		// Regression: an already-Ready hf:// Model takes the early exit in
+		// reconcileRuntimeResolvedSource, so the series used to vanish after
+		// the first reconcile and never come back.
+		It("stays published across repeated reconciles of an already-Ready model", func() {
+			modelName := "model-metrics-steady"
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec:       inferencev1alpha1.ModelSpec{Source: "hf://org/repo"},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			llmkubemetrics.DeleteModelSeries(modelName, "default")
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+			}
+
+			// First pass drives the Model to Ready.
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Clearing here is the point: a second reconcile of an unchanged,
+			// already-Ready Model must republish from observed state.
+			llmkubemetrics.DeleteModelSeries(modelName, "default")
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(testutil.ToFloat64(
+				llmkubemetrics.ModelStatus.WithLabelValues(modelName, "default", PhaseReady),
+			)).To(Equal(1.0), "second reconcile must republish the Ready series")
+			Expect(llmkubemetrics.ModelStatus.DeletePartialMatch(modelLabels(modelName))).To(Equal(1))
+		})
+
+		// Real Failed -> Ready sequence: the gauge only accumulates when the
+		// controller itself writes the second phase. Deliberately does NOT
+		// clear the vec between reconciles — clearing would mask an
+		// accumulating gauge.
+		It("keeps exactly one series when the phase changes", func() {
+			modelName := "model-metrics-transition"
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				// Outside testLocalRoots, so the host-path allowlist rejects it
+				// and the Model lands in Failed without needing the network.
+				Spec: inferencev1alpha1.ModelSpec{Source: "/forbidden/model.gguf"},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			llmkubemetrics.DeleteModelSeries(modelName, "default")
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+			}
+
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testutil.ToFloat64(
+				llmkubemetrics.ModelStatus.WithLabelValues(modelName, "default", PhaseFailed),
+			)).To(Equal(1.0), "rejected source should publish Failed")
+
+			// Point at a source that resolves, so the next reconcile reaches Ready.
+			Expect(k8sClient.Get(ctx, req.NamespacedName, model)).To(Succeed())
+			model.Spec.Source = "hf://org/repo"
+			Expect(k8sClient.Update(ctx, model)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(testutil.ToFloat64(
+				llmkubemetrics.ModelStatus.WithLabelValues(modelName, "default", PhaseReady),
+			)).To(Equal(1.0), "the current phase must be the one published")
+			Expect(llmkubemetrics.ModelStatus.DeletePartialMatch(modelLabels(modelName))).
+				To(Equal(1), "the Failed series must be dropped, not left alongside Ready")
+		})
+
+		It("drops the series when the model is gone", func() {
+			modelName := "model-metrics-deleted"
+			llmkubemetrics.ModelStatus.
+				WithLabelValues(modelName, "default", PhaseReady).Set(1)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(llmkubemetrics.ModelStatus.DeletePartialMatch(modelLabels(modelName))).
+				To(Equal(0), "a deleted Model must stop being reported")
+		})
+	})
+
+	Describe("InferenceService metrics", func() {
+		It("keeps exactly one phase series when the phase changes", func() {
+			name := "isvc-metrics-transition"
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "some-model"},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+			llmkubemetrics.DeleteInferenceServiceSeries(name, "default")
+
+			reconciler := &InferenceServiceReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+
+			// publishInferenceServiceState is what Reconcile's defer calls once
+			// the status is written; calling it here drives the same two-phase
+			// publish without standing up a full reconcile.
+			_, err := reconciler.updateStatusWithSchedulingInfo(
+				ctx, isvc, PhaseCreating, false, 0, 1, "", "", nil)
+			Expect(err).NotTo(HaveOccurred())
+			publishInferenceServiceState(isvc, nil)
+			_, err = reconciler.updateStatusWithSchedulingInfo(
+				ctx, isvc, PhaseReady, true, 1, 1, "http://example", "", nil)
+			Expect(err).NotTo(HaveOccurred())
+			publishInferenceServiceState(isvc, nil)
+
+			Expect(testutil.ToFloat64(
+				llmkubemetrics.InferenceServicePhase.WithLabelValues(name, "default", PhaseReady),
+			)).To(Equal(1.0))
+			Expect(llmkubemetrics.InferenceServicePhase.DeletePartialMatch(isvcLabels(name))).
+				To(Equal(1), "Creating must be dropped once the service reaches Ready")
+
+			// Replica counts follow the same status update.
+			Expect(testutil.ToFloat64(
+				llmkubemetrics.InferenceServiceReplicas.WithLabelValues(name, "default", "ready"),
+			)).To(Equal(1.0))
+			llmkubemetrics.DeleteInferenceServiceSeries(name, "default")
+		})
+
+		// The live case: two Ready, serving InferenceServices failed
+		// reconcileDeployment on every pass (#1225), returned before the status
+		// update, and so exported no series at all for as long as that error
+		// persisted. Publishing from the call site cannot cover this; the
+		// deferred publish reads what the service already is.
+		It("keeps exporting phase, replicas and info when the reconcile errors early", func() {
+			name := "isvc-metrics-early-return"
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "early-return-model", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "hf://org/repo",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: acceleratorCUDA},
+				},
+				Status: inferencev1alpha1.ModelStatus{Phase: PhaseReady},
+			}
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: model.Name},
+				Status: inferencev1alpha1.InferenceServiceStatus{
+					Phase:           PhaseReady,
+					ReadyReplicas:   2,
+					DesiredReplicas: 2,
+				},
+			}
+
+			reconciler := &InferenceServiceReconciler{Scheme: k8sClient.Scheme()}
+			// Seeding the Deployment the controller would build puts
+			// reconcileDeployment on its in-place Update path, which is where the
+			// live failure lands; the interceptor then rejects that Update.
+			deployment := reconciler.constructDeployment(isvc, model, 2)
+			reconciler.Client = fake.NewClientBuilder().
+				WithScheme(k8sClient.Scheme()).
+				WithObjects(model, isvc, deployment).
+				WithStatusSubresource(&inferencev1alpha1.InferenceService{}, &inferencev1alpha1.Model{}).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(ctx context.Context, c client.WithWatch, obj client.Object,
+						opts ...client.UpdateOption) error {
+						if _, ok := obj.(*appsv1.Deployment); ok {
+							return fmt.Errorf("activeDeadlineSeconds in ReplicaSet is not Supported")
+						}
+						return c.Update(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			llmkubemetrics.DeleteInferenceServiceSeries(name, "default")
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
+			})
+			Expect(err).To(HaveOccurred(), "this spec is only meaningful if the reconcile fails")
+
+			Expect(testutil.ToFloat64(
+				llmkubemetrics.InferenceServicePhase.WithLabelValues(name, "default", PhaseReady),
+			)).To(Equal(1.0), "a failed reconcile must still report the stored phase")
+			Expect(testutil.ToFloat64(
+				llmkubemetrics.InferenceServiceReplicas.WithLabelValues(name, "default", "ready"),
+			)).To(Equal(2.0))
+			Expect(testutil.ToFloat64(
+				llmkubemetrics.InferenceServiceInfo.WithLabelValues(name, "default", acceleratorCUDA, "llamacpp"),
+			)).To(Equal(1.0), "info must carry the Model's accelerator, not the cpu fallback")
+			llmkubemetrics.DeleteInferenceServiceSeries(name, "default")
+		})
+
+		It("drops phase, info and replica series when the service is gone", func() {
+			name := "isvc-metrics-deleted"
+			llmkubemetrics.InferenceServicePhase.
+				WithLabelValues(name, "default", PhaseReady).Set(1)
+			llmkubemetrics.InferenceServiceInfo.
+				WithLabelValues(name, "default", "cpu", "llamacpp").Set(1)
+			llmkubemetrics.InferenceServiceReplicas.
+				WithLabelValues(name, "default", "ready").Set(1)
+
+			reconciler := &InferenceServiceReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Every per-service vec must be covered, or a deleted service keeps
+			// reporting through whichever one was missed.
+			Expect(llmkubemetrics.InferenceServicePhase.DeletePartialMatch(isvcLabels(name))).To(Equal(0))
+			Expect(llmkubemetrics.InferenceServiceInfo.DeletePartialMatch(isvcLabels(name))).To(Equal(0))
+			Expect(llmkubemetrics.InferenceServiceReplicas.DeletePartialMatch(isvcLabels(name))).To(Equal(0))
+		})
+	})
+})

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -155,16 +155,19 @@ func (r *ModelReconciler) metadataClient() *http.Client {
 
 func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reconcileStart := time.Now()
+	model := &inferencev1alpha1.Model{}
 	defer func() {
 		llmkubemetrics.ReconcileDuration.WithLabelValues("model").Observe(time.Since(reconcileStart).Seconds())
+		// Republish from observed state: every steady-state path returns before a Set.
+		llmkubemetrics.PublishModelPhase(model.Name, model.Namespace, model.Status.Phase)
 	}()
 
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling Model", "name", req.Name, "namespace", req.Namespace)
 
-	model := &inferencev1alpha1.Model{}
 	if err := r.Get(ctx, req.NamespacedName, model); err != nil {
 		if errors.IsNotFound(err) {
+			llmkubemetrics.DeleteModelSeries(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get Model")
@@ -256,7 +259,6 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if err != nil {
 		logger.Error(err, "Failed to fetch model")
 		llmkubemetrics.ReconcileTotal.WithLabelValues("model", "error").Inc()
-		llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, PhaseFailed).Set(1)
 		model.Status.Phase = PhaseFailed
 		if statusErr := r.updateStatus(ctx, model, ConditionDegraded, metav1.ConditionTrue, failReason, err.Error()); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status after fetch failure")
@@ -291,7 +293,6 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		logger.Error(err, "SHA256 integrity check failed")
 		_ = os.Remove(downloadPath)
 		llmkubemetrics.ReconcileTotal.WithLabelValues("model", "error").Inc()
-		llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, PhaseFailed).Set(1)
 		model.Status.Phase = PhaseFailed
 		if statusErr := r.updateStatus(ctx, model, ConditionDegraded, metav1.ConditionTrue, "IntegrityCheckFailed", err.Error()); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status after integrity check failure")
@@ -330,7 +331,6 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "Ready").Set(1)
 	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
 	logger.Info("Model ready and cached", "path", finalPath, "size", model.Status.Size, "cacheKey", cacheKey)
 	return ctrl.Result{}, nil
@@ -394,7 +394,6 @@ func (r *ModelReconciler) reconcileCachedModelFile(ctx context.Context, model *i
 			return true, err
 		}
 
-		llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "Cached").Set(1)
 		llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
 		return true, nil
 	}
@@ -416,7 +415,6 @@ func (r *ModelReconciler) rejectDisallowedLocalSource(ctx context.Context, model
 
 	logger.Error(valErr, "rejected local model source by host-path allowlist", "source", model.Spec.Source)
 	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "error").Inc()
-	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, PhaseFailed).Set(1)
 	model.Status.Phase = PhaseFailed
 	if statusErr := r.updateStatus(ctx, model, ConditionDegraded, metav1.ConditionTrue, "SourceNotAllowed", valErr.Error()); statusErr != nil {
 		return true, statusErr
@@ -445,7 +443,6 @@ func (r *ModelReconciler) failInvalidFileSet(ctx context.Context, model *inferen
 		logger.Error(updateErr, "Failed to update status after invalid file set")
 	}
 	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "error").Inc()
-	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, PhaseFailed).Set(1)
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}
 }
 
@@ -556,7 +553,6 @@ func (r *ModelReconciler) reconcilePVCSource(ctx context.Context, model *inferen
 		return ctrl.Result{}, err
 	}
 
-	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "Ready").Set(1)
 	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
 	logger.Info("PVC model ready", "pvc", claimName, "path", mountPath)
 	return ctrl.Result{}, nil
@@ -678,7 +674,6 @@ func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, mo
 				logger.Error(updateErr, "Failed to update status after invalid file set")
 			}
 			llmkubemetrics.ReconcileTotal.WithLabelValues("model", "error").Inc()
-			llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, PhaseFailed).Set(1)
 			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 		}
 		model.Status.StagedFiles = plan.Files
@@ -722,7 +717,6 @@ func (r *ModelReconciler) reconcileRuntimeResolvedSource(ctx context.Context, mo
 		return ctrl.Result{}, err
 	}
 
-	llmkubemetrics.ModelStatus.WithLabelValues(model.Name, model.Namespace, "Ready").Set(1)
 	llmkubemetrics.ReconcileTotal.WithLabelValues("model", "success").Inc()
 	logger.Info("Runtime-resolved model ready", "source", model.Spec.Source)
 	return ctrl.Result{}, nil

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,11 +126,35 @@ func (r *InferenceServiceReconciler) constructEndpoint(isvc *inferencev1alpha1.I
 	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", svc.Name, svc.Namespace, port, path)
 }
 
+// publishInferenceServiceState exports the phase, replica and info series from
+// stored status, so a reconcile that returns before the status update still
+// reports what the service is. No-ops on an empty phase: nothing was observed
+// (Get failed, or the object has no status yet). model is nil on the paths that
+// never resolved one; the info series then falls back to cpu/llamacpp, which is
+// what the call site did with a nil model.
+func publishInferenceServiceState(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) {
+	if isvc.Status.Phase == "" {
+		return
+	}
+
+	accelerator := "cpu"
+	if model != nil && model.Spec.Hardware != nil && model.Spec.Hardware.Accelerator != "" {
+		accelerator = model.Spec.Hardware.Accelerator
+	}
+	runtime := isvc.Spec.Runtime
+	if runtime == "" {
+		runtime = "llamacpp"
+	}
+
+	llmkubemetrics.PublishInferenceServicePhase(isvc.Name, isvc.Namespace, isvc.Status.Phase)
+	llmkubemetrics.PublishInferenceServiceReplicas(isvc.Name, isvc.Namespace, isvc.Status.ReadyReplicas, isvc.Status.DesiredReplicas)
+	llmkubemetrics.PublishInferenceServiceInfo(isvc.Name, isvc.Namespace, accelerator, runtime)
+}
+
 // nolint:unparam // ctrl.Result is always zero but callers take &result to signal status-update path
 func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 	ctx context.Context,
 	isvc *inferencev1alpha1.InferenceService,
-	model *inferencev1alpha1.Model,
 	phase string,
 	modelReady bool,
 	readyReplicas int32,
@@ -155,30 +178,9 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 
 	isvc.Status.EffectivePriority = r.resolveEffectivePriority(isvc)
 
-	// Update phase gauge metric
-	llmkubemetrics.InferenceServicePhase.WithLabelValues(isvc.Name, isvc.Namespace, phase).Set(1)
-	if previousPhase != "" && previousPhase != phase {
-		llmkubemetrics.InferenceServicePhase.WithLabelValues(isvc.Name, isvc.Namespace, previousPhase).Set(0)
-	}
-
-	// Emit info metric with hardware labels (accelerator, runtime)
-	accelerator := "cpu"
-	runtime := isvc.Spec.Runtime
-	if model != nil && model.Spec.Hardware != nil {
-		if model.Spec.Hardware.Accelerator != "" {
-			accelerator = model.Spec.Hardware.Accelerator
-		}
-	}
-	if runtime == "" {
-		runtime = "llamacpp"
-	}
-	// Delete any prior series for this InferenceService so that when the
-	// accelerator or runtime changes in place only one series exists per ISvc.
-	llmkubemetrics.InferenceServiceInfo.DeletePartialMatch(prometheus.Labels{
-		"inferenceservice": isvc.Name,
-		"namespace":        isvc.Namespace,
-	})
-	llmkubemetrics.InferenceServiceInfo.WithLabelValues(isvc.Name, isvc.Namespace, accelerator, runtime).Set(1)
+	// The phase, replica and info series are published by Reconcile's defer
+	// from the status written above, not here: this call site is unreachable
+	// on any pass that errors earlier.
 
 	// Track time-to-ready using creation timestamp
 	if phase == PhaseReady && previousPhase != PhaseReady {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,7 +36,7 @@ var (
 	ModelStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "llmkube_model_status",
-			Help: "Current status of models. Value encodes phase: 0=Unknown, 1=Downloading, 2=Copying, 3=Ready, 4=Cached, 5=Failed.",
+			Help: "Current phase of models. Value is always 1; use the phase label for filtering.",
 		},
 		[]string{"model", "namespace", "phase"},
 	)
@@ -66,6 +66,14 @@ var (
 			Help: "Information about inference services. Value is always 1; use accelerator and runtime labels for grouping.",
 		},
 		[]string{"inferenceservice", "namespace", "accelerator", "runtime"},
+	)
+
+	InferenceServiceReplicas = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llmkube_inferenceservice_replicas",
+			Help: "InferenceService replica counts. Use the state label: ready, desired.",
+		},
+		[]string{"inferenceservice", "namespace", "state"},
 	)
 
 	GPUQueueDepth = prometheus.NewGauge(
@@ -216,28 +224,92 @@ var (
 	)
 )
 
+// AllCollectors is every metric this operator registers. init() registers
+// these and the tests range over the same slice, so a metric cannot be added
+// to one list and silently missed in the other.
+var AllCollectors = []prometheus.Collector{
+	GPUQuotaUsedGPUCount,
+	GPUQuotaGPUCountLimit,
+	GPUQuotaAdmissionDenialsTotal,
+	GPUQuotaUsedVRAMBytes,
+	GPUQuotaVRAMBytesLimit,
+	ModelDownloadDuration,
+	ModelStatus,
+	InferenceServiceReadyDuration,
+	InferenceServicePhase,
+	InferenceServiceInfo,
+	InferenceServiceReplicas,
+	GPUQueueDepth,
+	GPUQueueWaitDuration,
+	ReconcileTotal,
+	ReconcileDuration,
+	RouterRequestsTotal,
+	RouterRequestDuration,
+	RouterFailClosedTotal,
+	RouterActiveBackends,
+	RouterBackendHealth,
+	RouterFirstTokenSeconds,
+	RouterBudgetUtilization,
+}
+
 func init() {
-	ctrlmetrics.Registry.MustRegister(
-		GPUQuotaUsedGPUCount,
-		GPUQuotaGPUCountLimit,
-		GPUQuotaAdmissionDenialsTotal,
-		GPUQuotaUsedVRAMBytes,
-		GPUQuotaVRAMBytesLimit,
-		ModelDownloadDuration,
-		ModelStatus,
-		InferenceServiceReadyDuration,
-		InferenceServicePhase,
-		InferenceServiceInfo,
-		GPUQueueDepth,
-		GPUQueueWaitDuration,
-		ReconcileTotal,
-		ReconcileDuration,
-		RouterRequestsTotal,
-		RouterRequestDuration,
-		RouterFailClosedTotal,
-		RouterActiveBackends,
-		RouterBackendHealth,
-		RouterFirstTokenSeconds,
-		RouterBudgetUtilization,
-	)
+	ctrlmetrics.Registry.MustRegister(AllCollectors...)
+}
+
+// PublishModelPhase makes phase the only llmkube_model_status series for a
+// Model. The delete is unconditional so a failed status write cannot strand the
+// series it already published. No-ops on an empty phase, so callers can defer it.
+// Delete-then-set is not atomic: a scrape landing between the two ops sees no
+// series for this Model. Accepted — the window is sub-microsecond.
+func PublishModelPhase(name, namespace, phase string) {
+	if phase == "" {
+		return
+	}
+	DeleteModelSeries(name, namespace)
+	ModelStatus.WithLabelValues(name, namespace, phase).Set(1)
+}
+
+// DeleteModelSeries drops every series held for one Model. The phase label is
+// open-ended, so the exact series cannot be named.
+func DeleteModelSeries(name, namespace string) {
+	ModelStatus.DeletePartialMatch(modelLabels(name, namespace))
+}
+
+// PublishInferenceServicePhase makes phase the only phase series for one
+// InferenceService. Same self-healing argument as PublishModelPhase.
+func PublishInferenceServicePhase(name, namespace, phase string) {
+	InferenceServicePhase.DeletePartialMatch(inferenceServiceLabels(name, namespace))
+	InferenceServicePhase.WithLabelValues(name, namespace, phase).Set(1)
+}
+
+// PublishInferenceServiceInfo makes accelerator/runtime the only info series for
+// one InferenceService, so changing either in place does not leave both.
+func PublishInferenceServiceInfo(name, namespace, accelerator, runtime string) {
+	InferenceServiceInfo.DeletePartialMatch(inferenceServiceLabels(name, namespace))
+	InferenceServiceInfo.WithLabelValues(name, namespace, accelerator, runtime).Set(1)
+}
+
+// PublishInferenceServiceReplicas keeps the state label vocabulary next to the
+// declaration that documents it.
+func PublishInferenceServiceReplicas(name, namespace string, ready, desired int32) {
+	InferenceServiceReplicas.WithLabelValues(name, namespace, "ready").Set(float64(ready))
+	InferenceServiceReplicas.WithLabelValues(name, namespace, "desired").Set(float64(desired))
+}
+
+// DeleteInferenceServiceSeries drops the state gauges held for one
+// InferenceService. Cumulative metrics are deliberately kept: resetting
+// InferenceServiceReadyDuration would break rate() across a recreate.
+func DeleteInferenceServiceSeries(name, namespace string) {
+	labels := inferenceServiceLabels(name, namespace)
+	InferenceServicePhase.DeletePartialMatch(labels)
+	InferenceServiceInfo.DeletePartialMatch(labels)
+	InferenceServiceReplicas.DeletePartialMatch(labels)
+}
+
+func modelLabels(name, namespace string) prometheus.Labels {
+	return prometheus.Labels{"model": name, "namespace": namespace}
+}
+
+func inferenceServiceLabels(name, namespace string) prometheus.Labels {
+	return prometheus.Labels{"inferenceservice": name, "namespace": namespace}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -40,34 +41,18 @@ func getHistogramMetric(t *testing.T, h *prometheus.HistogramVec, labels []strin
 }
 
 func TestMetricsRegistered(t *testing.T) {
-	// Verify all metrics are registered by checking that re-registration
-	// fails with AlreadyRegisteredError. This confirms init() ran correctly.
-	collectors := []struct {
-		name      string
-		collector prometheus.Collector
-	}{
-		{"llmkube_model_download_duration_seconds", ModelDownloadDuration},
-		{"llmkube_model_status", ModelStatus},
-		{"llmkube_inferenceservice_ready_duration_seconds", InferenceServiceReadyDuration},
-		{"llmkube_inferenceservice_phase", InferenceServicePhase},
-		{"llmkube_inferenceservice_info", InferenceServiceInfo},
-		{"llmkube_gpu_queue_depth", GPUQueueDepth},
-		{"llmkube_gpu_queue_wait_duration_seconds", GPUQueueWaitDuration},
-		{"llmkube_reconcile_total", ReconcileTotal},
-		{"llmkube_reconcile_duration_seconds", ReconcileDuration},
+	if len(AllCollectors) == 0 {
+		t.Fatal("AllCollectors is empty")
 	}
-
-	for _, c := range collectors {
-		t.Run(c.name, func(t *testing.T) {
-			err := ctrlmetrics.Registry.Register(c.collector)
-			if err == nil {
-				t.Errorf("metric %q was not already registered — init() did not register it", c.name)
-				// Unregister if we accidentally succeeded
-				ctrlmetrics.Registry.Unregister(c.collector)
-			} else if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-				t.Errorf("unexpected error registering %q: %v", c.name, err)
-			}
-		})
+	for _, c := range AllCollectors {
+		err := ctrlmetrics.Registry.Register(c)
+		if err == nil {
+			t.Errorf("collector %T was not registered by init()", c)
+			continue
+		}
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			t.Errorf("collector %T: unexpected error: %v", c, err)
+		}
 	}
 }
 
@@ -95,68 +80,64 @@ func TestModelStatus(t *testing.T) {
 }
 
 func TestInferenceServicePhase(t *testing.T) {
-	InferenceServicePhase.WithLabelValues("phase-test", "default", "Creating").Set(1)
+	labels := inferenceServiceLabels("phase-test", "default")
+	InferenceServicePhase.DeletePartialMatch(labels)
 
-	var m dto.Metric
-	if err := InferenceServicePhase.WithLabelValues("phase-test", "default", "Creating").Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
-	}
-	if m.GetGauge().GetValue() != 1 {
-		t.Errorf("expected gauge value 1, got %f", m.GetGauge().GetValue())
-	}
-
-	// Verify phase transition clears old phase
-	InferenceServicePhase.WithLabelValues("phase-test", "default", "Creating").Set(0)
-	InferenceServicePhase.WithLabelValues("phase-test", "default", "Ready").Set(1)
-
-	if err := InferenceServicePhase.WithLabelValues("phase-test", "default", "Creating").Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
-	}
-	if m.GetGauge().GetValue() != 0 {
-		t.Errorf("expected Creating phase to be 0 after transition, got %f", m.GetGauge().GetValue())
+	PublishInferenceServicePhase("phase-test", "default", "Creating")
+	if got := testutil.ToFloat64(
+		InferenceServicePhase.WithLabelValues("phase-test", "default", "Creating")); got != 1 {
+		t.Errorf("expected gauge value 1, got %f", got)
 	}
 
-	if err := InferenceServicePhase.WithLabelValues("phase-test", "default", "Ready").Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
+	// A phase change drops the old series rather than zeroing it, so the vec
+	// holds one series per service no matter how much the phase churns.
+	PublishInferenceServicePhase("phase-test", "default", "Ready")
+	if got := testutil.ToFloat64(
+		InferenceServicePhase.WithLabelValues("phase-test", "default", "Ready")); got != 1 {
+		t.Errorf("expected Ready phase to be 1 after transition, got %f", got)
 	}
-	if m.GetGauge().GetValue() != 1 {
-		t.Errorf("expected Ready phase to be 1 after transition, got %f", m.GetGauge().GetValue())
+	// WithLabelValues above resurrected Ready at its real value; count after.
+	if got := InferenceServicePhase.DeletePartialMatch(labels); got != 1 {
+		t.Errorf("expected exactly 1 series after transition, got %d", got)
 	}
 }
 
 func TestInferenceServiceInfo(t *testing.T) {
-	// Verify the info metric is emitted with accelerator and runtime labels.
-	InferenceServiceInfo.WithLabelValues("info-test", "default", "cuda", "llamacpp").Set(1)
+	labels := inferenceServiceLabels("info-test", "default")
+	InferenceServiceInfo.DeletePartialMatch(labels)
 
-	var m dto.Metric
-	if err := InferenceServiceInfo.WithLabelValues("info-test", "default", "cuda", "llamacpp").Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
-	}
-	if m.GetGauge().GetValue() != 1 {
-		t.Errorf("expected gauge value 1, got %f", m.GetGauge().GetValue())
+	PublishInferenceServiceInfo("info-test", "default", "cuda", "llamacpp")
+	if got := testutil.ToFloat64(
+		InferenceServiceInfo.WithLabelValues("info-test", "default", "cuda", "llamacpp")); got != 1 {
+		t.Errorf("expected gauge value 1, got %f", got)
 	}
 
-	// Simulate an accelerator change: delete the old series and emit the new one.
-	InferenceServiceInfo.DeletePartialMatch(prometheus.Labels{
-		"inferenceservice": "info-test",
-		"namespace":        "default",
-	})
-	InferenceServiceInfo.WithLabelValues("info-test", "default", "rocm", "llamacpp").Set(1)
+	// An in-place accelerator change must not leave both series behind.
+	PublishInferenceServiceInfo("info-test", "default", "rocm", "llamacpp")
+	if got := testutil.ToFloat64(
+		InferenceServiceInfo.WithLabelValues("info-test", "default", "rocm", "llamacpp")); got != 1 {
+		t.Errorf("expected gauge value 1 for rocm, got %f", got)
+	}
+	if got := InferenceServiceInfo.DeletePartialMatch(labels); got != 1 {
+		t.Errorf("expected exactly 1 series after an accelerator change, got %d", got)
+	}
+}
 
-	// Verify the new accelerator series is 1.
-	if err := InferenceServiceInfo.WithLabelValues("info-test", "default", "rocm", "llamacpp").Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
-	}
-	if m.GetGauge().GetValue() != 1 {
-		t.Errorf("expected gauge value 1 for rocm, got %f", m.GetGauge().GetValue())
-	}
+func TestPublishInferenceServiceReplicas(t *testing.T) {
+	labels := inferenceServiceLabels("replicas-test", "default")
+	InferenceServiceReplicas.DeletePartialMatch(labels)
 
-	// Verify the old cuda series is gone (not present / 0).
-	if err := InferenceServiceInfo.WithLabelValues("info-test", "default", "cuda", "llamacpp").Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
+	PublishInferenceServiceReplicas("replicas-test", "default", 2, 3)
+	if got := testutil.ToFloat64(
+		InferenceServiceReplicas.WithLabelValues("replicas-test", "default", "ready")); got != 2 {
+		t.Errorf("expected ready 2, got %f", got)
 	}
-	if m.GetGauge().GetValue() != 0 {
-		t.Errorf("expected cuda gauge value 0 after deletion, got %f", m.GetGauge().GetValue())
+	if got := testutil.ToFloat64(
+		InferenceServiceReplicas.WithLabelValues("replicas-test", "default", "desired")); got != 3 {
+		t.Errorf("expected desired 3, got %f", got)
+	}
+	if got := InferenceServiceReplicas.DeletePartialMatch(labels); got != 2 {
+		t.Errorf("expected exactly 2 series (ready, desired), got %d", got)
 	}
 }
 
@@ -234,5 +215,75 @@ func TestHistogramBuckets(t *testing.T) {
 				t.Errorf("expected at least %d buckets, got %d", tt.minBkts, bucketCount)
 			}
 		})
+	}
+}
+
+func TestDeleteModelSeries(t *testing.T) {
+	// Counts are taken as deltas: these vecs are package-level and other tests
+	// in this file leave series behind.
+	before := testutil.CollectAndCount(ModelStatus)
+
+	ModelStatus.WithLabelValues("del-model", "default", "Ready").Set(1)
+	ModelStatus.WithLabelValues("del-model", "default", "Failed").Set(1)
+	ModelStatus.WithLabelValues("keep-model", "default", "Ready").Set(1)
+	if got, want := testutil.CollectAndCount(ModelStatus), before+3; got != want {
+		t.Fatalf("setup: got %d series, want %d", got, want)
+	}
+
+	DeleteModelSeries("del-model", "default")
+
+	// Both phases of the deleted Model go, the unrelated Model stays.
+	if got, want := testutil.CollectAndCount(ModelStatus), before+1; got != want {
+		t.Errorf("after delete: got %d series, want %d", got, want)
+	}
+	if testutil.ToFloat64(ModelStatus.WithLabelValues("keep-model", "default", "Ready")) != 1 {
+		t.Error("unrelated Model series was removed")
+	}
+}
+
+func TestDeleteInferenceServiceSeries(t *testing.T) {
+	beforePhase := testutil.CollectAndCount(InferenceServicePhase)
+	beforeInfo := testutil.CollectAndCount(InferenceServiceInfo)
+	beforeReplicas := testutil.CollectAndCount(InferenceServiceReplicas)
+
+	InferenceServicePhase.WithLabelValues("del-isvc", "default", "Ready").Set(1)
+	InferenceServiceInfo.WithLabelValues("del-isvc", "default", "cpu", "llamacpp").Set(1)
+	InferenceServiceReplicas.WithLabelValues("del-isvc", "default", "ready").Set(1)
+	InferenceServiceReplicas.WithLabelValues("del-isvc", "default", "desired").Set(1)
+
+	DeleteInferenceServiceSeries("del-isvc", "default")
+
+	// Every per-service vec must be covered, or a deleted service keeps
+	// reporting through whichever one was missed.
+	if got := testutil.CollectAndCount(InferenceServicePhase); got != beforePhase {
+		t.Errorf("phase: got %d series, want %d", got, beforePhase)
+	}
+	if got := testutil.CollectAndCount(InferenceServiceInfo); got != beforeInfo {
+		t.Errorf("info: got %d series, want %d", got, beforeInfo)
+	}
+	if got := testutil.CollectAndCount(InferenceServiceReplicas); got != beforeReplicas {
+		t.Errorf("replicas: got %d series, want %d", got, beforeReplicas)
+	}
+}
+
+func TestPublishModelPhase(t *testing.T) {
+	labels := modelLabels("publish-test", "default")
+	ModelStatus.DeletePartialMatch(labels)
+
+	// No phase yet: callers defer this unconditionally, so it must no-op
+	// rather than publish an empty label.
+	PublishModelPhase("publish-test", "default", "")
+	if got := ModelStatus.DeletePartialMatch(labels); got != 0 {
+		t.Errorf("empty phase should publish nothing, got %d series", got)
+	}
+
+	PublishModelPhase("publish-test", "default", "Downloading")
+	PublishModelPhase("publish-test", "default", "Ready")
+	if got := testutil.ToFloat64(
+		ModelStatus.WithLabelValues("publish-test", "default", "Ready")); got != 1 {
+		t.Errorf("expected Ready to be 1, got %f", got)
+	}
+	if got := ModelStatus.DeletePartialMatch(labels); got != 1 {
+		t.Errorf("expected exactly 1 series after a phase change, got %d", got)
 	}
 }


### PR DESCRIPTION
Closes #1219, closes #1221, closes #1222.

All three are the same defect shape — the operator's state gauges are written at transitions rather than derived from observed state — so they're one change rather than three PRs.

## Observed on a live install

Scraped from a 25-day-old cluster running the released `0.9.10`, with four Models and four InferenceServices, all `Ready`:

```
llmkube_model_status                                                  <- absent entirely
llmkube_inferenceservice_replicas                                     <- does not exist
llmkube_inferenceservice_phase{inferenceservice="qwen36-27b",phase="Creating"} 0
llmkube_inferenceservice_phase{inferenceservice="qwen36-27b",phase="Ready"}    1
```

Every Model is `Ready` and `llmkube_model_status` has zero series, which is #1219. The stranded `phase="Creating"` at `0` next to `phase="Ready"` at `1` is the zeroing behaviour — and it is also the honest version of the claim: the count was never wrong, the zero-valued series just never shed.

I then built this branch, swapped the controller image on that same cluster, and rescraped:

```
llmkube_model_status{model="qwen35-2b",namespace="ai",phase="Ready"}       1
llmkube_model_status{model="qwen36-27b-awq",namespace="ai",phase="Ready"}  1
llmkube_model_status{model="qwen3-embedding",namespace="ai",phase="Ready"} 1
llmkube_model_status{model="vmcp-embedding",namespace="ai",phase="Ready"}  1
llmkube_inferenceservice_replicas{inferenceservice="qwen35-2b",state="desired"} 1
llmkube_inferenceservice_replicas{inferenceservice="qwen35-2b",state="ready"}   1
llmkube_inferenceservice_replicas{inferenceservice="qwen36-27b",state="desired"} 1
llmkube_inferenceservice_replicas{inferenceservice="qwen36-27b",state="ready"}   1
```

All four Models report, against zero before. Replicas exist for both InferenceServices that complete a reconcile (the other two are the #1225 case described under *Not in scope*).

For the deletion half I applied a throwaway Model, confirmed `llmkube_model_status{model="metrics-probe-model"} 1`, deleted the CR, and rescraped: zero series for it, the other four untouched. Before this change that series would have persisted until the process restarted.

The four inference Deployments were never restarted during any of this — the operator is not in the data path — and the cluster was reverted to `0.9.10` afterwards.

## What changed

**`llmkube_model_status` is republished on every reconcile** (#1219), from `model.Status.Phase` in a defer. It was set at nine call sites, all on transitions, and every steady-state path returns before reaching one: `hf://` and remote-HTTP take the already-Ready exit in `reconcileRuntimeResolvedSource`, cached files take `handleReadyCachedModel`, PVC sources take `reconcilePVCSource`.

**Series are dropped when the CR is gone** (#1221), in the `IsNotFound` branch of both reconcilers. Best-effort: if the controller is down when the delete lands, client-go's relist on restart won't replay the missed event, so that one series survives until the process restarts. Bounded and self-healing, rather than the current permanent leak.

**Exactly one phase series per object.** Zeroing only the immediately-previous phase left every earlier phase in place at 0, so the vec grew with phase churn and never shed. Both gauges now delete before setting.

**New `llmkube_inferenceservice_replicas{state="ready"|"desired"}`** (#1222), set where `Status.ReadyReplicas`/`DesiredReplicas` are already assigned.

The publish/delete pairs live in `internal/metrics` rather than the controllers, so the label sets sit with the declarations they belong to and a controller never spells out a label map. That's a structural call — happy to move them back if you'd rather `internal/metrics` stay declarations-only.

I also replaced the hand-copied collector list in `init()` with an exported `AllCollectors` that `init()` and the tests both range over. The new gauge was silently missing from `TestMetricsRegistered`'s parallel list, which is the bug that list invites.

## Two behaviour changes worth your attention

**`llmkube_model_status` no longer emits `phase="Cached"`.** `PhaseCached` is declared but never assigned to `Model.Status.Phase`, so that label never matched what `kubectl get model` reports; the gauge now mirrors the CR. The metric was absent in steady state anyway, so nothing could have depended on it — I didn't mark this breaking, but say the word and I'll carry the cache-hit distinction as its own label.

**A phase change now deletes the old series instead of zeroing it.** `TestInferenceServicePhase` asserted the zeroing convention, so it's updated here. Worth being precise about the old behaviour, because the issue text overstated it: zeroing kept exactly one series at `1`, so `count(... == 1)` was never wrong. What accumulated was zero-valued series that never shed — a cardinality leak, not a wrong count.

I also corrected the `ModelStatus` help text, which documented a numeric phase encoding (`0=Unknown, 1=Downloading, …`) that no call site implemented.

## On cost

The delete is unconditional rather than gated on an observed transition. I tried the gated version — cheaper, since `DeletePartialMatch` takes an exclusive lock and scans the vec — and backed it out: it isn't self-healing. Seven paths set `Status.Phase = PhaseFailed` and then call `updateStatus`, which can fail; the defer has already published `Failed`, the next reconcile reads the older stored phase back, the gate doesn't fire, and the orphan is permanent. That's the bug this PR exists to fix, so the scan stays. It's a map walk over one entry per object.

## Verification

- `make lint` — 0 issues
- `make test` — green (`internal/controller` 86.0%, `internal/metrics` 100%)
- `internal/controller` no longer imports prometheus outside tests: the label and `state=` vocabulary lives only next to the declarations
- **All six new specs confirmed to fail without the production change.** The five Model/deletion specs: the three controller files checked out from `upstream/main`, tests left in place — 5 failures, re-confirmed after the rebase. The sixth (InferenceService early return) can't use that method, since it calls a helper `main` doesn't have; removing only the deferred publish from `Reconcile` fails it and nothing else — 601 of 602 pass.

The transition specs drive a real two-phase publish rather than patching `Status.Phase` directly — the Model goes Failed (host-path allowlist rejection, no network needed) then Ready, because the gauge only accumulates when the controller itself writes the second phase. They also deliberately don't clear the vec between reconciles, since clearing is exactly what would mask an accumulating gauge.

## InferenceService, in full

I first wrote this up as narrow, on the reasoning that the happy path always publishes. Running the branch on a real cluster showed that is wrong. Two of four InferenceServices there are `Ready` and serving, but fail `reconcileDeployment` on every pass with `activeDeadlineSeconds in ReplicaSet is not Supported` (#1225) — so they return early every time and export no phase, replicas or info series at all. Not a transient: for as long as an earlier reconcile step errors, a healthy service is invisible.

You said either way was fine, so it's in rather than deferred. `Reconcile` hoists the object above the defer and publishes phase, replicas and info from stored status, the same shape as the Model half. `updateStatusWithSchedulingInfo` no longer publishes at all — it is unreachable on exactly the passes that need reporting — so each object has one writer. `model` fell out unused there and in `reconcileService`; both params are removed.

The spec drives the live failure rather than approximating it: a seeded Deployment puts `reconcileDeployment` on its in-place `Update` path, an interceptor rejects that `Update` the way the API server does, and the assertions are that a `Ready` service with 2 replicas still reports phase, replica counts and the Model's `cuda` accelerator afterwards. #1222 is now fully closed rather than half — replicas no longer depend on the reconcile completing.

## Not in scope

`llmkube_gpu_queue_depth` (#1224) is untouched — signature change, and I'd rather have your call on deprecate-vs-change first.

GPUQuota has the same deletion bug; filed as #1230 rather than widened into this PR, since #1221 is scoped to InferenceService and Model. Happy to follow up once this lands — it reuses `DeleteInferenceServiceSeries`'s shape.




