### PR TITLE
fix(controller): stage files and mmproj from an s3:// object store

### DIFF
--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -395,7 +395,7 @@ var _ = Describe("buildEmptyDirStorageConfig multi-file staging", func() {
 
 var _ = Describe("buildMultiFileInitCommand", func() {
 	It("generates download loop for IfNotPresent policy", func() {
-		cmd := buildMultiFileInitCommand(true, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 		Expect(cmd).To(ContainSubstring("printf '%s\\n' \"$MODEL_FILES\""))
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$(dirname "$dest")"`))
@@ -405,13 +405,13 @@ var _ = Describe("buildMultiFileInitCommand", func() {
 	})
 
 	It("fails init container if any curl fails in IfNotPresent policy", func() {
-		cmd := buildMultiFileInitCommand(true, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`exit 1`))
 		Expect(cmd).To(ContainSubstring("failed to download"))
 	})
 
 	It("generates HEAD revalidation for OnChange policy", func() {
-		cmd := buildMultiFileInitCommand(true, RefreshPolicyOnChange)
+		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyOnChange)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 		Expect(cmd).To(ContainSubstring("remote_size"))
 		Expect(cmd).To(ContainSubstring("skipped download"))
@@ -419,18 +419,18 @@ var _ = Describe("buildMultiFileInitCommand", func() {
 	})
 
 	It("uses emptyDir prefix without cache dir for non-cached storage", func() {
-		cmd := buildMultiFileInitCommand(false, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`mkdir -p /models`))
 		Expect(cmd).NotTo(ContainSubstring(`"$CACHE_DIR"`))
 	})
 
 	It("normalizes hf:// URLs via MODEL_SOURCE in the generated command", func() {
-		cmd := buildMultiFileInitCommand(true, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring("normalize_hf_source"))
 	})
 
 	It("uses POSIX-compatible shell (no bashisms)", func() {
-		cmd := buildMultiFileInitCommand(true, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).NotTo(ContainSubstring("[["))
 		Expect(cmd).To(ContainSubstring("case"))
 		Expect(cmd).To(ContainSubstring("esac"))
@@ -440,12 +440,12 @@ var _ = Describe("buildMultiFileInitCommand", func() {
 		// The bug: url="${SOURCE%/}$rel" strips trailing slash from SOURCE (which ends in /)
 		// and glues filename directly, producing ".../resolve/main" + "a.gguf" = ".../resolve/maina.gguf"
 		// The fix: url="${SOURCE%/}/$rel" adds the slash back, producing ".../resolve/main/a.gguf"
-		cmd := buildMultiFileInitCommand(true, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`url="${SOURCE%/}/$rel"`))
 	})
 
 	It("preserves slash between resolve base and filename in OnChange policy (regression test for #1110)", func() {
-		cmd := buildMultiFileInitCommand(true, RefreshPolicyOnChange)
+		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyOnChange)
 		Expect(cmd).To(ContainSubstring(`url="${SOURCE%/}/$rel"`))
 	})
 })

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -433,8 +433,20 @@ func (r *ModelReconciler) validateMultiFileStagingSource(ctx context.Context, mo
 	if valErr := validateHFRepoSource(model.Spec.Source); valErr != nil {
 		return true, r.failInvalidFileSet(ctx, model, valErr.Error())
 	}
-	if !isHFRepoSource(model.Spec.Source) {
-		msg := fmt.Sprintf("multi-file staging requires a HuggingFace repo source, but got: %s", model.Spec.Source)
+	// Multi-file staging fetches each artifact individually from the init
+	// container, so it works for any source that can address one object per
+	// file. That is the HF repo path and, since #1465, s3:// object stores,
+	// where buildMultiFileInitCommand signs a per-file request.
+	//
+	// This gate is why signing alone did not fix #1465: it runs in the
+	// reconciler, well before storage config is built, so an s3:// Model with
+	// mmproj set failed here and the download code was never reached. Verified
+	// on the fleet against a real MinIO, where the Model went straight to
+	// Failed/InvalidFileSet while both objects were fetchable by hand.
+	if !isHFRepoSource(model.Spec.Source) && !isS3Source(model.Spec.Source) {
+		msg := fmt.Sprintf(
+			"multi-file staging requires a HuggingFace repo or s3:// source, but got: %s",
+			model.Spec.Source)
 		return true, r.failInvalidFileSet(ctx, model, msg)
 	}
 	return false, ctrl.Result{}

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -1459,6 +1459,89 @@ var _ = Describe("Multi-File Staging Reconcile", func() {
 		Expect(hasInvalidFileSet).To(BeTrue())
 	})
 
+	// The regression for #1465. Signing the multi-file download was necessary
+	// but not sufficient: this validation rejected every non-HuggingFace source
+	// before the storage config was ever built, so the signed command could not
+	// be reached. Caught only by running it against a real object store, since
+	// the unit tests call buildMultiFileInitCommand directly and never pass
+	// through the reconciler.
+	It("should accept multi-file staging from an s3:// source", func() {
+		modelName := "model-multifile-s3"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "s3://models/KyleHessling1/Qwopus3.6-27B-Fusion-GGUF",
+				Files:  []string{"Qwopus3.6-27B-Fusion-Q4_K_M.gguf"},
+				Mmproj: "Qwopus3.6-27B-Fusion-mmproj-Q8_0.gguf",
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		reconciler := &ModelReconciler{
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+
+		for _, cond := range updated.Status.Conditions {
+			if cond.Type == ConditionDegraded && cond.Reason == "InvalidFileSet" {
+				Fail("s3:// multi-file staging was rejected: " + cond.Message)
+			}
+		}
+		Expect(updated.Status.Phase).NotTo(Equal(PhaseFailed))
+		// The file set still resolves, so the init container knows what to pull.
+		Expect(updated.Status.StagedFiles).To(ContainElement("Qwopus3.6-27B-Fusion-mmproj-Q8_0.gguf"))
+	})
+
+	// A source that genuinely cannot address one object per file must still be
+	// refused, or relaxing the gate would turn a clear failure into a confusing
+	// one deep inside the init container.
+	It("should still reject multi-file staging from an unsupported source", func() {
+		modelName := "model-multifile-unsupported"
+		model := &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source: "https://example.com/models/single-file.gguf",
+				Files:  []string{"a.gguf"},
+				Mmproj: "mmproj-F16.gguf",
+			},
+		}
+		Expect(k8sClient.Create(ctx, model)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+		tempDir, err := os.MkdirTemp("", "llmkube-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		reconciler := &ModelReconciler{
+			Client:               k8sClient,
+			Scheme:               k8sClient.Scheme(),
+			StoragePath:          tempDir,
+			AllowedHostPathRoots: testLocalRoots,
+		}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &inferencev1alpha1.Model{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: "default"}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(PhaseFailed))
+	})
+
 	It("should fail with InvalidFileSet when files contains directory escape", func() {
 		modelName := "model-files-escape"
 		model := &inferencev1alpha1.Model{

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -509,28 +509,78 @@ func cachePrepInitContainer(initImage string, resolvedFSGroup int64) corev1.Cont
 
 // multiFileInitEnvVars returns env vars for a multi-file init container.
 // MODEL_SOURCE is normalized (hf:// -> https://huggingface.co/), and
-// MODEL_FILES is newline-delimited.
+// MODEL_FILES is newline-delimited. For s3:// sources, S3_BUCKET and
+// S3_PREFIX are emitted (the key prefix from the s3:// source); per-file
+// object keys are constructed as "${S3_PREFIX}/$rel" in the shell command.
 func multiFileInitEnvVars(source, cacheDir string, files []string) []corev1.EnvVar {
 	normalized := resolveHFSourceURL(source)
-	return []corev1.EnvVar{
+	envs := []corev1.EnvVar{
 		{Name: "MODEL_SOURCE", Value: normalized},
 		{Name: "CACHE_DIR", Value: cacheDir},
 		{Name: "MODEL_FILES", Value: strings.Join(files, "\n")},
 	}
+	if isS3Source(source) {
+		bucket, key, err := parseS3Source(source)
+		if err == nil {
+			envs = append(envs, corev1.EnvVar{Name: "S3_BUCKET", Value: bucket}, corev1.EnvVar{Name: "S3_PREFIX", Value: key})
+		}
+	}
+	return envs
 }
 
 // buildMultiFileInitCommand returns a shell command that downloads each file
 // listed in $MODEL_FILES from the normalized $MODEL_SOURCE. For cached storage
 // (useCache=true), it creates $CACHE_DIR first. For emptyDir (useCache=false),
 // it creates /models. The command uses env vars only, never embedding user
-// values directly in the script.
-func buildMultiFileInitCommand(useCache bool, refreshPolicy string) string {
+// values directly in the script. When isS3 is true, the curl command is signed
+// with --aws-sigv4 and uses ${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_PREFIX}/$rel
+// as the per-file URL (S3_PREFIX may be empty for bare-bucket sources).
+func buildMultiFileInitCommand(useCache, isS3 bool, refreshPolicy string) string {
 	prefix := `mkdir -p "$CACHE_DIR" && find "$CACHE_DIR" -name '*.tmp' -delete && `
 	if !useCache {
 		prefix = `mkdir -p /models && find /models -name '*.tmp' -delete && `
 	}
 
 	normalizeFn := `normalize_hf_source() { case "$1" in hf://*) src="${1#hf://}"; rev="${src#*@}"; if [ "$rev" != "$src" ]; then echo "https://huggingface.co/${src%%@*}/resolve/$rev/"; else echo "https://huggingface.co/$src/resolve/main/"; fi ;; *) echo "$1" ;; esac; }` + " && "
+
+	if isS3 {
+		if refreshPolicy == RefreshPolicyOnChange {
+			body := normalizeFn +
+				`SOURCE="$(normalize_hf_source "$MODEL_SOURCE")" && ` +
+				`printf '%s\n' "$MODEL_FILES" | while IFS= read -r rel; do ` +
+				`[ -n "$rel" ] || continue; ` +
+				`dest="$CACHE_DIR/$rel"; ` +
+				`mkdir -p "$(dirname "$dest")"; ` +
+				`key="${S3_PREFIX:+${S3_PREFIX}/}$rel"; ` +
+				`url="${AWS_ENDPOINT_URL}/${S3_BUCKET}/${key}"; ` +
+				`remote_size=$(curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -fsSL -I "$url" -o /dev/null -w '%header{content-length}' 2>/dev/null || echo 0); ` +
+				`if [ -f "$dest" ] && [ "$(stat -c %s "$dest" 2>/dev/null || echo 0)" = "$remote_size" ] && [ "$remote_size" != "0" ]; then ` +
+				`echo "Model artifact $rel revalidated (unchanged, skipped download)"; ` +
+				`else ` +
+				`if curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$dest.tmp" "$url" && mv "$dest.tmp" "$dest"; then ` +
+				`echo "Model artifact $rel revalidated (downloaded)"; ` +
+				`elif [ -f "$dest" ]; then echo "Revalidation unreachable for $rel; kept cached copy"; ` +
+				`else echo "ERROR: model artifact $rel missing and revalidation failed"; exit 1; fi; ` +
+				`fi; ` +
+				`done`
+			return prefix + body
+		}
+
+		body := normalizeFn +
+			`SOURCE="$(normalize_hf_source "$MODEL_SOURCE")" && ` +
+			`printf '%s\n' "$MODEL_FILES" | while IFS= read -r rel; do ` +
+			`[ -n "$rel" ] || continue; ` +
+			`dest="$CACHE_DIR/$rel"; ` +
+			`mkdir -p "$(dirname "$dest")"; ` +
+			`key="${S3_PREFIX:+${S3_PREFIX}/}$rel"; ` +
+			`url="${AWS_ENDPOINT_URL}/${S3_BUCKET}/${key}"; ` +
+			`if [ ! -f "$dest" ]; then ` +
+			`echo "Downloading model artifact $rel..."; ` +
+			`curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$dest.tmp" "$url" && mv "$dest.tmp" "$dest" || { echo "ERROR: failed to download $rel"; exit 1; }; ` +
+			`else echo "Model artifact $rel already cached, skipping download"; fi; ` +
+			`done`
+		return prefix + body
+	}
 
 	if refreshPolicy == RefreshPolicyOnChange {
 		body := normalizeFn +
@@ -705,7 +755,7 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1a
 	}
 	if plan != nil {
 		modelPath := stagedCachePath(cacheDir, plan.Primary)
-		cmd := buildMultiFileInitCommand(true, model.Spec.RefreshPolicy)
+		cmd := buildMultiFileInitCommand(true, isS3Source(model.Spec.Source), model.Spec.RefreshPolicy)
 		env := multiFileInitEnvVars(model.Spec.Source, cacheDir, plan.Files)
 
 		initVolumeMounts := []corev1.VolumeMount{
@@ -732,6 +782,7 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1a
 				Image:           initContainerImage,
 				Command:         []string{"sh", "-c", cmd},
 				Env:             env,
+				EnvFrom:         modelEnvFrom(model),
 				VolumeMounts:    initVolumeMounts,
 				SecurityContext: initContainerSecurityContext(isvc),
 			},
@@ -835,7 +886,7 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 	if plan != nil {
 		stagedDir := fmt.Sprintf("/models/%s-%s", namespace, model.Name)
 		modelPath := fmt.Sprintf("%s/%s", stagedDir, plan.Primary)
-		cmd := buildMultiFileInitCommand(false, model.Spec.RefreshPolicy)
+		cmd := buildMultiFileInitCommand(false, isS3Source(model.Spec.Source), model.Spec.RefreshPolicy)
 		env := multiFileInitEnvVars(model.Spec.Source, stagedDir, plan.Files)
 
 		initVolumeMounts := []corev1.VolumeMount{{Name: "model-storage", MountPath: "/models"}}
@@ -858,6 +909,7 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 				Image:           initContainerImage,
 				Command:         []string{"sh", "-c", cmd},
 				Env:             env,
+				EnvFrom:         modelEnvFrom(model),
 				VolumeMounts:    initVolumeMounts,
 				SecurityContext: initContainerSecurityContext(isvc),
 			}},

--- a/internal/controller/model_storage_test.go
+++ b/internal/controller/model_storage_test.go
@@ -121,6 +121,67 @@ var _ = Describe("modelInitEnvVars (s3)", func() {
 	})
 })
 
+var _ = Describe("buildMultiFileInitCommand (s3)", func() {
+	It("should emit --aws-sigv4 for s3 source with cache (IfNotPresent)", func() {
+		cmd := buildMultiFileInitCommand(true, true, "")
+		Expect(cmd).To(ContainSubstring("curl --aws-sigv4"))
+		Expect(cmd).To(ContainSubstring("${AWS_ENDPOINT_URL}/${S3_BUCKET}/"))
+		Expect(cmd).To(ContainSubstring("${S3_PREFIX:+${S3_PREFIX}/}"))
+		Expect(cmd).To(ContainSubstring("Downloading model artifact"))
+		Expect(cmd).To(ContainSubstring("Model artifact"))
+		Expect(cmd).To(ContainSubstring(`-o "$dest.tmp"`))
+		Expect(cmd).To(ContainSubstring(`&& mv "$dest.tmp" "$dest"`))
+	})
+
+	It("should emit --aws-sigv4 for s3 source without cache (emptyDir)", func() {
+		cmd := buildMultiFileInitCommand(false, true, "")
+		Expect(cmd).To(ContainSubstring("curl --aws-sigv4"))
+		Expect(cmd).To(ContainSubstring("${AWS_ENDPOINT_URL}/${S3_BUCKET}/"))
+		Expect(cmd).To(ContainSubstring("${S3_PREFIX:+${S3_PREFIX}/}"))
+	})
+
+	It("should emit --aws-sigv4 for s3 source with OnChange refresh", func() {
+		cmd := buildMultiFileInitCommand(true, true, RefreshPolicyOnChange)
+		Expect(cmd).To(ContainSubstring("curl --aws-sigv4"))
+		Expect(cmd).To(ContainSubstring("${AWS_ENDPOINT_URL}/${S3_BUCKET}/"))
+		Expect(cmd).To(ContainSubstring("${S3_PREFIX:+${S3_PREFIX}/}"))
+		Expect(cmd).To(ContainSubstring("revalidated"))
+	})
+
+	It("should NOT emit --aws-sigv4 for non-s3 source (HTTP regression)", func() {
+		cmd := buildMultiFileInitCommand(true, false, "")
+		Expect(cmd).ToNot(ContainSubstring("aws-sigv4"))
+		Expect(cmd).To(ContainSubstring(`curl -f -L -o "$dest.tmp" "$url"`))
+		Expect(cmd).To(ContainSubstring("${SOURCE%/}/$rel"))
+	})
+
+	It("should NOT emit --aws-sigv4 for non-s3 source with OnChange (HTTP regression)", func() {
+		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyOnChange)
+		Expect(cmd).ToNot(ContainSubstring("aws-sigv4"))
+		Expect(cmd).To(ContainSubstring(`curl -fsSL -o "$dest.tmp" "$url"`))
+		Expect(cmd).To(ContainSubstring("${SOURCE%/}/$rel"))
+	})
+})
+
+var _ = Describe("multiFileInitEnvVars (s3)", func() {
+	It("should include S3_BUCKET and S3_PREFIX for s3 source", func() {
+		envs := multiFileInitEnvVars("s3://my-bucket/models/model.gguf", "/models/cache", []string{"model.gguf", "mmproj.gguf"})
+		Expect(envs).To(HaveLen(5))
+		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "S3_BUCKET", Value: "my-bucket"}))
+		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "S3_PREFIX", Value: "models/model.gguf"}))
+		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "MODEL_SOURCE", Value: "s3://my-bucket/models/model.gguf"}))
+		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "CACHE_DIR", Value: "/models/cache"}))
+		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "MODEL_FILES", Value: "model.gguf\nmmproj.gguf"}))
+	})
+
+	It("should NOT include S3_BUCKET and S3_PREFIX for non-s3 source", func() {
+		envs := multiFileInitEnvVars("https://example.com/models/", "/models/cache", []string{"model.gguf"})
+		Expect(envs).To(HaveLen(3))
+		Expect(envs).ToNot(ContainElement(corev1.EnvVar{Name: "S3_BUCKET"}))
+		Expect(envs).ToNot(ContainElement(corev1.EnvVar{Name: "S3_PREFIX"}))
+	})
+})
+
 var _ = Describe("modelEnvFrom", func() {
 	It("should return nil when SourceSecretRef is nil", func() {
 		model := &inferencev1alpha1.Model{}


### PR DESCRIPTION
## What

Multi-file staging (`spec.files` / `spec.mmproj`) can pull from an `s3://`
object store. Two commits: the first signs the multi-file download, the second
lets a Model with an `s3://` source reach it at all.

## Why

Fixes #1465

A model needing more than one artifact could only be staged over plain HTTP, so
a projector had to come from the public internet even with the weights sitting
in the cluster's own object store. `mmproj` forces the multi-file path, which is
why this reads as "vision models cannot be served from a local object store".

## How

**Signing (commit 1).** `buildMultiFileInitCommand` takes an `isS3` flag,
gated on the same `isS3Source` predicate the single-file path uses, and emits
the `--aws-sigv4` invocation copied from that path. `multiFileInitEnvVars` grows
`S3_BUCKET` and `S3_PREFIX`; the per-file object key is
`${S3_PREFIX:+${S3_PREFIX}/}$rel`, which keeps a bare-bucket source from
producing a doubled slash. Both refresh-policy branches sign, including the
`OnChange` HEAD: an unsigned HEAD against a private bucket returns 403, which
would read as "size 0" and silently redownload every reconcile. The multi-file
init containers also gain `EnvFrom`, without which the credentials never reach
the container at all.

**Reachability (commit 2).** Signing alone did not fix the issue.
`validateMultiFileStagingSource` refuses any non-HuggingFace source the moment
`files` or `mmproj` is set, and it runs in the reconciler well before storage
config is built. An `s3://` Model with a projector went straight to
`Failed/InvalidFileSet`, so every line of the new download path was unreachable.

The gate now accepts `s3://` alongside the HF repo path, since both can address
one object per file, and still refuses sources that cannot, so a single-file URL
fails with a clear message instead of confusingly deep inside the init
container. The `s3://` case already existed in the reconcile dispatch switch and
routes correctly; the other two `isHFRepoSource` call sites are a non-blocking
advisory warning and a source-agnostic file-set resolve.

**Why nothing caught the second half.** The multi-file tests call
`buildMultiFileInitCommand` and `multiFileInitEnvVars` directly. They assert the
emitted command while bypassing the validation that prevents it ever being
emitted, so `gofmt`, `vet`, `build`, `golangci-lint` and the full envtest suite
all passed on a change that could not work. The two regression tests added here
go through the reconciler instead.

## Testing

`internal/controller` envtest suite passes (246s), `make lint` 0 issues.

Verified end to end against a real MinIO rather than inferred. Before the second
commit the Model failed:

```
Degraded  InvalidFileSet  multi-file staging requires a HuggingFace repo source,
                          but got: s3://models/KyleHessling1/Qwopus3.6-27B-Fusion-GGUF
```

After it, the same Model reached `Ready` with both artifacts planned:

```
stagedFiles: [Qwopus3.6-27B-Fusion-Q4_K_M.gguf, Qwopus3.6-27B-Fusion-mmproj-Q8_0.gguf]
```

The init container completed in 2m55s, and the emitted command carried
`--aws-sigv4` with `S3_PREFIX` set. Both objects landed byte-exact against what
the store reports:

```
16810712160  Qwopus3.6-27B-Fusion-Q4_K_M.gguf
  629246880  Qwopus3.6-27B-Fusion-mmproj-Q8_0.gguf
```

llama-server then loaded the projector:

```
srv load_model: loaded multimodal model, '.../Qwopus3.6-27B-Fusion-mmproj-Q8_0.gguf'
```

and answered a multimodal request correctly, describing an overexposed render
unprompted, with nothing fetched from Hugging Face at any point.

## Not in this change

The `s3://` branch still emits the `normalize_hf_source` helper and computes
`SOURCE` from it, both dead on that path since the URL is built from
`AWS_ENDPOINT_URL`. Harmless, and left rather than folded into an unrelated
cleanup.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance (if any) is disclosed above
- [x] Documentation updated (if user-facing change) — no user-facing docs
      describe a HuggingFace-only restriction on multi-file staging

Assisted-by: Claude Code (commit 1 authored by the Foreman coder agent; commit 2
and its tests written after I reproduced the failure on a live cluster, and I
ran the suite, the lint and the end-to-end MinIO verification myself)
