### PR TITLE
fix(grafana): delete dashboard panels for metrics nothing emits

### DIFF
--- a/config/grafana/SETUP.md
+++ b/config/grafana/SETUP.md
@@ -256,12 +256,12 @@ curl http://prometheus:9090/api/v1/targets
 
 | Metric | Description |
 |--------|-------------|
-| `llamacpp_tokens_second` | Current generation speed (tokens/sec) |
-| `llamacpp_tokens_predicted_total` | Total generated tokens |
-| `llamacpp_prompt_tokens_total` | Total prompt tokens processed |
-| `llamacpp_kv_cache_usage_ratio` | KV cache utilization (0-1) |
-| `llamacpp_requests_processing` | Currently processing requests |
-| `llamacpp_requests_deferred` | Deferred/queued requests |
+| `llamacpp:predicted_tokens_seconds` | Current decode speed (tokens/sec) |
+| `llamacpp:prompt_tokens_seconds` | Current prefill speed (tokens/sec) |
+| `llamacpp:tokens_predicted_total` | Total generated tokens |
+| `llamacpp:prompt_tokens_total` | Total prompt tokens processed |
+| `llamacpp:requests_processing` | Currently processing requests |
+| `llamacpp:requests_deferred` | Deferred/queued requests |
 
 ### LLMKube Controller Metrics
 
@@ -273,8 +273,6 @@ curl http://prometheus:9090/api/v1/targets
 | `llmkube_inferenceservice_ready_duration_seconds` | Time to Ready phase |
 | `llmkube_reconcile_total` | Total reconciliation cycles |
 | `llmkube_reconcile_duration_seconds` | Reconciliation cycle duration |
-| `llmkube_active_models_total` | Models in Ready/Cached phase |
-| `llmkube_active_inferenceservices_total` | Inference services in Ready phase |
 
 ### LLMKube Metal Agent Metrics
 

--- a/config/grafana/llmkube-gpu-dashboard.json
+++ b/config/grafana/llmkube-gpu-dashboard.json
@@ -1545,17 +1545,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [
-            {
-              "options": {
-                "Ready": { "color": "green", "index": 0 },
-                "Downloading": { "color": "yellow", "index": 1 },
-                "Pending": { "color": "blue", "index": 2 },
-                "Failed": { "color": "red", "index": 3 }
-              },
-              "type": "value"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1587,8 +1577,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "llmkube_model_status{instance=~\"$instance\"}",
-          "legendFormat": "{{name}} ({{namespace}})",
+          "expr": "llmkube_model_status",
+          "legendFormat": "{{model}} ({{namespace}}) {{phase}}",
           "refId": "A"
         }
       ],
@@ -1605,16 +1595,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [
-            {
-              "options": {
-                "Running": { "color": "green", "index": 0 },
-                "Pending": { "color": "yellow", "index": 1 },
-                "Failed": { "color": "red", "index": 2 }
-              },
-              "type": "value"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1646,188 +1627,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "llmkube_inferenceservice_status{instance=~\"$instance\"}",
-          "legendFormat": "{{name}} ({{namespace}})",
+          "expr": "llmkube_inferenceservice_phase",
+          "legendFormat": "{{inferenceservice}} ({{namespace}}) {{phase}}",
           "refId": "A"
         }
       ],
       "title": "Inference Service Status",
       "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 63 },
-      "id": 52,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "max"],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "11.4.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(llmkube_inference_requests_total{instance=~\"$instance\"}[5m])",
-          "legendFormat": "{{service}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Inference Requests/sec",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 63 },
-      "id": 53,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "max", "p99"],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "11.4.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.95, rate(llmkube_inference_latency_seconds_bucket{instance=~\"$instance\"}[5m]))",
-          "legendFormat": "{{service}} p95",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.50, rate(llmkube_inference_latency_seconds_bucket{instance=~\"$instance\"}[5m]))",
-          "legendFormat": "{{service}} p50",
-          "refId": "B"
-        }
-      ],
-      "title": "Inference Latency",
-      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/config/grafana/llmkube-inference-dashboard.json
+++ b/config/grafana/llmkube-inference-dashboard.json
@@ -61,7 +61,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "llmkube_active_models_total",
+          "expr": "count(llmkube_model_status{phase=\"Ready\"})",
           "legendFormat": "Models",
           "refId": "A"
         }
