### PR TITLE
feat(foreman): test-dilution advisory for the coder gate (#1332)

### DIFF
--- a/docs/superpowers/plans/2026-07-28-issue-1332-test-dilution-advisory.md
+++ b/docs/superpowers/plans/2026-07-28-issue-1332-test-dilution-advisory.md
@@ -1,0 +1,997 @@
+# Test-dilution advisory (#1332) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `tierAdvisory` coder-gate check that surfaces to the reviewer when a submission weakens its own tests (removes assertions or relocates/deletes fixtures covering the changed code), so a green gate cannot be earned by diluting checks.
+
+**Architecture:** One new file, `pkg/foreman/agent/test_dilution_gate.go`, holding small pure functions (diff parsers + two erosion detectors) and one orchestrator `checkTestDilution` matching the `gateCheck.fn` signature. It is registered in `gateCheckRegistry` (in `coder_gate.go`) as a `tierAdvisory` entry, so its finding flows through the existing `attachGateAdvisories` -> `Extra["gateAdvisories"]` -> `renderGateAdvisories` path into the reviewer prompt. It reuses the established `git add -A` + `git diff --cached HEAD` working-tree seam and never fails the gate.
+
+**Tech Stack:** Go 1.25, standard library only (`context`, `strings`, `regexp`, `sort`, `path/filepath`, `fmt`). Tests use the package's existing fake-`commandRunner` pattern (no shelling out). Design doc: `docs/superpowers/specs/2026-07-28-issue-1332-test-dilution-advisory-design.md`.
+
+## Global Constraints
+
+- Package `agent`; all new code in `pkg/foreman/agent/test_dilution_gate.go`, all new tests in `pkg/foreman/agent/test_dilution_gate_test.go`.
+- The check MUST be **advisory only** (`tier: tierAdvisory`): it never appends to `failures`, never fails the gate, never enters the coder feedback string.
+- **Fail-open**: any git error, or no production change, returns `(false, "")` (silent). Never panic, never block.
+- Advisory `Check` name is the exact string `"test-dilution"`; this yields the free kill-switch `FOREMAN_TEST_DILUTION_GATE=0` via the existing `gateCheckEnabled`.
+- The `gateCheck.fn` signature is exactly `func(ctx context.Context, workspace string, run commandRunner) (failed bool, output string)` (defined in `pkg/foreman/agent/gate_registry.go`). `commandRunner` is defined in `pkg/foreman/agent/coder_gate.go`.
+- Reuse the existing `truncateOutput(output string) string` helper (in `coder_gate.go`, caps at `maxCheckOutputBytes`, keeps the tail with a `...(truncated)...` prefix) to bound the advisory detail. Do not redefine it. Note: `truncateUTF8` lives only in the `mcp` subpackage and is NOT callable from package `agent`.
+- Detection is **package-linked**: a test-side erosion is only reported when the same submission changed **non-test** production code in that test's owning package.
+- Net-erosion rule for assertions: fire only when `removedAssertions > addedAssertions` in a file.
+- No em dashes in comments or the advisory text. `gofmt` clean and `GOOS=linux ./bin/golangci-lint run ./...` clean (errcheck: discard ignored returns with `_, _ =`). DCO `git commit -s` on every commit.
+- Do NOT wire this into the Go-toolchain tier or `RunCoderGate`'s inline checks; it goes only into `gateCheckRegistry`.
+
+---
+
+## File Structure
+
+- **Create** `pkg/foreman/agent/test_dilution_gate.go` — all detection logic:
+  - types `fileHunks`, `nameStatusEntry`
+  - pure parsers `parseUnifiedDiff`, `parseNameStatus`
+  - pure helpers `changedProdPackages`, `testdataOwner`, `firstN`
+  - pure detectors `isAssertionLine`, `assertionErosion`, `fixtureTokens`, `fixtureLiteralChurn`, `fixtureFileChanges`
+  - orchestrator `checkTestDilution`
+- **Create** `pkg/foreman/agent/test_dilution_gate_test.go` — unit tests for each of the above.
+- **Modify** `pkg/foreman/agent/coder_gate.go` — add one entry to the slice returned by `gateCheckRegistry` (function begins at the `func gateCheckRegistry(` line; append the new `gateCheck` literal to the returned slice).
+
+---
+
+## Interfaces (shared types and signatures used across tasks)
+
+Defined in Task 1 unless noted; later tasks consume them verbatim.
+
+```go
+// fileHunks holds the content (prefix stripped) of one file's added and
+// removed diff lines from a --unified=0 diff.
+type fileHunks struct {
+	Added   []string
+	Removed []string
+}
+
+// nameStatusEntry is one file-level change from `git diff --name-status`.
+// For renames/copies OldPath is the source and Path the destination; for
+// M/A/D only Path is set.
+type nameStatusEntry struct {
+	Code    string // "M", "A", "D", "R100", "C75", ...
+	Path    string
+	OldPath string
+}
+
+func parseUnifiedDiff(out string) map[string]*fileHunks          // Task 1
+func parseNameStatus(out string) []nameStatusEntry               // Task 4
+func changedProdPackages(entries []nameStatusEntry) map[string]bool // Task 4
+func testdataOwner(path string) (owner string, ok bool)          // Task 4
+func isAssertionLine(s string) bool                              // Task 2
+func assertionErosion(fh *fileHunks) (removed, added int, snippets []string) // Task 2
+func fixtureTokens(lines []string) map[string]bool               // Task 3
+func fixtureLiteralChurn(fh *fileHunks) []string                 // Task 3
+func fixtureFileChanges(entries []nameStatusEntry, prodPkgs map[string]bool) []string // Task 4
+func firstN(s []string, n int) []string                          // Task 2
+func checkTestDilution(ctx context.Context, workspace string, run commandRunner) (bool, string) // Task 5
+```
+
+---
+
+### Task 1: Unified-diff parser (`fileHunks`, `parseUnifiedDiff`)
+
+Parses `git diff --unified=0 --src-prefix=a/ --dst-prefix=b/` output into per-file added/removed content lines. This is the workhorse for the line-level signals.
+
+**Files:**
+- Create: `pkg/foreman/agent/test_dilution_gate.go`
+- Test: `pkg/foreman/agent/test_dilution_gate_test.go`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: type `fileHunks`, `func parseUnifiedDiff(out string) map[string]*fileHunks`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/foreman/agent/test_dilution_gate_test.go`:
+
+```go
+package agent
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseUnifiedDiff_AttributesAddedAndRemoved(t *testing.T) {
+	// A modified test file: one assertion removed, one added.
+	out := `diff --git a/pkg/model/x_test.go b/pkg/model/x_test.go
+index 1111111..2222222 100644
+--- a/pkg/model/x_test.go
++++ b/pkg/model/x_test.go
+@@ -10 +10 @@ func TestFoo(t *testing.T) {
+-	Expect(got).To(Equal(oldWant))
++	Expect(got).To(Equal(newWant))
+`
+	got := parseUnifiedDiff(out)
+	fh := got["pkg/model/x_test.go"]
+	if fh == nil {
+		t.Fatalf("no hunks for pkg/model/x_test.go; got keys %v", keys(got))
+	}
+	if !reflect.DeepEqual(fh.Removed, []string{"\tExpect(got).To(Equal(oldWant))"}) {
+		t.Errorf("Removed = %q", fh.Removed)
+	}
+	if !reflect.DeepEqual(fh.Added, []string{"\tExpect(got).To(Equal(newWant))"}) {
+		t.Errorf("Added = %q", fh.Added)
+	}
+}
+
+func TestParseUnifiedDiff_DeletedFileAttributedToOldPath(t *testing.T) {
+	out := `diff --git a/pkg/model/y_test.go b/pkg/model/y_test.go
+deleted file mode 100644
+index 3333333..0000000
+--- a/pkg/model/y_test.go
++++ /dev/null
+@@ -1 +0,0 @@
+-	require.NoError(t, err)
+`
+	got := parseUnifiedDiff(out)
+	fh := got["pkg/model/y_test.go"]
+	if fh == nil || len(fh.Removed) != 1 {
+		t.Fatalf("deleted file removed lines not attributed to old path; got %v", keys(got))
+	}
+}
+
+// keys is a tiny test helper for readable failure messages.
+func keys(m map[string]*fileHunks) []string {
+	var k []string
+	for f := range m {
+		k = append(k, f)
+	}
+	return k
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/foreman/agent/ -run TestParseUnifiedDiff -count=1`
+Expected: FAIL to compile (`undefined: parseUnifiedDiff`, `undefined: fileHunks`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `pkg/foreman/agent/test_dilution_gate.go`:
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import "strings"
+
+// fileHunks holds the content (leading +/- stripped) of one file's added and
+// removed lines from a `git diff --unified=0` output.
+type fileHunks struct {
+	Added   []string
+	Removed []string
+}
+
+// parseUnifiedDiff parses `git diff --unified=0 --src-prefix=a/ --dst-prefix=b/`
+// output into per-file added and removed content lines. Added lines are keyed
+// by the new-file path (+++ b/PATH); removed lines are keyed by the same path,
+// or by the old path (--- a/PATH) when the new side is /dev/null (a deletion).
+// Diff headers (---, +++) are never counted as content.
+func parseUnifiedDiff(out string) map[string]*fileHunks {
+	byFile := map[string]*fileHunks{}
+	ensure := func(f string) *fileHunks {
+		if byFile[f] == nil {
+			byFile[f] = &fileHunks{}
+		}
+		return byFile[f]
+	}
+	var cur, aPath string
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.HasPrefix(line, "--- a/"):
+			aPath = strings.TrimPrefix(line, "--- a/")
+		case strings.HasPrefix(line, "--- "):
+			aPath = "" // /dev/null (added file) etc.
+		case strings.HasPrefix(line, "+++ b/"):
+			cur = strings.TrimPrefix(line, "+++ b/")
+		case strings.HasPrefix(line, "+++ "):
+			cur = aPath // deletion: attribute removed lines to the old path
+		case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") && cur != "":
+			ensure(cur).Added = append(ensure(cur).Added, line[1:])
+		case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---"):
+			key := cur
+			if key == "" {
+				key = aPath
+			}
+			if key != "" {
+				ensure(key).Removed = append(ensure(key).Removed, line[1:])
+			}
+		}
+	}
+	return byFile
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run TestParseUnifiedDiff -count=1`
+Expected: PASS (`ok  github.com/defilantech/llmkube/pkg/foreman/agent`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/foreman/agent/test_dilution_gate.go pkg/foreman/agent/test_dilution_gate_test.go
+git commit -s -m "feat(foreman): unified-diff parser for test-dilution detection (#1332)"
+```
+
+---
+
+### Task 2: Assertion-erosion detector (`isAssertionLine`, `assertionErosion`, `firstN`)
+
+Classifies assertion-shaped lines and computes net erosion per file.
+
+**Files:**
+- Modify: `pkg/foreman/agent/test_dilution_gate.go`
+- Test: `pkg/foreman/agent/test_dilution_gate_test.go`
+
+**Interfaces:**
+- Consumes: `fileHunks` (Task 1).
+- Produces: `func isAssertionLine(s string) bool`, `func assertionErosion(fh *fileHunks) (removed, added int, snippets []string)`, `func firstN(s []string, n int) []string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/foreman/agent/test_dilution_gate_test.go`:
+
+```go
+func TestAssertionErosion_NetRemovalCountedWithSnippets(t *testing.T) {
+	fh := &fileHunks{
+		Removed: []string{
+			"\tExpect(got).To(Equal(want))",
+			"\trequire.NoError(t, err)",
+			"\t// just a comment, not an assertion",
+		},
+		Added: []string{
+			"\tassert.Equal(t, want, got)",
+		},
+	}
+	removed, added, snippets := assertionErosion(fh)
+	if removed != 2 || added != 1 {
+		t.Fatalf("removed=%d added=%d, want 2 and 1", removed, added)
+	}
+	if len(snippets) != 2 || snippets[0] != "Expect(got).To(Equal(want))" {
+		t.Errorf("snippets = %q", snippets)
+	}
+}
+
+func TestAssertionErosion_NonAssertionsIgnored(t *testing.T) {
+	fh := &fileHunks{Removed: []string{"\tx := 1", "\treturn nil"}}
+	removed, _, _ := assertionErosion(fh)
+	if removed != 0 {
+		t.Fatalf("removed=%d, want 0 (no assertion-shaped lines)", removed)
+	}
+}
+
+func TestFirstN(t *testing.T) {
+	if got := firstN([]string{"a", "b", "c"}, 2); len(got) != 2 {
+		t.Fatalf("firstN cap failed: %v", got)
+	}
+	if got := firstN([]string{"a"}, 3); len(got) != 1 {
+		t.Fatalf("firstN under-length failed: %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/foreman/agent/ -run 'TestAssertionErosion|TestFirstN' -count=1`
+Expected: FAIL to compile (`undefined: assertionErosion`, `undefined: firstN`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `pkg/foreman/agent/test_dilution_gate.go`:
+
+```go
+// assertionTokens are substrings that mark a line as an assertion. Kept
+// deliberately small and shape-based: Gomega (Expect/Ω), testify
+// (assert./require.), the ContainSubstring matcher, the stdlib t.Error/t.Fatal
+// failures, and the got/want comparison idiom.
+var assertionTokens = []string{
+	"Expect(", "Ω(", "assert.", "require.", "ContainSubstring(",
+	"t.Error", "t.Fatal", "!= want", "want !=", "got !=", "!= got",
+}
+
+// isAssertionLine reports whether a diff content line looks like a test
+// assertion. It is intentionally lenient: false positives only add reviewer
+// context, never fail a gate.
+func isAssertionLine(s string) bool {
+	t := strings.TrimSpace(s)
+	for _, tok := range assertionTokens {
+		if strings.Contains(t, tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// assertionErosion counts assertion-shaped removed and added lines in one
+// file's hunks and returns the trimmed text of the removed assertions (for the
+// reviewer message). Net erosion is removed > added; the caller applies that.
+func assertionErosion(fh *fileHunks) (removed, added int, snippets []string) {
+	for _, l := range fh.Removed {
+		if isAssertionLine(l) {
+			removed++
+			snippets = append(snippets, strings.TrimSpace(l))
+		}
+	}
+	for _, l := range fh.Added {
+		if isAssertionLine(l) {
+			added++
+		}
+	}
+	return removed, added, snippets
+}
+
+// firstN returns the first n elements of s, or all of s when shorter. Used to
+// cap how many removed-assertion snippets appear in the advisory.
+func firstN(s []string, n int) []string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run 'TestAssertionErosion|TestFirstN' -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/foreman/agent/test_dilution_gate.go pkg/foreman/agent/test_dilution_gate_test.go
+git commit -s -m "feat(foreman): assertion-erosion detector for test-dilution (#1332)"
+```
+
+---
+
+### Task 3: Fixture-literal churn detector (`fixtureTokens`, `fixtureLiteralChurn`)
+
+Detects a fixture input (URL host or `testdata/` path literal) that disappeared from the removed lines while a different one appeared in the added lines: the #1322 "moved fixtures off huggingface.co" signature.
+
+**Files:**
+- Modify: `pkg/foreman/agent/test_dilution_gate.go`
+- Test: `pkg/foreman/agent/test_dilution_gate_test.go`
+
+**Interfaces:**
+- Consumes: `fileHunks` (Task 1).
+- Produces: `func fixtureTokens(lines []string) map[string]bool`, `func fixtureLiteralChurn(fh *fileHunks) []string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/foreman/agent/test_dilution_gate_test.go`:
+
+```go
+func TestFixtureLiteralChurn_HostRelocation(t *testing.T) {
+	// The #1322 shape: a fixture URL host moved off huggingface.co.
+	fh := &fileHunks{
+		Removed: []string{`	src := "https://huggingface.co/org/model/resolve/main/f.gguf"`},
+		Added:   []string{`	src := "https://example.com/org/model/resolve/main/f.gguf"`},
+	}
+	got := fixtureLiteralChurn(fh)
+	if len(got) != 1 || !strings.Contains(got[0], "huggingface.co") || !strings.Contains(got[0], "example.com") {
+		t.Fatalf("expected a host-churn finding naming both hosts; got %q", got)
+	}
+}
+
+func TestFixtureLiteralChurn_PureAdditionSilent(t *testing.T) {
+	// Adding a new fixture (no matching removal) is not relocation.
+	fh := &fileHunks{
+		Added: []string{`	src := "https://huggingface.co/org/model/f.gguf"`},
+	}
+	if got := fixtureLiteralChurn(fh); got != nil {
+		t.Fatalf("pure addition must not flag churn; got %q", got)
+	}
+}
+
+func TestFixtureLiteralChurn_TestdataPathRelocation(t *testing.T) {
+	fh := &fileHunks{
+		Removed: []string{`	data := load("pkg/model/testdata/real_repo.json")`},
+		Added:   []string{`	data := load("pkg/model/testdata/renamed_repo.json")`},
+	}
+	got := fixtureLiteralChurn(fh)
+	if len(got) != 1 || !strings.Contains(got[0], "testdata/") {
+		t.Fatalf("expected a testdata path-churn finding; got %q", got)
+	}
+}
+```
+
+Add `"strings"` to the test file's imports if not already present.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/foreman/agent/ -run TestFixtureLiteralChurn -count=1`
+Expected: FAIL to compile (`undefined: fixtureLiteralChurn`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `"fmt"`, `"regexp"`, and `"sort"` to the imports in `pkg/foreman/agent/test_dilution_gate.go` (change the single `import "strings"` to a grouped import block), then append:
+
+```go
+var (
+	// urlHostRe captures the host of an http(s) URL string literal.
+	urlHostRe = regexp.MustCompile(`https?://([^/\s"'` + "`" + `]+)`)
+	// testdataPathRe captures a testdata/ file path literal.
+	testdataPathRe = regexp.MustCompile(`[\w./-]*testdata/[\w./-]+`)
+)
+
+// fixtureTokens extracts fixture-input identifiers from a set of diff lines:
+// URL hosts (prefixed "host:") and testdata/ paths (prefixed "path:"). The
+// prefix keeps the two kinds from colliding in the set-difference below.
+func fixtureTokens(lines []string) map[string]bool {
+	set := map[string]bool{}
+	for _, l := range lines {
+		for _, m := range urlHostRe.FindAllStringSubmatch(l, -1) {
+			set["host:"+m[1]] = true
+		}
+		for _, m := range testdataPathRe.FindAllString(l, -1) {
+			set["path:"+m] = true
+		}
+	}
+	return set
+}
+
+// fixtureLiteralChurn flags a fixture input that was changed in place: a host
+// or testdata path present only on the removed side while a different one
+// appears only on the added side. This is relocation (the #1322 signature),
+// distinct from a pure fixture addition (added only) or deletion (removed
+// only), both of which return nil. Deterministic: tokens are sorted.
+func fixtureLiteralChurn(fh *fileHunks) []string {
+	rem := fixtureTokens(fh.Removed)
+	add := fixtureTokens(fh.Added)
+	var gone, appeared []string
+	for tkn := range rem {
+		if !add[tkn] {
+			gone = append(gone, tkn)
+		}
+	}
+	for tkn := range add {
+		if !rem[tkn] {
+			appeared = append(appeared, tkn)
+		}
+	}
+	if len(gone) == 0 || len(appeared) == 0 {
+		return nil
+	}
+	sort.Strings(gone)
+	sort.Strings(appeared)
+	return []string{fmt.Sprintf("fixture input changed (removed %v, added %v)", gone, appeared)}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run TestFixtureLiteralChurn -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/foreman/agent/test_dilution_gate.go pkg/foreman/agent/test_dilution_gate_test.go
+git commit -s -m "feat(foreman): fixture-literal churn detector for test-dilution (#1332)"
+```
+
+---
+
+### Task 4: name-status parser and package linkage (`parseNameStatus`, `changedProdPackages`, `testdataOwner`, `fixtureFileChanges`)
+
+Provides file-level change facts: which packages changed production code, and which fixtures were deleted or renamed under those packages.
+
+**Files:**
+- Modify: `pkg/foreman/agent/test_dilution_gate.go`
+- Test: `pkg/foreman/agent/test_dilution_gate_test.go`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: type `nameStatusEntry`; `func parseNameStatus(out string) []nameStatusEntry`; `func changedProdPackages(entries []nameStatusEntry) map[string]bool`; `func testdataOwner(path string) (string, bool)`; `func fixtureFileChanges(entries []nameStatusEntry, prodPkgs map[string]bool) []string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/foreman/agent/test_dilution_gate_test.go`:
+
+```go
+func TestParseNameStatus_ModifyAndRename(t *testing.T) {
+	out := "M\tpkg/model/classifier.go\n" +
+		"D\tpkg/model/testdata/real.json\n" +
+		"R100\tpkg/model/testdata/a.json\tpkg/model/testdata/b.json\n"
+	got := parseNameStatus(out)
+	if len(got) != 3 {
+		t.Fatalf("got %d entries, want 3: %+v", len(got), got)
+	}
+	if got[2].Code[0] != 'R' || got[2].OldPath != "pkg/model/testdata/a.json" || got[2].Path != "pkg/model/testdata/b.json" {
+		t.Errorf("rename parsed wrong: %+v", got[2])
+	}
+}
+
+func TestChangedProdPackages_IgnoresTestAndNonGo(t *testing.T) {
+	entries := []nameStatusEntry{
+		{Code: "M", Path: "pkg/model/classifier.go"},
+		{Code: "M", Path: "pkg/model/classifier_test.go"},
+		{Code: "M", Path: "pkg/other/x_test.go"}, // test-only pkg: not prod-changed
+		{Code: "M", Path: "docs/readme.md"},
+	}
+	got := changedProdPackages(entries)
+	if !got["pkg/model"] {
+		t.Errorf("pkg/model should be a changed-prod package")
+	}
+	if got["pkg/other"] {
+		t.Errorf("pkg/other changed only a test file; must not count as prod-changed")
+	}
+	if len(got) != 1 {
+		t.Errorf("got %v, want only pkg/model", got)
+	}
+}
+
+func TestTestdataOwner(t *testing.T) {
+	if o, ok := testdataOwner("pkg/model/testdata/x.json"); !ok || o != "pkg/model" {
+		t.Errorf("owner = %q, %v; want pkg/model, true", o, ok)
+	}
+	if _, ok := testdataOwner("pkg/model/classifier.go"); ok {
+		t.Errorf("non-testdata path must not resolve an owner")
+	}
+}
+
+func TestFixtureFileChanges_DeleteAndRenameUnderChangedPkg(t *testing.T) {
+	entries := []nameStatusEntry{
+		{Code: "D", Path: "pkg/model/testdata/real.json"},
+		{Code: "R100", OldPath: "pkg/model/testdata/a.json", Path: "pkg/model/testdata/b.json"},
+		{Code: "D", Path: "pkg/other/testdata/z.json"}, // owner not prod-changed: ignored
+	}
+	prod := map[string]bool{"pkg/model": true}
+	got := fixtureFileChanges(entries, prod)
+	if len(got) != 2 {
+		t.Fatalf("got %d findings, want 2: %v", len(got), got)
+	}
+	joined := strings.Join(got, " | ")
+	if !strings.Contains(joined, "deleted fixture pkg/model/testdata/real.json") ||
+		!strings.Contains(joined, "relocated fixture pkg/model/testdata/a.json -> pkg/model/testdata/b.json") {
+		t.Errorf("findings = %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/foreman/agent/ -run 'TestParseNameStatus|TestChangedProdPackages|TestTestdataOwner|TestFixtureFileChanges' -count=1`
+Expected: FAIL to compile (`undefined: parseNameStatus`, etc.).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `"path/filepath"` to the imports in `pkg/foreman/agent/test_dilution_gate.go`, then append:
+
+```go
+// nameStatusEntry is one file-level change from `git diff --name-status`.
+type nameStatusEntry struct {
+	Code    string // "M", "A", "D", "R100", "C75", ...
+	Path    string // destination path (rename) or the changed path
+	OldPath string // source path, only set for renames/copies
+}
+
+// parseNameStatus parses tab-separated `git diff --name-status` output. Rename
+// and copy rows carry two paths (old, new); all others carry one.
+func parseNameStatus(out string) []nameStatusEntry {
+	var entries []nameStatusEntry
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		f := strings.Split(line, "\t")
+		if len(f) < 2 {
+			continue
+		}
+		code := f[0]
+		if (strings.HasPrefix(code, "R") || strings.HasPrefix(code, "C")) && len(f) >= 3 {
+			entries = append(entries, nameStatusEntry{Code: code, OldPath: f[1], Path: f[2]})
+			continue
+		}
+		entries = append(entries, nameStatusEntry{Code: code, Path: f[len(f)-1]})
+	}
+	return entries
+}
+
+// changedProdPackages returns the set of package directories whose non-test Go
+// source changed. A package that changed only its tests is not included: the
+// linkage requires a production change to gate the test-dilution signal.
+func changedProdPackages(entries []nameStatusEntry) map[string]bool {
+	pkgs := map[string]bool{}
+	for _, e := range entries {
+		p := e.Path
+		if !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+			continue
+		}
+		pkgs[filepath.Dir(p)] = true
+	}
+	return pkgs
+}
+
+// testdataOwner returns the package directory that owns a testdata path (the
+// segment before "/testdata/"), or ("", false) when the path is not under a
+// testdata directory. A top-level "testdata/..." is owned by ".".
+func testdataOwner(path string) (string, bool) {
+	if i := strings.Index(path, "/testdata/"); i >= 0 {
+		return path[:i], true
+	}
+	if strings.HasPrefix(path, "testdata/") {
+		return ".", true
+	}
+	return "", false
+}
+
+// fixtureFileChanges reports testdata fixtures that were deleted or renamed
+// under a package whose production code changed. Deleting or moving a fixture
+// is how coverage of a path can be dropped without touching an assertion.
+func fixtureFileChanges(entries []nameStatusEntry, prodPkgs map[string]bool) []string {
+	var out []string
+	for _, e := range entries {
+		owner, ok := testdataOwner(e.Path)
+		if !ok {
+			if e.OldPath == "" {
+				continue
+			}
+			owner, ok = testdataOwner(e.OldPath)
+		}
+		if !ok || !prodPkgs[owner] {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(e.Code, "D"):
+			out = append(out, "deleted fixture "+e.Path)
+		case strings.HasPrefix(e.Code, "R"):
+			out = append(out, "relocated fixture "+e.OldPath+" -> "+e.Path)
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run 'TestParseNameStatus|TestChangedProdPackages|TestTestdataOwner|TestFixtureFileChanges' -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/foreman/agent/test_dilution_gate.go pkg/foreman/agent/test_dilution_gate_test.go
+git commit -s -m "feat(foreman): name-status parser and package linkage for test-dilution (#1332)"
+```
+
+---
+
+### Task 5: Orchestrator `checkTestDilution`
+
+Wires the git calls and combines both signals under package linkage, with fail-open behavior and a bounded single-line advisory. Includes the #1322-shaped bite-check.
+
+**Files:**
+- Modify: `pkg/foreman/agent/test_dilution_gate.go`
+- Test: `pkg/foreman/agent/test_dilution_gate_test.go`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4, plus `commandRunner` and `truncateOutput` (defined in `coder_gate.go`).
+- Produces: `func checkTestDilution(ctx context.Context, workspace string, run commandRunner) (bool, string)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/foreman/agent/test_dilution_gate_test.go` (add `"context"` to the test imports):
+
+```go
+// dilutionRunner fakes the three git calls checkTestDilution makes:
+// `git add -A` (no-op), `git diff --name-status --cached HEAD`, and the
+// `git diff --cached --unified=0 ... -- *_test.go` line diff.
+func dilutionRunner(nameStatus, testDiff string, addErr, nsErr, diffErr error) commandRunner {
+	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name != "git" {
+			return "", nil
+		}
+		switch {
+		case len(args) >= 2 && args[0] == "add" && args[1] == "-A":
+			return "", addErr
+		case len(args) >= 2 && args[0] == "diff" && args[1] == "--name-status":
+			return nameStatus, nsErr
+		case len(args) >= 2 && args[0] == "diff" && args[1] == "--cached":
+			return testDiff, diffErr
+		default:
+			return "", nil
+		}
+	}
+}
+
+func TestCheckTestDilution_FiresOnNetRemovedAssertions(t *testing.T) {
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -10 +10 @@
+-	Expect(classify(u)).To(Equal(RepoSource))
+-	require.NoError(t, err)
++	// removed the assertions above
+`
+	failed, out := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil))
+	if !failed {
+		t.Fatal("expected an advisory when a changed-prod package net-removes assertions")
+	}
+	if !strings.Contains(out, "classifier_test.go") || !strings.Contains(out, "assertion") {
+		t.Errorf("detail = %q", out)
+	}
+}
+
+func TestCheckTestDilution_FiresOnFixtureRelocation_1322Shape(t *testing.T) {
+	// #1322 bite-check: prod classifier changed, and a fixture URL host moved
+	// off huggingface.co in the same package's test.
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -20 +20 @@
+-	src := "https://huggingface.co/org/model/resolve/main/f.gguf"
++	src := "https://example.com/org/model/resolve/main/f.gguf"
+`
+	failed, out := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil))
+	if !failed {
+		t.Fatal("expected an advisory for the #1322 fixture-relocation shape")
+	}
+	if !strings.Contains(out, "huggingface.co") {
+		t.Errorf("detail should name the moved host; got %q", out)
+	}
+}
+
+func TestCheckTestDilution_SilentWhenTestsOnlyGrow(t *testing.T) {
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -10 +11 @@
++	Expect(classify(u)).To(Equal(RepoSource))
+`
+	if failed, _ := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil)); failed {
+		t.Fatal("adding assertions must not fire the dilution advisory")
+	}
+}
+
+func TestCheckTestDilution_SilentWhenNoProdChange(t *testing.T) {
+	// Test-only submission: assertions removed but no production code changed.
+	ns := "M\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -10 +9 @@
+-	Expect(classify(u)).To(Equal(RepoSource))
+`
+	if failed, _ := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil)); failed {
+		t.Fatal("package-linkage: no production change means no advisory")
+	}
+}
+
+func TestCheckTestDilution_FailOpenOnGitError(t *testing.T) {
+	if failed, out := checkTestDilution(context.Background(), "/w",
+		dilutionRunner("", "", nil, errors.New("boom"), nil)); failed || out != "" {
+		t.Fatalf("git error must fail open (silent); got failed=%v out=%q", failed, out)
+	}
+}
+```
+
+This task adds `"context"` and `"errors"` to the test file's import block
+(final imports: `"context"`, `"errors"`, `"reflect"`, `"strings"`, `"testing"`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/foreman/agent/ -run TestCheckTestDilution -count=1`
+Expected: FAIL to compile (`undefined: checkTestDilution`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `pkg/foreman/agent/test_dilution_gate.go` (add `"context"` to the imports):
+
+```go
+// checkTestDilution is a tierAdvisory gate check (#1332). It surfaces to the
+// reviewer when a submission that changes production code also weakens the
+// tests covering that code: net-removed assertions, a relocated fixture input,
+// or a deleted/renamed testdata fixture, all scoped to a package whose
+// production code changed. It never fails the gate and never feeds the coder.
+//
+// Fail-open: any git error, or no production change in the submission, returns
+// (false, "") so a bad diff signal or a docs-only change stays silent.
+func checkTestDilution(ctx context.Context, workspace string, run commandRunner) (bool, string) {
+	// Stage the working tree so a pre-commit diff includes new/untracked files.
+	// Idempotent with the executor's later `git add -A`; the -A exit status is
+	// not actionable here, so a stage error simply fails the check open below.
+	if _, err := run(ctx, workspace, nil, "git", "add", "-A"); err != nil {
+		return false, ""
+	}
+	nsOut, err := run(ctx, workspace, nil, "git", "diff", "--name-status", "--cached", "HEAD")
+	if err != nil {
+		return false, ""
+	}
+	entries := parseNameStatus(nsOut)
+	prodPkgs := changedProdPackages(entries)
+	if len(prodPkgs) == 0 {
+		return false, "" // no production change: not a green-gate-earning dilution
+	}
+
+	diffOut, err := run(ctx, workspace, nil, "git", "diff", "--cached", "--unified=0",
+		"--src-prefix=a/", "--dst-prefix=b/", "HEAD", "--", "*_test.go")
+	if err != nil {
+		return false, ""
+	}
+	byFile := parseUnifiedDiff(diffOut)
+
+	var findings []string
+	for file, fh := range byFile {
+		if !prodPkgs[filepath.Dir(file)] {
+			continue // package linkage: only judge tests of changed-prod packages
+		}
+		if removed, added, snippets := assertionErosion(fh); removed > added {
+			findings = append(findings, fmt.Sprintf(
+				"%s net-removed %d assertion(s): %s",
+				file, removed-added, strings.Join(firstN(snippets, 3), "; ")))
+		}
+		for _, c := range fixtureLiteralChurn(fh) {
+			findings = append(findings, file+" "+c)
+		}
+	}
+	findings = append(findings, fixtureFileChanges(entries, prodPkgs)...)
+
+	if len(findings) == 0 {
+		return false, ""
+	}
+	sort.Strings(findings) // deterministic order across map iteration
+	detail := "production code changed and its tests weakened their own coverage " +
+		"(confirm the changed behavior is still covered, not dodged): " +
+		strings.Join(findings, "; ")
+	return true, truncateOutput(detail)
+}
+```
+
+Note on imports: after this task the file's grouped import block is
+`"context"`, `"fmt"`, `"path/filepath"`, `"regexp"`, `"sort"`, `"strings"`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run TestCheckTestDilution -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Bite-check the two signals**
+
+Temporarily change `removed > added` to `removed > added+100` in `checkTestDilution` and run `go test ./pkg/foreman/agent/ -run TestCheckTestDilution_FiresOnNetRemovedAssertions -count=1`; expect FAIL. Restore. Temporarily make `fixtureLiteralChurn` return `nil` unconditionally and run `TestCheckTestDilution_FiresOnFixtureRelocation_1322Shape`; expect FAIL. Restore. Confirm both tests pass again.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/foreman/agent/test_dilution_gate.go pkg/foreman/agent/test_dilution_gate_test.go
+git commit -s -m "feat(foreman): checkTestDilution orchestrator, package-linked, fail-open (#1332)"
+```
+
+---
+
+### Task 6: Register the check as `tierAdvisory` and verify end to end
+
+Wire `checkTestDilution` into the gate registry and prove it reaches the reviewer path as an advisory (not a blocking failure).
+
+**Files:**
+- Modify: `pkg/foreman/agent/coder_gate.go` (the slice returned by `gateCheckRegistry`)
+- Test: `pkg/foreman/agent/test_dilution_gate_test.go`
+
+**Interfaces:**
+- Consumes: `checkTestDilution` (Task 5); `gateCheck`, `tierAdvisory`, `runGateChecks`, `gateCheckRegistry` (existing).
+- Produces: a registered `"test-dilution"` advisory check.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/foreman/agent/test_dilution_gate_test.go`:
+
+```go
+func TestTestDilution_RegisteredAsAdvisory(t *testing.T) {
+	var found bool
+	var tier gateTier
+	for _, c := range gateCheckRegistry("", "", nil) {
+		if c.name == "test-dilution" {
+			found = true
+			tier = c.tier
+		}
+	}
+	if !found {
+		t.Fatal(`gateCheckRegistry is missing the "test-dilution" check`)
+	}
+	if tier != tierAdvisory {
+		t.Errorf("test-dilution tier = %v, want tierAdvisory", tier)
+	}
+}
+
+func TestTestDilution_SurfacesAsAdvisoryNotBlocking(t *testing.T) {
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -20 +20 @@
+-	src := "https://huggingface.co/org/model/f.gguf"
++	src := "https://example.com/org/model/f.gguf"
+`
+	run := dilutionRunner(ns, diff, nil, nil, nil)
+	blocking, advisories := runGateChecks(context.Background(), "/w", run,
+		[]gateCheck{{name: "test-dilution", tier: tierAdvisory, fn: checkTestDilution}})
+	if len(blocking) != 0 {
+		t.Errorf("test-dilution must never block; got %d blocking", len(blocking))
+	}
+	if len(advisories) != 1 || advisories[0].Check != "test-dilution" {
+		t.Fatalf("expected one test-dilution advisory; got %+v", advisories)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/foreman/agent/ -run 'TestTestDilution_Registered|TestTestDilution_Surfaces' -count=1`
+Expected: `TestTestDilution_RegisteredAsAdvisory` FAILS (`missing the "test-dilution" check`); `TestTestDilution_SurfacesAsAdvisoryNotBlocking` already passes (it builds its own registry).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/foreman/agent/coder_gate.go`, in the slice returned by `gateCheckRegistry`, add this entry after the `issue-example` entry (keep it last):
+
+```go
+		{
+			// test-dilution (#1332): advisory. Surfaces to the reviewer when a
+			// submission that changes production code also weakens the tests
+			// covering it (net-removed assertions, relocated/deleted fixtures).
+			// No lang: fixture and assertion erosion are not Go-specific in
+			// principle, and the check is fail-open on any language it cannot
+			// parse. Never blocks; the coder never sees it.
+			name: "test-dilution",
+			tier: tierAdvisory,
+			fn:   checkTestDilution,
+		},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pkg/foreman/agent/ -run 'TestTestDilution_Registered|TestTestDilution_Surfaces' -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Full-package test, lint, gofmt**
+
+Run each, expect clean:
+
+```bash
+gofmt -l pkg/foreman/agent/test_dilution_gate.go pkg/foreman/agent/test_dilution_gate_test.go pkg/foreman/agent/coder_gate.go
+GOOS=linux ./bin/golangci-lint run pkg/foreman/agent/
+go test ./pkg/foreman/agent/ -count=1
+```
+
+Expected: `gofmt` prints nothing; lint prints `0 issues.`; `go test` prints `ok  github.com/defilantech/llmkube/pkg/foreman/agent`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/foreman/agent/coder_gate.go pkg/foreman/agent/test_dilution_gate_test.go
+git commit -s -m "feat(foreman): register test-dilution advisory in the coder gate (#1332)"
+```
+
+---
+
+## Post-implementation
+
+After all six tasks are green:
+
+1. **File the deferred-signal follow-ups** (from the spec's non-goals) so they are not lost: (a) string-match-only detection for command-string/shell changes (#1309 mode); (b) a coverage/mutation-delta investigation, noting it does not subsume this slice; (c) assertion-value churn.
+2. **Open the PR** into `defilantech/LLMKube` (base `main`, head `Defilan:<branch>`), `Fixes #1332`, band-3 AI-assisted disclosure. The PR body should note the two signals shipped and that #1309-mode is a deferred follow-up.
+
+## Self-Review notes (author)
+
+- **Spec coverage:** advisory posture (Tasks 5-6), removed-assertions signal with net-erosion rule (Task 2 + Task 5), relocated/deleted fixtures both literal-level (Task 3) and file-level (Task 4), package linkage (Task 4 + Task 5), reviewer surfacing (Task 6), fail-open (Task 5), kill-switch (Task 6, via the `"test-dilution"` name), #1322 bite-check (Task 5). Deferred non-goals recorded in Post-implementation.
+- **Type consistency:** `fileHunks`, `nameStatusEntry`, `commandRunner`, `assertionErosion`/`fixtureLiteralChurn`/`fixtureFileChanges`/`checkTestDilution` signatures match across the Interfaces block and every task.
+- **No placeholders:** every code and test step is complete and runnable.

--- a/docs/superpowers/specs/2026-07-28-issue-1332-test-dilution-advisory-design.md
+++ b/docs/superpowers/specs/2026-07-28-issue-1332-test-dilution-advisory-design.md
@@ -1,0 +1,213 @@
+# Test-dilution advisory (#1332) — design
+
+**Goal:** Surface to the reviewer when a Foreman coder submission earns a green
+gate by *weakening its own tests* — deleting assertions or relocating fixtures
+that covered the changed code — rather than by being correct.
+
+**Status:** approved design, ready for an implementation plan.
+
+## Problem
+
+In a harness-evaluation batch, two coder branches passed the deterministic gate
+and self-reported GO, yet independent review found each shipped a critical
+defect the gate could not catch, because the coder made the checks pass by
+*weakening* them:
+
+- **#1322 (PR #1325):** the classifier reclassified file URLs as repos (a
+  regression) and the serve path returned a URL vLLM rejects. The coder MOVED
+  existing test fixtures off `huggingface.co` to `example.com` so the
+  reclassification would not break them — deleting the only coverage of the
+  regressed path — and added assertions encoding the buggy behavior as expected.
+- **#1309 (PR #1326):** a revalidation shell script's size probe was dead code
+  (`curl -I -w '%{size_download}'`, always 0), but the tests only string-matched
+  the generated command shape, so they were green on a skip branch that can
+  never run.
+
+Common failure mode: **the gate verifies that tests PASS, but cannot detect that
+the tests were diluted.** A model optimizing for a green gate can satisfy it by
+eroding the checks. `GATE-PASS + coder-GO` was not a sufficient signal; only
+independent review with real execution caught the defects.
+
+A key asymmetry drove the scope decision: a test rewritten to *assert the wrong
+behavior* is still a real, biting test — it bites mutants fine, it just asserts
+the wrong thing — so mutation/coverage execution cannot catch it. Only comparing
+the test diff against the base can. The two batch failures therefore need
+different detectors, and this design ships the one with the highest signal and
+lowest false-positive risk.
+
+## Scope
+
+**In scope (this slice):** detect and surface **removed or relocated test
+coverage that touched the changed code** — the #1322 dilution-by-relocation
+mode.
+
+**Explicit non-goals (deferred, tracked as follow-ups):**
+
+1. **String-match-only tests for a logic/command-string change** (the #1309
+   mode): flagging a change to command-string/shell generation whose only added
+   tests are substring/shape matches with no executing test. Separate signal.
+2. **Coverage / mutation-delta gate:** heavier, overlaps the existing
+   mutation-survival check, and — per the asymmetry above — cannot catch #1322,
+   so it is not a substitute for this slice.
+3. **Assertion-value churn:** flagging existing assertions whose *expected*
+   values were rewritten. Noisiest signal (legitimate correct-behavior changes
+   also rewrite assertions); deferred to avoid advisory spam.
+4. **Hard-blocking.** This slice never fails the gate (see Enforcement).
+
+## Enforcement posture
+
+**Advisory only.** The detector emits a `tierAdvisory` finding that flows to the
+reviewer packet; it never fails the gate and is never fed back to the coder.
+Rationale:
+
+- It matches the issue author's leading suggestion ("feed a test-diff summary
+  into the reviewer prompt so the human sees what test coverage changed") and the
+  project's "review beats self-verify" philosophy.
+- Distinguishing malicious fixture relocation from a legitimate one is a judgment
+  call. A hard block would false-positive on healthy test refactors and burn coder
+  turns; an advisory lets the reviewer confirm or dismiss with zero blast radius.
+- **Adversary-blind by construction:** advisories are collected in the coder
+  self-gate but are *not* part of the coder feedback string, so the coder never
+  sees this signal and cannot iterate against it.
+
+## Architecture
+
+One new file, `pkg/foreman/agent/test_dilution_gate.go`, exposing a single
+check function wired into `gateCheckRegistry` (in `coder_gate.go`) as a
+`tierAdvisory` entry. It reuses the established gate machinery unchanged:
+
+- **`gateCheck` contract** (`gate_registry.go`): the function has signature
+  `func(ctx context.Context, workspace string, run commandRunner) (failed bool, output string)`.
+  For a `tierAdvisory` check, `failed == true` causes `runGateChecks` to emit
+  `advisory{Check: name, Detail: output}`. `failed == false` is silent.
+- **Surfacing:** advisories reach the reviewer via the existing
+  `attachGateAdvisories` → `Extra["gateAdvisories"]` → `renderGateAdvisories`
+  path, rendered under "Gate advisories to verify (confirm or dismiss each)" as
+  `[test-dilution] <detail>`. No new plumbing.
+- **Kill-switch:** `gateCheckEnabled` gives every registered check a free
+  `FOREMAN_TEST_DILUTION_GATE=0` env toggle. No new config.
+- **Diff seam:** the same working-tree basis the other diff-based checks use —
+  `git add -A` then `git diff --cached HEAD` (the gate runs before the coder
+  commits, so `HEAD` is the base branch tip and the staged working tree is the
+  full submission). `git diff --name-status --cached HEAD` supplies file-level
+  add/delete/rename status for fixture detection.
+
+The check function is a thin orchestrator; the detection logic below lives in
+small, individually testable helpers in the same file.
+
+## Detection logic
+
+Let `changedProdPkgs` = the set of package directories that contain a changed
+**non-test** Go source file (a changed `*.go` that is not `*_test.go`).
+
+For each changed **test artifact** (a `*_test.go` file, or a file under a
+`testdata/` directory) that belongs to a package in `changedProdPkgs`, evaluate
+two erosion sub-signals:
+
+### (A) Removed assertions (net erosion)
+
+Parse the unified test diff. Classify each hunk line that is added (`+`) or
+removed (`-`) as *assertion-shaped* if, after trimming, it contains any of a
+fixed set of assertion tokens:
+
+```
+Expect(   Ω(   assert.   require.   ContainSubstring(   t.Error   t.Fatal
+!= want   want !=   got !=   != got
+```
+
+Per test file, compute `removedAssertions` and `addedAssertions` counts. The
+file is flagged for (A) only when `removedAssertions > addedAssertions` — **net
+erosion**. Requiring a net decrease keeps a rename, reorder, or one-for-one
+rewrite from tripping the signal; it fires only when coverage shrank.
+
+### (B) Relocated or deleted fixtures
+
+Fires on either:
+
+- **File-level:** a file under a `testdata/` directory within a changed-prod
+  package's directory tree whose `git diff --name-status` code is `D` (deleted)
+  or `R` (renamed). Linkage is by path containment (deterministic); we do not
+  attempt to resolve which fixture a given test loads.
+- **Literal-level:** within a changed test file, a *fixture-input literal* whose
+  value changed — a removed (`-`) line and an added (`+`) line that each contain
+  a URL, host, or `testdata/` path literal where the host or path differs. This
+  is the exact #1322 signature (`-…huggingface.co…` / `+…example.com…`).
+
+Literal-level detection is scoped to fixture *inputs* (URLs, hosts, `testdata/`
+paths), NOT assertion right-hand-side values, to stay inside this slice and out
+of the deferred assertion-value-churn signal.
+
+### Fire condition and output
+
+If any package in `changedProdPkgs` shows (A) or (B), the check returns
+`failed = true` with a `Detail` that:
+
+- names each affected package,
+- states which sub-signal fired and the concrete removed items (removed
+  assertion snippets; deleted/renamed fixture paths; changed host/path literals),
+- ends with a fixed reviewer instruction, e.g. *"Confirm coverage of the changed
+  behavior was not weakened or dodged."*
+
+`Detail` is truncated to the gate's existing `maxCheckOutputBytes` cap so a large
+diff cannot produce an unbounded advisory.
+
+## Data flow
+
+```
+RunCoderGate
+  └─ runGateChecks(..., gateCheckRegistry)
+       └─ checkTestDilution(ctx, workspace, run)          [tierAdvisory]
+            ├─ git add -A                                  (stage submission)
+            ├─ git diff --name-status --cached HEAD        (file add/del/rename)
+            ├─ git diff --cached HEAD -- <test paths>      (unified test diff)
+            ├─ changedProdPkgs  ← non-test changed files
+            ├─ (A) net-removed assertions in changed-prod pkg?
+            ├─ (B) deleted/renamed/relocated fixture in changed-prod pkg?
+            └─ failed?, detail
+  advisories ─ attachGateAdvisories ─ Extra["gateAdvisories"]
+             └─ renderGateAdvisories ─ reviewer prompt
+```
+
+## Error handling
+
+Fail-open throughout. Any git error, unparseable diff, or empty diff returns
+`(false, "")` — the check stays silent rather than blocking or crashing. Because
+the tier is advisory, a false negative costs only the pre-existing state (the
+reviewer relies on independent review, as today); a crash or block is never
+acceptable for a heuristic. Fail-open is the same posture the other diff-based
+advisory checks take.
+
+## Testing
+
+Table-driven unit tests with an injected fake `commandRunner` returning canned
+`git diff` / `git diff --name-status` output — the established gate-test pattern
+(no shelling out). Required cases:
+
+| case | expectation |
+|---|---|
+| net-removed assertions in a changed-prod package | fires; detail lists removed assertions + names the package |
+| fixture host churn (`huggingface.co`→`example.com`) in a changed-prod package | fires; detail names the changed host |
+| deleted `testdata/` fixture under a changed-prod package | fires |
+| tests only ADDED (coverage grew) | silent |
+| assertions removed but that package's production code did NOT change | silent (package-linkage) |
+| removed == added assertions (rename/reorder) | silent (net-erosion rule) |
+| `git` command error | silent (fail-open) |
+| no production change at all (test-only submission) | silent |
+
+Plus a **bite-check** reconstructing a minimal #1322-shaped diff (a fixture URL
+moved off `huggingface.co` in a package whose production classifier changed) and
+asserting the advisory fires with the host named. Each new helper gets a
+bite-check: revert the helper's core condition and confirm its test fails.
+
+## Non-goal follow-ups to file
+
+After this ships, open follow-up issues for the deferred signals so they are not
+silently lost: (1) string-match-only detection for command-string/shell changes
+(#1309 mode), and (2) a coverage/mutation-delta investigation, noting it does not
+subsume this slice.
+
+## Conventions
+
+DCO `git commit -s`; fork workflow (PR into `defilantech/LLMKube`); no em dashes
+in prose; `gofmt` + `GOOS=linux ./bin/golangci-lint run ./...` clean before push;
+band-3 AI-assisted disclosure on the PR.

--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -308,6 +308,17 @@ func gateCheckRegistry(issueText, evidenceBaseSHA string, evidence []grounding.E
 				return checkIssueExample(issueText)(ctx, ws, run)
 			},
 		},
+		{
+			// test-dilution (#1332): advisory. Surfaces to the reviewer when a
+			// submission that changes production code also weakens the tests
+			// covering it (net-removed assertions, relocated/deleted fixtures).
+			// No lang: fixture and assertion erosion are not Go-specific in
+			// principle, and the check is fail-open on any language it cannot
+			// parse. Never blocks; the coder never sees it.
+			name: "test-dilution",
+			tier: tierAdvisory,
+			fn:   checkTestDilution,
+		},
 	}
 }
 

--- a/pkg/foreman/agent/test_dilution_gate.go
+++ b/pkg/foreman/agent/test_dilution_gate.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import "strings"
+
+// fileHunks holds the content (leading +/- stripped) of one file's added and
+// removed lines from a `git diff --unified=0` output.
+type fileHunks struct {
+	Added   []string
+	Removed []string
+}
+
+// parseUnifiedDiff parses `git diff --unified=0 --src-prefix=a/ --dst-prefix=b/`
+// output into per-file added and removed content lines. Added lines are keyed
+// by the new-file path (+++ b/PATH); removed lines are keyed by the same path,
+// or by the old path (--- a/PATH) when the new side is /dev/null (a deletion).
+// Diff headers (---, +++) are never counted as content.
+func parseUnifiedDiff(out string) map[string]*fileHunks {
+	byFile := map[string]*fileHunks{}
+	ensure := func(f string) *fileHunks {
+		if byFile[f] == nil {
+			byFile[f] = &fileHunks{}
+		}
+		return byFile[f]
+	}
+	var cur, aPath string
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.HasPrefix(line, "--- a/"):
+			aPath = strings.TrimPrefix(line, "--- a/")
+		case strings.HasPrefix(line, "--- "):
+			aPath = "" // /dev/null (added file) etc.
+		case strings.HasPrefix(line, "+++ b/"):
+			cur = strings.TrimPrefix(line, "+++ b/")
+		case strings.HasPrefix(line, "+++ "):
+			cur = aPath // deletion: attribute removed lines to the old path
+		case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") && cur != "":
+			ensure(cur).Added = append(ensure(cur).Added, line[1:])
+		case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---"):
+			key := cur
+			if key == "" {
+				key = aPath
+			}
+			if key != "" {
+				ensure(key).Removed = append(ensure(key).Removed, line[1:])
+			}
+		}
+	}
+	return byFile
+}

--- a/pkg/foreman/agent/test_dilution_gate.go
+++ b/pkg/foreman/agent/test_dilution_gate.go
@@ -233,13 +233,16 @@ func testdataOwner(path string) (string, bool) {
 func fixtureFileChanges(entries []nameStatusEntry, prodPkgs map[string]bool) []string {
 	var out []string
 	for _, e := range entries {
-		owner, ok := testdataOwner(e.Path)
-		if !ok {
-			if e.OldPath == "" {
-				continue
-			}
-			owner, ok = testdataOwner(e.OldPath)
+		// Resolve the fixture's owning package from its PRE-change location:
+		// OldPath for a rename/copy (the package the fixture came from, which
+		// could have lost coverage), Path for a plain delete (no OldPath).
+		// Destination-first would miss a fixture moved OUT of a changed package
+		// into an untouched one, the exact dilution this catches (#1332).
+		lookup := e.Path
+		if e.OldPath != "" {
+			lookup = e.OldPath
 		}
+		owner, ok := testdataOwner(lookup)
 		if !ok || !prodPkgs[owner] {
 			continue
 		}

--- a/pkg/foreman/agent/test_dilution_gate.go
+++ b/pkg/foreman/agent/test_dilution_gate.go
@@ -63,3 +63,52 @@ func parseUnifiedDiff(out string) map[string]*fileHunks {
 	}
 	return byFile
 }
+
+// assertionTokens are substrings that mark a line as an assertion. Kept
+// deliberately small and shape-based: Gomega (Expect/Ω), testify
+// (assert./require.), the ContainSubstring matcher, the stdlib t.Error/t.Fatal
+// failures, and the got/want comparison idiom.
+var assertionTokens = []string{
+	"Expect(", "Ω(", "assert.", "require.", "ContainSubstring(",
+	"t.Error", "t.Fatal", "!= want", "want !=", "got !=", "!= got",
+}
+
+// isAssertionLine reports whether a diff content line looks like a test
+// assertion. It is intentionally lenient: false positives only add reviewer
+// context, never fail a gate.
+func isAssertionLine(s string) bool {
+	t := strings.TrimSpace(s)
+	for _, tok := range assertionTokens {
+		if strings.Contains(t, tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// assertionErosion counts assertion-shaped removed and added lines in one
+// file's hunks and returns the trimmed text of the removed assertions (for the
+// reviewer message). Net erosion is removed > added; the caller applies that.
+func assertionErosion(fh *fileHunks) (removed, added int, snippets []string) {
+	for _, l := range fh.Removed {
+		if isAssertionLine(l) {
+			removed++
+			snippets = append(snippets, strings.TrimSpace(l))
+		}
+	}
+	for _, l := range fh.Added {
+		if isAssertionLine(l) {
+			added++
+		}
+	}
+	return removed, added, snippets
+}
+
+// firstN returns the first n elements of s, or all of s when shorter. Used to
+// cap how many removed-assertion snippets appear in the advisory.
+func firstN(s []string, n int) []string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}

--- a/pkg/foreman/agent/test_dilution_gate.go
+++ b/pkg/foreman/agent/test_dilution_gate.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package agent
 
-import "strings"
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
 
 // fileHunks holds the content (leading +/- stripped) of one file's added and
 // removed lines from a `git diff --unified=0` output.
@@ -111,4 +116,54 @@ func firstN(s []string, n int) []string {
 		return s[:n]
 	}
 	return s
+}
+
+var (
+	// urlHostRe captures the host of an http(s) URL string literal.
+	urlHostRe = regexp.MustCompile(`https?://([^/\s"'` + "`" + `]+)`)
+	// testdataPathRe captures a testdata/ file path literal.
+	testdataPathRe = regexp.MustCompile(`[\w./-]*testdata/[\w./-]+`)
+)
+
+// fixtureTokens extracts fixture-input identifiers from a set of diff lines:
+// URL hosts (prefixed "host:") and testdata/ paths (prefixed "path:"). The
+// prefix keeps the two kinds from colliding in the set-difference below.
+func fixtureTokens(lines []string) map[string]bool {
+	set := map[string]bool{}
+	for _, l := range lines {
+		for _, m := range urlHostRe.FindAllStringSubmatch(l, -1) {
+			set["host:"+m[1]] = true
+		}
+		for _, m := range testdataPathRe.FindAllString(l, -1) {
+			set["path:"+m] = true
+		}
+	}
+	return set
+}
+
+// fixtureLiteralChurn flags a fixture input that was changed in place: a host
+// or testdata path present only on the removed side while a different one
+// appears only on the added side. This is relocation (the #1322 signature),
+// distinct from a pure fixture addition (added only) or deletion (removed
+// only), both of which return nil. Deterministic: tokens are sorted.
+func fixtureLiteralChurn(fh *fileHunks) []string {
+	rem := fixtureTokens(fh.Removed)
+	add := fixtureTokens(fh.Added)
+	var gone, appeared []string
+	for tkn := range rem {
+		if !add[tkn] {
+			gone = append(gone, tkn)
+		}
+	}
+	for tkn := range add {
+		if !rem[tkn] {
+			appeared = append(appeared, tkn)
+		}
+	}
+	if len(gone) == 0 || len(appeared) == 0 {
+		return nil
+	}
+	sort.Strings(gone)
+	sort.Strings(appeared)
+	return []string{fmt.Sprintf("fixture input changed (removed %v, added %v)", gone, appeared)}
 }

--- a/pkg/foreman/agent/test_dilution_gate.go
+++ b/pkg/foreman/agent/test_dilution_gate.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -166,4 +167,88 @@ func fixtureLiteralChurn(fh *fileHunks) []string {
 	sort.Strings(gone)
 	sort.Strings(appeared)
 	return []string{fmt.Sprintf("fixture input changed (removed %v, added %v)", gone, appeared)}
+}
+
+// nameStatusEntry is one file-level change from `git diff --name-status`.
+type nameStatusEntry struct {
+	Code    string // "M", "A", "D", "R100", "C75", ...
+	Path    string // destination path (rename) or the changed path
+	OldPath string // source path, only set for renames/copies
+}
+
+// parseNameStatus parses tab-separated `git diff --name-status` output. Rename
+// and copy rows carry two paths (old, new); all others carry one.
+func parseNameStatus(out string) []nameStatusEntry {
+	var entries []nameStatusEntry
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		f := strings.Split(line, "\t")
+		if len(f) < 2 {
+			continue
+		}
+		code := f[0]
+		if (strings.HasPrefix(code, "R") || strings.HasPrefix(code, "C")) && len(f) >= 3 {
+			entries = append(entries, nameStatusEntry{Code: code, OldPath: f[1], Path: f[2]})
+			continue
+		}
+		entries = append(entries, nameStatusEntry{Code: code, Path: f[len(f)-1]})
+	}
+	return entries
+}
+
+// changedProdPackages returns the set of package directories whose non-test Go
+// source changed. A package that changed only its tests is not included: the
+// linkage requires a production change to gate the test-dilution signal.
+func changedProdPackages(entries []nameStatusEntry) map[string]bool {
+	pkgs := map[string]bool{}
+	for _, e := range entries {
+		p := e.Path
+		if !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+			continue
+		}
+		pkgs[filepath.Dir(p)] = true
+	}
+	return pkgs
+}
+
+// testdataOwner returns the package directory that owns a testdata path (the
+// segment before "/testdata/"), or ("", false) when the path is not under a
+// testdata directory. A top-level "testdata/..." is owned by ".".
+func testdataOwner(path string) (string, bool) {
+	if i := strings.Index(path, "/testdata/"); i >= 0 {
+		return path[:i], true
+	}
+	if strings.HasPrefix(path, "testdata/") {
+		return ".", true
+	}
+	return "", false
+}
+
+// fixtureFileChanges reports testdata fixtures that were deleted or renamed
+// under a package whose production code changed. Deleting or moving a fixture
+// is how coverage of a path can be dropped without touching an assertion.
+func fixtureFileChanges(entries []nameStatusEntry, prodPkgs map[string]bool) []string {
+	var out []string
+	for _, e := range entries {
+		owner, ok := testdataOwner(e.Path)
+		if !ok {
+			if e.OldPath == "" {
+				continue
+			}
+			owner, ok = testdataOwner(e.OldPath)
+		}
+		if !ok || !prodPkgs[owner] {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(e.Code, "D"):
+			out = append(out, "deleted fixture "+e.Path)
+		case strings.HasPrefix(e.Code, "R"):
+			out = append(out, "relocated fixture "+e.OldPath+" -> "+e.Path)
+		}
+	}
+	return out
 }

--- a/pkg/foreman/agent/test_dilution_gate.go
+++ b/pkg/foreman/agent/test_dilution_gate.go
@@ -265,9 +265,6 @@ func fixtureFileChanges(entries []nameStatusEntry, prodPkgs map[string]bool) []s
 //
 // Fail-open: any git error, or no production change in the submission, returns
 // (false, "") so a bad diff signal or a docs-only change stays silent.
-// nolint:unparam // workspace is parameterized to match the commandRunner-based
-// gate-check shape (see gateCheckRegistry in coder_gate.go); only the test file
-// calls this today and all its cases use "/w".
 func checkTestDilution(ctx context.Context, workspace string, run commandRunner) (bool, string) {
 	// Stage the working tree so a pre-commit diff includes new/untracked files.
 	// Idempotent with the executor's later `git add -A`; the -A exit status is

--- a/pkg/foreman/agent/test_dilution_gate.go
+++ b/pkg/foreman/agent/test_dilution_gate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package agent
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -254,4 +255,65 @@ func fixtureFileChanges(entries []nameStatusEntry, prodPkgs map[string]bool) []s
 		}
 	}
 	return out
+}
+
+// checkTestDilution is a tierAdvisory gate check (#1332). It surfaces to the
+// reviewer when a submission that changes production code also weakens the
+// tests covering that code: net-removed assertions, a relocated fixture input,
+// or a deleted/renamed testdata fixture, all scoped to a package whose
+// production code changed. It never fails the gate and never feeds the coder.
+//
+// Fail-open: any git error, or no production change in the submission, returns
+// (false, "") so a bad diff signal or a docs-only change stays silent.
+// nolint:unparam // workspace is parameterized to match the commandRunner-based
+// gate-check shape (see gateCheckRegistry in coder_gate.go); only the test file
+// calls this today and all its cases use "/w".
+func checkTestDilution(ctx context.Context, workspace string, run commandRunner) (bool, string) {
+	// Stage the working tree so a pre-commit diff includes new/untracked files.
+	// Idempotent with the executor's later `git add -A`; the -A exit status is
+	// not actionable here, so a stage error simply fails the check open below.
+	if _, err := run(ctx, workspace, nil, "git", "add", "-A"); err != nil {
+		return false, ""
+	}
+	nsOut, err := run(ctx, workspace, nil, "git", "diff", "--name-status", "--cached", "HEAD")
+	if err != nil {
+		return false, ""
+	}
+	entries := parseNameStatus(nsOut)
+	prodPkgs := changedProdPackages(entries)
+	if len(prodPkgs) == 0 {
+		return false, "" // no production change: not a green-gate-earning dilution
+	}
+
+	diffOut, err := run(ctx, workspace, nil, "git", "diff", "--cached", "--unified=0",
+		"--src-prefix=a/", "--dst-prefix=b/", "HEAD", "--", "*_test.go")
+	if err != nil {
+		return false, ""
+	}
+	byFile := parseUnifiedDiff(diffOut)
+
+	var findings []string
+	for file, fh := range byFile {
+		if !prodPkgs[filepath.Dir(file)] {
+			continue // package linkage: only judge tests of changed-prod packages
+		}
+		if removed, added, snippets := assertionErosion(fh); removed > added {
+			findings = append(findings, fmt.Sprintf(
+				"%s net-removed %d assertion(s): %s",
+				file, removed-added, strings.Join(firstN(snippets, 3), "; ")))
+		}
+		for _, c := range fixtureLiteralChurn(fh) {
+			findings = append(findings, file+" "+c)
+		}
+	}
+	findings = append(findings, fixtureFileChanges(entries, prodPkgs)...)
+
+	if len(findings) == 0 {
+		return false, ""
+	}
+	sort.Strings(findings) // deterministic order across map iteration
+	detail := "production code changed and its tests weakened their own coverage " +
+		"(confirm the changed behavior is still covered, not dodged): " +
+		strings.Join(findings, "; ")
+	return true, truncateOutput(detail)
 }

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -52,3 +52,40 @@ func keys(m map[string]*fileHunks) []string {
 	}
 	return k
 }
+
+func TestAssertionErosion_NetRemovalCountedWithSnippets(t *testing.T) {
+	fh := &fileHunks{
+		Removed: []string{
+			"\tExpect(got).To(Equal(want))",
+			"\trequire.NoError(t, err)",
+			"\t// just a comment, not an assertion",
+		},
+		Added: []string{
+			"\tassert.Equal(t, want, got)",
+		},
+	}
+	removed, added, snippets := assertionErosion(fh)
+	if removed != 2 || added != 1 {
+		t.Fatalf("removed=%d added=%d, want 2 and 1", removed, added)
+	}
+	if len(snippets) != 2 || snippets[0] != "Expect(got).To(Equal(want))" {
+		t.Errorf("snippets = %q", snippets)
+	}
+}
+
+func TestAssertionErosion_NonAssertionsIgnored(t *testing.T) {
+	fh := &fileHunks{Removed: []string{"\tx := 1", "\treturn nil"}}
+	removed, _, _ := assertionErosion(fh)
+	if removed != 0 {
+		t.Fatalf("removed=%d, want 0 (no assertion-shaped lines)", removed)
+	}
+}
+
+func TestFirstN(t *testing.T) {
+	if got := firstN([]string{"a", "b", "c"}, 2); len(got) != 2 {
+		t.Fatalf("firstN cap failed: %v", got)
+	}
+	if got := firstN([]string{"a"}, 3); len(got) != 1 {
+		t.Fatalf("firstN under-length failed: %v", got)
+	}
+}

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -207,5 +209,96 @@ func TestFixtureFileChanges_CrossPackageRenameIntoChangedPkgSilent(t *testing.T)
 	prod := map[string]bool{"pkg/model": true}
 	if got := fixtureFileChanges(entries, prod); len(got) != 0 {
 		t.Fatalf("a fixture moved INTO the changed package must not fire; got %v", got)
+	}
+}
+
+// dilutionRunner fakes the three git calls checkTestDilution makes:
+// `git add -A` (no-op), `git diff --name-status --cached HEAD`, and the
+// `git diff --cached --unified=0 ... -- *_test.go` line diff.
+// nolint:unparam // addErr is parameterized for clarity at call sites even though existing tests all pass nil
+func dilutionRunner(nameStatus, testDiff string, addErr, nsErr, diffErr error) commandRunner {
+	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name != "git" {
+			return "", nil
+		}
+		switch {
+		case len(args) >= 2 && args[0] == "add" && args[1] == "-A":
+			return "", addErr
+		case len(args) >= 2 && args[0] == "diff" && args[1] == "--name-status":
+			return nameStatus, nsErr
+		case len(args) >= 2 && args[0] == "diff" && args[1] == "--cached":
+			return testDiff, diffErr
+		default:
+			return "", nil
+		}
+	}
+}
+
+func TestCheckTestDilution_FiresOnNetRemovedAssertions(t *testing.T) {
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -10 +10 @@
+-	Expect(classify(u)).To(Equal(RepoSource))
+-	require.NoError(t, err)
++	// removed the assertions above
+`
+	failed, out := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil))
+	if !failed {
+		t.Fatal("expected an advisory when a changed-prod package net-removes assertions")
+	}
+	if !strings.Contains(out, "classifier_test.go") || !strings.Contains(out, "assertion") {
+		t.Errorf("detail = %q", out)
+	}
+}
+
+func TestCheckTestDilution_FiresOnFixtureRelocation_1322Shape(t *testing.T) {
+	// #1322 bite-check: prod classifier changed, and a fixture URL host moved
+	// off huggingface.co in the same package's test.
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -20 +20 @@
+-	src := "https://huggingface.co/org/model/resolve/main/f.gguf"
++	src := "https://example.com/org/model/resolve/main/f.gguf"
+`
+	failed, out := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil))
+	if !failed {
+		t.Fatal("expected an advisory for the #1322 fixture-relocation shape")
+	}
+	if !strings.Contains(out, "huggingface.co") {
+		t.Errorf("detail should name the moved host; got %q", out)
+	}
+}
+
+func TestCheckTestDilution_SilentWhenTestsOnlyGrow(t *testing.T) {
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -10 +11 @@
++	Expect(classify(u)).To(Equal(RepoSource))
+`
+	if failed, _ := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil)); failed {
+		t.Fatal("adding assertions must not fire the dilution advisory")
+	}
+}
+
+func TestCheckTestDilution_SilentWhenNoProdChange(t *testing.T) {
+	// Test-only submission: assertions removed but no production code changed.
+	ns := "M\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -10 +9 @@
+-	Expect(classify(u)).To(Equal(RepoSource))
+`
+	if failed, _ := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil)); failed {
+		t.Fatal("package-linkage: no production change means no advisory")
+	}
+}
+
+func TestCheckTestDilution_FailOpenOnGitError(t *testing.T) {
+	if failed, out := checkTestDilution(context.Background(), "/w",
+		dilutionRunner("", "", nil, errors.New("boom"), nil)); failed || out != "" {
+		t.Fatalf("git error must fail open (silent); got failed=%v out=%q", failed, out)
 	}
 }

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseUnifiedDiff_AttributesAddedAndRemoved(t *testing.T) {
+	// A modified test file: one assertion removed, one added.
+	out := `diff --git a/pkg/model/x_test.go b/pkg/model/x_test.go
+index 1111111..2222222 100644
+--- a/pkg/model/x_test.go
++++ b/pkg/model/x_test.go
+@@ -10 +10 @@ func TestFoo(t *testing.T) {
+-	Expect(got).To(Equal(oldWant))
++	Expect(got).To(Equal(newWant))
+`
+	got := parseUnifiedDiff(out)
+	fh := got["pkg/model/x_test.go"]
+	if fh == nil {
+		t.Fatalf("no hunks for pkg/model/x_test.go; got keys %v", keys(got))
+	}
+	if !reflect.DeepEqual(fh.Removed, []string{"\tExpect(got).To(Equal(oldWant))"}) {
+		t.Errorf("Removed = %q", fh.Removed)
+	}
+	if !reflect.DeepEqual(fh.Added, []string{"\tExpect(got).To(Equal(newWant))"}) {
+		t.Errorf("Added = %q", fh.Added)
+	}
+}
+
+func TestParseUnifiedDiff_DeletedFileAttributedToOldPath(t *testing.T) {
+	out := `diff --git a/pkg/model/y_test.go b/pkg/model/y_test.go
+deleted file mode 100644
+index 3333333..0000000
+--- a/pkg/model/y_test.go
++++ /dev/null
+@@ -1 +0,0 @@
+-	require.NoError(t, err)
+`
+	got := parseUnifiedDiff(out)
+	fh := got["pkg/model/y_test.go"]
+	if fh == nil || len(fh.Removed) != 1 {
+		t.Fatalf("deleted file removed lines not attributed to old path; got %v", keys(got))
+	}
+}
+
+// keys is a tiny test helper for readable failure messages.
+func keys(m map[string]*fileHunks) []string {
+	k := make([]string, 0, len(m))
+	for f := range m {
+		k = append(k, f)
+	}
+	return k
+}

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -123,3 +123,64 @@ func TestFixtureLiteralChurn_TestdataPathRelocation(t *testing.T) {
 		t.Fatalf("expected a testdata path-churn finding; got %q", got)
 	}
 }
