### PR TITLE
fix(controller): Available goes False when no replicas are ready

### DIFF
--- a/internal/controller/status_builder.go
+++ b/internal/controller/status_builder.go
@@ -338,6 +338,35 @@ func (r *InferenceServiceReconciler) updateStatusWithSchedulingInfo(
 		meta.RemoveStatusCondition(&isvc.Status.Conditions, "GPUAvailable")
 	}
 
+	// Backstop the Available condition (#1303).
+	//
+	// Only some cases above touch Available; a case that omits it leaves
+	// whatever the previous reconcile wrote. determinePhase returns
+	// "Creating" whenever readyReplicas==0 && desiredReplicas>0, which is not
+	// only cold start: it is also the unplanned-outage path (drained node,
+	// CrashLoopBackOff, ImagePullBackOff, or a metal host going offline via a
+	// stale heartbeat). A service that was Ready and then lost every replica
+	// therefore kept reporting Available=True/"ready and serving requests"
+	// for as long as it stayed down, which is what users and our own e2e
+	// helpers gate on.
+	//
+	// Enforcing the invariant once here, rather than adding another case,
+	// means a phase added later cannot silently reintroduce this. Phases that
+	// set Available themselves (Ready, Stopped, Suspended) and Failed (which
+	// removes it) are unaffected: this only fires when the condition is still
+	// True with nothing serving.
+	if readyReplicas == 0 && meta.IsStatusConditionTrue(isvc.Status.Conditions, "Available") {
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type:               "Available",
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: isvc.Generation,
+			LastTransitionTime: now,
+			Reason:             "NoReadyReplicas",
+			Message: fmt.Sprintf("0/%d replicas ready; service is not serving (phase %s)",
+				desiredReplicas, phase),
+		})
+	}
+
 	// Set unconditionally (not gated on phase) so the Suspended condition
 	// flips to False on unsuspend rather than lingering True from a prior
 	// suspended pass.

--- a/internal/controller/status_builder_test.go
+++ b/internal/controller/status_builder_test.go
@@ -198,3 +198,116 @@ func TestUpdateStatusStoppedAndSuspendedReasonsDiffer(t *testing.T) {
 		t.Errorf("Stopped and Suspended reasons collapsed to %q; they must differ", stoppedCond.Reason)
 	}
 }
+
+// TestUpdateStatusAvailableFalseWhenNoReadyReplicas is the regression test for
+// #1303: Available must not stay True on a service that has stopped serving.
+//
+// determinePhase returns "Creating" whenever readyReplicas==0 &&
+// desiredReplicas>0, which covers the unplanned-outage path (drained node,
+// CrashLoopBackOff, metal host offline), so this is not a cold-start-only
+// concern. Before the fix, the Creating/Progressing/Pending/WaitingForGPU
+// cases left Available untouched and a previously-Ready service reported
+// Available=True/"ready and serving requests" for as long as it stayed down.
+//
+// Table covers every phase that can be reached with zero ready replicas so a
+// phase added later cannot regress the invariant unnoticed.
+func TestUpdateStatusAvailableFalseWhenNoReadyReplicas(t *testing.T) {
+	cases := []struct {
+		name       string
+		phase      string
+		wantReason string
+	}{
+		{"creating is the outage path", "Creating", "NoReadyReplicas"},
+		{"progressing with nothing ready", "Progressing", "NoReadyReplicas"},
+		{"pending", "Pending", "NoReadyReplicas"},
+		{"waiting for gpu", PhaseWaitingForGPU, "NoReadyReplicas"},
+		// Phases that set Available themselves keep their specific reason.
+		{"stopped keeps its own reason", PhaseStopped, "ManuallyScaledToZero"},
+		{"suspended keeps its own reason", PhaseSuspended, "Suspended"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "outage-isvc", Namespace: "default", Generation: 1,
+				},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "some-model",
+					Replicas: ptrInt32(1),
+				},
+			}
+			r := newStatusBuilderReconciler(t, isvc)
+			// Seed the stale True that the bug preserved.
+			seedReadyAvailable(t, ctx, r.Client, isvc)
+
+			if _, err := r.updateStatusWithSchedulingInfo(
+				ctx, isvc, tc.phase, true, 0, 1, "", "", nil); err != nil {
+				t.Fatalf("updateStatusWithSchedulingInfo: %v", err)
+			}
+
+			got := &inferencev1alpha1.InferenceService{}
+			if err := r.Client.Get(ctx, types.NamespacedName{
+				Name: isvc.Name, Namespace: isvc.Namespace,
+			}, got); err != nil {
+				t.Fatalf("get: %v", err)
+			}
+
+			cond := meta.FindStatusCondition(got.Status.Conditions, "Available")
+			if cond == nil {
+				t.Fatalf("Available condition missing for phase %q", tc.phase)
+			}
+			if cond.Status != metav1.ConditionFalse {
+				t.Errorf("phase %q: Available = %q, want False (0 ready replicas)",
+					tc.phase, cond.Status)
+			}
+			if cond.Reason != tc.wantReason {
+				t.Errorf("phase %q: Available reason = %q, want %q",
+					tc.phase, cond.Reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestUpdateStatusAvailableStaysTrueWithReadyReplicas guards the other
+// direction: the #1303 backstop must not fire when replicas are serving. A
+// partially-rolled deployment with some Ready replicas is still available,
+// matching Deployment semantics.
+func TestUpdateStatusAvailableStaysTrueWithReadyReplicas(t *testing.T) {
+	ctx := context.Background()
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "partial-isvc", Namespace: "default", Generation: 1,
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "some-model",
+			Replicas: ptrInt32(3),
+		},
+	}
+	r := newStatusBuilderReconciler(t, isvc)
+	seedReadyAvailable(t, ctx, r.Client, isvc)
+
+	// 1 of 3 ready: still serving, so Available must remain True.
+	if _, err := r.updateStatusWithSchedulingInfo(
+		ctx, isvc, "Progressing", true, 1, 3, "", "", nil); err != nil {
+		t.Fatalf("updateStatusWithSchedulingInfo: %v", err)
+	}
+
+	got := &inferencev1alpha1.InferenceService{}
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Name: isvc.Name, Namespace: isvc.Namespace,
+	}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, "Available")
+	if cond == nil {
+		t.Fatal("Available condition missing")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("Available = %q, want True (1/3 replicas serving)", cond.Status)
+	}
+	if cond.Reason != "InferenceReady" {
+		t.Errorf("Available reason = %q, want InferenceReady", cond.Reason)
+	}
+}


