### PR TITLE
feat(observability): AMD GPU tier — amdgpu-exporter DaemonSet, metric contract, dashboard reconcile

### DIFF
--- a/charts/llmkube/dashboards/amd-gpu-observability.json
+++ b/charts/llmkube/dashboards/amd-gpu-observability.json
@@ -49,23 +49,39 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 70 },
-              { "color": "red", "value": 85 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
             ]
           },
           "unit": "celsius"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "id": 1,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -102,23 +118,39 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 200 },
-              { "color": "red", "value": 300 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
             ]
           },
           "unit": "watt"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
       "id": 2,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -155,23 +187,39 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 70 },
-              { "color": "red", "value": 90 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
             ]
           },
           "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
       "id": 3,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -208,21 +256,31 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "mhz"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
       "id": 4,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -237,7 +295,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "amdgpu_sclk_mhz{card=\"card0\"}",
+          "expr": "amdgpu_clock_hertz{card=\"card0\", sensor=\"sclk\"} / 1000000",
           "legendFormat": "SCLK",
           "refId": "A"
         }
@@ -272,23 +330,39 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 40000000000 },
-              { "color": "red", "value": 48000000000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 40000000000
+              },
+              {
+                "color": "red",
+                "value": 48000000000
+              }
             ]
           },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 7 },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
       "id": 5,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -325,23 +399,39 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1500000000 },
