### PR TITLE
fix(foreman): add chart validation to the coder gate, and install helm so it can run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,11 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet setup-envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
+.PHONY: test-chart
+test-chart: ## Lint and unit-test the Helm charts (requires helm + helm-unittest plugin).
+	helm lint charts/llmkube charts/foreman
+	helm unittest charts/llmkube charts/foreman
+
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # CertManager is installed by default; skip with:

--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -88,6 +88,48 @@ spec:
               echo "=== {{ firstLine . }} ==="; ( {{ indentShell . }} ) || rc=1
               {{- end }}
               {{- else }}
+              {{- if .HelmVersion }}
+              # helm + helm-unittest for the chart checks (#1441). The gate
+              # image is a plain golang image with no helm, so a chart check
+              # would fail with "helm: command not found" without this.
+              #
+              # This deliberately mirrors .github/workflows/helm-chart.yml
+              # rather than using `helm plugin install`, for the reason that
+              # workflow documents: helm 3.x has no --verify skip and the
+              # runner has no GPG keyring, and the plugin's plugin.yaml
+              # carries `platformHooks`, a field added after 3.13 that older
+              # loaders reject outright ("unknown field platformHooks", which
+              # makes the next `helm plugin list` hard-fail). So: fetch the
+              # tarball, unpack into HELM_PLUGINS, strip the field.
+              #
+              # Versions are pinned to CI's so the gate and CI validate charts
+              # with the same tooling; a gate that disagrees with CI is worse
+              # than no gate.
+              #
+              # Installed under the gate cache PVC (/cache/bin, and the plugin
+              # under XDG_DATA_HOME=/cache/xdg), so a warm cache makes this a
+              # no-op. Cold it is ~17MB and a few seconds, against a run that
+              # already fetches golangci-lint, controller-gen and envtest.
+              export PATH="/cache/bin:$PATH"
+              mkdir -p /cache/bin
+              if ! command -v helm >/dev/null 2>&1; then
+                echo "=== install helm {{ .HelmVersion }} ==="
+                curl -sSfL "https://get.helm.sh/helm-{{ .HelmVersion }}-linux-amd64.tar.gz" -o /tmp/helm.tgz \
+                  && tar -xzf /tmp/helm.tgz -C /tmp \
+                  && install /tmp/linux-amd64/helm /cache/bin/helm \
+                  || { echo "GATE FAIL: helm install"; exit 1; }
+              fi
+              if ! helm plugin list 2>/dev/null | grep -qi unittest; then
+                echo "=== install helm-unittest {{ .HelmUnittestVersion }} ==="
+                PLUGIN_DIR="$(helm env HELM_PLUGINS)/unittest"
+                rm -rf "$PLUGIN_DIR"; mkdir -p "$PLUGIN_DIR"
+                curl -fsSL "https://github.com/helm-unittest/helm-unittest/releases/download/v{{ .HelmUnittestVersion }}/unittest-{{ .HelmUnittestVersion }}.tgz" \
+                  | tar -xz -C "$PLUGIN_DIR" --strip-components=1 \
+                  || { echo "GATE FAIL: helm-unittest download"; exit 1; }
+                sed -i '/platformHooks/,$d' "$PLUGIN_DIR/plugin.yaml"
+                helm plugin list >/dev/null 2>&1 || { echo "GATE FAIL: helm-unittest unusable"; exit 1; }
+              fi
+              {{- end }}
               {{- range .Checks }}
               echo "=== make {{ . }} ==="; make {{ . }} || rc=1
               {{- end }}

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -65,7 +65,39 @@ const MaxLogTailBytes = 32 * 1024
 // pipeline ran across hundreds of coder-to-verifier runs.
 var DefaultGateChecks = []string{
 	"fmt", "vet", "lint", "test",
-	"manifests", "chart-crds", "foreman-chart-crds", "test-chart",
+	"manifests", "chart-crds", "foreman-chart-crds", ChartCheck,
+}
+
+// ChartCheck is the make target that lints and unit-tests the Helm charts.
+// Named because the Job has to know whether to install helm before running
+// the checks: the gate image is a plain golang image with no helm in it.
+const ChartCheck = "test-chart"
+
+// Pinned so a helm or plugin release cannot silently change gate behavior.
+// HelmUnittestVersion matches .github/workflows/helm-chart.yml so the gate
+// and CI validate charts with the same tool.
+const (
+	HelmVersion         = "v3.13.0"
+	HelmUnittestVersion = "1.1.1"
+)
+
+// helmVersionFor returns the pinned helm version when the checks need it, and
+// "" otherwise so the template skips the install entirely on Go-only runs.
+func helmVersionFor(checks []string) string {
+	if needsHelm(checks) {
+		return HelmVersion
+	}
+	return ""
+}
+
+// needsHelm reports whether any requested check requires helm on PATH.
+func needsHelm(checks []string) bool {
+	for _, c := range checks {
+		if c == ChartCheck {
+			return true
+		}
+	}
+	return false
 }
 
 // RunGateJobToolConfig is the static configuration the foreman-agent
