### PR TITLE
fix: ground the PR body summary against the branch diff

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -734,6 +734,12 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// (GO=APPROVE / NO-GO=REQUEST-CHANGES) is the authoritative
 		// signal regardless of findings validity (see pkg/foreman/agent/
 		// reviewer/findings.go for the schema).
+		//
+		// Declared out here so the PR-body summary grounding (#1411) can
+		// reuse the same base + name-only diff the reviewer rails ran on
+		// instead of resolving and shelling out for them a second time.
+		var reviewBase string
+		var reviewDiff []string
 		if agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer &&
 			loopRes.Terminal != nil {
 			// Ground-truth filesTouched against the actual diff before
@@ -747,7 +753,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// reviewer clones the fork, whose local `main` lags upstream, so
 			// diffing against local `main` sweeps in the whole intervening
 			// upstream delta and neuters every rail (#1005).
-			reviewBase := e.reviewerDiffBase(ctx, log, task, workspace)
+			reviewBase = e.reviewerDiffBase(ctx, log, task, workspace)
 			reconcileReviewerFilesTouched(ctx, log, workspace, reviewBase, loopRes.Terminal.Extra)
 			// Ground-truth issueAsk against the fetch_issue tool result
 			// the model already had in its context. Devstral on the same
@@ -760,7 +766,8 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			reconcileReviewerIssueAsk(log, loopRes.Transcript, loopRes.Terminal.Extra)
 			// Ground-truth the branch diff ONCE for the two computable rails
 			// below (grounded-finding + scope-overlap).
-			reviewDiff, reviewDiffErr := repo.DiffNameOnly(ctx, workspace, reviewBase)
+			var reviewDiffErr error
+			reviewDiff, reviewDiffErr = repo.DiffNameOnly(ctx, workspace, reviewBase)
 			// Grounded-finding rail: a NO-GO must be earned by >=1 blocking
 			// finding citing a line the diff changed; otherwise demote it to GO
 			// and archive the rejected findings. Mirror of scope-overlap, in the
@@ -810,7 +817,8 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// INCOMPLETE (this is NOT a GO); we only commit + push the branch and
 		// record it under r.Extra. Coder-role only (reviewers are read-only).
 		e.maybePreserveGateFailedBranch(ctx, log, agent, task, workspace, branch, auth, loopRes, r)
-		e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r)
+		e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r,
+			workspace, reviewBase, reviewDiff)
 		// Attach the normalized failure reason from the model-to-CRD
 		// mapping (e.g. ERROR→INCOMPLETE + ModelReportedError for #649). Only
 		// set when the normalizer produced a reason AND the result does
@@ -1065,7 +1073,10 @@ func (e *NativeAgentLoopExecutor) retryCoderTerminalResult(
 ) *Result {
 	r := e.modelDecidedResult(start, tref, lr, verdict)
 	e.maybePreserveGateFailedBranch(ctx, log, agent, task, workspace, branch, auth, lr, r)
-	e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r)
+	// No reviewer rails ran on this path, so there is no resolved review base
+	// to ground the summary against; #1411's check degrades open on the empty
+	// base rather than grounding against a base it had to guess at.
+	e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r, workspace, "", nil)
 	if normReason != "" && r.FailureReason == "" {
 		r.FailureReason = normReason
 	}
@@ -1740,6 +1751,7 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 	ctx context.Context, log logr.Logger,
 	task *foremanv1alpha1.AgenticTask, auth *repo.Auth,
 	verdict foremanv1alpha1.AgenticTaskVerdict, r *Result,
+	workspace, reviewBase string, reviewDiff []string,
 ) {
 	if verdict != foremanv1alpha1.AgenticTaskVerdictGo ||
 		task.Spec.Kind != foremanv1alpha1.AgenticTaskKindReview ||
@@ -1747,7 +1759,8 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 		e.codeHost(authToken(auth)) == nil {
 		return
 	}
-	if prURL, prErr := e.openPullRequest(ctx, task, auth, r.Summary); prErr != nil {
+	body := e.groundPRSummary(ctx, log, r, workspace, reviewBase, reviewDiff)
+	if prURL, prErr := e.openPullRequest(ctx, task, auth, body); prErr != nil {
 		log.Error(prErr, "review GO: opening pull request failed",
 			"repo", task.Spec.Payload.Repo, "branch", task.Spec.Payload.Branch)
 		r.Extra["pullRequestError"] = prErr.Error()
@@ -1756,6 +1769,48 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 			"repo", task.Spec.Payload.Repo, "pr", prURL)
 		r.Extra["pullRequestURL"] = prURL
 	}
+}
+
+// groundPRSummary cross-checks the summary that is about to become the PR
+// description against the branch diff (#1411) and returns the prose to
+// render. Concrete claims the diff does not support get a visible note
+// appended; the model's original is archived under `extra.summaryClaimed`
+// alongside the claims that failed, mirroring `issueAskClaimed` (#644).
+//
+// Note the premise correction: the summary rendered here is the
+// *reviewer's* (maybeOpenPullRequest only fires for a review-kind task and
+// passes r.Summary), not the coder's. Grounding it is still the fix --
+// the reviewer read the diff to reach GO but its prose is no more
+// ground-truthed than any other model-authored field.
+//
+// Degrades open in every direction: no diff, a git failure, or an empty
+// summary all return the model's prose untouched.
+func (e *NativeAgentLoopExecutor) groundPRSummary(
+	ctx context.Context, log logr.Logger, r *Result,
+	workspace, reviewBase string, reviewDiff []string,
+) string {
+	summary := r.Summary
+	if strings.TrimSpace(summary) == "" || workspace == "" || reviewBase == "" {
+		return summary
+	}
+	g := diffGroundTruth{
+		workspace: workspace,
+		files:     reviewDiff,
+		text:      branchDiffText(ctx, workspace, reviewBase, execCommandRunner),
+	}
+	unverified := ungroundedSummaryClaims(summary, g)
+	if len(unverified) == 0 {
+		return summary
+	}
+	body := annotateUnverifiedClaims(summary, unverified)
+	if r.Extra == nil {
+		r.Extra = map[string]any{}
+	}
+	r.Extra["summaryClaimed"] = summary
+	r.Extra["summaryUnverifiedClaims"] = unverified
+	log.Info("PR body: summary claims not found in the branch diff; annotating",
+		"claims", unverified, "base", reviewBase)
+	return body
 }
 
 // openPullRequest ensures the PR for the task's branch exists: title