+
+func TestParseNameStatus_ModifyAndRename(t *testing.T) {
+	out := "M\tpkg/model/classifier.go\n" +
+		"D\tpkg/model/testdata/real.json\n" +
+		"R100\tpkg/model/testdata/a.json\tpkg/model/testdata/b.json\n"
+	got := parseNameStatus(out)
+	if len(got) != 3 {
+		t.Fatalf("got %d entries, want 3: %+v", len(got), got)
+	}
+	wantOldPath := "pkg/model/testdata/a.json"
+	wantNewPath := "pkg/model/testdata/b.json"
+	if got[2].Code[0] != 'R' || got[2].OldPath != wantOldPath || got[2].Path != wantNewPath {
+		t.Errorf("rename parsed wrong: %+v", got[2])
+	}
+}
+
+func TestChangedProdPackages_IgnoresTestAndNonGo(t *testing.T) {
+	entries := []nameStatusEntry{
+		{Code: "M", Path: "pkg/model/classifier.go"},
+		{Code: "M", Path: "pkg/model/classifier_test.go"},
+		{Code: "M", Path: "pkg/other/x_test.go"}, // test-only pkg: not prod-changed
+		{Code: "M", Path: "docs/readme.md"},
+	}
+	got := changedProdPackages(entries)
+	if !got["pkg/model"] {
+		t.Errorf("pkg/model should be a changed-prod package")
+	}
+	if got["pkg/other"] {
+		t.Errorf("pkg/other changed only a test file; must not count as prod-changed")
+	}
+	if len(got) != 1 {
+		t.Errorf("got %v, want only pkg/model", got)
+	}
+}
+
+func TestTestdataOwner(t *testing.T) {
+	if o, ok := testdataOwner("pkg/model/testdata/x.json"); !ok || o != "pkg/model" {
+		t.Errorf("owner = %q, %v; want pkg/model, true", o, ok)
+	}
+	if _, ok := testdataOwner("pkg/model/classifier.go"); ok {
+		t.Errorf("non-testdata path must not resolve an owner")
+	}
+}
+
+func TestFixtureFileChanges_DeleteAndRenameUnderChangedPkg(t *testing.T) {
+	entries := []nameStatusEntry{
+		{Code: "D", Path: "pkg/model/testdata/real.json"},
+		{Code: "R100", OldPath: "pkg/model/testdata/a.json", Path: "pkg/model/testdata/b.json"},
+		{Code: "D", Path: "pkg/other/testdata/z.json"}, // owner not prod-changed: ignored
+	}
+	prod := map[string]bool{"pkg/model": true}
+	got := fixtureFileChanges(entries, prod)
+	if len(got) != 2 {
+		t.Fatalf("got %d findings, want 2: %v", len(got), got)
+	}
+	joined := strings.Join(got, " | ")
+	if !strings.Contains(joined, "deleted fixture pkg/model/testdata/real.json") ||
+		!strings.Contains(joined, "relocated fixture pkg/model/testdata/a.json -> pkg/model/testdata/b.json") {
+		t.Errorf("findings = %v", got)
+	}
+}

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -233,6 +233,18 @@ func dilutionRunner(nameStatus, testDiff string, addErr, nsErr, diffErr error) c
 	}
 }
 
