### PR TITLE
fix: skip GitHub auth and repo clone for freeform tasks without a repo

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -359,11 +359,25 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 		}()
 	}
 
-	auth, err := e.buildAuth()
-	if err != nil {
-		return e.failResult(start, foremanv1alpha1.FailureAuthUnavailable, err.Error()), nil
+	// needsRepo decides whether this task requires a cloned working tree.
+	// issue-fix and verify always need one; freeform and other kinds need
+	// one only when payload.repo (or a static --git-remote-url) is set.
+	// A freeform task with only a prompt runs the loop against an empty
+	// workspace with no auth and no clone (#1288).
+	needsRepo := task.Spec.Payload.Repo != "" ||
+		task.Spec.Kind == foremanv1alpha1.AgenticTaskKindIssueFix ||
+		task.Spec.Kind == foremanv1alpha1.AgenticTaskKindVerify ||
+		e.GitRemoteURL != ""
+
+	var auth *repo.Auth
+	if needsRepo {
+		a, err := e.buildAuth()
+		if err != nil {
+			return e.failResult(start, foremanv1alpha1.FailureAuthUnavailable, err.Error()), nil
+		}
+		auth = a
+		defer func() { _ = auth.Close() }()
 	}
-	defer func() { _ = auth.Close() }()
 
 	// resolveUpstream derives a repo's git URL from its payload.repo
 	// "owner/name" slug. It picks the clone target when no static fork
@@ -375,34 +389,38 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 		resolveUpstream = e.UpstreamURLForRepo
 	}
 
-	// Clone target: the statically configured fork remote when set,
-	// otherwise the task's own repo (#915). Deriving the clone+push target
-	// from payload.repo lets a single agent serve many repos instead of
-	// being pinned to one --git-remote-url; the branch still pushes to this
-	// clone's origin, which in that case is the task's repo itself.
-	cloneURL := e.GitRemoteURL
-	if cloneURL == "" {
-		cloneURL = resolveUpstream(task.Spec.Payload.Repo)
-	}
-	if cloneURL == "" {
-		return e.failResult(start, foremanv1alpha1.FailureGitRemoteNotConfigured,
-			"no --git-remote-url configured and task payload.repo is empty or invalid; cannot clone"), nil
-	}
-	if err := repo.Clone(ctx, repo.CloneOptions{
-		RemoteURL: cloneURL,
-		Dest:      workspace,
-		Auth:      auth,
-	}); err != nil {
-		return e.failResult(start, foremanv1alpha1.FailureCloneFailed, err.Error()), nil
-	}
-
-	// 4. Cut the task branch (see setupTaskBranch: revise-from-branch
-	// restore (#951), then upstream base fetch (#813), then clone-HEAD
-	// fallback). Failures bucket with CloneFailed for the retry policy.
 	branch := branchNameForTask(task)
-	baseBranch := baseBranchOrDefault(task.Spec.Payload.BaseBranch)
-	if err := setupTaskBranch(ctx, task, workspace, branch, baseBranch, resolveUpstream, auth, log); err != nil {
-		return e.failResult(start, foremanv1alpha1.FailureCloneFailed, err.Error()), nil
+	if needsRepo {
+		// Clone target: the statically configured fork remote when set,
+		// otherwise the task's own repo (#915). Deriving the clone+push
+		// target from payload.repo lets a single agent serve many repos
+		// instead of being pinned to one --git-remote-url; the branch
+		// still pushes to this clone's origin, which in that case is the
+		// task's repo itself.
+		cloneURL := e.GitRemoteURL
+		if cloneURL == "" {
+			cloneURL = resolveUpstream(task.Spec.Payload.Repo)
+		}
+		if cloneURL == "" {
+			return e.failResult(start, foremanv1alpha1.FailureGitRemoteNotConfigured,
+				"no --git-remote-url configured and task payload.repo is empty or invalid; cannot clone"), nil
+		}
+		if err := repo.Clone(ctx, repo.CloneOptions{
+			RemoteURL: cloneURL,
+			Dest:      workspace,
+			Auth:      auth,
+		}); err != nil {
+			return e.failResult(start, foremanv1alpha1.FailureCloneFailed, err.Error()), nil
+		}
+
+		// 4. Cut the task branch (see setupTaskBranch: revise-from-branch
+		// restore (#951), then upstream base fetch (#813), then
+		// clone-HEAD fallback). Failures bucket with CloneFailed for the
+		// retry policy.
+		baseBranch := baseBranchOrDefault(task.Spec.Payload.BaseBranch)
+		if err := setupTaskBranch(ctx, task, workspace, branch, baseBranch, resolveUpstream, auth, log); err != nil {
+			return e.failResult(start, foremanv1alpha1.FailureCloneFailed, err.Error()), nil
+		}
 	}
 
 	// 5. Build tool registry pinned to this workspace + filtered by the
@@ -426,7 +444,7 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	// 6+. LLM-driven path: extracted to keep Execute below the
 	// cyclomatic-complexity threshold. runLLMPath owns OAI + loop +
 	// transcript + commit/push.
-	return e.runLLMPath(ctx, task, &agent, endpoint, workspace, branch, registry, auth, start)
+	return e.runLLMPath(ctx, task, &agent, endpoint, workspace, branch, registry, auth, needsRepo, start)
 }
 
 // setupTaskBranch cuts the task's working branch in the freshly cloned
