### PR TITLE
fix(chart): make PrometheusRule select the chart's own scrape targets

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -265,6 +265,27 @@ jobs:
           fi
           echo "✅ PrometheusRule renders correctly with GPU alerts"
 
+      - name: Validate rule expressions with promtool
+        # grep proves the rules render, not that the PromQL parses.
+        run: |
+          set -euo pipefail
+          # No tag: always the latest release, nothing to keep pinned.
+          gh release download --repo prometheus/prometheus \
+            --pattern 'prometheus-*.linux-amd64.tar.gz' --output - \
+            | tar -xz --strip-components=1 --wildcards '*/promtool'
+
+          # serviceMonitor on: ControllerMetricsMissing is gated behind it.
+          helm template llmkube charts/llmkube \
+            --namespace llmkube-system \
+            --set prometheus.prometheusRule.enabled=true \
+            --set prometheus.serviceMonitor.enabled=true \
+            --show-only templates/prometheusrule.yaml \
+            | yq '.spec' > /tmp/rules.yaml
+
+          ./promtool check rules /tmp/rules.yaml
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Test Alert Threshold Customization
         run: |
           helm template llmkube charts/llmkube \
@@ -798,13 +819,14 @@ jobs:
           helm unittest --help > /dev/null
           echo "✅ helm-unittest installed"
 
-      - name: Run foreman chart unit tests
+      - name: Run chart unit tests
         # Covers the agents: map multi-fleet (#994) shape plus the legacy
         # single-agent backward-compat path. Fails CI on any drift in the
         # expected resource names, suffixes, or per-agent field flow.
+        # charts/llmkube/tests had four suites and no runner until #1223.
         run: |
-          helm unittest charts/foreman
-          echo "✅ foreman chart unit tests passed"
+          helm unittest charts/foreman charts/llmkube
+          echo "✅ chart unit tests passed"
 
       - name: Template foreman with defaults
         # foreman is a sibling chart to llmkube (no Helm subchart

--- a/charts/llmkube/README.md
+++ b/charts/llmkube/README.md
@@ -151,6 +151,19 @@ The following table lists the configurable parameters of the LLMKube chart and t
 | `prometheus.prometheusRule.rules.gpu.powerLimitThreshold` | GPU power limit threshold (W) | `250` |
 | `prometheus.prometheusRule.rules.inference.enabled` | Enable inference alerts | `true` |
 
+#### Scrape labels
+
+Both monitors pin the `job` label so the chart's own alerts can select their
+targets: the ServiceMonitor sets `job="llmkube-controller"` and the inference
+PodMonitor sets `job="llmkube-inference"`. Left to the Prometheus Operator's
+defaults these come out as the metrics Service name and
+`<namespace>/<podmonitor name>` — which is what `ControllerDown` and
+`InferenceServiceDown` used to fail to match. Queries of your own written
+against those older values need updating.
+
+The PodMonitor additionally promotes `service`, `namespace`, `model` and
+`runtime` onto every inference series.
+
 ### CRD Parameters
 
 | Parameter | Description | Default |

--- a/charts/llmkube/templates/inference-podmonitor.yaml
+++ b/charts/llmkube/templates/inference-podmonitor.yaml
@@ -22,6 +22,10 @@ spec:
       path: /metrics
       interval: {{ .Values.prometheus.inferencePodMonitor.interval | default "30s" }}
       relabelings:
+        # Operator default is `<namespace>/<podmonitor name>`, which
+        # InferenceServiceDown cannot match.
+        - targetLabel: job
+          replacement: llmkube-inference
         # Promote the operator-managed pod labels onto every scraped series so
         # recording rules and dashboards can group by service / namespace /
         # runtime without re-joining against the kube_pod_labels metric.

--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -86,15 +86,26 @@ spec:
         summary: "LLMKube controller is down"
         description: "Controller {{`{{ $labels.instance }}`}} has been down for more than 2 minutes"
 