+// erosionNS + erosionDiff describe a genuine dilution: a changed-prod package
+// (pkg/model) whose test net-removes an assertion. A fail-open test feeds these
+// plus one non-nil git error, so that WITHOUT the checked error branch execution
+// would reach this finding and return (true, ...); only the fail-open return
+// keeps it silent. That makes each fail-open test isolate its branch.
+const erosionNS = "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+const erosionDiff = `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -10 +9 @@
+-	Expect(classify(u)).To(Equal(RepoSource))
+`
+
 func TestCheckTestDilution_FiresOnNetRemovedAssertions(t *testing.T) {
 	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
 	diff := `--- a/pkg/model/classifier_test.go
@@ -296,27 +308,26 @@ func TestCheckTestDilution_SilentWhenNoProdChange(t *testing.T) {
 }
 
 func TestCheckTestDilution_FailOpenOnGitError(t *testing.T) {
+	// name-status call errors: must fail open even though a real dilution is present.
 	if failed, out := checkTestDilution(context.Background(), "/w",
-		dilutionRunner("", "", nil, errors.New("boom"), nil)); failed || out != "" {
-		t.Fatalf("git error must fail open (silent); got failed=%v out=%q", failed, out)
+		dilutionRunner(erosionNS, erosionDiff, nil, errors.New("boom"), nil)); failed || out != "" {
+		t.Fatalf("name-status error must fail open (silent) despite a real dilution; got failed=%v out=%q", failed, out)
 	}
 }
 
 func TestCheckTestDilution_FailOpenOnAddError(t *testing.T) {
-	// git add -A failing must fail open (silent): exercises the stage-error branch.
+	// git add -A errors: must fail open even though a real dilution is present.
 	if failed, out := checkTestDilution(context.Background(), "/w",
-		dilutionRunner("", "", errors.New("boom"), nil, nil)); failed || out != "" {
-		t.Fatalf("git add error must fail open (silent); got failed=%v out=%q", failed, out)
+		dilutionRunner(erosionNS, erosionDiff, errors.New("boom"), nil, nil)); failed || out != "" {
+		t.Fatalf("git add error must fail open (silent) despite a real dilution; got failed=%v out=%q", failed, out)
 	}
 }
 
 func TestCheckTestDilution_FailOpenOnDiffError(t *testing.T) {
-	// The unified-diff call failing must fail open. A production change is present
-	// so execution reaches the diff call (past the no-prod-change early return).
-	ns := "M\tpkg/model/classifier.go\n"
+	// unified-diff call errors: must fail open even though a real dilution is present.
 	if failed, out := checkTestDilution(context.Background(), "/w",
-		dilutionRunner(ns, "", nil, nil, errors.New("boom"))); failed || out != "" {
-		t.Fatalf("unified-diff error must fail open (silent); got failed=%v out=%q", failed, out)
+		dilutionRunner(erosionNS, erosionDiff, nil, nil, errors.New("boom"))); failed || out != "" {
+		t.Fatalf("unified-diff error must fail open (silent) despite a real dilution; got failed=%v out=%q", failed, out)
 	}
 }
 

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -184,3 +184,28 @@ func TestFixtureFileChanges_DeleteAndRenameUnderChangedPkg(t *testing.T) {
 		t.Errorf("findings = %v", got)
 	}
 }
