### PR TITLE
fix(chart): default the router-proxy image tag to the chart appVersion

### DIFF
--- a/charts/llmkube/tests/router-proxy-image_test.yaml
+++ b/charts/llmkube/tests/router-proxy-image_test.yaml
@@ -1,0 +1,31 @@
+suite: router-proxy default image
+templates:
+  - deployment.yaml
+
+tests:
+  # The published router-proxy image is tagged with the release version, so
+  # the default must track the chart appVersion — a stock install of a
+  # ModelRouter must never point at an unpublished tag (#1426).
+  - it: should default the router-proxy image tag to the chart appVersion
+    chart:
+      appVersion: 9.9.9
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --router-proxy-image=ghcr.io/defilantech/llmkube-router-proxy:9.9.9
+
+  - it: should honor an explicit tag override
+    set:
+      controllerManager.routerProxy.tag: my-tag
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --router-proxy-image=ghcr.io/defilantech/llmkube-router-proxy:my-tag
+
+  - it: should prefer a digest over the tag
+    set:
+      controllerManager.routerProxy.digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --router-proxy-image=ghcr.io/defilantech/llmkube-router-proxy@sha256:0000000000000000000000000000000000000000000000000000000000000000

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -99,33 +99,19 @@ controllerManager:
   # InferenceServices and external provider backends, speaks
   # OpenAI chat completions, and enforces policy routing.
   #
-  # IMPORTANT (Phase 1 alpha): the release pipeline does not yet build
-  # and push the router-proxy image alongside the controller image.
-  # The default tag below is "dev" rather than the chart appVersion so
-  # users who never create a ModelRouter resource are unaffected, and
-  # users who do create one know they need to either:
-  #
-  #   1. Build the image locally (`make docker-build-router-proxy`)
-  #      and push it to a registry their cluster can reach, then
-  #      override repository / tag here.
-  #   2. Override `spec.proxy.image` per ModelRouter with their own
-  #      build.
-  #
-  # See https://github.com/defilantech/LLMKube/issues/449 for the
-  # tracking issue on integrating the router-proxy image into the
-  # release flow.
+  # The release pipeline publishes ghcr.io/defilantech/llmkube-router-proxy
+  # alongside the controller image with matching version tags (#449), so the
+  # empty tag below resolves to the chart appVersion.
   routerProxy:
     # Registry prefix for the router-proxy image (mirrors controller image).
     # Useful for air-gapped or enterprise proxy registries.
     registry: ""
     repository: ghcr.io/defilantech/llmkube-router-proxy
     pullPolicy: IfNotPresent
-    # Default tag. "dev" is intentional until the release pipeline
-    # ships versioned router-proxy images alongside the controller.
-    tag: "dev"
+    # Image tag. Empty defaults to the chart appVersion, which matches the
+    # tag the release pipeline publishes for this chart version.
+    tag: ""
     # Image digest (sha256:...) - takes precedence over tag when set.
-    # Use digests for production deployments once the release pipeline
-    # publishes them.
     digest: ""
 
     # Cluster-wide default URL for ModelRouter External backends whose

