### PR TITLE
docs(foreman): fix AgenticTask names in minimal example

### DIFF
--- a/docs/site/foreman/README.md
+++ b/docs/site/foreman/README.md
@@ -146,8 +146,9 @@ spec:
 kubectl get workload,agentictask -n default -w
 ```
 
-The Workload synthesizes a `code-510` AgenticTask (coder) and a
-`verify-510` AgenticTask (gate, depends on code). When both succeed,
+The Workload synthesizes a `fix-one-bug-code-510` AgenticTask (coder)
+and a `fix-one-bug-verify-510` AgenticTask (gate, depends on code),
+each step name prefixed with the Workload name. When both succeed,
 a DCO-signed branch lands on the fork
 (`Defilan/LLMKube:foreman/fix-one-bug/issue-510`). Verdict
 `GATE-PASS` means it cleared the gate; open the branch as an


### PR DESCRIPTION
## What

Fixes the AgenticTask names in the Foreman README's "A minimal example"
section so they match what Foreman actually creates.

## Why

Fixes #1289

The section named the tasks `code-510` and `verify-510`, which are the
**PipelineStep** names. `absoluteTaskName` prefixes the step with the Workload
name when materializing the AgenticTask, so for the example's `fix-one-bug`
Workload the objects are `fix-one-bug-code-510` and `fix-one-bug-verify-510`.

A reader following the `kubectl get workload,agentictask` command shown
directly above that paragraph sees the prefixed names, and
`kubectl get agentictask code-510` returns NotFound.

## How

One paragraph, documentation only. The M4 runbook's `code-503` reference is
deliberately left alone: those are hand-authored AgenticTasks
(`examples/foreman/m4-two-step-demo.yaml` sets `metadata.name: code-503`
directly), so the unprefixed name is correct there. Only workload-synthesized
tasks carry the prefix.

## Provenance

This change was written by Foreman itself, which makes it a reasonable
end-to-end test of the thing it documents.

It ran on a throwaway kind cluster built from the published 0.9.11 charts, with
a `cloud-proxy` Agent pointed at Claude Sonnet 5, and produced the branch in
**4 turns and 14 seconds**. The task Foreman created for it was named
`fix-docs-code-1289`, which is the exact naming this PR documents.

I reviewed the diff and made one change before opening: the model's version used
an em dash, which is against house style. Everything else is as it wrote it,
including the commit message.

Worth recording that its first attempt failed honestly. With a credential that
could not push, it committed the work, failed at the push, and reported
`NO-GO / PUSH-FAILED` with the verbatim git error in task status rather than
claiming success.

Assisted-by: Foreman (LLMKube agentic coder, Claude Sonnet 5 via cloud-proxy), reviewed by me

## Checklist

- [x] Tests added/updated (n/a: documentation only)
- [x] `make test` passes locally (n/a: no code changed)
- [x] `make lint` passes locally (n/a: no code changed)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): this is the documentation change
