### PR TITLE
fix(foreman): fail loudly when a revision's prior attempt cannot be restored

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -456,8 +456,9 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 //     earlier commits forward on top of work merged since instead of reverting
 //     it. The executor owns this restore+rebase — prompt-driven git proved
 //     fragile under stuck-loop forcing windows. When the ref is gone from the
-//     remote (pruned, or the prior attempt never pushed) it logs and falls
-//     through to (2). Under the default "reset" strategy the restore is skipped
+//     remote the task FAILS (#1364) — falling through to (2) would rebuild
+//     from base and, with allowOverwrite, force-push over the prior attempt,
+//     silently destroying it. Under the default "reset" strategy the restore is skipped
 //     entirely: a retry or repair re-dispatch redoes the work fresh from base,
 //     so a stale prior branch can never drift from base and revert merged work.
 //  2. Upstream base fetch (#813): when the task carries a repo slug, fetch the
@@ -489,7 +490,8 @@ func setupTaskBranch(
 
 	// rebase (in-review revision): restore the prior attempt AND rebase it onto
 	// the current base, so its commits replay on top of work merged since rather
-	// than reverting it. reset (the default) skips the restore entirely and cuts
+	// than reverting it. A restore miss fails the task (#1364) — see below.
+	// reset (the default) skips the restore entirely and cuts
 	// fresh from the current base below, so a retry or repair re-dispatch can
 	// never carry a stale branch that drifts from base.
 	if strategy == foremanv1alpha1.BranchStrategyRebase &&
@@ -523,8 +525,19 @@ func setupTaskBranch(
 				"reviseFromBranch", ref, "branch", branch, "baseBranch", baseBranch)
 			return nil
 		}
-		log.Info("reviseFromBranch ref not found on push remote; falling back to base branch",
-			"reviseFromBranch", ref, "baseBranch", baseBranch)
+		// The caller named a prior attempt; its absence is an error, not a
+		// fallback. Falling through to a fresh base-cut here silently discards
+		// the prior attempt's work — and when the payload also carries
+		// allowOverwrite (revisions and pr-fixes always do), the base-cut then
+		// force-pushes over the surviving remote ref, destroying reviewed work
+		// with no error anywhere (#1364: a reviewed 554-line migration was
+		// replaced by a +3/−1 CI tweak this way, three times in one day). A
+		// miss here means the ref was pruned or a concurrent fix attempt is
+		// racing this one — both are conditions to surface, not paper over.
+		return fmt.Errorf(
+			"revision restore failed: reviseFromBranch %q not found on push remote "+
+				"(pruned, never pushed, or racing a concurrent fix attempt); refusing "+
+				"to rebuild from %s and overwrite the prior attempt", ref, baseBranch)
 	}
 
 	if upstreamURL := resolveUpstream(task.Spec.Payload.Repo); upstreamURL != "" {

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2312,16 +2312,19 @@ func TestSetupTaskBranch_RestoresPriorAttempt(t *testing.T) {
 	}
 }
 
-// TestSetupTaskBranch_MissingRefFallsBackToBase pins the degradation
-// contract: when the reviseFromBranch ref is gone from the remote the
-// task still runs — branched from the upstream base — instead of
-// failing.
-func TestSetupTaskBranch_MissingRefFallsBackToBase(t *testing.T) {
+// TestSetupTaskBranch_MissingRefFailsLoud pins the #1364 contract: when the
+// reviseFromBranch ref is gone from the remote the task FAILS instead of
+// rebuilding from base. The old fallback, combined with allowOverwrite (which
+// revisions and pr-fixes always carry), force-pushed a fresh base-cut over the
+// prior attempt — silently destroying reviewed work. A named prior attempt
+// that cannot be restored is an error to surface (pruned ref, or a race with
+// a concurrent fix attempt), never a fallback.
+func TestSetupTaskBranch_MissingRefFailsLoud(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not on PATH")
 	}
 	dir := t.TempDir()
-	bare, mainSHA := seededRemote(t, dir)
+	bare, _ := seededRemote(t, dir)
 	const branch = "foreman/wl/issue-641"
 
 	ws := filepath.Join(dir, "ws")
@@ -2329,14 +2332,12 @@ func TestSetupTaskBranch_MissingRefFallsBackToBase(t *testing.T) {
 
 	err := setupTaskBranch(context.Background(), revisionTask(branch), ws, branch, "main",
 		func(string) string { return bare }, nil, logr.Discard())
-	if err != nil {
-		t.Fatalf("setupTaskBranch must fall back, not fail: %v", err)
+	if err == nil {
+		t.Fatal("missing reviseFromBranch ref must fail the task, not fall back to base")
 	}
-	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != mainSHA {
-		t.Errorf("HEAD = %s, want base tip %s (fallback branches from base)", got, mainSHA)
-	}
-	if got := gitIn(t, ws, "branch", "--show-current"); got != branch {
-		t.Errorf("current branch = %q, want %q", got, branch)
+	if !strings.Contains(err.Error(), "reviseFromBranch") ||
+		!strings.Contains(err.Error(), "refusing") {
+		t.Errorf("error must explain the refusal, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

A `reviseFromBranch` restore miss now fails the task with an explicit error instead of silently falling back to a fresh base-cut.

## Why

Fixes #1364

The fallback was a data-loss primitive: revisions and pr-fixes always carry `allowOverwrite`, so the base-cut force-pushed over the surviving remote ref — reviewed work destroyed with no error anywhere. Observed blast radius in one day: a reviewed 554-line migration replaced by a +3/−1 CI tweak (pr-reviewer-action#444, three force-pushes, reviewer approval auto-dismissed each time), plus two sibling PRs merged as lockfile-only husks that falsely closed their issues (miso-chat#726/#727 → #718/#712 reopened).

A caller that names a prior attempt is asserting it exists. A miss means the ref was pruned or — the prime suspect given three same-day occurrences — a **concurrent fix attempt raced this one**; both are conditions to surface. The failed task lands in the existing retry/escalation ladder instead of eating the branch.

## How

- `setupTaskBranch`: the `found == false` branch returns an error (task fails as `FailureCloneFailed` with the full message: ref, suspected causes, what was refused). The base-branch path is unchanged for the `reset` strategy and non-revision tasks, where no prior attempt is claimed. Happy to add a dedicated `FailureRestoreFailed` reason instead if you'd prefer the enum churn.
- `TestSetupTaskBranch_MissingRefFallsBackToBase` (which pinned the old fallback) inverted into `TestSetupTaskBranch_MissingRefFailsLoud`; the restore/reset/default-strategy tests are untouched and green.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (agent 88.0%, controller 82.8%)
- [x] `make lint` passes locally (0 issues)
- [x] Conventional commits, DCO signed
- [x] AI assistance disclosed — authored with Claude Code
- [ ] Documentation updated — n/a (internal executor behavior; doc comments updated in-code)