### PR TITLE
feat(grafana): chart the InferenceService metrics with no panel

### DIFF
--- a/config/grafana/llmkube-inference-dashboard.json
+++ b/config/grafana/llmkube-inference-dashboard.json
@@ -524,7 +524,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 33 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
       "id": 42,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
@@ -537,6 +537,45 @@
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "llmkube_inferenceservice_phase{namespace=~\"$namespace\"}",
           "legendFormat": "{{inferenceservice}} ({{phase}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Ready trailing desired is a partially rolled out service; a flat gap is a stuck one.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "id": 53,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Replicas ready vs desired",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (inferenceservice, state) (llmkube_inferenceservice_replicas{namespace=~\"$namespace\"})",
+          "legendFormat": "{{inferenceservice}} {{state}}",
           "refId": "A"
         }
       ]
@@ -655,6 +694,61 @@
           "expr": "rate(llmkube_reconcile_total{result=\"error\"}[5m])",
           "legendFormat": "Error",
           "refId": "B"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 },
+      "id": 54,
+      "panels": [],
+      "title": "Fleet Inventory",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Runtime and accelerator per InferenceService. llmkube_inferenceservice_info is always 1; only its labels carry information.",
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "cellOptions": { "type": "auto" } } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 51 },
+      "id": 55,
+      "options": { "showHeader": true },
+      "title": "Service inventory",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "llmkube_inferenceservice_info{namespace=~\"$namespace\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "container": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "pod": true,
+              "prometheus": true,
+              "service": true
+            },
+            "renameByName": {
+              "accelerator": "Accelerator",
+              "inferenceservice": "Service",
+              "namespace": "Namespace",
+              "runtime": "Runtime"
+            }
+          }
         }
       ]
     }

--- a/config/grafana/llmkube-inference-dashboard.json
+++ b/config/grafana/llmkube-inference-dashboard.json
@@ -564,7 +564,7 @@
         "overrides": []
       },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
-      "id": 53,
+      "id": 43,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
         "tooltip": { "mode": "multi", "sort": "desc" }
@@ -574,7 +574,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (inferenceservice, state) (llmkube_inferenceservice_replicas{namespace=~\"$namespace\"})",
+          "expr": "llmkube_inferenceservice_replicas{namespace=~\"$namespace\"}",
           "legendFormat": "{{inferenceservice}} {{state}}",
           "refId": "A"
         }
@@ -700,7 +700,7 @@
     {
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 },
-      "id": 54,
+      "id": 60,
       "panels": [],
       "title": "Fleet Inventory",
       "type": "row"
@@ -709,18 +709,17 @@
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Runtime and accelerator per InferenceService. llmkube_inferenceservice_info is always 1; only its labels carry information.",
       "fieldConfig": {
-        "defaults": { "custom": { "align": "auto", "cellOptions": { "type": "auto" } } },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 51 },
-      "id": 55,
-      "options": { "showHeader": true },
+      "id": 61,
       "title": "Service inventory",
       "type": "table",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "llmkube_inferenceservice_info{namespace=~\"$namespace\"}",
+          "expr": "max by (inferenceservice, namespace, accelerator, runtime) (llmkube_inferenceservice_info{namespace=~\"$namespace\"})",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -732,15 +731,7 @@
           "options": {
             "excludeByName": {
               "Time": true,
-              "Value": true,
-              "__name__": true,
-              "container": true,
-              "endpoint": true,
-              "instance": true,
-              "job": true,
-              "pod": true,
-              "prometheus": true,
-              "service": true
+              "Value": true
             },
             "renameByName": {
               "accelerator": "Accelerator",


### PR DESCRIPTION
Follow-up to #1244, now rebased onto `main` with #1244's own commit merged (`9c586d9`).
#1226 and #1244 handle one direction: panels querying names nothing emits. The opposite gap was never measured, so I measured it.

## The gap

Of the 43 names this repo declares or records, **16 appear on a dashboard and 27 do not**. Cross-referencing against 30 days of production data narrows what is worth acting on:

| category | count | action |
|---|---|---|
| emitted per InferenceService, no panel | 2 | **charted here** |
| Metal agent (`llmkube_metal_agent_*`) | 19 | left alone, see below |
| router (`llmkube_router_first_token_seconds`) | 1 | blocked on the missing `/metrics` endpoint noted in #1244 |
| vLLM TTFT recording rule | 1 | not a gap; empty only where `prometheus.prometheusRule.enabled=false` |
| histogram base names whose `_bucket` is charted | 4 | not a gap; artefact of my first count |

## What this adds

**Replicas ready vs desired** — `llmkube_inferenceservice_replicas`, plotted per service and state (the metric is already unique on those two labels, so no aggregation is needed). The phase timeline reports `Ready` as soon as one replica is, so a service sitting at 1/3 looks healthy on every existing panel. Ready trailing desired is a partial rollout; a flat gap is a stuck one.

**Service inventory** — a table over `llmkube_inferenceservice_info`, aggregated server-side with `max by (inferenceservice, namespace, accelerator, runtime)` so ServiceMonitor scrape-metadata labels never reach the table, even if a future label gets added. The value is always 1 and the labels are the payload, so a timeseries is the wrong shape; an `organize` transformation renames the four real labels for display. Answers "what is actually running, on what" without reading CRs.

`InferenceService Phase` goes back to half width. #1244 widened it to 24 only because deleting a phantom neighbour left the row half empty — that was filling a hole, not a layout decision, and the row now has a real second panel.

## Verification

Both names pass #1244's guard test (`TestDashboardsQueryEmittedMetrics`), which now runs against the merged collector set on `main`.

Live data, same cluster and window as the #1244 evidence:

- `llmkube_inferenceservice_info` — 4 live series, e.g. `{inferenceservice="qwen36-27b", runtime="sglang", accelerator="rocm"}`
- `llmkube_inferenceservice_replicas` — no current series, and that is expected rather than a phantom: `v0.9.10` (the running release) contains **no reference to this metric at all**. It was added in #1229 and is published from `status_builder.go:150` via `Reconcile`'s defer, so it starts emitting with the next release.

Grid verified programmatically: JSON valid, no duplicate panel ids, every row sums to 24 columns.

## Why the Metal agent set is not charted

19 metrics with zero coverage is the largest remaining gap, and I deliberately did not fill it. Nothing in this repo's test or staging surface emits them — they need a macOS host running the Metal agent — so the panels, their units, and their thresholds would all be guesswork. Writing dashboards for metrics nobody has observed is exactly how the panels #1244 removes came to exist. Happy to do it against a real agent, or to pair with someone who has one.