### PR TITLE
fix(foreman): split git committer identity from author for human DCO sign-off

### DIFF
--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -153,10 +153,12 @@ func main() {
 		inferenceURLHostOverride string
 
 		// M4 gate-tool flags
-		foremanNamespace  string
-		commitAuthorName  string
-		commitAuthorEmail string
-		keepWorkspace     bool
+		foremanNamespace     string
+		commitAuthorName     string
+		commitAuthorEmail    string
+		commitCommitterName  string
+		commitCommitterEmail string
+		keepWorkspace        bool
 
 		// #620 coder-Job git Secret selection
 		coderGitSecret    string
@@ -224,9 +226,15 @@ func main() {
 			"controller-runtime cache re-reads the current port on each task dispatch, so "+
 			"this stays current without restart.")
 	flag.StringVar(&commitAuthorName, "commit-author-name", "Foreman Bot",
-		"git author + committer name for branches produced by the native loop.")
+		"git author name for branches produced by the native loop.")
 	flag.StringVar(&commitAuthorEmail, "commit-author-email", "",
-		"git author + committer email. Required when --agent-mode=native.")
+		"git author email. Required when --agent-mode=native.")
+	flag.StringVar(&commitCommitterName, "commit-committer-name", "",
+		"git committer name for the DCO sign-off trailer. Defaults to "+
+			"--commit-author-name so existing deployments are unchanged.")
+	flag.StringVar(&commitCommitterEmail, "commit-committer-email", "",
+		"git committer email for the DCO sign-off trailer. Defaults to "+
+			"--commit-author-email so existing deployments are unchanged.")
 	flag.BoolVar(&keepWorkspace, "keep-workspace", false,
 		"Preserve the per-task clone workspace after the run. Useful for debugging; default removes it.")
 	flag.StringVar(&foremanNamespace, "foreman-namespace", "foreman-system",
@@ -424,7 +432,8 @@ func main() {
 				Name: commitAuthorName, Email: commitAuthorEmail,
 			},
 			CommitCommitter: repo.Identity{
-				Name: commitAuthorName, Email: commitAuthorEmail,
+				Name:  committerName(commitCommitterName, commitAuthorName),
+				Email: committerEmail(commitCommitterEmail, commitAuthorEmail),
 			},
 			KeepWorkspace:   keepWorkspace,
 			RegistryFactory: makeRegistryFactory(kc, kcs, foremanNamespace),
@@ -446,10 +455,12 @@ func main() {
 					// into the coder Job's run-task invocation so the in-pod
 					// clone + push can authenticate and commit; without these
 					// run-task fails with GitRemoteNotConfigured (#620).
-					GitRemoteURL:      gitRemoteURL,
-					CommitAuthorName:  commitAuthorName,
-					CommitAuthorEmail: commitAuthorEmail,
-					LogTailFn:         makePodLogTailFn(kcs),
+					GitRemoteURL:         gitRemoteURL,
+					CommitAuthorName:     commitAuthorName,
+					CommitAuthorEmail:    commitAuthorEmail,
+					CommitCommitterName:  committerName(commitCommitterName, commitAuthorName),
+					CommitCommitterEmail: committerEmail(commitCommitterEmail, commitAuthorEmail),
+					LogTailFn:            makePodLogTailFn(kcs),
 				},
 			},
 			// EnvtestJobRunner verifies envtest-backed packages post-push in a
@@ -523,6 +534,8 @@ func runTaskCommand(args []string) {
 		inferenceURLHostOverride string
 		commitAuthorName         string
 		commitAuthorEmail        string
+		commitCommitterName      string
+		commitCommitterEmail     string
 		foremanNamespace         string
 		keepWorkspace            bool
 	)
