### PR TITLE
docs: fix autoscaling guide to use a metric llama.cpp actually exports

### DIFF
--- a/docs/site/guides/metrics-driven-autoscaling.md
+++ b/docs/site/guides/metrics-driven-autoscaling.md
@@ -185,11 +185,11 @@ This is the lowest-friction signal. It scales on raw concurrency, not
 quality. Good for batch-oriented workloads where you just need more
 capacity.
 
-### Option B: KV cache pressure (memory-driven)
+### Option B: Deferred requests (saturation-driven)
 
-`llamacpp_kv_cache_usage_ratio` is a gauge reporting how full the
-llama.cpp KV cache is (0.0–1.0). When the cache is near capacity the
-server starts evicting entries and latency rises, so scaling out
+`llamacpp:requests_deferred` is a gauge reporting how many requests
+llama.cpp has deferred because every slot is busy. When this rises the
+server is saturated and more replicas would help, so scaling out
 before that point keeps throughput stable:
 
 ```yaml
@@ -208,10 +208,10 @@ spec:
     - type: Pods
       pods:
         metric:
-          name: llamacpp:kv_cache_usage_ratio
+          name: llamacpp:requests_deferred
         target:
           type: AverageValue
-          averageValue: "0.8"   # scale up when avg KV cache usage > 80%
+          averageValue: "2"   # scale up when avg deferred requests > 2
 ```
 
 Use this when your prompts vary in length and you want to avoid
@@ -345,10 +345,10 @@ changes. The HPA reconciles every 15 seconds by default.
       - type: Pods
         pods:
           metric:
-            name: llamacpp:kv_cache_usage_ratio
+            name: llamacpp:requests_deferred
           target:
             type: AverageValue
-            averageValue: "0.8"
+            averageValue: "2"
     behavior:
       scaleUp:
         selectPolicy: Max


### PR DESCRIPTION
## What

Replaces `llamacpp:kv_cache_usage_ratio` with `llamacpp:requests_deferred` in the
metrics-driven autoscaling guide, in both the Option B example and the full
manifest later in the page.

## Why

llama.cpp does not export `kv_cache_usage_ratio`. The guide as written produced
an HPA that never scales, because the custom metric never resolves.

Fixes #1373

## How

`llamacpp:requests_deferred` is exported by the runtime and is a saturation
signal: it counts requests deferred because every decode slot is busy.

Two details worth calling out for review:

- The metric semantics changed, so the target changed with it. The old value was
  `"0.8"` against a 0-1 ratio; the new value is `"2"` against a request count.
  Carrying `0.8` over would have produced an HPA that scales on almost any
  traffic.
- It is a gauge, not a counter, so it is used directly with `AverageValue` and
  needs no `rate()`. Verified against a live server:
  `# TYPE llamacpp:requests_deferred gauge`.

Prose and the section heading were updated to match ("KV cache pressure
(memory-driven)" becomes "Deferred requests (saturation-driven)").

Assisted-by: Qwopus3.6-27B-Fusion (local, llama.cpp) under Foreman; reviewed and
verified against a live llama.cpp `/metrics` endpoint before opening.

## Checklist

- [x] Tests added/updated (n/a, documentation only)
- [x] `make test` passes locally (n/a, documentation only)
- [x] `make lint` passes locally (n/a, documentation only)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)
