### PR TITLE
fix(controller): cpu-offload verify advisory, parallelism validation, and a sample that actually runs

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -1034,14 +1034,16 @@ type VLLMConfig struct {
 	// means 4 GB of CPU RAM per GPU. Throughput hit is 2-5x on the offloaded
 	// path when it works.
 	//
-	// KNOWN ISSUE: on vLLM V1-engine releases through at least v0.26,
-	// including the default image, this flag is a silent no-op upstream
-	// (vllm-project/vllm#48468): it is accepted but no weights are offloaded,
-	// so VRAM-tight models OOM instead of spilling to host RAM. Setting it
-	// surfaces a CPUOffloadIneffective warning on the VLLMSpecValid condition
-	// and as an Event. Verify offload in the server logs before relying on
-	// it; for MoE VRAM relief use the llama.cpp runtime's spec.moeCPUOffload
-	// instead.
+	// RELIABILITY NOTE: --cpu-offload-gb is reported silently ineffective in
+	// some configurations on current vLLM (vllm-project/vllm#48468, open):
+	// accepted but no weights offloaded, so VRAM-tight models OOM instead of
+	// spilling to host RAM. It is verified working in others, including the
+	// cpu-offload sample's configuration on both its pinned image and the
+	// operator default. Setting it surfaces a CPUOffloadUnverified advisory
+	// on the VLLMSpecValid condition and as an Event; confirm offload took
+	// effect in the server logs (Offloader/offloaded-parameters lines, or a
+	// Model-loading size below the full footprint) before relying on it. For
+	// MoE VRAM relief on llama.cpp use spec.moeCPUOffload.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	CPUOffloadGB *int32 `json:"cpuOffloadGB,omitempty"`

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -1030,10 +1030,18 @@ type VLLMConfig struct {
 	// +optional
 	HFTokenSecretRef *corev1.SecretKeySelector `json:"hfTokenSecretRef,omitempty"`
 
-	// CPUOffloadGB increases the GPU memory size. When set, passes
-	// --cpu-offload-gb to vLLM. Per-rank, so 4 on TP=2 means 4 GB of
-	// CPU RAM per GPU. Use when FP8 model weights don't fit VRAM.
-	// Throughput hit is 2-5x on the offloaded path.
+	// CPUOffloadGB passes --cpu-offload-gb to vLLM. Per-rank, so 4 on TP=2
+	// means 4 GB of CPU RAM per GPU. Throughput hit is 2-5x on the offloaded
+	// path when it works.
+	//
+	// KNOWN ISSUE: on vLLM V1-engine releases through at least v0.26,
+	// including the default image, this flag is a silent no-op upstream
+	// (vllm-project/vllm#48468): it is accepted but no weights are offloaded,
+	// so VRAM-tight models OOM instead of spilling to host RAM. Setting it
+	// surfaces a CPUOffloadIneffective warning on the VLLMSpecValid condition
+	// and as an Event. Verify offload in the server logs before relying on
+	// it; for MoE VRAM relief use the llama.cpp runtime's spec.moeCPUOffload
+	// instead.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	CPUOffloadGB *int32 `json:"cpuOffloadGB,omitempty"`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -5521,14 +5521,16 @@ spec:
                       means 4 GB of CPU RAM per GPU. Throughput hit is 2-5x on the offloaded
                       path when it works.
 
-                      KNOWN ISSUE: on vLLM V1-engine releases through at least v0.26,
-                      including the default image, this flag is a silent no-op upstream
-                      (vllm-project/vllm#48468): it is accepted but no weights are offloaded,
-                      so VRAM-tight models OOM instead of spilling to host RAM. Setting it
-                      surfaces a CPUOffloadIneffective warning on the VLLMSpecValid condition
-                      and as an Event. Verify offload in the server logs before relying on
-                      it; for MoE VRAM relief use the llama.cpp runtime's spec.moeCPUOffload
-                      instead.
+                      RELIABILITY NOTE: --cpu-offload-gb is reported silently ineffective in
+                      some configurations on current vLLM (vllm-project/vllm#48468, open):
+                      accepted but no weights offloaded, so VRAM-tight models OOM instead of
+                      spilling to host RAM. It is verified working in others, including the
+                      cpu-offload sample's configuration on both its pinned image and the
+                      operator default. Setting it surfaces a CPUOffloadUnverified advisory
+                      on the VLLMSpecValid condition and as an Event; confirm offload took
+                      effect in the server logs (Offloader/offloaded-parameters lines, or a
+                      Model-loading size below the full footprint) before relying on it. For
+                      MoE VRAM relief on llama.cpp use spec.moeCPUOffload.
                     format: int32
                     minimum: 0
                     type: integer

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -5517,10 +5517,18 @@ spec:
                     type: string
                   cpuOffloadGB:
                     description: |-
-                      CPUOffloadGB increases the GPU memory size. When set, passes
-                      --cpu-offload-gb to vLLM. Per-rank, so 4 on TP=2 means 4 GB of
-                      CPU RAM per GPU. Use when FP8 model weights don't fit VRAM.
-                      Throughput hit is 2-5x on the offloaded path.
+                      CPUOffloadGB passes --cpu-offload-gb to vLLM. Per-rank, so 4 on TP=2
+                      means 4 GB of CPU RAM per GPU. Throughput hit is 2-5x on the offloaded
+                      path when it works.
+
+                      KNOWN ISSUE: on vLLM V1-engine releases through at least v0.26,
+                      including the default image, this flag is a silent no-op upstream
+                      (vllm-project/vllm#48468): it is accepted but no weights are offloaded,
+                      so VRAM-tight models OOM instead of spilling to host RAM. Setting it
+                      surfaces a CPUOffloadIneffective warning on the VLLMSpecValid condition
+                      and as an Event. Verify offload in the server logs before relying on
+                      it; for MoE VRAM relief use the llama.cpp runtime's spec.moeCPUOffload
+                      instead.
                     format: int32
                     minimum: 0
                     type: integer

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -5513,10 +5513,18 @@ spec:
                     type: string
                   cpuOffloadGB:
                     description: |-
-                      CPUOffloadGB increases the GPU memory size. When set, passes
-                      --cpu-offload-gb to vLLM. Per-rank, so 4 on TP=2 means 4 GB of
-                      CPU RAM per GPU. Use when FP8 model weights don't fit VRAM.
-                      Throughput hit is 2-5x on the offloaded path.
+                      CPUOffloadGB passes --cpu-offload-gb to vLLM. Per-rank, so 4 on TP=2
+                      means 4 GB of CPU RAM per GPU. Throughput hit is 2-5x on the offloaded
+                      path when it works.
+
+                      KNOWN ISSUE: on vLLM V1-engine releases through at least v0.26,
+                      including the default image, this flag is a silent no-op upstream
+                      (vllm-project/vllm#48468): it is accepted but no weights are offloaded,
+                      so VRAM-tight models OOM instead of spilling to host RAM. Setting it
+                      surfaces a CPUOffloadIneffective warning on the VLLMSpecValid condition
+                      and as an Event. Verify offload in the server logs before relying on
+                      it; for MoE VRAM relief use the llama.cpp runtime's spec.moeCPUOffload
+                      instead.
                     format: int32
                     minimum: 0
                     type: integer

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -5517,14 +5517,16 @@ spec:
                       means 4 GB of CPU RAM per GPU. Throughput hit is 2-5x on the offloaded
                       path when it works.
 
-                      KNOWN ISSUE: on vLLM V1-engine releases through at least v0.26,
-                      including the default image, this flag is a silent no-op upstream
-                      (vllm-project/vllm#48468): it is accepted but no weights are offloaded,
-                      so VRAM-tight models OOM instead of spilling to host RAM. Setting it
-                      surfaces a CPUOffloadIneffective warning on the VLLMSpecValid condition
-                      and as an Event. Verify offload in the server logs before relying on
-                      it; for MoE VRAM relief use the llama.cpp runtime's spec.moeCPUOffload
-                      instead.
+                      RELIABILITY NOTE: --cpu-offload-gb is reported silently ineffective in
+                      some configurations on current vLLM (vllm-project/vllm#48468, open):
+                      accepted but no weights offloaded, so VRAM-tight models OOM instead of
+                      spilling to host RAM. It is verified working in others, including the
+                      cpu-offload sample's configuration on both its pinned image and the
+                      operator default. Setting it surfaces a CPUOffloadUnverified advisory
+                      on the VLLMSpecValid condition and as an Event; confirm offload took
+                      effect in the server logs (Offloader/offloaded-parameters lines, or a
+                      Model-loading size below the full footprint) before relying on it. For
+                      MoE VRAM relief on llama.cpp use spec.moeCPUOffload.
                     format: int32
                     minimum: 0
                     type: integer

--- a/config/samples/inferenceservice_qwen36_35b_fp8_cpu_offload.yaml
+++ b/config/samples/inferenceservice_qwen36_35b_fp8_cpu_offload.yaml
@@ -5,7 +5,7 @@ metadata:
   name: qwen3-6-35b-a3b-fp8
   namespace: default
 spec:
-  source: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8"
+  source: "Qwen/Qwen3.6-35B-A3B-FP8"
   format: safetensors
   quantization: fp8
   hardware:
@@ -22,6 +22,10 @@ metadata:
   namespace: default
 spec:
   modelRef: qwen3-6-35b-a3b-fp8
+  # The source is an HF repo id resolved by vLLM at startup (with
+  # hfTokenSecretRef below); without this the init container tries to
+  # fetch the repo URL as a single file and produces an invalid artifact.
+  skipModelInit: true
   runtime: vllm
   image: vllm/vllm-openai:v0.20.0
   replicas: 1
@@ -29,8 +33,19 @@ spec:
     hfTokenSecretRef:
       name: hf-token
       key: HF_TOKEN
-    # Qwen3.6-35B-A3B-FP8 on 2x 5060 Ti needs ~18 GB/shard 
-    # `--cpu-offload-gb 4` per rank makes it fit at a throughput .
+    # Qwen3.6-35B-A3B-FP8 needs ~16.5 GB/rank at TP=2; a 5060 Ti has 16 GB.
+    # `--cpu-offload-gb 4` per rank makes it fit, at a 2-5x throughput cost
+    # on the offloaded path.
+    #
+    # Verified working for THIS configuration on 2x RTX 5060 Ti, on both the
+    # v0.20.0 image pinned above (model loading 13.01 GiB vs ~16.5 full,
+    # 4.2 GB offloaded per rank) and the operator-default v0.25.1 (13.17
+    # GiB, same offloader lines). --cpu-offload-gb is reported silently
+    # ineffective in OTHER configurations on current vLLM
+    # (vllm-project/vllm#48468, open), so the operator surfaces a
+    # CPUOffloadUnverified advisory whenever the field is set: after any
+    # image or model change, confirm the "Offloader set to" /
+    # "offloaded parameters" lines still appear in the server logs.
     cpuOffloadGB: 4
     # On tight setups raising it to 0.95-0.97 buys the headroom
     # needed for profile-run + cudagraph capture.
@@ -38,7 +53,6 @@ spec:
     maxNumBatchedTokens: 4096
     maxModelLen: 32768
     quantization: fp8
-    tensorParallelSize: 8
   endpoint:
     port: 8000
     type: ClusterIP

--- a/internal/controller/gpu_sharing.go
+++ b/internal/controller/gpu_sharing.go
@@ -275,6 +275,73 @@ func gpuSharingParallelismConflict(isvc *inferencev1alpha1.InferenceService) err
 	return nil
 }
 
+// parallelismExceedsGPUCount rejects explicit per-pod parallelism that needs
+// more GPUs than the pod requests. LLMKube has no multi-node inference (no
+// Ray, no LeaderWorkerSet), so a world size larger than the pod's GPU count
+// can never start: vLLM and SGLang crash-loop probing for devices that do not
+// exist (#1320).
+//
+// Only EXPLICIT sizes are checked. When unset, the arg builders auto-derive
+// the size from the GPU count and are already correct. The check is skipped
+// when the resolved count is 0, which covers admission-time Model-not-found
+// (the reconcile backstop re-checks with the real Model) and DRA
+// resourceClaims, whose device count is unknowable here; silent beats wrong.
+//
+// vLLM's world size is TP alone today: VLLMConfig has no data/pipeline
+// parallel size fields, and EnableExpertParallel redistributes experts across
+// existing TP ranks. If DP/PP fields are ever added, this becomes the
+// product. SGLang differs: its in-process --dp launches dp engine replicas of
+// tp GPUs each inside one pod, so the per-pod need is tp*dp, and --ep cannot
+// exceed the world size either.
+func parallelismExceedsGPUCount(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) error {
+	var count int32
+	if model != nil {
+		count = resolveGPUCount(isvc, model)
+	} else if isvc.Spec.Resources != nil {
+		count = isvc.Spec.Resources.GPU
+	}
+	if count == 0 {
+		return nil
+	}
+
+	if cfg := isvc.Spec.VLLMConfig; cfg != nil && cfg.TensorParallelSize != nil &&
+		*cfg.TensorParallelSize > count {
+		return fmt.Errorf(
+			"vllmConfig.tensorParallelSize %d exceeds the %d GPU(s) this pod requests "+
+				"(model hardware.gpu.count / resources.gpu); multi-node inference is not "+
+				"supported, so the pod can never start. Lower tensorParallelSize, remove "+
+				"it to auto-match the GPU count, or request more GPUs",
+			*cfg.TensorParallelSize, count)
+	}
+
+	if cfg := isvc.Spec.SGLangConfig; cfg != nil {
+		tp, dp := int32(1), int32(1)
+		if cfg.TensorParallelSize != nil {
+			tp = *cfg.TensorParallelSize
+		}
+		if cfg.DataParallelSize != nil {
+			dp = *cfg.DataParallelSize
+		}
+		// Only enforce when at least one factor was explicit; both defaulted
+		// means the auto-derive path owns the answer.
+		if (cfg.TensorParallelSize != nil || cfg.DataParallelSize != nil) && tp*dp > count {
+			return fmt.Errorf(
+				"sglangConfig tensorParallelSize x dataParallelSize (%d x %d) needs %d "+
+					"GPUs but this pod requests %d; multi-node inference is not supported, "+
+					"so the pod can never start. Lower the sizes, remove them to auto-match "+
+					"the GPU count, or request more GPUs",
+				tp, dp, tp*dp, count)
+		}
+		if cfg.ExpertParallelSize != nil && *cfg.ExpertParallelSize > count {
+			return fmt.Errorf(
+				"sglangConfig.expertParallelSize %d exceeds the %d GPU(s) this pod "+
+					"requests; expert parallelism cannot exceed the pod's world size",
+				*cfg.ExpertParallelSize, count)
+		}
+	}
+	return nil
+}
+
 // serviceVRAMBytesFor derives the total VRAM footprint of an
 // InferenceService (per-pod footprint x replicas), fetching its Model for the
 // shared-mode hardware.gpu.memory fallback. A missing Model is not an error:

--- a/internal/controller/gpu_sharing_test.go
+++ b/internal/controller/gpu_sharing_test.go
@@ -352,3 +352,150 @@ func TestConstructDeploymentGPUSharing(t *testing.T) {
 		}
 	})
 }
+
+// TestGPUSharingParallelismConflict backfills coverage for the mode-based
+// parallelism rule, which had none (#1320 review).
+func TestGPUSharingParallelismConflict(t *testing.T) {
+	tp2 := int32(2)
+	cases := []struct {
+		name    string
+		isvc    *inferencev1alpha1.InferenceService
+		wantErr bool
+	}{
+		{
+			name:    "exclusive mode allows explicit TP",
+			isvc:    withVLLMTP(sharingISvc(2, nil), &tp2),
+			wantErr: false,
+		},
+		{
+			name: "shared mode rejects explicit TP > 1",
+			isvc: withVLLMTP(sharingISvc(1, &inferencev1alpha1.GPUSharingSpec{
+				Mode: inferencev1alpha1.GPUSharingModeShared,
+			}), &tp2),
+			wantErr: true,
+		},
+		{
+			name: "partitioned mode rejects explicit TP > 1",
+			isvc: withVLLMTP(sharingISvc(1, &inferencev1alpha1.GPUSharingSpec{
+				Mode:    inferencev1alpha1.GPUSharingModePartitioned,
+				Profile: "1g.24gb",
+			}), &tp2),
+			wantErr: true,
+		},
+		{
+			name: "shared mode with no explicit parallelism is fine",
+			isvc: sharingISvc(1, &inferencev1alpha1.GPUSharingSpec{
+				Mode: inferencev1alpha1.GPUSharingModeShared,
+			}),
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := gpuSharingParallelismConflict(tc.isvc)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("gpuSharingParallelismConflict() err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// withVLLMTP sets an explicit vllmConfig.tensorParallelSize on a fixture.
+func withVLLMTP(isvc *inferencev1alpha1.InferenceService, tp *int32) *inferencev1alpha1.InferenceService {
+	isvc.Spec.VLLMConfig = &inferencev1alpha1.VLLMConfig{TensorParallelSize: tp}
+	return isvc
+}
+
+// TestParallelismExceedsGPUCount is the regression test for #1320: explicit
+// parallelism larger than the pod's GPU count was admitted cleanly and died
+// in a crashloop (the shipped cpu-offload sample carried tensorParallelSize 8
+// on a 2 GPU spec).
+func TestParallelismExceedsGPUCount(t *testing.T) {
+	n := func(v int32) *int32 { return &v }
+	sglang := func(tp, dp, ep *int32) *inferencev1alpha1.SGLangConfig {
+		return &inferencev1alpha1.SGLangConfig{
+			TensorParallelSize: tp, DataParallelSize: dp, ExpertParallelSize: ep,
+		}
+	}
+	cases := []struct {
+		name    string
+		isvc    *inferencev1alpha1.InferenceService
+		model   *inferencev1alpha1.Model
+		wantErr string // substring; empty = no error
+	}{
+		{
+			name:  "TP nil is fine, auto-derive owns it",
+			isvc:  sharingISvc(2, nil),
+			model: sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Count: 2}),
+		},
+		{
+			name:  "TP equal to count is fine",
+			isvc:  withVLLMTP(sharingISvc(2, nil), n(2)),
+			model: sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Count: 2}),
+		},
+		{
+			name:    "TP 8 on 2 GPUs is the shipped-sample bug",
+			isvc:    withVLLMTP(sharingISvc(2, nil), n(8)),
+			model:   sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Count: 2}),
+			wantErr: "tensorParallelSize 8 exceeds the 2 GPU",
+		},
+		{
+			name:  "TP below count is legitimate headroom",
+			isvc:  withVLLMTP(sharingISvc(2, nil), n(1)),
+			model: sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Count: 2}),
+		},
+		{
+			name: "count 0 skips the check entirely",
+			isvc: withVLLMTP(sharingISvc(0, nil), n(8)),
+		},
+		{
+			name:    "model count wins over resources.gpu",
+			isvc:    withVLLMTP(sharingISvc(2, nil), n(4)),
+			model:   sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Count: 4}),
+			wantErr: "",
+		},
+		{
+			name: "sglang tp x dp within count is fine",
+			isvc: func() *inferencev1alpha1.InferenceService {
+				i := sharingISvc(4, nil)
+				i.Spec.SGLangConfig = sglang(n(2), n(2), nil)
+				return i
+			}(),
+			model: sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Count: 4}),
+		},
+		{
+			name: "sglang tp x dp over count fails",
+			isvc: func() *inferencev1alpha1.InferenceService {
+				i := sharingISvc(2, nil)
+				i.Spec.SGLangConfig = sglang(n(2), n(2), nil)
+				return i
+			}(),
+			model:   sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Count: 2}),
+			wantErr: "needs 4 GPUs but this pod requests 2",
+		},
+		{
+			name: "sglang ep over count fails",
+			isvc: func() *inferencev1alpha1.InferenceService {
+				i := sharingISvc(2, nil)
+				i.Spec.SGLangConfig = sglang(n(2), nil, n(4))
+				return i
+			}(),
+			model:   sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Count: 2}),
+			wantErr: "expertParallelSize 4 exceeds",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parallelismExceedsGPUCount(tc.isvc, tc.model)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("parallelismExceedsGPUCount() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("parallelismExceedsGPUCount() = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -228,20 +228,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	isMetal := isMetalModel(model)
 
-	if r.Recorder != nil && needsOffloadMemoryWarning(inferenceService) {
-		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "MissingMemoryRequest", "Reconcile",
-			"CPU/KV offloading is enabled but resources.memory/hostMemory is not set; hybrid pods consume significant host RAM")
-	}
-
-	if r.Recorder != nil && shouldWarnMissingSkipModelInit(model, inferenceService) {
-		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "MissingSkipModelInit", "Reconcile",
-			"Model source is a HuggingFace repo ID (resolved by the runtime at startup); set spec.skipModelInit=true so the init container does not run")
-	}
-
-	if r.Recorder != nil && needsCPUOffloadNoopWarning(inferenceService) {
-		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "CPUOffloadUnverified", "Reconcile",
-			cpuOffloadIneffectiveMessage)
-	}
+	r.emitSpecAdvisoryEvents(inferenceService, model)
 
 	deployment, readyReplicas, metalSnap, result, err := r.reconcileDeployment(ctx, inferenceService, model, desiredReplicas, modelReady, isMetal)
 	if err != nil || result != nil {
@@ -774,6 +761,29 @@ func shouldWarnMissingSkipModelInit(model *inferencev1alpha1.Model, isvc *infere
 		return false
 	}
 	return !needsSkipModelInit(isvc)
+}
+
+// emitSpecAdvisoryEvents emits the non-blocking spec-hygiene warnings in one
+// place: config that reconciliation tolerates but that predictably surprises
+// the operator later (host-RAM surprises, redundant init downloads, a
+// cpu-offload flag with an open upstream reliability report). Extracted from
+// Reconcile so each new advisory does not grow its cyclomatic complexity.
+func (r *InferenceServiceReconciler) emitSpecAdvisoryEvents(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) {
+	if r.Recorder == nil {
+		return
+	}
+	if needsOffloadMemoryWarning(isvc) {
+		r.Recorder.Eventf(isvc, nil, corev1.EventTypeWarning, "MissingMemoryRequest", "Reconcile",
+			"CPU/KV offloading is enabled but resources.memory/hostMemory is not set; hybrid pods consume significant host RAM")
+	}
+	if shouldWarnMissingSkipModelInit(model, isvc) {
+		r.Recorder.Eventf(isvc, nil, corev1.EventTypeWarning, "MissingSkipModelInit", "Reconcile",
+			"Model source is a HuggingFace repo ID (resolved by the runtime at startup); set spec.skipModelInit=true so the init container does not run")
+	}
+	if needsCPUOffloadNoopWarning(isvc) {
+		r.Recorder.Eventf(isvc, nil, corev1.EventTypeWarning, "CPUOffloadUnverified", "Reconcile",
+			cpuOffloadIneffectiveMessage)
+	}
 }
 
 func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -238,6 +238,11 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			"Model source is a HuggingFace repo ID (resolved by the runtime at startup); set spec.skipModelInit=true so the init container does not run")
 	}
 
