### PR TITLE
feat(dashboards): SGLang queue-wait, stage latency, token mix and HiCache L3 panels

### DIFF
--- a/charts/llmkube/dashboards/llmkube-quota.json
+++ b/charts/llmkube/dashboards/llmkube-quota.json
@@ -49,7 +49,9 @@
               {"color": "red", "value": 0.9}
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
@@ -221,7 +223,9 @@
               {"color": "red", "value": 0.9}
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },

--- a/charts/llmkube/dashboards/llmkube-slo.json
+++ b/charts/llmkube/dashboards/llmkube-slo.json
@@ -111,7 +111,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "budget remaining", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },
@@ -138,7 +138,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "budget remaining", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },
@@ -174,7 +174,7 @@
       "description": "Pyrra's up:burnrate<window> recording rules (bool_gauge indicator) plus reference lines at the ErrorBudgetBurn alert factors (14x/7x critical, 2x/1x warning), computed from the `objective` variable. A line crossing its paired-window threshold for the alert's `for:` duration is what actually pages; see docs/observability/slo.md.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "burn rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },
@@ -215,7 +215,7 @@
       "description": "Pyrra's vllm:e2e_request_latency_seconds:burnrate<window> recording rules (latency indicator) plus reference lines at the ErrorBudgetBurn alert factors (14x/7x critical, 2x/1x warning), computed from the `objective` variable.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "burn rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "percentunit"
         },

--- a/charts/llmkube/dashboards/model-router-dashboard.json
+++ b/charts/llmkube/dashboards/model-router-dashboard.json
@@ -33,6 +33,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []
@@ -60,6 +61,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []
@@ -122,6 +124,7 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"axisLabel": "rej/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []

--- a/charts/llmkube/dashboards/sglang-dashboard.json
+++ b/charts/llmkube/dashboards/sglang-dashboard.json
@@ -31,8 +31,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tok/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -72,7 +73,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -105,7 +106,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -138,7 +139,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -173,8 +174,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -214,8 +216,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tokens", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -247,7 +250,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -276,7 +279,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "hit rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -313,7 +316,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "short"
@@ -347,7 +350,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "reqps"
@@ -380,7 +383,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "max": 1,
               "min": 0,
@@ -409,8 +412,9 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "slots", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
               "unit": "short"
             },
             "overrides": []
@@ -451,8 +455,9 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "tokens", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
               "unit": "short"
             },
             "overrides": []

--- a/charts/llmkube/dashboards/sglang-dashboard.json
+++ b/charts/llmkube/dashboards/sglang-dashboard.json
@@ -72,6 +72,7 @@
         },
         "overrides": []
       },
+      "description": "Splits the prompt half of the panel beside it (Generation vs prompt tokens/sec) by cache hit versus recompute; prefill_cache + prefill_compute sum to the same prompt token total, so this shows how much of prefill is served from cache rather than a different quantity.",
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
       "id": 23,
       "options": {
@@ -416,6 +417,7 @@
         "defaults": {
           "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "reqps"
         },
         "overrides": []
@@ -445,11 +447,7 @@
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
-        "overrides": [
-          {"matcher": {"id": "byRegexp", "options": "p50$"}, "properties": [{"id": "color", "value": {"fixedColor": "light-blue", "mode": "fixed"}}]},
-          {"matcher": {"id": "byRegexp", "options": "p90$"}, "properties": [{"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}}]},
-          {"matcher": {"id": "byRegexp", "options": "p99$"}, "properties": [{"id": "color", "value": {"fixedColor": "dark-blue", "mode": "fixed"}}]}
-        ]
+        "overrides": []
       },
       "gridPos": {"h": 8, "w": 8, "x": 8, "y": 46},
       "id": 17,
@@ -460,24 +458,18 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "histogram_quantile(0.50, sum by (service, namespace, le) (rate(sglang:queue_time_seconds_bucket{service=~\"$service\"}[5m])))",
-          "legendFormat": "{{service}} ({{namespace}}) p50",
+          "expr": "llmkube:inference:queue_time_seconds:p95_5m{runtime=\"sglang\", service=~\"$service\"}",
+          "legendFormat": "{{service}} ({{namespace}}) p95",
           "refId": "A"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "histogram_quantile(0.90, sum by (service, namespace, le) (rate(sglang:queue_time_seconds_bucket{service=~\"$service\"}[5m])))",
-          "legendFormat": "{{service}} ({{namespace}}) p90",
+          "expr": "llmkube:inference:queue_time_seconds:p50_5m{runtime=\"sglang\", service=~\"$service\"}",
+          "legendFormat": "{{service}} ({{namespace}}) p50",
           "refId": "B"
-        },
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "histogram_quantile(0.99, sum by (service, namespace, le) (rate(sglang:queue_time_seconds_bucket{service=~\"$service\"}[5m])))",
-          "legendFormat": "{{service}} ({{namespace}}) p99",
-          "refId": "C"
         }
       ],