--- a/docs/site/concepts/model-router.md
+++ b/docs/site/concepts/model-router.md
@@ -20,19 +20,6 @@ ModelRouter is **alpha** as of LLMKube 0.8. The CRD lives in `inference.llmkube.
 
 </DocCallout>
 
-<DocCallout variant="warn" title="Router-proxy image not yet in the release pipeline">
-
-The release pipeline currently builds and publishes the controller image (`ghcr.io/defilantech/llmkube-controller`) on every release. The router-proxy image (`ghcr.io/defilantech/llmkube-router-proxy`) is not yet built by CI: see [issue #449](https://github.com/defilantech/LLMKube/issues/449).
-
-The Helm chart's default for `controllerManager.routerProxy.tag` is `"dev"` until that lands. Users who want to deploy a ModelRouter today have two options:
-
-1. **Build locally and push.** Run `make docker-build-router-proxy ROUTER_PROXY_IMG=<your-registry>/llmkube-router-proxy:dev`, push it, then `--set controllerManager.routerProxy.repository=<your-registry>/llmkube-router-proxy` on the Helm install.
-2. **Override per ModelRouter.** Set `spec.proxy.image` on each ModelRouter to an image your cluster can pull.
-
-Users who never create a ModelRouter resource are unaffected.
-
-</DocCallout>
-
 ## Why this exists
 
 LLMs are increasingly composed: an agent does some work on a fast local model, hands off a hard step to a frontier cloud model, then comes back. Every team building this hits the same three problems:

--- a/docs/site/guides/air-gapped.md
+++ b/docs/site/guides/air-gapped.md
@@ -13,8 +13,8 @@ operator image, the runtime image, the model weights, and a CA
 bundle to the cluster once, then never reach the public internet
 again.
 
-This guide covers each piece end to end against the current `v0.7.7`
-release.
+This guide covers each piece end to end against the current `0.9.14`
+release. Image tags on ghcr are bare versions, without a `v` prefix.
 
 ## Prerequisites
 
@@ -31,23 +31,18 @@ release.
 
 Three workloads need to land inside the air gap:
 
-1. **The operator** (`ghcr.io/defilantech/llmkube-controller:v0.7.7`)
+1. **The operator** (`ghcr.io/defilantech/llmkube-controller:0.9.14`)
    reconciles `Model`, `InferenceService`, and `ModelRouter` custom
    resources.
 2. **The runtime images** (`ghcr.io/ggml-org/llama.cpp:server-cuda13`
    for llama.cpp; equivalents for vLLM, TGI, Ollama). The operator
    only schedules pods using these; it doesn't pull weights into
    them.
-3. **The router-proxy** (`ghcr.io/defilantech/llmkube-router-proxy:dev`)
+3. **The router-proxy** (`ghcr.io/defilantech/llmkube-router-proxy:0.9.14`)
    if you use `ModelRouter`. Only needed when you want the
-   policy-aware routing layer. The release pipeline does not yet
-   ship versioned router-proxy images alongside the controller, so
-   the chart default is the `dev` tag (see
-   [`#449`](https://github.com/defilantech/LLMKube/issues/449)). If
-   you need a pinned tag in an air-gapped registry, build the image
-   yourself from this commit (`make docker-build-router-proxy
-   ROUTER_PROXY_IMG=registry.internal.corp/defilantech/llmkube-router-proxy:0.7.7`)
-   and use that tag below.
+   policy-aware routing layer. The release pipeline publishes a
+   versioned router-proxy image alongside the controller on every
+   release; mirror the tag that matches your controller version.
 
 Plus the model weights themselves, which the operator either copies
 from a local source or mounts from a PVC. There is no model-weight
@@ -58,14 +53,14 @@ download from the operator's runtime pods at request time.
 On a connected machine, save the four images you need:
 
 ```bash
-docker pull ghcr.io/defilantech/llmkube-controller:v0.7.7
-docker pull ghcr.io/defilantech/llmkube-router-proxy:dev
+docker pull ghcr.io/defilantech/llmkube-controller:0.9.14
+docker pull ghcr.io/defilantech/llmkube-router-proxy:0.9.14
 docker pull ghcr.io/ggml-org/llama.cpp:server-cuda13
 docker pull docker.io/curlimages/curl:8.18.0   # init container
 
 docker save \
-  ghcr.io/defilantech/llmkube-controller:v0.7.7 \
-  ghcr.io/defilantech/llmkube-router-proxy:dev \
+  ghcr.io/defilantech/llmkube-controller:0.9.14 \
+  ghcr.io/defilantech/llmkube-router-proxy:0.9.14 \
   ghcr.io/ggml-org/llama.cpp:server-cuda13 \
   docker.io/curlimages/curl:8.18.0 \
   > llmkube-bundle.tar
@@ -77,8 +72,8 @@ private registry:
 ```bash
 docker load < llmkube-bundle.tar
 for img in \
-  ghcr.io/defilantech/llmkube-controller:v0.7.7 \
-  ghcr.io/defilantech/llmkube-router-proxy:dev \
+  ghcr.io/defilantech/llmkube-controller:0.9.14 \
+  ghcr.io/defilantech/llmkube-router-proxy:0.9.14 \
   ghcr.io/ggml-org/llama.cpp:server-cuda13 \
   docker.io/curlimages/curl:8.18.0
 do
