### PR TITLE
fix(controller): correct the speculative-decoding draft flag and dedupe --metrics

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -63,7 +63,7 @@ type RopeScalingSpec struct {
 type SpeculativeDecodingType string
 
 // SpeculativeDecodingSpec configures speculative decoding for the llama.cpp
-// runtime. It maps to --spec-type (Type) and --draft-n-max (NDraftMax).
+// runtime. It maps to --spec-type (Type) and --spec-draft-n-max (NDraftMax).
 // Only the "llamacpp" runtime supports this field; other runtimes must not
 // set it.
 type SpeculativeDecodingSpec struct {
@@ -73,7 +73,7 @@ type SpeculativeDecodingSpec struct {
 	Type SpeculativeDecodingType `json:"type"`
 
 	// NDraftMax is the maximum number of draft tokens to propose per step
-	// (--draft-n-max). Only emitted when set; llama.cpp uses its own default
+	// (--spec-draft-n-max). Only emitted when set; llama.cpp uses its own default
 	// otherwise.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
@@ -334,7 +334,7 @@ type InferenceServiceSpec struct {
 
 	// SpeculativeDecoding configures speculative decoding for the llama.cpp
 	// runtime using MTP (Multi-Token Prediction) or draft-model decoding.
-	// Maps to llama.cpp --spec-type and --draft-n-max flags. Only the
+	// Maps to llama.cpp --spec-type and --spec-draft-n-max flags. Only the
 	// "llamacpp" runtime supports this field; other runtimes must not set it.
 	// +optional
 	SpeculativeDecoding *SpeculativeDecodingSpec `json:"speculativeDecoding,omitempty"`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -5165,13 +5165,13 @@ spec:
                 description: |-
                   SpeculativeDecoding configures speculative decoding for the llama.cpp
                   runtime using MTP (Multi-Token Prediction) or draft-model decoding.
-                  Maps to llama.cpp --spec-type and --draft-n-max flags. Only the
+                  Maps to llama.cpp --spec-type and --spec-draft-n-max flags. Only the
                   "llamacpp" runtime supports this field; other runtimes must not set it.
                 properties:
                   nDraftMax:
                     description: |-
                       NDraftMax is the maximum number of draft tokens to propose per step
-                      (--draft-n-max). Only emitted when set; llama.cpp uses its own default
+                      (--spec-draft-n-max). Only emitted when set; llama.cpp uses its own default
                       otherwise.
                     format: int32
                     minimum: 1

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -5161,13 +5161,13 @@ spec:
                 description: |-
                   SpeculativeDecoding configures speculative decoding for the llama.cpp
                   runtime using MTP (Multi-Token Prediction) or draft-model decoding.
-                  Maps to llama.cpp --spec-type and --draft-n-max flags. Only the
+                  Maps to llama.cpp --spec-type and --spec-draft-n-max flags. Only the
                   "llamacpp" runtime supports this field; other runtimes must not set it.
                 properties:
                   nDraftMax:
                     description: |-
                       NDraftMax is the maximum number of draft tokens to propose per step
-                      (--draft-n-max). Only emitted when set; llama.cpp uses its own default
+                      (--spec-draft-n-max). Only emitted when set; llama.cpp uses its own default
                       otherwise.
                     format: int32
                     minimum: 1

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -156,8 +156,14 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 		args = append(args, isvc.Spec.ExtraArgs...)
 	}
 
-	// Enable Prometheus metrics endpoint on llama.cpp
-	args = append(args, "--metrics")
+	// Enable Prometheus metrics endpoint on llama.cpp, unless the user already
+	// asked for it in ExtraArgs. Appending unconditionally emitted
+	// "--metrics --metrics" (#1384); llama.cpp tolerates the repeat, but the
+	// operator should not be delegating its own flag decisions to the
+	// runtime's last-flag-wins semantics.
+	if !hasMatchingExtraArg(isvc.Spec.ExtraArgs, "metrics") {
+		args = append(args, "--metrics")
+	}
 
 	return args
 }

--- a/internal/controller/runtime_llamacpp_args.go
+++ b/internal/controller/runtime_llamacpp_args.go
@@ -211,7 +211,13 @@ func appendSpeculativeDecodingArgs(args []string, spec *inferencev1alpha1.Specul
 	}
 	args = append(args, "--spec-type", specType)
 	if spec.NDraftMax != nil && *spec.NDraftMax > 0 {
-		args = append(args, "--draft-n-max", fmt.Sprintf("%d", *spec.NDraftMax))
+		// --spec-draft-n-max, not --draft-n-max: llama.cpp has never accepted
+		// the latter. Its removed aliases are --draft, --draft-n and
+		// --draft-max, all of which now report "the argument has been removed.
+		// use --spec-draft-n-max". Emitting the old spelling aborted the
+		// server at startup, so any InferenceService setting nDraftMax
+		// crashlooped (#1382).
+		args = append(args, "--spec-draft-n-max", fmt.Sprintf("%d", *spec.NDraftMax))
 	}
 	return args
 }

--- a/internal/controller/runtime_llamacpp_router.go
+++ b/internal/controller/runtime_llamacpp_router.go
@@ -122,8 +122,14 @@ func (b *LlamaCppRouterBackend) BuildArgs(isvc *inferencev1alpha1.InferenceServi
 		)
 	}
 
