### PR TITLE
fix(chart): correct stale Blackwell platform floors (R570 is EOL)

### DIFF
--- a/charts/llmkube/templates/NOTES.txt
+++ b/charts/llmkube/templates/NOTES.txt
@@ -95,6 +95,23 @@ PLATFORM FLOORS (NVIDIA Blackwell / B200-class serving):
   - CUDA toolkit:   {{ .Values.platformFloors.cudaToolkit }}
   - NCCL:           {{ .Values.platformFloors.nccl }}
   - GPU Operator:   {{ .Values.platformFloors.gpuOperator }}
+{{- with .Values.platformFloors.k8sDevicePlugin }}
+  - Device plugin:  {{ . }}
+{{- end }}
+{{- with .Values.platformFloors.dcgmExporter }}
+  - dcgm-exporter:  {{ . }}
+{{- end }}
+{{- with .Values.platformFloors.fabricManager }}
+
+  Multi-GPU (NVLink) nodes, verify this one first:
+
+  - Fabric Manager: {{ . }}
+
+    A Fabric Manager / driver version mismatch silently degrades NVLink to
+    PCIe. There is no error surface: jobs still run, just far slower. Check
+    with `nvidia-smi -q | grep -i fabric` and compare the Fabric Manager
+    package version against `nvidia-smi --query-gpu=driver_version --format=csv`.
+{{- end }}
 
   Runtime notes: prefer vLLM or SGLang on Blackwell. TGI is archived upstream
   (final release 3.3.7) with no stated Blackwell support. llama.cpp prebuilt

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -499,7 +499,10 @@
         "nvidiaDriver": { "type": "string" },
         "cudaToolkit": { "type": "string" },
         "nccl": { "type": "string" },
-        "gpuOperator": { "type": "string" }
+        "gpuOperator": { "type": "string" },
+        "k8sDevicePlugin": { "type": "string" },
+        "dcgmExporter": { "type": "string" },
+        "fabricManager": { "type": "string" }
       }
     }
   }

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -490,12 +490,30 @@ runtimeImages:
 # (#1197). Rendered into NOTES.txt at install time so a first deploy on new
 # silicon fails loudly at the checklist, not cryptically at CUDA init. These
 # do not gate anything; they document what the fleet's nodes must satisfy.
-# Verified 2026-07-21 against the NVIDIA Blackwell Compatibility Guide, the
-# GPU Operator platform-support matrix, and the NCCL release notes.
+# Verified 2026-07-31 (#1374) against the NVIDIA supported-drivers matrix, the
+# CUDA release notes, the GPU Operator release notes, the k8s-device-plugin and
+# DCGM releases, and the NCCL release notes. Re-verify quarterly: this stack
+# moves fast enough that a floor can go end-of-life between releases.
 platformFloors:
   # Render the floors block in NOTES.txt.
   show: true
