### PR TITLE
fix(router): rewrite body.model for external backends via bodyMutation

### DIFF
--- a/internal/controller/gateway_resources_modelrouter.go
+++ b/internal/controller/gateway_resources_modelrouter.go
@@ -177,6 +177,9 @@ type routerBackendResource struct {
 	// Only ever true for external backends; in-cluster backends always resolve
 	// to a Service FQDN.
 	IsIP bool
+	// ModelOverride is an external backend's external.model. Empty for
+	// in-cluster backends and for external backends that did not set one.
+	ModelOverride string
 }
 
 // routerRuleResource is one resolved ModelRouter rule ready to compile: the
@@ -290,6 +293,18 @@ func newRouterAIServiceBackend(mr *inferencev1alpha1.ModelRouter, b routerBacken
 			"kind":            gatewayBackendKind,
 			"group":           gatewayBackendGroup,
 		},
+	}
+	// modelNameOverride on the route rewrites the routing/metrics model name but
+	// does NOT rewrite the request body, so an upstream that reads body.model
+	// still receives the ModelRouter rule key and rejects it (#1399). bodyMutation
+	// is the mechanism that actually edits the JSON before it leaves the gateway.
+	if b.ModelOverride != "" {
+		spec := u.Object["spec"].(map[string]interface{})
+		spec["bodyMutation"] = map[string]interface{}{
+			"set": []interface{}{
+				map[string]interface{}{"path": "model", "value": b.ModelOverride},
+			},
+		}
 	}
 	return u
 }

--- a/internal/controller/gateway_resources_modelrouter_test.go
+++ b/internal/controller/gateway_resources_modelrouter_test.go
@@ -193,3 +193,38 @@ func TestGatewayNotReadyWithoutRecorderDoesNotPanic(t *testing.T) {
 		t.Fatalf("nil Recorder must not error: %v", err)
 	}
 }
+
+// TestAIServiceBackendBodyMutationRewritesModel covers #1399: modelNameOverride
+// on the route rewrites routing/metrics only, so an upstream that reads
+// body.model still receives the ModelRouter rule key. bodyMutation is what
+// actually edits the outgoing JSON.
+func TestAIServiceBackendBodyMutationRewritesModel(t *testing.T) {
+	mr := &inferencev1alpha1.ModelRouter{}
+	mr.SetName("r")
+	mr.SetNamespace("default")
+
+	u := newRouterAIServiceBackend(mr, routerBackendResource{
+		Name: "ext", FQDN: "192.168.1.47", Port: 8083, Healthy: true, IsIP: true,
+		ModelOverride: "/models/qwopus-fusion-mxfp4",
+	})
+	set, found, err := unstructured.NestedSlice(u.Object, "spec", "bodyMutation", "set")
+	if err != nil || !found {
+		t.Fatalf("external backend with a model must set bodyMutation: found=%v err=%v", found, err)
+	}
+	entry := set[0].(map[string]interface{})
+	if entry["path"] != "model" {
+		t.Errorf("bodyMutation must target the model field, got %v", entry)
+	}
+	if entry["value"] != "/models/qwopus-fusion-mxfp4" {
+		t.Errorf("bodyMutation must carry the upstream model id, got %v", entry)
+	}
+
+	// In-cluster backends must be byte-identical to before: llama.cpp ignores
+	// body.model, and adding a mutation would rewrite it to an empty string.
+	plain := newRouterAIServiceBackend(mr, routerBackendResource{
+		Name: "in", FQDN: "svc.default.svc.cluster.local", Port: 8080, Healthy: true,
+	})
+	if _, found, _ := unstructured.NestedSlice(plain.Object, "spec", "bodyMutation", "set"); found {
+		t.Errorf("in-cluster backend must not carry a bodyMutation")
+	}
+}

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -1030,11 +1030,12 @@ func resolveExternalBackend(b inferencev1alpha1.RouterBackend) (routerBackendRes
 	}
 
 	return routerBackendResource{
-		Name:    b.Name,
-		FQDN:    host,
-		Port:    port,
-		Healthy: true,
-		IsIP:    net.ParseIP(host) != nil,
+		Name:          b.Name,
+		FQDN:          host,
+		Port:          port,
+		Healthy:       true,
+		IsIP:          net.ParseIP(host) != nil,
+		ModelOverride: b.External.Model,
 	}, nil
 }
 


### PR DESCRIPTION
## What

Emits `bodyMutation.set` on the generated AIServiceBackend so an external
backend's `external.model` actually reaches the upstream in the request body.

## Why

#1398 put `modelNameOverride` into the AIGatewayRoute and it lands correctly:

```json
{"modelNameOverride": "/Users/defilan/mlx-models/qwopus-fusion-mxfp4",
 "name": "fusion-m5-mlx", "priority": 0, "weight": 50}
```

Every request to that backend still returned 404. `modelNameOverride` rewrites
the **routing and metrics** model name; it does not rewrite the **request body**.
An upstream that reads `body.model` still received `coder-fusion`, the
ModelRouter rule key.

## Diagnosis

My first hypothesis was a version gap. It was wrong, and worth recording so
nobody re-runs it: `modelNameOverride` has been in Envoy AI Gateway since
**August 2025** (envoyproxy/ai-gateway#1021 "extproc: fixes modelNameOverride",
#1135 "update model name header in case of modelNameOverride"). The installed
controller is v0.7.0, so the feature is present and behaving as designed. Note
#1135's wording: *header*.

`AIServiceBackend.bodyMutation` is the mechanism that edits outgoing JSON:

> **set**: Set overwrites/adds the request body with the given JSON field
> (name, value) before sending to the backend.

Its own schema example uses `model`.

Fixes #1399

## How

`routerBackendResource` carries `ModelOverride` from `external.model`, and
`newRouterAIServiceBackend` emits:

```yaml
bodyMutation:
  set:
    - path: model
      value: <external.model>
```

Only for external backends that set `external.model`. In-cluster backends are
byte-identical to before, which matters: llama.cpp ignores `body.model`, so an
unconditional mutation would rewrite it to an empty string for every existing
backend.

This is complementary to #1398 rather than replacing it. `modelNameOverride`
still gives correct routing and metrics attribution; `bodyMutation` makes the
upstream accept the request.

## Verification

- `TestAIServiceBackendBodyMutationRewritesModel` asserts the mutation targets
  `model`, carries the upstream id, and is **absent** for in-cluster backends.
- **Bite-checked**: changing the path to `modelx` fails with
  `bodyMutation must target the model field`; restoring passes.
- `go build ./...`, `go vet`, `gofmt -l` clean.

## Remaining

`credentialsSecretRef` is still unwired, so this covers unauthenticated
OpenAI-compatible endpoints.

Assisted-by: Claude (Anthropic), including the live cluster repro and the
upstream-history check.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (unit tiers; envtest needs assets CI has)
- [x] `make lint` passes locally (`go vet`, `gofmt` clean)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated - external backends want a docs section once credentials land
