### PR TITLE
feat: cache prep subcommand with direct chown/chmod syscalls (#890 item 3)

### DIFF
--- a/pkg/cli/cache.go
+++ b/pkg/cli/cache.go
@@ -79,6 +79,7 @@ Examples:
 	cmd.AddCommand(newCacheListCommand())
 	cmd.AddCommand(newCacheClearCommand())
 	cmd.AddCommand(newCachePreloadCommand())
+	cmd.AddCommand(NewCachePrepCommand())
 
 	return cmd
 }

--- a/pkg/cli/cache_prep.go
+++ b/pkg/cli/cache_prep.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// parseOwner parses a "uid:gid" string into two int values.
+// Returns an error if the format is invalid or the integers do not parse.
+func parseOwner(owner string) (int, int, error) {
+	parts := strings.Split(owner, ":")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid owner format %q: expected uid:gid", owner)
+	}
+	if parts[0] == "" || parts[1] == "" {
+		return 0, 0, fmt.Errorf("invalid owner format %q: uid and gid must not be empty", owner)
+	}
+	uid, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid uid in %q: %w", owner, err)
+	}
+	gid, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid gid in %q: %w", owner, err)
+	}
+	return uid, gid, nil
+}
+
+// parseMode parses an octal mode string (e.g. "0775") into an os.FileMode.
+func parseMode(mode string) (os.FileMode, error) {
+	v, err := strconv.ParseUint(mode, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid octal mode %q: %w", mode, err)
+	}
+	return os.FileMode(v), nil
+}
+
+// NewCachePrepCommand creates the cache-prep subcommand.
+func NewCachePrepCommand() *cobra.Command {
+	var owner, mode string
+
+	cmd := &cobra.Command{
+		Use:   "prep DIR",
+		Short: "Prepare a model cache directory for shared access",
+		Long: `Prepare a model cache directory for shared access by changing its
+ownership and permissions via direct syscalls.
+
+This command is intended to be used as the entrypoint of an init container
+so that it retains its effective capabilities (CAP_CHOWN/CAP_FOWNER) without
+an intermediate exec. It calls os.Chown and os.Chmod directly.
+
+Examples:
+  # Change ownership to root:102 and set group rwX
+  llmkube cache prep --owner 0:102 --mode 0775 /models
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := args[0]
+
+			// Validate target directory exists and is a directory.
+			info, err := os.Stat(dir)
+			if err != nil {
+				return fmt.Errorf("cannot stat target directory %q: %w", dir, err)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("target %q is not a directory", dir)
+			}
+
+			// Parse owner.
+			uid, gid, err := parseOwner(owner)
+			if err != nil {
+				return err
+			}
+
+			// Parse mode.
+			fileMode, err := parseMode(mode)
+			if err != nil {
+				return err
+			}
+
+			// Perform chown.
+			if err := os.Chown(dir, uid, gid); err != nil {
+				return fmt.Errorf("chown %q to %d:%d: %w", dir, uid, gid, err)
+			}
+
+			// Perform chmod.
+			if err := os.Chmod(dir, fileMode); err != nil {
+				return fmt.Errorf("chmod %q to %o: %w", dir, fileMode, err)
+			}
+
+			fmt.Printf("Prepared %q: owner %d:%d, mode %o\n", dir, uid, gid, fileMode)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&owner, "owner", "", "Owner in uid:gid format (e.g. 0:102)")
+	cmd.Flags().StringVar(&mode, "mode", "", "Octal permission mode (e.g. 0775)")
+	_ = cmd.MarkFlagRequired("owner")
+	_ = cmd.MarkFlagRequired("mode")
+
+	return cmd
+}

--- a/pkg/cli/cache_prep_test.go
+++ b/pkg/cli/cache_prep_test.go
@@ -1,0 +1,309 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"os"
+	"os/user"
+	"runtime"
+	"strconv"
+	"testing"
+)
+
+func TestParseOwner(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantUID int
+		wantGID int
+		wantErr bool
+	}{
+		{"valid 0:102", "0:102", 0, 102, false},
+		{"valid 1000:1000", "1000:1000", 1000, 1000, false},
+		{"valid 0:0", "0:0", 0, 0, false},
+		{"invalid abc", "abc", 0, 0, true},
+		{"invalid 1:", "1:", 0, 0, true},
+		{"invalid :2", ":2", 0, 0, true},
+		{"invalid 1:2:3", "1:2:3", 0, 0, true},
+		{"invalid empty", "", 0, 0, true},
+		{"invalid uid not int", "abc:102", 0, 0, true},
+		{"invalid gid not int", "0:abc", 0, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uid, gid, err := parseOwner(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseOwner(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if uid != tt.wantUID {
+					t.Errorf("parseOwner(%q) uid = %d, want %d", tt.input, uid, tt.wantUID)
+				}
+				if gid != tt.wantGID {
+					t.Errorf("parseOwner(%q) gid = %d, want %d", tt.input, gid, tt.wantGID)
+				}
+			}
+		})
+	}
+}
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    os.FileMode
+		wantErr bool
+	}{
+		{"valid 0775", "0775", 0775, false},
+		{"valid 0755", "0755", 0755, false},
+		{"valid 0644", "0644", 0644, false},
+		{"valid 0777", "0777", 0777, false},
+		{"invalid abc", "abc", 0, true},
+		{"invalid 9999", "9999", 0, true},
+		{"invalid empty", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mode, err := parseMode(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseMode(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && mode != tt.want {
+				t.Errorf("parseMode(%q) = %o, want %o", tt.input, mode, tt.want)
+			}
+		})
+	}
+}
+
+func TestChmodChangesMode(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cache-prep-chmod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+
+	// Set initial mode.
+	if err := os.Chmod(tmpDir, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewCachePrepCommand()
+	cmd.SetArgs([]string{"--owner", "0:0", "--mode", "0775", tmpDir})
+
+	// We expect chown to fail (unless running as root), but we can still
+	// test the chmod path by checking the error message contains "chown".
+	// Instead, test chmod directly via parseMode + os.Chmod.
+	mode, err := parseMode("0775")
+	if err != nil {
+		t.Fatalf("parseMode(0775): %v", err)
+	}
+	if err := os.Chmod(tmpDir, mode); err != nil {
+		t.Fatalf("os.Chmod: %v", err)
+	}
+
+	info, err := os.Stat(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0775 {
+		t.Errorf("chmod did not change mode: got %o, want 0775", info.Mode().Perm())
+	}
+}
+
+func TestChownSameOwnerSucceeds(t *testing.T) {
+	// Get the current process uid/gid — chown to self always succeeds.
+	u, err := user.Current()
+	if err != nil {
+		t.Skip("cannot determine current user")
+	}
+	_, err = strconv.Atoi(u.Uid)
+	if err != nil {
+		t.Skipf("cannot parse uid %q: %v", u.Uid, err)
+	}
+	_, err = strconv.Atoi(u.Gid)
+	if err != nil {
+		t.Skipf("cannot parse gid %q: %v", u.Gid, err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "cache-prep-chown")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+
+	owner := u.Uid + ":" + u.Gid
+	cmd := NewCachePrepCommand()
+	cmd.SetArgs([]string{"--owner", owner, "--mode", "0755", tmpDir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cache-prep to same owner failed: %v", err)
+	}
+}
+
+func TestMissingTargetErrors(t *testing.T) {
+	cmd := NewCachePrepCommand()
+	cmd.SetArgs([]string{"--owner", "0:0", "--mode", "0755", "/nonexistent-dir-12345"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing target directory, got nil")
+	}
+}
+
+func TestNotADirectoryErrors(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "cache-prep-file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("close temp file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+
+	cmd := NewCachePrepCommand()
+	cmd.SetArgs([]string{"--owner", "0:0", "--mode", "0755", tmpFile.Name()})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-directory target, got nil")
+	}
+}
+
+func TestNewCachePrepCommand(t *testing.T) {
+	cmd := NewCachePrepCommand()
+
+	if cmd.Use != "prep DIR" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "prep DIR")
+	}
+
+	if f := cmd.Flags().Lookup("owner"); f == nil {
+		t.Error("Missing --owner flag")
+	}
+
+	if f := cmd.Flags().Lookup("mode"); f == nil {
+		t.Error("Missing --mode flag")
+	}
+}
+
+func TestCachePrepRegistered(t *testing.T) {
+	cmd := NewCacheCommand()
+
+	subcommands := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		subcommands[sub.Name()] = true
+	}
+
+	if !subcommands["prep"] {
+		t.Error("cache-prep subcommand not registered under cache command")
+	}
+}
+
+func TestCachePrepRequiresOwnerAndMode(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cache-prep-flags")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+
+	cmd := NewCachePrepCommand()
+
+	// Missing --owner
+	cmd.SetArgs([]string{"--mode", "0755", tmpDir})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when --owner is missing")
+	}
+
+	// Missing --mode
+	cmd.SetArgs([]string{"--owner", "0:0", tmpDir})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when --mode is missing")
+	}
+}
+
+func TestCachePrepRequiresExactlyOneArg(t *testing.T) {
+	cmd := NewCachePrepCommand()
+
+	// No args
+	cmd.SetArgs([]string{"--owner", "0:0", "--mode", "0755"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when no directory arg is provided")
+	}
+
+	// Too many args
+	cmd.SetArgs([]string{"--owner", "0:0", "--mode", "0755", "/a", "/b"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when too many args are provided")
+	}
+}
+
+func TestCachePrepEndToEnd(t *testing.T) {
+	// Skip on Windows where chown/chmod semantics differ.
+	if runtime.GOOS == "windows" {
+		t.Skip("chown/chmod not supported on Windows")
+	}
+
+	u, err := user.Current()
+	if err != nil {
+		t.Skip("cannot determine current user")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "cache-prep-e2e")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+
+	owner := u.Uid + ":" + u.Gid
+	cmd := NewCachePrepCommand()
+	cmd.SetArgs([]string{"--owner", owner, "--mode", "0775", tmpDir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cache-prep failed: %v", err)
+	}
+
+	info, err := os.Stat(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0775 {
+		t.Errorf("mode after cache-prep = %o, want 0775", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## What

A `llmkube cache prep` subcommand that changes ownership and permissions on a target directory via direct Go syscalls (os.Chown / os.Chmod) instead of shelling out, plus unit tests.

## Why

This is the load-bearing primitive from item 3 of #890: the model-cache-prep init container currently runs `sh -c "chown ... && chmod ..."` and must run as root because containerd clears ambient capabilities on exec. A helper that performs the syscalls as its own entrypoint process, with no intermediate exec, retains effective CAP_CHOWN/CAP_FOWNER, which is what lets a follow-up run the prep non-root at PSA baseline.

Refs #890 (item 3 primitive only; wiring it into the init container, the init-image packaging decision, and the fsGroupPolicy=None CSI e2e remain, so this does not close the issue).

## How

- `cache prep --owner <uid>:<gid> --mode <octal> <dir>`: validates inputs (malformed owner, unparseable mode, missing or non-directory target all return clear errors), then os.Chown + os.Chmod directly. Stdlib only.
- Tests cover owner parsing (valid and malformed forms), octal mode parsing, an actual chmod on a temp dir, a same-owner chown (portable without root; privileged chown is not testable in CI), missing/non-directory targets, required flags, and end-to-end execution.

Provenance: authored by an autonomous Foreman coder run against #890 (verdict GO). The original gate run returned a false GATE-FAIL caused by a stale fork main in the gate's bite check (unrelated-package compile failures; forensics and fix tracked in a separate Foreman bug issue). The commit is cherry-picked unchanged onto current main; all gate checks (build, fmt, vet, lint, pkg/cli tests) re-run green locally.

AI assistance: implemented by an autonomous Foreman coder agent; human-reviewed, verified, and cherry-picked by the maintainer.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (pkg/cli suite; full build green)
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)
