### PR TITLE
fix(foreman): auto-apply gofmt in the coder gate instead of failing the coder (#1327)

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -119,9 +119,17 @@ func RunCoderGate(
 ) (pass bool, feedback string, advisories []advisory) {
 	var failures []checkFailure
 
-	// 1. gofmt -l . lists misformatted files on stdout and exits 0 even
-	// when files are listed, so the failure signal is non-empty output,
-	// not the exec error.
+	// 1. gofmt: auto-apply formatting rather than failing the coder on a
+	// mechanical step (#1327). Coders (especially smaller models) burn turns,
+	// sometimes their whole budget, hand-fixing gofmt via str_replace instead
+	// of doing the actual work. `gofmt -w .` rewrites misformatted files in
+	// place; the executor's `git add -A` (repo.Commit) commits them, mirroring
+	// the codegen-drift resolution below (#851). The tree is gofmt-clean in CI,
+	// so -w only touches the coder's own changes. Re-run `gofmt -l .`
+	// afterward: a file gofmt cannot rewrite (e.g. a syntax error) is still
+	// listed, so a genuine formatting problem surfaces rather than being
+	// silently swallowed.
+	run(ctx, workspace, nil, "gofmt", "-w", ".")
 	if out, _ := run(ctx, workspace, nil, "gofmt", "-l", "."); strings.TrimSpace(out) != "" {
 		failures = append(failures, checkFailure{name: "gofmt -l .", output: out})
 	}

--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -128,8 +128,10 @@ func RunCoderGate(
 	// so -w only touches the coder's own changes. Re-run `gofmt -l .`
 	// afterward: a file gofmt cannot rewrite (e.g. a syntax error) is still
 	// listed, so a genuine formatting problem surfaces rather than being
-	// silently swallowed.
-	run(ctx, workspace, nil, "gofmt", "-w", ".")
+	// silently swallowed. The -w exit status is intentionally ignored: any
+	// file it could not rewrite is reported by the -l re-check immediately
+	// below.
+	_, _ = run(ctx, workspace, nil, "gofmt", "-w", ".")
 	if out, _ := run(ctx, workspace, nil, "gofmt", "-l", "."); strings.TrimSpace(out) != "" {
 		failures = append(failures, checkFailure{name: "gofmt -l .", output: out})
 	}

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -137,6 +137,53 @@ func TestRunCoderGate(t *testing.T) {
 	}
 }
 
+// TestRunCoderGateAutoAppliesGofmt asserts the gate runs `gofmt -w .` to
+// auto-apply formatting and passes when gofmt can fix the tree, so a coder is
+// never sent back to hand-fix a mechanical formatting nit (#1327). The
+// rewritten files are left in the workspace for the executor's git add -A.
+func TestRunCoderGateAutoAppliesGofmt(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	var sawGofmtWrite bool
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name == "gofmt" && len(args) > 0 {
+			switch args[0] {
+			case "-w":
+				sawGofmtWrite = true // gofmt -w rewrites misformatted files in place
+				return "", nil
+			case "-l":
+				return "", nil // after -w the tree is clean
+			}
+		}
+		return "", nil // go vet/build/test and lint all pass
+	}
+	pass, feedback, _ := RunCoderGate(context.Background(), "/work", golangciPath, run, "", "main", nil)
+	if !sawGofmtWrite {
+		t.Error("gate did not run `gofmt -w .` to auto-apply formatting")
+	}
+	if !pass {
+		t.Errorf("gate should pass when gofmt can auto-fix the tree; feedback:\n%s", feedback)
+	}
+}
+
+// TestRunCoderGateGofmtUnfixableStillFails asserts that a file gofmt -w cannot
+// rewrite (for example a syntax error) still surfaces as a gofmt failure: the
+// auto-apply must not swallow a genuine problem.
+func TestRunCoderGateGofmtUnfixableStillFails(t *testing.T) {
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name == "gofmt" && len(args) > 0 && args[0] == "-l" {
+			return "internal/broken/parse_error.go\n", nil // still listed after -w
+		}
+		return "", nil
+	}
+	pass, feedback, _ := RunCoderGate(context.Background(), "/work", "./bin/golangci-lint", run, "", "main", nil)
+	if pass {
+		t.Error("gate should fail when gofmt cannot format a file")
+	}
+	if !strings.Contains(feedback, "gofmt -l .") {
+		t.Errorf("feedback should report the gofmt failure; got:\n%s", feedback)
+	}
+}
+
 // TestRunCoderGateLintEnv asserts the lint check receives GOOS=linux as an
 // extra env var while the other checks receive none.
 func TestRunCoderGateLintEnv(t *testing.T) {


### PR DESCRIPTION
## What

The in-loop coder gate ran `gofmt -l .` and handed any misformatted files back to the coder as a failure to fix by hand. Coders, especially smaller models, burn turns (sometimes their whole turn budget) hand-fixing gofmt via `str_replace` instead of doing the actual work.

## Why

Fixes #1327

In a harness-evaluation batch, #1298 went INCOMPLETE exactly this way: a correct fix (all three provider-seam bypasses closed, compiled, passed the gate's tests) that tripped only on a gofmt nit and three line-length lines, and the coder could not clear them within its turn budget.

## How

Run `gofmt -w .` before the `gofmt -l .` check, mirroring the existing codegen-drift auto-resolution (#851): the rewritten files are left in the workspace and committed by the executor's `git add -A` (repo.Commit). The `-l` re-check runs afterward, so a file gofmt *cannot* rewrite (a syntax error) still surfaces as a failure rather than being swallowed. The tree is gofmt-clean in CI, so `-w` only touches the coder's own changes.

Line-length (`lll`) is intentionally left to the coder: splitting a long line is not a safe deterministic rewrite the way gofmt is. Auto-fixing the `golangci-lint --fix`-able subset is a reasonable follow-up but is out of scope here.

Tests: `TestRunCoderGateAutoAppliesGofmt` (the auto-fix path passes and asserts `gofmt -w .` is invoked) and `TestRunCoderGateGofmtUnfixableStillFails` (a file gofmt cannot format still fails the gate). Bite-checked: removing the `gofmt -w .` line fails the auto-apply test.

AI-assisted (band 3): implemented, tested, and bite-checked by me.