@@ -99,7 +99,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "llmkube_active_inferenceservices_total",
+          "expr": "count(llmkube_inferenceservice_phase{phase=\"Ready\"})",
           "legendFormat": "Services",
           "refId": "A"
         }
@@ -176,7 +176,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(llamacpp_tokens_second{namespace=~\"$namespace\"})",
+          "expr": "sum(llamacpp:predicted_tokens_seconds{namespace=~\"$namespace\"})",
           "legendFormat": "tok/s",
           "refId": "A"
         }
@@ -214,7 +214,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(llamacpp_requests_processing{namespace=~\"$namespace\"})",
+          "expr": "sum(llamacpp:requests_processing{namespace=~\"$namespace\"})",
           "legendFormat": "Processing",
           "refId": "A"
         }
@@ -252,7 +252,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(llamacpp_requests_deferred{namespace=~\"$namespace\"})",
+          "expr": "sum(llamacpp:requests_deferred{namespace=~\"$namespace\"})",
           "legendFormat": "Deferred",
           "refId": "A"
         }
@@ -299,7 +299,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "llamacpp_tokens_second{namespace=~\"$namespace\"}",
+          "expr": "llamacpp:predicted_tokens_seconds{namespace=~\"$namespace\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -338,7 +338,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "rate(llamacpp_prompt_tokens_total{namespace=~\"$namespace\"}[5m])",
+          "expr": "rate(llamacpp:prompt_tokens_total{namespace=~\"$namespace\"}[5m])",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -374,7 +374,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 15 },
       "id": 21,
       "options": {
         "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
@@ -388,51 +388,6 @@
           "expr": "llmkube_gpu_queue_depth",
           "legendFormat": "Queue Depth",
           "refId": "A"
-        }
-      ]
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisBorderShow": false,
-            "axisLabel": "seconds",
-            "drawStyle": "line",
-            "fillOpacity": 15,
-            "gradientMode": "none",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" }
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
-      "id": 22,
-      "options": {
-        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
-      },
-      "title": "GPU Queue Wait Duration",
-      "type": "timeseries",
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.50, rate(llmkube_gpu_queue_wait_duration_seconds_bucket[5m]))",
-          "legendFormat": "P50",
-          "refId": "A"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.95, rate(llmkube_gpu_queue_wait_duration_seconds_bucket[5m]))",
-          "legendFormat": "P95",
-          "refId": "B"
         }
       ]
     },
@@ -545,49 +500,8 @@
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
       "id": 40,
       "panels": [],
-      "title": "KV Cache and Service Status",
+      "title": "Service Status",
       "type": "row"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisBorderShow": false,
-            "axisLabel": "usage ratio",
-            "drawStyle": "line",
-            "fillOpacity": 15,
-            "gradientMode": "none",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" }
-          },
-          "max": 1,
-          "min": 0,
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
-      "id": 41,
-      "options": {
-        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
-      },
-      "title": "KV Cache Usage",
-      "type": "timeseries",
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "llamacpp_kv_cache_usage_ratio{namespace=~\"$namespace\"}",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
-        }
-      ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
@@ -610,7 +524,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 33 },
       "id": 42,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -20,9 +20,11 @@ PrometheusRule and PodMonitor templates.
 
 | File | Description |
 |---|---|
