### PR TITLE
fix(foreman): ParseRepo delegates to the shared codehost slug validator (#1343)

### DIFF
--- a/pkg/foreman/agent/githubissue/fetch.go
+++ b/pkg/foreman/agent/githubissue/fetch.go
@@ -40,8 +40,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
 )
 
 // DefaultBodyCap bounds the issue body size we paste into the user
@@ -223,15 +224,20 @@ func truncateBody(body string, cap int) string {
 // (no slash, empty segments, or a ".." traversal segment); the executor
 // logs the error and skips the fetch (best-effort).
 func ParseRepo(s string) (owner, repo string, err error) {
-	idx := strings.LastIndex(s, "/")
-	if idx <= 0 || idx == len(s)-1 {
-		return "", "", errors.New("githubissue: repo must be owner/repo")
+	// Delegate to the shared codehost validator so a repo slug is validated
+	// and split by the SAME rule the clone and change-request paths use,
+	// rather than a divergent local reimplementation. The old local version
+	// checked only segment count and "..", so it accepted whitespace and
+	// other non-git-safe characters that codehost.IsValidRepoSlug rejects
+	// (e.g. "owner/name with space") -- inconsistent validation across the
+	// code-host seam (#1343). SplitRepoSlug enforces the character class,
+	// rejects empty/absolute/whitespace slugs and ".." traversal segments,
+	// and splits on the last slash so multi-segment slugs like
+	// "group/subgroup/project" yield owner="group/subgroup", repo="project".
+	namespace, name, ok := codehost.SplitRepoSlug(s)
+	if !ok {
+		return "", "", errors.New("githubissue: invalid repo slug (want owner/name or " +
+			"group/.../name with git-safe segments; no whitespace, empty, absolute, or '..' segments)")
 	}
-	owner, repo = s[:idx], s[idx+1:]
-	for _, seg := range strings.Split(s, "/") {
-		if seg == "" || seg == ".." {
-			return "", "", errors.New("githubissue: repo must not contain empty or '..' segments")
-		}
-	}
-	return owner, repo, nil
+	return namespace, name, nil
 }

--- a/pkg/foreman/agent/githubissue/fetch_test.go
+++ b/pkg/foreman/agent/githubissue/fetch_test.go
@@ -41,6 +41,13 @@ func TestParseRepo(t *testing.T) {
 		{"/empty-owner", "", "", true},
 		{"empty-repo/", "", "", true},
 		{"empty-segment//repo", "", "", true},
+		// #1343: the shared validator's character class rejects whitespace and
+		// other non-git-safe characters that the old local ParseRepo accepted.
+		{"owner/name with space", "", "", true},
+		{"owner/na\tme", "", "", true},
+		// #1343: ".." traversal segments stay rejected (guarded by name).
+		{"owner/..", "", "", true},
+		{"../etc/passwd", "", "", true},
 	}
 	for _, tc := range cases {
 		o, r, err := ParseRepo(tc.in)

--- a/pkg/foreman/agent/tools/fetch_issue_test.go
+++ b/pkg/foreman/agent/tools/fetch_issue_test.go
@@ -157,7 +157,7 @@ func TestFetchIssueTool_ArgValidation(t *testing.T) {
 		{"missing-repo", `{"number":1}`, "repo is required"},
 		{"zero-number", `{"repo":"o/r","number":0}`, "number must be a positive integer"},
 		{"negative-number", `{"repo":"o/r","number":-3}`, "number must be a positive integer"},
-		{"malformed-repo", `{"repo":"no-slash","number":1}`, "owner/repo"},
+		{"malformed-repo", `{"repo":"no-slash","number":1}`, "invalid repo slug"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What

`githubissue.ParseRepo` reimplemented repo-slug validation independently of the shared `codehost.IsValidRepoSlug`, checking only segment count and `..`, so it accepted whitespace and other non-git-safe characters the shared validator rejects. `ParseRepo("owner/name with space")` returned `owner="owner", repo="name with space"` with no error, while `codehost.IsValidRepoSlug` rejects it. Every consumer routing through `ParseRepo` (worktracker, tools/fetch_issue, cli/dispatch, cli/slice_planner) therefore validated slugs inconsistently with the clone and change-request paths.

## Why

Fixes #1343 (fast-follow to #1299 / #1341, surfaced by that PR's review).

## How

`ParseRepo` delegates to `codehost.SplitRepoSlug`, which validates via `IsValidRepoSlug` (enforcing the git-safe character class, rejecting empty/absolute/whitespace slugs and `..` traversal) and splits multi-segment slugs on the last slash (`group/subgroup/project` -> owner=`group/subgroup`, repo=`project`). The local `strings`-based reimplementation is removed. No import cycle: `codehost` does not import `githubissue`.

Regression tests: whitespace and tab rejection, and `..` traversal rejection, added to `TestParseRepo`; the existing accept/reject cases are unchanged. One consumer test (`TestFetchIssueTool_ArgValidation/malformed-repo`) is updated to the new, more descriptive error string.

## AI-assisted (band 3)

Agent-authored, bite-checked, and opened by me.