-      "title": "Queue wait p50 / p90 / p99 (5m)",
+      "title": "Queue wait p95 / p50 (5m)",
       "type": "timeseries"
     },
     {
@@ -539,7 +531,7 @@
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
-        "defaults": {"custom": {"scaleDistribution": {"type": "linear"}}, "unit": "short"},
+        "defaults": {"custom": {"scaleDistribution": {"type": "linear"}}, "noValue": "0", "unit": "short"},
         "overrides": []
       },
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 54},
@@ -690,6 +682,7 @@
             "defaults": {
               "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "tokens/sec", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
               "unit": "short"
             },
             "overrides": []
@@ -723,6 +716,7 @@
             "defaults": {
               "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "tokens/sec", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
               "unit": "short"
             },
             "overrides": []

--- a/charts/llmkube/dashboards/sglang-dashboard.json
+++ b/charts/llmkube/dashboards/sglang-dashboard.json
@@ -65,7 +65,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tok/s", "drawStyle": "line", "fillOpacity": 40, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "normal"}},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -79,7 +81,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "sum by (mode) (rate(sglang:realtime_tokens_total[$__rate_interval]))",
+          "expr": "sum by (mode, service, namespace) (rate(sglang:realtime_tokens_total{service=~\"$service\"}[5m]))",
           "legendFormat": "{{mode}}",
           "refId": "A"
         }
@@ -401,123 +403,8 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 45},
-      "id": 105,
-      "panels": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "fieldConfig": {
-            "defaults": {
-              "color": {"mode": "palette-classic-by-name"},
-              "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
-              "max": 1,
-              "min": 0,
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 46},
-          "id": 13,
-          "options": {
-            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
-            "tooltip": {"mode": "multi", "sort": "desc"}
-          },
-          "targets": [
-            {
-              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-              "expr": "max by (service, namespace) (sglang:mamba_usage{service=~\"$service\"})",
-              "legendFormat": "{{service}} ({{namespace}})",
-              "refId": "A"
-            }
-          ],
-          "title": "Mamba pool utilization (max across replicas)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "fieldConfig": {
-            "defaults": {
-              "color": {"mode": "palette-classic-by-name"},
-              "custom": {"axisLabel": "slots", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
-              "noValue": "0",
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 46},
-          "id": 14,
-          "options": {
-            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
-            "tooltip": {"mode": "multi", "sort": "desc"}
-          },
-          "targets": [
-            {
-              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-              "expr": "sum by (service, namespace) (sglang:mamba_used_tokens{service=~\"$service\"})",
-              "legendFormat": "{{service}} ({{namespace}}) used",
-              "refId": "A"
-            },
-            {
-              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-              "expr": "sum by (service, namespace) (sglang:mamba_available_tokens{service=~\"$service\"})",
-              "legendFormat": "{{service}} ({{namespace}}) available",
-              "refId": "B"
-            }
-          ],
-          "title": "Mamba pool used vs available",
-          "type": "timeseries"
-        }
-      ],
-      "title": "Mamba pool (hybrid-attention models only)",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 46},
-      "id": 106,
-      "panels": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "fieldConfig": {
-            "defaults": {
-              "color": {"mode": "palette-classic-by-name"},
-              "custom": {"axisLabel": "tokens", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
-              "noValue": "0",
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 47},
-          "id": 15,
-          "options": {
-            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
-            "tooltip": {"mode": "multi", "sort": "desc"}
-          },
-          "targets": [
-            {
-              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-              "expr": "sum by (service, namespace) (sglang:hicache_host_used_tokens{service=~\"$service\"})",
-              "legendFormat": "{{service}} ({{namespace}}) used",
-              "refId": "A"
-            },
-            {
-              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-              "expr": "sum by (service, namespace) (sglang:hicache_host_total_tokens{service=~\"$service\"})",
-              "legendFormat": "{{service}} ({{namespace}}) total",
-              "refId": "B"
-            }
-          ],
-          "title": "HiCache host pool used vs total",
-          "type": "timeseries"
-        }
-      ],
-      "title": "HiCache host pool (requires --hicache)",
-      "type": "row"
-    },
-    {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 47},
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 45},
       "id": 107,
       "panels": [],
       "title": "Queue wait, prefill mix and request rate",
