### PR TITLE
fix(controller): route s3:// model sources to the runtime-resolved path

### DIFF
--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -609,6 +609,20 @@ func (r *ModelReconciler) reconcileBySourceType(
 			ctx, model, computeCacheKey(model.Spec.Source))
 		return true, result, err
 
+	// S3: the InferenceService Pod's init container fetches the object with a
+	// sigv4-signed curl (see buildS3DownloadCommand). Deferred to the workload
+	// for the same reason as remote HTTP — a controller-side download lands on
+	// the operator-namespace PVC that inference Pods cannot mount — and for one
+	// more: the credentials live in the Model's sourceSecretRef, which is
+	// projected into the init container and never resolved by the controller.
+	// Without this case s3:// matched nothing here and fell through to the
+	// controller-side fetch, where net/http rejects the scheme and the Model
+	// wedges in Downloading with "unsupported protocol scheme".
+	case isS3Source(model.Spec.Source):
+		result, err = r.reconcileRuntimeResolvedSource(
+			ctx, model, computeCacheKey(model.Spec.Source))
+		return true, result, err
+
 	// Metal-accelerated models with a local-path source live on the Metal
 	// node's own filesystem and are loaded directly by the host metal-agent.
 	// The in-cluster controller cannot see that path, so it neither downloads

--- a/internal/controller/model_source_s3_test.go
+++ b/internal/controller/model_source_s3_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// newModelReconcilerWithStatus builds a reconciler whose fake client supports
+// the status subresource, which reconcileBySourceType needs because every
+// terminal path there writes status via r.Status().Update.
+func newModelReconcilerWithStatus(t *testing.T, objects ...client.Object) *ModelReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add inference: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(&inferencev1alpha1.Model{}).
+		Build()
+	return &ModelReconciler{Client: c, Scheme: scheme}
+}
+
+// An s3:// Model must be routed to the runtime-resolved path, exactly like a
+// remote http(s) source: the InferenceService Pod's init container does the
+// fetch with a sigv4-signed curl, using credentials from sourceSecretRef that
+// the controller never resolves.
+//
+// Before this was wired, s3:// matched no case in reconcileBySourceType and
+// fell through to the controller-side eager fetch, where net/http rejected the
+// scheme outright:
+//
+//	failed to download: Get "s3://bucket/key": unsupported protocol scheme "s3"
+//
+// The model never left Downloading, so no Pod was ever created and the
+// perfectly good init-container S3 support in model_storage.go never ran.
+func TestReconcileBySourceType_S3IsRuntimeResolved(t *testing.T) {
+	const source = "s3://models/org/repo/model-Q4_K_M.gguf"
+
+	model := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "s3-model", Namespace: "default"},
+		Spec: inferencev1alpha1.ModelSpec{
+			Source:          source,
+			SourceSecretRef: &corev1.LocalObjectReference{Name: "minio-models"},
+		},
+	}
+	r := newModelReconcilerWithStatus(t, model)
+
+	handled, _, err := r.reconcileBySourceType(context.Background(), model)
+	if err != nil {
+		t.Fatalf("reconcileBySourceType: %v", err)
+	}
+	if !handled {
+		t.Fatal("s3:// source fell through to the controller-side download path; " +
+			"net/http cannot fetch an s3:// URL, so the Model can only fail there")
+	}
+	if model.Status.Phase != PhaseReady {
+		t.Errorf("phase = %q, want %q", model.Status.Phase, PhaseReady)
+	}
+	// A cache key is what points the storage builder at the shared cache PVC
+	// rather than an emptyDir; without it every Pod re-downloads the weights,
+	// which is the whole thing an object store exists to avoid.
+	if want := computeCacheKey(source); model.Status.CacheKey != want {
+		t.Errorf("cacheKey = %q, want %q", model.Status.CacheKey, want)
+	}
+}
+
+// The controller must not try to fetch an s3:// source itself. This pins the
+// classification the dispatch depends on, independent of the switch above.
+func TestS3SourceIsNotClassifiedAsFetchableByController(t *testing.T) {
+	const source = "s3://models/org/repo/model.gguf"
+
+	if !isS3Source(source) {
+		t.Fatalf("isS3Source(%q) = false", source)
+	}
+	if isLocalSource(source) {
+		t.Errorf("isLocalSource(%q) = true; fetchModel would try a filesystem copy", source)
+	}
+	if isRemoteHTTPSource(source) {
+		t.Errorf("isRemoteHTTPSource(%q) = true; the controller would attempt an HTTP GET", source)
+	}
+}


