### PR TITLE
feat(foreman): support chat_template_kwargs on agent chat requests

### DIFF
--- a/api/foreman/v1alpha1/agent_types.go
+++ b/api/foreman/v1alpha1/agent_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -256,6 +257,20 @@ type AgentSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MaxOutputTokens int32 `json:"maxOutputTokens,omitempty"`
+
+	// ChatTemplateKwargs is a free-form map of template-specific keyword
+	// arguments forwarded verbatim on every chat-completions request as
+	// chat_template_kwargs. Each value is a raw JSON blob so booleans stay
+	// booleans (a JSON false must not become the string "false"). The
+	// primary use case is disabling thinking on reasoning models: llama.cpp
+	// supplies enable_thinking=true itself when the client omits the kwarg,
+	// so every request today is thinking-on. Setting
+	// {"enable_thinking": false} here turns it off.
+	//
+	// Omitted entirely when nil or empty so the request is byte-identical
+	// to today for any agent that does not set it.
+	// +optional
+	ChatTemplateKwargs map[string]apiextensionsv1.JSON `json:"chatTemplateKwargs,omitempty"`
 
 	// ContextWindowTokens is the soft token budget for the wire payload
 	// the loop sends on every turn. When the running message list

--- a/api/foreman/v1alpha1/zz_generated.deepcopy.go
+++ b/api/foreman/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1alpha1
 
 import (
 	"k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -280,6 +281,13 @@ func (in *AgentSpec) DeepCopyInto(out *AgentSpec) {
 		in, out := &in.MaxEnvtestIterations, &out.MaxEnvtestIterations
 		*out = new(int32)
 		**out = **in
+	}
+	if in.ChatTemplateKwargs != nil {
+		in, out := &in.ChatTemplateKwargs, &out.ChatTemplateKwargs
+		*out = make(map[string]apiextensionsv1.JSON, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
+		}
 	}
 	if in.StuckLoopDetection != nil {
 		in, out := &in.StuckLoopDetection, &out.StuckLoopDetection

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -74,6 +74,22 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              chatTemplateKwargs:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  ChatTemplateKwargs is a free-form map of template-specific keyword
+                  arguments forwarded verbatim on every chat-completions request as
+                  chat_template_kwargs. Each value is a raw JSON blob so booleans stay
+                  booleans (a JSON false must not become the string "false"). The
+                  primary use case is disabling thinking on reasoning models: llama.cpp
+                  supplies enable_thinking=true itself when the client omits the kwarg,
+                  so every request today is thinking-on. Setting
+                  {"enable_thinking": false} here turns it off.
+
+                  Omitted entirely when nil or empty so the request is byte-identical
+                  to today for any agent that does not set it.
+                type: object
               contextStrategy:
                 default: window
                 description: |-

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -73,6 +73,22 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              chatTemplateKwargs:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  ChatTemplateKwargs is a free-form map of template-specific keyword
+                  arguments forwarded verbatim on every chat-completions request as
+                  chat_template_kwargs. Each value is a raw JSON blob so booleans stay
+                  booleans (a JSON false must not become the string "false"). The
+                  primary use case is disabling thinking on reasoning models: llama.cpp
+                  supplies enable_thinking=true itself when the client omits the kwarg,
+                  so every request today is thinking-on. Setting
+                  {"enable_thinking": false} here turns it off.
+
+                  Omitted entirely when nil or empty so the request is byte-identical
+                  to today for any agent that does not set it.
+                type: object
               contextStrategy:
                 default: window
                 description: |-

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -633,6 +633,11 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// into a bounded, recoverable truncation (see ErrAssistantTruncated).
 		// Agent.spec.maxOutputTokens overrides; 0 uses the package default.
 		MaxTokensPerTurn: maxTokensPerTurnForAgent(agent),
+		// chat_template_kwargs: forwarded verbatim so a configured kwarg
+		// map (e.g. {"enable_thinking": false}) reaches the server's chat
+		// template. Nil/empty omits the field on the wire so the request
+		// is byte-identical to today for agents that do not set it.
+		ChatTemplateKwargs: agent.Spec.ChatTemplateKwargs,
 	}
 
 	// Coder gate feedback loop (#749): coders verify their work through a

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -28,6 +28,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
 )
 
