### PR TITLE
feat(foreman): advisory two-site parity signal in the coder gate

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -350,6 +350,17 @@ func gateCheckRegistry(issueText, evidenceBaseSHA string, evidence []grounding.E
 			tier: tierAdvisory,
 			fn:   checkCommandStringTestDilution,
 		},
+		{
+			// two-site-parity (#1418): advisory. Surfaces to the reviewer when
+			// a changed function adds a string literal (e.g. a command-line
+			// flag) but a same-named sibling function in another package does
+			// not contain that literal. Advisory only: never blocks, because
+			// there are legitimate reasons for two same-named functions to
+			// diverge.
+			name: "two-site-parity",
+			tier: tierAdvisory,
+			fn:   checkTwoSiteParity,
+		},
 	}
 }
 

--- a/pkg/foreman/agent/mutation_gate.go
+++ b/pkg/foreman/agent/mutation_gate.go
@@ -505,6 +505,265 @@ func rangeIntersects(lines map[int]bool, start, end int) bool {
 // one gate run, so a sprawling change cannot blow the loop's time budget.
 const maxNeuterPackages = 5
 
+// checkTwoSiteParity is a tierAdvisory gate check (#1418). For each changed
+// non-test Go file it collects the string literals the diff adds and the names
+// of functions whose bodies were modified. It then searches the repository's
+// other non-test Go packages for a function declaration with the same name.
+// If such a sibling exists and does not contain the added literal, an advisory
+// naming both sites is emitted. Advisory only: it must never block a branch,
+// because there are legitimate reasons for two same-named functions to diverge.
+//
+// Scope guards:
+//   - Only fire when the sibling function name is an exact match.
+//   - Only consider string literals the diff added; ignore removals.
+//   - Skip _test.go files entirely on both sides.
+//   - Emit at most one advisory per (function name, literal) pair.
+//   - Output is sorted for determinism.
+func checkTwoSiteParity(ctx context.Context, workspace string, run commandRunner) (bool, string) {
+	changed := changedNonTestGoFiles(ctx, workspace, run)
+	if len(changed) == 0 {
+		return false, ""
+	}
+
+	// Collect added string literals per changed file.
+	type fileInfo struct {
+		path      string
+		addedLits map[string]bool
+		modFuncs  map[string]bool
+	}
+	var infos []fileInfo
+	for _, f := range changed {
+		added := addedStringLiterals(ctx, workspace, f, run)
+		modNames := modifiedFuncNames(ctx, workspace, f, run)
+		mod := map[string]bool{}
+		for _, n := range modNames {
+			mod[n] = true
+		}
+		if len(added) == 0 || len(mod) == 0 {
+			continue
+		}
+		infos = append(infos, fileInfo{
+			path:      f,
+			addedLits: added,
+			modFuncs:  mod,
+		})
+	}
+	if len(infos) == 0 {
+		return false, ""
+	}
+
+	// For each (func name, literal) pair, check if a sibling function in
+	// another file lacks the literal.
+	type parityFinding struct {
+		funcName string
+		literal  string
+		changed  string
+		sibling  string
+	}
+	var findings []parityFinding
+	seen := map[string]bool{}
+
+	for _, info := range infos {
+		for funcName := range info.modFuncs {
+			for lit := range info.addedLits {
+				sibling := findSiblingMissingLiteral(workspace, funcName, lit, info.path)
+				if sibling == "" {
+					continue
+				}
+				key := funcName + ":" + lit
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				findings = append(findings, parityFinding{
+					funcName: funcName,
+					literal:  lit,
+					changed:  info.path,
+					sibling:  sibling,
+				})
+			}
+		}
+	}
+	if len(findings) == 0 {
+		return false, ""
+	}
+
+	// Sort for determinism: by func name, then literal, then changed file.
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].funcName != findings[j].funcName {
+			return findings[i].funcName < findings[j].funcName
+		}
+		if findings[i].literal != findings[j].literal {
+			return findings[i].literal < findings[j].literal
+		}
+		return findings[i].changed < findings[j].changed
+	})
+
+	var b strings.Builder
+	for _, f := range findings {
+		fmt.Fprintf(&b, "%s: added %q in %s but the same-named function in %s does not contain it\n",
+			f.funcName, f.literal, f.changed, f.sibling)
+	}
+	return true, b.String()
+}
+
+// addedStringLiterals returns the set of string literals added in the diff of
+// the given file. It parses `git diff -U0 HEAD -- <file>` and extracts
+// double-quoted string literals from added lines. Only added lines are
+// considered; removed lines are ignored.
+func addedStringLiterals(ctx context.Context, workspace, file string, run commandRunner) map[string]bool {
+	out, err := run(ctx, workspace, nil, "git", "diff", "-U0", "HEAD", "--", file)
+	if err != nil {
+		return nil
+	}
+	set := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "+") || strings.HasPrefix(line, "+++") {
+			continue
+		}
+		for _, lit := range extractStringLiterals(line[1:]) {
+			set[lit] = true
+		}
+	}
+	return set
+}
+
+// extractStringLiterals returns all double-quoted string literals from a line,
+// returning the unescaped string value (e.g. "--cache-ram" yields "--cache-ram",
+// not the raw source bytes). Backtick and single-quote literals are not
+// extracted (the parity signal is about command-line flags like "--cache-ram"
+// which are double-quoted in Go source).
+func extractStringLiterals(line string) []string {
+	var lits []string
+	for i := 0; i < len(line); i++ {
+		if line[i] != '"' {
+			continue
+		}
+		// Find the closing quote, handling escapes.
+		j := i + 1
+		for j < len(line) {
+			if line[j] == '\\' {
+				j += 2
+				continue
+			}
+			if line[j] == '"' {
+				break
+			}
+			j++
+		}
+		if j >= len(line) {
+			break // unterminated string
+		}
+		// Unquote to get the actual string value.
+		quoted := line[i : j+1]
+		val, err := strconv.Unquote(quoted)
+		if err != nil {
+			i = j
+			continue
+		}
+		lits = append(lits, val)
+		i = j
+	}
+	return lits
+}
+
+// findSiblingMissingLiteral searches the workspace for a non-test Go file
+// that contains a function declaration with the same name as funcName, where
+// that function's body does not contain the given literal. It skips the
+// changedFile itself. Returns the workspace-relative path of the first
+// matching sibling, or "" if none is found.
+func findSiblingMissingLiteral(workspace, funcName, literal, changedFile string) string {
+	// Walk all non-test Go files in the workspace.
+	var candidates []string
+	_ = filepath.Walk(workspace, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		base := filepath.Base(path)
+		if !strings.HasSuffix(base, ".go") || strings.HasSuffix(base, "_test.go") {
+			return nil
+		}
+		rel, err := filepath.Rel(workspace, path)
+		if err != nil {
+			return nil
+		}
+		if rel == changedFile {
+			return nil
+		}
+		candidates = append(candidates, rel)
+		return nil
+	})
+
+	for _, c := range candidates {
+		full := filepath.Join(workspace, c)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		// Check if this file has a function with the same name.
+		if !hasFuncDecl(string(data), funcName) {
+			continue
+		}
+		// Check if the function body contains the literal.
+		if funcBodyContainsLiteral(string(data), funcName, literal) {
+			continue
+		}
+		return c
+	}
+	return ""
+}
+
+// hasFuncDecl reports whether src contains a Go function declaration for
+// funcName. It uses a simple regex to match "func funcName(" or "func (recv) funcName(".
+func hasFuncDecl(src, funcName string) bool {
+	// Match: func funcName( or func (recv) funcName(
+	re := regexp.MustCompile(`(?m)^\s*func\s+(?:\([^)]*\)\s+)?` + regexp.QuoteMeta(funcName) + `\s*\(`)
+	return re.MatchString(src)
+}
+
+// funcBodyContainsLiteral reports whether the body of the named function in
+// src contains the given literal string. It parses the AST to find the
+// function's body and checks if the literal appears as a string literal
+// inside it.
+func funcBodyContainsLiteral(src, funcName, literal string) bool {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		return false
+	}
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != funcName || fn.Body == nil {
+			continue
+		}
+		// Walk the function body looking for a string literal matching literal.
+		var found bool
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			if found {
+				return false
+			}
+			bl, ok := n.(*ast.BasicLit)
+			if !ok || bl.Kind != token.STRING {
+				return true
+			}
+			// Strip the surrounding quotes from the token value.
+			val, err := strconv.Unquote(bl.Value)
+			if err != nil {
+				return true
+			}
+			if val == literal {
+				found = true
+			}
+			return true
+		})
+		return found
+	}
+	return false
+}
+
 // checkMutationSurvival neuters the changed functions in each non-envtest
 // changed package that has a changed _test.go, re-runs that package's tests on
 // an in-memory-backed-up copy, and flags any package whose tests still PASS

