### PR TITLE
feat: Kueue prerequisites: spec.suspend, GPUQuota deferral, pkg/apiutil GPU mapping

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -137,6 +137,16 @@ type InferenceServiceSpec struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// Suspend stops the inference workload without losing the desired
+	// replica count: the serving Deployment (or metal process) is scaled to
+	// zero while spec.replicas is preserved, and the service reports phase
+	// Suspended. Intended for external admission controllers (for example
+	// the Kueue integration, which holds a queue-labeled service suspended
+	// until its ClusterQueue admits it). Defaults to false.
+	// +kubebuilder:default=false
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
+
 	// RevisionHistoryLimit caps how many old ReplicaSets the inference
 	// Deployment keeps for rollback. Unset uses the Kubernetes default (10);
 	// 0 keeps none.
@@ -1091,11 +1101,13 @@ type TGIConfig struct {
 type InferenceServiceStatus struct {
 	// Phase represents the current lifecycle phase of the InferenceService.
 	// Possible values: Pending, Creating, Progressing, Ready, WaitingForGPU,
-	// Stopped, Failed. Stopped is the terminal state when spec.replicas=0
-	// has caused the agent to tear down the workload; tooling polling for
-	// readiness should treat Stopped the same as Pending (the user
-	// intentionally took the service offline; this is not an error).
-	// +kubebuilder:validation:Enum=Pending;Creating;Progressing;Ready;WaitingForGPU;Stopped;Failed
+	// Stopped, Suspended, Failed. Stopped is the terminal state when
+	// spec.replicas=0 has caused the agent to tear down the workload; tooling
+	// polling for readiness should treat Stopped the same as Pending (the
+	// user intentionally took the service offline; this is not an error).
+	// Suspended is the equivalent state when spec.suspend=true has scaled the
+	// workload to zero while spec.replicas is preserved for restoration.
+	// +kubebuilder:validation:Enum=Pending;Creating;Progressing;Ready;WaitingForGPU;Stopped;Suspended;Failed
 	// +optional
 	Phase string `json:"phase,omitempty"`
 

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -5175,6 +5175,16 @@ spec:
                 required:
                 - type
                 type: object
+              suspend:
+                default: false
+                description: |-
+                  Suspend stops the inference workload without losing the desired
+                  replica count: the serving Deployment (or metal process) is scaled to
+                  zero while spec.replicas is preserved, and the service reports phase
+                  Suspended. Intended for external admission controllers (for example
+                  the Kueue integration, which holds a queue-labeled service suspended
+                  until its ClusterQueue admits it). Defaults to false.
+                type: boolean
               tensorOverrides:
                 description: |-
                   TensorOverrides provides fine-grained tensor placement overrides for power users.
@@ -5802,10 +5812,12 @@ spec:
                 description: |-
                   Phase represents the current lifecycle phase of the InferenceService.
                   Possible values: Pending, Creating, Progressing, Ready, WaitingForGPU,
-                  Stopped, Failed. Stopped is the terminal state when spec.replicas=0
-                  has caused the agent to tear down the workload; tooling polling for
-                  readiness should treat Stopped the same as Pending (the user
-                  intentionally took the service offline; this is not an error).
+                  Stopped, Suspended, Failed. Stopped is the terminal state when
+                  spec.replicas=0 has caused the agent to tear down the workload; tooling
+                  polling for readiness should treat Stopped the same as Pending (the
+                  user intentionally took the service offline; this is not an error).
+                  Suspended is the equivalent state when spec.suspend=true has scaled the
+                  workload to zero while spec.replicas is preserved for restoration.
                 enum:
                 - Pending
                 - Creating
@@ -5813,6 +5825,7 @@ spec:
                 - Ready
                 - WaitingForGPU
                 - Stopped
+                - Suspended
                 - Failed
                 type: string
               queuePosition:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -5171,6 +5171,16 @@ spec:
                 required:
                 - type
                 type: object
+              suspend:
+                default: false
+                description: |-
+                  Suspend stops the inference workload without losing the desired
+                  replica count: the serving Deployment (or metal process) is scaled to
+                  zero while spec.replicas is preserved, and the service reports phase
+                  Suspended. Intended for external admission controllers (for example
+                  the Kueue integration, which holds a queue-labeled service suspended
+                  until its ClusterQueue admits it). Defaults to false.
+                type: boolean
               tensorOverrides:
                 description: |-
                   TensorOverrides provides fine-grained tensor placement overrides for power users.
@@ -5798,10 +5808,12 @@ spec:
                 description: |-
                   Phase represents the current lifecycle phase of the InferenceService.
                   Possible values: Pending, Creating, Progressing, Ready, WaitingForGPU,
-                  Stopped, Failed. Stopped is the terminal state when spec.replicas=0
-                  has caused the agent to tear down the workload; tooling polling for
-                  readiness should treat Stopped the same as Pending (the user
-                  intentionally took the service offline; this is not an error).
+                  Stopped, Suspended, Failed. Stopped is the terminal state when
+                  spec.replicas=0 has caused the agent to tear down the workload; tooling
+                  polling for readiness should treat Stopped the same as Pending (the
+                  user intentionally took the service offline; this is not an error).
+                  Suspended is the equivalent state when spec.suspend=true has scaled the
+                  workload to zero while spec.replicas is preserved for restoration.
                 enum:
                 - Pending
                 - Creating
@@ -5809,6 +5821,7 @@ spec:
                 - Ready
                 - WaitingForGPU
                 - Stopped
+                - Suspended
                 - Failed
                 type: string
               queuePosition:

--- a/docs/kueue-integration.md
+++ b/docs/kueue-integration.md
@@ -1,0 +1,49 @@
+# Suspend and the Kueue integration
+
+## spec.suspend
+
+Setting `spec.suspend: true` on an InferenceService stops its workload
+without losing the desired scale: the serving Deployment (or metal-agent
+process) is scaled to zero, `spec.replicas` is preserved, the service
+reports `phase: Suspended`, and a `Suspended` condition is set. If
+autoscaling is configured, the HPA is removed while suspended and recreated
+on resume. Setting `spec.suspend: false` restores the service to
+`spec.replicas`.
+
+Suspend is the admission lever used by external queueing controllers. It is
+also useful on its own for temporarily parking a service without recording
+its replica count somewhere else.
+
+## GPUQuota and Kueue
+
+LLMKube's built-in `GPUQuota` admission stays the default for clusters
+without Kueue. When an InferenceService carries the
+`kueue.x-k8s.io/queue-name` label, the GPUQuota webhook defers: quota
+admission for that service is owned by Kueue's ClusterQueue (via the
+[llmkube-kueue](https://github.com/defilantech/llmkube-kueue) integration),
+and LLMKube does not double-gate it. Spec validation (for example
+`gpuSharing` rules) still applies to every service. `GPUQuota` status
+continues to report usage from all services, labeled or not, for
+observability.
+
+Removing the label opts the service back into GPUQuota gating.
+
+Tracking: [#1253](https://github.com/defilantech/LLMKube/issues/1253)
+(epic), [#1251](https://github.com/defilantech/LLMKube/issues/1251)
+(this slice), [#1252](https://github.com/defilantech/LLMKube/issues/1252)
+(the external component).
+
+### Notes
+
+The queue-name label is effectively a quota bypass for GPUQuota: any
+service that carries it skips GPUQuota admission entirely. Controlling who
+may set labels on InferenceServices, through RBAC, is the actual guard
+against misuse; the label itself carries no authorization check.
+
+In a namespace that mixes labeled and unlabeled services, GPUQuota status
+usage aggregates both, by design, for observability. This means
+`status.usedGPUCount` can exceed the quota limit without any violation
+being recorded, since the labeled services were never subject to the
+limit. Unlabeled services are still admitted against that same aggregate
+count, so a labeled service's usage can push an unlabeled service's
+admission request over the limit and cause it to be denied.

--- a/internal/controller/gpu_resources.go
+++ b/internal/controller/gpu_resources.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/apiutil"
 )
 
 const (
@@ -79,27 +80,7 @@ func isROCmRuntime(runtime string) bool {
 }
 
 func gpuResourceNameForSpec(model *inferencev1alpha1.Model) corev1.ResourceName {
-	if model != nil && model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil {
-		if override := strings.TrimSpace(model.Spec.Hardware.GPU.ResourceName); override != "" {
-			return corev1.ResourceName(override)
-		}
-
-		switch strings.ToLower(strings.TrimSpace(model.Spec.Hardware.GPU.Vendor)) {
-		case "amd":
-			// Both the Vulkan and ROCm runtimes schedule against the shared
-			// generic-device-plugin /dev/dri resource (vulkanDRIResourceName),
-			// not the amd.com/gpu resource; see gpuRuntimeROCm for why.
-			if isVulkanRuntime(model.Spec.Hardware.GPU.Runtime) ||
-				isROCmRuntime(model.Spec.Hardware.GPU.Runtime) {
-				return vulkanDRIResourceName
-			}
-			return amdGPUResourceName
-		case "intel":
-			return intelGPUResourceNameI915
-		}
-	}
-
-	return nvidiaGPUResourceName
+	return apiutil.GPUResourceName(model)
 }
 
 // gpuTolerationKeyForSpec returns the taint key the GPU toleration should

--- a/internal/controller/hpa_reconciler.go
+++ b/internal/controller/hpa_reconciler.go
@@ -49,11 +49,18 @@ func (r *InferenceServiceReconciler) reconcileHPA(
 		Namespace: isvc.Namespace,
 	}
 
-	// If autoscaling is not configured, clean up any existing HPA
-	if isvc.Spec.Autoscaling == nil {
+	// If autoscaling is not configured, or the service is suspended, clean
+	// up any existing HPA. Suspension must win over autoscaling: otherwise
+	// the HPA's minReplicas (defaults to 1) would scale the Deployment back
+	// above zero on its own reconcile loop.
+	if isvc.Spec.Autoscaling == nil || isvc.Spec.Suspend {
 		existingHPA := &autoscalingv2.HorizontalPodAutoscaler{}
 		if err := r.Get(ctx, hpaName, existingHPA); err == nil {
-			logger.Info("Autoscaling removed, deleting HPA",
+			reason := "Autoscaling removed"
+			if isvc.Spec.Suspend {
+				reason = "InferenceService suspended"
+			}
+			logger.Info(reason+", deleting HPA",
 				"name", isvc.Name)
 			if err := r.Delete(ctx, existingHPA); err != nil {
 				return fmt.Errorf("failed to delete HPA: %w", err)

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -208,6 +208,14 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		desiredReplicas = *inferenceService.Spec.Replicas
 	}
 
+	// Suspend (spec.suspend) scales the workload to zero without touching
+	// spec.replicas, so unsuspend restores the user's desired count. The
+	// forced zero flows through reconcileDeployment (Deployment replicas),
+	// the metal-agent state, and status.desiredReplicas.
+	if inferenceService.Spec.Suspend {
+		desiredReplicas = 0
+	}
+
 	if effectiveModelCacheKey(model) != "" && r.ModelCachePath != "" {
 		if err := r.ensureModelCachePVC(ctx, inferenceService); err != nil {
 			log.Error(err, "Failed to ensure model cache PVC exists", "namespace", inferenceService.Namespace)

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -510,8 +510,9 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	// the live value rather than overwriting it with the operator's desired
 	// count. Setting it to nil does not work here: a plain Update with a nil
 	// replicas field is defaulted back to 1 by the API server, which fights
-	// the HPA on every reconcile.
-	if isvc.Spec.Autoscaling != nil {
+	// the HPA on every reconcile. Suspension overrides this: the HPA is
+	// deleted while suspended, and the forced zero must land.
+	if isvc.Spec.Autoscaling != nil && !isvc.Spec.Suspend {
 		existingDeployment.Spec.Replicas = existingReplicas
 	}
 	if err := r.Update(ctx, existingDeployment); err != nil {

--- a/internal/controller/inferenceservice_quota_webhook.go
+++ b/internal/controller/inferenceservice_quota_webhook.go
@@ -36,6 +36,14 @@ import (
 
 // +kubebuilder:webhook:path=/validate-inference-llmkube-dev-v1alpha1-inferenceservice-quota,mutating=false,failurePolicy=fail,sideEffects=None,groups=inference.llmkube.dev,resources=inferenceservices,verbs=create;update,versions=v1alpha1,name=vinferenceservicequota.inference.llmkube.dev,admissionReviewVersions=v1
 
+// kueueQueueNameLabel marks an InferenceService as Kueue-managed. Quota
+// admission for such services is owned by Kueue (ClusterQueue quota via the
+// llmkube-kueue integration); the GPUQuota webhook defers so the two
+// systems never double-gate the same object (a suspended service being
+// unsuspended by Kueue admission would otherwise be re-denied here when
+// the namespace quota is tight, deadlocking admission). See #1251.
+const kueueQueueNameLabel = "kueue.x-k8s.io/queue-name"
+
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=gpuquotas,verbs=get;list;watch
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=inferenceservices,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
@@ -128,6 +136,16 @@ func (v *InferenceServiceQuotaValidator) validate(ctx context.Context, isvc *inf
 	// (multitenancy disabled).
 	if err := v.validateGPUSharing(ctx, isvc); err != nil {
 		return fmt.Errorf("invalid gpuSharing spec: %w", err)
+	}
+
+	// Kueue-managed services defer quota gating to Kueue. Spec validation
+	// above still applies; only the GPUQuota accounting is skipped. The
+	// GPUQuota status reconciler continues to include these services in
+	// usage aggregation for observability.
+	if isvc.Labels[kueueQueueNameLabel] != "" {
+		log.FromContext(ctx).V(1).Info("skipping GPUQuota gating for Kueue-managed InferenceService",
+			"name", isvc.Name, "namespace", isvc.Namespace)
+		return nil
 	}
 
 	quotas, err := v.listApplicableQuotas(ctx, isvc)

--- a/internal/controller/inferenceservice_quota_webhook_test.go
+++ b/internal/controller/inferenceservice_quota_webhook_test.go
@@ -286,6 +286,142 @@ func TestInferenceServiceQuotaValidator(t *testing.T) {
 			t.Fatalf("expected admission, got error: %v", err)
 		}
 	})
+
+	// #1251: the GPUQuota webhook defers QUOTA gating (not spec validation)
+	// for InferenceServices carrying the Kueue queue-name label, since
+	// admission for those objects is owned by Kueue's ClusterQueue quota.
+	t.Run("admits a Kueue-managed InferenceService that exceeds the GPUQuota", func(t *testing.T) {
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "kueue-quota"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "default",
+				GPUCount:     1,
+			},
+		}
+		// Existing ISVC already consuming the entire 1-GPU quota.
+		existingISVC := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Replicas: ptrInt32Val(1),
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					GPU: 1,
+				},
+			},
+		}
+		// New ISVC requests 1 more GPU (1+1=2 > 1 quota) but is Kueue-managed.
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kueue-svc",
+				Namespace: "default",
+				Labels:    map[string]string{"kueue.x-k8s.io/queue-name": "inference-queue"},
+			},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Replicas: ptrInt32Val(1),
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					GPU: 1,
+				},
+			},
+		}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&quota, &existingISVC, &ns).
+			Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		_, err := v.ValidateCreate(ctx, &isvc)
+		if err != nil {
+			t.Fatalf("expected admission for Kueue-managed ISVC despite exceeding the GPUQuota, got error: %v", err)
+		}
+	})
+
+	t.Run("still denies an unlabeled InferenceService that exceeds the GPUQuota", func(t *testing.T) {
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "kueue-quota"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "default",
+				GPUCount:     1,
+			},
+		}
+		existingISVC := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Replicas: ptrInt32Val(1),
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					GPU: 1,
+				},
+			},
+		}
+		// Same over-quota shape as above, but with no Kueue label.
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "unlabeled-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Replicas: ptrInt32Val(1),
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					GPU: 1,
+				},
+			},
+		}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&quota, &existingISVC, &ns).
+			Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		_, err := v.ValidateCreate(ctx, &isvc)
+		if err == nil {
+			t.Fatal("expected denial for unlabeled ISVC exceeding the GPUQuota, got nil")
+		}
+		if !strContains(err.Error(), "kueue-quota") {
+			t.Fatalf("expected error to mention the GPUQuota name, got: %v", err)
+		}
+	})
+
+	t.Run("still rejects an invalid gpuSharing spec even when Kueue-managed", func(t *testing.T) {
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "kueue-quota"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "default",
+				GPUCount:     100, // permissive: only the sharing spec should reject.
+			},
+		}
+		// Shared mode with no configured pool is the suite's existing
+		// invalid-gpuSharing fixture (see TestGPUSharingAdmission).
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kueue-bad-sharing",
+				Namespace: "default",
+				Labels:    map[string]string{"kueue.x-k8s.io/queue-name": "inference-queue"},
+			},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Replicas: ptrInt32Val(1),
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					GPU: 1,
+					GPUSharing: &inferencev1alpha1.GPUSharingSpec{
+						Mode: inferencev1alpha1.GPUSharingModeShared,
+					},
+				},
+			},
+		}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&quota, &ns).
+			Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		_, err := v.ValidateCreate(ctx, &isvc)
+		if err == nil {
+			t.Fatal("expected rejection of the invalid gpuSharing spec, got nil")
+		}
+		if !strContains(err.Error(), "requires a configured shared pool") {
+			t.Fatalf("expected sharing-pool rejection reason, got: %v", err)
+		}
+	})
 }
 
 func ptrInt32Val(i int32) *int32 {

--- a/internal/controller/inferenceservice_suspend_test.go
+++ b/internal/controller/inferenceservice_suspend_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -75,6 +76,10 @@ var _ = Describe("InferenceService suspend", func() {
 			dep := &appsv1.Deployment{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
 				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
 			}
 		}()
 
@@ -144,6 +149,10 @@ var _ = Describe("InferenceService suspend", func() {
 			dep := &appsv1.Deployment{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
 				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
 			}
 		}()
 

--- a/internal/controller/inferenceservice_suspend_test.go
+++ b/internal/controller/inferenceservice_suspend_test.go
@@ -22,7 +22,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -184,5 +186,91 @@ var _ = Describe("InferenceService suspend", func() {
 		cond := meta.FindStatusCondition(updated.Status.Conditions, "Suspended")
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	})
+
+	It("deletes the HPA and forces zero replicas when a suspended service has autoscaling", func() {
+		modelName := "suspend-hpa-model"
+		isvcName := "suspend-hpa-isvc"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(2)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "ghcr.io/ggml-org/llama.cpp:server",
+				Suspend:  false,
+				Autoscaling: &inferencev1alpha1.AutoscalingSpec{
+					MaxReplicas: 3,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		hpaKey := types.NamespacedName{Name: isvcName, Namespace: "default"}
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
+			}
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+			if err := k8sClient.Get(ctx, hpaKey, hpa); err == nil {
+				_ = k8sClient.Delete(ctx, hpa)
+			}
+		}()
+
+		// First reconcile with suspend=false: autoscaling is active, HPA should exist.
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, hpaKey, &autoscalingv2.HorizontalPodAutoscaler{})).To(Succeed())
+
+		// Patch suspend=true and reconcile again.
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, isvc)).To(Succeed())
+		isvc.Spec.Suspend = true
+		Expect(k8sClient.Update(ctx, isvc)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			return errors.IsNotFound(k8sClient.Get(ctx, hpaKey, &autoscalingv2.HorizontalPodAutoscaler{}))
+		}, "5s", "100ms").Should(BeTrue())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(0)))
+
+		// Unsuspend and reconcile again: the HPA should be recreated.
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, isvc)).To(Succeed())
+		isvc.Spec.Suspend = false
+		Expect(k8sClient.Update(ctx, isvc)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, hpaKey, &autoscalingv2.HorizontalPodAutoscaler{})).To(Succeed())
 	})
 })

