### PR TITLE
refactor: hoist shared phase-string constants into api/v1alpha1

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -47,6 +47,40 @@ const (
 	DefaultAgentHeartbeatTimeout = 3 * time.Minute
 )
 
+// InferenceService and Model lifecycle phase strings written to
+// status.phase by both the operator (internal/controller) and the
+// metal-agent (pkg/agent). Hoisted here so a rename on either side is a
+// compile error rather than a silent status-thrash bug: the two writers
+// previously disagreed on the phase string for a suspended service (#1254)
+// because pkg/agent could not import internal/controller and carried its
+// own copy. The string values are CRD- and client-visible and must not
+// change without a corresponding API bump.
+const (
+	// PhaseReady means the workload is serving (InferenceService) or the
+	// model is cached and available (Model).
+	PhaseReady = "Ready"
+	// PhaseFailed means the workload or model could not be brought up.
+	PhaseFailed = "Failed"
+	// PhaseCached means the model file is present in the cache but not
+	// yet referenced by a ready InferenceService.
+	PhaseCached = "Cached"
+	// PhaseDownloading means the model is being fetched or copied into
+	// the cache.
+	PhaseDownloading = "Downloading"
+	// PhaseCreating means the InferenceService is being provisioned
+	// (deployment/service creation, or waiting for the metal-agent).
+	PhaseCreating = "Creating"
+	// PhaseStopped means the InferenceService has been scaled to zero
+	// (spec.replicas=0) and the workload torn down.
+	PhaseStopped = "Stopped"
+	// PhaseSuspended means the InferenceService has spec.suspend=true and
+	// the workload torn down while preserving spec.replicas for resume.
+	PhaseSuspended = "Suspended"
+	// PhaseWaitingForGPU means the InferenceService is queued waiting for
+	// GPU resources to become available.
+	PhaseWaitingForGPU = "WaitingForGPU"
+)
+
 const (
 	// ConditionRolloutDeferred indicates whether a rollout is being deferred
 	// because the InferenceService has waitForIdle enabled and pods are not yet

--- a/api/v1alpha1/constants_test.go
+++ b/api/v1alpha1/constants_test.go
@@ -119,3 +119,33 @@ func TestDefaultRouteStrategyConstants(t *testing.T) {
 		t.Errorf("DefaultRouteStrategyBackendNameMatch = %q; want %q", got, "BackendNameMatch")
 	}
 }