@@ -1772,7 +1827,7 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 // owner — or one that is not an owner/repo-shaped URL at all (local
 // paths in tests) — keeps the same-repo shape.
 func (e *NativeAgentLoopExecutor) openPullRequest(
-	ctx context.Context, task *foremanv1alpha1.AgenticTask, auth *repo.Auth, reviewSummary string,
+	ctx context.Context, task *foremanv1alpha1.AgenticTask, auth *repo.Auth, summaryBody string,
 ) (string, error) {
 	p := task.Spec.Payload
 	owner, _, ok := codehost.SplitRepoSlug(p.Repo)
@@ -1795,10 +1850,11 @@ func (e *NativeAgentLoopExecutor) openPullRequest(
 		title = fmt.Sprintf("Fix #%d", p.Issue)
 	}
 	// Body: the reviewer's own summary of the change (it read the full diff
-	// against the issue to reach GO), then the issue link and provenance. Falls
-	// back to just the link when the reviewer returned no summary.
+	// against the issue to reach GO), already diff-grounded by groundPRSummary
+	// (#1411), then the issue link and provenance. Falls back to just the link
+	// when the reviewer returned no summary.
 	var bodyB strings.Builder
-	if s := strings.TrimSpace(reviewSummary); s != "" {
+	if s := strings.TrimSpace(summaryBody); s != "" {
 		bodyB.WriteString(s)
 		bodyB.WriteString("\n\n")
 	}

--- a/pkg/foreman/agent/executor_pr_test.go
+++ b/pkg/foreman/agent/executor_pr_test.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -111,7 +112,7 @@ func TestMaybeOpenPullRequest_Gating(t *testing.T) {
 			task := reviewTaskForPR(tc.kind, tc.openPR)
 			r := &Result{Extra: map[string]any{}}
 
-			e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil, tc.verdict, r)
+			e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil, tc.verdict, r, "", "", nil)
 
 			if called := len(fe.ensures) > 0; called != tc.wantCalled {
 				t.Fatalf("EnsurePR called=%v, want %v (calls=%+v)", called, tc.wantCalled, fe.ensures)
@@ -130,7 +131,7 @@ func TestMaybeOpenPullRequest_NilEnsurerIsDisabled(t *testing.T) {
 	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
 	r := &Result{Extra: map[string]any{}}
 	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, r)
+		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil)
 	if len(r.Extra) != 0 {
 		t.Fatalf("nil ensurer must be a no-op; extra=%+v", r.Extra)
 	}
@@ -149,7 +150,7 @@ func TestMaybeOpenPullRequest_BodyCarriesReviewSummary(t *testing.T) {
 	}
 
 	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, r)
