### PR TITLE
feat(inferenceservice): add spec.modelCache.persistence for an ephemeral model cache

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -879,6 +879,13 @@ type InferenceResourceRequirements struct {
 	// download. Node disk capacity varies by an order of magnitude across
 	// distributions and machine types, so there is no default that is safe
 	// everywhere and none is applied.
+	//
+	// The pattern is the Kubernetes quantity format, so a malformed value is
+	// rejected at admission. The sibling quantity fields above predate this and
+	// carry no pattern; they reach resource.MustParse, which panics on
+	// malformed input and takes the controller down for every workload rather
+	// than failing the one object at fault.
+	// +kubebuilder:validation:Pattern=`^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`
 	// +optional
 	EphemeralStorage string `json:"ephemeralStorage,omitempty"`
 

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -115,18 +115,32 @@ type ModelCacheSpec struct {
 	// entirely: weights land in an emptyDir and are re-downloaded every time
 	// the Pod starts. No cache PVC is created, mounted, or required.
 	//
-	// Ephemeral is for two situations. First, nodes where dynamic provisioning
-	// is not available: a provisioner whose volume-creation helper cannot
-	// tolerate the node's taints will never bind the claim, and with
-	// microk8s-hostpath that failure is silent, so the Pod waits forever on a
-	// volume that will never arrive. Second, a fast local origin, where the
-	// cache does not earn its keep: pulling from an on-LAN object store can be
-	// quick enough that a per-service volume on every GPU node costs more than
-	// the occasional re-download.
+	// Ephemeral is for two situations.
 	//
-	// The trade is paid at a time far removed from the decision: the first
-	// request after any restart waits for a full re-download. Prefer Cached
-	// unless one of the situations above applies.
+	// A model origin fast enough that the cache does not earn its keep. Pulling
+	// from an in-cluster or on-LAN object store can be quick enough that a
+	// per-service volume on every GPU node costs more than the occasional
+	// re-download, particularly since perService caches are node-local and are
+	// never shared between services.
+	//
+	// Clusters where a cache PVC is impractical for this workload: no suitable
+	// StorageClass for the nodes it must run on, or a local-volume provisioner
+	// that creates volumes through a helper Pod pinned to the target node and
+	// so cannot serve a node whose taints that helper does not tolerate. That
+	// last case can fail silently, leaving the Pod waiting on a volume that
+	// will never bind. It does not arise on provisioners that create volumes
+	// through a control-plane API call rather than an on-node Pod, which is how
+	// most managed-cloud CSI drivers work.
+	//
+	// Two costs, both paid later than the decision. The first request after ANY
+	// restart waits for a full re-download, and with more than one replica every
+	// replica downloads its own copy. Prefer Cached unless one of the situations
+	// above applies.
+	//
+	// Pair this with resources.ephemeralStorage. Weights land on node local
+	// disk, and without a declared budget the scheduler cannot account for the
+	// download and the kubelet has no per-pod ceiling to enforce; the operator
+	// emits an UnboundedEphemeralCache warning when it is unset.
 	//
 	// Mutually exclusive with claimName, which names a cache volume to use.
 	// +optional
@@ -846,6 +860,27 @@ type InferenceResourceRequirements struct {
 	// which can lead to OOM kills after model load.
 	// +optional
 	HostMemory string `json:"hostMemory,omitempty"`
+
+	// EphemeralStorage is the node local-disk budget for this pod (e.g. "40Gi").
+	// Translated to BOTH requests and limits for ephemeral-storage, and, when
+	// modelCache.persistence is Ephemeral, to the sizeLimit of the emptyDir the
+	// weights download into.
+	//
+	// Set this whenever weights land on node disk rather than a cache PVC.
+	// Without it the scheduler has no visibility into a download that can run to
+	// tens of gigabytes and will place further pods on a node that is about to
+	// fill, and the kubelet has no per-pod ceiling to enforce: the node crosses
+	// its DiskPressure threshold instead, and eviction then proceeds by QoS
+	// class, which can remove unrelated workloads before this one. The request
+	// makes the download visible to scheduling; the limit keeps an overrun
+	// charged to this pod.
+	//
+	// Size it above the model on disk with room for the partial file during
+	// download. Node disk capacity varies by an order of magnitude across
+	// distributions and machine types, so there is no default that is safe
+	// everywhere and none is applied.
+	// +optional
+	EphemeralStorage string `json:"ephemeralStorage,omitempty"`
 
 	// GPUMemory is recorded on the object and has no effect. It sets no pod
 	// resource request, does not influence scheduling, and is not validated;

--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -85,7 +85,53 @@ type SpeculativeDecodingSpec struct {
 // mounts and populates the claim through the same prep + download init
 // containers as the built-in cache, but never creates, mutates, or deletes it;
 // the user owns the PVC end-to-end.
+// ModelCachePersistence selects whether this InferenceService keeps its model
+// weights on a cache volume across restarts.
+//
+// Deliberately NOT named "mode": the operator already has a --model-cache-mode
+// flag (shared / perService) that selects WHICH cache PVC is used. This field
+// answers a different question, whether there is a cache PVC at all, and one
+// field named "mode" sitting next to another named "mode" on a different axis
+// is a footgun.
+// +kubebuilder:validation:Enum=Cached;Ephemeral
+type ModelCachePersistence string
+
+const (
+	// ModelCachePersistenceCached keeps weights on the model cache PVC. The
+	// default, and what an empty value resolves to.
+	ModelCachePersistenceCached ModelCachePersistence = "Cached"
+
+	// ModelCachePersistenceEphemeral downloads into an emptyDir that dies with
+	// the Pod, so no cache PVC is created or mounted.
+	ModelCachePersistenceEphemeral ModelCachePersistence = "Ephemeral"
+)
+
+// +kubebuilder:validation:XValidation:rule="!(has(self.persistence) && self.persistence == 'Ephemeral' && has(self.claimName))",message="claimName cannot be set when persistence is Ephemeral: one names a cache volume to use, the other declines to use any"
 type ModelCacheSpec struct {
+	// Persistence selects whether weights survive a Pod restart.
+	//
+	// Cached (the default) downloads into the model cache PVC, so a restart
+	// reuses the bytes already on the node. Ephemeral declines the cache
+	// entirely: weights land in an emptyDir and are re-downloaded every time
+	// the Pod starts. No cache PVC is created, mounted, or required.
+	//
+	// Ephemeral is for two situations. First, nodes where dynamic provisioning
+	// is not available: a provisioner whose volume-creation helper cannot
+	// tolerate the node's taints will never bind the claim, and with
+	// microk8s-hostpath that failure is silent, so the Pod waits forever on a
+	// volume that will never arrive. Second, a fast local origin, where the
+	// cache does not earn its keep: pulling from an on-LAN object store can be
+	// quick enough that a per-service volume on every GPU node costs more than
+	// the occasional re-download.
+	//
+	// The trade is paid at a time far removed from the decision: the first
+	// request after any restart waits for a full re-download. Prefer Cached
+	// unless one of the situations above applies.
+	//
+	// Mutually exclusive with claimName, which names a cache volume to use.
+	// +optional
+	Persistence ModelCachePersistence `json:"persistence,omitempty"`
+
 	// ClaimName names a pre-existing PersistentVolumeClaim in the
 	// InferenceService's namespace to use as the writable model cache volume.
 	// Weights land under the usual <cacheKey>/ subdirectory of the claim, so

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -4467,6 +4467,13 @@ spec:
                       download. Node disk capacity varies by an order of magnitude across
                       distributions and machine types, so there is no default that is safe
                       everywhere and none is applied.
+
+                      The pattern is the Kubernetes quantity format, so a malformed value is
+                      rejected at admission. The sibling quantity fields above predate this and
+                      carry no pattern; they reach resource.MustParse, which panics on
+                      malformed input and takes the controller down for every workload rather
+                      than failing the one object at fault.
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                   gpu:
                     description: |-

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -3542,18 +3542,32 @@ spec:
                       entirely: weights land in an emptyDir and are re-downloaded every time
                       the Pod starts. No cache PVC is created, mounted, or required.
 
-                      Ephemeral is for two situations. First, nodes where dynamic provisioning
-                      is not available: a provisioner whose volume-creation helper cannot
-                      tolerate the node's taints will never bind the claim, and with
-                      microk8s-hostpath that failure is silent, so the Pod waits forever on a
-                      volume that will never arrive. Second, a fast local origin, where the
-                      cache does not earn its keep: pulling from an on-LAN object store can be
-                      quick enough that a per-service volume on every GPU node costs more than
-                      the occasional re-download.
+                      Ephemeral is for two situations.
 
-                      The trade is paid at a time far removed from the decision: the first
-                      request after any restart waits for a full re-download. Prefer Cached
-                      unless one of the situations above applies.
+                      A model origin fast enough that the cache does not earn its keep. Pulling
+                      from an in-cluster or on-LAN object store can be quick enough that a
+                      per-service volume on every GPU node costs more than the occasional
+                      re-download, particularly since perService caches are node-local and are
+                      never shared between services.
+
+                      Clusters where a cache PVC is impractical for this workload: no suitable
+                      StorageClass for the nodes it must run on, or a local-volume provisioner
+                      that creates volumes through a helper Pod pinned to the target node and
+                      so cannot serve a node whose taints that helper does not tolerate. That
+                      last case can fail silently, leaving the Pod waiting on a volume that
+                      will never bind. It does not arise on provisioners that create volumes
+                      through a control-plane API call rather than an on-node Pod, which is how
+                      most managed-cloud CSI drivers work.
+
+                      Two costs, both paid later than the decision. The first request after ANY
+                      restart waits for a full re-download, and with more than one replica every
+                      replica downloads its own copy. Prefer Cached unless one of the situations
+                      above applies.
+
+                      Pair this with resources.ephemeralStorage. Weights land on node local
+                      disk, and without a declared budget the scheduler cannot account for the
+                      download and the kubelet has no per-pod ceiling to enforce; the operator
+                      emits an UnboundedEphemeralCache warning when it is unset.
 
                       Mutually exclusive with claimName, which names a cache volume to use.
                     enum:
@@ -4432,6 +4446,27 @@ spec:
                 properties:
                   cpu:
                     description: CPU requests (e.g., "2" or "2000m")
+                    type: string
+                  ephemeralStorage:
+                    description: |-
+                      EphemeralStorage is the node local-disk budget for this pod (e.g. "40Gi").
+                      Translated to BOTH requests and limits for ephemeral-storage, and, when
+                      modelCache.persistence is Ephemeral, to the sizeLimit of the emptyDir the
+                      weights download into.
+
+                      Set this whenever weights land on node disk rather than a cache PVC.
+                      Without it the scheduler has no visibility into a download that can run to
+                      tens of gigabytes and will place further pods on a node that is about to
+                      fill, and the kubelet has no per-pod ceiling to enforce: the node crosses
+                      its DiskPressure threshold instead, and eviction then proceeds by QoS
+                      class, which can remove unrelated workloads before this one. The request
+                      makes the download visible to scheduling; the limit keeps an overrun
+                      charged to this pod.
+
+                      Size it above the model on disk with room for the partial file during
+                      download. Node disk capacity varies by an order of magnitude across
+                      distributions and machine types, so there is no default that is safe
+                      everywhere and none is applied.
                     type: string
                   gpu:
                     description: |-

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -3533,7 +3533,39 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
+                  persistence:
+                    description: |-
+                      Persistence selects whether weights survive a Pod restart.
+
+                      Cached (the default) downloads into the model cache PVC, so a restart
+                      reuses the bytes already on the node. Ephemeral declines the cache
+                      entirely: weights land in an emptyDir and are re-downloaded every time
+                      the Pod starts. No cache PVC is created, mounted, or required.
+
+                      Ephemeral is for two situations. First, nodes where dynamic provisioning
+                      is not available: a provisioner whose volume-creation helper cannot
+                      tolerate the node's taints will never bind the claim, and with
+                      microk8s-hostpath that failure is silent, so the Pod waits forever on a
+                      volume that will never arrive. Second, a fast local origin, where the
+                      cache does not earn its keep: pulling from an on-LAN object store can be
+                      quick enough that a per-service volume on every GPU node costs more than
+                      the occasional re-download.
+
+                      The trade is paid at a time far removed from the decision: the first
+                      request after any restart waits for a full re-download. Prefer Cached
+                      unless one of the situations above applies.
+
+                      Mutually exclusive with claimName, which names a cache volume to use.
+                    enum:
+                    - Cached
+                    - Ephemeral
+                    type: string
                 type: object
+                x-kubernetes-validations:
+                - message: 'claimName cannot be set when persistence is Ephemeral:
+                    one names a cache volume to use, the other declines to use any'
+                  rule: '!(has(self.persistence) && self.persistence == ''Ephemeral''
+                    && has(self.claimName))'
               modelRef:
                 description: ModelRef references the Model CR that contains the model
                   to serve

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -4463,6 +4463,13 @@ spec:
                       download. Node disk capacity varies by an order of magnitude across
                       distributions and machine types, so there is no default that is safe
                       everywhere and none is applied.
+
+                      The pattern is the Kubernetes quantity format, so a malformed value is
+                      rejected at admission. The sibling quantity fields above predate this and
+                      carry no pattern; they reach resource.MustParse, which panics on
+                      malformed input and takes the controller down for every workload rather
+                      than failing the one object at fault.
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                   gpu:
                     description: |-

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -3529,7 +3529,39 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
+                  persistence:
+                    description: |-
+                      Persistence selects whether weights survive a Pod restart.
+
+                      Cached (the default) downloads into the model cache PVC, so a restart
+                      reuses the bytes already on the node. Ephemeral declines the cache
+                      entirely: weights land in an emptyDir and are re-downloaded every time
+                      the Pod starts. No cache PVC is created, mounted, or required.
+
+                      Ephemeral is for two situations. First, nodes where dynamic provisioning
+                      is not available: a provisioner whose volume-creation helper cannot
+                      tolerate the node's taints will never bind the claim, and with
+                      microk8s-hostpath that failure is silent, so the Pod waits forever on a
+                      volume that will never arrive. Second, a fast local origin, where the
+                      cache does not earn its keep: pulling from an on-LAN object store can be
+                      quick enough that a per-service volume on every GPU node costs more than
+                      the occasional re-download.
+
+                      The trade is paid at a time far removed from the decision: the first
+                      request after any restart waits for a full re-download. Prefer Cached
+                      unless one of the situations above applies.
+
+                      Mutually exclusive with claimName, which names a cache volume to use.
+                    enum:
+                    - Cached
+                    - Ephemeral
+                    type: string
                 type: object
+                x-kubernetes-validations:
+                - message: 'claimName cannot be set when persistence is Ephemeral:
+                    one names a cache volume to use, the other declines to use any'
+                  rule: '!(has(self.persistence) && self.persistence == ''Ephemeral''
+                    && has(self.claimName))'
               modelRef:
                 description: ModelRef references the Model CR that contains the model
                   to serve

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -3538,18 +3538,32 @@ spec:
                       entirely: weights land in an emptyDir and are re-downloaded every time
                       the Pod starts. No cache PVC is created, mounted, or required.
 
-                      Ephemeral is for two situations. First, nodes where dynamic provisioning
-                      is not available: a provisioner whose volume-creation helper cannot
-                      tolerate the node's taints will never bind the claim, and with
-                      microk8s-hostpath that failure is silent, so the Pod waits forever on a
-                      volume that will never arrive. Second, a fast local origin, where the
-                      cache does not earn its keep: pulling from an on-LAN object store can be
-                      quick enough that a per-service volume on every GPU node costs more than
-                      the occasional re-download.
+                      Ephemeral is for two situations.
 
-                      The trade is paid at a time far removed from the decision: the first
-                      request after any restart waits for a full re-download. Prefer Cached
-                      unless one of the situations above applies.
+                      A model origin fast enough that the cache does not earn its keep. Pulling
+                      from an in-cluster or on-LAN object store can be quick enough that a
+                      per-service volume on every GPU node costs more than the occasional
+                      re-download, particularly since perService caches are node-local and are
+                      never shared between services.
+
+                      Clusters where a cache PVC is impractical for this workload: no suitable
+                      StorageClass for the nodes it must run on, or a local-volume provisioner
+                      that creates volumes through a helper Pod pinned to the target node and
+                      so cannot serve a node whose taints that helper does not tolerate. That
+                      last case can fail silently, leaving the Pod waiting on a volume that
+                      will never bind. It does not arise on provisioners that create volumes
+                      through a control-plane API call rather than an on-node Pod, which is how
+                      most managed-cloud CSI drivers work.
+
+                      Two costs, both paid later than the decision. The first request after ANY
+                      restart waits for a full re-download, and with more than one replica every
+                      replica downloads its own copy. Prefer Cached unless one of the situations
+                      above applies.
+
+                      Pair this with resources.ephemeralStorage. Weights land on node local
+                      disk, and without a declared budget the scheduler cannot account for the
+                      download and the kubelet has no per-pod ceiling to enforce; the operator
+                      emits an UnboundedEphemeralCache warning when it is unset.
 
                       Mutually exclusive with claimName, which names a cache volume to use.
                     enum:
@@ -4428,6 +4442,27 @@ spec:
                 properties:
                   cpu:
                     description: CPU requests (e.g., "2" or "2000m")
+                    type: string
+                  ephemeralStorage:
+                    description: |-
+                      EphemeralStorage is the node local-disk budget for this pod (e.g. "40Gi").
+                      Translated to BOTH requests and limits for ephemeral-storage, and, when
+                      modelCache.persistence is Ephemeral, to the sizeLimit of the emptyDir the
+                      weights download into.
+
+                      Set this whenever weights land on node disk rather than a cache PVC.
+                      Without it the scheduler has no visibility into a download that can run to
+                      tens of gigabytes and will place further pods on a node that is about to
+                      fill, and the kubelet has no per-pod ceiling to enforce: the node crosses
+                      its DiskPressure threshold instead, and eviction then proceeds by QoS
+                      class, which can remove unrelated workloads before this one. The request
+                      makes the download visible to scheduling; the limit keeps an overrun
+                      charged to this pod.
+
+                      Size it above the model on disk with room for the partial file during
+                      download. Node disk capacity varies by an order of magnitude across
+                      distributions and machine types, so there is no default that is safe
+                      everywhere and none is applied.
                     type: string
                   gpu:
                     description: |-

--- a/config/samples/inferenceservice_ephemeral_cache.yaml
+++ b/config/samples/inferenceservice_ephemeral_cache.yaml
@@ -3,23 +3,39 @@
 # Weights download into an emptyDir that dies with the Pod, so no cache PVC is
 # created, mounted, or required. Two situations call for this:
 #
-#   1. Nodes where dynamic provisioning is unavailable. A provisioner whose
-#      volume-creation helper cannot tolerate the node's taints will never bind
-#      the claim, and with microk8s-hostpath that failure is silent: the Pod
-#      waits forever on a volume that will never arrive.
+#   1. A model origin fast enough that the cache does not earn its keep.
+#      Pulling from an in-cluster or on-LAN object store can be quick enough
+#      that a per-service volume on every GPU node costs more than the
+#      occasional re-download, and perService caches are node-local so they are
+#      never shared between services anyway. Measured on one fleet, the same
+#      15.65 GB GGUF took 4m22s at 61 MB/s from a public origin over the
+#      internet and 2m52s at 93 MB/s from an in-cluster object store.
 #
-#   2. A fast local origin. Pulling from an on-LAN object store can be quick
-#      enough that a per-service volume on every GPU node costs more than the
-#      occasional re-download. Measured on one fleet, the same 15.65 GB GGUF
-#      took 4m22s at 61 MB/s from Hugging Face and 2m52s at 93 MB/s from an
-#      in-cluster MinIO.
+#   2. Clusters where a cache PVC is impractical for this workload: no suitable
+#      StorageClass for the nodes it must run on, or a local-volume provisioner
+#      that creates volumes through a helper Pod pinned to the target node and
+#      therefore cannot serve a node whose taints that helper does not
+#      tolerate. That case can fail silently, leaving the Pod waiting on a
+#      volume that never binds. It does not arise on provisioners that create
+#      volumes through a control-plane API call rather than an on-node Pod,
+#      which is how most managed-cloud CSI drivers work.
 #
-# The cost is paid at a time far removed from the decision: the first request
-# after ANY restart waits for a full re-download. Prefer the default (Cached)
-# unless one of the above applies.
+# Two costs, both paid later than the decision: the first request after ANY
+# restart waits for a full re-download, and with more than one replica every
+# replica downloads its own copy. Prefer the default (Cached) unless one of the
+# above applies.
 #
 # persistence is mutually exclusive with claimName, which names a cache volume
 # to use; the CRD rejects setting both.
+#
+# ALWAYS pair Ephemeral with spec.resources.ephemeralStorage. Weights land on
+# node local disk, and without a declared budget the scheduler cannot see the
+# download coming (so it keeps placing pods on a node that is about to fill) and
+# the kubelet has no per-pod ceiling to enforce (so the node crosses its
+# DiskPressure threshold and evicts by QoS class, which can remove unrelated
+# workloads first). Node disk capacity varies by an order of magnitude across
+# distributions and machine types, so no default is safe everywhere and none is
+# applied; the operator emits an UnboundedEphemeralCache warning if it is unset.
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
@@ -33,3 +49,7 @@ spec:
   resources:
     cpu: "4"
     memory: 8Gi
+    # Above the model's size on disk, with room for the partial file while it
+    # downloads. Becomes both the ephemeral-storage request/limit and the
+    # sizeLimit of the emptyDir the weights land in.
+    ephemeralStorage: 40Gi

--- a/config/samples/inferenceservice_ephemeral_cache.yaml
+++ b/config/samples/inferenceservice_ephemeral_cache.yaml
@@ -1,0 +1,35 @@
+# InferenceService that declines the model cache PVC (#1451).
+#
+# Weights download into an emptyDir that dies with the Pod, so no cache PVC is
+# created, mounted, or required. Two situations call for this:
+#
+#   1. Nodes where dynamic provisioning is unavailable. A provisioner whose
+#      volume-creation helper cannot tolerate the node's taints will never bind
+#      the claim, and with microk8s-hostpath that failure is silent: the Pod
+#      waits forever on a volume that will never arrive.
+#
+#   2. A fast local origin. Pulling from an on-LAN object store can be quick
+#      enough that a per-service volume on every GPU node costs more than the
+#      occasional re-download. Measured on one fleet, the same 15.65 GB GGUF
+#      took 4m22s at 61 MB/s from Hugging Face and 2m52s at 93 MB/s from an
+#      in-cluster MinIO.
+#
+# The cost is paid at a time far removed from the decision: the first request
+# after ANY restart waits for a full re-download. Prefer the default (Cached)
+# unless one of the above applies.
+#
+# persistence is mutually exclusive with claimName, which names a cache volume
+# to use; the CRD rejects setting both.
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: inferenceservice-ephemeral-cache
+spec:
+  modelRef: model-sample
+  runtime: llamacpp
+  replicas: 1
+  modelCache:
+    persistence: Ephemeral
+  resources:
+    cpu: "4"
+    memory: 8Gi

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,4 +2,5 @@
 resources:
 - inference_v1alpha1_model.yaml
 - inference_v1alpha1_inferenceservice.yaml
+- inferenceservice_ephemeral_cache.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -352,7 +352,10 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	var storageConfig modelStorageConfig
 	var modelPath string
 	if backend.NeedsModelInit() && !skipInit {
-		useCache := effectiveModelCacheKey(model) != "" && r.ModelCachePath != ""
+		// Same predicate as the provisioning side (modelNeedsCachePVC), so a
+		// service that declined the cache mounts an emptyDir instead of a claim
+		// nobody created (#1451).
+		useCache := modelWantsCacheVolume(model, isvc, r.ModelCachePath)
 		storageConfig = buildModelStorageConfig(model, isvc, isvc.Namespace, useCache, r.ModelCacheMode, r.CACertConfigMap, r.InitContainerImage, r.DefaultFSGroup, r.AllowedHostPathRoots)
 		modelPath = servedModelPath(isvc, model, storageConfig)
 	}

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -585,6 +585,16 @@ func buildContainerResources(isvc *inferencev1alpha1.InferenceService, model *in
 		} else if isvc.Spec.Resources.Memory != "" {
 			res.Requests[corev1.ResourceMemory] = resource.MustParse(isvc.Spec.Resources.Memory)
 		}
+		// Request AND limit. The request is what the scheduler reserves, so it
+		// stops placing further pods on a node this download is about to fill.
+		// The limit is what keeps an overrun charged to this pod: without one
+		// the node crosses its DiskPressure threshold instead and eviction
+		// proceeds by QoS class, which can remove unrelated workloads first.
+		if isvc.Spec.Resources.EphemeralStorage != "" {
+			q := resource.MustParse(isvc.Spec.Resources.EphemeralStorage)
+			res.Requests[corev1.ResourceEphemeralStorage] = q
+			res.Limits[corev1.ResourceEphemeralStorage] = q
+		}
 	}
 
 	return res

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -590,10 +590,15 @@ func buildContainerResources(isvc *inferencev1alpha1.InferenceService, model *in
 		// The limit is what keeps an overrun charged to this pod: without one
 		// the node crosses its DiskPressure threshold instead and eviction
 		// proceeds by QoS class, which can remove unrelated workloads first.
+		// ParseQuantity, not MustParse: a CRD pattern rejects malformed values at
+		// admission, but MustParse panics, and a panic here takes the controller
+		// down for every workload rather than failing the one object at fault.
+		// Not worth that blast radius to save an error check.
 		if isvc.Spec.Resources.EphemeralStorage != "" {
-			q := resource.MustParse(isvc.Spec.Resources.EphemeralStorage)
-			res.Requests[corev1.ResourceEphemeralStorage] = q
-			res.Limits[corev1.ResourceEphemeralStorage] = q
+			if q, err := resource.ParseQuantity(isvc.Spec.Resources.EphemeralStorage); err == nil {
+				res.Requests[corev1.ResourceEphemeralStorage] = q
+				res.Limits[corev1.ResourceEphemeralStorage] = q
+			}
 		}
 	}
 

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -223,7 +223,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		desiredReplicas = 0
 	}
 
-	if modelNeedsCachePVC(model, r.ModelCachePath) {
+	if modelNeedsCachePVC(model, inferenceService, r.ModelCachePath) {
 		if err := r.ensureModelCachePVC(ctx, inferenceService); err != nil {
 			log.Error(err, "Failed to ensure model cache PVC exists", "namespace", inferenceService.Namespace)
 			return r.updateStatusWithSchedulingInfo(ctx, inferenceService, PhaseFailed, modelReady, 0, desiredReplicas, "",

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -232,6 +232,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	r.warnIgnoredModelCacheClaim(inferenceService, model)
+	r.warnUnboundedEphemeralCache(inferenceService)
 
 	isMetal := isMetalModel(model)
 

--- a/internal/controller/model_cache_ephemeral_sizing_test.go
+++ b/internal/controller/model_cache_ephemeral_sizing_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Bounding the ephemeral model cache (#1451 follow-up).
+//
+// An emptyDir with no sizeLimit is written to the node's ephemeral storage,
+// which the scheduler cannot see and the kubelet will not charge to this Pod
+// alone. A multi-gigabyte model on a node with a small boot disk therefore
+// fills the node and triggers DiskPressure, and the kubelet then evicts by QoS
+// class, which can take out unrelated workloads. Node disk size varies wildly
+// across distributions, so this must be expressible rather than assumed.
+//
+// spec.resources.ephemeralStorage drives both halves: the emptyDir's sizeLimit
+// (so the kubelet evicts THIS Pod instead of starving the node) and the
+// container's ephemeral-storage request (so the scheduler stops overcommitting
+// the node in the first place).
+
+func isvcWithEphemeralCache(storage string) *inferencev1alpha1.InferenceService {
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "m",
+			ModelCache: &inferencev1alpha1.ModelCacheSpec{
+				Persistence: inferencev1alpha1.ModelCachePersistenceEphemeral,
+			},
+		},
+	}
+	if storage != "" {
+		isvc.Spec.Resources = &inferencev1alpha1.InferenceResourceRequirements{
+			EphemeralStorage: storage,
+		}
+	}
+	return isvc
+}
+
+func TestEphemeralCacheSizeLimit_SetFromResources(t *testing.T) {
+	got := ephemeralCacheSizeLimit(isvcWithEphemeralCache("40Gi"))
+	if got == nil {
+		t.Fatal("expected a sizeLimit when resources.ephemeralStorage is set")
+	}
+	want := resource.MustParse("40Gi")
+	if got.Cmp(want) != 0 {
+		t.Errorf("sizeLimit = %s, want %s", got.String(), want.String())
+	}
+}
+
+// No declared budget means no sizeLimit rather than a guessed one. Model size
+// is not reliably known (Status.Size is populated from the GGUF metadata range
+// read, which only runs for remote http(s) sources), so inventing a limit would
+// evict Pods for exceeding a number the user never chose.
+func TestEphemeralCacheSizeLimit_UnsetWithoutBudget(t *testing.T) {
+	if got := ephemeralCacheSizeLimit(isvcWithEphemeralCache("")); got != nil {
+		t.Errorf("sizeLimit = %v, want nil when no ephemeralStorage is declared", got)
+	}
+	if got := ephemeralCacheSizeLimit(nil); got != nil {
+		t.Errorf("sizeLimit = %v, want nil for a nil isvc", got)
+	}
+}
+
+// The limit belongs to the ephemeral path only. A Cached service writes to the
+// cache PVC, where a sizeLimit on the (unused) emptyDir would mean nothing.
+func TestEphemeralCacheSizeLimit_OnlyWhenEphemeral(t *testing.T) {
+	cached := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef:  "m",
+			Resources: &inferencev1alpha1.InferenceResourceRequirements{EphemeralStorage: "40Gi"},
+		},
+	}
+	if got := ephemeralCacheSizeLimit(cached); got != nil {
+		t.Errorf("sizeLimit = %v, want nil when persistence is not Ephemeral", got)
+	}
+}
+
+// The scheduler half: without an ephemeral-storage REQUEST the scheduler cannot
+// see the download coming and will stack several such Pods onto one node.
+func TestEphemeralStorage_BecomesRequestAndLimit(t *testing.T) {
+	isvc := isvcWithEphemeralCache("40Gi")
+	res := buildContainerResources(isvc, &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+	}, 0, "")
+
+	req, ok := res.Requests[corev1.ResourceEphemeralStorage]
+	if !ok {
+		t.Fatal("no ephemeral-storage request; the scheduler cannot account for the download")
+	}
+	if want := resource.MustParse("40Gi"); req.Cmp(want) != 0 {
+		t.Errorf("request = %s, want %s", req.String(), want.String())
+	}
+
+	// A limit as well as a request: the request is what the scheduler reserves,
+	// the limit is what makes the kubelet evict THIS Pod rather than let the
+	// node fill and evict by QoS class.
+	lim, ok := res.Limits[corev1.ResourceEphemeralStorage]
+	if !ok {
+		t.Fatal("no ephemeral-storage limit; overrun would starve the node instead of this Pod")
+	}
+	if want := resource.MustParse("40Gi"); lim.Cmp(want) != 0 {
+		t.Errorf("limit = %s, want %s", lim.String(), want.String())
+	}
+}
+
+func TestEphemeralStorage_AbsentByDefault(t *testing.T) {
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef:  "m",
+			Resources: &inferencev1alpha1.InferenceResourceRequirements{CPU: "2", Memory: "4Gi"},
+		},
+	}
+	res := buildContainerResources(isvc, &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+	}, 0, "")
+	if _, ok := res.Requests[corev1.ResourceEphemeralStorage]; ok {
+		t.Error("ephemeral-storage must not appear unless the user asked for it")
+	}
+	if _, ok := res.Limits[corev1.ResourceEphemeralStorage]; ok {
+		t.Error("ephemeral-storage limit must not appear unless the user asked for it")
+	}
+}

