### PR TITLE
fix(controller): charge GPUQuota by the resolved GPU count, closing the Model-declared-count bypass

### DIFF
--- a/internal/controller/gpuquota_controller.go
+++ b/internal/controller/gpuquota_controller.go
@@ -34,6 +34,7 @@ import (
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
+	"github.com/defilantech/llmkube/pkg/apiutil"
 )
 
 const (
@@ -123,17 +124,22 @@ func (r *GPUQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, err
 		}
 		for _, isvc := range isvcList.Items {
-			// GPU count per pod: nil resources means 0.
-			gpuPerPod := int32(0)
-			if isvc.Spec.Resources != nil && isvc.Spec.Resources.GPU > 0 {
-				gpuPerPod = isvc.Spec.Resources.GPU
+			// Fetch the referenced Model best-effort so the per-pod GPU
+			// count matches the pod spec (which prefers hardware.gpu.count).
+			// A nil Model falls through to resources.gpu in apiutil.GPUCount.
+			var model *inferencev1alpha1.Model
+			if isvc.Spec.ModelRef != "" {
+				m := &inferencev1alpha1.Model{}
+				if err := r.Get(ctx, types.NamespacedName{Name: isvc.Spec.ModelRef, Namespace: isvc.Namespace}, m); err == nil {
+					model = m
+				}
 			}
 			// Replicas: nil means 1.
 			replicas := int32(1)
 			if isvc.Spec.Replicas != nil {
 				replicas = *isvc.Spec.Replicas
 			}
-			usedGPUCount += gpuPerPod * replicas
+			usedGPUCount += apiutil.GPUCount(&isvc, model) * replicas
 
 			if vram, known := serviceVRAMBytesFor(ctx, r.Client, &isvc, r.VRAMPerDeviceGiB); known {
 				usedVRAMBytes += vram

--- a/internal/controller/gpuquota_controller_test.go
+++ b/internal/controller/gpuquota_controller_test.go
@@ -768,6 +768,79 @@ func TestReconcileNilReplicas(t *testing.T) {
 	}
 }
 
+// #1310: a Model declaring hardware.gpu.count must be charged against
+// status.UsedGPUCount, not silently bypassed. The reconciler must fetch
+// the referenced Model and route through apiutil.GPUCount, matching the
+// pod spec.
+func TestReconcileModelDeclaredGPUCount(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	gq := &inferencev1alpha1.GPUQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+		Spec: inferencev1alpha1.GPUQuotaSpec{
+			NamespaceRef: "my-ns",
+			GPUCount:     10,
+		},
+	}
+
+	// Model declares 4 GPUs; ISVC leaves resources.gpu unset.
+	// With replicas: 2 the pod requests 8 GPUs (4 x 2).
+	model := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-model",
+			Namespace: "my-ns",
+		},
+		Spec: inferencev1alpha1.ModelSpec{
+			Hardware: &inferencev1alpha1.HardwareSpec{
+				GPU: &inferencev1alpha1.GPUSpec{
+					Count: 4,
+				},
+			},
+		},
+	}
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-isvc",
+			Namespace: "my-ns",
+		},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "my-model",
+			Replicas: ptrInt32GPUQuota(2),
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&inferencev1alpha1.GPUQuota{}).WithObjects(gq, model, isvc).Build()
+	r := &GPUQuotaReconciler{Client: c, Scheme: scheme}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-gq",
+			Namespace: "default",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() returned %+v, want empty Result", result)
+	}
+
+	var updatedGQ inferencev1alpha1.GPUQuota
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "my-gq", Namespace: "default"}, &updatedGQ); err != nil {
+		t.Fatalf("failed to get GPUQuota after reconcile: %v", err)
+	}
+	if updatedGQ.Status.UsedGPUCount != 8 {
+		t.Errorf("Reconcile() status.UsedGPUCount = %d, want 8 (model gpu 4 * 2 replicas)", updatedGQ.Status.UsedGPUCount)
+	}
+}
+
 func TestReconcileNoScope(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/internal/controller/inferenceservice_quota_webhook.go
+++ b/internal/controller/inferenceservice_quota_webhook.go
@@ -32,6 +32,7 @@ import (
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
 	"github.com/defilantech/llmkube/internal/webhook/quota"
+	"github.com/defilantech/llmkube/pkg/apiutil"
 )
 
 // +kubebuilder:webhook:path=/validate-inference-llmkube-dev-v1alpha1-inferenceservice-quota,mutating=false,failurePolicy=fail,sideEffects=None,groups=inference.llmkube.dev,resources=inferenceservices,verbs=create;update,versions=v1alpha1,name=vinferenceservicequota.inference.llmkube.dev,admissionReviewVersions=v1
@@ -153,8 +154,14 @@ func (v *InferenceServiceQuotaValidator) validate(ctx context.Context, isvc *inf
 		return fmt.Errorf("listing applicable GPUQuotas: %w", err)
 	}
 
+	// Fetch the referenced Model best-effort so GPU-count accounting matches
+	// the pod spec (which prefers hardware.gpu.count). At admission time the
+	// Model may not exist yet; a nil Model falls through to resources.gpu in
+	// apiutil.GPUCount, exactly as the reconciler would on first sight.
+	model := v.fetchModel(ctx, isvc)
+
 	for _, q := range quotas {
-		allow, reason := v.decide(ctx, q, isvc)
+		allow, reason := v.decide(ctx, q, isvc, model)
 		if !allow {
 			// Record the denial as a metric (#416): a sideEffects=None
 			// validating webhook cannot mutate the GPUQuota status counter,
@@ -167,19 +174,29 @@ func (v *InferenceServiceQuotaValidator) validate(ctx context.Context, isvc *inf
 	return nil
 }
 
+// fetchModel returns the Model referenced by isvc.Spec.ModelRef, or nil when
+// the reference is empty or the Model cannot be read. Admission-time Model
+// absence is expected (the reconciler backstops with the real Model); a nil
+// Model resolves with the NVIDIA-default vendor exactly as the reconciler
+// would on first sight.
+func (v *InferenceServiceQuotaValidator) fetchModel(ctx context.Context, isvc *inferencev1alpha1.InferenceService) *inferencev1alpha1.Model {
+	if isvc.Spec.ModelRef == "" {
+		return nil
+	}
+	m := &inferencev1alpha1.Model{}
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: isvc.Spec.ModelRef, Namespace: isvc.Namespace}, m); err != nil {
+		return nil
+	}
+	return m
+}
+
 // validateGPUSharing runs the resolver's sharing rules plus the explicit
 // parallelism cross-checks against the incoming InferenceService. The Model
 // is fetched best-effort: at admission time it may not exist yet, and a nil
 // Model resolves with the NVIDIA-default vendor exactly as the reconciler
 // would on first sight.
 func (v *InferenceServiceQuotaValidator) validateGPUSharing(ctx context.Context, isvc *inferencev1alpha1.InferenceService) error {
-	var model *inferencev1alpha1.Model
-	if isvc.Spec.ModelRef != "" {
-		m := &inferencev1alpha1.Model{}
-		if err := v.Client.Get(ctx, types.NamespacedName{Name: isvc.Spec.ModelRef, Namespace: isvc.Namespace}, m); err == nil {
-			model = m
-		}
-	}
+	model := v.fetchModel(ctx, isvc)
 	if _, err := resolveGPUSharing(isvc, model, v.GPUSharingSharedPool); err != nil {
 		return err
 	}
@@ -233,7 +250,7 @@ func (v *InferenceServiceQuotaValidator) listApplicableQuotas(ctx context.Contex
 // the pure quota.Decide function. It computes current usage by listing
 // InferenceServices in the quota's scope and summing their GPU and VRAM
 // allocations.
-func (v *InferenceServiceQuotaValidator) decide(ctx context.Context, q inferencev1alpha1.GPUQuota, isvc *inferencev1alpha1.InferenceService) (bool, string) {
+func (v *InferenceServiceQuotaValidator) decide(ctx context.Context, q inferencev1alpha1.GPUQuota, isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) (bool, string) {
 	currentUsage, err := v.currentUsage(ctx, q, isvc)
 	if err != nil {
 		// If we cannot read current usage, deny to be safe.
@@ -254,7 +271,7 @@ func (v *InferenceServiceQuotaValidator) decide(ctx context.Context, q inference
 	}
 
 	incoming := quota.Incoming{
-		GPUCount:  gpuCount(isvc),
+		GPUCount:  gpuCount(isvc, model),
 		VRAMBytes: vramBytes,
 		Priority:  isvc.Spec.Priority,
 	}
@@ -299,7 +316,11 @@ func (v *InferenceServiceQuotaValidator) currentUsage(ctx context.Context, q inf
 		if i.Namespace == isvc.Namespace && i.Name == isvc.Name {
 			continue
 		}
-		usage.GPUCount += gpuCount(&i)
+		// Fetch the referenced Model best-effort so the per-pod GPU count
+		// matches the pod spec (which prefers hardware.gpu.count). A nil
+		// Model falls through to resources.gpu in apiutil.GPUCount.
+		model := v.fetchModel(ctx, &i)
+		usage.GPUCount += gpuCount(&i, model)
 		// Stored objects whose VRAM footprint cannot be derived contribute
 		// zero: they were admitted before the cap (or before their footprint
 		// was declarable) and cannot be retroactively rejected. The cap
@@ -312,16 +333,15 @@ func (v *InferenceServiceQuotaValidator) currentUsage(ctx context.Context, q inf
 	return usage, nil
 }
 
-// gpuCount returns the GPU count for an InferenceService, defaulting to 0
-// when resources or resources.gpu is nil. It multiplies by replicas
-// (defaulting to 1 if nil) to account for total GPU usage across all pods.
-func gpuCount(isvc *inferencev1alpha1.InferenceService) int32 {
-	if isvc.Spec.Resources == nil {
-		return 0
-	}
+// gpuCount returns the total GPU count for an InferenceService across all
+// replicas, routing through apiutil.GPUCount so a Model-declared
+// hardware.gpu.count is charged the same way the pod spec requests it.
+// The Model argument is nil-safe; when nil the count falls back to
+// isvc.Spec.Resources.GPU. Replicas default to 1 when nil.
+func gpuCount(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) int32 {
 	replicas := int32(1)
 	if isvc.Spec.Replicas != nil {
 		replicas = *isvc.Spec.Replicas
 	}
-	return isvc.Spec.Resources.GPU * replicas
+	return apiutil.GPUCount(isvc, model) * replicas
 }

--- a/internal/controller/inferenceservice_quota_webhook_test.go
+++ b/internal/controller/inferenceservice_quota_webhook_test.go
@@ -170,6 +170,96 @@ func TestInferenceServiceQuotaValidator(t *testing.T) {
 		}
 	})
 
+	// #1310: a Model declaring hardware.gpu.count must be charged against
+	// the gpuCount quota, not silently bypassed. The pod spec requests the
+	// GPUs via apiutil.GPUCount (which prefers the Model), so the quota
+	// must resolve through the same path.
+	t.Run("model-declared gpu count is charged against gpuCount", func(t *testing.T) {
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-quota"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "default",
+				GPUCount:     4,
+			},
+		}
+		// Model declares 4 GPUs; ISVC leaves resources.gpu unset.
+		// With replicas: 2 the pod requests 8 GPUs (4 x 2), exceeding the
+		// 4-GPU cap. Before #1310 the quota charged 0 and admitted anyway.
+		model := inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					GPU: &inferencev1alpha1.GPUSpec{
+						Count: 4,
+					},
+				},
+			},
+		}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: "my-model",
+				Replicas: ptrInt32Val(2),
+			},
+		}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&quota, &model, &ns).
+			Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		_, err := v.ValidateCreate(ctx, &isvc)
+		if err == nil {
+			t.Fatal("expected denial (model gpu 4 * replicas 2 = 8 > 4), got nil")
+		}
+		if !strContains(err.Error(), "would exceed gpuCount") {
+			t.Fatalf("expected reason to mention gpuCount, got: %v", err)
+		}
+	})
+
+	t.Run("model-declared gpu count within quota is admitted", func(t *testing.T) {
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-quota"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "default",
+				GPUCount:     8,
+			},
+		}
+		// Model declares 4 GPUs; ISVC leaves resources.gpu unset.
+		// With replicas: 1 the pod requests 4 GPUs, within the 8-GPU cap.
+		model := inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					GPU: &inferencev1alpha1.GPUSpec{
+						Count: 4,
+					},
+				},
+			},
+		}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: "my-model",
+				Replicas: ptrInt32Val(1),
+			},
+		}
+		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&quota, &model, &ns).
+			Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		_, err := v.ValidateCreate(ctx, &isvc)
+		if err != nil {
+			t.Fatalf("expected admission (model gpu 4 <= 8), got error: %v", err)
+		}
+	})
+
 	t.Run("priority-floor deny", func(t *testing.T) {
 		quota := inferencev1alpha1.GPUQuota{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-quota"},
@@ -473,6 +563,60 @@ func TestInferenceServiceScheme(t *testing.T) {
 	}
 }
 
+// TestFetchModel verifies that fetchModel returns the referenced Model when
+// it exists, nil when ModelRef is empty, and nil when the Model cannot be
+// read (best-effort at admission time).
+func TestFetchModel(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = inferencev1alpha1.AddToScheme(scheme)
+
+	ctx := context.Background()
+
+	model := inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+	}
+
+	t.Run("returns the Model when it exists", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&model).Build()
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "my-model"},
+		}
+		got := v.fetchModel(ctx, &isvc)
+		if got == nil {
+			t.Fatal("expected non-nil Model, got nil")
+		}
+		if got.Name != "my-model" {
+			t.Errorf("expected Model name my-model, got %s", got.Name)
+		}
+	})
+
+	t.Run("returns nil when ModelRef is empty", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+		}
+		if got := v.fetchModel(ctx, &isvc); got != nil {
+			t.Fatalf("expected nil for empty ModelRef, got %v", got)
+		}
+	})
+
+	t.Run("returns nil when the Model does not exist", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "not-found"},
+		}
+		if got := v.fetchModel(ctx, &isvc); got != nil {
+			t.Fatalf("expected nil for missing Model, got %v", got)
+		}
+	})
+}
+
 // TestValidateDelete verifies that ValidateDelete is a no-op allow.
 func TestValidateDelete(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -629,7 +773,7 @@ func TestDecide(t *testing.T) {
 			Build()
 
 		v := &InferenceServiceQuotaValidator{Client: fakeClient}
-		allow, reason := v.decide(ctx, quota, &isvc)
+		allow, reason := v.decide(ctx, quota, &isvc, nil)
 		if !allow {
 			t.Fatalf("expected allow, got deny: %s", reason)
 		}
@@ -661,7 +805,7 @@ func TestDecide(t *testing.T) {
 			Build()
 
 		v := &InferenceServiceQuotaValidator{Client: fakeClient}
-		allow, reason := v.decide(ctx, quota, &isvc)
+		allow, reason := v.decide(ctx, quota, &isvc, nil)
 		if allow {
 			t.Fatal("expected deny (2*3=6 > 5), got allow")
 		}
@@ -694,7 +838,7 @@ func TestDecide(t *testing.T) {
 			Build()
 
 		v := &InferenceServiceQuotaValidator{Client: fakeClient}
-		allow, reason := v.decide(ctx, quota, &isvc)
+		allow, reason := v.decide(ctx, quota, &isvc, nil)
 		if allow {
 			t.Fatal("expected deny, got allow")
 		}
@@ -729,12 +873,58 @@ func TestDecide(t *testing.T) {
 			Build()
 
 		v := &InferenceServiceQuotaValidator{Client: fakeClient}
-		allow, reason := v.decide(ctx, quota, &isvc)
+		allow, reason := v.decide(ctx, quota, &isvc, nil)
 		if allow {
 			t.Fatal("expected deny, got allow")
 		}
 		if !strContains(reason, "priority") {
 			t.Fatalf("expected reason to mention priority, got: %s", reason)
+		}
+	})
+
+	// #1310: a Model declaring hardware.gpu.count must be charged against
+	// the gpuCount quota, not silently bypassed.
+	t.Run("model-declared gpu count is charged against gpuCount", func(t *testing.T) {
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-quota"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "default",
+				GPUCount:     4,
+			},
+		}
+		// Model declares 4 GPUs; ISVC leaves resources.gpu unset.
+		// With replicas: 2 the pod requests 8 GPUs (4 x 2), exceeding the
+		// 4-GPU cap. Before #1310 the quota charged 0 and admitted anyway.
+		model := inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					GPU: &inferencev1alpha1.GPUSpec{
+						Count: 4,
+					},
+				},
+			},
+		}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef: "my-model",
+				Replicas: ptrInt32Val(2),
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&quota, &model, &ns).
+			Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		allow, reason := v.decide(ctx, quota, &isvc, &model)
+		if allow {
+			t.Fatal("expected deny (model gpu 4 * replicas 2 = 8 > 4), got allow")
+		}
+		if !strContains(reason, "would exceed gpuCount") {
+			t.Fatalf("expected reason to mention gpuCount, got: %s", reason)
 		}
 	})
 }