+
+// TestPhaseConstants verifies the lifecycle phase string values that are
+// shared between the operator (internal/controller) and the metal-agent
+// (pkg/agent). These strings are written to status.phase and are CRD- and
+// client-visible, so they must not change without an API bump. The test
+// pins the exact wire values so a rename on either side is caught here
+// rather than silently reintroducing the status-thrash bug from #1254.
+func TestPhaseConstants(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"PhaseReady", PhaseReady, "Ready"},
+		{"PhaseFailed", PhaseFailed, "Failed"},
+		{"PhaseCached", PhaseCached, "Cached"},
+		{"PhaseDownloading", PhaseDownloading, "Downloading"},
+		{"PhaseCreating", PhaseCreating, "Creating"},
+		{"PhaseStopped", PhaseStopped, "Stopped"},
+		{"PhaseSuspended", PhaseSuspended, "Suspended"},
+		{"PhaseWaitingForGPU", PhaseWaitingForGPU, "WaitingForGPU"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("%s = %q; want %q", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -48,15 +48,17 @@ import (
 )
 
 const (
-	PhaseReady  = "Ready"
-	PhaseFailed = "Failed"
-	PhaseCached = "Cached"
-	// PhaseDownloading is also written as a raw string by the legacy
-	// download path's progressPhase; the const is the canonical spelling.
-	PhaseDownloading = "Downloading"
-	PhaseCreating    = "Creating"
-	PhaseStopped     = "Stopped"
-	PhaseSuspended   = "Suspended"
+	// Phase constants are hoisted to api/v1alpha1 so the metal-agent
+	// (pkg/agent) and the operator share one importable home; aliases keep
+	// the unqualified references in this package working. See
+	// api/v1alpha1/constants.go for the canonical definitions.
+	PhaseReady       = inferencev1alpha1.PhaseReady
+	PhaseFailed      = inferencev1alpha1.PhaseFailed
+	PhaseCached      = inferencev1alpha1.PhaseCached
+	PhaseDownloading = inferencev1alpha1.PhaseDownloading
+	PhaseCreating    = inferencev1alpha1.PhaseCreating
+	PhaseStopped     = inferencev1alpha1.PhaseStopped
+	PhaseSuspended   = inferencev1alpha1.PhaseSuspended
 	// acceleratorMetal is the Model.Spec.Hardware.Accelerator value for the
 	// host metal-agent path.
 	acceleratorMetal      = "metal"

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -35,7 +35,9 @@ import (
 //   - FIFO queue-position calculation across WaitingForGPU services
 //   - Priority → PriorityClass and preemption-value mapping
 
-const PhaseWaitingForGPU = "WaitingForGPU"
+// PhaseWaitingForGPU is hoisted to api/v1alpha1; aliased here for
+// unqualified use within the controller package.
+const PhaseWaitingForGPU = inferencev1alpha1.PhaseWaitingForGPU
 
 // Priority class mapping from priority level to Kubernetes PriorityClass name
 var priorityClassMap = map[string]string{

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1027,18 +1027,16 @@ func (a *MetalAgent) deleteProcess(ctx context.Context, key string) error {
 
 // Condition / reason constants for the stop-path status patch. Kept here
 // next to the only caller; if we grow more agent-driven conditions they can
-// move into a shared constants file. The phase strings must match the
-// operator's PhaseStopped / PhaseSuspended values (internal/controller):
-// determinePhase returns Suspended unconditionally for spec.suspend, so if
-// the agent wrote Stopped for a suspended service the two status writers
-// would overwrite each other forever (the operator's watch has no
-// status-only filter).
+// move into a shared constants file. The phase strings are hoisted to
+// api/v1alpha1 (PhaseStopped / PhaseSuspended) so the agent and the operator
+// share one importable home: determinePhase returns Suspended
+// unconditionally for spec.suspend, so if the agent wrote Stopped for a
+// suspended service the two status writers would overwrite each other
+// forever (the operator's watch has no status-only filter).
 const (
 	conditionAvailable          = "Available"
 	reasonManuallyScaledToZero  = "ManuallyScaledToZero"
 	reasonSuspended             = "Suspended"
-	phaseStopped                = "Stopped"
-	phaseSuspended              = "Suspended"
 	messageManuallyScaledToZero = "spec.replicas=0; metal-agent has torn down the workload"
 	messageSuspended            = "spec.suspend=true; metal-agent has torn down the workload; spec.replicas preserved"
 )
@@ -1108,11 +1106,11 @@ func (a *MetalAgent) markStopped(ctx context.Context, isvc *inferencev1alpha1.In
 	// the source of truth (a suspend flipped between the watch event and
 	// now should win). Suspend beats replicas==0 when both hold, exactly
 	// like the operator's determinePhase ordering.
-	targetPhase := phaseStopped
+	targetPhase := inferencev1alpha1.PhaseStopped
 	reason := reasonManuallyScaledToZero
 	message := messageManuallyScaledToZero
 	if fresh.Spec.Suspend {
-		targetPhase = phaseSuspended
+		targetPhase = inferencev1alpha1.PhaseSuspended
 		reason = reasonSuspended
 		message = messageSuspended
 	}


### PR DESCRIPTION
## What

Hoists the InferenceService and Model lifecycle phase strings into
`api/v1alpha1` so the operator and the metal-agent share one definition.

## Why

Fixes #1256

`pkg/agent` cannot import `internal/controller`, so both sides carried their own
copies of the phase strings, coupled only by a comment. #1254 fixed a live
status-thrash bug that existed precisely because the two writers disagreed about
the phase string for a suspended service. That fix addressed the symptom; the
duplicate definitions that allowed it were still there.

## How

`api/v1alpha1` was chosen over `pkg/apiutil` because it sits next to the
`InferenceServiceStatus.Phase` and `ModelStatus.Phase` fields these strings
populate.

`internal/controller` keeps its unqualified references through aliases bound to
the canonical constants, so the diff at the call sites stays small. `pkg/agent`
now references `inferencev1alpha1.PhaseStopped` / `PhaseSuspended` directly, and
its private `phaseStopped` / `phaseSuspended` are gone.

The protection is at compile time: there is no second copy left to drift.
`TestPhaseConstants` additionally pins the wire values, so a rename or a
re-spelling is caught by the suite rather than shipping as a silent CRD-visible
change.

## Verification

Reviewed and run before opening, not taken on the gate's word:

```
go build ./...                              OK
go vet ./api/... ./pkg/agent/... ./internal/controller/...   OK
go test ./api/v1alpha1/... ./pkg/agent/...  ok (both)
```

I checked the specific thing that would make this dangerous: every string value
is byte-identical to what it replaced (`Ready`, `Failed`, `Cached`,
`Downloading`, `Creating`, `Stopped`, `Suspended`, `WaitingForGPU`). These are
CRD- and client-visible, so a typo here is a production incident, and this is a
refactor with no intended behaviour change.

## Provenance

Authored by the Foreman coder (Laguna S 2.1 on gfx1151), which reached GO and
GATE-PASS. I reviewed the diff, verified the string values by hand, and ran the
builds and tests above. The commit keeps Foreman as author and carries my
sign-off as the accountable human.

I amended the commit for two things before opening: it contained an em dash, and
it carried a bot-only DCO sign-off, which CONTRIBUTING.md rejects.

Assisted-by: Foreman (LLMKube agentic coder), reviewed by me

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran the affected packages directly, output above)
- [x] `make lint` passes locally (`go vet` clean on touched packages)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): n/a, no user-facing change