-	// Enable Prometheus metrics endpoint on llama.cpp
-	args = append(args, "--metrics")
+	// Enable Prometheus metrics endpoint on llama.cpp, unless the user already
+	// asked for it in ExtraArgs (#1384). Note this path appends ExtraArgs
+	// *after* the operator's flags, the opposite of the single-model path, so
+	// without the guard the user's copy would win by position here and the
+	// operator's would win there. Guarding removes the ordering dependency.
+	if !hasMatchingExtraArg(isvc.Spec.ExtraArgs, "metrics") {
+		args = append(args, "--metrics")
+	}
 
 	// Append user-provided extra args last so they can override defaults
 	if len(isvc.Spec.ExtraArgs) > 0 {

--- a/internal/controller/runtime_llamacpp_test.go
+++ b/internal/controller/runtime_llamacpp_test.go
@@ -519,7 +519,7 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 			},
 			contains: []FlagCheck{
 				{"--spec-type", "draft-mtp"},
-				{"--draft-n-max", "5"},
+				{"--spec-draft-n-max", "5"},
 			},
 		},
 		{
@@ -532,7 +532,7 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 					Type: "disabled",
 				},
 			},
-			notContains: []string{"--spec-type", "--draft-n-max"},
+			notContains: []string{"--spec-type", "--spec-draft-n-max"},
 		},
 		{
 			model: model,
@@ -541,7 +541,7 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 				Runtime:  "llama",
 				ModelRef: "test-model",
 			},
-			notContains: []string{"--spec-type", "--draft-n-max"},
+			notContains: []string{"--spec-type", "--spec-draft-n-max"},
 		},
 		{
 			model: model,
@@ -553,11 +553,11 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 					Type: "",
 				},
 			},
-			notContains: []string{"--spec-type", "--draft-n-max"},
+			notContains: []string{"--spec-type", "--spec-draft-n-max"},
 		},
 		{
 			model: model,
-			name:  "speculativeDecoding mtp without nDraftMax does not emit --draft-n-max",
+			name:  "speculativeDecoding mtp without nDraftMax does not emit --spec-draft-n-max",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -566,7 +566,7 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 				},
 			},
 			contains:    []FlagCheck{{"--spec-type", "draft-mtp"}},