--- a/internal/controller/inferenceservice_suspend_test.go
+++ b/internal/controller/inferenceservice_suspend_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("InferenceService suspend", func() {
+	ctx := context.Background()
+
+	var reconciler *InferenceServiceReconciler
+
+	BeforeEach(func() {
+		reconciler = &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+	})
+
+	It("scales the Deployment to zero and preserves spec.replicas when suspended", func() {
+		modelName := "suspend-model"
+		isvcName := "suspend-isvc"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(2)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "ghcr.io/ggml-org/llama.cpp:server",
+				Suspend:  false,
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+		}()
+
+		// First reconcile with suspend=false: Deployment should run at 2 replicas.
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+
+		// Patch suspend=true and reconcile again.
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, isvc)).To(Succeed())
+		isvc.Spec.Suspend = true
+		Expect(k8sClient.Update(ctx, isvc)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(0)))
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(*updated.Spec.Replicas).To(Equal(int32(2)))
+		Expect(updated.Status.Phase).To(Equal(PhaseSuspended))
+		Expect(updated.Status.DesiredReplicas).To(Equal(int32(0)))
+
+		cond := meta.FindStatusCondition(updated.Status.Conditions, "Suspended")
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	})
+
+	It("restores the Deployment to spec.replicas on unsuspend", func() {
+		modelName := "unsuspend-model"
+		isvcName := "unsuspend-isvc"
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:   "https://example.com/model.gguf",
+				Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		replicas := int32(2)
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: modelName,
+				Replicas: &replicas,
+				Image:    "ghcr.io/ggml-org/llama.cpp:server",
+				Suspend:  true,
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, isvc)
+			dep := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+				_ = k8sClient.Delete(ctx, dep)
+			}
+		}()
+
+		// First reconcile while suspended: Deployment starts at 0 replicas.
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(0)))
+
+		// Unsuspend and reconcile again.
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, isvc)).To(Succeed())
+		isvc.Spec.Suspend = false
+		Expect(k8sClient.Update(ctx, isvc)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+		cond := meta.FindStatusCondition(updated.Status.Conditions, "Suspended")
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	})
+})

