### PR TITLE
test: fix intermittent countOldPods flake (shared-namespace pod label collision)

### DIFF
--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -2170,8 +2170,12 @@ var _ = Describe("RolloutPolicy crashlooping pods", func() {
 
 	Context("when all old-generation pods are crashlooping", func() {
 		It("should proceed with rollout because there is no work to protect", func() {
-			modelName := "model-all-crashloop"
-			isvcName := "isvc-all-crashloop"
+			// Names must be unique across the shared "default" namespace: envtest
+			// has no pod GC, and this spec's crashlooping pods would otherwise
+			// leak into the countOldPods unit spec that reuses this label
+			// selector, inflating its count under Ginkgo's randomized ordering.
+			modelName := "model-rollout-all-crashloop"
+			isvcName := "isvc-rollout-all-crashloop"
 
 			model := &inferencev1alpha1.Model{
 				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},


### PR DESCRIPTION
## What

Renames the InferenceService used by the "proceed with rollout because there is no work to protect" RolloutPolicy spec from `isvc-all-crashloop` to `isvc-rollout-all-crashloop`, so it no longer collides with the `countOldPods` unit spec that uses the same name.

## Why

The 0.9.11 release PR (#1217) failed CI on `countOldPods should count zero ready when all pods are crashlooping`, an intermittent flake that passes locally and on most CI runs. Root cause: two pod-creating specs added in #1250 (#1262) both used `isvcName = "isvc-all-crashloop"`, so their pods carried the identical `inference.llmkube.dev/service: isvc-all-crashloop` label. envtest runs no pod garbage collector and Ginkgo randomizes spec order, so when the RolloutPolicy spec ran before the countOldPods unit spec, its three crashlooping pods persisted in the shared `default` namespace and were counted by the unit spec's label-selector List, making `total` exceed the expected 3. The order dependence explains why it only surfaced occasionally, and on the exact combined run it reproduced about one in three.

## How

Unique names make the selector unique, which is the actual fix (an `Eventually` wrapper does not help: the extra pod is persistent, not lagging, so polling times out). Verified by stress-running the two blocks together: the previously-flaky combination now passes 8 for 8, and the full `internal/controller` suite is green. `isvc-all-crashloop` was the only duplicated name in the file.

A follow-up worth doing separately: these rollout specs share the `default` namespace with no pod cleanup, so a future duplicate name reintroduces the same class of flake. Per-spec namespaces or explicit pod cleanup would remove the hazard structurally; this PR fixes the live collision. (The envtest guide added in #1263 is the natural place to document the unique-names/unique-namespace rule.)

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

AI assistance: diagnosed and fixed with an AI coding assistant (root-caused from the CI failure, reproduced locally, verified with repeated stress runs); reviewed by the maintainer.