-              { "color": "red", "value": 2000000000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1500000000
+              },
+              {
+                "color": "red",
+                "value": 2000000000
+              }
             ]
           },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 7 },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
       "id": 6,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -378,14 +468,22 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 7 },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
       "id": 7,
       "options": {
         "colorMode": "value",
@@ -393,7 +491,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -441,14 +541,22 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 12, "x": 0, "y": 13 },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
       "id": 8,
       "options": {
         "colorMode": "value",
@@ -456,7 +564,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -491,16 +601,30 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 10 },
-              { "color": "red", "value": 20 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 12, "x": 12, "y": 13 },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
       "id": 10,
       "options": {
         "colorMode": "value",
@@ -508,7 +632,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -589,19 +715,34 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 85 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
             ]
           },
           "unit": "celsius"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 19 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
       "id": 20,
       "options": {
         "legend": {
-          "calcs": ["min", "max", "mean"],
+          "calcs": [
+            "min",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -673,18 +814,30 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "watt"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 19 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
       "id": 21,
       "options": {
         "legend": {
-          "calcs": ["min", "max", "mean"],
+          "calcs": [
+            "min",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -756,18 +909,30 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 27 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
       "id": 22,
       "options": {
         "legend": {
-          "calcs": ["min", "max", "mean"],
+          "calcs": [
+            "min",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -839,18 +1004,30 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 27 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
       "id": 23,
       "options": {
         "legend": {
-          "calcs": ["min", "max", "lastNotNull"],
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -944,18 +1121,30 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
       "id": 30,
       "options": {
         "legend": {
-          "calcs": ["min", "max", "mean"],
+          "calcs": [
+            "min",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1027,18 +1216,30 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
       "id": 32,
       "options": {
         "legend": {
-          "calcs": ["min", "max", "mean"],
+          "calcs": [
+            "min",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true

--- a/config/monitoring/amdgpu-exporter.yaml
+++ b/config/monitoring/amdgpu-exporter.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: amdgpu-exporter
+  namespace: monitoring
+  labels:
+    app: amdgpu-exporter
+spec:
+  selector:
+    matchLabels:
+      app: amdgpu-exporter
+  template:
+    metadata:
+      labels:
+        app: amdgpu-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9494"
+    spec:
+      containers:
+      - name: amdgpu-exporter
+        # Pinned to the candidate digest; move to an amdgpu-exporter-v* release
+        # tag once one is cut.
+        image: ghcr.io/defilantech/llmkube-amdgpu-exporter@sha256:7fb21e54382afd60ddd3f0f5f69bd16f653fe3db300c6f8765124e5598818192
+        ports:
+        - containerPort: 9494
+          hostPort: 9494
+          name: metrics
+          protocol: TCP
+        env:
+        - name: SYSFS_ROOT
+          value: /host/sys
+        - name: LISTEN_ADDR
+          value: ":9494"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+          runAsGroup: 65534
+        volumeMounts:
+        - name: sys
+          mountPath: /host/sys
+          readOnly: true
+      nodeSelector:
+        # Only run on nodes with AMD GPUs.
+        # Adjust this selector based on your cluster labels.
+        llmkube.dev/gpu-vendor: amd
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: amdgpu-exporter
+  namespace: monitoring
+  labels:
+    app: amdgpu-exporter
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9494"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 9494
+    targetPort: 9494
+    protocol: TCP
+  selector:
+    app: amdgpu-exporter

--- a/config/monitoring/amdgpu-exporter.yaml
+++ b/config/monitoring/amdgpu-exporter.yaml
@@ -55,7 +55,7 @@ spec:
       nodeSelector:
         # Only run on nodes with AMD GPUs.
         # Adjust this selector based on your cluster labels.
-        llmkube.dev/gpu-vendor: amd
+        accelerator: amd
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/config/monitoring/amdgpu-exporter.yaml
+++ b/config/monitoring/amdgpu-exporter.yaml
@@ -19,9 +19,8 @@ spec:
     spec:
       containers:
       - name: amdgpu-exporter
-        # Pinned to the candidate digest; move to an amdgpu-exporter-v* release
-        # tag once one is cut.
-        image: ghcr.io/defilantech/llmkube-amdgpu-exporter@sha256:7fb21e54382afd60ddd3f0f5f69bd16f653fe3db300c6f8765124e5598818192
+        # Pinned to the amdgpu-exporter-v0.1.0 release (tag + digest).
+        image: ghcr.io/defilantech/llmkube-amdgpu-exporter:0.1.0@sha256:150fc4ad15677fa43f747842404e23b23834f980b54151749048eb650bd5fcef
         ports:
         - containerPort: 9494
           hostPort: 9494

--- a/config/monitoring/kustomization.yaml
+++ b/config/monitoring/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - namespace.yaml
 - node-exporter.yaml
 - dcgm-exporter.yaml
+- amdgpu-exporter.yaml

--- a/config/monitoring/prometheus-scrape-config.yaml
+++ b/config/monitoring/prometheus-scrape-config.yaml
@@ -21,3 +21,13 @@ scrape_configs:
         labels:
           cluster: 'llmkube'
           instance: 'gpu-node'
+
+  # AMDGPU Exporter - AMD GPU metrics from amdgpu sysfs (utilization, VRAM/GTT,
+  # temp, power, clocks). See docs/observability/amd-gpu-metrics.md.
+  - job_name: 'llmkube-amd-gpu'
+    static_configs:
+      - targets:
+        - '<YOUR-AMD-NODE-IP>:9494'
+        labels:
+          cluster: 'llmkube'
+          instance: 'amd-gpu-node'

--- a/docs/observability/amd-gpu-metrics.md
+++ b/docs/observability/amd-gpu-metrics.md
@@ -1,0 +1,61 @@
+# AMD GPU metric contract
+
+The pinned metric names for the AMD tier (issue #700, slices #1185/#1187).
+Dashboards and alerts key off these names; changing them is a breaking change
+to this contract and must update `charts/llmkube/dashboards/amd-gpu-observability.json`
+in the same PR.
+
+## Source: amdgpu-exporter (DaemonSet, `config/monitoring/amdgpu-exporter.yaml`)
+
+`ghcr.io/defilantech/llmkube-amdgpu-exporter` (this org's `llmkube-runtimes`
+repo) reads amdgpu **sysfs/hwmon** directly — no `rocm-smi`/ROCm userspace
+required, which is what makes it work on Vulkan-first boxes (gfx1151) where
+the datacenter exporters (`device-metrics-exporter`, `amd_smi_exporter`) do
+not enumerate the iGPU.
+
+Every per-GPU series carries `card` (e.g. `card0`) and `pci_slot`
+(e.g. `0000:c5:00.0`). **`pci_slot` is the stable join/alert key** — card
+indices can move across reboots.
+
+| Metric | Unit | Notes |
+| --- | --- | --- |
+| `amdgpu_gpus_discovered` | count | AMD DRM devices found (vendor `0x1002`) |
+| `amdgpu_gpu_info` | 1 | static labels: device/subsystem/revision ids, product name |
+| `amdgpu_gpu_busy_percent` | % | GPU engine busy |
+| `amdgpu_memory_busy_percent` | % | memory controller busy (absent on some APUs) |
+| `amdgpu_vram_used_bytes` / `amdgpu_vram_total_bytes` | bytes | dedicated VRAM |
+| `amdgpu_visible_vram_used_bytes` / `_total_bytes` | bytes | CPU-visible VRAM |
+| `amdgpu_gtt_used_bytes` / `amdgpu_gtt_total_bytes` | bytes | **GTT — on APUs the model weights live here**, this is the key memory signal |
+| `amdgpu_temperature_celsius{sensor}` | °C | hwmon temp sensors (`edge`, …) |
+| `amdgpu_power_watts{sensor,type}` | W | hwmon power (`type`: `average`/`cap`/…) |
+| `amdgpu_clock_hertz{sensor}` | Hz | hwmon freq sensors; **`sensor="sclk"` is the core clock**. `mclk` is not exposed via hwmon on gfx1151 (only `pp_dpm_mclk`); memory clock is a known gap |
+| `amdgpu_voltage_volts{sensor}` | V | hwmon voltage |
+| `amdgpu_fan_rpm{sensor}` / `amdgpu_fan_pwm{sensor}` | rpm / raw | absent on fanless boxes |
+| `amdgpu_pcie_replay_total` | counter | PCIe replay events |
+| `amdgpu_scrape_success` / `amdgpu_scrape_failures_total` / `amdgpu_last_scrape_duration_seconds` | — | exporter health |
+
+Per-metric failures are isolated: a missing sysfs attribute skips that one
+metric, never the scrape. A node with zero AMD GPUs serves an empty-but-healthy
+`/metrics` (`amdgpu_gpus_discovered 0`).
+
+## Cross-check: node-exporter hwmon
+
+node-exporter's hwmon collector independently exposes the same sensors as
+`node_hwmon_temp_celsius` / `node_hwmon_power_watt`, joinable on
+`node_hwmon_chip_names{chip_name="amdgpu"}`. The dashboard's health row uses
+these (verified on gfx1151); the `amdgpu_*` equivalents are the per-GPU-labeled
+versions of the same readings.
+
+## Inference signals (slice #1186)
+
+SLO metrics come from llama.cpp `/metrics` (`--metrics`), not this exporter:
+`llamacpp:tokens_per_second`-family, `llamacpp:kv_cache_usage_ratio`,
+`llamacpp:requests_processing`. Backend-agnostic and already emitted.
+
+## Known gaps (deliberate)
+
+- Memory clock (`mclk`): only available via `pp_dpm_mclk` text parsing; not
+  yet exported.
+- Per-process attribution: not available from sysfs; would need ROCm userspace.
+- Instinct/MI datacenter tiers: use `ROCm/device-metrics-exporter` when that
+  hardware exists; this exporter targets the iGPU/APU class it was built on.


### PR DESCRIPTION
## What

AMD GPU observability slices for #700: the exporter DaemonSet + metric contract (#1185) and the dashboard reconcile for #1187 — consolidated onto the merged `llmkube-amdgpu-exporter` (#16 in llmkube-runtimes) as the canonical sysfs exporter.

## Why

Fixes #1185; unblocks the remaining scrape-confirm halves of #1186/#1187.

The Jul-21 decomposition pinned a contract from the quick lab exporter (`amdgpu_sclk_mhz`, llmkubelab manifest). Since then the reviewed sysfs exporter merged into `llmkube-runtimes` with slightly different (richer) names — per-sensor labels, `pci_slot` as the stable key, native temp/power, `pcie_replay_total`. This PR makes that the single contract everywhere:

- **`config/monitoring/amdgpu-exporter.yaml`** — DaemonSet + headless Service mirroring `dcgm-exporter.yaml` (hostPort 9494, scrape annotations), with the exporter's hardened posture (nonroot 65534, read-only rootfs, caps dropped, `/sys` ro). Image pinned to the candidate digest — happy to swap to `amdgpu-exporter-v0.1.0` in this PR if you cut the tag.
- **`prometheus-scrape-config.yaml`** — `llmkube-amd-gpu` static job, matching the doc's existing style.
- **`docs/observability/amd-gpu-metrics.md`** — the pinned contract #1185 owns: full metric table, `pci_slot`-is-the-stable-key, the GTT note (model weights live there on APUs), `node_hwmon_*` cross-check for the health row, `llamacpp:*` inference signals (slice 2), and deliberate gaps (mclk via `pp_dpm_*` only, no per-process attribution).
- **`amd-gpu-observability.json`** — one expr fix: `amdgpu_sclk_mhz` → `amdgpu_clock_hertz{sensor="sclk"} / 1e6` (unit stays MHz). `busy`/`vram`/`gtt` exprs and the `node_hwmon` health panels already matched the merged exporter, so they're untouched.

## Checklist

- [x] Tests added/updated — n/a (manifests/docs/dashboard); `kustomize build config/monitoring` validates, dashboard JSON validated
- [x] `make lint` — no Go changes
- [x] Conventional commits, DCO signed
- [x] AI assistance disclosed — authored with Claude Code
- [x] Documentation updated — the contract doc is the deliverable