+    {{- if .Values.prometheus.serviceMonitor.enabled }}
+    # up{} == 0 needs the series to exist; a stale job label removes it
+    # instead, which is how #1223 stayed silent. Gated on the chart owning
+    # the scrape target.
+    - alert: ControllerMetricsMissing
+      expr: absent(up{job="llmkube-controller"})
+      for: 15m
+      labels:
+        severity: warning
+        component: controller
+      annotations:
+        summary: "LLMKube controller metrics are not being scraped"
+        description: "No up series for job=llmkube-controller for 15 minutes — the scrape target is gone, or its job label no longer matches ControllerDown."
+    {{- end }}
+
   - name: llmkube-inference-recording
     interval: 30s
     rules:
-    # Request latency p95 over 5m, unified across llama.cpp and vLLM. Each
-    # runtime publishes its own histogram name; this rule exposes a single
-    # series families (one per runtime) so dashboards can render either one
-    # without knowing the upstream metric path. TTFT is exposed only for vLLM
-    # today; llama.cpp lacks a first-token-specific histogram, so we report
-    # end-to-end request latency for it instead.
+    # Request latency p95 over 5m. vLLM-only: llama.cpp's server exposes 11
+    # metrics and none of them is a request-latency histogram.
     - record: llmkube:inference:request_latency:p95_5m
       expr: |
         histogram_quantile(0.95,
@@ -104,28 +115,19 @@ spec:
         )
       labels:
         latency_kind: end_to_end
-    - record: llmkube:inference:llamacpp_request:p95_5m
-      expr: |
-        histogram_quantile(0.95,
-          sum by (service, namespace, runtime, le) (
-            rate(llamacpp:request_seconds_bucket[5m])
-          )
-        )
-      labels:
-        latency_kind: end_to_end
 
     # Inference pod restart rate as a coarse error proxy. Per-request
     # 4xx/5xx counters are tracked in #409 and will replace this once the
-    # upstream metric paths are confirmed for each runtime. The container
-    # regex below must be extended when new runtimes ship a real container
-    # name (e.g. add `vllm-swift` to the alternation when that backend
-    # graduates from skeletal to a deployable runtime; tracked in #409).
+    # upstream metric paths are confirmed for each runtime.
+    #
+    # Alternation is every backend's ContainerName(), enforced by
+    # TestChartRestartRuleCoversEveryBackend. Keyed by pod because
+    # kube-state-metrics carries no service or runtime label.
     - record: llmkube:inference:restarts:rate5m
       expr: |
