### PR TITLE
fix(foreman): make coder self-gate diff-aware, skip Go tier on non-Go diffs (#1292)

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -119,65 +119,80 @@ func RunCoderGate(
 ) (pass bool, feedback string, advisories []advisory) {
 	var failures []checkFailure
 
-	// 1. gofmt: auto-apply formatting rather than failing the coder on a
-	// mechanical step (#1327). Coders (especially smaller models) burn turns,
-	// sometimes their whole budget, hand-fixing gofmt via str_replace instead
-	// of doing the actual work. `gofmt -w .` rewrites misformatted files in
-	// place; the executor's `git add -A` (repo.Commit) commits them, mirroring
-	// the codegen-drift resolution below (#851). The tree is gofmt-clean in CI,
-	// so -w only touches the coder's own changes. Re-run `gofmt -l .`
-	// afterward: a file gofmt cannot rewrite (e.g. a syntax error) is still
-	// listed, so a genuine formatting problem surfaces rather than being
-	// silently swallowed. The -w exit status is intentionally ignored: any
-	// file it could not rewrite is reported by the -l re-check immediately
-	// below.
-	_, _ = run(ctx, workspace, nil, "gofmt", "-w", ".")
-	if out, _ := run(ctx, workspace, nil, "gofmt", "-l", "."); strings.TrimSpace(out) != "" {
-		failures = append(failures, checkFailure{name: "gofmt -l .", output: out})
-	}
-
-	// 2. go vet ./... fails with a non-nil error.
-	if out, err := run(ctx, workspace, nil, "go", "vet", "./..."); err != nil {
-		failures = append(failures, checkFailure{name: "go vet ./...", output: out})
-	}
-
-	// 3. go build ./... fails with a non-nil error.
-	if out, err := run(ctx, workspace, nil, "go", "build", "./..."); err != nil {
-		failures = append(failures, checkFailure{name: "go build ./...", output: out})
-	}
-
-	// 4. golangci-lint run ./... fails with a non-nil error. GOOS=linux is
-	// required: on macOS, plain lint silently skips //go:build !darwin
-	// files and would not match CI. GOLANGCI_LINT_CACHE is scoped to a
-	// per-workspace sibling directory so stale analysis results from
-	// another coder workspace cannot pollute this run's lint (#759); the
-	// sibling location keeps the cache out of the workspace git tree.
-	lintEnv := []string{"GOOS=linux", "GOLANGCI_LINT_CACHE=" + workspace + ".golangci-cache"}
-	if out, err := run(ctx, workspace, lintEnv, golangciPath, "run", "./..."); err != nil {
-		failures = append(failures, checkFailure{name: golangciPath + " run ./...", output: out})
-	}
-
-	// 5. Fast unit-test tier: go test on the non-envtest packages the coder
-	// changed. The static checks above cannot catch a failing or panicking
-	// unit test, so a broken test would otherwise reach a GO and only fail
-	// in CI (#762). Envtest/integration packages are excluded (they need
-	// KUBEBUILDER_ASSETS / a cluster the workspace lacks; CI runs them).
-	if pkgs := changedTestPackages(ctx, workspace, run); len(pkgs) > 0 {
-		args := append([]string{"test", "-count=1", "-timeout=180s"}, pkgs...)
-		if out, err := run(ctx, workspace, nil, "go", args...); err != nil {
-			failures = append(failures, checkFailure{name: "go test " + strings.Join(pkgs, " "), output: out})
+	// Checks 1-6 exercise the Go toolchain (gofmt, go vet, go build,
+	// golangci-lint, the unit-test tier, and codegen regeneration). A diff
+	// that changes no Go source (a docs- or config-only edit) cannot fail
+	// any of them, so running them wastes turns and, worse, surfaces a
+	// toolchain/env error the model cannot act on: an agent-image go.mod
+	// version wall reported as "go build ./... failed" is fed back as "fix
+	// the issues below and resubmit", burning the fix-attempt budget on an
+	// unfixable premise (#1292). Skip the whole Go tier when nothing Go
+	// changed, mirroring the diff-awareness the verify gate learned in
+	// #1072. The diff-aware checks below (goreleaser, scope-overlap,
+	// test-presence, mutation, reference-grounding) are already path-scoped
+	// and still run -- reference-grounding in particular is what validates a
+	// docs-only change.
+	if goToolchainRelevantChange(ctx, workspace, run) {
+		// 1. gofmt: auto-apply formatting rather than failing the coder on a
+		// mechanical step (#1327). Coders (especially smaller models) burn turns,
+		// sometimes their whole budget, hand-fixing gofmt via str_replace instead
+		// of doing the actual work. `gofmt -w .` rewrites misformatted files in
+		// place; the executor's `git add -A` (repo.Commit) commits them, mirroring
+		// the codegen-drift resolution below (#851). The tree is gofmt-clean in CI,
+		// so -w only touches the coder's own changes. Re-run `gofmt -l .`
+		// afterward: a file gofmt cannot rewrite (e.g. a syntax error) is still
+		// listed, so a genuine formatting problem surfaces rather than being
+		// silently swallowed. The -w exit status is intentionally ignored: any
+		// file it could not rewrite is reported by the -l re-check immediately
+		// below.
+		_, _ = run(ctx, workspace, nil, "gofmt", "-w", ".")
+		if out, _ := run(ctx, workspace, nil, "gofmt", "-l", "."); strings.TrimSpace(out) != "" {
+			failures = append(failures, checkFailure{name: "gofmt -l .", output: out})
 		}
-	}
 
-	// 6. Codegen drift: regenerate manifests/CRDs/deepcopy and deterministically
-	// resolve any drift confined to generated artifacts, rather than failing the
-	// coder on a mechanical step it was already told to run (#851). Regenerated
-	// generated files are left in the workspace and committed by the executor's
-	// `git add -A` (repo.Commit). Only a make error, or regeneration touching a
-	// NON-generated file, is reported as a failure. Skipped gracefully if
-	// controller-gen is unavailable. (Originally a hard drift check, #775.)
-	if failed, out := resolveCodegenDrift(ctx, workspace, run); failed {
-		failures = append(failures, checkFailure{name: "codegen drift", output: out})
+		// 2. go vet ./... fails with a non-nil error.
+		if out, err := run(ctx, workspace, nil, "go", "vet", "./..."); err != nil {
+			failures = append(failures, checkFailure{name: "go vet ./...", output: out})
+		}
+
+		// 3. go build ./... fails with a non-nil error.
+		if out, err := run(ctx, workspace, nil, "go", "build", "./..."); err != nil {
+			failures = append(failures, checkFailure{name: "go build ./...", output: out})
+		}
+
+		// 4. golangci-lint run ./... fails with a non-nil error. GOOS=linux is
+		// required: on macOS, plain lint silently skips //go:build !darwin
+		// files and would not match CI. GOLANGCI_LINT_CACHE is scoped to a
+		// per-workspace sibling directory so stale analysis results from
+		// another coder workspace cannot pollute this run's lint (#759); the
+		// sibling location keeps the cache out of the workspace git tree.
+		lintEnv := []string{"GOOS=linux", "GOLANGCI_LINT_CACHE=" + workspace + ".golangci-cache"}
+		if out, err := run(ctx, workspace, lintEnv, golangciPath, "run", "./..."); err != nil {
+			failures = append(failures, checkFailure{name: golangciPath + " run ./...", output: out})
+		}
+
+		// 5. Fast unit-test tier: go test on the non-envtest packages the coder
+		// changed. The static checks above cannot catch a failing or panicking
+		// unit test, so a broken test would otherwise reach a GO and only fail
+		// in CI (#762). Envtest/integration packages are excluded (they need
+		// KUBEBUILDER_ASSETS / a cluster the workspace lacks; CI runs them).
+		if pkgs := changedTestPackages(ctx, workspace, run); len(pkgs) > 0 {
+			args := append([]string{"test", "-count=1", "-timeout=180s"}, pkgs...)
+			if out, err := run(ctx, workspace, nil, "go", args...); err != nil {
+				failures = append(failures, checkFailure{name: "go test " + strings.Join(pkgs, " "), output: out})
+			}
+		}
+
+		// 6. Codegen drift: regenerate manifests/CRDs/deepcopy and deterministically
+		// resolve any drift confined to generated artifacts, rather than failing the
+		// coder on a mechanical step it was already told to run (#851). Regenerated
+		// generated files are left in the workspace and committed by the executor's
+		// `git add -A` (repo.Commit). Only a make error, or regeneration touching a
+		// NON-generated file, is reported as a failure. Skipped gracefully if
+		// controller-gen is unavailable. (Originally a hard drift check, #775.)
+		if failed, out := resolveCodegenDrift(ctx, workspace, run); failed {
+			failures = append(failures, checkFailure{name: "codegen drift", output: out})
+		}
 	}
 
 	// 7. Goreleaser config check: when .goreleaser.yaml or any
@@ -793,6 +808,40 @@ func checkReferenceGrounding(ctx context.Context, workspace string, run commandR
 		fmt.Fprintf(&b, "  - %s\n", f.String())
 	}
 	return true, b.String()
+}
+
+// goToolchainRelevantChange reports whether the coder's working-tree diff
+// touches any file the Go toolchain tier (gofmt, go vet, go build,
+// golangci-lint, the unit-test tier, codegen) could act on: a .go file
+// (test or not) or a module file (go.mod/go.sum). It stages everything with
+// `git add -A` and diffs against HEAD with `git diff --name-only --cached`,
+// the same working-tree basis the rest of the gate uses (the gate runs
+// before any commit, so `...HEAD` alone would see nothing). Test files are
+// deliberately included: a _test.go-only change must still vet/build/test.
+//
+// It is fail-safe: a git error returns true, so a bad diff signal runs the
+// checks rather than skipping them. When it returns false -- a docs- or
+// config-only diff -- the Go tier is skipped so the coder is not blocked on,
+// or fed, a Go check it cannot make pass (#1292).
+func goToolchainRelevantChange(ctx context.Context, workspace string, run commandRunner) bool {
+	if _, err := run(ctx, workspace, nil, "git", "add", "-A"); err != nil {
+		return true
+	}
+	out, err := run(ctx, workspace, nil, "git", "diff", "--name-only", "--cached", "HEAD")
+	if err != nil {
+		return true
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		base := filepath.Base(line)
+		if strings.HasSuffix(line, ".go") || base == "go.mod" || base == "go.sum" {
+			return true
+		}
+	}
+	return false
 }
 
 // changedWorkingTreeGoFiles returns the workspace-relative Go file paths that

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -47,6 +47,16 @@ func newFakeRunner(responses map[string]fakeCommand) (commandRunner, *[]recorded
 	calls := &[]recordedCall{}
 	run := func(_ context.Context, _ string, extraEnv []string, name string, args ...string) (string, error) {
 		*calls = append(*calls, recordedCall{name: name, args: args, extraEnv: extraEnv})
+		if name == "git" {
+			// Report a changed Go file on the working-tree diff seam so the
+			// Go-toolchain tier (guarded by goToolchainRelevantChange, #1292)
+			// runs for these Go-check tests. git status -z stays empty, so
+			// the unit-test tier still sees no changed *packages*.
+			if len(args) >= 2 && args[0] == "diff" && args[1] == "--name-only" {
+				return "pkg/foreman/agent/sample.go\n", nil
+			}
+			return "", nil
+		}
 		resp := responses[name]
 		return resp.output, resp.err
 	}
@@ -154,6 +164,9 @@ func TestRunCoderGateAutoAppliesGofmt(t *testing.T) {
 				return "", nil // after -w the tree is clean
 			}
 		}
+		if name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--name-only" {
+			return "pkg/foreman/agent/sample.go\n", nil // Go change: run the Go tier (#1292)
+		}
 		return "", nil // go vet/build/test and lint all pass
 	}
 	pass, feedback, _ := RunCoderGate(context.Background(), "/work", golangciPath, run, "", "main", nil)
@@ -172,6 +185,9 @@ func TestRunCoderGateGofmtUnfixableStillFails(t *testing.T) {
 	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
 		if name == "gofmt" && len(args) > 0 && args[0] == "-l" {
 			return "internal/broken/parse_error.go\n", nil // still listed after -w
+		}
+		if name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--name-only" {
+			return "pkg/foreman/agent/sample.go\n", nil // Go change: run the Go tier (#1292)
 		}
 		return "", nil
 	}