@@ -179,6 +181,20 @@ type LoopConfig struct {
 	// (finish_reason=="length") becomes a bounded, recoverable event rather
 	// than a multi-hour hang. See ErrAssistantTruncated and #650.
 	MaxTokensPerTurn int
+
+	// ChatTemplateKwargs is the free-form map of template-specific keyword
+	// arguments forwarded verbatim on every chat-completions request as
+	// chat_template_kwargs. Each value is a raw JSON blob so booleans stay
+	// booleans (a JSON false must not become the string "false"). The
+	// primary use case is disabling thinking on reasoning models: llama.cpp
+	// supplies enable_thinking=true itself when the client omits the kwarg,
+	// so every request today is thinking-on. Setting
+	// {"enable_thinking": false} here turns it off.
+	//
+	// The executor maps Agent.spec.chatTemplateKwargs here. Nil or empty
+	// omits the field on the wire so the request is byte-identical to today
+	// for any agent that does not set it.
+	ChatTemplateKwargs map[string]apiextensionsv1.JSON
 
 	// MaxTruncationRetries bounds the streak of turns truncated by the token
 	// cap (finish_reason=="length") before the loop gives up with
@@ -1037,6 +1053,11 @@ func (l *Loop) runOneTurn(
 		// unbudgeted turn cannot run effectively unbounded on a
 		// large-context serve.
 		MaxTokens: cfg.MaxTokensPerTurn,
+		// chat_template_kwargs: forwarded verbatim so a configured kwarg
+		// map (e.g. {"enable_thinking": false}) reaches the server's chat
+		// template. Nil/empty omits the field on the wire so the request
+		// is byte-identical to today for agents that do not set it.
+		ChatTemplateKwargs: cfg.ChatTemplateKwargs,
 	}
 	resp, err := l.client.Chat(ctx, req)
 	if err != nil {

--- a/pkg/foreman/agent/oai/types.go
+++ b/pkg/foreman/agent/oai/types.go
@@ -24,7 +24,11 @@ limitations under the License.
 // v0.1.
 package oai
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
 
 // Role names the chat-completions message role. We use the OpenAI v1
 // values verbatim; llama.cpp's OAI surface accepts the same set.
@@ -167,6 +171,20 @@ type ChatRequest struct {
 	// Stream is set by the client just before the wire send; callers
 	// do not need to populate it.
 	Stream bool `json:"stream"`
+
+	// ChatTemplateKwargs is the OAI chat_template_kwargs field: a
+	// free-form map of template-specific keyword arguments forwarded
+	// verbatim to the server's chat template. Each value is a raw JSON
+	// blob so booleans stay booleans (a JSON false must not become the
+	// string "false"). The primary use case is disabling thinking on
+	// reasoning models: llama.cpp supplies enable_thinking=true itself
+	// when the client omits the kwarg, so every request today is
+	// thinking-on. Setting {"enable_thinking": false} here turns it off.
+	//
+	// Omitted entirely when nil or empty so the request is byte-identical
+	// to today for any agent that does not set it.
+	// +optional
+	ChatTemplateKwargs map[string]apiextensionsv1.JSON `json:"chat_template_kwargs,omitempty"`
 }
 
 // ChatResponse is the relevant subset of the response body. The Client

--- a/pkg/foreman/agent/oai/types_test.go
+++ b/pkg/foreman/agent/oai/types_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 // TestMessageMarshalJSON_NonAssistantAlwaysIncludesContent pins the
@@ -202,5 +204,88 @@ func TestMessageMarshalJSON_RoleAlwaysEmitted(t *testing.T) {
 		if !strings.Contains(string(raw), want) {
 			t.Errorf("role %q missing from payload %s", role, raw)
 		}
+	}
+}
+
+// TestChatRequestMarshalJSON_ChatTemplateKwargs pins the wire contract
+// for chat_template_kwargs (#1283): a configured kwarg map must appear
+// verbatim in the outbound JSON, and an empty/unset map must omit the
+// field entirely so the request is byte-identical to today. Values must
+// survive round-trip without coercion: a JSON false must not become the
+// string "false".
+func TestChatRequestMarshalJSON_ChatTemplateKwargs(t *testing.T) {
+	// A boolean false encoded as a raw JSON blob. The whole point of
+	// #1283 is that enable_thinking=false (a real boolean) disables
+	// thinking; a stringified "false" would not.
+	falseJSON := apiextensionsv1.JSON{Raw: []byte("false")}
+
+	cases := []struct {
+		name            string
+		kwargs          map[string]apiextensionsv1.JSON
+		wantHasKey      bool
+		wantBoolValue   bool // only checked when wantHasKey && key present
+		wantBoolPresent bool // whether the value should be a real bool, not a string
+	}{
+		{
+			name:            "set with enable_thinking=false emits real boolean",
+			kwargs:          map[string]apiextensionsv1.JSON{"enable_thinking": falseJSON},
+			wantHasKey:      true,
+			wantBoolValue:   false,
+			wantBoolPresent: true,
+		},
+		{
+			name:            "nil map omits the field entirely",
+			kwargs:          nil,
+			wantHasKey:      false,
+			wantBoolPresent: false,
+		},
+		{
+			name:            "empty map omits the field entirely",
+			kwargs:          map[string]apiextensionsv1.JSON{},
+			wantHasKey:      false,
+			wantBoolPresent: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := ChatRequest{
+				Model:              "test",
+				Messages:           []Message{{Role: RoleUser, Content: "go"}},
+				ChatTemplateKwargs: tc.kwargs,
+			}
+			raw, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			hasKey := strings.Contains(string(raw), `"chat_template_kwargs":`)
+			if hasKey != tc.wantHasKey {
+				t.Fatalf("chat_template_kwargs present=%v want=%v in %s", hasKey, tc.wantHasKey, raw)
+			}
+			if !tc.wantHasKey {
+				return
+			}
+			// Round-trip parse to confirm the value is a real boolean,
+			// not the string "false".
+			var decoded map[string]any
+			if err := json.Unmarshal(raw, &decoded); err != nil {
+				t.Fatalf("round-trip decode: %v", err)
+			}
+			kwargs, ok := decoded["chat_template_kwargs"].(map[string]any)
+			if !ok {
+				t.Fatalf("chat_template_kwargs is not a JSON object: %v", decoded["chat_template_kwargs"])
+			}
+			val, ok := kwargs["enable_thinking"]
+			if !ok {
+				t.Fatalf("enable_thinking missing from chat_template_kwargs: %v", kwargs)
+			}
+			// A real boolean false, not the string "false".
+			boolVal, isBool := val.(bool)
+			if !isBool {
+				t.Errorf("enable_thinking is %T (%v), want bool — coercion bug", val, val)
+			}
+			if tc.wantBoolPresent && boolVal != tc.wantBoolValue {
+				t.Errorf("enable_thinking: want %v got %v", tc.wantBoolValue, boolVal)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Adds `chat_template_kwargs` support end to end, so an agent can control the
model's chat template.

## Why

Fixes #1283

We could not turn thinking off for a reasoning coder, and it turns out omitting
the kwarg is not neutral: llama.cpp supplies `enable_thinking=true` itself when
the client says nothing, so **every request we send today is thinking-on**.

Measured on Laguna S 2.1, 45 requests, three prompt shapes, interleaved, prompt
cache disabled, `max_tokens` held fixed:

| `enable_thinking` | reasoned | hit the token cap |
|---|---|---|
| absent (what we send today) | 8/15 | 1/15 |
| `false` | **0/15** | **0/15** |
| `true` | 9/15 | 2/15 |

Confirmed deterministically via `/apply-template`: the rendered prompt for
"absent" is byte-identical to `true`, and only `false` yields a pre-closed
`</think>`.

That is the root of #1139, where a coder burned 99.9 minutes truncating and
retrying, and it is upstream of #1276. Raising `maxOutputTokens` buys budget to
absorb the reasoning; this removes the reasoning instead.

## How

Mirrors the path `MaxOutputTokens` already takes: Agent spec, read in
`executor_native.go`, onto `LoopConfig`, onto the `ChatRequest` built in
`runOneTurn`.

The value type is `map[string]apiextensionsv1.JSON` rather than
`map[string]string` or a `disableThinking` bool. Raw JSON keeps booleans as
booleans, and free-form keeps it usable when a different template wants
something other than `enable_thinking`.

## Verification

I checked the three acceptance criteria by marshalling rather than by reading
the struct, since `omitempty` is where this class of bug lives:

```
set    -> {"model":"m",...,"chat_template_kwargs":{"enable_thinking":false}}
unset  -> {"model":"m","messages":null,"stream":false}
empty  -> {"model":"m","messages":null,"stream":false}
```

Boolean preserved with no coercion to `"false"`, and the key is absent entirely
when unset or empty, so the request is byte-identical to today for every agent
that does not set it.

```
go build ./...                              OK
go vet ./pkg/foreman/... ./api/...          OK
gofmt -l pkg/foreman api                    clean
go test ./pkg/foreman/agent/... ./api/...   ok
```

Both generated CRD copies are updated, `config/crd/bases/` and
`charts/foreman/templates/crds/`, along with `zz_generated.deepcopy.go`.

## Provenance

Authored by the Foreman coder (Laguna S 2.1 on gfx1151), GO and GATE-PASS in 31
minutes. I reviewed the diff against the issue's acceptance criteria, verified
the marshalling behaviour independently, and confirmed the codegen step was not
skipped. Amended before opening to add my sign-off, which CONTRIBUTING.md
requires and a bot-only sign-off does not satisfy (#1281).

Assisted-by: Foreman (LLMKube agentic coder), reviewed by me

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran the affected packages, output above)
- [x] `make lint` passes locally (`go vet` and `gofmt` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): field is documented inline on the Agent spec and surfaces in the CRD