@@ -533,7 +420,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 48},
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 46},
       "id": 16,
       "options": {
         "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
@@ -564,7 +451,7 @@
           {"matcher": {"id": "byRegexp", "options": "p99$"}, "properties": [{"id": "color", "value": {"fixedColor": "dark-blue", "mode": "fixed"}}]}
         ]
       },
-      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 48},
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 46},
       "id": 17,
       "options": {
         "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
@@ -603,7 +490,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 48},
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 46},
       "id": 18,
       "options": {
         "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
@@ -632,7 +519,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 56},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 54},
       "id": 19,
       "options": {
         "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
@@ -655,7 +542,7 @@
         "defaults": {"custom": {"scaleDistribution": {"type": "linear"}}, "unit": "short"},
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 56},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 54},
       "id": 20,
       "options": {
         "calculate": false,
@@ -676,6 +563,121 @@
       ],
       "title": "Prompt length distribution (5m)",
       "type": "heatmap"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 62},
+      "id": 105,
+      "panels": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic-by-name"},
+              "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "max": 1,
+              "min": 0,
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 63},
+          "id": 13,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+              "expr": "max by (service, namespace) (sglang:mamba_usage{service=~\"$service\"})",
+              "legendFormat": "{{service}} ({{namespace}})",
+              "refId": "A"
+            }
+          ],
+          "title": "Mamba pool utilization (max across replicas)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic-by-name"},
+              "custom": {"axisLabel": "slots", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 63},
+          "id": 14,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+              "expr": "sum by (service, namespace) (sglang:mamba_used_tokens{service=~\"$service\"})",
+              "legendFormat": "{{service}} ({{namespace}}) used",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+              "expr": "sum by (service, namespace) (sglang:mamba_available_tokens{service=~\"$service\"})",
+              "legendFormat": "{{service}} ({{namespace}}) available",
+              "refId": "B"
+            }
+          ],
+          "title": "Mamba pool used vs available",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Mamba pool (hybrid-attention models only)",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 63},
+      "id": 106,
+      "panels": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic-by-name"},
+              "custom": {"axisLabel": "tokens", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "noValue": "0",
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 64},
+          "id": 15,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+              "expr": "sum by (service, namespace) (sglang:hicache_host_used_tokens{service=~\"$service\"})",
+              "legendFormat": "{{service}} ({{namespace}}) used",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+              "expr": "sum by (service, namespace) (sglang:hicache_host_total_tokens{service=~\"$service\"})",
+              "legendFormat": "{{service}} ({{namespace}}) total",
+              "refId": "B"
+            }
+          ],
+          "title": "HiCache host pool used vs total",
+          "type": "timeseries"
+        }
+      ],
+      "title": "HiCache host pool (requires --hicache)",
+      "type": "row"
     },
     {
       "collapsed": true,

--- a/charts/llmkube/dashboards/sglang-dashboard.json
+++ b/charts/llmkube/dashboards/sglang-dashboard.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "LLMKube SGLang runtime observability. Throughput, TTFT / E2E / inter-token latency, queue depth, KV pool utilization, scheduler backpressure and prefix cache hit rate, grouped by service / namespace from the sglang: metrics the chart's inference PodMonitor scrapes. TTFT and end-to-end p95 / p50 read the chart's llmkube:inference: recording rules. Mamba and HiCache rows are collapsed because those pools only exist on hybrid-attention models and with --hicache enabled respectively.",
+  "description": "LLMKube SGLang runtime observability. Throughput, TTFT / E2E / inter-token latency, queue depth, KV pool utilization, scheduler backpressure, prefix cache hit rate, queue wait, per-stage latency, new token ratio, prompt length distribution and request rate, grouped by service / namespace from the sglang: metrics the chart's inference PodMonitor scrapes. TTFT and end-to-end p95 / p50 read the chart's llmkube:inference: recording rules. Mamba, HiCache host and HiCache L3 rows are collapsed because those pools only exist on hybrid-attention models, with --hicache enabled, and with --hicache-storage-backend enabled respectively.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -38,7 +38,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 1},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
       "id": 1,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -59,6 +59,32 @@
         }
       ],
       "title": "Generation vs prompt tokens/sec (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"axisLabel": "tok/s", "drawStyle": "line", "fillOpacity": 40, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "normal"}},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "id": 23,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (mode) (rate(sglang:realtime_tokens_total[$__rate_interval]))",
