### PR TITLE
docs(foreman): replace em dash with colon in README heading

### DIFF
--- a/docs/site/foreman/README.md
+++ b/docs/site/foreman/README.md
@@ -220,7 +220,7 @@ An issue whose base coder returns NO-GO or trips the coder gate is
 re-dispatched once to `qwopus-27b-dense-coder`, with the base
 model's failure summary threaded into the prompt.
 
-### `ALREADY-RESOLVED` — honest "already done" bail (#970)
+### `ALREADY-RESOLVED`: honest "already done" bail (#970)
 
 When a coder concludes the work is already present on the branch or
 upstream base (e.g. a `Fixes #N` commit since `BaseBranch`, or an


### PR DESCRIPTION
## What

One character in `docs/site/foreman/README.md`: the `ALREADY-RESOLVED` heading used an em dash where the project's writing style calls for a colon.

```diff
-### `ALREADY-RESOLVED` — honest "already done" bail (#970)
+### `ALREADY-RESOLVED`: honest "already done" bail (#970)
```

## Why

Fixes #1291

## How

This branch was produced by Foreman, not by hand. It is the walkthrough run for the Foreman 101 post, executed against the released 0.9.12 charts on a throwaway kind cluster with a cloud-proxy coder Agent:

```
verdict:    GO
summary:    Replaced em dash with colon in Foreman README heading per writing style.
turnCount:  4
elapsedSec: 15.42
branch:     foreman/fix-emdash/issue-1291
commitSHA:  970f3d69595931c5d5146fe2adb8cc3846f2a977
```

Reviewed before opening: the branch is one commit, one file, +1/-1, and `behind_by=0` against main, so it carries nothing else. Confirmed no other em dashes remain in the file, so the fix is not partial.

## Checklist

- [x] Tests added/updated (n/a, documentation copy)
- [x] `make test` passes locally (n/a, no code changed)
- [x] `make lint` passes locally (n/a, no code changed)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

AI-assisted (band 3): the commit was authored by a Foreman coder agent; the review, verification, and decision to open this are mine.