### PR TITLE
fix: waitForIdle proceeds past crashlooping pods; truthful deferral reason on mixed state (#1250)

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -73,6 +73,13 @@ const (
 	// implement IdleDetector, so drain-before-roll cannot probe idleness.
 	ReasonIdleCheckUnsupported string = "IdleCheckUnsupported"
 
+	// ReasonPodsCrashLooping is set when RolloutDeferred=True because some
+	// old-generation pods are crashlooping (not Ready) while others are Ready
+	// and serving. The rollout is deferred to protect in-flight work on the
+	// Ready pods; when ALL old pods are unready the rollout proceeds instead
+	// (no work to protect).
+	ReasonPodsCrashLooping string = "PodsCrashLooping"
+
 	// DefaultIdleCheckInterval is how often the controller re-checks pod
 	// idleness when waiting for idle before rollout.
 	DefaultIdleCheckInterval = 5 * time.Second

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -2024,6 +2024,9 @@ var _ = Describe("countOldPods", func() {
 						"inference.llmkube.dev/service": isvcName,
 					},
 				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "dummy"}},
+				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
@@ -2065,6 +2068,9 @@ var _ = Describe("countOldPods", func() {
 						"app":                           isvcName,
 						"inference.llmkube.dev/service": isvcName,
 					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "dummy"}},
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
@@ -2108,6 +2114,9 @@ var _ = Describe("countOldPods", func() {
 					"inference.llmkube.dev/service": isvcName,
 				},
 			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main", Image: "dummy"}},
+			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
 				Conditions: []corev1.PodCondition{
@@ -2127,6 +2136,9 @@ var _ = Describe("countOldPods", func() {
 						"app":                           isvcName,
 						"inference.llmkube.dev/service": isvcName,
 					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "dummy"}},
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
@@ -2222,6 +2234,9 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 							"app":                           isvcName,
 							"inference.llmkube.dev/service": isvcName,
 						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: isvcName, Image: "dummy"}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -2346,6 +2361,9 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 						"inference.llmkube.dev/service": isvcName,
 					},
 				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: isvcName, Image: "dummy"}},
+				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
@@ -2367,6 +2385,9 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 							"app":                           isvcName,
 							"inference.llmkube.dev/service": isvcName,
 						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: isvcName, Image: "dummy"}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -2494,6 +2515,9 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 							"app":                           isvcName,
 							"inference.llmkube.dev/service": isvcName,
 						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: isvcName, Image: "dummy"}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodRunning,

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -1976,3 +1976,569 @@ var _ = Describe("Multi-replica drain-before-roll", func() {
 		Expect(cond.Reason).To(Equal(ReasonIdleCheckUnsupported))
 	})
 })
