### PR TITLE
fix(router): surface a gateway reconcile failure as a Warning Event

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -523,8 +523,9 @@ func main() {
 	// self-gates on the aigw CRDs being present, so a cluster without the gateway
 	// stack still starts the operator cleanly and this controller no-ops.
 	if err := (&controller.ModelRouterGatewayReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("modelrouter-gateway"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ModelRouterGateway")
 		os.Exit(1)

--- a/internal/controller/gateway_resources_modelrouter_test.go
+++ b/internal/controller/gateway_resources_modelrouter_test.go
@@ -1,7 +1,13 @@
 package controller
 
 import (
+	"context"
+	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -126,5 +132,64 @@ func TestExternalModelOverrideReachesBackendRef(t *testing.T) {
 	second := refs[1].(map[string]interface{})
 	if _, ok := second["modelNameOverride"]; ok {
 		t.Errorf("in-cluster backendRef must omit modelNameOverride entirely, got %v", second)
+	}
+}
+
+// TestGatewayNotReadyEmitsWarningEvent covers #1395 ask 2: a failed reconcile
+// must be visible somewhere an operator actually looks. The gateway keeps
+// serving its last-good compilation, so a status condition alone lets traffic
+// flow against a spec the operator believes they replaced.
+func TestGatewayNotReadyEmitsWarningEvent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	mr := &inferencev1alpha1.ModelRouter{}
+	mr.SetName("fleet-router")
+	mr.SetNamespace("default")
+
+	rec := record.NewFakeRecorder(4)
+	r := &ModelRouterGatewayReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(mr).WithStatusSubresource(mr).Build(),
+		Scheme:   scheme,
+		Recorder: rec,
+	}
+
+	if err := r.setGatewayNotReady(context.Background(), mr, "ReconcileFailed", "backend \"ext\" is broken"); err != nil {
+		t.Fatalf("setGatewayNotReady: %v", err)
+	}
+
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, "Warning") {
+			t.Errorf("event must be a Warning, got %q", ev)
+		}
+		// The point of the event is not that something failed, but that stale
+		// routes are still live. Without that sentence an operator reads the
+		// warning and assumes traffic stopped.
+		if !strings.Contains(ev, "last successfully compiled routes") {
+			t.Errorf("event must say the stale routes are still serving, got %q", ev)
+		}
+	default:
+		t.Fatal("no event emitted; a failed reconcile would be invisible at the request path")
+	}
+}
+
+// TestGatewayNotReadyWithoutRecorderDoesNotPanic pins the nil-Recorder path,
+// which every existing unit test constructs.
+func TestGatewayNotReadyWithoutRecorderDoesNotPanic(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	mr := &inferencev1alpha1.ModelRouter{}
+	mr.SetName("r")
+	mr.SetNamespace("default")
+	r := &ModelRouterGatewayReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(mr).WithStatusSubresource(mr).Build(),
+		Scheme: scheme,
+	}
+	if err := r.setGatewayNotReady(context.Background(), mr, "ReconcileFailed", "msg"); err != nil {
+		t.Fatalf("nil Recorder must not error: %v", err)
 	}
 }

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -27,12 +27,14 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -111,6 +113,12 @@ var defaultSensitiveClassifications = []string{"pii", "phi"}
 type ModelRouterGatewayReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// Recorder surfaces reconcile failures as Kubernetes Events. A failed
+	// reconcile does not retract the previously compiled gateway resources, so
+	// the data plane keeps serving its last-good config: requests still succeed
+	// while silently using stale routing. A status condition alone is not
+	// enough, because nobody watches conditions during a routing change (#1395).
+	Recorder record.EventRecorder
 
 	// detector is the shared CRD-presence gate, lazily initialized on first
 	// reconcile and reused thereafter. It requires slice 1's three kinds plus
@@ -467,6 +475,14 @@ func (r *ModelRouterGatewayReconciler) setGatewayNotReady(
 		Reason:  reason,
 		Message: message,
 	})
+	// Say plainly that the previously compiled routes are still live. The
+	// dangerous case is not the failure itself but that traffic keeps flowing
+	// against a config the operator believes they just replaced.
+	if r.Recorder != nil {
+		r.Recorder.Eventf(mr, corev1.EventTypeWarning, reason,
+			"%s; the gateway continues serving the last successfully compiled routes, "+
+				"so this router's traffic does NOT reflect the current spec", message)
+	}
 	return r.Status().Patch(ctx, mr, patch)
 }
 


### PR DESCRIPTION
## What

`setGatewayNotReady` now emits a Warning Event alongside the status condition,
stating explicitly that the previously compiled routes are still serving traffic.

## Why

A failed reconcile does not retract the gateway resources it compiled earlier.
The data plane keeps serving its last-good config, so requests continue to
succeed against routing the operator believes they just replaced. Until now the
only signal was a `GatewayReady=False` status condition, and nobody watches
conditions during a routing change.

This is not theoretical. It happened twice in one session:

- a backend was silently dropped from a rule. **12/12 requests returned HTTP
  200**, all served by the remaining backend, while the newly added one received
  nothing. Everything at the request layer looked healthy.
- later, with `modelNameOverride` correctly emitted into the route, the request
  path gave no indication the gateway was ignoring it.

Each time the diagnosis required counting requests at the upstream servers
themselves, because the client could not distinguish "working" from "serving a
config you replaced an hour ago".

Addresses the second ask of #1395. #1396 fixed the first and deferred this one;
the issue has been reopened.

## How

`ModelRouterGatewayReconciler` gains a `Recorder`, wired in `cmd/main.go`. Every
`setGatewayNotReady` path now also emits a Warning.

The wording is the substance of the change, so it is worth quoting:

> `<reason>`; the gateway continues serving the last successfully compiled
> routes, so this router's traffic does NOT reflect the current spec

An operator reading only "reconcile failed" reasonably assumes traffic stopped.
The dangerous property is the opposite: traffic is flowing, against the old
config. The event has to say that, which is why the test asserts on the wording
and not merely on an event existing.

A nil `Recorder` is tolerated so existing unit-test constructions keep working.

## Verification

- `TestGatewayNotReadyEmitsWarningEvent` asserts the event is a Warning **and**
  that it carries the stale-routes sentence.
- `TestGatewayNotReadyWithoutRecorderDoesNotPanic` pins the nil-Recorder path.
- **Bite-checked with two compiling mutations**: downgrading `EventTypeWarning`
  to `EventTypeNormal` fails with `event must be a Warning`; removing the word
  "successfully" from the message fails with `event must say the stale routes
  are still serving`. Restoring passes both.
- `go build ./...`, `go vet ./internal/controller/... ./cmd/...`, `gofmt -l` all
  clean.

## Scope

This makes the failure *visible*. It does not make it *safe*: the gateway still
serves the stale compilation. Refusing to serve an affected rule would be the
stronger guarantee, but it converts a silent degradation into an outage and
deserves its own discussion rather than riding along here.

Assisted-by: Claude (Anthropic).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (unit tiers; envtest needs assets CI has)
- [x] `make lint` passes locally (`go vet`, `gofmt` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated - n/a, operational behavior
