### PR TITLE
test(router-proxy): pin the metrics endpoint to the llmkube registry

### DIFF
--- a/cmd/router-proxy/main.go
+++ b/cmd/router-proxy/main.go
@@ -132,7 +132,7 @@ func main() {
 	var metricsSrv *http.Server
 	if *metricsListen != "" {
 		metricsMux := http.NewServeMux()
-		metricsMux.Handle("GET /metrics", promhttp.HandlerFor(ctrlmetrics.Registry, promhttp.HandlerOpts{}))
+		metricsMux.Handle("GET /metrics", newMetricsHandler())
 		metricsSrv = &http.Server{
 			Addr:              *metricsListen,
 			Handler:           metricsMux,
@@ -216,4 +216,21 @@ func newActivator(baseCtx context.Context, logger *slog.Logger) (*router.Activat
 // Activator falls back to "default".
 func routerNameFromEnv() string {
 	return os.Getenv("ROUTER_NAME")
+}
+
+// newMetricsHandler serves controller-runtime's registry, NOT the Prometheus
+// default one.
+//
+// Every llmkube collector, llmkube_router_* and llmkube_modelpool_* alike, is
+// registered into ctrlmetrics.Registry by internal/metrics' init().
+// promhttp.Handler() serves prometheus.DefaultGatherer, a different registry,
+// so using it here returns HTTP 200 carrying Go runtime and process metrics and
+// none of the series this endpoint exists for. That failure is silent: the
+// scrape succeeds, the PodMonitor reports a healthy target, and the dashboards
+// are simply empty.
+//
+// Extracted from main() purely so it can be asserted on; see the regression
+// test alongside this file.
+func newMetricsHandler() http.Handler {
+	return promhttp.HandlerFor(ctrlmetrics.Registry, promhttp.HandlerOpts{})
 }

--- a/cmd/router-proxy/metrics_handler_test.go
+++ b/cmd/router-proxy/metrics_handler_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	prommetrics "github.com/defilantech/llmkube/internal/metrics"
+)
+
+// The metrics endpoint must serve the registry the llmkube collectors are
+// actually registered in.
+//
+// This is a regression test for a silent failure that shipped once already.
+// promhttp.Handler() serves prometheus.DefaultGatherer, while internal/metrics
+// registers every collector into controller-runtime's registry. Wiring the
+// wrong one still returns HTTP 200, with roughly 38 families of Go runtime and
+// process metrics, so the scrape succeeds, the PodMonitor reports a healthy
+// target, and the dashboards are just empty. Nothing logs an error, which is
+// why it survived review and a merge.
+//
+// Asserting on a real series rather than a synthetic collector is deliberate:
+// it pins the contract (this endpoint exposes the llmkube collectors) rather
+// than the mechanism, so the test still means something if registration is
+// refactored.
+func TestMetricsHandlerServesLLMKubeCollectors(t *testing.T) {
+	// Load-bearing: a labelled collector emits no family until it has at least
+	// one child series, so an idle scrape is byte-identical under either
+	// registry. Without touching a counter first, this test passes on the bug.
+	prommetrics.RouterRequestsTotal.WithLabelValues(
+		"test-router", "test-rule", "test-backend", "test-class", "success").Inc()
+
+	rec := httptest.NewRecorder()
+	newMetricsHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "llmkube_router_requests_total") {
+		t.Errorf("metrics endpoint does not expose llmkube_router_requests_total; "+
+			"it is serving the wrong registry. Got %d bytes beginning: %.200s",
+			len(body), body)
+	}
+}


### PR DESCRIPTION
## What

A regression test pinning the router-proxy metrics endpoint to the registry the
llmkube collectors actually register into, plus the small extraction that makes
it testable.

## Why

Refs #1427

**The fix this PR originally carried is already on main.** #1393 landed it while
this was open, so all that remains, and the part that was missing, is a test.

The endpoint added in #1457 wired `promhttp.Handler()`, which serves
`prometheus.DefaultGatherer`, while `internal/metrics` registers every collector
into `ctrlmetrics.Registry`. Different registries, so it exposed none of
`llmkube_router_*` or `llmkube_modelpool_*`.

That is worth a test rather than care, because the failure is silent in every
direction: the scrape returns HTTP 200, the PodMonitor from #1473 reports a
healthy target, and the dashboards are just empty. It survived review and a
merge for exactly that reason. Measured on the built binaries at the time: 38
metric families under the default registry, 149 under controller-runtime's.

## How

One detail is load-bearing. The test increments a real router counter before
scraping, because a labelled collector emits no family until it has a child
series, so an idle scrape is byte-identical under either registry and the
obvious version of this test passes on the bug.

I verified that by reintroducing `promhttp.Handler()` and confirming the test
fails, then restoring the fix and confirming it passes. A regression test nobody
has watched fail is not yet a regression test.

`newMetricsHandler()` is extracted from `main()` only so there is something to
assert against; the behaviour is unchanged from what #1393 landed.

## Credit

The underlying bug was found by @sylvainsf while rebasing #1393. This PR was
opened to carry the fix separately, and has been repurposed to the test now that
their fix has merged.

## Testing

`go test ./cmd/router-proxy/`, `make lint` 0 issues, and the fails-without-the-fix
check described above.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance (if any) is disclosed above
- [x] Documentation updated (if user-facing change) — none needed, no behaviour change

Assisted-by: Claude Code (wrote the test and the extraction, and ran the
two-binary comparison and the fails-without-the-fix validation)