+
+func TestFixtureFileChanges_CrossPackageRenameOutOfChangedPkgFires(t *testing.T) {
+	// Moved OUT of a changed package into an untouched one: the changed
+	// package lost the fixture, so this must fire (was a false negative).
+	entries := []nameStatusEntry{
+		{Code: "R100", OldPath: "pkg/model/testdata/a.json", Path: "pkg/other/testdata/a.json"},
+	}
+	prod := map[string]bool{"pkg/model": true}
+	got := fixtureFileChanges(entries, prod)
+	if len(got) != 1 || !strings.Contains(got[0], "pkg/model/testdata/a.json -> pkg/other/testdata/a.json") {
+		t.Fatalf("expected a relocation finding attributed to the changed source package; got %v", got)
+	}
+}
+
+func TestFixtureFileChanges_CrossPackageRenameIntoChangedPkgSilent(t *testing.T) {
+	// Moved INTO a changed package from an untouched one: nothing was lost
+	// from the changed package, so this must stay silent (was a false positive).
+	entries := []nameStatusEntry{
+		{Code: "R100", OldPath: "pkg/other/testdata/a.json", Path: "pkg/model/testdata/a.json"},
+	}
+	prod := map[string]bool{"pkg/model": true}
+	if got := fixtureFileChanges(entries, prod); len(got) != 0 {
+		t.Fatalf("a fixture moved INTO the changed package must not fire; got %v", got)
+	}
+}

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -215,7 +215,6 @@ func TestFixtureFileChanges_CrossPackageRenameIntoChangedPkgSilent(t *testing.T)
 // dilutionRunner fakes the three git calls checkTestDilution makes:
 // `git add -A` (no-op), `git diff --name-status --cached HEAD`, and the
 // `git diff --cached --unified=0 ... -- *_test.go` line diff.