+	if r.Recorder != nil && needsCPUOffloadNoopWarning(inferenceService) {
+		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "CPUOffloadIneffective", "Reconcile",
+			cpuOffloadIneffectiveMessage)
+	}
+
 	deployment, readyReplicas, metalSnap, result, err := r.reconcileDeployment(ctx, inferenceService, model, desiredReplicas, modelReady, isMetal)
 	if err != nil || result != nil {
 		if result != nil {
@@ -362,6 +367,16 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 	if _, err := resolveGPUSharing(isvc, model, r.GPUSharingSharedPool); err != nil {
 		log.Info("Rejecting InferenceService with invalid gpuSharing spec", "reason", err.Error())
 		result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, modelReady, 0, desiredReplicas, "", fmt.Sprintf("Invalid gpuSharing: %v", err), nil)
+		return nil, 0, nil, &result, updateErr
+	}
+
+	// Explicit parallelism that cannot fit the pod's GPUs is equally fatal:
+	// the engine crash-loops probing for devices that do not exist (#1320).
+	// The quota webhook rejects this at admission when multitenancy is
+	// enabled; this backstop covers default installs.
+	if err := parallelismExceedsGPUCount(isvc, model); err != nil {
+		log.Info("Rejecting InferenceService with unsatisfiable parallelism", "reason", err.Error())
+		result, updateErr := r.updateStatusWithSchedulingInfo(ctx, isvc, PhaseFailed, modelReady, 0, desiredReplicas, "", fmt.Sprintf("Invalid parallelism: %v", err), nil)
 		return nil, 0, nil, &result, updateErr
 	}
 

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -239,7 +239,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	if r.Recorder != nil && needsCPUOffloadNoopWarning(inferenceService) {
-		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "CPUOffloadIneffective", "Reconcile",
+		r.Recorder.Eventf(inferenceService, nil, corev1.EventTypeWarning, "CPUOffloadUnverified", "Reconcile",
 			cpuOffloadIneffectiveMessage)
 	}
 

--- a/internal/controller/inferenceservice_quota_webhook.go
+++ b/internal/controller/inferenceservice_quota_webhook.go
@@ -183,7 +183,10 @@ func (v *InferenceServiceQuotaValidator) validateGPUSharing(ctx context.Context,
 	if _, err := resolveGPUSharing(isvc, model, v.GPUSharingSharedPool); err != nil {
 		return err
 	}
-	return gpuSharingParallelismConflict(isvc)
+	if err := gpuSharingParallelismConflict(isvc); err != nil {
+		return err
+	}
+	return parallelismExceedsGPUCount(isvc, model)
 }
 
 // listApplicableQuotas returns all GPUQuotas whose scope covers the given

--- a/internal/controller/inferenceservice_quota_webhook_test.go
+++ b/internal/controller/inferenceservice_quota_webhook_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -875,6 +876,62 @@ func TestValidate(t *testing.T) {
 		}
 		if !strContains(err.Error(), "would exceed gpuCount") {
 			t.Fatalf("expected error to mention gpuCount, got: %v", err)
+		}
+	})
+}
+
+// TestQuotaWebhookRejectsUnsatisfiableParallelism covers the #1320 wiring:
+// explicit TP larger than the pod's GPUs is denied at admission when the
+// webhook is enabled, and skipped (not falsely denied) when the count is
+// unknowable.
+func TestQuotaWebhookRejectsUnsatisfiableParallelism(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	tp8 := int32(8)
+
+	t.Run("explicit TP over GPU count is denied naming the field", func(t *testing.T) {
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "tp-over", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Runtime:    "vllm",
+				VLLMConfig: &inferencev1alpha1.VLLMConfig{TensorParallelSize: &tp8},
+				Resources:  &inferencev1alpha1.InferenceResourceRequirements{GPU: 2},
+			},
+		}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&ns).Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		_, err := v.ValidateCreate(ctx, &isvc)
+		if err == nil {
+			t.Fatal("expected denial, got admission")
+		}
+		if !strings.Contains(err.Error(), "tensorParallelSize") {
+			t.Fatalf("denial must name the offending field, got: %v", err)
+		}
+	})
+
+	t.Run("unknown GPU count is admitted, not falsely denied", func(t *testing.T) {
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "tp-unknown", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Runtime:    "vllm",
+				ModelRef:   "not-created-yet",
+				VLLMConfig: &inferencev1alpha1.VLLMConfig{TensorParallelSize: &tp8},
+			},
+		}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&ns).Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		if _, err := v.ValidateCreate(ctx, &isvc); err != nil {
+			t.Fatalf("count-unknown must be admitted (backstop re-checks), got: %v", err)
 		}
 	})
 }

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -173,7 +173,9 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 // when the config is fine. The caller is expected to translate these into a
 // metav1.Condition on the InferenceService status.
 //
