### PR TITLE
fix(foreman): run the coder gate's Go checks with GOTOOLCHAIN=auto

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -150,13 +150,30 @@ func RunCoderGate(
 			failures = append(failures, checkFailure{name: "gofmt -l .", output: out})
 		}
 
+		// Every check below drives the Go toolchain, so each needs
+		// GOTOOLCHAIN=auto. The coder agent image is built FROM golang:1.26,
+		// which bakes GOTOOLCHAIN=local; when go.mod's floor moves past the
+		// tag's patch release (go.mod 1.26.5 vs image 1.26.4) every Go command
+		// refuses to run. That surfaces as "go build ./... failed" and is fed
+		// back to the model as "fix the issues below and resubmit", so the
+		// agent spends its whole fix budget on a premise it cannot act on and
+		// the run ends with correct work discarded unpushed (#1388).
+		//
+		// The gate Job hit this first and fixed it the same way
+		// (gate_job_template.yaml, #1019); this is the in-agent path that was
+		// missed. `auto` downloads whatever go.mod requires, which keeps the
+		// gate immune to go.mod patch bumps instead of coupling it to whatever
+		// Go the image happens to ship. #1292 reduced the blast radius by
+		// skipping this tier for non-Go diffs; it does not help a Go diff.
+		goEnv := []string{"GOTOOLCHAIN=auto"}
+
 		// 2. go vet ./... fails with a non-nil error.
