### PR TITLE
fix(modelpool): guard the nil HTTPClient that panics every swap

### DIFF
--- a/internal/controller/modelpool_controller.go
+++ b/internal/controller/modelpool_controller.go
@@ -363,7 +363,23 @@ func (r *ModelPoolReconciler) memberIdle(ctx context.Context, isvc *inferencev1a
 		}
 		baseURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", sanitizeDNSName(isvc.Name), isvc.Namespace, port)
 	}
-	return detector.IdleProbe(isvc, r.HTTPClient)(ctx, baseURL)
+	// HTTPClient is optional on the struct and is not wired at any construction
+	// site, so it is nil in the running operator. Passing nil straight through
+	// panics inside net/http.(*Client).do the first time a swap needs an idle
+	// check, which takes the whole reconcile down and wedges the pool in
+	// Swapping: every request against it then burns the full swapBudget and
+	// returns 503.
+	//
+	// It also defeats the fail-closed contract this function documents. The
+	// probe cannot defer a swap if it panics before it can return an error.
+	//
+	// Same guard the rollout drain already uses (drain_before_rollout.go), and
+	// the same default timeout, so both users of this probe behave alike.
+	httpClient := r.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	return detector.IdleProbe(isvc, httpClient)(ctx, baseURL)
 }
 
 // metalMembers returns the names of members whose referenced Model targets a

--- a/internal/controller/modelpool_nil_client_test.go
+++ b/internal/controller/modelpool_nil_client_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// A ModelPoolReconciler built without an HTTPClient must not panic.
+//
+// This is the shape the operator actually runs in: cmd/main.go constructs the
+// reconciler with Client, Scheme and Recorder and never sets HTTPClient, so it
+// is nil in production. memberIdle passed that nil straight to IdleProbe, and
+// net/http.(*Client).do dereferences it, so the first idle check of the first
+// swap panicked and took the reconcile with it. The pool then wedged in
+// Swapping and every request against it burned the full swapBudget before
+// returning 503.
+//
+// The existing suite could not catch this because every other ModelPool test
+// injects the IdleCheck hook, which returns before HTTPClient is ever read.
+// This test deliberately does NOT set that hook, so it exercises the real
+// probe path.
+//
+// The assertion is only "does not panic, and reports an error". Reaching a
+// cluster DNS name from a unit test must fail; what matters is that it fails
+// as a returned error the caller can act on, which is what lets the documented
+// fail-closed behaviour actually happen.
+func TestMemberIdle_NilHTTPClientDoesNotPanic(t *testing.T) {
+	r := &ModelPoolReconciler{} // no HTTPClient, no IdleCheck: production shape
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-member", Namespace: "default"},
+		Spec: inferencev1alpha1.InferenceServiceSpec{
+			Runtime: "llamacpp",
+		},
+	}
+
+	defer func() {
+		if p := recover(); p != nil {
+			t.Fatalf("memberIdle panicked with a nil HTTPClient: %v", p)
+		}
+	}()
+
+	idle, err := r.memberIdle(context.Background(), isvc)
+	if err == nil {
+		t.Fatal("expected an error probing an unreachable member, got nil")
+	}
+	if idle {
+		t.Error("an unreachable member must never be reported idle; that would " +
+			"unload a possibly-busy model")
+	}
+	// The failure should be a transport error, not a nil-pointer recovery.
+	if strings.Contains(strings.ToLower(err.Error()), "nil pointer") {
+		t.Errorf("error looks like a recovered panic rather than a probe failure: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Guards the nil `HTTPClient` that panics on every ModelPool swap.

## Why

**ModelPool cannot complete a single swap in 0.9.16.**

`cmd/main.go:476` constructs `ModelPoolReconciler` with `Client`, `Scheme` and
`Recorder` and never sets `HTTPClient`, so it is nil in the running operator.
`memberIdle` passed that nil straight into `IdleProbe`, and
`net/http.(*Client).do` dereferences it:

```
net/http.(*Client).do(0x0, ...)
runtime_llamacpp.go:236      llamaCppSlotsIdleProbe.func1
modelpool_controller.go:366  memberIdle
modelpool_controller.go:145  Reconcile
```

The panic takes the reconcile down, so the pool wedges in `Swapping`. Every
request for a non-resident member then blocks for the full `swapBudget` and
returns `503 model pool activation did not complete within the request budget`.

Observed on hardware, not inferred. A two-member pool on a DGX Spark held a
request for exactly 300s and never swapped, with the incumbent still resident:

```
status:
  phase: Swapping
  residentMember: s5-pool-fusion
  conditions:
    SlotAllocated  False  Swapping      No member resident yet
    SwapDeferred   False  NotDeferred   No swap is being deferred
```

Note `SwapDeferred: NotDeferred`. That is the second half of the problem: the
panic also defeats the fail-closed contract `memberIdle` documents. The probe
cannot defer a swap if it panics before it can return an error, so the pool
reports nothing wrong while nothing works.

## How

Same guard the rollout drain has used all along
(`drain_before_rollout.go:138`), with the same 5s default, so both users of this
probe behave alike.

Guarding in the reconciler rather than only wiring `main.go` is deliberate: the
field is optional on the struct, and a future construction site that forgets it
would reintroduce a panic rather than a degraded probe.

## Why the suite missed it

Every other ModelPool test injects the `IdleCheck` hook, which returns before
`HTTPClient` is ever read, so no existing test touches the real probe path. The
regression test here deliberately omits that hook and constructs the reconciler
in exactly the shape `main.go` uses.

It asserts two things: that it does not panic, and that an unreachable member is
never reported idle, since reporting idle would unload a possibly-busy model.

I verified the test fails with the guard removed and passes with it, rather than
assuming a new test must be catching something:

```
--- FAIL: TestMemberIdle_NilHTTPClientDoesNotPanic
    memberIdle panicked with a nil HTTPClient: runtime error: invalid memory
    address or nil pointer dereference
```

## Testing

`internal/controller` envtest suite passes (255s), `make lint` 0 issues.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance (if any) is disclosed above
- [x] Documentation updated (if user-facing change) — no doc describes the field

Assisted-by: Claude Code (found while running ModelPool on real hardware for a
GPU-sharing benchmark; wrote the fix and the regression test, and ran the suite,
the lint and the fails-without-the-fix check)
