### PR TITLE
fix(gate): check non-Go changes against the shared merge-base, not HEAD~1

### DIFF
--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -96,18 +96,17 @@ spec:
                 git diff --stat
                 rc=1
               fi
-              {{- if .BiteCheck }}
-              # Bite check: verify new/changed tests actually fail against pre-change
-              # production code. The gate Job clones the coder branch as a shallow,
-              # single-branch checkout (everything is committed, working tree is
-              # clean), so change detection works on the committed diff against the
-              # base branch, NOT on `git status`. Infra anomalies (base ref will not
-              # resolve, no merge-base found, a bogus base blowing up the diff size)
-              # are a loud skip (GATE-WARN), never a gate failure: only a genuine
-              # non-biting test result blocks the gate (#1259).
+              # --- shared change detection ------------------------------------------
+              # Resolve this branch's fork point ONCE and reuse it below. Both the
+              # non-Go lint and the revert-and-retest phase need to know what this
+              # branch changed, and the clone is `--depth 1`, so HEAD~1 does not
+              # exist. Anything that
+              # computes its own base from HEAD~N gets a fatal error, an empty file list
+              # once stderr is swallowed, and then silently checks nothing while still
+              # reporting a pass. That is how the first attempt at #1072 shipped a no-op.
               BASE="${BASE_BRANCH:-main}"
-              echo "=== bite check (base=$BASE) ==="
-              bite_skip() { echo "GATE-WARN: bite check skipped ($1)"; }
+              base_warn() { echo "GATE-WARN: change detection skipped ($1)"; }
+              BASE="${BASE_BRANCH:-main}"
               MB=""
               if [ -n "${UPSTREAM_URL:-}" ]; then
                 # Fetch the base from the CANONICAL repo, not the fork: the fork
@@ -118,7 +117,7 @@ spec:
                 # The `--` end-of-options guard keeps a crafted URL starting
                 # with `-` from being read as a git option (argv smuggling).
                 if ! git fetch --depth 100 -- "$UPSTREAM_URL" "+refs/heads/$BASE:refs/remotes/ubase/$BASE" >/dev/null 2>&1; then
-                  bite_skip "could not fetch $BASE from upstream"
+                  base_warn "could not fetch $BASE from upstream"
                 else
                   # The clone is shallow; deepen until the histories connect. Two
                   # rounds is plenty for any sane coder branch; beyond that the base
@@ -129,28 +128,85 @@ spec:
                     git fetch --deepen=1000 -- "$UPSTREAM_URL" "+refs/heads/$BASE:refs/remotes/ubase/$BASE" >/dev/null 2>&1 || true
                     MB=$(git merge-base HEAD "refs/remotes/ubase/$BASE" 2>/dev/null || true)
                   fi
-                  [ -z "$MB" ] && bite_skip "no merge-base between HEAD and upstream $BASE after deepening"
+                  [ -z "$MB" ] && base_warn "no merge-base between HEAD and upstream $BASE after deepening"
                 fi
               else
                 # No upstream URL (freeform task without a repo slug): pre-#1259
                 # behavior, fetch the base ref from origin and use its tip.
                 if ! git fetch --depth 1 origin "+refs/heads/$BASE:refs/remotes/origin/$BASE" >/dev/null 2>&1; then
-                  bite_skip "could not fetch base ref origin/$BASE"
+                  base_warn "could not fetch base ref origin/$BASE"
                 elif ! git rev-parse --verify --quiet "origin/$BASE" >/dev/null; then
-                  bite_skip "base ref origin/$BASE did not resolve after fetch"
+                  base_warn "base ref origin/$BASE did not resolve after fetch"
                 else
                   MB="origin/$BASE"
                 fi
               fi
+              changed=""
               if [ -n "$MB" ]; then
                 changed=$(git diff --name-only "$MB" HEAD)
                 nchanged=$(printf '%s\n' "$changed" | sed '/^$/d' | wc -l | tr -d ' ')
                 if [ "$nchanged" -gt 200 ]; then
                   # A coder diff is tens of files at most. Hundreds means the base