+		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil)
 
 	if len(fe.ensures) != 1 {
 		t.Fatalf("want 1 EnsurePR call, got %+v", fe.ensures)
@@ -181,7 +182,7 @@ func TestMaybeOpenPullRequest_ForkRemoteQualifiesHead(t *testing.T) {
 	r := &Result{Extra: map[string]any{}}
 
 	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, r)
+		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil)
 
 	if len(fe.ensures) != 1 {
 		t.Fatalf("want 1 EnsurePR call, got %+v", fe.ensures)
@@ -223,7 +224,7 @@ func TestMaybeOpenPullRequest_SameRepoRemoteKeepsBareHead(t *testing.T) {
 		r := &Result{Extra: map[string]any{}}
 
 		e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-			foremanv1alpha1.AgenticTaskVerdictGo, r)
+			foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil)
 
 		if len(fe.ensures) != 1 {
 			t.Fatalf("remote %q: want 1 EnsurePR call, got %+v", remote, fe.ensures)
@@ -265,5 +266,114 @@ func TestGitRemoteOwnerRepo(t *testing.T) {
 			t.Errorf("gitRemoteOwnerRepo(%q) = %q, %q; want %q, %q",
 				tc.url, owner, name, tc.owner, tc.name)
 		}
+	}
+}
+
+// TestMaybeOpenPullRequest_BodyFlagsUngroundedClaim is the #1411 wiring
+// test: the summary that becomes the PR description is cross-checked
+// against the branch diff before it is rendered, the note lands in the
+// body a human reads, and the model's original is archived under
+// extra.summaryClaimed the way issueAskClaimed is (#644).
+func TestMaybeOpenPullRequest_BodyFlagsUngroundedClaim(t *testing.T) {
+	orig := execCommandRunner
+	t.Cleanup(func() { execCommandRunner = orig })
+	execCommandRunner = func(_ context.Context, _ string, _ []string,
+		name string, args ...string) (string, error) {
+		if name != "git" || args[0] != "diff" {
+			t.Fatalf("unexpected command %s %v", name, args)
+		}
+		return loggingDiff, nil
+	}
+
+	fe := &fakePREnsurer{subject: "feat: structured logging", url: "https://example/pr/9"}
+	e := &NativeAgentLoopExecutor{PREnsurer: fe}
+	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
+	summary := "Replaces bare `print()` calls with `logger.info()` and adds a `/health` endpoint."
+	r := &Result{Summary: summary, Extra: map[string]any{}}
+
+	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+		foremanv1alpha1.AgenticTaskVerdictGo, r, t.TempDir(), "main", []string{"bridge/app.py"})
+
+	if len(fe.ensures) != 1 {
+		t.Fatalf("want 1 EnsurePR call, got %+v", fe.ensures)
+	}
+	body := fe.ensures[0].body
+	if !strings.Contains(body, summary) {
+		t.Errorf("the reviewer's prose must survive verbatim; got %q", body)
+	}
+	if !strings.Contains(body, "Unverified claims") || !strings.Contains(body, "`/health`") {
+		t.Errorf("body must flag the ungrounded claim; got %q", body)
+	}
+	if r.Extra["summaryClaimed"] != summary {
+		t.Errorf("summaryClaimed must archive the model's original; got %v", r.Extra["summaryClaimed"])
+	}
+	claims, _ := r.Extra["summaryUnverifiedClaims"].([]string)
+	if len(claims) != 1 || claims[0] != "/health" {
+		t.Errorf("summaryUnverifiedClaims = %v, want [/health]", r.Extra["summaryUnverifiedClaims"])
+	}
+	if r.Summary != summary {
+		t.Errorf("r.Summary must stay the model's own; got %q", r.Summary)
+	}
+}
+
+// TestMaybeOpenPullRequest_GroundedSummaryUntouched: the common case. A
+// summary whose claims the diff supports renders byte-for-byte as before,
+// with no note and no summaryClaimed archive.
+func TestMaybeOpenPullRequest_GroundedSummaryUntouched(t *testing.T) {
+	orig := execCommandRunner
+	t.Cleanup(func() { execCommandRunner = orig })
+	execCommandRunner = func(_ context.Context, _ string, _ []string,
+		_ string, _ ...string) (string, error) {
+		return loggingDiff, nil
+	}
+
+	fe := &fakePREnsurer{subject: "feat: structured logging", url: "https://example/pr/10"}
+	e := &NativeAgentLoopExecutor{PREnsurer: fe}
+	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
+	summary := "Replaces bare `print()` calls in `bridge/app.py` with `logger.info()`."
+	r := &Result{Summary: summary, Extra: map[string]any{}}
+
+	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+		foremanv1alpha1.AgenticTaskVerdictGo, r, t.TempDir(), "main", []string{"bridge/app.py"})
+
+	body := fe.ensures[0].body
+	if strings.Contains(body, "Unverified claims") {
+		t.Errorf("a grounded summary must render clean; got %q", body)
+	}
+	if _, archived := r.Extra["summaryClaimed"]; archived {
+		t.Errorf("nothing to archive when the body equals the summary; extra=%+v", r.Extra)
+	}
+}
+
+// TestMaybeOpenPullRequest_NoDiffSkipsGrounding: an unresolved review base
+// (the coder-retry path) or a git failure must leave the summary alone.
+// Warning on missing ground truth would put the note on honest PRs.
+func TestMaybeOpenPullRequest_NoDiffSkipsGrounding(t *testing.T) {
+	orig := execCommandRunner
+	t.Cleanup(func() { execCommandRunner = orig })
+	execCommandRunner = func(_ context.Context, _ string, _ []string,
+		_ string, _ ...string) (string, error) {
+		return "", errors.New("fatal: bad revision")
+	}
+
+	for _, tc := range []struct{ name, workspace, base string }{
+		{"git failure", "/tmp", "main"},
+		{"no resolved base", "/tmp", ""},
+		{"no workspace", "", "main"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fe := &fakePREnsurer{subject: "feat: x", url: "https://example/pr/11"}
+			e := &NativeAgentLoopExecutor{PREnsurer: fe}
+			task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
+			summary := "Adds a `/health` endpoint."
+			r := &Result{Summary: summary, Extra: map[string]any{}}
+
+			e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+				foremanv1alpha1.AgenticTaskVerdictGo, r, tc.workspace, tc.base, nil)
+
+			if body := fe.ensures[0].body; strings.Contains(body, "Unverified claims") {
+				t.Errorf("no ground truth must mean no note; got %q", body)
+			}
+		})
 	}
 }

