### PR TITLE
fix(metrics): report GPU queue depth per namespace

### DIFF
--- a/charts/llmkube/templates/servicemonitor.yaml
+++ b/charts/llmkube/templates/servicemonitor.yaml
@@ -15,6 +15,9 @@ spec:
     port: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
     scheme: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
     interval: {{ .Values.prometheus.serviceMonitor.interval }}
+    # llmkube_* metrics label the workload's namespace themselves. Without this
+    # the scrape target's namespace wins and theirs becomes exported_namespace.
+    honorLabels: true
     {{- if .Values.metrics.secure }}
     tlsConfig:
       insecureSkipVerify: true

--- a/charts/llmkube/tests/metrics_test.yaml
+++ b/charts/llmkube/tests/metrics_test.yaml
@@ -89,6 +89,18 @@ tests:
           path: spec.endpoints[0].scheme
           value: http
 
+  # Without honorLabels the scrape target's namespace wins and the workload
+  # namespace llmkube_* metrics carry is renamed exported_namespace, which the
+  # dashboards and the GPUQueueBacklog annotation do not select on.
+  - it: should honor the metric's own namespace label
+    template: servicemonitor.yaml
+    set:
+      prometheus.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].honorLabels
+          value: true
+
   # ServiceMonitor: tlsConfig only when secure
   - it: should include tlsConfig when secure
     template: servicemonitor.yaml

--- a/config/grafana/llmkube-inference-dashboard.json
+++ b/config/grafana/llmkube-inference-dashboard.json
@@ -137,7 +137,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "llmkube_gpu_queue_depth",
+          "expr": "sum(llmkube_gpu_queue_depth{namespace=~\"$namespace\"})",
           "legendFormat": "Queue",
           "refId": "A"
         }
@@ -385,8 +385,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "llmkube_gpu_queue_depth",
-          "legendFormat": "Queue Depth",
+          "expr": "llmkube_gpu_queue_depth{namespace=~\"$namespace\"}",
+          "legendFormat": "{{namespace}}",
           "refId": "A"
         }
       ]

--- a/config/prometheus/llmkube-alerts.yaml
+++ b/config/prometheus/llmkube-alerts.yaml
@@ -115,4 +115,4 @@ spec:
         component: gpu
       annotations:
         summary: "GPU queue has pending workloads"
-        description: "GPU queue depth is {{ $value }} for more than 15 minutes"
+        description: "GPU queue depth in {{ $labels.namespace }} is {{ $value }} for more than 15 minutes"

--- a/internal/controller/inferenceservice_scheduling_test.go
+++ b/internal/controller/inferenceservice_scheduling_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -30,6 +31,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -688,4 +691,76 @@ var _ = Describe("HPA Autoscaling", func() {
 			Expect(*dep.Spec.Replicas).To(Equal(int32(5)))
 		})
 	})
