### PR TITLE
docs(chart): dashboard datasources examples must use the datasource UID, not its display name

### DIFF
--- a/charts/llmkube/README.md
+++ b/charts/llmkube/README.md
@@ -268,8 +268,12 @@ desired state`), so an upgrade that flips it to `false` fails until the CRs are
 deleted.
 
 `operator.datasources` is a literal `${inputName}` -> `datasourceName` replace
-over the dashboard JSON before it reaches Grafana. Most of the shipped
-dashboards read their datasource from a `DS_PROMETHEUS` template variable;
+over the dashboard JSON before it reaches Grafana. `datasourceName` must be the
+datasource **UID**, not its display name: the placeholder sits inside the
+dashboards' `"uid"` fields, so a display name lands verbatim as a uid that
+resolves to nothing and every panel silently renders "datasource not found"
+(unless the UID happens to equal the name). Most of the shipped dashboards read
+their datasource from a `DS_PROMETHEUS` template variable;
 `amd-gpu-observability.json` uses one named `datasource`. None of them declares
 a dashboard `__inputs` block, so both names are plain template variables and
 covering every dashboard takes two entries:
@@ -285,9 +289,9 @@ grafana:
           dashboards: grafana
       datasources:
         - inputName: DS_PROMETHEUS
-          datasourceName: VictoriaMetrics
+          datasourceName: prometheus-uid # the datasource's UID, not its name
         - inputName: datasource
-          datasourceName: VictoriaMetrics
+          datasourceName: prometheus-uid
 ```
 
 The two dashboards under `config/grafana/` are not part of the chart and stay

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -311,9 +311,14 @@ grafana:
       # CRD default (5m).
       resyncPeriod: ""
       # Literal ${inputName} -> datasourceName replace over the dashboard JSON.
+      # datasourceName must be the datasource UID, not its display name: the
+      # placeholder sits inside the dashboards' "uid" fields, so a display name
+      # lands verbatim as a uid that resolves to nothing and every panel
+      # silently renders "datasource not found" (unless the UID happens to
+      # equal the name).
       #   datasources:
       #     - inputName: DS_PROMETHEUS
-      #       datasourceName: VictoriaMetrics
+      #       datasourceName: prometheus-uid
       datasources: []
 
 # Pyrra SLO integration. When enabled, the operator renders a Pyrra


### PR DESCRIPTION
## What

Docs-only: the `grafana.dashboards.operator.datasources` examples in values.yaml and the chart README now use a UID-shaped value and state the constraint, instead of the display-name example (`datasourceName: VictoriaMetrics`).

## Why

grafana-operator's `resolveDatasources` does a literal `${inputName}` → value `ReplaceAll` over the dashboard JSON, and the shipped dashboards (schemaVersion 39, no `__inputs`) carry the placeholder inside `"uid"` fields — so the configured value lands verbatim as a datasource **UID**. Following the documented display-name example silently blanks every panel of every dashboard on any Grafana where a datasource's UID differs from its name (ours: name=`Mimir`, uid=`prom`; the documented form would have produced eight dead dashboards — caught pre-merge by inspecting the substituted JSON).

Fixes #1430

## How

Comment/README text only; no template or values-shape change. The test fixtures in `tests/dashboards_test.yaml` keep their existing placeholder value since they assert pass-through rendering, not datasource semantics.

## Checklist

- [ ] Tests added/updated (docs-only; `helm unittest` still 60/60, `helm template` clean)
- [x] `make test` passes locally (no Go change)
- [x] `make lint` passes locally (6 pre-existing staticcheck findings in `pkg/foreman/agent` tests, identical on the base commit; nothing from this change)
- [x] Commit messages follow conventional commits

---
Assisted-by: Claude (Anthropic). Investigated, verified, and reviewed by a human; the blank-dashboard failure mode was reproduced against a live grafana-operator v5 install.
