### PR TITLE
fix(router): use the non-deprecated events API for the gateway recorder

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -525,7 +525,7 @@ func main() {
 	if err := (&controller.ModelRouterGatewayReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("modelrouter-gateway"),
+		Recorder: mgr.GetEventRecorder("modelrouter-gateway"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ModelRouterGateway")
 		os.Exit(1)

--- a/internal/controller/gateway_resources_modelrouter_test.go
+++ b/internal/controller/gateway_resources_modelrouter_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -106,7 +106,7 @@ func TestGatewayNotReadyEmitsWarningEvent(t *testing.T) {
 	mr.SetName("fleet-router")
 	mr.SetNamespace("default")
 
-	rec := record.NewFakeRecorder(4)
+	rec := events.NewFakeRecorder(4)
 	r := &ModelRouterGatewayReconciler{
 		Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(mr).WithStatusSubresource(mr).Build(),
 		Scheme:   scheme,

--- a/internal/controller/modelrouter_gateway_controller.go
+++ b/internal/controller/modelrouter_gateway_controller.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -118,7 +118,7 @@ type ModelRouterGatewayReconciler struct {
 	// the data plane keeps serving its last-good config: requests still succeed
 	// while silently using stale routing. A status condition alone is not
 	// enough, because nobody watches conditions during a routing change (#1395).
-	Recorder record.EventRecorder
+	Recorder events.EventRecorder
 
 	// detector is the shared CRD-presence gate, lazily initialized on first
 	// reconcile and reused thereafter. It requires slice 1's three kinds plus
@@ -479,7 +479,7 @@ func (r *ModelRouterGatewayReconciler) setGatewayNotReady(
 	// dangerous case is not the failure itself but that traffic keeps flowing
 	// against a config the operator believes they just replaced.
 	if r.Recorder != nil {
-		r.Recorder.Eventf(mr, corev1.EventTypeWarning, reason,
+		r.Recorder.Eventf(mr, nil, corev1.EventTypeWarning, reason, "Reconcile",
 			"%s; the gateway continues serving the last successfully compiled routes, "+
 				"so this router's traffic does NOT reflect the current spec", message)
 	}


### PR DESCRIPTION
## What

Switch the ModelRouter gateway reconciler from the deprecated `record.EventRecorder` to `events.EventRecorder`.

## Why

Fixes #1408

`cmd/main.go:528` called `mgr.GetEventRecorderFor`, which staticcheck flags as `SA1019` — `controller-runtime v0.24.1` (already our pinned version) deprecates it in favour of `GetEventRecorder`.

The failure is invisible on `main` and only surfaces on PRs that touch `go.mod`. Both open dependabot PRs (#1403, #1404) currently fail on this line despite changing nothing but `go.mod`/`go.sum`, and every future bump would too. The call came in with #1400, and `main`'s Lint job reported success on that commit — so it landed without CI catching it.

## How

The rest of the operator already uses the new API — `cmd/main.go:443`, `cmd/foreman-operator/main.go:142`, `inferenceservice_controller.go:50`, `workload_controller.go:63` — so this brings the one holdout in line rather than adding a `//nolint`.

The two APIs are not drop-in. `Eventf` goes from `(object, eventtype, reason, messageFmt, args...)` to `(regarding, related, eventtype, reason, action, note, args...)`. I pass `nil` for `related` and `"Reconcile"` for `action`, matching what `inferenceservice_controller.go` already does.

Event type, reason and message text are unchanged, so the existing assertions in `TestGatewayNotReadyEmitsWarningEvent` still hold unmodified — it checks for `Warning` and for the "last successfully compiled routes" sentence. `events.FakeRecorder` exposes the same `Events chan string` as `record.FakeRecorder`, so only the constructor changed in the test.

Verified locally:

```
./bin/golangci-lint run ./cmd/... ./internal/controller/...   ->  0 issues
go test ./internal/controller/ -run TestGatewayNotReady       ->  ok
go build ./... && go vet ./cmd/... ./internal/controller/...  ->  clean
```

Once this lands, #1403 and #1404 should go green on a re-run with no changes to either.

## Checklist

- [x] Tests added/updated — existing gateway event test retargeted to the new fake recorder; its assertions are unchanged deliberately, since the emitted event should be identical
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: written with Claude Code; I reviewed the change and ran the verification above myself
- [ ] Documentation updated — not user-facing; event type, reason and text are unchanged