-        sum by (service, namespace, runtime) (
+        sum by (namespace, pod, container) (
           rate(kube_pod_container_status_restarts_total{
-            pod=~".+",
-            container=~"llamacpp|vllm|tgi|personaplex|llm-server"
+            container=~"llama-server|sglang|vllm|tgi|personaplex|inference-server"
           }[5m])
         )
 

--- a/charts/llmkube/templates/servicemonitor.yaml
+++ b/charts/llmkube/templates/servicemonitor.yaml
@@ -19,6 +19,11 @@ spec:
     tlsConfig:
       insecureSkipVerify: true
     {{- end }}
+    relabelings:
+      # Operator default is the metrics Service name, which ControllerDown
+      # cannot match.
+      - targetLabel: job
+        replacement: llmkube-controller
   selector:
     matchLabels:
       {{- include "llmkube.selectorLabels" . | nindent 6 }}

--- a/charts/llmkube/tests/prometheusrule_test.yaml
+++ b/charts/llmkube/tests/prometheusrule_test.yaml
@@ -1,0 +1,107 @@
+suite: prometheus rules match the chart's own scrape targets
+# A rule whose matcher selects nothing installs clean and evaluates empty,
+# which is indistinguishable from a healthy cluster (#1223). Rules are
+# addressed by name, never by index.
+templates:
+  - prometheusrule.yaml
+  - inference-podmonitor.yaml
+  - servicemonitor.yaml
+
+tests:
+  # --- job label: pinned on the monitors, matched by the alerts ---
+
+  - it: should pin the inference job label to what InferenceServiceDown matches
+    template: inference-podmonitor.yaml
+    set:
+      prometheus.inferencePodMonitor.enabled: true
+    asserts:
+      - contains:
+          path: spec.podMetricsEndpoints[0].relabelings
+          content:
+            targetLabel: job
+            replacement: llmkube-inference
+
+  - it: should pin the controller job label to what ControllerDown matches
+    template: servicemonitor.yaml
+    set:
+      prometheus.serviceMonitor.enabled: true
+    asserts:
+      - contains:
+          path: spec.endpoints[0].relabelings
+          content:
+            targetLabel: job
+            replacement: llmkube-controller
+
+  - it: should alert on the job names the monitors pin
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+    asserts:
+      - equal:
+          path: spec.groups[?(@.name=="llmkube-inference")].rules[?(@.alert=="InferenceServiceDown")].expr
+          value: up{job="llmkube-inference"} == 0
+      - equal:
+          path: spec.groups[?(@.name=="llmkube-inference")].rules[?(@.alert=="ControllerDown")].expr
+          value: up{job="llmkube-controller"} == 0
+
+  - it: should guard the controller job label with an absence alert
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+      prometheus.serviceMonitor.enabled: true
+    asserts:
+      # up{} == 0 needs the series to exist; a stale job label removes it.
+      - equal:
+          path: spec.groups[?(@.name=="llmkube-inference")].rules[?(@.alert=="ControllerMetricsMissing")].expr
+          value: absent(up{job="llmkube-controller"})
+      - lengthEqual:
+          path: spec.groups[?(@.name=="llmkube-inference")].rules
+          count: 3
+
+  - it: should omit the absence alert when the chart scrapes nothing
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+      prometheus.serviceMonitor.enabled: false
+    asserts:
+      # No chart-owned target means nothing to be absent from; the alert
+      # would fire forever.
+      - lengthEqual:
+          path: spec.groups[?(@.name=="llmkube-inference")].rules
+          count: 2
+
+  # --- restart rule: every backend container, keyed by a label KSM emits ---
+
+  - it: should select every backend container, keyed by a label KSM carries
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+    asserts:
+      # Whole alternation, not substrings: a bare `vllm` also matches
+      # `vllm-swift`. TestChartRestartRuleCoversEveryBackend owns the list.
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:restarts:rate5m")].expr
+          pattern: 'container=~"llama-server\|sglang\|vllm\|tgi\|personaplex\|inference-server"'
+      # service and runtime exist only on the inference pods' own metrics.
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:restarts:rate5m")].expr
+          pattern: 'sum by \(namespace, pod, container\)'
+
+  # --- recording rules: only histograms some runtime emits ---
+
+  - it: should record only latency histograms a runtime publishes
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+    asserts:
+      # Three and no more: llama.cpp exposes no request-latency histogram,
+      # so a rule over llamacpp:request_seconds_bucket is always empty.
+      - lengthEqual:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules
+          count: 3
+      - isNotNullOrEmpty:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:request_latency:p95_5m")].expr
+      - isNotNullOrEmpty:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:restarts:rate5m")].expr
+      - isNotNullOrEmpty:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:ttft_seconds:p95_5m")].expr

--- a/charts/llmkube/tests/webhook_test.yaml
+++ b/charts/llmkube/tests/webhook_test.yaml
@@ -4,12 +4,12 @@ templates:
 
 tests:
   # Default ON: the chart self-generates a stable serving cert, so the webhook
-  # is wired by default (matches foreman). Renders exactly three documents:
-  # the cert Secret, the webhook Service, and the ValidatingWebhookConfiguration.
-  - it: should render Secret + Service + ValidatingWebhookConfiguration by default
+  # is wired by default (matches foreman). Four documents: cert Secret, webhook
+  # Service, and the validating + mutating configurations.
+  - it: should render Secret + Service + both webhook configurations by default
     asserts:
       - hasDocuments:
-          count: 3
+          count: 4
 
   - it: should render a kubernetes.io/tls cert Secret
     documentIndex: 0
@@ -64,6 +64,25 @@ tests:
       - equal:
           path: webhooks[0].failurePolicy
           value: Fail
+
+  - it: should render a MutatingWebhookConfiguration for models
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: MutatingWebhookConfiguration
+      - equal:
+          path: webhooks[0].name
+          value: mmodel.inference.llmkube.dev
+      - equal:
+          path: webhooks[0].clientConfig.service.path
+          value: /mutate-inference-llmkube-dev-v1alpha1-model
+      - equal:
+          path: webhooks[0].rules[0].resources[0]
+          value: models
+      # Ignore, not Fail: a Model apply must survive an unreachable defaulter.
+      - equal:
+          path: webhooks[0].failurePolicy
+          value: Ignore
 
   # failurePolicy is wired from values.
   - it: should honor a custom failurePolicy

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -21,6 +21,10 @@ spec:
         # To apply this configuration, enable cert-manager and use the patch located at config/prometheus/servicemonitor_tls_patch.yaml,
         # which securely references the certificate from the 'metrics-server-cert' secret.
         insecureSkipVerify: true
+      relabelings:
+        # Matches llmkube-alerts.yaml's ControllerDown, as the chart does.
+        - targetLabel: job
+          replacement: llmkube-controller
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -20,7 +20,7 @@ PrometheusRule and PodMonitor templates.
 
 | File | Description |
 |---|---|
-| `llmkube-inference.json` | Request latency, TTFT (vLLM only), GPU queue wait, container restart rate. Grouped by service, runtime, namespace. |
+| `llmkube-inference.json` | Request latency (vLLM only), GPU queue wait, container restart rate. Latency is grouped by service, runtime, namespace; restarts by pod, container, namespace. |
 | `llmkube-slo.json` | Error budget remaining and multi-window burn rate for InferenceServices with `spec.slo` set, plus an SLO overview table. Reads the recording rules Pyrra's kubernetes operator writes per SLO. Templated on a `$slo` variable (`label_values(slo)`) and a manual `$objective` percentage variable, since Pyrra does not expose the target itself as a Prometheus series. Assumes the default 28d SLO window; see the dashboard description for details. |
 | `amd-gpu-observability.json` | AMD GPU health, memory, and inference SLO signals for Strix (gfx1151) nodes. Consumes the verified metric contract from #1187: amdgpu-sysfs exporter, node-exporter hwmon, and llama.cpp /metrics. Panels cover GPU temperature, power, busy %, GTT/VRAM memory, GPU clock, tokens/sec, KV-cache occupancy, and in-flight requests. |
 

--- a/docs/grafana/llmkube-inference.json
+++ b/docs/grafana/llmkube-inference.json
@@ -49,12 +49,6 @@
           "expr": "llmkube:inference:request_latency:p95_5m",
           "legendFormat": "{{service}} ({{runtime}})",
           "refId": "A"
-        },
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "llmkube:inference:llamacpp_request:p95_5m",
-          "legendFormat": "{{service}} ({{runtime}})",
-          "refId": "B"
         }
       ],
       "title": "End-to-end request latency p95 (5m)",
