### PR TITLE
docs(api): correct MemoryLimitGiB doc, it is quota-accounting only with no runtime enforcement (#1312)

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -852,11 +852,12 @@ type GPUSharingSpec struct {
 	// +optional
 	Profile string `json:"profile,omitempty"`
 
-	// MemoryLimitGiB caps this service's device-memory footprint in
-	// shared mode. It drives quota accounting (a shared workload counts
-	// this many GiB against a GPUQuota vramBytes cap) and, where the
-	// runtime supports it, a memory-cap enforcement flag. Only valid for
-	// mode shared.
+	// MemoryLimitGiB declares this service's device-memory footprint in
+	// shared mode, in GiB. It is used for quota accounting only: a shared
+	// workload counts this many GiB against a GPUQuota vramBytes cap. It
+	// is NOT enforced at runtime; nothing caps the process's actual VRAM
+	// use. For hard isolation between tenants use mode partitioned (MIG).
+	// Only valid for mode shared.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	MemoryLimitGiB *int32 `json:"memoryLimitGiB,omitempty"`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -4427,11 +4427,12 @@ spec:
                     properties:
                       memoryLimitGiB:
                         description: |-
-                          MemoryLimitGiB caps this service's device-memory footprint in
-                          shared mode. It drives quota accounting (a shared workload counts
-                          this many GiB against a GPUQuota vramBytes cap) and, where the
-                          runtime supports it, a memory-cap enforcement flag. Only valid for
-                          mode shared.
+                          MemoryLimitGiB declares this service's device-memory footprint in
+                          shared mode, in GiB. It is used for quota accounting only: a shared
+                          workload counts this many GiB against a GPUQuota vramBytes cap. It
+                          is NOT enforced at runtime; nothing caps the process's actual VRAM
+                          use. For hard isolation between tenants use mode partitioned (MIG).
+                          Only valid for mode shared.
                         format: int32
                         minimum: 1
                         type: integer

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -4423,11 +4423,12 @@ spec:
                     properties:
                       memoryLimitGiB:
                         description: |-
-                          MemoryLimitGiB caps this service's device-memory footprint in
-                          shared mode. It drives quota accounting (a shared workload counts
-                          this many GiB against a GPUQuota vramBytes cap) and, where the
-                          runtime supports it, a memory-cap enforcement flag. Only valid for
-                          mode shared.
+                          MemoryLimitGiB declares this service's device-memory footprint in
+                          shared mode, in GiB. It is used for quota accounting only: a shared
+                          workload counts this many GiB against a GPUQuota vramBytes cap. It
+                          is NOT enforced at runtime; nothing caps the process's actual VRAM
+                          use. For hard isolation between tenants use mode partitioned (MIG).
+                          Only valid for mode shared.
                         format: int32
                         minimum: 1
                         type: integer


### PR DESCRIPTION
## What

Corrects the `MemoryLimitGiB` field doc comment in `api/v1alpha1/inferenceservice_types.go`, which falsely claimed a runtime memory-cap enforcement flag "where the runtime supports it". That has no implementation: `MemoryLimitGiB`'s only non-test reader is `podVRAMBytes` (`internal/controller/gpu_sharing.go`), a pure quota-accounting function; the value never reaches the pod spec, a container arg, env var, or annotation. The comment renders into the CRD (`kubectl explain`), so a reader would reasonably conclude shared mode has a memory guard when it does not.

## Why

Fixes #1312

## Change (doc comment + regenerated CRDs only)

Keeps the true part (drives GPUQuota `vramBytes` accounting), deletes the false enforcement clause, and states plainly: *"It is NOT enforced at runtime; nothing caps the process's actual VRAM use. For hard isolation between tenants use mode partitioned (MIG)."* Regenerated CRD artifacts (`config/crd/bases/...`, `charts/llmkube/templates/crds/...`) via `make manifests` so `kubectl explain` matches. No Go logic changed, no test (none needed for a comment).

## Provenance

Produced by a Foreman coder run (Laguna), which converged and self-declared **GO**. The run's recorded verdict shows NO-GO, but that is a harness artifact, not a rejection: the #1075 work-class verdict policy classified the change as `mixed` (it spans `.go` + regenerated chart/config CRDs, three path-classes at once, none reaching the 70% dominance threshold), and `mixed` is absent from the default self-GO allowlist `[code-fix, docs, packaging, config]`, so the GO was auto-downgraded to a `NEEDS-VERIFICATION` outcome that surfaces in the verdict field as NO-GO. Reviewed independently against the source and confirmed merge-ready.

## AI-assisted (band 3)

Agent-authored, human-reviewed for accuracy, opened by me.