@@ -271,6 +303,8 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 		Branch:                  a.Branch,
 		BaseBranch:              a.BaseBranch,
 		Checks:                  a.Checks,
+		HelmVersion:             helmVersionFor(a.Checks),
+		HelmUnittestVersion:     HelmUnittestVersion,
 		BiteCheck:               a.BiteCheck,
 		Generic:                 a.Generic,
 		Commands:                a.Commands,
@@ -425,13 +459,17 @@ func upstreamURLSafe(s string) bool {
 // @ <branch> ===") so an operator scanning Pod logs sees what was
 // being verified, regardless of where the branch physically lives.
 type rendererInput struct {
-	Name                    string
-	Namespace               string
-	Image                   string
-	Repo                    string
-	Branch                  string
-	BaseBranch              string
-	Checks                  []string
+	Name       string
+	Namespace  string
+	Image      string
+	Repo       string
+	Branch     string
+	BaseBranch string
+	Checks     []string
+	// HelmVersion is non-empty only when a chart check was requested; the
+	// template installs helm and the unittest plugin when it is set.
+	HelmVersion             string
+	HelmUnittestVersion     string
 	BiteCheck               bool
 	Generic                 bool
 	Commands                []string

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -65,7 +65,7 @@ const MaxLogTailBytes = 32 * 1024
 // pipeline ran across hundreds of coder-to-verifier runs.
 var DefaultGateChecks = []string{
 	"fmt", "vet", "lint", "test",
-	"manifests", "chart-crds", "foreman-chart-crds",
+	"manifests", "chart-crds", "foreman-chart-crds", "test-chart",
 }
 
 // RunGateJobToolConfig is the static configuration the foreman-agent

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -327,6 +327,23 @@ func TestApplyConfigDefaults_FillsEveryField(t *testing.T) {
 	}
 }
 
+// TestDefaultGateChecks_ContainsTestChart asserts that the chart validation
+// target is present in DefaultGateChecks so a future refactor cannot silently
+// drop it. Regression for #1441: a chart-only change that broke every helm
+// test still returned GATE-PASS because no chart check existed.
+func TestDefaultGateChecks_ContainsTestChart(t *testing.T) {
+	found := false
+	for _, c := range DefaultGateChecks {
+		if c == "test-chart" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DefaultGateChecks missing test-chart: %v", DefaultGateChecks)
+	}
+}
+
 func TestSanitizeName(t *testing.T) {
 	cases := map[string]string{
 		"issue-503-foo": "issue-503-foo",

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -1164,3 +1164,58 @@ func TestRenderGateJob_SingleLineCommandUnchanged(t *testing.T) {
 		t.Error("single-line command must not gain an ellipsis")
 	}
 }
+
+// TestGateJobInstallsHelmOnlyForChartChecks pins the #1441 fix. The gate image
+// is a plain golang image with no helm, so rendering the chart check without
+// installing helm turns every gate run into "helm: command not found". The
+// install must appear when a chart check is requested and must NOT appear
+// otherwise, so Go-only branches do not pay for a download they cannot use.
+func TestGateJobInstallsHelmOnlyForChartChecks(t *testing.T) {
+	render := func(checks []string) string {
+		job, err := renderGateJob(rendererInput{
+			Name: "g", Namespace: "foreman-system", Image: "golang:1.26",
+			Repo: "o/r", Branch: "b", BaseBranch: "main", Checks: checks,
+			PVCName: "foreman-gate-cache", CloneURLBase: "https://github.com",
+			ActiveDeadlineSeconds: 1800, TTLSecondsAfterFinished: 86400,
+			CPURequest: "1", CPULimit: "2", MemRequest: "1Gi", MemLimit: "2Gi",
+			HelmVersion: helmVersionFor(checks), HelmUnittestVersion: HelmUnittestVersion,
+		})
+		if err != nil {
+			t.Fatalf("renderGateJob: %v", err)
+		}
+		return strings.Join(job.Spec.Template.Spec.Containers[0].Args, "\n")
+	}
+
+	withChart := render([]string{"test", ChartCheck})
+	if !strings.Contains(withChart, "install helm "+HelmVersion) {
+		t.Error("chart check requested but the helm install is missing; the gate image has no helm")
+	}
+	// The plugin is fetched as a pinned tarball rather than via
+	// `helm plugin install`, mirroring CI; assert on the pinned URL.
+	if !strings.Contains(withChart, "unittest-"+HelmUnittestVersion+".tgz") {
+		t.Errorf("helm-unittest tarball not pinned to %s", HelmUnittestVersion)
+	}
+	// platformHooks must be stripped or the 3.x plugin loader rejects the
+	// plugin and the next `helm plugin list` hard-fails.
+	if !strings.Contains(withChart, "platformHooks") {
+		t.Error("plugin.yaml platformHooks strip is missing; helm 3.x will reject the plugin")
+	}
+
+	goOnly := render([]string{"fmt", "vet", "test"})
+	if strings.Contains(goOnly, "install helm") {
+		t.Error("helm installed for a Go-only run; the install must be conditional")
+	}
+}
+
+// TestNeedsHelm covers the predicate directly.
+func TestNeedsHelm(t *testing.T) {
+	if !needsHelm([]string{"fmt", ChartCheck}) {
+		t.Error("needsHelm should be true when the chart check is present")
+	}
+	if needsHelm([]string{"fmt", "vet", "lint", "test"}) {
+		t.Error("needsHelm should be false without a chart check")
+	}
+	if !needsHelm(DefaultGateChecks) {
+		t.Error("DefaultGateChecks must include the chart check (#1441)")
+	}
+}


### PR DESCRIPTION
## What

Adds a `test-chart` make target (`helm lint` + `helm unittest` over both charts), puts it in `DefaultGateChecks`, and installs helm in the gate Job so the check can actually execute.

Fixes #1441

## Why

`DefaultGateChecks` was Go-only. Its three chart-*named* checks (`manifests`, `chart-crds`, `foreman-chart-crds`) regenerate CRDs into the chart and assert no drift; none renders the chart, resolves values against `values.schema.json`, or runs the chart's own tests.

Measured on a real coder branch (#1440): a chart-only change that broke **every** helm test still returned GATE-PASS after 318s of checks.

| ref | `helm unittest charts/llmkube` |
|---|---|
| `main` | 70 passed |
| that branch | 72 failed, 72 errored, 0 passed |

## How

**`make test-chart`** runs `helm lint` and `helm unittest` over `charts/llmkube` and `charts/foreman`, added to `DefaultGateChecks`.

**The gate Job installs helm.** This is the part that makes the check real rather than decorative: the gate image is `golang:1.26`, which has no helm and no unittest plugin. I verified this directly against the running gate image, and without the install the new check fails with `helm: command not found` on *every* gate run, Go-only branches included, which would be worse than the bug being fixed.

The install deliberately mirrors `.github/workflows/helm-chart.yml` instead of using `helm plugin install`, for the reason that workflow already documents: helm 3.x cannot skip signature verification, and the plugin's `plugin.yaml` carries `platformHooks`, a field added after 3.13 that older loaders reject. Confirmed empirically in the gate image:

```
$ helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.1.1
Error: plugin is installed but unusable: failed to load plugin at
".../plugin.yaml": error unmarshaling JSON: unknown field "platformHooks"
```

So it fetches the pinned tarball, unpacks into `$(helm env HELM_PLUGINS)`, and strips the field, exactly as CI does.

Versions are pinned to CI's (`helm v3.13.0`, `unittest 1.1.1`) so the gate and CI validate charts with the same tooling. A gate that disagrees with CI is worse than no gate.

The binary and plugin land on the existing gate cache PVC (`/cache/bin`, `XDG_DATA_HOME=/cache/xdg`), so a warm cache makes this a no-op. The install renders **only when a chart check is requested**, so Go-only runs pay nothing.

## Testing

End-to-end in the actual gate image (`golang:1.26`), cloning this branch and running the real check:

```
install OK in 3s
=== make test-chart ===
Charts:      2 passed, 2 total
Test Suites: 8 passed, 8 total
Tests:       102 passed, 102 total
```

3 seconds against a gate run that already spends minutes fetching golangci-lint, controller-gen and the envtest binaries.

Unit tests: `TestGateJobInstallsHelmOnlyForChartChecks` asserts the install renders for chart checks, does **not** render for Go-only checks, pins the tarball version, and keeps the `platformHooks` strip. `TestNeedsHelm` covers the predicate and that `DefaultGateChecks` contains the chart check. Both bite-checked: deleting the install block from the template fails the first test and nothing else.

`go test ./pkg/foreman/agent/tools/` passes.

## Note on provenance

The `test-chart` target and the `DefaultGateChecks` entry came from the Foreman coder (Qwopus3.6-27B-Fusion on Strix), which returned GO and GATE-PASS. That GATE-PASS could not have meant anything: `DefaultGateChecks` is compiled into the agent binary, so the gate verifying the branch ran the *old* check list. It was structurally incapable of testing its own change. The missing helm install was found by probing the gate image by hand.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance disclosed above
- [x] Documentation updated (the template and target carry the rationale inline)

## AI assistance

Assisted-by: Foreman harness (coder) for the make target and check-list entry; Claude Code for the gate-image investigation, the CI-mirroring install, the tests, and the end-to-end verification. I reviewed and ran everything before submitting.