@@ -542,9 +555,15 @@ func runTaskCommand(args []string) {
 		"Rewrite the host of the resolved InferenceService URL and substitute the live port "+
 			"from the v1 Endpoints object (off-cluster same-host installs).")
 	fs.StringVar(&commitAuthorName, "commit-author-name", "Foreman Bot",
-		"git author + committer name for the produced branch.")
+		"git author name for the produced branch.")
 	fs.StringVar(&commitAuthorEmail, "commit-author-email", "",
-		"git author + committer email. Required for coder tasks that commit.")
+		"git author email. Required for coder tasks that commit.")
+	fs.StringVar(&commitCommitterName, "commit-committer-name", "",
+		"git committer name for the DCO sign-off trailer. Defaults to "+
+			"--commit-author-name so existing deployments are unchanged.")
+	fs.StringVar(&commitCommitterEmail, "commit-committer-email", "",
+		"git committer email for the DCO sign-off trailer. Defaults to "+
+			"--commit-author-email so existing deployments are unchanged.")
 	fs.StringVar(&foremanNamespace, "foreman-namespace", "foreman-system",
 		"Namespace deterministic tools (e.g. run_gate_job) submit Jobs into.")
 	fs.BoolVar(&keepWorkspace, "keep-workspace", false,
@@ -590,12 +609,15 @@ func runTaskCommand(args []string) {
 		InferenceBaseURLOverride:     inferenceURLOverride,
 		InferenceBaseURLHostOverride: inferenceURLHostOverride,
 		CommitAuthor:                 repo.Identity{Name: commitAuthorName, Email: commitAuthorEmail},
-		CommitCommitter:              repo.Identity{Name: commitAuthorName, Email: commitAuthorEmail},
-		KeepWorkspace:                keepWorkspace,
-		RegistryFactory:              makeRegistryFactory(kc, kcs, foremanNamespace),
-		CodeHost:                     githubCodeHost(),
-		WorkItems:                    githubWorkItems(),
-		ChangePolicy:                 changepolicy.NewDefaultPolicy(),
+		CommitCommitter: repo.Identity{
+			Name:  committerName(commitCommitterName, commitAuthorName),
+			Email: committerEmail(commitCommitterEmail, commitAuthorEmail),
+		},
+		KeepWorkspace:   keepWorkspace,
+		RegistryFactory: makeRegistryFactory(kc, kcs, foremanNamespace),
+		CodeHost:        githubCodeHost(),
+		WorkItems:       githubWorkItems(),
+		ChangePolicy:    changepolicy.NewDefaultPolicy(),
 	})
 	if err != nil {
 		// System / execution failure: the result line + ERROR sentinel
@@ -607,6 +629,27 @@ func runTaskCommand(args []string) {
 	setupLog.Info("run-task completed",
 		"task", taskName, "namespace", namespace,
 		"verdict", res.Verdict, "branch", res.Branch, "commitSHA", res.CommitSHA)
+}
+
+// committerName resolves the git committer name, falling back to the
+// author name when --commit-committer-name is unset. This preserves the
+// previous behavior (author == committer) for deployments that have not
+// opted into a separate committer identity, while letting a human
+// committer produce a human DCO sign-off trailer via `git commit -s`.
+func committerName(committerName, authorName string) string {
+	if committerName != "" {
+		return committerName
+	}
+	return authorName
+}
+
+// committerEmail resolves the git committer email, falling back to the
+// author email when --commit-committer-email is unset. See committerName.
+func committerEmail(committerEmail, authorEmail string) string {
+	if committerEmail != "" {
+		return committerEmail
+	}
+	return authorEmail
 }
 
 // loadKubeconfig defers to controller-runtime's standard discovery chain:

--- a/cmd/foreman-agent/main_test.go
+++ b/cmd/foreman-agent/main_test.go
@@ -252,3 +252,61 @@ func TestParseKeyValueCSV(t *testing.T) {
 		})
 	}
 }
