### PR TITLE
fix(dashboard): select the latency success series by le!="" so llmkube-slo error-budget panels render for any threshold

### DIFF
--- a/charts/llmkube/dashboards/llmkube-slo.json
+++ b/charts/llmkube/dashboards/llmkube-slo.json
@@ -69,7 +69,7 @@
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "1 - ((1 - actual on-time fraction over the SLO's window) / (1 - objective)), using Pyrra's vllm:e2e_request_latency_seconds:increase${window_suffix} recording rule (latency indicator; the le=\"2\" series is the fast/good count, the le=\"\" series is the total count). Set the `objective` variable to this SLO's spec.slo.objective first. Latency SLOs are vllm-runtime only.",
+      "description": "1 - ((1 - actual on-time fraction over the SLO's window) / (1 - objective)), using Pyrra's vllm:e2e_request_latency_seconds:increase${window_suffix} recording rule (latency indicator; the le!=\"\" series is the fast/good count, the le=\"\" series is the total count). Set the `objective` variable to this SLO's spec.slo.objective first. Latency SLOs are vllm-runtime only.",
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
@@ -99,7 +99,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "1 - ((1 - (vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le=\"2\"} / ignoring(le) vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le=\"\"})) / (1 - $objective/100))",
+          "expr": "1 - ((1 - (vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le!=\"\"} / ignoring(le) vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le=\"\"})) / (1 - $objective/100))",
           "legendFormat": "{{slo}}",
           "refId": "A"
         }
@@ -153,7 +153,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "1 - ((1 - (vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le=\"2\"} / ignoring(le) vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le=\"\"})) / (1 - $objective/100))",
+          "expr": "1 - ((1 - (vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le!=\"\"} / ignoring(le) vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le=\"\"})) / (1 - $objective/100))",
           "legendFormat": "{{slo}}",
           "refId": "A"
         }
@@ -287,7 +287,7 @@
         },
         {
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le=\"2\"} / ignoring(le) vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le=\"\"}",
+          "expr": "vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le!=\"\"} / ignoring(le) vllm:e2e_request_latency_seconds:increase${window_suffix}{slo=~\"$slo\", le=\"\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",


### PR DESCRIPTION
Fixes #1445.

## What was wrong

Three panels in `llmkube-slo.json` selected Pyrra's latency *success* series with a hardcoded `le="2"` — both "Latency error budget remaining" panels and the "SLO overview" table. Pyrra puts the SLO's own threshold in that label, so those panels showed **No data** for every SLO whose `spec.slo.latencyThreshold` was not exactly `2`, while the burn-rate panels populated normally from the same SLO.

Declaring `"2"` was not a workaround on every image. The threshold must also match a bucket boundary the runtime emits, and vLLM builds that render integer boundaries with a decimal emit `le="2.0"` — so the SLO has to declare `"2.0"` to record anything, and `"2.0"` is then what lands in the rule label, which `le="2"` misses.

## The change

```diff
-{slo=~"$slo", le="2"} / ignoring(le) {slo=~"$slo", le=""}
+{slo=~"$slo", le!=""} / ignoring(le) {slo=~"$slo", le=""}
```

Three expressions plus the panel description that documented the old matcher. Nothing else.

`le!=""` is correct rather than merely convenient, and the reason is in Pyrra's own rule generation:

- Per SLO, `…:increase<window>` carries exactly **two** series — the total at `le=""` and the success series at the threshold. That is stated in `slo/rules.go:1100-1106`: *"the total series has no `le` while the success series carries the threshold bucket (e.g. `le="60.0"`)"*. So `le!=""` is single-match by construction and pairs with the existing `ignoring(le)` denominator unchanged.
- The threshold's formatting is not even consistent within Pyrra: the classic `latency` indicator copies the label verbatim from the success matcher (`slo/rules.go:1034-1041`), while `latencyNative` formats it with `%g`, turning `1.0` into `1` (`slo/rules.go:1246`). A dashboard cannot know which applies, so it should not try.
- It still works with the multi-value `$slo` variable, since each SLO pairs with its own total.

A `label_values(…, le)` template variable would also fix the immediate bug, but it would force a single threshold across all selected SLOs, so this seemed strictly better. Happy to switch if you prefer the threshold visible in the UI.

Burn-rate panels are untouched — they select on `slo=` only and were never affected. They are also what suggested the fix.

## Verification

- `helm unittest charts/llmkube -f 'tests/dashboards_test.yaml'` — 20/20 pass.
- `go test ./internal/metrics/...` (the dashboard-sync suite) — pass.
- `make lint` — 0 issues, on this branch rebased onto current `main` (606c7f9).
- `make test` — the two `pkg/foreman/agent/tools` reconcile tests (`TestRunReconcile_CleanIsGatePass`, `TestRunReconcile_DriftIsGateFail`) fail in my clone with `pathspec 'FETCH_HEAD' did not match any file(s)`. I confirmed they fail identically on pristine `origin/main` with my change stashed, so it is environmental in my clone and unrelated. Everything else passes.
- **Both selectors run against the real recorded series** (detail below), so the fix is confirmed on data rather than by reading the generator.

## Verified against the recorded series

Rather than rebuild the workload, I ran the old and new selectors against the series Pyrra actually recorded during the original investigation, which are still inside Mimir's retention. The panel *is* this query, and those series are its only input.

The recorded series for one latency SLO — which also shows the two-series contract in the wild, and that the classic indicator preserves the declared string (`1.0`, not `%g`-normalized to `1`):

```
vllm:e2e_request_latency_seconds:increase4w{slo="vllm-lat-latency", le="0.5", namespace="default", service="vllm-lat"}
vllm:e2e_request_latency_seconds:increase4w{slo="vllm-lat-latency", le="1.0", namespace="default", service="vllm-lat"}   # after re-patching the threshold
vllm:e2e_request_latency_seconds:increase4w{slo="vllm-lat-latency",          namespace="default", service="vllm-lat"}   # total
```

Note the total carries **no** `le` label at all rather than an empty one. `le=""` still selects it, because absent and empty are the same thing to a PromQL matcher — which is why the denominator has always worked and why `le!=""` cleanly excludes it.

Old versus new, at the two instants where the increase rule had samples:

| selector | t = 15:07 (threshold `0.5`) | t = 15:12 (threshold `1.0`) |
| --- | --- | --- |
| `le="2"` (current) | 0 series — No data | 0 series — No data |
| `le!=""` (this PR) | 1 series, `0.2785` | 1 series, `0.9812` |

Feeding those through the panel's own formula with `objective=95` yields `-13.43` and `+0.6237` — an error budget of -1343% and then +62%. Both match the values I derived by hand during the original investigation (27.8% of requests under 0.5s on a contended GPU; 98.1% under 1.0s). So the panels do not merely render, they render the right number.

One nuance this surfaced, worth stating rather than burying: changing `latencyThreshold` leaves the previous series in the TSDB, so two non-empty `le` series can exist for one SLO. They can only overlap for as long as the staleness lookback, and I could not produce a multi-match from this data — the closest instant I could construct, exactly one lookback after the `0.5` sample, still returned a single series. If you would rather be defensive about that transient than rely on staleness, I can wrap the numerator, but adding machinery for a few minutes right after a deliberate spec change seemed like the wrong trade.

Assisted-by: Claude Code (drafted the dashboard edit, this description, and #1443 from my live findings; I reviewed the Pyrra source citations line by line, ran the chart and Go test suites and `make lint` myself, and confirmed the unrelated `make test` failures reproduce on a clean tree).
