### PR TITLE
fix(foreman): record IsError on MCP transport failures (#1330)

### DIFF
--- a/pkg/foreman/agent/mcp/tool.go
+++ b/pkg/foreman/agent/mcp/tool.go
@@ -52,11 +52,13 @@ type mcpCallRecord struct {
 	Truncated   bool
 	LatencyMs   int64
 	Error       string // "" on success; the callTool error string otherwise
-	// IsError reflects the remote server's tool-level isError flag: the
-	// call itself succeeded (no Go error, Error is "") but the tool
-	// reported its own failure (e.g. a bad lookup, an invalid argument
-	// the server validated itself). Distinct from Error, which is a
-	// transport/protocol failure.
+	// IsError is true whenever the call did not succeed, so success
+	// accounting can key on this single field (#1330). It covers two
+	// cases, told apart by Error:
+	//   - transport/protocol failure (timeout, dial error): Error is
+	//     non-empty.
+	//   - tool-level failure reported by the remote server (bad lookup,
+	//     invalid argument the server validated itself): Error is "".
 	IsError bool
 }
 
@@ -153,9 +155,15 @@ func (t *mcpTool) Execute(ctx context.Context, args json.RawMessage) (*agent.Too
 	latency := time.Since(start).Milliseconds()
 
 	if err != nil {
+		// A transport/protocol failure (timeout, dial error) is a failed
+		// call: set IsError so success accounting keyed on it does not
+		// miscount the call as a success (#1330). Error stays populated so
+		// downstream can still tell a transport failure from a tool-level
+		// one (which sets IsError with an empty Error).
 		t.recordCall(args, mcpCallRecord{
 			LatencyMs: latency,
 			Error:     err.Error(),
+			IsError:   true,
 		})
 		return &agent.ToolResult{Output: "MCP error: " + err.Error()}, nil
 	}

--- a/pkg/foreman/agent/mcp/tool_test.go
+++ b/pkg/foreman/agent/mcp/tool_test.go
@@ -228,6 +228,11 @@ func TestMcpTool_Execute_SoftErrorOnCallToolFailure(t *testing.T) {
 	if records[0].Error != "boom" {
 		t.Fatalf("record.Error = %q, want %q", records[0].Error, "boom")
 	}
+	// A transport failure must set IsError so success accounting does not
+	// count it as a success (#1330).
+	if !records[0].IsError {
+		t.Fatalf("record.IsError = false, want true for a transport failure")
+	}
 	if records[0].Server != "fake" || records[0].Tool != "echo" {
 		t.Fatalf("record.Server/Tool = %q/%q, want fake/echo", records[0].Server, records[0].Tool)
 	}
@@ -291,6 +296,11 @@ func TestMcpTool_Execute_CallTimeout(t *testing.T) {
 	}
 	if records[0].Error == "" {
 		t.Fatalf("record.Error = %q, want non-empty (timeout should be recorded)", records[0].Error)
+	}
+	// The exact scenario in #1330: a timed-out call must record IsError so
+	// success metrics do not count it as a success.
+	if !records[0].IsError {
+		t.Fatalf("record.IsError = false, want true for a timed-out call")
 	}
 }
 


### PR DESCRIPTION
## What

An MCP tool call that fails on transport (a `perplexity_ask` hitting the 30s `callTimeout`, a dial error) recorded `callError` but left `isError` at its zero value `false`. So the logged event was `callError:"context deadline exceeded", isError:false` -- a failed call indistinguishable from a success by `isError`, and any success accounting keyed on it (including a downstream MCP audit histogram) miscounts the timeout as a success.

## Why

Fixes #1330

## How

Set `IsError` in the transport-error branch of `mcpTool.Execute` and redefine the field as "the call did not succeed", so success accounting can key on a single field. `Error` stays the discriminator: non-empty for a transport/protocol failure, empty for a tool-level failure the remote server itself reported (that path already set `IsError`). No behavior change for the run -- MCP still never fails a Foreman run; this is an observability-correctness fix.

The two existing transport-error tests (`SoftErrorOnCallToolFailure`, `CallTimeout` -- the exact repro in the issue) now assert `IsError`. Bite-checked: reverting the one-line fix fails both with "record.IsError = false, want true".

Note: the issue also floats a longer timeout for `perplexity_ask` / steering quick lookups to `perplexity_search`. That is a tuning change on a different surface (server config), left out of this correctness fix.

## AI-assisted (band 3)

Investigated, fixed, bite-checked, and opened by me.