-// Today it only checks speculative decoding; add cases here as the CRD grows.
+// Only one (reason, message) is returned, so check ordering is precedence:
+// SpeculativeMissingModel (a flag that gets skipped entirely) outranks
+// CPUOffloadIneffective (a flag that is passed but inert upstream).
 func ValidateVLLMConfig(isvc *inferencev1alpha1.InferenceService) (reason, message string) {
 	if isvc == nil || isvc.Spec.VLLMConfig == nil {
 		return "", ""
@@ -185,8 +187,23 @@ func ValidateVLLMConfig(isvc *inferencev1alpha1.InferenceService) (reason, messa
 				"spec.vllmConfig.speculative.enabled is true but spec.vllmConfig.speculative.model is empty; speculative decoding flags will be skipped"
 		}
 	}
+	// TODO(#1320): remove once vllm-project/vllm#48468 ships in DefaultImage.
+	if cfg.CPUOffloadGB != nil && *cfg.CPUOffloadGB > 0 {
+		return "CPUOffloadIneffective", cpuOffloadIneffectiveMessage
+	}
 	return "", ""
 }
+
+// cpuOffloadIneffectiveMessage is shared by the VLLMSpecValid condition and
+// the reconcile-time Warning Event so the two surfaces cannot drift. Worded
+// as a dated factual claim so it stays true if upstream later fixes it.
+const cpuOffloadIneffectiveMessage = "spec.vllmConfig.cpuOffloadGB is set, but vLLM's " +
+	"--cpu-offload-gb is a known silent no-op on V1-engine releases through at " +
+	"least v0.26 (vllm-project/vllm#48468, unfixed as of the pinned default " +
+	"image): the flag is accepted but weights are not offloaded, so VRAM-tight " +
+	"models OOM instead of spilling to host RAM. Verify offload in the server " +
+	"logs before relying on it; for MoE VRAM relief use the llama.cpp runtime's " +
+	"spec.moeCPUOffload instead"
 
 func (b *VLLMBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *corev1.Probe) {
 	startup := &corev1.Probe{

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -175,7 +175,7 @@ func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model 
 //
 // Only one (reason, message) is returned, so check ordering is precedence:
 // SpeculativeMissingModel (a flag that gets skipped entirely) outranks
-// CPUOffloadIneffective (a flag that is passed but inert upstream).
+// CPUOffloadUnverified (a flag with an open upstream reliability report).
 func ValidateVLLMConfig(isvc *inferencev1alpha1.InferenceService) (reason, message string) {
 	if isvc == nil || isvc.Spec.VLLMConfig == nil {
 		return "", ""
@@ -189,7 +189,7 @@ func ValidateVLLMConfig(isvc *inferencev1alpha1.InferenceService) (reason, messa
 	}
 	// TODO(#1320): remove once vllm-project/vllm#48468 ships in DefaultImage.
 	if cfg.CPUOffloadGB != nil && *cfg.CPUOffloadGB > 0 {
-		return "CPUOffloadIneffective", cpuOffloadIneffectiveMessage
+		return "CPUOffloadUnverified", cpuOffloadIneffectiveMessage
 	}
 	return "", ""
 }
@@ -197,13 +197,14 @@ func ValidateVLLMConfig(isvc *inferencev1alpha1.InferenceService) (reason, messa
 // cpuOffloadIneffectiveMessage is shared by the VLLMSpecValid condition and
 // the reconcile-time Warning Event so the two surfaces cannot drift. Worded
 // as a dated factual claim so it stays true if upstream later fixes it.
-const cpuOffloadIneffectiveMessage = "spec.vllmConfig.cpuOffloadGB is set, but vLLM's " +
-	"--cpu-offload-gb is a known silent no-op on V1-engine releases through at " +
-	"least v0.26 (vllm-project/vllm#48468, unfixed as of the pinned default " +
-	"image): the flag is accepted but weights are not offloaded, so VRAM-tight " +
-	"models OOM instead of spilling to host RAM. Verify offload in the server " +
-	"logs before relying on it; for MoE VRAM relief use the llama.cpp runtime's " +
-	"spec.moeCPUOffload instead"
+const cpuOffloadIneffectiveMessage = "spec.vllmConfig.cpuOffloadGB is set. " +
+	"vLLM's --cpu-offload-gb is reported silently ineffective in some " +
+	"configurations on current releases (vllm-project/vllm#48468, open): the " +
+	"flag is accepted but no weights offload, so VRAM-tight models OOM instead " +
+	"of spilling to host RAM. It is verified working in others (see the " +
+	"cpu-offload sample). Confirm it took effect in the server logs, via " +
+	"'Offloader set to' / 'offloaded parameters' lines or a Model-loading size " +
+	"below the full footprint, before relying on it"
 
 func (b *VLLMBackend) BuildProbes(port int32) (*corev1.Probe, *corev1.Probe, *corev1.Probe) {
 	startup := &corev1.Probe{

--- a/internal/controller/runtime_vllm_args.go
+++ b/internal/controller/runtime_vllm_args.go
@@ -177,3 +177,16 @@ func appendTensorParallelSize(args []string, tensorParallelSize *int32) []string
 	}
 	return args
 }
+
+// needsCPUOffloadNoopWarning returns true when the vLLM runtime is selected
+// and spec.vllmConfig.cpuOffloadGB is set to a positive value. The flag is a
+// known silent no-op on current vLLM (vllm-project/vllm#48468), so the
+// controller emits a warning event: the field targets VRAM-constrained boxes,
+// where the no-op surfaces as an unexplained OOM rather than an error. The
+// runtime gate matters because the caller is not runtime-scoped.
+func needsCPUOffloadNoopWarning(isvc *inferencev1alpha1.InferenceService) bool {
+	return isvc.Spec.Runtime == RuntimeVLLM &&
+		isvc.Spec.VLLMConfig != nil &&
+		isvc.Spec.VLLMConfig.CPUOffloadGB != nil &&
+		*isvc.Spec.VLLMConfig.CPUOffloadGB > 0
+}

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -678,7 +678,7 @@ func TestValidateVLLMConfig(t *testing.T) {
 			wantReason: "SpeculativeMissingModel",
 		},
 		{
-			name: "cpuOffloadGB set surfaces CPUOffloadIneffective",
+			name: "cpuOffloadGB set surfaces CPUOffloadUnverified",
 			isvc: &inferencev1alpha1.InferenceService{
 				Spec: inferencev1alpha1.InferenceServiceSpec{
 					Runtime: "vllm",
@@ -687,7 +687,7 @@ func TestValidateVLLMConfig(t *testing.T) {
 					},
 				},
 			},
-			wantReason: "CPUOffloadIneffective",
+			wantReason: "CPUOffloadUnverified",
 		},
 		{
 			name: "cpuOffloadGB zero is not warned",

--- a/internal/controller/runtime_vllm_test.go
+++ b/internal/controller/runtime_vllm_test.go
@@ -677,6 +677,43 @@ func TestValidateVLLMConfig(t *testing.T) {
 			},
 			wantReason: "SpeculativeMissingModel",
 		},
+		{
+			name: "cpuOffloadGB set surfaces CPUOffloadIneffective",
+			isvc: &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					Runtime: "vllm",
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{
+						CPUOffloadGB: ptrInt32(4),
+					},
+				},
+			},
+			wantReason: "CPUOffloadIneffective",
+		},
+		{
+			name: "cpuOffloadGB zero is not warned",
+			isvc: &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					Runtime: "vllm",
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{
+						CPUOffloadGB: ptrInt32(0),
+					},
+				},
+			},
+			wantReason: "",
+		},
+		{
+			name: "speculative-missing outranks cpu-offload (pins precedence)",
+			isvc: &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					Runtime: "vllm",
+					VLLMConfig: &inferencev1alpha1.VLLMConfig{
+						CPUOffloadGB: ptrInt32(4),
+						Speculative:  &inferencev1alpha1.SpeculativeConfig{Enabled: ptrBool(true)},
+					},
+				},
+			},
+			wantReason: "SpeculativeMissingModel",
+		},
 	}
 
 	for _, tc := range cases {
@@ -687,6 +724,38 @@ func TestValidateVLLMConfig(t *testing.T) {
 			}
 			if reason != "" && message == "" {
 				t.Errorf("expected non-empty message when reason is set, got empty")
+			}
+		})
+	}
+}
+
+// TestNeedsCPUOffloadNoopWarning covers the event predicate for #1320. The
+// runtime gate matters: the event call site is not runtime-scoped, so a
+// llamacpp service with a leftover vllmConfig must not warn.
+func TestNeedsCPUOffloadNoopWarning(t *testing.T) {
+	mk := func(runtime string, gb *int32) *inferencev1alpha1.InferenceService {
+		isvc := &inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{Runtime: runtime},
+		}
+		if gb != nil {
+			isvc.Spec.VLLMConfig = &inferencev1alpha1.VLLMConfig{CPUOffloadGB: gb}
+		}
+		return isvc
+	}
+	cases := []struct {
+		name string
+		isvc *inferencev1alpha1.InferenceService
+		want bool
+	}{
+		{"vllm with offload set", mk("vllm", ptrInt32(4)), true},
+		{"llamacpp with vllmConfig leftover", mk("llamacpp", ptrInt32(4)), false},
+		{"vllm with zero", mk("vllm", ptrInt32(0)), false},
+		{"vllm with nil config", mk("vllm", nil), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := needsCPUOffloadNoopWarning(tc.isvc); got != tc.want {
+				t.Fatalf("needsCPUOffloadNoopWarning() = %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Three connected fixes from #1320: a verify advisory when `vllmConfig.cpuOffloadGB` is set, admission plus reconcile-time validation that explicit tensor parallelism fits the pod's GPUs, and a rewrite of the cpu-offload sample, which as shipped had never been run.

## Why

Fixes #1320

@brandonliuli reported `--cpu-offload-gb` as a silent no-op on vLLM 0.25.1/0.26.0 (upstream vllm-project/vllm#48468, open), measured on his sm_120 hardware. Triage found the shipped sample also carried `tensorParallelSize: 8` on a 2-GPU spec, and that nothing validates explicit TP against available GPUs, so that class is admitted cleanly and dies in a crashloop.

## The live verification changed the story

We ran the sample's own configuration on our 2x RTX 5060 Ti (sm_120, the exact hardware its comment names):

| image | result |
|---|---|
| `v0.20.0` (sample pin) | **offload works**: `Offloader set to UVAOffloader`, 4.2 GB offloaded per rank, model loading **13.01 GiB** vs ~16.5 full |
| `v0.25.1` (operator default) | **offload works**: same offloader lines, **13.17 GiB** |

So the upstream no-op is **configuration-dependent**, not blanket: real on the reporter's single-GPU DeepSeek/Qwen3-30B runs, absent on this TP=2 FP8 MoE config, same image version. The warning is therefore worded as a *verify advisory* (`CPUOffloadUnverified`), naming both the open upstream report and a verified-working configuration, with concrete log lines to check. The first commit asserted a blanket no-op; the second corrects it to what we measured, because asserting more than the evidence supports is the defect class this issue belongs to.

## The sample had never been run as shipped

Four independent defects, each found only by executing it:

1. `tensorParallelSize: 8` on 2 GPUs, unstartable (removed; auto-derive yields 2)
2. Comment truncated mid-sentence (finished, measured numbers inlined)
3. No `skipModelInit` for an HF-repo source, so the init container fabricates an invalid single-file artifact from a safetensors repo (`GGUF magic invalid`)
4. Source in `https://` URL form, which `normalizeHFSource` passes through verbatim and vLLM rejects (changed to the bare repo id)

The fixed sample passes server-side dry-run under the new validation, starts, downloads via the HF token, offloads, and produced the numbers above on both images.

## Parallelism validation

`parallelismExceedsGPUCount` rejects explicit world sizes above the pod's GPU count (no multi-node inference exists, so they can never start): at the quota webhook when multitenancy is enabled, and always at the reconcile backstop as `Phase=Failed` with an actionable message instead of a crashloop. Explicit-only (auto-derive already matches the count), skip on count 0 (Model-not-yet-created, DRA claims), vLLM checks TP alone (no DP/PP fields exist), SGLang checks `tp x dp` and `ep` per its in-process semantics. Also backfills tests for `gpuSharingParallelismConflict`, which had none.

## Verification

- All new checks bite-checked: each reverted in turn, its tests fail, restored.
- Precedence pinned: `SpeculativeMissingModel` outranks `CPUOffloadUnverified` in the single-reason `ValidateVLLMConfig`.
- `make manifests && make chart-crds` twice, zero diff (matches `crd-sync-check`).
- End-to-end on the cluster as above, including that the ORIGINAL sample's TP=8 is now rejected at admission with the field named.
- `gofmt`, `go vet` clean, no em dashes; envtest suite needs assets absent locally, CI covers it.

Follow-up worth its own issue rather than scope creep here: `normalizeHFSource`/`isHFRepoSource` do not recognise the `https://huggingface.co/...` URL form, so the most natural user input gets neither download handling nor the `MissingSkipModelInit` warning.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (targeted packages; envtest assets absent, CI covers)
- [x] `make lint` passes locally (no local golangci-lint binary; CI covers)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

AI-assisted (band 3): triage, fix, tests, and live verification run with Claude Code; review, hardware decisions, and node reboot mine.