@@ -104,9 +99,9 @@ overrides pointing at your registry:
 helm install llmkube ./llmkube \
   --namespace llmkube-system --create-namespace \
   --set controllerManager.image.repository=registry.internal.corp/defilantech/llmkube-controller \
-  --set controllerManager.image.tag=v0.7.7 \
+  --set controllerManager.image.tag=0.9.14 \
   --set controllerManager.routerProxy.repository=registry.internal.corp/defilantech/llmkube-router-proxy \
-  --set controllerManager.routerProxy.tag=dev \
+  --set controllerManager.routerProxy.tag=0.9.14 \
   --set controllerManager.initContainer.repository=registry.internal.corp/curlimages/curl \
   --set controllerManager.initContainer.tag=8.18.0
 ```
@@ -131,7 +126,7 @@ helm install llmkube ./llmkube \
   -f ./llmkube/values-openshift.yaml \
   --namespace llmkube-system --create-namespace \
   --set controllerManager.image.repository=registry.internal.corp/defilantech/llmkube-controller \
-  --set controllerManager.image.tag=v0.7.7 \
+  --set controllerManager.image.tag=0.9.14 \
   --set controllerManager.initContainer.repository=registry.internal.corp/curlimages/curl \
   --set controllerManager.initContainer.tag=8.18.0
 ```


### PR DESCRIPTION
## What

Default the router-proxy image tag to the chart appVersion instead of the unpublished `dev` tag, drop the stale "the release pipeline does not yet build this image" comment block, and retire the same stale premise from the docs (model-router concept page, air-gapped guide).

## Why

Since #449 closed, `.goreleaser.yaml` builds and pushes `ghcr.io/defilantech/llmkube-router-proxy:{{ .Version }}` on every release — `0.9.14` resolves on ghcr today. But the chart still pins `tag: "dev"`, which was never published, so a stock `ModelRouter` lands in `ImagePullBackOff` until the user discovers the undocumented bare-version tag. (#609's own description names this chart default as the adoption blocker it was solving; the chart flip was the unfinished half.)

Fixes #1426

## How

`tag: ""` in values.yaml — the `llmkube.routerProxyImage` helper already falls back to `.Chart.AppVersion`, which matches the tag goreleaser publishes for that release, so no template change is needed. The `defaultRouterProxyImage = …:dev` constant in the operator is untouched: chart installs always pass `--router-proxy-image`, and the constant keeps flagless local dev working. It is also what the ModelRouter e2e cluster context keys on: `test/e2e/e2e_suite_test.go` side-loads exactly the constant's `:dev` tag into Kind so the operator dispatches without a `--router-proxy-image` rewrite — leaving the constant untouched keeps that flow unchanged.

Docs carrying the same premise updated in the same pass:
- `docs/site/concepts/model-router.md`: removed the "Router-proxy image not yet in the release pipeline" warning callout (the alpha Status callout stays).
- `docs/site/guides/air-gapped.md`: staged images now reference the published `0.9.14` tags. While there, fixed the guide's controller pins too — ghcr tags are bare versions, so the `v0.7.7`-style pulls the guide showed never resolved (`v0.7.7` 404s, `0.7.7` exists; verified against the registry).

New chart test suite (`router-proxy-image_test.yaml`) asserts the rendered `--router-proxy-image` arg: appVersion default, explicit tag override, digest precedence. Mutation-checked: reverting `tag` to `"dev"` fails the suite.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`helm unittest`: 63/63 incl. the new suite; no Go change)
- [x] `make lint` / `make lint-all` pass locally aside from 6 pre-existing staticcheck findings in `pkg/foreman/agent` tests, identical on the base commit (nothing from this change)
- [x] Commit messages follow conventional commits

---
Assisted-by: Claude (Anthropic). Investigated, verified, and reviewed by a human; the ImagePullBackOff and the working bare-version tag were confirmed on a live AKS cluster, and every image tag referenced in the doc changes was verified to resolve on ghcr.
