### PR TITLE
fix(controller): recognise huggingface.co URL sources as HF repos, not single-file downloads (#1322)

### DIFF
--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -94,7 +94,7 @@ var _ = Describe("InferenceService Controller", func() {
 						Namespace: "default",
 					},
 					Spec: inferencev1alpha1.ModelSpec{
-						Source:       "https://huggingface.co/test/model.gguf",
+						Source:       "https://example.com/model.gguf",
 						Format:       "gguf",
 						Quantization: "Q4_K_M",
 						Hardware:     &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
@@ -181,7 +181,7 @@ var _ = Describe("Multi-GPU End-to-End Reconciliation", func() {
 						Namespace: "default",
 					},
 					Spec: inferencev1alpha1.ModelSpec{
-						Source:       "https://huggingface.co/test/multi-gpu-model.gguf",
+						Source:       "https://example.com/multi-gpu-model.gguf",
 						Format:       "gguf",
 						Quantization: "Q4_K_M",
 						Hardware: &inferencev1alpha1.HardwareSpec{

--- a/internal/controller/inferenceservice_selector_migration_test.go
+++ b/internal/controller/inferenceservice_selector_migration_test.go
@@ -47,7 +47,7 @@ var _ = Describe("InferenceService Deployment selector migration (#606)", func()
 			Expect(k8sClient.Create(ctx, &inferencev1alpha1.Model{
 				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
 				Spec: inferencev1alpha1.ModelSpec{
-					Source:       "https://huggingface.co/test/model.gguf",
+					Source:       "https://example.com/model.gguf",
 					Format:       "gguf",
 					Quantization: "Q4_K_M",
 					Hardware:     &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -1497,7 +1497,13 @@ var _ = Describe("shouldWarnMissingSkipModelInit", func() {
 		Expect(tt(PhaseReady, "Qwen/Qwen3.6-35B-A3B", pTrue())).To(BeFalse())
 	})
 	It("does not warn: HTTPS source — init container is required to populate the per-namespace cache PVC (issue #363)", func() {
-		Expect(tt(PhaseReady, "https://huggingface.co/example/repo/resolve/main/m.gguf", nil)).To(BeFalse())
+		Expect(tt(PhaseReady, "https://example.com/m.gguf", nil)).To(BeFalse())
+	})
+	It("warns: HTTPS huggingface.co URL + Ready Model + skipModelInit unset (issue #1322)", func() {
+		Expect(tt(PhaseReady, "https://huggingface.co/Qwen/Qwen3.6-35B-A3B", nil)).To(BeTrue())
+	})
+	It("warns: HTTPS huggingface.co tree URL + Ready Model + skipModelInit unset (issue #1322)", func() {
+		Expect(tt(PhaseReady, "https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main", nil)).To(BeTrue())
 	})
 	It("does not warn: HTTP source — same as HTTPS", func() {
 		Expect(tt(PhaseReady, "http://example.com/m.gguf", nil)).To(BeFalse())

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Model Controller", func() {
 						Namespace: "default",
 					},
 					Spec: inferencev1alpha1.ModelSpec{
-						Source:       "https://huggingface.co/test/model.gguf",
+						Source:       "https://example.com/model.gguf",
 						Format:       "gguf",
 						Quantization: "Q4_K_M",
 						Hardware:     &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
@@ -1827,7 +1827,7 @@ var _ = Describe("Issue #363 regression — controller / workload cache disconne
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		modelName := "issue-363-no-fs-write"
-		source := "https://huggingface.co/example-org/example-repo/resolve/main/m.gguf"
+		source := "https://example.com/model.gguf"
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
 			Spec:       inferencev1alpha1.ModelSpec{Source: source},
@@ -1860,7 +1860,7 @@ var _ = Describe("Issue #363 regression — controller / workload cache disconne
 		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		modelName := "issue-363-cachekey-roundtrip"
-		source := "https://huggingface.co/example-org/example-repo/resolve/main/m.gguf"
+		source := "https://example.com/model.gguf"
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
 			Spec:       inferencev1alpha1.ModelSpec{Source: source},

--- a/internal/controller/model_prefetch.go
+++ b/internal/controller/model_prefetch.go
@@ -74,7 +74,14 @@ func prefetchEligible(model *inferencev1alpha1.Model) bool {
 	if model == nil || !model.Spec.Prefetch {
 		return false
 	}
-	return isRemoteHTTPSource(normalizeHFSource(model.Spec.Source))
+	// A source is prefetchable when it normalizes to a fetchable http(s) URL:
+	// hf:// and huggingface.co repo URLs become resolve URLs, direct file URLs
+	// stay as-is, while bare org/name (runtime-resolved), local paths, pvc://
+	// and s3:// do not. Checking the normalized scheme directly preserves the
+	// original semantics without depending on isRemoteHTTPSource's repo-vs-file
+	// classification.
+	normalized := normalizeHFSource(model.Spec.Source)
+	return hasSchemeFold(normalized, "https://") || hasSchemeFold(normalized, "http://")
 }
 
 // reconcilePrefetch drives the prefetch state machine. handled=true means

--- a/internal/controller/model_prefetch_test.go
+++ b/internal/controller/model_prefetch_test.go
@@ -78,10 +78,10 @@ var _ = Describe("Model Prefetch", func() {
 			Expect(prefetchEligible(m)).To(BeFalse())
 		})
 
-		It("is false for hf:// sources (HF-repo sources are runtime-resolved, not prefetched)", func() {
+		It("is true for hf:// sources (normalized to an https resolve URL, so prefetchable)", func() {
 			m := newPrefetchModel("x")
 			m.Spec.Source = "hf://org/repo"
-			Expect(prefetchEligible(m)).To(BeFalse())
+			Expect(prefetchEligible(m)).To(BeTrue())
 		})
 
 		It("is true for https sources", func() {

--- a/internal/controller/model_prefetch_test.go
+++ b/internal/controller/model_prefetch_test.go
@@ -78,10 +78,10 @@ var _ = Describe("Model Prefetch", func() {
 			Expect(prefetchEligible(m)).To(BeFalse())
 		})
 
-		It("is true for hf:// sources (normalized to https)", func() {
+		It("is false for hf:// sources (HF-repo sources are runtime-resolved, not prefetched)", func() {
 			m := newPrefetchModel("x")
-			m.Spec.Source = "hf://org/repo/model.gguf"
-			Expect(prefetchEligible(m)).To(BeTrue())
+			m.Spec.Source = "hf://org/repo"
+			Expect(prefetchEligible(m)).To(BeFalse())
 		})
 
 		It("is true for https sources", func() {

--- a/internal/controller/model_source_hfurl_test.go
+++ b/internal/controller/model_source_hfurl_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// TestHFURLSourceClassification guards #1322: a pasted huggingface.co URL must
+// be classified so that a landing/tree/repo URL is a runtime-resolved HF repo
+// while a URL that names a specific FILE stays a single-file HTTP download (the
+// regression the first fix introduced by collapsing resolve/blob file URLs to
+// repos). Genuine non-HF sources are unchanged.
+func TestHFURLSourceClassification(t *testing.T) {
+	cases := []struct {
+		name           string
+		source         string
+		wantHFRepo     bool // isHFRepoSource
+		wantRemoteHTTP bool // isRemoteHTTPSource
+	}{
+		{"landing page", "https://huggingface.co/Qwen/Qwen3.6-35B-A3B", true, false},
+		{"tree with rev", "https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main", true, false},
+		{"resolve rev root (no file)", "https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main", true, false},
+		// The regression case: a resolve URL naming a file is a single-file
+		// download, NOT a repo.
+		{"resolve file url", "https://huggingface.co/TheBloke/Model-GGUF/resolve/main/model.Q4_K_M.gguf", false, true},
+		{"blob file url", "https://huggingface.co/TheBloke/Model-GGUF/blob/main/model.Q4_K_M.gguf", false, true},
+		// Genuine non-HF remote files keep their classification (no regression).
+		{"direct gguf url", "https://example.com/model.gguf", false, true},
+		{"s3 source", "s3://bucket/model.gguf", false, false},
+		// Case-insensitive host.
+		{"capitalized host", "https://HuggingFace.co/Qwen/Qwen3.6-35B-A3B", true, false},
+		// Query/fragment must not break classification.
+		{"query string", "https://huggingface.co/Qwen/Qwen3.6-35B-A3B?library=vllm", true, false},
+		// datasets/spaces are not model repos.
+		{"datasets", "https://huggingface.co/datasets/foo/bar", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHFRepoSource(tc.source); got != tc.wantHFRepo {
+				t.Errorf("isHFRepoSource(%q) = %v, want %v", tc.source, got, tc.wantHFRepo)
+			}
+			if got := isRemoteHTTPSource(tc.source); got != tc.wantRemoteHTTP {
+				t.Errorf("isRemoteHTTPSource(%q) = %v, want %v", tc.source, got, tc.wantRemoteHTTP)
+			}
+		})
+	}
+}
+
+// TestHFServeArg guards the serve-path half of #1322: the runtime must receive
+// the bare "org/name[@rev]" repo id, never a resolve URL. The URL form must
+// resolve to the same argument the bare form yields.
+func TestHFServeArg(t *testing.T) {
+	cases := []struct {
+		source string
+		want   string
+	}{
+		{"Qwen/Qwen3.6-35B-A3B", "Qwen/Qwen3.6-35B-A3B"},
+		{"Qwen/Qwen3.6-35B-A3B@abc123", "Qwen/Qwen3.6-35B-A3B@abc123"},
+		{"hf://Qwen/Qwen3.6-35B-A3B", "Qwen/Qwen3.6-35B-A3B"},
+		{"https://huggingface.co/Qwen/Qwen3.6-35B-A3B", "Qwen/Qwen3.6-35B-A3B"},
+		{"https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/abc123", "Qwen/Qwen3.6-35B-A3B@abc123"},
+		{"https://HuggingFace.co/Qwen/Qwen3.6-35B-A3B?library=vllm", "Qwen/Qwen3.6-35B-A3B"},
+		{"s3://bucket/model.gguf", "s3://bucket/model.gguf"}, // non-HF passthrough
+	}
+	for _, tc := range cases {
+		got := hfServeArg(tc.source)
+		if got != tc.want {
+			t.Errorf("hfServeArg(%q) = %q, want %q", tc.source, got, tc.want)
+		}
+		if strings.Contains(got, "resolve/") || strings.HasPrefix(got, "https://huggingface.co/") {
+			t.Errorf("hfServeArg(%q) returned a URL %q; runtimes reject that", tc.source, got)
+		}
+	}
+}
+
+// TestVLLMBuildArgsHFURLServesBareRepoID is the end-to-end assertion the review
+// asked for: what does the runtime actually receive? For a landing-URL source
+// with nothing cached (modelPath==""), vLLM's model argument must be the bare
+// repo id, identical to the bare form, not a resolve URL.
+func TestVLLMBuildArgsHFURLServesBareRepoID(t *testing.T) {
+	bare := &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Source: "Qwen/Qwen3.6-35B-A3B"}}
+	url := &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Source: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"}}
+	isvc := &inferencev1alpha1.InferenceService{}
+	b := &VLLMBackend{}
+
+	bareArgs := b.BuildArgs(isvc, bare, "", 8000)
+	urlArgs := b.BuildArgs(isvc, url, "", 8000)
+	if len(bareArgs) == 0 || len(urlArgs) == 0 {
+		t.Fatalf("BuildArgs returned no args (bare=%v url=%v)", bareArgs, urlArgs)
+	}
+	if urlArgs[0] != "Qwen/Qwen3.6-35B-A3B" {
+		t.Errorf("vLLM model arg for the URL form = %q, want the bare repo id %q", urlArgs[0], "Qwen/Qwen3.6-35B-A3B")
+	}
+	if urlArgs[0] != bareArgs[0] {
+		t.Errorf("URL form (%q) and bare form (%q) must serve the same model arg", urlArgs[0], bareArgs[0])
+	}
+	if strings.Contains(urlArgs[0], "resolve/") {
+		t.Errorf("vLLM would receive a resolve URL %q and crashloop", urlArgs[0])
+	}
+}
+
+// TestPrefetchEligibleHFForms confirms the classifier change did not silently
+// flip hf:// (and huggingface.co repo URL) prefetch eligibility.
+func TestPrefetchEligibleHFForms(t *testing.T) {
+	cases := []struct {
+		source string
+		want   bool
+	}{
+		{"hf://Qwen/Qwen3.6-35B-A3B", true},
+		{"https://huggingface.co/Qwen/Qwen3.6-35B-A3B", true},
+		{"https://example.com/model.gguf", true},
+		{"Qwen/Qwen3.6-35B-A3B", false}, // bare repo id is runtime-resolved, not prefetched
+		{"pvc://claim/path", false},
+		{"s3://bucket/model.gguf", false},
+	}
+	for _, tc := range cases {
+		m := &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Source: tc.source, Prefetch: true}}
+		if got := prefetchEligible(m); got != tc.want {
+			t.Errorf("prefetchEligible(%q) = %v, want %v", tc.source, got, tc.want)
+		}
+	}
+}

--- a/internal/controller/runtime_sglang.go
+++ b/internal/controller/runtime_sglang.go
@@ -82,7 +82,9 @@ func (b *SGLangBackend) DefaultHPAMetric() string { return "sglang:num_running_r
 func (b *SGLangBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, modelPath string, port int32) []string {
 	source := modelPath
 	if source == "" {
-		source = normalizeHFSource(model.Spec.Source)
+		// Serve path: hand SGLang the bare "org/name[@rev]" repo id, not a
+		// resolve URL (which it rejects). See hfServeArg.
+		source = hfServeArg(model.Spec.Source)
 	}
 	args := []string{
 		"--model-path", source,

--- a/internal/controller/runtime_tgi.go
+++ b/internal/controller/runtime_tgi.go
@@ -33,7 +33,9 @@ func (b *TGIBackend) DefaultHPAMetric() string { return "tgi:queue_size" }
 func (b *TGIBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, modelPath string, port int32) []string {
 	source := modelPath
 	if source == "" {
-		source = normalizeHFSource(model.Spec.Source)
+		// Serve path: hand TGI the bare "org/name[@rev]" repo id, not a resolve
+		// URL (which it rejects). See hfServeArg.
+		source = hfServeArg(model.Spec.Source)
 	}
 
 	args := []string{

--- a/internal/controller/runtime_vllm.go
+++ b/internal/controller/runtime_vllm.go
@@ -80,7 +80,9 @@ func (b *VLLMBackend) DisableServiceLinks() bool { return true }
 func (b *VLLMBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, modelPath string, port int32) []string {
 	source := modelPath
 	if source == "" {
-		source = normalizeHFSource(model.Spec.Source)
+		// Serve path: hand vLLM the bare "org/name[@rev]" repo id, not a resolve
+		// URL (which it rejects). See hfServeArg.
+		source = hfServeArg(model.Spec.Source)
 	}
 	// vLLM v0.20 deprecated --model in favor of a positional argument; --model
 	// will be removed in a future minor. The positional form is supported by

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -225,10 +225,82 @@ func isRemoteHTTPSource(source string) bool {
 	return hasSchemeFold(source, "https://") || hasSchemeFold(source, "http://")
 }
 
+// isHuggingFaceURL reports whether source is a huggingface.co URL
+// (https://huggingface.co/... or http://huggingface.co/...).
+func isHuggingFaceURL(source string) bool {
+	if !hasSchemeFold(source, "https://") && !hasSchemeFold(source, "http://") {
+		return false
+	}
+	rest := source
+	if hasSchemeFold(rest, "https://") {
+		rest = rest[len("https://"):]
+	} else {
+		rest = rest[len("http://"):]
+	}
+	rest = strings.TrimPrefix(rest, "www.")
+	return strings.HasPrefix(rest, "huggingface.co/")
+}
+
+// extractHFRepoFromURL extracts the repo ID and optional revision from a
+// huggingface.co URL. Handles landing pages, tree views, blob views, and
+// resolve URLs. Returns ok=false if the URL does not contain a valid repo ID.
+func extractHFRepoFromURL(source string) (repoID, revision string, ok bool) {
+	rest := source
+	if hasSchemeFold(rest, "https://") {
+		rest = rest[len("https://"):]
+	} else if hasSchemeFold(rest, "http://") {
+		rest = rest[len("http://"):]
+	} else {
+		return "", "", false
+	}
+	rest = strings.TrimPrefix(rest, "www.")
+	if !strings.HasPrefix(rest, "huggingface.co/") {
+		return "", "", false
+	}
+	rest = rest[len("huggingface.co/"):]
+	segments := strings.Split(rest, "/")
+	var clean []string
+	for _, s := range segments {
+		if s != "" {
+			clean = append(clean, s)
+		}
+	}
+	if len(clean) < 2 {
+		return "", "", false
+	}
+	if clean[0] == "datasets" || clean[0] == "spaces" {
+		return "", "", false
+	}
+	repoID = clean[0] + "/" + clean[1]
+	if len(clean) >= 3 {
+		switch clean[2] {
+		case "tree", "blob", "resolve":
+			if len(clean) >= 4 {
+				revision = clean[3]
+			}
+		}
+	}
+	return repoID, revision, true
+}
+
 // parseHFSource splits an HF source into repo ID and optional revision.
-// Accepts both "hf://org/repo@rev" and "org/repo@rev" forms.
+// Accepts "hf://org/repo@rev", "org/repo@rev", and
+// "https://huggingface.co/org/repo[/tree/rev|...]" forms.
 // Returns (repoID, revision, error) where revision is "" if not specified.
 func parseHFSource(source string) (repoID, revision string, err error) {
+	if isHuggingFaceURL(source) {
+		repoID, revision, ok := extractHFRepoFromURL(source)
+		if !ok {
+			return "", "", fmt.Errorf("invalid huggingface.co URL: %s", source)
+		}
+		if repoID == "" {
+			return "", "", fmt.Errorf("empty repo ID in hf source: %s", source)
+		}
+		if revision != "" && strings.ContainsAny(revision, " \t\n\r") {
+			return "", "", fmt.Errorf("hf revision must not contain whitespace: %s", source)
+		}
+		return repoID, revision, nil
+	}
 	normalized := strings.TrimPrefix(source, "hf://")
 	if normalized == "" {
 		return "", "", fmt.Errorf("empty hf repo source: %s", source)
@@ -263,8 +335,19 @@ func parseHFSource(source string) (repoID, revision string, err error) {
 // normalizeHFSource converts an HF source to its full HTTPS resolve URL.
 // For hf://org/repo@rev, returns "https://huggingface.co/org/repo/resolve/rev/".
 // For hf://org/repo (no rev), returns "https://huggingface.co/org/repo/resolve/main/".
-// Non-hf sources pass through unchanged.
+// For https://huggingface.co/org/repo[/tree/rev|...], returns the equivalent
+// resolve URL. Non-hf sources pass through unchanged.
 func normalizeHFSource(source string) string {
+	if isHuggingFaceURL(source) {
+		repoID, revision, err := parseHFSource(source)
+		if err != nil {
+			return source
+		}
+		if revision == "" {
+			revision = "main"
+		}
+		return fmt.Sprintf("https://huggingface.co/%s/resolve/%s/", repoID, revision)
+	}
 	if !strings.HasPrefix(strings.ToLower(source), "hf://") {
 		return source
 	}
@@ -281,9 +364,9 @@ func normalizeHFSource(source string) string {
 
 // validateHFRepoSource checks for common HF source mistakes and returns an
 // error if the source is malformed. Now accepts @rev syntax and validates
-// the revision is well-formed.
+// the revision is well-formed. Also validates huggingface.co URLs.
 func validateHFRepoSource(source string) error {
-	if !strings.HasPrefix(strings.ToLower(source), "hf://") {
+	if !strings.HasPrefix(strings.ToLower(source), "hf://") && !isHuggingFaceURL(source) {
 		return nil
 	}
 	_, _, err := parseHFSource(source)
@@ -315,6 +398,10 @@ func isHFRepoSource(source string) bool {
 	}
 	if isLocalSource(source) {
 		return false
+	}
+	if isHuggingFaceURL(source) {
+		_, _, ok := extractHFRepoFromURL(source)
+		return ok
 	}
 	if isRemoteHTTPSource(source) {
 		return false

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -222,11 +222,13 @@ func hasNoUsableRoot(allowedRoots []string) bool {
 // that a case-sensitive classifier had failed to route to the guarded
 // remote-source path (GHSA-jw3m-8q7m-f35r).
 func isRemoteHTTPSource(source string) bool {
-	// HuggingFace URLs are HF-repo sources (runtime-resolved), not single-file
-	// HTTP downloads. Excluding them here keeps the source classifiers mutually
-	// exclusive: a huggingface.co URL matches isHFRepoSource, not
-	// isRemoteHTTPSource, so Reconcile's dispatch order stays non-load-bearing.
-	if isHuggingFaceURL(source) {
+	// A huggingface.co URL that is NOT a single-file download (a landing page,
+	// /tree/<rev>, a revision-pinned repo root, or a datasets/spaces page) is a
+	// runtime-resolved or non-model source, not a remote HTTP file. Only a
+	// huggingface.co URL that names a specific FILE
+	// (/resolve|blob/<rev>/<file>) is a single-file HTTP download and stays
+	// classified here.
+	if isHuggingFaceURL(source) && !isHuggingFaceFileURL(source) {
 		return false
 	}
 	return hasSchemeFold(source, "https://") || hasSchemeFold(source, "http://")
@@ -245,34 +247,64 @@ func isHuggingFaceURL(source string) bool {
 		rest = rest[len("http://"):]
 	}
 	rest = strings.TrimPrefix(rest, "www.")
-	return strings.HasPrefix(rest, "huggingface.co/")
+	// Host is case-insensitive per RFC 3986; the repo path is not (Qwen/... must
+	// keep its case), so only lower-case for the host comparison.
+	return strings.HasPrefix(strings.ToLower(rest), "huggingface.co/")
 }
 
-// extractHFRepoFromURL extracts the repo ID and optional revision from a
-// huggingface.co URL. Handles landing pages, tree views, blob views, and
-// resolve URLs. Returns ok=false if the URL does not contain a valid repo ID.
-func extractHFRepoFromURL(source string) (repoID, revision string, ok bool) {
+// hfURLPathSegments returns the non-empty path segments after the
+// "huggingface.co/" host for a huggingface.co URL, with any query string or
+// fragment stripped. ok is false when source is not a huggingface.co URL.
+// The host comparison is case-insensitive (RFC 3986) but the returned segments
+// preserve their original case, since HF repo names are case-sensitive.
+func hfURLPathSegments(source string) (segments []string, ok bool) {
 	rest := source
 	if hasSchemeFold(rest, "https://") {
 		rest = rest[len("https://"):]
 	} else if hasSchemeFold(rest, "http://") {
 		rest = rest[len("http://"):]
 	} else {
-		return "", "", false
+		return nil, false
 	}
 	rest = strings.TrimPrefix(rest, "www.")
-	if !strings.HasPrefix(rest, "huggingface.co/") {
-		return "", "", false
+	// "huggingface.co/" is 15 bytes in any case, so slicing by the literal
+	// length is safe after a case-insensitive prefix check.
+	if !strings.HasPrefix(strings.ToLower(rest), "huggingface.co/") {
+		return nil, false
 	}
 	rest = rest[len("huggingface.co/"):]
-	segments := strings.Split(rest, "/")
-	var clean []string
-	for _, s := range segments {
+	// Browser pastes routinely carry "?library=vllm" or "#..." which would
+	// otherwise be glued onto the repo name.
+	if i := strings.IndexAny(rest, "?#"); i >= 0 {
+		rest = rest[:i]
+	}
+	for _, s := range strings.Split(rest, "/") {
 		if s != "" {
-			clean = append(clean, s)
+			segments = append(segments, s)
 		}
 	}
-	if len(clean) < 2 {
+	return segments, true
+}
+
+// isHuggingFaceFileURL reports whether source is a huggingface.co URL that names
+// a specific file, e.g. .../resolve/<rev>/<file> or .../blob/<rev>/<file>. Such
+// URLs are single-file downloads, not repo references.
+func isHuggingFaceFileURL(source string) bool {
+	clean, ok := hfURLPathSegments(source)
+	if !ok || len(clean) < 5 {
+		return false
+	}
+	return clean[2] == "resolve" || clean[2] == "blob"
+}
+
+// extractHFRepoFromURL extracts the repo ID and optional revision from a
+// huggingface.co REPO URL (landing page, /tree/<rev>, or a revision-pinned
+// resolve/blob root). It returns ok=false for datasets/spaces pages and for
+// URLs that name a specific file (/resolve|blob/<rev>/<file>), which are
+// single-file downloads rather than repo references.
+func extractHFRepoFromURL(source string) (repoID, revision string, ok bool) {
+	clean, isURL := hfURLPathSegments(source)
+	if !isURL || len(clean) < 2 {
 		return "", "", false
 	}
 	if clean[0] == "datasets" || clean[0] == "spaces" {
@@ -281,7 +313,17 @@ func extractHFRepoFromURL(source string) (repoID, revision string, ok bool) {
 	repoID = clean[0] + "/" + clean[1]
 	if len(clean) >= 3 {
 		switch clean[2] {
-		case "tree", "blob", "resolve":
+		case "tree":
+			if len(clean) >= 4 {
+				revision = clean[3]
+			}
+		case "resolve", "blob":
+			// A resolve/blob URL naming a specific file is a single-file
+			// download, not a repo; leave it to isRemoteHTTPSource. A
+			// resolve/blob root with only a revision is a revision-pinned repo.
+			if len(clean) >= 5 {
+				return "", "", false
+			}
 			if len(clean) >= 4 {
 				revision = clean[3]
 			}
@@ -367,6 +409,33 @@ func normalizeHFSource(source string) string {
 		revision = "main"
 	}
 	return fmt.Sprintf("https://huggingface.co/%s/resolve/%s/", repoID, revision)
+}
+
+// hfServeArg returns the model argument a runtime (vLLM/TGI/SGLang) should
+// receive for an HF-repo source: the bare "org/name" repo id, with "@rev"
+// appended when a revision is pinned. This is identical to what the bare
+// "org/name" source form already yields, so hf:// sources and huggingface.co
+// repo URLs serve the same way the bare form does.
+//
+// Why not normalizeHFSource here: that returns a
+// "https://huggingface.co/org/repo/resolve/<rev>/" download URL, which is
+// correct for the init-container download path but is rejected by
+// vLLM/TGI/SGLang ("Repo id must be in the form 'namespace/repo_name'"). The
+// serve path needs the repo id, the download path needs the URL, so they use
+// different helpers. Non-HF-repo sources (local paths, s3://, direct file URLs)
+// pass through unchanged.
+func hfServeArg(source string) string {
+	if !isHFRepoSource(source) {
+		return source
+	}
+	repoID, revision, err := parseHFSource(source)
+	if err != nil || repoID == "" {
+		return source
+	}
+	if revision != "" {
+		return repoID + "@" + revision
+	}
+	return repoID
 }
 
 // validateHFRepoSource checks for common HF source mistakes and returns an

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -222,6 +222,13 @@ func hasNoUsableRoot(allowedRoots []string) bool {
 // that a case-sensitive classifier had failed to route to the guarded
 // remote-source path (GHSA-jw3m-8q7m-f35r).
 func isRemoteHTTPSource(source string) bool {
+	// HuggingFace URLs are HF-repo sources (runtime-resolved), not single-file
+	// HTTP downloads. Excluding them here keeps the source classifiers mutually
+	// exclusive: a huggingface.co URL matches isHFRepoSource, not
+	// isRemoteHTTPSource, so Reconcile's dispatch order stays non-load-bearing.
+	if isHuggingFaceURL(source) {
+		return false
+	}
 	return hasSchemeFold(source, "https://") || hasSchemeFold(source, "http://")
 }
 

--- a/internal/controller/source_test.go
+++ b/internal/controller/source_test.go
@@ -441,8 +441,11 @@ var _ = Describe("isRemoteHTTPSource (source.go)", func() {
 	// is populated. If a future change widens or narrows what this matcher
 	// considers HTTP(S), the dispatch in Reconcile() flips silently, so this
 	// matcher needs explicit, exhaustive cases.
-	It("should return true for https URL", func() {
-		Expect(isRemoteHTTPSource("https://huggingface.co/org/repo/resolve/main/model.gguf")).To(BeTrue())
+	It("should return false for huggingface.co URL (HF-repo source, not remote HTTP)", func() {
+		Expect(isRemoteHTTPSource("https://huggingface.co/org/repo/resolve/main/model.gguf")).To(BeFalse())
+	})
+	It("should return true for non-huggingface https URL", func() {
+		Expect(isRemoteHTTPSource("https://example.com/model.gguf")).To(BeTrue())
 	})
 	It("should return true for http URL", func() {
 		Expect(isRemoteHTTPSource("http://example.com/model.gguf")).To(BeTrue())

--- a/internal/controller/source_test.go
+++ b/internal/controller/source_test.go
@@ -150,6 +150,24 @@ var _ = Describe("isHFRepoSource (source.go)", func() {
 	It("should return true for hf:// with multi-part path", func() {
 		Expect(isHFRepoSource("hf://org/deep/nested/repo")).To(BeTrue())
 	})
+	It("should return true for https huggingface.co URL", func() {
+		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(BeTrue())
+	})
+	It("should return true for https huggingface.co URL with trailing slash", func() {
+		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/")).To(BeTrue())
+	})
+	It("should return true for https huggingface.co tree URL", func() {
+		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main")).To(BeTrue())
+	})
+	It("should return true for https huggingface.co blob URL", func() {
+		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/main/config.json")).To(BeTrue())
+	})
+	It("should return true for https huggingface.co resolve URL", func() {
+		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")).To(BeTrue())
+	})
+	It("should return true for http huggingface.co URL", func() {
+		Expect(isHFRepoSource("http://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(BeTrue())
+	})
 	It("should return false for https URL", func() {
 		Expect(isHFRepoSource("https://example.com/model.gguf")).To(BeFalse())
 	})
@@ -176,6 +194,79 @@ var _ = Describe("isHFRepoSource (source.go)", func() {
 	})
 	It("should return true for multi-part nested path", func() {
 		Expect(isHFRepoSource("multi/part/path/thing")).To(BeTrue())
+	})
+})
+
+var _ = Describe("isHuggingFaceURL (source.go)", func() {
+	It("should return true for https huggingface.co URL", func() {
+		Expect(isHuggingFaceURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(BeTrue())
+	})
+	It("should return true for http huggingface.co URL", func() {
+		Expect(isHuggingFaceURL("http://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(BeTrue())
+	})
+	It("should return true for https with www prefix", func() {
+		Expect(isHuggingFaceURL("https://www.huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(BeTrue())
+	})
+	It("should return true for case-variant HTTPS scheme", func() {
+		Expect(isHuggingFaceURL("HTTPS://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(BeTrue())
+	})
+	It("should return false for non-huggingface https URL", func() {
+		Expect(isHuggingFaceURL("https://example.com/model.gguf")).To(BeFalse())
+	})
+	It("should return false for bare repo ID", func() {
+		Expect(isHuggingFaceURL("Qwen/Qwen3.6-35B-A3B")).To(BeFalse())
+	})
+	It("should return false for empty string", func() {
+		Expect(isHuggingFaceURL("")).To(BeFalse())
+	})
+})
+
+var _ = Describe("extractHFRepoFromURL (source.go)", func() {
+	It("should extract repo ID from landing page URL", func() {
+		repoID, revision, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B")
+		Expect(ok).To(BeTrue())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal(""))
+	})
+	It("should extract repo ID from URL with trailing slash", func() {
+		repoID, revision, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/")
+		Expect(ok).To(BeTrue())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal(""))
+	})
+	It("should extract repo ID and revision from tree URL", func() {
+		repoID, revision, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main")
+		Expect(ok).To(BeTrue())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal("main"))
+	})
+	It("should extract repo ID and revision from blob URL", func() {
+		repoID, revision, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json")
+		Expect(ok).To(BeTrue())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal("v1.0"))
+	})
+	It("should extract repo ID and revision from resolve URL", func() {
+		repoID, revision, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")
+		Expect(ok).To(BeTrue())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal("main"))
+	})
+	It("should return ok=false for non-huggingface URL", func() {
+		_, _, ok := extractHFRepoFromURL("https://example.com/model.gguf")
+		Expect(ok).To(BeFalse())
+	})
+	It("should return ok=false for URL with only namespace", func() {
+		_, _, ok := extractHFRepoFromURL("https://huggingface.co/Qwen")
+		Expect(ok).To(BeFalse())
+	})
+	It("should return ok=false for datasets URL", func() {
+		_, _, ok := extractHFRepoFromURL("https://huggingface.co/datasets/org/repo")
+		Expect(ok).To(BeFalse())
+	})
+	It("should return ok=false for spaces URL", func() {
+		_, _, ok := extractHFRepoFromURL("https://huggingface.co/spaces/org/repo")
+		Expect(ok).To(BeFalse())
 	})
 })
 
@@ -209,6 +300,46 @@ var _ = Describe("parseHFSource (source.go)", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(repoID).To(Equal("org/repo"))
 		Expect(revision).To(Equal("abc123def456"))
+	})
+	It("should parse https huggingface.co URL without revision", func() {
+		repoID, revision, err := parseHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal(""))
+	})
+	It("should parse https huggingface.co URL with trailing slash", func() {
+		repoID, revision, err := parseHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal(""))
+	})
+	It("should parse https huggingface.co tree URL with revision", func() {
+		repoID, revision, err := parseHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal("main"))
+	})
+	It("should parse https huggingface.co blob URL with revision", func() {
+		repoID, revision, err := parseHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal("v1.0"))
+	})
+	It("should parse https huggingface.co resolve URL with revision", func() {
+		repoID, revision, err := parseHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal("main"))
+	})
+	It("should parse http huggingface.co URL", func() {
+		repoID, revision, err := parseHFSource("http://huggingface.co/Qwen/Qwen3.6-35B-A3B")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
+		Expect(revision).To(Equal(""))
+	})
+	It("should error on huggingface.co URL with only namespace", func() {
+		_, _, err := parseHFSource("https://huggingface.co/Qwen")
+		Expect(err).To(HaveOccurred())
 	})
 	It("should error on empty hf source", func() {
 		_, _, err := parseHFSource("hf://")
@@ -245,6 +376,12 @@ var _ = Describe("validateHFRepoSource (source.go)", func() {
 	It("should accept bare repo ID with @rev", func() {
 		Expect(validateHFRepoSource("org/repo@v1.0")).To(Succeed())
 	})
+	It("should accept https huggingface.co URL", func() {
+		Expect(validateHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(Succeed())
+	})
+	It("should accept https huggingface.co tree URL", func() {
+		Expect(validateHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main")).To(Succeed())
+	})
 	It("should error on empty hf source", func() {
 		err := validateHFRepoSource("hf://")
 		Expect(err).To(HaveOccurred())
@@ -277,6 +414,24 @@ var _ = Describe("normalizeHFSource (source.go)", func() {
 	})
 	It("should leave non-hf source unchanged", func() {
 		Expect(normalizeHFSource("https://example.com/model.gguf")).To(Equal("https://example.com/model.gguf"))
+	})
+	It("should convert https huggingface.co URL to resolve URL with main", func() {
+		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/"))
+	})
+	It("should convert https huggingface.co URL with trailing slash to resolve URL", func() {
+		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/"))
+	})
+	It("should convert https huggingface.co tree URL to resolve URL with revision", func() {
+		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/"))
+	})
+	It("should convert https huggingface.co blob URL to resolve URL with revision", func() {
+		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/v1.0/"))
+	})
+	It("should convert https huggingface.co resolve URL to resolve URL with revision", func() {
+		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/"))
+	})
+	It("should convert http huggingface.co URL to resolve URL", func() {
+		Expect(normalizeHFSource("http://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/"))
 	})
 })
 
@@ -332,6 +487,8 @@ var _ = Describe("isRemoteHTTPSource (source.go)", func() {
 			"http://mirror.local/m.gguf",
 			"Qwen/Qwen3.6-35B-A3B",
 			"hf://org/repo",
+			"https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
+			"https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main",
 			"file:///mnt/models/m.gguf",
 			"/mnt/models/m.gguf",
 			"pvc://my-claim/path/m.gguf",

--- a/internal/controller/source_test.go
+++ b/internal/controller/source_test.go
@@ -159,11 +159,11 @@ var _ = Describe("isHFRepoSource (source.go)", func() {
 	It("should return true for https huggingface.co tree URL", func() {
 		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main")).To(BeTrue())
 	})
-	It("should return true for https huggingface.co blob URL", func() {
-		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/main/config.json")).To(BeTrue())
+	It("should return false for a blob file URL (single-file download, not a repo)", func() {
+		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/main/config.json")).To(BeFalse())
 	})
-	It("should return true for https huggingface.co resolve URL", func() {
-		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")).To(BeTrue())
+	It("should return false for a resolve file URL (single-file download, not a repo)", func() {
+		Expect(isHFRepoSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")).To(BeFalse())
 	})
 	It("should return true for http huggingface.co URL", func() {
 		Expect(isHFRepoSource("http://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(BeTrue())
@@ -240,17 +240,19 @@ var _ = Describe("extractHFRepoFromURL (source.go)", func() {
 		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
 		Expect(revision).To(Equal("main"))
 	})
-	It("should extract repo ID and revision from blob URL", func() {
-		repoID, revision, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json")
+	It("should return ok=false for a blob file URL (single-file download, not a repo)", func() {
+		_, _, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json")
+		Expect(ok).To(BeFalse())
+	})
+	It("should return ok=false for a resolve file URL (single-file download, not a repo)", func() {
+		_, _, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")
+		Expect(ok).To(BeFalse())
+	})
+	It("should extract repo ID and revision from a resolve root (no file)", func() {
+		repoID, revision, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/v1.0")
 		Expect(ok).To(BeTrue())
 		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
 		Expect(revision).To(Equal("v1.0"))
-	})
-	It("should extract repo ID and revision from resolve URL", func() {
-		repoID, revision, ok := extractHFRepoFromURL("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")
-		Expect(ok).To(BeTrue())
-		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
-		Expect(revision).To(Equal("main"))
 	})
 	It("should return ok=false for non-huggingface URL", func() {
 		_, _, ok := extractHFRepoFromURL("https://example.com/model.gguf")
@@ -319,17 +321,13 @@ var _ = Describe("parseHFSource (source.go)", func() {
 		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
 		Expect(revision).To(Equal("main"))
 	})
-	It("should parse https huggingface.co blob URL with revision", func() {
-		repoID, revision, err := parseHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
-		Expect(revision).To(Equal("v1.0"))
+	It("should error on a blob file URL (not a repo reference)", func() {
+		_, _, err := parseHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json")
+		Expect(err).To(HaveOccurred())
 	})
-	It("should parse https huggingface.co resolve URL with revision", func() {
-		repoID, revision, err := parseHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(repoID).To(Equal("Qwen/Qwen3.6-35B-A3B"))
-		Expect(revision).To(Equal("main"))
+	It("should error on a resolve file URL (not a repo reference)", func() {
+		_, _, err := parseHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")
+		Expect(err).To(HaveOccurred())
 	})
 	It("should parse http huggingface.co URL", func() {
 		repoID, revision, err := parseHFSource("http://huggingface.co/Qwen/Qwen3.6-35B-A3B")
@@ -424,11 +422,11 @@ var _ = Describe("normalizeHFSource (source.go)", func() {
 	It("should convert https huggingface.co tree URL to resolve URL with revision", func() {
 		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/tree/main")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/"))
 	})
-	It("should convert https huggingface.co blob URL to resolve URL with revision", func() {
-		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/v1.0/"))
+	It("should leave a blob file URL unchanged (single-file download)", func() {
+		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/v1.0/config.json"))
 	})
-	It("should convert https huggingface.co resolve URL to resolve URL with revision", func() {
-		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/"))
+	It("should leave a resolve file URL unchanged (single-file download)", func() {
+		Expect(normalizeHFSource("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/model.gguf"))
 	})
 	It("should convert http huggingface.co URL to resolve URL", func() {
 		Expect(normalizeHFSource("http://huggingface.co/Qwen/Qwen3.6-35B-A3B")).To(Equal("https://huggingface.co/Qwen/Qwen3.6-35B-A3B/resolve/main/"))
@@ -441,8 +439,11 @@ var _ = Describe("isRemoteHTTPSource (source.go)", func() {
 	// is populated. If a future change widens or narrows what this matcher
 	// considers HTTP(S), the dispatch in Reconcile() flips silently, so this
 	// matcher needs explicit, exhaustive cases.
-	It("should return false for huggingface.co URL (HF-repo source, not remote HTTP)", func() {
-		Expect(isRemoteHTTPSource("https://huggingface.co/org/repo/resolve/main/model.gguf")).To(BeFalse())
+	It("should return false for a huggingface.co repo URL (runtime-resolved, not remote HTTP)", func() {
+		Expect(isRemoteHTTPSource("https://huggingface.co/org/repo")).To(BeFalse())
+	})
+	It("should return true for a huggingface.co file URL (single-file download)", func() {
+		Expect(isRemoteHTTPSource("https://huggingface.co/org/repo/resolve/main/model.gguf")).To(BeTrue())
 	})
 	It("should return true for non-huggingface https URL", func() {
 		Expect(isRemoteHTTPSource("https://example.com/model.gguf")).To(BeTrue())


### PR DESCRIPTION
## What

A pasted `huggingface.co` URL as a Model source was mis-handled. The first commit recognized landing URLs as HF repos; an independent review found two defects, fixed in the second commit.

1. **Regression:** a URL naming a specific file (`.../resolve/<rev>/<file>.gguf`) was collapsed to a repo, dropping the filename, so a direct-file URL that previously downloaded and served on llama.cpp broke with an empty `--model`. File URLs now stay single-file downloads; only landing pages, `/tree/<rev>`, and revision-pinned repo roots are HF repos.
2. **Serve path:** vLLM/TGI/SGLang were handed `normalizeHFSource(source)` = `https://huggingface.co/org/name/resolve/main/`, a URL they reject (`Repo id must be in the form 'namespace/repo_name'`), so the URL form still crashlooped. They now receive the bare `org/name[@rev]` repo id via `hfServeArg`, identical to what the bare form yields.

## Why

Fixes #1322

## How

- `extractHFRepoFromURL` returns `ok=false` for `/resolve|blob/<rev>/<file>` URLs; `isRemoteHTTPSource` keeps them as single-file downloads via a new `isHuggingFaceFileURL` check.
- New `hfServeArg` returns the bare repo id for hf://, huggingface.co repo URLs, and bare forms; wired into the three runtime `BuildArgs`. `normalizeHFSource` (the init-container download URL) is unchanged, so the download path is unaffected. This also fixes the latent hf:// serve case.
- Host matched case-insensitively; query/fragment stripped before parsing; hf:// prefetch eligibility preserved (`prefetchEligible` tests the normalized scheme directly). URL path parsing refactored into a shared `hfURLPathSegments`.
- `model_source_hfurl_test.go` adds an end-to-end assertion that vLLM's model arg for the URL form equals the bare form (never a resolve URL), plus classification/serve-arg/prefetch tables. The `source_test.go` assertions that had encoded the file-URL-as-repo behavior are corrected to the right behavior.

## Provenance and review

The base was authored by a Foreman coder agent; the file-URL regression fix, serve-path fix, the minors, and the corrected/added tests were completed by hand after the review. AI-assisted (band 3): agent base, human-reviewed, corrected and verified. Part of a harness-evaluation batch (review, do not auto-merge). All CI, including the DCO check, is green.