-                  # resolution is wrong (the #1259 incident swept 103 commits of
-                  # drift); skipping is honest, failing would blame the coder.
-                  bite_skip "diff vs merge-base names $nchanged files; base resolution suspect"
-                else
+                  # resolution is wrong (the #1259 incident swept 103 commits of drift).
+                  # Drop the base rather than act on it: both consumers below then
+                  # degrade to a loud skip instead of blaming the coder.
+                  base_warn "diff vs merge-base names $nchanged files; base resolution suspect"
+                  MB=""; changed=""
+                fi
+              fi
+
+              # --- non-Go lint -------------------------------------------------------
+              # A diff that is entirely non-Go (CI YAML, shell, Ruby) otherwise reaches
+              # GATE PASS with nothing meaningful checked (#1072). Each checker is scoped
+              # to the files THIS branch changed: linting the whole repo would fail an
+              # unrelated contributor on a pre-existing violation they never touched.
+              # A missing linter is reported and skipped, never a failure, since the gate
+              # runs in a Go image. Only a real finding sets rc=1.
+              echo "=== non-go lint ==="
+              if [ -z "$MB" ]; then
+                echo "non-go lint: skipped, no usable base to diff against"
+              else
+                ng_wf=$(printf '%s\n' "$changed" | grep -E '^\.github/workflows/.+\.ya?ml$' || true)
+                ng_sh=$(printf '%s\n' "$changed" | grep -E '\.sh$' || true)
+                ng_rb=$(printf '%s\n' "$changed" | grep -E '\.rb$' || true)
+                if [ -z "$ng_wf$ng_sh$ng_rb" ]; then
+                  echo "non-go lint: no checkable non-Go files changed"
+                fi
+                if [ -n "$ng_wf" ]; then
+                  if command -v actionlint >/dev/null 2>&1; then
+                    echo "--- actionlint ---"
+                    printf '%s\n' "$ng_wf" | xargs -r actionlint || rc=1
+                  else
+                    echo "non-go lint: actionlint not installed, changed workflows unchecked"
+                  fi
+                fi
+                if [ -n "$ng_sh" ]; then
+                  if command -v shellcheck >/dev/null 2>&1; then
+                    echo "--- shellcheck ---"
+                    printf '%s\n' "$ng_sh" | xargs -r shellcheck || rc=1
+                  else
+                    echo "non-go lint: shellcheck not installed, changed shell scripts unchecked"
+                  fi
+                fi
+                if [ -n "$ng_rb" ]; then
+                  if command -v rubocop >/dev/null 2>&1; then
+                    echo "--- rubocop ---"
+                    printf '%s\n' "$ng_rb" | xargs -r rubocop --format progress || rc=1
+                  else
+                    echo "non-go lint: rubocop not installed, changed Ruby files unchecked"
+                  fi
+                fi
+              fi
+              {{- if .BiteCheck }}
+              # Bite check: verify new/changed tests actually fail against pre-change
+              # production code, using the base resolved above. Infra anomalies are a
+              # loud skip (GATE-WARN), never a gate failure: only a genuine non-biting
+              # test result blocks the gate (#1259).
+              bite_skip() { echo "GATE-WARN: bite check skipped ($1)"; }
+              echo "=== bite check (base=$BASE) ==="
+              if [ -z "$MB" ]; then
+                bite_skip "no usable base from change detection"
+              else
                   test_files=$(printf '%s\n' "$changed" | grep '_test\.go$' || true)
                   prod_files=$(printf '%s\n' "$changed" | grep '\.go$' | grep -v '_test\.go$' || true)
                   if [ -z "$test_files" ]; then
@@ -182,7 +238,6 @@ spec:
                       git checkout HEAD -- $prod_files >/dev/null 2>&1 || true
                     fi
                   fi
-                fi
               fi
               {{- end }}
               {{- end }}