-		if out, err := run(ctx, workspace, nil, "go", "vet", "./..."); err != nil {
+		if out, err := run(ctx, workspace, goEnv, "go", "vet", "./..."); err != nil {
 			failures = append(failures, checkFailure{name: "go vet ./...", output: out})
 		}
 
 		// 3. go build ./... fails with a non-nil error.
-		if out, err := run(ctx, workspace, nil, "go", "build", "./..."); err != nil {
+		if out, err := run(ctx, workspace, goEnv, "go", "build", "./..."); err != nil {
 			failures = append(failures, checkFailure{name: "go build ./...", output: out})
 		}
 
@@ -166,7 +183,9 @@ func RunCoderGate(
 		// per-workspace sibling directory so stale analysis results from
 		// another coder workspace cannot pollute this run's lint (#759); the
 		// sibling location keeps the cache out of the workspace git tree.
-		lintEnv := []string{"GOOS=linux", "GOLANGCI_LINT_CACHE=" + workspace + ".golangci-cache"}
+		// golangci-lint loads packages through go/packages, so it needs the
+		// same GOTOOLCHAIN treatment as the plain go commands.
+		lintEnv := append([]string{"GOOS=linux", "GOLANGCI_LINT_CACHE=" + workspace + ".golangci-cache"}, goEnv...)
 		if out, err := run(ctx, workspace, lintEnv, golangciPath, "run", "./..."); err != nil {
 			failures = append(failures, checkFailure{name: golangciPath + " run ./...", output: out})
 		}
@@ -178,7 +197,7 @@ func RunCoderGate(
 		// KUBEBUILDER_ASSETS / a cluster the workspace lacks; CI runs them).
 		if pkgs := changedTestPackages(ctx, workspace, run); len(pkgs) > 0 {
 			args := append([]string{"test", "-count=1", "-timeout=180s"}, pkgs...)
-			if out, err := run(ctx, workspace, nil, "go", args...); err != nil {
+			if out, err := run(ctx, workspace, goEnv, "go", args...); err != nil {
 				failures = append(failures, checkFailure{name: "go test " + strings.Join(pkgs, " "), output: out})
 			}
 		}
@@ -437,7 +456,11 @@ func resolveCodegenDrift(ctx context.Context, workspace string, run commandRunne
 	// foreman CRDs need the separate foreman-chart-crds target; `generate`
 	// (deepcopy) is included so an API change that only alters zz_generated
 	// does not slip through to CI.
-	out, err := run(ctx, workspace, nil,
+	// GOTOOLCHAIN=auto for the same reason the static checks set it: these
+	// make targets shell out to the Go toolchain (controller-gen), and the
+	// agent image's baked GOTOOLCHAIN=local refuses to run once go.mod's
+	// floor passes the image's Go patch release (#1388).
+	out, err := run(ctx, workspace, []string{"GOTOOLCHAIN=auto"},
 		"make", "manifests", "generate", "chart-crds", "foreman-chart-crds")
 	if err != nil {
 		return true, "make manifests generate chart-crds foreman-chart-crds failed:\n" + out

--- a/pkg/foreman/agent/coder_gate_test.go
+++ b/pkg/foreman/agent/coder_gate_test.go
@@ -282,6 +282,60 @@ func TestRunCoderGateLintCacheScopedToWorkspace(t *testing.T) {
 	}
 }
 
+// TestRunCoderGateGoToolchainAuto asserts every Go-toolchain-driving check
+// runs with GOTOOLCHAIN=auto (#1388).
+//
+// The agent image is built FROM golang:1.26, which bakes GOTOOLCHAIN=local.
+// Once go.mod's floor passes the image's patch release (go.mod 1.26.5 vs
+// image 1.26.4) every `go` invocation refuses to run, the gate reports it as
+// "go build ./... failed", and the model spends its whole fix budget on a
+// premise it cannot act on while its correct work is discarded unpushed.
+func TestRunCoderGateGoToolchainAuto(t *testing.T) {
+	const golangciPath = "./bin/golangci-lint"
+	run, calls := newFakeRunner(map[string]fakeCommand{
+		"gofmt":      {},
+		"go":         {},
+		golangciPath: {},
+	})
+
+	RunCoderGate(context.Background(), "/work", golangciPath, run, "", "main", nil)
+
+	hasAuto := func(env []string) bool {
+		for _, e := range env {
+			if e == "GOTOOLCHAIN=auto" {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Every `go` invocation and the lint run drive the toolchain and so must
+	// carry it. gofmt is a standalone binary that never consults go.mod.
+	sawGo, sawLint := false, false
+	for i := range *calls {
+		c := (*calls)[i]
+		switch c.name {
+		case "go":
+			sawGo = true
+			if !hasAuto(c.extraEnv) {
+				t.Errorf("go %v extraEnv = %v, want it to include GOTOOLCHAIN=auto",
+					c.args, c.extraEnv)
+			}
+		case golangciPath:
+			sawLint = true
+			if !hasAuto(c.extraEnv) {
+				t.Errorf("lint extraEnv = %v, want it to include GOTOOLCHAIN=auto", c.extraEnv)
+			}
+		}
+	}
+	if !sawGo {
+		t.Fatal("no `go` command was invoked; the Go tier did not run")
+	}
+	if !sawLint {
+		t.Fatal("golangci-lint was never invoked")
+	}
+}
+
 // TestChangedTestPackages_ExcludesEnvtestAndDedups verifies the changed
 // package set covers non-envtest packages, dedups, and excludes
 // envtest/integration packages and non-Go files (#762).


### PR DESCRIPTION
## What

Runs the coder gate's Go-toolchain checks with `GOTOOLCHAIN=auto`: `go vet`,
`go build`, `golangci-lint`, the unit-test tier, and the codegen `make` targets.

## Why

The coder agent image is built `FROM golang:1.26`, which bakes
`GOTOOLCHAIN=local`. Once `go.mod`'s floor passes that tag's patch release, every
Go command refuses to run before evaluating anything the coder wrote:

```
## go vet ./...
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)

## go build ./...
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

Observed live:

```console
$ kubectl exec -n foreman-system foreman-agent-5cd74c6588-hr5dc -- go version
go version go1.26.4 linux/amd64
$ kubectl exec -n foreman-system foreman-agent-5cd74c6588-hr5dc -- go env GOTOOLCHAIN
local
$ grep '^go ' go.mod
go 1.26.5
```

The gate reports this as an ordinary check failure and feeds it back as "fix the
issues below and resubmit", so the agent spends its whole fix budget on a premise
it cannot act on, the run ends `LOOP-INCOMPLETE`, and **the branch is never
pushed**.

In the run that surfaced this, the coder had already found the existing
`hasMatchingExtraArg` helper, located both `--metrics` call sites, applied
`str_replace` to both (each `"matched_via":"exact"`), and called `submit_result`
with GO. All of it was discarded, and the task's final status read `model did not
call submit_result within max_turns` after it had called it three times.

Fixes #1388

## How

Adds `GOTOOLCHAIN=auto` to the env of each check that drives the toolchain. The
gate Job already does exactly this and its comment describes this scenario
verbatim (`gate_job_template.yaml`, #1019); this is the in-agent path that was
missed. `auto` downloads whatever `go.mod` requires, so the gate stays immune to
`go.mod` patch bumps rather than being coupled to whatever Go the image ships.

`gofmt` is deliberately left alone: it is a standalone binary that never consults
`go.mod`.

Related but not sufficient: #1292 reduced the blast radius by skipping the Go
tier entirely for non-Go diffs. That does nothing for a diff that does touch Go,
which is exactly when the gate matters.

Worth considering as a follow-up (not in this PR): the gate cannot currently
distinguish "the toolchain could not run" from "the change failed verification".
An unrunnable gate arguably belongs in the infrastructure-error path rather than
being looped back at a model that cannot act on it.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (package tests pass; bite-checked)
- [x] `make lint` passes locally (`go vet` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) - n/a, internal gate behavior

### Verification

`TestRunCoderGateGoToolchainAuto` asserts every `go` invocation and the lint run
carry `GOTOOLCHAIN=auto`. Bite-checked: reverting just the `go vet` line fails it
with `go [vet ./...] extraEnv = [], want it to include GOTOOLCHAIN=auto`, and
restoring passes. Full `pkg/foreman/agent` suite green (25.3s).

Assisted-by: Claude (Anthropic), including the live diagnosis from the failing
task transcript.
