### PR TITLE
fix(controller): make the custom CA additive to the system trust store

### DIFF
--- a/internal/controller/ca_cert_bundle_test.go
+++ b/internal/controller/ca_cert_bundle_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// A private CA must be ADDITIVE to the system trust store, never a replacement.
+//
+// Setting CURL_CA_BUNDLE to a single file overrides the system bundle
+// entirely, so enabling --ca-cert-configmap for a private endpoint silently
+// breaks every PUBLIC source on the fleet. Observed 2026-08-09: after the flag
+// was enabled for a private object store, a Hugging Face pull failed with
+//
+//	curl: (60) SSL certificate OpenSSL verify result:
+//	      unable to get local issuer certificate (20)
+//
+// while every private-endpoint download kept working, which is what made it
+// hard to spot: the fleet had been pulling from the private store all day.
+
+func caCmd() string {
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
+	cmd := "echo download"
+	addCACertVolume(&volumes, &mounts, &cmd, "llmkube-ca-cert")
+	return cmd
+}
+
+func TestCACertBundle_KeepsSystemTrust(t *testing.T) {
+	cmd := caCmd()
+
+	// The system bundle must be part of what curl ends up trusting. Without
+	// this the private CA is the ONLY trusted root and every public TLS
+	// endpoint fails to verify.
+	if !strings.Contains(cmd, "/etc/ssl/certs/ca-certificates.crt") {
+		t.Errorf("system CA bundle is never referenced, so public sources cannot verify:\n%s", cmd)
+	}
+	// And the custom CA must still be trusted, or the private endpoint breaks.
+	if !strings.Contains(cmd, "/custom-certs") {
+		t.Errorf("custom CA is not referenced:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, "CURL_CA_BUNDLE") {
+		t.Errorf("CURL_CA_BUNDLE is never set:\n%s", cmd)
+	}
+}
+
+// The combined bundle must not be written to the system path: the init
+// container may run read-only or as a non-root user, and clobbering the image's
+// trust store is a side effect no download command should have.
+func TestCACertBundle_DoesNotWriteToSystemPath(t *testing.T) {
+	cmd := caCmd()
+	for _, bad := range []string{
+		"> /etc/ssl/certs/ca-certificates.crt",
+		">/etc/ssl/certs/ca-certificates.crt",
+		">> /etc/ssl/certs/ca-certificates.crt",
+	} {
+		if strings.Contains(cmd, bad) {
+			t.Errorf("command writes to the system trust store (%q):\n%s", bad, cmd)
+		}
+	}
+}
+
+// Absent config stays a no-op: no CA plumbing at all, so the image's own trust
+// store is used untouched.
+func TestCACertBundle_NoOpWhenUnset(t *testing.T) {
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
+	cmd := "echo download"
+	addCACertVolume(&volumes, &mounts, &cmd, "")
+	if cmd != "echo download" {
+		t.Errorf("command mutated with no configmap set: %s", cmd)
+	}
+	if len(volumes) != 0 || len(mounts) != 0 {
+		t.Errorf("volumes/mounts added with no configmap set: %d/%d", len(volumes), len(mounts))
+	}
+}
+
+// The volume and mount still have to be wired, whatever the command does.
+func TestCACertBundle_MountsTheConfigMap(t *testing.T) {
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
+	cmd := "echo download"
+	addCACertVolume(&volumes, &mounts, &cmd, "llmkube-ca-cert")
+	if len(volumes) != 1 || volumes[0].ConfigMap == nil ||
+		volumes[0].ConfigMap.Name != "llmkube-ca-cert" {
+		t.Fatalf("configmap volume not wired: %+v", volumes)
+	}
+	if len(mounts) != 1 || mounts[0].MountPath != "/custom-certs" {
+		t.Fatalf("mount not wired: %+v", mounts)
+	}
+}

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -108,7 +108,11 @@ var _ = Describe("buildCachedStorageConfig", func() {
 			}
 		}
 		Expect(found).To(BeTrue())
-		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+		// Additive, not a replacement: the system roots must survive so
+		// public sources keep verifying (see addCACertVolume).
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE"))
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("/etc/ssl/certs/ca-certificates.crt"))
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("/custom-certs/"))
 	})
 })
 
@@ -291,7 +295,11 @@ var _ = Describe("buildCachedStorageConfig multi-file staging", func() {
 			}
 		}
 		Expect(foundCA).To(BeTrue())