+})
+
+// queuedISVC builds an InferenceService for the GPU queue specs; createdAt is
+// the FIFO key.
+func queuedISVC(name, namespace string, createdAt int64, phase string) *inferencev1alpha1.InferenceService {
+	return &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(time.Unix(createdAt, 0)),
+		},
+		Spec:   inferencev1alpha1.InferenceServiceSpec{ModelRef: "queue-model"},
+		Status: inferencev1alpha1.InferenceServiceStatus{Phase: phase},
+	}
+}
+
+var _ = Describe("evaluateGPUQueue", func() {
+	// Stored cluster state: alpha, beta and gamma queued across two namespaces,
+	// one service already serving, one still Pending, and a third namespace
+	// whose only service is serving.
+	fixture := func() []client.Object {
+		return []client.Object{
+			queuedISVC("alpha", "default", 10, PhaseWaitingForGPU),
+			queuedISVC("beta", "default", 20, PhaseWaitingForGPU),
+			queuedISVC("gamma", "team-a", 30, PhaseWaitingForGPU),
+			queuedISVC("ready-one", "default", 5, PhaseReady),
+			queuedISVC("delta", "default", 40, "Pending"),
+			queuedISVC("idle-one", "team-b", 50, PhaseReady),
+		}
+	}
+
+	// memoryPhase is what the caller has just written to isvc.Status; the
+	// fixture holds whatever phase the listing still reports for that name.
+	DescribeTable("reports the FIFO position and the per-namespace depths",
+		func(name, namespace string, createdAt int64, memoryPhase string,
+			expectedPos int32, expectedDepths map[string]int32) {
+			reconciler := &InferenceServiceReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(k8sClient.Scheme()).
+					WithObjects(fixture()...).
+					Build(),
+				Scheme: k8sClient.Scheme(),
+			}
+			subject := queuedISVC(name, namespace, createdAt, memoryPhase)
+
+			pos, depths, err := reconciler.evaluateGPUQueue(context.Background(), subject)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pos).To(Equal(expectedPos))
+			Expect(depths).To(Equal(expectedDepths))
+		},
+		Entry("head of the queue", "alpha", "default", int64(10), PhaseWaitingForGPU,
+			int32(1), map[string]int32{"default": 2, "team-a": 1, "team-b": 0}),
+		Entry("second in the queue", "beta", "default", int64(20), PhaseWaitingForGPU,
+			int32(2), map[string]int32{"default": 2, "team-a": 1, "team-b": 0}),
+		Entry("queued in another namespace", "gamma", "team-a", int64(30), PhaseWaitingForGPU,
+			int32(3), map[string]int32{"default": 2, "team-a": 1, "team-b": 0}),
+		// A service that is not queued reports position 0 and the full depths.
+		Entry("not queued", "ready-one", "default", int64(5), PhaseReady,
+			int32(0), map[string]int32{"default": 2, "team-a": 1, "team-b": 0}),
+		// The reconcile that enters the queue: the listing still says Pending.
+		Entry("entering the queue counts itself", "delta", "default", int64(40), PhaseWaitingForGPU,
+			int32(4), map[string]int32{"default": 3, "team-a": 1, "team-b": 0}),
+		// The reconcile that leaves it: the listing still says WaitingForGPU.
+		Entry("leaving the queue drops itself", "alpha", "default", int64(10), PhaseReady,
+			int32(0), map[string]int32{"default": 1, "team-a": 1, "team-b": 0}),
+		// Created and reconciled before the cache caught up.
+		Entry("absent from the listing counts itself", "epsilon", "default", int64(15), PhaseWaitingForGPU,
+			int32(2), map[string]int32{"default": 3, "team-a": 1, "team-b": 0}),
+		// The subject's namespace is always reported, so draining it reads 0.
+		Entry("only queued service in its namespace leaving", "gamma", "team-a", int64(30), PhaseReady,
+			int32(0), map[string]int32{"default": 2, "team-a": 0, "team-b": 0}),
+	)
 })

--- a/internal/controller/inferenceservice_scheduling_test.go
+++ b/internal/controller/inferenceservice_scheduling_test.go
@@ -764,3 +764,33 @@ var _ = Describe("evaluateGPUQueue", func() {
 			int32(0), map[string]int32{"default": 2, "team-a": 0, "team-b": 0}),
 	)
 })
+
+var _ = Describe("evaluateGPUQueue tie-breaking", func() {
+	// alpha and beta queued in the same wall-clock second: CreationTimestamp
+	// alone can't order them, so the tie must break by name.
+	fixture := func() []client.Object {
+		return []client.Object{
+			queuedISVC("alpha", "default", 10, PhaseWaitingForGPU),
+			queuedISVC("beta", "default", 10, PhaseWaitingForGPU),
+		}
+	}
+
+	DescribeTable("orders tied CreationTimestamps by name",
+		func(name string, expectedPos int32) {
+			reconciler := &InferenceServiceReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(k8sClient.Scheme()).
+					WithObjects(fixture()...).
+					Build(),
+				Scheme: k8sClient.Scheme(),
+			}
+			subject := queuedISVC(name, "default", 10, PhaseWaitingForGPU)
+
+			pos, _, err := reconciler.evaluateGPUQueue(context.Background(), subject)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pos).To(Equal(expectedPos))
+		},
+		Entry("alpha sorts before beta", "alpha", int32(1)),
+		Entry("beta sorts after alpha", "beta", int32(2)),
+	)
+})

--- a/internal/controller/metrics_lifecycle_test.go
+++ b/internal/controller/metrics_lifecycle_test.go
@@ -282,4 +282,78 @@ var _ = Describe("Operator state metrics lifecycle", func() {
 			Expect(llmkubemetrics.InferenceServiceReplicas.DeletePartialMatch(isvcLabels(name))).To(Equal(0))
 		})
 	})
