### PR TITLE
feat(foreman): read-only fetch_pull_request tool

### DIFF
--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -72,6 +72,7 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubprfetch"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/mcp"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	foremantools "github.com/defilantech/llmkube/pkg/foreman/agent/tools"
@@ -810,6 +811,16 @@ func makeRegistryFactory(
 			// Closes #580.
 			&foremantools.FetchIssueTool{
 				Fetcher: githubissue.NewClient(),
+				Token:   repo.TokenFromEnvOrFile,
+			},
+			// fetch_pull_request: read-only GitHub PR surface for the
+			// coder. The same token the foreman-agent already loads
+			// at startup (via repo.TokenFromEnvOrFile) reaches GitHub
+			// through one bounded Go-side call instead of being
+			// inherited by every bash subprocess via $GH_TOKEN.
+			// Closes #1434.
+			&foremantools.FetchPullRequestTool{
+				Fetcher: githubprfetch.NewClient(),
 				Token:   repo.TokenFromEnvOrFile,
 			},
 			// run_integrate: deterministic tool for a sliced Workload's

--- a/pkg/foreman/agent/githubprfetch/fetch.go
+++ b/pkg/foreman/agent/githubprfetch/fetch.go
@@ -1,0 +1,429 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package githubprfetch fetches a single GitHub pull request's details,
+// reviews, review comments, and check runs so a coder Agent can read the
+// PR it is asked to fix. The model needs to know WHAT it is fixing; reading
+// the PR body and review feedback is the obvious way to learn that, and the
+// harness reading it for the model keeps the model's tool budget free for
+// the actual fix.
+//
+// Trade-offs deliberately taken:
+//
+//   - REST, not GraphQL: one endpoint per call, one JSON shape, no scopes
+//     to guess. Body caps address the "rich content" argument for GraphQL.
+//   - Title + body + state + reviews + review_comments + check_runs. The
+//     model can pull more via `bash` if it really needs it (it almost
+//     never does).
+//   - Best-effort. A failed fetch logs and the executor keeps the existing
+//     empty-body behavior; the loop runs with whatever buildUserPrompt
+//     produces from the (empty) payload prompt.
+package githubprfetch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
+)
+
+// DefaultBodyCap bounds the PR body size we paste into the user prompt.
+// 16 KiB is enough for the actual feature/bug description on the LLMKube
+// tracker (median PR body ~1-2 KB, p99 ~8 KB). Larger PRs get truncated
+// with a marker so the model knows there is more.
+const DefaultBodyCap = 16 * 1024
+
+// DefaultTimeout caps a single fetch. The GitHub API is fast; if the
+// network is slow we'd rather skip the fetch than hold up the loop.
+const DefaultTimeout = 10 * time.Second
+
+// PullRequest is the minimum subset of the GitHub PR payload the executor
+// needs. State is included so a model handed a closed PR can decide to
+// NO-GO immediately rather than re-implement a fix that already shipped.
+type PullRequest struct {
+	Number         int             `json:"number"`
+	Title          string          `json:"title"`
+	Body           string          `json:"body"`
+	State          string          `json:"state"`
+	Merged         bool            `json:"merged"`
+	HeadRef        string          `json:"head_ref"`
+	BaseRef        string          `json:"base_ref"`
+	Reviews        []Review        `json:"reviews,omitempty"`
+	ReviewComments []ReviewComment `json:"review_comments,omitempty"`
+	CheckRuns      []CheckRun      `json:"check_runs,omitempty"`
+}
+
+// Review is a single PR review.
+type Review struct {
+	Author    string `json:"author"`
+	State     string `json:"state"`
+	Body      string `json:"body"`
+	Submitted string `json:"submitted_at"`
+}
+
+// ReviewComment is an inline review comment on a specific file/line.
+type ReviewComment struct {
+	Author       string `json:"author"`
+	Path         string `json:"path"`
+	Line         int    `json:"line"`
+	OriginalLine int    `json:"original_line"`
+	Body         string `json:"body"`
+}
+
+// CheckRun is a single check run result.
+type CheckRun struct {
+	Name       string `json:"name"`
+	Conclusion string `json:"conclusion"`
+	DetailsURL string `json:"details_url"`
+}
+
+// Fetcher is the seam between the executor and the GitHub API. The
+// executor takes a Fetcher in via dependency injection so unit tests
+// can substitute an httptest server. Production builds wire a Client
+// backed by net/http.
+type Fetcher interface {
+	Fetch(ctx context.Context, owner, repo string, number int, token string) (*PullRequest, error)
+}
+
+// Client is the production Fetcher. BaseURL is overridable so tests
+// can point at an httptest server; production leaves it empty and the
+// client uses https://api.github.com.
+type Client struct {
+	HTTPClient *http.Client
+	BaseURL    string // empty defaults to https://api.github.com
+	BodyCap    int    // 0 defaults to DefaultBodyCap
+}
+
+// NewClient constructs a Client with sensible defaults: 10s timeout,
+// GitHub's public API base URL, and the standard body cap.
+func NewClient() *Client {
+	return &Client{
+		HTTPClient: &http.Client{Timeout: DefaultTimeout},
+	}
+}
+
+// Fetch calls GET /repos/{owner}/{repo}/pulls/{number} and related
+// endpoints to gather reviews, review comments, and check runs. Token
+// is the GitHub PAT (or fine-grained token) used in the Authorization
+// header; the empty string sends an unauthenticated request, which
+// works for public repos at the lower rate-limit tier (60/hr/IP).
+func (c *Client) Fetch(ctx context.Context, owner, repo string, number int, token string) (*PullRequest, error) {
+	if owner == "" || repo == "" {
+		return nil, fmt.Errorf("githubprfetch: owner+repo required")
+	}
+	if number <= 0 {
+		return nil, fmt.Errorf("githubprfetch: PR number must be positive")
+	}
+
+	base := c.BaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+
+	// Fetch PR details.
+	pr, err := c.fetchPR(ctx, base, owner, repo, number, token)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch reviews (best-effort; a failure here does not abort the whole fetch).
+	pr.Reviews, _ = c.fetchReviews(ctx, base, owner, repo, number, token)
+
+	// Fetch review comments (best-effort).
+	pr.ReviewComments, _ = c.fetchReviewComments(ctx, base, owner, repo, number, token)
+
+	// Fetch check runs (best-effort).
+	pr.CheckRuns, _ = c.fetchCheckRuns(ctx, base, owner, repo, number, token)
+
+	return pr, nil
+}
+
+func (c *Client) fetchPR(
+	ctx context.Context, base, owner, repo string, number int, token string,
+) (*PullRequest, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", base, owner, repo, number)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("githubprfetch: build request: %w", err)
+	}
+	c.headers(req, token)
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("githubprfetch: http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("githubprfetch: read body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
+	}
+
+	var raw struct {
+		Number  int    `json:"number"`
+		Title   string `json:"title"`
+		Body    string `json:"body"`
+		State   string `json:"state"`
+		Merged  bool   `json:"merged"`
+		HeadRef string `json:"head_ref"`
+		BaseRef string `json:"base_ref"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("githubprfetch: decode: %w", err)
+	}
+
+	return &PullRequest{
+		Number:  raw.Number,
+		Title:   raw.Title,
+		Body:    truncateBody(raw.Body, c.BodyCap),
+		State:   raw.State,
+		Merged:  raw.Merged,
+		HeadRef: raw.HeadRef,
+		BaseRef: raw.BaseRef,
+	}, nil
+}
+
+func (c *Client) fetchReviews(
+	ctx context.Context, base, owner, repo string, number int, token string,
+) ([]Review, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews", base, owner, repo, number)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("githubprfetch: build reviews request: %w", err)
+	}
+	c.headers(req, token)
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("githubprfetch: reviews http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
+	}
+
+	var raw []struct {
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		State     string `json:"state"`
+		Body      string `json:"body"`
+		Submitted string `json:"submitted_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("githubprfetch: decode reviews: %w", err)
+	}
+
+	out := make([]Review, 0, len(raw))
+	for _, r := range raw {
+		out = append(out, Review{
+			Author:    r.User.Login,
+			State:     r.State,
+			Body:      truncateBody(r.Body, c.BodyCap),
+			Submitted: r.Submitted,
+		})
+	}
+	return out, nil
+}
+
+func (c *Client) fetchReviewComments(
+	ctx context.Context, base, owner, repo string, number int, token string,
+) ([]ReviewComment, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/comments", base, owner, repo, number)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("githubprfetch: build review comments request: %w", err)
+	}
+	c.headers(req, token)
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("githubprfetch: review comments http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
+	}
+
+	var raw []struct {
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		Path         string `json:"path"`
+		Line         int    `json:"line"`
+		OriginalLine int    `json:"original_line"`
+		Body         string `json:"body"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("githubprfetch: decode review comments: %w", err)
+	}
+
+	out := make([]ReviewComment, 0, len(raw))
+	for _, r := range raw {
+		out = append(out, ReviewComment{
+			Author:       r.User.Login,
+			Path:         r.Path,
+			Line:         r.Line,
+			OriginalLine: r.OriginalLine,
+			Body:         r.Body,
+		})
+	}
+	return out, nil
+}
+
+func (c *Client) fetchCheckRuns(
+	ctx context.Context, base, owner, repo string, number int, token string,
+) ([]CheckRun, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/check-runs", base, owner, repo, number)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("githubprfetch: build check runs request: %w", err)
+	}
+	c.headers(req, token)
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("githubprfetch: check runs http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
+	}
+
+	var raw struct {
+		CheckRuns []struct {
+			Name       string `json:"name"`
+			Conclusion string `json:"conclusion"`
+			DetailsURL string `json:"details_url"`
+		} `json:"check_runs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("githubprfetch: decode check runs: %w", err)
+	}
+
+	out := make([]CheckRun, 0, len(raw.CheckRuns))
+	for _, r := range raw.CheckRuns {
+		out = append(out, CheckRun{
+			Name:       r.Name,
+			Conclusion: r.Conclusion,
+			DetailsURL: r.DetailsURL,
+		})
+	}
+	return out, nil
+}
+
+func (c *Client) headers(req *http.Request, token string) {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+}
+
+// HTTPError is returned when the GitHub API returns a non-200 status.
+// Callers that want to distinguish "PR not found" from "token
+// invalid" from "rate limited" can errors.As() into this and read
+// StatusCode.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+}
+
+// Error implements error.
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("githubprfetch: %s returned HTTP %d", e.URL, e.StatusCode)
+}
+
+// IsNotFound is true when the API returned 404; the executor uses this
+// to log a single helpful line rather than a generic "fetch failed."
+func (e *HTTPError) IsNotFound() bool { return e.StatusCode == http.StatusNotFound }
+
+// IsUnauthorized is true when the API returned 401 or 403; usually
+// means the token is wrong or the PR is in a private repo the
+// token does not see.
+func (e *HTTPError) IsUnauthorized() bool {
+	return e.StatusCode == http.StatusUnauthorized || e.StatusCode == http.StatusForbidden
+}
+
+// truncateBody bounds the body size. The marker is parseable by both
+// humans and models: a clear note that more text exists and the
+// model can pull the full PR via the GitHub UI / `gh` if needed.
+func truncateBody(body string, cap int) string {
+	if cap <= 0 {
+		cap = DefaultBodyCap
+	}
+	if len(body) <= cap {
+		return body
+	}
+	const marker = "\n\n... [PR body truncated; full text on GitHub]"
+	keep := cap - len(marker)
+	if keep < 0 {
+		keep = 0
+	}
+	return body[:keep] + marker
+}
+
+// ParseRepo splits a repo slug into its owner (namespace) and repo
+// (name) parts, splitting on the last slash so multi-segment slugs like
+// "group/subgroup/project" are accepted: owner="group/subgroup",
+// repo="project". For GitHub this means the namespace is passed as-is
+// to the API path; GitHub will reject slugs that are not valid owner/repo
+// pairs at request time. Returns an error if the input is malformed
+// (no slash, empty segments, or a ".." traversal segment); the executor
+// logs the error and skips the fetch (best-effort).
+func ParseRepo(s string) (owner, repo string, err error) {
+	// Delegate to the shared codehost validator so a repo slug is validated
+	// and split by the SAME rule the clone and change-request paths use,
+	// rather than a divergent local reimplementation.
+	namespace, name, ok := codehost.SplitRepoSlug(s)
+	if !ok {
+		return "", "", errors.New("githubprfetch: invalid repo slug (want owner/name or " +
+			"group/.../name with git-safe segments; no whitespace, empty, absolute, or '..' segments)")
+	}
+	return namespace, name, nil
+}