--- a/pkg/foreman/agent/summary_grounding.go
+++ b/pkg/foreman/agent/summary_grounding.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Summary grounding (#1411). Every other model-supplied claim in this
+// pipeline is ground-truthed before it is trusted -- filesTouched against
+// `git diff --name-only` (#582), issueAsk against the fetched issue body
+// (#644), reviewer findings against the lines the diff changed (#1166) --
+// but the summary that becomes the PR description a human reads at merge
+// time was passed through verbatim. A reviewer GO on a real, good diff
+// still shipped a body claiming "adds a /health endpoint" for a diff that
+// contained zero occurrences of "health".
+//
+// The check here is deterministic and deliberately narrow, matching the
+// rails it sits beside: extract the concrete, checkable things the summary
+// names (backticked identifiers, file paths, route-shaped strings) and
+// require each to appear somewhere in the branch diff. It is NOT a
+// semantic check and makes no attempt to decide whether the summary is a
+// fair description of the change.
+//
+// The bias throughout is against false positives. A correct summary that
+// gets flagged puts noise on every PR and trains humans to ignore the
+// note, which is strictly worse than the bug it guards. Concretely:
+//
+//   - Only backticked spans are considered. Unbackticked prose is never
+//     parsed, so ordinary English cannot trip the check.
+//   - Grounding uses the FULL diff (added, removed, and context lines,
+//     plus the file headers), not just added lines. "renamed `foo` to
+//     `bar`" therefore grounds `foo` on the removal that renamed it.
+//   - A claim with no literal hit falls back to its identifier atoms and
+//     passes if ANY atom appears. `logger.info()` grounds on `logger`.
+//   - Claim shapes that are indistinguishable from English (a bare
+//     lowercase word in backticks) are not checkable and are skipped.
+//   - Any missing input -- no diff, git error, empty summary -- skips the
+//     check entirely and preserves the model's prose.
+
+// maxListedUnverifiedClaims bounds the note appended to the PR body. A
+// summary that trips more than a handful of claims is better read as
+// "distrust the whole summary" than as a list, and an unbounded list
+// would bury the diff link under generated text.
+const maxListedUnverifiedClaims = 5
+
+var (
+	// inlineCodeRe matches a backticked span: the "quoted identifiers"
+	// the summary is claiming exist. Spans must close on the same line,
+	// so a summary truncated mid-span yields no claim.
+	inlineCodeRe = regexp.MustCompile("`([^`\n]+)`")
+
+	// fencedCodeRe strips fenced blocks before extraction: a code sample
+	// is an illustration, not a claim about the diff.
+	fencedCodeRe = regexp.MustCompile("(?s)```.*?```")
+
+	// pathClaimRe matches a slash-separated or bare filename carrying an
+	// extension: `pkg/foreman/agent/loop.go`, `README.md`.
+	pathClaimRe = regexp.MustCompile(`^[\w.@~-]+(?:/[\w.@~-]+)*\.[A-Za-z][A-Za-z0-9]{0,9}$`)
+
+	// routeClaimRe matches a route-ish string: a leading slash and no
+	// file extension. `/health`, `/api/v1/models`, `/users/{id}`.
+	routeClaimRe = regexp.MustCompile(`^/[A-Za-z0-9][A-Za-z0-9/_{}:.-]*$`)
+
+	// identClaimRe matches a single (possibly dotted) identifier with an
+	// optional call suffix: `submit_result`, `logger.info()`, `Ensurer`.
+	identClaimRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*(?:\(\))?$`)
+
+	// atomRe pulls identifier atoms out of a claim for the tolerant
+	// fallback pass. Three characters minimum: shorter atoms match
+	// everything and would ground any claim at all.
+	atomRe = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_]{2,}`)
+)
+
+// claimKind classifies an extracted backtick span. Spans that do not fall
+// into one of the checkable shapes are skipped rather than guessed at.
+type claimKind int
+
+const (
+	claimSkip claimKind = iota
+	claimPath
+	claimRoute
+	claimIdent
+)
+
+// classifySummaryClaim decides whether a backticked span is a concrete,
+// checkable claim about the change and, if so, which shape it is.
+//
+// The identifier rule is the load-bearing false-positive guard: a bare
+// lowercase word in backticks (`logging`, `health`, `tests`) is
+// indistinguishable from emphasis and is NOT checked. An identifier only
+// qualifies once it carries a code marker -- an underscore, a dot, a call
+// suffix, or an uppercase letter.
+func classifySummaryClaim(span string) (string, claimKind) {
+	c := strings.TrimSpace(span)
+	// Prose in backticks (a command line, a phrase) is not a single
+	// claim; refuse to guess which of its words the diff should contain.
+	if c == "" || strings.ContainsAny(c, " \t") {
+		return "", claimSkip
+	}
+	// Trailing sentence punctuation belongs to the prose, not the claim.
+	c = strings.TrimRight(c, ".,;:!?")
+	if c == "" {
+		return "", claimSkip
+	}
+	switch {
+	case pathClaimRe.MatchString(c):
+		return c, claimPath
+	case routeClaimRe.MatchString(c) && len(c) > 2:
+		return c, claimRoute
+	case identClaimRe.MatchString(c) && codeShapedIdent(c):
+		return c, claimIdent
+	}
+	return "", claimSkip
+}
+
+// codeShapedIdent reports whether an identifier carries a marker that
+// distinguishes it from an ordinary English word: an underscore, a dot, a
+// call suffix, or any uppercase letter.
+func codeShapedIdent(c string) bool {
+	if strings.ContainsAny(c, "_.") || strings.HasSuffix(c, "()") {
+		return true
+	}
+	return strings.ToLower(c) != c
+}
+
+// extractSummaryClaims returns the checkable claims a summary makes, in
+// first-occurrence order and deduplicated.
+func extractSummaryClaims(summary string) []string {
+	prose := fencedCodeRe.ReplaceAllString(summary, " ")
+	var claims []string
+	seen := map[string]bool{}
+	for _, m := range inlineCodeRe.FindAllStringSubmatch(prose, -1) {
+		c, kind := classifySummaryClaim(m[1])
+		if kind == claimSkip || seen[c] {
+			continue
+		}
+		seen[c] = true
+		claims = append(claims, c)
+	}
+	return claims
+}
+
+// diffGroundTruth is what a claim is checked against: the full text of
+// `git diff <base>...HEAD` plus the changed-file list, and the workspace
+// root so a path claim can be grounded on the file merely existing.
+type diffGroundTruth struct {
+	workspace string
+	text      string
+	files     []string
+}
+
+// branchDiffText returns the full unified diff of the branch against base,
+// context lines included. Context is deliberate: it widens what counts as
+// grounded, and this check must err toward accepting the summary.
+func branchDiffText(ctx context.Context, workspace, base string, run commandRunner) string {
+	out, err := run(ctx, workspace, nil, "git", "diff", base+"...HEAD")
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+// claimGrounded reports whether a single claim is supported by the diff.
+func claimGrounded(claim string, kind claimKind, g diffGroundTruth) bool {
+	if strings.Contains(g.text, claim) {
+		return true
+	}
+	if kind == claimPath {
+		return pathClaimGrounded(claim, g)
+	}
+	// Route and identifier claims: any identifier atom appearing anywhere
+	// in the diff grounds the claim. `logger.info()/warning()` never gets
+	// here (it is not a single identifier), but `logger.info()` does, and
+	// grounds on `logger` even when the diff spells the call differently.
+	for _, a := range atomRe.FindAllString(claim, -1) {
+		if strings.Contains(g.text, a) {
+			return true
+		}
+		for _, f := range g.files {
+			if strings.Contains(f, a) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pathClaimGrounded grounds a file-path claim. Basename equality against
+// the changed-file list covers the normal case; existence in the workspace
+// covers a summary that legitimately points at a file it did not change
+// ("follows the pattern in `pkg/foreman/agent/loop.go`"), which must not
+// be reported as an invented path.
+//
+// Path claims deliberately skip the atom fallback: a claim's leading
+// segments (`pkg`, `internal`, `cmd`) appear in almost any diff and would
+// ground a wholly fabricated path.
+func pathClaimGrounded(claim string, g diffGroundTruth) bool {
+	base := path.Base(claim)
+	if strings.Contains(g.text, base) {
+		return true
+	}
+	for _, f := range g.files {
+		if f == claim || path.Base(f) == base {
+			return true
+		}
+	}
+	return workspaceHasPath(g.workspace, claim)
+}
+
+// workspaceHasPath reports whether the claimed path exists in the checked
+// out tree. Claims that try to escape the workspace are refused rather
+// than followed.
+func workspaceHasPath(workspace, claim string) bool {
+	if workspace == "" || strings.Contains(claim, "..") || path.IsAbs(claim) {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(workspace, filepath.FromSlash(claim)))
+	return err == nil
+}
+
+// ungroundedSummaryClaims returns the checkable claims the summary makes
+// that the diff does not support, in summary order. An empty result means
+// either that every claim checked out or that there was nothing to check.
+func ungroundedSummaryClaims(summary string, g diffGroundTruth) []string {
+	if strings.TrimSpace(summary) == "" {
+		return nil
+	}
+	// No ground truth means no check. Reporting "unverified" because git
+	// failed would put the note on honest PRs, which is the failure mode
+	// this whole file is built to avoid.
+	if g.text == "" && len(g.files) == 0 {
+		return nil
+	}
+	var out []string
+	for _, claim := range extractSummaryClaims(summary) {
+		_, kind := classifySummaryClaim(claim)
+		if !claimGrounded(claim, kind, g) {
+			out = append(out, claim)
+		}
+	}
+	return out
+}
+
+// annotateUnverifiedClaims appends a visible note to the summary naming
+// the claims the diff does not support.
+//
+// It appends rather than rewrites on purpose. Deleting the offending
+// sentence would require deciding, without any parse of the prose, which
+// sentence a claim belongs to -- and a wrong guess silently destroys an
+// accurate description, which is unrecoverable for the human reading the
+// PR. Appending is additive: the reviewer's words survive verbatim and
+// the disagreement between the words and the diff is stated where the
+// merge decision is made. The original is archived under
+// `extra.summaryClaimed` either way.
+func annotateUnverifiedClaims(summary string, unverified []string) string {
+	if len(unverified) == 0 {
+		return summary
+	}
+	shown := unverified
+	var more int
+	if len(shown) > maxListedUnverifiedClaims {
+		more = len(shown) - maxListedUnverifiedClaims
+		shown = shown[:maxListedUnverifiedClaims]
+	}
+	quoted := make([]string, 0, len(shown))
+	for _, c := range shown {
+		quoted = append(quoted, "`"+c+"`")
+	}
+	list := strings.Join(quoted, ", ")
+	if more > 0 {
+		list += fmt.Sprintf(" (+%d more)", more)
+	}
+	var b strings.Builder
+	b.WriteString(strings.TrimRight(summary, "\n"))
+	b.WriteString("\n\n> [!WARNING]\n")
+	b.WriteString("> **Unverified claims.** The summary above is the reviewer's; foreman ")
+	b.WriteString("cross-checks the concrete things it names against the branch diff. ")
+	fmt.Fprintf(&b, "These do not appear in the diff: %s.\n", list)
+	b.WriteString("> Treat them as unsubstantiated when deciding whether this branch ")
+	b.WriteString("closes the linked issue.")
+	return b.String()
+}

--- a/pkg/foreman/agent/summary_grounding_test.go
+++ b/pkg/foreman/agent/summary_grounding_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// loggingDiff is the shape of the diff behind #1411's report: real
+// structured-logging work, and not one occurrence of "health".
+const loggingDiff = `diff --git a/bridge/app.py b/bridge/app.py
+--- a/bridge/app.py
++++ b/bridge/app.py
+@@ -1,8 +1,12 @@
++import logging
++
++logger = logging.getLogger(__name__)
++
+ def handle(event):
+-    print("claiming", event)
++    logger.info("claiming", extra={"event": event})
+     return claim(event)
+`
+
+// TestUngroundedSummaryClaims_HealthEndpoint is the #1411 regression: the
+// PR body claimed a /health endpoint that the diff never added. The claim
+// must be reported.
+func TestUngroundedSummaryClaims_HealthEndpoint(t *testing.T) {
+	summary := "Introduces structured JSON logging across the bridge, replacing all bare " +
+		"`print()` calls with `logger.info()`, and adds a `/health` endpoint."
+	g := diffGroundTruth{text: loggingDiff, files: []string{"bridge/app.py"}}
+
+	got := ungroundedSummaryClaims(summary, g)
+
+	if len(got) != 1 || got[0] != "/health" {
+		t.Fatalf("want exactly [/health] reported, got %v", got)
+	}
+}
+
+// TestUngroundedSummaryClaims_NoFalsePositives is the guard that matters
+// more than the check itself: a summary whose claims the diff does support
+// must come back clean. Every case here is a way an over-eager check would
+// put a warning on an honest PR.
+func TestUngroundedSummaryClaims_NoFalsePositives(t *testing.T) {
+	cases := []struct {
+		name    string
+		summary string
+		g       diffGroundTruth
+	}{
+		{
+			// The rename trap: `oldHandler` no longer exists at HEAD, but
+			// the diff removed it, so the claim is true.
+			name:    "renamed identifier grounds on the removed line",
+			summary: "Renames `oldHandler` to `newHandler` for clarity.",
+			g: diffGroundTruth{text: "@@\n-func oldHandler() {}\n+func newHandler() {}\n",
+				files: []string{"pkg/http/handler.go"}},
+		},
+		{
+			name:    "call claim grounds on its receiver atom",
+			summary: "Replaces `print()` with `logger.info()` throughout.",
+			g:       diffGroundTruth{text: loggingDiff, files: []string{"bridge/app.py"}},
+		},
+		{
+			name:    "bare lowercase word in backticks is not a checkable claim",
+			summary: "Adds `logging` and `tests` for the claim path.",
+			g:       diffGroundTruth{text: "@@\n+x := 1\n", files: []string{"a.go"}},
+		},
+		{
+			name:    "backticked prose is not a single claim",
+			summary: "Verified with `go test ./... -run TestNothingHere`.",
+			g:       diffGroundTruth{text: "@@\n+x := 1\n", files: []string{"a.go"}},
+		},
+		{
+			name:    "fenced code sample is an illustration, not a claim",
+			summary: "Adds the helper:\n```go\nfunc totallyAbsentSymbol_XYZ() {}\n```",
+			g:       diffGroundTruth{text: "@@\n+x := 1\n", files: []string{"a.go"}},
+		},
+		{
+			name:    "path claim grounds on the changed-file list by basename",
+			summary: "Rewrites `agent/loop.go` to drain the channel.",
+			g:       diffGroundTruth{text: "@@\n+x := 1\n", files: []string{"pkg/foreman/agent/loop.go"}},
+		},
+		{
+			name:    "no ground truth means no check",
+			summary: "Adds a `/health` endpoint and `SomeSymbol`.",
+			g:       diffGroundTruth{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ungroundedSummaryClaims(tc.summary, tc.g); len(got) != 0 {
+				t.Errorf("honest summary flagged claims %v", got)
+			}
+		})
+	}
+}
+
+// TestUngroundedSummaryClaims_UnchangedButRealFileIsGrounded: a summary
+// that points at a file it did not change ("follows the pattern in X") is
+// making a true statement. Grounding path claims on existence in the
+// workspace, not only on the diff, keeps that out of the warning.
+func TestUngroundedSummaryClaims_UnchangedButRealFileIsGrounded(t *testing.T) {
+	ws := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(ws, "pkg", "foreman"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	real := filepath.Join(ws, "pkg", "foreman", "existing_helper.go")
+	if err := os.WriteFile(real, []byte("package foreman\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	g := diffGroundTruth{workspace: ws, text: "@@\n+x := 1\n", files: []string{"other.go"}}
+
+	summary := "Follows the pattern in `pkg/foreman/existing_helper.go`."
+	if got := ungroundedSummaryClaims(summary, g); len(got) != 0 {
+		t.Errorf("a real (if unchanged) path must not be flagged; got %v", got)
+	}
+
+	summary = "Follows the pattern in `pkg/foreman/invented_helper.go`."
+	if got := ungroundedSummaryClaims(summary, g); len(got) != 1 || got[0] != "pkg/foreman/invented_helper.go" {
+		t.Errorf("an invented path must be flagged; got %v", got)
+	}
+}
+
+// TestUngroundedSummaryClaims_PathAtomsDoNotGround: a fabricated path must
+// not be rescued by its leading segments. `pkg` and `agent` appear in
+// almost every diff of this repo.
+func TestUngroundedSummaryClaims_PathAtomsDoNotGround(t *testing.T) {
+	g := diffGroundTruth{
+		text:  "diff --git a/pkg/foreman/agent/loop.go b/pkg/foreman/agent/loop.go\n@@\n+x := 1\n",
+		files: []string{"pkg/foreman/agent/loop.go"},
+	}
+	summary := "Adds the retry to `pkg/foreman/agent/nonexistent_gate.go`."
+	got := ungroundedSummaryClaims(summary, g)
+	if len(got) != 1 || got[0] != "pkg/foreman/agent/nonexistent_gate.go" {
+		t.Fatalf("fabricated path must be flagged, got %v", got)
+	}
+}
+
+// TestClassifySummaryClaim pins which backtick spans are treated as
+// concrete claims. Everything classified claimSkip is prose the check
+// refuses to interpret.
+func TestClassifySummaryClaim(t *testing.T) {
+	cases := []struct {
+		span string
+		want claimKind
+		norm string
+	}{
+		{"/health", claimRoute, "/health"},
+		{"/api/v1/models", claimRoute, "/api/v1/models"},
+		{"pkg/foreman/agent/loop.go", claimPath, "pkg/foreman/agent/loop.go"},
+		{"README.md", claimPath, "README.md"},
+		{"submit_result", claimIdent, "submit_result"},
+		{"logger.info()", claimIdent, "logger.info()"},
+		{"EnsurePR", claimIdent, "EnsurePR"},
+		{"issueAsk", claimIdent, "issueAsk"},
+		{"Handler.", claimIdent, "Handler"}, // trailing sentence period trimmed
+		// Not checkable: indistinguishable from emphasis or prose.
+		{"logging", claimSkip, ""},
+		{"health", claimSkip, ""},
+		{"git diff --name-only", claimSkip, ""},
+		{"logger.info()/warning()/error()", claimSkip, ""},
+		{"", claimSkip, ""},
+		{"...", claimSkip, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.span, func(t *testing.T) {
+			norm, kind := classifySummaryClaim(tc.span)
+			if kind != tc.want || norm != tc.norm {
+				t.Errorf("classifySummaryClaim(%q) = (%q, %d), want (%q, %d)",
+					tc.span, norm, kind, tc.norm, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnnotateUnverifiedClaims: the note is appended, never substituted --
+// the model's prose survives verbatim so an accurate description is never
+// destroyed by a wrong guess about which sentence a claim belongs to.
+func TestAnnotateUnverifiedClaims(t *testing.T) {
+	summary := "Adds structured logging and a `/health` endpoint."
+	got := annotateUnverifiedClaims(summary, []string{"/health"})
+
+	if !strings.HasPrefix(got, summary) {
+		t.Errorf("original summary must survive verbatim at the head; got %q", got)
+	}
+	if !strings.Contains(got, "Unverified claims") || !strings.Contains(got, "`/health`") {
+		t.Errorf("note must name the unverified claim; got %q", got)
+	}
+	if unchanged := annotateUnverifiedClaims(summary, nil); unchanged != summary {
+		t.Errorf("no claims means no note; got %q", unchanged)
+	}
+}
+
+// TestAnnotateUnverifiedClaims_ListIsBounded keeps a confabulated summary
+// from burying the diff link under a wall of generated text.
+func TestAnnotateUnverifiedClaims_ListIsBounded(t *testing.T) {
+	claims := []string{"/a1", "/b2", "/c3", "/d4", "/e5", "/f6", "/g7"}
+	got := annotateUnverifiedClaims("x", claims)
+	if strings.Contains(got, "`/g7`") {
+		t.Errorf("list must be capped at %d entries; got %q", maxListedUnverifiedClaims, got)
+	}
+	if !strings.Contains(got, "+2 more") {
+		t.Errorf("the elided count must be stated; got %q", got)
+	}
+}
+
+// TestBranchDiffText_GitFailureIsEmpty: a git error must produce no ground
+// truth at all, so ungroundedSummaryClaims skips rather than warning.
+func TestBranchDiffText_GitFailureIsEmpty(t *testing.T) {
+	failing := func(context.Context, string, []string, string, ...string) (string, error) {
+		return "partial output", errors.New("fatal: bad revision")
+	}
+	if got := branchDiffText(context.Background(), t.TempDir(), "main", failing); got != "" {
+		t.Errorf("git failure must yield empty diff text, got %q", got)
+	}
+}

--- a/pkg/foreman/agent/tools/submit_result.go
+++ b/pkg/foreman/agent/tools/submit_result.go
@@ -33,25 +33,63 @@ const MaxSubmitSummaryLen = 280
 // truncateRuneSafe truncates s to at most maxLen bytes, appending an
 // ellipsis if truncation occurred. It never splits a multi-byte rune:
 // if the byte limit falls inside a rune, the rune is dropped entirely.
+//
+// When a sentence boundary survives in the tail of the budget, the cut is
+// taken there instead of mid-word (#1411). A reviewer summary is rendered
+// verbatim as the PR description, and a body that ends "... plus in
+// `claim.…" reads as a corrupted artifact rather than a capped one.
+// Backing off to the boundary costs a few characters and yields prose
+// that ends where a sentence ends.
 func truncateRuneSafe(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	ellipsis := "…"
-	// Reserve space for the ellipsis.
-	avail := maxLen - len(ellipsis)
-	// Walk runes until we would exceed avail.
-	var b []rune
-	byteLen := 0
-	for _, r := range s {
-		runeBytes := len(string(r))
-		if byteLen+runeBytes > avail {
-			break
+	const ellipsis = "…"
+	// A boundary cut keeps its terminating punctuation, so the marker is
+	// spaced off it: "First sentence. …" rather than "First sentence.…".
+	const boundarySuffix = " …"
+	if cut := runePrefix(s, maxLen-len(boundarySuffix)); cut != "" {
+		// Only back off when the boundary keeps most of the budget;
+		// otherwise a summary whose first sentence is short would lose
+		// nearly all of its content to the sentence rule.
+		if b := lastSentenceEnd(cut); b*5 >= len(cut)*3 {
+			return cut[:b] + boundarySuffix
 		}
-		b = append(b, r)
+	}
+	return runePrefix(s, maxLen-len(ellipsis)) + ellipsis
+}
+
+// runePrefix returns the longest prefix of s that fits in maxBytes without
+// splitting a rune.
+func runePrefix(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	byteLen := 0
+	for i, r := range s {
+		runeBytes := len(string(r))
+		if byteLen+runeBytes > maxBytes {
+			return s[:i]
+		}
 		byteLen += runeBytes
 	}
-	return string(b) + ellipsis
+	return s
+}
+
+// lastSentenceEnd returns the index just past the last sentence-ending
+// punctuation in s, or 0 when there is none. A terminator counts only when
+// followed by whitespace or the end of the string, so decimals and dotted
+// identifiers ("v1.2", "logger.info") are not mistaken for boundaries.
+func lastSentenceEnd(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		switch s[i] {
+		case '.', '!', '?':
+			if i == len(s)-1 || s[i+1] == ' ' || s[i+1] == '\n' || s[i+1] == '\t' {
+				return i + 1
+			}
+		}
+	}
+	return 0
 }
 
 // SubmitResultTool is the terminal tool. When the model calls it, the

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -1143,3 +1143,52 @@ func TestTruncateRuneSafe(t *testing.T) {
 		})
 	}
 }
+
+// TestTruncateRuneSafe_CutsOnSentenceBoundary is the #1411 secondary
+// defect: the reviewer summary is rendered verbatim as the PR body, and a
+// hard byte cut left it ending mid-word ("... plus in `claim.…"). When a
+// sentence boundary survives in the tail of the budget, the cut is taken
+// there instead.
+func TestTruncateRuneSafe_CutsOnSentenceBoundary(t *testing.T) {
+	first := "Replaces every bare print call with a structured logger. "
+	s := first + strings.Repeat("and then some more prose that overflows the cap ", 4)
+
+	got := truncateRuneSafe(s, 90)
+
+	if len(got) > 90 {
+		t.Fatalf("result exceeds cap: %d bytes (%q)", len(got), got)
+	}
+	if got != "Replaces every bare print call with a structured logger. …" {
+		t.Errorf("want a cut at the sentence boundary, got %q", got)
+	}
+}
+
+// TestTruncateRuneSafe_NoUsableBoundaryKeepsHardCut: backing off must not
+// gut a summary whose only sentence boundary sits near the start.
+func TestTruncateRuneSafe_NoUsableBoundaryKeepsHardCut(t *testing.T) {
+	s := "Ok. " + strings.Repeat("x", 200)
+
+	got := truncateRuneSafe(s, 60)
+
+	if len(got) > 60 {
+		t.Fatalf("result exceeds cap: %d bytes", len(got))
+	}
+	if len(got) < 50 {
+		t.Errorf("an early boundary must not gut the summary; got %q", got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncation must still be marked; got %q", got)
+	}
+}
+
+// TestTruncateRuneSafe_DottedIdentifierIsNotASentenceEnd: "v1.2" and
+// "logger.info" must not be mistaken for sentence terminators.
+func TestTruncateRuneSafe_DottedIdentifierIsNotASentenceEnd(t *testing.T) {
+	s := "Bumps the client to v1.2 and rewires logger.info " + strings.Repeat("y", 100)
+
+	got := truncateRuneSafe(s, 60)
+
+	if strings.HasSuffix(got, "v1. …") || strings.HasSuffix(got, "logger. …") {
+		t.Errorf("dotted identifier treated as a sentence end: %q", got)
+	}
+}


### PR DESCRIPTION
## What

Cross-checks the summary that becomes the PR description against the branch diff
before rendering it, and caps `submit_result.summary` on a sentence boundary.

New `pkg/foreman/agent/summary_grounding.go` extracts the concrete, checkable
things a summary names — backticked file paths, route-shaped strings, code-shaped
identifiers — and requires each to appear in `git diff <base>...HEAD` or the
changed-file list. Claims the diff does not support get a `[!WARNING]` note
appended to the body; the model's original prose is archived under
`extra.summaryClaimed` with the failing claims in `extra.summaryUnverifiedClaims`.

Second commit: `truncateRuneSafe` backs off to the last sentence terminator when
one survives in the tail of the 280-byte budget.

**One correction to the issue's premise.** The issue says the body comes from the
*coder's* `submit_result` summary. It does not. `maybeOpenPullRequest` fires only
for `AgenticTaskKindReview` and passes `r.Summary` — the **reviewer's** summary.
The fix is unaffected (the reviewer read the diff to reach GO, but its prose is no
more ground-truthed than any other model-authored field, and it is still what a
human reads at merge time), but the mechanism in the issue text is wrong and the
code comments say so rather than repeating it.

## Why

Fixes #1411

Every other model-supplied claim in this pipeline is already ground-truthed —
`filesTouched` from `git diff --name-only` (#582), `issueAsk` against the fetched
issue body (#644), findings against the lines the diff changed (#1166) — but the
summary that becomes the PR description a human trusts at merge time was passed
through verbatim. Combined with `Fixes #N` auto-close, an overclaiming body can
close an issue as satisfied by work that was never done.

## How

**Mismatch handling: append, never rewrite.** The issue offered three options
(strip the sentence, append a note, fail back to the coder). Stripping requires
deciding which sentence a claim belongs to without any parse of the prose, and a
wrong guess silently destroys an accurate description — unrecoverable for the
human reading the PR. Appending is additive: the reviewer's words survive
verbatim and the disagreement between the words and the diff is stated where the
merge decision is made. The note renders as a GitHub `[!WARNING]` callout, so it
is impossible to miss and impossible to mistake for the reviewer's own prose. The
list is capped at 5 claims so a confabulated summary cannot bury the diff link.

**Deterministic, not semantic** — matching the rails it sits beside. No model
call, no embedding.

**Biased hard against false positives.** A correct summary that gets flagged puts
noise on every PR and trains humans to ignore the note, which is worse than the
bug it guards. Concretely:

- Only backticked spans are considered; unbackticked prose is never parsed, so
  ordinary English cannot trip the check.
- Grounding uses the **full** diff — added, removed, and context lines, plus file
  headers — not just added lines. "renames \`oldHandler\` to \`newHandler\`"
  therefore grounds `oldHandler` on the removal that renamed it.
- A claim with no literal hit falls back to its identifier atoms and passes if
  **any** atom appears. \`logger.info()\` grounds on `logger`.
- Identifiers must carry a code marker (underscore, dot, call suffix, or an
  uppercase letter) to be checkable at all. A bare lowercase word in backticks
  (\`logging\`, \`health\`) is indistinguishable from emphasis and is skipped.
- Path claims also ground on the file merely *existing* in the workspace, so
  "follows the pattern in \`pkg/foreman/agent/loop.go\`" is not reported as an
  invented path. Path claims skip the atom fallback in exchange — `pkg`,
  `internal`, and `cmd` appear in almost every diff and would ground a wholly
  fabricated path.
- Every missing input degrades open: no diff, a git error, an unresolved review
  base, or an empty summary all skip the check and preserve the model's prose.

**Plumbing.** `reviewBase` and `reviewDiff` are hoisted out of the reviewer-rails
block so the check reuses the base and name-only diff the grounded-finding and
scope-overlap rails already computed. One extra `git diff` is needed for the diff
*text* (name-only cannot ground `/health`), taken lazily after
`maybeOpenPullRequest`'s gate so non-PR paths do not pay for it.

**Truncation (issue item 3).** The cap is `MaxSubmitSummaryLen = 280` in
`pkg/foreman/agent/tools/submit_result.go`; it was a hard byte cut, which is what
produced `... plus in \`claim.…\`. It now backs off to the last sentence
terminator when the boundary keeps at least 60% of the budget, and keeps the hard
rune-safe cut otherwise so a summary whose only boundary sits near the start is
not gutted. A terminator counts only when followed by whitespace, so `v1.2` and
`logger.info` are not mistaken for sentence ends.

**Residual false-positive risk I could not eliminate.** An identifier claim about
pre-existing code the diff does not touch (\`Handler\`, when the change only calls
it and the call site is outside the diff context) can still be flagged. Grounding
identifiers against the whole repo instead of the diff would fix it but would also
have let this issue's `/health` through if "health" appeared anywhere in the tree,
so I kept the diff bound. The append-don't-rewrite choice is what makes this
acceptable: the cost is one visible line of noise, not a mangled description.

**Testing.** `pkg/foreman/agent/summary_grounding_test.go` covers the #1411
regression (the `/health` body against a logging-only diff) plus a false-positive
table — renames, call claims, bare words, backticked prose, fenced samples,
basename path matches, and missing ground truth. `executor_pr_test.go` covers the
wiring end to end: note in the body, `summaryClaimed` archived, `r.Summary` left
as the model's, and grounding skipped when there is no diff. Mutation-checked in
both directions: disabling the check fails 5 tests; making it over-eager (dropping
the English-word guard, the atom fallback, and the workspace-existence grounding)
fails 6, including the false-positive table.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (and `make lint-all`, 0 issues on darwin + linux)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — no user-facing docs surface; the behaviour is described in the package comment on `summary_grounding.go`

Assisted-by: Claude Code (wrote the grounding check, the truncation fix, and the tests from my issue and brief; I reviewed the design rationale and the change description, and ran `make test` and `make lint` locally before submitting)