### PR TITLE
fix(foreman): three first-run failures on a clean cluster

### DIFF
--- a/internal/foreman/webhook/agent_webhook.go
+++ b/internal/foreman/webhook/agent_webhook.go
@@ -166,11 +166,17 @@ func validateAgentPromptShape(agent *foremanv1alpha1.Agent, specPath *field.Path
 		return errs
 	}
 
-	// LLM-driven Agent.
+	// LLM-driven Agent. Name whichever field actually made it LLM-driven: a
+	// cloud-proxy Agent has no inferenceServiceRef, so citing that field sends
+	// the operator looking at something they never set.
 	if strings.TrimSpace(agent.Spec.SystemPrompt) == "" {
+		because := "inferenceServiceRef is set"
+		if agent.Spec.Provider == foremanv1alpha1.AgentProviderCloudProxy {
+			because = "provider is cloud-proxy"
+		}
 		errs = append(errs, field.Required(
 			specPath.Child("systemPrompt"),
-			"LLM-driven Agent (inferenceServiceRef set) requires a non-empty systemPrompt"))
+			"LLM-driven Agent ("+because+") requires a non-empty systemPrompt"))
 	}
 	return errs
 }

--- a/internal/foreman/webhook/agent_webhook_test.go
+++ b/internal/foreman/webhook/agent_webhook_test.go
@@ -18,6 +18,8 @@ package webhook
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -283,5 +285,60 @@ func TestCanonicalToolNamesCoversWhitelist(t *testing.T) {
 		if !have[w] {
 			t.Errorf("canonical tool set missing expected tool %q (have %v)", w, names)
 		}
+	}
+}
+
+// TestValidateAgentPromptShape_MessageNamesTheRightField pins the wording of
+// the missing-systemPrompt error. A cloud-proxy Agent has no
+// inferenceServiceRef, so an error citing that field sends the operator
+// looking at something they never set. Hit on a clean cluster while writing
+// the getting-started walkthrough.
+func TestValidateAgentPromptShape_MessageNamesTheRightField(t *testing.T) {
+	cases := []struct {
+		name     string
+		agent    *foremanv1alpha1.Agent
+		wantCite string
+		notCite  string
+	}{
+		{
+			name: "cloud-proxy cites the provider",
+			agent: func() *foremanv1alpha1.Agent {
+				a := validLLMAgent()
+				a.Spec.Provider = foremanv1alpha1.AgentProviderCloudProxy
+				a.Spec.InferenceServiceRef = corev1.LocalObjectReference{}
+				a.Spec.ProviderConfig = &foremanv1alpha1.ProviderConfig{
+					BaseURL: "https://example.invalid/v1", Model: "m",
+				}
+				a.Spec.SystemPrompt = ""
+				return a
+			}(),
+			wantCite: "provider is cloud-proxy",
+			notCite:  "inferenceServiceRef is set",
+		},
+		{
+			name: "local cites the inferenceServiceRef",
+			agent: func() *foremanv1alpha1.Agent {
+				a := validLLMAgent()
+				a.Spec.SystemPrompt = ""
+				return a
+			}(),
+			wantCite: "inferenceServiceRef is set",
+			notCite:  "cloud-proxy",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateAgentPromptShape(tc.agent, field.NewPath("spec"))
+			if len(errs) == 0 {
+				t.Fatal("expected a validation error for the empty systemPrompt")
+			}
+			joined := errs.ToAggregate().Error()
+			if !strings.Contains(joined, tc.wantCite) {
+				t.Errorf("message should cite %q, got: %s", tc.wantCite, joined)
+			}
+			if strings.Contains(joined, tc.notCite) {
+				t.Errorf("message should not cite %q, got: %s", tc.notCite, joined)
+			}
+		})
 	}
 }

--- a/internal/foreman/webhook/agent_webhook_test.go
+++ b/internal/foreman/webhook/agent_webhook_test.go
@@ -18,13 +18,13 @@ package webhook
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	executoragent "github.com/defilantech/llmkube/pkg/foreman/agent"

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -973,6 +974,19 @@ func stripReasoningForWire(msgs []oai.Message, preserveTrailingReasoning bool) [
 	return wire
 }
 
