### PR TITLE
fix(foreman): test-presence accepts behavioral coverage of unexported helpers (#1329)

### DIFF
--- a/pkg/foreman/agent/mutation_gate.go
+++ b/pkg/foreman/agent/mutation_gate.go
@@ -279,12 +279,18 @@ func dedupSorted(in []string) []string {
 }
 
 // checkTestPresence fails when a changed package has NET-NEW functions in
-// hand-written, non-test Go that are not referenced by name in any changed
-// _test.go in that package. Body-modified functions are exempt: Layer 2
-// (mutation survival) covers them where the package has a changed test, and
-// CI's full suite covers them everywhere. Pure inspection -- no test
-// execution -- so it covers envtest/controller packages the fast unit-test
-// tier cannot run. Returns (failed, feedback).
+// hand-written, non-test Go that are not covered by a changed _test.go in
+// that package. An EXPORTED net-new function must be referenced by name in a
+// changed test (the public surface a test would name directly). An UNEXPORTED
+// net-new helper is accepted when the package has any changed test, since it
+// is an implementation detail exercised transitively through a tested public
+// entry point; it is only flagged when the package has NO changed test at all
+// (genuinely untested). This avoids the false rejection where a helper is
+// covered behaviorally but not named (#1329). Body-modified functions are
+// exempt: Layer 2 (mutation survival) covers them where the package has a
+// changed test, and CI's full suite covers them everywhere. Pure inspection --
+// no test execution -- so it covers envtest/controller packages the fast
+// unit-test tier cannot run. Returns (failed, feedback).
 func checkTestPresence(ctx context.Context, workspace string, run commandRunner) (bool, string) {
 	changed := changedNonTestGoFiles(ctx, workspace, run)
 	if len(changed) == 0 {
@@ -331,6 +337,16 @@ func checkTestPresence(ctx context.Context, workspace string, run commandRunner)
 
 		var unreferenced []string
 		for name := range funcSet {
+			// Unexported helpers are implementation details, exercised
+			// transitively through a tested public entry point: accept them
+			// when the package has any changed test, rather than demanding the
+			// helper's own name appear literally in a test (#1329). Exported
+			// functions -- the public surface a test would name directly --
+			// still require a by-name reference. An unexported helper in a
+			// package with NO changed test stays flagged (genuinely untested).
+			if !token.IsExported(name) && len(testFiles) > 0 {
+				continue
+			}
 			referenced := false
 			for _, tf := range testFiles {
 				if testFileReferencesFunc(workspace, tf, name) {
@@ -347,8 +363,10 @@ func checkTestPresence(ctx context.Context, workspace string, run commandRunner)
 		}
 		failed = true
 		sort.Strings(unreferenced)
-		fmt.Fprintf(&b, "Package %s/ changed functions (%s) have no test referencing them by name. "+
-			"Add a test that exercises the new behavior and fails without it.\n",
+		fmt.Fprintf(&b, "Package %s/ changed functions (%s) are not covered by a test. "+
+			"Name each changed EXPORTED function in a test that fails without it; for an "+
+			"unexported helper, add or change a test in this package that exercises it "+
+			"(directly or through a public entry point).\n",
 			dir, strings.Join(unreferenced, ", "))
 	}
 	if !failed {

--- a/pkg/foreman/agent/mutation_gate_test.go
+++ b/pkg/foreman/agent/mutation_gate_test.go
@@ -202,6 +202,75 @@ func TestCheckTestPresence_ReferencingTestPasses(t *testing.T) { //nolint:dupl
 	}
 }
 
+// TestCheckTestPresence_ExportedFlaggedUnexportedAcceptedWithChangedTest pins
+// the #1329 split: with a changed test present, an EXPORTED net-new function
+// still requires a by-name reference (flagged if missing), while an UNEXPORTED
+// helper is accepted as covered transitively. Package pkg/model adds Classify
+// (exported) and extractRepo (unexported); the changed test names neither.
+func TestCheckTestPresence_ExportedFlaggedUnexportedAcceptedWithChangedTest(t *testing.T) {
+	ws := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(ws, "pkg/model"), 0o755)
+	_ = os.WriteFile(filepath.Join(ws, "pkg/model/classifier.go"),
+		[]byte("package model\nfunc Classify() {}\nfunc extractRepo() {}\n"), 0o644)
+	// Changed test names neither Classify nor extractRepo.
+	_ = os.WriteFile(filepath.Join(ws, "pkg/model/classifier_test.go"),
+		[]byte("package model\nimport \"testing\"\nfunc TestSomething(t *testing.T) { _ = 1 }\n"), 0o644)
+
+	statusOut := " M pkg/model/classifier.go\x00 M pkg/model/classifier_test.go\x00"
+	diffOut := "@@ -0,0 +1,3 @@\n+package model\n+func Classify() {}\n+func extractRepo() {}\n"
+	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "git" && args[0] == "status":
+			return statusOut, nil
+		case name == "git" && args[0] == "diff" && len(args) > 2 && args[1] == "-U0" && args[2] == "HEAD":
+			return diffOut, nil
+		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "HEAD":
+			return diffOut, nil
+		}
+		return "", nil
+	}
+
+	failed, out := checkTestPresence(context.Background(), ws, runner)
+	if !failed {
+		t.Fatal("expected failure: exported Classify has no test naming it")
+	}
+	if !strings.Contains(out, "Classify") {
+		t.Errorf("feedback should flag the exported Classify; got:\n%s", out)
+	}
+	if strings.Contains(out, "extractRepo") {
+		t.Errorf("unexported extractRepo must be accepted (changed test present), not flagged; got:\n%s", out)
+	}
+}
+
+// TestCheckTestPresence_UnexportedHelperFlaggedWithoutChangedTest pins the
+// honest boundary of #1329: an unexported helper is still flagged when the
+// package has NO changed test at all (nothing exercises it).
+func TestCheckTestPresence_UnexportedHelperFlaggedWithoutChangedTest(t *testing.T) {
+	ws := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(ws, "pkg/model"), 0o755)
+	_ = os.WriteFile(filepath.Join(ws, "pkg/model/classifier.go"),
+		[]byte("package model\nfunc extractRepo() {}\n"), 0o644)
+
+	statusOut := " M pkg/model/classifier.go\x00" // no changed _test.go
+	diffOut := "@@ -0,0 +1,2 @@\n+package model\n+func extractRepo() {}\n"
+	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "git" && args[0] == "status":
+			return statusOut, nil
+		case name == "git" && args[0] == "diff" && len(args) > 2 && args[1] == "-U0" && args[2] == "HEAD":
+			return diffOut, nil
+		case name == "git" && args[0] == "diff" && len(args) > 1 && args[1] == "HEAD":
+			return diffOut, nil
+		}
+		return "", nil
+	}
+
+	failed, out := checkTestPresence(context.Background(), ws, runner)
+	if !failed || !strings.Contains(out, "extractRepo") {
+		t.Fatalf("unexported helper with no changed test must be flagged; got failed=%v out=%q", failed, out)
+	}
+}
+
 // TestCheckTestPresence_ModifiedFuncDoesNotNeedTest verifies that a
 // body-modified function (no net-new +func line) does NOT demand a named
 // test. Behavior-preserving edits to existing functions are covered by


