### PR TITLE
fix(controller): gate HPA scale-up by GPUQuota via maxReplicas accounting (#1311)

### DIFF
--- a/internal/controller/gpuquota_controller.go
+++ b/internal/controller/gpuquota_controller.go
@@ -134,9 +134,14 @@ func (r *GPUQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 					model = m
 				}
 			}
-			// Replicas: nil means 1.
+			// Replicas: nil means 1. When autoscaling is configured, charge
+			// maxReplicas (the HPA ceiling) rather than spec.replicas so
+			// status.usedGPUCount reflects the worst-case headroom the service
+			// can reach, matching the admission-time accounting (#1311).
 			replicas := int32(1)
-			if isvc.Spec.Replicas != nil {
+			if isvc.Spec.Autoscaling != nil {
+				replicas = isvc.Spec.Autoscaling.MaxReplicas
+			} else if isvc.Spec.Replicas != nil {
 				replicas = *isvc.Spec.Replicas
 			}
 			usedGPUCount += apiutil.GPUCount(&isvc, model) * replicas

--- a/internal/controller/inferenceservice_quota_webhook.go
+++ b/internal/controller/inferenceservice_quota_webhook.go
@@ -337,11 +337,25 @@ func (v *InferenceServiceQuotaValidator) currentUsage(ctx context.Context, q inf
 // replicas, routing through apiutil.GPUCount so a Model-declared
 // hardware.gpu.count is charged the same way the pod spec requests it.
 // The Model argument is nil-safe; when nil the count falls back to
-// isvc.Spec.Resources.GPU. Replicas default to 1 when nil.
+// isvc.Spec.Resources.GPU.
+//
+// When autoscaling is configured, the replica count used for quota
+// accounting is the autoscaling maxReplicas (the worst-case headroom the
+// service can reach under HPA), not spec.replicas. The HPA targets the
+// Deployment directly, so HPA-driven scale-up never re-enters the
+// InferenceService admission webhook; charging spec.replicas would let a
+// service admitted at 1 GPU scale to maxReplicas GPU-consuming pods with no
+// further quota check (#1311). maxReplicas is capped at 100 by the CRD, so
+// this is the ceiling the quota must cover.
 func gpuCount(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model) int32 {
+	perPod := apiutil.GPUCount(isvc, model)
 	replicas := int32(1)
-	if isvc.Spec.Replicas != nil {
+	if isvc.Spec.Autoscaling != nil {
+		// maxReplicas is a required field of AutoscalingSpec (no pointer),
+		// so it is always present when autoscaling is configured.
+		replicas = isvc.Spec.Autoscaling.MaxReplicas
+	} else if isvc.Spec.Replicas != nil {
 		replicas = *isvc.Spec.Replicas
 	}
-	return apiutil.GPUCount(isvc, model) * replicas
+	return perPod * replicas
 }

--- a/internal/controller/inferenceservice_quota_webhook_test.go
+++ b/internal/controller/inferenceservice_quota_webhook_test.go
@@ -1125,3 +1125,130 @@ func TestQuotaWebhookRejectsUnsatisfiableParallelism(t *testing.T) {
 		}
 	})
 }
