### PR TITLE
fix(controller): set TerminationMessagePolicy on generated init containers

### DIFF
--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -487,7 +487,10 @@ func normalizeContainers(containers []corev1.Container) {
 	for i := range containers {
 		c := &containers[i]
 		c.TerminationMessagePath = ""
-		c.TerminationMessagePolicy = ""
+		// TerminationMessagePolicy is NOT stripped: the operator sets it on
+		// every container it generates (runtime container since #1425, init
+		// containers since #1437), so it is an owned field rather than
+		// API-server defaulting, and drift in it should be comparable.
 		c.ImagePullPolicy = ""
 		c.WorkingDir = ""
 		if c.SecurityContext != nil {

--- a/internal/controller/init_container_diagnostics_test.go
+++ b/internal/controller/init_container_diagnostics_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Init-container crash diagnosis (#1437, following #1425).
+//
+// #1425 set TerminationMessagePolicy: FallbackToLogsOnError on the runtime
+// container so a fatal engine error is self-describing. The init containers
+// never got it, which is backwards: on a fresh deploy the downloader is the
+// container most likely to fail (bad credentials, 404, disk full, evicted for
+// exceeding an emptyDir sizeLimit), and it reported nothing.
+//
+// Setting it on every generated init container also removes the asymmetry that
+// made normalizeContainers unable to stop stripping the field: with the
+// operator setting it everywhere it generates a container, desired and live
+// agree and there is nothing to normalise away.
+
+func storageConfigModel(source string) *inferencev1alpha1.Model {
+	m := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+		Spec:       inferencev1alpha1.ModelSpec{Source: source},
+	}
+	m.Status.CacheKey = "deadbeefdeadbeef"
+	return m
+}
+
+// Every init container the storage builder emits, on every source path, must
+// carry the policy. Table-driven over the paths rather than one case, because
+// the builder has several branches and a new one must not silently miss it.
+func TestInitContainersCarryTerminationMessagePolicy(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		useCache bool
+	}{
+		{"remote http, cached", "https://example.com/model.gguf", true},
+		{"remote http, emptyDir", "https://example.com/model.gguf", false},
+		{"s3, cached", "s3://bucket/key/model.gguf", true},
+		{"s3, emptyDir", "s3://bucket/key/model.gguf", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := buildModelStorageConfig(
+				storageConfigModel(tc.source), nil, "default", tc.useCache,
+				ModelCacheModeShared, "", "docker.io/curlimages/curl:8.18.0", 102, nil)
+			if len(cfg.initContainers) == 0 {
+				t.Fatal("no init containers built; fixture does not exercise the path")
+			}
+			for _, c := range cfg.initContainers {
+				if c.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
+					t.Errorf("init container %q has TerminationMessagePolicy %q, want %q",
+						c.Name, c.TerminationMessagePolicy,
+						corev1.TerminationMessageFallbackToLogsOnError)
+				}
+			}
+		})
+	}
+}
+
+// normalizeContainers must stop blanking the field, so drift in something the
+// operator now sets deliberately is comparable rather than normalised away.
+func TestNormalizeContainersKeepsTerminationMessagePolicy(t *testing.T) {
+	containers := []corev1.Container{{
+		Name:                     "c",
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		TerminationMessagePath:   "/dev/termination-log",
+		ImagePullPolicy:          corev1.PullAlways,
+	}}
+	normalizeContainers(containers)
+
+	if got := containers[0].TerminationMessagePolicy; got != corev1.TerminationMessageFallbackToLogsOnError {
+		t.Errorf("TerminationMessagePolicy = %q, want it preserved", got)
+	}
+	// The genuinely-defaulted neighbours must still be stripped; this is the
+	// line between "the operator sets it" and "the API server defaults it".
+	if containers[0].TerminationMessagePath != "" {
+		t.Error("TerminationMessagePath should still be normalised away")
+	}
+	if containers[0].ImagePullPolicy != "" {
+		t.Error("ImagePullPolicy should still be normalised away")
+	}
+}
+
+// The property that keeping the field comparable could plausibly break: a
+// desired template compared against itself must report no drift. If the
+// operator ever leaves the policy unset on a container it generates, the live
+// object gets the API-server default and every reconcile sees a difference.
+func TestPodTemplatesDoNotDifferFromThemselves(t *testing.T) {
+	cfg := buildModelStorageConfig(
+		storageConfigModel("https://example.com/model.gguf"), nil, "default", true,
+		ModelCacheModeShared, "", "docker.io/curlimages/curl:8.18.0", 102, nil)
+
+	// Live objects come back from the API server with the policy defaulted on
+	// any container that did not set one. Simulate that on a copy.
+	desired := corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+		InitContainers: append([]corev1.Container(nil), cfg.initContainers...),
+		Containers:     []corev1.Container{{Name: "server", TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError}},
+	}}
+	live := *desired.DeepCopy()
+	for i := range live.Spec.InitContainers {
+		if live.Spec.InitContainers[i].TerminationMessagePolicy == "" {
+			live.Spec.InitContainers[i].TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		}
+	}
+	for i := range live.Spec.Containers {
+		if live.Spec.Containers[i].TerminationMessagePolicy == "" {
+			live.Spec.Containers[i].TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		}
+	}
+
+	if podTemplatesDiffer(live, desired) {
+		t.Error("a template differs from itself once the API server defaults " +
+			"TerminationMessagePolicy: the operator left it unset on a container it generates")
+	}
+}

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -557,7 +557,30 @@ type modelStorageConfig struct {
 	volumeMounts   []corev1.VolumeMount
 }
 