@@ -116,7 +110,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "expr": "llmkube:inference:restarts:rate5m",
-          "legendFormat": "{{service}} ({{runtime}}, {{namespace}})",
+          "legendFormat": "{{pod}} ({{container}}, {{namespace}})",
           "refId": "A"
         }
       ],

--- a/internal/controller/runtime_chart_sync_test.go
+++ b/internal/controller/runtime_chart_sync_test.go
@@ -1,0 +1,113 @@
+package controller
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+const (
+	runtimeTypesPath  = "../../api/v1alpha1/inferenceservice_types.go"
+	prometheusRuleTpl = "../../charts/llmkube/templates/prometheusrule.yaml"
+)
+
+// runtimeEnumValues returns the runtimes the CRD accepts. The kubebuilder Enum
+// marker is the one place a new runtime must be declared for the API to accept
+// it, so it is the source of truth for "every runtime that can exist".
+func runtimeEnumValues(t *testing.T) []string {
+	t.Helper()
+
+	src, err := os.ReadFile(runtimeTypesPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", runtimeTypesPath, err)
+	}
+
+	lines := strings.Split(string(src), "\n")
+	field := -1
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "Runtime string ") {
+			field = i
+			break
+		}
+	}
+	if field < 0 {
+		t.Fatalf("no `Runtime string` field in %s", runtimeTypesPath)
+	}
+
+	// Nearest marker above the field: the file holds several Enums.
+	const marker = "// +kubebuilder:validation:Enum="
+	for i := field; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, marker) {
+			return strings.Split(strings.TrimPrefix(trimmed, marker), ";")
+		}
+	}
+	t.Fatalf("no Enum marker above the Runtime field in %s", runtimeTypesPath)
+	return nil
+}
+
+// chartRestartRuleContainers returns the container names the chart's
+// llmkube:inference:restarts:rate5m recording rule selects.
+func chartRestartRuleContainers(t *testing.T) []string {
+	t.Helper()
+
+	tpl, err := os.ReadFile(prometheusRuleTpl)
+	if err != nil {
+		t.Fatalf("read %s: %v", prometheusRuleTpl, err)
+	}
+
+	m := regexp.MustCompile(`container=~"([^"]+)"`).FindSubmatch(tpl)
+	if m == nil {
+		t.Fatalf("no container=~\"...\" matcher in %s", prometheusRuleTpl)
+	}
+	return strings.Split(string(m[1]), "|")
+}
+
+// TestChartRestartRuleCoversEveryBackend keeps the chart's restart recording
+// rule in step with the Go backends. It shipped matching runtime names instead
+// of container names, and nothing failed: a rule that selects nothing looks
+// like a cluster with no restarts (#1223). Set equality catches both a new
+// backend missing from the chart and a stale name left behind.
+func TestChartRestartRuleCoversEveryBackend(t *testing.T) {
+	// "" is a valid spec.Runtime and resolves to llamacpp.
+	want := map[string]bool{}
+	for _, runtime := range append(runtimeEnumValues(t), "") {
+		isvc := &inferencev1alpha1.InferenceService{}
+		isvc.Spec.Runtime = runtime
+		want[resolveBackend(isvc).ContainerName()] = true
+	}
+
+	got := map[string]bool{}
+	for _, container := range chartRestartRuleContainers(t) {
+		got[container] = true
+	}
+
+	for name := range want {
+		if !got[name] {
+			t.Errorf("container %q is a backend ContainerName() but is not selected by the chart restart rule in %s", name, prometheusRuleTpl)
+		}
+	}
+	for name := range got {
+		if !want[name] {
+			t.Errorf("container %q is selected by the chart restart rule in %s but no backend returns it", name, prometheusRuleTpl)
+		}
+	}
+
+	if t.Failed() {
+		t.Logf("backends: %v", sortedKeys(want))
+		t.Logf("chart:    %v", sortedKeys(got))
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
Closes #1223.

Verified end to end on a live cluster, evidence below. Two decisions at the bottom are yours rather than mine.

## The three mismatches

**Job names.** The two `up{}` alerts match `job="llmkube-inference"` and `job="llmkube-controller"`. Prometheus Operator derives `job` from the monitor, so a real cluster gets `ai/llmkube-inference` and `llmkube-controller-manager-metrics-service`. Neither alert could ever fire.

I pinned `job` in each monitor's `relabelings` rather than rewriting the alerts to key on `service`. Two reasons: user relabelings are applied after the operator's own, so the pin wins whichever operator converts the CRs; and `service` is already spoken for — `internal/controller/slo_resources.go:126` renders the Pyrra availability indicator as `up{namespace=…,service=…}`. Alerts keying on `job` and SLOs keying on `service` keeps those separate.

`config/prometheus/monitor.yaml` gets the same pin. That's the ServiceMonitor the kustomize path installs, and `config/prometheus/llmkube-alerts.yaml` carries the same two alerts, so without it `ControllerDown` stays dead on that path.

**Container names.** The restart rule matched `container=~"llamacpp|vllm|tgi|personaplex|llm-server"`. The backends' `ContainerName()` returns:

| runtime | container | was in the regex |
|---|---|---|
| llamacpp (default), llamacpp-router | `llama-server` | no |
| sglang | `sglang` | no |
| generic | `inference-server` | no |
| vllm, tgi, personaplex | as named | yes |

Two of the five alternatives were runtime names, not container names.

Second problem in the same rule: it grouped by `(service, namespace, runtime)` over `kube_pod_container_status_restarts_total`. kube-state-metrics series carry no `runtime` at all, and their `service` label is the exporter's own — so the rule collapsed to a single series attributed to kube-state-metrics rather than to any inference service. Now keyed by `(namespace, pod, container)`, with the Grafana `legendFormat` following.

**A rule with no producer.** `llmkube:inference:llamacpp_request:p95_5m` keyed on `llamacpp:request_seconds_bucket`. The llama.cpp server exposes 11 metrics and none of them is a request-latency histogram, so it could never produce. Dropped, along with its target in `docs/grafana/llmkube-inference.json`.

## Why it stayed invisible, and the guard for next time

`up{job=…} == 0` needs the series to **exist**. A job label that stops matching doesn't zero the series, it removes it — so the alert goes quiet rather than firing. That's the property that let this ship and sit.

`ControllerMetricsMissing` closes it: `absent(up{job="llmkube-controller"})`, `for: 15m`. It renders only when `prometheus.serviceMonitor.enabled` is true, so it can't fire on an install that scrapes the controller some other way.

No inference equivalent on purpose — a cluster with zero InferenceServices legitimately has nothing to scrape, so `absent()` there would be noise on every fresh install.

## Guarding the container list from the Go side

My first pass pinned the alternation in a helm-unittest assertion. That's backwards: it catches a name *deleted* from the regex, but the bug was a backend the regex never *gained*. A new runtime would still drop out silently, now with a green suite behind it.

`TestChartRestartRuleCoversEveryBackend` reads the `spec.runtime` kubebuilder enum — the one place a runtime must be declared for the API to accept it, and already sync-checked into `config/crd/bases` — maps each value plus `""` through `resolveBackend().ContainerName()`, and asserts set equality against the regex in the chart template. Both directions, so a stale name fails too. It runs under the existing `go test ./...`, no new CI wiring.

Proof it bites, dropping `sglang` from the regex:

```
container "sglang" is a backend ContainerName() but is not selected by the chart restart rule
backends: [inference-server llama-server personaplex sglang tgi vllm]
chart:    [inference-server llama-server personaplex tgi vllm]
```

## Nothing in CI parsed a rule expression

`Test PrometheusRule Creation` greps for `kind: PrometheusRule` and `GPUHighUtilization`. That proves the template renders, not that the PromQL is valid — a malformed expression would ship and first fail at rule-load time inside a user's Prometheus.

Added `promtool check rules` over the rendered output. It pulls the latest promtool release rather than pinning a version, because Dependabot has no manager that can see a version literal in a workflow env var — a pin here would rot silently, which is the same failure mode this PR is about. Verified it catches a real break, dropping one closing paren:

```
FAILED: group "llmkube-inference-recording", rule 2, "llmkube:inference:restarts:rate5m":
could not parse expression: parse error: unexpected "(" in grouping opts, expected "," or ")"
```

Being straight about the limit: promtool would **not** have caught #1223. The old expressions were valid PromQL that selected nothing. It guards the syntax axis; the sync test and the `absent()` alert guard the semantic one.

## Chart tests weren't running

`charts/llmkube/tests` has four suites, and CI only ever invoked `helm unittest charts/foreman`. Consequence: `webhook_test.yaml` has been red on `main` since the Model defaulting webhook added a fourth document — asserts 3, renders 4.

Fixed that assertion, added one covering the mutating webhook, added a suite for the scrape-target contract, and changed the existing step to `helm unittest charts/foreman charts/llmkube` — the plugin takes both paths, so no new job and no second copy of the 3.13 plugin-install workaround.

## Verified on a live cluster

3-node Talos cluster, 4 InferenceServices (three llama.cpp, one vLLM), VictoriaMetrics operator converting the monitors to `VMPodScrape`/`VMServiceScrape`. Read-only queries first, then both fixed monitors applied as *additive* canaries under different names, so no existing object was modified and nothing was suspended.

Worth noting this cluster had already turned the chart's `prometheusRule` off, with the reason written into its values file: *"Chart alerts key on job=llmkube-inference/llmkube-controller but this cluster's scrape job is ai/llmkube-inference, so they can never fire."*

Before, from the cluster's own metrics:

```
count by (job) (up{job=~".*llmkube.*"})
  ai/llmkube-inference                        = 4
  llmkube-controller-manager-metrics-service  = 1

up{job="llmkube-inference"}     -> 0 series     # InferenceServiceDown can never fire
up{job="llmkube-controller"}    -> 0 series     # ControllerDown can never fire
llamacpp:request_seconds_bucket -> 0 series     # the dropped rule had no source
```

The restart rule, old vs new, against real pods:

```
OLD  sum by (service, namespace, runtime) (... container=~"llamacpp|vllm|tgi|personaplex|llm-server" ...)
  -> 1 series: {namespace="ai", service="kube-state-metrics"}

NEW  sum by (namespace, pod, container) (... container=~"llama-server|sglang|vllm|tgi|personaplex|inference-server" ...)
  -> 4 series:
       ai/qwen3-embedding-...    container=llama-server
       ai/qwen35-2b-...          container=llama-server
       ai/vmcp-embedding-...     container=llama-server
       ai/qwen36-27b-vllm-...    container=vllm
```

Every llama.cpp container is named `llama-server`, which the old alternation did not contain — so the rule covered one of four services, and reported that one under the exporter's name rather than its own.

With the fixed monitors applied, `up{job="llmkube-inference"}` went 0 → 4 within 60s, carrying `service`, `runtime` and `model` intact alongside the pinned `job`. That confirms the pin doesn't clobber the other relabelings, and that the VictoriaMetrics operator honours `targetLabel: job` the same way Prometheus Operator does — the one assumption in this PR I couldn't check offline.

`ControllerMetricsMissing` behaved as designed in both directions: `absent(up{job="llmkube-controller"})` evaluated to **1** before the pin — it would have fired, correctly reporting that `ControllerDown`'s target does not exist — and dropped to **0** within 20s of the pinned target appearing.

Both canaries were then deleted and the revert verified: only the pre-existing scrape objects remain, the VM operator garbage-collected the derived scrapes, and the cluster's own `up{job="ai/llmkube-inference"}` alert kept returning 4 series throughout.

## Verification summary

- Live cluster (detail above): `up{job="llmkube-inference"}` 0 → 4 with `service`/`runtime`/`model` intact, `absent(up{job="llmkube-controller"})` 1 → 0, restart rule 1 → 4 series. Applied as additive canaries, reverted clean, no existing object modified
- 68 chart tests across both charts, `helm lint` clean, all three example value files render
- `promtool check rules` on the rendered output: 10 rules, all parse
- Full `internal/controller` package green (246s, envtest), `make lint` 0 issues
- Fail-on-main: reverting only the three template files fails 5 of the 7 new specs. The two that pass are the ones that should — the alert-expression spec (those exprs are unchanged by this PR) and the "no absence alert without a ServiceMonitor" spec (`main` renders two rules there, which is what it asserts)

## Two things that are your call

1. **The `gpu` rule group.** Defaults on, entirely DCGM, so it's dead on AMD and Apple Silicon — and the two `vllm:*` recording rules render for llama.cpp-only installs. Your issue comment said the flag names and defaults are a product call, so I left all of it alone. Happy to add `rules.gpu.vendor` or split flags in a follow-up once you've picked the shape.

2. **The job label is a visible change.** An existing install's `up{}` series moves off `<namespace>/<name>` and off the metrics Service name. Nothing in-repo consumes the old values (grep for `job=` finds only these alerts), but user-side queries, panels and silences will need updating — the test cluster above had exactly one such alert of its own. Documented in the chart README; flagging in case you'd rather it wait for a minor bump.

Two more I noticed and deliberately didn't bundle:

- The recording-rule names are four-part (`llmkube:inference:restarts:rate5m`). Prometheus convention is three: `level:metric:operation`. Renaming all four breaks anyone's saved queries, so it wants its own PR if you want it at all.
- `config/prometheus/llmkube-alerts.yaml` isn't in `config/prometheus/kustomization.yaml` and its only referrers are the frozen v0.2.0 release notes and the changelog. Looks like an orphaned duplicate of the chart template — worth deleting, but that's yours to decide.

Also happy to rename the `foreman-chart` job now that it gates llmkube's chart too. I left the name alone in case it's a required check in branch protection.


