### PR TITLE
test(chart): use a uid-shaped datasourceName in the dashboards fixture

### DIFF
--- a/charts/llmkube/tests/dashboards_test.yaml
+++ b/charts/llmkube/tests/dashboards_test.yaml
@@ -157,7 +157,7 @@ tests:
       grafana.dashboards.operator.enabled: true
       grafana.dashboards.operator.datasources:
         - inputName: DS_PROMETHEUS
-          datasourceName: VictoriaMetrics
+          datasourceName: prometheus-uid
     documentSelector:
       path: metadata.name
       value: RELEASE-NAME-llmkube-llmkube-slo
@@ -166,7 +166,7 @@ tests:
           path: spec.datasources
           content:
             inputName: DS_PROMETHEUS
-            datasourceName: VictoriaMetrics
+            datasourceName: prometheus-uid
 
   - it: should render no CRs when the operator is enabled but dashboards are off
     set:


### PR DESCRIPTION
## What

The one spot the #1433 sweep missed, per the review there: the `dashboards_test.yaml` fixture still demonstrated `datasourceName: VictoriaMetrics` — the display-name shape that PR's docs now warn against. Switched to a uid-shaped value.

## Why

Functionally identical (the assertion only checks pass-through into `GrafanaDashboard.spec.datasources`), but a fixture is a plausible place for someone to copy a pattern from, so it shouldn't model the misleading shape.

Follow-up to #1433 (merged before this could be folded in). Review context: https://github.com/defilantech/LLMKube/pull/1433#pullrequestreview (Defilan's approval note).

## How

Value-only change in the fixture and its matching assertion. `helm unittest`: 60/60.

## Checklist

- [x] Tests added/updated (fixture value only)
- [x] `make test` passes locally (no Go change; `helm unittest` 60/60)
- [x] `make lint` n/a (no Go change)
- [x] Commit messages follow conventional commits

---
Assisted-by: Claude (Anthropic).
