### PR TITLE
fix(foreman): detect assertion-value churn in the test-dilution gate

### DIFF
--- a/pkg/foreman/agent/test_dilution_gate.go
+++ b/pkg/foreman/agent/test_dilution_gate.go
@@ -125,6 +125,9 @@ var (
 	urlHostRe = regexp.MustCompile(`https?://([^/\s"'` + "`" + `]+)`)
 	// testdataPathRe captures a testdata/ file path literal.
 	testdataPathRe = regexp.MustCompile(`[\w./-]*testdata/[\w./-]+`)
+	// assertionValueRe captures the matcher name and expected value in
+	// Gomega-style assertions like Equal(N) or ContainSubstring(N).
+	assertionValueRe = regexp.MustCompile(`(Equal|ContainSubstring)\(([^)]+)\)`)
 )
 
 // fixtureTokens extracts fixture-input identifiers from a set of diff lines:
@@ -168,6 +171,47 @@ func fixtureLiteralChurn(fh *fileHunks) []string {
 	sort.Strings(gone)
 	sort.Strings(appeared)
 	return []string{fmt.Sprintf("fixture input changed (removed %v, added %v)", gone, appeared)}
+}
+
+// assertionValueChurn flags an assertion whose expected value was rewritten
+// in place: a matcher+value pair (e.g. Equal(N)) present only on the removed
+// side while a different one appears only on the added side. This is the
+// #1347 shape: the coder changed the expected value to match buggy behavior.
+// Pure additions or deletions of assertions are not churn (those are caught
+// by assertionErosion). Deterministic: tokens are sorted.
+func assertionValueChurn(fh *fileHunks) []string {
+	rem := assertionValueTokens(fh.Removed)
+	add := assertionValueTokens(fh.Added)
+	var gone, appeared []string
+	for tkn := range rem {
+		if !add[tkn] {
+			gone = append(gone, tkn)
+		}
+	}
+	for tkn := range add {
+		if !rem[tkn] {
+			appeared = append(appeared, tkn)
+		}
+	}
+	if len(gone) == 0 || len(appeared) == 0 {
+		return nil
+	}
+	sort.Strings(gone)
+	sort.Strings(appeared)
+	return []string{fmt.Sprintf("assertion value changed (removed %v, added %v)", gone, appeared)}
+}
+
+// assertionValueTokens extracts matcher+value pairs from assertion lines:
+// e.g. "Equal(42)" or "ContainSubstring(boom)". The key is the full
+// matcher+value string so that Equal(42) vs Equal(0) is a churn signal.
+func assertionValueTokens(lines []string) map[string]bool {
+	set := map[string]bool{}
+	for _, l := range lines {
+		for _, m := range assertionValueRe.FindAllStringSubmatch(l, -1) {
+			set[m[0]] = true
+		}
+	}
+	return set
 }
 
 // nameStatusEntry is one file-level change from `git diff --name-status`.
@@ -300,6 +344,9 @@ func checkTestDilution(ctx context.Context, workspace string, run commandRunner)
 				file, removed-added, strings.Join(firstN(snippets, 3), "; ")))
 		}
 		for _, c := range fixtureLiteralChurn(fh) {
+			findings = append(findings, file+" "+c)
+		}
+		for _, c := range assertionValueChurn(fh) {
 			findings = append(findings, file+" "+c)
 		}
 	}

--- a/pkg/foreman/agent/test_dilution_gate.go
+++ b/pkg/foreman/agent/test_dilution_gate.go
@@ -127,7 +127,6 @@ var (
 	testdataPathRe = regexp.MustCompile(`[\w./-]*testdata/[\w./-]+`)
 	// assertionValueRe captures the matcher name and expected value in
 	// Gomega-style assertions like Equal(N) or ContainSubstring(N).
-	assertionValueRe = regexp.MustCompile(`(Equal|ContainSubstring)\(([^)]+)\)`)
 )
 
 // fixtureTokens extracts fixture-input identifiers from a set of diff lines:
@@ -207,11 +206,105 @@ func assertionValueChurn(fh *fileHunks) []string {
 func assertionValueTokens(lines []string) map[string]bool {
 	set := map[string]bool{}
 	for _, l := range lines {
-		for _, m := range assertionValueRe.FindAllStringSubmatch(l, -1) {
-			set[m[0]] = true
+		for _, tok := range extractAssertionTokens(l) {
+			set[tok] = true
 		}
 	}
 	return set
+}
+
+// assertionMatchers are the matcher names whose expected value is compared.
+var assertionMatchers = []string{"Equal", "ContainSubstring"}
+
+// extractAssertionTokens pulls "Equal(...)" / "ContainSubstring(...)" spans out
+// of a line using BALANCED paren matching, not a `[^)]+` run. A regex stops at
+// the first ')', so Equal(f(x), 42) truncates to "Equal(f(x)" and a rewrite of
+// the trailing 42 yields an identical token on both sides -- a silent miss, the
+// wrong failure direction for a dilution signal.
+func extractAssertionTokens(line string) []string {
+	var out []string
+	for _, name := range assertionMatchers {
+		for off := 0; off < len(line); {
+			i := strings.Index(line[off:], name+"(")
+			if i < 0 {
+				break
+			}
+			start := off + i
+			// Reject a match inside a longer identifier (e.g. NotEqual().
+			if start > 0 && isIdentByte(line[start-1]) {
+				off = start + 1
+				continue
+			}
+			end := matchParen(line, start+len(name))
+			if end < 0 {
+				off = start + 1
+				continue
+			}
+			out = append(out, normalizeAssertionToken(line[start:end+1]))
+			off = end + 1
+		}
+	}
+	return out
+}
+
+// matchParen returns the index of the ')' closing the '(' at open, or -1.
+// Parens inside string literals do not count toward the depth.
+func matchParen(s string, open int) int {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '"', '`', '\'':
+			if j := skipString(s, i); j > i {
+				i = j
+			}
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// skipString returns the index of the closing quote for the literal opening at
+// i, or i if unterminated.
+func skipString(s string, i int) int {
+	q := s[i]
+	for j := i + 1; j < len(s); j++ {
+		if s[j] == '\\' && q != '`' {
+			j++
+			continue
+		}
+		if s[j] == q {
+			return j
+		}
+	}
+	return i
+}
+
+// normalizeAssertionToken drops whitespace that sits OUTSIDE string literals,
+// so a gofmt-driven respacing such as Equal( 42 ) does not read as churn
+// against Equal(42). Whitespace inside a literal is preserved, because
+// Equal("a b") and Equal("a  b") are genuinely different expectations.
+func normalizeAssertionToken(tok string) string {
+	var b strings.Builder
+	for i := 0; i < len(tok); i++ {
+		c := tok[i]
+		if c == '"' || c == '`' || c == '\'' {
+			end := skipString(tok, i)
+			b.WriteString(tok[i : end+1])
+			i = end
+			continue
+		}
+		if c == ' ' || c == '\t' {
+			continue
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
 }
 
 // nameStatusEntry is one file-level change from `git diff --name-status`.

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -126,6 +126,60 @@ func TestFixtureLiteralChurn_TestdataPathRelocation(t *testing.T) {
 	}
 }
 
+func TestAssertionValueChurn_EqualValueRewritten(t *testing.T) {
+	// #1347 shape: the coder changed Equal(42) to Equal(0) to match buggy behavior.
+	fh := &fileHunks{
+		Removed: []string{`	Expect(got).To(Equal(42))`},
+		Added:   []string{`	Expect(got).To(Equal(0))`},
+	}
+	got := assertionValueChurn(fh)
+	if len(got) != 1 || !strings.Contains(got[0], "Equal(42)") || !strings.Contains(got[0], "Equal(0)") {
+		t.Fatalf("expected an assertion-value-churn finding naming both values; got %q", got)
+	}
+}
+
+func TestAssertionValueChurn_ContainSubstringValueRewritten(t *testing.T) {
+	fh := &fileHunks{
+		Removed: []string{`	Expect(got).To(ContainSubstring("boom"))`},
+		Added:   []string{`	Expect(got).To(ContainSubstring("ok"))`},
+	}
+	got := assertionValueChurn(fh)
+	if len(got) != 1 || !strings.Contains(got[0], "ContainSubstring") {
+		t.Fatalf("expected a ContainSubstring churn finding; got %q", got)
+	}
+}
+
+func TestAssertionValueChurn_PureAdditionSilent(t *testing.T) {
+	// Adding a new assertion (no matching removal) is not churn.
+	fh := &fileHunks{
+		Added: []string{`	Expect(got).To(Equal(42))`},
+	}
+	if got := assertionValueChurn(fh); got != nil {
+		t.Fatalf("pure addition must not flag churn; got %q", got)
+	}
+}
+
+func TestAssertionValueChurn_PureDeletionSilent(t *testing.T) {
+	// Removing an assertion (no matching addition) is not churn (caught by erosion).
+	fh := &fileHunks{
+		Removed: []string{`	Expect(got).To(Equal(42))`},
+	}
+	if got := assertionValueChurn(fh); got != nil {
+		t.Fatalf("pure deletion must not flag churn; got %q", got)
+	}
+}
+
+func TestAssertionValueChurn_SameValueSilent(t *testing.T) {
+	// The assertion value did not change: no churn.
+	fh := &fileHunks{
+		Removed: []string{`	Expect(got).To(Equal(42))`},
+		Added:   []string{`	Expect(got).To(Equal(42))`},
+	}
+	if got := assertionValueChurn(fh); got != nil {
+		t.Fatalf("same value must not flag churn; got %q", got)
+	}
+}
+
 func TestParseNameStatus_ModifyAndRename(t *testing.T) {
 	out := "M\tpkg/model/classifier.go\n" +
 		"D\tpkg/model/testdata/real.json\n" +
@@ -279,6 +333,25 @@ func TestCheckTestDilution_FiresOnFixtureRelocation_1322Shape(t *testing.T) {
 	}
 	if !strings.Contains(out, "huggingface.co") {
 		t.Errorf("detail should name the moved host; got %q", out)
+	}
+}
+
+func TestCheckTestDilution_FiresOnAssertionValueChurn_1347Shape(t *testing.T) {
+	// #1347 shape: prod classifier changed, and an assertion's expected value
+	// was rewritten from Equal(42) to Equal(0) in the same package's test.
+	ns := "M\tpkg/model/classifier.go\nM\tpkg/model/classifier_test.go\n"
+	diff := `--- a/pkg/model/classifier_test.go
++++ b/pkg/model/classifier_test.go
+@@ -10 +10 @@
+-	Expect(classify(u)).To(Equal(42))
++	Expect(classify(u)).To(Equal(0))
+`
+	failed, out := checkTestDilution(context.Background(), "/w", dilutionRunner(ns, diff, nil, nil, nil))
+	if !failed {
+		t.Fatal("expected an advisory for the #1347 assertion-value-churn shape")
+	}
+	if !strings.Contains(out, "Equal(42)") || !strings.Contains(out, "Equal(0)") {
+		t.Errorf("detail should name both assertion values; got %q", out)
 	}
 }
 

--- a/pkg/foreman/agent/test_dilution_gate_test.go
+++ b/pkg/foreman/agent/test_dilution_gate_test.go
@@ -453,3 +453,44 @@ func TestTestDilution_SurfacesAsAdvisoryNotBlocking(t *testing.T) {
 		t.Fatalf("expected one test-dilution advisory; got %+v", advisories)
 	}
 }
+
+// TestAssertionValueChurn_NestedParens covers the review note on #1416: a
+// `[^)]+` regex stops at the first ')', so Equal(f(x), 42) truncated to
+// "Equal(f(x)" and a rewrite of the trailing value produced an IDENTICAL
+// token on both sides. That is a silent miss, the wrong failure direction
+// for a dilution signal. Balanced-paren matching fixes it.
+func TestAssertionValueChurn_NestedParens(t *testing.T) {
+	got := assertionValueChurn(&fileHunks{
+		Removed: []string{`Expect(y).To(Equal(f(x), 42))`},
+		Added:   []string{`Expect(y).To(Equal(f(x), 0))`},
+	})
+	if len(got) == 0 {
+		t.Fatalf("expected churn for a value rewrite behind a nested paren, got none")
+	}
+}
+
+// TestAssertionValueChurn_SpacingIsNotChurn covers the review note that the
+// detector's description claimed normalisation it did not perform: a
+// gofmt-driven respacing inside the parens read as churn.
+func TestAssertionValueChurn_SpacingIsNotChurn(t *testing.T) {
+	got := assertionValueChurn(&fileHunks{
+		Removed: []string{`Expect(x).To(Equal(42))`},
+		Added:   []string{`Expect(x).To(Equal( 42 ))`},
+	})
+	if len(got) != 0 {
+		t.Fatalf("respacing alone must not be churn, got %v", got)
+	}
+}
+
+// TestAssertionValueChurn_LiteralSpacingIsChurn pins the boundary of the
+// normalisation: whitespace OUTSIDE a string literal is noise, whitespace
+// INSIDE one is a genuinely different expectation.
+func TestAssertionValueChurn_LiteralSpacingIsChurn(t *testing.T) {
+	got := assertionValueChurn(&fileHunks{
+		Removed: []string{`Expect(x).To(Equal("a b"))`},
+		Added:   []string{`Expect(x).To(Equal("a  b"))`},
+	})
+	if len(got) == 0 {
+		t.Fatalf("a changed string literal must still be churn, got none")
+	}
+}


### PR DESCRIPTION
## What

Add an `assertionValueChurn` detector to the Foreman test-dilution gate, so an assertion whose expected value was rewritten in place is surfaced to the reviewer.

## Why

Fixes #1347

The gate had two detectors and neither covered this shape:

- `assertionErosion` only **counts** removed versus added assertion lines and fires when removed exceeds added. A one-for-one value rewrite nets to zero, so it is invisible.
- `fixtureLiteralChurn` compares URL hosts and `testdata/` paths only, never the expected value.

So a coder changing `Equal(42)` to `Equal(0)` to make a test agree with the behaviour it was meant to catch passed the gate silently. This is the signal #1332 (slice 1) deferred as the noisiest one.

## How

`assertionValueChurn` extracts matcher-plus-value tokens (`Equal(...)`, `ContainSubstring(...)`) from the removed and added sides of a changed test file in a changed production package, and reports a finding when a token appears on exactly one side. Pure additions or deletions are not churn and are left to `assertionErosion`. Output tokens are sorted so findings are deterministic.

One subtlety worth calling out for review: the gate computes its diff with `--unified=0`, so removed and added lines arrive **unpaired**. The detector therefore matches on the normalised matcher-plus-value token rather than assuming line-by-line correspondence between the two lists.

The detector is registered under `tierAdvisory` (`coder_gate.go:338`), which per its own comment "never blocks; the coder never sees it". A false positive is reviewer-visible noise, not a blocked branch.

## Testing

- New test `TestCheckTestDilution_FiresOnAssertionValueChurn_1347Shape`, mirroring the existing `..._FiresOnFixtureRelocation_1322Shape` case and its `dilutionRunner` fake.
- Confirmed it is a real regression test: unwiring only the `assertionValueChurn` call from `checkTestDilution` makes it fail; it passes with the detector wired.
- `go test ./pkg/foreman/agent/` passes (full package, 33s).
- `make lint` clean, 0 issues, CI-pinned golangci-lint v2.12.2. `gofmt` clean.
- The full suite ran in the Foreman clean-room gate: GATE-PASS.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (full suite via the clean-room gate; the affected package run directly)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance disclosed below
- [ ] Documentation updated (internal gate behaviour, no user-facing surface)

## AI assistance

Implemented by the Foreman agentic-coding harness (Qwopus3.6-27B-Fusion as the coder). I reviewed the diff, independently verified the regression test fails when the detector is unwired and passes when it is not, ran the package suite and `make lint` locally, and rebased onto current `main`. Band-3 disclosure per the project's AI-assisted contribution policy.

Note for the record: the harness reviewer returned NO-GO on this branch, but its own structured result carried `verdictClaimed: "GO"` with `demotionReason: "issueAsk could not be verified as covering the fetched issue body"`. The reviewer approved it; an `issueAsk` verification rail demoted the verdict. I verified the branch by hand rather than relying on either signal.
