### PR TITLE
feat(controller): diagnose CUDA driver/runtime mismatch from crashed pods

### DIFF
--- a/docs/gpu-setup-guide.md
+++ b/docs/gpu-setup-guide.md
@@ -319,6 +319,35 @@ kubectl logs $POD -c llama-server | grep -i cuda
 # If not: Image may not have CUDA support, check image tag
 ```
 
+### Crash at startup: "driver on your system is too old" / "CUDA driver version is insufficient"
+
+The image's CUDA userspace is newer than what the node's kernel driver supports.
+When the error appears in the crashed container's termination message (the log
+tail on error), the operator diagnoses it and reports it on the
+InferenceService, so start there instead of the pod logs:
+
+```bash
+kubectl get inferenceservice $NAME -o jsonpath='{.status.conditions[?(@.type=="DriverCompatible")]}'
+# status: "False", reason: CudaDriverInsufficient — the message names the node,
+# its supported CUDA version (from GPU feature labels, when present), and the
+# runtime's own error line.
+kubectl get events --field-selector reason=CUDADriverInsufficient
+```
+
+The compatibility rule: the node driver's supported CUDA **major** version must
+be >= the image's CUDA major (a CUDA 12.9 image runs on a 12.4 driver; a CUDA
+13.x image does not). Minor versions within a major are compatible per
+[NVIDIA's minor version compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html),
+with two exceptions: PTX JIT compilation, and APIs introduced in a newer minor
+that need a matching driver. Fix: use an image built for the node's CUDA
+major, or move the workload to nodes with a newer driver. Check what a node
+supports with (older gpu-feature-discovery releases publish the same value
+under the deprecated `nvidia.com/cuda.runtime.major`):
+
+```bash
+kubectl get node $NODE -o jsonpath='{.metadata.labels.nvidia\.com/cuda\.runtime-version\.major}'
+```
+
 ### Poor GPU performance
 ```bash
 # Check GPU utilization

