### PR TITLE
fix: delete GPUQuota metric series when the CR is deleted (#1230)

### DIFF
--- a/internal/controller/gpuquota_controller.go
+++ b/internal/controller/gpuquota_controller.go
@@ -73,6 +73,7 @@ func (r *GPUQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	gq := &inferencev1alpha1.GPUQuota{}
 	if err := r.Get(ctx, req.NamespacedName, gq); err != nil {
 		if errors.IsNotFound(err) {
+			llmkubemetrics.DeleteGPUQuotaSeries(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "failed to get GPUQuota")

--- a/internal/controller/gpuquota_controller_test.go
+++ b/internal/controller/gpuquota_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -609,6 +610,51 @@ func TestReconcileNotFound(t *testing.T) {
 	}
 	if result != (ctrl.Result{}) {
 		t.Errorf("Reconcile() returned %+v, want empty Result for NotFound", result)
+	}
+}
+
+func TestReconcileNotFoundDeletesMetrics(t *testing.T) {
+	// Seed the four per-quota gauges as if a GPUQuota had been reconciled.
+	llmkubemetrics.GPUQuotaUsedGPUCount.WithLabelValues("del-gq", "default").Set(3)
+	llmkubemetrics.GPUQuotaGPUCountLimit.WithLabelValues("del-gq", "default").Set(10)
+	llmkubemetrics.GPUQuotaUsedVRAMBytes.WithLabelValues("del-gq", "default").Set(16000000000)
+	llmkubemetrics.GPUQuotaVRAMBytesLimit.WithLabelValues("del-gq", "default").Set(32000000000)
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "del-gq",
+			Namespace: "default",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() returned error for NotFound: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() returned %+v, want empty Result for NotFound", result)
+	}
+
+	// Every per-quota gauge must be gone, or a deleted quota keeps
+	// reporting through whichever one was missed.
+	if got := llmkubemetrics.GPUQuotaUsedGPUCount.DeletePartialMatch(prometheus.Labels{"gpuquota": "del-gq", "namespace": "default"}); got != 0 {
+		t.Errorf("GPUQuotaUsedGPUCount: got %d series, want 0", got)
+	}
+	if got := llmkubemetrics.GPUQuotaGPUCountLimit.DeletePartialMatch(prometheus.Labels{"gpuquota": "del-gq", "namespace": "default"}); got != 0 {
+		t.Errorf("GPUQuotaGPUCountLimit: got %d series, want 0", got)
+	}
+	if got := llmkubemetrics.GPUQuotaUsedVRAMBytes.DeletePartialMatch(prometheus.Labels{"gpuquota": "del-gq", "namespace": "default"}); got != 0 {
+		t.Errorf("GPUQuotaUsedVRAMBytes: got %d series, want 0", got)
+	}
+	if got := llmkubemetrics.GPUQuotaVRAMBytesLimit.DeletePartialMatch(prometheus.Labels{"gpuquota": "del-gq", "namespace": "default"}); got != 0 {
+		t.Errorf("GPUQuotaVRAMBytesLimit: got %d series, want 0", got)
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -306,10 +306,27 @@ func DeleteInferenceServiceSeries(name, namespace string) {
 	InferenceServiceReplicas.DeletePartialMatch(labels)
 }
 
+const nsLabel = "namespace"
+
 func modelLabels(name, namespace string) prometheus.Labels {
-	return prometheus.Labels{"model": name, "namespace": namespace}
+	return prometheus.Labels{"model": name, nsLabel: namespace}
 }
 
 func inferenceServiceLabels(name, namespace string) prometheus.Labels {
-	return prometheus.Labels{"inferenceservice": name, "namespace": namespace}
+	return prometheus.Labels{"inferenceservice": name, nsLabel: namespace}
+}
+
+// DeleteGPUQuotaSeries drops every per-quota gauge held for one GPUQuota.
+// The admission-denial counter is deliberately kept: resetting it would
+// break rate() across a recreate.
+func DeleteGPUQuotaSeries(name, namespace string) {
+	labels := gpuQuotaLabels(name, namespace)
+	GPUQuotaUsedGPUCount.DeletePartialMatch(labels)
+	GPUQuotaGPUCountLimit.DeletePartialMatch(labels)
+	GPUQuotaUsedVRAMBytes.DeletePartialMatch(labels)
+	GPUQuotaVRAMBytesLimit.DeletePartialMatch(labels)
+}
+
+func gpuQuotaLabels(name, namespace string) prometheus.Labels {
+	return prometheus.Labels{"gpuquota": name, nsLabel: namespace}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -266,6 +266,45 @@ func TestDeleteInferenceServiceSeries(t *testing.T) {
 	}
 }
 
+func TestDeleteGPUQuotaSeries(t *testing.T) {
+	beforeUsedGPU := testutil.CollectAndCount(GPUQuotaUsedGPUCount)
+	beforeLimitGPU := testutil.CollectAndCount(GPUQuotaGPUCountLimit)
+	beforeUsedVRAM := testutil.CollectAndCount(GPUQuotaUsedVRAMBytes)
+	beforeLimitVRAM := testutil.CollectAndCount(GPUQuotaVRAMBytesLimit)
+
+	GPUQuotaUsedGPUCount.WithLabelValues("del-gq", "default").Set(3)
+	GPUQuotaGPUCountLimit.WithLabelValues("del-gq", "default").Set(10)
+	GPUQuotaUsedVRAMBytes.WithLabelValues("del-gq", "default").Set(16000000000)
+	GPUQuotaVRAMBytesLimit.WithLabelValues("del-gq", "default").Set(32000000000)
+
+	DeleteGPUQuotaSeries("del-gq", "default")
+
+	// Every per-quota gauge must be covered, or a deleted quota keeps
+	// reporting through whichever one was missed.
+	if got := testutil.CollectAndCount(GPUQuotaUsedGPUCount); got != beforeUsedGPU {
+		t.Errorf("used gpu: got %d series, want %d", got, beforeUsedGPU)
+	}
+	if got := testutil.CollectAndCount(GPUQuotaGPUCountLimit); got != beforeLimitGPU {
+		t.Errorf("gpu limit: got %d series, want %d", got, beforeLimitGPU)
+	}
+	if got := testutil.CollectAndCount(GPUQuotaUsedVRAMBytes); got != beforeUsedVRAM {
+		t.Errorf("used vram: got %d series, want %d", got, beforeUsedVRAM)
+	}
+	if got := testutil.CollectAndCount(GPUQuotaVRAMBytesLimit); got != beforeLimitVRAM {
+		t.Errorf("vram limit: got %d series, want %d", got, beforeLimitVRAM)
+	}
+}
+
+func TestGPUQuotaLabels(t *testing.T) {
+	labels := gpuQuotaLabels("my-quota", "my-ns")
+	if labels["gpuquota"] != "my-quota" {
+		t.Errorf("gpuquota label = %q, want %q", labels["gpuquota"], "my-quota")
+	}
+	if labels["namespace"] != "my-ns" {
+		t.Errorf("namespace label = %q, want %q", labels["namespace"], "my-ns")
+	}
+}
+
 func TestPublishModelPhase(t *testing.T) {
 	labels := modelLabels("publish-test", "default")
 	ModelStatus.DeletePartialMatch(labels)


### PR DESCRIPTION
## What

Delete the four per-quota metric series when a `GPUQuota` CR is deleted.

## Why

`GPUQuota` had the same "no cleanup on delete" bug as Model and InferenceService (#1221, fixed in #1229): after the CR is deleted, its four per-quota gauges kept reporting the last known values until the controller process restarted.

Fixes #1230

## How

Added `DeleteGPUQuotaSeries` to `internal/metrics` (mirroring `DeleteModelSeries` / `DeleteInferenceServiceSeries`) and called it from the `IsNotFound` branch of the GPUQuota reconciler. It drops the four gauges (`used_gpu_count`, `gpu_count_limit`, `used_vram_bytes`, `vram_bytes_limit`) and deliberately keeps the admission-denial counter so `rate()` survives a recreate, matching the InferenceService pattern.

Authored autonomously by the Foreman agent harness (MCP-enabled), mirroring the just-merged #1229 pattern, then human-reviewed: I confirmed the test actually invokes `Reconcile` on a NotFound request (not a hollow assertion), the helper deletes exactly the four gauges, and the counter exclusion is intentional.

## Checklist

- [x] Tests added/updated (envtest `TestReconcileNotFoundDeletesMetrics`)
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — n/a, metric-cleanup behavior only
