### PR TITLE
feat(dashboards): add an operator-health row to llmkube-inference

### DIFF
--- a/charts/llmkube/dashboards/llmkube-inference.json
+++ b/charts/llmkube/dashboards/llmkube-inference.json
@@ -104,6 +104,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "reconciles/s", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "ops"
         },
         "overrides": [
@@ -226,6 +227,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "replicas", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": [

--- a/charts/llmkube/dashboards/llmkube-inference.json
+++ b/charts/llmkube/dashboards/llmkube-inference.json
@@ -89,6 +89,192 @@
       ],
       "title": "Inference container restart rate (5m)",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 18},
+      "id": 102,
+      "panels": [],
+      "title": "Operator health",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "reconciles/s", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "ops"
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": "/success/"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byRegexp", "options": "/error/"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 19},
+      "id": 5,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (controller, result) (rate(llmkube_reconcile_total[5m]))",
+          "legendFormat": "{{controller}} ({{result}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile rate by result (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic-by-name"},
+          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 19},
+      "id": 6,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.95, sum by (le, controller) (rate(llmkube_reconcile_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{controller}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile duration p95 (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic-by-name"},
+          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 27},
+      "id": 7,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.95, sum by (le, inferenceservice, namespace) (rate(llmkube_inferenceservice_ready_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{inferenceservice}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Time to Ready p95 (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 6, "x": 12, "y": 27},
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "count(llmkube_inferenceservice_phase{phase=\"Ready\"})",
+          "legendFormat": "Ready",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "count(llmkube_inferenceservice_phase)",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Services Ready vs total",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "replicas", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "short"
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": "/ready/"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byRegexp", "options": "/desired/"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "blue"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 6, "x": 18, "y": 27},
+      "id": 9,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (state) (llmkube_inferenceservice_replicas)",
+          "legendFormat": "{{state}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Fleet replicas: ready vs desired",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic-by-name"},
+          "custom": {"axisLabel": "pending services", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 35},
+      "id": 10,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "llmkube_gpu_queue_depth",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU queue depth by namespace",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/charts/llmkube/dashboards/llmkube-inference.json
+++ b/charts/llmkube/dashboards/llmkube-inference.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Starter dashboard for LLMKube inference workloads. Surfaces request latency, queue wait, and restart-rate by service / runtime / namespace using the recording rules in the llmkube Helm chart's PrometheusRule.",
+  "description": "Starter dashboard for LLMKube inference workloads. Surfaces request latency, restart rate, and operator health (reconcile rate/duration, time-to-ready, fleet readiness, replica state, GPU queue depth) by service / runtime / namespace using the recording rules and controller metrics from the llmkube Helm chart.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -114,7 +114,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 19},
       "id": 5,
       "options": {
-        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
         "tooltip": {"mode": "multi", "sort": "desc"}
       },
       "targets": [
@@ -132,7 +132,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic-by-name"},
+          "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -141,7 +141,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 19},
       "id": 6,
       "options": {
-        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
         "tooltip": {"mode": "multi", "sort": "desc"}
       },
       "targets": [
@@ -159,7 +159,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic-by-name"},
+          "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -168,7 +168,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 27},
       "id": 7,
       "options": {
-        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
         "tooltip": {"mode": "multi", "sort": "desc"}
       },
       "targets": [
@@ -188,6 +188,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "mappings": [],
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -235,7 +236,7 @@
       "gridPos": {"h": 8, "w": 6, "x": 18, "y": 27},
       "id": 9,
       "options": {
-        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
         "tooltip": {"mode": "multi", "sort": "desc"}
       },
       "targets": [
@@ -253,7 +254,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic-by-name"},
+          "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "pending services", "drawStyle": "line", "fillOpacity": 8, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "short"
         },
@@ -262,7 +263,7 @@
       "gridPos": {"h": 8, "w": 24, "x": 0, "y": 35},
       "id": 10,
       "options": {
-        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
         "tooltip": {"mode": "multi", "sort": "desc"}
       },
       "targets": [

--- a/charts/llmkube/dashboards/llmkube-quota.json
+++ b/charts/llmkube/dashboards/llmkube-quota.json
@@ -49,7 +49,9 @@
               {"color": "red", "value": 0.9}
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
@@ -221,7 +223,9 @@
               {"color": "red", "value": 0.9}
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },

--- a/charts/llmkube/dashboards/llmkube-slo.json
+++ b/charts/llmkube/dashboards/llmkube-slo.json
@@ -111,7 +111,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "budget remaining", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },
@@ -138,7 +138,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "budget remaining", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },
@@ -174,7 +174,7 @@
       "description": "Pyrra's up:burnrate<window> recording rules (bool_gauge indicator) plus reference lines at the ErrorBudgetBurn alert factors (14x/7x critical, 2x/1x warning), computed from the `objective` variable. A line crossing its paired-window threshold for the alert's `for:` duration is what actually pages; see docs/observability/slo.md.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "burn rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },
@@ -215,7 +215,7 @@
       "description": "Pyrra's vllm:e2e_request_latency_seconds:burnrate<window> recording rules (latency indicator) plus reference lines at the ErrorBudgetBurn alert factors (14x/7x critical, 2x/1x warning), computed from the `objective` variable.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "burn rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },

--- a/charts/llmkube/dashboards/model-router-dashboard.json
+++ b/charts/llmkube/dashboards/model-router-dashboard.json
@@ -33,6 +33,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []
@@ -60,6 +61,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []
@@ -122,6 +124,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "rej/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []

--- a/charts/llmkube/dashboards/sglang-dashboard.json
+++ b/charts/llmkube/dashboards/sglang-dashboard.json
@@ -31,8 +31,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tok/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -72,7 +73,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -105,7 +106,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -138,7 +139,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -173,8 +174,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -214,8 +216,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tokens", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -247,7 +250,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -276,7 +279,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "hit rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -313,7 +316,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "short"
@@ -347,7 +350,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "reqps"
@@ -380,7 +383,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "max": 1,
               "min": 0,
@@ -409,8 +412,9 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "slots", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
               "unit": "short"
             },
             "overrides": []
@@ -451,8 +455,9 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "tokens", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
               "unit": "short"
             },
             "overrides": []