@@ -534,6 +552,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	workspace, branch string,
 	registry ToolRegistry,
 	auth *repo.Auth,
+	needsRepo bool,
 	start time.Time,
 ) (*Result, error) {
 	log := logf.FromContext(ctx).WithName("native-agent-loop").WithValues("task", task.Name, "ns", task.Namespace)
@@ -600,17 +619,9 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// Resolve an optional ModelProfile and layer it onto the loop config
 	// below. Cluster-scoped; a dangling ref degrades gracefully (run without
 	// the profile) rather than failing the task.
-	var modelProfile *foremanv1alpha1.ModelProfile
-	if ref := agent.Spec.ModelProfileRef; ref != "" {
-		var mp foremanv1alpha1.ModelProfile
-		switch err := e.Client.Get(ctx, types.NamespacedName{Name: ref}, &mp); {
-		case err == nil:
-			modelProfile = &mp
-		case apierrors.IsNotFound(err):
-			log.Info("modelProfileRef not found; running without profile", "profile", ref)
-		default:
-			return nil, fmt.Errorf("resolve model profile %q: %w", ref, err)
-		}
+	modelProfile, mpErr := e.resolveModelProfile(ctx, agent, log)
+	if mpErr != nil {
+		return nil, mpErr
 	}
 
 	cfg := LoopConfig{
@@ -806,6 +817,12 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// re-gate, bounded by the resolved iteration count (#768). Attempt 0 is
 	// the pre-#768 behavior byte-for-byte; exhausting the bound falls back to
 	// the pre-#768 ENVTEST-GATE-FAILED downgrade.
+	//
+	// A freeform task without a repo has no working tree to commit or push:
+	// return the GO result directly (#1288).
+	if r := e.freeformGoResult(start, transcriptRef, loopRes, branch, needsRepo); r != nil {
+		return r, nil
+	}
 	baseBranch := baseBranchOrDefault(task.Spec.Payload.BaseBranch)
 	maxEnvtestIters := effectiveMaxEnvtestIterations(agent)
 	var sha string
@@ -2131,6 +2148,43 @@ func (e *NativeAgentLoopExecutor) pushFailedResult(
 		"turnCount":      lr.Turns,
 	}
 	return r
+}
+
+// freeformGoResult returns a non-nil GO Result when the task does not need a
+// repo (e.g. a freeform task with only a prompt). In that case there is no
+// working tree to commit or push, so the GO verdict is returned directly
+// without entering the commit/push/gate loop (#1288). Returns nil when
+// needsRepo is true, so the caller falls through to the normal commit path.
+func (e *NativeAgentLoopExecutor) freeformGoResult(
+	start time.Time, tref corev1.ObjectReference, lr *LoopResult, branch string, needsRepo bool,
+) *Result {
+	if needsRepo {
+		return nil
+	}
+	return e.goResult(start, tref, lr, branch, "")
+}
+
+// resolveModelProfile fetches the ModelProfile referenced by the Agent's
+// spec.modelProfileRef. A dangling ref degrades gracefully (returns nil,
+// run without the profile) rather than failing the task. Extracted from
+// runLLMPath to keep that function under the gocyclo ceiling.
+func (e *NativeAgentLoopExecutor) resolveModelProfile(
+	ctx context.Context, agent *foremanv1alpha1.Agent, log logr.Logger,
+) (*foremanv1alpha1.ModelProfile, error) {
+	ref := agent.Spec.ModelProfileRef
+	if ref == "" {
+		return nil, nil
+	}
+	var mp foremanv1alpha1.ModelProfile
+	switch err := e.Client.Get(ctx, types.NamespacedName{Name: ref}, &mp); {
+	case err == nil:
+		return &mp, nil
+	case apierrors.IsNotFound(err):
+		log.Info("modelProfileRef not found; running without profile", "profile", ref)
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("resolve model profile %q: %w", ref, err)
+	}
 }
 
 func (e *NativeAgentLoopExecutor) goResult(

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -303,6 +303,76 @@ func TestNativeExecutor_NoAgentRefIsHardError(t *testing.T) {
 	}
 }
 
+// --- Freeform without repo: no auth, no clone (#1288) --------------------
+
+// TestNativeExecutor_FreeformNoRepoSkipsAuthAndClone proves that a freeform
+// AgenticTask with no payload.repo and no --git-remote-url does not attempt
+// GitHub auth resolution or repo clone. The AuthFactory is wired to fail if
+// called, and the workspace is checked to confirm no .git directory was
+// created. The model still runs and returns its verdict.
+func TestNativeExecutor_FreeformNoRepoSkipsAuthAndClone(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+
+	agent, task := taskAndAgent("freeform-no-repo")
+	task.Spec.Kind = foremanv1alpha1.AgenticTaskKindFreeform
+	task.Spec.Payload.Repo = ""
+	task.Spec.Payload.Prompt = "Reply by calling submit_result immediately."
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(agent, task).
+		Build()
+
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true, Verdict: "GO", Summary: "received",
+			},
+		},
+	}
+
+	workspaceRoot := filepath.Join(root, "ws")
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            workspaceRoot,
+		KeepWorkspace:            true,
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Bot", Email: "b@x"},
+		CommitCommitter:          repo.Identity{Name: "Bot", Email: "b@x"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		// AuthFactory that fails if called: proves auth resolution is
+		// skipped for a freeform task with no repo (#1288).
+		AuthFactory: func() (*repo.Auth, error) {
+			return nil, errors.New("auth should not be called for freeform without repo")
+		},
+		// No GitRemoteURL: proves clone is skipped.
+	}
+
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("verdict: want GO got %s; result=%+v", res.Verdict, res)
+	}
+	// No commit SHA: there was no repo to commit to.
+	if got := res.Extra["commitSHA"]; got != "" && got != nil {
+		t.Errorf("commitSHA: want empty (no repo) got %v", got)
+	}
+	// The workspace should not be a git repo (no clone happened).
+	ws := filepath.Join(workspaceRoot, task.Namespace, task.Name)
+	if _, err := os.Stat(filepath.Join(ws, ".git")); !os.IsNotExist(err) {
+		t.Errorf("workspace should not be a git repo (no clone): %v", err)
+	}
+}
+
 // --- Happy path: clone, loop, submit_result GO, commit, push -------------
 
 const submitGoBody = `{


### PR DESCRIPTION
## What

A freeform `AgenticTask` (kind `freeform`, only a prompt, no `payload.repo`) no
longer requires a GitHub token or a repo clone. The executor decides `needsRepo`
up front and skips auth resolution, clone, and branch setup when a task has no
repository to work on.

## Why

The CRD contract allows freeform tasks with just a prompt, but the executor
unconditionally called `buildAuth()` and cloned a repo, so a freeform task with
no repo failed with `AuthUnavailable` before the model ever ran, contradicting
the documented contract.

Fixes #1288

## How

`Execute` computes:

```
needsRepo = payload.repo != "" || kind in {issue-fix, verify} || --git-remote-url set
```

and gates auth + clone + `setupTaskBranch` behind it (`auth` stays nil, and
`authToken` is already nil-safe, when unused). `runLLMPath` takes `needsRepo`; a
new `freeformGoResult` short-circuits the commit/push/envtest-gate loop for
no-repo tasks (nothing to commit). `resolveModelProfile` was extracted from
`runLLMPath` (behavior unchanged) to keep it under the gocyclo ceiling after
adding the branch.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — n/a, the CRD contract already documents this behavior

Assisted-by: Foreman (LLMKube's own agentic harness) generated the fix and tests; I reviewed the diff, bite-checked the new test (reverting the fix makes it fail with the exact original bug, `verdict=INCOMPLETE FailureReason:AuthUnavailable`), and ran the package tests plus cross-arch lint before submitting.
