### PR TITLE
refactor(chart): apply three dashboard conventions across every board

### DIFF
--- a/charts/llmkube/dashboards/llmkube-quota.json
+++ b/charts/llmkube/dashboards/llmkube-quota.json
@@ -49,7 +49,9 @@
               {"color": "red", "value": 0.9}
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
@@ -221,7 +223,9 @@
               {"color": "red", "value": 0.9}
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },

--- a/charts/llmkube/dashboards/llmkube-slo.json
+++ b/charts/llmkube/dashboards/llmkube-slo.json
@@ -111,7 +111,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "budget remaining", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },
@@ -138,7 +138,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "budget remaining", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },
@@ -174,7 +174,7 @@
       "description": "Pyrra's up:burnrate<window> recording rules (bool_gauge indicator) plus reference lines at the ErrorBudgetBurn alert factors (14x/7x critical, 2x/1x warning), computed from the `objective` variable. A line crossing its paired-window threshold for the alert's `for:` duration is what actually pages; see docs/observability/slo.md.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "burn rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },
@@ -215,7 +215,7 @@
       "description": "Pyrra's vllm:e2e_request_latency_seconds:burnrate<window> recording rules (latency indicator) plus reference lines at the ErrorBudgetBurn alert factors (14x/7x critical, 2x/1x warning), computed from the `objective` variable.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "burn rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },

--- a/charts/llmkube/dashboards/model-router-dashboard.json
+++ b/charts/llmkube/dashboards/model-router-dashboard.json
@@ -33,6 +33,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []
@@ -60,6 +61,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []
@@ -122,6 +124,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "rej/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []

--- a/charts/llmkube/dashboards/sglang-dashboard.json
+++ b/charts/llmkube/dashboards/sglang-dashboard.json
@@ -31,8 +31,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tok/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -72,7 +73,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -105,7 +106,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -138,7 +139,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -173,8 +174,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -214,8 +216,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tokens", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -247,7 +250,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -276,7 +279,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "hit rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -313,7 +316,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "short"
@@ -347,7 +350,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "reqps"
@@ -380,7 +383,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "max": 1,
               "min": 0,
@@ -409,8 +412,9 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "slots", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
               "unit": "short"
             },
             "overrides": []
@@ -451,8 +455,9 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "tokens", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
               "unit": "short"
             },
             "overrides": []

--- a/charts/llmkube/dashboards/vllm-dashboard.json
+++ b/charts/llmkube/dashboards/vllm-dashboard.json
@@ -31,8 +31,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tok/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -72,7 +73,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -105,7 +106,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -138,7 +139,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -173,8 +174,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -214,7 +216,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -243,7 +245,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "hit rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -280,7 +282,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "reqps"
@@ -308,7 +310,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "reqps"
@@ -341,7 +343,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "unit": "s"
             },
@@ -368,7 +370,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "unit": "s"
             },
@@ -395,7 +397,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "unit": "s"
             },

--- a/internal/metrics/dashboard_sync_test.go
+++ b/internal/metrics/dashboard_sync_test.go
@@ -77,6 +77,9 @@ var (
 	// Desc keeps fqName unexported; String() is the only accessor.
 	descFQName = regexp.MustCompile(`fqName: "([^"]+)"`)
 	recordRule = regexp.MustCompile(`(?m)^\s*- record:\s*(\S+)`)
+
+	labelMatcher    = regexp.MustCompile(`\{[^}]*\}`)
+	soleAggregation = regexp.MustCompile(`^(?:sum|count)(?:\s+(?:by|without)\s*\([^)]*\))?\s*\(`)
 )
 
 // declaredNames returns the fqName of every collector this repo registers.
@@ -225,6 +228,219 @@ func dashboardQueries(t *testing.T, path string) []string {
 		}
 	}
 	return queries