-| `llmkube-inference.json` | Request latency (vLLM only), GPU queue wait, container restart rate. Latency is grouped by service, runtime, namespace; restarts by pod, container, namespace. |
+| `llmkube-inference.json` | Request latency (vLLM only) and container restart rate. Latency is grouped by service, runtime, namespace; restarts by pod, container, namespace. |
 | `llmkube-slo.json` | Error budget remaining and multi-window burn rate for InferenceServices with `spec.slo` set, plus an SLO overview table. Reads the recording rules Pyrra's kubernetes operator writes per SLO. Templated on a `$slo` variable (`label_values(slo)`) and a manual `$objective` percentage variable, since Pyrra does not expose the target itself as a Prometheus series. Assumes the default 28d SLO window; see the dashboard description for details. |
-| `amd-gpu-observability.json` | AMD GPU health, memory, and inference SLO signals for Strix (gfx1151) nodes. Consumes the verified metric contract from #1187: amdgpu-sysfs exporter, node-exporter hwmon, and llama.cpp /metrics. Panels cover GPU temperature, power, busy %, GTT/VRAM memory, GPU clock, tokens/sec, KV-cache occupancy, and in-flight requests. |
+| `amd-gpu-observability.json` | AMD GPU health, memory, and inference SLO signals for Strix (gfx1151) nodes. Reads the amdgpu-sysfs exporter, node-exporter hwmon, and the `llamacpp:*` series llama.cpp exposes on `/metrics`. Panels cover GPU temperature, power, busy %, GTT/VRAM memory, GPU clock, tokens/sec, and in-flight requests. |
+| `llmkube-quota.json` | Per-GPUQuota usage against the declared GPU and VRAM caps, plus admission denials. |
+| `model-router-dashboard.json` | Router-proxy request rate, latency, backend health and fail-closed rejections. **Renders empty today:** `cmd/router-proxy` mounts no `/metrics` handler, so the `llmkube_router_*` collectors it registers are never scraped. The panels are correct and will populate once the endpoint is served. |
 
 ## Importing
 

--- a/docs/grafana/amd-gpu-observability.json
+++ b/docs/grafana/amd-gpu-observability.json
@@ -448,7 +448,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 13 },
+      "gridPos": { "h": 5, "w": 12, "x": 0, "y": 13 },
       "id": 8,
       "options": {
         "colorMode": "value",
@@ -469,66 +469,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "llamacpp:tokens_per_second",
+          "expr": "llamacpp:predicted_tokens_seconds",
           "legendFormat": "Tokens/s",
           "refId": "A"
         }
       ],
       "title": "Tokens / Second",
       "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.7 },
-              { "color": "red", "value": 0.9 }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 13 },
-      "id": 9,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "11.4.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "llamacpp:kv_cache_usage_ratio",
-          "legendFormat": "KV cache",
-          "refId": "A"
-        }
-      ],
-      "title": "KV Cache Occupancy",
-      "type": "gauge"
     },
     {
       "datasource": {
@@ -553,7 +500,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 13 },
+      "gridPos": { "h": 5, "w": 12, "x": 12, "y": 13 },
       "id": 10,
       "options": {
         "colorMode": "value",
@@ -1025,97 +972,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "llamacpp:tokens_per_second",
+          "expr": "llamacpp:predicted_tokens_seconds",
           "legendFormat": "Tokens/s",
           "refId": "A"
         }
       ],
       "title": "Tokens / Second History",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "line"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.7 },
