### PR TITLE
refactor: make ChangePolicy classification rules injectable (enabling step for #1302)

### DIFF
--- a/pkg/foreman/agent/changepolicy/changepolicy.go
+++ b/pkg/foreman/agent/changepolicy/changepolicy.go
@@ -40,15 +40,20 @@ const (
 // diff to take that class; below it the footprint is mixed.
 const footprintDominance = 0.70
 
-type classRule struct {
-	globs []string
-	class WorkClass
+// ClassRule maps a set of path globs to a work class. Rules are evaluated
+// in order; the first matching glob wins. Globs match with path.Match
+// against the full slash path and against the base name, plus a prefix
+// form for directory trees (dir/**).
+type ClassRule struct {
+	Globs []string
+	Class WorkClass
 }
 
-// classRules is evaluated in order; first matching glob wins. Globs match
-// with path.Match against the full slash path and against the base name,
-// plus a prefix form for directory trees (dir/**).
-var classRules = []classRule{
+// DefaultClassRules is the default set of path-to-class rules, mirroring
+// the GitHub-specific classification in workclass.go and the human-review
+// gate in verdict_policy.go. NewDefaultPolicy uses these rules so existing
+// behavior is unchanged.
+var DefaultClassRules = []ClassRule{
 	{[]string{".github/workflows/**", ".github/actions/**"}, workClassCIPolicy},
 	{[]string{".goreleaser*", "release-please*"}, workClassReleasePolicy},
 	{[]string{"Formula/**", "Dockerfile*", "charts/**", "*.spec",
@@ -72,39 +77,6 @@ func matchGlob(glob, path string) bool {
 	return false
 }
 
-func classifyFile(path string) WorkClass {
-	for _, r := range classRules {
-		for _, g := range r.globs {
-			if matchGlob(g, path) {
-				return r.class
-			}
-		}
-	}
-	return workClassCodeFix
-}
-
-func classifyFootprint(changed map[string]int) WorkClass {
-	if len(changed) == 0 {
-		return workClassCodeFix
-	}
-	total, byClass := 0, map[WorkClass]int{}
-	for f, n := range changed {
-		total += n
-		byClass[classifyFile(f)] += n
-	}
-	// Zero-line diffs (rename-only, permission-only) must not nondeterministically
-	// classify as a self-GO-able class; mixed is the safe fallback.
-	if total == 0 {
-		return workClassMixed
-	}
-	for class, n := range byClass {
-		if float64(n) >= footprintDominance*float64(total) {
-			return class
-		}
-	}
-	return workClassMixed
-}
-
 // ChangePolicy classifies changed paths into work classes and gates
 // human review when a change falls outside the self-GO allowlist.
 type ChangePolicy interface {
@@ -126,28 +98,38 @@ type ChangePolicy interface {
 // GitHub-specific classification in workclass.go and the human-review
 // gate in verdict_policy.go.
 func NewDefaultPolicy() ChangePolicy {
-	return defaultPolicy{}
+	return NewPolicy(DefaultClassRules)
+}
+
+// NewPolicy returns a ChangePolicy configured with the given path-to-class
+// rules. Pass DefaultClassRules (or use NewDefaultPolicy) for the GitHub
+// defaults; pass a custom set to classify non-GitHub paths (e.g. a
+// Woodpecker config at .woodpecker/**) as ci-policy without recompiling.
+func NewPolicy(rules []ClassRule) ChangePolicy {
+	return defaultPolicy{rules: rules}
 }
 
 // defaultPolicy is the default implementation that mirrors the
 // workclass.go/verdict_policy.go logic.
-type defaultPolicy struct{}
+type defaultPolicy struct {
+	rules []ClassRule
+}
 
 // Classify implements ChangePolicy.Classify.
-func (defaultPolicy) Classify(changed map[string]int) WorkClass {
-	return classifyFootprint(changed)
+func (p defaultPolicy) Classify(changed map[string]int) WorkClass {
+	return p.classifyFootprint(changed)
 }
 
 // RequiresHumanReview implements ChangePolicy.RequiresHumanReview.
-func (d defaultPolicy) RequiresHumanReview(changedPaths []string, selfGO []string) bool {
+func (p defaultPolicy) RequiresHumanReview(changedPaths []string, selfGO []string) bool {
 	// Each path counts as 1 line (callers with real line counts use
 	// NeedsVerification directly). Delegate so the mixed-all-selfGO
 	// relaxation (#1342) is applied consistently.
 	changed := map[string]int{}
-	for _, p := range changedPaths {
-		changed[p] = 1
+	for _, path := range changedPaths {
+		changed[path] = 1
 	}
-	return d.NeedsVerification(changed, selfGO)
+	return p.NeedsVerification(changed, selfGO)
 }
 
 // NeedsVerification implements ChangePolicy.NeedsVerification. A change needs
@@ -158,13 +140,13 @@ func (d defaultPolicy) RequiresHumanReview(changedPaths []string, selfGO []strin
 // self-GO), not a genuinely unverifiable change, so it does not require
 // verification (#1342). A zero-line/empty footprint yields no constituent
 // classes and is never relaxed, so a rename-only change still needs review.
-func (defaultPolicy) NeedsVerification(changed map[string]int, selfGO []string) bool {
-	class := classifyFootprint(changed)
+func (p defaultPolicy) NeedsVerification(changed map[string]int, selfGO []string) bool {
+	class := p.classifyFootprint(changed)
 	if workClassInList(class, selfGO) {
 		return false
 	}
 	if class == workClassMixed {
-		if cs := footprintClasses(changed); len(cs) > 0 {
+		if cs := p.footprintClasses(changed); len(cs) > 0 {
 			for _, c := range cs {
 				if !workClassInList(c, selfGO) {
 					return true
@@ -176,17 +158,54 @@ func (defaultPolicy) NeedsVerification(changed map[string]int, selfGO []string) 
 	return true
 }
 
+// classifyFile returns the work class for a single path, using the
+// policy's rules. First matching glob wins; unmatched paths are code-fix.
+func (p defaultPolicy) classifyFile(path string) WorkClass {
+	for _, r := range p.rules {
+		for _, g := range r.Globs {
+			if matchGlob(g, path) {
+				return r.Class
+			}
+		}
+	}
+	return workClassCodeFix
+}
+
+// classifyFootprint returns the dominant work class for a set of changed
+// paths with their added+deleted line counts.
+func (p defaultPolicy) classifyFootprint(changed map[string]int) WorkClass {
+	if len(changed) == 0 {
+		return workClassCodeFix
+	}
+	total, byClass := 0, map[WorkClass]int{}
+	for f, n := range changed {
+		total += n
+		byClass[p.classifyFile(f)] += n
+	}
+	// Zero-line diffs (rename-only, permission-only) must not nondeterministically
+	// classify as a self-GO-able class; mixed is the safe fallback.
+	if total == 0 {
+		return workClassMixed
+	}
+	for class, n := range byClass {
+		if float64(n) >= footprintDominance*float64(total) {
+			return class
+		}
+	}
+	return workClassMixed
+}
+
 // footprintClasses returns the distinct work classes present in a footprint,
 // counting only files with a positive changed-line count. It returns nil for
 // an empty or zero-line footprint (rename-only / permission-only), so such a
 // change is never treated as a set of self-GO classes.
-func footprintClasses(changed map[string]int) []WorkClass {
+func (p defaultPolicy) footprintClasses(changed map[string]int) []WorkClass {
 	total := 0
 	set := map[WorkClass]bool{}
 	for f, n := range changed {
 		total += n
 		if n > 0 {
-			set[classifyFile(f)] = true
+			set[p.classifyFile(f)] = true
 		}
 	}
 	if total == 0 {

--- a/pkg/foreman/agent/changepolicy/changepolicy_test.go
+++ b/pkg/foreman/agent/changepolicy/changepolicy_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestClassify(t *testing.T) {
-	policy := defaultPolicy{}
+	policy := NewDefaultPolicy()
 
 	tests := []struct {
 		name    string
@@ -147,7 +147,7 @@ func TestClassify(t *testing.T) {
 }
 
 func TestNeedsVerification(t *testing.T) {
-	policy := defaultPolicy{}
+	policy := NewDefaultPolicy()
 	tests := []struct {
 		name    string
 		changed map[string]int
@@ -198,7 +198,7 @@ func TestNeedsVerification(t *testing.T) {
 }
 
 func TestRequiresHumanReview(t *testing.T) {
-	policy := defaultPolicy{}
+	policy := NewDefaultPolicy()
 
 	tests := []struct {
 		name         string
@@ -310,7 +310,7 @@ func TestRequiresHumanReview(t *testing.T) {
 
 func TestClassifyCiPolicy(t *testing.T) {
 	// Regression test: .github/workflows must classify as ci-policy.
-	policy := defaultPolicy{}
+	policy := NewDefaultPolicy()
 	got := policy.Classify(map[string]int{".github/workflows/ci.yml": 10})
 	if got != workClassCIPolicy {
 		t.Errorf("Classify(ci.yml) = %q, want %q", got, workClassCIPolicy)
@@ -319,7 +319,7 @@ func TestClassifyCiPolicy(t *testing.T) {
 
 func TestClassifyCiPolicyActions(t *testing.T) {
 	// Regression test: .github/actions must classify as ci-policy.
-	policy := defaultPolicy{}
+	policy := NewDefaultPolicy()
 	got := policy.Classify(map[string]int{".github/actions/lint/action.yml": 5})
 	if got != workClassCIPolicy {
 		t.Errorf("Classify(actions/lint/action.yml) = %q, want %q", got, workClassCIPolicy)
@@ -329,7 +329,7 @@ func TestClassifyCiPolicyActions(t *testing.T) {
 func TestRequiresHumanReviewCiPolicyGate(t *testing.T) {
 	// Regression test: RequiresHumanReview returns true when
 	// a ci-policy change is not in the selfGO list.
-	policy := defaultPolicy{}
+	policy := NewDefaultPolicy()
 	got := policy.RequiresHumanReview(
 		[]string{".github/workflows/ci.yml"},
 		[]string{"code-fix", "docs", "config"},
@@ -388,6 +388,7 @@ func TestMatchGlob(t *testing.T) {
 }
 
 func TestClassifyFile(t *testing.T) {
+	policy := defaultPolicy{rules: DefaultClassRules}
 	tests := []struct {
 		name string
 		path string
@@ -481,7 +482,7 @@ func TestClassifyFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classifyFile(tt.path)
+			got := policy.classifyFile(tt.path)
 			if got != tt.want {
 				t.Errorf("classifyFile(%q) = %q, want %q", tt.path, got, tt.want)
 			}
@@ -490,6 +491,7 @@ func TestClassifyFile(t *testing.T) {
 }
 
 func TestClassifyFootprint(t *testing.T) {
+	policy := defaultPolicy{rules: DefaultClassRules}
 	tests := []struct {
 		name    string
 		changed map[string]int
@@ -523,7 +525,7 @@ func TestClassifyFootprint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classifyFootprint(tt.changed)
+			got := policy.classifyFootprint(tt.changed)
 			if got != tt.want {
 				t.Errorf("classifyFootprint() = %q, want %q", got, tt.want)
 			}
@@ -565,4 +567,105 @@ func TestWorkClassInList(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNewDefaultPolicyMatchesDefaultRules verifies that NewDefaultPolicy
+// classifies exactly as the GitHub defaults, so existing behavior is
+// unchanged when no custom rules are supplied.
+func TestNewDefaultPolicyMatchesDefaultRules(t *testing.T) {
+	policy := NewDefaultPolicy()
+	tests := []struct {
+		name    string
+		changed map[string]int
+		want    WorkClass
+	}{
+		{"ci-policy: .github/workflows", map[string]int{".github/workflows/ci.yml": 10}, workClassCIPolicy},
+		{"ci-policy: .github/actions", map[string]int{".github/actions/lint/action.yml": 5}, workClassCIPolicy},
+		{"release-policy: .goreleaser", map[string]int{".goreleaser.yaml": 8}, workClassReleasePolicy},
+		{"release-policy: release-please", map[string]int{"release-please-config.json": 3}, workClassReleasePolicy},
+		{"packaging: Dockerfile", map[string]int{"Dockerfile": 20}, workClassPackaging},
+		{"packaging: charts", map[string]int{"charts/llmkube/values.yaml": 15}, workClassPackaging},
+		{"docs: README.md", map[string]int{"README.md": 7}, workClassDocs},
+		{"config: *.yaml", map[string]int{"config/rbac/role.yaml": 14}, workClassConfig},
+		{"code-fix: Go source", map[string]int{"pkg/agent/loop.go": 25}, workClassCodeFix},
+		{"empty changed", map[string]int{}, workClassCodeFix},
+		{"mixed: no dominant class", map[string]int{"pkg/agent/loop.go": 10, "README.md": 10}, workClassMixed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := policy.Classify(tt.changed)
+			if got != tt.want {
+				t.Errorf("Classify() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewPolicyCustomRules verifies that a caller-supplied rule set
+// classifies a non-GitHub path (e.g. a Woodpecker config) as ci-policy,
+// while the default policy would classify it as code-fix.
+func TestNewPolicyCustomRules(t *testing.T) {
+	// A Woodpecker CI config path that the default GitHub rules would
+	// classify as code-fix (no extension match).
+	woodpeckerPath := ".woodpecker/ci.yaml"
+
+	t.Run("default policy classifies woodpecker path as config not ci-policy", func(t *testing.T) {
+		policy := NewDefaultPolicy()
+		got := policy.Classify(map[string]int{woodpeckerPath: 10})
+		if got == workClassCIPolicy {
+			t.Errorf("default Classify(%q) = %q, want something other than ci-policy", woodpeckerPath, got)
+		}
+	})
+
+	t.Run("custom rules classify woodpecker path as ci-policy", func(t *testing.T) {
+		// Custom rules: a Woodpecker config glob maps to ci-policy,
+		// followed by the default rules so other paths still classify.
+		rules := append([]ClassRule{
+			{[]string{".woodpecker/**"}, workClassCIPolicy},
+		}, DefaultClassRules...)
+		policy := NewPolicy(rules)
+		got := policy.Classify(map[string]int{woodpeckerPath: 10})
+		if got != workClassCIPolicy {
+			t.Errorf("custom Classify(%q) = %q, want %q", woodpeckerPath, got, workClassCIPolicy)
+		}
+	})
+
+	t.Run("custom rules still classify github paths as ci-policy", func(t *testing.T) {
+		rules := append([]ClassRule{
+			{[]string{".woodpecker/**"}, workClassCIPolicy},
+		}, DefaultClassRules...)
+		policy := NewPolicy(rules)
+		got := policy.Classify(map[string]int{".github/workflows/ci.yml": 10})
+		if got != workClassCIPolicy {
+			t.Errorf("custom Classify(.github/workflows/ci.yml) = %q, want %q", got, workClassCIPolicy)
+		}
+	})
+
+	t.Run("custom rules: ci-policy change requires review when not in selfGO", func(t *testing.T) {
+		rules := append([]ClassRule{
+			{[]string{".woodpecker/**"}, workClassCIPolicy},
+		}, DefaultClassRules...)
+		policy := NewPolicy(rules)
+		got := policy.RequiresHumanReview(
+			[]string{woodpeckerPath},
+			[]string{"code-fix", "docs", "config"},
+		)
+		if !got {
+			t.Error("RequiresHumanReview(woodpecker) = false, want true")
+		}
+	})
+
+	t.Run("custom rules: ci-policy change stands when in selfGO", func(t *testing.T) {
+		rules := append([]ClassRule{
+			{[]string{".woodpecker/**"}, workClassCIPolicy},
+		}, DefaultClassRules...)
+		policy := NewPolicy(rules)
+		got := policy.RequiresHumanReview(
+			[]string{woodpeckerPath},
+			[]string{"ci-policy", "code-fix", "docs", "config"},
+		)
+		if got {
+			t.Error("RequiresHumanReview(woodpecker) = true, want false")
+		}
+	})
 }


### PR DESCRIPTION
## What

Makes `ChangePolicy` path-to-class classification injectable at the code level:
exports `ClassRule` and `DefaultClassRules`, adds a `NewPolicy(rules []ClassRule)`
constructor, and turns the classify helpers into methods on the policy. Existing
behavior is unchanged: `NewDefaultPolicy()` now returns `NewPolicy(DefaultClassRules)`.

## Why

#1302 asks for configurable classification so non-GitHub CI (e.g. a Woodpecker
config at `.woodpecker/**`) can be classed as `ci-policy` without recompiling.
The rule set was previously a package-private `var`, so the boundary was
structurally sound but practically unusable off GitHub.

Refs #1302 — this is the enabling refactor, not the full feature (see below).

## How

`ClassRule`/`DefaultClassRules` are exported; `NewPolicy(rules)` stores the rules
on `defaultPolicy`; `classifyFile`/`classifyFootprint`/`footprintClasses` become
methods that read `p.rules`. The `#1342` mixed-all-selfGO relaxation is preserved.

**Deliberately out of scope (keeps #1302 open):** no user-facing config surface is
wired yet. `main.go` and `executor_native.go` still call `NewDefaultPolicy()`, so
a real Woodpecker user cannot configure paths through a chart value / Agent field /
ConfigMap without code. The issue flags two decisions to make together — where the
rules live, and whether a no-inferable-path repo can opt into "always require human
review" — both of which remain open. This PR unblocks that work without pre-empting
those decisions.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — n/a, no user-facing config surface yet

Assisted-by: Foreman (LLMKube's own agentic harness) generated the refactor and tests; I reviewed the diff, confirmed it only adds the code seam (no config surface wired, so it does not close #1302), bite-checked the tests (same `.woodpecker/ci.yaml` classifies as config by default but ci-policy under a custom rule via `NewPolicy`), and ran the package tests plus cross-arch lint before submitting.