--- a/internal/controller/model_cache_ephemeral_test.go
+++ b/internal/controller/model_cache_ephemeral_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Ephemeral model cache (#1451). An InferenceService can decline the cache PVC
+// and download into an emptyDir instead, for two cases: a node where dynamic
+// provisioning is unavailable (a NoSchedule taint the storage provisioner
+// cannot follow), and a fast local origin where re-pulling on restart is
+// cheaper than carrying a 100Gi volume on every GPU node.
+//
+// The two gates that must agree are the provisioning side (modelNeedsCachePVC,
+// which decides whether to create the claim) and the mount side (the useCache
+// value the deployment builder passes to buildModelStorageConfig). If they
+// disagree the pod either mounts a claim nobody created or leaves an orphaned
+// claim behind, so both are pinned here.
+
+func ephemeralISvc() *inferencev1alpha1.InferenceService {
+	return &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			ModelRef: "m",
+			ModelCache: &inferencev1alpha1.ModelCacheSpec{
+				Persistence: inferencev1alpha1.ModelCachePersistenceEphemeral,
+			},
+		},
+	}
+}
+
+func cacheableModel() *inferencev1alpha1.Model {
+	m := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+		Spec:       inferencev1alpha1.ModelSpec{Source: "s3://models/org/repo/m.gguf"},
+	}
+	m.Status.CacheKey = "deadbeefdeadbeef"
+	return m
+}
+
+func TestModelCachePersistence_EphemeralSkipsPVC(t *testing.T) {
+	model := cacheableModel()
+
+	// Control: the same model without the opt-out does want a cache PVC.
+	// Without this the test could pass because the model was never cacheable.
+	if !modelNeedsCachePVC(model, nil, "/models") {
+		t.Fatal("control failed: a cacheable model with caching enabled should want a PVC")
+	}
+
+	if modelNeedsCachePVC(model, ephemeralISvc(), "/models") {
+		t.Error("ephemeral persistence should skip the cache PVC, but the operator would provision one")
+	}
+}
+
+func TestModelCachePersistence_DefaultAndCachedStillCache(t *testing.T) {
+	model := cacheableModel()
+
+	cases := []struct {
+		name string
+		isvc *inferencev1alpha1.InferenceService
+	}{
+		{"nil isvc", nil},
+		{"no modelCache block", &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		}},
+		{"modelCache set but persistence empty", &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelCache: &inferencev1alpha1.ModelCacheSpec{ClaimName: "user-pvc"},
+			},
+		}},
+		{"persistence explicitly Cached", &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelCache: &inferencev1alpha1.ModelCacheSpec{
+					Persistence: inferencev1alpha1.ModelCachePersistenceCached,
+				},
+			},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !modelNeedsCachePVC(model, tc.isvc, "/models") {
+				t.Error("caching should remain on; only an explicit Ephemeral opt-out disables it")
+			}
+		})
+	}
+}
+
+// The mount side must reach the same verdict as the provisioning side. A
+// mismatch is the failure worth guarding: the pod mounts a claim that was never
+// created, and stays Pending on a volume that will never appear.
+func TestModelCachePersistence_MountSideAgrees(t *testing.T) {
+	model := cacheableModel()
+
+	if !modelWantsCacheVolume(model, nil, "/models") {
+		t.Fatal("control failed: a cacheable model should mount the cache volume")
+	}
+	if modelWantsCacheVolume(model, ephemeralISvc(), "/models") {
+		t.Error("ephemeral persistence should mount an emptyDir, not the cache volume")
+	}
+
+	// Both gates must agree for every combination, since disagreement is what
+	// produces an orphaned claim or an unschedulable pod.
+	for _, isvc := range []*inferencev1alpha1.InferenceService{nil, ephemeralISvc()} {
+		if got, want := modelWantsCacheVolume(model, isvc, "/models"), modelNeedsCachePVC(model, isvc, "/models"); got != want {
+			t.Errorf("mount side (%v) and provisioning side (%v) disagree", got, want)
+		}
+	}
+}
+
+// Ephemeral must not resurrect caching when the operator has it switched off
+// globally, and must not override the pvc:// exclusion.
+func TestModelCachePersistence_DoesNotOverrideOtherExclusions(t *testing.T) {
+	if modelNeedsCachePVC(cacheableModel(), ephemeralISvc(), "") {
+		t.Error("caching disabled on the operator must stay disabled")
+	}
+	staged := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+		Spec:       inferencev1alpha1.ModelSpec{Source: "pvc://weights/m.gguf"},
+	}
+	staged.Status.CacheKey = "deadbeefdeadbeef"
+	if modelNeedsCachePVC(staged, ephemeralISvc(), "/models") {
+		t.Error("pvc:// sources are pre-staged and never take a cache PVC")
+	}
+}