-		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+		// Additive, not a replacement: the system roots must survive so
+		// public sources keep verifying (see addCACertVolume).
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE"))
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("/etc/ssl/certs/ca-certificates.crt"))
+		Expect(config.initContainers[1].Command[2]).To(ContainSubstring("/custom-certs/"))
 	})
 
 	It("uses OnChange per-file HEAD revalidation for multi-file model", func() {
@@ -601,7 +609,11 @@ var _ = Describe("buildEmptyDirStorageConfig", func() {
 			}
 		}
 		Expect(found).To(BeTrue())
-		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE=/custom-certs/"))
+		// Additive, not a replacement: the system roots must survive so
+		// public sources keep verifying (see addCACertVolume).
+		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("CURL_CA_BUNDLE"))
+		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("/etc/ssl/certs/ca-certificates.crt"))
+		Expect(config.initContainers[0].Command[2]).To(ContainSubstring("/custom-certs/"))
 	})
 
 	It("should inherit runAsUser/runAsGroup in emptyDir storage", func() {

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -245,8 +245,21 @@ func isLocalModelSource(source string) bool {
 }
 
 // addCACertVolume appends the custom CA cert volume and volume mount to the
-// given slices, and prefixes the command with the CURL_CA_BUNDLE export.
+// given slices, and prefixes the command with a CURL_CA_BUNDLE export.
 // No-op when caCertConfigMap is empty.
+//
+// The bundle is ADDITIVE: the system trust store is concatenated with the
+// custom CA into a scratch file, and CURL_CA_BUNDLE points at that. Setting
+// CURL_CA_BUNDLE to the custom cert alone REPLACES the system roots, so
+// enabling this flag for one private endpoint silently breaks every public
+// source on the fleet. Observed 2026-08-09: a Hugging Face pull failed with
+// "unable to get local issuer certificate" while private-endpoint downloads
+// kept working, which is what made it hard to spot.
+//
+// Written to /tmp rather than over /etc/ssl/certs: the init container may run
+// read-only or as a non-root user, and a download command should not mutate
+// the image's trust store. The system bundle is globbed rather than assumed,
+// so an image that keeps its roots elsewhere still gets the custom CA.
 func addCACertVolume(volumes *[]corev1.Volume, mounts *[]corev1.VolumeMount, cmd *string, caCertConfigMap string) {
 	if caCertConfigMap == "" {
 		return
@@ -264,7 +277,13 @@ func addCACertVolume(volumes *[]corev1.Volume, mounts *[]corev1.VolumeMount, cmd
 		MountPath: "/custom-certs",
 		ReadOnly:  true,
 	})
-	*cmd = fmt.Sprintf("export CURL_CA_BUNDLE=/custom-certs/$(ls /custom-certs | grep -v '^\\.' | head -n 1) && %s", *cmd)
+	// cat both into a scratch bundle; the || keeps a missing system store from
+	// failing the download, since the custom CA alone is still better than none.
+	const caPrelude = "export LLMKUBE_CA_BUNDLE=/tmp/llmkube-ca-bundle.crt && " +
+		"cat /etc/ssl/certs/ca-certificates.crt /custom-certs/* > \"$LLMKUBE_CA_BUNDLE\" 2>/dev/null || " +
+		"cat /custom-certs/* > \"$LLMKUBE_CA_BUNDLE\" && " +
+		"export CURL_CA_BUNDLE=\"$LLMKUBE_CA_BUNDLE\" && "
+	*cmd = caPrelude + *cmd
 }
 
 // All transfers write to "$MODEL_PATH.tmp" and mv onto "$MODEL_PATH" on


### PR DESCRIPTION
## What

`--ca-cert-configmap` set `CURL_CA_BUNDLE` to the private CA file. That names the ONE file curl trusts, so enabling it for a private endpoint made the private CA the only trusted root and broke every public HTTPS model source.

## Why it hid

Private-endpoint downloads keep working perfectly. A fleet pulling from its own object store sees nothing wrong until the next public pull, which can be days later and looks unrelated to the flag that caused it.

Found when a Hugging Face pull failed with `unable to get local issuer certificate` on a fleet that had enabled the flag for a private MinIO. The diagnosis condition from #1463 identified it correctly and unprompted:

```
ModelTransferHealthy  False  ModelSourceUntrusted
  Model transfer failed: curl: (60) SSL certificate OpenSSL verify result:
  unable to get local issuer certificate (20) (node ahazidgx1)
```

## How

Concatenate the system bundle with the custom CA into a scratch file and point `CURL_CA_BUNDLE` at that. Written to `/tmp` rather than over `/etc/ssl/certs`: the init container may run read-only or non-root, and a download command should not mutate the image trust store. A missing system store falls back to the custom CA alone rather than failing the download.

## Verification

In-cluster with the real init image, both endpoints:

```
bundle bytes: 223412
  public  (huggingface.co): HTTP 200
  private (minio lab CA):   HTTP 200
```

Before the change the second worked and the first did not.

Full `internal/controller` suite with envtest passes (253s), `make lint` 0 issues.

**Note on the existing tests:** three envtest specs asserted the buggy substring `CURL_CA_BUNDLE=/custom-certs/`, encoding the defect rather than the intent. They now assert both roots are present. Worth a look, since a test that pins broken behaviour is the reason this could regress quietly.

Fixes #1468

Assisted-by: Claude Code (diagnosis, fix and tests; I confirmed the failure and the fix against both a public and a private endpoint from inside the cluster, and ran the envtest suite and lint myself)