### PR TITLE
fix(foreman): preserve the coder Job name's uniqueness suffix on truncation

### DIFF
--- a/pkg/foreman/agent/tools/run_coder_job.go
+++ b/pkg/foreman/agent/tools/run_coder_job.go
@@ -605,12 +605,30 @@ func applyCoderConfigDefaults(c RunCoderJobConfig) RunCoderJobConfig {
 	}
 	if c.NameFn == nil {
 		c.NameFn = func(taskName string) string {
-			name := fmt.Sprintf("foreman-coder-%s-%d", sanitizeName(taskName), time.Now().UnixMilli())
-			if len(name) > 63 {
-				name = name[:63]
-			}
-			return name
+			return coderJobName(taskName, time.Now().UnixMilli())
 		}
 	}
 	return c
+}
+
+// coderJobName builds the coder Job name "foreman-coder-<task>-<unix-ms>",
+// trimmed to the 63-char k8s object-name limit by truncating the TASK
+// portion, never the trailing <unix-ms> disambiguator. The #1405 retry loop
+// submits a second coder Job for the same task while the prior attempt's Job
+// still exists; the old code trimmed the whole name from the right, cutting
+// off the timestamp for long task names, so the retry's Create collided with
+// the prior Job (AlreadyExists -> ERROR -> could-not-recover). Keeping the
+// suffix guarantees each submission gets a distinct name.
+func coderJobName(taskName string, unixMilli int64) string {
+	const prefix = "foreman-coder-"
+	suffix := fmt.Sprintf("-%d", unixMilli)
+	budget := 63 - len(prefix) - len(suffix)
+	if budget < 0 {
+		budget = 0
+	}
+	task := sanitizeName(taskName)
+	if len(task) > budget {
+		task = task[:budget]
+	}
+	return prefix + task + suffix
 }

--- a/pkg/foreman/agent/tools/run_coder_job_test.go
+++ b/pkg/foreman/agent/tools/run_coder_job_test.go
@@ -815,5 +815,30 @@ func TestApplyCoderConfigDefaults_FillsEveryField(t *testing.T) {
 	}
 }
 
+// TestCoderJobNamePreservesUniquenessSuffixWhenTruncated covers #1405. A
+// long task name whose "foreman-coder-<task>" already exceeds the 63-char
+// k8s object-name limit. The old code trimmed the whole name from the right,
+// cutting off the trailing unix-ms disambiguator, so a retry's Create
+// collided with the prior Job (AlreadyExists -> ERROR -> could-not-recover).
+// The suffix must survive truncation.
+func TestCoderJobNamePreservesUniquenessSuffixWhenTruncated(t *testing.T) {
+	long := "misospace-pr-reviewer-action-438-code-438-1785"
+	n1 := coderJobName(long, 1784157000000)
+	n2 := coderJobName(long, 1784157000001)
+
+	if len(n1) > 63 {
+		t.Fatalf("name exceeds the 63-char k8s limit: len=%d %q", len(n1), n1)
+	}
+	if !strings.HasPrefix(n1, "foreman-coder-") {
+		t.Fatalf("lost the foreman-coder- prefix: %q", n1)
+	}
+	if !strings.HasSuffix(n1, "-1784157000000") {
+		t.Fatalf("uniqueness suffix was truncated away: %q", n1)
+	}
+	if n1 == n2 {
+		t.Fatalf("two submissions of the same long task name collide: %q", n1)
+	}
+}
+
 // ensure corev1 stays imported for the resource-shape assertions above.
 var _ = corev1.ResourceRequirements{}


### PR DESCRIPTION
## What

Fix the coder Job name so a re-dispatch cannot collide with a surviving Job from a prior attempt.

## Why

Fixes #1405

`applyCoderConfigDefaults` built the Job name as `foreman-coder-<task>-<unix-ms>` and truncated it from the right at 63 characters. For a long enough task name that removed the trailing timestamp, so repeated dispatches produced identical names. `Create` then returned `AlreadyExists` and the task failed terminally with no recovery path.

The gate path already had this right: `gateJobName` budgets the prefix and suffix and truncates the task portion, so its disambiguator always survives. That was fixed in #1135; the coder path was missed at the time.

## How

Adds `coderJobName(taskName string, unixMilli int64) string`, mirroring `gateJobName`:

- budget = `63 - len("foreman-coder-") - len("-<unix-ms>")`
- truncate the sanitised task name to that budget
- concatenate, so the suffix is never cut

#1405 offered three options: adopt the surviving Job, replace it, or uniquify the name. This takes the third, which is the one the gate path already implements.

## Testing

- New regression test `TestCoderJobNamePreservesUniquenessSuffixWhenTruncated`, mirroring the gate-side test from #1135. Confirmed it is a real regression test: reverting only the production change makes it fail with `uniqueness suffix was truncated away: "foreman-coder-misospace-pr-reviewer-action-438-code-438-1785-17"`, and it passes with the change in place.
- `go test ./pkg/foreman/agent/tools/` passes (full package).
- `make lint` clean, 0 issues, using the CI-pinned golangci-lint v2.12.2.
- `gofmt` and `go vet` clean.
- The full suite ran in the Foreman clean-room gate, which returned GATE-PASS. I did not run the envtest suite in my own working tree.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (full suite via the clean-room gate; package tests run directly)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance disclosed below
- [ ] Documentation updated (not user-facing; internal harness behaviour)

## AI assistance

Implemented by the Foreman agentic-coding harness (Qwopus3.6-27B-Fusion as the coder), which produced the fix and the test. I reviewed the diff, independently verified the regression test fails before and passes after the change, ran the package suite and `make lint` locally, and rebased onto current `main`. Band-3 disclosure per the project's AI-assisted contribution policy.