+
+	Describe("GPU queue depth gauge", func() {
+		const queueNS = "gpu-queue"
+
+		queued := func(name string, createdAt int64, phase string) *inferencev1alpha1.InferenceService {
+			return queuedISVC(name, queueNS, createdAt, phase)
+		}
+
+		reconcilerFor := func(objs ...client.Object) *InferenceServiceReconciler {
+			builder := fake.NewClientBuilder().
+				WithScheme(k8sClient.Scheme()).
+				WithStatusSubresource(&inferencev1alpha1.InferenceService{}).
+				WithObjects(objs...)
+			return &InferenceServiceReconciler{Client: builder.Build(), Scheme: k8sClient.Scheme()}
+		}
+
+		depth := func() float64 {
+			return testutil.ToFloat64(llmkubemetrics.GPUQueueDepth.WithLabelValues(queueNS))
+		}
+
+		// Each spec asserts on absolute depths, so none of them may inherit a
+		// value another one published.
+		BeforeEach(func() {
+			llmkubemetrics.GPUQueueDepth.Reset()
+		})
+
+		// Old gauge held the reconciling service's position: 3, 2, 1 by order.
+		It("reports how many services are queued, not the position of one", func() {
+			alpha := queued("alpha", 10, PhaseWaitingForGPU)
+			beta := queued("beta", 20, PhaseWaitingForGPU)
+			gamma := queued("gamma", 30, PhaseWaitingForGPU)
+			reconciler := reconcilerFor(alpha, beta, gamma)
+
+			for _, isvc := range []*inferencev1alpha1.InferenceService{gamma, beta, alpha} {
+				_, err := reconciler.updateStatusWithSchedulingInfo(
+					ctx, isvc, PhaseWaitingForGPU, true, 0, 1, "", "", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(depth()).To(Equal(3.0),
+					"three services are queued whichever one reconciled")
+			}
+		})
+
+		It("returns to zero as the queue drains", func() {
+			alpha := queued("alpha", 10, PhaseWaitingForGPU)
+			beta := queued("beta", 20, PhaseWaitingForGPU)
+			gamma := queued("gamma", 30, PhaseWaitingForGPU)
+			reconciler := reconcilerFor(alpha, beta, gamma)
+
+			for i, isvc := range []*inferencev1alpha1.InferenceService{alpha, beta, gamma} {
+				_, err := reconciler.updateStatusWithSchedulingInfo(
+					ctx, isvc, PhaseReady, true, 1, 1, "http://example", "", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(depth()).To(Equal(float64(2-i)),
+					"the depth must drop as each service is scheduled")
+				Expect(isvc.Status.QueuePosition).To(Equal(int32(0)))
+			}
+		})
+
+		// delta is oldest, so position (1) and depth (3) are different numbers.
+		It("counts a service on the reconcile that puts it in the queue", func() {
+			delta := queued("delta", 5, "Pending")
+			alpha := queued("alpha", 10, PhaseWaitingForGPU)
+			beta := queued("beta", 20, PhaseWaitingForGPU)
+			reconciler := reconcilerFor(delta, alpha, beta)
+
+			_, err := reconciler.updateStatusWithSchedulingInfo(
+				ctx, delta, PhaseWaitingForGPU, true, 0, 1, "", "", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(depth()).To(Equal(3.0), "the entering service must count itself")
+			Expect(delta.Status.QueuePosition).To(Equal(int32(1)),
+				"position 0 would reach the user through the Progressing condition")
+		})
+	})
 })

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -176,7 +176,12 @@ func (r *InferenceServiceReconciler) evaluateGPUQueue(
 		depth := depths[svc.Namespace]
 		if svc.Status.Phase == PhaseWaitingForGPU {
 			depth++
-			if svc.CreationTimestamp.Before(&isvc.CreationTimestamp) {
+			// CreationTimestamp is 1s resolution, so a Helm release or a
+			// scripted loop can create several services within the same
+			// second; break the tie by name so positions stay a strict
+			// 1..N permutation instead of colliding.
+			if svc.CreationTimestamp.Before(&isvc.CreationTimestamp) ||
+				(svc.CreationTimestamp.Equal(&isvc.CreationTimestamp) && svc.Name < isvc.Name) {
 				ahead++
 			}
 		}

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -181,7 +181,9 @@ func (r *InferenceServiceReconciler) evaluateGPUQueue(
 			// second; break the tie by name so positions stay a strict
 			// 1..N permutation instead of colliding.
 			if svc.CreationTimestamp.Before(&isvc.CreationTimestamp) ||
-				(svc.CreationTimestamp.Equal(&isvc.CreationTimestamp) && svc.Name < isvc.Name) {
+				(svc.CreationTimestamp.Equal(&isvc.CreationTimestamp) &&
+					(svc.Namespace < isvc.Namespace ||
+						(svc.Namespace == isvc.Namespace && svc.Name < isvc.Name))) {
 				ahead++
 			}
 		}

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -23,7 +23,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -148,49 +147,48 @@ func (r *InferenceServiceReconciler) getPodSchedulingInfo(ctx context.Context, i
 	return nil, nil
 }
 
-func (r *InferenceServiceReconciler) calculateQueuePosition(ctx context.Context, isvc *inferencev1alpha1.InferenceService) (int32, error) {
-	if isvc.Status.Phase != PhaseWaitingForGPU {
-		return 0, nil
-	}
-
+// evaluateGPUQueue returns isvc's 1-based position in the cluster-wide FIFO GPU
+// queue, and the number of services waiting for GPU in every namespace that
+// holds an InferenceService. Position is 0 when isvc is not waiting.
+//
+// isvc carries the authoritative phase and creation time: the cache-backed
+// listing still reports the previous phase on the reconcile that changes it,
+// and may not list a freshly created object at all.
+func (r *InferenceServiceReconciler) evaluateGPUQueue(
+	ctx context.Context,
+	isvc *inferencev1alpha1.InferenceService,
+) (int32, map[string]int32, error) {
 	allServices := &inferencev1alpha1.InferenceServiceList{}
 	if err := r.List(ctx, allServices); err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 
-	type queueEntry struct {
-		name      string
-		namespace string
-		created   metav1.Time
-	}
+	// Every namespace holding an InferenceService is keyed, queued or not, so a
+	// namespace that drains to 0 reports 0 instead of losing its series.
+	depths := map[string]int32{isvc.Namespace: 0}
 
-	var waitingServices []queueEntry
-	for _, svc := range allServices.Items {
-		if svc.Status.Phase == PhaseWaitingForGPU {
-			waitingServices = append(waitingServices, queueEntry{
-				name:      svc.Name,
-				namespace: svc.Namespace,
-				created:   svc.CreationTimestamp,
-			})
+	var ahead int32
+	for i := range allServices.Items {
+		svc := &allServices.Items[i]
+		if svc.Name == isvc.Name && svc.Namespace == isvc.Namespace {
+			continue // counted once below, from isvc's own phase
 		}
-	}
-
-	// Sort by creation timestamp (FIFO)
-	for i := 0; i < len(waitingServices)-1; i++ {
-		for j := i + 1; j < len(waitingServices); j++ {
-			if waitingServices[j].created.Before(&waitingServices[i].created) {
-				waitingServices[i], waitingServices[j] = waitingServices[j], waitingServices[i]
+		depth := depths[svc.Namespace]
+		if svc.Status.Phase == PhaseWaitingForGPU {
+			depth++
+			if svc.CreationTimestamp.Before(&isvc.CreationTimestamp) {
+				ahead++
 			}
 		}
+		depths[svc.Namespace] = depth
 	}
 
-	for pos, entry := range waitingServices {
-		if entry.name == isvc.Name && entry.namespace == isvc.Namespace {
-			return int32(pos + 1), nil //nolint:gosec // G115: queue index bounded by waitingServices size
-		}
+	if isvc.Status.Phase != PhaseWaitingForGPU {
+		return 0, depths, nil
 	}
+	depths[isvc.Namespace]++
 
-	return 0, nil
+	return ahead + 1, depths, nil
 }
 
 func (r *InferenceServiceReconciler) resolvePriorityClassName(isvc *inferencev1alpha1.InferenceService) string {

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -198,16 +198,15 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 	// (e.g. InsufficientMemory, MemoryCheckFailed) so the controller does not
 	// clobber them on its next status update (#643).
 
-	if phase == PhaseWaitingForGPU {
-		queuePos, err := r.calculateQueuePosition(ctx, isvc)
-		if err != nil {
-			log.Error(err, "Failed to calculate queue position")
-		}
-		isvc.Status.QueuePosition = queuePos
-		llmkubemetrics.GPUQueueDepth.Set(float64(queuePos))
+	// The depths cover every namespace, so each status write refreshes the whole
+	// gauge rather than only this service's series.
+	queuePos, queueDepths, err := r.evaluateGPUQueue(ctx, isvc)
+	if err != nil {
+		log.Error(err, "Failed to evaluate GPU queue")
 	} else {
-		isvc.Status.QueuePosition = 0
+		llmkubemetrics.PublishGPUQueueDepth(queueDepths)
 	}
+	isvc.Status.QueuePosition = queuePos
 
 	var condition metav1.Condition
 	switch phase {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -21,6 +21,9 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+// goconst caps this file at 14 "namespace" literals (.golangci.yml min-occurrences: 15).
+const labelNamespace = "namespace"
+
 var (
 	// Model metrics
 
@@ -76,11 +79,12 @@ var (
 		[]string{"inferenceservice", "namespace", "state"},
 	)
 
-	GPUQueueDepth = prometheus.NewGauge(
+	GPUQueueDepth = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "llmkube_gpu_queue_depth",
-			Help: "Number of InferenceServices waiting for GPU resources.",
+			Help: "Number of InferenceServices waiting for GPU resources, per namespace.",
 		},
+		[]string{labelNamespace},
 	)
 
 	// Reconcile metrics
@@ -284,6 +288,15 @@ func PublishInferenceServiceInfo(name, namespace, accelerator, runtime string) {
 func PublishInferenceServiceReplicas(name, namespace string, ready, desired int32) {
 	InferenceServiceReplicas.WithLabelValues(name, namespace, "ready").Set(float64(ready))
 	InferenceServiceReplicas.WithLabelValues(name, namespace, "desired").Set(float64(desired))
+}
+
+// PublishGPUQueueDepth makes depths the whole of llmkube_gpu_queue_depth: a
+// namespace absent from the map stops being reported.
+func PublishGPUQueueDepth(depths map[string]int32) {
+	GPUQueueDepth.Reset()
+	for namespace, depth := range depths {
+		GPUQueueDepth.WithLabelValues(namespace).Set(float64(depth))
+	}
 }
 
 // DeleteInferenceServiceSeries drops the state gauges held for one

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -142,23 +142,26 @@ func TestPublishInferenceServiceReplicas(t *testing.T) {
 }
 
 func TestGPUQueueDepth(t *testing.T) {
-	GPUQueueDepth.Set(3)
+	PublishGPUQueueDepth(map[string]int32{"default": 3, "team-a": 1})
 
-	var m dto.Metric
-	if err := GPUQueueDepth.Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
+	if got := testutil.ToFloat64(GPUQueueDepth.WithLabelValues("default")); got != 3 {
+		t.Errorf("expected default depth 3, got %f", got)
 	}
-	if m.GetGauge().GetValue() != 3 {
-		t.Errorf("expected gauge value 3, got %f", m.GetGauge().GetValue())
+	if got := testutil.ToFloat64(GPUQueueDepth.WithLabelValues("team-a")); got != 1 {
+		t.Errorf("expected team-a depth 1, got %f", got)
 	}
 
-	GPUQueueDepth.Set(0)
-	if err := GPUQueueDepth.Write(&m); err != nil {
-		t.Fatalf("failed to write metric: %v", err)
+	// Read values before counting series: WithLabelValues resurrects a dropped
+	// series at 0 rather than reporting it missing.
+	PublishGPUQueueDepth(map[string]int32{"default": 0})
+	if got := testutil.ToFloat64(GPUQueueDepth.WithLabelValues("default")); got != 0 {
+		t.Errorf("expected default depth 0 once the queue drained, got %f", got)
 	}
-	if m.GetGauge().GetValue() != 0 {
-		t.Errorf("expected gauge value 0, got %f", m.GetGauge().GetValue())
+	if got := GPUQueueDepth.DeletePartialMatch(prometheus.Labels{"namespace": "team-a"}); got != 0 {
+		t.Errorf("expected team-a to stop being reported, got %d series", got)
 	}
+
+	GPUQueueDepth.Reset()
 }
 
 func TestReconcileTotal(t *testing.T) {


### PR DESCRIPTION
Closes #1224

## The defect

`llmkube_gpu_queue_depth` was a single global gauge (`prometheus.NewGauge`, no labels) set from `calculateQueuePosition`'s return value. That return value is the reconciling service's **1-based FIFO position**, not a depth, so the gauge reported whichever position reconciled last and had no namespace dimension. With three services queued it reads 1, 2 or 3 depending purely on reconcile ordering.

## The change

`evaluateGPUQueue` returns the per-namespace depth map alongside the position, and `PublishGPUQueueDepth` makes that map the whole of the metric: a namespace absent from it stops being reported, so a namespace draining to 0 reports 0 instead of holding a stale value.

Position and depth are derived in a single pass over the listing. The previous hand-rolled selection sort over the waiting set is gone: counting services created before the subject gives the same FIFO position without ordering the slice.

## Two things that go beyond the metric, declared

**1. The publish is unconditional, not gated on a queue transition.**

An earlier revision of this branch gated the publish on entering or leaving `WaitingForGPU`. That is the shape `Reconcile`'s own defer warns about:

```go
// A live cluster hit this via #1225 — two Ready, serving services
// failed reconcileDeployment every pass and exported no series at all.
```

Gating also left the `GaugeVec` exporting no series at all on an idle cluster after an operator restart, so the stat panel would read "No data" rather than 0. The publish is now unconditional, matching `publishInferenceServiceState`. Cost is one cache-backed `List` per status write; `gpuquota_controller.go:120` already does one `List` per in-scope namespace per reconcile.

**2. `Status.QueuePosition` changes, not only the metric.**

The subject's phase is taken from `isvc` rather than from the cache-backed listing, which still reports the previous phase on the reconcile that changes it, and may not list a freshly created object at all. Without this a service entering the queue reports position 0, which reaches the user through the Progressing condition as "Queued at position 0 waiting for GPU". It self-corrects on the next reconcile, so this fixes a transient user-visible status string as well as the metric.

The dashboard changes are required by the new label rather than cosmetic: `legendFormat` becomes `{{namespace}}` (a fixed string would render N identically-labelled series) and the stat panel is wrapped in `sum()` to stay a single cluster-wide number. The alert expression needs no change — `llmkube_gpu_queue_depth > 0` now fires per namespace — and its annotation gains `{{ $labels.namespace }}` to match the neighbouring `InferenceServiceStuckCreating` rule.

## Verification

`make lint` → `0 issues`. `make test` → all packages `ok`, `internal/controller` 86.2%, `internal/metrics` 100.0%.

Behavioural fail-on-main proof: main's semantics were restored **behind the new signatures**, so the build stays intact and the specs fail on values rather than on compilation. Under that build, `TestGPUQueueDepth` fails with `expected team-a to stop being reported, got 1 series`, and all 11 new controller specs fail, including:

- `head of the queue` — `{"default": 0}` vs `{"default": 2, "team-a": 1, "team-b": 0}`
- `reports how many services are queued, not the position of one` — `2` vs `3`
- `counts a service on the reconcile that puts it in the queue` — `0` vs `3`

The lifecycle spec that enters the queue was rewritten so it cannot pass by coincidence: `delta` is now created *first*, so its position (1) and the depth (3) are different numbers. Previously it was created last, making position numerically equal to depth, which main's last-writer-wins gauge satisfied by accident. A `BeforeEach` resets the gauge so no spec inherits another's value.

## Known limitation, not addressed here

Deleting an InferenceService never routes through `updateStatusWithSchedulingInfo` — `Reconcile`'s `IsNotFound` branch calls `DeleteInferenceServiceSeries` and returns. Deleting the last queued service in a namespace can therefore strand a depth series until some other transition republishes the map. This is strictly better than main, where the single gauge stuck at the last position forever with no reset at all, but it is not fully fixed. Happy to add a republish on the deletion path here if you would rather it land in one go.

## Update: tie-break fix

Fixed the requested-changes item: `evaluateGPUQueue` now breaks ties on equal `CreationTimestamp` (1s resolution) by name, so two services created in the same wall-clock second get a strict `1..N` ordering instead of colliding on the same reported position. Added `evaluateGPUQueue tie-breaking`, a dedicated `DescribeTable` with two same-second entries verifying the ordering both ways.

Also rebased onto current `main` now that #1244, #1230 and #1240 have merged. #1230 touches the same `internal/metrics/metrics.go`/`metrics_test.go` files this PR does (different metric, `GPUQuota` deletion vs `GPUQueueDepth`); the rebase applied clean with no manual conflict resolution needed.