-              { "color": "red", "value": 0.9 }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
-      "id": 31,
-      "options": {
-        "legend": {
-          "calcs": ["min", "max", "mean"],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "11.4.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "llamacpp:kv_cache_usage_ratio",
-          "legendFormat": "KV cache",
-          "refId": "A"
-        }
-      ],
-      "title": "KV Cache Occupancy History",
       "type": "timeseries"
     },
     {
@@ -1172,7 +1034,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 44 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
       "id": 32,
       "options": {
         "legend": {

--- a/docs/grafana/llmkube-inference.json
+++ b/docs/grafana/llmkube-inference.json
@@ -59,35 +59,8 @@
       "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
       "id": 101,
       "panels": [],
-      "title": "Queue + reliability",
+      "title": "Reliability",
       "type": "row"
-    },
-    {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "fieldConfig": {
-        "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
-      "id": 3,
-      "options": {
-        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
-        "tooltip": {"mode": "multi", "sort": "desc"}
-      },
-      "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "histogram_quantile(0.95, sum by (inferenceservice, namespace, le) (rate(llmkube_gpu_queue_wait_duration_seconds_bucket[5m])))",
-          "legendFormat": "{{inferenceservice}} ({{namespace}})",
-          "refId": "A"
-        }
-      ],
-      "title": "GPU queue wait p95 (5m)",
-      "type": "timeseries"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
@@ -100,7 +73,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 10},
       "id": 4,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},

--- a/docs/grafana/model-router-dashboard.json
+++ b/docs/grafana/model-router-dashboard.json
@@ -126,7 +126,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 10},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
       "id": 4,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -155,7 +155,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 10},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
       "id": 5,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -170,33 +170,6 @@
         }
       ],
       "title": "Budget utilization (rule vs. proxy scope)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "fieldConfig": {