+          "legendFormat": "{{mode}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Token throughput by mode",
       "type": "timeseries"
     },
     {
@@ -487,6 +513,243 @@
         }
       ],
       "title": "HiCache host pool (requires --hicache)",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 47},
+      "id": 107,
+      "panels": [],
+      "title": "Queue wait, prefill mix and request rate",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic-by-name"},
+          "custom": {"axisLabel": "req/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 48},
+      "id": 16,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (service, namespace) (rate(sglang:num_requests_total{service=~\"$service\"}[5m]))",
+          "legendFormat": "{{service}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic-by-name"},
+          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "s"
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": "p50$"}, "properties": [{"id": "color", "value": {"fixedColor": "light-blue", "mode": "fixed"}}]},
+          {"matcher": {"id": "byRegexp", "options": "p90$"}, "properties": [{"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}}]},
+          {"matcher": {"id": "byRegexp", "options": "p99$"}, "properties": [{"id": "color", "value": {"fixedColor": "dark-blue", "mode": "fixed"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 48},
+      "id": 17,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.50, sum by (service, namespace, le) (rate(sglang:queue_time_seconds_bucket{service=~\"$service\"}[5m])))",
+          "legendFormat": "{{service}} ({{namespace}}) p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.90, sum by (service, namespace, le) (rate(sglang:queue_time_seconds_bucket{service=~\"$service\"}[5m])))",
+          "legendFormat": "{{service}} ({{namespace}}) p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.99, sum by (service, namespace, le) (rate(sglang:queue_time_seconds_bucket{service=~\"$service\"}[5m])))",
+          "legendFormat": "{{service}} ({{namespace}}) p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Queue wait p50 / p90 / p99 (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic-by-name"},
+          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 48},
+      "id": 18,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.95, sum by (service, namespace, stage, le) (rate(sglang:per_stage_req_latency_seconds_bucket{service=~\"$service\"}[5m])))",
+          "legendFormat": "{{service}} ({{namespace}}) {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-stage latency p95 by stage (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic-by-name"},
+          "custom": {"axisLabel": "ratio", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 56},
+      "id": 19,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "avg by (service, namespace) (sglang:new_token_ratio{service=~\"$service\"})",
+          "legendFormat": "{{service}} ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "New token ratio (prefill/decode mix)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"custom": {"scaleDistribution": {"type": "linear"}}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 56},
+      "id": 20,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {"exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64},
+        "legend": {"show": true},
+        "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false},
+        "yAxis": {"axisPlacement": "left", "reverse": false, "unit": "short"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (le) (rate(sglang:prompt_tokens_histogram_bucket{service=~\"$service\"}[5m]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Prompt length distribution (5m)",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 64},
+      "id": 108,
+      "panels": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic-by-name"},
+              "custom": {"axisLabel": "tokens/sec", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 65},
+          "id": 21,
+          "options": {
+            "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+              "expr": "sum by (service, namespace) (rate(sglang:backuped_tokens_total{service=~\"$service\"}[5m]))",
+              "legendFormat": "{{service}} ({{namespace}}) backup",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+              "expr": "sum by (service, namespace) (rate(sglang:load_back_tokens_total{service=~\"$service\"}[5m]))",
+              "legendFormat": "{{service}} ({{namespace}}) load-back",
+              "refId": "B"
+            }
+          ],
+          "title": "L3 backup vs load-back rate (5m)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic-by-name"},
+              "custom": {"axisLabel": "tokens/sec", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 65},
+          "id": 22,
+          "options": {
+            "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+              "expr": "sum by (service, namespace) (rate(sglang:cached_tokens_total{service=~\"$service\"}[5m]))",
+              "legendFormat": "{{service}} ({{namespace}}) cached",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+              "expr": "sum by (service, namespace) (rate(sglang:evicted_tokens_total{service=~\"$service\"}[5m]))",
+              "legendFormat": "{{service}} ({{namespace}}) evicted",
+              "refId": "B"
+            }
+          ],
+          "title": "L3 cached vs evicted tokens (5m)",
+          "type": "timeseries"
+        }
+      ],
+      "title": "HiCache L3 pool (requires --hicache-storage-backend)",
       "type": "row"
     }
   ],

--- a/charts/llmkube/dashboards/vllm-dashboard.json
+++ b/charts/llmkube/dashboards/vllm-dashboard.json
@@ -31,8 +31,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "tok/s", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -72,7 +73,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -105,7 +106,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -138,7 +139,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "unit": "s"
         },
@@ -173,8 +174,9 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "requests", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
+          "noValue": "0",
           "unit": "short"
         },
         "overrides": []
@@ -214,7 +216,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "utilization", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -243,7 +245,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "hit rate", "drawStyle": "line", "fillOpacity": 5, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "max": 1,
           "min": 0,
@@ -280,7 +282,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "reqps"
@@ -308,7 +310,7 @@
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "palette-classic-by-name"},
           "custom": {"axisLabel": "req/s", "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 0, "pointSize": 5, "showPoints": "never", "spanNulls": true},
           "noValue": "0",
           "unit": "reqps"
@@ -341,7 +343,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "unit": "s"
             },
@@ -368,7 +370,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "unit": "s"
             },
@@ -395,7 +397,7 @@
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {"mode": "palette-classic-by-name"},
               "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "pointSize": 5, "showPoints": "never", "spanNulls": true},
               "unit": "s"
             },

--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -154,5 +154,16 @@ spec:
       expr: histogram_quantile(0.50, sum by (service, namespace, runtime, le) (rate(vllm:time_to_first_token_seconds_bucket[5m]) or rate(sglang:time_to_first_token_seconds_bucket[5m])))
       labels:
         latency_kind: ttft
+
+    # Queue wait over 5m. SGLang-only for now; no vllm equivalent metric.
+    - record: llmkube:inference:queue_time_seconds:p95_5m
+      expr: histogram_quantile(0.95, sum by (service, namespace, runtime, le) (rate(sglang:queue_time_seconds_bucket[5m])))
+      labels:
+        latency_kind: queue_wait
+
+    - record: llmkube:inference:queue_time_seconds:p50_5m
+      expr: histogram_quantile(0.50, sum by (service, namespace, runtime, le) (rate(sglang:queue_time_seconds_bucket[5m])))
+      labels:
+        latency_kind: queue_wait
   {{- end }}
 {{- end }}

--- a/charts/llmkube/tests/prometheusrule_test.yaml
+++ b/charts/llmkube/tests/prometheusrule_test.yaml
@@ -94,14 +94,16 @@ tests:
     set:
       prometheus.prometheusRule.enabled: true
     asserts:
-      # Five and no more: llama.cpp exposes no request-latency histogram,
+      # Seven and no more: llama.cpp exposes no request-latency histogram,
       # so a rule over llamacpp:request_seconds_bucket is always empty.
       - lengthEqual:
           path: spec.groups[?(@.name=="llmkube-inference-recording")].rules
-          count: 5
+          count: 7
       - isNotNullOrEmpty:
           path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:request_latency:p95_5m")].expr
       - isNotNullOrEmpty:
           path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:restarts:rate5m")].expr
       - isNotNullOrEmpty:
           path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:ttft_seconds:p95_5m")].expr
+      - isNotNullOrEmpty:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:queue_time_seconds:p95_5m")].expr

--- a/internal/metrics/dashboard_sync_test.go
+++ b/internal/metrics/dashboard_sync_test.go
@@ -77,6 +77,9 @@ var (
 	// Desc keeps fqName unexported; String() is the only accessor.
 	descFQName = regexp.MustCompile(`fqName: "([^"]+)"`)
 	recordRule = regexp.MustCompile(`(?m)^\s*- record:\s*(\S+)`)
+
+	labelMatcher    = regexp.MustCompile(`\{[^}]*\}`)
+	soleAggregation = regexp.MustCompile(`^(?:sum|count)(?:\s+(?:by|without)\s*\([^)]*\))?\s*\(`)
 )
 
 // declaredNames returns the fqName of every collector this repo registers.
@@ -225,6 +228,219 @@ func dashboardQueries(t *testing.T, path string) []string {
 		}
 	}
 	return queries
+}
+
+// panelConvention pairs a panel's own fieldConfig.defaults with the PromQL
+// its own targets evaluate, so a convention can check both together instead
+// of the flat, panel-agnostic list dashboardQueries returns.
+type panelConvention struct {
+	title     string
+	panelType string
+	defaults  map[string]any
+	exprs     []string
+}
+
+// dashboardPanels walks a dashboard like dashboardQueries does, but stops at
+// every object carrying its own fieldConfig.defaults (a panel) instead of
+// flattening every "expr" found anywhere in the document. It also returns
+// the dashboard's template variable names, needed by the label-matcher
+// convention.
+func dashboardPanels(t *testing.T, path string) ([]panelConvention, []string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var panels []panelConvention
+	var walk func(node any)
+	walk = func(node any) {
+		switch typed := node.(type) {
+		case map[string]any:
+			if fc, ok := typed["fieldConfig"].(map[string]any); ok {
+				if defaults, ok := fc["defaults"].(map[string]any); ok {
+					targets, _ := typed["targets"].([]any)
+					var exprs []string
+					for _, target := range targets {
+						if tm, ok := target.(map[string]any); ok {
+							if s, ok := tm["expr"].(string); ok {
+								exprs = append(exprs, s)
+							}
+						}
+					}
+					title, _ := typed["title"].(string)
+					panelType, _ := typed["type"].(string)
+					panels = append(panels, panelConvention{title: title, panelType: panelType, defaults: defaults, exprs: exprs})
+				}
+			}
+			for _, child := range typed {
+				walk(child)
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(doc)
+
+	var vars []string
+	templating, _ := doc["templating"].(map[string]any)
+	list, _ := templating["list"].([]any)
+	for _, item := range list {
+		variable, _ := item.(map[string]any)
+		if name, ok := variable["name"].(string); ok {
+			vars = append(vars, name)
+		}
+	}
+	return panels, vars
+}
+
+// isRatioAgainstLimit reports whether expr is a bare "metric / metric"
+// division: exactly one '/', no other arithmetic mixed in, not a formula
+// that starts from a constant. That excludes the shapes the convention
+// exempts: an error budget ("1 - (...)") that can go negative, and a
+// burn-rate reference line ("14 * (1 - $objective/100)") that is unbounded.
+func isRatioAgainstLimit(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	if strings.Count(expr, "/") != 1 || strings.ContainsAny(expr, "*+") {
+		return false
+	}
+	return expr != "" && (expr[0] < '0' || expr[0] > '9')
+}
+
+// isSoleAggregation reports whether expr's outermost operation is a single
+// sum() or count() call with nothing applied outside it. A ratio-of-sums
+// like sum(a)/sum(b) also starts with "sum(", but its outer operator is the
+// division, so the sum() match must close at the very end of expr, not
+// partway through, to count.
+func isSoleAggregation(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	loc := soleAggregation.FindStringIndex(expr)
+	if loc == nil {
+		return false
+	}
+	depth := 0
+	for i := loc[1] - 1; i < len(expr); i++ {
+		switch expr[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i == len(expr)-1
+			}
+		}
+	}
+	return false
+}
+
+// filtersTemplateVarInLabelMatcher reports whether any of expr's label
+// matchers ({...}) references one of the dashboard's own template
+// variables, e.g. {service=~"$service"}.
+func filtersTemplateVarInLabelMatcher(expr string, vars []string) bool {
+	for _, matcher := range labelMatcher.FindAllString(expr, -1) {
+		for _, v := range vars {
+			if regexp.MustCompile(`\$` + regexp.QuoteMeta(v) + `\b`).MatchString(matcher) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// dashboardConventions are the three conventions applied by hand across
+// every panel in charts/llmkube/dashboards (see the "apply shared
+// conventions for min/max, noValue, and series color" commit). All three
+// are scoped to timeseries panels: stat and gauge panels color by
+// threshold, not by series, and table panels have neither a per-series
+// color nor an axis to autoscale, so none of the three read on them the way
+// they do on a graph.
+var dashboardConventions = []struct {
+	name    string
+	applies func(p panelConvention, vars []string) bool
+	holds   func(p panelConvention) bool
+	reason  string
+}{
+	{
+		name: `percentunit ratio against a hard limit sets min:0 and max:1`,
+		applies: func(p panelConvention, _ []string) bool {
+			if p.panelType != "timeseries" || p.defaults["unit"] != "percentunit" {
+				return false
+			}
+			return slices.ContainsFunc(p.exprs, isRatioAgainstLimit)
+		},
+		holds: func(p panelConvention) bool {
+			min, minOK := p.defaults["min"].(float64)
+			max, maxOK := p.defaults["max"].(float64)
+			return minOK && min == 0 && maxOK && max == 1
+		},
+		reason: "reads against the limit instead of autoscaling",
+	},
+	{
+		name: `sum()/count() as the outer PromQL operator sets noValue:"0"`,
+		applies: func(p panelConvention, _ []string) bool {
+			return slices.ContainsFunc(p.exprs, isSoleAggregation)
+		},
+		holds: func(p panelConvention) bool {
+			noValue, ok := p.defaults["noValue"].(string)
+			return ok && noValue == "0"
+		},
+		reason: `an empty vector on a fresh cluster otherwise renders "No data" instead of a real zero`,
+	},
+	{
+		name: `a template variable inside a label matcher sets color.mode "palette-classic-by-name"`,
+		applies: func(p panelConvention, vars []string) bool {
+			if p.panelType != "timeseries" {
+				return false
+			}
+			return slices.ContainsFunc(p.exprs, func(e string) bool {
+				return filtersTemplateVarInLabelMatcher(e, vars)
+			})
+		},
+		holds: func(p panelConvention) bool {
+			color, _ := p.defaults["color"].(map[string]any)
+			mode, _ := color["mode"].(string)
+			return mode == "palette-classic-by-name"
+		},
+		reason: "so filtering the variable doesn't repaint the series that remain",
+	},
+}
+
+// TestDashboardConventions fails when a panel matches one of the three
+// conventions above but doesn't carry the fieldConfig it requires. Unlike
+// TestDashboardsQueryEmittedMetrics, which flattens every dashboard into a
+// bare list of expr strings, this walks panel by panel so a convention can
+// see a panel's unit, color and target queries together.
+//
+// Scoped to charts/llmkube/dashboards: conventions were hand-applied only to
+// the dashboards shipped in the chart, not to config/grafana's standalone
+// pair, which predates that pass.
+func TestDashboardConventions(t *testing.T) {
+	dashboards, err := filepath.Glob("../../charts/*/dashboards/*.json")
+	if err != nil {
+		t.Fatalf("glob charts dashboards: %v", err)
+	}
+	if len(dashboards) == 0 {
+		t.Fatalf("no dashboards matching ../../charts/*/dashboards/*.json")
+	}
+
+	for _, dashboard := range dashboards {
+		panels, vars := dashboardPanels(t, dashboard)
+		for _, p := range panels {
+			for _, rule := range dashboardConventions {
+				if !rule.applies(p, vars) || rule.holds(p) {
+					continue
+				}
+				t.Errorf("%s panel %q violates convention %s: %s", dashboard, p.title, rule.name, rule.reason)
+			}
+		}
+	}
 }
 
 func emitted(name string, known map[string]bool) bool {


### PR DESCRIPTION
Fixes #1360. Stacked on #1368 — this branch contains that PR commits; the layer own change is 3 files, +281/-9.

## What

| Row | Panels |
|---|---|
| Throughput | request rate, prompt-length distribution (heatmap), token throughput by mode |
| Latency | queue wait p95/p50, per-stage latency by stage |
| Scheduler | new token ratio |
| HiCache L3 (collapsed) | backup vs load-back rate, cached vs evicted tokens |

Queue-wait quantiles are backed by new `llmkube:inference:queue_time_seconds:{p50,p95}_5m` recording rules that mirror the TTFT and e2e siblings exactly, rather than three inline `histogram_quantile` calls recomputing one aggregation per refresh.

## Live validation

Production cluster, SGLang v0.5.16 on an AMD R9700 under real traffic. The recording rules materialise and carry signal no existing panel showed:

| Series | Before apply | After apply |
|---|---|---|
| `llmkube:inference:queue_time_seconds:p95_5m` | absent | **18.0 s** |
| `llmkube:inference:queue_time_seconds:p50_5m` | absent | **1.0 s** |

A 1 s median with an 18 s tail is queueing, not slow inference. Every other new panel returns live data: request rate 1 series, per-stage latency 3 (one per stage), new token ratio 1, prompt-length heatmap 36 buckets, L3 backup/load-back 2, L3 cached/evicted 2.

Token throughput by mode returns 3 series (`decode`, `prefill_cache`, `prefill_compute`) and is not a duplicate of the generation-vs-prompt panel: it is the same prefill total split by cache hit versus recompute. Verified on the same cluster, `prefill_cache + prefill_compute` equals `prompt_tokens_total` (45,898,768 + 5,503,461 vs 51,385,859 sampled moments apart).

The L3 row is collapsed by default, matching the mamba and HiCache host rows, so a non-HiCache install does not open onto empty panels.

## Merge-order note

This branch and the GPU-alerts work both edit `charts/llmkube/tests/prometheusrule_test.yaml` and conflict; whichever lands second needs the rule-count assertion reconciled.

Happy to be told otherwise on any of this: if you would rather these panels lived elsewhere, or not at all, say so and I will revert it.

Assisted-by: OpenCode (generated the change; I reviewed)