### PR TITLE
fix(controller): revalidate model cache via HEAD + Content-Length, atomic download (#1309)

### DIFF
--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -294,7 +294,7 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
 	})
 
-	It("uses OnChange per-file etag revalidation for multi-file model", func() {
+	It("uses OnChange per-file HEAD revalidation for multi-file model", func() {
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: "refresh-model", Namespace: "default"},
 			Spec: inferencev1alpha1.ModelSpec{
@@ -307,8 +307,8 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 
 		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 		cmd := config.initContainers[1].Command[2]
-		Expect(cmd).To(ContainSubstring("--etag-compare"))
-		Expect(cmd).To(ContainSubstring("--etag-save"))
+		Expect(cmd).To(ContainSubstring("remote_size"))
+		Expect(cmd).To(ContainSubstring("skipped download"))
 		Expect(cmd).To(ContainSubstring("kept cached copy"))
 	})
 
@@ -367,7 +367,7 @@ var _ = Describe("buildEmptyDirStorageConfig multi-file staging", func() {
 		Expect(config.modelPath).To(Equal("/models/default-empty-model/model.gguf"))
 	})
 
-	It("uses OnChange per-file etag revalidation in emptyDir storage", func() {
+	It("uses OnChange per-file HEAD revalidation in emptyDir storage", func() {
 		model := &inferencev1alpha1.Model{
 			ObjectMeta: metav1.ObjectMeta{Name: "empty-refresh", Namespace: "default"},
 			Spec: inferencev1alpha1.ModelSpec{
@@ -379,8 +379,8 @@ var _ = Describe("buildEmptyDirStorageConfig multi-file staging", func() {
 
 		config := buildEmptyDirStorageConfig(model, nil, "default", "", "curl:8.18.0")
 		cmd := config.initContainers[0].Command[2]
-		Expect(cmd).To(ContainSubstring("--etag-compare"))
-		Expect(cmd).To(ContainSubstring("--etag-save"))
+		Expect(cmd).To(ContainSubstring("remote_size"))
+		Expect(cmd).To(ContainSubstring("skipped download"))
 		Expect(cmd).To(ContainSubstring("kept cached copy"))
 	})
 })
@@ -401,11 +401,11 @@ var _ = Describe("buildMultiFileInitCommand", func() {
 		Expect(cmd).To(ContainSubstring("failed to download"))
 	})
 
-	It("generates etag revalidation for OnChange policy", func() {
+	It("generates HEAD revalidation for OnChange policy", func() {
 		cmd := buildMultiFileInitCommand(true, RefreshPolicyOnChange)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
-		Expect(cmd).To(ContainSubstring("--etag-compare"))
-		Expect(cmd).To(ContainSubstring("--etag-save"))
+		Expect(cmd).To(ContainSubstring("remote_size"))
+		Expect(cmd).To(ContainSubstring("skipped download"))
 		Expect(cmd).To(ContainSubstring("kept cached copy"))
 	})
 
@@ -1272,25 +1272,22 @@ var _ = Describe("buildModelInitCommand", func() {
 	})
 
 	Context("RefreshPolicy=OnChange (http/https revalidation, issue #619)", func() {
-		It("cached: emits curl conditional GET against an etag marker beside the model", func() {
+		It("cached: emits HEAD-based revalidation comparing Content-Length to local file size", func() {
 			cmd := buildModelInitCommand(false, false, true, RefreshPolicyOnChange)
 			// Still provisions the cache dir like IfNotPresent.
 			Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
-			// Conditional GET via curl's native ETag flags.
-			Expect(cmd).To(ContainSubstring("--etag-compare"))
-			Expect(cmd).To(ContainSubstring("--etag-save"))
-			// Marker is a dotfile sibling derived from the model path.
-			Expect(cmd).To(ContainSubstring(`.etag`))
+			// HEAD-based revalidation: compare Content-Length against local file size.
+			Expect(cmd).To(ContainSubstring("remote_size"))
+			Expect(cmd).To(ContainSubstring("skipped download"))
 			Expect(cmd).To(ContainSubstring(`"$MODEL_PATH"`))
 			Expect(cmd).To(ContainSubstring(`"$MODEL_SOURCE"`))
 			// It is NOT the existence-only path.
 			Expect(cmd).NotTo(ContainSubstring("skipping download"))
 		})
 
-		It("uncached: emits the same conditional GET without the cache dir mkdir", func() {
+		It("uncached: emits the same HEAD-based revalidation without the cache dir mkdir", func() {
 			cmd := buildModelInitCommand(false, false, false, RefreshPolicyOnChange)
-			Expect(cmd).To(ContainSubstring("--etag-compare"))
-			Expect(cmd).To(ContainSubstring("--etag-save"))
+			Expect(cmd).To(ContainSubstring("remote_size"))
 			Expect(cmd).To(ContainSubstring(`"$MODEL_SOURCE"`))
 			Expect(cmd).NotTo(ContainSubstring("mkdir -p"))
 			Expect(cmd).NotTo(ContainSubstring("skipping download"))
@@ -1313,7 +1310,7 @@ var _ = Describe("buildModelInitCommand", func() {
 			ifNotPresent := buildModelInitCommand(true, false, true, RefreshPolicyIfNotPresent)
 			onChange := buildModelInitCommand(true, false, true, RefreshPolicyOnChange)
 			Expect(onChange).To(Equal(ifNotPresent))
-			Expect(onChange).NotTo(ContainSubstring("--etag-compare"))
+			Expect(onChange).NotTo(ContainSubstring("remote_size"))
 		})
 
 		It("does not contain user-controlled values in the OnChange command string", func() {
@@ -1335,7 +1332,7 @@ var _ = Describe("buildCachedStorageConfig RefreshPolicy plumbing", func() {
 		}
 		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 		cmd := config.initContainers[1].Command[2]
-		Expect(cmd).To(ContainSubstring("--etag-compare"))
+		Expect(cmd).To(ContainSubstring("remote_size"))
 		Expect(cmd).To(ContainSubstring("kept cached copy"))
 	})
 
@@ -1346,7 +1343,7 @@ var _ = Describe("buildCachedStorageConfig RefreshPolicy plumbing", func() {
 		}
 		config := buildCachedStorageConfig(model, nil, "", "", "curl:8.18.0", 102)
 		cmd := config.initContainers[1].Command[2]
-		Expect(cmd).NotTo(ContainSubstring("--etag-compare"))
+		Expect(cmd).NotTo(ContainSubstring("remote_size"))
 		Expect(cmd).To(ContainSubstring("skipping download"))
 	})
 })

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -204,7 +204,14 @@ func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) s
 // good cache before any decision is made.
 //
 // Strategy (works for both origin and CDN-served files):
-//  1. HEAD the artifact and read Content-Length.
+//  1. HEAD the artifact and read Content-Length. This MUST use curl's
+//     -w '%header{content-length}' (curl 7.84+, satisfied by curlimages/curl):
+//     a HEAD has no response body, so -w '%{size_download}' would always report
+//     0 and the skip branch below could never fire. -L makes %header report the
+//     final CDN response's Content-Length across HuggingFace's 302 redirect.
+//     If the header is absent or the HEAD is rejected, remote_size is empty/0
+//     and the script downloads (size-equality is a truncation guard, not an
+//     integrity check).
 //  2. If the local file exists and its size matches Content-Length, the cache
 //     is current: log "revalidated" and skip the transfer.
 //  3. Otherwise download to "$dest.tmp" and `mv` it onto "$dest" on success,
@@ -218,7 +225,7 @@ func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) s
 // genuinely-missing file (nothing cached and the fetch failed) fails the init
 // container.
 const remoteRevalidateScript = `echo 'Revalidating model against upstream (RefreshPolicy=OnChange)...'; ` +
-	`remote_size=$(curl -fsSL -I "$MODEL_SOURCE" -o /dev/null -w '%{size_download}' 2>/dev/null || echo 0); ` +
+	`remote_size=$(curl -fsSL -I "$MODEL_SOURCE" -o /dev/null -w '%header{content-length}' 2>/dev/null || echo 0); ` +
 	`if [ -f "$MODEL_PATH" ] && [ "$(stat -c %s "$MODEL_PATH" 2>/dev/null || echo 0)" = "$remote_size" ] && [ "$remote_size" != "0" ]; then ` +
 	`echo 'Model revalidated (unchanged, skipped download)'; ` +
 	`else ` +
@@ -406,7 +413,7 @@ func buildMultiFileInitCommand(useCache bool, refreshPolicy string) string {
 			`dest="$CACHE_DIR/$rel"; ` +
 			`mkdir -p "$(dirname "$dest")"; ` +
 			`url="${SOURCE%/}/$rel"; ` +
-			`remote_size=$(curl -fsSL -I "$url" -o /dev/null -w '%{size_download}' 2>/dev/null || echo 0); ` +
+			`remote_size=$(curl -fsSL -I "$url" -o /dev/null -w '%header{content-length}' 2>/dev/null || echo 0); ` +
 			`if [ -f "$dest" ] && [ "$(stat -c %s "$dest" 2>/dev/null || echo 0)" = "$remote_size" ] && [ "$remote_size" != "0" ]; then ` +
 			`echo "Model artifact $rel revalidated (unchanged, skipped download)"; ` +
 			`else ` +

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -191,11 +191,25 @@ func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) s
 }
 
 // remoteRevalidateScript implements RefreshPolicy=OnChange for http/https
-// sources fetched by the init container. It uses curl's native conditional
-// GET (--etag-compare / --etag-save) against a marker file kept next to the
-// model on the PVC: on a 304 curl leaves the cached file untouched, on a 200
-// (ETag changed) it overwrites in place. The cache layout is unchanged; the
-// marker is a dotfile sibling of the model file.
+// sources fetched by the init container. It revalidates the cached artifact
+// before transferring, so a warm cache skips the download entirely.
+//
+// Why not curl --etag-compare/--etag-save: HuggingFace serves LFS-backed
+// weights via a 302 redirect to a signed CDN URL on a different host, and the
+// If-None-Match conditional header is not forwarded across that redirect hop,
+// so the CDN always streams the full body. A 304 is therefore unreachable for
+// any LFS artifact, and --etag-compare can only ever short-circuit the small
+// origin-served config files. On top of that, `curl -o "$dest"` truncates the
+// cached file at request start, so a failed or full-200 transfer destroys the
+// good cache before any decision is made.
+//
+// Strategy (works for both origin and CDN-served files):
+//  1. HEAD the artifact and read Content-Length.
+//  2. If the local file exists and its size matches Content-Length, the cache
+//     is current: log "revalidated" and skip the transfer.
+//  3. Otherwise download to "$dest.tmp" and `mv` it onto "$dest" on success,
+//     so a redundant or failed transfer can never truncate a good cache. The
+//     rename also makes the artifact publish atomically.
 //
 // Robustness: the init container gates pod startup, so a transient network
 // failure (air-gapped, upstream 5xx, DNS) must not take down an
@@ -203,17 +217,15 @@ func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) s
 // already exists, the script logs and exits 0, keeping the cached file. Only a
 // genuinely-missing file (nothing cached and the fetch failed) fails the init
 // container.
-//
-// curlimages/curl 8.x supports --etag-compare/--etag-save (added in curl
-// 7.68.0), so no HEAD-compare fallback is needed for the default image.
-const remoteRevalidateScript = `ETAG_MARKER="$(dirname "$MODEL_PATH")/.$(basename "$MODEL_PATH").etag"; ` +
-	`echo 'Revalidating model against upstream (RefreshPolicy=OnChange)...'; ` +
-	`if curl -fsSL --etag-compare "$ETAG_MARKER" --etag-save "$ETAG_MARKER" -o "$MODEL_PATH" "$MODEL_SOURCE"; then ` +
-	`echo 'Model revalidated (downloaded or unchanged)'; ` +
-	`elif [ -f "$MODEL_PATH" ]; then ` +
-	`echo 'Revalidation unreachable; kept cached copy'; exit 0; ` +
+const remoteRevalidateScript = `echo 'Revalidating model against upstream (RefreshPolicy=OnChange)...'; ` +
+	`remote_size=$(curl -fsSL -I "$MODEL_SOURCE" -o /dev/null -w '%{size_download}' 2>/dev/null || echo 0); ` +
+	`if [ -f "$MODEL_PATH" ] && [ "$(stat -c %s "$MODEL_PATH" 2>/dev/null || echo 0)" = "$remote_size" ] && [ "$remote_size" != "0" ]; then ` +
+	`echo 'Model revalidated (unchanged, skipped download)'; ` +
 	`else ` +
-	`echo 'ERROR: model missing and revalidation failed'; exit 1; ` +
+	`if curl -fsSL -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH"; then ` +
+	`echo 'Model revalidated (downloaded)'; ` +
+	`elif [ -f "$MODEL_PATH" ]; then echo 'Revalidation unreachable; kept cached copy'; exit 0; ` +
+	`else echo 'ERROR: model missing and revalidation failed'; exit 1; fi; ` +
 	`fi`
 
 func modelInitEnvVars(source, cacheDir, modelPath string) []corev1.EnvVar {
@@ -394,11 +406,15 @@ func buildMultiFileInitCommand(useCache bool, refreshPolicy string) string {
 			`dest="$CACHE_DIR/$rel"; ` +
 			`mkdir -p "$(dirname "$dest")"; ` +
 			`url="${SOURCE%/}/$rel"; ` +
-			`etag="$(dirname "$dest")/.$(basename "$dest").etag"; ` +
-			`if curl -fsSL --etag-compare "$etag" --etag-save "$etag" -o "$dest" "$url"; then ` +
-			`echo "Model artifact $rel revalidated"; ` +
+			`remote_size=$(curl -fsSL -I "$url" -o /dev/null -w '%{size_download}' 2>/dev/null || echo 0); ` +
+			`if [ -f "$dest" ] && [ "$(stat -c %s "$dest" 2>/dev/null || echo 0)" = "$remote_size" ] && [ "$remote_size" != "0" ]; then ` +
+			`echo "Model artifact $rel revalidated (unchanged, skipped download)"; ` +
+			`else ` +
+			`if curl -fsSL -o "$dest.tmp" "$url" && mv "$dest.tmp" "$dest"; then ` +
+			`echo "Model artifact $rel revalidated (downloaded)"; ` +
 			`elif [ -f "$dest" ]; then echo "Revalidation unreachable for $rel; kept cached copy"; ` +
 			`else echo "ERROR: model artifact $rel missing and revalidation failed"; exit 1; fi; ` +
+			`fi; ` +
 			`done`
 		return prefix + body
 	}

--- a/internal/controller/model_storage_revalidate_test.go
+++ b/internal/controller/model_storage_revalidate_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestRemoteRevalidateScript_Behavioral drives the actual OnChange revalidation
+// shell (remoteRevalidateScript) against a stub HTTP server. It is the
+// regression guard for #1309: the remote-size probe must read Content-Length
+// from the HEAD response. A HEAD has no body, so the earlier
+// -w '%{size_download}' always reported 0, the size comparison never matched,
+// and a warm, unchanged cache was re-downloaded on every restart.
+//
+// Unlike the ContainSubstring assertions elsewhere in this package (which pass
+// on a script whose skip branch can never fire), this test counts actual GET
+// requests, so it FAILS if the probe returns 0 and the script downloads a
+// size-matching cache. It skips when curl is unavailable (the init image ships
+// curlimages/curl 8.x, and CI runners have curl).
+func TestRemoteRevalidateScript_Behavioral(t *testing.T) {
+	if _, err := exec.LookPath("curl"); err != nil {
+		t.Skip("curl not available; skipping behavioral revalidation test")
+	}
+	// The init-container script uses `stat -c %s` (GNU/busybox). On hosts whose
+	// stat lacks -c (macOS/BSD) the local-size read fails and this would false-
+	// fail, so skip there: this stays a Linux/CI behavioral guard (the runtime
+	// is always the Alpine curlimages/curl image, verified separately).
+	probe := filepath.Join(t.TempDir(), "probe")
+	if err := os.WriteFile(probe, []byte("abc"), 0o644); err != nil {
+		t.Fatalf("probe file: %v", err)
+	}
+	if out, err := exec.Command("stat", "-c", "%s", probe).Output(); err != nil || strings.TrimSpace(string(out)) != "3" {
+		t.Skip("host stat lacks the -c size format (script targets the busybox/Linux init image)")
+	}
+
+	body := []byte(strings.Repeat("x", 4096))
+	var gets int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Advertise Content-Length on every response, including HEAD, exactly
+		// as an origin or CDN does. The revalidation probe relies on it.
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		atomic.AddInt32(&gets, 1)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	run := func(t *testing.T, cacheContents []byte) (string, int32) {
+		t.Helper()
+		atomic.StoreInt32(&gets, 0)
+		dir := t.TempDir()
+		modelPath := filepath.Join(dir, "model.gguf")
+		if cacheContents != nil {
+			if err := os.WriteFile(modelPath, cacheContents, 0o644); err != nil {
+				t.Fatalf("seed cache: %v", err)
+			}
+		}
+		cmd := exec.Command("sh", "-c", remoteRevalidateScript)
+		cmd.Env = append(os.Environ(),
+			"MODEL_SOURCE="+srv.URL+"/model.gguf",
+			"MODEL_PATH="+modelPath,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("revalidation script failed: %v\n%s", err, out)
+		}
+		return string(out), atomic.LoadInt32(&gets)
+	}
+
+	t.Run("warm cache with matching size skips the download", func(t *testing.T) {
+		out, downloads := run(t, body) // cached size == remote Content-Length
+		if downloads != 0 {
+			t.Errorf("expected 0 downloads for a size-matching warm cache, got %d "+
+				"(the size probe likely returned 0 instead of Content-Length)\n%s", downloads, out)
+		}
+		if !strings.Contains(out, "skipped download") {
+			t.Errorf("expected 'skipped download' in output, got:\n%s", out)
+		}
+	})
+
+	t.Run("size mismatch re-downloads", func(t *testing.T) {
+		out, downloads := run(t, []byte("stale")) // cached size != remote size
+		if downloads != 1 {
+			t.Errorf("expected exactly 1 download for a size-mismatched cache, got %d\n%s", downloads, out)
+		}
+		if !strings.Contains(out, "downloaded") {
+			t.Errorf("expected 'downloaded' in output, got:\n%s", out)
+		}
+	})
+
+	t.Run("no cache downloads", func(t *testing.T) {
+		out, downloads := run(t, nil)
+		if downloads != 1 {
+			t.Errorf("expected exactly 1 download when nothing is cached, got %d\n%s", downloads, out)
+		}
+	})
+}


### PR DESCRIPTION
## What

The model-download init container revalidates a cached model on `RefreshPolicy=OnChange`. The first commit replaced the broken `curl --etag-compare` strategy with a HEAD + size comparison and an atomic `.tmp` + `mv` download.

An independent review then found the size probe was inert: `curl -I ... -w '%{size_download}'` counts response-body bytes, and a HEAD has no body, so it was always `0`. The skip-download guard `[ "$remote_size" != "0" ]` could never be true, and the full weight set was still re-downloaded on every restart. Fixed by hand in the second commit.

## Why

Fixes #1309

## How

- Read the remote size from the HEAD's Content-Length via `-w '%header{content-length}'` (curl 7.84+, satisfied by the `curlimages/curl` init image), following HuggingFace's 302 to the signed CDN with `-L` (`%header` reports the final response). Absent header or rejected HEAD → download (size-equality is a truncation guard, not an integrity check).
- Keep the atomic `$dest.tmp` + `mv` download and the cache-preserving exit-0-on-failure; those halves were already correct.
- Add `model_storage_revalidate_test.go`: it execs the actual script against an `httptest` server and counts GET requests, asserting a size-matching warm cache produces zero downloads. Unlike the existing `ContainSubstring` shape assertions (which passed on the dead script), this test fails if the probe returns 0. It skips on hosts without `stat -c` (macOS/BSD); the behavior was verified on the Alpine/busybox + curl production runtime (fixed skips, old re-downloads).

## Provenance and review

The structure (atomic download, revalidation strategy) was authored by a Foreman coder agent; the size-probe fix and the behavioral test were completed by hand after the review found the dead probe. Verified: `%header{content-length}` returns the real size (491 MB on a live HF LFS file), `%{size_download}` returns 0.

AI-assisted (band 3): agent-authored base, independently reviewed, corrected and verified by hand. Part of a harness-evaluation batch (review, do not auto-merge). All CI, including the DCO check, is green.