--- a/pkg/foreman/agent/tools/run_gate_job_nongo_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_nongo_test.go
@@ -1,0 +1,261 @@
+package tools
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The non-Go lint block is shell embedded in a Job template, so a
+// strings.Contains assertion on the rendered YAML can only prove the text is
+// present, never that it works. The first attempt at #1072 passed exactly that
+// kind of test while being a complete no-op: it derived its own base with
+// `git diff HEAD~1 HEAD` inside a `--depth 1` clone, where HEAD~1 does not
+// exist, so the command failed, stderr was swallowed, no files were ever
+// matched, and the gate printed a header and passed. One of its tests asserted
+// the rendered args contained the literal string
+// `git diff --name-only HEAD~1 HEAD`, which pinned the bug in place.
+//
+// These tests therefore EXECUTE the block with a stubbed PATH and assert on
+// what the linters actually received.
+//
+// On the `bash -c` below: running a shell is the point here, since the artifact
+// under test IS shell. Nothing untrusted reaches it. The script is our own
+// rendered template, the file lists are test literals, and PATH is pinned to a
+// temp dir holding stub executables so no real linter and no repo file is
+// touched. This is not the pattern to copy into production code, where argv
+// should be passed directly rather than through a shell.
+
+// extractNonGoLintBlock pulls the non-Go lint shell out of the rendered args so
+// it can be run standalone. Fails loudly rather than silently testing nothing
+// if the markers move.
+func extractNonGoLintBlock(t *testing.T, args string) string {
+	t.Helper()
+	const startMark = `echo "=== non-go lint ==="`
+	start := strings.Index(args, startMark)
+	if start < 0 {
+		t.Fatalf("non-go lint block not found in rendered args")
+	}
+	rest := args[start+len(startMark):]
+	// The block ends where the next phase begins, or at the gate verdict.
+	end := len(rest)
+	for _, mark := range []string{`echo "=== bite check`, `[ "$rc" -eq 0 ]`} {
+		if i := strings.Index(rest, mark); i >= 0 && i < end {
+			end = i
+		}
+	}
+	return rest[:end]
+}
+
+// hermeticBin returns a directory to be used as the ENTIRE PATH. It symlinks
+// only the coreutils the block genuinely needs, so a checker is present exactly
+// when a test puts a stub there.
+//
+// Inheriting the real PATH is not an option: shellcheck is installed on plenty
+// of developer machines, so a "checker is absent" test would quietly exercise
+// the present-checker path instead, and pass while proving nothing.
+func hermeticBin(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+// testPATH is the PATH the block runs under: the test's stub dir first, then
+// only the system coreutils directories. Linters normally install outside
+// these (/opt/homebrew/bin, /usr/local/bin, a gem or npm prefix), so a checker
+// is present when a test stubs it and otherwise absent.
+func testPATH(binDir string) string {
+	return binDir + ":/bin:/usr/bin"
+}
+
+// requireCheckerAbsent skips rather than fails when the machine really does
+// provide the checker on the reduced PATH, which happens on distros that ship
+// it in /usr/bin. Asserting "absent" on a box where it is present would test
+// the present-checker path while claiming to test the absent one.
+func requireCheckerAbsent(t *testing.T, binDir, name string) {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", "command -v "+name)
+	cmd.Env = append(os.Environ(), "PATH="+testPATH(binDir))
+	if out, _ := cmd.Output(); len(strings.TrimSpace(string(out))) > 0 {
+		t.Skipf("%s is present at %s on the reduced PATH; cannot exercise the "+
+			"missing-checker path here", name, strings.TrimSpace(string(out)))
+	}
+}
+
+// stubLinter writes a fake executable that appends its argv to a log file and
+// exits with the given code, so a test can see exactly which files a checker
+// was handed.
+func stubLinter(t *testing.T, dir, name, logPath string, exitCode int) {
+	t.Helper()
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" >> " + logPath + "\nexit " +
+		map[bool]string{true: "0", false: "1"}[exitCode == 0] + "\n"
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub %s: %v", name, err)
+	}
+}
+
+// runNonGoLint executes the extracted block with `changed` preset, a stub PATH,
+// and returns combined output plus the final rc.
+func runNonGoLint(t *testing.T, changed string, binDir string) (string, string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell block test requires a POSIX shell")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	block := extractNonGoLintBlock(t, renderGateArgsForTest(t, map[string]any{
+		"repo": "defilantech/LLMKube", "branch": "foreman/x", "biteCheck": true,
+		"upstreamURL": "https://github.com/defilantech/LLMKube.git",
+	}))
+
+	script := "set -uo pipefail\n" +
+		"rc=0\n" +
+		`MB="deadbeef"` + "\n" +
+		"changed=$(cat <<'CHANGED_EOF'\n" + changed + "\nCHANGED_EOF\n)\n" +
+		block + "\n" +
+		`echo "FINAL_RC=$rc"` + "\n"
+
+	cmd := exec.Command("bash", "-c", script)
+	// binDir is the ENTIRE PATH: it carries symlinked coreutils plus whatever
+	// stubs the test placed. A checker is therefore present exactly when the
+	// test says so, regardless of what is installed on the machine.
+	cmd.Env = append(os.Environ(), "PATH="+testPATH(binDir))
+	out, _ := cmd.CombinedOutput()
+	text := string(out)
+	rc := "unknown"
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "FINAL_RC=") {
+			rc = strings.TrimPrefix(line, "FINAL_RC=")
+		}
+	}
+	return text, rc
+}
+
+// TestNonGoLint_ScopesCheckersToChangedFilesOnly is the regression that matters
+// for a false GATE-FAIL: a checker must see the files this branch changed and
+// nothing else. Linting the whole repo would fail an unrelated contributor on a
+// pre-existing violation in a file they never touched.
+func TestNonGoLint_ScopesCheckersToChangedFilesOnly(t *testing.T) {
+	bin := hermeticBin(t)
+	log := filepath.Join(t.TempDir(), "argv.log")
+	stubLinter(t, bin, "shellcheck", log, 0)
+
+	changed := "hack/one.sh\ndocs/readme.md\npkg/foo/foo.go"
+	out, rc := runNonGoLint(t, changed, bin)
+
+	got, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("shellcheck stub was never invoked; output:\n%s", out)
+	}
+	received := strings.Fields(string(got))
+	if len(received) != 1 || received[0] != "hack/one.sh" {
+		t.Errorf("shellcheck must receive exactly the changed shell files, got %v", received)
+	}
+	if rc != "0" {
+		t.Errorf("a passing checker must not fail the gate, rc=%s\n%s", rc, out)
+	}
+}
+
+// TestNonGoLint_MissingCheckerIsReportedNotFailed pins the degrade-gracefully
+// requirement: the gate runs in a Go image, so an absent linter must be stated
+// honestly and must not fail the branch.
+func TestNonGoLint_MissingCheckerIsReportedNotFailed(t *testing.T) {
+	bin := hermeticBin(t)
+	requireCheckerAbsent(t, bin, "shellcheck")
+	out, rc := runNonGoLint(t, "hack/one.sh", bin)
+
+	if !strings.Contains(out, "shellcheck not installed") {
+		t.Errorf("a missing checker must be reported, got:\n%s", out)
+	}
+	if rc != "0" {
+		t.Errorf("a missing checker must not fail the gate, rc=%s\n%s", rc, out)
+	}
+}
+
+// TestNonGoLint_CheckerFindingFailsTheGate is the other half: when the checker
+// is present and reports a problem, the gate must actually fail. Without this
+// the whole block could no-op and still pass every other test here.
+func TestNonGoLint_CheckerFindingFailsTheGate(t *testing.T) {
+	bin := hermeticBin(t)
+	log := filepath.Join(t.TempDir(), "argv.log")
+	stubLinter(t, bin, "shellcheck", log, 1) // non-zero: a real finding
+
+	out, rc := runNonGoLint(t, "hack/one.sh", bin)
+	if rc != "1" {
+		t.Errorf("a checker finding must set rc=1, got rc=%s\n%s", rc, out)
+	}
+}
+
+// TestNonGoLint_GoOnlyDiffChecksNothingAndPasses guards the "do not turn
+// nothing-to-check into an error" requirement, and guards against a future
+// change that lints the repo regardless of the diff: a stub that gets invoked
+// here means the scoping regressed.
+func TestNonGoLint_GoOnlyDiffChecksNothingAndPasses(t *testing.T) {
+	bin := hermeticBin(t)
+	log := filepath.Join(t.TempDir(), "argv.log")
+	stubLinter(t, bin, "shellcheck", log, 1) // would fail if wrongly invoked
+	stubLinter(t, bin, "actionlint", log, 1)
+	stubLinter(t, bin, "rubocop", log, 1)
+
+	out, rc := runNonGoLint(t, "pkg/foo/foo.go\npkg/foo/foo_test.go", bin)
+
+	if _, err := os.ReadFile(log); err == nil {
+		t.Errorf("no checker may run for a Go-only diff; output:\n%s", out)
+	}
+	if !strings.Contains(out, "no checkable non-Go files changed") {
+		t.Errorf("a Go-only diff should say so, got:\n%s", out)
+	}
+	if rc != "0" {
+		t.Errorf("a Go-only diff must pass, rc=%s\n%s", rc, out)
+	}
+}
+
+// TestNonGoLint_NoBaseSkipsHonestly covers the path that caused #1072. When the
+// base cannot be resolved there is no reliable file list, and the block must
+// say so rather than silently checking nothing while reporting success.
+func TestNonGoLint_NoBaseSkipsHonestly(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := hermeticBin(t)
+	block := extractNonGoLintBlock(t, renderGateArgsForTest(t, map[string]any{
+		"repo": "defilantech/LLMKube", "branch": "foreman/x", "biteCheck": true,
+		"upstreamURL": "https://github.com/defilantech/LLMKube.git",
+	}))
+	// MB empty is the "could not resolve a base" state.
+	script := "set -uo pipefail\nrc=0\nMB=\"\"\nchanged=\"\"\n" + block +
+		"\necho \"FINAL_RC=$rc\"\n"
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "PATH="+testPATH(bin))
+	out, _ := cmd.CombinedOutput()
+
+	if !strings.Contains(string(out), "no usable base") {
+		t.Errorf("an unresolved base must be reported, got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "FINAL_RC=0") {
+		t.Errorf("an unresolved base is an infra anomaly, not a coder failure:\n%s", out)
+	}
+}
+
+// TestNonGoLint_DoesNotDeriveItsOwnBase is a cheap guard on the specific
+// regression: the block must use the shared `$changed`, never compute a base
+// from HEAD~N, which silently yields nothing in the `--depth 1` clone the gate
+// actually runs in.
+func TestNonGoLint_DoesNotDeriveItsOwnBase(t *testing.T) {
+	block := extractNonGoLintBlock(t, renderGateArgsForTest(t, map[string]any{
+		"repo": "defilantech/LLMKube", "branch": "foreman/x", "biteCheck": true,
+	}))
+	for _, forbidden := range []string{"HEAD~", "git ls-files", "git diff"} {
+		if strings.Contains(block, forbidden) {
+			t.Errorf("non-go lint must use the shared $changed list, found %q in:\n%s",
+				forbidden, block)
+		}
+	}
+	if !strings.Contains(block, `"$changed"`) {
+		t.Errorf("non-go lint must consume the shared $changed list:\n%s", block)
+	}
+}