+}
+
+// panelConvention pairs a panel's own fieldConfig.defaults with the PromQL
+// its own targets evaluate, so a convention can check both together instead
+// of the flat, panel-agnostic list dashboardQueries returns.
+type panelConvention struct {
+	title     string
+	panelType string
+	defaults  map[string]any
+	exprs     []string
+}
+
+// dashboardPanels walks a dashboard like dashboardQueries does, but stops at
+// every object carrying its own fieldConfig.defaults (a panel) instead of
+// flattening every "expr" found anywhere in the document. It also returns
+// the dashboard's template variable names, needed by the label-matcher
+// convention.
+func dashboardPanels(t *testing.T, path string) ([]panelConvention, []string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var panels []panelConvention
+	var walk func(node any)
+	walk = func(node any) {
+		switch typed := node.(type) {
+		case map[string]any:
+			if fc, ok := typed["fieldConfig"].(map[string]any); ok {
+				if defaults, ok := fc["defaults"].(map[string]any); ok {
+					targets, _ := typed["targets"].([]any)
+					var exprs []string
+					for _, target := range targets {
+						if tm, ok := target.(map[string]any); ok {
+							if s, ok := tm["expr"].(string); ok {
+								exprs = append(exprs, s)
+							}
+						}
+					}
+					title, _ := typed["title"].(string)
+					panelType, _ := typed["type"].(string)
+					panels = append(panels, panelConvention{title: title, panelType: panelType, defaults: defaults, exprs: exprs})
+				}
+			}
+			for _, child := range typed {
+				walk(child)
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(doc)
+
+	var vars []string
+	templating, _ := doc["templating"].(map[string]any)
+	list, _ := templating["list"].([]any)
+	for _, item := range list {
+		variable, _ := item.(map[string]any)
+		if name, ok := variable["name"].(string); ok {
+			vars = append(vars, name)
+		}
+	}
+	return panels, vars
+}
+
+// isRatioAgainstLimit reports whether expr is a bare "metric / metric"
+// division: exactly one '/', no other arithmetic mixed in, not a formula
+// that starts from a constant. That excludes the shapes the convention
+// exempts: an error budget ("1 - (...)") that can go negative, and a
+// burn-rate reference line ("14 * (1 - $objective/100)") that is unbounded.
+func isRatioAgainstLimit(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	if strings.Count(expr, "/") != 1 || strings.ContainsAny(expr, "*+") {
+		return false
+	}
+	return expr != "" && (expr[0] < '0' || expr[0] > '9')
+}
+
+// isSoleAggregation reports whether expr's outermost operation is a single
+// sum() or count() call with nothing applied outside it. A ratio-of-sums
+// like sum(a)/sum(b) also starts with "sum(", but its outer operator is the
+// division, so the sum() match must close at the very end of expr, not
+// partway through, to count.
+func isSoleAggregation(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	loc := soleAggregation.FindStringIndex(expr)
+	if loc == nil {
+		return false
+	}
+	depth := 0
+	for i := loc[1] - 1; i < len(expr); i++ {
+		switch expr[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i == len(expr)-1
+			}
+		}
+	}
+	return false
+}
+
+// filtersTemplateVarInLabelMatcher reports whether any of expr's label
+// matchers ({...}) references one of the dashboard's own template
+// variables, e.g. {service=~"$service"}.
+func filtersTemplateVarInLabelMatcher(expr string, vars []string) bool {
+	for _, matcher := range labelMatcher.FindAllString(expr, -1) {
+		for _, v := range vars {
+			if regexp.MustCompile(`\$` + regexp.QuoteMeta(v) + `\b`).MatchString(matcher) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// dashboardConventions are the three conventions applied by hand across
+// every panel in charts/llmkube/dashboards (see the "apply shared
+// conventions for min/max, noValue, and series color" commit). All three
+// are scoped to timeseries panels: stat and gauge panels color by
+// threshold, not by series, and table panels have neither a per-series
+// color nor an axis to autoscale, so none of the three read on them the way
+// they do on a graph.
+var dashboardConventions = []struct {
+	name    string
+	applies func(p panelConvention, vars []string) bool
+	holds   func(p panelConvention) bool
+	reason  string
+}{
+	{
+		name: `percentunit ratio against a hard limit sets min:0 and max:1`,
+		applies: func(p panelConvention, _ []string) bool {
+			if p.panelType != "timeseries" || p.defaults["unit"] != "percentunit" {
+				return false
+			}
+			return slices.ContainsFunc(p.exprs, isRatioAgainstLimit)
+		},
+		holds: func(p panelConvention) bool {
+			min, minOK := p.defaults["min"].(float64)
+			max, maxOK := p.defaults["max"].(float64)
+			return minOK && min == 0 && maxOK && max == 1
+		},
+		reason: "reads against the limit instead of autoscaling",
+	},
+	{
+		name: `sum()/count() as the outer PromQL operator sets noValue:"0"`,
+		applies: func(p panelConvention, _ []string) bool {
+			return slices.ContainsFunc(p.exprs, isSoleAggregation)
+		},
+		holds: func(p panelConvention) bool {
+			noValue, ok := p.defaults["noValue"].(string)
+			return ok && noValue == "0"
+		},
+		reason: `an empty vector on a fresh cluster otherwise renders "No data" instead of a real zero`,
+	},
+	{
+		name: `a template variable inside a label matcher sets color.mode "palette-classic-by-name"`,
+		applies: func(p panelConvention, vars []string) bool {
+			if p.panelType != "timeseries" {
+				return false
+			}
+			return slices.ContainsFunc(p.exprs, func(e string) bool {
+				return filtersTemplateVarInLabelMatcher(e, vars)
+			})
+		},
+		holds: func(p panelConvention) bool {
+			color, _ := p.defaults["color"].(map[string]any)
+			mode, _ := color["mode"].(string)
+			return mode == "palette-classic-by-name"
+		},
+		reason: "so filtering the variable doesn't repaint the series that remain",
+	},
+}
+
+// TestDashboardConventions fails when a panel matches one of the three
+// conventions above but doesn't carry the fieldConfig it requires. Unlike
+// TestDashboardsQueryEmittedMetrics, which flattens every dashboard into a
+// bare list of expr strings, this walks panel by panel so a convention can
+// see a panel's unit, color and target queries together.
+//
+// Scoped to charts/llmkube/dashboards: conventions were hand-applied only to
+// the dashboards shipped in the chart, not to config/grafana's standalone
+// pair, which predates that pass.
+func TestDashboardConventions(t *testing.T) {
+	dashboards, err := filepath.Glob("../../charts/*/dashboards/*.json")
+	if err != nil {
+		t.Fatalf("glob charts dashboards: %v", err)
+	}
+	if len(dashboards) == 0 {
+		t.Fatalf("no dashboards matching ../../charts/*/dashboards/*.json")
+	}
+
+	for _, dashboard := range dashboards {
+		panels, vars := dashboardPanels(t, dashboard)
+		for _, p := range panels {
+			for _, rule := range dashboardConventions {
+				if !rule.applies(p, vars) || rule.holds(p) {
+					continue
+				}
+				t.Errorf("%s panel %q violates convention %s: %s", dashboard, p.title, rule.name, rule.reason)
+			}
+		}
+	}
 }
 
 func emitted(name string, known map[string]bool) bool {


### PR DESCRIPTION
First of four. The three layers stacked on this branch (operator-health row, SGLang panels, llama.cpp board) follow one at a time as this merges, so each arrives as its own reviewable diff rather than one large change.

Adds no panels and no features: it exists so those layers inherit one convention instead of each inventing their own.

## What

| Convention | Applied to |
|---|---|
| `min: 0` / `max: 1` on percentunit ratios against a hard limit | llmkube-quota ids 1, 5 |
| `noValue: "0"` where the outer PromQL is `sum()`/`count()` | model-router 1/2/4, sglang 1/6/8/14/15, vllm 1/6 |
| `palette-classic-by-name` where series vary with a template variable | 30 timeseries panels across sglang, vllm, llmkube-slo |

Plus `TestDashboardConventions` in `internal/metrics/dashboard_sync_test.go`, so a future dashboard cannot silently violate any of the three. It walks `fieldConfig.defaults` per panel, pairing each panel with its own target exprs, and scopes the rules structurally rather than with an exemption list: error budgets (`1 - (...)`) and burn-rate thresholds (`14 * (...)`) fall out of rule 1 by shape, and `sum(a)/sum(b)` ratio-of-sums falls out of rule 2 because the `sum()` match does not close at the end of the string.

## Why

`palette-classic` assigns colour by series order, so filtering `$service` repaints the survivors and a reader who learned "service X is green" is misled. Ratio panels without a `max` autoscale, so a 2% blip renders identically to saturation. `count()` over an empty vector reads "No data" on a fresh cluster instead of 0.

## Not in scope

Legend calcs (`["mean","max"]` is the existing convention and stays), fillOpacity (a `drawStyle: bars` panel legitimately needs a high fill), colours on fixed series sets, and `config/grafana`s two boards, which predate this pass.

## Evidence

- Audited all 7 boards, not only the 5 changed: `amd-gpu-observability` and `llmkube-inference` have no qualifying panels.
- Diffing both trees with min/max/noValue/color stripped is byte-identical on all 7 files, so no legend, fill, panel-id or formatting churn.
- `helm unittest charts/llmkube` 60/60, `go test ./internal/metrics/...` ok, all dashboard JSON valid.
- The test was falsified rather than assumed: removing one `noValue` makes it fail naming the exact panel, restoring makes it pass. It has already caught six real violations in the layers stacked on top, two of them in a commit that claimed to have fixed them.

Happy to split or reorder if you would rather see the test separately from the JSON changes.

## Live validation

Chart rendered from all four branches merged, applied to a production cluster (AMD R9700, SGLang v0.5.16 + three llama.cpp services) behind a suspended HelmRelease, then reverted and proved clean.

**33 of 37 panels return live data.** The four empties: two are `histogram_quantile` over an idle operator, one was the queue-wait panel awaiting its recording rules (which materialised on apply at p95 18.0s / p50 1.0s), and one was a real defect in the llama.cpp branch, now fixed there.

Revert proof: recording rules back to the 5 the release ships, dashboards back to the 2 Flux owns, zero suspended Flux objects.

Assisted-by: OpenCode (generated the change; I reviewed)