### PR TITLE
feat(controller): diagnose model-transfer failures from init containers

### DIFF
--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -487,7 +487,10 @@ func normalizeContainers(containers []corev1.Container) {
 	for i := range containers {
 		c := &containers[i]
 		c.TerminationMessagePath = ""
-		c.TerminationMessagePolicy = ""
+		// TerminationMessagePolicy is NOT stripped: the operator sets it on
+		// every container it generates (runtime container since #1425, init
+		// containers since #1437), so it is an owned field rather than
+		// API-server defaulting, and drift in it should be comparable.
 		c.ImagePullPolicy = ""
 		c.WorkingDir = ""
 		if c.SecurityContext != nil {

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -263,6 +263,10 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// natively), so the pod scan is skipped there.
 	if !isMetal {
 		r.reconcileDriverCompatCondition(ctx, inferenceService)
+		// Sibling diagnosis for the containers that stage weights. Scans init
+		// containers only, as the driver diagnosis scans the runtime container
+		// only, so one failure never collects two contradictory diagnoses.
+		r.reconcileModelTransferCondition(ctx, inferenceService)
 	}
 
 	endpoint := r.constructEndpoint(inferenceService, service)

--- a/internal/controller/init_container_diagnostics_test.go
+++ b/internal/controller/init_container_diagnostics_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Init-container crash diagnosis (#1437, following #1425).
+//
+// #1425 set TerminationMessagePolicy: FallbackToLogsOnError on the runtime
+// container so a fatal engine error is self-describing. The init containers
+// never got it, which is backwards: on a fresh deploy the downloader is the
+// container most likely to fail (bad credentials, 404, disk full, evicted for
+// exceeding an emptyDir sizeLimit), and it reported nothing.
+//
+// Setting it on every generated init container also removes the asymmetry that
+// made normalizeContainers unable to stop stripping the field: with the
+// operator setting it everywhere it generates a container, desired and live
+// agree and there is nothing to normalise away.
+
+func storageConfigModel(source string) *inferencev1alpha1.Model {
+	m := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+		Spec:       inferencev1alpha1.ModelSpec{Source: source},
+	}
+	m.Status.CacheKey = "deadbeefdeadbeef"
+	return m
+}
+
+// Every init container the storage builder emits, on every source path, must
+// carry the policy. Table-driven over the paths rather than one case, because
+// the builder has several branches and a new one must not silently miss it.
+func TestInitContainersCarryTerminationMessagePolicy(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		useCache bool
+	}{
+		{"remote http, cached", "https://example.com/model.gguf", true},
+		{"remote http, emptyDir", "https://example.com/model.gguf", false},
+		{"s3, cached", "s3://bucket/key/model.gguf", true},
+		{"s3, emptyDir", "s3://bucket/key/model.gguf", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := buildModelStorageConfig(
+				storageConfigModel(tc.source), nil, "default", tc.useCache,
+				ModelCacheModeShared, "", "docker.io/curlimages/curl:8.18.0", 102, nil)
+			if len(cfg.initContainers) == 0 {
+				t.Fatal("no init containers built; fixture does not exercise the path")
+			}
+			for _, c := range cfg.initContainers {
+				if c.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
+					t.Errorf("init container %q has TerminationMessagePolicy %q, want %q",
+						c.Name, c.TerminationMessagePolicy,
+						corev1.TerminationMessageFallbackToLogsOnError)
+				}
+			}
+		})
+	}
+}
+
+// normalizeContainers must stop blanking the field, so drift in something the
+// operator now sets deliberately is comparable rather than normalised away.
+func TestNormalizeContainersKeepsTerminationMessagePolicy(t *testing.T) {
+	containers := []corev1.Container{{
+		Name:                     "c",
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		TerminationMessagePath:   "/dev/termination-log",
+		ImagePullPolicy:          corev1.PullAlways,
+	}}
+	normalizeContainers(containers)
+
+	if got := containers[0].TerminationMessagePolicy; got != corev1.TerminationMessageFallbackToLogsOnError {
+		t.Errorf("TerminationMessagePolicy = %q, want it preserved", got)
+	}
+	// The genuinely-defaulted neighbours must still be stripped; this is the
+	// line between "the operator sets it" and "the API server defaults it".
+	if containers[0].TerminationMessagePath != "" {
+		t.Error("TerminationMessagePath should still be normalised away")
+	}
+	if containers[0].ImagePullPolicy != "" {
+		t.Error("ImagePullPolicy should still be normalised away")
+	}
+}
+
+// The property that keeping the field comparable could plausibly break: a
+// desired template compared against itself must report no drift. If the
+// operator ever leaves the policy unset on a container it generates, the live
+// object gets the API-server default and every reconcile sees a difference.
+func TestPodTemplatesDoNotDifferFromThemselves(t *testing.T) {
+	cfg := buildModelStorageConfig(
+		storageConfigModel("https://example.com/model.gguf"), nil, "default", true,
+		ModelCacheModeShared, "", "docker.io/curlimages/curl:8.18.0", 102, nil)
+
+	// Live objects come back from the API server with the policy defaulted on
+	// any container that did not set one. Simulate that on a copy.
+	desired := corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+		InitContainers: append([]corev1.Container(nil), cfg.initContainers...),
+		Containers:     []corev1.Container{{Name: "server", TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError}},
+	}}
+	live := *desired.DeepCopy()
+	for i := range live.Spec.InitContainers {
+		if live.Spec.InitContainers[i].TerminationMessagePolicy == "" {
+			live.Spec.InitContainers[i].TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		}
+	}
+	for i := range live.Spec.Containers {
+		if live.Spec.Containers[i].TerminationMessagePolicy == "" {
+			live.Spec.Containers[i].TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		}
+	}
+
+	if podTemplatesDiffer(live, desired) {
+		t.Error("a template differs from itself once the API server defaults " +
+			"TerminationMessagePolicy: the operator left it unset on a container it generates")
+	}
+}

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -557,7 +557,30 @@ type modelStorageConfig struct {
 	volumeMounts   []corev1.VolumeMount
 }
 
