### PR TITLE
revert: remove the inert model-rewrite paths for external backends

### DIFF
--- a/internal/controller/gateway_resources_modelrouter.go
+++ b/internal/controller/gateway_resources_modelrouter.go
@@ -177,9 +177,6 @@ type routerBackendResource struct {
 	// Only ever true for external backends; in-cluster backends always resolve
 	// to a Service FQDN.
 	IsIP bool
-	// ModelOverride is an external backend's external.model. Empty for
-	// in-cluster backends and for external backends that did not set one.
-	ModelOverride string
 }
 
 // routerRuleResource is one resolved ModelRouter rule ready to compile: the
@@ -224,16 +221,6 @@ type routerBackendRef struct {
 	// Weight is the traffic share for the weighted strategy. nil when the
 	// strategy is primary-fallback.
 	Weight *int64
-	// ModelNameOverride is the model identifier the upstream should receive,
-	// taken from an external backend's external.model. Empty for in-cluster
-	// backends and for external backends that did not set it, in which case the
-	// client's own model value passes through unchanged.
-	//
-	// Without this the upstream receives the ModelRouter rule key (e.g.
-	// "coder-fusion"), which any server that validates model names rejects.
-	// llama.cpp ignores the field, which is why in-cluster backends never
-	// needed it (#1397).
-	ModelNameOverride string
 }
 
 // modelRouterGatewayResourceName is the shared, DNS-sanitized name for the
@@ -293,18 +280,6 @@ func newRouterAIServiceBackend(mr *inferencev1alpha1.ModelRouter, b routerBacken
 			"kind":            gatewayBackendKind,
 			"group":           gatewayBackendGroup,
 		},
-	}
-	// modelNameOverride on the route rewrites the routing/metrics model name but
-	// does NOT rewrite the request body, so an upstream that reads body.model
-	// still receives the ModelRouter rule key and rejects it (#1399). bodyMutation
-	// is the mechanism that actually edits the JSON before it leaves the gateway.
-	if b.ModelOverride != "" {
-		spec := u.Object["spec"].(map[string]interface{})
-		spec["bodyMutation"] = map[string]interface{}{
-			"set": []interface{}{
-				map[string]interface{}{"path": "model", "value": b.ModelOverride},
-			},
-		}
 	}
 	return u
 }
@@ -490,9 +465,6 @@ func compileRuleBackendRefs(refs []routerBackendRef) []interface{} {
 		}
 		if ref.Weight != nil {
 			backendRef["weight"] = *ref.Weight
-		}
-		if ref.ModelNameOverride != "" {
-			backendRef["modelNameOverride"] = ref.ModelNameOverride
 		}
 		out = append(out, backendRef)
 	}

--- a/internal/controller/gateway_resources_modelrouter_test.go
+++ b/internal/controller/gateway_resources_modelrouter_test.go
@@ -9,8 +9,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -95,46 +93,6 @@ func TestNewRouterBackendIPUsesIPEndpoint(t *testing.T) {
 	}
 }
 
-// TestExternalModelOverrideReachesBackendRef covers #1397: an external
-// backend's external.model must reach the upstream as modelNameOverride,
-// otherwise the upstream receives the ModelRouter rule key and rejects it.
-func TestExternalModelOverrideReachesBackendRef(t *testing.T) {
-	mr := &inferencev1alpha1.ModelRouter{}
-	mr.Spec.Backends = []inferencev1alpha1.RouterBackend{
-		{Name: "ext", External: &inferencev1alpha1.ExternalProvider{
-			URL: "http://192.168.1.47:8083/v1", Model: "/models/qwopus-fusion-mxfp4"}},
-		{Name: "ext-no-model", External: &inferencev1alpha1.ExternalProvider{
-			URL: "http://192.168.1.47:8083/v1"}},
-		{Name: "in-cluster", InferenceServiceRef: &corev1.LocalObjectReference{Name: "svc"}},
-	}
-
-	got := externalModelOverrides(mr)
-	if got["ext"] != "/models/qwopus-fusion-mxfp4" {
-		t.Errorf("external backend with a model: got %q, want the upstream identifier", got["ext"])
-	}
-	// Absent, not empty-string: an external backend that set no model must keep
-	// today's pass-through, since some providers accept the router key directly.
-	if _, ok := got["ext-no-model"]; ok {
-		t.Errorf("external backend without a model must not get an override, got %q", got["ext-no-model"])
-	}
-	if _, ok := got["in-cluster"]; ok {
-		t.Errorf("in-cluster backend must never get an override, got %q", got["in-cluster"])
-	}
-
-	refs := compileRuleBackendRefs([]routerBackendRef{
-		{Name: "ext", ModelNameOverride: "/models/qwopus-fusion-mxfp4"},
-		{Name: "in-cluster"},
-	})
-	first := refs[0].(map[string]interface{})
-	if first["modelNameOverride"] != "/models/qwopus-fusion-mxfp4" {
-		t.Errorf("backendRef missing modelNameOverride: %v", first)
-	}
-	second := refs[1].(map[string]interface{})
-	if _, ok := second["modelNameOverride"]; ok {
-		t.Errorf("in-cluster backendRef must omit modelNameOverride entirely, got %v", second)
-	}
-}
-
 // TestGatewayNotReadyEmitsWarningEvent covers #1395 ask 2: a failed reconcile
 // must be visible somewhere an operator actually looks. The gateway keeps
 // serving its last-good compilation, so a status condition alone lets traffic
