### PR TITLE
feat(api): add mxfp4 quantization and correct Blackwell runtime reality

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -958,10 +958,25 @@ type VLLMConfig struct {
 
 	// Quantization method.
 	// awq, gptq, squeezellm are classic 4-bit formats. fp8 targets 8-bit FP
-	// checkpoints (Qwen FP8, Llama FP8, etc.). nvfp4 is NVIDIA's Blackwell-native
-	// 4-bit format. compressed-tensors is the neuralmagic/vLLM cross-format
-	// loader used by Unsloth and other recent releases.
-	// +kubebuilder:validation:Enum=awq;gptq;squeezellm;fp8;nvfp4;compressed-tensors
+	// checkpoints (Qwen FP8, Llama FP8, etc.). compressed-tensors is the
+	// neuralmagic/vLLM cross-format loader used by Unsloth and other recent
+	// releases.
+	//
+	// The two FP4 formats both require Blackwell-class hardware (sm_100 for
+	// datacenter B200/GB200, sm_120 for consumer RTX 50-series):
+	//   - nvfp4 is NVIDIA's own 4-bit format. Ready-made checkpoints are
+	//     published under nvidia/*-NVFP4 on Hugging Face; local conversion
+	//     uses NVIDIA/Model-Optimizer (PyPI nvidia-modelopt), which was
+	//     renamed from NVIDIA/TensorRT-Model-Optimizer.
+	//   - mxfp4 is the OCP standard 4-bit format, with broader vLLM support.
+	//
+	// Both are hardware-supported on sm_100 and sm_120; kernel coverage is the
+	// practical limit and it is thinner on consumer sm_120. On Blackwell, use
+	// a vLLM image >= v0.25.0: v0.22.0 through v0.24.0 carry a regression that
+	// collapses NVFP4 output throughput (vllm-project/vllm#42988, fixed by
+	// #45739). The chart's pinned default is safe; see
+	// docs/operations/b200-validation-matrix.md.
+	// +kubebuilder:validation:Enum=awq;gptq;squeezellm;fp8;nvfp4;mxfp4;compressed-tensors
 	// +optional
 	Quantization string `json:"quantization,omitempty"`
 

--- a/charts/llmkube/templates/NOTES.txt
+++ b/charts/llmkube/templates/NOTES.txt
@@ -113,11 +113,13 @@ PLATFORM FLOORS (NVIDIA Blackwell / B200-class serving):
     package version against `nvidia-smi --query-gpu=driver_version --format=csv`.
 {{- end }}
 
-  Runtime notes: prefer vLLM or SGLang on Blackwell. TGI is archived upstream
-  (final release 3.3.7) with no stated Blackwell support. llama.cpp prebuilt
-  CUDA images carry no native sm_100 codegen (PTX JIT only); build with
-  CUDA_DOCKER_ARCH=100a-real for peak B200 performance and point
-  runtimeImages.llamacpp at the result.
+  Runtime notes: prefer vLLM or SGLang on datacenter Blackwell (B200/GB200,
+  sm_100). On vLLM use >= v0.25.0: v0.22.0-v0.24.0 carry an NVFP4 throughput
+  regression. TGI is archived upstream (final release 3.3.7) with no stated
+  Blackwell support. llama.cpp does not target sm_100 at all -- its Blackwell
+  tensor-core paths gate on consumer sm_120 -- so it runs on B200 only via
+  PTX JIT and is not the recommended datacenter runtime. It remains a good
+  choice for consumer Blackwell (sm_120) and CPU serving.
 {{- end }}
 
 ---

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -5649,15 +5649,31 @@ spec:
                     description: |-
                       Quantization method.
                       awq, gptq, squeezellm are classic 4-bit formats. fp8 targets 8-bit FP
-                      checkpoints (Qwen FP8, Llama FP8, etc.). nvfp4 is NVIDIA's Blackwell-native
-                      4-bit format. compressed-tensors is the neuralmagic/vLLM cross-format
-                      loader used by Unsloth and other recent releases.
+                      checkpoints (Qwen FP8, Llama FP8, etc.). compressed-tensors is the
+                      neuralmagic/vLLM cross-format loader used by Unsloth and other recent
+                      releases.
+
+                      The two FP4 formats both require Blackwell-class hardware (sm_100 for
+                      datacenter B200/GB200, sm_120 for consumer RTX 50-series):
+                        - nvfp4 is NVIDIA's own 4-bit format. Ready-made checkpoints are
+                          published under nvidia/*-NVFP4 on Hugging Face; local conversion
+                          uses NVIDIA/Model-Optimizer (PyPI nvidia-modelopt), which was
+                          renamed from NVIDIA/TensorRT-Model-Optimizer.
+                        - mxfp4 is the OCP standard 4-bit format, with broader vLLM support.
+
+                      Both are hardware-supported on sm_100 and sm_120; kernel coverage is the
+                      practical limit and it is thinner on consumer sm_120. On Blackwell, use
+                      a vLLM image >= v0.25.0: v0.22.0 through v0.24.0 carry a regression that
+                      collapses NVFP4 output throughput (vllm-project/vllm#42988, fixed by
+                      #45739). The chart's pinned default is safe; see
+                      docs/operations/b200-validation-matrix.md.
                     enum:
                     - awq
                     - gptq
                     - squeezellm
                     - fp8
                     - nvfp4
+                    - mxfp4
                     - compressed-tensors
                     type: string
                   speculative:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -5645,15 +5645,31 @@ spec:
                     description: |-
                       Quantization method.
                       awq, gptq, squeezellm are classic 4-bit formats. fp8 targets 8-bit FP
-                      checkpoints (Qwen FP8, Llama FP8, etc.). nvfp4 is NVIDIA's Blackwell-native
-                      4-bit format. compressed-tensors is the neuralmagic/vLLM cross-format
-                      loader used by Unsloth and other recent releases.
+                      checkpoints (Qwen FP8, Llama FP8, etc.). compressed-tensors is the
+                      neuralmagic/vLLM cross-format loader used by Unsloth and other recent
+                      releases.
+
+                      The two FP4 formats both require Blackwell-class hardware (sm_100 for
+                      datacenter B200/GB200, sm_120 for consumer RTX 50-series):
+                        - nvfp4 is NVIDIA's own 4-bit format. Ready-made checkpoints are
+                          published under nvidia/*-NVFP4 on Hugging Face; local conversion
+                          uses NVIDIA/Model-Optimizer (PyPI nvidia-modelopt), which was
+                          renamed from NVIDIA/TensorRT-Model-Optimizer.
+                        - mxfp4 is the OCP standard 4-bit format, with broader vLLM support.
+
+                      Both are hardware-supported on sm_100 and sm_120; kernel coverage is the
+                      practical limit and it is thinner on consumer sm_120. On Blackwell, use
+                      a vLLM image >= v0.25.0: v0.22.0 through v0.24.0 carry a regression that
+                      collapses NVFP4 output throughput (vllm-project/vllm#42988, fixed by
+                      #45739). The chart's pinned default is safe; see
+                      docs/operations/b200-validation-matrix.md.
                     enum:
                     - awq
                     - gptq
                     - squeezellm
                     - fp8
                     - nvfp4
+                    - mxfp4
                     - compressed-tensors
                     type: string
                   speculative:

--- a/docs/operations/b200-validation-matrix.md
+++ b/docs/operations/b200-validation-matrix.md
@@ -10,12 +10,12 @@ LLMKube is currently validated on H100, L4, and L40S. This document captures the
 
 | Field | Value |
 |---|---|
-| Document version | 1 (initial) |
-| Last updated | 2026-05-07 |
+| Document version | 2 (floors + runtime reality corrected) |
+| Last updated | 2026-07-31 |
 | Hardware access | Not currently reachable. Pending: NVIDIA dev partnership, customer install, or rented capacity. |
 | Rows passing | 0 / 10 |
 | Rows blocked on hardware | 10 / 10 |
-| Concrete deltas already landed | None yet (see "Concrete deltas" below for the queue) |
+| Concrete deltas already landed | 1 (floors, #1197/#1374), 2 (DCGM floor, #1374), 3 (runtime pins, #1197/#1204), 4 (FP4 quantization, #1375). Remaining: 5-6 are documentation-only. |
 | Source-fact-checked | **2026-07-31** (#1374) against the NVIDIA supported-drivers matrix, CUDA release notes, gpu-operator + k8s-device-plugin + DCGM + NCCL release notes, the DCGM field reference, and DGX OS 7 release notes. Previous pass 2026-05-07. Re-verify version floors quarterly: the 2026-05 pass went stale in under three months, and one floor (driver R570) reached end-of-life in the interval. |
 
 When a row's status changes, update both this document and the tracking issue's checklist.
@@ -30,14 +30,14 @@ When a row's status changes, update both this document and the tracking issue's 
 
 | # | Test | Status | Notes |
 |---|---|---|---|
-| 1 | Single-GPU TinyLlama-1.1B serve on B200 (FP16) | ⏳ blocked-by-hardware | Baseline sanity. Llama.cpp + GGUF Q4_K_M, default flags. Confirms driver, CUDA toolkit, GPU operator, and device plugin are wired. |
+| 1 | Single-GPU small-model serve on B200 (FP16) | ⏳ blocked-by-hardware | Baseline sanity: driver, CUDA toolkit, GPU operator, and device plugin are wired. **Corrected 2026-07-31 (#1375): use vLLM, not llama.cpp.** llama.cpp has no `sm_100` codegen (see delta 3), so a llama.cpp baseline would measure the PTX-JIT Ampere/Hopper path and misreport it as a Blackwell baseline. |
 | 2 | Single-GPU 8B model FP8 (E4M3) serve | ⏳ blocked-by-hardware | Existing FP8 checkpoints (Llama-3.x-FP8, Qwen2.5-FP8) load unchanged on B200. Verify `vllm/vllm-openai` image runs the FP8 path under Blackwell Tensor Core Gen-5. |
 | 3 | Single-GPU 70B FP8 serve, single chassis | ⏳ blocked-by-hardware | Memory-bound; exercises HBM3e bandwidth. End-to-end `llmkube deploy` on a single B200 with a 70B-class FP8 model. |
 | 4 | 8x B200 single-chassis multi-GPU sharding via NVLink5 | ⏳ blocked-by-hardware | Validate layer-based offload across 8 GPUs and confirm NVSwitch5 topology shows up correctly to the device plugin and the runtime. |
-| 5 | DCGM exporter scrape with Blackwell-native counters | ⏳ blocked-by-hardware | Confirm dcgm-exporter publishes NVLink5 per-link, FP4 / Tensor Core Gen-5 utilization, per-die power split, HBM3e bandwidth, and PCIe Gen6 link health. Update the LLMKube Grafana dashboard from #409 to surface the new counters. |
+| 5 | DCGM exporter scrape with Blackwell counters | ⏳ blocked-by-hardware | **Scope corrected 2026-07-31 (#1375).** Confirm **NVLink5 per-link** (field IDs 1525-1533, DCGM 4.6.0+, entity selector `gpu_link:<gpuId>:<linkIndex>`) and `DCGM_FI_PROF_DRAM_UTIL_RATIO` (1005). **Do not test for FP4 utilization, per-die power, or absolute HBM3e bandwidth: those fields do not exist** (see delta 2). Requires a custom CSV; dcgm-exporter ships zero Blackwell counters by default. Then update the #409 dashboard. |
 | 6 | Recording rules from #409 produce series under load | ⏳ blocked-by-hardware | TTFT, queue wait, request restart rate at FP8 throughput. Confirms the observability contract scales to Blackwell-class throughput. |
-| 7 | MIG profile deploys: 1g.23gb, 2g.45gb, 7g.180gb | ⏳ blocked-by-hardware | Verify the device plugin advertises `nvidia.com/mig-1g.23gb`, `nvidia.com/mig-2g.45gb`, `nvidia.com/mig-7g.180gb`, and that LLMKube Pods land correctly when those resources are requested. May surface a CRD field gap if MIG profile selection turns out to be needed at Model spec level. |
-| 8 | NVFP4 inference (vLLM 0.10+, ModelOpt-converted) | ⏳ blocked-by-hardware | Real path but ModelOpt is proprietary; document the conversion workflow as part of the row. Likely the test that takes longest because of the conversion step. |
+| 7 | MIG profile deploys | ⏳ blocked-by-hardware | **Corrected 2026-07-31 (#1375): B200 exposes 7 profiles, not 3, and is 180GB not 192GB** — `1g.23gb`(x7), `1g.23gb+me`(x1), `1g.45gb`(x4), `2g.45gb`(x3), `3g.90gb`(x2), `4g.90gb`(x1), `7g.180gb`(x1). Verify the device plugin advertises the corresponding `nvidia.com/mig-*` resources and Pods land. **NCCL is unsupported with MIG**, so instances stay single-GPU islands regardless of NVLink5. Ops landmine: on B200 with `1g.23gb`, `nvidia-smi` takes ~44s while containerd runs (NVIDIA/gpu-operator#2155) — enable MIG on a drained node. |
+| 8 | NVFP4 inference | ⏳ blocked-by-hardware | **Requires vLLM >= v0.25.0** (see delta 3). **Corrected 2026-07-31 (#1375): prefer the ready-made `nvidia/*-NVFP4` checkpoints on Hugging Face** over a local conversion, so this is a serve test rather than a conversion project. Local conversion, if needed, uses `NVIDIA/Model-Optimizer` (renamed from `TensorRT-Model-Optimizer`). |
 | 9 | MXFP4 inference | ⏳ blocked-by-hardware | OCP standard FP4, broader vLLM support than NVFP4. Document the per-runtime support matrix as part of the row. |
 | 10 | Crashloop / OOM / NVLink-degrade operational runbooks fire correctly | ⏳ blocked-by-hardware | End-to-end exercise of the operational runbooks under `docs/operations/runbooks/` against B200 hardware. Validates that triage signals (DCGM alerts, MemoryPressure events from #390, controller logs) actually surface what an operator needs to act on. |
 
@@ -90,27 +90,34 @@ These are project changes the LLMKube codebase, Helm chart, or docs need to abso
 **LANDED (#1197, pins verified 2026-07-21).** Current defaults and their Blackwell status:
 
 - `internal/controller/runtime_vllm.go`: pinned to `vllm/vllm-openai:v0.25.1` (newest stable). Blackwell has been first-class since before the v0.20.0 floor (FA4 default on SM100, MXFP4 CUTLASS MoE per the v0.20.0 release notes); the default build ships CUDA 13 userspace, with a `v0.25.1-cu129` variant for 570-branch drivers (`runtimeImages.vllm` or `spec.image`).
+
+  **⚠️ Do not downgrade below v0.25.0 on Blackwell.** vLLM PR #42988 (shipped in **v0.22.0**) removed the zero-initialization of the swizzled NVFP4 scale buffer. On Blackwell with `modelopt_fp4` this produces an **87-93% output-throughput collapse, truncated outputs, and 8-15x inter-token latency** — with no crash and no error, so it reads as "the GPU is slow" rather than a bug. Fixed by vllm-project/vllm#45739, first released in **v0.25.0**. **v0.22.0, v0.22.1, v0.23.0, and v0.24.0 are unsafe for NVFP4 on Blackwell.** The pinned default is above that window; anyone overriding `runtimeImages.vllm` or `spec.image` must stay >= v0.25.0. (Upstream measured the regression on B300/sm_103; the code path is not arch-gated within Blackwell, so B200 is affected on the same reasoning.)
 - `internal/controller/runtime_sglang.go`: pinned to `lmsysorg/sglang:v0.5.15.post1-cu129` (SM100 CuteDSL kernels since v0.5.14; `-cu130` variant for 580-branch fleets).
 - `internal/controller/runtime_tgi.go`: pinned to `:3.3.7`, the FINAL release; upstream archived the repository 2026-03-21 with no stated Blackwell support. Do not use TGI as a B200 default; prefer vLLM/SGLang.
-- `internal/controller/runtime_llamacpp.go` / `deployment_builder.go`: Models declaring an NVIDIA GPU now auto-divert from the CPU-only `:server` default to `ghcr.io/ggml-org/llama.cpp:server-cuda-b10068` (immutable per-build tag). CAVEAT: upstream's prebuilt CUDA images ship no native `sm_100` codegen (ggml defaults cover 50..90-virtual plus consumer 120a/121a only), so B200 runs via PTX JIT from `90-virtual`. For peak llama.cpp-on-B200, build with `CUDA_DOCKER_ARCH=100a-real` and point `runtimeImages.llamacpp` at it. Validate the JIT path on hardware (matrix row 3) before deciding whether an LLMKube-owned sm_100 build is warranted.
+- `internal/controller/runtime_llamacpp.go` / `deployment_builder.go`: Models declaring an NVIDIA GPU now auto-divert from the CPU-only `:server` default to `ghcr.io/ggml-org/llama.cpp:server-cuda-b10068` (immutable per-build tag).
+
+  **CAVEAT, corrected 2026-07-31 (#1375): llama.cpp does not target `sm_100` at all, and building for it does not help.** `ggml/src/ggml-cuda/common.cuh` defines `GGML_CUDA_CC_BLACKWELL 1200` — that is *consumer* Blackwell — and every Blackwell tensor-core path gates on `>= 1200`. The default arch list (`75-virtual 80-virtual 86-real 89-real 90-virtual 120a-real 121a-real`) contains no `100`. So adding `100a-real` to `CUDA_DOCKER_ARCH` yields a native cubin that still compiles down the **Ampere/Hopper** path: you get no sm_100 optimization either way. (An earlier version of this doc recommended that build as a route to "peak B200 performance"; that was wrong.) On B200, llama.cpp runs via PTX JIT from `90-virtual` — functional, but it is not the recommended datacenter runtime. **Route sm_100 to vLLM or SGLang.** llama.cpp remains a strong choice for consumer Blackwell (`sm_120`, where `120a-real` is native) and CPU serving; upstream now also ships a `:server-cuda13` family (CUDA 13.3, amd64 **and** arm64) that is useful for the sm_120 and Grace tiers.
 - Fleet-wide overrides for air-gapped/mirrored registries: chart values `runtimeImages.{llamacpp,vllm,sglang,tgi}` flow to the operator's `--runtime-images` flag; an explicit `spec.image` still wins.
 
 ### 4. FP8 / FP4 quantization in the CRD
 
-`InferenceServiceSpec.VLLMConfig.Quantization` already exists. Verify and document:
+**LANDED (#1375).** `InferenceServiceSpec.VLLMConfig.Quantization` accepts
+`awq;gptq;squeezellm;fp8;nvfp4;mxfp4;compressed-tensors`.
 
-- FP8 (E4M3, E5M2) values pass through cleanly.
-- NVFP4 and MXFP4 are in the allowed value set.
-- The field's GoDoc records the per-runtime support matrix.
-- The model catalog docs name a conversion path for both NVFP4 (NVIDIA ModelOpt, proprietary) and MXFP4 (OCP standard).
+- FP8 (E4M3, E5M2) values pass through cleanly; `kvCacheDtype` separately accepts `fp8_e5m2` / `fp8_e4m3`.
+- **`mxfp4` was added in #1375** (the OCP standard 4-bit format, with broader vLLM support than NVFP4); `nvfp4` was already present.
+- The field's GoDoc records the per-runtime notes, the sm_100/sm_120 hardware requirement, and the vLLM >= v0.25.0 floor.
+- Conversion paths: NVFP4 has ready-made checkpoints published under `nvidia/*-NVFP4` on Hugging Face — prefer those to a local conversion. For local conversion the tool is **`NVIDIA/Model-Optimizer`** (PyPI `nvidia-modelopt`), **renamed from `NVIDIA/TensorRT-Model-Optimizer`**; the old URL 301-redirects. MXFP4 is the OCP standard.
+- Known-dead configuration as of 2026-07: DeepEP / wide-EP + NVFP4 + SwiGLU-clamp models.
 
 ### 5. NCCL version floor for multi-GPU
 
 Document in the multi-GPU deployment guide:
 
-- **`NCCL >= 2.25.1`** introduced Blackwell support; `2.25.2+` for GB200 MNNVL.
-- **`NCCL 2.27+ / 2.28+` recommended** for NVLSTree tuning and Blackwell perf fixes.
+- **`NCCL >= 2.25.1`** introduced Blackwell support.
+- **`NCCL 2.30.x` recommended** (current line as of 2026-07-31) for NVLSTree tuning and Blackwell perf fixes.
 - `NCCL 2.24` and earlier predate Blackwell support entirely; the previously-circulated "2.23 floor" is incorrect.
+- **Unverified, do not repeat as fact:** an earlier revision of this doc claimed `2.25.2+` was required for GB200 MNNVL. The 2026-07-31 re-verification found **no such upstream tag** and could not corroborate the claim. Pin the GB200 MNNVL floor against NCCL's release notes at validation time.
 
 ### 6. OFED / OS floors for GPUDirect RDMA on Gen6
 
@@ -124,7 +131,7 @@ For the air-gapped install guide and any future multi-node sharding work:
 
 Each of these gets a runbook entry under `docs/operations/runbooks/` (filed as part of the broader operational runbook effort, not gated on B200 hardware):
 
-1. **Fabric Manager / driver version mismatch.** NVLink5 degrades to PCIe with no clear error. Detection: NVLink bandwidth scrape from DCGM; alert if reported topology bandwidth diverges from expected.
+1. **Fabric Manager / driver version mismatch.** NVLink degrades to PCIe with no clear error. **Runbook: [`runbooks/nvlink-degrade-to-pcie.md`](./runbooks/nvlink-degrade-to-pcie.md) (landed #1374).** Detection: NVLink per-link throughput from DCGM (field IDs 1525-1533, DCGM 4.6.0+); alert if links stay flat under a multi-GPU load.
 2. **Old base image (CUDA 12.4 or earlier) on B200.** Kernels appear to load but fall back or fail at launch. Detection: container logs around model load; capture `cuobjdump --list-elf` for the runtime image.
 3. **NCCL 2.24 or earlier on Blackwell.** Lacks the NVLink5 / NVSwitch5 topology support introduced in NCCL 2.25.1; results in small-message all-reduce regressions on multi-GPU. Detection: collective benchmark in row #4 of the matrix.
 4. **Old OFED on Gen6.** GPUDirect RDMA disabled silently; looks like generic network slowness. Detection: `nvidia-smi topo --matrix` plus an RDMA performance benchmark.


### PR DESCRIPTION
## What

Adds `mxfp4` to the vLLM quantization enum, and corrects Blackwell runtime guidance that the 2026-07-31 re-verification found wrong or unsafe.

> **Stacked on #1380** (the platform-floors fix) because both touch `NOTES.txt` and the validation-matrix doc. **Review the second commit only**; this rebases down to a single commit once #1380 merges.

## Why

Two of these are safety issues, not tidying:

- **A vLLM version window silently destroys throughput on Blackwell.** vLLM PR #42988 (shipped in v0.22.0) removed the zero-initialization of the swizzled NVFP4 scale buffer. With `modelopt_fp4` on Blackwell that produces an **87-93% output-throughput collapse, truncated outputs, and 8-15x inter-token latency** — with no crash and no error, so it presents as "the GPU is slow." Fixed by vllm-project/vllm#45739, first released in **v0.25.0**. Our pinned default (`v0.25.1`) is above the window, but nothing documented that, so an override or a "helpful" downgrade walks straight into it.
- **We were recommending a llama.cpp build that cannot do what we claimed.** The docs advised building with `CUDA_DOCKER_ARCH=100a-real` "for peak B200 performance." In fact llama.cpp does not target `sm_100` at all: `ggml/src/ggml-cuda/common.cuh` defines `GGML_CUDA_CC_BLACKWELL 1200` (that is *consumer* Blackwell) and every Blackwell tensor-core path gates on `>= 1200`, while the default arch list contains no `100`. An `sm_100` cubin still compiles down the **Ampere/Hopper** path, so the recommended build buys nothing.

Refs #1375

## How

**API (`mxfp4`)**

`VLLMConfig.Quantization` accepted `nvfp4` but not its OCP counterpart. Enum is now `awq;gptq;squeezellm;fp8;nvfp4;mxfp4;compressed-tensors`. The GoDoc gains the sm_100/sm_120 hardware requirement, the vLLM >= v0.25.0 floor, and the conversion paths. CRDs regenerated with `make manifests` + `make chart-crds`.

**Runtime reality corrections** (chart `NOTES.txt` + `docs/operations/b200-validation-matrix.md`)

- vLLM: v0.22.0-v0.24.0 documented as unsafe on Blackwell, with the reason and the fix version.
- llama.cpp: corrected to "does not target sm_100; route datacenter Blackwell to vLLM/SGLang." Kept as the right choice for consumer `sm_120` and CPU, and notes the new `:server-cuda13` family (CUDA 13.3, amd64 **and arm64**) for the sm_120 / Grace tiers.
- ModelOpt renamed `NVIDIA/TensorRT-Model-Optimizer` → **`NVIDIA/Model-Optimizer`**; prefer the ready-made `nvidia/*-NVFP4` checkpoints over local conversion.
- NCCL recommendation moved to the 2.30.x line, and the previously-circulated **"2.25.2+ for GB200 MNNVL" is now flagged unverified** — re-verification found no such upstream tag. Better to mark it unknown than to keep repeating it.

**Matrix rows corrected for internal consistency.** With delta 3 now saying "llama.cpp is not an sm_100 path," row 1 still specifying "Llama.cpp + GGUF Q4_K_M" made the document contradict itself, so the affected rows are fixed here rather than left to the harness issue:

- **Row 1** moves off llama.cpp — otherwise it would measure the PTX-JIT Ampere/Hopper path and report it as a Blackwell baseline.
- **Row 5** drops the three DCGM counters that **do not exist** (FP4 utilization, per-die power, absolute HBM3e bandwidth) and pins the two that do (NVLink5 per-link 1525-1533, DRAM util ratio 1005).
- **Row 7** lists all **7** B200 MIG profiles at **180GB** (was 3 profiles), plus the NCCL-with-MIG limitation and the `nvidia-smi` 44s/containerd landmine.
- **Row 8** prefers published checkpoints over a local conversion.

Status summary re-stamped: document version 2, last updated 2026-07-31, and the landed-deltas row now reflects reality (1, 2, 3, 4 landed).

## Checklist

- [x] Tests added/updated — n/a (enum value + docs); existing API and chart tests cover the paths
- [x] `make test` passes locally — `go build ./...` clean; `go test ./api/...` pass; `helm unittest`: **60/60, 6/6 suites**
- [x] `make lint` passes locally — `gofmt` clean; `GOOS=linux golangci-lint run ./api/...`: **0 issues**; `helm lint`: 0 failed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated — the doc corrections are the deliverable

**CRD sync verified the way CI does it:** committed, then re-ran `make manifests` + `make chart-crds` — **zero diff**.

Assisted-by: Claude Code — ran the upstream re-verification and drafted the enum, GoDoc, and doc corrections; I checked each claim against the cited upstream sources (vLLM PRs #42988/#45739, ggml `common.cuh`, DCGM field reference, NVIDIA MIG docs), ran the build, API tests, helm lint/unittest, cross-arch lint, and the CRD-sync check before submitting.