### PR DESCRIPTION
## What

Makes the gate actually check non-Go changes, by giving it the same merge-base
the bite check already resolves.

## Why

Fixes #1072

A diff that is entirely CI YAML, shell or Ruby reached GATE PASS with nothing
meaningful verified. Two real cases passed that way: an invalid SLSA workflow
and a Homebrew formula defining `install` twice.

## How

**The base resolution is hoisted above its consumers.** The bite check already
did this correctly, fetching the base from the canonical repo and taking
`merge-base(HEAD, base)` with deepening, but it did so inside its own block, so
anything else needing "what did this branch change" had nowhere to get it. It is
now computed once and both consumers use the same `$changed` list.

That sharing is the entire point of the change. The gate clones with
`--depth 1`, so `HEAD~1` does not exist. A block that derives its own base from
`HEAD~N` gets a fatal error, an empty file list once stderr is swallowed, and
then silently checks nothing while the gate still reports a pass. A first
attempt at this issue did exactly that and looked correct in review.

**Checkers are scoped to the changed files.** Linting the whole repo would fail
an unrelated contributor on a pre-existing violation in a file they never
touched, which converts a blind gate into a noisy one. A missing linter is
reported and skipped rather than failed, since the gate runs in a Go image, and
a diff with no checkable non-Go content says so and passes.