+
+var _ = Describe("countOldPods", func() {
+	ctx := context.Background()
+
+	It("should return zero when no pods exist", func() {
+		isvcName := "isvc-no-pods"
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: "dummy",
+				Image:    "dummy",
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		total, ready := reconciler.countOldPods(ctx, isvc)
+		Expect(total).To(Equal(int32(0)))
+		Expect(ready).To(Equal(int32(0)))
+	})
+
+	It("should count all pods as ready when all are Ready", func() {
+		isvcName := "isvc-all-ready"
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: "dummy",
+				Image:    "dummy",
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+		for i := 0; i < 3; i++ {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      isvcName + "-ready-" + string(rune('a'+i)),
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                           isvcName,
+						"inference.llmkube.dev/service": isvcName,
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		}
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		total, ready := reconciler.countOldPods(ctx, isvc)
+		Expect(total).To(Equal(int32(3)))
+		Expect(ready).To(Equal(int32(3)))
+	})
+
+	It("should count zero ready when all pods are crashlooping", func() {
+		isvcName := "isvc-all-crashloop"
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: "dummy",
+				Image:    "dummy",
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+		for i := 0; i < 3; i++ {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      isvcName + "-crash-" + string(rune('a'+i)),
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                           isvcName,
+						"inference.llmkube.dev/service": isvcName,
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		}
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		total, ready := reconciler.countOldPods(ctx, isvc)
+		Expect(total).To(Equal(int32(3)))
+		Expect(ready).To(Equal(int32(0)))
+	})
+
+	It("should count mixed ready and crashlooping correctly", func() {
+		isvcName := "isvc-mixed"
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: "dummy",
+				Image:    "dummy",
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+		// 1 Ready pod
+		readyPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      isvcName + "-ready",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app":                           isvcName,
+					"inference.llmkube.dev/service": isvcName,
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, readyPod)).To(Succeed())
+
+		// 2 crashlooping pods
+		for i := 0; i < 2; i++ {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      isvcName + "-crash-" + string(rune('a'+i)),
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                           isvcName,
+						"inference.llmkube.dev/service": isvcName,
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		}
+
+		reconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+		}
+		total, ready := reconciler.countOldPods(ctx, isvc)
+		Expect(total).To(Equal(int32(3)))
+		Expect(ready).To(Equal(int32(1)))
+	})
+})
+
+var _ = Describe("RolloutPolicy crashlooping pods", func() {
+	ctx := context.Background()
+
+	Context("when all old-generation pods are crashlooping", func() {
+		It("should proceed with rollout because there is no work to protect", func() {
+			modelName := "model-all-crashloop"
+			isvcName := "isvc-all-crashloop"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(3)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server",
+					RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+						WaitForIdle:        true,
+						IdleTimeoutSeconds: 30,
+						Force:              false,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, isvc)
+				dep := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+					_ = k8sClient.Delete(ctx, dep)
+				}
+				svc := &corev1.Service{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+					_ = k8sClient.Delete(ctx, svc)
+				}
+			}()
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			// First reconcile: creates the deployment
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+			// Create 3 crashlooping pods (not Ready)
+			for i := 0; i < 3; i++ {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName + "-crashloop-" + string(rune('a'+i)),
+						Namespace: "default",
+						Labels: map[string]string{
+							"app":                           isvcName,
+							"inference.llmkube.dev/service": isvcName,
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  isvcName,
+								Ready: false,
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason: "CrashLoopBackOff",
+									},
+								},
+								LastTerminationState: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										ExitCode: 1,
+										Reason:   "Error",
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			}
+
+			// Update the image to trigger a template change
+			updated := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+			updated.Spec.Image = "ghcr.io/ggml-org/llama.cpp:server-v2"
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			// Second reconcile: all pods crashlooping → proceed
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			// Verify deployment WAS updated (image changed)
+			finalDep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, finalDep)).To(Succeed())
+			Expect(finalDep.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/ggml-org/llama.cpp:server-v2"))
+
+			// Verify RolloutDeferred condition is NOT set
+			finalISVC := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, finalISVC)).To(Succeed())
+			cond := findRolloutDeferredCondition(finalISVC.Status.Conditions)
+			Expect(cond).To(BeNil())
+		})
+	})
+
+	Context("when some old-generation pods are crashlooping and some are Ready", func() {
+		It("should defer rollout with ReasonPodsCrashLooping", func() {
+			modelName := "model-mixed-crashloop"
+			isvcName := "isvc-mixed-crashloop"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(3)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server",
+					RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+						WaitForIdle:        true,
+						IdleTimeoutSeconds: 30,
+						Force:              false,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, isvc)
+				dep := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+					_ = k8sClient.Delete(ctx, dep)
+				}
+				svc := &corev1.Service{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+					_ = k8sClient.Delete(ctx, svc)
+				}
+			}()
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			// First reconcile: creates the deployment
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+			// Create 1 Ready pod and 2 crashlooping pods
+			readyPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      isvcName + "-ready",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                           isvcName,
+						"inference.llmkube.dev/service": isvcName,
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: isvcName, Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, readyPod)).To(Succeed())
+
+			for i := 0; i < 2; i++ {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName + "-crashloop-" + string(rune('a'+i)),
+						Namespace: "default",
+						Labels: map[string]string{
+							"app":                           isvcName,
+							"inference.llmkube.dev/service": isvcName,
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  isvcName,
+								Ready: false,
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason: "CrashLoopBackOff",
+									},
+								},
+								LastTerminationState: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										ExitCode: 1,
+										Reason:   "Error",
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			}
+
+			// Update the image to trigger a template change
+			updated := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+			updated.Spec.Image = "ghcr.io/ggml-org/llama.cpp:server-v2"
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			// Second reconcile: mixed state → defer with ReasonPodsCrashLooping
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			// Verify RolloutDeferred condition with ReasonPodsCrashLooping
+			deferredISVC := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, deferredISVC)).To(Succeed())
+			cond := findRolloutDeferredCondition(deferredISVC.Status.Conditions)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(ReasonPodsCrashLooping))
+			Expect(cond.Message).To(ContainSubstring("crashlooping"))
+
+			// Verify deployment was NOT updated
+			notUpdated := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, notUpdated)).To(Succeed())
+			Expect(notUpdated.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/ggml-org/llama.cpp:server"))
+		})
+	})
+
+	Context("when force=true overrides crashlooping", func() {
+		It("should proceed with rollout regardless of crashlooping pods", func() {
+			modelName := "model-force-crashloop"
+			isvcName := "isvc-force-crashloop"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(2)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server",
+					RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+						WaitForIdle:        true,
+						IdleTimeoutSeconds: 30,
+						Force:              true,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, isvc)
+				dep := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+					_ = k8sClient.Delete(ctx, dep)
+				}
+				svc := &corev1.Service{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+					_ = k8sClient.Delete(ctx, svc)
+				}
+			}()
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+
+			// First reconcile: creates the deployment
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+
+			// Create 2 crashlooping pods
+			for i := 0; i < 2; i++ {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName + "-crashloop-" + string(rune('a'+i)),
+						Namespace: "default",
+						Labels: map[string]string{
+							"app":                           isvcName,
+							"inference.llmkube.dev/service": isvcName,
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  isvcName,
+								Ready: false,
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason: "CrashLoopBackOff",
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			}
+
+			// Update the image to trigger a template change
+			updated := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+			updated.Spec.Image = "ghcr.io/ggml-org/llama.cpp:server-v2"
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			// Second reconcile: force=true → proceed regardless
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			// Verify deployment WAS updated
+			finalDep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, finalDep)).To(Succeed())
+			Expect(finalDep.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/ggml-org/llama.cpp:server-v2"))
+
+			// Verify RolloutDeferred condition is NOT set
+			finalISVC := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, finalISVC)).To(Succeed())
+			cond := findRolloutDeferredCondition(finalISVC.Status.Conditions)
+			Expect(cond).To(BeNil())
+		})
+	})
+})

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -2027,14 +2027,15 @@ var _ = Describe("countOldPods", func() {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: "main", Image: "dummy"}},
 				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					Conditions: []corev1.PodCondition{
-						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
-					},
-				},
 			}
 			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			pod.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
 		}
 
 		reconciler := &InferenceServiceReconciler{
@@ -2072,14 +2073,15 @@ var _ = Describe("countOldPods", func() {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: "main", Image: "dummy"}},
 				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					Conditions: []corev1.PodCondition{
-						{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
-					},
-				},
 			}
 			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			pod.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
 		}
 
 		reconciler := &InferenceServiceReconciler{
@@ -2117,14 +2119,15 @@ var _ = Describe("countOldPods", func() {
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{Name: "main", Image: "dummy"}},
 			},
-			Status: corev1.PodStatus{
-				Phase: corev1.PodRunning,
-				Conditions: []corev1.PodCondition{
-					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
-				},
-			},
 		}
 		Expect(k8sClient.Create(ctx, readyPod)).To(Succeed())