-        "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"axisLabel": "depth", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 10},
-      "id": 6,
-      "options": {
-        "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "bottom"},
-        "tooltip": {"mode": "multi", "sort": "desc"}
-      },
-      "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "sum by (router, routing_fallback_depth) (increase(otel_span_metrics{span_name=\"backend.request\"}[5m]))",
-          "legendFormat": "depth {{routing_fallback_depth}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Fallback depth distribution (5m)",
       "type": "timeseries"
     },
     {

--- a/internal/metrics/dashboard_sync_test.go
+++ b/internal/metrics/dashboard_sync_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"encoding/json"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/defilantech/llmkube/pkg/agent"
+)
+
+const prometheusRuleTpl = "../../charts/llmkube/templates/prometheusrule.yaml"
+
+// Every grafana directory in the repo, so a new one is covered without an edit.
+const dashboardGlob = "../../*/grafana/*.json"
+
+// externalPrefixes are exporters config/grafana/SETUP.md tells operators to
+// install. An exporter this repo does not document is a phantom metric, not an
+// external one: otel_span_metrics was deleted rather than listed here.
+var externalPrefixes = []string{
+	"vllm:",        // vLLM runtime, and the Pyrra rules derived from it
+	"up:",          // Pyrra burn-rate rules over scrape liveness
+	"DCGM_FI_DEV_", // NVIDIA dcgm-exporter
+	"amdgpu_",      // amdgpu-sysfs exporter
+	"node_",        // node-exporter
+}
+
+// promqlWords are the identifiers PromQL allows outside a call: operators and
+// modifiers. Function names need no listing, a call is stripped by its "(".
+var promqlWords = strings.Fields(`
+and atan2 bool by group_left group_right ignoring inf nan offset on or unless without
+`)
+
+// llamacppNames is what the llama.cpp server exposes on /metrics under
+// --metrics. Refresh with:
+//
+//	curl -s $POD:8080/metrics | grep -oP '^# TYPE \K\S+' | sort
+var llamacppNames = strings.Fields(`
+llamacpp:n_busy_slots_per_decode llamacpp:n_decode_total llamacpp:n_tokens_max
+llamacpp:predicted_tokens_seconds llamacpp:prompt_seconds_total
+llamacpp:prompt_tokens_seconds llamacpp:prompt_tokens_total
+llamacpp:requests_deferred llamacpp:requests_processing
+llamacpp:tokens_predicted_seconds_total llamacpp:tokens_predicted_total
+`)
+
+var (
+	// label_values(metric, label) selects on metric; label_values(label) does not.
+	labelValues = regexp.MustCompile(`label_values\(\s*(?:(.*),)?\s*\w+\s*\)`)
+	// Order matters: Grafana variables come out before the label matchers they
+	// are glued into, e.g. up:sum${window_suffix}{slo=~"$slo"}.
+	exprNoise = []*regexp.Regexp{
+		regexp.MustCompile(`\$\{[^}]*\}`), // ${datasource}
+		regexp.MustCompile(`\$\w+`),       // $namespace
+		regexp.MustCompile(`"[^"]*"`),     // string literals
+		regexp.MustCompile(`\{[^}]*\}`),   // label matchers
+		regexp.MustCompile(`\[[^\]]*\]`),  // range selectors
+		regexp.MustCompile(`\b(?:by|without|on|ignoring|group_left|group_right)\s*\([^)]*\)`),
+		// Last: an identifier before "(" is a function, never a metric.
+		regexp.MustCompile(`[a-zA-Z_:][a-zA-Z0-9_:]*\s*\(`),
+	}
+	identifier = regexp.MustCompile(`[a-zA-Z_:][a-zA-Z0-9_:]*`)
+	// Desc keeps fqName unexported; String() is the only accessor.
+	descFQName = regexp.MustCompile(`fqName: "([^"]+)"`)
+	recordRule = regexp.MustCompile(`(?m)^\s*- record:\s*(\S+)`)
+)
+
+// declaredNames returns the fqName of every collector this repo registers,
+// controller plus Metal agent.
+func declaredNames(t *testing.T) map[string]bool {
+	t.Helper()
+
+	registered := append(slices.Clone(AllCollectors), agent.AgentRegistry)
+
+	descs := make(chan *prometheus.Desc)
+	go func() {
+		defer close(descs)
+		for _, collector := range registered {
+			collector.Describe(descs)
+		}
+	}()
+
+	names := map[string]bool{}
+	for desc := range descs {
+		m := descFQName.FindStringSubmatch(desc.String())
+		if m == nil {
+			t.Fatalf("no fqName in Desc %s", desc)
+		}
+		names[m[1]] = true
+	}
+	return names
+}
+
+// chartRecordingRules returns the names the chart's PrometheusRule records.
+// These are the only llmkube: series that exist.
+func chartRecordingRules(t *testing.T) map[string]bool {
+	t.Helper()
+
+	tpl, err := os.ReadFile(prometheusRuleTpl)
+	if err != nil {
+		t.Fatalf("read %s: %v", prometheusRuleTpl, err)
+	}
+
+	names := map[string]bool{}
+	for _, m := range recordRule.FindAllStringSubmatch(string(tpl), -1) {
+		names[m[1]] = true
+	}
+	if len(names) == 0 {
+		t.Fatalf("no recording rules in %s", prometheusRuleTpl)
+	}
+	return names
+}
+
+// metricNames extracts the metric selectors from a PromQL expression.
+func metricNames(expr string) []string {
+	expr = labelValues.ReplaceAllString(expr, " $1 ")
+	for _, noise := range exprNoise {
+		expr = noise.ReplaceAllString(expr, " ")
+	}
+
+	var names []string
+	for _, token := range identifier.FindAllString(expr, -1) {
+		if !slices.Contains(promqlWords, token) {
+			names = append(names, token)
+		}
+	}
+	return names
+}
+
+// dashboardQueries returns every PromQL string a dashboard evaluates: panel
+// target expressions and the queries behind its template variables.
+func dashboardQueries(t *testing.T, path string) []string {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var queries []string
+	var walk func(node any)
+	walk = func(node any) {
+		switch typed := node.(type) {
+		case map[string]any:
+			if s, ok := typed["expr"].(string); ok {
+				queries = append(queries, s)
+			}
+			for _, child := range typed {
+				walk(child)
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(doc)
+
+	// Only type=query variables hold PromQL; custom, textbox and datasource
+	// variables hold literal option lists.
+	templating, _ := doc["templating"].(map[string]any)
+	list, _ := templating["list"].([]any)
+	for _, item := range list {
+		variable, _ := item.(map[string]any)
+		if variable["type"] != "query" {
+			continue
+		}
+		switch query := variable["query"].(type) {
+		case string:
+			queries = append(queries, query)
+		case map[string]any:
+			if s, ok := query["query"].(string); ok {
+				queries = append(queries, s)
+			}
+		}
+	}
+	return queries
+}
+
+func emitted(name string, known map[string]bool) bool {
+	if known[name] {
+		return true
+	}
+	// Dashboards select histogram series; the Desc carries only the base name.
+	for _, suffix := range []string{"_bucket", "_sum", "_count"} {
+		if base := strings.TrimSuffix(name, suffix); base != name && known[base] {
+			return true
+		}
+	}
+	for _, prefix := range externalPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDashboardsQueryEmittedMetrics checks a queried name is declared, not that
+// anything ever writes it, so it catches a misspelled or renamed series (#1223,
+// #1226) but not an inert one. It would not have caught #786, where
+// llmkube_inference_ttft_seconds was declared and registered with no Observe
+// call; that class is only fixed by deleting the declaration.
+func TestDashboardsQueryEmittedMetrics(t *testing.T) {
+	known := declaredNames(t)
+	maps.Copy(known, chartRecordingRules(t))
+	for _, name := range llamacppNames {
+		known[name] = true
+	}
+
+	dashboards, err := filepath.Glob(dashboardGlob)
+	if err != nil {
+		t.Fatalf("glob %s: %v", dashboardGlob, err)
+	}
+	if len(dashboards) == 0 {
+		t.Fatalf("no dashboards under %s", dashboardGlob)
+	}
+
+	for _, dashboard := range dashboards {
+		reported := map[string]bool{}
+		for _, query := range dashboardQueries(t, dashboard) {
+			for _, name := range metricNames(query) {
+				if emitted(name, known) || reported[name] {
+					continue
+				}
+				reported[name] = true
+				t.Errorf("%s queries %q, which no registered collector, chart recording rule or allowlisted exporter emits\n\tquery: %s",
+					dashboard, name, query)
+			}
+		}
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -83,15 +83,6 @@ var (
 		},
 	)
 
-	GPUQueueWaitDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "llmkube_gpu_queue_wait_duration_seconds",
-			Help:    "Time InferenceServices spend waiting for GPU resources.",
-			Buckets: prometheus.ExponentialBuckets(10, 2, 10), // 10s to ~5120s
-		},
-		[]string{"inferenceservice", "namespace"},
-	)
-
 	// Reconcile metrics
 
 	ReconcileTotal = prometheus.NewCounterVec(
@@ -240,7 +231,6 @@ var AllCollectors = []prometheus.Collector{
 	InferenceServiceInfo,
 	InferenceServiceReplicas,
 	GPUQueueDepth,
-	GPUQueueWaitDuration,
 	ReconcileTotal,
 	ReconcileDuration,
 	RouterRequestsTotal,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -203,7 +203,6 @@ func TestHistogramBuckets(t *testing.T) {
 	}{
 		{"ModelDownloadDuration", ModelDownloadDuration, []string{"bkt-test", "default", "http"}, 12},
 		{"InferenceServiceReadyDuration", InferenceServiceReadyDuration, []string{"bkt-test", "default"}, 10},
-		{"GPUQueueWaitDuration", GPUQueueWaitDuration, []string{"bkt-test", "default"}, 10},
 		{"ReconcileDuration", ReconcileDuration, []string{"bkt-test-ctrl"}, 11},
 	}
 


### PR DESCRIPTION
Closes #1226

## The defect

Shipped dashboards query metric names nothing in the repo produces. A panel on a name that is never emitted renders empty, which looks exactly like an idle cluster, so the dashboard silently misleads rather than failing.

Confirmed against a live Prometheus over a 30-day window: neither `llamacpp:tokens_per_second` nor `llamacpp:kv_cache_usage_ratio` has ever been scraped. llama.cpp exposes `llamacpp:predicted_tokens_seconds` and has no KV-cache-ratio series at all.

## The change

Phantom panels are deleted, and `internal/metrics/dashboard_sync_test.go` walks every dashboard's PromQL and fails when a queried name is not one of:

- an fqName declared by a collector in `AllCollectors` or `agent.AgentRegistry`
- a name recorded by the chart's PrometheusRule
- owned by an exporter `config/grafana/SETUP.md` tells operators to install

That last rule is the one worth stating explicitly, because it is what stops the allowlist becoming a hole. `otel_span_metrics` was **deleted rather than allowlisted**: nothing in this repo emits it, nothing documents installing a spanmetrics connector, and listing it would have meant shipping a guard test that suppresses the exact defect it was written to catch.

The known-names set is built from the registries the repo already maintains rather than a hand-written list, so it cannot drift from what the operator actually registers.

## What this guard does not do, stated plainly

It checks a name is **declared**, not that anything ever writes it. It would **not** have caught #786, where `llmkube_inference_ttft_seconds` was declared, registered, dashboarded, and never observed — `declaredNames()` would have returned it and the test would have passed. The doc comment says so rather than implying broader coverage.

That limit is why this PR also deletes `GPUQueueWaitDuration`. It is declared at `metrics.go:86` and registered at `:243`, and the only `Observe()` call in the entire tree is in `metrics_test.go`. Its panels are among those being deleted here, so leaving the declaration behind would let them be re-added tomorrow with CI green. Removing the declaration is what makes the guard's answer correct rather than accidentally correct, and it is the same class of removal `9e42217` did for #786 in the same file.

## Verification

`make lint` → `0 issues`. `make test` → all packages `ok`, `internal/metrics` 100.0%.

The guard discriminates rather than merely passing. Re-injecting the phantom name this PR removes:

```
--- FAIL: TestDashboardsQueryEmittedMetrics (0.01s)
    dashboard_sync_test.go:251: ../../docs/grafana/llmkube-inference.json queries
    "llamacpp:tokens_per_second", which no registered collector, chart recording
    rule or allowlisted exporter emits
        query: rate(llamacpp:tokens_per_second[5m])
```

Panel deletion left four grid rows half empty; those are repacked so the survivors fill the width. Verified programmatically that every row in every shipped dashboard now sums to 24 columns, except one pre-existing gap in `llmkube-inference.json` that predates this change and is left alone.

## Adjacent problems found and deliberately not fixed here

1. **`model-router-dashboard.json` cannot populate at all.** `internal/router/proxy.go` registers seven `llmkube_router_*` collectors, but `proxy.Mount` registers only `/v1/chat/completions`, `/v1/models`, `/health` and `/healthz` — there is no `/metrics` handler in `cmd/router-proxy`. This is a missing scrape path, not a naming bug, and wiring it needs a port, Service, PodMonitor and chart values. The guard cannot see it, because a `Desc` exists. Documented in the README table so the dashboard is not mistaken for broken-by-naming; happy to file it separately.

2. **`docs/site/guides/metrics-driven-autoscaling.md`** ships a prometheus-adapter rule matching `llamacpp_.+` and renaming to `llamacpp:$1`. Per the metric names confirmed here, llama.cpp emits `llamacpp:` natively, so that rule matches nothing and the custom metric never exists — while `runtime_llamacpp.go:67` and `hpa_reconciler.go:114` make `llamacpp:requests_processing` the default HPA metric. Same bug class as this issue with an HPA that never scales instead of a panel that never fills. Left alone because it is a larger blast radius than dashboards; say the word and I will widen the guard to cover shipped YAML `expr:` and adapter `metricName:` too.
