### PR TITLE
fix: stop wasted-turn context ballooning on max_tokens truncation

### DIFF
--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -547,8 +547,8 @@ func ReasoningOnlyNudgeMessage() string {
 func TruncationContinueMessage() string {
 	return "Your previous turn hit the token limit before you finished. Do " +
 		"not restart your reasoning. Stop deliberating now and emit the tool " +
-		"call for your next concrete action. If your work is complete, call " +
-		"submit_result with your verdict."
+		"call for your next concrete action. Keep your reasoning short. If " +
+		"your work is complete, call submit_result with your verdict."
 }
 
 // NoToolCallNudgeMessage is the corrective the loop appends as a user
@@ -792,6 +792,18 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 		preserveReasoning := streaks.preserveReasoningNext
 		streaks.preserveReasoningNext = false
 		editSucceeded, turnErr := l.runOneTurn(ctx, cfg, activeSchemas, res, preserveReasoning, &sessionDrop)
+
+		// After a truncation-continuation turn, the just-truncated assistant
+		// message's partial reasoning has served its purpose: the model
+		// resumed from it on this turn. Trim it from the persisted transcript
+		// so the wasted generation does not re-enter the context window on
+		// every subsequent turn, which is what drives the context ballooning
+		// and per-turn cost blowup described in #1328. The wire payload for
+		// THIS turn already carried the reasoning (via preserveTrailingReasoning
+		// in runOneTurn), so stripping it here only affects future turns.
+		if preserveReasoning {
+			trimTruncatedReasoning(res.Transcript)
+		}
 		if turnErr != nil {
 			if errors.Is(turnErr, errTerminalReached) {
 				// Coder gate feedback loop (#749): give the gate a chance to
@@ -972,6 +984,29 @@ func stripReasoningForWire(msgs []oai.Message, preserveTrailingReasoning bool) [
 		}
 	}
 	return wire
+}
+
+// trimTruncatedReasoning strips reasoning_content from the assistant
+// message that was just continued after a truncation. It is called after a
+// truncation-continuation turn (where preserveTrailingReasoning was true):
+// the model has now resumed from the partial reasoning and emitted its
+// tool call, so the wasted generation has served its purpose and must not
+// re-enter the context window on future turns. Without this, every
+// subsequent turn re-prefills the truncated reasoning, driving the context
+// ballooning and per-turn cost blowup described in #1328.
+//
+// The truncated assistant message is the one carrying reasoning_content
+// (a finish_reason=="length" turn is reasoning-only by construction). It
+// is NOT necessarily the most-recent assistant message: the continuation
+// turn appends a new assistant message with tool_calls, so the truncated
+// message is the one before it. The transcript is mutated in place.
+func trimTruncatedReasoning(transcript []oai.Message) {
+	for i := len(transcript) - 1; i >= 0; i-- {
+		if transcript[i].Role == oai.RoleAssistant && transcript[i].ReasoningContent != "" {
+			transcript[i].ReasoningContent = ""
+			return
+		}
+	}
 }
 
 // rejectsTemperature reports whether err is a provider rejecting the

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -995,14 +995,22 @@ func stripReasoningForWire(msgs []oai.Message, preserveTrailingReasoning bool) [
 // subsequent turn re-prefills the truncated reasoning, driving the context
 // ballooning and per-turn cost blowup described in #1328.
 //
-// The truncated assistant message is the one carrying reasoning_content
-// (a finish_reason=="length" turn is reasoning-only by construction). It
-// is NOT necessarily the most-recent assistant message: the continuation
-// turn appends a new assistant message with tool_calls, so the truncated
-// message is the one before it. The transcript is mutated in place.
+// The truncated assistant message is reasoning-only: a finish_reason=="length"
+// turn carries reasoning_content and NO tool_calls by construction (truncation
+// is only classified when len(ToolCalls)==0, see runOneTurn). It is NOT the
+// most-recent assistant message: the continuation turn appends a new assistant
+// message WITH tool_calls, and that continuation may itself carry a short
+// reasoning_content (the nudge asks to keep reasoning short, not to omit it).
+// So we must target the most-recent reasoning-only (no tool_calls) assistant
+// message, not simply the most-recent assistant message with any reasoning:
+// the latter would clear the continuation's live reasoning and leave the wasted
+// truncated reasoning in place, defeating the fix. The transcript is mutated in
+// place.
 func trimTruncatedReasoning(transcript []oai.Message) {
 	for i := len(transcript) - 1; i >= 0; i-- {
-		if transcript[i].Role == oai.RoleAssistant && transcript[i].ReasoningContent != "" {
+		if transcript[i].Role == oai.RoleAssistant &&
+			transcript[i].ReasoningContent != "" &&
+			len(transcript[i].ToolCalls) == 0 {
 			transcript[i].ReasoningContent = ""
 			return
 		}

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -1152,6 +1152,127 @@ func TestLoop_TruncatedTurn_ContinuationRetainsReasoningAndRecovers(t *testing.T
 	}
 }
 
+// TestLoop_TruncatedTurn_TrimsReasoningAfterContinuation pins the #1328
+// fix: after a truncation-continuation turn, the truncated assistant
+// message's partial reasoning is trimmed from the persisted transcript so
+// it does not re-enter the context window on every subsequent turn. The
+// continuation turn itself still receives the reasoning on the wire (that
+// is tested above), but the transcript must not retain it once the model
+// has resumed and acted.
+func TestLoop_TruncatedTurn_TrimsReasoningAfterContinuation(t *testing.T) {
+	srv, captured := capturingScriptedServer(t, []string{
+		assistantTruncated, toolCallSubmitGo,
+	})
+	reg := &fakeRegistry{results: map[string]*ToolResult{
+		"submit_result": {Terminal: true, Verdict: "GO"},
+	}}
+	loop := newTestLoop(srv, reg)
+
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "test", SystemPrompt: "sys", UserPrompt: "go",
+		MaxTurns: 5, MaxTokensPerTurn: 4096,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Fatalf("expected GO terminal after recovery, got %+v", res.Terminal)
+	}
+
+	// The truncated assistant message (the one that originally carried
+	// reasoning_content) must have its reasoning stripped from the persisted
+	// transcript after the continuation turn completed. We identify it by
+	// its position: it is the assistant message that precedes the
+	// continuation directive user message.
+	var sawTruncatedMsg bool
+	var sawReasoningTrimmed bool
+	for i := range res.Transcript {
+		if res.Transcript[i].Role == oai.RoleAssistant &&
+			strings.Contains(res.Transcript[i].ReasoningContent, "design the edit") {
+			// This should NOT happen — the reasoning should have been trimmed.
+			t.Errorf("truncated reasoning must be trimmed from transcript after continuation; "+
+				"found reasoning %q at idx %d", res.Transcript[i].ReasoningContent, i)
+		}
+		// The truncated assistant message is the one before the continuation
+		// directive. It should still exist (with its content/tool_calls) but
+		// with empty reasoning_content.
+		if res.Transcript[i].Role == oai.RoleUser &&
+			res.Transcript[i].Content == TruncationContinueMessage() {
+			// The assistant message immediately before this should be the
+			// truncated one.
+			if i > 0 && res.Transcript[i-1].Role == oai.RoleAssistant {
+				sawTruncatedMsg = true
+				if res.Transcript[i-1].ReasoningContent == "" {
+					sawReasoningTrimmed = true
+				}
+			}
+		}
+	}
+	if !sawTruncatedMsg {
+		t.Fatal("expected a truncated assistant message before the continuation directive")
+	}
+	if !sawReasoningTrimmed {
+		t.Error("truncated assistant message must have its reasoning trimmed after continuation")
+	}
+
+	// The continuation request (2nd) must still have retained the reasoning
+	// on the wire — the trim only affects the persisted transcript, not the
+	// continuation turn's request.
+	reqs := *captured
+	if len(reqs) != 2 {
+		t.Fatalf("want 2 captured requests, got %d", len(reqs))
+	}
+	var sawRetainedReasoning bool
+	for _, m := range reqs[1].Messages {
+		if m.Role == oai.RoleAssistant && strings.Contains(m.ReasoningContent, "design the edit") {
+			sawRetainedReasoning = true
+		}
+	}
+	if !sawRetainedReasoning {
+		t.Errorf("continuation request must retain the truncated reasoning on the wire")
+	}
+}
+
+// TestTrimTruncatedReasoning_TrimsReasoningCarryingAssistant pins the
+// helper in isolation: it strips reasoning_content from the assistant
+// message that carries it (the truncated turn), leaving earlier assistant
+// messages untouched. The truncated message is not necessarily the most-
+// recent one — the continuation turn appends a new assistant message with
+// tool_calls, so the truncated message is the one before it.
+func TestTrimTruncatedReasoning_TrimsReasoningCarryingAssistant(t *testing.T) {
+	tx := []oai.Message{
+		{Role: oai.RoleSystem, Content: "sys"},
+		{Role: oai.RoleAssistant, ReasoningContent: "old thought", Content: "prior"},
+		{Role: oai.RoleTool, Name: "read_file", Content: "{}"},
+		{Role: oai.RoleAssistant, ReasoningContent: "the truncated in-progress thought"},
+		{Role: oai.RoleUser, Content: TruncationContinueMessage()},
+		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{{
+			ID: "tc", Function: oai.ToolCallFunction{Name: "submit_result"},
+		}}},
+	}
+	trimTruncatedReasoning(tx)
+	if tx[1].ReasoningContent != "old thought" {
+		t.Errorf("earlier assistant reasoning must be untouched, got %q", tx[1].ReasoningContent)
+	}
+	if tx[3].ReasoningContent != "" {
+		t.Errorf("truncated assistant reasoning must be trimmed, got %q", tx[3].ReasoningContent)
+	}
+	if tx[5].ReasoningContent != "" {
+		t.Errorf("continuation assistant reasoning must be untouched, got %q", tx[5].ReasoningContent)
+	}
+}
+
+// TestLoop_TruncatedTurn_ContinuationMessageStrengthened pins the #1328
+// rail strengthening: the truncation continuation directive now includes
+// a "keep your reasoning short" instruction so the model does not re-enter
+// a long deliberation on the continuation turn.
+func TestLoop_TruncatedTurn_ContinuationMessageStrengthened(t *testing.T) {
+	msg := TruncationContinueMessage()
+	if !strings.Contains(msg, "Keep your reasoning short") {
+		t.Errorf("TruncationContinueMessage must include a short-reasoning rail; got %q", msg)
+	}
+}
+
 // TestLoop_TruncatedTurn_StreakResetsOnToolCall confirms a successful
 // tool-calling turn between truncations resets the streak, so intermittent
 // truncations never accumulate to a spurious ErrAssistantTruncated. The

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -1262,6 +1262,32 @@ func TestTrimTruncatedReasoning_TrimsReasoningCarryingAssistant(t *testing.T) {
 	}
 }
 
+// TestTrimTruncatedReasoning_ContinuationCarryingReasoning pins the case the
+// #1328 fix exists for: a verbose model keeps its reasoning "short" but
+// non-empty on the continuation turn, so the continuation assistant message
+// has BOTH reasoning_content and tool_calls. trimTruncatedReasoning must trim
+// the reasoning-only truncated message (no tool_calls) and leave the
+// continuation's live reasoning intact. A prior "most-recent assistant with
+// any reasoning" scan clears the continuation and leaves the wasted truncated
+// reasoning, defeating the fix.
+func TestTrimTruncatedReasoning_ContinuationCarryingReasoning(t *testing.T) {
+	tx := []oai.Message{
+		{Role: oai.RoleAssistant, ReasoningContent: "wasted truncated thought"},
+		{Role: oai.RoleUser, Content: TruncationContinueMessage()},
+		{Role: oai.RoleAssistant, ReasoningContent: "short continuation thought",
+			ToolCalls: []oai.ToolCall{{
+				ID: "tc", Function: oai.ToolCallFunction{Name: "submit_result"},
+			}}},
+	}
+	trimTruncatedReasoning(tx)
+	if tx[0].ReasoningContent != "" {
+		t.Errorf("wasted truncated reasoning must be trimmed, got %q", tx[0].ReasoningContent)
+	}
+	if tx[2].ReasoningContent != "short continuation thought" {
+		t.Errorf("continuation reasoning must survive (it has tool_calls), got %q", tx[2].ReasoningContent)
+	}
+}
+
 // TestLoop_TruncatedTurn_ContinuationMessageStrengthened pins the #1328
 // rail strengthening: the truncation continuation directive now includes
 // a "keep your reasoning short" instruction so the model does not re-enter


### PR DESCRIPTION
## What

Stops the Foreman coder loop from wasting a turn (and ballooning context) when a
generation reaches `max_tokens` mid-reasoning. Two parts: a firmer continuation
rail ("Keep your reasoning short"), and trimming the wasted truncated reasoning
from the persisted transcript after the continuation turn so it no longer
re-prefills on every later turn.

## Why

When the coder model hits `max_tokens` before emitting a tool call, the harness
injects a recovery nudge and continues, but the truncated multi-thousand-token
reasoning stayed in the transcript and re-entered the context on every
subsequent turn. In a harness-eval batch this drove context to ~82k tokens and
contributed to a 120-turn budget exhaustion, all from per-turn cost, not turn
count.

Fixes #1328

## How

- `TruncationContinueMessage()` gains a "Keep your reasoning short" instruction.
- After a truncation-continuation turn, `trimTruncatedReasoning` clears the
  wasted reasoning from the transcript (the wire payload for that turn already
  carried it, so only future turns are affected).

**Review fix (second commit).** The coder's first cut targeted the most-recent
assistant message carrying any `reasoning_content`. But the strengthened nudge
invites a *short but non-empty* continuation reasoning, so that scan would clear
the continuation's live reasoning and leave the wasted truncated reasoning in
place, silently defeating the fix for the exact verbose-model case #1328 is
about. The fix now targets the most-recent *reasoning-only* assistant message
(reasoning set, no tool_calls) — a `finish_reason==length` truncation is
reasoning-only by construction, while the continuation carries tool_calls.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — n/a, internal harness behavior

Assisted-by: Foreman (LLMKube's own agentic harness) generated the first commit (the rail + trim). On review I found the trim targeted the wrong message when the continuation turn carries reasoning; I proved it with a probe test, added the second commit to target the reasoning-only truncated message, added a regression test, bite-checked it (reverting the guard makes the new test fail with the exact defect), and ran the full package tests plus cross-arch lint before submitting.
