### PR TITLE
fix(controller): clean up orphaned .tmp files from interrupted model transfers

### DIFF
--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -275,15 +275,15 @@ func addCACertVolume(volumes *[]corev1.Volume, mounts *[]corev1.VolumeMount, cmd
 func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) string {
 	if useCache {
 		if isLocal {
-			return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Copying model from local source...'; cp /host-model/model.gguf "$MODEL_PATH.tmp" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model copied successfully'; else echo 'Model already cached, skipping copy'; fi`
+			return `mkdir -p "$CACHE_DIR" && rm -f "$MODEL_PATH.tmp" && if [ ! -f "$MODEL_PATH" ]; then echo 'Copying model from local source...'; cp /host-model/model.gguf "$MODEL_PATH.tmp" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model copied successfully'; else echo 'Model already cached, skipping copy'; fi`
 		}
 		if isS3 {
-			return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model from S3...'; curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$MODEL_PATH.tmp" "${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
+			return `mkdir -p "$CACHE_DIR" && rm -f "$MODEL_PATH.tmp" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model from S3...'; curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$MODEL_PATH.tmp" "${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
 		}
 		if refreshPolicy == RefreshPolicyOnChange {
-			return "mkdir -p \"$CACHE_DIR\" && " + remoteRevalidateScript
+			return "mkdir -p \"$CACHE_DIR\" && rm -f \"$MODEL_PATH.tmp\" && " + remoteRevalidateScript
 		}
-		return `mkdir -p "$CACHE_DIR" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
+		return `mkdir -p "$CACHE_DIR" && rm -f "$MODEL_PATH.tmp" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
 	}
 
 	if isLocal {
@@ -506,9 +506,9 @@ func multiFileInitEnvVars(source, cacheDir string, files []string) []corev1.EnvV
 // it creates /models. The command uses env vars only, never embedding user
 // values directly in the script.
 func buildMultiFileInitCommand(useCache bool, refreshPolicy string) string {
-	prefix := `mkdir -p "$CACHE_DIR" && `
+	prefix := `mkdir -p "$CACHE_DIR" && find "$CACHE_DIR" -name '*.tmp' -delete && `
 	if !useCache {
-		prefix = `mkdir -p /models && `
+		prefix = `mkdir -p /models && find /models -name '*.tmp' -delete && `
 	}
 
 	normalizeFn := `normalize_hf_source() { case "$1" in hf://*) src="${1#hf://}"; rev="${src#*@}"; if [ "$rev" != "$src" ]; then echo "https://huggingface.co/${src%%@*}/resolve/$rev/"; else echo "https://huggingface.co/$src/resolve/main/"; fi ;; *) echo "$1" ;; esac; }` + " && "

--- a/internal/controller/model_storage_test.go
+++ b/internal/controller/model_storage_test.go
@@ -77,6 +77,31 @@ var _ = Describe("buildModelInitCommand (s3)", func() {
 	})
 })
 
+// Issue #1435: interrupted transfers leave orphaned .tmp files that nothing
+// cleans up. The init command must remove stale .tmp files before starting a
+// new download so they do not accumulate on the shared cache PVC.
+var _ = Describe("buildModelInitCommand (orphan .tmp cleanup, #1435)", func() {
+	It("should remove stale .tmp before downloading in cached remote path", func() {
+		cmd := buildModelInitCommand(false, false, true, RefreshPolicyIfNotPresent)
+		Expect(cmd).To(ContainSubstring(`rm -f "$MODEL_PATH.tmp"`))
+	})
+
+	It("should remove stale .tmp before downloading in cached S3 path", func() {
+		cmd := buildModelInitCommand(false, true, true, RefreshPolicyIfNotPresent)
+		Expect(cmd).To(ContainSubstring(`rm -f "$MODEL_PATH.tmp"`))
+	})
+
+	It("should remove stale .tmp before downloading in cached local path", func() {
+		cmd := buildModelInitCommand(true, false, true, RefreshPolicyIfNotPresent)
+		Expect(cmd).To(ContainSubstring(`rm -f "$MODEL_PATH.tmp"`))
+	})
+
+	It("should remove stale .tmp before downloading in cached OnChange path", func() {
+		cmd := buildModelInitCommand(false, false, true, RefreshPolicyOnChange)
+		Expect(cmd).To(ContainSubstring(`rm -f "$MODEL_PATH.tmp"`))
+	})
+})
+
 var _ = Describe("modelInitEnvVars (s3)", func() {
 	It("should include S3_BUCKET and S3_KEY for s3 source", func() {
 		envs := modelInitEnvVars("s3://my-bucket/models/model.gguf", "/models/cache", "/models/cache/model.gguf")


### PR DESCRIPTION
## What

Removes stale `.tmp` files before a model transfer starts, so interrupted
transfers stop accumulating on the durable model-cache PVC.

## Why

Fixes #1435

Transfers publish atomically via `<path>.tmp` then `mv`, which is correct, but
nothing ever removed a `.tmp` left by a transfer that never completed.

## How

Cleanup happens in the init-container command in `model_storage.go`, where the
atomic publish already lives, rather than adding a reaper Deployment or CronJob.
Single-file paths `rm -f "$MODEL_PATH.tmp"`; multi-file paths
`find "$CACHE_DIR" -name '*.tmp' -delete`, where `CACHE_DIR` is the per-model
cache directory, so the sweep is scoped to one model and never touches another
model's cache. Atomic publish semantics and RefreshPolicy handling are unchanged.

## Scope note

The cleanup is unconditional rather than age-based, so it will also remove a
`.tmp` belonging to a transfer of **the same model** running concurrently in
another pod (replicas > 1, or two InferenceServices sharing a cache key).

Worth being precise about why I do not consider that a regression: concurrent
transfers of the same model already write the same `.tmp` path today, so that
case is unsafe with or without this change. This does not make it worse, and it
does fix the leak.

If we want it properly safe, an age guard is a small delta
(`find ... -mmin +N -delete`, and matching for the single-file path), and it
would let the cleanup skip anything plausibly still in flight. Happy to add it
here if preferred, otherwise concurrent same-model transfer safety is its own
issue.

## Verification

Build, vet, and the full `internal/controller` suite with envtest all pass in a
clean worktree against current main.

Assisted-by: Claude Code (branch produced by the Foreman agent harness on a self-hosted model; I reviewed the diff, ran build, vet and the package test suites in a clean worktree, and verified the specifics called out above).