-			notContains: []string{"--draft-n-max"},
+			notContains: []string{"--spec-draft-n-max"},
 		},
 		{
 			model: &inferencev1alpha1.Model{
@@ -684,5 +684,69 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// countArg returns how many times flag appears verbatim in args.
+func countArg(args []string, flag string) int {
+	n := 0
+	for _, a := range args {
+		if a == flag {
+			n++
+		}
+	}
+	return n
+}
+
+// TestLlamaCppMetricsNotDuplicated covers #1384: the operator appended
+// --metrics unconditionally while ExtraArgs was appended verbatim, so a user
+// who set --metrics themselves got it twice. Both llama.cpp backends are
+// checked because they append ExtraArgs on opposite sides of the operator's
+// own flags, so a positional fix would only have corrected one of them.
+func TestLlamaCppMetricsNotDuplicated(t *testing.T) {
+	model := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+		Spec:       inferencev1alpha1.ModelSpec{Format: "gguf"},
+	}
+
+	cases := []struct {
+		name      string
+		extraArgs []string
+		want      int
+	}{
+		{name: "operator supplies it when the user does not", extraArgs: nil, want: 1},
+		{name: "bare user flag is not duplicated", extraArgs: []string{"--metrics"}, want: 1},
+		{name: "inline user flag is not duplicated", extraArgs: []string{"--metrics=true"}, want: 0},
+	}
+
+	for _, tc := range cases {
+		for _, backend := range []struct {
+			name string
+			args func(*inferencev1alpha1.InferenceService) []string
+		}{
+			{"single-model", func(isvc *inferencev1alpha1.InferenceService) []string {
+				return (&LlamaCppBackend{}).BuildArgs(isvc, model, "/models/m.gguf", 8080)
+			}},
+			{"router", func(isvc *inferencev1alpha1.InferenceService) []string {
+				return (&LlamaCppRouterBackend{}).BuildArgs(isvc, model, "/models/m.gguf", 8080)
+			}},
+		} {
+			t.Run(backend.name+": "+tc.name, func(t *testing.T) {
+				isvc := &inferencev1alpha1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: "isvc", Namespace: "default"},
+					Spec: inferencev1alpha1.InferenceServiceSpec{
+						Runtime:   "llama",
+						ModelRef:  "test-model",
+						ExtraArgs: tc.extraArgs,
+					},
+				}
+				args := backend.args(isvc)
+				// The inline form means the operator must not add its own bare
+				// --metrics; the user's --metrics=true is the only copy.
+				if got := countArg(args, "--metrics"); got != tc.want {
+					t.Errorf("bare --metrics appeared %d times, want %d; args: %v", got, tc.want, args)
+				}
+			})
+		}
 	}
 }

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -447,7 +447,14 @@ func buildLlamaServerArgs(modelPath string, port int, config ExecutorConfig) []s
 		"--port", fmt.Sprintf("%d", port),
 		"--n-gpu-layers", fmt.Sprintf("%d", gpuLayers),
 		"--ctx-size", fmt.Sprintf("%d", config.ContextSize),