+		readyPod.Status = corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, readyPod)).To(Succeed())
 
 		// 2 crashlooping pods
 		for i := 0; i < 2; i++ {
@@ -2140,14 +2143,15 @@ var _ = Describe("countOldPods", func() {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: "main", Image: "dummy"}},
 				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					Conditions: []corev1.PodCondition{
-						{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
-					},
-				},
 			}
 			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			pod.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
 		}
 
 		reconciler := &InferenceServiceReconciler{
@@ -2238,31 +2242,32 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{Name: isvcName, Image: "dummy"}},
 					},
-					Status: corev1.PodStatus{
-						Phase: corev1.PodRunning,
-						Conditions: []corev1.PodCondition{
-							{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
-						},
-						ContainerStatuses: []corev1.ContainerStatus{
-							{
-								Name:  isvcName,
-								Ready: false,
-								State: corev1.ContainerState{
-									Waiting: &corev1.ContainerStateWaiting{
-										Reason: "CrashLoopBackOff",
-									},
+				}
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status = corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  isvcName,
+							Ready: false,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: "CrashLoopBackOff",
 								},
-								LastTerminationState: corev1.ContainerState{
-									Terminated: &corev1.ContainerStateTerminated{
-										ExitCode: 1,
-										Reason:   "Error",
-									},
+							},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: 1,
+									Reason:   "Error",
 								},
 							},
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
 			}
 
 			// Update the image to trigger a template change
@@ -2336,10 +2341,28 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 				}
 			}()
 
