### PR TITLE
fix(controller): emit draft-simple for speculativeDecoding type draft

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -68,7 +68,7 @@ type SpeculativeDecodingType string
 // set it.
 type SpeculativeDecodingSpec struct {
 	// Type is the speculative decoding method (--spec-type). "mtp" maps to
-	// draft-mtp, "draft" maps to draft, and "disabled" (or omitting the
+	// draft-mtp, "draft" maps to draft-simple, and "disabled" (or omitting the
 	// entire SpeculativeDecoding block) means no speculative decoding.
 	Type SpeculativeDecodingType `json:"type"`
 

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -5179,7 +5179,7 @@ spec:
                   type:
                     description: |-
                       Type is the speculative decoding method (--spec-type). "mtp" maps to
-                      draft-mtp, "draft" maps to draft, and "disabled" (or omitting the
+                      draft-mtp, "draft" maps to draft-simple, and "disabled" (or omitting the
                       entire SpeculativeDecoding block) means no speculative decoding.
                     enum:
                     - mtp

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -5175,7 +5175,7 @@ spec:
                   type:
                     description: |-
                       Type is the speculative decoding method (--spec-type). "mtp" maps to
-                      draft-mtp, "draft" maps to draft, and "disabled" (or omitting the
+                      draft-mtp, "draft" maps to draft-simple, and "disabled" (or omitting the
                       entire SpeculativeDecoding block) means no speculative decoding.
                     enum:
                     - mtp

--- a/internal/controller/runtime_llamacpp_args.go
+++ b/internal/controller/runtime_llamacpp_args.go
@@ -216,7 +216,7 @@ func appendSpeculativeDecodingArgs(args []string, spec *inferencev1alpha1.Specul
 	case "mtp":
 		specType = "draft-mtp"
 	case "draft":
-		specType = "draft"
+		specType = "draft-simple"
 	default:
 		return args
 	}

--- a/internal/controller/runtime_llamacpp_test.go
+++ b/internal/controller/runtime_llamacpp_test.go
@@ -496,7 +496,7 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 		},
 		{
 			model: model,
-			name:  "speculativeDecoding draft emits --spec-type draft",
+			name:  "speculativeDecoding draft emits --spec-type draft-simple",
 			spec: &inferencev1alpha1.InferenceServiceSpec{
 				Runtime:  "llama",
 				ModelRef: "test-model",
@@ -504,7 +504,7 @@ func TestLlamaCppBuildArgs(t *testing.T) {
 					Type: "draft",
 				},
 			},
-			contains: []FlagCheck{{"--spec-type", "draft"}},
+			contains: []FlagCheck{{"--spec-type", "draft-simple"}},
 		},
 		{
 			model: model,


### PR DESCRIPTION
## What

Emit `--spec-type draft-simple` instead of the invalid `--spec-type draft` for `speculativeDecoding.type: draft`.

## Why

Fixes #1414
Refs #1383

llama.cpp declares its accepted `--spec-type` values in `common/speculative.cpp`:

```
none, draft-simple, draft-eagle3, draft-mtp, draft-dflash,
draft-dspark, ngram-simple, ngram-map-k, ngram-map-k4v,
ngram-mod, ngram-cache
```

Bare `draft` is not among them, so llama-server aborted during argument parsing and the pod never started. The adjacent `mtp` arm already does the right thing, translating to `draft-mtp` rather than passing its own name through; the `draft` arm was missing the same translation.

## How

One-line mapping change in `appendSpeculativeDecodingArgs`, plus:

- the existing test that asserted the broken value, updated rather than worked around (it was named "emits --spec-type draft" and asserted `{"--spec-type", "draft"}`)
- the doc comment on `SpeculativeDecodingSpec`, which claimed `draft` maps to `draft`, corrected — this regenerates the CRD description in both `config/crd/bases/` and `charts/llmkube/templates/crds/`

The CRD **enum value** stays `draft`. Only the emitted string changes, so this is not a breaking API change and no existing manifest becomes invalid.

## Scope

This does not make `type: draft` actually serve. Without draft weights the configuration still fails, but as an honest missing-draft-model failure rather than an invalid-argument abort. The draft-model `modelRef`, its wiring through the download and cache path, and admission validation remain tracked on #1383, which stays open.

## Testing

- Confirmed the updated assertion is a real regression test: reverting only the production line makes it fail with `expected "--spec-type" "draft-simple" in args, got: [... --spec-type draft ...]`, and it passes with the fix.
- `go test ./internal/controller/ -run TestLlamaCppBuildArgs` passes.
- `make manifests` and `make chart-crds` produce **zero** drift against the committed CRDs.
- `make lint` clean, 0 issues, CI-pinned golangci-lint v2.12.2. `gofmt` clean.
- The full suite ran in the Foreman clean-room gate: GATE-PASS.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (full suite via the clean-room gate; the affected test run directly)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance disclosed below
- [ ] Documentation updated (the CRD field description is corrected in this change)

## AI assistance

Implemented by the Foreman agentic-coding harness (Qwopus3.6-27B-Fusion as the coder). I verified the accepted `--spec-type` set against llama.cpp source directly rather than from documentation, reviewed the diff, confirmed the test fails without the production change, checked codegen drift, and ran lint locally. Band-3 disclosure per the project's AI-assisted contribution policy.

Note for the record: the harness reviewer returned NO-GO on this branch with the summary "runtime_llamacpp_args.go still maps 'draft' to 'draft' instead of 'draft-simple'". That is incorrect — the diff makes exactly that change; the reviewer appears to have read the `case "draft":` label as the mapping. I verified by hand rather than relying on the verdict.
