### PR TITLE
fix(router): apply external.model as modelNameOverride on backendRefs

### DIFF
--- a/internal/controller/gateway_resources_modelrouter.go
+++ b/internal/controller/gateway_resources_modelrouter.go
@@ -221,6 +221,16 @@ type routerBackendRef struct {
 	// Weight is the traffic share for the weighted strategy. nil when the
 	// strategy is primary-fallback.
 	Weight *int64
+	// ModelNameOverride is the model identifier the upstream should receive,
+	// taken from an external backend's external.model. Empty for in-cluster
+	// backends and for external backends that did not set it, in which case the
+	// client's own model value passes through unchanged.
+	//
+	// Without this the upstream receives the ModelRouter rule key (e.g.
+	// "coder-fusion"), which any server that validates model names rejects.
+	// llama.cpp ignores the field, which is why in-cluster backends never
+	// needed it (#1397).
+	ModelNameOverride string
 }
 
 // modelRouterGatewayResourceName is the shared, DNS-sanitized name for the
@@ -465,6 +475,9 @@ func compileRuleBackendRefs(refs []routerBackendRef) []interface{} {
 		}
 		if ref.Weight != nil {
 			backendRef["weight"] = *ref.Weight
+		}
+		if ref.ModelNameOverride != "" {
+			backendRef["modelNameOverride"] = ref.ModelNameOverride
 		}
 		out = append(out, backendRef)
 	}

--- a/internal/controller/gateway_resources_modelrouter_test.go
+++ b/internal/controller/gateway_resources_modelrouter_test.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -84,5 +86,45 @@ func TestNewRouterBackendIPUsesIPEndpoint(t *testing.T) {
 	ep2 := eps2[0].(map[string]interface{})
 	if _, ok := ep2["fqdn"]; !ok {
 		t.Errorf("hostname backend must use fqdn, got %v", ep2)
+	}
+}
+
+// TestExternalModelOverrideReachesBackendRef covers #1397: an external
+// backend's external.model must reach the upstream as modelNameOverride,
+// otherwise the upstream receives the ModelRouter rule key and rejects it.
+func TestExternalModelOverrideReachesBackendRef(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{}
+	mr.Spec.Backends = []inferencev1alpha1.RouterBackend{
+		{Name: "ext", External: &inferencev1alpha1.ExternalProvider{
+			URL: "http://192.168.1.47:8083/v1", Model: "/models/qwopus-fusion-mxfp4"}},
+		{Name: "ext-no-model", External: &inferencev1alpha1.ExternalProvider{
+			URL: "http://192.168.1.47:8083/v1"}},
+		{Name: "in-cluster", InferenceServiceRef: &corev1.LocalObjectReference{Name: "svc"}},
+	}
+
+	got := externalModelOverrides(mr)
+	if got["ext"] != "/models/qwopus-fusion-mxfp4" {
+		t.Errorf("external backend with a model: got %q, want the upstream identifier", got["ext"])
+	}
+	// Absent, not empty-string: an external backend that set no model must keep
+	// today's pass-through, since some providers accept the router key directly.
+	if _, ok := got["ext-no-model"]; ok {
+		t.Errorf("external backend without a model must not get an override, got %q", got["ext-no-model"])
+	}
+	if _, ok := got["in-cluster"]; ok {
+		t.Errorf("in-cluster backend must never get an override, got %q", got["in-cluster"])
+	}
+
+	refs := compileRuleBackendRefs([]routerBackendRef{
+		{Name: "ext", ModelNameOverride: "/models/qwopus-fusion-mxfp4"},
+		{Name: "in-cluster"},
+	})
+	first := refs[0].(map[string]interface{})
+	if first["modelNameOverride"] != "/models/qwopus-fusion-mxfp4" {
+		t.Errorf("backendRef missing modelNameOverride: %v", first)
+	}
+	second := refs[1].(map[string]interface{})
+	if _, ok := second["modelNameOverride"]; ok {
+		t.Errorf("in-cluster backendRef must omit modelNameOverride entirely, got %v", second)
 	}
 }

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -527,6 +527,7 @@ func (r *ModelRouterGatewayReconciler) modelRoutersForInferenceService(ctx conte
 // matches were already vetted by unsupportedMatchMessage. Strategy decides
 // whether backendRefs carry priority (primary-fallback) or weight (weighted).
 func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource, error) {
+	overrides := externalModelOverrides(mr)
 	weights := backendWeights(mr)
 	// header-only is the only mode that reaches compilation with a
 	// dataClassification match; detector/hybrid are rejected earlier by
@@ -537,7 +538,7 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 
 	rules := make([]routerRuleResource, 0, len(mr.Spec.Rules)+len(mr.Spec.Backends)+1)
 	for _, rule := range mr.Spec.Rules {
-		refs, err := compileBackendRefs(rule.Name, rule.Route, weights)
+		refs, err := compileBackendRefs(rule.Name, rule.Route, weights, overrides)
 		if err != nil {
 			return nil, err
 		}
@@ -566,7 +567,7 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 			}
 			rules = append(rules, routerRuleResource{
 				Models:      []string{modelID},
-				BackendRefs: []routerBackendRef{{Name: b.Name}},
+				BackendRefs: []routerBackendRef{{Name: b.Name, ModelNameOverride: overrides[b.Name]}},
 			})
 		}
 	}
@@ -575,7 +576,7 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 	// routing to the named backend.
 	if mr.Spec.DefaultRoute != "" {
 		rules = append(rules, routerRuleResource{
-			BackendRefs: []routerBackendRef{{Name: mr.Spec.DefaultRoute}},
+			BackendRefs: []routerBackendRef{{Name: mr.Spec.DefaultRoute, ModelNameOverride: overrides[mr.Spec.DefaultRoute]}},
 		})
 	}
 
