### PR TITLE
fix(metrics): correct the AMD doc's metric contract and guard prose docs

### DIFF
--- a/docs/observability/amd-gpu-metrics.md
+++ b/docs/observability/amd-gpu-metrics.md
@@ -48,9 +48,11 @@ versions of the same readings.
 
 ## Inference signals (slice #1186)
 
+<!-- metrics-contract:begin -->
 SLO metrics come from llama.cpp `/metrics` (`--metrics`), not this exporter:
-`llamacpp:tokens_per_second`-family, `llamacpp:kv_cache_usage_ratio`,
+`llamacpp:predicted_tokens_seconds`, `llamacpp:prompt_tokens_seconds`,
 `llamacpp:requests_processing`. Backend-agnostic and already emitted.
+<!-- metrics-contract:end -->
 
 ## Known gaps (deliberate)
 

--- a/internal/metrics/dashboard_sync_test.go
+++ b/internal/metrics/dashboard_sync_test.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"encoding/json"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -500,6 +501,66 @@ func TestDashboardsQueryEmittedMetrics(t *testing.T) {
 
 	if t.Failed() {
 		t.Logf("emittable: %v", slices.Sorted(maps.Keys(known)))
+	}
+}
+
+// TestDocContractMetrics fails when a prose document's metrics-contract region
+// names a metric that nothing produces. The region is delimited by
+// <!-- metrics-contract:begin --> and <!-- metrics-contract:end --> markers so
+// that "Known gaps" sections that deliberately name missing metrics are not
+// flagged.
+func TestDocContractMetrics(t *testing.T) {
+	known := declaredNames(t)
+	maps.Copy(known, chartRecordingRules(t))
+	maps.Copy(known, runtimeNames(t))
+
+	// Walk for markdown files rather than globbing: filepath.Glob has no "**"
+	// operator, so "docs/**/*.md" silently means "docs/*/*.md" and would skip
+	// every doc nested deeper than one directory, including
+	// docs/site/guides/, where this same defect class was fixed in #1386.
+	var mdFiles []string
+	for _, root := range []string{"../../docs", "../../config"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() && strings.HasSuffix(path, ".md") {
+				mdFiles = append(mdFiles, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	for _, path := range mdFiles {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		// Only process files with the contract markers.
+		begin := "<!-- metrics-contract:begin -->"
+		end := "<!-- metrics-contract:end -->"
+		idxBegin := strings.Index(string(raw), begin)
+		idxEnd := strings.Index(string(raw), end)
+		if idxBegin < 0 || idxEnd < 0 || idxEnd <= idxBegin {
+			continue
+		}
+
+		region := string(raw)[idxBegin+len(begin) : idxEnd]
+
+		// Extract backticked metric names (llamacpp:*, sglang:*, vllm:*, etc.).
+		backtick := regexp.MustCompile("`([a-zA-Z_:][a-zA-Z0-9_:]*)`")
+		for _, m := range backtick.FindAllStringSubmatch(region, -1) {
+			name := m[1]
+			if emitted(name, known) {
+				continue
+			}
+			t.Errorf("%s names %q inside metrics-contract region, which no registered collector, chart recording rule or allowlisted exporter emits",
+				path, name)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Correct two non-existent llama.cpp metric names in the AMD observability contract, and add a guard so prose documentation cannot assert a metric that nothing emits.

## Why

Fixes #1419

`docs/observability/amd-gpu-metrics.md` named three metrics and asserted they were "already emitted". Checked against `internal/metrics/testdata/llamacpp-metrics.txt`, the scrape-captured fixture, only one existed:

| named in the doc | emitted? |
|---|---|
| `llamacpp:tokens_per_second` | no — real names are `predicted_tokens_seconds` / `prompt_tokens_seconds` |
| `llamacpp:kv_cache_usage_ratio` | no — llama.cpp emits no kv-cache series at all |
| `llamacpp:requests_processing` | yes |

An operator following that contract builds an alert that silently never fires. #1386 fixed exactly this in the autoscaling guide; this second occurrence in the observability doc was not part of that change and survived.

## How

The kv-cache entry is dropped rather than given a replacement, because no such series exists.

`TestDocContractMetrics` asserts every backticked metric name inside a `<!-- metrics-contract:begin/end -->` region is one the repo can emit, reusing the same `known` set the dashboard guard builds (`declaredNames` + `chartRecordingRules` + `runtimeNames`).

The region is **delimited rather than whole-file** on purpose: the same document's `## Known gaps (deliberate)` section names metrics that intentionally do not exist (`mclk`, `pp_dpm_mclk`), and a whole-file scan would flag them as false positives.

## Reviewer note on the file walk

The original implementation used `filepath.Glob("../../docs/**/*.md")`. Go's `filepath.Glob` has **no `**` operator**, so that pattern silently means `docs/*/*.md`. Measured on this tree: it matches 26 files at one level and misses 35 nested deeper, including `docs/site/guides/metrics-driven-autoscaling.md` — the very guide where this defect class was fixed in #1386. A guard whose purpose is preventing recurrence would have skipped the file the recurrence happened in.

Replaced with `filepath.WalkDir`. This is my change on top of the generated branch, not the coder's, and is called out in the AI-assistance section below.

## Testing

- `go test ./internal/metrics/` passes.
- Verified the guard genuinely fires: reinstating `llamacpp:kv_cache_usage_ratio` inside the marked region fails with `names "llamacpp:kv_cache_usage_ratio" inside metrics-contract region, which no registered collector, chart recording rule or allowlisted exporter emits`.
- Verified it stays silent on `## Known gaps (deliberate)`, which sits outside the markers, and on all other docs now reachable by the walk.
- `make lint` clean, 0 issues, CI-pinned golangci-lint v2.12.2. `gofmt` clean.
- The full suite ran in the Foreman clean-room gate: GATE-PASS.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (full suite via the clean-room gate; `./internal/metrics/` run directly)
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance disclosed below
- [x] Documentation updated (this change corrects the doc)

## AI assistance

The doc correction, the marker design and `TestDocContractMetrics` were produced by the Foreman agentic-coding harness (Qwopus3.6-27B-Fusion as the coder), working from an issue that specified the fixture-verified names and the delimited-region requirement. I reviewed the diff, verified the guard fires and stays silent on the deliberate-gaps section, and **replaced the file walk after finding the `**` glob silently skipped 35 nested docs**. Band-3 disclosure per the project's AI-assisted contribution policy.