--- a/pkg/foreman/agent/githubprfetch/fetch.go
+++ b/pkg/foreman/agent/githubprfetch/fetch.go
@@ -28,7 +28,7 @@ limitations under the License.
 //   - Title + body + state + reviews + review_comments + check_runs. The
 //     model can pull more via `bash` if it really needs it (it almost
 //     never does).
-//   - Best-effort. A failed fetch logs and the executor keeps the existing
+//   - Best-effort. A failed sub-fetch is recorded in Warnings and the executor keeps the existing
 //     empty-body behavior; the loop runs with whatever buildUserPrompt
 //     produces from the (empty) payload prompt.
 package githubprfetch
@@ -59,13 +59,21 @@ const DefaultTimeout = 10 * time.Second
 // needs. State is included so a model handed a closed PR can decide to
 // NO-GO immediately rather than re-implement a fix that already shipped.
 type PullRequest struct {
-	Number         int             `json:"number"`
-	Title          string          `json:"title"`
-	Body           string          `json:"body"`
-	State          string          `json:"state"`
-	Merged         bool            `json:"merged"`
-	HeadRef        string          `json:"head_ref"`
-	BaseRef        string          `json:"base_ref"`
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	Body    string `json:"body"`
+	State   string `json:"state"`
+	Merged  bool   `json:"merged"`
+	HeadRef string `json:"head_ref"`
+	// HeadSHA is the head commit. Needed because check runs are addressed per
+	// commit ref, not per pull request.
+	HeadSHA string `json:"head_sha"`
+	BaseRef string `json:"base_ref"`
+	// Warnings records sub-fetches that failed. The whole fetch is
+	// best-effort, so a missing section must be distinguishable from a section
+	// that is genuinely empty; without this the coder cannot tell "no review
+	// comments" from "review comments could not be read".
+	Warnings       []string        `json:"warnings,omitempty"`
 	Reviews        []Review        `json:"reviews,omitempty"`
 	ReviewComments []ReviewComment `json:"review_comments,omitempty"`
 	CheckRuns      []CheckRun      `json:"check_runs,omitempty"`
@@ -144,14 +152,25 @@ func (c *Client) Fetch(ctx context.Context, owner, repo string, number int, toke
 		return nil, err
 	}
 
-	// Fetch reviews (best-effort; a failure here does not abort the whole fetch).
-	pr.Reviews, _ = c.fetchReviews(ctx, base, owner, repo, number, token)
-
-	// Fetch review comments (best-effort).
-	pr.ReviewComments, _ = c.fetchReviewComments(ctx, base, owner, repo, number, token)
-
-	// Fetch check runs (best-effort).
-	pr.CheckRuns, _ = c.fetchCheckRuns(ctx, base, owner, repo, number, token)
+	// The sections below are best-effort: a failure degrades the result rather
+	// than aborting the fetch. Each failure is recorded, though. Discarding the
+	// error made a permanently broken sub-fetch indistinguishable from an empty
+	// section, which is how the check-runs endpoint stayed wrong and silent.
+	var warnErr error
+	if pr.Reviews, warnErr = c.fetchReviews(ctx, base, owner, repo, number, token); warnErr != nil {
+		pr.Warnings = append(pr.Warnings, fmt.Sprintf("reviews unavailable: %v", warnErr))
+	}
+	if pr.ReviewComments, warnErr = c.fetchReviewComments(ctx, base, owner, repo, number, token); warnErr != nil {
+		pr.Warnings = append(pr.Warnings, fmt.Sprintf("review comments unavailable: %v", warnErr))
+	}
+	// Check runs hang off the head commit, not the pull request.
+	if pr.HeadSHA != "" {
+		if pr.CheckRuns, warnErr = c.fetchCheckRuns(ctx, base, owner, repo, pr.HeadSHA, token); warnErr != nil {
+			pr.Warnings = append(pr.Warnings, fmt.Sprintf("check runs unavailable: %v", warnErr))
+		}
+	} else {
+		pr.Warnings = append(pr.Warnings, "check runs unavailable: no head SHA in the pull request response")
+	}
 
 	return pr, nil
 }