@@ -191,40 +149,5 @@ func TestGatewayNotReadyWithoutRecorderDoesNotPanic(t *testing.T) {
 	}
 	if err := r.setGatewayNotReady(context.Background(), mr, "ReconcileFailed", "msg"); err != nil {
 		t.Fatalf("nil Recorder must not error: %v", err)
-	}
-}
-
-// TestAIServiceBackendBodyMutationRewritesModel covers #1399: modelNameOverride
-// on the route rewrites routing/metrics only, so an upstream that reads
-// body.model still receives the ModelRouter rule key. bodyMutation is what
-// actually edits the outgoing JSON.
-func TestAIServiceBackendBodyMutationRewritesModel(t *testing.T) {
-	mr := &inferencev1alpha1.ModelRouter{}
-	mr.SetName("r")
-	mr.SetNamespace("default")
-
-	u := newRouterAIServiceBackend(mr, routerBackendResource{
-		Name: "ext", FQDN: "192.168.1.47", Port: 8083, Healthy: true, IsIP: true,
-		ModelOverride: "/models/qwopus-fusion-mxfp4",
-	})
-	set, found, err := unstructured.NestedSlice(u.Object, "spec", "bodyMutation", "set")
-	if err != nil || !found {
-		t.Fatalf("external backend with a model must set bodyMutation: found=%v err=%v", found, err)
-	}
-	entry := set[0].(map[string]interface{})
-	if entry["path"] != "model" {
-		t.Errorf("bodyMutation must target the model field, got %v", entry)
-	}
-	if entry["value"] != "/models/qwopus-fusion-mxfp4" {
-		t.Errorf("bodyMutation must carry the upstream model id, got %v", entry)
-	}
-
-	// In-cluster backends must be byte-identical to before: llama.cpp ignores
-	// body.model, and adding a mutation would rewrite it to an empty string.
-	plain := newRouterAIServiceBackend(mr, routerBackendResource{
-		Name: "in", FQDN: "svc.default.svc.cluster.local", Port: 8080, Healthy: true,
-	})
-	if _, found, _ := unstructured.NestedSlice(plain.Object, "spec", "bodyMutation", "set"); found {
-		t.Errorf("in-cluster backend must not carry a bodyMutation")
 	}
 }

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -543,7 +543,6 @@ func (r *ModelRouterGatewayReconciler) modelRoutersForInferenceService(ctx conte
 // matches were already vetted by unsupportedMatchMessage. Strategy decides
 // whether backendRefs carry priority (primary-fallback) or weight (weighted).
 func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource, error) {
-	overrides := externalModelOverrides(mr)
 	weights := backendWeights(mr)
 	// header-only is the only mode that reaches compilation with a
 	// dataClassification match; detector/hybrid are rejected earlier by
@@ -554,7 +553,7 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 
 	rules := make([]routerRuleResource, 0, len(mr.Spec.Rules)+len(mr.Spec.Backends)+1)
 	for _, rule := range mr.Spec.Rules {
-		refs, err := compileBackendRefs(rule.Name, rule.Route, weights, overrides)
+		refs, err := compileBackendRefs(rule.Name, rule.Route, weights)
 		if err != nil {
 			return nil, err
 		}
@@ -583,7 +582,7 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 			}
 			rules = append(rules, routerRuleResource{
 				Models:      []string{modelID},
-				BackendRefs: []routerBackendRef{{Name: b.Name, ModelNameOverride: overrides[b.Name]}},
+				BackendRefs: []routerBackendRef{{Name: b.Name}},
 			})
 		}
 	}
@@ -592,7 +591,7 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 	// routing to the named backend.
 	if mr.Spec.DefaultRoute != "" {
 		rules = append(rules, routerRuleResource{
-			BackendRefs: []routerBackendRef{{Name: mr.Spec.DefaultRoute, ModelNameOverride: overrides[mr.Spec.DefaultRoute]}},
+			BackendRefs: []routerBackendRef{{Name: mr.Spec.DefaultRoute}},
 		})
 	}
 
