### PR TITLE
test: fresh command per case in TestCachePrepRequiresOwnerAndMode

### DIFF
--- a/pkg/cli/cache_prep_test.go
+++ b/pkg/cli/cache_prep_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package cli
 
 import (
+	"io"
 	"os"
 	"os/user"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -239,18 +241,41 @@ func TestCachePrepRequiresOwnerAndMode(t *testing.T) {
 		}
 	})
 
-	cmd := NewCachePrepCommand()
-
-	// Missing --owner
-	cmd.SetArgs([]string{"--mode", "0755", tmpDir})
-	if err := cmd.Execute(); err == nil {
-		t.Error("expected error when --owner is missing")
+	// Each case needs its own command. Cobra marks a flag Changed once it has
+	// been parsed, and that state survives on a reused command, so a second
+	// Execute still counted the first case's --mode as provided and skipped
+	// the required-flag check entirely. The command then ran the real chown,
+	// which errors only because chown is denied to a non-root user. That is
+	// why this passed locally and failed in CI: the gate runs as root, the
+	// chown succeeded, no error came back, and the test failed even though
+	// the production code was correct.
+	//
+	// Asserting on the specific error rather than merely that one occurred is
+	// what stops a case from passing for the wrong reason again.
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"missing owner", []string{"--mode", "0755", tmpDir}, `required flag(s) "owner" not set`},
+		{"missing mode", []string{"--owner", "0:0", tmpDir}, `required flag(s) "mode" not set`},
 	}
 
-	// Missing --mode
-	cmd.SetArgs([]string{"--owner", "0:0", tmpDir})
-	if err := cmd.Execute(); err == nil {
-		t.Error("expected error when --mode is missing")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewCachePrepCommand()
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #1270

## What

`TestCachePrepRequiresOwnerAndMode` reused a single Cobra command across both of its cases. Each case now gets its own command, and each asserts on the specific error string rather than merely that an error occurred.

## Why

Cobra marks a flag `Changed` once it has been parsed, and that state survives on the command object. The second `Execute()` therefore still counted the first case's `--mode` as provided, skipped required-flag validation, and fell through to the real `chown`.

Proven directly:

```
after case 1:                 mode.Changed=true value="0755"
case 2, reused command:       err=chown ... operation not permitted   <- reached chown
a FRESH command, no --mode:   err=required flag(s) "mode" not set     <- correct
```

This is why it passed locally and failed in CI. As a non-root user the `chown` is denied, so an error came back anyway and `err == nil` was satisfied for entirely the wrong reason. The gate runs as root, the `chown` succeeds, no error is returned, and the test fails.

**The production code was never wrong.** Both `--owner` and `--mode` are already `MarkFlagRequired`. My first read of this in the issue was incorrect and is corrected in a comment there.

Because the gate runs the whole package suite, this failed the gate for **any** change touching `pkg/cli`, and it already produced one false GATE-FAIL on unrelated, correct work.

## How it is verified

The new assertions resolve during flag validation, before any `chown`, so the test now behaves identically as root and non-root. That removes the environment dependence that hid the bug.

```
go test ./pkg/cli/ -run TestCachePrepRequiresOwnerAndMode -v
  --- PASS: TestCachePrepRequiresOwnerAndMode
      === RUN   .../missing_owner
      === RUN   .../missing_mode
go test ./pkg/cli/...   ok
go vet ./pkg/cli/...    clean
go build ./...          clean
gofmt                   clean
```

AI-assisted (band 3): authored with Claude Code, diagnosed and verified by me.