-func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64, allowedHostPathRoots []string) modelStorageConfig {
+// applyInitContainerDiagnostics makes every generated init container report its
+// own fatal error, mirroring what #1425 did for the runtime container.
+//
+// On a fresh deploy the downloader is the container most likely to fail (bad
+// credentials, a 404, a full disk, eviction for exceeding an emptyDir
+// sizeLimit) and it wrote nothing to the termination message, so the failure
+// surfaced only as a non-zero exit code. FallbackToLogsOnError makes the log
+// tail the termination message on failure.
+//
+// Applying it to every container the operator generates also removes the
+// asymmetry that forced normalizeContainers to strip the field: when the
+// operator sets it everywhere, desired and live agree and there is nothing to
+// normalise away.
+func applyInitContainerDiagnostics(containers []corev1.Container) {
+	for i := range containers {
+		containers[i].TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
+	}
+}
+
+func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64, allowedHostPathRoots []string) (cfg modelStorageConfig) {
+	// Stamp crash diagnostics on whatever the branches below return. Done
+	// once here rather than at each construction site so a future storage
+	// path cannot be added without it (#1437).
+	defer func() { applyInitContainerDiagnostics(cfg.initContainers) }()
 	// Host-path allowlist gate (GHSA-jw3m-8q7m-f35r), belt-and-suspenders to
 	// the upfront check in the InferenceService reconcile: a local source
 	// outside the allowed roots must never yield a HostPathVolumeSource, even


### PR DESCRIPTION
## What

Sets `TerminationMessagePolicy: FallbackToLogsOnError` on every generated init
container, then stops `normalizeContainers` stripping the field.

## Why

Fixes #1437

#1425 made the runtime container report its own fatal error. The init containers
never got it, which is backwards: on a fresh deploy the downloader is the
container most likely to fail (bad credentials, a 404, a full disk, eviction for
exceeding an emptyDir sizeLimit), and it wrote nothing to the termination
message. The failure surfaced only as a non-zero exit code.

## How

Stamped once on the value `buildModelStorageConfig` returns rather than at each
of the nine construction sites, so a storage path added later cannot silently
miss it. One place covers both consumers (the InferenceService Deployment and
the prefetch Job) because both build init containers through it.

Only once that asymmetry is gone does dropping the strip line become safe.
Removing it alone, which is the literal reading of the issue, would have left
every generated init container comparing an unset desired value against the
API-server default of `File`.

## Correcting the issue's premise

Worth recording, because #1437 assumes more than is true and the next reader
deserves better:

- **Drift is corrected unconditionally.** The reconciler assigns the desired
  spec over the live one and `Update`s on every pass, regardless of any
  comparison.
- **`podTemplatesDiffer` only gates draining** before a roll, plus the
  `RolloutDeferred` condition.
- **It is superseded whenever the `desired-template-hash` annotation is
  present,** which is every operator-created Deployment (27 of 29 in the cluster
  I checked; the two without are not operator-generated).

So the field was never invisible to correction. This change improves drain
accuracy on the legacy no-annotation path and, mainly, makes init-container
failures self-describing.

## Testing

- Table-driven over the storage branches (http/s3 x cached/emptyDir), so a new
  branch that misses the policy fails.
- `normalizeContainers` keeps the owned field while still stripping its
  genuinely-defaulted neighbours (`TerminationMessagePath`, `ImagePullPolicy`),
  which is the line between the two categories.
- A regression test for the property this could plausibly break: a desired
  template compared against itself, with the API-server default applied to the
  live copy, must report no drift.

All three fail before the change. Full `internal/controller` suite with envtest
passes (251s), `make lint` 0 issues.

## Known limitation

`driver_compat.go` reads only `ContainerStatuses`, not
`InitContainerStatuses`, so nothing consumes init-container termination messages
automatically yet. The immediate win is `kubectl describe` and human debugging.
Extending the diagnosis path is a reasonable follow-up.

Assisted-by: Claude Code (investigation, implementation and tests; I reviewed
the change, confirmed what the drift comparison actually gates against the live
cluster, and ran the envtest suite and lint myself)
