### PR TITLE
feat(controller): opt-in Prometheus scrape annotations on inference pods

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
         - --metrics-bind-address=:{{ .Values.metrics.service.port }}
         - --metrics-secure={{ .Values.metrics.secure }}
         {{- end }}
+        {{- if .Values.metrics.emitScrapeAnnotations }}
+        - --emit-scrape-annotations
+        {{- end }}
         {{- if .Values.pyrra.enabled }}
         - --enable-pyrra-slo
         {{- end }}

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -151,6 +151,7 @@
       "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
+        "emitScrapeAnnotations": { "type": "boolean" },
         "secure": { "type": "boolean" },
         "service": {
           "type": "object",

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -158,6 +158,12 @@ rbac:
 metrics:
   # Enable metrics endpoint
   enabled: true
+  # Add prometheus.io/scrape,path,port annotations (port = the resolved
+  # spec.endpoint.port) to every inference Pod so annotation-based scrapers
+  # (e.g. Grafana Alloy) discover the runtime's /metrics without a
+  # per-InferenceService podAnnotations block or a PodMonitor. A user-set
+  # spec.podAnnotations value always wins. Default off.
+  emitScrapeAnnotations: false
   # Serve metrics over HTTPS with authn/authz (true) or plain HTTP (false).
   # Set to false when scraping from outside the cluster without a ServiceAccount token.
   secure: true

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -158,11 +158,17 @@ rbac:
 metrics:
   # Enable metrics endpoint
   enabled: true
-  # Add prometheus.io/scrape,path,port annotations (port = the resolved
-  # spec.endpoint.port) to every inference Pod so annotation-based scrapers
-  # (e.g. Grafana Alloy) discover the runtime's /metrics without a
-  # per-InferenceService podAnnotations block or a PodMonitor. A user-set
-  # spec.podAnnotations value always wins. Default off.
+  # Add prometheus.io/scrape,path,port annotations (port = the fully-resolved
+  # container port: spec.containerPort -> spec.endpoint.port -> the runtime's
+  # default) to every inference Pod so annotation-based scrapers (e.g. Grafana
+  # Alloy) discover the runtime's /metrics without a per-InferenceService
+  # podAnnotations block or a PodMonitor. A user-set spec.podAnnotations value
+  # always wins. Default off.
+  #
+  # This is an ALTERNATIVE to a PodMonitor/ServiceMonitor, not a companion: if
+  # one already scrapes these pods, do NOT also enable this against the same
+  # Prometheus, or every target is scraped twice (duplicated series and
+  # samples). Pick one discovery mechanism per Prometheus.
   emitScrapeAnnotations: false
   # Serve metrics over HTTPS with authn/authz (true) or plain HTTP (false).
   # Set to false when scraping from outside the cluster without a ServiceAccount token.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -127,6 +127,7 @@ func main() {
 	var caCertConfigMap string
 	var initContainerImage string
 	var defaultFSGroup int64
+	var emitScrapeAnnotations bool
 	var routerProxyImage string
 	var defaultLiteLLMURL string
 	var tlsOpts []func(*tls.Config)
@@ -152,6 +153,10 @@ func main() {
 	flag.StringVar(&allowedHostPathRoots, "allowed-host-path-roots", "",
 		"Comma-separated absolute path prefixes under which local/file:// and hostPath model "+
 			"sources are permitted. Empty (default) disables all local/hostPath sources (GHSA-jw3m-8q7m-f35r).")
+	flag.BoolVar(&emitScrapeAnnotations, "emit-scrape-annotations", false,
+		"Add prometheus.io/scrape,path,port annotations (port = resolved endpoint port) to every "+
+			"inference Pod so annotation-based scrapers discover /metrics without a per-InferenceService "+
+			"podAnnotations block or a PodMonitor. User-set podAnnotations win. Default false.")
 	flag.StringVar(&gpuSharingSharedPoolSelector, "gpu-sharing-shared-pool-selector", "",
 		"Node selector (key=value[,key=value]) for the shared-GPU pool that gpuSharing mode "+
 			"shared schedules onto. Empty (default) means no shared pool exists and mode shared "+
@@ -444,6 +449,7 @@ func main() {
 		CACertConfigMap:       caCertConfigMap,
 		InitContainerImage:    initContainerImage,
 		DefaultFSGroup:        defaultFSGroup,
+		EmitScrapeAnnotations: emitScrapeAnnotations,
 		AllowedHostPathRoots:  allowedHostPathRootList,
 		GPUSharingSharedPool:  gpuSharingSharedPool,
 		RuntimeImageOverrides: runtimeImageOverrides,

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -280,7 +280,7 @@ func shouldProtectFromDisruption(isvc *inferencev1alpha1.InferenceService) bool 
 // buildPodAnnotations merges the user's podAnnotations with the operator's
 // disruption-protection annotation and, when emitScrape is set, Prometheus
 // annotation-discovery hints. User-provided values always win on collision.
-func buildPodAnnotations(isvc *inferencev1alpha1.InferenceService, emitScrape bool) map[string]string {
+func buildPodAnnotations(isvc *inferencev1alpha1.InferenceService, emitScrape bool, port int32) map[string]string {
 	annotations := copyMap(isvc.Spec.PodAnnotations)
 	set := func(k, v string) {
 		if annotations == nil {
@@ -295,23 +295,16 @@ func buildPodAnnotations(isvc *inferencev1alpha1.InferenceService, emitScrape bo
 		set("karpenter.sh/do-not-disrupt", "true")
 	}
 	if emitScrape {
-		// port is the resolved endpoint port, so annotation-based scrapers
-		// hit the app port regardless of its container-port name (which is
-		// "http", not a metrics-named port most scrape regexes match).
+		// port is the fully-resolved container port (spec.containerPort ->
+		// spec.endpoint.port -> backend.DefaultPort(), resolved once in
+		// constructDeployment), so annotation scrapers hit the real app port
+		// for every runtime and honor spec.containerPort — regardless of the
+		// container-port name ("http", which metrics-named scrape regexes miss).
 		set("prometheus.io/scrape", "true")
 		set("prometheus.io/path", "/metrics")
-		set("prometheus.io/port", fmt.Sprintf("%d", endpointPort(isvc)))
+		set("prometheus.io/port", fmt.Sprintf("%d", port))
 	}
 	return annotations
-}
-
-// endpointPort returns the resolved inference service port: the explicit
-// spec.endpoint.port when set, else the CRD default (8080).
-func endpointPort(isvc *inferencev1alpha1.InferenceService) int32 {
-	if isvc.Spec.Endpoint != nil && isvc.Spec.Endpoint.Port != 0 {
-		return isvc.Spec.Endpoint.Port
-	}
-	return 8080
 }
 
 // servedModelPath picks the path handed to the runtime. For a multi-file model
@@ -449,7 +442,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      mergePodLabels(labels, isvc.Spec.PodLabels),
-					Annotations: buildPodAnnotations(isvc, r.EmitScrapeAnnotations),
+					Annotations: buildPodAnnotations(isvc, r.EmitScrapeAnnotations, port),
 				},
 				Spec: corev1.PodSpec{
 					SecurityContext:    inferPodSecurityContext(isvc, r.DefaultFSGroup),

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -278,20 +278,40 @@ func shouldProtectFromDisruption(isvc *inferencev1alpha1.InferenceService) bool 
 }
 
 // buildPodAnnotations merges the user's podAnnotations with the operator's
-// disruption-protection annotation. User-provided values always win on
-// collision.
-func buildPodAnnotations(isvc *inferencev1alpha1.InferenceService) map[string]string {
+// disruption-protection annotation and, when emitScrape is set, Prometheus
+// annotation-discovery hints. User-provided values always win on collision.
+func buildPodAnnotations(isvc *inferencev1alpha1.InferenceService, emitScrape bool) map[string]string {
 	annotations := copyMap(isvc.Spec.PodAnnotations)
-	if shouldProtectFromDisruption(isvc) {
+	set := func(k, v string) {
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		// Only set the annotation if the user hasn't already set it
-		if _, ok := annotations["karpenter.sh/do-not-disrupt"]; !ok {
-			annotations["karpenter.sh/do-not-disrupt"] = "true"
+		// The user's value always wins.
+		if _, ok := annotations[k]; !ok {
+			annotations[k] = v
 		}
 	}
+	if shouldProtectFromDisruption(isvc) {
+		set("karpenter.sh/do-not-disrupt", "true")
+	}
+	if emitScrape {
+		// port is the resolved endpoint port, so annotation-based scrapers
+		// hit the app port regardless of its container-port name (which is
+		// "http", not a metrics-named port most scrape regexes match).
+		set("prometheus.io/scrape", "true")
+		set("prometheus.io/path", "/metrics")
+		set("prometheus.io/port", fmt.Sprintf("%d", endpointPort(isvc)))
+	}
 	return annotations
+}
+
+// endpointPort returns the resolved inference service port: the explicit
+// spec.endpoint.port when set, else the CRD default (8080).
+func endpointPort(isvc *inferencev1alpha1.InferenceService) int32 {
+	if isvc.Spec.Endpoint != nil && isvc.Spec.Endpoint.Port != 0 {
+		return isvc.Spec.Endpoint.Port
+	}
+	return 8080
 }
 
 // servedModelPath picks the path handed to the runtime. For a multi-file model
@@ -429,7 +449,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      mergePodLabels(labels, isvc.Spec.PodLabels),
-					Annotations: buildPodAnnotations(isvc),
+					Annotations: buildPodAnnotations(isvc, r.EmitScrapeAnnotations),
 				},
 				Spec: corev1.PodSpec{
 					SecurityContext:    inferPodSecurityContext(isvc, r.DefaultFSGroup),

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -415,9 +415,10 @@ func TestBuildPodAnnotations(t *testing.T) {
 	pFalse := func() *bool { b := false; return &b }
 
 	cases := []struct {
-		name     string
-		isvc     *inferencev1alpha1.InferenceService
-		expected map[string]string
+		name       string
+		isvc       *inferencev1alpha1.InferenceService
+		emitScrape bool
+		expected   map[string]string
 	}{
 		{
 			name: "not Ready, no user annotations → add disruption annotation",
@@ -480,11 +481,62 @@ func TestBuildPodAnnotations(t *testing.T) {
 			},
 			expected: map[string]string{"karpenter.sh/do-not-disrupt": "true"},
 		},
+		{
+			name: "emitScrape off → no prometheus.io annotations",
+			isvc: &inferencev1alpha1.InferenceService{
+				Status: inferencev1alpha1.InferenceServiceStatus{Phase: PhaseReady},
+			},
+			emitScrape: false,
+			expected:   nil,
+		},
+		{
+			name: "emitScrape on, explicit endpoint port → scrape annotations with that port",
+			isvc: &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					Endpoint: &inferencev1alpha1.EndpointSpec{Port: 8000},
+				},
+				Status: inferencev1alpha1.InferenceServiceStatus{Phase: PhaseReady},
+			},
+			emitScrape: true,
+			expected: map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/path":   "/metrics",
+				"prometheus.io/port":   "8000",
+			},
+		},
+		{
+			name: "emitScrape on, no endpoint → falls back to default port 8080",
+			isvc: &inferencev1alpha1.InferenceService{
+				Status: inferencev1alpha1.InferenceServiceStatus{Phase: PhaseReady},
+			},
+			emitScrape: true,
+			expected: map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/path":   "/metrics",
+				"prometheus.io/port":   "8080",
+			},
+		},
+		{
+			name: "emitScrape on, user set prometheus.io/port → user value wins",
+			isvc: &inferencev1alpha1.InferenceService{
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					Endpoint:       &inferencev1alpha1.EndpointSpec{Port: 8000},
+					PodAnnotations: map[string]string{"prometheus.io/port": "9000"},
+				},
+				Status: inferencev1alpha1.InferenceServiceStatus{Phase: PhaseReady},
+			},
+			emitScrape: true,
+			expected: map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/path":   "/metrics",
+				"prometheus.io/port":   "9000",
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildPodAnnotations(tc.isvc)
+			got := buildPodAnnotations(tc.isvc, tc.emitScrape)
 			if len(got) != len(tc.expected) {
 				t.Fatalf("buildPodAnnotations() = %v, want %v", got, tc.expected)
 			}

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -418,6 +418,7 @@ func TestBuildPodAnnotations(t *testing.T) {
 		name       string
 		isvc       *inferencev1alpha1.InferenceService
 		emitScrape bool
+		port       int32
 		expected   map[string]string
 	}{
 		{
@@ -490,14 +491,12 @@ func TestBuildPodAnnotations(t *testing.T) {
 			expected:   nil,
 		},
 		{
-			name: "emitScrape on, explicit endpoint port → scrape annotations with that port",
+			name: "emitScrape on → emits the resolved port it is handed",
 			isvc: &inferencev1alpha1.InferenceService{
-				Spec: inferencev1alpha1.InferenceServiceSpec{
-					Endpoint: &inferencev1alpha1.EndpointSpec{Port: 8000},
-				},
 				Status: inferencev1alpha1.InferenceServiceStatus{Phase: PhaseReady},
 			},
 			emitScrape: true,
+			port:       8000,
 			expected: map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/path":   "/metrics",
@@ -505,27 +504,31 @@ func TestBuildPodAnnotations(t *testing.T) {
 			},
 		},
 		{
-			name: "emitScrape on, no endpoint → falls back to default port 8080",
+			// Regression guard: the port is emitted verbatim, never a hardcoded
+			// 8080. Resolution itself is covered end-to-end in the
+			// constructDeployment tests (per-runtime default + spec.containerPort).
+			name: "emitScrape on, non-8080 port → emitted verbatim (not hardcoded)",
 			isvc: &inferencev1alpha1.InferenceService{
 				Status: inferencev1alpha1.InferenceServiceStatus{Phase: PhaseReady},
 			},
 			emitScrape: true,
+			port:       30000,
 			expected: map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/path":   "/metrics",
-				"prometheus.io/port":   "8080",
+				"prometheus.io/port":   "30000",
 			},
 		},
 		{
 			name: "emitScrape on, user set prometheus.io/port → user value wins",
 			isvc: &inferencev1alpha1.InferenceService{
 				Spec: inferencev1alpha1.InferenceServiceSpec{
-					Endpoint:       &inferencev1alpha1.EndpointSpec{Port: 8000},
 					PodAnnotations: map[string]string{"prometheus.io/port": "9000"},
 				},
 				Status: inferencev1alpha1.InferenceServiceStatus{Phase: PhaseReady},
 			},
 			emitScrape: true,
+			port:       8000,
 			expected: map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/path":   "/metrics",
@@ -536,7 +539,7 @@ func TestBuildPodAnnotations(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildPodAnnotations(tc.isvc, tc.emitScrape)
+			got := buildPodAnnotations(tc.isvc, tc.emitScrape, tc.port)
 			if len(got) != len(tc.expected) {
 				t.Fatalf("buildPodAnnotations() = %v, want %v", got, tc.expected)
 			}

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -74,6 +74,13 @@ type InferenceServiceReconciler struct {
 	// on OpenShift, where the restricted-v2 SCC injects fsGroup from the
 	// namespace's allocated range). Set via --default-fsgroup; default 102.
 	DefaultFSGroup int64
+	// EmitScrapeAnnotations, when true, adds Prometheus annotation-discovery
+	// hints (prometheus.io/scrape, /path, /port) to every inference Pod, with
+	// port set to the resolved endpoint port, so annotation-based scrapers
+	// (e.g. Grafana Alloy) discover /metrics without a per-InferenceService
+	// podAnnotations block or a PodMonitor. User-supplied podAnnotations win.
+	// Set via --emit-scrape-annotations; default false.
+	EmitScrapeAnnotations bool
 	// HTTPClient overrides the HTTP client used for idle checks. When nil, a
 	// default client with a 5-second timeout is created per request. Primarily
 	// useful in tests to capture requests or control timeouts.

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -567,6 +569,113 @@ var _ = Describe("Multi-GPU Deployment Construction", func() {
 				Expect(deployment.Spec.RevisionHistoryLimit).NotTo(BeNil())
 				Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(want))
 			}
+		})
+	})
+
+	Context("when emitting Prometheus scrape annotations", func() {
+		// These pin the port that lands in prometheus.io/port to the SAME
+		// fully-resolved container port constructDeployment uses
+		// (spec.containerPort -> spec.endpoint.port -> backend.DefaultPort()).
+		// Before threading the resolved port through, the annotation hardcoded
+		// 8080 — wrong for every non-llama.cpp runtime and blind to
+		// spec.containerPort. (#1366)
+		var model *inferencev1alpha1.Model
+
+		newReconciler := func(emit bool) *InferenceServiceReconciler {
+			return &InferenceServiceReconciler{
+				Client:                k8sClient,
+				Scheme:                k8sClient.Scheme(),
+				InitContainerImage:    "docker.io/curlimages/curl:8.18.0",
+				DefaultFSGroup:        102,
+				EmitScrapeAnnotations: emit,
+			}
+		}
+
+		BeforeEach(func() {
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "scrape-model", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:       "https://example.com/model.gguf",
+					Format:       "gguf",
+					Quantization: "Q4_K_M",
+					Hardware:     &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+				Status: inferencev1alpha1.ModelStatus{Phase: "Ready"},
+			}
+		})
+
+		newISVC := func(mutate func(*inferencev1alpha1.InferenceService)) *inferencev1alpha1.InferenceService {
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "scrape-service", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "scrape-model",
+					Replicas: &replicas,
+					// Pin the image so resolveRuntimeImage never gates the test.
+					Image: "example.local/runtime:test",
+				},
+			}
+			if mutate != nil {
+				mutate(isvc)
+			}
+			return isvc
+		}
+
+		scrapePort := func(d *appsv1.Deployment) string {
+			return d.Spec.Template.ObjectMeta.Annotations["prometheus.io/port"]
+		}
+
+		It("uses the runtime's DefaultPort for a non-llama.cpp backend (vLLM → 8000)", func() {
+			isvc := newISVC(func(s *inferencev1alpha1.InferenceService) {
+				s.Spec.Runtime = RuntimeVLLM
+			})
+			d := newReconciler(true).constructDeployment(isvc, model, 1)
+			// vLLM DefaultPort is 8000; the old hardcoded 8080 was wrong here.
+			Expect(scrapePort(d)).To(Equal("8000"))
+			Expect(d.Spec.Template.ObjectMeta.Annotations["prometheus.io/scrape"]).To(Equal("true"))
+		})
+
+		It("honors spec.containerPort over the runtime default", func() {
+			cp := int32(9090)
+			isvc := newISVC(func(s *inferencev1alpha1.InferenceService) {
+				s.Spec.Runtime = RuntimeVLLM
+				s.Spec.ContainerPort = &cp
+			})
+			d := newReconciler(true).constructDeployment(isvc, model, 1)
+			Expect(scrapePort(d)).To(Equal("9090"))
+		})
+
+		It("uses spec.endpoint.port when containerPort is unset", func() {
+			isvc := newISVC(func(s *inferencev1alpha1.InferenceService) {
+				s.Spec.Endpoint = &inferencev1alpha1.EndpointSpec{Port: 7070}
+			})
+			d := newReconciler(true).constructDeployment(isvc, model, 1)
+			Expect(scrapePort(d)).To(Equal("7070"))
+		})
+
+		It("falls back to the llama.cpp default (8080) with no port hints", func() {
+			d := newReconciler(true).constructDeployment(newISVC(nil), model, 1)
+			Expect(scrapePort(d)).To(Equal("8080"))
+		})
+
+		It("matches the port actually exposed on the container", func() {
+			// The annotation must never diverge from the real ContainerPort.
+			isvc := newISVC(func(s *inferencev1alpha1.InferenceService) {
+				s.Spec.Runtime = RuntimeVLLM
+			})
+			d := newReconciler(true).constructDeployment(isvc, model, 1)
+			containerPort := d.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
+			Expect(scrapePort(d)).To(Equal(fmt.Sprintf("%d", containerPort)))
+		})
+
+		It("emits no scrape annotations when the reconciler flag is off", func() {
+			isvc := newISVC(func(s *inferencev1alpha1.InferenceService) {
+				s.Spec.Runtime = RuntimeVLLM
+			})
+			d := newReconciler(false).constructDeployment(isvc, model, 1)
+			ann := d.Spec.Template.ObjectMeta.Annotations
+			Expect(ann).NotTo(HaveKey("prometheus.io/scrape"))
+			Expect(ann).NotTo(HaveKey("prometheus.io/port"))
 		})
 	})
 


### PR DESCRIPTION
# Upstream LLMKube proposal — inference-pod metrics discoverable by annotation scrapers

## Problem
LLMKube runtimes expose Prometheus metrics on the inference container's app port
(llama.cpp `llamacpp:*`, vLLM `vllm:*`, TGI `tgi_*`) at `/metrics`. But making a
cluster-wide metrics agent scrape them today requires either:

- the `inferencePodMonitor` (needs prometheus-operator, which many clusters don't run), or
- hand-adding `prometheus.io/*` annotations to **every** InferenceService's `spec.podAnnotations`.

There's also a real footgun: the inference container's metrics port is named
**`http`** (the app port), which does **not** match the port-name regexes most
annotation-scrape configs use (`metrics|http-metrics|metrics-port`). So even
annotation-based discovery misses it unless `prometheus.io/port` is set explicitly.

Net: no zero-config path to inference metrics without prometheus-operator.

## Proposal — two shapes (seeking maintainer preference)

Both extend the existing operator-default pattern on `InferenceServiceReconciler`
(cf. `DefaultFSGroup`, `ModelCacheMode`) and the merge point `buildPodAnnotations`
in `internal/controller/deployment_builder.go`. In both, a user's explicit
`spec.podAnnotations` value always wins.

### Option A — opt-in scrape-annotation emission *(reference PR implements this)*
A `--emit-scrape-annotations` flag (chart `metrics.emitScrapeAnnotations`, default
off). When on, the operator adds `prometheus.io/scrape=true`, `path=/metrics`, and
`port=<resolved spec.endpoint.port>` to every inference pod.

- **Pro:** the operator *knows* the endpoint port, so `prometheus.io/port` is always
  correct — this dissolves the `http`-port-name footgun at the source, across all
  runtimes. Zero per-CR boilerplate.
- **Con:** opinionated toward `prometheus.io`-annotation scraping (though it's a
  no-op unless explicitly enabled).

### Option B — generic operator-level default pod annotations
A `--default-pod-annotations key=val,...` flag (chart `defaultPodAnnotations`) that
seeds `buildPodAnnotations` at lowest precedence. The operator sets nothing metrics-
specific; the platform supplies the `prometheus.io/*` values (including a port).

- **Pro:** fully generic, reusable for any default annotation, not just metrics.
- **Con:** the port is **static config** — wrong for a fleet where InferenceServices
  use different `endpoint.port` values; the platform has to know/guess the port. Does
  not solve the port-name footgun on its own.

## Recommendation
**Option A** — it fixes the actual discovery problem (the port) at the one place that
authoritatively knows the port, and stays a no-op until enabled. Option B is a nice
generic primitive but leaves the port problem to the caller. (They're not mutually
exclusive; A could later sit on top of a generic B.)

## Reference PR
Implements Option A: reconciler field + `--emit-scrape-annotations` flag + chart
value/schema/arg + table-driven unit test (`TestBuildPodAnnotations`: emit off,
explicit port, default-8080 fallback, user-port-wins). `go build`, `go vet`, `gofmt`,
and the targeted test are green locally (envtest-gated tests need `setup-envtest`
binaries, unrelated).

---
_AI-assisted: this change and text were drafted with an AI coding agent (Claude) and
are being reviewed, tested, and submitted by a human who takes DCO accountability for
the result._
