### PR TITLE
docs: add observability maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@ This file lists the maintainers of LLMKube.
 | ----------- | -------------------------------------------- | ------------------------------------- |
 | Chris Maher | [@Defilan](https://github.com/Defilan)       | Lead: operator, CLI, Helm, docs       |
 | Jory Irving | [@joryirving](https://github.com/joryirving) | Foreman (coder/reviewer harness)      |
+| Tanguille   | [@Tanguille](https://github.com/Tanguille)   | Observability                         |
 
 Maintainers review and merge pull requests, triage issues, and help set
 technical direction. Area maintainers focus their review and merge authority


### PR DESCRIPTION
## What

Adds me to `MAINTAINERS.md` as the maintainer for observability.

## Why

To formalize me joining as a maintainer of the observability region of the codebase. I have been contributing in this space and am looking forward to helping review related PRs and do my part to improve the project overall. Thanks to Chris for the trust and invitation.

No related issue; this was requested by @Defilan.

## How

Added my GitHub profile and observability area to the current-maintainers table.

Assisted-by: OpenCode (helped draft this PR; I reviewed the final change and stand behind it.)

## Checklist

- [ ] Tests added/updated
- [x] `make test` passes locally
- [ ] `make lint` passes locally (blocked by the existing staticcheck deprecation in `cmd/main.go:528`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)