### PR TITLE
fix(api): reject unservable speculativeDecoding type draft at admission

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -66,6 +66,7 @@ type SpeculativeDecodingType string
 // runtime. It maps to --spec-type (Type) and --spec-draft-n-max (NDraftMax).
 // Only the "llamacpp" runtime supports this field; other runtimes must not
 // set it.
+// +kubebuilder:validation:XValidation:rule="self.type != 'draft'",message="type \"draft\" is not supported: there is no draft-model field to name the draft weights; use type \"mtp\" for self-speculation instead"
 type SpeculativeDecodingSpec struct {
 	// Type is the speculative decoding method (--spec-type). "mtp" maps to
 	// draft-mtp, "draft" maps to draft-simple, and "disabled" (or omitting the

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -5263,6 +5263,11 @@ spec:
                 required:
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: 'type "draft" is not supported: there is no draft-model
+                    field to name the draft weights; use type "mtp" for self-speculation
+                    instead'
+                  rule: self.type != 'draft'
               suspend:
                 default: false
                 description: |-

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -5259,6 +5259,11 @@ spec:
                 required:
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: 'type "draft" is not supported: there is no draft-model
+                    field to name the draft weights; use type "mtp" for self-speculation
+                    instead'
+                  rule: self.type != 'draft'
               suspend:
                 default: false
                 description: |-

--- a/internal/controller/speculative_decoding_validation_test.go
+++ b/internal/controller/speculative_decoding_validation_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// These specs exercise the InferenceService CRD's server-side validation for
+// spec.speculativeDecoding: the CEL rule that rejects type "draft" because
+// there is no draft-model field to name the draft weights. They run against
+// the envtest apiserver, so a failure here means the generated CRD schema
+// does not enforce what the type claims.
+var _ = Describe("InferenceService speculativeDecoding CRD validation", func() {
+	ctx := context.Background()
+
+	newISvc := func(name string, sd *inferencev1alpha1.SpeculativeDecodingSpec) *inferencev1alpha1.InferenceService {
+		return &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:            "specdec-cel-model",
+				SpeculativeDecoding: sd,
+			},
+		}
+	}
+
+	It("admits type mtp (self-speculation)", func() {
+		isvc := newISvc("sd-valid-mtp", &inferencev1alpha1.SpeculativeDecodingSpec{
+			Type: "mtp",
+		})
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	It("admits type disabled", func() {
+		isvc := newISvc("sd-valid-disabled", &inferencev1alpha1.SpeculativeDecodingSpec{
+			Type: "disabled",
+		})
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	It("rejects type draft with a helpful message", func() {
+		isvc := newISvc("sd-invalid-draft", &inferencev1alpha1.SpeculativeDecodingSpec{
+			Type: "draft",
+		})
+		err := k8sClient.Create(ctx, isvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("type \"draft\" is not supported"))
+		Expect(err.Error()).To(ContainSubstring("use type \"mtp\""))
+	})
+})


### PR DESCRIPTION
## What

Reject `speculativeDecoding.type: draft` at admission with a CEL rule, so the CRD
stops admitting a configuration that can never be served.

## Why

Fixes #1383

`SpeculativeDecodingSpec` accepted `type: draft` but carries no field naming the
draft weights, so an admitted spec was unservable. Of the two possible fixes,
this is the narrower: rejecting the unservable combination is far smaller and
lower-risk than adding a draft-model field plus its plumbing into runtime args.
The error message names the supported alternative (`mtp`) rather than just
refusing.

## How

One `XValidation` rule on the struct. Both CRDs regenerated and in sync.
`type: mtp` and `disabled` are untouched.

**Migration note, worth an explicit decision:** this tightens an existing API.
Any InferenceService already carrying `type: draft` will be rejected on its next
update. Such an object cannot be serving today (that is the bug), but it will
now fail to update rather than failing at runtime.

## Verification

Build, vet, and the full `internal/controller` suite with envtest all pass, run
in a clean worktree against current main. Envtest specs cover the admission
behaviour.

Assisted-by: Claude Code (branch produced by the Foreman agent harness on a self-hosted model; I reviewed the diff, ran build, vet and the package test suites in a clean worktree, and verified the specifics called out above).
