### PR TITLE
fix(foreman): do not downgrade a mixed footprint whose classes are all self-GO (#1342)

### DIFF
--- a/pkg/foreman/agent/changepolicy/changepolicy.go
+++ b/pkg/foreman/agent/changepolicy/changepolicy.go
@@ -111,9 +111,15 @@ type ChangePolicy interface {
 	// Classify returns the dominant work class for a set of changed paths
 	// with their added+deleted line counts.
 	Classify(changed map[string]int) WorkClass
-	// RequiresHumanReview returns true when any changed path classifies
-	// to a class NOT in the provided selfGO list.
+	// RequiresHumanReview returns true when a change over the given paths
+	// needs human review (falls outside the selfGO allowlist).
 	RequiresHumanReview(changedPaths []string, selfGO []string) bool
+	// NeedsVerification reports whether a change with the given footprint
+	// (path -> changed-line count) needs human verification: its class is
+	// outside selfGO, EXCEPT a "mixed" footprint whose every constituent
+	// class is itself in selfGO (a change merely spanning several self-GO
+	// classes, e.g. code plus its regenerated manifests, #1342).
+	NeedsVerification(changed map[string]int, selfGO []string) bool
 }
 
 // NewDefaultPolicy returns the default ChangePolicy, which mirrors the
@@ -133,16 +139,64 @@ func (defaultPolicy) Classify(changed map[string]int) WorkClass {
 }
 
 // RequiresHumanReview implements ChangePolicy.RequiresHumanReview.
-func (defaultPolicy) RequiresHumanReview(changedPaths []string, selfGO []string) bool {
-	// Build the footprint map from the path list (each path counts as 1
-	// line for the purpose of this gate; the caller may pass a richer
-	// map via Classify when line counts are available).
+func (d defaultPolicy) RequiresHumanReview(changedPaths []string, selfGO []string) bool {
+	// Each path counts as 1 line (callers with real line counts use
+	// NeedsVerification directly). Delegate so the mixed-all-selfGO
+	// relaxation (#1342) is applied consistently.
 	changed := map[string]int{}
 	for _, p := range changedPaths {
 		changed[p] = 1
 	}
+	return d.NeedsVerification(changed, selfGO)
+}
+
+// NeedsVerification implements ChangePolicy.NeedsVerification. A change needs
+// verification when its dominant class is outside selfGO, EXCEPT a "mixed"
+// footprint whose every constituent class is itself in selfGO: that is a
+// change merely spanning several self-GO classes (e.g. a doc-comment edit in a
+// *.go file that regenerates its CRDs spans code-fix + packaging + config, all
+// self-GO), not a genuinely unverifiable change, so it does not require
+// verification (#1342). A zero-line/empty footprint yields no constituent
+// classes and is never relaxed, so a rename-only change still needs review.
+func (defaultPolicy) NeedsVerification(changed map[string]int, selfGO []string) bool {
 	class := classifyFootprint(changed)
-	return !workClassInList(class, selfGO)
+	if workClassInList(class, selfGO) {
+		return false
+	}
+	if class == workClassMixed {
+		if cs := footprintClasses(changed); len(cs) > 0 {
+			for _, c := range cs {
+				if !workClassInList(c, selfGO) {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	return true
+}
+
+// footprintClasses returns the distinct work classes present in a footprint,
+// counting only files with a positive changed-line count. It returns nil for
+// an empty or zero-line footprint (rename-only / permission-only), so such a
+// change is never treated as a set of self-GO classes.
+func footprintClasses(changed map[string]int) []WorkClass {
+	total := 0
+	set := map[WorkClass]bool{}
+	for f, n := range changed {
+		total += n
+		if n > 0 {
+			set[classifyFile(f)] = true
+		}
+	}
+	if total == 0 {
+		return nil
+	}
+	out := make([]WorkClass, 0, len(set))
+	for c := range set {
+		out = append(out, c)
+	}
+	return out
 }
 
 // workClassInList reports whether class's string form appears in list.

--- a/pkg/foreman/agent/changepolicy/changepolicy_test.go
+++ b/pkg/foreman/agent/changepolicy/changepolicy_test.go
@@ -146,6 +146,57 @@ func TestClassify(t *testing.T) {
 	}
 }
 
+func TestNeedsVerification(t *testing.T) {
+	policy := defaultPolicy{}
+	tests := []struct {
+		name    string
+		changed map[string]int
+		selfGO  []string
+		want    bool
+	}{
+		{
+			// #1342 / #1312: doc-comment edit + regenerated CRDs spans
+			// code-fix + packaging + config (all selfGO) -> no verification.
+			name: "crd-regen doc change all selfGO",
+			changed: map[string]int{
+				"api/v1alpha1/inferenceservice_types.go":                        6,
+				"charts/llmkube/templates/crds/inferenceservices.yaml":          6,
+				"config/crd/bases/inference.llmkube.dev_inferenceservices.yaml": 6,
+			},
+			selfGO: []string{"code-fix", "docs", "packaging", "config"},
+			want:   false,
+		},
+		{
+			name:    "mixed with a non-selfGO constituent needs verification",
+			changed: map[string]int{"pkg/agent/loop.go": 10, ".github/workflows/ci.yml": 10},
+			selfGO:  []string{"code-fix", "docs", "packaging", "config"},
+			want:    true,
+		},
+		{
+			name:    "dominant selfGO class needs no verification",
+			changed: map[string]int{"pkg/agent/loop.go": 40},
+			selfGO:  []string{"code-fix", "docs", "packaging", "config"},
+			want:    false,
+		},
+		{
+			// Zero-line safety: a rename-only change (0 changed lines) has no
+			// constituent classes, so the mixed relaxation does not apply and
+			// it still needs verification.
+			name:    "zero-line rename still needs verification",
+			changed: map[string]int{"pkg/agent/loop.go": 0},
+			selfGO:  []string{"code-fix", "docs", "packaging", "config"},
+			want:    true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := policy.NeedsVerification(tc.changed, tc.selfGO); got != tc.want {
+				t.Errorf("NeedsVerification() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRequiresHumanReview(t *testing.T) {
 	policy := defaultPolicy{}
 
@@ -204,10 +255,34 @@ func TestRequiresHumanReview(t *testing.T) {
 			want:         true,
 		},
 		{
-			name:         "mixed change with selfGO missing mixed",
+			// #1342: a mixed footprint whose every constituent class is
+			// itself in selfGO (code-fix + docs) must NOT require review,
+			// even though "mixed" is absent from selfGO.
+			name:         "mixed change whose constituents are all selfGO",
 			changedPaths: []string{"pkg/agent/loop.go", "README.md"},
 			selfGO:       []string{"code-fix", "docs", "config"},
+			want:         false,
+		},
+		{
+			// #1342 boundary: a mixed footprint with a constituent OUTSIDE
+			// selfGO (ci-policy) still requires review.
+			name:         "mixed change with a non-selfGO constituent",
+			changedPaths: []string{"pkg/agent/loop.go", ".github/workflows/ci.yml"},
+			selfGO:       []string{"code-fix", "docs", "config"},
 			want:         true,
+		},
+		{
+			// #1342 / #1312: a doc-comment edit that regenerates its CRDs
+			// spans code-fix + packaging + config (all selfGO) -> mixed,
+			// no dominant class -> must NOT require review.
+			name: "crd-regen doc change: code-fix + packaging + config",
+			changedPaths: []string{
+				"api/v1alpha1/inferenceservice_types.go",
+				"charts/llmkube/templates/crds/inferenceservices.yaml",
+				"config/crd/bases/inference.llmkube.dev_inferenceservices.yaml",
+			},
+			selfGO: []string{"code-fix", "docs", "packaging", "config"},
+			want:   false,
 		},
 		{
 			name:         "mixed change with selfGO including mixed",

--- a/pkg/foreman/agent/verdict_policy.go
+++ b/pkg/foreman/agent/verdict_policy.go
@@ -155,7 +155,13 @@ func applyVerdictPolicy(
 		res.Extra["declaredWorkClass"] = declared
 	}
 
-	if !workClassInList(class, selfGO) {
+	// Downgrade to NEEDS-VERIFICATION when the change falls outside the
+	// self-GO allowlist. This delegates to the policy's NeedsVerification so
+	// a "mixed" footprint whose every constituent class is itself in selfGO
+	// (e.g. a doc-comment edit that regenerates its CRDs: code-fix +
+	// packaging + config) is NOT downgraded just because the mix has no
+	// dominant class (#1342). class above is retained for the audit record.
+	if policy.NeedsVerification(changed, selfGO) {
 		res.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
 		res.Extra["outcome"] = needsVerificationOutcome
 		res.Extra["unverified"] = []map[string]string{unverifiedPolicyEntry(class)}

--- a/pkg/foreman/agent/verdict_policy_test.go
+++ b/pkg/foreman/agent/verdict_policy_test.go
@@ -60,6 +60,22 @@ func TestApplyVerdictPolicy(t *testing.T) {
 			t.Fatalf("verdict = %v, want GO", res.Verdict)
 		}
 	})
+	t.Run("mixed footprint of all self-GO classes stands (crd-regen, #1342)", func(t *testing.T) {
+		res := applyVerdictPolicy(goResult(),
+			map[string]int{
+				"api/v1alpha1/inferenceservice_types.go":                        6,
+				"charts/llmkube/templates/crds/inferenceservices.yaml":          6,
+				"config/crd/bases/inference.llmkube.dev_inferenceservices.yaml": 6,
+			}, defaultSelfGO, changepolicy.NewDefaultPolicy())
+		if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+			t.Fatalf("verdict = %v, want GO: a doc change that regenerates CRDs spans "+
+				"code-fix+packaging+config, all self-GO", res.Verdict)
+		}
+		if res.Extra["actualWorkClass"] != "mixed" {
+			t.Errorf("actualWorkClass = %v, want mixed (recorded even when it stands)",
+				res.Extra["actualWorkClass"])
+		}
+	})
 	t.Run("operator opt-in allows ci-policy", func(t *testing.T) {
 		res := applyVerdictPolicy(goResult(),
 			map[string]int{".github/workflows/release.yml": 40},


### PR DESCRIPTION
## What

The work-class verdict policy downgraded a coder GO to NO-GO (outcome `NEEDS-VERIFICATION`) whenever the change classified as `mixed`, and a change is `mixed` when no single class reaches the 70% dominance threshold. A correct doc-comment or field edit in `api/*.go` that regenerates its CRDs necessarily spans `code-fix` + `packaging` + `config` at once, so it was classified `mixed` and downgraded even though every constituent class is individually in the self-GO allowlist. #1312 hit exactly this: a correct doc fix (comment + regenerated CRDs) recorded `verdict=NO-GO` and read as rejected.

## Why

Fixes #1342 (the over-downgrade half; see Scope).

## How

Add `ChangePolicy.NeedsVerification(changed, selfGO)`, the single source of truth for the human-verification decision. It returns:
- `false` when the dominant class is in selfGO (unchanged), and
- `false` for a `mixed` footprint whose **every constituent class** is itself in selfGO (a change merely spanning several self-GO classes, e.g. code plus its regenerated manifests), and
- `true` otherwise (a genuine class outside selfGO, including a mixed footprint with any non-selfGO constituent).

A zero-line/rename-only footprint has no constituent classes, so the relaxation never applies and it still needs verification (existing safety preserved). Both `applyVerdictPolicy` (the active gate) and `RequiresHumanReview` (previously an unused method whose doc claimed a per-path check it did not implement) route their decision through `NeedsVerification`, so the two gates now agree.

Tests: `TestNeedsVerification` covers the CRD-regen shape (no verification), a mixed footprint with a non-selfGO constituent (needs verification), a dominant self-GO class, and the zero-line rename (still needs verification). The agent-level `TestApplyVerdictPolicy` gains a wiring case proving a mixed CRD-regen GO stands. Bite-checked: removing the relaxation fails the wiring test. One existing `RequiresHumanReview` case that encoded the old bug (`code-fix + docs` mixed -> review) is corrected to the new behavior.

## Scope

This addresses the over-downgrade that caused the #1312 false NO-GO. The second half of #1342 -- surfacing `NEEDS-VERIFICATION` distinctly from `NO-GO` in the verdict field, so a needs-human-eyes outcome is not indistinguishable from a rejection -- is a separate status-API change and is left as a follow-up.

## AI-assisted (band 3)

Agent-authored, bite-checked, and opened by me.