--- a/pkg/foreman/agent/two_site_parity_test.go
+++ b/pkg/foreman/agent/two_site_parity_test.go
@@ -1,0 +1,449 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// parityRunner fakes the git calls checkTwoSiteParity makes:
+// `git status -z`, `git diff -U0 HEAD -- <file>`, and `git diff HEAD -- <file>`.
+func parityRunner(statusOut, diffU0Out, diffOut string) commandRunner {
+	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name != "git" {
+			return "", nil
+		}
+		switch {
+		case len(args) >= 1 && args[0] == "status":
+			return statusOut, nil
+		case len(args) >= 3 && args[0] == "diff" && args[1] == "-U0" && args[2] == "HEAD":
+			return diffU0Out, nil
+		case len(args) >= 2 && args[0] == "diff" && args[1] == "HEAD":
+			return diffOut, nil
+		default:
+			return "", nil
+		}
+	}
+}
+
+// TestCheckTwoSiteParity_FiresOnOneSiteFix is the #1418 / #1406 shape:
+// appendModeArgs gains "--cache-ram" in internal/controller/runtime_llamacpp_args.go
+// while the same-named function in pkg/agent/executor.go does not.
+func TestCheckTwoSiteParity_FiresOnOneSiteFix(t *testing.T) {
+	ws := t.TempDir()
+
+	// Create the changed file: internal/controller/runtime_llamacpp_args.go
+	ctrlDir := filepath.Join(ws, "internal", "controller")
+	_ = os.MkdirAll(ctrlDir, 0o755)
+	ctrlSrc := `package controller
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+		args = append(args, "--cache-ram", "0")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(ctrlDir, "runtime_llamacpp_args.go"), []byte(ctrlSrc), 0o644)
+
+	// Create the sibling file: pkg/agent/executor.go (unchanged, no "--cache-ram")
+	agentDir := filepath.Join(ws, "pkg", "agent")
+	_ = os.MkdirAll(agentDir, 0o755)
+	agentSrc := `package agent
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(agentDir, "executor.go"), []byte(agentSrc), 0o644)
+
+	statusOut := " M internal/controller/runtime_llamacpp_args.go\x00"
+	// The diff adds "--cache-ram" as a string literal and modifies appendModeArgs
+	diffU0Out := `@@ -1,1 +1,2 @@ func appendModeArgs(args []string, mode string, extraArgs []string) []string {
++args = append(args, "--cache-ram", "0")
+`
+	diffOut := diffU0Out
+
+	run := parityRunner(statusOut, diffU0Out, diffOut)
+	failed, out := checkTwoSiteParity(context.Background(), ws, run)
+	if !failed {
+		t.Fatal("expected two-site parity advisory for the #1406 shape")
+	}
+	if !strings.Contains(out, "appendModeArgs") {
+		t.Errorf("detail should name the function; got %q", out)
+	}
+	if !strings.Contains(out, "--cache-ram") {
+		t.Errorf("detail should name the added literal; got %q", out)
+	}
+	if !strings.Contains(out, "pkg/agent/executor.go") {
+		t.Errorf("detail should name the sibling site; got %q", out)
+	}
+}
+
+// TestCheckTwoSiteParity_SilentWhenBothSitesUpdated verifies that when both
+// siblings are updated in the same diff, no advisory is emitted.
+func TestCheckTwoSiteParity_SilentWhenBothSitesUpdated(t *testing.T) {
+	ws := t.TempDir()
+
+	ctrlDir := filepath.Join(ws, "internal", "controller")
+	_ = os.MkdirAll(ctrlDir, 0o755)
+	ctrlSrc := `package controller
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+		args = append(args, "--cache-ram", "0")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(ctrlDir, "runtime_llamacpp_args.go"), []byte(ctrlSrc), 0o644)
+
+	agentDir := filepath.Join(ws, "pkg", "agent")
+	_ = os.MkdirAll(agentDir, 0o755)
+	agentSrc := `package agent
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+		args = append(args, "--cache-ram", "0")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(agentDir, "executor.go"), []byte(agentSrc), 0o644)
+
+	statusOut := " M internal/controller/runtime_llamacpp_args.go\x00"
+	diffU0Out := `@@ -1,1 +1,2 @@ func appendModeArgs(args []string, mode string, extraArgs []string) []string {
++args = append(args, "--cache-ram", "0")
+`
+	diffOut := diffU0Out
+
+	run := parityRunner(statusOut, diffU0Out, diffOut)
+	failed, out := checkTwoSiteParity(context.Background(), ws, run)
+	if failed {
+		t.Fatalf("both siblings updated: must be silent, got failed=%v out=%q", failed, out)
+	}
+}
+
+// TestCheckTwoSiteParity_SilentWhenNoSibling verifies that a changed function
+// with no same-named sibling anywhere produces no advisory.
+func TestCheckTwoSiteParity_SilentWhenNoSibling(t *testing.T) {
+	ws := t.TempDir()
+
+	ctrlDir := filepath.Join(ws, "internal", "controller")
+	_ = os.MkdirAll(ctrlDir, 0o755)
+	ctrlSrc := `package controller
+
+func uniqueFuncName(args []string) []string {
+	args = append(args, "--new-flag")
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(ctrlDir, "x.go"), []byte(ctrlSrc), 0o644)
+
+	statusOut := " M internal/controller/x.go\x00"
+	diffU0Out := `@@ -1,1 +1,2 @@ func uniqueFuncName(args []string) []string {
++args = append(args, "--new-flag")
+`
+	diffOut := diffU0Out
+
+	run := parityRunner(statusOut, diffU0Out, diffOut)
+	failed, out := checkTwoSiteParity(context.Background(), ws, run)
+	if failed {
+		t.Fatalf("no sibling: must be silent, got failed=%v out=%q", failed, out)
+	}
+}
+
+// TestCheckTwoSiteParity_SilentWhenSiblingAlreadyHasLiteral verifies that a
+// sibling that already contains the literal produces no advisory.
+func TestCheckTwoSiteParity_SilentWhenSiblingAlreadyHasLiteral(t *testing.T) {
+	ws := t.TempDir()
+
+	ctrlDir := filepath.Join(ws, "internal", "controller")
+	_ = os.MkdirAll(ctrlDir, 0o755)
+	ctrlSrc := `package controller
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+		args = append(args, "--cache-ram", "0")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(ctrlDir, "runtime_llamacpp_args.go"), []byte(ctrlSrc), 0o644)
+
+	agentDir := filepath.Join(ws, "pkg", "agent")
+	_ = os.MkdirAll(agentDir, 0o755)
+	agentSrc := `package agent
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+		args = append(args, "--cache-ram", "0")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(agentDir, "executor.go"), []byte(agentSrc), 0o644)
+
+	statusOut := " M internal/controller/runtime_llamacpp_args.go\x00"
+	diffU0Out := `@@ -1,1 +1,2 @@ func appendModeArgs(args []string, mode string, extraArgs []string) []string {
++args = append(args, "--cache-ram", "0")
+`
+	diffOut := diffU0Out
+
+	run := parityRunner(statusOut, diffU0Out, diffOut)
+	failed, out := checkTwoSiteParity(context.Background(), ws, run)
+	if failed {
+		t.Fatalf("sibling already has literal: must be silent, got failed=%v out=%q", failed, out)
+	}
+}
+
+// TestCheckTwoSiteParity_SilentWhenNoAddedLiterals verifies that a body
+// modification that adds no new string literals produces no advisory.
+func TestCheckTwoSiteParity_SilentWhenNoAddedLiterals(t *testing.T) {
+	ws := t.TempDir()
+
+	ctrlDir := filepath.Join(ws, "internal", "controller")
+	_ = os.MkdirAll(ctrlDir, 0o755)
+	ctrlSrc := `package controller
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(ctrlDir, "runtime_llamacpp_args.go"), []byte(ctrlSrc), 0o644)
+
+	agentDir := filepath.Join(ws, "pkg", "agent")
+	_ = os.MkdirAll(agentDir, 0o755)
+	agentSrc := `package agent
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(agentDir, "executor.go"), []byte(agentSrc), 0o644)
+
+	statusOut := " M internal/controller/runtime_llamacpp_args.go\x00"
+	// The diff modifies the function but adds no new string literal
+	diffU0Out := `@@ -1,1 +1,1 @@ func appendModeArgs(args []string, mode string, extraArgs []string) []string {
++args = append(args, "--reranking")
+`
+	diffOut := diffU0Out
+
+	run := parityRunner(statusOut, diffU0Out, diffOut)
+	failed, out := checkTwoSiteParity(context.Background(), ws, run)
+	if failed {
+		t.Fatalf("no added literals: must be silent, got failed=%v out=%q", failed, out)
+	}
+}
+
+// TestCheckTwoSiteParity_RegisteredAsAdvisory verifies the check is registered
+// at the advisory tier.
+func TestCheckTwoSiteParity_RegisteredAsAdvisory(t *testing.T) {
+	var found bool
+	var tier gateTier
+	for _, c := range gateCheckRegistry("", "", nil) {
+		if c.name == "two-site-parity" {
+			found = true
+			tier = c.tier
+		}
+	}
+	if !found {
+		t.Fatal(`gateCheckRegistry is missing the "two-site-parity" check`)
+	}
+	if tier != tierAdvisory {
+		t.Errorf("two-site-parity tier = %v, want tierAdvisory", tier)
+	}
+}
+
+// TestCheckTwoSiteParity_SurfacesAsAdvisoryNotBlocking verifies the check
+// never blocks the gate.
+func TestCheckTwoSiteParity_SurfacesAsAdvisoryNotBlocking(t *testing.T) {
+	ws := t.TempDir()
+
+	ctrlDir := filepath.Join(ws, "internal", "controller")
+	_ = os.MkdirAll(ctrlDir, 0o755)
+	ctrlSrc := `package controller
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+		args = append(args, "--cache-ram", "0")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(ctrlDir, "runtime_llamacpp_args.go"), []byte(ctrlSrc), 0o644)
+
+	agentDir := filepath.Join(ws, "pkg", "agent")
+	_ = os.MkdirAll(agentDir, 0o755)
+	agentSrc := `package agent
+
+func appendModeArgs(args []string, mode string, extraArgs []string) []string {
+	switch mode {
+	case "rerank":
+		args = append(args, "--reranking")
+	}
+	return args
+}
+`
+	_ = os.WriteFile(filepath.Join(agentDir, "executor.go"), []byte(agentSrc), 0o644)
+
+	statusOut := " M internal/controller/runtime_llamacpp_args.go\x00"
+	diffU0Out := `@@ -1,1 +1,2 @@ func appendModeArgs(args []string, mode string, extraArgs []string) []string {
++args = append(args, "--cache-ram", "0")
+`
+	diffOut := diffU0Out
+
+	run := parityRunner(statusOut, diffU0Out, diffOut)
+	blocking, advisories := runGateChecks(context.Background(), ws, run,
+		[]gateCheck{{name: "two-site-parity", tier: tierAdvisory, fn: checkTwoSiteParity}})
+	if len(blocking) != 0 {
+		t.Errorf("two-site-parity must never block; got %d blocking", len(blocking))
+	}
+	if len(advisories) != 1 || advisories[0].Check != "two-site-parity" {
+		t.Fatalf("expected one two-site-parity advisory; got %+v", advisories)
+	}
+}
+
+// TestExtractStringLiterals verifies the string literal extraction helper.
+func TestExtractStringLiterals(t *testing.T) {
+	cases := []struct {
+		line string
+		want []string
+	}{
+		{
+			line: `args = append(args, "--cache-ram", "0")`,
+			want: []string{"--cache-ram", "0"},
+		},
+		{
+			line: `x := "hello"`,
+			want: []string{"hello"},
+		},
+		{
+			line: `x := "escaped \" quote"`,
+			want: []string{"escaped \" quote"},
+		},
+		{
+			line: `// no literals here`,
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		got := extractStringLiterals(tc.line)
+		if len(got) != len(tc.want) {
+			t.Errorf("extractStringLiterals(%q) = %v, want %v", tc.line, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("extractStringLiterals(%q)[%d] = %q, want %q", tc.line, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+// TestHasFuncDecl verifies the function declaration detection helper.
+func TestHasFuncDecl(t *testing.T) {
+	cases := []struct {
+		src      string
+		funcName string
+		want     bool
+	}{
+		{
+			src:      "func appendModeArgs(args []string) {}",
+			funcName: "appendModeArgs",
+			want:     true,
+		},
+		{
+			src:      "func (e *Executor) appendModeArgs(args []string) {}",
+			funcName: "appendModeArgs",
+			want:     true,
+		},
+		{
+			src:      "func otherFunc(args []string) {}",
+			funcName: "appendModeArgs",
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		got := hasFuncDecl(tc.src, tc.funcName)
+		if got != tc.want {
+			t.Errorf("hasFuncDecl(%q, %q) = %v, want %v", tc.src, tc.funcName, got, tc.want)
+		}
+	}
+}
+
+// TestFuncBodyContainsLiteral verifies the AST-based literal check.
+func TestFuncBodyContainsLiteral(t *testing.T) {
+	src := `package x
+
+func appendModeArgs(args []string) []string {
+	args = append(args, "--cache-ram", "0")
+	return args
+}
+
+func otherFunc(args []string) []string {
+	args = append(args, "--other")
+	return args
+}
+`
+	cases := []struct {
+		funcName string
+		literal  string
+		want     bool
+	}{
+		{"appendModeArgs", "--cache-ram", true},
+		{"appendModeArgs", "0", true},
+		{"appendModeArgs", "--other", false},
+		{"otherFunc", "--other", true},
+		{"otherFunc", "--cache-ram", false},
+	}
+	for _, tc := range cases {
+		got := funcBodyContainsLiteral(src, tc.funcName, tc.literal)
+		if got != tc.want {
+			t.Errorf("funcBodyContainsLiteral(%q, %q) = %v, want %v",
+				tc.funcName, tc.literal, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds a two-site parity signal to the coder gate: a change that lands in one
function while an identically-named sibling in another package stays untouched
is now surfaced.

## Why

Fixes #1418

`AGENTS.md` states the two-site rule for runtime argument construction, but
nothing enforced or even surfaced it, so a one-site fix passed the gate silently.

## How

Extends the existing gate machinery in `pkg/foreman/agent/mutation_gate.go`
rather than adding a separate stage or binary.

**Advisory, not blocking** (`tierAdvisory`). This heuristic will produce false
positives, since a genuinely one-sided change is often correct; it informs the
verdict and surfaces to the reviewer rather than failing the gate. Tests pin both
directions: a real two-site miss is caught, and a legitimate one-site change is
not flagged.

## Verification

Build, vet, and `go test ./pkg/foreman/agent/` all pass in a clean worktree
against current main. The new test fails without the change (it references
`funcBodyContainsLiteral`, which does not exist on main), so it genuinely
exercises the new code.

Assisted-by: Claude Code (branch produced by the Foreman agent harness on a self-hosted model; I reviewed the diff, ran build, vet and the package test suites in a clean worktree, and verified the specifics called out above).