+
+// #1311: HPA-driven scale-up is not gated by GPUQuota because the HPA
+// targets the Deployment, not the InferenceService, so HPA scaling never
+// re-enters the admission webhook. The quota must therefore charge
+// autoscaling.maxReplicas (the worst-case headroom) at admission time, not
+// spec.replicas.
+func TestQuotaWebhookChargesMaxReplicas(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core1: %v", err)
+	}
+
+	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+	t.Run("maxReplicas over quota is denied at admission", func(t *testing.T) {
+		// gpu: 1, maxReplicas: 100 => 100 GPUs requested. Quota cap is 4.
+		// Before #1311 the webhook charged spec.replicas (1) and admitted.
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-quota"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "default",
+				GPUCount:     4,
+			},
+		}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "autoscaled-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Replicas: ptrInt32Val(1),
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					GPU: 1,
+				},
+				Autoscaling: &inferencev1alpha1.AutoscalingSpec{
+					MaxReplicas: 100,
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&quota, &ns).
+			Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		_, err := v.ValidateCreate(ctx, &isvc)
+		if err == nil {
+			t.Fatal("expected denial (1*100=100 > 4), got nil")
+		}
+		if !strContains(err.Error(), "would exceed gpuCount") {
+			t.Fatalf("expected reason to mention gpuCount, got: %v", err)
+		}
+	})
+
+	t.Run("maxReplicas within quota is admitted", func(t *testing.T) {
+		// gpu: 1, maxReplicas: 4 => 4 GPUs requested. Quota cap is 8.
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-quota"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "default",
+				GPUCount:     8,
+			},
+		}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "autoscaled-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Replicas: ptrInt32Val(1),
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					GPU: 1,
+				},
+				Autoscaling: &inferencev1alpha1.AutoscalingSpec{
+					MaxReplicas: 4,
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&quota, &ns).
+			Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		if _, err := v.ValidateCreate(ctx, &isvc); err != nil {
+			t.Fatalf("expected admission (1*4=4 <= 8), got error: %v", err)
+		}
+	})
+
+	t.Run("decide charges maxReplicas not spec.replicas", func(t *testing.T) {
+		// gpu: 2, maxReplicas: 3 => 6 GPUs. Quota cap is 5 => denied.
+		// spec.replicas is 1, which would have been admitted before #1311.
+		quota := inferencev1alpha1.GPUQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-quota"},
+			Spec: inferencev1alpha1.GPUQuotaSpec{
+				NamespaceRef: "default",
+				GPUCount:     5,
+			},
+		}
+		isvc := inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "autoscaled-svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Replicas: ptrInt32Val(1),
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					GPU: 2,
+				},
+				Autoscaling: &inferencev1alpha1.AutoscalingSpec{
+					MaxReplicas: 3,
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&quota, &ns).
+			Build()
+
+		v := &InferenceServiceQuotaValidator{Client: fakeClient}
+		allow, reason := v.decide(ctx, quota, &isvc, nil)
+		if allow {
+			t.Fatal("expected deny (2*3=6 > 5), got allow")
+		}
+		if !strContains(reason, "would exceed gpuCount") {
+			t.Fatalf("expected reason to mention gpuCount, got: %s", reason)
+		}
+	})
+}


### PR DESCRIPTION
## What

HPA-driven scale-up is not gated by `GPUQuota`. A service admitted charging 1 GPU can reach `autoscaling.maxReplicas` GPU-consuming pods, and `status.usedGPUCount` reports the admitted figure the whole time, because the HPA targets the Deployment (never re-entering the InferenceService admission webhook) and both accounting paths charged `spec.replicas`.

## Why

Fixes #1311

## How

Charge `autoscaling.maxReplicas` (the worst-case headroom, capped at 100 by the CRD) rather than `spec.replicas` in both accounting paths when autoscaling is configured: the admission webhook (`inferenceservice_quota_webhook.go`) so a service whose `maxReplicas` would exceed the quota is denied, and the status reconciler (`gpuquota_controller.go`) so `status.usedGPUCount` reflects the ceiling. Non-autoscaled services are unchanged.

`TestQuotaWebhookChargesMaxReplicas` covers admission denial when `maxReplicas` exceeds the quota, admission when within, and the `decide` path charging `maxReplicas` not `spec.replicas`. The test sets `Replicas: 1` explicitly and expects a deny on `maxReplicas: 100`, so it fails if the code charges `spec.replicas` (bite-checked: disabling the `maxReplicas` branch fails the test with "expected denial (1*100=100 > 4), got nil").

## Provenance and review

The change was produced by a Foreman coder run (Laguna) and passed the deterministic gate; I reviewed the diff, confirmed both accounting paths, and bite-checked the test before landing it on this branch.

AI-assisted (band 3): agent-authored, human-reviewed, bite-checked, and opened by me.
