### PR TITLE
fix(controller): skip model-cache PVC for pvc:// sources

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -216,7 +216,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		desiredReplicas = 0
 	}
 
-	if effectiveModelCacheKey(model) != "" && r.ModelCachePath != "" {
+	if modelNeedsCachePVC(model, r.ModelCachePath) {
 		if err := r.ensureModelCachePVC(ctx, inferenceService); err != nil {
 			log.Error(err, "Failed to ensure model cache PVC exists", "namespace", inferenceService.Namespace)
 			return r.updateStatusWithSchedulingInfo(ctx, inferenceService, PhaseFailed, modelReady, 0, desiredReplicas, "",

--- a/internal/controller/model_cache_pvc_test.go
+++ b/internal/controller/model_cache_pvc_test.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"testing"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// TestModelNeedsCachePVC guards the fix for the unused cache PVC on pvc://
+// sources: a pre-staged pvc:// model is mounted read-only (no download), so the
+// operator must not provision a per-ISVC cache PVC for it. Each model below
+// sets Status.CacheKey so effectiveModelCacheKey is non-empty -- the pvc:// case
+// is therefore false ONLY because of the isPVCSource guard. Remove that guard
+// and the pvc:// case flips to true, failing this test.
+func TestModelNeedsCachePVC(t *testing.T) {
+	withKey := func(source string) *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{
+			Spec:   inferencev1alpha1.ModelSpec{Source: source},
+			Status: inferencev1alpha1.ModelStatus{CacheKey: "deadbeef"},
+		}
+	}
+	const cachePath = "/models"
+
+	tests := []struct {
+		name      string
+		model     *inferencev1alpha1.Model
+		cachePath string
+		want      bool
+	}{
+		{"https source is downloaded -> needs a cache", withKey("https://example.com/model.gguf"), cachePath, true},
+		{"http source is downloaded -> needs a cache", withKey("http://example.com/model.gguf"), cachePath, true},
+		{"s3 source is downloaded -> needs a cache", withKey("s3://bucket/model.gguf"), cachePath, true},
+		{"pvc:// source is pre-staged/read-only -> no cache PVC", withKey("pvc://my-models/model.gguf"), cachePath, false},
+		{"caching disabled (empty cache path) -> no cache PVC", withKey("https://example.com/model.gguf"), "", false},
+		{"no cache key -> no cache PVC", &inferencev1alpha1.Model{Spec: inferencev1alpha1.ModelSpec{Source: "https://example.com/model.gguf"}}, cachePath, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := modelNeedsCachePVC(tc.model, tc.cachePath); got != tc.want {
+				t.Errorf("modelNeedsCachePVC(source=%q, cachePath=%q) = %v, want %v",
+					tc.model.Spec.Source, tc.cachePath, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -118,6 +118,20 @@ func (r *InferenceServiceReconciler) warnIgnoredModelCacheClaim(
 	}
 }
 
+// modelNeedsCachePVC reports whether the operator should provision a model
+// cache PVC for this reconcile. Caching must be enabled on the operator
+// (modelCachePath set) and the model must have a cache key. It must NOT be a
+// pvc:// source: those are pre-staged and mounted read-only
+// (buildModelStorageConfig dispatches to buildPVCStorageConfig, never the
+// cache), so provisioning a cache PVC for them only leaves an unused,
+// ISVC-owned claim. Kept as its own predicate so the mount side (isPVCSource
+// in buildModelStorageConfig) and the provisioning side agree on pvc://.
+func modelNeedsCachePVC(model *inferencev1alpha1.Model, modelCachePath string) bool {
+	return modelCachePath != "" &&
+		effectiveModelCacheKey(model) != "" &&
+		!isPVCSource(model.Spec.Source)
+}
+
 // modelCachePVCName returns the name of the model cache PVC for the given mode.
 // A per-InferenceService spec.modelCache.claimName override (#928) wins over
 // the operator-global mode: that user-owned PVC becomes the cache volume for


### PR DESCRIPTION
## What

A `pvc://` model source is pre-staged and mounted read-only (`buildModelStorageConfig` dispatches to `buildPVCStorageConfig`, never the cache), so provisioning a per-InferenceService model-cache PVC for it only leaves an empty, unused, ISVC-owned claim.

The **mount** path already special-cases `pvc://`; the **provisioning** call site did not. This adds a small `modelNeedsCachePVC` predicate that applies the same `isPVCSource` check, and uses it to gate the `ensureModelCachePVC` call.

Fixes #1353.

## Change

- `internal/controller/model_storage.go`: new `modelNeedsCachePVC(model, modelCachePath)` predicate (caching enabled + has cache key + **not** `pvc://`).
- `internal/controller/inferenceservice_controller.go`: gate the `ensureModelCachePVC` call with it (was an inline condition missing the `pvc://` check).

No behavior change for downloadable sources (http/https/s3) or shared-mode caching — only `pvc://` sources stop getting an unused per-ISVC cache PVC.

## Test

`TestModelNeedsCachePVC` (table-driven) covers http/https/s3 (cache provisioned), `pvc://` (no cache — the fix), caching-disabled, and no-cache-key. Mutation-checked: removing the `isPVCSource` guard flips the `pvc://` case and fails the test.

```
go test ./internal/controller/ -run '^TestModelNeedsCachePVC$'
```

## Checklist
- [x] Commit signed off (DCO)
- [x] `gofmt` / `go vet` clean on the changed package
- [x] Test exercises real behavior (fails when the guard is removed)
- [x] Scope matches the issue (no unrelated changes)

Assisted-by: Claude Code (drafted the fix, the test, and this description; a human reviewed the diff and ran the focused test — it passes and fails when the guard is removed).