-func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64, allowedHostPathRoots []string) modelStorageConfig {
+// applyInitContainerDiagnostics makes every generated init container report its
+// own fatal error, mirroring what #1425 did for the runtime container.
+//
+// On a fresh deploy the downloader is the container most likely to fail (bad
+// credentials, a 404, a full disk, eviction for exceeding an emptyDir
+// sizeLimit) and it wrote nothing to the termination message, so the failure
+// surfaced only as a non-zero exit code. FallbackToLogsOnError makes the log
+// tail the termination message on failure.
+//
+// Applying it to every container the operator generates also removes the
+// asymmetry that forced normalizeContainers to strip the field: when the
+// operator sets it everywhere, desired and live agree and there is nothing to
+// normalise away.
+func applyInitContainerDiagnostics(containers []corev1.Container) {
+	for i := range containers {
+		containers[i].TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
+	}
+}
+
+func buildModelStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1alpha1.InferenceService, namespace string, useCache bool, cacheMode string, caCertConfigMap string, initContainerImage string, defaultFSGroup int64, allowedHostPathRoots []string) (cfg modelStorageConfig) {
+	// Stamp crash diagnostics on whatever the branches below return. Done
+	// once here rather than at each construction site so a future storage
+	// path cannot be added without it (#1437).
+	defer func() { applyInitContainerDiagnostics(cfg.initContainers) }()
 	// Host-path allowlist gate (GHSA-jw3m-8q7m-f35r), belt-and-suspenders to
 	// the upfront check in the InferenceService reconcile: a local source
 	// outside the allowed roots must never yield a HostPathVolumeSource, even

--- a/internal/controller/model_transfer_diag.go
+++ b/internal/controller/model_transfer_diag.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// Model-transfer diagnosis. The sibling of the CUDA driver/runtime diagnosis in
+// driver_compat.go, aimed at the containers that actually fail on a fresh
+// deploy: the init containers that fetch the weights.
+//
+// The engine crashing is diagnosed there and deliberately scans only the
+// runtime container. This scans only the init containers, for the same reason
+// in reverse: a curl failure in the engine would be a different problem, and
+// one failure must never collect two contradictory diagnoses.
+//
+// Without this, a transfer failure surfaces as a Pod wedged in Init with a
+// non-zero exit code and nothing naming the cause. The operator already knows
+// the cause; it is in the termination message, which every generated init
+// container now reports (#1437).
+
+const (
+	// ConditionModelTransferHealthy reports whether the init containers that
+	// stage model weights completed. Diagnostic only: it never feeds phase or
+	// the Available condition. Absent until a failure is first diagnosed;
+	// True once a subsequent pod gets past its init containers.
+	ConditionModelTransferHealthy = "ModelTransferHealthy"
+
+	// ReasonModelSourceUnauthorized: the source rejected our credentials
+	// (401/403). Usually a missing or wrong sourceSecretRef, or a signature
+	// the object store did not accept.
+	ReasonModelSourceUnauthorized = "ModelSourceUnauthorized"
+
+	// ReasonModelSourceNotFound: the source returned 404. Usually a wrong
+	// bucket, key, or file name in spec.source.
+	ReasonModelSourceNotFound = "ModelSourceNotFound"
+
+	// ReasonModelSourceUntrusted: TLS verification failed. Typically a private
+	// endpoint signed by an internal CA that the downloader does not trust,
+	// which is what --ca-cert-configmap exists to fix.
+	ReasonModelSourceUntrusted = "ModelSourceUntrusted"
+
+	// ReasonModelSourceUnreachable: DNS or connection failure reaching the
+	// source. A wrong endpoint, a NetworkPolicy, or an egress-blocked cluster.
+	ReasonModelSourceUnreachable = "ModelSourceUnreachable"
+
+	// ReasonModelTransferOutOfSpace: the write ran out of room. Node
+	// ephemeral storage, or an emptyDir sizeLimit smaller than the model.
+	ReasonModelTransferOutOfSpace = "ModelTransferOutOfSpace"
+
+	// ReasonModelTransferSucceeded is set when ModelTransferHealthy flips back
+	// to True: a pod has since got past its init containers.
+	ReasonModelTransferSucceeded = "ModelTransferSucceeded"
+)
+
+// modelTransferSignature pairs a diagnosis with the substrings that justify it.
+// Matching is case-insensitive, so entries must be lowercase.
+type modelTransferSignature struct {
+	reason  string
+	remedy  string
+	matches []string
+}
+
+// modelTransferSignatures are matched in order, so the more specific entries
+// come first. Every entry is a failure observed in practice; a signature that
+// cannot be tied to a real message does not belong here, because a confident
+// wrong label is worse than the bare exit code the user already has.
+var modelTransferSignatures = []modelTransferSignature{
+	{
+		reason: ReasonModelSourceUntrusted,
+		remedy: "the endpoint's CA is not trusted by the downloader; " +
+			"publish it via the operator's --ca-cert-configmap (the ConfigMap must exist " +
+			"in the workload's namespace, not the operator's)",
+		// Both curl spellings: 8.x prints "SSL certificate OpenSSL verify
+		// result: ...", older builds print "SSL certificate problem: ...".
+		// Verified against curl 8.18 (the pinned init image) hitting a private
+		// endpoint with no CA bundle.
+		matches: []string{
+			"ssl certificate problem",
+			"ssl certificate openssl verify result",
+			"unable to get local issuer certificate",
+			"self signed certificate",
+			"certificate verify failed",
+		},
+	},
+	{
+		reason: ReasonModelSourceUnauthorized,
+		remedy: "check spec.sourceSecretRef and the credentials it names",
+		matches: []string{
+			"returned error: 401",
+			"returned error: 403",
+			"403 forbidden",
+			"401 unauthorized",
+			"signaturedoesnotmatch",
+			"invalidaccesskeyid",
+		},
+	},
+	{
+		reason:  ReasonModelSourceNotFound,
+		remedy:  "check spec.source: the bucket, key or file name does not exist at the endpoint",
+		matches: []string{"returned error: 404", "404 not found", "nosuchkey", "nosuchbucket"},
+	},
+	{
+		reason: ReasonModelTransferOutOfSpace,
+		remedy: "raise spec.resources.ephemeralStorage (which also sizes the emptyDir) " +
+			"or give the model cache a larger volume",
+		matches: []string{"no space left on device", "disk quota exceeded"},
+	},
+	{
+		reason: ReasonModelSourceUnreachable,
+		remedy: "check the endpoint address, cluster DNS, and any NetworkPolicy or egress restriction",
+		matches: []string{
+			"could not resolve host",
+			"failed to connect to",
+			"connection refused",
+			"connection timed out",
+		},
+	},
+}
+
+// matchModelTransferFailure classifies an init container's termination message.
+// Returns the reason, the (sanitized, length-capped) line that justified it,
+// and whether anything matched at all.
+//
+// Reuses driver_compat.go's asciiLower and sanitizeMessageLine: the input is
+// arbitrary container output, so offsets must stay byte-stable and the result
+// must be bounded no matter what was printed.
+func matchModelTransferFailure(msg string) (reason, matchedLine string, found bool) {
+	if msg == "" {
+		return "", "", false
+	}
+	lower := asciiLower(msg)
+	for _, sig := range modelTransferSignatures {
+		for _, m := range sig.matches {
+			idx := strings.Index(lower, m)
+			if idx < 0 {
+				continue
+			}
+			// Report the whole line the match sits on, not the fragment: the
+			// surrounding text is what makes the diagnosis actionable (which
+			// URL, which host, which file).
+			start := strings.LastIndexByte(msg[:idx], '\n') + 1
+			end := strings.IndexByte(msg[idx:], '\n')
+			if end < 0 {
+				end = len(msg)
+			} else {
+				end += idx
+			}
+			return sig.reason, sanitizeMessageLine(msg[start:end]), true
+		}
+	}
+	return "", "", false
+}
+
+// isGeneratedInitContainer reports whether a container name is one the operator
+// generates for model staging. Scoped by name rather than by position so an
+// init container injected by a mesh or a policy controller is never diagnosed
+// as our transfer failing.
+func isGeneratedInitContainer(name string) bool {
+	return name == "model-downloader" || name == "model-cache-prep"
+}
+
+// findModelTransferFailure scans pods for a generated init container that
+// terminated non-zero with a recognisable cause. Both the current terminated
+// state (fresh failure, before backoff) and the last terminated state
+// (CrashLoopBackOff) are checked, mirroring findCudaDriverCrash.
+func findModelTransferFailure(pods []corev1.Pod) (nodeName, reason, matchedLine string, found bool) {
+	for i := range pods {
+		pod := &pods[i]
+		for j := range pod.Status.InitContainerStatuses {
+			cs := &pod.Status.InitContainerStatuses[j]
+			if !isGeneratedInitContainer(cs.Name) {
+				continue
+			}
+			for _, term := range []*corev1.ContainerStateTerminated{
+				cs.State.Terminated,
+				cs.LastTerminationState.Terminated,
+			} {
+				if term == nil || term.ExitCode == 0 {
+					continue
+				}
+				if r, line, ok := matchModelTransferFailure(term.Message); ok {
+					return pod.Spec.NodeName, r, line, true
+				}
+			}
+		}
+	}
+	return "", "", "", false
+}
+
+// initContainersCompleted reports whether any pod has got past every generated
+// init container. The recovery gate: weights staged successfully somewhere is
+// the only observation that justifies clearing the diagnosis.
+func initContainersCompleted(pods []corev1.Pod) bool {
+	for i := range pods {
+		seen, ok := false, true
+		for _, cs := range pods[i].Status.InitContainerStatuses {
+			if !isGeneratedInitContainer(cs.Name) {
+				continue
+			}
+			seen = true
+			if cs.State.Terminated == nil || cs.State.Terminated.ExitCode != 0 {
+				ok = false
+			}
+		}
+		if seen && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// reconcileModelTransferCondition diagnoses model-staging failures onto the
+// InferenceService. Mirrors reconcileDriverCompatCondition, including its
+// transition-only recovery: pods merely disappearing never asserts health we
+// have not observed.
+func (r *InferenceServiceReconciler) reconcileModelTransferCondition(
+	ctx context.Context, isvc *inferencev1alpha1.InferenceService,
+) {
+	log := logf.FromContext(ctx)
+
+	podList := &corev1.PodList{}
+	labels := client.MatchingLabels{
+		"app":                           isvc.Name,
+		"inference.llmkube.dev/service": isvc.Name,
+	}
+	if err := r.List(ctx, podList, client.InNamespace(isvc.Namespace), labels); err != nil {
+		log.Error(err, "Failed to list pods for model-transfer diagnosis")
+		return
+	}
+
+	now := metav1.NewTime(time.Now())
+	nodeName, reason, matchedLine, found := findModelTransferFailure(podList.Items)
+
+	if !found {
+		existing := meta.FindStatusCondition(isvc.Status.Conditions, ConditionModelTransferHealthy)
+		if existing == nil || existing.Status != metav1.ConditionFalse {
+			return
+		}
+		if !initContainersCompleted(podList.Items) {
+			return
+		}
+		meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+			Type:               ConditionModelTransferHealthy,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: isvc.Generation,
+			LastTransitionTime: now,
+			Reason:             ReasonModelTransferSucceeded,
+			Message:            "Model weights staged successfully",
+		})
+		return
+	}
+
+	var remedy string
+	for _, sig := range modelTransferSignatures {
+		if sig.reason == reason {
+			remedy = sig.remedy
+			break
+		}
+	}
+	message := fmt.Sprintf("Model transfer failed: %s", matchedLine)
+	if nodeName != "" {
+		message += fmt.Sprintf(" (node %s)", nodeName)
+	}
+	if remedy != "" {
+		message += ". " + remedy
+	}
+
+	existing := meta.FindStatusCondition(isvc.Status.Conditions, ConditionModelTransferHealthy)
+	changed := existing == nil || existing.Status != metav1.ConditionFalse || existing.Reason != reason
+	meta.SetStatusCondition(&isvc.Status.Conditions, metav1.Condition{
+		Type:               ConditionModelTransferHealthy,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: isvc.Generation,
+		LastTransitionTime: now,
+		Reason:             reason,
+		Message:            message,
+	})
+	if changed && r.Recorder != nil {
+		r.Recorder.Eventf(isvc, nil, corev1.EventTypeWarning, reason, "Reconcile", "%s", message)
+	}
+}

--- a/internal/controller/model_transfer_diag_test.go
+++ b/internal/controller/model_transfer_diag_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Model-transfer diagnosis. The sibling of the CUDA driver diagnosis, for the
+// containers that actually fail on a fresh deploy: the init containers that
+// fetch the weights.
+//
+// Every signature here is a failure mode seen in practice, not a guess. The
+// TLS one in particular: an object store behind a private CA returns exactly
+// this when the operator's CA bundle is not mounted, and the symptom (a pod
+// stuck in Init with a non-zero exit) names nothing.
+
+func TestMatchModelTransferFailure_Signatures(t *testing.T) {
+	cases := []struct {
+		name       string
+		msg        string
+		wantReason string
+	}{
+		{
+			name:       "curl 403 from a signed request with bad credentials",
+			msg:        "curl: (22) The requested URL returned error: 403",
+			wantReason: ReasonModelSourceUnauthorized,
+		},
+		{
+			name:       "curl 401",
+			msg:        "curl: (22) The requested URL returned error: 401 Unauthorized",
+			wantReason: ReasonModelSourceUnauthorized,
+		},
+		{
+			name:       "curl 404 for a wrong key or path",
+			msg:        "curl: (22) The requested URL returned error: 404",
+			wantReason: ReasonModelSourceNotFound,
+		},
+		{
+			// Captured verbatim from curl 8.18 (the pinned init-container image)
+			// against a private endpoint with no CA bundle mounted. Note the
+			// wording is NOT "SSL certificate problem:", which is what older
+			// curl prints; both spellings are carried in the signature list
+			// because the init-container image is pinned but overridable.
+			name:       "private CA not trusted, curl 8.x wording",
+			msg:        "curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)\nMore details here: https://curl.se/docs/sslcerts.html",
+			wantReason: ReasonModelSourceUntrusted,
+		},
+		{
+			name:       "private CA not trusted, older curl wording",
+			msg:        "curl: (60) SSL certificate problem: unable to get local issuer certificate",
+			wantReason: ReasonModelSourceUntrusted,
+		},
+		{
+			name:       "endpoint DNS does not resolve",
+			msg:        "curl: (6) Could not resolve host: nope.invalid.internal",
+			wantReason: ReasonModelSourceUnreachable,
+		},
+		{
+			name:       "endpoint refuses the connection",
+			msg:        "curl: (7) Failed to connect to 10.0.0.5 port 9000: Connection refused",
+			wantReason: ReasonModelSourceUnreachable,
+		},
+		{
+			name:       "node disk or emptyDir sizeLimit exhausted",
+			msg:        "sh: write error: No space left on device",
+			wantReason: ReasonModelTransferOutOfSpace,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, line, ok := matchModelTransferFailure(tc.msg)
+			if !ok {
+				t.Fatalf("no diagnosis for %q", tc.msg)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+			if line == "" {
+				t.Error("matched line is empty; the condition message would name no evidence")
+			}
+		})
+	}
+}
+
+// Anything unrecognised must produce no diagnosis at all. Guessing a reason
+// would put a confident, wrong label on a failure, which is worse than the
+// generic non-zero exit the user already sees.
+func TestMatchModelTransferFailure_UnknownIsNotDiagnosed(t *testing.T) {
+	for _, msg := range []string{
+		"",
+		"Model downloaded successfully",
+		"curl: (18) transfer closed with outstanding read data remaining",
+	} {
+		if reason, _, ok := matchModelTransferFailure(msg); ok {
+			t.Errorf("msg %q was diagnosed as %q; unknown failures must not be labelled", msg, reason)
+		}
+	}
+}
+
+func initPod(node string, statuses ...corev1.ContainerStatus) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: node},
+		Status:     corev1.PodStatus{InitContainerStatuses: statuses},
+	}
+}
+
+func terminatedInit(name string, exit int32, msg string) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name: name,
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: exit, Message: msg},
+		},
+	}
+}
+
+func TestFindModelTransferFailure(t *testing.T) {
+	t.Run("diagnoses a failed downloader", func(t *testing.T) {
+		pods := []corev1.Pod{initPod("node-a",
+			terminatedInit("model-downloader", 22,
+				"curl: (60) SSL certificate problem: unable to get local issuer certificate"))}
+		node, reason, line, found := findModelTransferFailure(pods)
+		if !found {
+			t.Fatal("no failure found")
+		}
+		if node != "node-a" || reason != ReasonModelSourceUntrusted || line == "" {
+			t.Errorf("got node=%q reason=%q line=%q", node, reason, line)
+		}
+	})
+
+	t.Run("ignores a clean exit", func(t *testing.T) {
+		pods := []corev1.Pod{initPod("node-a",
+			terminatedInit("model-downloader", 0, "Model downloaded successfully"))}
+		if _, _, _, found := findModelTransferFailure(pods); found {
+			t.Error("a zero exit code must never be diagnosed as a failure")
+		}
+	})
+
+	// The engine's own crash is the CUDA diagnosis's job. A signature match in
+	// the runtime container must not be claimed here, or one failure gets two
+	// contradictory diagnoses.
+	t.Run("ignores non-init containers", func(t *testing.T) {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				terminatedInit("llama-server", 1, "curl: (22) The requested URL returned error: 404"),
+			}},
+		}}
+		if _, _, _, found := findModelTransferFailure(pods); found {
+			t.Error("runtime-container output must not be diagnosed as a transfer failure")
+		}
+	})
+
+	// A pod that got past its init containers is evidence the transfer works
+	// now; a stale message must not keep the service diagnosed forever.
+	t.Run("ignores a pod whose init containers have since succeeded", func(t *testing.T) {
+		cs := terminatedInit("model-downloader", 0, "")
+		cs.Ready = true
+		pods := []corev1.Pod{initPod("node-a", cs)}
+		if _, _, _, found := findModelTransferFailure(pods); found {
+			t.Error("a completed init container must not be reported as failing")
+		}
+	})
+}


