### PR TITLE
test: guard GPU resource-name literal drift between pkg/apiutil and internal/controller

### DIFF
--- a/internal/controller/gpu_resources_drift_test.go
+++ b/internal/controller/gpu_resources_drift_test.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/apiutil"
+)
+
+// TestGPUResourceNameLiteralsMatchAPIUtil is a drift guard for the four GPU
+// extended-resource literals that are duplicated between this package
+// (gpu_resources.go) and pkg/apiutil (gpu.go). PR #1254 exported the mapping
+// via apiutil and made gpuResourceNameForSpec delegate to it, but the
+// internal copies are still read directly by gpuTolerationKeyForSpec, the
+// federation edge controller, and the model controller's readiness check.
+//
+// A future edit to one copy that silently diverges would let a pod's GPU
+// resource request (apiutil path) disagree with its toleration key
+// (internal path), leaving the pod unschedulable. This test pins the two
+// sets of literals together for all four vendors so the build fails the
+// moment they drift.
+func TestGPUResourceNameLiteralsMatchAPIUtil(t *testing.T) {
+	cases := []struct {
+		name  string
+		model *inferencev1alpha1.Model
+		// internal is the literal resolved by this package's own variables.
+		internal corev1.ResourceName
+	}{
+		{
+			name:     "nvidia.com/gpu",
+			model:    &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Hardware: &inferencev1alpha1.HardwareSpec{GPU: &inferencev1alpha1.GPUSpec{Vendor: "nvidia"}}}},
+			internal: nvidiaGPUResourceName,
+		},
+		{
+			name:     "amd.com/gpu",
+			model:    &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Hardware: &inferencev1alpha1.HardwareSpec{GPU: &inferencev1alpha1.GPUSpec{Vendor: "amd"}}}},
+			internal: amdGPUResourceName,
+		},
+		{
+			name:     "gpu.intel.com/i915",
+			model:    &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Hardware: &inferencev1alpha1.HardwareSpec{GPU: &inferencev1alpha1.GPUSpec{Vendor: "intel"}}}},
+			internal: intelGPUResourceNameI915,
+		},
+		{
+			name:     "devic.es/dri-render",
+			model:    &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Hardware: &inferencev1alpha1.HardwareSpec{GPU: &inferencev1alpha1.GPUSpec{Vendor: "amd", Runtime: "vulkan"}}}},
+			internal: vulkanDRIResourceName,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := apiutil.GPUResourceName(tc.model)
+			if got != tc.internal {
+				t.Fatalf(
+					"apiutil.GPUResourceName() = %q, internal literal = %q; "+
+						"the two packages' GPU resource-name literals have drifted",
+					got, tc.internal,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a build-time drift guard asserting the four GPU resource-name literals
(`nvidia.com/gpu`, `amd.com/gpu`, `gpu.intel.com/i915`, and the Vulkan DRI
path) stay identical between their two homes: the exported `pkg/apiutil`
mapping and the `internal/controller` package constants.

## Why

#1254 exported the mapping and made `gpuResourceNameForSpec` delegate to it, but
left the internal literal constants in place for the direct-const call sites
(`gpuTolerationKeyForSpec`, the federation edge controller, the model
controller). Nothing pinned the two copies together, so a future edit to one and
not the other would silently diverge.

Fixes #1255

## How

A table test (`TestGPUResourceNameLiteralsMatchAPIUtil`) compares
`apiutil.GPUResourceName(model)` against each internal constant for all four
vendors, so the build fails if the packages drift.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — n/a, test-only change

Assisted-by: Foreman (LLMKube's own agentic harness) generated the test; I reviewed the diff, bite-checked it (diverging the internal `amdGPUResourceName` const makes the guard fail while the other three vendors pass), and ran the package tests plus cross-arch lint before submitting.