@@ -604,18 +603,18 @@ func compileRouterRules(mr *inferencev1alpha1.ModelRouter) ([]routerRuleResource
 // weighted assigns each backend's declared Weight (default 1). The shadow
 // strategy has no gateway equivalent and is rejected (caught earlier by
 // unsupportedMatchMessage, defended again here).
-func compileBackendRefs(ruleName string, route inferencev1alpha1.RuleRoute, weights map[string]int64, overrides map[string]string) ([]routerBackendRef, error) {
+func compileBackendRefs(ruleName string, route inferencev1alpha1.RuleRoute, weights map[string]int64) ([]routerBackendRef, error) {
 	refs := make([]routerBackendRef, 0, len(route.Backends))
 	switch route.Strategy {
 	case "", "primary-fallback":
 		for i, name := range route.Backends {
 			priority := int64(i)
-			refs = append(refs, routerBackendRef{Name: name, Priority: &priority, ModelNameOverride: overrides[name]})
+			refs = append(refs, routerBackendRef{Name: name, Priority: &priority})
 		}
 	case weightedStrategy:
 		for _, name := range route.Backends {
 			weight := weights[name]
-			refs = append(refs, routerBackendRef{Name: name, Weight: &weight, ModelNameOverride: overrides[name]})
+			refs = append(refs, routerBackendRef{Name: name, Weight: &weight})
 		}
 	default:
 		return nil, fmt.Errorf("rule %q uses strategy %q which has no gateway equivalent", ruleName, route.Strategy)
@@ -1030,29 +1029,10 @@ func resolveExternalBackend(b inferencev1alpha1.RouterBackend) (routerBackendRes
 	}
 
 	return routerBackendResource{
-		Name:          b.Name,
-		FQDN:          host,
-		Port:          port,
-		Healthy:       true,
-		IsIP:          net.ParseIP(host) != nil,
-		ModelOverride: b.External.Model,
+		Name:    b.Name,
+		FQDN:    host,
+		Port:    port,
+		Healthy: true,
+		IsIP:    net.ParseIP(host) != nil,
 	}, nil
-}
-
-// externalModelOverrides maps backend name to the upstream model identifier for
-// every external backend that set external.model.
-//
-// The ModelRouter rule key is what a client sends and what the gateway forwards
-// by default, but it is a routing label, not an upstream model name. An
-// external server that validates the field rejects it; mlx_lm.server treats an
-// unknown name as a HuggingFace repo and 404s. In-cluster backends are absent
-// from this map because llama.cpp ignores the field entirely (#1397).
-func externalModelOverrides(mr *inferencev1alpha1.ModelRouter) map[string]string {
-	out := make(map[string]string, len(mr.Spec.Backends))
-	for _, b := range mr.Spec.Backends {
-		if b.External != nil && b.External.Model != "" {
-			out[b.Name] = b.External.Model
-		}
-	}
-	return out
 }


### PR DESCRIPTION
## What

Reverts #1398 (`modelNameOverride` on route `backendRefs`) and #1401
(`bodyMutation` on the AIServiceBackend). Both emitted correct-looking fields
that Envoy AI Gateway v0.7.0 does not apply, so neither had any effect.

Keeps #1396 (external backends compile and route) and #1400 (reconcile failures
surface as Warning Events). Both are independently verified.

## Why

Both were merged on the strength of a plausible CRD field. That was the wrong
standard of evidence. Capturing the actual request at the upstream settles it:

```
body.model    : 'coder-fusion'
x-ai-eg-model : 'coder-fusion'
upstream      : 404
```

The gateway sent the ModelRouter rule key in **both** the body and its own
`x-ai-eg-model` header, untouched by either mechanism. The `x-ai-eg-*` headers
confirm the request went through extproc, so this is not a bypass: v0.7.0
simply does not apply these fields on this path.

Note `modelNameOverride` has existed upstream since August 2025
(envoyproxy/ai-gateway#1021, #1135), so this was never a version gap either.

## Why revert rather than leave it

Dead code here is actively misleading. The next person debugging external
backends will see `bodyMutation` in the generated AIServiceBackend, conclude
model rewriting is handled, and look elsewhere. That is precisely the wrong
turn, and it cost an afternoon to find the first time.

The underlying need is real and stays open in #1399: routing to an upstream
that validates model names requires rewriting the outgoing `model` field. That
now needs a mechanism that actually works, which may be an upstream fix, a
newer gateway version, or a different data plane.

## Verification

- `go build ./...`, `go vet ./internal/controller/...`, `gofmt -l` clean.
- The tests belonging to the reverted features are removed with them; the tests
  from #1396 (`TestResolveExternalBackend`, `TestNewRouterBackendIPUsesIPEndpoint`)
  and #1400 (`TestGatewayNotReadyEmitsWarningEvent`,
  `TestGatewayNotReadyWithoutRecorderDoesNotPanic`) all still pass.
- Confirmed by grep that `modelNameOverride` and `bodyMutation` no longer appear
  in `internal/controller`, while `Recorder` and `resolveExternalBackend` remain.

Refs #1399.

Assisted-by: Claude (Anthropic).

## Checklist

- [x] Tests added/updated (removed with the reverted features)
- [x] `make test` passes locally (unit tiers; envtest needs assets CI has)
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated - n/a