@@ -186,14 +205,23 @@ func (c *Client) fetchPR(
 		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
 	}
 
+	// head and base are nested objects on the GitHub API; there are no
+	// top-level head_ref/base_ref fields. Decoding them as top-level silently
+	// yields empty strings against the real API while a mock that invents the
+	// flat shape passes, which is exactly how this shipped.
 	var raw struct {
-		Number  int    `json:"number"`
-		Title   string `json:"title"`
-		Body    string `json:"body"`
-		State   string `json:"state"`
-		Merged  bool   `json:"merged"`
-		HeadRef string `json:"head_ref"`
-		BaseRef string `json:"base_ref"`
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		State  string `json:"state"`
+		Merged bool   `json:"merged"`
+		Head   struct {
+			Ref string `json:"ref"`
+			SHA string `json:"sha"`
+		} `json:"head"`
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("githubprfetch: decode: %w", err)
@@ -205,15 +233,19 @@ func (c *Client) fetchPR(
 		Body:    truncateBody(raw.Body, c.BodyCap),
 		State:   raw.State,
 		Merged:  raw.Merged,
-		HeadRef: raw.HeadRef,
-		BaseRef: raw.BaseRef,
+		HeadRef: raw.Head.Ref,
+		HeadSHA: raw.Head.SHA,
+		BaseRef: raw.Base.Ref,
 	}, nil
 }
 
 func (c *Client) fetchReviews(
 	ctx context.Context, base, owner, repo string, number int, token string,
 ) ([]Review, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews", base, owner, repo, number)
+	// per_page=100 is the API maximum. This does not follow Link headers, so a
+	// pull request with more than 100 reviews is still truncated.
+	// TODO: follow rel="next" if that ceiling is ever reached in practice.
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews?per_page=100", base, owner, repo, number)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -262,7 +294,8 @@ func (c *Client) fetchReviews(
 func (c *Client) fetchReviewComments(
 	ctx context.Context, base, owner, repo string, number int, token string,
 ) ([]ReviewComment, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/comments", base, owner, repo, number)
+	// See the pagination note in fetchReviews; same ceiling applies.
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/comments?per_page=100", base, owner, repo, number)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -310,10 +343,13 @@ func (c *Client) fetchReviewComments(
 	return out, nil
 }
 
+// fetchCheckRuns lists the check runs for the pull request's head commit.
+// Check runs are addressed per commit ref: /repos/{o}/{r}/pulls/{n}/check-runs
+// does not exist and returns 404 against the real API.
 func (c *Client) fetchCheckRuns(
-	ctx context.Context, base, owner, repo string, number int, token string,
+	ctx context.Context, base, owner, repo, sha, token string,
 ) ([]CheckRun, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/check-runs", base, owner, repo, number)
+	url := fmt.Sprintf("%s/repos/%s/%s/commits/%s/check-runs", base, owner, repo, sha)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/foreman/agent/githubprfetch/fetch_test.go
+++ b/pkg/foreman/agent/githubprfetch/fetch_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package githubprfetch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// isPRDetailsPath returns true when the path is the PR details endpoint
+// (not reviews, comments, or check-runs sub-paths).
+func isPRDetailsPath(path string) bool {
+	return strings.Contains(path, "/pulls/") &&
+		!strings.Contains(path, "/reviews") &&
+		!strings.Contains(path, "/comments") &&
+		!strings.Contains(path, "/check-runs")
+}
+
+func TestClient_Fetch_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer t-happy" {
+			t.Errorf("auth header: want 'Bearer t-happy' got %q", got)
+		}
+		switch {
+		case isPRDetailsPath(r.URL.Path):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+		  "number": 42,
+		  "title": "fix: something",
+		  "body": "PR body text",
+		  "state": "open",
+		  "merged": false,
+		  "head_ref": "fix/something",
+		  "base_ref": "main"
+		}`)
+		case strings.Contains(r.URL.Path, "/reviews"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `[{"user":{"login":"reviewer1"},`+
+				`"state":"APPROVED","body":"LGTM",`+
+				`"submitted_at":"2025-01-01T00:00:00Z"}]`)
+		case strings.Contains(r.URL.Path, "/comments"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `[{"user":{"login":"reviewer1"},`+
+				`"path":"pkg/foo.go","line":10,`+
+				`"original_line":10,"body":"fix this"}]`)
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"check_runs":[{"name":"lint",`+
+				`"conclusion":"success",`+
+				`"details_url":"https://example.com"}]}`)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL}
+	pr, err := c.Fetch(context.Background(), "defilantech", "LLMKube", 42, "t-happy")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if pr.Number != 42 {
+		t.Errorf("Number: want 42 got %d", pr.Number)
+	}
+	if pr.Title != "fix: something" {
+		t.Errorf("Title: want 'fix: something' got %q", pr.Title)
+	}
+	if pr.Body != "PR body text" {
+		t.Errorf("Body: want 'PR body text' got %q", pr.Body)
+	}
+	if pr.State != "open" {
+		t.Errorf("State: want 'open' got %q", pr.State)
+	}
+	if pr.Merged {
+		t.Errorf("Merged: want false got true")
+	}
+	if pr.HeadRef != "fix/something" {
+		t.Errorf("HeadRef: want 'fix/something' got %q", pr.HeadRef)
+	}
+	if pr.BaseRef != "main" {
+		t.Errorf("BaseRef: want 'main' got %q", pr.BaseRef)
+	}
+	if len(pr.Reviews) != 1 || pr.Reviews[0].Author != "reviewer1" {
+		t.Errorf("Reviews: %v", pr.Reviews)
+	}
+	if len(pr.ReviewComments) != 1 || pr.ReviewComments[0].Path != "pkg/foo.go" {
+		t.Errorf("ReviewComments: %v", pr.ReviewComments)
+	}
+	if len(pr.CheckRuns) != 1 || pr.CheckRuns[0].Name != "lint" {
+		t.Errorf("CheckRuns: %v", pr.CheckRuns)
+	}
+}
+
+func TestClient_Fetch_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL}
+	_, err := c.Fetch(context.Background(), "o", "r", 99999, "t")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("error should name HTTP 404: %v", err)
+	}
+	var herr *HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected *HTTPError, got %T", err)
+	}
+	if !herr.IsNotFound() {
+		t.Errorf("IsNotFound should be true")
+	}
+}
+
+func TestClient_Fetch_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL}
+	_, err := c.Fetch(context.Background(), "o", "r", 1, "bad-token")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	var herr *HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected *HTTPError, got %T", err)
+	}
+	if !herr.IsUnauthorized() {
+		t.Errorf("IsUnauthorized should be true")
+	}
+}
+
+func TestClient_Fetch_BestEffortSubFetches(t *testing.T) {
+	// PR details succeed, but reviews endpoint returns 500.
+	// The overall fetch should still succeed with empty reviews.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case isPRDetailsPath(r.URL.Path):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+		  "number": 42,
+		  "title": "fix: something",
+		  "body": "PR body text",
+		  "state": "open",
+		  "merged": false,
+		  "head_ref": "fix/something",
+		  "base_ref": "main"
+		}`)
+		case strings.Contains(r.URL.Path, "/reviews"):
+			w.WriteHeader(http.StatusInternalServerError)
+		case strings.Contains(r.URL.Path, "/comments"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `[]`)
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"check_runs":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL}
+	pr, err := c.Fetch(context.Background(), "o", "r", 42, "t")
+	if err != nil {
+		t.Fatalf("Fetch should succeed even when sub-fetches fail: %v", err)
+	}
+	if pr.Number != 42 {
+		t.Errorf("Number: want 42 got %d", pr.Number)
+	}
+	if len(pr.Reviews) != 0 {
+		t.Errorf("Reviews should be empty on sub-fetch failure: %v", pr.Reviews)
+	}
+}
+
+func TestClient_Fetch_Validation(t *testing.T) {
+	c := NewClient()
+	_, err := c.Fetch(context.Background(), "", "r", 1, "t")
+	if err == nil {
+		t.Fatal("expected error on empty owner")
+	}
+	_, err = c.Fetch(context.Background(), "o", "", 1, "t")
+	if err == nil {
+		t.Fatal("expected error on empty repo")
+	}
+	_, err = c.Fetch(context.Background(), "o", "r", 0, "t")
+	if err == nil {
+		t.Fatal("expected error on zero number")
+	}
+	_, err = c.Fetch(context.Background(), "o", "r", -1, "t")
+	if err == nil {
+		t.Fatal("expected error on negative number")
+	}
+}
+
+func TestHTTPError_IsNotFound(t *testing.T) {
+	e := &HTTPError{StatusCode: http.StatusNotFound}
+	if !e.IsNotFound() {
+		t.Error("IsNotFound should be true for 404")
+	}
+	e2 := &HTTPError{StatusCode: http.StatusOK}
+	if e2.IsNotFound() {
+		t.Error("IsNotFound should be false for 200")
+	}
+}
+
+func TestHTTPError_IsUnauthorized(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		e := &HTTPError{StatusCode: code}
+		if !e.IsUnauthorized() {
+			t.Errorf("IsUnauthorized should be true for %d", code)
+		}
+	}
+	e2 := &HTTPError{StatusCode: http.StatusOK}
+	if e2.IsUnauthorized() {
+		t.Error("IsUnauthorized should be false for 200")
+	}
+}
+
+func TestParseRepo(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{"owner/name", "defilantech/LLMKube", "defilantech", "LLMKube", false},
+		{"group/subgroup/project", "group/subgroup/project", "group/subgroup", "project", false},
+		{"no-slash", "noslash", "", "", true},
+		{"empty-segment", "owner/", "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			owner, repo, err := ParseRepo(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tc.wantOwner || repo != tc.wantRepo {
+				t.Errorf("ParseRepo(%q) = %q, %q; want %q, %q",
+					tc.input, owner, repo, tc.wantOwner, tc.wantRepo)
+			}
+		})
+	}
+}
+
+func TestTruncateBody(t *testing.T) {
+	// Short body: no truncation.
+	short := "short body"
+	if got := truncateBody(short, 1024); got != short {
+		t.Errorf("short body: got %q, want %q", got, short)
+	}
+	// Long body: truncated with marker.
+	long := strings.Repeat("x", 2048)
+	got := truncateBody(long, 1024)
+	if len(got) > 1024 {
+		t.Errorf("truncated body too long: %d bytes", len(got))
+	}
+	if !strings.Contains(got, "[PR body truncated") {
+		t.Errorf("truncated body missing marker: %q", got)
+	}
+	// Zero cap: uses default.
+	got2 := truncateBody(long, 0)
+	if len(got2) > DefaultBodyCap {
+		t.Errorf("zero cap body too long: %d bytes", len(got2))
+	}
+}

--- a/pkg/foreman/agent/githubprfetch/fetch_test.go
+++ b/pkg/foreman/agent/githubprfetch/fetch_test.go
@@ -49,8 +49,8 @@ func TestClient_Fetch_HappyPath(t *testing.T) {
 		  "body": "PR body text",
 		  "state": "open",
 		  "merged": false,
-		  "head_ref": "fix/something",
-		  "base_ref": "main"
+		  "head": {"ref": "fix/something", "sha": "abc123def456"},
+		  "base": {"ref": "main"}
 		}`)
 		case strings.Contains(r.URL.Path, "/reviews"):
 			w.Header().Set("Content-Type", "application/json")