@@ -304,7 +320,12 @@ func TestRunCoderGate_FailsOnChangedPackageUnitTest(t *testing.T) {
 		switch {
 		case name == "gofmt":
 			return "", nil
+		case name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--name-only":
+			// working-tree diff seam (goToolchainRelevantChange, #1292):
+			// clean newline-separated paths, so the Go tier runs.
+			return "pkg/cli/cache_inspect_test.go\n", nil
 		case name == "git":
+			// git status -z: NUL-terminated porcelain for changedTestPackages.
 			return " M pkg/cli/cache_inspect_test.go\x00", nil
 		case name == "go" && len(args) > 0 && args[0] == "test":
 			out := "panic: runtime error: invalid memory address\n" +
@@ -340,6 +361,52 @@ func TestRunCoderGate_SkipsTestTierWhenNoChangedPackages(t *testing.T) {
 	}
 	if sawGoTest {
 		t.Error("test tier should not run go test when no packages changed")
+	}
+}
+
+// TestRunCoderGate_SkipsGoTierOnDocsOnlyDiff pins #1292: a diff that changes no
+// Go source must not run the Go-toolchain tier (gofmt, go vet, go build,
+// golangci-lint, the unit-test tier, codegen). A docs-only edit cannot fail any
+// of them, and running them can surface an agent-image toolchain error (a go.mod
+// version wall) the model is then asked to "fix and resubmit", burning fix
+// attempts on an unfixable premise. The diff-aware checks (reference grounding
+// etc.) still run.
+func TestRunCoderGate_SkipsGoTierOnDocsOnlyDiff(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	saw := map[string]bool{}
+	run := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--name-only":
+			return "docs/foreman-gate.md\n", nil // docs-only change
+		case name == "git":
+			return "", nil // add -A no-op; status -z empty; unified diff empty
+		case name == "gofmt":
+			saw["gofmt"] = true
+			// A go.mod version wall would make go vet/build/lint fail; model
+			// them as failing to prove the skip, not the pass, carries the gate.
+			return "", nil
+		case name == "go":
+			saw["go "+strings.Join(args, " ")] = true
+			return "go: go.mod requires go >= 1.26.5 (running go 1.26.4)", errors.New("exit status 1")
+		case name == golangciPath:
+			saw["lint"] = true
+			return "level=error msg=\"go.mod requires go >= 1.26.5\"", errors.New("exit status 3")
+		case name == "make":
+			saw["make"] = true
+			return "", errors.New("exit status 1")
+		default:
+			return "", nil
+		}
+	}
+
+	pass, fb, _ := RunCoderGate(context.Background(), "/work", golangciPath, run, "", "main", nil)
+	if !pass {
+		t.Fatalf("docs-only diff should pass the gate (Go tier skipped), got fail:\n%s", fb)
+	}
+	for _, forbidden := range []string{"gofmt", "go vet ./...", "go build ./...", "lint", "make"} {
+		if saw[forbidden] {
+			t.Errorf("%q ran on a docs-only diff; the Go tier must be skipped (#1292)", forbidden)
+		}
 	}
 }
 