### PR DESCRIPTION
## What

The `Available` condition on InferenceService stays `True` when a service has zero ready replicas, so a service that has stopped serving keeps reporting itself healthy.

`updateStatusWithSchedulingInfo` sets `Available` from a switch on phase, and only some cases touch it. `Creating`/`Progressing`/`Pending`/`WaitingForGPU` leave whatever the previous reconcile wrote.

## Why

Fixes #1303

This is not a cold-start-only path. `determinePhase` returns `Creating` whenever `readyReplicas == 0 && desiredReplicas > 0`, which is also how a drained node, a `CrashLoopBackOff`, an `ImagePullBackOff`, or a metal host going offline via a stale heartbeat present. So a previously-Ready service that dies keeps:

```yaml
- type: Available
  status: "True"
  reason: InferenceReady
  message: Inference service is ready and serving requests
```

`Available` is load-bearing: four `config/samples/*.yaml` tell users to `kubectl wait --for=condition=Available`, and `test/utils`, `test/e2e`, and `.github/workflows/foreman-e2e.yml` all gate on it.

Found independently by two separate post-merge audits looking at unrelated PRs, which is why it is fixed structurally rather than with one more case.

## How

Enforce the invariant once, after the switch, instead of adding a case per phase that the next phase would forget again:

```go
if readyReplicas == 0 && meta.IsStatusConditionTrue(isvc.Status.Conditions, "Available") {
	// set Available=False, reason NoReadyReplicas
}
```

Deliberately narrow. Phases that set `Available` themselves keep their specific reasons (`ManuallyScaledToZero`, `Suspended` from #1273), and `PhaseFailed` still removes the condition. The backstop only fires where the condition was left stale.

Not addressed here, tracked in #1303 for follow-up: `PhaseFailed` removing the condition rather than setting it `False` (consumers cannot distinguish "not available" from "not yet reported"), and the `Pending` short-circuit that can produce `Suspended: True` alongside `Available: True`.

## Verification

- Tests are table-driven over every phase reachable with zero ready replicas, so a phase added later cannot regress it silently.
- A guard for the other direction: 1-of-3 replicas Ready stays `Available: True`, matching Deployment semantics.
- **Bite-checked**: reverting the production change fails the four zero-replica subtests while `stopped` and `suspended` still pass, confirming the tests catch this bug specifically and that #1273's behaviour is untouched.
- `gofmt` clean, `go vet` clean, no em dashes.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (targeted package tests; the envtest suite needs assets not present in this worktree, CI covers it)
- [x] `make lint` passes locally (no local golangci-lint binary; CI covers it)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) (n/a, condition semantics corrected to match documented intent)

AI-assisted (band 3): found via automated post-merge audit, fix and tests written with Claude Code, reviewed and verified by me.