### PR TITLE
fix(foreman): hold the session compaction drop point steady across turns

### DIFF
--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -252,6 +252,18 @@ const (
 	ContextStrategySession = "session"
 )
 
+// sessionCompactionTargetPercent is how far below ContextWindowTokens a
+// session compaction compacts to. Compaction TRIGGERS at the budget and
+// compacts to this fraction of it, so the turns that follow fit without
+// dropping anything and the wire prefix stays byte-identical. Without the
+// gap, each turn drops one more group, the prefix changes every turn, and
+// the server's prefix-matched KV cache is invalidated every turn (#1286).
+//
+// 60 leaves roughly 36k tokens of headroom on the default 90k budget, which
+// is many turns of tool output, while still retaining the majority of the
+// window as history.
+const sessionCompactionTargetPercent = 60
+
 // charsPerTokenApprox is the rough chars-per-token ratio used for
 // budget estimation. Real tokenizers vary by model and language; for
 // the masking decision, 4 is close enough (arXiv 2508.21433 showed
@@ -735,6 +747,12 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	// bookkeeping. Each streak resets after any successful tool-calling turn,
 	// so only a sustained no-progress run exhausts its budget.
 	var streaks noProgressStreaks
+	// sessionDrop is how many oldest turn-groups the session strategy is
+	// currently dropping. It persists across turns deliberately: holding the
+	// drop point fixed keeps the wire prefix byte-identical, which is what
+	// lets the server reuse its prefix-matched KV cache instead of
+	// re-prefilling the entire context every turn (#1286).
+	sessionDrop := 0
 	// verifyRetries counts coder-gate fix attempts spent so far (#749).
 	verifyRetries := 0
 
@@ -772,7 +790,7 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 		// payload, so it is cleared immediately regardless of the outcome.
 		preserveReasoning := streaks.preserveReasoningNext
 		streaks.preserveReasoningNext = false