--- a/charts/llmkube/dashboards/vllm-dashboard.json
+++ b/charts/llmkube/dashboards/vllm-dashboard.json
@@ -31,8 +31,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tok/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -72,7 +73,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -105,7 +106,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -138,7 +139,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -173,8 +174,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -214,7 +216,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -243,7 +245,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "hit rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -280,7 +282,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "reqps"
@@ -308,7 +310,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "reqps"
@@ -341,7 +343,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "unit": "s"
             },
@@ -368,7 +370,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "unit": "s"
             },
@@ -395,7 +397,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "unit": "s"
             },

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -28,7 +28,7 @@ All paths below are relative to `charts/llmkube/dashboards/`.
 
 | File | Description |
 |---|---|
-| `llmkube-inference.json` | Request latency (vLLM and SGLang) and container restart rate. Latency is grouped by service, runtime, namespace; restarts by pod, container, namespace. |
+| `llmkube-inference.json` | Request latency (vLLM and SGLang), container restart rate, and operator health: reconcile rate/duration, InferenceService time-to-ready, fleet ready-vs-total, replica state, and GPU queue depth. Latency is grouped by service, runtime, namespace; restarts by pod, container, namespace. Supersedes the equivalent panels in `config/grafana/llmkube-inference-dashboard.json` (ids 52, 51, 32, 3, 43, 21) — that board predates the chart-templated dashboards and is not kept in sync with them. |
 | `llmkube-slo.json` | Error budget remaining and multi-window burn rate for InferenceServices with `spec.slo` set, plus an SLO overview table. Reads the recording rules Pyrra's kubernetes operator writes per SLO. Templated on a `$slo` variable (`label_values(slo)`) and a manual `$objective` percentage variable, since Pyrra does not expose the target itself as a Prometheus series. Assumes the default 28d SLO window; see the dashboard description for details. |
 | `amd-gpu-observability.json` | AMD GPU health, memory, and inference SLO signals for Strix (gfx1151) nodes. Reads the amdgpu-sysfs exporter, node-exporter hwmon, and the `llamacpp:*` series llama.cpp exposes on `/metrics`. Panels cover GPU temperature, power, busy %, GTT/VRAM memory, GPU clock, tokens/sec, and in-flight requests. |
 | `llmkube-quota.json` | Per-GPUQuota usage against the declared GPU and VRAM caps, plus admission denials. |

--- a/internal/metrics/dashboard_sync_test.go
+++ b/internal/metrics/dashboard_sync_test.go
@@ -77,6 +77,9 @@ var (
 	// Desc keeps fqName unexported; String() is the only accessor.
 	descFQName = regexp.MustCompile(`fqName: "([^"]+)"`)
 	recordRule = regexp.MustCompile(`(?m)^\s*- record:\s*(\S+)`)
+
+	labelMatcher    = regexp.MustCompile(`\{[^}]*\}`)
+	soleAggregation = regexp.MustCompile(`^(?:sum|count)(?:\s+(?:by|without)\s*\([^)]*\))?\s*\(`)
 )
 
 // declaredNames returns the fqName of every collector this repo registers.
