### PR TITLE
fix(foreman): apply the empty-assistant guard to the preserved truncated turn

### DIFF
--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -914,21 +914,23 @@ func stripReasoningForWire(msgs []oai.Message, preserveTrailingReasoning bool) [
 	wire := make([]oai.Message, len(msgs))
 	copy(wire, msgs)
 	for i := range wire {
-		if wire[i].ReasoningContent == "" {
-			continue
+		// Strip reasoning everywhere except the one preserved turn, whose
+		// partial <think> must survive into the continuation request.
+		if wire[i].ReasoningContent != "" && i != keepIdx {
+			wire[i].ReasoningContent = ""
 		}
-		if i == keepIdx {
-			// Preserve this one message's reasoning so the truncated turn's
-			// partial <think> survives into the continuation request.
-			continue
-		}
-		wire[i].ReasoningContent = ""
-		// A reasoning-only turn would become a fully empty assistant
-		// message, which llama-server rejects with 400 ("Assistant
-		// message must contain either 'content' or 'tool_calls'!"),
-		// poisoning every later turn of the conversation. Leave a
-		// placeholder so the template stays valid and the adjacent
-		// continuation nudge still reads coherently.
+		// Invariant, evaluated for every assistant message rather than only
+		// the ones just stripped: llama-server rejects a request carrying an
+		// assistant message with neither content nor tool_calls, with 400
+		// ("Assistant message must contain either 'content' or
+		// 'tool_calls'!"), poisoning every later turn of the conversation.
+		//
+		// reasoning_content does not satisfy that check, so the preserved
+		// turn needs the placeholder too. It is not an edge case there: a
+		// turn cut off by the per-turn token cap was interrupted mid-<think>,
+		// before it could emit content or a tool call, so it is reasoning-only
+		// by construction. Skipping the check for that one message is what
+		// killed runs at the first truncation-continuation turn (#1276).
 		if wire[i].Role == oai.RoleAssistant &&
 			strings.TrimSpace(wire[i].Content) == "" && len(wire[i].ToolCalls) == 0 {
 			wire[i].Content = "[paused to reason internally; no action taken this turn]"

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -1224,11 +1224,16 @@ func TestStripReasoningForWire_PreserveTrailing(t *testing.T) {
 	if wire[3].ReasoningContent != "the truncated in-progress thought" {
 		t.Errorf("trailing assistant reasoning must be preserved, got %q", wire[3].ReasoningContent)
 	}
-	// A stripped reasoning-only assistant becomes non-empty (placeholder) so
-	// the wire stays valid (#935); the preserved one keeps its reasoning and
-	// needs no placeholder.
-	if strings.TrimSpace(wire[3].Content) != "" {
-		t.Errorf("preserved trailing message should not get a placeholder, got content=%q", wire[3].Content)
+	// The preserved message needs the placeholder too (#1276). This assertion
+	// previously required the opposite, on the premise that keeping
+	// reasoning_content was enough to make the message valid. It is not:
+	// Content and ReasoningContent are both omitempty, so a preserved
+	// reasoning-only turn serializes as {"role":"assistant",
+	// "reasoning_content":"..."} with no content key and no tool_calls, and
+	// llama-server rejects it with 400. That premise is what shipped the bug.
+	if strings.TrimSpace(wire[3].Content) == "" && len(wire[3].ToolCalls) == 0 {
+		t.Error("preserved trailing message must still carry content or tool_calls; " +
+			"reasoning_content alone does not satisfy the server and returns 400")
 	}
 	// Original transcript untouched.
 	if transcript[1].ReasoningContent != "old thought" {
@@ -1420,6 +1425,58 @@ func TestLoop_StrippedReasoningDoesNotProduceEmptyAssistant(t *testing.T) {
 		t.Errorf("wire assistant message must carry content or tool_calls after stripping; got empty message")
 	}
 	if transcript[0].ReasoningContent == "" || transcript[0].Content != "" {
+		t.Errorf("original transcript must be untouched: %+v", transcript[0])
+	}
+}
+
+// TestLoop_PreservedTruncatedReasoningDoesNotProduceEmptyAssistant covers the
+// case the sibling test above misses: preserveTrailingReasoning=true (#1276).
+//
+// A turn cut off by the per-turn token cap is reasoning-only by construction:
+// it was interrupted mid-<think>, before it could emit content or a tool call.
+// That is exactly the message preserveTrailingReasoning keeps, so the preserve
+// path selects for the empty-assistant case rather than rarely meeting it.
+// Keeping its reasoning must not also let it reach the wire with neither
+// content nor tool_calls, which llama-server rejects with 400 "Assistant
+// message must contain either 'content' or 'tool_calls'!", killing the run.
+func TestLoop_PreservedTruncatedReasoningDoesNotProduceEmptyAssistant(t *testing.T) {
+	transcript := []oai.Message{
+		{Role: oai.RoleAssistant, ReasoningContent: "partial think, cut off by the token cap"},
+		{Role: oai.RoleUser, Content: TruncationContinueMessage()},
+	}
+	wire := stripReasoningForWire(transcript, true)
+
+	// The point of the preserve path: the partial reasoning survives so the
+	// model resumes instead of re-thinking from scratch.
+	if wire[0].ReasoningContent == "" {
+		t.Error("preserved turn must keep its reasoning_content for the continuation")
+	}
+	// ...but it still may not be an otherwise-empty assistant message.
+	if strings.TrimSpace(wire[0].Content) == "" && len(wire[0].ToolCalls) == 0 {
+		t.Error("wire assistant message must carry content or tool_calls; " +
+			"an empty one is rejected with 400 and poisons every later turn")
+	}
+
+	// Assert on the serialized payload, not just the struct: Content and
+	// ReasoningContent are both omitempty, so the struct-level distinction
+	// that made this look safe disappears on the wire. Before the fix this
+	// marshalled to {"role":"assistant","reasoning_content":"..."} with no
+	// content key at all, which is precisely what the server rejects.
+	raw, err := json.Marshal(wire[0])
+	if err != nil {
+		t.Fatalf("marshal wire message: %v", err)
+	}
+	var sent map[string]any
+	if err := json.Unmarshal(raw, &sent); err != nil {
+		t.Fatalf("unmarshal wire message: %v", err)
+	}
+	if _, hasContent := sent["content"]; !hasContent {
+		if _, hasCalls := sent["tool_calls"]; !hasCalls {
+			t.Errorf("serialized assistant message has neither content nor tool_calls: %s", raw)
+		}
+	}
+
+	if transcript[0].Content != "" {
 		t.Errorf("original transcript must be untouched: %+v", transcript[0])
 	}
 }


### PR DESCRIPTION
## What

Applies the existing empty-assistant guard to the one message it was skipping,
so a token-cap truncation no longer kills the run.

## Why

Fixes #1276

A run dies with `status 400: Assistant message must contain either 'content' or
'tool_calls'` and every later turn of that conversation is unrecoverable. It
killed 5 of 14 recent runs on a thinking-capable coder, including both attempts
to fix this issue.

## Root cause

`stripReasoningForWire` already guards against putting an empty assistant
message on the wire. The guard sat below a `continue` that skipped the single
message `preserveTrailingReasoning` keeps:

```go
if i == keepIdx {
    continue        // skips the reasoning strip AND the empty-assistant guard
}
```

That message is not an edge case. A turn cut off by the per-turn token cap was
interrupted mid-`<think>`, before it could emit content or a tool call, so it is
**reasoning-only by construction**. The preserve path selects for exactly the
shape the guard exists to catch, which is why this reproduces rather than being
rare.

The chain, all in `pkg/foreman/agent/loop.go`:

1. model hits `MaxTokensPerTurn` mid-think, `finish_reason == "length"`
2. `:597` sets `preserveReasoningNext = true`
3. next turn calls `stripReasoningForWire(msgs, true)`
4. `keepIdx` selects the truncated reasoning-only message
5. the `continue` skips the guard
6. 400

`Content` and `ReasoningContent` are both `omitempty`, so that message
serialized as `{"role":"assistant","reasoning_content":"..."}` with no `content`
key at all. `reasoning_content` does not satisfy the server's check.

There is a nice irony: `MaxTokensPerTurn` exists to bound a reasoning model's
think, and hitting that bound is what triggered the crash.

## How

The `keepIdx` exception now scopes to the reasoning strip only, and the
empty-assistant check runs for every assistant message as an invariant. The
preserved turn keeps its partial `<think>` (the point of the feature) and also
gets the placeholder, so the continuation stays valid.

## A test that asserted the bug

`TestStripReasoningForWire_PreserveTrailing` required the opposite behaviour,
and its comment states the premise outright:

> the preserved one keeps its reasoning and needs no placeholder

That premise is what shipped the bug. I corrected the assertion rather than
working around it. Flagging it explicitly because silently flipping an existing
test is how a real defect gets re-buried.

The new regression test asserts on the **marshalled payload**, not the struct,
since `omitempty` is exactly where the struct-level distinction disappears.
Against the unfixed code it fails with the production payload:

```
serialized assistant message has neither content nor tool_calls:
{"role":"assistant","reasoning_content":"partial think, cut off by the token cap"}
```

## Verification

```
go build ./...                    OK
go vet ./pkg/foreman/...          OK
gofmt -l pkg/foreman/             clean
go test ./pkg/foreman/agent/      ok (full package, 31s)
```

I verified the new test fails before the change and passes after, by reverting
only `loop.go` and re-running. The other reasoning and truncation tests
(`TestLoop_TruncatedTurn_ContinuationRetainsReasoningAndRecovers`,
`TestLoop_ReasoningOnlyTurn_ContinuesAndRecovers`, and the rest) still pass, so
the preserve feature itself is intact.

Assisted-by: Claude Code (Opus), reviewed by me

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran `./pkg/foreman/agent/` in full, output above)
- [x] `make lint` passes locally (`go vet` and `gofmt` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): n/a, internal loop fix