-  nvidiaDriver: ">= 570.133.20 (R570 branch; R580/CUDA 13 current)"
-  cudaToolkit: ">= 12.8 (first release with sm_100 codegen)"
-  nccl: ">= 2.25.1 (first Blackwell support; 2.27+ recommended)"
-  gpuOperator: ">= v25.3.0 (first HGX B200 support)"
+  # R570 reached end-of-life in Feb 2026. R580 is the current LTS branch
+  # (EOL Jun 2028) and is what DGX OS 7.5 ships; any driver >= 580 covers
+  # the whole CUDA 13.x family via minor-version compatibility.
+  nvidiaDriver: ">= 580.173.02 (R580 LTS; R570 is EOL)"
+  # 12.8 is the first toolkit with sm_100 codegen. 13.3 Update 1 is the
+  # current GA line (13.4 is developer-preview only). CUDA 13 drops
+  # pre-Turing architectures.
+  cudaToolkit: ">= 12.8 (first sm_100 codegen; 13.3 GA current)"
+  nccl: ">= 2.25.1 (first Blackwell support; 2.30.x recommended)"
+  # Pin v26.3.3 exactly: v26.3.0/.1/.2 unconditionally set MOFED_ENABLED and
+  # GDS_ENABLED, injecting ibverbs device nodes into every GPU container and
+  # breaking RDMA/NCCL -- the multi-GPU path a Blackwell fleet depends on.
+  gpuOperator: ">= v26.3.3 (do NOT use v26.3.0/.1/.2: they break RDMA/NCCL)"
+  k8sDevicePlugin: ">= v0.19.3 (Blackwell-aware product labels)"
+  # Tag format is "<DCGM version>-<exporter version>". The 3.3.x line is not
+  # viable on B200: Blackwell NVSwitch telemetry needs the 4.x NVSDM backend.
+  dcgmExporter: ">= 4.6.0-4.8.3 (DCGM 3.3.x is not viable on B200)"
+  # A Fabric Manager / driver mismatch silently degrades NVLink to PCIe with
+  # no error surface. See docs/operations/runbooks/nvlink-degrade-to-pcie.md.
+  fabricManager: "must match the installed NVIDIA driver version exactly"

--- a/docs/operations/b200-validation-matrix.md
+++ b/docs/operations/b200-validation-matrix.md
@@ -16,7 +16,7 @@ LLMKube is currently validated on H100, L4, and L40S. This document captures the
 | Rows passing | 0 / 10 |
 | Rows blocked on hardware | 10 / 10 |
 | Concrete deltas already landed | None yet (see "Concrete deltas" below for the queue) |