@@ -225,6 +228,219 @@ func dashboardQueries(t *testing.T, path string) []string {
 		}
 	}
 	return queries
+}
+
+// panelConvention pairs a panel's own fieldConfig.defaults with the PromQL
+// its own targets evaluate, so a convention can check both together instead
+// of the flat, panel-agnostic list dashboardQueries returns.
+type panelConvention struct {
+	title     string
+	panelType string
+	defaults  map[string]any
+	exprs     []string
+}
+
+// dashboardPanels walks a dashboard like dashboardQueries does, but stops at
+// every object carrying its own fieldConfig.defaults (a panel) instead of
+// flattening every "expr" found anywhere in the document. It also returns
+// the dashboard's template variable names, needed by the label-matcher
+// convention.
+func dashboardPanels(t *testing.T, path string) ([]panelConvention, []string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var panels []panelConvention
+	var walk func(node any)
+	walk = func(node any) {
+		switch typed := node.(type) {
+		case map[string]any:
+			if fc, ok := typed["fieldConfig"].(map[string]any); ok {
+				if defaults, ok := fc["defaults"].(map[string]any); ok {
+					targets, _ := typed["targets"].([]any)
+					var exprs []string
+					for _, target := range targets {
+						if tm, ok := target.(map[string]any); ok {
+							if s, ok := tm["expr"].(string); ok {
+								exprs = append(exprs, s)
+							}
+						}
+					}
+					title, _ := typed["title"].(string)
+					panelType, _ := typed["type"].(string)
+					panels = append(panels, panelConvention{title: title, panelType: panelType, defaults: defaults, exprs: exprs})
+				}
+			}
+			for _, child := range typed {
+				walk(child)
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(doc)
+
+	var vars []string
+	templating, _ := doc["templating"].(map[string]any)
+	list, _ := templating["list"].([]any)
+	for _, item := range list {
+		variable, _ := item.(map[string]any)
+		if name, ok := variable["name"].(string); ok {
+			vars = append(vars, name)
+		}
+	}
+	return panels, vars
+}
+
+// isRatioAgainstLimit reports whether expr is a bare "metric / metric"
+// division: exactly one '/', no other arithmetic mixed in, not a formula
+// that starts from a constant. That excludes the shapes the convention
+// exempts: an error budget ("1 - (...)") that can go negative, and a
+// burn-rate reference line ("14 * (1 - $objective/100)") that is unbounded.
+func isRatioAgainstLimit(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	if strings.Count(expr, "/") != 1 || strings.ContainsAny(expr, "*+") {
+		return false
+	}
+	return expr != "" && (expr[0] < '0' || expr[0] > '9')
+}
+
+// isSoleAggregation reports whether expr's outermost operation is a single
+// sum() or count() call with nothing applied outside it. A ratio-of-sums
+// like sum(a)/sum(b) also starts with "sum(", but its outer operator is the
+// division, so the sum() match must close at the very end of expr, not
+// partway through, to count.
+func isSoleAggregation(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	loc := soleAggregation.FindStringIndex(expr)
+	if loc == nil {
+		return false
+	}
+	depth := 0
+	for i := loc[1] - 1; i < len(expr); i++ {
+		switch expr[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i == len(expr)-1
+			}
+		}
+	}
+	return false
+}
+
+// filtersTemplateVarInLabelMatcher reports whether any of expr's label
+// matchers ({...}) references one of the dashboard's own template
+// variables, e.g. {service=~"$service"}.
+func filtersTemplateVarInLabelMatcher(expr string, vars []string) bool {
+	for _, matcher := range labelMatcher.FindAllString(expr, -1) {
+		for _, v := range vars {
+			if regexp.MustCompile(`\$` + regexp.QuoteMeta(v) + `\b`).MatchString(matcher) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// dashboardConventions are the three conventions applied by hand across
+// every panel in charts/llmkube/dashboards (see the "apply shared
+// conventions for min/max, noValue, and series color" commit). All three
+// are scoped to timeseries panels: stat and gauge panels color by
+// threshold, not by series, and table panels have neither a per-series
+// color nor an axis to autoscale, so none of the three read on them the way
+// they do on a graph.
+var dashboardConventions = []struct {
+	name    string
+	applies func(p panelConvention, vars []string) bool
+	holds   func(p panelConvention) bool
+	reason  string
+}{
+	{
+		name: `percentunit ratio against a hard limit sets min:0 and max:1`,
+		applies: func(p panelConvention, _ []string) bool {
+			if p.panelType != "timeseries" || p.defaults["unit"] != "percentunit" {
+				return false
+			}
+			return slices.ContainsFunc(p.exprs, isRatioAgainstLimit)
+		},
+		holds: func(p panelConvention) bool {
+			min, minOK := p.defaults["min"].(float64)
+			max, maxOK := p.defaults["max"].(float64)
+			return minOK && min == 0 && maxOK && max == 1
+		},
+		reason: "reads against the limit instead of autoscaling",
+	},
+	{
+		name: `sum()/count() as the outer PromQL operator sets noValue:"0"`,
+		applies: func(p panelConvention, _ []string) bool {
+			return slices.ContainsFunc(p.exprs, isSoleAggregation)
+		},
+		holds: func(p panelConvention) bool {
+			noValue, ok := p.defaults["noValue"].(string)
+			return ok && noValue == "0"
+		},
+		reason: `an empty vector on a fresh cluster otherwise renders "No data" instead of a real zero`,
+	},
+	{
+		name: `a template variable inside a label matcher sets color.mode "palette-classic-by-name"`,
+		applies: func(p panelConvention, vars []string) bool {
+			if p.panelType != "timeseries" {
+				return false
+			}
+			return slices.ContainsFunc(p.exprs, func(e string) bool {
+				return filtersTemplateVarInLabelMatcher(e, vars)
+			})
+		},
+		holds: func(p panelConvention) bool {
+			color, _ := p.defaults["color"].(map[string]any)
+			mode, _ := color["mode"].(string)
+			return mode == "palette-classic-by-name"
+		},
+		reason: "so filtering the variable doesn't repaint the series that remain",
+	},
+}
+
+// TestDashboardConventions fails when a panel matches one of the three
+// conventions above but doesn't carry the fieldConfig it requires. Unlike
+// TestDashboardsQueryEmittedMetrics, which flattens every dashboard into a
+// bare list of expr strings, this walks panel by panel so a convention can
+// see a panel's unit, color and target queries together.
+//
+// Scoped to charts/llmkube/dashboards: conventions were hand-applied only to
+// the dashboards shipped in the chart, not to config/grafana's standalone
+// pair, which predates that pass.
+func TestDashboardConventions(t *testing.T) {
+	dashboards, err := filepath.Glob("../../charts/*/dashboards/*.json")
+	if err != nil {
+		t.Fatalf("glob charts dashboards: %v", err)
+	}
+	if len(dashboards) == 0 {
+		t.Fatalf("no dashboards matching ../../charts/*/dashboards/*.json")
+	}
+
+	for _, dashboard := range dashboards {
+		panels, vars := dashboardPanels(t, dashboard)
+		for _, p := range panels {
+			for _, rule := range dashboardConventions {
+				if !rule.applies(p, vars) || rule.holds(p) {
+					continue
+				}
+				t.Errorf("%s panel %q violates convention %s: %s", dashboard, p.title, rule.name, rule.reason)
+			}
+		}
+	}
 }
 
 func emitted(name string, known map[string]bool) bool {


### PR DESCRIPTION
Fixes #1362. Stacked on #1368 — this branch contains that PR commits, so review the top commits only; the layer own change is 2 files, +191/-2.

## What

An `Operator` row on `llmkube-inference.json`: reconcile rate by result, reconcile p95, time-to-Ready p95, Services Ready (stat), fleet replicas ready vs desired, GPU queue depth.

## Why

The chart already scrapes the controller and alerts on it (`ControllerDown`), but no board showed it, so an operator that is up and reconciling badly surfaced nowhere. All six series exist whenever the chart is installed, so the row is unconditional and the board correctly stays out of `$runtimeDashboards`: these are controller-scoped metrics, not an InferenceService fact.

## Overlap with config/grafana

Six panels overlap `config/grafana/llmkube-inference-dashboard.json` (ids 52, 51, 32, 3, 43, 21), verified id-for-id. The chart board supersedes them, noted in `docs/grafana/README.md` rather than left for a reviewer to find. Happy to instead narrow the row if you would rather keep that board canonical.

## Live validation

Applied to a production cluster behind a suspended HelmRelease, then reverted and proved clean.

```
GrafanaDashboard llmkube-llmkube-inference: DashboardSynchronized=True
  "Dashboard was successfully applied to 1 instances"
```

Panel data: reconcile rate 2 series (by result), Services Ready 1+1, fleet replicas 2, GPU queue depth 1. `Reconcile duration p95` and `Time to Ready p95` return empty on an idle operator, which is correct: they are `histogram_quantile` over a 5m rate and populate during a rollout.

Assisted-by: OpenCode (generated the change; I reviewed)