### PR DESCRIPTION
## What

Adds a `ModelTransferHealthy` condition that turns a failed model-staging init
container into a named diagnosis with a remedy, alongside the existing
`DriverCompatible`.

> Stacked on #1460 (`fix/1437-init-termination-policy`) and should merge after
> it. Without that branch the init containers write no termination message, so
> there is nothing to diagnose.

## Why

Refs #1425, #1437

#1425 made a crashed *runtime* container self-describing. Nothing did the same
for the containers that actually fail on a fresh deploy. A bad key, a wrong
credential, an untrusted private CA or a full disk all surfaced as a Pod wedged
in `Init:0/1` with a non-zero exit code and nothing naming the cause, even
though the operator can read the cause straight out of the termination message.

## How

Five reasons, each carrying a remedy in the condition message, because the
matched line names the symptom and the remedy names the field to edit:

| Reason | Remedy in the message |
| --- | --- |
| `ModelSourceUnauthorized` | check `spec.sourceSecretRef` |
| `ModelSourceNotFound` | check `spec.source` bucket/key/file |
| `ModelSourceUntrusted` | publish the CA via `--ca-cert-configmap`, in the workload's namespace |
| `ModelSourceUnreachable` | endpoint, DNS, NetworkPolicy, egress |
| `ModelTransferOutOfSpace` | raise `spec.resources.ephemeralStorage` |