@@ -399,6 +466,10 @@ func codegenFake(
 				return "Error: controller-gen: exit status 1\n", makeErr
 			}
 			return "", nil
+		case name == "git" && len(args) >= 2 && args[0] == "diff" && args[1] == "--name-only":
+			// working-tree diff seam (goToolchainRelevantChange, #1292): a
+			// changed Go file so the codegen tier (inside the Go guard) runs.
+			return "api/v1alpha1/types.go\n", nil
 		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "-z":
 			return "", nil // changedTestPackages: no changed packages
 		case name == "git" && len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain":


### PR DESCRIPTION
## What

The coder's in-loop self-gate ran the full Go toolchain (gofmt, go vet, go build, golangci-lint, the unit-test tier, codegen) on every diff, regardless of what changed. On task `local-emdash-code-1291` -- a one-character markdown edit -- the gate blocked the correct diff on `go build ./...`, which was itself failing on an agent-image toolchain wall (`go.mod requires go >= 1.26.5, running 1.26.4`). The model was told "fix the issues below and resubmit" three times and the run ended INCOMPLETE after 12 turns / 4 minutes of GPU on a task whose right answer was reached in the first two.

## Why

Fixes #1292

## How

Guard checks 1-6 (the Go-toolchain tier) behind a new `goToolchainRelevantChange` predicate. It reports whether the coder's working-tree diff touches any `.go` file (test or not) or a module file (`go.mod`/`go.sum`), using the same `git add -A` + `git diff --name-only --cached HEAD` basis the gate already uses elsewhere (the gate runs before any commit). A docs- or config-only diff skips the whole tier; the diff-aware checks below it (goreleaser, scope-overlap, test-presence, mutation, **reference grounding**) still run, so a docs-only change is still validated. This mirrors the diff-awareness the **verify** gate learned in #1072. The predicate is fail-safe: a git error runs the checks rather than skipping them.

`TestRunCoderGate_SkipsGoTierOnDocsOnlyDiff` proves a docs-only diff passes the gate while gofmt/vet/build/lint/make are never invoked (their fakes are wired to *fail* like the toolchain wall, so the skip -- not a spurious pass -- carries the gate). Bite-checked: removing the guard fails the new test. The existing gate fakes were updated to model the `git diff --name-only` seam distinctly from `git status -z`.

## Scope note

This fixes the reported docs-only incident. The issue's **second** problem -- distinguishing an environment failure from a code failure so a toolchain wall does not consume fix attempts even on a *Go-changing* diff -- is executor retry-classification work on a different surface and is intentionally out of scope here.

## AI-assisted (band 3)

Investigated, implemented, bite-checked, and opened by me.