--- a/docs/gpu-setup-guide.md
+++ b/docs/gpu-setup-guide.md
@@ -328,7 +328,7 @@ InferenceService, so start there instead of the pod logs:
 
 ```bash
 kubectl get inferenceservice $NAME -o jsonpath='{.status.conditions[?(@.type=="DriverCompatible")]}'
-# status: "False", reason: CudaDriverInsufficient — the message names the node,
+# status: "False", reason: CUDADriverInsufficient — the message names the node,
 # its supported CUDA version (from GPU feature labels, when present), and the
 # runtime's own error line.
 kubectl get events --field-selector reason=CUDADriverInsufficient

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -363,6 +363,11 @@ func (r *InferenceServiceReconciler) constructDeployment(
 		Name:            backend.ContainerName(),
 		Image:           image,
 		SecurityContext: inferContainerSecurityContext(isvc),
+		// Engines print the fatal error (CUDA init, model load) to the log
+		// rather than /dev/termination-log, so fall back to the log tail on
+		// error to make terminations self-describing; the driver-compat
+		// diagnosis reads its signatures from this message.
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "http",

--- a/internal/controller/driver_compat.go
+++ b/internal/controller/driver_compat.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// CUDA driver/runtime mismatch diagnosis. A serving image bundles a CUDA
+// userspace; the node's kernel driver supports CUDA up to some version. When
+// the image's CUDA major is newer than the driver's, the engine dies at init
+// — after a GPU node has been provisioned and a multi-GB image pulled — with
+// the real error buried in the crashed container's logs. This file turns that
+// termination message into a named diagnosis on the InferenceService, the
+// same move getPodSchedulingInfo makes for Insufficient-GPU pod conditions.
+
+const (
+	// ConditionDriverCompatible reports whether the node's GPU driver
+	// satisfied the CUDA userspace bundled in the runtime image, as observed
+	// from actual container terminations. Diagnostic only: it never feeds
+	// phase or the Available condition. Absent until a mismatch is first
+	// diagnosed; True once the runtime container subsequently starts (proof
+	// CUDA init succeeded).
+	ConditionDriverCompatible = "DriverCompatible"
+
+	// ReasonCUDADriverInsufficient is set when DriverCompatible=False because
+	// the runtime container terminated with a CUDA driver/runtime version
+	// incompatibility. Also the reason of the Warning event emitted on that
+	// transition, so one string serves kubectl field-selectors and condition
+	// queries alike.
+	ReasonCUDADriverInsufficient = "CUDADriverInsufficient"
+
+	// ReasonRuntimeStarted is set when DriverCompatible flips back to True: a
+	// previously diagnosed service now has a ready runtime container, so CUDA
+	// initialization against the node driver succeeded.
+	ReasonRuntimeStarted = "RuntimeStarted"
+)
+
+// cudaDriverMismatchSignatures are substrings CUDA-based runtimes print when
+// the node's kernel driver is older than the CUDA userspace in the image:
+// PyTorch's wording ("The NVIDIA driver on your system is too old (found
+// version 12040)"), the CUDA runtime's canonical error string (also what
+// llama.cpp's ggml_cuda_init surfaces via cudaGetErrorString), and both
+// error-enum spellings (runtime API camelCase, driver API underscores).
+// Matching is case-insensitive; entries must be lowercase. Deliberately
+// absent: "Driver/library version mismatch" (NVML), which is node-internal
+// driver/userspace skew after an in-place driver change, not an
+// image-vs-driver incompatibility — diagnosing it with this message would
+// misdirect the fix.
+var cudaDriverMismatchSignatures = []string{
+	"driver on your system is too old",
+	"cuda driver version is insufficient",
+	"cudaerrorinsufficientdriver",
+	"cuda_error_insufficient_driver",
+}
+
+// asciiLower lowercases ASCII letters only, preserving byte length and
+// offsets. strings.ToLower is unusable here: Unicode simple case mapping can
+// change byte length (e.g. U+023A lowercases from 2 to 3 bytes), so an index
+// found in its output does not address the input — and the input is arbitrary
+// container output, which must never be able to panic the controller. The
+// signatures are pure ASCII, so ASCII folding is sufficient.
+func asciiLower(s string) string {
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			if b == nil {
+				b = []byte(s)
+			}
+			b[i] = c + ('a' - 'A')
+		}
+	}
+	if b == nil {
+		return s
+	}
+	return string(b)
+}
+
+// sanitizeMessageLine trims the line, replaces control characters with
+// spaces, and caps its length on a rune boundary, so the condition message
+// and the (quoted, length-limited) event note stay valid and bounded no
+// matter what the container printed.
+func sanitizeMessageLine(line string) string {
+	line = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, strings.TrimSpace(line))
+	const maxLine = 200
+	if len(line) <= maxLine {
+		return line
+	}
+	cut := maxLine
+	for cut > 0 && !utf8.RuneStart(line[cut]) {
+		cut--
+	}
+	return line[:cut] + "..."
+}
+
+// matchCudaDriverMismatch reports whether msg contains a known CUDA
+// driver-too-old signature, returning the (sanitized, length-capped) line
+// that matched for inclusion in the condition message.
+func matchCudaDriverMismatch(msg string) (string, bool) {
+	if msg == "" {
+		return "", false
+	}
+	lower := asciiLower(msg)
+	for _, sig := range cudaDriverMismatchSignatures {
+		idx := strings.Index(lower, sig)
+		if idx < 0 {
+			continue
+		}
+		// Report the full line containing the signature so the condition
+		// carries the runtime's own words (e.g. the found-version number).
+		start := strings.LastIndexByte(msg[:idx], '\n') + 1
+		end := strings.IndexByte(msg[idx:], '\n')
+		if end < 0 {
+			end = len(msg)
+		} else {
+			end += idx
+		}
+		return sanitizeMessageLine(msg[start:end]), true
+	}
+	return "", false
+}
+
+// findCudaDriverCrash scans the service's pods for a runtime container that
+// terminated with a CUDA driver/runtime incompatibility. Only the container
+// named containerName is inspected: init containers (model download, cache
+// prep) and sidecars never run the engine, and a signature match there would
+// be a different problem. Both the current terminated state (fresh crash,
+// before backoff) and the last terminated state (CrashLoopBackOff) are
+// checked. Returns the node the pod ran on and the matched message line.
+func findCudaDriverCrash(pods []corev1.Pod, containerName string) (nodeName, matchedLine string, found bool) {
+	for i := range pods {
+		pod := &pods[i]
+		for j := range pod.Status.ContainerStatuses {
+			cs := &pod.Status.ContainerStatuses[j]
+			if cs.Name != containerName {
+				continue
+			}
+			for _, term := range []*corev1.ContainerStateTerminated{
+				cs.State.Terminated,
+				cs.LastTerminationState.Terminated,
+			} {
+				if term == nil || term.ExitCode == 0 {
+					continue
+				}
+				if line, ok := matchCudaDriverMismatch(term.Message); ok {
+					return pod.Spec.NodeName, line, true
+				}
+			}
+		}
+	}
+	return "", "", false
+}
+
+// runtimeContainerReady reports whether any pod's runtime container is Ready.
+// Used as the recovery gate: a ready runtime container means CUDA init
+// succeeded against the node driver, which is the only observation that
+// justifies flipping DriverCompatible back to True.
+func runtimeContainerReady(pods []corev1.Pod, containerName string) bool {
+	for i := range pods {
+		for _, cs := range pods[i].Status.ContainerStatuses {
+			if cs.Name == containerName && cs.Ready {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// gfdCudaOffer extracts the node's supported CUDA version and driver version
+// from gpu-feature-discovery labels, preferring the current label names and
+// falling back to the deprecated pre-GFD-0.15 forms. Empty strings when the
+// node carries no GFD labels (clusters without gpu-operator/GFD).
+func gfdCudaOffer(labels map[string]string) (cudaMajor, cudaMinor, driverVersion string) {
+	cudaMajor = labels["nvidia.com/cuda.runtime-version.major"]
+	cudaMinor = labels["nvidia.com/cuda.runtime-version.minor"]
+	if cudaMajor == "" {
+		cudaMajor = labels["nvidia.com/cuda.runtime.major"]
+		cudaMinor = labels["nvidia.com/cuda.runtime.minor"]
+	}
+	driverVersion = labels["nvidia.com/cuda.driver-version.full"]
+	if driverVersion == "" {
+		if major := labels["nvidia.com/cuda.driver.major"]; major != "" {
+			driverVersion = major
+			if minor := labels["nvidia.com/cuda.driver.minor"]; minor != "" {
+				driverVersion += "." + minor
+				if rev := labels["nvidia.com/cuda.driver.rev"]; rev != "" {
+					driverVersion += "." + rev
+				}
+			}
+		}
+	}
+	return cudaMajor, cudaMinor, driverVersion
+}
+
+// reconcileDriverCompatCondition maintains the DriverCompatible condition
+// from observed pod terminations. Never touches phase, Available, or
+// scheduling status; failures to list/get only log (a diagnosis must never
+// fail a reconcile).
+func (r *InferenceServiceReconciler) reconcileDriverCompatCondition(ctx context.Context, isvc *inferencev1alpha1.InferenceService) {
+	log := logf.FromContext(ctx)
+
+	podList := &corev1.PodList{}
+	labels := client.MatchingLabels{
+		"app":                           isvc.Name,
+		"inference.llmkube.dev/service": isvc.Name,
+	}
+	if err := r.List(ctx, podList, client.InNamespace(isvc.Namespace), labels); err != nil {
+		log.Error(err, "Failed to list pods for driver-compat diagnosis")
+		return
+	}
+
+	containerName := resolveBackend(isvc).ContainerName()
+	now := metav1.NewTime(time.Now())
+
+	// A Ready runtime container is checked before crash evidence: CUDA init
+	// succeeding now outranks a stale signature that lingers in a pod's
+	// LastTerminationState for its whole lifetime (e.g. a container that
+	// crashed before the node's driver daemonset finished, then started in
+	// place) or in an old pod still draining during a rollout. Without this
+	// ordering the diagnosis would stick at False forever on a serving pod.
+	ready := runtimeContainerReady(podList.Items, containerName)
+	nodeName, matchedLine, found := findCudaDriverCrash(podList.Items, containerName)
+
+	if ready || !found {
+		// Recovery follows the transition-only convention (cf.
+		// reconcileVLLMSpecCondition): flip to True only when a prior
+		// diagnosis exists AND the runtime container has demonstrably
+		// started. Pods merely gone, or failing some other way, keep the
+		// last diagnosis in place rather than asserting compatibility we
+		// have not observed.
+		existing := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if existing == nil || existing.Status != metav1.ConditionFalse {
+			return
+		}
+		if !ready {
+			return
+		}
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type:               ConditionDriverCompatible,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: isvc.Generation,
+			LastTransitionTime: now,
+			Reason:             ReasonRuntimeStarted,
+			Message:            "Runtime container started; CUDA initialization succeeded against the node driver",
+		})
+		return
+	}
+
+	message := r.buildDriverMismatchMessage(ctx, nodeName, matchedLine)
+	transitioned := !meta.IsStatusConditionFalse(isvc.Status.Conditions, ConditionDriverCompatible)
+	meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+		Type:               ConditionDriverCompatible,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: isvc.Generation,
+		LastTransitionTime: now,
+		Reason:             ReasonCUDADriverInsufficient,
+		Message:            message,
+	})
+	// Warning event on transition only, so a crash loop emits one event per
+	// episode instead of one per restart.
+	if transitioned && r.Recorder != nil {
+		r.Recorder.Eventf(isvc, nil, corev1.EventTypeWarning, ReasonCUDADriverInsufficient, "Reconcile", "%s", message)
+	}
+}
+
+// buildDriverMismatchMessage assembles the condition/event message from the
+// matched termination line plus, when readable, the node's GFD-reported
+// driver and CUDA support. One targeted node Get, no fleet listing: the
+// diagnosis names the node the crash actually happened on. Guidance stays at
+// the constraint level (which CUDA major to build for) and never recommends a
+// specific image version.
+func (r *InferenceServiceReconciler) buildDriverMismatchMessage(ctx context.Context, nodeName, matchedLine string) string {
+	base := fmt.Sprintf("Runtime container terminated with a CUDA driver/runtime incompatibility: %q. "+
+		"The image's CUDA userspace requires a newer GPU driver than the node provides.", matchedLine)
+
+	if nodeName == "" {
+		return base + " Use an image whose CUDA major matches the node's driver support, or schedule onto nodes with a newer driver."
+	}
+
+	node := &corev1.Node{}
+	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		// The node may already be gone (autoscaler scale-down); the error
+		// text alone still names the failure class.
+		return base + fmt.Sprintf(" Pod ran on node %q (no longer readable). "+
+			"Use an image whose CUDA major matches that node pool's driver support, or schedule onto nodes with a newer driver.", nodeName)
+	}
+
+	cudaMajor, cudaMinor, driverVersion := gfdCudaOffer(node.Labels)
+	if cudaMajor == "" {
+		return base + fmt.Sprintf(" Pod ran on node %q, which carries no GPU feature labels to report its supported CUDA version. "+
+			"Use an image whose CUDA major matches the node's driver support, or schedule onto nodes with a newer driver.", nodeName)
+	}
+
+	supported := cudaMajor
+	if cudaMinor != "" {
+		supported += "." + cudaMinor
+	}
+	detail := fmt.Sprintf(" Node %q supports CUDA <= %s", nodeName, supported)
+	if driverVersion != "" {
+		detail += fmt.Sprintf(" (driver %s)", driverVersion)
+	}
+	return base + detail + fmt.Sprintf(". Use an image built for CUDA %s.x, or schedule onto nodes with a newer driver.", cudaMajor)
+}

--- a/internal/controller/driver_compat.go
+++ b/internal/controller/driver_compat.go
@@ -24,6 +24,7 @@ import (
 	"unicode/utf8"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -159,8 +160,15 @@ func matchCudaDriverMismatch(msg string) (string, bool) {
 // prep) and sidecars never run the engine, and a signature match there would
 // be a different problem. Both the current terminated state (fresh crash,
 // before backoff) and the last terminated state (CrashLoopBackOff) are
-// checked. Returns the node the pod ran on and the matched message line.
-func findCudaDriverCrash(pods []corev1.Pod, containerName string) (nodeName, matchedLine string, found bool) {
+// checked.
+//
+// The evidence is paired with the pod that carries it: carrierReady reports
+// whether that pod's own runtime container is Ready now. A carrier that has
+// NOT come back Ready (an active crash) is preferred over one that has
+// (stale evidence on a recovered pod) — with replicas split across a
+// driver-skewed node pool, a recovered or healthy replica must never mask
+// the one still crashing.
+func findCudaDriverCrash(pods []corev1.Pod, containerName string) (nodeName, matchedLine string, carrierReady, found bool) {
 	for i := range pods {
 		pod := &pods[i]
 		for j := range pod.Status.ContainerStatuses {
@@ -176,12 +184,19 @@ func findCudaDriverCrash(pods []corev1.Pod, containerName string) (nodeName, mat
 					continue
 				}
 				if line, ok := matchCudaDriverMismatch(term.Message); ok {
-					return pod.Spec.NodeName, line, true
+					if !cs.Ready {
+						return pod.Spec.NodeName, line, false, true
+					}
+					// Remember the stale-evidence carrier, but keep
+					// scanning for an active one.
+					if !found {
+						nodeName, matchedLine, carrierReady, found = pod.Spec.NodeName, line, true, true
+					}
 				}
 			}
 		}
 	}
-	return "", "", false
+	return nodeName, matchedLine, carrierReady, found
 }
 
 // runtimeContainerReady reports whether any pod's runtime container is Ready.
@@ -245,16 +260,19 @@ func (r *InferenceServiceReconciler) reconcileDriverCompatCondition(ctx context.
 	containerName := resolveBackend(isvc).ContainerName()
 	now := metav1.NewTime(time.Now())
 
-	// A Ready runtime container is checked before crash evidence: CUDA init
-	// succeeding now outranks a stale signature that lingers in a pod's
+	// Readiness outranks crash evidence only within the same pod: CUDA init
+	// succeeding now outranks a stale signature that lingers in that pod's
 	// LastTerminationState for its whole lifetime (e.g. a container that
 	// crashed before the node's driver daemonset finished, then started in
-	// place) or in an old pod still draining during a rollout. Without this
-	// ordering the diagnosis would stick at False forever on a serving pod.
+	// place). Without this the diagnosis would stick at False forever on a
+	// serving pod. A DIFFERENT pod being Ready says nothing about the one
+	// still crashing — with replicas split across a driver-skewed node pool,
+	// the healthy replica must not mask the diagnosis — so an active
+	// (not-Ready) carrier always wins over fleet-wide readiness.
 	ready := runtimeContainerReady(podList.Items, containerName)
-	nodeName, matchedLine, found := findCudaDriverCrash(podList.Items, containerName)
+	nodeName, matchedLine, carrierReady, found := findCudaDriverCrash(podList.Items, containerName)
 
-	if ready || !found {
+	if !found || carrierReady {
 		// Recovery follows the transition-only convention (cf.
 		// reconcileVLLMSpecCondition): flip to True only when a prior
 		// diagnosis exists AND the runtime container has demonstrably
@@ -312,10 +330,16 @@ func (r *InferenceServiceReconciler) buildDriverMismatchMessage(ctx context.Cont
 
 	node := &corev1.Node{}
 	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
-		// The node may already be gone (autoscaler scale-down); the error
-		// text alone still names the failure class.
-		return base + fmt.Sprintf(" Pod ran on node %q (no longer readable). "+
-			"Use an image whose CUDA major matches that node pool's driver support, or schedule onto nodes with a newer driver.", nodeName)
+		guidance := " Use an image whose CUDA major matches that node pool's driver support, or schedule onto nodes with a newer driver."
+		if apierrors.IsNotFound(err) {
+			// The node is genuinely gone (autoscaler scale-down); the
+			// error text alone still names the failure class.
+			return base + fmt.Sprintf(" Pod ran on node %q (no longer exists).", nodeName) + guidance
+		}
+		// Read failures (throttling, RBAC, transient API errors) are not
+		// deletion; log them so a persistent problem leaves a trail.
+		logf.FromContext(ctx).Error(err, "Failed to read node for driver-compat diagnosis", "node", nodeName)
+		return base + fmt.Sprintf(" Pod ran on node %q (not readable right now).", nodeName) + guidance
 	}
 
 	cudaMajor, cudaMinor, driverVersion := gfdCudaOffer(node.Labels)

--- a/internal/controller/driver_compat_envtest_test.go
+++ b/internal/controller/driver_compat_envtest_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// End-to-end pin for the driver-compat diagnosis: a real Reconcile pass over
+// a crashlooping runtime pod must persist the DriverCompatible condition on
+// the InferenceService through the controller's own status write. The unit
+// tests call reconcileDriverCompatCondition directly, so without this spec
+// the Reconcile call site could be deleted and the suite would still pass.
+var _ = Describe("InferenceService driver-compat diagnosis (Reconcile integration)", func() {
+	It("persists DriverCompatible=False from a crashed runtime pod's termination message", func() {
+		const name = "driver-compat-e2e"
+		skipInit := true
+
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "driver-compat-node",
+				Labels: map[string]string{
+					"nvidia.com/cuda.runtime-version.major": "12",
+					"nvidia.com/cuda.runtime-version.minor": "4",
+					"nvidia.com/cuda.driver-version.full":   "550.144.03",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, node) }()
+
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "https://example.com/model.safetensors",
+				Format: "safetensors",
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+		model.Status.Phase = PhaseReady
+		Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:      name,
+				Runtime:       RuntimeVLLM,
+				SkipModelInit: &skipInit,
+			},
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+		// The pod a Deployment would have produced, crashlooping with the
+		// real PyTorch wording in its termination message. envtest has no
+		// kubelet, so the status is written directly.
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name + "-pod",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app":                           name,
+					"inference.llmkube.dev/service": name,
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: node.Name,
+				Containers: []corev1.Container{{
+					Name:  "vllm",
+					Image: "vllm/vllm-openai:test",
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, pod) }()
+		pod.Status = corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "vllm",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+				},
+				LastTerminationState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 1,
+						Message:  "RuntimeError: The NVIDIA driver on your system is too old (found version 12040).",
+					},
+				},
+			}},
+		}
+		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+
+		reconciler := &InferenceServiceReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, updated)).To(Succeed())
+
+		var cond *metav1.Condition
+		for i := range updated.Status.Conditions {
+			if updated.Status.Conditions[i].Type == ConditionDriverCompatible {
+				cond = &updated.Status.Conditions[i]
+			}
+		}
+		Expect(cond).NotTo(BeNil(), "DriverCompatible condition must be persisted by Reconcile")
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(ReasonCUDADriverInsufficient))
+		Expect(cond.Message).To(ContainSubstring("found version 12040"))
+		Expect(cond.Message).To(ContainSubstring(node.Name))
+		Expect(cond.Message).To(ContainSubstring("CUDA <= 12.4"))
+
+		// The diagnosis must not have hijacked the lifecycle fields.
+		Expect(updated.Status.Phase).NotTo(Equal(PhaseFailed))
+	})
+})

--- a/internal/controller/driver_compat_test.go
+++ b/internal/controller/driver_compat_test.go
@@ -72,6 +72,14 @@ func TestMatchCudaDriverMismatch(t *testing.T) {
 			wantMatch: true,
 		},
 		{
+			// No uppercase bytes at all: asciiLower must take its
+			// zero-copy path and matching must still work.
+			name:      "already-lowercase input, no-copy fold path",
+			msg:       "runtimeerror: the nvidia driver on your system is too old (found version 12040)",
+			wantMatch: true,
+			wantIn:    "found version 12040",
+		},
+		{
 			name:      "driver-API enum spelling",
 			msg:       "cuInit failed: CUDA_ERROR_INSUFFICIENT_DRIVER",
 			wantMatch: true,

--- a/internal/controller/driver_compat_test.go
+++ b/internal/controller/driver_compat_test.go
@@ -1,0 +1,539 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// The observed PyTorch wording from a real vLLM crash on a CUDA 12.4 driver.
+const torchDriverTooOld = `Traceback (most recent call last):
+  File "/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py", line 412, in _lazy_init
+RuntimeError: The NVIDIA driver on your system is too old (found version 12040).
+Please update your GPU driver by downloading and installing a new version.`
+
+func TestMatchCudaDriverMismatch(t *testing.T) {
+	cases := []struct {
+		name      string
+		msg       string
+		wantMatch bool
+		wantIn    string
+	}{
+		{
+			name:      "pytorch driver too old, multiline",
+			msg:       torchDriverTooOld,
+			wantMatch: true,
+			wantIn:    "found version 12040",
+		},
+		{
+			name:      "cuda runtime canonical wording",
+			msg:       "CUDA error: CUDA driver version is insufficient for CUDA runtime version",
+			wantMatch: true,
+			wantIn:    "insufficient",
+		},
+		{
+			name:      "raw error enum",
+			msg:       "rpc failed: cudaErrorInsufficientDriver",
+			wantMatch: true,
+			wantIn:    "cudaErrorInsufficientDriver",
+		},
+		{
+			name:      "case-insensitive",
+			msg:       "THE NVIDIA DRIVER ON YOUR SYSTEM IS TOO OLD",
+			wantMatch: true,
+		},
+		{
+			name:      "driver-API enum spelling",
+			msg:       "cuInit failed: CUDA_ERROR_INSUFFICIENT_DRIVER",
+			wantMatch: true,
+			wantIn:    "CUDA_ERROR_INSUFFICIENT_DRIVER",
+		},
+		{
+			// Regression: strings.ToLower can change byte length for some
+			// runes (U+023A grows from 2 to 3 bytes), so byte offsets from a
+			// naive lowered copy would panic slicing the original message.
+			name:      "multibyte prefix whose lowercase changes byte length",
+			msg:       strings.Repeat("Ⱥ", 50) + "cudaErrorInsufficientDriver",
+			wantMatch: true,
+			wantIn:    "cudaErrorInsufficientDriver",
+		},
+		{
+			name:      "control characters are sanitized out of the matched line",
+			msg:       "CUDA driver version is insufficient\tfor CUDA runtime version\x1b[0m",
+			wantMatch: true,
+			wantIn:    "insufficient for CUDA runtime version",
+		},
+		{
+			name:      "oom is not a driver mismatch",
+			msg:       "CUDA out of memory. Tried to allocate 20.00 MiB",
+			wantMatch: false,
+		},
+		{
+			name:      "nvml skew is deliberately excluded",
+			msg:       "Failed to initialize NVML: Driver/library version mismatch",
+			wantMatch: false,
+		},
+		{
+			name:      "empty message",
+			msg:       "",
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			line, ok := matchCudaDriverMismatch(tc.msg)
+			if ok != tc.wantMatch {
+				t.Fatalf("matchCudaDriverMismatch() match = %v, want %v", ok, tc.wantMatch)
+			}
+			if tc.wantIn != "" && !strings.Contains(line, tc.wantIn) {
+				t.Errorf("matched line %q does not contain %q", line, tc.wantIn)
+			}
+			if ok && strings.Contains(line, "\n") {
+				t.Errorf("matched line %q spans multiple lines", line)
+			}
+		})
+	}
+}
+
+func TestMatchCudaDriverMismatchCapsLineLength(t *testing.T) {
+	msg := "CUDA driver version is insufficient " + strings.Repeat("x", 1000)
+	line, ok := matchCudaDriverMismatch(msg)
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if len(line) > 250 {
+		t.Errorf("matched line not capped: len=%d", len(line))
+	}
+}
+
+func crashPod(node, containerName, message string, exitCode int32, inLastState bool) corev1.Pod {
+	term := &corev1.ContainerStateTerminated{ExitCode: exitCode, Message: message}
+	cs := corev1.ContainerStatus{Name: containerName}
+	if inLastState {
+		cs.State = corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}
+		cs.LastTerminationState = corev1.ContainerState{Terminated: term}
+	} else {
+		cs.State = corev1.ContainerState{Terminated: term}
+	}
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "p1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":                           "svc",
+				"inference.llmkube.dev/service": "svc",
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: node},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{cs}},
+	}
+}
+
+func TestFindCudaDriverCrash(t *testing.T) {
+	cases := []struct {
+		name      string
+		pods      []corev1.Pod
+		container string
+		wantFound bool
+		wantNode  string
+	}{
+		{
+			name:      "crashloop with mismatch in last termination state",
+			pods:      []corev1.Pod{crashPod("node-a", "vllm", torchDriverTooOld, 1, true)},
+			container: "vllm",
+			wantFound: true,
+			wantNode:  "node-a",
+		},
+		{
+			name:      "fresh crash in current state, before backoff",
+			pods:      []corev1.Pod{crashPod("node-b", "vllm", torchDriverTooOld, 1, false)},
+			container: "vllm",
+			wantFound: true,
+			wantNode:  "node-b",
+		},
+		{
+			name:      "clean exit is not a crash",
+			pods:      []corev1.Pod{crashPod("node-a", "vllm", torchDriverTooOld, 0, false)},
+			container: "vllm",
+			wantFound: false,
+		},
+		{
+			name:      "non-runtime container is ignored",
+			pods:      []corev1.Pod{crashPod("node-a", "model-downloader", torchDriverTooOld, 1, true)},
+			container: "vllm",
+			wantFound: false,
+		},
+		{
+			name:      "unrelated crash message",
+			pods:      []corev1.Pod{crashPod("node-a", "vllm", "CUDA out of memory", 1, true)},
+			container: "vllm",
+			wantFound: false,
+		},
+		{
+			name:      "no pods",
+			pods:      nil,
+			container: "vllm",
+			wantFound: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			node, _, found := findCudaDriverCrash(tc.pods, tc.container)
+			if found != tc.wantFound {
+				t.Fatalf("found = %v, want %v", found, tc.wantFound)
+			}
+			if found && node != tc.wantNode {
+				t.Errorf("node = %q, want %q", node, tc.wantNode)
+			}
+		})
+	}
+}
+
+func TestGfdCudaOffer(t *testing.T) {
+	cases := []struct {
+		name       string
+		labels     map[string]string
+		wantMajor  string
+		wantMinor  string
+		wantDriver string
+	}{
+		{
+			name: "current GFD label names",
+			labels: map[string]string{
+				"nvidia.com/cuda.runtime-version.major": "12",
+				"nvidia.com/cuda.runtime-version.minor": "4",
+				"nvidia.com/cuda.driver-version.full":   "550.144.03",
+			},
+			wantMajor:  "12",
+			wantMinor:  "4",
+			wantDriver: "550.144.03",
+		},
+		{
+			name: "deprecated label fallback",
+			labels: map[string]string{
+				"nvidia.com/cuda.runtime.major": "12",
+				"nvidia.com/cuda.runtime.minor": "4",
+				"nvidia.com/cuda.driver.major":  "550",
+				"nvidia.com/cuda.driver.minor":  "144",
+				"nvidia.com/cuda.driver.rev":    "03",
+			},
+			wantMajor:  "12",
+			wantMinor:  "4",
+			wantDriver: "550.144.03",
+		},
+		{
+			name:   "no GFD labels",
+			labels: map[string]string{"kubernetes.io/hostname": "node-a"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			major, minor, driver := gfdCudaOffer(tc.labels)
+			if major != tc.wantMajor || minor != tc.wantMinor || driver != tc.wantDriver {
+				t.Errorf("gfdCudaOffer() = (%q, %q, %q), want (%q, %q, %q)",
+					major, minor, driver, tc.wantMajor, tc.wantMinor, tc.wantDriver)
+			}
+		})
+	}
+}
+
+// newDriverCompatReconciler builds an InferenceServiceReconciler over a fake
+// client seeded with the given objects, plus a buffered FakeRecorder for
+// asserting event emission.
+func newDriverCompatReconciler(t *testing.T, objs ...client.Object) (*InferenceServiceReconciler, *events.FakeRecorder) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add inference scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&inferencev1alpha1.InferenceService{}).
+		WithObjects(objs...).
+		Build()
+	recorder := events.NewFakeRecorder(16)
+	return &InferenceServiceReconciler{Client: c, Scheme: scheme, Recorder: recorder}, recorder
+}
+
+func driverCompatISVC() *inferencev1alpha1.InferenceService {
+	return &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "m", Runtime: RuntimeVLLM},
+	}
+}
+
+func gfdNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"nvidia.com/cuda.runtime-version.major": "12",
+				"nvidia.com/cuda.runtime-version.minor": "4",
+				"nvidia.com/cuda.driver-version.full":   "550.144.03",
+			},
+		},
+	}
+}
+
+// The diagnosis reads its signatures from the container's termination
+// message, so the builder must opt every runtime container into the log-tail
+// fallback: engines print the fatal error to the log, not /dev/termination-log.
+func TestConstructDeploymentSetsTerminationMessagePolicy(t *testing.T) {
+	r := &InferenceServiceReconciler{DefaultFSGroup: 102}
+	isvc := sharingISvc(1, nil)
+	model := sharingModel(&inferencev1alpha1.GPUSpec{Enabled: true, Vendor: "nvidia"})
+
+	deployment := r.constructDeployment(isvc, model, 1)
+
+	c := deployment.Spec.Template.Spec.Containers[0]
+	if c.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
+		t.Fatalf("TerminationMessagePolicy = %q, want %q", c.TerminationMessagePolicy, corev1.TerminationMessageFallbackToLogsOnError)
+	}
+}
+
+func TestReconcileDriverCompatCondition(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("diagnoses mismatch with node detail and emits one event", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		pod := crashPod("node-a", "vllm", torchDriverTooOld, 1, true)
+		r, recorder := newDriverCompatReconciler(t, isvc, &pod, gfdNode("node-a"))
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil {
+			t.Fatal("expected DriverCompatible condition")
+		}
+		if cond.Status != metav1.ConditionFalse || cond.Reason != ReasonCUDADriverInsufficient {
+			t.Fatalf("condition = %s/%s, want False/%s", cond.Status, cond.Reason, ReasonCUDADriverInsufficient)
+		}
+		for _, want := range []string{"node-a", "CUDA <= 12.4", "driver 550.144.03", "found version 12040", "CUDA 12.x"} {
+			if !strings.Contains(cond.Message, want) {
+				t.Errorf("message %q missing %q", cond.Message, want)
+			}
+		}
+		if got := len(recorder.Events); got != 1 {
+			t.Fatalf("events emitted = %d, want 1", got)
+		}
+		if ev := <-recorder.Events; !strings.Contains(ev, ReasonCUDADriverInsufficient) {
+			t.Errorf("event %q missing reason CUDADriverInsufficient", ev)
+		}
+
+		// Second pass over the same crash: condition stays False, no new event.
+		r.reconcileDriverCompatCondition(ctx, isvc)
+		if got := len(recorder.Events); got != 0 {
+			t.Fatalf("repeat reconcile emitted %d extra event(s), want 0", got)
+		}
+	})
+
+	t.Run("no condition without a diagnosed crash", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		healthy := crashPod("node-a", "vllm", "", 0, false)
+		healthy.Status.ContainerStatuses[0].State = corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}
+		r, _ := newDriverCompatReconciler(t, isvc, &healthy)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		if meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible) != nil {
+			t.Fatal("condition must stay absent until a mismatch is diagnosed")
+		}
+	})
+
+	t.Run("unrelated crash does not flip a prior diagnosis", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type: ConditionDriverCompatible, Status: metav1.ConditionFalse,
+			Reason: ReasonCUDADriverInsufficient, Message: "prior diagnosis",
+		})
+		oom := crashPod("node-a", "vllm", "CUDA out of memory", 1, true)
+		r, _ := newDriverCompatReconciler(t, isvc, &oom)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatal("prior diagnosis must persist while the runtime has not started")
+		}
+	})
+
+	t.Run("recovers to True when the runtime container is ready", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type: ConditionDriverCompatible, Status: metav1.ConditionFalse,
+			Reason: ReasonCUDADriverInsufficient, Message: "prior diagnosis",
+		})
+		ready := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "p2", Namespace: "default",
+				Labels: map[string]string{
+					"app":                           "svc",
+					"inference.llmkube.dev/service": "svc",
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-a"},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "vllm", Ready: true,
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}}},
+		}
+		r, _ := newDriverCompatReconciler(t, isvc, &ready)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionTrue || cond.Reason != ReasonRuntimeStarted {
+			t.Fatalf("condition = %+v, want True/%s", cond, ReasonRuntimeStarted)
+		}
+	})
+
+	t.Run("node gone: diagnosis from error text alone", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		pod := crashPod("node-gone", "vllm", torchDriverTooOld, 1, true)
+		r, _ := newDriverCompatReconciler(t, isvc, &pod)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatal("expected False condition")
+		}
+		if !strings.Contains(cond.Message, "no longer readable") {
+			t.Errorf("message %q missing node-gone fallback", cond.Message)
+		}
+	})
+
+	t.Run("node without GFD labels", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		pod := crashPod("node-plain", "vllm", torchDriverTooOld, 1, true)
+		plain := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-plain"}}
+		r, _ := newDriverCompatReconciler(t, isvc, &pod, plain)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatal("expected False condition")
+		}
+		if !strings.Contains(cond.Message, "no GPU feature labels") {
+			t.Errorf("message %q missing no-labels fallback", cond.Message)
+		}
+	})
+}
+
+// Recovery-path behaviors, split out to keep each test function within the
+// lint complexity budget.
+func TestReconcileDriverCompatConditionRecovery(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ready container outranks its own stale crash evidence", func(t *testing.T) {
+		// Regression: a container that crashed with the signature (e.g.
+		// before the node's driver daemonset finished) and then started in
+		// place keeps the message in LastTerminationState for the pod's
+		// lifetime; once Ready, that evidence must not diagnose — or recover
+		// a prior diagnosis — incorrectly.
+		isvc := driverCompatISVC()
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type: ConditionDriverCompatible, Status: metav1.ConditionFalse,
+			Reason: ReasonCUDADriverInsufficient, Message: "prior diagnosis",
+		})
+		recovered := crashPod("node-a", "vllm", torchDriverTooOld, 1, true)
+		recovered.Status.ContainerStatuses[0].State = corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}
+		recovered.Status.ContainerStatuses[0].Ready = true
+		r, _ := newDriverCompatReconciler(t, isvc, &recovered)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionTrue || cond.Reason != ReasonRuntimeStarted {
+			t.Fatalf("condition = %+v, want True/%s despite stale LastTerminationState", cond, ReasonRuntimeStarted)
+		}
+	})
+
+	t.Run("re-crash after recovery emits a second event", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type: ConditionDriverCompatible, Status: metav1.ConditionTrue,
+			Reason: ReasonRuntimeStarted, Message: "recovered earlier",
+		})
+		pod := crashPod("node-a", "vllm", torchDriverTooOld, 1, true)
+		r, recorder := newDriverCompatReconciler(t, isvc, &pod, gfdNode("node-a"))
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatal("expected a fresh False diagnosis after re-crash")
+		}
+		if got := len(recorder.Events); got != 1 {
+			t.Fatalf("events emitted = %d, want 1 for the new episode", got)
+		}
+	})
+
+	t.Run("metal-style absence of pods leaves prior diagnosis intact", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type: ConditionDriverCompatible, Status: metav1.ConditionFalse,
+			Reason: ReasonCUDADriverInsufficient, Message: "prior diagnosis",
+		})
+		r, _ := newDriverCompatReconciler(t, isvc)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatal("prior diagnosis must persist when no pods exist")
+		}
+	})
+
+	t.Run("never touches phase or other conditions", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		isvc.Status.Phase = PhaseCreating
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type: "Available", Status: metav1.ConditionTrue, Reason: "InferenceReady", Message: "serving",
+		})
+		pod := crashPod("node-a", "vllm", torchDriverTooOld, 1, true)
+		r, _ := newDriverCompatReconciler(t, isvc, &pod, gfdNode("node-a"))
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		if isvc.Status.Phase != PhaseCreating {
+			t.Errorf("phase changed to %q; diagnosis must not touch phase", isvc.Status.Phase)
+		}
+		if !meta.IsStatusConditionTrue(isvc.Status.Conditions, "Available") {
+			t.Error("Available condition disturbed; diagnosis must not touch it")
+		}
+	})
+}

--- a/internal/controller/driver_compat_test.go
+++ b/internal/controller/driver_compat_test.go
@@ -231,7 +231,7 @@ func TestFindCudaDriverCrash(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			node, _, found := findCudaDriverCrash(tc.pods, tc.container)
+			node, _, _, found := findCudaDriverCrash(tc.pods, tc.container)
 			if found != tc.wantFound {
 				t.Fatalf("found = %v, want %v", found, tc.wantFound)
 			}
@@ -455,7 +455,7 @@ func TestReconcileDriverCompatCondition(t *testing.T) {
 		if cond == nil || cond.Status != metav1.ConditionFalse {
 			t.Fatal("expected False condition")
 		}
-		if !strings.Contains(cond.Message, "no longer readable") {
+		if !strings.Contains(cond.Message, "no longer exists") {
 			t.Errorf("message %q missing node-gone fallback", cond.Message)
 		}
 	})
@@ -604,4 +604,135 @@ func TestReconcileDriverCompatConditionRecovery(t *testing.T) {
 			t.Error("Available condition disturbed; diagnosis must not touch it")
 		}
 	})
+}
+
+// Driver-skew behaviors: replicas split across nodes with different driver
+// support. Readiness recovers a diagnosis only within the pod that carries
+// the crash evidence — a healthy or recovered replica elsewhere must never
+// mask the one still crashing.
+func TestReconcileDriverCompatConditionDriverSkew(t *testing.T) {
+	ctx := context.Background()
+
+	readyPod := func(name, node string) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: "default",
+				Labels: map[string]string{
+					"app":                           "svc",
+					"inference.llmkube.dev/service": "svc",
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: node},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "vllm", Ready: true,
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}}},
+		}
+	}
+
+	t.Run("healthy replica does not mask a crash-looping one", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		good := readyPod("p-good", "node-good")
+		bad := crashPod("node-bad", "vllm", torchDriverTooOld, 1, true)
+		bad.Name = "p-bad"
+		r, recorder := newDriverCompatReconciler(t, isvc, &good, &bad)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != ReasonCUDADriverInsufficient {
+			t.Fatalf("condition = %+v, want False/%s despite the healthy replica", cond, ReasonCUDADriverInsufficient)
+		}
+		if !strings.Contains(cond.Message, "node-bad") {
+			t.Errorf("message %q must name the crashing pod's node", cond.Message)
+		}
+		if got := len(recorder.Events); got != 1 {
+			t.Fatalf("events emitted = %d, want 1", got)
+		}
+	})
+
+	t.Run("scale-up onto a healthy node does not recover a still-crashing carrier", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type: ConditionDriverCompatible, Status: metav1.ConditionFalse,
+			Reason: ReasonCUDADriverInsufficient, Message: "prior diagnosis",
+		})
+		good := readyPod("p-good", "node-good")
+		bad := crashPod("node-bad", "vllm", torchDriverTooOld, 1, true)
+		bad.Name = "p-bad"
+		r, recorder := newDriverCompatReconciler(t, isvc, &good, &bad)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatalf("condition = %+v, must stay False while the carrier still crashes", cond)
+		}
+		if got := len(recorder.Events); got != 0 {
+			t.Fatalf("events emitted = %d, want 0 for an unbroken episode", got)
+		}
+	})
+
+	t.Run("active crash outranks another pod's stale recovered evidence", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		recovered := crashPod("node-a", "vllm", torchDriverTooOld, 1, true)
+		recovered.Name = "a-recovered"
+		recovered.Status.ContainerStatuses[0].State = corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}
+		recovered.Status.ContainerStatuses[0].Ready = true
+		crashing := crashPod("node-b", "vllm", torchDriverTooOld, 1, true)
+		crashing.Name = "b-crashing"
+		r, _ := newDriverCompatReconciler(t, isvc, &recovered, &crashing)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatalf("condition = %+v, want False from the active carrier", cond)
+		}
+		if !strings.Contains(cond.Message, "node-b") {
+			t.Errorf("message %q must come from the active carrier's node, not the recovered one's", cond.Message)
+		}
+	})
+}
+
+// A node Get failure is not node deletion: the message must not claim the
+// node is gone, and the error must leave a log trail.
+func TestDriverCompatNodeReadFailure(t *testing.T) {
+	ctx := context.Background()
+	isvc := driverCompatISVC()
+	pod := crashPod("node-a", "vllm", torchDriverTooOld, 1, true)
+
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add inference scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(isvc, &pod, gfdNode("node-a")).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, isNode := obj.(*corev1.Node); isNode {
+					return errors.New("apiserver throttled")
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	r := &InferenceServiceReconciler{Client: c, Scheme: scheme}
+
+	r.reconcileDriverCompatCondition(ctx, isvc)
+
+	cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatal("expected False condition despite the node read failure")
+	}
+	if !strings.Contains(cond.Message, "not readable right now") {
+		t.Errorf("message %q must say the node is unreadable, not gone", cond.Message)
+	}
+	if strings.Contains(cond.Message, "no longer exists") {
+		t.Errorf("message %q claims deletion on a transient read failure", cond.Message)
+	}
 }

--- a/internal/controller/driver_compat_test.go
+++ b/internal/controller/driver_compat_test.go
@@ -319,10 +319,10 @@ func driverCompatISVC() *inferencev1alpha1.InferenceService {
 	}
 }
 
-func gfdNode(name string) *corev1.Node {
+func gfdNode() *corev1.Node {
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name: "node-a",
 			Labels: map[string]string{
 				"nvidia.com/cuda.runtime-version.major": "12",
 				"nvidia.com/cuda.runtime-version.minor": "4",
@@ -354,7 +354,7 @@ func TestReconcileDriverCompatCondition(t *testing.T) {
 	t.Run("diagnoses mismatch with node detail and emits one event", func(t *testing.T) {
 		isvc := driverCompatISVC()
 		pod := crashPod("node-a", "vllm", torchDriverTooOld, 1, true)
-		r, recorder := newDriverCompatReconciler(t, isvc, &pod, gfdNode("node-a"))
+		r, recorder := newDriverCompatReconciler(t, isvc, &pod, gfdNode())
 
 		r.reconcileDriverCompatCondition(ctx, isvc)
 
@@ -514,7 +514,7 @@ func TestReconcileDriverCompatConditionRecovery(t *testing.T) {
 			Reason: ReasonRuntimeStarted, Message: "recovered earlier",
 		})
 		pod := crashPod("node-a", "vllm", torchDriverTooOld, 1, true)
-		r, recorder := newDriverCompatReconciler(t, isvc, &pod, gfdNode("node-a"))
+		r, recorder := newDriverCompatReconciler(t, isvc, &pod, gfdNode())
 
 		r.reconcileDriverCompatCondition(ctx, isvc)
 
@@ -593,7 +593,7 @@ func TestReconcileDriverCompatConditionRecovery(t *testing.T) {
 			Type: "Available", Status: metav1.ConditionTrue, Reason: "InferenceReady", Message: "serving",
 		})
 		pod := crashPod("node-a", "vllm", torchDriverTooOld, 1, true)
-		r, _ := newDriverCompatReconciler(t, isvc, &pod, gfdNode("node-a"))
+		r, _ := newDriverCompatReconciler(t, isvc, &pod, gfdNode())
 
 		r.reconcileDriverCompatCondition(ctx, isvc)
 
@@ -711,7 +711,7 @@ func TestDriverCompatNodeReadFailure(t *testing.T) {
 	}
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(isvc, &pod, gfdNode("node-a")).
+		WithObjects(isvc, &pod, gfdNode()).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 				if _, isNode := obj.(*corev1.Node); isNode {

--- a/internal/controller/driver_compat_test.go
+++ b/internal/controller/driver_compat_test.go
@@ -18,8 +18,10 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -28,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -130,6 +133,20 @@ func TestMatchCudaDriverMismatchCapsLineLength(t *testing.T) {
 	}
 	if len(line) > 250 {
 		t.Errorf("matched line not capped: len=%d", len(line))
+	}
+
+	// The cap must land on a rune boundary: place a multibyte rune across
+	// the cut point and require valid UTF-8 output.
+	msg = "cudaErrorInsufficientDriver " + strings.Repeat("x", 170) + strings.Repeat("€", 20)
+	line, ok = matchCudaDriverMismatch(msg)
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if !utf8.ValidString(line) {
+		t.Errorf("capped line is not valid UTF-8: %q", line)
+	}
+	if !strings.HasSuffix(line, "...") {
+		t.Errorf("capped line missing ellipsis: %q", line)
 	}
 }
 
@@ -515,6 +532,49 @@ func TestReconcileDriverCompatConditionRecovery(t *testing.T) {
 		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
 		if cond == nil || cond.Status != metav1.ConditionFalse {
 			t.Fatal("prior diagnosis must persist when no pods exist")
+		}
+	})
+
+	t.Run("pod list failure only logs; no condition, no panic", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		scheme := runtime.NewScheme()
+		if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+			t.Fatalf("add inference scheme: %v", err)
+		}
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatalf("add corev1 scheme: %v", err)
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(isvc).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					return errors.New("apiserver unavailable")
+				},
+			}).
+			Build()
+		r := &InferenceServiceReconciler{Client: c, Scheme: scheme}
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		if meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible) != nil {
+			t.Fatal("a failed pod list must not produce a condition")
+		}
+	})
+
+	t.Run("crash on a pod with no node name diagnoses from the error text", func(t *testing.T) {
+		isvc := driverCompatISVC()
+		pod := crashPod("", "vllm", torchDriverTooOld, 1, true)
+		r, _ := newDriverCompatReconciler(t, isvc, &pod)
+
+		r.reconcileDriverCompatCondition(ctx, isvc)
+
+		cond := meta.FindStatusCondition(isvc.Status.Conditions, ConditionDriverCompatible)
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatal("expected False condition")
+		}
+		if !strings.Contains(cond.Message, "newer GPU driver than the node provides") {
+			t.Errorf("message %q missing generic diagnosis", cond.Message)
 		}
 	})
 

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -250,6 +250,13 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
+	// Post-hoc crash diagnosis before the status write persists conditions.
+	// Metal services have no pods to diagnose (the agent runs the server
+	// natively), so the pod scan is skipped there.
+	if !isMetal {
+		r.reconcileDriverCompatCondition(ctx, inferenceService)
+	}
+
 	endpoint := r.constructEndpoint(inferenceService, service)
 	phase, schedulingInfo := r.determinePhase(ctx, inferenceService, readyReplicas, desiredReplicas, isMetal, deployment, metalSnap)
 


### PR DESCRIPTION
## What

Diagnose CUDA driver/runtime mismatch crashes on the InferenceService itself: an advisory `DriverCompatible` condition plus a transition-only Warning event, built from the crashed runtime container's termination message and the node it actually ran on. Purely post-hoc — no prediction, no blocking, never wired into phase or `Available`.

## Why

A runtime image whose CUDA userspace is newer than the node driver's supported major dies at engine init, after a GPU node has been provisioned and a multi-GB image pulled, with the only explanation buried in the crashed container's logs (`The NVIDIA driver on your system is too old`). Hit live on AKS (baked-in driver 550/CUDA 12.4 vs. a CUDA 13 image). Today diagnosing it takes log archaeology; with this change it's one `kubectl describe isvc`.

Fixes #1424

## How

Same design move as `getPodSchedulingInfo` (opaque pod failure → named diagnosis), observable-state-driven throughout:

- `terminationMessagePolicy: FallbackToLogsOnError` on the generated runtime container makes terminations self-describing (benefits every crash class, not just this one).
- `reconcileDriverCompatCondition` (called from `Reconcile` before the omnibus status update, non-metal only) lists the service's pods, and matches known driver-too-old signatures — PyTorch's wording, the cudart canonical string (also what llama.cpp's `ggml_cuda_init` surfaces), and both error-enum spellings — in the **runtime container's** terminated states only. Init containers and sidecars are never inspected. NVML's `Driver/library version mismatch` is deliberately excluded (node-internal skew, different fix — see the code comment).
- On a match: one targeted `Get` of `pod.spec.nodeName` (nodes RBAC already exists — no `make manifests` churn), enriching the message with GFD's driver/CUDA-support labels when present (current names, with the deprecated pre-0.15 fallbacks); graceful degradation when the node is gone or unlabeled. No node watch, no fleet listing.
- Condition semantics follow the house anti-churn convention (`VLLMSpecValid`): absent until first diagnosis; `False/CUDADriverInsufficient` while crash evidence stands; `True/RuntimeStarted` only when readiness proves recovery: an active (not-Ready) crash carrier always diagnoses even when other replicas are healthy (driver-skewed node pools must not be masked), readiness outranks stale `LastTerminationState` evidence only within the pod that produced it (a container that crashed once — e.g. driver daemonset race — and then started in place recovers correctly), and fleet readiness recovers a prior diagnosis only once no pod carries crash evidence anymore (rollout replaced the crashing pods). The Warning event (same reason string, for one `--field-selector` vocabulary) fires on transition only, computed against in-memory conditions before the reconcile's status write — effectively one event per episode, at-least-once if that status write fails and the next pass recomputes the transition.
- Signature matching folds case in ASCII only and sanitizes/caps the reported line: Unicode lowering can change byte length, and termination messages are arbitrary container output that must never be able to panic the controller or produce an over-long/invalid status write.

Design decisions worth noting:

- **Behavior change on upgrade:** the pod-template change (termination policy) rolls existing InferenceService Deployments once on operator upgrade (Recreate strategy for GPU workloads — one restart per service). Called out here so it can ride a release that's expected to roll templates anyway if preferred.
- **Coverage is bounded by the log tail:** `FallbackToLogsOnError` captures the last 2048 bytes/80 lines; a runtime that prints shutdown noise after the traceback can push the signature out of view. A miss fails safe (no condition, no noise). The docs phrase the feature accordingly.
- The condition constant lives controller-local (`driver_compat.go`), matching the `ConditionVLLMSpecValid`/`ConditionSGLangSpecValid` precedent for single-writer conditions.
- Naming (`DriverCompatible` / `CUDADriverInsufficient` / `RuntimeStarted`) follows the repo's uppercase-acronym convention (`GPUAvailable`, `InsufficientGPU`); happy to rename before merge — it freezes into user automation after.

Possible follow-up (separate PR if there's appetite): CUDA-major metadata on the operator's own default runtime images with a lockstep test (default-image tag bump fails CI unless the metadata moves with it), used to generate the compatibility doc so the hand-maintained matrix can retire.

Branch note: the head is based on my fork's last-synced main (0.9.13) for fork-permission reasons; the change was developed and fully validated against current `main` as well (same clean apply, `make lint`/`lint-all` 0 issues, suite green). Happy to rebase the head onto current main if you prefer.

AI assistance disclosure: implementation and tests were AI-assisted (Claude); design, review, and validation are owned by the submitter, per CONTRIBUTING.md.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (two pre-existing failures in `pkg/foreman/agent/tools` on my workstation come from Apple git 2.39 not supporting `--end-of-options` in `checkout` — unrelated to this change; everything else green)
- [x] `make lint` passes locally (`lint-all` too)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