--- a/internal/controller/inferenceservice_suspend_test.go
+++ b/internal/controller/inferenceservice_suspend_test.go
@@ -117,6 +117,7 @@ var _ = Describe("InferenceService suspend", func() {
 		cond := meta.FindStatusCondition(updated.Status.Conditions, "Suspended")
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.ObservedGeneration).To(Equal(updated.Generation))
 	})
 
 	It("restores the Deployment to spec.replicas on unsuspend", func() {

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -56,6 +56,7 @@ const (
 	PhaseDownloading = "Downloading"
 	PhaseCreating    = "Creating"
 	PhaseStopped     = "Stopped"
+	PhaseSuspended   = "Suspended"
 	// acceleratorMetal is the Model.Spec.Hardware.Accelerator value for the
 	// host metal-agent path.
 	acceleratorMetal      = "metal"

--- a/internal/controller/runtime.go
+++ b/internal/controller/runtime.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/apiutil"
 )
 
 // RuntimeBackend generates runtime-specific container configuration
@@ -120,13 +121,7 @@ func runtimeNameLabel(isvc *inferencev1alpha1.InferenceService) string {
 
 // resolveGPUCount determines the GPU count from Model spec or InferenceService spec.
 func resolveGPUCount(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) int32 {
-	if model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil && model.Spec.Hardware.GPU.Count > 0 {
-		return model.Spec.Hardware.GPU.Count
-	}
-	if isvc.Spec.Resources != nil && isvc.Spec.Resources.GPU > 0 {
-		return isvc.Spec.Resources.GPU
-	}
-	return 0
+	return apiutil.GPUCount(isvc, model)
 }
 
 // hasGPUPresent returns true when the workload has GPU access through either

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -64,6 +64,10 @@ type SchedulingInfo struct {
 }
 
 func (r *InferenceServiceReconciler) determinePhase(ctx context.Context, isvc *inferencev1alpha1.InferenceService, readyReplicas, desiredReplicas int32, isMetal bool, deployment *appsv1.Deployment, snap *metalSnapshot) (string, *SchedulingInfo) {
+	if isvc.Spec.Suspend {
+		return PhaseSuspended, nil
+	}
+
 	log := logf.FromContext(ctx)
 
 	if readyReplicas == desiredReplicas && readyReplicas > 0 {

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -110,6 +110,27 @@ func (r *InferenceServiceReconciler) reconcileSGLangSpecCondition(isvc *inferenc
 	})
 }
 
+// setSuspendedCondition records whether the service is administratively
+// suspended (spec.suspend). Uses meta.SetStatusCondition so external
+// controllers' foreign condition types are never disturbed.
+func setSuspendedCondition(isvc *inferencev1alpha1.InferenceService) {
+	status := metav1.ConditionFalse
+	reason := "NotSuspended"
+	message := "Service is not suspended"
+	if isvc.Spec.Suspend {
+		status = metav1.ConditionTrue
+		reason = "Suspended"
+		message = "Service is suspended (spec.suspend=true); workload scaled to zero, spec.replicas preserved"
+	}
+	meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+		Type:               "Suspended",
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	})
+}
+
 func (r *InferenceServiceReconciler) constructEndpoint(isvc *inferencev1alpha1.InferenceService, svc *corev1.Service) string {
 	port := int32(8080)
 	path := "/v1/chat/completions"
@@ -280,6 +301,11 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 		}
 		meta.SetStatusCondition(&isvc.Status.Conditions, condition)
 	}