### PR DESCRIPTION
## What

The coder gate's test-presence check (`checkTestPresence`) rejected a submit when a changed function's identifier did not appear by name in a test, even when the new behavior was covered behaviorally through a public entry point that calls it. In the #1322 harness run, unexported helpers (`extractHFRepoFromURL`, `isHuggingFaceURL`) were covered by a table test on the public classifier, but the gate still rejected them for not being named, costing a full submit/gate/fix cycle.

## Why

Fixes #1329

## How

Scope the by-name requirement to **exported** changed functions (the public surface a test names directly). For an **unexported** changed helper, accept it when the package has any changed test, since it is an implementation detail exercised transitively through a tested public entry point. Keep the check honest: an exported function with no by-name test is still flagged, and an unexported helper in a package with **no** changed test at all is still flagged (genuinely untested). The failure message now states the rule up front so a coder complies on the first submit.

Uses `token.IsExported` (already imported). Two regression tests: a combined test proving the split (exported `Classify` flagged, unexported `extractRepo` accepted when a changed test is present), and the honest boundary (unexported helper with no changed test still flagged). Bite-checked: removing the accept branch fails the split test.

## Provenance

This issue was first queued to a Foreman coder run, which **wedged** on the meta-difficulty of editing the very gate check its own submission runs under (a hung tool call after one gate bounce). Hand-fixed after that, per the "do it by hand if it fails" rule.

## AI-assisted (band 3)

Agent-authored, bite-checked, and opened by me.