@@ -62,7 +62,11 @@ func TestClient_Fetch_HappyPath(t *testing.T) {
 			_, _ = fmt.Fprintf(w, `[{"user":{"login":"reviewer1"},`+
 				`"path":"pkg/foo.go","line":10,`+
 				`"original_line":10,"body":"fix this"}]`)
-		case strings.Contains(r.URL.Path, "/check-runs"):
+		// Only the real endpoint shape is answered: check runs hang off a
+		// commit ref, so /pulls/{n}/check-runs must 404 here exactly as it
+		// does on GitHub. A mock that answers any URL cannot catch a wrong
+		// endpoint, which is how the original shipped.
+		case strings.Contains(r.URL.Path, "/commits/") && strings.Contains(r.URL.Path, "/check-runs"):
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintf(w, `{"check_runs":[{"name":"lint",`+
 				`"conclusion":"success",`+
@@ -166,15 +170,19 @@ func TestClient_Fetch_BestEffortSubFetches(t *testing.T) {
 		  "body": "PR body text",
 		  "state": "open",
 		  "merged": false,
-		  "head_ref": "fix/something",
-		  "base_ref": "main"
+		  "head": {"ref": "fix/something", "sha": "abc123def456"},
+		  "base": {"ref": "main"}
 		}`)
 		case strings.Contains(r.URL.Path, "/reviews"):
 			w.WriteHeader(http.StatusInternalServerError)
 		case strings.Contains(r.URL.Path, "/comments"):
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintf(w, `[]`)
-		case strings.Contains(r.URL.Path, "/check-runs"):
+		// Only the real endpoint shape is answered: check runs hang off a
+		// commit ref, so /pulls/{n}/check-runs must 404 here exactly as it
+		// does on GitHub. A mock that answers any URL cannot catch a wrong
+		// endpoint, which is how the original shipped.
+		case strings.Contains(r.URL.Path, "/commits/") && strings.Contains(r.URL.Path, "/check-runs"):
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintf(w, `{"check_runs":[]}`)
 		}
@@ -290,5 +298,60 @@ func TestTruncateBody(t *testing.T) {
 	got2 := truncateBody(long, 0)
 	if len(got2) > DefaultBodyCap {
 		t.Errorf("zero cap body too long: %d bytes", len(got2))
+	}
+}
+
+// The two contract bugs this package shipped with, pinned explicitly rather
+// than left to the happy-path mock: head/base arrive as nested objects, and
+// check runs are addressed per commit ref. Both passed review and a full test
+// suite because the mock answered whatever URL it was given and invented a flat
+// PR shape. Asserting the request the client actually makes is the only thing
+// that catches that class of error without calling GitHub.
+func TestClient_UsesRealGitHubContract(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch {
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"check_runs":[{"name":"lint","conclusion":"success"}]}`)
+		case strings.HasSuffix(r.URL.Path, "/reviews"), strings.HasSuffix(r.URL.Path, "/comments"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"number":7,"title":"t","body":"b","state":"open",
+			  "head":{"ref":"feature","sha":"deadbeef"},"base":{"ref":"main"}}`)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	pr, err := c.Fetch(context.Background(), "o", "r", 7, "tok")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	// Nested head/base must be read; the flat spelling yields empty strings.
+	if pr.HeadRef != "feature" || pr.BaseRef != "main" || pr.HeadSHA != "deadbeef" {
+		t.Errorf("head/base not parsed from the nested objects: ref=%q base=%q sha=%q",
+			pr.HeadRef, pr.BaseRef, pr.HeadSHA)
+	}
+
+	// Check runs must be requested per commit ref, never per pull request.
+	var checkPath string
+	for _, p := range paths {
+		if strings.Contains(p, "/check-runs") {
+			checkPath = p
+		}
+	}
+	if checkPath == "" {
+		t.Fatal("no check-runs request was made")
+	}
+	if !strings.Contains(checkPath, "/commits/deadbeef/check-runs") {
+		t.Errorf("check runs requested at %q, want /commits/{head sha}/check-runs", checkPath)
+	}
+	if strings.Contains(checkPath, "/pulls/") {
+		t.Errorf("check runs requested under /pulls/, which returns 404 on GitHub: %q", checkPath)
 	}
 }

--- a/pkg/foreman/agent/tools/fetch_pr.go
+++ b/pkg/foreman/agent/tools/fetch_pr.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubprfetch"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// FetchPullRequestTool is the coder's read-only path to a GitHub pull
+// request. It wraps the same githubprfetch.Client the executor uses and
+// exposes it as a first-class tool so the coder can read the PR it is
+// asked to fix — including reviews, review comments, and check runs —
+// without needing a separately-authed `gh` CLI on its FleetNode.
+//
+// Why this exists (issue #1434): the v0.4 PR-fix path mandated that the
+// coder reason from a pre-chewed digest assembled by the orchestrator.
+// The coder could not see other reviews, inline review comments with
+// file/line anchors, or check-run conclusions beyond a pre-trimmed log
+// excerpt. The fix is to stop passing a digest and instead expose one
+// bounded GitHub surface (this tool) using the same token the
+// foreman-agent already loads at startup.
+//
+// Security shape vs the GH_TOKEN-env alternative:
+//
+//   - Read-only by construction: exactly one GET per Execute (PR details,
+//     reviews, review comments, check runs). The model has no path to
+//     gh pr create / gh repo delete / generic authenticated REST writes
+//     through this tool.
+//   - The token lives behind a TokenSource closure; the struct stores
+//     no credentials between calls.
+//   - Containerised foreman-agents do not need `gh` installed in their
+//     image; pure Go HTTP suffices.
+//   - Token rotation surface is one file (~/.config/foreman/github-token)
+//     instead of also a per-user `gh` config or per-process env var
+//     inherited by every bash subprocess.
+type FetchPullRequestTool struct {
+	// Fetcher is the GitHub PR client. Required. Production wires
+	// githubprfetch.NewClient(); tests pass a fake or an httptest-backed
+	// Client.
+	Fetcher githubprfetch.Fetcher
+	// Token resolves the GitHub PAT at Execute time. Required.
+	Token TokenSource
+}
+
+type fetchPullRequestArgs struct {
+	Repo   string `json:"repo"`
+	Number int    `json:"number"`
+}
+
+// Name returns the tool name as advertised to the model.
+func (t *FetchPullRequestTool) Name() string { return "fetch_pull_request" }
+
+// Schema returns the OAI schema advertisement.
+func (t *FetchPullRequestTool) Schema() oai.ToolSchemaDef {
+	return oai.ToolSchemaDef{
+		Name: "fetch_pull_request",
+		Description: "Read a GitHub pull request's title, body, state, merged, " +
+			"head_ref, base_ref, reviews, review_comments, and check_runs. " +
+			"Use this as the scope anchor before fixing a PR: a verbatim " +
+			"sentence from a review comment is the right citation for " +
+			"whether the diff addresses what was asked. Returns title, body " +
+			"(truncated to ~16 KiB if needed), state, merged, head_ref, " +
+			"base_ref, reviews, review_comments, check_runs.",
+		Parameters: json.RawMessage(`{
+"type": "object",
+"properties": {
+  "repo":   {"type": "string", "description": "owner/name, e.g. \"defilantech/LLMKube\"."},
+  "number": {"type": "integer", "minimum": 1, "description": "PR number."}
+},
+"required": ["repo", "number"]
+}`),
+	}
+}
+
+// Execute reads the GitHub pull request at args.repo / args.number. All
+// failure modes are surfaced via the returned error, which the loop
+// emits as the tool-result content the model sees on its next turn.
+//
+//   - bad args (missing repo, non-positive number, malformed repo
+//     string): wrapped fmt.Errorf naming the field.
+//   - token resolution failure: wrapped error citing the env var /
+//     file the operator is expected to populate; this points at the
+//     foreman-agent host, not the model.
+//   - 404: "PR not found" so the model can choose to ERROR out rather
+//     than guess.
+//   - 401 / 403: "unauthorized" with a hint that the token is wrong
+//     or out of scope.
+//   - 5xx / network: generic transient failure; the model can retry
+//     once or call submit_result with verdict=ERROR.
+func (t *FetchPullRequestTool) Execute(ctx context.Context, args json.RawMessage) (*agent.ToolResult, error) {
+	if t.Fetcher == nil {
+		return nil, fmt.Errorf("fetch_pull_request: tool not configured (Fetcher is nil)")
+	}
+	if t.Token == nil {
+		return nil, fmt.Errorf("fetch_pull_request: tool not configured (Token resolver is nil)")
+	}
+	var a fetchPullRequestArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("fetch_pull_request: bad args: %w", err)
+	}
+	if a.Repo == "" {
+		return nil, fmt.Errorf("fetch_pull_request: repo is required (owner/name)")
+	}
+	if a.Number <= 0 {
+		return nil, fmt.Errorf("fetch_pull_request: number must be a positive integer (got %d)", a.Number)
+	}
+	owner, name, err := githubprfetch.ParseRepo(a.Repo)
+	if err != nil {
+		return nil, fmt.Errorf("fetch_pull_request: %w", err)
+	}
+	token, err := t.Token()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"fetch_pull_request: no GitHub token "+
+				"(set GITHUB_TOKEN env or populate "+
+				"~/.config/foreman/github-token on the FleetNode): %w", err)
+	}
+	pr, err := t.Fetcher.Fetch(ctx, owner, name, a.Number, token)
+	if err != nil {
+		var herr *githubprfetch.HTTPError
+		if errors.As(err, &herr) {
+			switch {
+			case herr.IsNotFound():
+				return nil, fmt.Errorf("fetch_pull_request: PR %s#%d not found", a.Repo, a.Number)
+			case herr.IsUnauthorized():
+				return nil, fmt.Errorf(
+					"fetch_pull_request: unauthorized for %s#%d; "+
+						"foreman-agent's GitHub token may be missing the repo scope, "+
+						"or the PR is in a private repo not visible to it",
+					a.Repo, a.Number)
+			}
+		}
+		return nil, fmt.Errorf("fetch_pull_request: %w", err)
+	}
+	return &agent.ToolResult{
+		Output: map[string]any{
+			"repo":            a.Repo,
+			"number":          pr.Number,
+			"title":           pr.Title,
+			"body":            pr.Body,
+			"state":           pr.State,
+			"merged":          pr.Merged,
+			"head_ref":        pr.HeadRef,
+			"base_ref":        pr.BaseRef,
+			"reviews":         pr.Reviews,
+			"review_comments": pr.ReviewComments,
+			"check_runs":      pr.CheckRuns,
+		},
+	}, nil
+}

--- a/pkg/foreman/agent/tools/fetch_pr.go
+++ b/pkg/foreman/agent/tools/fetch_pr.go
@@ -166,6 +166,10 @@ func (t *FetchPullRequestTool) Execute(ctx context.Context, args json.RawMessage
 			"reviews":         pr.Reviews,
 			"review_comments": pr.ReviewComments,
 			"check_runs":      pr.CheckRuns,
+			// Surfaced to the coder, not just logged: it is the coder that
+			// acts on this context, and it must be able to tell an empty
+			// section from one that could not be read.
+			"warnings": pr.Warnings,
 		},
 	}, nil
 }

--- a/pkg/foreman/agent/tools/fetch_pr_test.go
+++ b/pkg/foreman/agent/tools/fetch_pr_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubprfetch"
+)
+
+// fakePRFetcher lets a test inject a canned outcome without spinning up
+// an httptest server. Used for the failure-shape and arg-validation
+// cases; the body-truncation and authorization-header cases go through
+// a real Client + httptest server below.
+type fakePRFetcher struct {
+	gotOwner  string
+	gotRepo   string
+	gotNumber int
+	gotToken  string
+	pr        *githubprfetch.PullRequest
+	err       error
+}
+
+func (f *fakePRFetcher) Fetch(
+	_ context.Context, owner, repo string, number int, token string,
+) (*githubprfetch.PullRequest, error) {
+	f.gotOwner, f.gotRepo, f.gotNumber, f.gotToken = owner, repo, number, token
+	return f.pr, f.err
+}
+
+// isPRDetailsPath returns true when the path is the PR details endpoint
+// (not reviews, comments, or check-runs sub-paths).
+func isPRDetailsPath(path string) bool {
+	return strings.Contains(path, "/pulls/") &&
+		!strings.Contains(path, "/reviews") &&
+		!strings.Contains(path, "/comments") &&
+		!strings.Contains(path, "/check-runs")
+}
+
+// TestFetchPullRequestTool_HappyPath verifies the tool round-trips a parsed
+// PR through a real githubprfetch.Client backed by httptest, and that
+// the Authorization header carries the token the TokenSource returns.
+func TestFetchPullRequestTool_HappyPath(t *testing.T) {
+	body := strings.Repeat("body line\n", 5)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer t-happy" {
+			t.Errorf("auth header: want 'Bearer t-happy' got %q", got)
+		}
+		switch {
+		case isPRDetailsPath(r.URL.Path):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+		  "number": 526,
+		  "title": "[BUG] host-ip auto-detect picks unreachable virtual interface",
+		  "body": %q,
+		  "state": "open",
+		  "merged": false,
+		  "head_ref": "fix/host-ip",
+		  "base_ref": "main"
+		}`, body)
+		case strings.Contains(r.URL.Path, "/reviews"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `[{"user":{"login":"reviewer1"},`+
+				`"state":"APPROVED","body":"LGTM",`+
+				`"submitted_at":"2025-01-01T00:00:00Z"}]`)
+		case strings.Contains(r.URL.Path, "/comments"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `[{"user":{"login":"reviewer1"},`+
+				`"path":"pkg/foo.go","line":10,`+
+				`"original_line":10,"body":"fix this"}]`)
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"check_runs":[{"name":"lint",`+
+				`"conclusion":"success",`+
+				`"details_url":"https://example.com"}]}`)
+		}
+	}))
+	defer srv.Close()
+
+	tool := &FetchPullRequestTool{
+		Fetcher: &githubprfetch.Client{BaseURL: srv.URL},
+		Token:   staticToken("t-happy"),
+	}
+	res, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"repo":"defilantech/LLMKube","number":526}`))
+	if err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+	out, _ := res.Output.(map[string]any)
+	if out["number"] != 526 {
+		t.Errorf("number: want 526 got %v", out["number"])
+	}
+	if !strings.Contains(out["title"].(string), "host-ip") {
+		t.Errorf("title: %v", out["title"])
+	}
+	if !strings.Contains(out["body"].(string), "body line") {
+		t.Errorf("body: %v", out["body"])
+	}
+	if out["state"] != "open" {
+		t.Errorf("state: want open got %v", out["state"])
+	}
+	if out["merged"] != false {
+		t.Errorf("merged: want false got %v", out["merged"])
+	}
+	if out["head_ref"] != "fix/host-ip" {
+		t.Errorf("head_ref: want fix/host-ip got %v", out["head_ref"])
+	}
+	if out["base_ref"] != "main" {
+		t.Errorf("base_ref: want main got %v", out["base_ref"])
+	}
+}
+
+func TestFetchPullRequestTool_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	tool := &FetchPullRequestTool{
+		Fetcher: &githubprfetch.Client{BaseURL: srv.URL},
+		Token:   staticToken("t"),
+	}
+	_, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"repo":"o/r","number":99999}`))
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("404 error should name 'not found': %v", err)
+	}
+}
+
+func TestFetchPullRequestTool_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer srv.Close()
+
+	tool := &FetchPullRequestTool{
+		Fetcher: &githubprfetch.Client{BaseURL: srv.URL},
+		Token:   staticToken("bad-token"),
+	}
+	_, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"repo":"o/r","number":1}`))
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !strings.Contains(err.Error(), "unauthorized") {
+		t.Errorf("401 error should name 'unauthorized': %v", err)
+	}
+}
+
+// TestFetchPullRequestTool_ArgValidation exercises the arg-shape failures:
+// bad JSON, missing repo, non-positive number, malformed repo string.
+// The fake fetcher is never called on these paths.
+func TestFetchPullRequestTool_ArgValidation(t *testing.T) {
+	ff := &fakePRFetcher{}
+	tool := &FetchPullRequestTool{Fetcher: ff, Token: staticToken("t")}
+
+	// bad JSON
+	_, err := tool.Execute(context.Background(), json.RawMessage(`not-json`))
+	if err == nil || !strings.Contains(err.Error(), "bad args") {
+		t.Errorf("bad-json: %v", err)
+	}
+	if ff.gotNumber != 0 {
+		t.Errorf("fetcher called on bad-json: number=%d", ff.gotNumber)
+	}
+
+	// missing repo
+	_, err = tool.Execute(context.Background(), json.RawMessage(`{"number":1}`))
+	if err == nil || !strings.Contains(err.Error(), "repo is required") {
+		t.Errorf("missing-repo: %v", err)
+	}
+
+	// zero number
+	_, err = tool.Execute(context.Background(),
+		json.RawMessage(`{"repo":"o/r","number":0}`))
+	if err == nil || !strings.Contains(err.Error(), "number must be a positive integer") {
+		t.Errorf("zero-number: %v", err)
+	}
+
+	// negative number
+	_, err = tool.Execute(context.Background(),
+		json.RawMessage(`{"repo":"o/r","number":-3}`))
+	if err == nil || !strings.Contains(err.Error(), "number must be a positive integer") {
+		t.Errorf("negative-number: %v", err)
+	}
+
+	// malformed repo
+	_, err = tool.Execute(context.Background(),
+		json.RawMessage(`{"repo":"no-slash","number":1}`))
+	if err == nil || !strings.Contains(err.Error(), "invalid repo slug") {
+		t.Errorf("malformed-repo: %v", err)
+	}
+}
+
+func TestFetchPullRequestTool_TokenResolutionFailure(t *testing.T) {
+	ff := &fakePRFetcher{}
+	tool := &FetchPullRequestTool{Fetcher: ff, Token: errToken("askpass not configured")}
+	_, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"repo":"o/r","number":1}`))
+	if err == nil {
+		t.Fatal("expected error on token resolution failure")
+	}
+	if !strings.Contains(err.Error(), "no GitHub token") {
+		t.Errorf("token error should name 'no GitHub token': %v", err)
+	}
+	if !strings.Contains(err.Error(), "GITHUB_TOKEN") {
+		t.Errorf("token error should hint at GITHUB_TOKEN env var: %v", err)
+	}
+	if ff.gotNumber != 0 {
+		t.Errorf("fetcher should not have been called when token resolution fails; called with number=%d", ff.gotNumber)
+	}
+}
+
+func TestFetchPullRequestTool_NilDepsFailLoud(t *testing.T) {
+	cases := []struct {
+		name string
+		tool *FetchPullRequestTool
+		want string
+	}{
+		{"nil-fetcher", &FetchPullRequestTool{Fetcher: nil, Token: staticToken("t")}, "Fetcher is nil"},
+		{"nil-token", &FetchPullRequestTool{Fetcher: &fakePRFetcher{}, Token: nil}, "Token resolver is nil"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.tool.Execute(context.Background(),
+				json.RawMessage(`{"repo":"o/r","number":1}`))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error: want substring %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestFetchPullRequestTool_Schema verifies the OAI advertisement is
+// wellformed JSONSchema and names the two required args. The loop sends
+// this schema to the model verbatim; a typo here would be invisible
+// until the model decided not to call the tool at all.
+func TestFetchPullRequestTool_Schema(t *testing.T) {
+	tool := &FetchPullRequestTool{Fetcher: &fakePRFetcher{}, Token: staticToken("t")}
+	if tool.Name() != "fetch_pull_request" {
+		t.Errorf("Name(): %q", tool.Name())
+	}
+	schema := tool.Schema()
+	if schema.Name != "fetch_pull_request" {
+		t.Errorf("schema.Name: %q", schema.Name)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(schema.Parameters, &parsed); err != nil {
+		t.Fatalf("schema parameters not valid JSON: %v", err)
+	}
+	required, _ := parsed["required"].([]any)
+	if len(required) != 2 {
+		t.Fatalf("required should have 2 fields, got %v", required)
+	}
+}
+
+// TestFetchPullRequestTool_FetcherReceivesParsedRepo confirms ParseRepo's
+// owner+name split flows through to the Fetcher call. A regression
+// where the tool passed the full "owner/name" string as owner is the
+// kind of bug that only surfaces against a real GitHub API; this test
+// pins the contract early.
+func TestFetchPullRequestTool_FetcherReceivesParsedRepo(t *testing.T) {
+	type repoSplit struct {
+		input     string
+		wantOwner string
+		wantRepo  string
+	}
+	cases := []repoSplit{
+		{"defilantech/LLMKube", "defilantech", "LLMKube"},
+		{"group/subgroup/project", "group/subgroup", "project"},
+		{"a/b/c/d", "a/b/c", "d"},
+	}
+	for _, cs := range cases {
+		t.Run(cs.input, func(t *testing.T) {
+			ff := &fakePRFetcher{
+				pr: &githubprfetch.PullRequest{
+					Number: 42, Title: "t", Body: "b", State: "open",
+				},
+			}
+			tool := &FetchPullRequestTool{
+				Fetcher: ff, Token: staticToken("tok"),
+			}
+			args := json.RawMessage(
+				`{"repo":"` + cs.input + `","number":42}`)
+			_, err := tool.Execute(context.Background(), args)
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if ff.gotOwner != cs.wantOwner {
+				t.Errorf("owner: got %q want %q", ff.gotOwner, cs.wantOwner)
+			}
+			if ff.gotRepo != cs.wantRepo {
+				t.Errorf("repo: got %q want %q", ff.gotRepo, cs.wantRepo)
+			}
+			if ff.gotNumber != 42 {
+				t.Errorf("number: got %d want 42", ff.gotNumber)
+			}
+			if ff.gotToken != "tok" {
+				t.Errorf("token: got %q want tok", ff.gotToken)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/tools/fetch_pr_test.go
+++ b/pkg/foreman/agent/tools/fetch_pr_test.go
@@ -75,8 +75,8 @@ func TestFetchPullRequestTool_HappyPath(t *testing.T) {
 		  "body": %q,
 		  "state": "open",
 		  "merged": false,
-		  "head_ref": "fix/host-ip",
-		  "base_ref": "main"
+		  "head": {"ref": "fix/host-ip", "sha": "abc123def456"},
+		  "base": {"ref": "main"}
 		}`, body)
 		case strings.Contains(r.URL.Path, "/reviews"):
 			w.Header().Set("Content-Type", "application/json")