@@ -587,18 +588,18 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 // weighted assigns each backend's declared Weight (default 1). The shadow
 // strategy has no gateway equivalent and is rejected (caught earlier by
 // unsupportedMatchMessage, defended again here).
-func compileBackendRefs(ruleName string, route inferencev1alpha1.RuleRoute, weights map[string]int64) ([]routerBackendRef, error) {
+func compileBackendRefs(ruleName string, route inferencev1alpha1.RuleRoute, weights map[string]int64, overrides map[string]string) ([]routerBackendRef, error) {
 	refs := make([]routerBackendRef, 0, len(route.Backends))
 	switch route.Strategy {
 	case "", "primary-fallback":
 		for i, name := range route.Backends {
 			priority := int64(i)
-			refs = append(refs, routerBackendRef{Name: name, Priority: &priority})
+			refs = append(refs, routerBackendRef{Name: name, Priority: &priority, ModelNameOverride: overrides[name]})
 		}
 	case weightedStrategy:
 		for _, name := range route.Backends {
 			weight := weights[name]
-			refs = append(refs, routerBackendRef{Name: name, Weight: &weight})
+			refs = append(refs, routerBackendRef{Name: name, Weight: &weight, ModelNameOverride: overrides[name]})
 		}
 	default:
 		return nil, fmt.Errorf("rule %q uses strategy %q which has no gateway equivalent", ruleName, route.Strategy)
@@ -1019,4 +1020,22 @@ func resolveExternalBackend(b inferencev1alpha1.RouterBackend) (routerBackendRes
 		Healthy: true,
 		IsIP:    net.ParseIP(host) != nil,
 	}, nil
+}
+
+// externalModelOverrides maps backend name to the upstream model identifier for
+// every external backend that set external.model.
+//
+// The ModelRouter rule key is what a client sends and what the gateway forwards
+// by default, but it is a routing label, not an upstream model name. An
+// external server that validates the field rejects it; mlx_lm.server treats an
+// unknown name as a HuggingFace repo and 404s. In-cluster backends are absent
+// from this map because llama.cpp ignores the field entirely (#1397).
+func externalModelOverrides(mr *inferencev1alpha1.ModelRouter) map[string]string {
+	out := make(map[string]string, len(mr.Spec.Backends))
+	for _, b := range mr.Spec.Backends {
+		if b.External != nil && b.External.Model != "" {
+			out[b.Name] = b.External.Model
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## What

Applies an external backend's `external.model` to the upstream request as
`modelNameOverride` on the AIGatewayRoute's `backendRefs`.

## Why

#1396 made external backends routable. Every request that actually reached one
then failed, because the gateway forwards the client's `model` value, which is
the ModelRouter rule key, and `external.model` was never applied.

Measured on a live cluster with two weighted backends behind one `coder-fusion`
key, an in-cluster llama.cpp service and an external `mlx_lm.server`:

- routing worked, **7 of 12 requests reached the external backend**
- **all 7 returned 404**
- only the in-cluster backend's 5 succeeded

The upstream's access log and the client body agree on the cause:

```
"POST /v1/chat/completions HTTP/1.1" 404
{"error": "404 Client Error ... Repository Not Found for url:
https://huggingface.co/api/models/coder-fusion/revision/main"}
```

`mlx_lm.server` received `model: "coder-fusion"`, did not recognise it, and
treated it as a HuggingFace repo to fetch.

This never surfaced for in-cluster backends because llama.cpp ignores the `model`
field entirely. It appears against any upstream that validates it: mlx_lm.server,
vLLM with a `--served-model-name`, or a hosted provider.

Fixes #1397

## How

Envoy AI Gateway already models this. `AIGatewayRoute` `backendRefs[]` has:

> **modelNameOverride**: Name of the model in the backend. If provided this will
> override the name provided in the request.

`externalModelOverrides` maps backend name to `external.model` for the backends
that set it, and `compileRuleBackendRefs` emits the field. Threaded through
`compileRouterRules` and `compileBackendRefs` so both the failover and weighted
paths carry it, as well as the single-backend and default-route paths.

Two deliberate choices:

- **A backend without `external.model` gets no override**, not an empty one. The
  field is absent from the map rather than set to `""`, so today's pass-through
  is preserved for providers that accept the router key directly.
- **In-cluster backends never get the field.** They are absent from the map by
  construction, so their generated `backendRefs` are byte-identical to before.

## Verification

- `TestExternalModelOverrideReachesBackendRef` covers all three cases: external
  with a model gets the override, external without one is absent from the map,
  in-cluster is absent. It then asserts the compiled `backendRef` carries
  `modelNameOverride` for the first and omits it entirely for the third.
- **Bite-checked**: removing just the emission fails with
  `backendRef missing modelNameOverride: map[name:ext]`; restoring passes.
- `go build ./...`, `go vet ./internal/controller/...`, `gofmt -l` all clean.

## Note

This is the second half of making external backends usable. #1396 got the
request to the right host; this gets the upstream to accept it. `#1395` also
raised that a failed reconcile leaves the data plane serving a stale
compilation, which is still open and worth its own fix.

`credentialsSecretRef` remains unwired: this covers unauthenticated
OpenAI-compatible endpoints. Authenticated providers need the secret threaded
into the AIServiceBackend.

Assisted-by: Claude (Anthropic), including the live cluster repro.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (unit tiers; envtest needs assets CI has)
- [x] `make lint` passes locally (`go vet`, `gofmt` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated - external backends deserve a docs section once `credentialsSecretRef` lands
