### PR TITLE
feat(chart): expose --ca-cert-configmap as controllerManager.caCertConfigMap

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -95,6 +95,9 @@ spec:
         {{- with .Values.controllerManager.routerProxy.defaultLiteLLMURL }}
         - --default-litellm-url={{ . }}
         {{- end }}
+        {{- with .Values.controllerManager.caCertConfigMap }}
+        - --ca-cert-configmap={{ . }}
+        {{- end }}
         {{- /* Nil-safe at every level: with helm upgrade --reuse-values the
              chart defaults are NOT merged, so a release whose stored values
              predate the gpuSharing block would nil-pointer on a chained

--- a/charts/llmkube/tests/ca-cert-configmap_test.yaml
+++ b/charts/llmkube/tests/ca-cert-configmap_test.yaml
@@ -1,0 +1,18 @@
+suite: ca-cert-configmap operator flag
+templates:
+  - deployment.yaml
+
+tests:
+  - it: does not render --ca-cert-configmap when the value is empty (default)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --ca-cert-configmap=
+
+  - it: renders --ca-cert-configmap when a ConfigMap name is set
+    set:
+      controllerManager.caCertConfigMap: my-ca-bundle
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --ca-cert-configmap=my-ca-bundle

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -109,6 +109,7 @@
             "additionalProperties": true
           }
         },
+        "caCertConfigMap": { "type": "string" },
         "routerProxy": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -93,6 +93,11 @@ controllerManager:
   # Additional environment variables
   env: []
 
+  # Name of a ConfigMap (in the operator's namespace) holding a CA bundle for
+  # model downloads from endpoints signed by a private CA. Mounted into the
+  # model-downloader init container at /custom-certs.
+  caCertConfigMap: ""
+
   # Default container image for ModelRouter-managed router-proxy pods.
   # Per-ModelRouter spec.proxy.image overrides this for individual routers.
   # The router-proxy is a lightweight HTTP server that fronts


### PR DESCRIPTION
## What

Adds `controllerManager.caCertConfigMap` to the chart, rendering `--ca-cert-configmap` on the controller when set.

## Why

The operator has supported the flag for a while: `cmd/main.go` defines it, it reaches the reconciler as `CACertConfigMap`, and `addCACertVolume` mounts the named ConfigMap at `/custom-certs` and exports `CURL_CA_BUNDLE` for the model-downloader init container, wired into all three storage paths.

The chart could not set it. `templates/deployment.yaml` renders a fixed args list and there is no `extraArgs` hatch on the controller container, so a chart-installed operator could never be told about a private CA and every model pull over https against an internal endpoint failed TLS verification.

Fixes #1439

## How

Three small pieces plus the schema:

- `values.yaml`: `controllerManager.caCertConfigMap`, defaulting to `""`
- `templates/deployment.yaml`: `{{- with }}` block rendering the arg only when set, matching the surrounding flags
- `values.schema.json`: declares the new key
- `tests/ca-cert-configmap_test.yaml`: asserts the arg renders when set and is absent by default

The schema entry is not incidental. `controllerManager` sets `additionalProperties: false`, so adding the value without declaring it makes Helm reject it and **every** suite in the chart errors, not just the new one. Measured: 72 errored / 0 passed without it, against 70 passing on `main`.

## Testing

```
helm unittest charts/llmkube
Tests:  72 passed, 72 total     # 70 on main + the 2 added here
```

Bite-checked rather than assumed: deleting the `{{- with }}` block from the template fails exactly `renders --ca-cert-configmap when a ConfigMap name is set` and nothing else, so the test genuinely covers the behaviour.

No Go changes. The flag, the reconciler field, and `addCACertVolume` all already exist.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (chart-only change; `helm unittest` 72/72)
- [x] `make lint` passes locally (no Go changes)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance disclosed below
- [x] Documentation updated (the value carries an explanatory comment)

## AI assistance

The chart change, template conditional, and unit test were produced by the Foreman agentic-coding harness (Qwopus3.6-27B-Fusion coder on Strix). I reviewed the diff, found it omitted the `values.schema.json` declaration and so broke the whole chart suite, added that entry, and verified 72/72 plus a mutation check on the new test before submitting. Band-3 disclosure per CONTRIBUTING.md.