+			// The Ready pod means the idle check is actually consulted (unlike
+			// the all-crashlooping case, which short-circuits before probing).
+			// Stub the llama.cpp /slots endpoint as busy so checkServiceIdle
+			// succeeds with idle=false instead of failing closed on a real
+			// (unreachable) cluster DNS name — mirrors the "busy-defer
+			// behavior" Context's testServer pattern above.
+			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/slots" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`[{"id":0,"is_processing":true}]`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer testServer.Close()
+
 			reconciler := &InferenceServiceReconciler{
 				Client:             k8sClient,
 				Scheme:             k8sClient.Scheme(),
 				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+				RolloutIdleBaseURL: testServer.URL,
 			}
 
 			// First reconcile: creates the deployment
@@ -2364,17 +2387,18 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: isvcName, Image: "dummy"}},
 				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-					Conditions: []corev1.PodCondition{
-						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
-					},
-					ContainerStatuses: []corev1.ContainerStatus{
-						{Name: isvcName, Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
-					},
-				},
 			}
 			Expect(k8sClient.Create(ctx, readyPod)).To(Succeed())
+			readyPod.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: isvcName, Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, readyPod)).To(Succeed())
 
 			for i := 0; i < 2; i++ {
 				pod := &corev1.Pod{
@@ -2389,31 +2413,32 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{Name: isvcName, Image: "dummy"}},
 					},
-					Status: corev1.PodStatus{
-						Phase: corev1.PodRunning,
-						Conditions: []corev1.PodCondition{
-							{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
-						},
-						ContainerStatuses: []corev1.ContainerStatus{
-							{
-								Name:  isvcName,
-								Ready: false,
-								State: corev1.ContainerState{
-									Waiting: &corev1.ContainerStateWaiting{
-										Reason: "CrashLoopBackOff",
-									},
+				}
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status = corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  isvcName,
+							Ready: false,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: "CrashLoopBackOff",
 								},
-								LastTerminationState: corev1.ContainerState{
-									Terminated: &corev1.ContainerStateTerminated{
-										ExitCode: 1,
-										Reason:   "Error",
-									},
+							},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: 1,
+									Reason:   "Error",
 								},
 							},
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
 			}
 
 			// Update the image to trigger a template change
@@ -2519,25 +2544,26 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{Name: isvcName, Image: "dummy"}},
 					},
-					Status: corev1.PodStatus{
-						Phase: corev1.PodRunning,
-						Conditions: []corev1.PodCondition{
-							{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
-						},
-						ContainerStatuses: []corev1.ContainerStatus{
-							{
-								Name:  isvcName,
-								Ready: false,
-								State: corev1.ContainerState{
-									Waiting: &corev1.ContainerStateWaiting{
-										Reason: "CrashLoopBackOff",
-									},
+				}
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status = corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  isvcName,
+							Ready: false,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: "CrashLoopBackOff",
 								},
 							},
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
 			}
 
 			// Update the image to trigger a template change

--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -191,6 +191,32 @@ func (r *InferenceServiceReconciler) checkServiceIdle(ctx context.Context, isvc 
 	return true, nil
 }
 
+// countOldPods lists the pods owned by the InferenceService and returns the
+// total count and the number of Ready pods. A pod is considered Ready when its
+// PodReady condition is True. This is used by reconcileRolloutPolicy to decide
+// whether there is in-flight work to protect before deferring a rollout.
+func (r *InferenceServiceReconciler) countOldPods(ctx context.Context, isvc *inferencev1alpha1.InferenceService) (total, ready int32) {
+	podList := &corev1.PodList{}
+	labels := client.MatchingLabels{
+		"app":                           isvc.Name,
+		"inference.llmkube.dev/service": isvc.Name,
+	}
+	if err := r.List(ctx, podList, client.InNamespace(isvc.Namespace), labels); err != nil {
+		return 0, 0
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		total++
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				ready++
+				break
+			}
+		}
+	}
+	return total, ready
+}
+
 // reconcileRolloutPolicy checks whether the rollout should be deferred based on
 // the RolloutPolicy configuration. Returns a reconciliation result if the rollout
 // is deferred, or ctrl.Result{} if the rollout can proceed.
@@ -225,6 +251,21 @@ func (r *InferenceServiceReconciler) reconcileRolloutPolicy(
 	existingCond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionRolloutDeferred)
 	now := metav1.Now()
 