+// rejectsTemperature reports whether err is a provider rejecting the
+// temperature field itself, as opposed to any other 400. Matching on the
+// field name in the body is deliberately narrow: a 400 that does not mention
+// temperature is a real error and must not be retried, since a blind retry
+// would double the cost of every genuinely bad request.
+func rejectsTemperature(err error) bool {
+	var se *oai.StatusError
+	if !errors.As(err, &se) || se.Code != http.StatusBadRequest {
+		return false
+	}
+	return strings.Contains(strings.ToLower(se.Body), "temperature")
+}
+
 // mostRecentAssistantToolCalls walks the transcript backwards and
 // returns the tool_calls from the latest assistant message. Empty if
 // no assistant message exists. Used by the progress monitor to inspect
@@ -1079,6 +1093,17 @@ func (l *Loop) runOneTurn(
 		ChatTemplateKwargs: cfg.ChatTemplateKwargs,
 	}
 	resp, err := l.client.Chat(ctx, req)
+	if err != nil && req.Temperature != nil && rejectsTemperature(err) {
+		// Some providers reject the field outright rather than ignoring it:
+		// current Anthropic models answer 400 with "`temperature` is
+		// deprecated for this model". That is a hard failure on turn 1 for
+		// any Agent that sets a temperature, which is most of them, since
+		// our own examples do. Drop the field and retry once rather than
+		// making every operator discover this and edit their Agent.
+		span.AddEvent("temperature rejected by provider, retrying without it")
+		req.Temperature = nil
+		resp, err = l.client.Chat(ctx, req)
+	}
 	if err != nil {
 		span.RecordError(err)
 		return false, fmt.Errorf("turn %d: chat: %w", res.Turns, err)

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1478,5 +1479,75 @@ func TestLoop_PreservedTruncatedReasoningDoesNotProduceEmptyAssistant(t *testing
 
 	if transcript[0].Content != "" {
 		t.Errorf("original transcript must be untouched: %+v", transcript[0])
+	}
+}
+
+// TestLoop_RetriesWithoutTemperatureOn400 covers a provider that rejects the
+// temperature field outright. Current Anthropic models answer 400 with
+// "`temperature` is deprecated for this model", which is a hard failure on
+// turn 1 for any Agent that sets one, and our own examples set one.
+//
+// The loop should drop the field and retry once, and the SECOND request must
+// not carry temperature.
+func TestLoop_RetriesWithoutTemperatureOn400(t *testing.T) {
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(b))
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"temperature is deprecated for this model."}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: " + emptyAssistantReply + "\n\ndata: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	temp := 0.2
+	loop := newTestLoop(srv, &fakeRegistry{results: map[string]*ToolResult{}})
+	res := &LoopResult{Transcript: []oai.Message{
+		{Role: oai.RoleSystem, Content: "sys"},
+		{Role: oai.RoleUser, Content: "go"},
+	}}
+	_, _ = loop.runOneTurn(context.Background(),
+		LoopConfig{Model: "test", Temperature: &temp}, sixToolSchemas(), res, false, nil)
+
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 requests (reject then retry), got %d", len(bodies))
+	}
+	if !strings.Contains(bodies[0], `"temperature"`) {
+		t.Errorf("first request should carry temperature: %s", bodies[0])
+	}
+	if strings.Contains(bodies[1], `"temperature"`) {
+		t.Errorf("retry must NOT carry temperature, got: %s", bodies[1])
+	}
+}
+
+// TestLoop_DoesNotRetryOnUnrelated400 is the other half: a 400 that has
+// nothing to do with temperature must fail immediately. Retrying every 400
+// would double the cost of every genuinely bad request.
+func TestLoop_DoesNotRetryOnUnrelated400(t *testing.T) {
+	var n int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"context length exceeded"}}`))
+	}))
+	defer srv.Close()
+
+	temp := 0.2
+	loop := newTestLoop(srv, &fakeRegistry{results: map[string]*ToolResult{}})
+	res := &LoopResult{Transcript: []oai.Message{
+		{Role: oai.RoleSystem, Content: "sys"},
+		{Role: oai.RoleUser, Content: "go"},
+	}}
+	_, err := loop.runOneTurn(context.Background(),
+		LoopConfig{Model: "test", Temperature: &temp}, sixToolSchemas(), res, false, nil)
+	if err == nil {
+		t.Fatal("expected the 400 to propagate")
+	}
+	if n != 1 {
+		t.Errorf("an unrelated 400 must not be retried, saw %d requests", n)
 	}
 }

--- a/pkg/foreman/agent/oai/client.go
+++ b/pkg/foreman/agent/oai/client.go
@@ -288,7 +288,7 @@ func (c *Client) doOnce(ctx context.Context, req ChatRequest) (*ChatResponse, er
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, fmt.Errorf("oai: status %d: %s", resp.StatusCode, string(b))
+		return nil, &StatusError{Code: resp.StatusCode, Body: string(b)}
 	}
 
 	parsed, err := readSSEStream(resp.Body)

--- a/pkg/foreman/agent/oai/types.go
+++ b/pkg/foreman/agent/oai/types.go
@@ -26,6 +26,7 @@ package oai
 
 import (
 	"encoding/json"
+	"fmt"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
@@ -248,4 +249,18 @@ type ToolCallDelta struct {
 type ToolCallFunctionDelta struct {
 	Name      string `json:"name,omitempty"`
 	Arguments string `json:"arguments,omitempty"`
+}
+
+// StatusError is a non-2xx response from the chat endpoint. It carries the
+// status code and the response body verbatim so a caller can react to a
+// specific provider rejection instead of string-matching a wrapped error.
+// The Error() text is unchanged from the previous fmt.Errorf form so log
+// output and existing assertions keep working.
+type StatusError struct {
+	Code int
+	Body string
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("oai: status %d: %s", e.Code, e.Body)
 }

--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -85,7 +85,7 @@ spec:
               rc=0
               {{- if .Generic }}
               {{- range .Commands }}
-              echo "=== {{ . }} ==="; ( {{ . }} ) || rc=1
+              echo "=== {{ firstLine . }} ==="; ( {{ indentShell . }} ) || rc=1
               {{- end }}
               {{- else }}
               {{- range .Checks }}

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -459,7 +459,15 @@ func renderGateJob(in rendererInput) (*batchv1.Job, error) {
 	if in.BaseBranch == "" {
 		in.BaseBranch = "main"
 	}
-	tmpl, err := template.New("gate-job").Parse(gateJobTemplate)
+	tmpl, err := template.New("gate-job").Funcs(template.FuncMap{
+		// A gate command may legitimately be multi-line shell. The template
+		// interpolates it inside a YAML block scalar, so a raw newline ends
+		// the block and the Job fails to unmarshal (#1293). indentShell
+		// re-indents continuation lines to the block's own indentation;
+		// firstLine keeps the echo label on one line.
+		"indentShell": indentShell,
+		"firstLine":   firstLine,
+	}).Parse(gateJobTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("parse template: %w", err)
 	}
@@ -572,4 +580,29 @@ func sanitizeName(in string) string {
 		return "task"
 	}
 	return out
+}
+
+// gateBlockIndent is the indentation of the command lines inside the Job
+// template's args block scalar. Continuation lines of a multi-line command
+// must match it or the YAML block ends early.
+const gateBlockIndent = "              "
+
+// indentShell re-indents every line after the first to gateBlockIndent, so a
+// multi-line gate command stays inside the YAML block scalar it is rendered
+// into.
+func indentShell(cmd string) string {
+	lines := strings.Split(cmd, "\n")
+	for i := 1; i < len(lines); i++ {
+		lines[i] = gateBlockIndent + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// firstLine returns the first line of cmd, with an ellipsis when there are
+// more. Used for the "=== <cmd> ===" banner, which must stay on one line.
+func firstLine(cmd string) string {
+	if i := strings.IndexByte(cmd, '\n'); i >= 0 {
+		return strings.TrimSpace(cmd[:i]) + " ..."
+	}
+	return cmd
 }

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -389,6 +389,12 @@ func renderGateArgsForTest(t *testing.T, in map[string]any) string {
 	if v, ok := in["checks"].([]string); ok {
 		rin.Checks = v
 	}
+	if v, ok := in["generic"].(bool); ok {
+		rin.Generic = v
+	}
+	if v, ok := in["commands"].([]string); ok {
+		rin.Commands = v
+	}
 	job, err := renderGateJob(rin)
 	if err != nil {
 		t.Fatalf("renderGateJob: %v", err)
@@ -1102,5 +1108,42 @@ func TestGateJobNamePreservesUniquenessSuffixWhenTruncated(t *testing.T) {
 	}
 	if n1 == n2 {
 		t.Fatalf("two submissions of the same long task name collide: %q", n1)
+	}
+}
+
+// TestRenderGateJob_MultiLineCommandStillUnmarshals covers #1293. A gate
+// command is a plain string field and multi-line shell is the natural way to
+// write a real check, but the template interpolates it inside a YAML block
+// scalar. Before the fix a newline ended the block and the whole Job failed to
+// unmarshal with "could not find expected ':'", so the gate never ran and the
+// operator saw a YAML error citing a template they never wrote.
+func TestRenderGateJob_MultiLineCommandStillUnmarshals(t *testing.T) {
+	multi := "if grep -q needle file.txt; then\n  echo 'found'\n  exit 1\nfi\necho ok"
+	args := renderGateArgsForTest(t, map[string]any{
+		"generic":  true,
+		"commands": []string{multi},
+	})
+	for _, want := range []string{"if grep -q needle file.txt; then", "echo 'found'", "exit 1", "echo ok"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("rendered args lost %q:\n%s", want, args)
+		}
+	}
+	if !strings.Contains(args, "...") {
+		t.Errorf("multi-line banner should be truncated with an ellipsis:\n%s", args)
+	}
+}
+
+// TestRenderGateJob_SingleLineCommandUnchanged guards the common case: a
+// one-line command renders exactly as before, with no ellipsis added.
+func TestRenderGateJob_SingleLineCommandUnchanged(t *testing.T) {
+	args := renderGateArgsForTest(t, map[string]any{
+		"generic":  true,
+		"commands": []string{"go build ./..."},
+	})
+	if !strings.Contains(args, `echo "=== go build ./... ==="`) {
+		t.Errorf("single-line command should render unchanged:\n%s", args)
+	}
+	if strings.Contains(args, "go build ./... ...") {
+		t.Error("single-line command must not gain an ellipsis")
 	}
 }


### PR DESCRIPTION
Three failures hit in order on a fresh kind cluster, installing from the published charts and following our own docs. Each one stops a new user before they get a working run.

Fixes #1294, fixes #1293.

## 1. Providers that reject `temperature`

Current Anthropic models answer 400 with `` `temperature` is deprecated for this model ``. That is a hard failure on **turn 1** for any Agent that sets a temperature, and our own examples set one.

The loop now drops the field and retries once. The match is deliberately narrow: a 400 that does not mention temperature is a real error and is **not** retried, because a blind retry would double the cost of every genuinely bad request.

## 2. The webhook named the wrong field

Omitting `systemPrompt` produced:

```
spec.systemPrompt: Required value: LLM-driven Agent (inferenceServiceRef set)
requires a non-empty systemPrompt
```

on a `cloud-proxy` Agent, which has no `inferenceServiceRef`. It now cites whichever field actually made the Agent LLM-driven.

## 3. Multi-line gate commands broke Job rendering

`gateProfile.commands` are interpolated into a YAML block scalar, so a newline ended the block:

```
gate did not run: render: unmarshal job: error converting YAML to JSON:
yaml: line 89: could not find expected ":"
```

Multi-line shell is the natural way to write a real check, the field is a plain string with nothing warning against it, and the error names a template the operator never wrote. Continuation lines are now re-indented to the block, and the `echo` banner is truncated to its first line so it stays on one line.

## Supporting change

The OAI client returns a typed `*StatusError` carrying the status code and body, so callers can react to a specific provider rejection rather than string-matching a wrapped error. `Error()` text is unchanged, so logs and existing assertions are unaffected.

## Verification

Every fix has a test that fails without it, confirmed by reverting each change:

| reverted | result |
|---|---|
| the retry | request count drops to 1, test fails |
| the template indent | exact `could not find expected ":"` unmarshal error returns |
| (webhook) | message test checks both directions, local and cloud-proxy |

```
go build ./...                                   OK
go vet ./pkg/foreman/... ./internal/foreman/...  OK
gofmt -l pkg internal api                        clean
go test ./pkg/foreman/agent/... ./internal/foreman/webhook/   ok
```

Assisted-by: Claude Code (Opus), reproduced on a clean cluster and mutation-tested by me

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (affected packages, output above)
- [x] `make lint` passes locally (`go vet` and `gofmt` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): error message and retry behaviour are self-describing; no doc change needed