+
+	// Set unconditionally (not gated on phase) so the Suspended condition
+	// flips to False on unsuspend rather than lingering True from a prior
+	// suspended pass.
+	setSuspendedCondition(isvc)
 
 	if err := r.Status().Update(ctx, isvc); err != nil {
 		log.Error(err, "Failed to update InferenceService status")

--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -125,6 +125,7 @@ func setSuspendedCondition(isvc *inferencev1alpha1.InferenceService) {
 	meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
 		Type:               "Suspended",
 		Status:             status,
+		ObservedGeneration: isvc.Generation,
 		Reason:             reason,
 		Message:            message,
 		LastTransitionTime: metav1.Now(),

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1025,21 +1025,29 @@ func (a *MetalAgent) deleteProcess(ctx context.Context, key string) error {
 	return nil
 }
 
-// Condition / reason constants for the "manually scaled to zero"
-// status patch. Kept here next to the only caller; if we grow more
-// agent-driven conditions they can move into a shared constants file.
+// Condition / reason constants for the stop-path status patch. Kept here
+// next to the only caller; if we grow more agent-driven conditions they can
+// move into a shared constants file. The phase strings must match the
+// operator's PhaseStopped / PhaseSuspended values (internal/controller):
+// determinePhase returns Suspended unconditionally for spec.suspend, so if
+// the agent wrote Stopped for a suspended service the two status writers
+// would overwrite each other forever (the operator's watch has no
+// status-only filter).
 const (
 	conditionAvailable          = "Available"
 	reasonManuallyScaledToZero  = "ManuallyScaledToZero"
+	reasonSuspended             = "Suspended"
 	phaseStopped                = "Stopped"
+	phaseSuspended              = "Suspended"
 	messageManuallyScaledToZero = "spec.replicas=0; metal-agent has torn down the workload"
+	messageSuspended            = "spec.suspend=true; metal-agent has torn down the workload; spec.replicas preserved"
 )
 
 // handleScaleToZero stops the managed process (if any) for an
-// InferenceService with spec.replicas=0 and patches its status so
-// downstream observers see Phase=Stopped + readyReplicas=0
-// immediately. Extracted from ensureProcess to keep the parent
-// function under the gocyclo threshold.
+// InferenceService with spec.replicas=0 or spec.suspend and patches its
+// status so downstream observers see Phase=Stopped (or Suspended) +
+// readyReplicas=0 immediately. Extracted from ensureProcess to keep the
+// parent function under the gocyclo threshold.
 func (a *MetalAgent) handleScaleToZero(
 	ctx context.Context,
 	isvc *inferencev1alpha1.InferenceService,
@@ -1047,8 +1055,9 @@ func (a *MetalAgent) handleScaleToZero(
 	exists bool,
 ) error {
 	if exists {
-		a.logger.Infow("replicas=0; stopping process",
-			"namespace", isvc.Namespace, "name", isvc.Name)
+		a.logger.Infow("scaled to zero or suspended; stopping process",
+			"namespace", isvc.Namespace, "name", isvc.Name,
+			"suspend", isvc.Spec.Suspend)
 		if err := a.deleteProcess(ctx, key); err != nil {
 			return err
 		}
@@ -1068,12 +1077,21 @@ func (a *MetalAgent) handleScaleToZero(
 
 // markStopped patches the InferenceService status to reflect that the
 // metal-agent has stopped the managed llama-server in response to
-// spec.replicas=0. Without this patch, kubectl / dashboards / any HPA-
-// style controller keep observing the stale Phase=Ready and
-// ReadyReplicas count from before the stop. Best-effort: the caller
-// logs and continues on error rather than blocking the stop itself.
+// spec.suspend or spec.replicas=0. Without this patch, kubectl /
+// dashboards / any HPA-style controller keep observing the stale
+// Phase=Ready and ReadyReplicas count from before the stop. Best-effort:
+// the caller logs and continues on error rather than blocking the stop
+// itself.
 //
-// Surfaced as https://github.com/defilantech/LLMKube/issues/452.
+// The phase written branches on the actual cause: suspend takes
+// precedence (mirroring the operator's determinePhase, which checks
+// Spec.Suspend before anything else) and writes Phase=Suspended with a
+// suspend-specific reason/message; only a true replicas==0 writes
+// Phase=Stopped/ManuallyScaledToZero. Writing Stopped for a suspended
+// service would fight the operator's Suspended phase forever.
+//
+// Surfaced as https://github.com/defilantech/LLMKube/issues/452;
+// suspend cause added for the Kueue integration (#1251).
 func (a *MetalAgent) markStopped(ctx context.Context, isvc *inferencev1alpha1.InferenceService) error {
 	// Re-fetch to avoid a stale resource version under conflict; the
 	// watch may have delivered an older copy than what the apiserver
@@ -1086,15 +1104,31 @@ func (a *MetalAgent) markStopped(ctx context.Context, isvc *inferencev1alpha1.In
 		return fmt.Errorf("fetch InferenceService for status patch: %w", err)
 	}
 
-	// Idempotency: if we already patched to Stopped, skip the round
-	// trip. This is hit on every reconcile for a long-stopped service.
-	if fresh.Status.Phase == phaseStopped &&
+	// Branch the status text on the cause, using the re-fetched spec as
+	// the source of truth (a suspend flipped between the watch event and
+	// now should win). Suspend beats replicas==0 when both hold, exactly
+	// like the operator's determinePhase ordering.
+	targetPhase := phaseStopped
+	reason := reasonManuallyScaledToZero
+	message := messageManuallyScaledToZero
+	if fresh.Spec.Suspend {
+		targetPhase = phaseSuspended
+		reason = reasonSuspended
+		message = messageSuspended
+	}
+
+	// Idempotency: if the status already reflects the target settled
+	// state (whichever cause applies), skip the round trip. This is hit
+	// on every reconcile for a long-stopped/suspended service, and it is
+	// what keeps the agent from thrashing against the operator, which
+	// also writes Phase=Suspended for suspended services.
+	if fresh.Status.Phase == targetPhase &&
 		fresh.Status.ReadyReplicas == 0 &&
 		fresh.Status.DesiredReplicas == 0 {
 		return nil
 	}
 
-	fresh.Status.Phase = phaseStopped
+	fresh.Status.Phase = targetPhase
 	fresh.Status.ReadyReplicas = 0
 	fresh.Status.DesiredReplicas = 0
 
@@ -1103,8 +1137,8 @@ func (a *MetalAgent) markStopped(ctx context.Context, isvc *inferencev1alpha1.In
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: fresh.Generation,
 		LastTransitionTime: metav1.Now(),
-		Reason:             reasonManuallyScaledToZero,
-		Message:            messageManuallyScaledToZero,
+		Reason:             reason,
+		Message:            message,
 	})
 
 	return a.config.K8sClient.Status().Update(ctx, fresh)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -747,6 +747,16 @@ func (a *MetalAgent) currentBackend() (string, bool) {
 	return "", false
 }
 
+// isvcStopped reports whether the InferenceService desires zero running
+// serving processes: either explicitly scaled to zero or administratively
+// suspended (spec.suspend, e.g. held by the Kueue integration).
+func isvcStopped(isvc *inferencev1alpha1.InferenceService) bool {
+	if isvc.Spec.Suspend {
+		return true
+	}
+	return isvc.Spec.Replicas != nil && *isvc.Spec.Replicas == 0
+}
+
 func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.InferenceService) error {
 	key := types.NamespacedName{
 		Namespace: isvc.Namespace,
@@ -804,10 +814,12 @@ func (a *MetalAgent) ensureProcess(ctx context.Context, isvc *inferencev1alpha1.
 		return nil
 	}
 
-	// Honor spec.replicas=0 by stopping a running process and not respawning.
-	// Without this, a user trying to take a model offline via spec edits has
-	// to fully reload the metal-agent to evict it.
-	if isvc.Spec.Replicas != nil && *isvc.Spec.Replicas == 0 {
+	// Honor spec.replicas=0 or spec.suspend by stopping a running process and
+	// not respawning. Without this, a user trying to take a model offline via
+	// spec edits has to fully reload the metal-agent to evict it; without the
+	// suspend half, the Kueue integration's admission hold would be ignored
+	// on hosts running the metal agent, since it doesn't watch Deployments.
+	if isvcStopped(isvc) {
 		return a.handleScaleToZero(ctx, isvc, key, exists)
 	}
 
@@ -1346,10 +1358,11 @@ func (a *MetalAgent) heartbeatOnce(ctx context.Context) {
 			continue
 		}
 
-		// Skip re-registration when the service is being deleted or has been
-		// scaled to zero. Re-asserting Service+Endpoints here would resurrect
-		// networking that deleteProcess (or handleScaleToZero) just cleaned up.
-		if isvc.DeletionTimestamp != nil || (isvc.Spec.Replicas != nil && *isvc.Spec.Replicas == 0) {
+		// Skip re-registration when the service is being deleted, scaled to
+		// zero, or suspended. Re-asserting Service+Endpoints here would
+		// resurrect networking that deleteProcess (or handleScaleToZero) just
+		// cleaned up.
+		if isvc.DeletionTimestamp != nil || isvcStopped(isvc) {
 			continue
 		}
 
@@ -1742,6 +1755,7 @@ func computeSpecHash(isvc *inferencev1alpha1.InferenceService) string {
 		ReasoningBudgetMessage string
 		Mode                   string
 		Replicas               *int32
+		Suspend                bool
 		Runtime                string
 		TurboQuantBits         *int32
 		PagedSSDCacheDir       *string
@@ -1770,6 +1784,7 @@ func computeSpecHash(isvc *inferencev1alpha1.InferenceService) string {
 		ReasoningBudgetMessage: isvc.Spec.ReasoningBudgetMessage,
 		Mode:                   isvc.Spec.Mode,
 		Replicas:               isvc.Spec.Replicas,
+		Suspend:                isvc.Spec.Suspend,
 		Runtime:                isvc.Spec.Runtime,
 		TurboQuantBits:         isvc.Spec.TurboQuantBits,
 		PagedSSDCacheDir:       isvc.Spec.PagedSSDCacheDir,

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -610,6 +610,22 @@ func TestComputeSpecHash_ChangesWithExtraArgs(t *testing.T) {
 	}
 }
 
+// TestComputeSpecHash_ChangesWithSuspend guards the change-detection snapshot
+// (#1251): flipping spec.suspend must change the hash so ensureProcess's
+// spec-drift check (line ~813) notices and re-evaluates the desired state —
+// otherwise a suspend->resume flip on an unhealthy/matching-hash process
+// could be missed by the drift path (though isvcStopped/handleScaleToZero
+// still gate the stop/start decision independently).
+func TestComputeSpecHash_ChangesWithSuspend(t *testing.T) {
+	a := &inferencev1alpha1.InferenceService{Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m"}}
+	b := &inferencev1alpha1.InferenceService{
+		Spec: inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", Suspend: true},
+	}
+	if computeSpecHash(a) == computeSpecHash(b) {
+		t.Error("hash should differ when suspend changes")
+	}
+}
+
 func TestComputeSpecHash_NilIsvc(t *testing.T) {
 	if computeSpecHash(nil) != "" {
 		t.Error("nil isvc should produce empty hash, not panic")
@@ -818,6 +834,131 @@ func TestEnsureProcess_ReplicasZeroNoOpWhenNoProcess(t *testing.T) {
 
 	if err := agent.ensureProcess(context.Background(), isvc); err != nil {
 		t.Errorf("replicas=0 with no existing process should be a no-op (no error), got: %v", err)
+	}
+}
+
+// TestEnsureProcess_SuspendTrueTakesReplicasZeroStopPath covers the Kueue
+// integration path (#1251): an admission controller sets spec.suspend while
+// leaving spec.replicas at its prior desired count (2, not 0), so the count
+// is preserved for resume. The metal-agent must still take the identical
+// stop path as replicas=0 — same handleScaleToZero call, same status patch
+// (Phase=Stopped, reason=ManuallyScaledToZero) — proving suspend and
+// replicas=0 are handled by the same code path, not just a similar one.
+//
+// Deliberately does not pre-seed a managed process: this isolates the
+// status-patch side of the stop path (mirrors
+// TestEnsureProcess_ReplicasZeroPatchesStatus) without also depending on the
+// unrelated spec-hash-drift restart branch, which would evict a pre-seeded
+// process regardless of whether isvcStopped is honored.
+func TestEnsureProcess_SuspendTrueTakesReplicasZeroStopPath(t *testing.T) {
+	scheme := newTestScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+
+	replicas := int32(2)
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "suspended-isvc",
+			Namespace:  "default",
+			Generation: 4,
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "any-model",
+			Replicas: &replicas,
+			Suspend:  true,
+		},
+		Status: inferencev1alpha1.InferenceServiceStatus{
+			Phase:           "Ready",
+			ReadyReplicas:   1,
+			DesiredReplicas: 2,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&inferencev1alpha1.InferenceService{}).
+		WithRuntimeObjects(isvc).
+		Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
+	agent.executors["llama-server"] = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
+
+	if err := agent.ensureProcess(context.Background(), isvc); err != nil {
+		t.Fatalf("ensureProcess returned unexpected error: %v", err)
+	}
+
+	got := &inferencev1alpha1.InferenceService{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "suspended-isvc", Namespace: "default"}, got); err != nil {
+		t.Fatalf("fetch InferenceService back: %v", err)
+	}
+
+	if got.Status.Phase != "Stopped" {
+		t.Errorf("status.phase = %q, want Stopped (suspend=true, replicas=2 must take the stop path)", got.Status.Phase)
+	}
+	if got.Status.ReadyReplicas != 0 {
+		t.Errorf("status.readyReplicas = %d, want 0", got.Status.ReadyReplicas)
+	}
+	if got.Status.DesiredReplicas != 0 {
+		t.Errorf("status.desiredReplicas = %d, want 0", got.Status.DesiredReplicas)
+	}
+
+	var foundCond bool
+	for _, c := range got.Status.Conditions {
+		if c.Type == conditionAvailable {
+			foundCond = true
+			if c.Status != metav1.ConditionFalse {
+				t.Errorf("Available condition status = %q, want False", c.Status)
+			}
+			if c.Reason != reasonManuallyScaledToZero {
+				t.Errorf("Available condition reason = %q, want %q",
+					c.Reason, reasonManuallyScaledToZero)
+			}
+		}
+	}
+	if !foundCond {
+		t.Error("Available condition not set on suspended InferenceService")
+	}
+}
+
+// TestEnsureProcess_SuspendFalseWithReplicasIsNotStopped is the inverse of
+// TestEnsureProcess_SuspendTrueTakesReplicasZeroStopPath: with suspend left
+// false, a positive replicas count must not be treated as stopped, so a
+// healthy process with a matching spec hash is left running.
+func TestEnsureProcess_SuspendFalseWithReplicasIsNotStopped(t *testing.T) {
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
+	agent.executors["llama-server"] = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
+
+	replicas := int32(2)
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "not-suspended-isvc", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "any-model",
+			Replicas: &replicas,
+			Suspend:  false,
+		},
+	}
+
+	// Pre-seed a healthy process whose SpecHash matches the incoming spec, so
+	// if isvcStopped incorrectly reports true, the process would be deleted
+	// instead of hitting the no-op fast path.
+	agent.processes["default/not-suspended-isvc"] = &ManagedProcess{
+		Name:      "not-suspended-isvc",
+		Namespace: "default",
+		Healthy:   true,
+		SpecHash:  computeSpecHash(isvc),
+	}
+
+	if err := agent.ensureProcess(context.Background(), isvc); err != nil {
+		t.Errorf("suspend=false with matching specHash should no-op without error, got: %v", err)
+	}
+	if _, exists := agent.processes["default/not-suspended-isvc"]; !exists {
+		t.Error("process entry should remain running when suspend=false, even with replicas > 0")
 	}
 }
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -840,10 +840,15 @@ func TestEnsureProcess_ReplicasZeroNoOpWhenNoProcess(t *testing.T) {
 // TestEnsureProcess_SuspendTrueTakesReplicasZeroStopPath covers the Kueue
 // integration path (#1251): an admission controller sets spec.suspend while
 // leaving spec.replicas at its prior desired count (2, not 0), so the count
-// is preserved for resume. The metal-agent must still take the identical
-// stop path as replicas=0 — same handleScaleToZero call, same status patch
-// (Phase=Stopped, reason=ManuallyScaledToZero) — proving suspend and
-// replicas=0 are handled by the same code path, not just a similar one.
+// is preserved for resume. The metal-agent must take the same stop path as
+// replicas=0 (same handleScaleToZero call), but the status patch must state
+// the true cause: Phase=Suspended, matching the operator's determinePhase,
+// which returns PhaseSuspended unconditionally for spec.suspend. Writing
+// Stopped here would make the two writers overwrite each other forever
+// (Suspended<->Stopped thrash: the operator's watch has no status-only
+// filter). The reason/message must also be suspend-specific — the
+// replicas=0 wording ("spec.replicas=0...") would be factually wrong in
+// kubectl describe for a suspend with replicas=2.
 //
 // Deliberately does not pre-seed a managed process: this isolates the
 // status-patch side of the stop path (mirrors
@@ -894,8 +899,9 @@ func TestEnsureProcess_SuspendTrueTakesReplicasZeroStopPath(t *testing.T) {
 		t.Fatalf("fetch InferenceService back: %v", err)
 	}
 
-	if got.Status.Phase != "Stopped" {
-		t.Errorf("status.phase = %q, want Stopped (suspend=true, replicas=2 must take the stop path)", got.Status.Phase)
+	if got.Status.Phase != "Suspended" {
+		t.Errorf("status.phase = %q, want Suspended (must match the operator's PhaseSuspended, or the two writers thrash)",
+			got.Status.Phase)
 	}
 	if got.Status.ReadyReplicas != 0 {
 		t.Errorf("status.readyReplicas = %d, want 0", got.Status.ReadyReplicas)
@@ -911,14 +917,108 @@ func TestEnsureProcess_SuspendTrueTakesReplicasZeroStopPath(t *testing.T) {
 			if c.Status != metav1.ConditionFalse {
 				t.Errorf("Available condition status = %q, want False", c.Status)
 			}
-			if c.Reason != reasonManuallyScaledToZero {
+			if c.Reason != reasonSuspended {
 				t.Errorf("Available condition reason = %q, want %q",
-					c.Reason, reasonManuallyScaledToZero)
+					c.Reason, reasonSuspended)
+			}
+			if c.Message != messageSuspended {
+				t.Errorf("Available condition message = %q, want %q (the replicas=0 wording would be false for suspend)",
+					c.Message, messageSuspended)
 			}
 		}
 	}
 	if !foundCond {
 		t.Error("Available condition not set on suspended InferenceService")
+	}
+}
+
+// TestMarkStopped_SuspendedPhaseIsIdempotent verifies the idempotency guard
+// treats the operator-written Suspended phase as settled: a second
+// ensureProcess on an already-Suspended InferenceService must not rewrite
+// status (no condition transition churn). Before the cause-aware guard, the
+// agent only recognized Stopped as settled, so it kept flipping the
+// operator's Suspended phase back to Stopped on every reconcile — and the
+// operator flipped it right back (status thrash, no status-only watch
+// filter on the operator side).
+func TestMarkStopped_SuspendedPhaseIsIdempotent(t *testing.T) {
+	scheme := newTestScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = discoveryv1.AddToScheme(scheme)
+
+	replicas := int32(2)
+	prev := metav1.NewTime(metav1.Now().Add(-time.Hour))
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "settled-suspended",
+			Namespace:  "default",
+			Generation: 5,
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "any-model",
+			Replicas: &replicas,
+			Suspend:  true,
+		},
+		Status: inferencev1alpha1.InferenceServiceStatus{
+			Phase:           "Suspended",
+			ReadyReplicas:   0,
+			DesiredReplicas: 0,
+			Conditions: []metav1.Condition{{
+				Type:               conditionAvailable,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 5,
+				LastTransitionTime: prev,
+				Reason:             reasonSuspended,
+				Message:            messageSuspended,
+			}},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&inferencev1alpha1.InferenceService{}).
+		WithRuntimeObjects(isvc).
+		Build()
+
+	agent := NewMetalAgent(MetalAgentConfig{K8sClient: k8sClient, Namespace: "default"})
+	agent.executors["llama-server"] = NewMetalExecutor("/fake/llama-server", "/tmp/models", newNopLogger())
+	agent.registry = NewServiceRegistry(k8sClient, "", newNopLogger(), "")
+
+	// Snapshot the seeded transition time as the fake client stored it
+	// (second precision), mirroring
+	// TestEnsureProcess_ReplicasZeroStatusPatchIdempotent — comparing
+	// against the test's own metav1 value would mis-fire on sub-second
+	// serialization drift unrelated to the idempotency under test.
+	seeded := &inferencev1alpha1.InferenceService{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "settled-suspended", Namespace: "default"}, seeded); err != nil {
+		t.Fatalf("fetch seeded InferenceService: %v", err)
+	}
+	var seededTransition metav1.Time
+	for _, c := range seeded.Status.Conditions {
+		if c.Type == conditionAvailable {
+			seededTransition = c.LastTransitionTime
+		}
+	}
+
+	if err := agent.ensureProcess(context.Background(), isvc); err != nil {
+		t.Fatalf("ensureProcess returned unexpected error: %v", err)
+	}
+
+	got := &inferencev1alpha1.InferenceService{}
+	if err := k8sClient.Get(context.Background(),
+		types.NamespacedName{Name: "settled-suspended", Namespace: "default"}, got); err != nil {
+		t.Fatalf("fetch InferenceService back: %v", err)
+	}
+
+	if got.Status.Phase != "Suspended" {
+		t.Errorf("status.phase = %q, want Suspended left untouched (guard must treat Suspended as settled)", got.Status.Phase)
+	}
+	for _, c := range got.Status.Conditions {
+		if c.Type == conditionAvailable && !c.LastTransitionTime.Equal(&seededTransition) {
+			t.Errorf("Available condition transition time churned (%v -> %v); "+
+				"already-settled Suspended status must not be rewritten",
+				seededTransition, c.LastTransitionTime)
+		}
 	}
 }
 
@@ -1031,6 +1131,10 @@ func TestEnsureProcess_ReplicasZeroPatchesStatus(t *testing.T) {
 			if c.Reason != reasonManuallyScaledToZero {
 				t.Errorf("Available condition reason = %q, want %q",
 					c.Reason, reasonManuallyScaledToZero)
+			}
+			if c.Message != messageManuallyScaledToZero {
+				t.Errorf("Available condition message = %q, want %q",
+					c.Message, messageManuallyScaledToZero)
 			}
 			if c.ObservedGeneration != 7 {
 				t.Errorf("Available condition observedGeneration = %d, want 7",

--- a/pkg/apiutil/gpu.go
+++ b/pkg/apiutil/gpu.go
@@ -1,0 +1,70 @@
+// Package apiutil exposes stable helpers over the LLMKube API types for
+// external components (e.g. the llmkube-kueue integration) that need the
+// same GPU resource mapping the operator applies, without importing
+// operator internals.
+package apiutil
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+const (
+	runtimeVulkan = "vulkan"
+	runtimeROCm   = "rocm"
+)
+
+var (
+	nvidiaGPUResourceName    = corev1.ResourceName("nvidia.com/gpu")
+	amdGPUResourceName       = corev1.ResourceName("amd.com/gpu")
+	intelGPUResourceNameI915 = corev1.ResourceName("gpu.intel.com/i915")
+	vulkanDRIResourceName    = corev1.ResourceName("devic.es/dri-render")
+)
+
+func isRuntime(runtime, want string) bool {
+	return strings.EqualFold(strings.TrimSpace(runtime), want)
+}
+
+// GPUResourceName resolves the extended resource name an InferenceService
+// pod requests for GPU scheduling, given its referenced Model. Resolution
+// order matches the operator's deployment builder:
+//
+//  1. Model.Spec.Hardware.GPU.ResourceName override wins.
+//  2. amd vendor with the vulkan or rocm runtime -> devic.es/dri-render.
+//  3. Vendor default: nvidia -> nvidia.com/gpu, amd -> amd.com/gpu,
+//     intel -> gpu.intel.com/i915.
+//  4. Nil/unset/unknown -> nvidia.com/gpu.
+func GPUResourceName(model *inferencev1alpha1.Model) corev1.ResourceName {
+	if model != nil && model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil {
+		if override := strings.TrimSpace(model.Spec.Hardware.GPU.ResourceName); override != "" {
+			return corev1.ResourceName(override)
+		}
+		switch strings.ToLower(strings.TrimSpace(model.Spec.Hardware.GPU.Vendor)) {
+		case "amd":
+			if isRuntime(model.Spec.Hardware.GPU.Runtime, runtimeVulkan) ||
+				isRuntime(model.Spec.Hardware.GPU.Runtime, runtimeROCm) {
+				return vulkanDRIResourceName
+			}
+			return amdGPUResourceName
+		case "intel":
+			return intelGPUResourceNameI915
+		}
+	}
+	return nvidiaGPUResourceName
+}
+
+// GPUCount determines the desired GPU count per replica: the Model's
+// hardware count wins, else the InferenceService resources.gpu, else 0.
+// Both arguments are nil-safe.
+func GPUCount(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) int32 {
+	if model != nil && model.Spec.Hardware != nil && model.Spec.Hardware.GPU != nil && model.Spec.Hardware.GPU.Count > 0 {
+		return model.Spec.Hardware.GPU.Count
+	}
+	if isvc != nil && isvc.Spec.Resources != nil && isvc.Spec.Resources.GPU > 0 {
+		return isvc.Spec.Resources.GPU
+	}
+	return 0
+}

--- a/pkg/apiutil/gpu_test.go
+++ b/pkg/apiutil/gpu_test.go
@@ -1,0 +1,70 @@
+package apiutil
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func modelWithGPU(gpu *inferencev1alpha1.GPUSpec) *inferencev1alpha1.Model {
+	return &inferencev1alpha1.Model{
+		Spec: inferencev1alpha1.ModelSpec{
+			Hardware: &inferencev1alpha1.HardwareSpec{GPU: gpu},
+		},
+	}
+}
+
+func TestGPUResourceName(t *testing.T) {
+	cases := []struct {
+		name  string
+		model *inferencev1alpha1.Model
+		want  corev1.ResourceName
+	}{
+		{"nil model defaults to nvidia", nil, corev1.ResourceName("nvidia.com/gpu")},
+		{"explicit override wins", modelWithGPU(&inferencev1alpha1.GPUSpec{ResourceName: "squat.ai/dri-render", Vendor: "amd"}), corev1.ResourceName("squat.ai/dri-render")},
+		{"amd vulkan uses dri-render", modelWithGPU(&inferencev1alpha1.GPUSpec{Vendor: "amd", Runtime: "vulkan"}), corev1.ResourceName("devic.es/dri-render")},
+		{"amd rocm uses dri-render", modelWithGPU(&inferencev1alpha1.GPUSpec{Vendor: "amd", Runtime: "rocm"}), corev1.ResourceName("devic.es/dri-render")},
+		{"amd default uses amd.com/gpu", modelWithGPU(&inferencev1alpha1.GPUSpec{Vendor: "amd"}), corev1.ResourceName("amd.com/gpu")},
+		{"intel uses i915", modelWithGPU(&inferencev1alpha1.GPUSpec{Vendor: "intel"}), corev1.ResourceName("gpu.intel.com/i915")},
+		{"unknown vendor defaults to nvidia", modelWithGPU(&inferencev1alpha1.GPUSpec{Vendor: "other"}), corev1.ResourceName("nvidia.com/gpu")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GPUResourceName(tc.model); got != tc.want {
+				t.Fatalf("GPUResourceName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGPUCount(t *testing.T) {
+	isvcWith := func(gpu int32) *inferencev1alpha1.InferenceService {
+		return &inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: gpu},
+			},
+		}
+	}
+	cases := []struct {
+		name  string
+		isvc  *inferencev1alpha1.InferenceService
+		model *inferencev1alpha1.Model
+		want  int32
+	}{
+		{"model count wins", isvcWith(1), modelWithGPU(&inferencev1alpha1.GPUSpec{Count: 2}), 2},
+		{"isvc count when model has none", isvcWith(3), modelWithGPU(&inferencev1alpha1.GPUSpec{}), 3},
+		{"zero when neither set", &inferencev1alpha1.InferenceService{}, modelWithGPU(nil), 0},
+		{"nil model is safe", isvcWith(2), nil, 2},
+		{"nil isvc is safe", nil, modelWithGPU(&inferencev1alpha1.GPUSpec{Count: 4}), 4},
+		{"both nil is zero", nil, nil, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GPUCount(tc.isvc, tc.model); got != tc.want {
+				t.Fatalf("GPUCount() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Kueue prerequisites in the core operator (slice 0 of the Kueue integration epic #1253): a first-class `InferenceService.spec.suspend` field, GPUQuota admission deferral for Kueue-managed services, and a public `pkg/apiutil` package exposing the GPU resource mapping.

## Why

The external [llmkube-kueue](https://github.com/defilantech/llmkube-kueue) component (#1252, requested in #1249) needs three things from the core operator: a spec-level suspend lever the reconciler honors, quota admission that does not double-gate services whose quota is owned by Kueue, and importable GPU mapping helpers. Each is also useful standalone (suspend parks a service without losing its scale).

Fixes #1251

## How

- **`spec.suspend`**: the reconciler forces the desired replica count to zero while `spec.replicas` is preserved, reports phase `Suspended` (new enum value) plus a `Suspended` condition (with `ObservedGeneration` for external consumers). The HPA is deleted while suspended (its `minReplicas >= 1` would otherwise defeat suspension via the live-count preserve path, which is also bypassed) and recreated on resume. The metal-agent treats suspend as stop through the same `isvcStopped` helper and writes the identical `Suspended` phase with a truthful message, with an idempotency guard so the operator and agent never thrash each other's status.
- **GPUQuota deferral**: the validating webhook early-returns (admits) when the InferenceService carries `kueue.x-k8s.io/queue-name`, after spec validation (gpuSharing rules still apply). Without this, Kueue admitting a suspended service would be re-denied by our own webhook under a tight quota, a hard deadlock. Unlabeled services are gated exactly as before; GPUQuota status keeps aggregating all services for observability.
- **`pkg/apiutil`**: `GPUResourceName` and `GPUCount` reproduce the internal resolution logic (the internal functions now delegate), nil-safe on both arguments, importable by external modules.
- Docs in `docs/kueue-integration.md`, including the RBAC note (the label is a quota bypass; label RBAC is the guard) and the mixed-namespace usage-aggregation note. CRD and chart mirrors regenerated.

Follow-ups intentionally not in this PR (from the final branch review): a drift guard for the GPU resource-name literals now present in both `pkg/apiutil` and `internal/controller`; hoisting the phase-string constants shared by operator and metal-agent into a common package; condition hygiene for the pre-existing stale `Available: True` pattern shared by `Stopped` and now `Suspended`.

AI assistance: implemented with AI coding agents under maintainer direction and review; every change human-reviewed before merge.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (including `GOOS=linux` cross-arch)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)
