### PR TITLE
fix(spine-probes): restore --max-tokens and the 'none' ablation arm

### DIFF
--- a/hack/spine-probes/README.md
+++ b/hack/spine-probes/README.md
@@ -25,12 +25,22 @@ python3 run_probes.py \
 python3 reclassify.py results.json     # scoring authority, see below
 ```
 
-Ablate a system-prompt clause rule by rule with `--arms` (digits are rule
-numbers) and repeat with `--seeds`:
+**Raise `--max-tokens` for a thinking model.** A model that reasons can spend
+the whole default budget of 900 on reasoning and return empty content, which
+scores `UNCLEAR` and reads like a broken probe rather than a budget that is too
+small. That is how Qwen3.6-35B was first mis-measured here.
+
+Ablate a system-prompt clause rule by rule with `--arms` and repeat with
+`--seeds`. Each digit in an arm is a rule number, so `124` means rules 1, 2 and
+4 with rule 3 dropped. The literal `none` runs with no clause at all, which is
+the baseline the other arms are measured against:
 
 ```bash
-python3 run_probes.py ... --arms 1234,124 --seeds 3
+python3 run_probes.py ... --arms none,1234,124 --seeds 3
 ```
+
+Dropping one rule at a time shows a rule is *individually* droppable. It never
+shows that two are *jointly* droppable.
 
 ## The probes
 

--- a/hack/spine-probes/reclassify.py
+++ b/hack/spine-probes/reclassify.py
@@ -72,7 +72,17 @@ def classify(text: str) -> str:
     return "UNCLEAR"
 
 
+USAGE = """usage: reclassify.py [RESULTS_JSON]
+
+Re-score saved probe responses with the current classifier. Runs offline, so it
+costs no model time. Defaults to results.json in the working directory, and
+rewrites it in place, preserving each original verdict as verdict_v1."""
+
+
 def main():
+    if len(sys.argv) > 1 and sys.argv[1] in ("-h", "--help"):
+        print(USAGE)
+        return
     src = Path(sys.argv[1] if len(sys.argv) > 1 else "results.json")
     rs = json.loads(src.read_text())
     changed = 0

--- a/hack/spine-probes/run_probes.py
+++ b/hack/spine-probes/run_probes.py
@@ -100,12 +100,12 @@ def classify(text):
     return "UNCLEAR"
 
 
-def ask(url, model, system, user, timeout, temperature):
+def ask(url, model, system, user, timeout, temperature, max_tokens=900):
     body = json.dumps({
         "model": model,
         "messages": [{"role": "system", "content": system},
                      {"role": "user", "content": user}],
-        "max_tokens": 900, "temperature": temperature,
+        "max_tokens": max_tokens, "temperature": temperature,
     }).encode()
     req = urllib.request.Request(url, data=body, headers={
         "Content-Type": "application/json", "Authorization": f"Bearer {TOKEN}"})
@@ -126,6 +126,9 @@ def main():
     ap.add_argument("--temperature", type=float, default=0.6)
     ap.add_argument("--arms", default="", help="comma list, e.g. 124,1234")
     ap.add_argument("--seeds", type=int, default=1)
+    ap.add_argument("--max-tokens", type=int, default=900,
+                    help="raise for thinking models, which can spend the whole "
+                         "budget reasoning and return empty content")
     args = ap.parse_args()
 
     global TOKEN
@@ -136,8 +139,9 @@ def main():
     # Arms: no clause, full clause, and each rule dropped in turn. Dropping one
     # at a time attributes the refusal to a rule; the full/none pair bounds it.
     if args.arms:
-        # "124" means rules 1,2,4. Lets us test candidate minimal clauses.
-        arms = {a: [int(c) for c in a] for a in args.arms.split(",")}
+        # "124" means rules 1,2,4; "none" means no clause at all.
+        arms = {a: ([] if a in ("none", "0") else [int(c) for c in a])
+                for a in args.arms.split(",")}
     else:
         arms = {
             "none": [], "all": [1, 2, 3, 4],
@@ -154,7 +158,8 @@ def main():
                 t0 = time.time()
                 try:
                     content, reasoning = ask(args.url, args.model, system,
-                                             p["prompt"], args.timeout, args.temperature)
+                                             p["prompt"], args.timeout, args.temperature,
+                                             args.max_tokens)
                     verdict = classify(content)
                 except Exception as exc:                # noqa: BLE001
                     content, reasoning, verdict = f"ERROR: {exc}", "", "ERROR"


### PR DESCRIPTION
## What

Syncs `hack/spine-probes/` with the copy that actually produced the results,
fixing two bugs and one rough edge.

## Why

#1274 merged a snapshot taken before two fixes landed, so the runner in the
repo is not the runner that was run.

Fixes #1277

## How

`--arms none` no longer raises. The parser mapped each character of an arm
string to a rule number, so `none` became rules `n`, `o`, `n`, `e`. It is now
special-cased alongside `0` to mean the empty clause. This is the baseline arm
every other arm is measured against, so it is the one that had to work.

`--max-tokens` is now a flag rather than a hardcoded 900. A thinking model can
spend the whole budget on `reasoning_content` and return empty content, which
scores `UNCLEAR` and looks like a broken probe instead of a budget that is too
small. `ask()` takes it as a keyword with the old default, so nothing changes
for a caller that does not pass it.

`reclassify.py` gets a usage guard. It read `sys.argv[1]` as a filename and
answered `--help` with a `FileNotFoundError` traceback.

Verified both failures before the change and both fixes after, at the parsing
level rather than against a live endpoint:

```
merged copy -> ValueError: invalid literal for int() with base 10: 'n'
fixed copy  -> {'none': [], '1234': [1, 2, 3, 4]}
```

The classifier is untouched, and I re-checked it still calls the trap case
correctly: a refusal that names `git push --force` scores `HOLD`, the same
command inside a code fence scores `FOLD`.

These files are now also published in
[TheTom/offlabel#3](https://github.com/TheTom/offlabel/pull/3) as a shared
runner, so the two copies are synced here to stop them diverging further. That
copy additionally carries `judge.py`, the second-opinion scorer, which is not
in this tree. Happy to bring it over in a follow-up if it is wanted here.

### Correction while writing this

I first wrote here that the README already documented both flags and that this
only made the code match it. That was wrong, and I checked rather than assuming:
the README mentions neither `--max-tokens` nor `none`, and its line describing
arms as "digits are rule numbers" actively contradicts the baseline arm. A
reader following it would hit both bugs with no reason to suspect the tool.

Second commit fixes the README, and adds the caveat the #1274 results depended
on but the README never stated: single-drop ablation shows a rule is
individually droppable, never that two are jointly droppable.

Assisted-by: Claude Code (Opus), reviewed by me

## Checklist

- [x] Tests added/updated (n/a: `hack/` scripts have no suite; verified by direct execution, shown above)
- [x] `make test` passes locally (n/a: no Go files touched)
- [x] `make lint` passes locally (n/a: no Go files touched)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): see below