+
+// TestCommitterName_FallbackToAuthor verifies the committer identity
+// helpers default to the author values when the committer flags are unset,
+// preserving the previous behavior (author == committer) for deployments
+// that have not opted into a separate committer identity (#1281).
+func TestCommitterName_FallbackToAuthor(t *testing.T) {
+	cases := []struct {
+		name           string
+		committerName  string
+		authorName     string
+		wantName       string
+		committerEmail string
+		authorEmail    string
+		wantEmail      string
+	}{
+		{
+			name:           "unset_committer_falls_back_to_author",
+			committerName:  "",
+			authorName:     "Foreman Bot",
+			wantName:       "Foreman Bot",
+			committerEmail: "",
+			authorEmail:    "bot@foreman.test",
+			wantEmail:      "bot@foreman.test",
+		},
+		{
+			name:           "set_committer_overrides_author",
+			committerName:  "Jory Dogfood",
+			authorName:     "Foreman Bot",
+			wantName:       "Jory Dogfood",
+			committerEmail: "jory@example.com",
+			authorEmail:    "bot@foreman.test",
+			wantEmail:      "jory@example.com",
+		},
+		{
+			name:           "both_empty_returns_empty",
+			committerName:  "",
+			authorName:     "",
+			wantName:       "",
+			committerEmail: "",
+			authorEmail:    "",
+			wantEmail:      "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotName := committerName(tc.committerName, tc.authorName)
+			if gotName != tc.wantName {
+				t.Errorf("committerName(%q, %q) = %q, want %q",
+					tc.committerName, tc.authorName, gotName, tc.wantName)
+			}
+			gotEmail := committerEmail(tc.committerEmail, tc.authorEmail)
+			if gotEmail != tc.wantEmail {
+				t.Errorf("committerEmail(%q, %q) = %q, want %q",
+					tc.committerEmail, tc.authorEmail, gotEmail, tc.wantEmail)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/repo/commit_test.go
+++ b/pkg/foreman/agent/repo/commit_test.go
@@ -91,3 +91,76 @@ func TestSoftResetToBase_NoSelfCommitIsNothingToCommit(t *testing.T) {
 		t.Errorf("want ErrNothingToCommit, got %v", err)
 	}
 }
+
+// TestCommit_CommitterAuthorSplit verifies that when Author and Committer
+// differ, the commit's author block reflects the Author identity while the
+// DCO sign-off trailer (`Signed-off-by`) is derived from the Committer
+// identity. This is the fix for #1281: a bot author + human committer
+// produces a human sign-off that satisfies CONTRIBUTING.md's DCO policy.
+func TestCommit_CommitterAuthorSplit(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareOrigin(t, root)
+	seedOrigin(t, bare)
+
+	ctx := context.Background()
+	dest := filepath.Join(root, "work")
+	if err := Clone(ctx, CloneOptions{RemoteURL: bare, Dest: dest}); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	if err := CreateAndCheckoutBranch(ctx, dest, "foreman/issue-1281"); err != nil {
+		t.Fatalf("CreateAndCheckoutBranch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "change.txt"),
+		[]byte("bot-authored change\n"), 0o644); err != nil {
+		t.Fatalf("write change: %v", err)
+	}
+
+	bot := Identity{Name: "Foreman Bot", Email: "bot@foreman.test"}
+	human := Identity{Name: "Jory Dogfood", Email: "jory@example.com"}
+
+	sha, err := Commit(ctx, CommitOptions{
+		Workspace: dest,
+		Message:   "fix: demonstrate committer/author split\n\nFixes #1281",
+		Author:    bot,
+		Committer: human,
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if len(sha) < 7 {
+		t.Errorf("sha looks wrong: %q", sha)
+	}
+
+	// Author block must reflect the bot identity.
+	authorName := gitOut(t, dest, "log", "-1", "--format=%an", sha)
+	authorEmail := gitOut(t, dest, "log", "-1", "--format=%ae", sha)
+	if authorName != bot.Name {
+		t.Errorf("author name: got %q want %q", authorName, bot.Name)
+	}
+	if authorEmail != bot.Email {
+		t.Errorf("author email: got %q want %q", authorEmail, bot.Email)
+	}
+
+	// Committer block must reflect the human identity.
+	committerName := gitOut(t, dest, "log", "-1", "--format=%cn", sha)
+	committerEmail := gitOut(t, dest, "log", "-1", "--format=%ce", sha)
+	if committerName != human.Name {
+		t.Errorf("committer name: got %q want %q", committerName, human.Name)
+	}
+	if committerEmail != human.Email {
+		t.Errorf("committer email: got %q want %q", committerEmail, human.Email)
+	}
+
+	// The DCO sign-off trailer must be derived from the committer, not
+	// the author — this is the whole point of #1281.
+	body := gitOut(t, dest, "log", "-1", "--format=%B", sha)
+	wantSignoff := "Signed-off-by: " + human.Name + " <" + human.Email + ">"
+	if !strings.Contains(body, wantSignoff) {
+		t.Errorf("missing human DCO trailer; commit body was:\n%s", body)
+	}
+	botSignoff := "Signed-off-by: " + bot.Name + " <" + bot.Email + ">"
+	if strings.Contains(body, botSignoff) {
+		t.Errorf("bot DCO trailer must not appear; commit body was:\n%s", body)
+	}
+}

--- a/pkg/foreman/agent/tools/coder_job_template.yaml
+++ b/pkg/foreman/agent/tools/coder_job_template.yaml
@@ -46,9 +46,14 @@
 #                      tasks that need it then fail with
 #                      GitRemoteNotConfigured rather than parsing an empty
 #                      URL); gate-only installs have no remote.
-#   .CommitAuthorName / .CommitAuthorEmail -- optional. git author +
-#                      committer identity, passed as --commit-author-name /
+#   .CommitAuthorName / .CommitAuthorEmail -- optional. git author
+#                      identity, passed as --commit-author-name /
 #                      --commit-author-email. Each omitted when empty.
+#   .CommitCommitterName / .CommitCommitterEmail -- optional. git
+#                      committer identity for the DCO sign-off trailer,
+#                      passed as --commit-committer-name /
+#                      --commit-committer-email. Each omitted when empty
+#                      so run-task falls back to the author values (#1281).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -94,6 +99,12 @@ spec:
             {{- end }}
             {{- if .CommitAuthorEmail }}
             - --commit-author-email={{ .CommitAuthorEmail }}
+            {{- end }}
+            {{- if .CommitCommitterName }}
+            - --commit-committer-name={{ .CommitCommitterName }}
+            {{- end }}
+            {{- if .CommitCommitterEmail }}
+            - --commit-committer-email={{ .CommitCommitterEmail }}
             {{- end }}
           env:
             # The run-task body resolves git auth via

--- a/pkg/foreman/agent/tools/run_coder_job.go
+++ b/pkg/foreman/agent/tools/run_coder_job.go
@@ -120,16 +120,28 @@ type RunCoderJobConfig struct {
 	// the watcher's --git-remote-url.
 	GitRemoteURL string
 
-	// CommitAuthorName is the git author + committer name run-task stamps
-	// onto the produced branch. Passed through as --commit-author-name;
-	// omitted when empty so run-task falls back to its own default.
+	// CommitAuthorName is the git author name run-task stamps onto the
+	// produced branch. Passed through as --commit-author-name; omitted
+	// when empty so run-task falls back to its own default.
 	CommitAuthorName string
 
-	// CommitAuthorEmail is the git author + committer email run-task
-	// stamps onto the produced branch. Passed through as
-	// --commit-author-email; omitted when empty (coder tasks that commit
-	// then fail cleanly). Mirrors the watcher's --commit-author-email.
+	// CommitAuthorEmail is the git author email run-task stamps onto the
+	// produced branch. Passed through as --commit-author-email; omitted
+	// when empty (coder tasks that commit then fail cleanly). Mirrors the
+	// watcher's --commit-author-email.
 	CommitAuthorEmail string
+
+	// CommitCommitterName is the git committer name for the DCO sign-off
+	// trailer. Passed through as --commit-committer-name; omitted when
+	// empty so run-task falls back to --commit-author-name. Lets a human
+	// committer produce a human Signed-off-by trailer while authorship
+	// still credits the bot (#1281).
+	CommitCommitterName string
+
+	// CommitCommitterEmail is the git committer email for the DCO
+	// sign-off trailer. Passed through as --commit-committer-email;
+	// omitted when empty so run-task falls back to --commit-author-email.
+	CommitCommitterEmail string
 
 	// Resources, when non-nil, overrides the coder container's resource
 	// requests + limits (from Agent.spec.execution.resources). Any field
@@ -314,6 +326,8 @@ func (r *RunCoderJob) Run(ctx context.Context, args RunCoderJobArgs) (CoderJobRe
 		GitRemoteURL:            cfg.GitRemoteURL,
 		CommitAuthorName:        cfg.CommitAuthorName,
 		CommitAuthorEmail:       cfg.CommitAuthorEmail,
+		CommitCommitterName:     cfg.CommitCommitterName,
+		CommitCommitterEmail:    cfg.CommitCommitterEmail,
 		Resources:               cfg.Resources,
 	})
 	if err != nil {
@@ -495,6 +509,8 @@ type coderRendererInput struct {
 	GitRemoteURL            string
 	CommitAuthorName        string
 	CommitAuthorEmail       string
+	CommitCommitterName     string
+	CommitCommitterEmail    string
 
 	// Resources, when non-nil, replaces the container resources the
 	// string fields above produce. Applied after the template unmarshals

--- a/pkg/foreman/agent/tools/run_coder_job_test.go
+++ b/pkg/foreman/agent/tools/run_coder_job_test.go
@@ -323,8 +323,10 @@ func TestRunCoderJob_CustomGitSecretFlowsThroughRun(t *testing.T) {
 
 // TestRenderCoderJob_GitRemoteAndCommitAuthorArgs asserts the rendered
 // run-task args carry --git-remote-url / --commit-author-email /
-// --commit-author-name when set, so the coder Job can clone + push (#620).
-// Without these the run-task body fails with GitRemoteNotConfigured.
+// --commit-author-name / --commit-committer-email / --commit-committer-name
+// when set, so the coder Job can clone + push (#620) and produce a human
+// DCO sign-off (#1281). Without these the run-task body fails with
+// GitRemoteNotConfigured.
 func TestRenderCoderJob_GitRemoteAndCommitAuthorArgs(t *testing.T) {
 	job, err := renderCoderJob(coderRendererInput{
 		Name:                  "foreman-coder-gitremote",
@@ -341,6 +343,8 @@ func TestRenderCoderJob_GitRemoteAndCommitAuthorArgs(t *testing.T) {
 		GitRemoteURL:          "https://github.com/Defilan/LLMKube.git",
 		CommitAuthorName:      "Foreman Bot",
 		CommitAuthorEmail:     "foreman@defilan.tech",
+		CommitCommitterName:   "Jory Dogfood",
+		CommitCommitterEmail:  "jory@example.com",
 	})
 	if err != nil {
 		t.Fatalf("renderCoderJob: %v", err)
@@ -354,6 +358,12 @@ func TestRenderCoderJob_GitRemoteAndCommitAuthorArgs(t *testing.T) {
 	}
 	if !strings.Contains(args, "--commit-author-name=Foreman Bot") {
 		t.Errorf("Args missing --commit-author-name:\n%s", args)
+	}
+	if !strings.Contains(args, "--commit-committer-email=jory@example.com") {
+		t.Errorf("Args missing --commit-committer-email:\n%s", args)
+	}
+	if !strings.Contains(args, "--commit-committer-name=Jory Dogfood") {
+		t.Errorf("Args missing --commit-committer-name:\n%s", args)
 	}
 }
 
@@ -388,6 +398,12 @@ func TestRenderCoderJob_GitRemoteArgsOmittedWhenEmpty(t *testing.T) {
 	if strings.Contains(args, "--commit-author-name") {
 		t.Errorf("Args should omit --commit-author-name when empty:\n%s", args)
 	}
+	if strings.Contains(args, "--commit-committer-email") {
+		t.Errorf("Args should omit --commit-committer-email when empty:\n%s", args)
+	}
+	if strings.Contains(args, "--commit-committer-name") {
+		t.Errorf("Args should omit --commit-committer-name when empty:\n%s", args)
+	}
 }
 
 // TestRunCoderJob_GitRemoteFlowsThroughRun asserts the static Cfg's
@@ -406,13 +422,15 @@ func TestRunCoderJob_GitRemoteFlowsThroughRun(t *testing.T) {
 	tool := &RunCoderJob{
 		Client: c,
 		Cfg: RunCoderJobConfig{
-			NameFn:            pinName(jobName),
-			PollInterval:      5 * time.Millisecond,
-			PollTimeout:       2 * time.Second,
-			GitRemoteURL:      "https://github.com/Defilan/LLMKube.git",
-			CommitAuthorName:  "Foreman Bot",
-			CommitAuthorEmail: "foreman@defilan.tech",
-			LogTailFn:         func(context.Context, string, string) string { return "" },
+			NameFn:               pinName(jobName),
+			PollInterval:         5 * time.Millisecond,
+			PollTimeout:          2 * time.Second,
+			GitRemoteURL:         "https://github.com/Defilan/LLMKube.git",
+			CommitAuthorName:     "Foreman Bot",
+			CommitAuthorEmail:    "foreman@defilan.tech",
+			CommitCommitterName:  "Jory Dogfood",
+			CommitCommitterEmail: "jory@example.com",
+			LogTailFn:            func(context.Context, string, string) string { return "" },
 		},
 	}
 	if _, err := tool.Run(ctx, RunCoderJobArgs{TaskName: "gitflow", TaskNamespace: "default"}); err != nil {
@@ -431,6 +449,12 @@ func TestRunCoderJob_GitRemoteFlowsThroughRun(t *testing.T) {
 	}
 	if !strings.Contains(args, "--commit-author-name=Foreman Bot") {
 		t.Errorf("Args missing --commit-author-name:\n%s", args)
+	}
+	if !strings.Contains(args, "--commit-committer-email=jory@example.com") {
+		t.Errorf("Args missing --commit-committer-email:\n%s", args)
+	}
+	if !strings.Contains(args, "--commit-committer-name=Jory Dogfood") {
+		t.Errorf("Args missing --commit-committer-name:\n%s", args)
 	}
 }
 


### PR DESCRIPTION
## What

Foreman commits carry a bot-only `Signed-off-by` trailer, which `CONTRIBUTING.md` forbids, so every Foreman branch fails the DCO check. This lets the git committer identity differ from the author, so `git commit -s` derives a human `Signed-off-by` while `GIT_AUTHOR_*` still credits the bot.

## Why

Fixes #1281

Casualties cited in the issue: #1279, #1280 both needed manual amendment.

## How

New `--commit-committer-name` / `--commit-committer-email` flags on both the watcher and the `run-task` subcommand, defaulting to the author values (so unset preserves current behavior). Committer identity is threaded through **every** commit-creating path: the two `main.go` construction sites, and the Job-mode coder path (`run_coder_job.go` + `coder_job_template.yaml`), which commits in-pod via `run-task` and would otherwise still bot-sign.

The mechanic rests on `git commit -s` deriving the trailer from `GIT_COMMITTER_*`, verified against `pkg/foreman/agent/repo/commit.go`.

## Provenance and review

This branch was **authored by Foreman/Laguna** and reviewed independently (the reviewer was blind to the task intent). The review verified the core mechanic against source, confirmed all commit paths are covered, that the Job-template extension is correct completeness rather than scope creep, and that the two secondary ideas in the issue (em-dash sanitizer, bot-committer refusal) were correctly left out. Verdict: accept. One INFORMATIONAL note: an operator who sets the committer name but not the email gets a human-name/bot-email pair (still DCO-valid).

## Operational follow-up (not in this PR)

Defaults keep committer = author = bot for backward-compat, so branches only start passing DCO once the `foreman-agent` deployment sets `--commit-committer-email`/`--commit-committer-name` to the accountable human. Worth a deploy-args + docs line.

## Note on DCO

Correction: the repo's DCO check (`.github/workflows/dco.yml`) is presence-only, so this branch's bot `Signed-off-by` already passes it; all CI is green. What #1281 addresses is the `CONTRIBUTING.md` policy against bot-only sign-offs, not a failing check. (An earlier version of this description incorrectly said the DCO check would be red.)


AI-assisted (band 3): authored by a Foreman coder agent, independently reviewed, opened and verified by me. Part of a harness-evaluation batch (review, do not auto-merge).
