### PR TITLE
feat(chart): PodMonitor for router-proxy metrics

### DIFF
--- a/charts/llmkube/templates/router-podmonitor.yaml
+++ b/charts/llmkube/templates/router-podmonitor.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.prometheus.routerPodMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "llmkube.fullname" . }}-router
+  namespace: {{ .Values.prometheus.routerPodMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.routerPodMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    # Every router-proxy pod carries this label regardless of ModelRouter
+    # name (routerProxySelectorLabels in internal/controller/router_common.go),
+    # so Exists is the whole selector, same reasoning as inference-podmonitor.yaml.
+    matchExpressions:
+      - key: inference.llmkube.dev/model-router
+        operator: Exists
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.prometheus.routerPodMonitor.interval | default "30s" }}
+      relabelings:
+        # Operator default is `<namespace>/<podmonitor name>`; pin it so a
+        # future RouterProxyDown alert has a stable job label to match.
+        - targetLabel: job
+          replacement: llmkube-router
+        - sourceLabels: [__meta_kubernetes_pod_label_inference_llmkube_dev_model_router]
+          targetLabel: router
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+  namespaceSelector:
+    any: true
+{{- end }}

--- a/charts/llmkube/templates/router-podmonitor.yaml
+++ b/charts/llmkube/templates/router-podmonitor.yaml
@@ -12,8 +12,10 @@ metadata:
 spec:
   selector:
     # Every router-proxy pod carries this label regardless of ModelRouter
-    # name (routerProxySelectorLabels in internal/controller/router_common.go),
-    # so Exists is the whole selector, same reasoning as inference-podmonitor.yaml.
+    # name (routerProxySelectorLabels in internal/controller/router_common.go).
+    # A matchLabels entry with an empty value would be ANDed in and match
+    # nothing, so the Exists expression is the whole selector, same reasoning
+    # as inference-podmonitor.yaml.
     matchExpressions:
       - key: inference.llmkube.dev/model-router
         operator: Exists

--- a/charts/llmkube/tests/prometheusrule_test.yaml
+++ b/charts/llmkube/tests/prometheusrule_test.yaml
@@ -6,6 +6,7 @@ templates:
   - prometheusrule.yaml
   - inference-podmonitor.yaml
   - servicemonitor.yaml
+  - router-podmonitor.yaml
 
 tests:
   # --- job label: pinned on the monitors, matched by the alerts ---
@@ -20,6 +21,20 @@ tests:
           content:
             targetLabel: job
             replacement: llmkube-inference
+
+  - it: should pin the router job label for a future RouterProxyDown alert
+    template: router-podmonitor.yaml
+    set:
+      prometheus.routerPodMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.podMetricsEndpoints[0].port
+          value: metrics
+      - contains:
+          path: spec.podMetricsEndpoints[0].relabelings
+          content:
+            targetLabel: job
+            replacement: llmkube-router
 
   - it: should pin the controller job label to what ControllerDown matches
     template: servicemonitor.yaml

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -211,6 +211,18 @@
             "interval": { "type": "string" }
           }
         },
+        "routerPodMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "additionalLabels": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "interval": { "type": "string" }
+          }
+        },
         "prometheusRule": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -240,6 +240,16 @@ prometheus:
     # Scrape interval
     interval: 30s
 
+  # Enable PodMonitor for router-proxy metrics (llmkube_router_* on the
+  # --metrics-bind-address listener)
+  routerPodMonitor:
+    enabled: false
+    # Additional labels for PodMonitor
+    additionalLabels:
+      prometheus: kube-prometheus-stack-prometheus
+    # Scrape interval
+    interval: 30s
+
   # Enable PrometheusRule for alerts
   prometheusRule:
     enabled: false


### PR DESCRIPTION
## What

A `PodMonitor` for router-proxy pods, scraping the metrics listener #1457 adds.

## Why

Fixes #1472

#1457 adds a `--metrics-bind-address` listener (container port `metrics`,
default `:9090`) but nothing scrapes it: `inference-podmonitor.yaml` selects
`inference.llmkube.dev/service` on a port named `http`, and router-proxy pods
carry neither that label nor that port name. Without this, `model-router-dashboard.json`
still can't populate even once #1457 merges — its own PR body says so and
deliberately left #1427 open for that reason.

## How

`router-podmonitor.yaml` mirrors `inference-podmonitor.yaml`'s shape:

- Selector: `inference.llmkube.dev/model-router: Exists`, the stable label
  `routerProxySelectorLabels` (`internal/controller/router_common.go:68`)
  already puts on every router-proxy pod.
- `port: metrics`, `path: /metrics`.
- `job: llmkube-router` relabeling, so a future `RouterProxyDown` rule has a
  stable label to match — same pattern the inference/controller monitors use.
- Gated on `prometheus.routerPodMonitor.enabled` (default `false`, matching
  `inferencePodMonitor` and `serviceMonitor`'s existing default).

This PR is chart-only and depends on #1457 for the port to exist; opening as
draft until #1457 merges (port name/number final).

Assisted-by: OpenCode (helped draft this PR; I reviewed the final change and stand behind it.)

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)