-		"--metrics",
+	}
+
+	// Prometheus metrics, unless the user already asked for it in ExtraArgs
+	// (#1384). This mirrors the reranking/embedding/pooling guards below and
+	// the two controller paths; it was the one operator-owned flag here that
+	// was still emitted unconditionally.
+	if !hasMatchingExtraArg(config.ExtraArgs, "metrics") {
+		args = append(args, "--metrics")
 	}
 
 	// RoPE context extension (InferenceService.spec.ropeScaling). ExtraArgs

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -1000,3 +1000,41 @@ func TestBuildOMLXServeArgs_AllFlags(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildLlamaServerArgsMetricsNotDuplicated covers #1384 on the Metal agent
+// path. This file already guards reranking/embedding/pooling against ExtraArgs;
+// --metrics was the one operator-owned flag still emitted unconditionally, so a
+// user who set it in ExtraArgs got it twice.
+func TestBuildLlamaServerArgsMetricsNotDuplicated(t *testing.T) {
+	count := func(args []string, flag string) int {
+		n := 0
+		for _, a := range args {
+			if a == flag {
+				n++
+			}
+		}
+		return n
+	}
+
+	cases := []struct {
+		name      string
+		extraArgs []string
+		want      int
+	}{
+		{"operator supplies it when the user does not", nil, 1},
+		{"bare user flag is not duplicated", []string{"--metrics"}, 1},
+		{"inline user flag suppresses the operator's bare copy", []string{"--metrics=true"}, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildLlamaServerArgs("/models/m.gguf", 8080, ExecutorConfig{
+				ContextSize: 4096,
+				ExtraArgs:   tc.extraArgs,
+			})
+			if got := count(args, "--metrics"); got != tc.want {
+				t.Errorf("bare --metrics appeared %d times, want %d; args: %v", got, tc.want, args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Two fixes to llama.cpp argument construction:

1. `speculativeDecoding.nDraftMax` now emits `--spec-draft-n-max` instead of
   `--draft-n-max`.
2. `--metrics` is only added when the user has not already supplied it in
   `extraArgs`, at all three call sites.

## Why

Both were found by running the flags against the runtime we actually ship
rather than reading the code alone.

**#1382.** `llama-server --help` on the Vulkan image:

```
--draft, --draft-n, --draft-max N   the argument has been removed. use --spec-draft-n-max or
```

`--draft-n-max` is not in that removed-alias list either, so it is a spelling
llama.cpp has never accepted. The server aborts at startup, so any
InferenceService setting `nDraftMax` crashlooped. Note that recovery is stickier
than it looks: `kubectl patch --type merge` cannot delete the field, so it takes
a JSON-patch `remove` or an explicit `nDraftMax: null`.

**#1384.** `--metrics` was appended unconditionally while `ExtraArgs` was
appended verbatim, so a user setting `--metrics` got `--metrics --metrics`.
llama.cpp tolerates the repeat, but the operator should not be delegating its
own flag decisions to the runtime's last-flag-wins behavior.

Fixes #1382
Fixes #1384

## How

**Three** call sites had the `--metrics` defect, not the one originally
reported:

| path | file | ordering |
|---|---|---|
| single-model | `runtime_llamacpp.go` | ExtraArgs, then `--metrics` |
| router | `runtime_llamacpp_router.go` | `--metrics`, then ExtraArgs |
| Metal agent | `pkg/agent/executor.go` | `--metrics` in the initial slice, ExtraArgs last |

The two controller paths append `ExtraArgs` on **opposite sides** of the
operator's own flags, so a positional fix would have corrected one and left the
other. Guarding with `hasMatchingExtraArg` removes the ordering dependency
instead of relying on it.

`pkg/agent` already guards `reranking`, `embedding` and `pooling` exactly this
way, and its helper's own doc says it exists "so the agent path does not
duplicate flags the user set explicitly". `--metrics` was simply the one
operator-owned flag there that never got the treatment.

CRD doc comments naming the old flag were updated, and `make manifests` /
`make chart-crds` regenerated; a second run produces no diff.

## Verification

- `TestLlamaCppMetricsNotDuplicated` covers both controller backends, and
  `TestBuildLlamaServerArgsMetricsNotDuplicated` covers the Metal path. Each
  asserts an exact occurrence count rather than presence, since the bug is a
  duplicate rather than an absence, and each covers the bare (`--metrics`) and
  inline (`--metrics=true`) user forms.
- **Bite-checked all three guards individually**: reverting each one on its own
  fails its test, and restoring passes.
- Existing `--metrics` assertions still hold, since the default path still
  emits it.
- `go test ./pkg/agent/ ./api/...` green; `internal/controller` unit tests
  green. `TestControllers` (envtest) fails in my worktree for want of
  `bin/k8s`, and fails identically on a clean `upstream/main` checkout, so it is
  an environment gap rather than a regression. CI has the assets.
- `GOOS=linux go vet` clean on both packages.

## Note on scope

`type: draft` is still broken and deliberately untouched here: it maps to
`--spec-type draft`, and the runtime accepts only
`none, draft-simple, draft-eagle3, draft-mtp, ngram-*`. Fixing it also needs a
way to name the draft weights (`--spec-draft-model`), which is a CRD field
addition. Tracked separately in #1383.

Assisted-by: Claude (Anthropic).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (unit tiers; envtest needs assets CI has)
- [x] `make lint` passes locally (`GOOS=linux go vet` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - CRD field docs regenerated
