### PR TITLE
fix(controller): publish model downloads atomically so an interrupted transfer is never cached

### DIFF
--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -391,7 +391,8 @@ var _ = Describe("buildMultiFileInitCommand", func() {
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 		Expect(cmd).To(ContainSubstring("printf '%s\\n' \"$MODEL_FILES\""))
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$(dirname "$dest")"`))
-		Expect(cmd).To(ContainSubstring(`curl -f -L -o "$dest" "$url"`))
+		Expect(cmd).To(ContainSubstring(`curl -f -L -o "$dest.tmp" "$url" && mv "$dest.tmp" "$dest"`))
+		Expect(cmd).ToNot(ContainSubstring(`-o "$dest" `))
 		Expect(cmd).To(ContainSubstring("already cached, skipping download"))
 	})
 
@@ -1238,8 +1239,7 @@ var _ = Describe("buildModelInitCommand", func() {
 	It("should generate cached local copy command", func() {
 		cmd := buildModelInitCommand(true, false, true, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
-		Expect(cmd).To(ContainSubstring("cp /host-model/model.gguf"))
-		Expect(cmd).To(ContainSubstring(`"$MODEL_PATH"`))
+		Expect(cmd).To(ContainSubstring(`cp /host-model/model.gguf "$MODEL_PATH.tmp" && mv "$MODEL_PATH.tmp" "$MODEL_PATH"`))
 	})
 
 	It("should generate error exit for uncached local source", func() {

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -178,30 +178,35 @@ func addCACertVolume(volumes *[]corev1.Volume, mounts *[]corev1.VolumeMount, cmd
 	*cmd = fmt.Sprintf("export CURL_CA_BUNDLE=/custom-certs/$(ls /custom-certs | grep -v '^\\.' | head -n 1) && %s", *cmd)
 }
 
+// All transfers write to "$MODEL_PATH.tmp" and mv onto "$MODEL_PATH" on
+// success: the guard is a bare existence check, so publishing the file
+// non-atomically would let an interrupted transfer (OOM-kill, eviction,
+// node reboot) leave a truncated artifact that every subsequent restart
+// treats as cached. See remoteRevalidateScript for the same pattern.
 func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) string {
 	if useCache {
 		if isLocal {
-			return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Copying model from local source...'; cp /host-model/model.gguf "$MODEL_PATH" && echo 'Model copied successfully'; else echo 'Model already cached, skipping copy'; fi`
+			return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Copying model from local source...'; cp /host-model/model.gguf "$MODEL_PATH.tmp" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model copied successfully'; else echo 'Model already cached, skipping copy'; fi`
 		}
 		if isS3 {
-			return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model from S3...'; curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$MODEL_PATH" "${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
+			return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model from S3...'; curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$MODEL_PATH.tmp" "${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
 		}
 		if refreshPolicy == RefreshPolicyOnChange {
 			return "mkdir -p \"$CACHE_DIR\" && " + remoteRevalidateScript
 		}
-		return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH" "$MODEL_SOURCE" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
+		return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
 	}
 
 	if isLocal {
 		return `echo 'ERROR: Local model source requires model cache to be configured.'; exit 1`
 	}
 	if isS3 {
-		return `if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model from S3...'; curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$MODEL_PATH" "${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}" && echo 'Model downloaded successfully'; else echo 'Model already exists, skipping download'; fi`
+		return `if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model from S3...'; curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$MODEL_PATH.tmp" "${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already exists, skipping download'; fi`
 	}
 	if refreshPolicy == RefreshPolicyOnChange {
 		return remoteRevalidateScript
 	}
-	return `if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH" "$MODEL_SOURCE" && echo 'Model downloaded successfully'; else echo 'Model already exists, skipping download'; fi`
+	return `if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already exists, skipping download'; fi`
 }
 
 // remoteRevalidateScript implements RefreshPolicy=OnChange for http/https
@@ -449,7 +454,7 @@ func buildMultiFileInitCommand(useCache bool, refreshPolicy string) string {
 		`url="${SOURCE%/}/$rel"; ` +
 		`if [ ! -f "$dest" ]; then ` +
 		`echo "Downloading model artifact $rel..."; ` +
-		`curl -f -L -o "$dest" "$url" || { echo "ERROR: failed to download $rel"; exit 1; }; ` +
+		`curl -f -L -o "$dest.tmp" "$url" && mv "$dest.tmp" "$dest" || { echo "ERROR: failed to download $rel"; exit 1; }; ` +
 		`else echo "Model artifact $rel already cached, skipping download"; fi; ` +
 		`done`
 	return prefix + body

--- a/internal/controller/model_storage_test.go
+++ b/internal/controller/model_storage_test.go
@@ -32,6 +32,8 @@ var _ = Describe("buildModelInitCommand (s3)", func() {
 		Expect(cmd).To(ContainSubstring("Downloading model from S3"))
 		Expect(cmd).To(ContainSubstring("Model downloaded successfully"))
 		Expect(cmd).To(ContainSubstring("Model already cached, skipping download"))
+		Expect(cmd).To(ContainSubstring(`-o "$MODEL_PATH.tmp"`))
+		Expect(cmd).To(ContainSubstring(`&& mv "$MODEL_PATH.tmp" "$MODEL_PATH"`))
 	})
 
 	It("should emit the --aws-sigv4 curl line for s3 source without cache", func() {
@@ -41,12 +43,31 @@ var _ = Describe("buildModelInitCommand (s3)", func() {
 		Expect(cmd).To(ContainSubstring("Downloading model from S3"))
 		Expect(cmd).To(ContainSubstring("Model downloaded successfully"))
 		Expect(cmd).To(ContainSubstring("Model already exists, skipping download"))
+		Expect(cmd).To(ContainSubstring(`-o "$MODEL_PATH.tmp"`))
+		Expect(cmd).To(ContainSubstring(`&& mv "$MODEL_PATH.tmp" "$MODEL_PATH"`))
 	})
 
 	It("should NOT emit --aws-sigv4 for non-s3 source", func() {
 		cmd := buildModelInitCommand(false, false, true, "")
 		Expect(cmd).ToNot(ContainSubstring("aws-sigv4"))
-		Expect(cmd).To(ContainSubstring("curl -f -L -o \"$MODEL_PATH\" \"$MODEL_SOURCE\""))
+		Expect(cmd).To(ContainSubstring(`curl -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH"`))
+	})
+
+	// A truncated transfer must never be published at $MODEL_PATH: the guard
+	// is a bare existence check, so a non-atomic write would be cached as
+	// complete forever (#1428).
+	It("should never write the download target directly for any non-OnChange variant", func() {
+		for _, tc := range [][3]bool{
+			{false, false, true},  // https, cached
+			{false, false, false}, // https, uncached
+			{false, true, true},   // s3, cached
+			{false, true, false},  // s3, uncached
+			{true, false, true},   // local, cached
+		} {
+			cmd := buildModelInitCommand(tc[0], tc[1], tc[2], "")
+			Expect(cmd).ToNot(ContainSubstring(`-o "$MODEL_PATH" `), cmd)
+			Expect(cmd).ToNot(ContainSubstring(`cp /host-model/model.gguf "$MODEL_PATH" `), cmd)
+		}
 	})
 
 	It("should emit the --aws-sigv4 curl line for s3 source with OnChange refresh", func() {


### PR DESCRIPTION
## What

Make every non-`OnChange` model transfer publish atomically: download (or `cp`) to `"$MODEL_PATH.tmp"` / `"$dest.tmp"` and `mv` onto the final path on success. Covers the single-file https/S3/local branches (cached and uncached) in `buildModelInitCommand` and the multi-file `IfNotPresent` loop in `buildMultiFileInitCommand`.

## Why

The default init scripts wrote transfers straight to `$MODEL_PATH` behind a bare `[ ! -f ]` existence check. `curl -o` creates the destination at transfer start, so an init container interrupted mid-pull (OOM-kill, eviction, node reboot) leaves a truncated file that every subsequent restart reports as "Model already cached, skipping download" — and the runtime container then crash-loops on a corrupt model until someone clears the cache PVC by hand. Hit in practice: an interrupted GGUF pull left llama.cpp failing with "model is corrupted or incomplete" across restarts.

The `RefreshPolicy=OnChange` scripts already fixed exactly this in #1309 (`.tmp` + atomic `mv`, with a comment explaining that bare `curl -o` "destroys the good cache"); this applies the same publish pattern to the remaining branches.

Fixes #1428

## How

String-level change to the generated shell only; no controller logic touched. A failed transfer leaves at most a `.tmp` file, which the existence check ignores and the next attempt overwrites. Multi-file loop keeps its fail-fast `|| { …; exit 1; }` semantics (`a && b || c` runs the handler if either the download or the rename fails).

Tests: existing assertions updated to the atomic form, plus a new case asserting no non-`OnChange` variant writes the download target directly. Mutation-checked: reverting the cached-https branch to direct `-o "$MODEL_PATH"` fails the suite.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally for the affected packages (`internal/controller`, `api/...`; the only failures in a full run are 2 pre-existing `pkg/foreman/agent/tools` cases that fail identically on the untouched base commit — a local git incompatibility in that test harness, unrelated to this change)
- [x] `make lint` and `make lint-all` pass locally (6 pre-existing staticcheck findings in `pkg/foreman/agent` tests, identical on the base commit; nothing from this change)
- [x] Commit messages follow conventional commits

---
Assisted-by: Claude (Anthropic). Investigated, verified, and reviewed by a human.
