### PR TITLE
fix(runtime): disable the llama.cpp prompt cache for embedding and rerank

### DIFF
--- a/internal/controller/runtime_llamacpp_args.go
+++ b/internal/controller/runtime_llamacpp_args.go
@@ -173,6 +173,11 @@ func appendNoWarmupArgs(args []string, noWarmup *bool) []string {
 // A reranker needs both --reranking and --embedding. Flags already in extraArgs
 // win and are not duplicated, so hand-wired manifests are left untouched; chat
 // (or empty) adds nothing.
+//
+// For embedding and rerank modes, --cache-ram 0 is appended because llama.cpp
+// fills its host prompt cache up to --cache-ram (default 8 GiB) and never
+// releases it, while the cache read path is gated to completion tasks.
+// (#1406)
 func appendModeArgs(args []string, mode string, extraArgs []string) []string {
 	switch mode {
 	case servingModeRerank:
@@ -185,12 +190,18 @@ func appendModeArgs(args []string, mode string, extraArgs []string) []string {
 		if !hasMatchingExtraArg(extraArgs, "pooling") {
 			args = append(args, "--pooling", "rank")
 		}
+		if !hasMatchingExtraArg(extraArgs, "cache-ram") {
+			args = append(args, "--cache-ram", "0")
+		}
 	case servingModeEmbedding:
 		if !hasMatchingExtraArg(extraArgs, "embedding") {
 			args = append(args, "--embedding")
 		}
 		if !hasMatchingExtraArg(extraArgs, "pooling") {
 			args = append(args, "--pooling", "last")
+		}
+		if !hasMatchingExtraArg(extraArgs, "cache-ram") {
+			args = append(args, "--cache-ram", "0")
 		}
 	}
 	return args

--- a/internal/controller/runtime_mode_test.go
+++ b/internal/controller/runtime_mode_test.go
@@ -62,7 +62,7 @@ func TestAppendModeArgs(t *testing.T) {
 		}
 	})
 	t.Run("does not duplicate flags already in extraArgs", func(t *testing.T) {
-		extra := []string{"--embedding", "--pooling", "cls"}
+		extra := []string{"--embedding", "--pooling", "cls", "--cache-ram", "0"}
 		args := appendModeArgs(nil, servingModeEmbedding, extra)
 		if len(args) != 0 {
 			t.Fatalf("expected no appended flags when extraArgs already set them, got %v", args)
@@ -71,6 +71,25 @@ func TestAppendModeArgs(t *testing.T) {
 	t.Run("chat adds nothing", func(t *testing.T) {
 		if args := appendModeArgs(nil, servingModeChat, nil); len(args) != 0 {
 			t.Fatalf("chat mode should append nothing, got %v", args)
+		}
+	})
+	t.Run("embedding sets --cache-ram 0", func(t *testing.T) {
+		args := appendModeArgs(nil, servingModeEmbedding, nil)
+		if !containsArg(args, "--cache-ram", "0") {
+			t.Fatalf("embedding mode should set --cache-ram 0, got %v", args)
+		}
+	})
+	t.Run("rerank sets --cache-ram 0", func(t *testing.T) {
+		args := appendModeArgs(nil, servingModeRerank, nil)
+		if !containsArg(args, "--cache-ram", "0") {
+			t.Fatalf("rerank mode should set --cache-ram 0, got %v", args)
+		}
+	})
+	t.Run("does not override user --cache-ram in extraArgs", func(t *testing.T) {
+		extra := []string{"--cache-ram", "512"}
+		args := appendModeArgs(nil, servingModeEmbedding, extra)
+		if containsArg(args, "--cache-ram", "0") {
+			t.Fatalf("should not override user --cache-ram, got %v", args)
 		}
 	})
 }

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -408,6 +408,11 @@ func hasMatchingExtraArg(extraArgs []string, argName string) bool {
 // mirroring the controller's runtime_llamacpp arg builder. A reranker needs
 // both --reranking and --embedding; flags already in extraArgs win and are not
 // duplicated. Chat (or empty) adds nothing.
+//
+// For embedding and rerank modes, --cache-ram 0 is appended because llama.cpp
+// fills its host prompt cache up to --cache-ram (default 8 GiB) and never
+// releases it, while the cache read path is gated to completion tasks.
+// (#1406)
 func appendModeArgs(args []string, mode string, extraArgs []string) []string {
 	switch mode {
 	case inferencev1alpha1.ServingModeRerank:
@@ -420,12 +425,18 @@ func appendModeArgs(args []string, mode string, extraArgs []string) []string {
 		if !hasMatchingExtraArg(extraArgs, "pooling") {
 			args = append(args, "--pooling", "rank")
 		}
+		if !hasMatchingExtraArg(extraArgs, "cache-ram") {
+			args = append(args, "--cache-ram", "0")
+		}
 	case inferencev1alpha1.ServingModeEmbedding:
 		if !hasMatchingExtraArg(extraArgs, "embedding") {
 			args = append(args, "--embedding")
 		}
 		if !hasMatchingExtraArg(extraArgs, "pooling") {
 			args = append(args, "--pooling", "last")
+		}
+		if !hasMatchingExtraArg(extraArgs, "cache-ram") {
+			args = append(args, "--cache-ram", "0")
 		}
 	}
 	return args

--- a/pkg/agent/executor_mode_test.go
+++ b/pkg/agent/executor_mode_test.go
@@ -59,3 +59,28 @@ func TestBuildLlamaServerArgs_ChatModeAddsNoModeFlags(t *testing.T) {
 		t.Errorf("chat mode must add no serving-mode flags (full args: %v)", args)
 	}
 }
+
+func TestBuildLlamaServerArgs_EmbeddingModeDisablesCacheRam(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{ContextSize: 4096, Mode: "embedding"})
+	if got := flagValue(args, "--cache-ram"); got != "0" {
+		t.Errorf("--cache-ram = %q, want %q (full args: %v)", got, "0", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_RerankModeDisablesCacheRam(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{ContextSize: 4096, Mode: "rerank"})
+	if got := flagValue(args, "--cache-ram"); got != "0" {
+		t.Errorf("--cache-ram = %q, want %q (full args: %v)", got, "0", args)
+	}
+}
+
+func TestBuildLlamaServerArgs_CacheRamNotOverriddenByExtraArgs(t *testing.T) {
+	args := buildLlamaServerArgs("/m.gguf", 8080, ExecutorConfig{
+		ContextSize: 4096,
+		Mode:        "embedding",
+		ExtraArgs:   []string{"--cache-ram", "512"},
+	})
+	if got := flagValue(args, "--cache-ram"); got != "512" {
+		t.Errorf("--cache-ram = %q, want user value %q (full args: %v)", got, "512", args)
+	}
+}


### PR DESCRIPTION
## What

Pass `--cache-ram 0` to llama-server for `mode: embedding` and `mode: rerank`, so those InferenceServices stop holding a prompt cache they can never read from.

## Why

Fixes #1406

llama-server fills a host prompt cache up to `--cache-ram` (default 8192 MiB) and never releases it, while the cache read path is gated to completion tasks. An embedding or rerank service therefore accumulates up to 8 GiB of host RAM per replica for no possible benefit.

The measurements in #1406 (cgroup `memory.stat` `anon`, `qwen3-embedding` on llama.cpp `b10257`):

| distinct embedding requests | default | with `--cache-ram 0` |
|---|---|---|
| 100 | 7.95 GiB | 0.10 GiB |
| 300 | 8.06 GiB (saturated) | 0.10 GiB |

Saturation matches the documented 8192 MiB default exactly.

## How

`appendModeArgs` appends `--cache-ram 0` for the embedding and rerank cases, guarded by the existing `hasMatchingExtraArg` helper so an explicit user `--cache-ram` in `extraArgs` still wins.

Applied at **both** sites that build llama-server arguments, per the two-site parity rule in `AGENTS.md`:

- `internal/controller/runtime_llamacpp_args.go` (operator)
- `pkg/agent/executor.go` (metal agent)

`chat` and empty modes are untouched. #1406 notes `--no-cache-idle-slots` as a softer alternative that leaves the cache usable; for pure embedding and rerank the two are equivalent in effect, and `--cache-ram 0` is the option the issue proposed.

## Testing

- New tests at both sites: embedding sets `--cache-ram 0`, rerank sets it, and an explicit user value in `extraArgs` is not overridden.
- Confirmed these are real regression tests: reverting only the four production hunks makes them fail at both sites (`TestAppendModeArgs/embedding_sets_--cache-ram_0`, `TestAppendModeArgs/rerank_sets_--cache-ram_0`, `TestBuildLlamaServerArgs_EmbeddingModeDisablesCacheRam`, `TestBuildLlamaServerArgs_RerankModeDisablesCacheRam`), and pass with the change in place.
- One existing subtest was updated: `does not duplicate flags already in extraArgs` now includes `--cache-ram` in the `extraArgs` it passes. Its premise is "when extraArgs already sets every flag the mode would add, append nothing", so it still asserts the same property. The new override subtest covers `--cache-ram` precedence independently.
- `go test ./pkg/agent/` passes (full package). `make lint` clean, 0 issues, CI-pinned golangci-lint v2.12.2. `gofmt` clean.
- The full suite including envtest ran in the Foreman clean-room gate, which returned GATE-PASS. I did not run the envtest suite in my own working tree.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (full suite via the clean-room gate; affected packages run directly)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance disclosed below
- [ ] Documentation updated (no user-facing API change; behaviour is an internal default)

## AI assistance

Implemented by the Foreman agentic-coding harness (Qwopus3.6-27B-Fusion as the coder), which produced the change and the tests. I reviewed the diff, independently verified the regression tests fail before and pass after at both sites, checked that the one modified existing test preserves its original property, ran the affected packages and `make lint` locally, and rebased onto current `main`. Band-3 disclosure per the project's AI-assisted contribution policy.