--- a/internal/controller/model_cache_pvc_test.go
+++ b/internal/controller/model_cache_pvc_test.go
@@ -36,7 +36,10 @@ func TestModelNeedsCachePVC(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := modelNeedsCachePVC(tc.model, tc.cachePath); got != tc.want {
+			// nil isvc: these cases predate spec.modelCache.persistence and
+			// assert the operator-level behaviour, which a nil isvc preserves
+			// (no opt-out). Ephemeral is covered in model_cache_ephemeral_test.go.
+			if got := modelNeedsCachePVC(tc.model, nil, tc.cachePath); got != tc.want {
 				t.Errorf("modelNeedsCachePVC(source=%q, cachePath=%q) = %v, want %v",
 					tc.model.Spec.Source, tc.cachePath, got, tc.want)
 			}

--- a/internal/controller/model_cache_validation_test.go
+++ b/internal/controller/model_cache_validation_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// These specs exercise the InferenceService CRD's server-side validation for
+// spec.modelCache (the persistence enum, and the CEL rule making persistence
+// Ephemeral mutually exclusive with claimName). They run against the envtest
+// apiserver, so a failure here means the generated CRD schema does not enforce
+// what the type claims. Unit tests over the Go predicates cannot catch that:
+// the conflict is a static contradiction and is rejected at admission, never
+// reaching the reconciler.
+var _ = Describe("InferenceService modelCache CRD validation", func() {
+	ctx := context.Background()
+
+	newISvc := func(name string, cache *inferencev1alpha1.ModelCacheSpec) *inferencev1alpha1.InferenceService {
+		return &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:   "modelcache-cel-model",
+				ModelCache: cache,
+			},
+		}
+	}
+
+	It("admits an absent modelCache block", func() {
+		isvc := newISvc("mc-valid-absent", nil)
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	It("admits Ephemeral on its own", func() {
+		isvc := newISvc("mc-valid-ephemeral", &inferencev1alpha1.ModelCacheSpec{
+			Persistence: inferencev1alpha1.ModelCachePersistenceEphemeral,
+		})
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	It("admits claimName with persistence unset", func() {
+		isvc := newISvc("mc-valid-claim", &inferencev1alpha1.ModelCacheSpec{
+			ClaimName: "user-owned-cache",
+		})
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	// Cached is the resolution of an empty persistence, so pairing it with a
+	// claim must stay legal: that is the pre-#1451 behaviour spelled out.
+	It("admits claimName together with Cached", func() {
+		isvc := newISvc("mc-valid-claim-cached", &inferencev1alpha1.ModelCacheSpec{
+			Persistence: inferencev1alpha1.ModelCachePersistenceCached,
+			ClaimName:   "user-owned-cache",
+		})
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	It("rejects Ephemeral together with claimName", func() {
+		isvc := newISvc("mc-invalid-both", &inferencev1alpha1.ModelCacheSpec{
+			Persistence: inferencev1alpha1.ModelCachePersistenceEphemeral,
+			ClaimName:   "user-owned-cache",
+		})
+		err := k8sClient.Create(ctx, isvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(
+			"claimName cannot be set when persistence is Ephemeral"))
+	})
+
+	It("rejects an unknown persistence value", func() {
+		isvc := newISvc("mc-invalid-enum", &inferencev1alpha1.ModelCacheSpec{
+			Persistence: inferencev1alpha1.ModelCachePersistence("Sometimes"),
+		})
+		err := k8sClient.Create(ctx, isvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Unsupported value"))
+	})
+})

--- a/internal/controller/model_cache_validation_test.go
+++ b/internal/controller/model_cache_validation_test.go
@@ -91,6 +91,33 @@ var _ = Describe("InferenceService modelCache CRD validation", func() {
 			"claimName cannot be set when persistence is Ephemeral"))
 	})
 
+	// The quantity pattern exists because the value reaches resource parsing.
+	// Its sibling fields (cpu, memory, hostMemory) carry no pattern and reach
+	// resource.MustParse, which panics on malformed input and takes the
+	// controller down for every workload rather than failing the one object at
+	// fault. Rejecting at admission keeps that blast radius at zero here.
+	It("admits a well-formed ephemeralStorage quantity", func() {
+		isvc := newISvc("mc-valid-storage", &inferencev1alpha1.ModelCacheSpec{
+			Persistence: inferencev1alpha1.ModelCachePersistenceEphemeral,
+		})
+		isvc.Spec.Resources = &inferencev1alpha1.InferenceResourceRequirements{
+			EphemeralStorage: "40Gi",
+		}
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	It("rejects a malformed ephemeralStorage quantity", func() {
+		isvc := newISvc("mc-invalid-storage", &inferencev1alpha1.ModelCacheSpec{
+			Persistence: inferencev1alpha1.ModelCachePersistenceEphemeral,
+		})
+		isvc.Spec.Resources = &inferencev1alpha1.InferenceResourceRequirements{
+			EphemeralStorage: "40GB",
+		}
+		err := k8sClient.Create(ctx, isvc)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("rejects an unknown persistence value", func() {
 		isvc := newISvc("mc-invalid-enum", &inferencev1alpha1.ModelCacheSpec{
 			Persistence: inferencev1alpha1.ModelCachePersistence("Sometimes"),

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -118,6 +118,31 @@ func (r *InferenceServiceReconciler) warnIgnoredModelCacheClaim(
 	}
 }
 
+// warnUnboundedEphemeralCache emits a warning when a service opts out of the
+// cache but declares no ephemeral-storage budget, leaving the emptyDir the
+// weights land in unbounded.
+//
+// Not a hard failure: refusing to reconcile would take down a workload that
+// runs perfectly well on a node with room, and how much room a node has varies
+// by an order of magnitude across distributions and machine types. But it is
+// silent otherwise, and it is only visible once a node fills and the kubelet
+// starts evicting by QoS class, potentially removing unrelated workloads first.
+func (r *InferenceServiceReconciler) warnUnboundedEphemeralCache(
+	isvc *inferencev1alpha1.InferenceService,
+) {
+	if r.Recorder == nil || !modelCacheIsEphemeral(isvc) {
+		return
+	}
+	if isvc.Spec.Resources != nil && isvc.Spec.Resources.EphemeralStorage != "" {
+		return
+	}
+	r.Recorder.Eventf(isvc, nil, corev1.EventTypeWarning, "UnboundedEphemeralCache", "Reconcile",
+		"modelCache.persistence is Ephemeral but spec.resources.ephemeralStorage is unset: "+
+			"model weights download to node local disk with no size limit and no scheduler "+
+			"accounting. Set spec.resources.ephemeralStorage above the model size so an "+
+			"overrun evicts this pod rather than filling the node")
+}
+
 // modelNeedsCachePVC reports whether the operator should provision a model
 // cache PVC for this reconcile. Caching must be enabled on the operator
 // (modelCachePath set) and the model must have a cache key. It must NOT be a
@@ -152,6 +177,38 @@ func modelWantsCacheVolume(
 	return modelCachePath != "" &&
 		effectiveModelCacheKey(model) != "" &&
 		!modelCacheIsEphemeral(isvc)
+}
+
+// ephemeralCacheSizeLimit returns the sizeLimit to put on the emptyDir that
+// backs an ephemeral model cache, or nil to leave it unbounded.
+//
+// Bounded is strongly preferred. An emptyDir with no sizeLimit is written to
+// the node's ephemeral storage, where the kubelet will not charge it to this
+// Pod alone: a multi-gigabyte model on a node with a small boot disk crosses
+// the node's DiskPressure threshold, and eviction then proceeds by QoS class,
+// which can remove unrelated workloads before this one. With a sizeLimit the
+// kubelet evicts the Pod that actually overran.
+//
+// nil when the user declared no budget. Guessing is worse than not bounding:
+// the model's size on disk is not reliably known (Status.Size comes from the
+// GGUF metadata range read, which only runs for remote http(s) sources, so it
+// is absent for s3:// among others), and a guess that lands under the real size
+// evicts the Pod for exceeding a number nobody chose.
+func ephemeralCacheSizeLimit(isvc *inferencev1alpha1.InferenceService) *resource.Quantity {
+	if !modelCacheIsEphemeral(isvc) || isvc.Spec.Resources == nil {
+		return nil
+	}
+	if isvc.Spec.Resources.EphemeralStorage == "" {
+		return nil
+	}
+	q, err := resource.ParseQuantity(isvc.Spec.Resources.EphemeralStorage)
+	if err != nil {
+		// The CRD validates the format, so this is unreachable via the API. Do
+		// not fail the build over it: an unbounded emptyDir still serves, while
+		// refusing to construct the Pod would take the workload down.
+		return nil
+	}
+	return &q
 }
 
 // modelCacheIsEphemeral reports whether the InferenceService declined the cache
@@ -741,8 +798,10 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 		initVolumeMounts := []corev1.VolumeMount{{Name: "model-storage", MountPath: "/models"}}
 		volumes := []corev1.Volume{
 			{
-				Name:         "model-storage",
-				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				Name: "model-storage",
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{
+					SizeLimit: ephemeralCacheSizeLimit(isvc),
+				}},
 			},
 		}
 
@@ -770,8 +829,10 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 	initVolumeMounts := []corev1.VolumeMount{{Name: "model-storage", MountPath: "/models"}}
 	volumes := []corev1.Volume{
 		{
-			Name:         "model-storage",
-			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			Name: "model-storage",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{
+				SizeLimit: ephemeralCacheSizeLimit(isvc),
+			}},
 		},
 	}
 

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -203,9 +203,10 @@ func ephemeralCacheSizeLimit(isvc *inferencev1alpha1.InferenceService) *resource
 	}
 	q, err := resource.ParseQuantity(isvc.Spec.Resources.EphemeralStorage)
 	if err != nil {
-		// The CRD validates the format, so this is unreachable via the API. Do
-		// not fail the build over it: an unbounded emptyDir still serves, while
-		// refusing to construct the Pod would take the workload down.
+		// A CRD pattern rejects malformed values at admission, so this is not
+		// reachable through the API. Handled rather than asserted anyway: an
+		// unbounded emptyDir still serves, while panicking would take the
+		// controller down for every workload.
 		return nil
 	}
 	return &q

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -126,10 +126,41 @@ func (r *InferenceServiceReconciler) warnIgnoredModelCacheClaim(
 // cache), so provisioning a cache PVC for them only leaves an unused,
 // ISVC-owned claim. Kept as its own predicate so the mount side (isPVCSource
 // in buildModelStorageConfig) and the provisioning side agree on pvc://.
-func modelNeedsCachePVC(model *inferencev1alpha1.Model, modelCachePath string) bool {
+func modelNeedsCachePVC(
+	model *inferencev1alpha1.Model,
+	isvc *inferencev1alpha1.InferenceService,
+	modelCachePath string,
+) bool {
+	return modelWantsCacheVolume(model, isvc, modelCachePath) &&
+		!isPVCSource(model.Spec.Source)
+}
+
+// modelWantsCacheVolume reports whether this workload should download into the
+// model cache volume rather than an ephemeral emptyDir. It is the MOUNT-side
+// question, and modelNeedsCachePVC (the provisioning side) is defined in terms
+// of it so the two cannot drift: a mount without a claim leaves the Pod Pending
+// on a volume nobody creates, and a claim without a mount leaves an orphaned,
+// ISVC-owned PVC behind.
+//
+// The pvc:// exclusion lives only on the provisioning side because those
+// sources are dispatched to buildPVCStorageConfig, which never consults this.
+func modelWantsCacheVolume(
+	model *inferencev1alpha1.Model,
+	isvc *inferencev1alpha1.InferenceService,
+	modelCachePath string,
+) bool {
 	return modelCachePath != "" &&
 		effectiveModelCacheKey(model) != "" &&
-		!isPVCSource(model.Spec.Source)
+		!modelCacheIsEphemeral(isvc)
+}
+
+// modelCacheIsEphemeral reports whether the InferenceService declined the cache
+// (#1451). Only an explicit Ephemeral opts out: a nil isvc, an absent
+// modelCache block, and an empty persistence all resolve to Cached, so the
+// default behaviour is unchanged.
+func modelCacheIsEphemeral(isvc *inferencev1alpha1.InferenceService) bool {
+	return isvc != nil && isvc.Spec.ModelCache != nil &&
+		isvc.Spec.ModelCache.Persistence == inferencev1alpha1.ModelCachePersistenceEphemeral
 }
 
 // modelCachePVCName returns the name of the model cache PVC for the given mode.


### PR DESCRIPTION
## What

Adds `spec.modelCache.persistence` to InferenceService. `Ephemeral` declines the
model cache PVC and downloads into an `emptyDir` instead; `Cached` (the default,
and what an empty value resolves to) is today's behaviour.

```yaml
spec:
  modelRef: qwopus-fusion-q4km-s3
  modelCache:
    persistence: Ephemeral
```

## Why

Fixes #1451

`ModelCacheSpec` carried only `ClaimName`, which redirects the cache to a
user-managed PVC. There was no way to say "this service does not want a cache
volume at all". The only opt-out was global: unset `--model-cache-path`, which
disables caching for every workload in the cluster.

Two situations need it.

**Nodes where dynamic provisioning is unavailable.** A provisioner whose
volume-creation helper cannot tolerate the node's taints will never bind the
claim. microk8s-hostpath provisions by spawning a helper pod pinned to the PVC's
selected node; that helper carries no tolerations and the image exposes no args
and no ConfigMap, so a `NoSchedule` node blocks provisioning permanently and
silently: no error, no retry, no event naming a cause. A Pod on a tainted GPU
node waits forever on a volume that will never arrive. There is a storage-side
fix, but LLMKube should not require a particular provisioner to place a workload
on a tainted node.

**A fast local origin, where the cache does not earn its keep.** Measured on one
fleet, the same 15.65 GB GGUF took 4m22s at 61 MB/s from Hugging Face and 2m52s
at 93 MB/s from an in-cluster MinIO. At that rate a cold pull on restart can
cost less than a 100Gi per-service volume on every GPU node, particularly since
`perService` caches are node-local and never shared, so their only value is
surviving a restart on the same node.

This is the air-gapped and on-prem story: a user who has stood up a local model
origin should be able to treat node storage as disposable.

## How

**Named `persistence`, not `mode`.** The issue proposed `mode`, and I changed it
while implementing. The operator already has `--model-cache-mode`
(`shared` / `perService`) selecting WHICH cache PVC is used; this field answers
whether there is one at all. Two adjacent fields both called "mode" on different
axes is a footgun, and the CRD field docs would have had to spend a paragraph
undoing the confusion.

**Both gates now derive from one predicate.** The provisioning side
(`modelNeedsCachePVC`, which creates the claim) and the mount side (the
`useCache` value the deployment builder passes to `buildModelStorageConfig`)
were independent expressions of the same question. `modelWantsCacheVolume` is
now the mount-side answer and `modelNeedsCachePVC` is defined in terms of it, so
they cannot drift. Drift is the failure worth preventing: a mount without a
claim leaves the Pod Pending on a volume nobody creates, and a claim without a
mount leaves an orphaned ISVC-owned PVC. A test asserts their agreement directly
rather than trusting the two call sites to stay in sync.

The `pvc://` exclusion stays only on the provisioning side, because those
sources dispatch to `buildPVCStorageConfig` and never consult the mount gate.

**Only an explicit `Ephemeral` opts out.** A nil isvc, an absent `modelCache`
block, and an empty `persistence` all resolve to `Cached`. `Ephemeral` also does
not override the existing exclusions in either direction: caching disabled on
the operator stays disabled, and `pvc://` sources still take no cache PVC.

**Mutual exclusion with `claimName` is enforced by CEL,** not an event. One
names a cache volume to use and the other declines to use any, which is a static
contradiction, so it belongs at admission rather than in a warning the user
finds later. `claimName` with `Cached`, or with `persistence` unset, stays legal:
that is the pre-existing behaviour spelled out.

## Testing

Unit tests over the predicates (`model_cache_ephemeral_test.go`), including a
control assertion in each direction so a test cannot pass because the fixture
was never cacheable, and a direct check that the two gates agree.

Envtest specs (`model_cache_validation_test.go`) prove the CEL rule and the enum
are enforced **by the apiserver**, not merely present in the generated schema.
Unit tests over the Go predicates cannot catch a schema regression here, since
the conflict is rejected at admission and never reaches the reconciler. Verified
these actually execute rather than being filtered: `Ran 6 of 684 Specs ...
6 Passed | 0 Failed`.

- `go test ./internal/controller/` with envtest: pass (254s)
- `make lint`: 0 issues
- `make manifests` + `make chart-crds`: both CRDs regenerated and in sync
- `helm template charts/llmkube`: renders

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

Docs: the CRD field documentation carries the guidance (including that the cost
is paid at a time far removed from the decision, so the default should be
preferred), and `config/samples/inferenceservice_ephemeral_cache.yaml` is a
worked example registered in the samples kustomization.

Assisted-by: Claude Code (the implementation, tests, and this description;
I reviewed the change, chose the field naming, and ran the envtest suite,
make lint, and the CRD regeneration myself)