### PR DESCRIPTION
## What

Route `s3://` model sources to the runtime-resolved path in
`reconcileBySourceType`, so the S3 support added in #1098 actually runs.

## Why

Fixes #1449

An `s3://` Model never reached Ready. `reconcileBySourceType` handles the source
shapes that need no controller-side download (`pvc://`, HuggingFace repo IDs,
remote `http(s)://`, metal + local path). `s3://` matched none of them, so it
fell through to the eager controller-side fetch, where `net/http` rejects the
scheme:

```
failed to download: Get "s3://bucket/key": unsupported protocol scheme "s3"
```

The Model wedged in `Downloading`, no Pod was ever created, and the sigv4 curl
command in `model_storage.go` never ran.

ed351426 (#1098) added `isS3Source`/`parseS3Source` and the download command,
with tests for both, but did not touch `model_controller.go`. The routing half
was never written, so the feature has never worked end to end. Every test sat at
a layer that works.

## How

One case in the switch, mirroring the remote-HTTP case:

```go
case isS3Source(model.Spec.Source):
    result, err = r.reconcileRuntimeResolvedSource(
        ctx, model, computeCacheKey(model.Spec.Source))
    return true, result, err
```

`s3://` belongs on the runtime-resolved path for the same reason as remote HTTP
(a controller-side download lands on the operator-namespace PVC that inference
Pods cannot mount) plus one more: the credentials live in the Model's
`sourceSecretRef`, which is projected into the init container and never resolved
by the controller.

No guard changes were needed inside `reconcileRuntimeResolvedSource` — every
HTTP-specific step there (revalidation, the remote GGUF metadata range read) is
already gated on `isRemoteHTTPSource`, so an `s3://` source passes through
without touching them. The cache key is passed so the storage builder targets
the shared cache PVC rather than an emptyDir; without it every Pod would
re-download the weights, which is the thing an object store exists to prevent.

Tests are new at the dispatch layer, which is where the gap was: one asserts the
`s3://` Model is `handled` and lands Ready with a cache key, the other pins the
classification (`isS3Source` true, `isLocalSource`/`isRemoteHTTPSource` false)
that the dispatch depends on. Both fail before the change; the first fails with
the fall-through and the second passes, which is exactly the shape of the bug.

Reproduced and verified against a live cluster: a MinIO store behind TLS with a
read-only service account. Before the change, the Model failed as above. From a
Pod in the same namespace, using the same credentials and CA bundle the init
container mounts, a sigv4 `HEAD` returned 200 and a ranged `GET` returned 206 at
95 MB/s, confirming the store and the credentials were never the problem.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`internal/controller` with envtest, 250s)
- [x] `make lint` passes locally (0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)

Docs unchecked deliberately: `config/samples/model_s3_source.yaml` and the CRD
docs from #1098 already describe the intended behaviour correctly. This makes
the code match what is already documented rather than changing the contract.

One adjacent gap found while debugging, filed in #1449 rather than fixed here:
when `--ca-cert-configmap` is set, `addCACertVolume` builds the volume with a
`LocalObjectReference`, so the ConfigMap resolves in the *workload's* namespace,
not the operator's. The operator takes a single global name, so the ConfigMap
must be replicated into every namespace hosting a Model. Undocumented at
minimum, and a plausible propagation feature.

Assisted-by: Claude Code (root-cause investigation, the fix, and the tests;
I reviewed the change, ran the controller suite under envtest and make lint,
and confirmed the failure and the S3 read path against my own cluster)