-		editSucceeded, turnErr := l.runOneTurn(ctx, cfg, activeSchemas, res, preserveReasoning)
+		editSucceeded, turnErr := l.runOneTurn(ctx, cfg, activeSchemas, res, preserveReasoning, &sessionDrop)
 		if turnErr != nil {
 			if errors.Is(turnErr, errTerminalReached) {
 				// Coder gate feedback loop (#749): give the gate a chance to
@@ -1035,7 +1053,7 @@ func (l *Loop) applyTerminalGate(
 // reasoning-only turn) is untouched.
 func (l *Loop) runOneTurn(
 	ctx context.Context, cfg LoopConfig, schemas []oai.Tool, res *LoopResult,
-	preserveTrailingReasoning bool,
+	preserveTrailingReasoning bool, sessionDrop *int,
 ) (editSucceeded bool, err error) {
 	ctx, span := l.tracer.Start(ctx, "foreman.agent.turn",
 		trace.WithAttributes(attribute.Int("turn", res.Turns)))
@@ -1045,7 +1063,8 @@ func (l *Loop) runOneTurn(
 	req := oai.ChatRequest{
 		Model: cfg.Model,
 		Messages: stripReasoningForWire(
-			selectWireTranscript(cfg, res.Transcript), preserveTrailingReasoning),
+			selectWireTranscriptSticky(cfg, res.Transcript, sessionDrop),
+			preserveTrailingReasoning),
 		Tools:       schemas,
 		Temperature: cfg.Temperature,
 		// Per-turn generation cap (0 omits max_tokens, deferring to the
@@ -1331,9 +1350,9 @@ type turnGroup struct{ start, end int }
 // task message) and the most recent turn-group, so the agent never loses
 // its instructions, its task, or its latest work. Dropping is in
 // turn-group units so a tool_call_id is never orphaned. See issue #756.
-func compactTranscriptForWire(transcript []oai.Message, ctxBudget int) []oai.Message {
-	if ctxBudget <= 0 || approxTokens(transcript) <= ctxBudget {
-		return transcript
+func compactTranscriptForWire(transcript []oai.Message, ctxBudget, minDrop int) ([]oai.Message, int) {
+	if ctxBudget <= 0 {
+		return transcript, 0
 	}
 
 	// headEnd is the exclusive index of the pinned head: all leading
@@ -1359,30 +1378,67 @@ func compactTranscriptForWire(transcript []oai.Message, ctxBudget int) []oai.Mes
 	}
 
 	if len(groups) <= 1 {
-		return transcript // 0 or 1 groups: nothing to drop (head + at most one group is the floor)
+		return transcript, 0 // head + at most one group is the floor
+	}
+	if minDrop < 0 {
+		minDrop = 0
+	}
+	if minDrop > len(groups)-1 {
+		minDrop = len(groups) - 1
 	}
 
-	// Drop oldest groups (after head, before the last group) until under
-	// budget or only the last group remains.
-	for dropCount := 1; dropCount < len(groups); dropCount++ {
-		kept := assembleSessionWire(transcript, headEnd, groups, dropCount)
-		if approxTokens(kept) <= ctxBudget {
-			return kept
+	// Sticky: reuse the previous turn's drop point while the payload still
+	// fits. This is the property that matters, and it is not the same as
+	// "compact to a smaller target": the transcript grows every turn, so
+	// recomputing the drop point from scratch slides the window forward by one
+	// group per turn no matter what target is chosen, and the wire prefix
+	// changes every turn. Holding the drop point fixed means the turn only
+	// appends, the prefix is byte-identical, and the server's prefix-matched
+	// KV cache is reused (#1286).
+	if kept := assembleSessionWire(transcript, headEnd, groups, minDrop); approxTokens(kept) <= ctxBudget {
+		return kept, minDrop
+	}
+
+	// Over budget: compact PAST the budget to a low-water mark, so the next
+	// several turns fit at this same drop point rather than forcing another
+	// compaction (and another full re-prefill) on the very next turn.
+	target := ctxBudget * sessionCompactionTargetPercent / 100
+	if target <= 0 {
+		target = ctxBudget
+	}
+	for d := minDrop + 1; d < len(groups); d++ {
+		kept := assembleSessionWire(transcript, headEnd, groups, d)
+		if approxTokens(kept) <= target {
+			return kept, d
 		}
 	}
 	// Degenerate: only head + last group remain (still possibly over budget).
-	return assembleSessionWire(transcript, headEnd, groups, len(groups)-1)
+	return assembleSessionWire(transcript, headEnd, groups, len(groups)-1), len(groups) - 1
+}
+
+// selectWireTranscriptSticky calls selectWireTranscript and persists the
+// updated drop point through the caller's pointer, so the next turn reuses it.
+func selectWireTranscriptSticky(cfg LoopConfig, transcript []oai.Message, drop *int) []oai.Message {
+	cur := 0
+	if drop != nil {
+		cur = *drop
+	}
+	wire, next := selectWireTranscript(cfg, transcript, cur)
+	if drop != nil {
+		*drop = next
+	}
+	return wire
 }
 
 // selectWireTranscript routes the transcript through the configured
 // context strategy. "session" uses compactTranscriptForWire (stable
 // prefix, compact at budget); anything else (including "" and "window")
 // uses maskTranscriptForWire (observation masking).
-func selectWireTranscript(cfg LoopConfig, transcript []oai.Message) []oai.Message {
+func selectWireTranscript(cfg LoopConfig, transcript []oai.Message, minDrop int) ([]oai.Message, int) {
 	if cfg.ContextStrategy == ContextStrategySession {
-		return compactTranscriptForWire(transcript, cfg.ContextWindowTokens)
+		return compactTranscriptForWire(transcript, cfg.ContextWindowTokens, minDrop)
 	}
-	return maskTranscriptForWire(transcript, cfg.ObservationWindowTurns, cfg.ContextWindowTokens)
+	return maskTranscriptForWire(transcript, cfg.ObservationWindowTurns, cfg.ContextWindowTokens), minDrop
 }
 
 // assembleSessionWire builds the wire payload: the pinned head

--- a/pkg/foreman/agent/loop_session_test.go
+++ b/pkg/foreman/agent/loop_session_test.go
@@ -45,7 +45,7 @@ func assertNoOrphanedToolMessages(t *testing.T, wire []oai.Message) {
 
 func TestCompactTranscript_UnderBudgetReturnsIdentical(t *testing.T) {
 	tx := transcriptFixture(5, 200) // small, well under budget
-	wire := compactTranscriptForWire(tx, 100000)
+	wire, _ := compactTranscriptForWire(tx, 100000, 0)
 	if len(wire) != len(tx) {
 		t.Fatalf("wire length: want %d got %d", len(tx), len(wire))
 	}
@@ -58,7 +58,7 @@ func TestCompactTranscript_UnderBudgetReturnsIdentical(t *testing.T) {
 
 func TestCompactTranscript_ZeroBudgetReturnsIdentical(t *testing.T) {
 	tx := transcriptFixture(5, 200)
-	wire := compactTranscriptForWire(tx, 0)
+	wire, _ := compactTranscriptForWire(tx, 0, 0)
 	if len(wire) != len(tx) {
 		t.Fatalf("wire length: want %d got %d", len(tx), len(wire))
 	}
@@ -68,7 +68,7 @@ func TestCompactTranscript_OverBudgetDropsOldestMiddle(t *testing.T) {
 	// 8 turn-groups, each tool ~4000 bytes (~1000 tokens). Head is tiny.
 	tx := transcriptFixture(8, 4000)
 	budget := 3500 // tokens: keeps head + a few newest groups
-	wire := compactTranscriptForWire(tx, budget)
+	wire, _ := compactTranscriptForWire(tx, budget, 0)
 
 	// Something was dropped.
 	if len(wire) >= len(tx) {
@@ -98,8 +98,8 @@ func TestCompactTranscript_OverBudgetDropsOldestMiddle(t *testing.T) {
 }
 
 func TestCompactTranscript_DegenerateKeepsHeadAndLastGroup(t *testing.T) {
-	tx := transcriptFixture(4, 8000)          // each tool ~2000 tokens
-	wire := compactTranscriptForWire(tx, 100) // absurdly small budget
+	tx := transcriptFixture(4, 8000)                // each tool ~2000 tokens
+	wire, _ := compactTranscriptForWire(tx, 100, 0) // absurdly small budget
 
 	if wire[0].Role != oai.RoleSystem || wire[1].Role != oai.RoleUser {
 		t.Fatalf("head not preserved: %+v", wire[:2])
@@ -114,7 +114,7 @@ func TestCompactTranscript_DegenerateKeepsHeadAndLastGroup(t *testing.T) {
 func TestSelectWireTranscript_SessionDoesNotMask(t *testing.T) {
 	tx := transcriptFixture(6, 4000)
 	cfg := LoopConfig{ContextStrategy: ContextStrategySession, ContextWindowTokens: 1000000}
-	wire := selectWireTranscript(cfg, tx)
+	wire, _ := selectWireTranscript(cfg, tx, 0)
 	for i := range tx {
 		if wire[i].Content != tx[i].Content {
 			t.Errorf("session strategy masked content at %d", i)
@@ -125,7 +125,7 @@ func TestSelectWireTranscript_SessionDoesNotMask(t *testing.T) {
 func TestSelectWireTranscript_WindowMasks(t *testing.T) {
 	tx := transcriptFixture(6, 4000)
 	cfg := LoopConfig{ContextStrategy: ContextStrategyWindow, ObservationWindowTurns: 1}
-	wire := selectWireTranscript(cfg, tx)
+	wire, _ := selectWireTranscript(cfg, tx, 0)
 	changed := false
 	for i := range tx {
 		if tx[i].Role == oai.RoleTool && wire[i].Content != tx[i].Content {
@@ -139,7 +139,7 @@ func TestSelectWireTranscript_WindowMasks(t *testing.T) {
 
 func TestSelectWireTranscript_EmptyDefaultsToWindow(t *testing.T) {
 	tx := transcriptFixture(6, 4000)
-	got := selectWireTranscript(LoopConfig{ObservationWindowTurns: 1}, tx)
+	got, _ := selectWireTranscript(LoopConfig{ObservationWindowTurns: 1}, tx, 0)
 	want := maskTranscriptForWire(tx, 1, 0)
 	if len(got) != len(want) {
 		t.Fatalf("empty strategy did not route to window: len got=%d want=%d", len(got), len(want))
@@ -149,4 +149,93 @@ func TestSelectWireTranscript_EmptyDefaultsToWindow(t *testing.T) {
 			t.Errorf("message %d differs from window output", i)
 		}
 	}
+}
+
+// wireIsPrefixOf reports whether prev is an unchanged leading run of next.
+// This is the property the server's KV cache actually needs: it matches on
+// prefix, so a payload that keeps the previous turn's payload intact at the
+// front reuses the cache, and one that does not re-prefills everything.
+func wireIsPrefixOf(prev, next []oai.Message) bool {
+	if len(prev) > len(next) {
+		return false
+	}
+	for i := range prev {
+		if prev[i].Role != next[i].Role ||
+			prev[i].Content != next[i].Content ||
+			prev[i].ToolCallID != next[i].ToolCallID {
+			return false
+		}
+	}
+	return true
+}
+
+// TestCompactTranscript_PrefixStableAcrossTurns is the regression for #1286.
+//
+// Compacting only to the budget line leaves the payload sitting exactly at the
+// ceiling, so the next turn is over again and drops one more group. The prefix
+// then changes on EVERY turn, the KV cache matches nothing, and the full
+// context is re-prefilled each turn: measured live at 95,538 tokens and
+// n_prompt_tokens_cache=0, about 12.6 minutes of prefill per turn.
+//
+// Compacting to a low-water mark buys headroom, so most turns only append and
+// the prefix survives. This walks a run turn by turn and counts how often the
+// prefix breaks, which is exactly how often a real server pays a re-prefill.
+func TestCompactTranscript_PrefixStableAcrossTurns(t *testing.T) {
+	const (
+		budget    = 20000 // tokens
+		toolBytes = 4000  // ~1000 tokens per turn-group
+		turns     = 30    // well past the budget, so compaction must happen
+	)
+
+	var prev []oai.Message
+	drop := 0
+	breaks, compactions := 0, 0
+	for n := 1; n <= turns; n++ {
+		wire, next := compactTranscriptForWire(transcriptFixture(n, toolBytes), budget, drop)
+		drop = next
+		if approxTokens(wire) > budget {
+			t.Fatalf("turn %d: payload over budget: %d > %d", n, approxTokens(wire), budget)
+		}
+		if prev != nil && !wireIsPrefixOf(prev, wire) {
+			breaks++
+			compactions++
+		}
+		prev = wire
+	}
+
+	// Each break is one full re-prefill. Dropping the minimum would break on
+	// essentially every turn past the budget (about 10 of these 30 turns);
+	// with a low-water mark the run should pay it only a couple of times.
+	if breaks > 3 {
+		t.Errorf("wire prefix broke %d times over %d turns; the KV cache is being "+
+			"invalidated nearly every turn, which is #1286", breaks, turns)
+	}
+	if compactions == 0 {
+		t.Fatal("fixture never crossed the budget; this test proves nothing as written")
+	}
+}
+
+// TestCompactTranscript_CompactsBelowBudgetNotToIt pins the mechanism directly:
+// a compaction must leave real headroom, otherwise the next turn re-compacts
+// and the prefix churns again.
+func TestCompactTranscript_CompactsBelowBudgetNotToIt(t *testing.T) {
+	const budget = 20000
+	tx := transcriptFixture(40, 4000) // far over budget, forces a compaction
+	wire, _ := compactTranscriptForWire(tx, budget, 0)
+
+	got := approxTokens(wire)
+	want := budget * sessionCompactionTargetPercent / 100
+	if got > want {
+		t.Errorf("compaction left %d tokens, above the %d low-water mark: "+
+			"no headroom means the next turn re-compacts and the prefix churns",
+			got, want)
+	}
+	// The existing guarantees still hold.
+	if wire[0].Role != oai.RoleSystem || wire[1].Content != "fix issue 510" {
+		t.Errorf("pinned head not preserved: %+v %+v", wire[0], wire[1])
+	}
+	if wire[len(wire)-1].Content != tx[len(tx)-1].Content {
+		t.Error("most recent tool result not kept")
+	}
+	assertNoOrphanedToolMessages(t, wire)
 }

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -1308,7 +1308,7 @@ func TestRunOneTurn_EmptyAssistantReply_SubstitutesPlaceholder(t *testing.T) {
 			{Role: oai.RoleUser, Content: "go"},
 		},
 	}
-	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res, false)
+	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res, false, nil)
 	// The placeholder makes the message non-empty, so runOneTurn treats
 	// it as a no-tool-call turn and returns ErrAssistantNoToolCalls.
 	if !errors.Is(err, ErrAssistantNoToolCalls) {
@@ -1372,7 +1372,7 @@ func TestRunOneTurn_ToolCallTurnNotClobbered(t *testing.T) {
 			{Role: oai.RoleUser, Content: "go"},
 		},
 	}
-	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res, false)
+	_, err := loop.runOneTurn(context.Background(), LoopConfig{Model: "test"}, sixToolSchemas(), res, false, nil)
 	// A tool-call turn is a normal, successful turn: no error expected.
 	if err != nil {
 		t.Fatalf("runOneTurn: expected nil error for a tool-call turn with empty content, got %v", err)


### PR DESCRIPTION
## What

Holds the session compaction drop point steady across turns, so the wire prefix
stops changing every turn and the server's KV cache is actually reused.

## Why

Fixes #1286

Caught live on the #1139 coder run, from the server's `/slots`:

```
n_prompt_tokens:        95538
n_prompt_tokens_cache:      0      <- zero reuse
prompt_tokens_seconds:  125.9
```

95,538 tokens at 126 tok/s is **~12.6 minutes of prefill per turn** before the
model emits a single token. The rate is not anomalous, it sits on our own
published prefill curve for this hardware (394 tok/s at 1.4k, 288 at 21k, 136 at
56k). The agent never sets `cache_prompt`, so the cache was enabled and working.
The loop was handing it a different prefix every turn.

This was the dominant cost on long runs and it hid behind other diagnoses:

| run | crossed the budget | wall clock |
|---|---|---|
| #1072, #1256, #1269, #1283 | no | 16 to 31 min |
| #1139 (thinking on) | yes | 99.9 min, INCOMPLETE |
| #1139 (thinking off) | yes | 60+ min, did not converge |

The fast runs were fast because their context never crossed 90k. #1139 is the
only task big enough to cross it, and it has never completed.

## How

Two changes, and **the second is the one that matters.**

Compaction now targets a low-water mark below the budget rather than the budget
line. On its own that fixes nothing: the transcript grows every turn, so
recomputing the drop point from scratch slides the window forward by one group
per turn regardless of which target you pick, and the prefix still churns. I
wrote that version first and the regression test caught it, which is the reason
the test is shaped the way it is.

The fix is making the drop point **sticky**. It persists across turns and only
increases when the payload at the current point no longer fits. That makes the
normal turn append-only, so the prefix is byte-identical and the cache hits. The
low-water mark then does useful work: it buys enough headroom that the next
compaction is many turns away instead of on the very next turn.

## Verification

Measured on a 30-turn walk of a growing transcript:

| | prefix breaks over 30 turns |
|---|---|
| before | **11** |
| after | **2** |
| stickiness removed (mutation) | 29, and the test fails |

Each break is one full re-prefill. For a #1139-sized context that is roughly 139
minutes of pure prefill reduced to about 25.

The regression test walks the transcript turn by turn and counts prefix breaks,
which is exactly how often a real server pays a re-prefill, rather than
asserting on a single call's output. Existing guarantees are re-checked: pinned
head, most recent group kept, no orphaned tool messages, never over budget.

```
go build ./...                    OK
go vet ./pkg/foreman/...          OK
gofmt -l pkg/foreman/             clean
go test ./pkg/foreman/agent/      ok (full package)
```

## Trade-off

Compacting past the budget retains less history: at a 60 percent target on a 90k
budget, roughly 54k of history instead of 90k. That is the cheaper side of this
trade, since the alternative is a run that cannot converge.

Assisted-by: Claude Code (Opus), diagnosed from live server metrics and mutation-tested by me

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (full `./pkg/foreman/agent/`, output above)
- [x] `make lint` passes locally (`go vet` and `gofmt` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): n/a, internal loop behaviour