-// nolint:unparam // addErr is parameterized for clarity at call sites even though existing tests all pass nil
 func dilutionRunner(nameStatus, testDiff string, addErr, nsErr, diffErr error) commandRunner {
 	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
 		if name != "git" {
@@ -300,5 +299,37 @@ func TestCheckTestDilution_FailOpenOnGitError(t *testing.T) {
 	if failed, out := checkTestDilution(context.Background(), "/w",
 		dilutionRunner("", "", nil, errors.New("boom"), nil)); failed || out != "" {
 		t.Fatalf("git error must fail open (silent); got failed=%v out=%q", failed, out)
+	}
+}
+
+func TestCheckTestDilution_FailOpenOnAddError(t *testing.T) {
+	// git add -A failing must fail open (silent): exercises the stage-error branch.
+	if failed, out := checkTestDilution(context.Background(), "/w",
+		dilutionRunner("", "", errors.New("boom"), nil, nil)); failed || out != "" {
+		t.Fatalf("git add error must fail open (silent); got failed=%v out=%q", failed, out)
+	}
+}
+
+func TestCheckTestDilution_FailOpenOnDiffError(t *testing.T) {
+	// The unified-diff call failing must fail open. A production change is present
+	// so execution reaches the diff call (past the no-prod-change early return).
+	ns := "M\tpkg/model/classifier.go\n"
+	if failed, out := checkTestDilution(context.Background(), "/w",
+		dilutionRunner(ns, "", nil, nil, errors.New("boom"))); failed || out != "" {
+		t.Fatalf("unified-diff error must fail open (silent); got failed=%v out=%q", failed, out)
+	}
+}
+
+func TestCheckTestDilution_SilentWhenErosionInUnchangedPackage(t *testing.T) {
+	// Production changed in pkg/model, but the weakened test is in pkg/other,
+	// which has no production change: per-file package linkage must keep it silent.
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/other/thing_test.go\n"
+	diff := `--- a/pkg/other/thing_test.go
++++ b/pkg/other/thing_test.go
+@@ -10 +9 @@
+-	Expect(classify(u)).To(Equal(RepoSource))
+`
+	if failed, _ := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil)); failed {
+		t.Fatal("erosion in a package with no production change must not fire (package linkage)")
 	}
 }

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -87,5 +88,38 @@ func TestFirstN(t *testing.T) {
 	}
 	if got := firstN([]string{"a"}, 3); len(got) != 1 {
 		t.Fatalf("firstN under-length failed: %v", got)
+	}
+}
+
+func TestFixtureLiteralChurn_HostRelocation(t *testing.T) {
+	// The #1322 shape: a fixture URL host moved off huggingface.co.
+	fh := &fileHunks{
+		Removed: []string{`	src := "https://huggingface.co/org/model/resolve/main/f.gguf"`},
+		Added:   []string{`	src := "https://example.com/org/model/resolve/main/f.gguf"`},
+	}
+	got := fixtureLiteralChurn(fh)
+	if len(got) != 1 || !strings.Contains(got[0], "huggingface.co") || !strings.Contains(got[0], "example.com") {
+		t.Fatalf("expected a host-churn finding naming both hosts; got %q", got)
+	}
+}
+
+func TestFixtureLiteralChurn_PureAdditionSilent(t *testing.T) {
+	// Adding a new fixture (no matching removal) is not relocation.
+	fh := &fileHunks{
+		Added: []string{`	src := "https://huggingface.co/org/model/f.gguf"`},
+	}
+	if got := fixtureLiteralChurn(fh); got != nil {
+		t.Fatalf("pure addition must not flag churn; got %q", got)
+	}
+}
+
+func TestFixtureLiteralChurn_TestdataPathRelocation(t *testing.T) {
+	fh := &fileHunks{
+		Removed: []string{`	data := load("pkg/model/testdata/real_repo.json")`},
+		Added:   []string{`	data := load("pkg/model/testdata/renamed_repo.json")`},
+	}
+	got := fixtureLiteralChurn(fh)
+	if len(got) != 1 || !strings.Contains(got[0], "testdata/") {
+		t.Fatalf("expected a testdata path-churn finding; got %q", got)
 	}
 }

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -344,3 +344,39 @@ func TestCheckTestDilution_SilentWhenErosionInUnchangedPackage(t *testing.T) {
 		t.Fatal("erosion in a package with no production change must not fire (package linkage)")
 	}
 }