### PR DESCRIPTION
## What

A `GPUQuota` `gpuCount` cap is bypassed when the Model declares `hardware.gpu.count`: the pod requests the GPUs but the quota charges zero, because two count computations disagreed with the pod spec.

## Why

Fixes #1310

The pod's GPU limit comes from `apiutil.GPUCount(isvc, model)` (via `resolveGPUCount`, `deployment_builder.go:398`), which prefers the Model's count. Both quota paths read only `isvc.Spec.Resources.GPU`. Since `gpuCount` is the only required field on `GPUQuota`, the bypassable path is the common one.

## How

Route **both** quota count computations through the same `apiutil.GPUCount` the pod spec uses:
- **Admission** (`inferenceservice_quota_webhook.go`): candidate and stored-usage summation, each fetching its Model via a new shared `fetchModel` helper (best-effort, right namespace, nil-safe fallback to `resources.gpu`).
- **Status** (`gpuquota_controller.go`): the `UsedGPUCount` accumulator now fetches the Model and resolves through `apiutil.GPUCount * replicas`.

Replicas applied in both paths; DRA and absent-Model cases match the pod-spec resolution.

## Provenance and review

Authored by Foreman/Laguna, reviewed independently (reviewer blind to the intent). The review verified both count paths are fixed and consistent with `deployment_builder.go`'s resolver, that the Model fetch degrades safely on nil/missing, and that both new tests survive mutation (reverting the resolver swap fails each). Verdict: accept. Two non-blocking cosmetic notes: an N+1 Model Get at quota scale (fine today), and a stale doc phrase on `fetchModel` (mentions vendor defaulting, carried over from the sharing path).

AI-assisted (band 3): authored by a Foreman coder agent, independently reviewed, opened and verified by me. Part of a harness-evaluation batch (review, do not auto-merge). NOTE: the branch carries a bot-only DCO sign-off pending #1281.


## Note on DCO

Correction: the repo's DCO check (`.github/workflows/dco.yml`) is presence-only, so this branch's bot `Signed-off-by` already passes it; all CI is green. What #1281 addresses is the `CONTRIBUTING.md` policy against bot-only sign-offs, not a failing check. (An earlier version of this description incorrectly said the DCO check would be red.)