-| Source-fact-checked | 2026-05-07 against NVIDIA driver/CUDA/MIG docs, gpu-operator + k8s-device-plugin + dcgm-exporter + NCCL release notes, vllm-project/vllm RFC #18153, llama.cpp build docs, DGX OS 7 release notes. Re-verify version floors quarterly; this is a fast-moving stack. |
+| Source-fact-checked | **2026-07-31** (#1374) against the NVIDIA supported-drivers matrix, CUDA release notes, gpu-operator + k8s-device-plugin + DCGM + NCCL release notes, the DCGM field reference, and DGX OS 7 release notes. Previous pass 2026-05-07. Re-verify version floors quarterly: the 2026-05 pass went stale in under three months, and one floor (driver R570) reached end-of-life in the interval. |
 
 When a row's status changes, update both this document and the tracking issue's checklist.
 
@@ -66,18 +66,23 @@ These are project changes the LLMKube codebase, Helm chart, or docs need to abso
 
 ### 1. Driver, CUDA, and GPU operator floors documented
 
-`charts/llmkube/README.md` should grow a "Tested platforms" section capturing:
+**LANDED (#1197; values corrected #1374, re-verified 2026-07-31).** These ship as
+`platformFloors` in `charts/llmkube/values.yaml` and render into `NOTES.txt` at install time:
 
-- NVIDIA driver: **R570 minimum** (570.124.06 GA; 570.133.20 required for HGX B200 per the gpu-operator platform-support docs); R570.86+ recommended for DGX OS 7. R550 and earlier do not list B200 in supported hardware. (R555 was the open-kernel-module preview branch and is unrelated to Blackwell GA timing.)
-- CUDA toolkit: **12.8 minimum** (first public `sm_100` codegen, January 2025); 12.9+ recommended; forward target CUDA 13.x.
-- `gpu-operator >= v24.6` (v24.9 / v25.x recommended); **`k8s-device-plugin >= v0.17.2`** (Blackwell-aware product labels); v0.18.0+ preferred for full architecture detection. (v0.15 / v0.16 do not advertise Blackwell architecture labels.)
-- **Fabric Manager package version MUST match the NVIDIA driver exactly.** A mismatch silently degrades NVLink5 to PCIe with no clear error surface. Highest-priority silent-failure mode; deserves its own runbook entry under `docs/operations/runbooks/`.
+- NVIDIA driver: **>= 580.173.02 (R580 LTS)**. **R570 reached end-of-life in February 2026** and must not be used; R580 LTS (EOL June 2028) is what DGX OS 7.5 ships, and any driver >= 580 covers the whole CUDA 13.x family via minor-version compatibility.
+- CUDA toolkit: **12.8 minimum** (first public `sm_100` codegen); **13.3 Update 1 is the current GA line** (13.4 is developer-preview only). Note CUDA 13 dropped pre-Turing architectures.
+- `gpu-operator`: **>= v26.3.3, and do NOT use v26.3.0/.1/.2** — those three unconditionally set `MOFED_ENABLED`/`GDS_ENABLED`, injecting ibverbs device nodes into every GPU container and breaking RDMA/NCCL, i.e. exactly the multi-GPU path a Blackwell fleet depends on. Also: **CDI has been the default since v25.10.0**, so stop emitting `runtimeClassName: nvidia`.
+- `k8s-device-plugin`: **>= v0.19.3** (Blackwell-aware product labels).
+- **Fabric Manager package version MUST match the NVIDIA driver exactly.** A mismatch silently degrades NVLink to PCIe with no clear error surface. Highest-priority silent-failure mode; runbook: [`runbooks/nvlink-degrade-to-pcie.md`](./runbooks/nvlink-degrade-to-pcie.md).
 
 ### 2. DCGM exporter floor
 
-- Floor: `dcgm-exporter` 3.3.x line for basic Blackwell coverage; the 3.3.x line picked up Blackwell counters incrementally.
-- Recommended: **`dcgm-exporter 4.5+`** (current line as of Feb 2026).
-- Verify exact DCGM field IDs (NVLink5 throughput, HBM3e bandwidth, PCIe link health, etc.) against the DCGM field reference at validation time rather than relying on this doc to enumerate them; the named-counter list shifts release-to-release.
+**Values corrected #1374 (verified 2026-07-31).**
+
+- Floor: **`dcgm-exporter >= 4.6.0-4.8.3`**. The tag format is `<DCGM version>-<exporter version>`, so this is DCGM 4.6.0 with exporter 4.8.3. **The 3.3.x line is NOT viable on B200**: Blackwell NVSwitch telemetry requires the NVSDM backend, which is a 4.x dependency.
+- **NVLink5 per-link counters are real and new in DCGM 4.6.0**: field IDs **1525-1533**, selected with the entity selector `gpu_link:<gpuId>:<linkIndex>`, plus aggregates 1200-1220 and the FEC histogram 1404-1419.
+- **Three commonly-assumed Blackwell counters do not exist.** Do not build panels or matrix rows on them: there is **no FP4/NVFP4 utilization field** anywhere in DCGM (FP4 work is invisible inside the undifferentiated `PROF_PIPE_TENSOR_ACTIVE`), **no per-die power** (B200's two dies present as a single NVML device, so all power/temp is module-scope), and **no absolute HBM3e bandwidth field** (only the ratio `DCGM_FI_PROF_DRAM_UTIL_RATIO`, ID 1005 — multiply by known peak yourself). PCIe coverage is generic only (`PCIE_LINK_GEN` 237, `PCIE_CORRECTABLE_ERROR_TOTAL` 1501); there are no Gen6-specific counters.
+- **dcgm-exporter ships zero Blackwell counters in its default CSV**, and `dcp-metrics-included.csv` is byte-identical to the default in its active set — a custom CSV is required. Note 4.6.0 also renamed `..._BANDWIDTH_*` to `..._THROUGHPUT_*`, and the default CSV still ships the deprecated NVLink4-era alias.
 - Update the Grafana dashboard from #409 to surface the verified counters once a known-good `dcgm-exporter` version is bundled in the chart.
 
 ### 3. Runtime image bumps + sm_100 codegen

--- a/docs/operations/runbooks/README.md
+++ b/docs/operations/runbooks/README.md
@@ -24,6 +24,10 @@ Every runbook should be testable: an on-call engineer who has never seen the fai
 
 - [`metal-agent-memory-pressure.md`](./metal-agent-memory-pressure.md): the metal-agent watchdog reports Warning or Critical memory pressure and may evict managed inference processes.
 
+### GPU and interconnect
+
+- [`nvlink-degrade-to-pcie.md`](./nvlink-degrade-to-pcie.md): multi-GPU inference is unexpectedly slow with no errors anywhere, because a Fabric Manager / driver version mismatch silently dropped NVLink traffic to PCIe.
+
 ### Lifecycle
 
 - [`upgrade-rollback.md`](./upgrade-rollback.md): the supported Helm-based upgrade path for moving an LLMKube install between minor or patch versions, plus the rollback procedure when an upgrade goes wrong.
@@ -37,7 +41,6 @@ These are scheduled to land before the day-one production install. Each maps to 
 - `controller-crashloop.md`: controller-manager pod itself is restarting; how to triage.
 - `inference-pod-stuck-in-creating.md`: `InferenceService` phase stays `Creating`; init container, scheduling, image pull triage.
 - `inference-pod-oom-on-gpu.md`: GPU memory exhaustion; fits with `Memory.Budget` enforcement on metal-agent and with multi-GPU sharding gone wrong.
-- `nvlink-degrade-to-pcie.md`: Fabric Manager / driver mismatch causing NVLink5 to silently fall back to PCIe (B200 specific; severe).
 - `cold-start-timeout-at-large-context.md`: `--max-model-len` set high enough that the runtime startup probe times out before the model finishes loading.
 - `parser-race-on-tool-calls.md`: streaming parser race between tool-call frames and ordinary text frames.
 - `metal-agent-respawn-blocked.md`: agent refuses to respawn an evicted process; usually correct but documented for clarity.

--- a/docs/operations/runbooks/nvlink-degrade-to-pcie.md
+++ b/docs/operations/runbooks/nvlink-degrade-to-pcie.md
@@ -1,0 +1,134 @@
+# Multi-GPU inference is unexpectedly slow on NVLink hardware
+
+Multi-GPU serving works, produces correct output, and shows no errors anywhere,
+but throughput is far below what the hardware should deliver. Tensor-parallel or
+layer-sharded models are the usual victims.
+
+The most common cause on NVLink systems (HGX/DGX B200, GB200, and NVSwitch
+platforms generally) is a **Fabric Manager / driver version mismatch**. When the
+`nvidia-fabricmanager` package version does not exactly match the installed
+NVIDIA driver, the fabric fails to initialize and GPU-to-GPU traffic **silently
+falls back to PCIe**. Nothing crashes. Nothing logs an error at the LLMKube
+layer. You just lose most of your interconnect bandwidth.
+
+## Trigger
+
+Any of:
+
+- Multi-GPU throughput well below expectation, with no errors in the
+  InferenceService pod, the operator, or `dmesg`.
+- `nvidia-smi nvlink -s` reports links inactive or missing on a system that has
+  NVLink.
+- The `nvidia-fabricmanager` service is not running, or is in a crash loop, on a
+  node that has NVSwitch.
+- A node was recently upgraded (driver, DGX OS, or GPU Operator) and multi-GPU
+  performance regressed afterward. Driver upgrades that do not upgrade Fabric
+  Manager in lockstep are the usual way this is introduced.
+
+## Diagnose
+
+1. **Compare the two versions. They must match exactly.**
+
+   ```bash
+   # Installed driver
+   nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -1
+
+   # Fabric Manager package version
+   dpkg -l | grep nvidia-fabricmanager     # Debian/Ubuntu, incl. DGX OS
+   rpm -qa | grep nvidia-fabricmanager     # RHEL family
+   ```
+
+   A driver of `580.173.02` requires Fabric Manager `580.173.02`. Not
+   `580.126.20`, not "the 580 branch". Exact.
+
+2. **Check the service state.**
+
+   ```bash
+   systemctl status nvidia-fabricmanager
+   journalctl -u nvidia-fabricmanager --no-pager | tail -40
+   ```
+
+   A version mismatch typically shows here as a startup failure mentioning the
+   driver version, after which the service stays down.
+
+3. **Check fabric state as the GPUs report it.**
+
+   ```bash
+   nvidia-smi -q | grep -i -A4 fabric
+   nvidia-smi nvlink -s
+   ```
+
+   Healthy NVSwitch systems report a completed fabric state and active links.
+   Inactive links on NVLink-capable hardware is the confirmation.
+
+4. **Confirm the traffic is actually taking PCIe.** If `dcgm-exporter` is
+   running with Blackwell counters enabled, NVLink per-link throughput fields
+   (DCGM 4.6.0+, field IDs 1525-1533) stay flat at zero under a multi-GPU load
+   while the job clearly runs.
+
+## Mitigate (immediate)
+
+Stop scheduling multi-GPU work onto the affected node until the fabric is
+healthy. Single-GPU serving is unaffected and can stay up.
+
+```bash
+kubectl cordon <node>
+# or scale the affected multi-GPU InferenceService to zero
+kubectl patch inferenceservice <name> --type merge -p '{"spec":{"replicas":0}}'
+```
+
+Leaving the workload running is not dangerous, it is just quietly slow, so this
+is about not spending GPU hours at a fraction of expected throughput.
+
+## Resolve (structural)
+
+1. **Install the Fabric Manager build that matches the driver exactly**, then
+   restart it before the workload:
+
+   ```bash
+   sudo apt-get install -y nvidia-fabricmanager-<branch>=<exact-driver-version>
+   sudo systemctl enable --now nvidia-fabricmanager
+   sudo systemctl status nvidia-fabricmanager
+   ```
+
+2. **Keep them locked together across upgrades.** The mismatch is almost always
+   introduced by upgrading one and not the other. On DGX OS, upgrade the driver
+   and Fabric Manager as a unit. When the GPU Operator manages the driver, let
+   it manage Fabric Manager too rather than installing a host package alongside.
+
+3. **Verify the platform floors** rendered in the chart's `NOTES.txt`
+   (`platformFloors`) for the driver, CUDA, NCCL, and GPU Operator minimums the
+   node should satisfy.
+
+## Verify
+
+```bash
+# 1. Versions match
+nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -1
+dpkg -l | grep nvidia-fabricmanager
+
+# 2. Service healthy
+systemctl is-active nvidia-fabricmanager
+
+# 3. Links active
+nvidia-smi nvlink -s
+```
+
+Then uncordon and re-run the workload: multi-GPU throughput should return to
+expected levels, and NVLink throughput counters should move under load.
+
+```bash
+kubectl uncordon <node>
+llmkube benchmark <service> --output table
+```
+
+## Related
+
+- Chart values: `platformFloors.fabricManager` in `charts/llmkube/values.yaml`,
+  rendered into `NOTES.txt` at install time.
+- #1374: platform floors correction that added this runbook.
+- #413: Blackwell (B200 / sm_100) enterprise readiness, which identifies a
+  Fabric Manager mismatch as the highest-priority silent-failure mode on
+  Blackwell.
+- NCCL is unsupported with MIG, so a MIG-partitioned node will not use NVLink
+  between instances regardless of fabric health. That is expected, not this bug.


### PR DESCRIPTION
## What

Corrects the Blackwell `platformFloors` shipped in the chart, adds three floors that were missing, and lands the NVLink/Fabric-Manager runbook the runbook index already reserved.

## Why

`platformFloors` renders into `NOTES.txt` at install time to tell operators what their GPU nodes must satisfy. Two of its four values had gone stale, and one was actively harmful:

- **`nvidiaDriver: ">= 570.133.20"` — R570 reached end-of-life in February 2026.** We were pointing Blackwell operators at a dead branch.
- **`gpuOperator: ">= v25.3.0"`** missed that **v26.3.0/.1/.2 break RDMA/NCCL** (they unconditionally set `MOFED_ENABLED`/`GDS_ENABLED`, injecting ibverbs device nodes into every GPU container) — precisely the multi-GPU path a Blackwell fleet depends on.

Fixes #1374

## How

Re-verified every floor on 2026-07-31 against the NVIDIA supported-drivers matrix, CUDA release notes, gpu-operator / k8s-device-plugin / DCGM / NCCL release notes, the DCGM field reference, and the DGX OS 7 notes.

**Corrected:**

| Floor | Was | Now |
|---|---|---|
| `nvidiaDriver` | `>= 570.133.20 (R570 branch)` | `>= 580.173.02 (R580 LTS; R570 is EOL)` |
| `cudaToolkit` | `>= 12.8` | `>= 12.8 (first sm_100 codegen; 13.3 GA current)` |
| `nccl` | `2.27+ recommended` | `2.30.x recommended` |
| `gpuOperator` | `>= v25.3.0` | `>= v26.3.3 (do NOT use v26.3.0/.1/.2: they break RDMA/NCCL)` |

**Added (were missing entirely):** `k8sDevicePlugin` (`>= v0.19.3`), `dcgmExporter` (`>= 4.6.0-4.8.3` — the 3.3.x line is **not viable** on B200 because Blackwell NVSwitch telemetry needs the 4.x NVSDM backend), and `fabricManager` (must match the driver exactly).

**Runbook:** a Fabric Manager / driver mismatch silently degrades NVLink to PCIe with no error surface — #413 calls this the highest-priority silent-failure mode on Blackwell. `docs/operations/runbooks/nvlink-degrade-to-pcie.md` was already reserved in the runbook index under "Pending"; this fills it in (symptom-titled per the index conventions) and promotes it out of Pending. NOTES.txt now calls the Fabric Manager check out separately for multi-GPU nodes, with the exact commands.

**Validation-matrix doc:** the same stale floors lived there too, so they are corrected in place, sections 1 and 2 are marked landed/corrected, and the quarterly provenance is re-stamped (2026-05-07 → 2026-07-31). Also recorded, because it changes what row 5 can even test: **three commonly-assumed Blackwell DCGM counters do not exist** — no FP4/NVFP4 utilization field anywhere in DCGM, no per-die power (B200's two dies present as one NVML device), and no absolute HBM3e bandwidth (ratio `DCGM_FI_PROF_DRAM_UTIL_RATIO` 1005 only). NVLink5 per-link **is** real: field IDs 1525-1533, new in DCGM 4.6.0.

**Deliberately out of scope:** the NOTES.txt runtime note still suggests building llama.cpp with `CUDA_DOCKER_ARCH=100a-real` "for peak B200 performance". Re-verification found that misleading — llama.cpp's tensor-core gates are all `>= 1200` (consumer Blackwell), so an sm_100 cubin still compiles down the Ampere/Hopper path. That correction belongs to #1375 (runtime reality) rather than this floors fix, and is captured there so it is not lost.

## Checklist

- [x] Tests added/updated — n/a (chart values + docs); existing chart tests cover the render path
- [x] `make test` passes locally — `helm unittest charts/llmkube`: **60/60 passing, 6/6 suites**
- [x] `make lint` passes locally — `helm lint`: 0 failed; `helm template` renders; schema still rejects unknown keys (`additionalProperties: false` verified)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated — runbook added and indexed; validation-matrix doc corrected

Also verified the new keys degrade gracefully: with `k8sDevicePlugin`/`dcgmExporter`/`fabricManager` unset, their lines render 0 times (no empty bullets) and the four core floors still render.

Assisted-by: Claude Code — ran the version re-verification research and drafted the values, runbook, and doc corrections; I reviewed every floor against the cited sources, ran `helm lint` / `helm unittest` (60/60) / `helm template`, and verified the render and the unset-key degradation before submitting.