+
+func TestTestDilution_RegisteredAsAdvisory(t *testing.T) {
+	var found bool
+	var tier gateTier
+	for _, c := range gateCheckRegistry("", "", nil) {
+		if c.name == "test-dilution" {
+			found = true
+			tier = c.tier
+		}
+	}
+	if !found {
+		t.Fatal(`gateCheckRegistry is missing the "test-dilution" check`)
+	}
+	if tier != tierAdvisory {
+		t.Errorf("test-dilution tier = %v, want tierAdvisory", tier)
+	}
+}
+
+func TestTestDilution_SurfacesAsAdvisoryNotBlocking(t *testing.T) {
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -20 +20 @@
+-	src := "https://huggingface.co/org/model/f.gguf"
++	src := "https://example.com/org/model/f.gguf"
+`
+	run := dilutionRunner(ns, diff, nil, nil, nil)
+	blocking, advisories := runGateChecks(context.Background(), "/w", run,
+		[]gateCheck{{name: "test-dilution", tier: tierAdvisory, fn: checkTestDilution}})
+	if len(blocking) != 0 {
+		t.Errorf("test-dilution must never block; got %d blocking", len(blocking))
+	}
+	if len(advisories) != 1 || advisories[0].Check != "test-dilution" {
+		t.Fatalf("expected one test-dilution advisory; got %+v", advisories)
+	}
+}


### PR DESCRIPTION
## What

Adds a `test-dilution` advisory to the Foreman coder gate (#1332). It surfaces to the **reviewer** when a submission that changes production code also weakens the tests covering it, so a green gate cannot be earned by diluting checks. It **never blocks the gate and is never shown to the coder** (advisory-only, adversary-blind).

Motivated by two harness-eval branches that passed the gate with critical defects by weakening tests: #1322 moved fixtures off `huggingface.co` to dodge a reclassification (deleting the only coverage of the regressed path), and #1309 shipped dead code that string-match tests could never fail on.

## Signals (this slice)

Scoped by **package linkage** — a test-side erosion is only reported when the same submission changed non-test production code in that test's package:

- **Net-removed assertions** (`removed > added` assertion-shaped lines in a changed-prod package's test).
- **Relocated/deleted fixtures** — a testdata fixture deleted or renamed under a changed package (attributed by the pre-change package), or a fixture-input literal (URL host / `testdata/` path) whose value changed in a changed test (the exact #1322 signature).

Fires as a single `tierAdvisory` finding rendered in the reviewer prompt under "Gate advisories to verify (confirm or dismiss each)". Fail-open on any git error or no-production-change. Free kill-switch via `FOREMAN_TEST_DILUTION_GATE=0`.

## Explicit non-goals (deferred, follow-ups to file)

- String-match-only detection for command-string/shell changes (the #1309 mode).
- Coverage/mutation-delta gate — and note it does **not** subsume this slice: a test rewritten to assert the *wrong* behavior still bites mutants, so only diffing tests against base catches #1322.
- Assertion-value churn (noisiest signal).
- Hard-blocking.

## How

All logic in the new `pkg/foreman/agent/test_dilution_gate.go` (small pure parsers/detectors + one orchestrator `checkTestDilution`), registered as a `tierAdvisory` entry in `gateCheckRegistry`. Reuses the existing `git add -A` + `git diff --cached HEAD` seam, the `attachGateAdvisories` -> reviewer path, and `truncateOutput` to bound the detail. Design doc and implementation plan included under `docs/superpowers/`.

## Testing

TDD throughout. Unit tests for every parser/detector; the orchestrator's three fail-open branches are each **bite-checked** to prove they are load-bearing (neutering a guard fails only its test); the #1322 fixture-relocation and net-removed-assertion scenarios are covered; and `TestTestDilution_SurfacesAsAdvisoryNotBlocking` drives the real `runGateChecks` to prove the finding never lands in the blocking channel. gofmt + `GOOS=linux golangci-lint run` clean; full `pkg/foreman/agent` suite green.

## AI-assisted (band 3)

Brainstormed, planned, and implemented via subagent-driven development with per-task and final whole-branch review; every review finding fixed and re-verified. Human-owned throughout.

Fixes #1332
