### PR TITLE
fix(controller): append TGI extraArgs once, not four times

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -387,7 +387,9 @@ type InferenceServiceSpec struct {
 	// ExtraArgs provides additional command-line arguments passed directly to the
 	// runtime process. Use for flags not yet supported as typed CRD fields.
 	// Arguments are appended after all other configured flags.
-	// Supported by the "llamacpp" and "vllm" runtimes. Ignored by others.
+	// Supported by the "llamacpp", "llamacpp-router", "sglang", "tgi" and
+	// "vllm" runtimes. Ignored by "generic" (which takes spec.args instead)
+	// and "personaplex".
 	// Example: ["--seed", "42", "--log-disable"]
 	// +optional
 	ExtraArgs []string `json:"extraArgs,omitempty"`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -1428,7 +1428,9 @@ spec:
                   ExtraArgs provides additional command-line arguments passed directly to the
                   runtime process. Use for flags not yet supported as typed CRD fields.
                   Arguments are appended after all other configured flags.
-                  Supported by the "llamacpp" and "vllm" runtimes. Ignored by others.
+                  Supported by the "llamacpp", "llamacpp-router", "sglang", "tgi" and
+                  "vllm" runtimes. Ignored by "generic" (which takes spec.args instead)
+                  and "personaplex".
                   Example: ["--seed", "42", "--log-disable"]
                 items:
                   type: string

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -1424,7 +1424,9 @@ spec:
                   ExtraArgs provides additional command-line arguments passed directly to the
                   runtime process. Use for flags not yet supported as typed CRD fields.
                   Arguments are appended after all other configured flags.
-                  Supported by the "llamacpp" and "vllm" runtimes. Ignored by others.
+                  Supported by the "llamacpp", "llamacpp-router", "sglang", "tgi" and
+                  "vllm" runtimes. Ignored by "generic" (which takes spec.args instead)
+                  and "personaplex".
                   Example: ["--seed", "42", "--log-disable"]
                 items:
                   type: string

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -933,3 +933,57 @@ func TestBindAddressAcrossRuntimes(t *testing.T) {
 		})
 	}
 }
+
+// TestExtraArgsAppendedExactlyOnce is the regression test for #1305: the TGI
+// backend appended spec.extraArgs four times.
+//
+// The containsArg helper in this file cannot catch that. It returns on the
+// first match, so it is blind to repeats, and nothing else here asserts arg
+// counts. Counting occurrences is the point of this test; do not rewrite it in
+// terms of containsArg.
+//
+// Covers every runtime that consumes extraArgs, so a copy-paste into any of
+// them fails here rather than shipping.
+func TestExtraArgsAppendedExactlyOnce(t *testing.T) {
+	extra := []string{"--seed", "42", "--log-disable"}
+
+	backends := []struct {
+		runtime string
+		backend RuntimeBackend
+	}{
+		{"llamacpp", &LlamaCppBackend{}},
+		{"llamacpp-router", &LlamaCppRouterBackend{}},
+		{"vllm", &VLLMBackend{}},
+		{"tgi", &TGIBackend{}},
+		{"sglang", &SGLangBackend{}},
+	}
+
+	for _, tc := range backends {
+		t.Run(tc.runtime, func(t *testing.T) {
+			isvc := &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:  "m",
+					Runtime:   tc.runtime,
+					ExtraArgs: extra,
+				},
+			}
+			model := &inferencev1alpha1.Model{
+				Spec: inferencev1alpha1.ModelSpec{Source: "hf://org/model"},
+			}
+			args := tc.backend.BuildArgs(isvc, model, "/models/model.gguf", 8080)
+
+			for _, want := range extra {
+				n := 0
+				for _, a := range args {
+					if a == want {
+						n++
+					}
+				}
+				if n != 1 {
+					t.Errorf("runtime %s: arg %q appears %d times, want exactly 1\nargs: %v",
+						tc.runtime, want, n, args)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/runtime_tgi.go
+++ b/internal/controller/runtime_tgi.go
@@ -78,21 +78,6 @@ func (b *TGIBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model *
 		args = append(args, isvc.Spec.ExtraArgs...)
 	}
 
-	// ExtraArgs last (user wins).
-	if len(isvc.Spec.ExtraArgs) > 0 {
-		args = append(args, isvc.Spec.ExtraArgs...)
-	}
-
-	// ExtraArgs last (user wins).
-	if len(isvc.Spec.ExtraArgs) > 0 {
-		args = append(args, isvc.Spec.ExtraArgs...)
-	}
-
-	// ExtraArgs last (user wins).
-	if len(isvc.Spec.ExtraArgs) > 0 {
-		args = append(args, isvc.Spec.ExtraArgs...)
-	}
-
 	return args
 }
 


### PR DESCRIPTION
## What

`TGIBackend.BuildArgs` carried four verbatim copies of the `extraArgs` append block, so every `spec.extraArgs` entry reached the container args four times. Every other runtime has exactly one.

Also corrects the `ExtraArgs` CRD doc and regenerates the CRDs.

## Why

Fixes #1305

```yaml
runtime: tgi
extraArgs: ["--max-batch-size", "8", "--json-output"]
```

emitted those three tokens four times over. TGI 3.x parses with clap v4 where scalar flags let the last occurrence win, so most survive by luck, but anything with append or count semantics gets 4x its values, and `kubectl describe pod` is unreadable regardless.

The blocks arrived in #1247 as an undisclosed side effect. That PR described bindAddress wiring only, while also switching on `extraArgs` consumption for TGI for the first time (#1240 records that it previously ignored them). **Keeping the consumption is the right call** since every other runtime does it and the escape hatch is the point, so this deduplicates rather than removes.

Worth noting for release notes: because #1247 activated this, an existing TGI service carrying stale `extraArgs` that were previously inert began applying them on operator upgrade with no spec change by the user. That behaviour is unchanged here, just no longer quadrupled.

## How

Collapse the four blocks to one.

Separately, the CRD doc claimed `extraArgs` was *"Supported by the llamacpp and vllm runtimes. Ignored by others."* Five runtimes consume it (llamacpp, llamacpp-router, sglang, tgi, vllm) and two ignore it (generic, which takes `spec.args`, and personaplex). #1240 called out that exact line and #1247 closed the issue without touching it. Corrected, and `make manifests` + `make chart-crds` run; the generated diff is the doc text only.

## Verification

- **The existing helper could not catch this.** `containsArg` returns on its first match, so it is structurally blind to repeated arguments, and nothing else in `runtime_test.go` asserts arg counts. That is why `TestBindAddressAcrossRuntimes` passed green against the bug.
- New test counts occurrences across all five consuming runtimes, so a copy-paste into any of them fails here rather than shipping.
- **Bite-checked**: restoring the duplication fails only the `tgi` subtest while the other four stay green, confirming the test is specific to the defect.
- `gofmt`, `go vet` clean, CRDs regenerated, no em dashes.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (targeted package tests; the envtest suite needs assets not present in this worktree, CI covers it)
- [x] `make lint` passes locally (no local golangci-lint binary; CI covers it)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

AI-assisted (band 3): found via automated post-merge audit of #1247, fix and tests written with Claude Code, reviewed and verified by me.