### PR TITLE
fix(router): compile external backends in the Gateway data plane

### DIFF
--- a/internal/controller/gateway_resources_modelrouter.go
+++ b/internal/controller/gateway_resources_modelrouter.go
@@ -170,6 +170,13 @@ type routerBackendResource struct {
 	// Envoy fails over to a healthy backend, while its Backend/AIServiceBackend
 	// objects are still generated so it can be re-added on recovery.
 	Healthy bool
+	// IsIP reports that FQDN holds a literal IP address rather than a hostname.
+	// Envoy Gateway's Backend takes these through different endpoint types
+	// (`ip` vs `fqdn`) and rejects an IP supplied as an fqdn hostname, so the
+	// resolver records which one it found and the builder emits accordingly.
+	// Only ever true for external backends; in-cluster backends always resolve
+	// to a Service FQDN.
+	IsIP bool
 }
 
 // routerRuleResource is one resolved ModelRouter rule ready to compile: the
@@ -232,15 +239,25 @@ func newRouterBackend(mr *inferencev1alpha1.ModelRouter, b routerBackendResource
 	u.SetGroupVersionKind(backendGVK())
 	u.SetName(sanitizeDNSName(b.Name))
 	u.SetNamespace(mr.Namespace)
-	u.Object["spec"] = map[string]interface{}{
-		"endpoints": []interface{}{
-			map[string]interface{}{
-				"fqdn": map[string]interface{}{
-					"hostname": b.FQDN,
-					"port":     b.Port,
-				},
-			},
+	// Envoy Gateway validates the two endpoint types differently: `fqdn.hostname`
+	// must be a DNS name and rejects a literal IP, so an external backend given
+	// as an address has to go through `ip.address` instead (#1395).
+	endpoint := map[string]interface{}{
+		"fqdn": map[string]interface{}{
+			"hostname": b.FQDN,
+			"port":     b.Port,
 		},
+	}
+	if b.IsIP {
+		endpoint = map[string]interface{}{
+			"ip": map[string]interface{}{
+				"address": b.FQDN,
+				"port":    b.Port,
+			},
+		}
+	}
+	u.Object["spec"] = map[string]interface{}{
+		"endpoints": []interface{}{endpoint},
 	}
 	return u
 }

--- a/internal/controller/gateway_resources_modelrouter_test.go
+++ b/internal/controller/gateway_resources_modelrouter_test.go
@@ -1,0 +1,88 @@
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// TestResolveExternalBackend covers #1395: external backends are compiled into
+// the Gateway data plane instead of failing the whole reconcile.
+func TestResolveExternalBackend(t *testing.T) {
+	ext := func(u string) inferencev1alpha1.RouterBackend {
+		return inferencev1alpha1.RouterBackend{
+			Name:     "ext",
+			External: &inferencev1alpha1.ExternalProvider{URL: u},
+		}
+	}
+
+	cases := []struct {
+		name     string
+		url      string
+		wantHost string
+		wantPort int64
+		wantIsIP bool
+		wantErr  bool
+	}{
+		{name: "ip with explicit port", url: "http://192.168.1.47:8083/v1", wantHost: "192.168.1.47", wantPort: 8083, wantIsIP: true},
+		{name: "hostname with explicit port", url: "http://mac.lan:8083/v1", wantHost: "mac.lan", wantPort: 8083},
+		{name: "https defaults to 443", url: "https://api.example.com/v1", wantHost: "api.example.com", wantPort: 443},
+		{name: "http defaults to 80", url: "http://api.example.com/v1", wantHost: "api.example.com", wantPort: 80},
+		{name: "empty url is an error", url: "", wantErr: true},
+		{name: "relative url has no host", url: "/v1/chat", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveExternalBackend(ext(tc.url))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %q, got %+v", tc.url, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.url, err)
+			}
+			if got.FQDN != tc.wantHost || got.Port != tc.wantPort || got.IsIP != tc.wantIsIP {
+				t.Errorf("resolveExternalBackend(%q) = host=%q port=%d isIP=%v, want host=%q port=%d isIP=%v",
+					tc.url, got.FQDN, got.Port, got.IsIP, tc.wantHost, tc.wantPort, tc.wantIsIP)
+			}
+			// External backends have no InferenceService to read readiness from,
+			// so they must compile as Healthy or the ejection pass drops them.
+			if !got.Healthy {
+				t.Errorf("external backend %q compiled unhealthy; it would be ejected from every route", tc.url)
+			}
+		})
+	}
+}
+
+// TestNewRouterBackendIPUsesIPEndpoint pins the endpoint-type split: Envoy
+// Gateway rejects a literal address supplied as an fqdn hostname (#1395).
+func TestNewRouterBackendIPUsesIPEndpoint(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{}
+	mr.SetName("r")
+	mr.SetNamespace("default")
+
+	u := newRouterBackend(mr, routerBackendResource{Name: "ext", FQDN: "192.168.1.47", Port: 8083, Healthy: true, IsIP: true})
+	eps, _, _ := unstructured.NestedSlice(u.Object, "spec", "endpoints")
+	if len(eps) != 1 {
+		t.Fatalf("want 1 endpoint, got %d", len(eps))
+	}
+	ep := eps[0].(map[string]interface{})
+	if _, ok := ep["ip"]; !ok {
+		t.Errorf("IP backend must use the ip endpoint type, got %v", ep)
+	}
+	if _, ok := ep["fqdn"]; ok {
+		t.Errorf("IP backend must not use fqdn, got %v", ep)
+	}
+
+	u2 := newRouterBackend(mr, routerBackendResource{Name: "in", FQDN: "svc.default.svc.cluster.local", Port: 8080, Healthy: true})
+	eps2, _, _ := unstructured.NestedSlice(u2.Object, "spec", "endpoints")
+	ep2 := eps2[0].(map[string]interface{})
+	if _, ok := ep2["fqdn"]; !ok {
+		t.Errorf("hostname backend must use fqdn, got %v", ep2)
+	}
+}

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -19,7 +19,10 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -303,7 +306,12 @@ func (r *ModelRouterGatewayReconciler) resolveBackends(
 	resolved := make([]routerBackendResource, 0, len(mr.Spec.Backends))
 	for _, b := range mr.Spec.Backends {
 		if b.External != nil {
-			return nil, fmt.Errorf("backend %q is External; external backends are not supported in dataPlane: Gateway yet", b.Name)
+			res, err := resolveExternalBackend(b)
+			if err != nil {
+				return nil, err
+			}
+			resolved = append(resolved, res)
+			continue
 		}
 		if b.InferenceServiceRef == nil {
 			return nil, fmt.Errorf("backend %q has no inferenceServiceRef", b.Name)
@@ -953,4 +961,62 @@ func hasGlobModel(models []string) bool {
 		}
 	}
 	return false
+}
+
+// resolveExternalBackend turns a ModelRouter external backend into the
+// host/port pair the Gateway builders compile into an Envoy Backend (#1395).
+//
+// An external backend is any OpenAI-compatible endpoint outside the cluster: an
+// mlx_lm.server or llama.cpp on an Apple Silicon box, a LiteLLM proxy, a
+// workstation on the LAN. There is no InferenceService to read readiness from,
+// so these are always compiled as Healthy; liveness is Envoy's job via the
+// route's own health checking rather than something the reconciler can observe.
+//
+// The scheme supplies the port when the URL omits it, and a literal IP is
+// reported through IsIP because Envoy Gateway rejects an address given as an
+// fqdn hostname.
+func resolveExternalBackend(b inferencev1alpha1.RouterBackend) (routerBackendResource, error) {
+	raw := strings.TrimSpace(b.External.URL)
+	if raw == "" {
+		return routerBackendResource{}, fmt.Errorf("backend %q is External but has no url", b.Name)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return routerBackendResource{}, fmt.Errorf("backend %q: parsing external url %q: %w", b.Name, raw, err)
+	}
+	if u.Host == "" {
+		return routerBackendResource{}, fmt.Errorf(
+			"backend %q: external url %q has no host; it must be absolute, e.g. http://host:8080/v1", b.Name, raw)
+	}
+
+	host := u.Hostname()
+	port := int64(0)
+	if p := u.Port(); p != "" {
+		parsed, perr := strconv.ParseInt(p, 10, 32)
+		if perr != nil {
+			return routerBackendResource{}, fmt.Errorf("backend %q: external url %q has an invalid port: %w", b.Name, raw, perr)
+		}
+		port = parsed
+	} else {
+		switch strings.ToLower(u.Scheme) {
+		case "https":
+			port = 443
+		case "http":
+			port = 80
+		default:
+			return routerBackendResource{}, fmt.Errorf(
+				"backend %q: external url %q has no port and scheme %q implies none", b.Name, raw, u.Scheme)
+		}
+	}
+	if port < 1 || port > 65535 {
+		return routerBackendResource{}, fmt.Errorf("backend %q: external url %q port %d out of range", b.Name, raw, port)
+	}
+
+	return routerBackendResource{
+		Name:    b.Name,
+		FQDN:    host,
+		Port:    port,
+		Healthy: true,
+		IsIP:    net.ParseIP(host) != nil,
+	}, nil
 }


### PR DESCRIPTION
## What

Compiles `backends[].external` into the Gateway data plane instead of rejecting
it, so a `ModelRouter` can route to OpenAI-compatible endpoints outside the
cluster.

## Why

`ModelRouter` already models external backends in its schema (`provider`, `url`,
`model`, `credentialsSecretRef`), but `resolveBackends` refused them:

```go
if b.External != nil {
    return nil, fmt.Errorf("backend %q is External; external backends are not supported in dataPlane: Gateway yet", b.Name)
}
```

The comment above it said the hard error existed "so the user is not silently
missing a backend". In practice the opposite happened: a failed reconcile does
not retract previously compiled routes, so the gateway keeps serving its
last-good config.

Measured on a live cluster before the fix. Added a second backend for a shared
model key pointing at an `mlx_lm.server` on another machine, set the rule to
`strategy: weighted`, both backends weight 50, then sent 12 requests:

- **12/12 returned HTTP 200**
- **12/12 were served by the in-cluster backend**
- the external server logged **zero** completions, only my `GET /v1/models`
  probes (one of them from a cluster pod, confirming reachability)

The only signal was `GatewayReady=False ReconcileFailed`. Nothing at the request
path.

Fixes #1395

## How

`resolveExternalBackend` parses the external URL into the host/port pair the
existing Backend builders already consume, so the compile path is unchanged
past resolution. The port defaults from the scheme when the URL omits it
(443/https, 80/http), and a malformed or hostless URL is a clear error naming
the backend.

Two decisions worth calling out for review:

**External backends compile as `Healthy: true`.** There is no InferenceService
to read `Status.ReadyReplicas` from. Compiling them unhealthy would mean the
slice-4b ejection pass drops them from every route's `backendRefs`, so they
would never receive traffic at all. Liveness for an out-of-cluster endpoint is
Envoy's job via route health checking, not something this reconciler can
observe.

**A literal IP uses Envoy Gateway's `ip` endpoint type, not `fqdn`.** Envoy
validates the two differently and rejects an address supplied as an fqdn
hostname. `routerBackendResource.IsIP` records which form the resolver found and
the builder emits accordingly. This matters in practice: the motivating case is
a Mac on the LAN reached by address.

## Verification

- `TestResolveExternalBackend` covers IP with explicit port, hostname with
  explicit port, https and http scheme defaults, empty URL, and a relative URL
  with no host. It also asserts external backends compile Healthy, since
  compiling them unhealthy silently removes them from every route.
- `TestNewRouterBackendIPUsesIPEndpoint` pins the `ip`-vs-`fqdn` split in both
  directions.
- **Bite-checked**: reverting just the IP branch fails the endpoint test with
  `IP backend must use the ip endpoint type, got map[fqdn:...]`, and restoring
  passes.
- `go build ./...`, `go vet ./internal/controller/...`, and `gofmt -l` all clean.

## Not addressed here

Issue #1395 raises a second point: a failed reconcile leaving the data plane
serving a stale compilation is indistinguishable from success at the client.
This PR removes the specific trigger, but the general property remains. Worth a
follow-up so a `ReconcileFailed` router surfaces at the request path (refuse the
affected rule, or a Degraded condition plus a Warning Event naming the dropped
backend) rather than only in status.

`credentialsSecretRef` is also not wired here; this covers unauthenticated
OpenAI-compatible endpoints on the local network. Authenticated external
providers want a follow-up that threads the secret into the AIServiceBackend.

Assisted-by: Claude (Anthropic), including the live cluster repro.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (unit tiers; envtest needs assets CI has)
- [x] `make lint` passes locally (`go vet` clean, `gofmt` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated - external backends in Gateway mode should get a docs note once `credentialsSecretRef` lands