## Tests execute the shell

This is the part I would look at first. A `strings.Contains` assertion on
rendered YAML can only prove the text is present, never that it works, so the
new tests run the block under a reduced PATH with stub checkers and assert on
the argv each checker actually received.

Verified by mutation rather than by assertion alone:

| mutation | result |
|---|---|
| re-derive the base with `git diff HEAD~1 HEAD` | **4 tests fail** |
| lint repo-wide with `shellcheck $(git ls-files '*.sh')` | **2 tests fail** |
| unmutated | all pass |

Cases covered: scoping to changed files only, a missing checker being reported
and not failing, a checker finding setting `rc=1`, a Go-only diff checking
nothing and passing, and an unresolved base skipping honestly rather than
passing silently.

The absent-checker test verifies its own premise: if the machine really does
provide `shellcheck` on the reduced PATH, it skips rather than quietly
exercising the present-checker path while claiming to test absence.

## Verification

```
go build ./...                        OK
go vet ./pkg/foreman/...              OK
gofmt -l pkg/foreman/                 clean
go test ./pkg/foreman/agent/tools/    ok (all 33, including the 27 pre-existing)
```

The existing bite-check tests still pass unchanged, including the two that
assert `"bite check"` is absent from the rendered args when `biteCheck` is
false. That constraint is why the shared block is worded to avoid the phrase.

Assisted-by: Claude Code (Opus), reviewed and mutation-tested by me

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran the affected package, output above)
- [x] `make lint` passes locally (`go vet` and `gofmt` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): n/a, gate internals