+	// Check old-generation pod readiness before probing idle slots.
+	// If pods exist but none are Ready, there is no in-flight work to
+	// protect — proceed immediately instead of deferring forever.
+	totalPods, readyPods := r.countOldPods(ctx, isvc)
+	if totalPods > 0 && readyPods == 0 {
+		log.Info("All old-generation pods are unready; no work to protect, proceeding with rollout")
+		if existingCond != nil {
+			meta.RemoveStatusCondition(&isvc.Status.Conditions, ConditionRolloutDeferred)
+			if updateErr := r.Status().Update(ctx, isvc); updateErr != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to clear RolloutDeferred condition: %w", updateErr)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
 	idle, checkErr := r.checkServiceIdle(ctx, isvc, svc)
 
 	if checkErr == nil && idle {
@@ -254,6 +295,14 @@ func (r *InferenceServiceReconciler) reconcileRolloutPolicy(
 			reason = ReasonIdleCheckFailed
 			message = fmt.Sprintf("Idle check failed (%v); deferring rollout until idle or timeout", checkErr)
 		}
+	} else if totalPods > readyPods {
+		// Mixed state: some old pods are Ready (serving) while others are
+		// crashlooping. The rollout is deferred to protect in-flight work
+		// on the Ready pods, but the reason must distinguish this from the
+		// pure busy case so an operator can see why the rollout is waiting.
+		reason = ReasonPodsCrashLooping
+		message = fmt.Sprintf("%d of %d old-generation pods are crashlooping; deferring rollout to protect in-flight work on Ready pods", totalPods-readyPods, totalPods)
+		log.Info("Mixed pod state, deferring rollout to protect in-flight work", "totalPods", totalPods, "readyPods", readyPods)
 	} else {
 		log.Info("Backend slots are busy, deferring rollout")
 	}

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -83,6 +83,7 @@ const (
 	ReasonIdleCheckFailed      = inferencev1alpha1.ReasonIdleCheckFailed
 	ReasonIdleTimeoutExceeded  = inferencev1alpha1.ReasonIdleTimeoutExceeded
 	ReasonIdleCheckUnsupported = inferencev1alpha1.ReasonIdleCheckUnsupported
+	ReasonPodsCrashLooping     = inferencev1alpha1.ReasonPodsCrashLooping
 
 	ReasonWorkloadResolved = "WorkloadResolved"
 


### PR DESCRIPTION
## What

`rolloutPolicy.waitForIdle` no longer deadlocks rollouts onto crashlooping pods: when zero old-generation pods are Ready there is no in-flight work to protect, so the rollout proceeds; and when the state is mixed (some Ready, some crashlooping), the RolloutDeferred condition now says so (`ReasonPodsCrashLooping` with a counted message) instead of the misleading `PodsBusy`.

## Why

Reported in #1250 with a live repro: a correctly-applied config change could never roll out onto a fully crashlooping service, because the deferral logic conflated "not idle" with "busy". The only recovery was a human toggling `waitForIdle` off and back on. This implements both halves of the issue's desired behavior: proceed when there is provably nothing to protect, and tell the truth when deferring.

Fixes #1250

## How

- New `countOldPods` in the rollout-policy path counts owned pods and Ready pods from the already-listed state (no new API call patterns). All-pods-unready proceeds and clears any stale RolloutDeferred condition; mixed state defers with the truthful reason; the genuinely-busy path and `force` override are unchanged, and scale-from-zero (no old pods) keeps its existing behavior.
- Tests extend the existing `drain_before_roll_test.go` suite: all-crashlooping proceeds, mixed state defers with `ReasonPodsCrashLooping`, busy still defers with `PodsBusy`, force still wins. Fixtures set pod status through the status subresource (envtest strips inline status on create) and stub the idle probe the way the pre-existing busy-path specs do; the all-crashlooping spec was bite-verified by neutralizing the production guard and watching it fail.

Provenance: authored by an autonomous Foreman coder run against #1250. The coder implemented the fix and the test suite, ran its own post-push envtest gate, saw one fixture-related failure, and honestly declared INCOMPLETE rather than claiming success. Human triage found the production logic correct and the failures confined to test fixtures (inline pod status stripped by envtest, plus a missing idle-probe stub); those were repaired in a follow-up commit and the full suite, lint, and a bite check all pass.

AI assistance: implemented by an autonomous Foreman coder agent with human triage and fixture repair; human-reviewed, verified, and submitted by the maintainer.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (including `GOOS=linux` cross-arch)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)
