### PR TITLE
docs(api): stop the GPU-memory fields implying enforcement that does not exist

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -801,8 +801,14 @@ type InferenceResourceRequirements struct {
 	// +optional
 	HostMemory string `json:"hostMemory,omitempty"`
 
-	// GPUMemory specifies GPU memory limit per pod (e.g., "16Gi")
-	// Used for scheduling and validation
+	// GPUMemory is recorded on the object and has no effect. It sets no pod
+	// resource request, does not influence scheduling, and is not validated;
+	// nothing in the operator reads it.
+	//
+	// Superseded by gpuSharing.memoryLimitGiB for shared-GPU quota
+	// accounting, or the Model's hardware.gpu.memory to declare a model's
+	// footprint. This field is retained for compatibility with existing
+	// objects and will be removed in a future API version.
 	// +optional
 	GPUMemory string `json:"gpuMemory,omitempty"`
 
@@ -853,11 +859,16 @@ type GPUSharingSpec struct {
 	Profile string `json:"profile,omitempty"`
 
 	// MemoryLimitGiB declares this service's device-memory footprint in
-	// shared mode, in GiB. It is used for quota accounting only: a shared
-	// workload counts this many GiB against a GPUQuota vramBytes cap. It
-	// is NOT enforced at runtime; nothing caps the process's actual VRAM
-	// use. For hard isolation between tenants use mode partitioned (MIG).
-	// Only valid for mode shared.
+	// shared mode, in GiB. It drives quota accounting: a shared workload
+	// counts this many GiB against a GPUQuota vramBytes cap.
+	//
+	// It is NOT enforced at runtime. Nothing caps the process's actual VRAM
+	// use, so a workload that exceeds this figure will do so, and on a
+	// time-sliced device it can exhaust the VRAM its co-tenants need.
+	// Shared mode is co-scheduling for workloads that already trust each
+	// other, not an isolation boundary; for a hard boundary between tenants
+	// use mode partitioned (NVIDIA MIG), where the partition is enforced in
+	// hardware. Only valid for mode shared.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	MemoryLimitGiB *int32 `json:"memoryLimitGiB,omitempty"`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -4412,8 +4412,14 @@ spec:
                     type: integer
                   gpuMemory:
                     description: |-
-                      GPUMemory specifies GPU memory limit per pod (e.g., "16Gi")
-                      Used for scheduling and validation
+                      GPUMemory is recorded on the object and has no effect. It sets no pod
+                      resource request, does not influence scheduling, and is not validated;
+                      nothing in the operator reads it.
+
+                      Superseded by gpuSharing.memoryLimitGiB for shared-GPU quota
+                      accounting, or the Model's hardware.gpu.memory to declare a model's
+                      footprint. This field is retained for compatibility with existing
+                      objects and will be removed in a future API version.
                     type: string
                   gpuSharing:
                     description: |-
@@ -4428,11 +4434,16 @@ spec:
                       memoryLimitGiB:
                         description: |-
                           MemoryLimitGiB declares this service's device-memory footprint in
-                          shared mode, in GiB. It is used for quota accounting only: a shared
-                          workload counts this many GiB against a GPUQuota vramBytes cap. It
-                          is NOT enforced at runtime; nothing caps the process's actual VRAM
-                          use. For hard isolation between tenants use mode partitioned (MIG).
-                          Only valid for mode shared.
+                          shared mode, in GiB. It drives quota accounting: a shared workload
+                          counts this many GiB against a GPUQuota vramBytes cap.
+
+                          It is NOT enforced at runtime. Nothing caps the process's actual VRAM
+                          use, so a workload that exceeds this figure will do so, and on a
+                          time-sliced device it can exhaust the VRAM its co-tenants need.
+                          Shared mode is co-scheduling for workloads that already trust each
+                          other, not an isolation boundary; for a hard boundary between tenants
+                          use mode partitioned (NVIDIA MIG), where the partition is enforced in
+                          hardware. Only valid for mode shared.
                         format: int32
                         minimum: 1
                         type: integer

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -4408,8 +4408,14 @@ spec:
                     type: integer
                   gpuMemory:
                     description: |-
-                      GPUMemory specifies GPU memory limit per pod (e.g., "16Gi")
-                      Used for scheduling and validation
+                      GPUMemory is recorded on the object and has no effect. It sets no pod
+                      resource request, does not influence scheduling, and is not validated;
+                      nothing in the operator reads it.
+
+                      Superseded by gpuSharing.memoryLimitGiB for shared-GPU quota
+                      accounting, or the Model's hardware.gpu.memory to declare a model's
+                      footprint. This field is retained for compatibility with existing
+                      objects and will be removed in a future API version.
                     type: string
                   gpuSharing:
                     description: |-
@@ -4424,11 +4430,16 @@ spec:
                       memoryLimitGiB:
                         description: |-
                           MemoryLimitGiB declares this service's device-memory footprint in
-                          shared mode, in GiB. It is used for quota accounting only: a shared
-                          workload counts this many GiB against a GPUQuota vramBytes cap. It
-                          is NOT enforced at runtime; nothing caps the process's actual VRAM
-                          use. For hard isolation between tenants use mode partitioned (MIG).
-                          Only valid for mode shared.
+                          shared mode, in GiB. It drives quota accounting: a shared workload
+                          counts this many GiB against a GPUQuota vramBytes cap.
+
+                          It is NOT enforced at runtime. Nothing caps the process's actual VRAM
+                          use, so a workload that exceeds this figure will do so, and on a
+                          time-sliced device it can exhaust the VRAM its co-tenants need.
+                          Shared mode is co-scheduling for workloads that already trust each
+                          other, not an isolation boundary; for a hard boundary between tenants
+                          use mode partitioned (NVIDIA MIG), where the partition is enforced in
+                          hardware. Only valid for mode shared.
                         format: int32
                         minimum: 1
                         type: integer

--- a/config/samples/gpu-llama-3b-model.yaml
+++ b/config/samples/gpu-llama-3b-model.yaml
@@ -65,4 +65,4 @@ spec:
     gpu: 1  # Each pod gets 1 L4 GPU (23GB VRAM)
     cpu: "2"  # 2 vCPUs for inference serving (g2-standard-4 has 4 total, ~3.9 allocatable)
     memory: "4Gi"  # 4GB RAM (g2-standard-4 has 16GB total, ~13.5GB allocatable)
-    gpuMemory: "8Gi"  # Reserve 8GB of GPU memory
+    gpuMemory: "8Gi"  # Model footprint, informational only (not enforced)

--- a/config/samples/multi-gpu-llama-13b-model.yaml
+++ b/config/samples/multi-gpu-llama-13b-model.yaml
@@ -53,7 +53,7 @@ spec:
 
   resources:
     gpu: 2              # Request 2 GPUs per pod
-    gpuMemory: "16Gi"   # 8Gi per GPU minimum (16Gi total)
+    gpuMemory: "16Gi"   # ~8Gi per GPU across 2 GPUs, informational only (not enforced)
     cpu: "4"
     memory: "8Gi"
 

--- a/config/samples/multi-gpu-llama-70b-model.yaml
+++ b/config/samples/multi-gpu-llama-70b-model.yaml
@@ -45,7 +45,7 @@ spec:
 
   resources:
     gpu: 4              # Request 4 GPUs per pod
-    gpuMemory: "96Gi"   # 24Gi per GPU minimum (96Gi total)
+    gpuMemory: "96Gi"   # ~24Gi per GPU across 4 GPUs, informational only (not enforced)
     cpu: "8"
     memory: "32Gi"
 

--- a/docs/operations/gpu-sharing.md
+++ b/docs/operations/gpu-sharing.md
@@ -108,10 +108,18 @@ spec:
       memoryLimitGiB: 24
 ```
 
-This service co-locates on a shared GPU pool and declares a memory limit
-via `memoryLimitGiB`. The operator steers the pod onto the shared pool
-using the configured node selector. The `memoryLimitGiB` drives VRAM-based
-quota accounting.
+This service co-locates on a shared GPU pool and declares its memory
+footprint via `memoryLimitGiB`. The operator steers the pod onto the shared
+pool using the configured node selector. The `memoryLimitGiB` drives
+VRAM-based quota accounting.
+
+`memoryLimitGiB` is a declaration, not a cap. Nothing enforces it at
+runtime: a workload that grows its KV cache past the figure it declared will
+do so, and on a time-sliced device it can exhaust the VRAM its co-tenants
+need. Time-slicing multiplexes execution, not memory. Treat `shared` as
+co-scheduling for workloads that already trust each other, and reach for
+`partitioned` when you need a boundary that holds between tenants, since a
+MIG partition is enforced by the hardware.
 
 ## Fleet configuration
 

--- a/internal/controller/gpu_sharing_test.go
+++ b/internal/controller/gpu_sharing_test.go
@@ -351,6 +351,68 @@ func TestConstructDeploymentGPUSharing(t *testing.T) {
 			t.Fatalf("shared pod still requests the ordinary device resource, got %v", container.Resources.Limits)
 		}
 	})
+
+	// memoryLimitGiB is a quota-accounting declaration, not a runtime cap: its
+	// only reader is podVRAMBytes. The API doc used to claim it drove "a
+	// memory-cap enforcement flag", which sent an evaluator looking for an
+	// isolation guarantee that does not exist (#1312). This asserts the
+	// documented behaviour rather than trusting the comment, so the claim
+	// cannot come back without a test failing.
+	t.Run("memoryLimitGiB reaches nothing in the pod spec", func(t *testing.T) {
+		const declared = 24
+		r := &InferenceServiceReconciler{
+			DefaultFSGroup:       102,
+			GPUSharingSharedPool: map[string]string{"llmkube.dev/gpu-pool": "shared"},
+		}
+		limit := int32(declared)
+		isvc := sharingISvc(1, &inferencev1alpha1.GPUSharingSpec{
+			Mode:           inferencev1alpha1.GPUSharingModeShared,
+			MemoryLimitGiB: &limit,
+		})
+		model := sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Vendor: "nvidia"})
+
+		deployment := r.constructDeployment(isvc, model, 1)
+		pod := deployment.Spec.Template
+		container := pod.Spec.Containers[0]
+
+		// The declared figure must not appear as any resource quantity.
+		for name, q := range container.Resources.Limits {
+			if q.Value() == declared || q.Value() == declared*1024*1024*1024 {
+				t.Errorf("memoryLimitGiB leaked into resources.limits[%s] = %s", name, q.String())
+			}
+		}
+		for name, q := range container.Resources.Requests {
+			if q.Value() == declared || q.Value() == declared*1024*1024*1024 {
+				t.Errorf("memoryLimitGiB leaked into resources.requests[%s] = %s", name, q.String())
+			}
+		}
+
+		// Nor as a runtime flag, an env var, or an annotation. Substring match
+		// on "24" would be too eager, so look for the shapes a real cap would
+		// take.
+		needles := []string{"24Gi", "24GiB", "memoryLimitGiB", "--gpu-memory", "25769803776"}
+		for _, arg := range container.Args {
+			for _, n := range needles {
+				if strings.Contains(arg, n) {
+					t.Errorf("memoryLimitGiB leaked into container args: %q contains %q", arg, n)
+				}
+			}
+		}
+		for _, env := range container.Env {
+			for _, n := range needles {
+				if strings.Contains(env.Value, n) {
+					t.Errorf("memoryLimitGiB leaked into env %s = %q", env.Name, env.Value)
+				}
+			}
+		}
+		for k, v := range pod.Annotations {
+			for _, n := range needles {
+				if strings.Contains(v, n) {
+					t.Errorf("memoryLimitGiB leaked into annotation %s = %q", k, v)
+				}
+			}
+		}
+	})
 }
 
 // TestGPUSharingParallelismConflict backfills coverage for the mode-based

--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -172,7 +172,9 @@ Examples:
 	cmd.Flags().Int32Var(&opts.gpuCount, "gpu-count", 1, "Number of GPUs per pod")
 	cmd.Flags().Int32Var(&opts.gpuLayers, "gpu-layers", -1,
 		"Number of model layers to offload to GPU (-1 = all layers, 0 = auto)")
-	cmd.Flags().StringVar(&opts.gpuMemory, "gpu-memory", "", "GPU memory request (e.g., '8Gi', '16Gi')")
+	cmd.Flags().StringVar(&opts.gpuMemory, "gpu-memory", "",
+		"GPU memory footprint recorded on the InferenceService, e.g. '8Gi'. "+
+			"Not enforced (sets no pod resource request)")
 	cmd.Flags().StringVar(&opts.gpuVendor, "gpu-vendor", defaultGPUVendor, "GPU vendor (nvidia, amd, intel)")
 
 	cmd.Flags().Int32Var(&opts.contextSize, "context", 0,


### PR DESCRIPTION
## What

`spec.resources.gpuSharing.memoryLimitGiB` was documented as driving "where the runtime supports it, a memory-cap enforcement flag". No such wiring exists. Corrected, along with `spec.resources.gpuMemory`, the CLI flag help, and three sample comments that claimed a reservation or a minimum.

No runtime behaviour changes.

## Why

Fixes #1312

An engineer evaluating LLMKube for multi-tenant GPU use asked what stops a tenant exhausting VRAM on a shared GPU, and whether it is trust-based. It is, and our own API told him otherwise.

`memoryLimitGiB`'s only non-test reader is `podVRAMBytes` in `internal/controller/gpu_sharing.go`, a pure quota-accounting function. The value never reaches the pod spec, a container arg, an env var, or an annotation. A shared-mode service with `memoryLimitGiB: 24` renders `limits: {nvidia.com/gpu: 1}` and the 24 appears nowhere.

That text renders into `kubectl explain`, so it is what someone reads when deciding whether shared mode is safe for untrusted tenants. It is not: time-slicing multiplexes execution rather than memory, and only `partitioned`/MIG gives a boundary that holds, enforced by NVIDIA rather than by us.

`spec.resources.gpuMemory` had the same disease, claiming it was "Used for scheduling and validation" when it is used for neither: three writers in `pkg/cli`, zero readers anywhere in `internal/`.

## How

The `memoryLimitGiB` comment now states what it drives, then that it is **not** enforced at runtime, and points at `partitioned` for real isolation. `gpuMemory` is marked `Deprecated:` and described accurately.

**`gpuMemory` is redocumented rather than removed.** Removal is a breaking `v1alpha1` change and the field appears in eight samples, an example, `docs/gpu-setup-guide.md` and a CLI flag; it deserves its own issue and a deprecation cycle rather than riding along in a doc-accuracy fix.

Also corrected: the `--gpu-memory` flag help (it becomes no pod resource request), and the sample comments that said `# Reserve 8GB of GPU memory` and `# NNGi per GPU minimum`. Left `# T4 has ~15GB memory` alone, which is descriptive and true.

`docs/operations/gpu-sharing.md` is otherwise accurate and candid; one paragraph read as a cap and now states the non-enforcement explicitly.

## Verification

- **New test pins the behaviour.** `TestConstructDeploymentGPUSharing/memoryLimitGiB reaches nothing in the pod spec` asserts the declared figure appears as no resource quantity, no container arg, no env var, and no annotation. This converts the doc statement into something CI enforces so the claim cannot come back silently.
- **Bite-checked.** Wiring `memoryLimitGiB` into `resources.limits` fails only the new subtest while the two existing ones stay green, confirming it catches this specific defect.
- CRDs regenerated; a second `make manifests && make chart-crds` produces zero diff, matching what `crd-sync-check` runs. The generated diff is description text only.
- `go test ./api/... ./pkg/cli/...` green; `./internal/controller/` unit tests green (the envtest suite needs `bin/k8s` assets not present in this worktree, CI covers it).
- `gofmt`, `go vet` clean, no em dashes.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (targeted packages; envtest assets absent locally, CI covers)
- [x] `make lint` passes locally (no local golangci-lint binary; CI covers)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

AI-assisted (band 3): found while answering an external evaluation, fix and tests written with Claude Code, reviewed and verified by me.