**Scans init containers only, and only ones the operator generates.** Mirrors
the driver diagnosis scanning only the runtime container. The two must not
overlap: a curl failure in the engine is a different problem, and one failure
collecting two contradictory diagnoses is worse than one diagnosis fewer.
Matching by container name also means an init container injected by a mesh or a
policy controller is never diagnosed as our transfer failing.

**Unrecognised output is deliberately not diagnosed.** A confident wrong label
is worse than the bare exit code the user already has, so the signature list
only carries failures tied to a real observed message. There is a test asserting
unknown messages stay undiagnosed.

Recovery follows `DriverCompatible`'s transition-only convention: back to True
only when a pod has demonstrably got past its init containers. Pods merely
disappearing never asserts health that was not observed.

## Signatures were validated against reality, and it mattered

I ran the pinned init-container image against a live private object store rather
than writing the signatures from memory:

```
=== 404 (valid creds, wrong key) ===
curl: (22) The requested URL returned error: 404
=== 403 (bad secret) ===
curl: (22) The requested URL returned error: 403
=== TLS untrusted (no CA bundle) ===
curl: (60) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
=== unreachable host ===
curl: (6) Could not resolve host: nope.invalid.internal
```

That caught a real defect in my first draft: curl 8.x prints **"SSL certificate
OpenSSL verify result:"**, not the "SSL certificate problem:" wording I had
assumed, and the test fixture asserted a string curl never emits. The matcher
happened to still fire through a second signature, so the test passed while
testing fiction. Both spellings are now carried (the init image is pinned but
overridable), and the fixtures are captured output.

## Verification

Full `internal/controller` suite with envtest passes (250s), `make lint` 0
issues.

Assisted-by: Claude Code (implementation and tests; I designed the split from
the driver diagnosis, captured the real curl output against my own object store
to validate the signatures, and ran the envtest suite and lint myself)