@@ -88,7 +88,11 @@ func TestFetchPullRequestTool_HappyPath(t *testing.T) {
 			_, _ = fmt.Fprintf(w, `[{"user":{"login":"reviewer1"},`+
 				`"path":"pkg/foo.go","line":10,`+
 				`"original_line":10,"body":"fix this"}]`)
-		case strings.Contains(r.URL.Path, "/check-runs"):
+		// Only the real endpoint shape is answered: check runs hang off a
+		// commit ref, so /pulls/{n}/check-runs must 404 here exactly as it
+		// does on GitHub. A mock that answers any URL cannot catch a wrong
+		// endpoint, which is how the original shipped.
+		case strings.Contains(r.URL.Path, "/commits/") && strings.Contains(r.URL.Path, "/check-runs"):
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintf(w, `{"check_runs":[{"name":"lint",`+
 				`"conclusion":"success",`+


### PR DESCRIPTION
## What

Adds a read-only `fetch_pull_request` tool so a coder asked to fix a PR can
actually read it, mirroring `FetchIssueTool`.

## Why

Refs #1434

On the PR-fix path the coder previously saw only whatever text the orchestrator
pasted into `payload.prompt`.

## How

New `pkg/foreman/agent/githubprfetch` package plus the tool wrapper, following
the existing `fetch_issue` construction, registration and test shape.

**Read-only is enforced, not just intended:** every request is
`http.MethodGet`. Nothing posts, pushes, approves, merges or mutates.

## Defect found in review, needs fixing before merge

`fetchCheckRuns` requests `/repos/{owner}/{repo}/pulls/{n}/check-runs`, which is
not a GitHub endpoint. Verified against the live API:

```
GET /repos/defilantech/LLMKube/pulls/1452/check-runs   -> 404 Not Found
GET /repos/defilantech/LLMKube/commits/{sha}/check-runs -> total_count=24
```

Check runs are addressed per commit ref, so this needs the PR's `head.sha` (which
the code already fetches) rather than the PR number. The unit tests do not catch
it because they answer any URL from a mock server.

The error is also discarded at the call site
(`pr.CheckRuns, _ = c.fetchCheckRuns(...)`), so this fails silently forever:
`CheckRuns` is simply always empty against real GitHub. Non-fatal, but it means
the coder never sees CI status, and nothing ever says why.

The rest of the tool (title, body, state, reviews, comments) is correct and
useful as-is. Marked `Refs` not `Fixes` until the check-runs path is fixed.

## Verification

Build, vet, and `go test ./pkg/foreman/agent/tools/ ./pkg/foreman/agent/githubprfetch/`
all pass in a clean worktree against current main. The new tests fail without the
change.

Assisted-by: Claude Code (branch produced by the Foreman agent harness on a self-hosted model; I reviewed the diff, ran build, vet and the package test suites in a clean worktree, and verified the specifics called out above).
