### PR TITLE
feat(charts/foreman): expose the agent --accelerator flag (#1242)

### DIFF
--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -73,6 +73,9 @@ spec:
             {{- end }}
             {{- /* Always set: the binary default is "foreman-system", a namespace the chart never creates, so gate Jobs would land where the cache PVC does not exist. */}}
             - --foreman-namespace={{ $agent.foremanNamespace | default (include "foreman.namespace" $) }}
+            {{- if $agent.accelerator }}
+            - --accelerator={{ $agent.accelerator }}
+            {{- end }}
             {{- if $agent.installedModels }}
             - --installed-models={{ join "," $agent.installedModels }}
             {{- end }}

--- a/charts/foreman/tests/agents_test.yaml
+++ b/charts/foreman/tests/agents_test.yaml
@@ -211,6 +211,42 @@ tests:
           content:
             name: GITHUB_TOKEN
 
+  # ---- Accelerator flag (#1242) ----
+
+  - it: --accelerator flag renders when agent.accelerator is set
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.accelerator: cuda
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --accelerator=cuda
+
+  - it: --accelerator flag is absent when agent.accelerator is unset
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --accelerator=
+
+  - it: per-agent accelerator override beats the shared agent default
+    template: agent-deployment.yaml
+    set:
+      agent.accelerator: cuda
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --accelerator=vulkan
+
   # ---- agent.enabled: false skips that agent ----
 
   - it: agents entry with enabled false is omitted from the deployment list

--- a/charts/foreman/tests/values-multi.yaml
+++ b/charts/foreman/tests/values-multi.yaml
@@ -28,6 +28,7 @@ agents:
     coderGitSecretKey: token
     gateCache:
       enabled: false
+    accelerator: vulkan
   omitted-enabled:
     replicaCount: 5
     roles: [worker]

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -313,6 +313,11 @@ agent:
   # and the agent live in different namespaces.
   foremanNamespace: ""
 
+  # Accelerator family this node advertises in its FleetNode capability.
+  # One of: metal, cuda, vulkan, none. Required on Linux, since the
+  # scheduler rejects capability-pinned tasks when this is empty.
+  accelerator: ""
+
   # Models the foreman-agent advertises in its FleetNode.spec
   # heartbeat. Use kebab-case slugs (e.g. "qwen36-35b-carnice-mtp").
   installedModels: []


### PR DESCRIPTION
## What

`charts/foreman` gains an `agent.accelerator` value rendered as `--accelerator=<value>` on the foreman-agent container, with per-agent deep-merge through the `agents:` map and helm-unittest coverage (set, unset, and per-agent override cases).

## Why

Chart-installed Linux FleetNodes advertised no accelerator, so every capability-pinned task (including the repo's own shipped `gate.yaml` sample, pinned to `cuda`) hung Pending forever with no explanation. The binary documents the flag as required on Linux; the chart, the supported Linux install path, had no way to set it.

Fixes #1242

## How

Mirrors how #933 exposed `--foreman-namespace`: a documented `accelerator: ""` field under `agent:` in values.yaml, a conditional flag render in `agent-deployment.yaml` scoped per-agent so overrides in the `agents:` map win, and three new helm-unittest cases in `agents_test.yaml` proving the flag renders when set, is absent when unset, and per-agent values beat the shared default.

Provenance: authored by an autonomous Foreman coder run against #1242 (verdict GO), verified by the gate's new generic profile running real chart checks: `helm lint`, `helm template`, and a functional render assertion (flag present when `agent.accelerator=cuda`, absent when unset) -> GATE-PASS. First production use of the generic gate path, closing the non-Go blind spot (#1072) for this run by configuration. Branch cut from current main by the coder harness; opened unchanged.

AI assistance: implemented by an autonomous Foreman coder agent; human-reviewed, verified, and submitted by the maintainer.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (chart-only diff; helm lint + template + unittest cover it, verified by the gate and CI)
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)
