### PR TITLE
fix(foreman): one tool list, so a tool cannot ship unusable again

### DIFF
--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -72,7 +72,6 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubpr"
-	"github.com/defilantech/llmkube/pkg/foreman/agent/githubprfetch"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/mcp"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	foremantools "github.com/defilantech/llmkube/pkg/foreman/agent/tools"
@@ -789,55 +788,17 @@ func makeRegistryFactory(
 		if bashTimeout <= 0 {
 			bashTimeout = 30 * time.Second
 		}
-		native := []foremantools.Tool{
-			&foremantools.ReadFileTool{Workspace: workspace},
-			&foremantools.WriteFileTool{Workspace: workspace},
-			&foremantools.StrReplaceTool{Workspace: workspace},
-			&foremantools.GrepTool{Workspace: workspace},
-			&foremantools.BashTool{Workspace: workspace, Timeout: bashTimeout},
-			foremantools.SubmitResultTool{},
-			&foremantools.RunGateJobTool{
-				Client: kc,
-				Cfg: foremantools.RunGateJobToolConfig{
-					Namespace: foremanNamespace,
-					LogTailFn: logTail,
-				},
-			},
-			// fetch_issue: read-only GitHub issue surface for the
-			// reviewer. The same token the foreman-agent already
-			// loads at startup (via repo.TokenFromEnvOrFile) reaches
-			// GitHub through one bounded Go-side call instead of
-			// being inherited by every bash subprocess via $GH_TOKEN.
-			// Closes #580.
-			&foremantools.FetchIssueTool{
-				Fetcher: githubissue.NewClient(),
-				Token:   repo.TokenFromEnvOrFile,
-			},
-			// fetch_pull_request: read-only GitHub PR surface for the
-			// coder. The same token the foreman-agent already loads
-			// at startup (via repo.TokenFromEnvOrFile) reaches GitHub
-			// through one bounded Go-side call instead of being
-			// inherited by every bash subprocess via $GH_TOKEN.
-			// Closes #1434.
-			&foremantools.FetchPullRequestTool{
-				Fetcher: githubprfetch.NewClient(),
-				Token:   repo.TokenFromEnvOrFile,
-			},
-			// run_integrate: deterministic tool for a sliced Workload's
-			// integrate step. Unions the disjoint slice branches onto the
-			// current base and pushes the integration branch (#1033).
-			&foremantools.RunIntegrateTool{
-				Workspace: workspace,
-				Token:     repo.TokenFromEnvOrFile,
-			},
-			// run_reconcile: deterministic tool for a sliced Workload's
-			// reconcile step. Checks the integrated union against the pinned
-			// shared identifiers for cross-slice interface drift (#1033).
-			&foremantools.RunReconcileTool{
-				Workspace: workspace,
-				Token:     repo.TokenFromEnvOrFile,
-			},
-		}
+		// Constructed in pkg/foreman/agent/tools so there is exactly one list.
+		// Keeping it here made a third copy that drifted from the webhook
+		// allow-list, shipping three tools registered but unusable (#1482).
+		native := foremantools.BuildAll(foremantools.ToolDeps{
+			Workspace:        workspace,
+			BashTimeout:      bashTimeout,
+			Client:           kc,
+			ForemanNamespace: foremanNamespace,
+			LogTailFn:        logTail,
+			Token:            repo.TokenFromEnvOrFile,
+		})
 
 		var mcpTools []foremantools.Tool
 		// Gate-decision log (fires for EVERY run, both kinds) so we can see

--- a/pkg/foreman/agent/tools/buildall.go
+++ b/pkg/foreman/agent/tools/buildall.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/githubprfetch"
+)
+
+// BuildAll is the single place the agent's native tool set is constructed.
+//
+// It used to live inline in cmd/foreman-agent/main.go, which made three copies
+// of the same list: the runtime registry there, the webhook allow-list in
+// catalog, and a hand-written mirror in the drift test. The drift test compared
+// the two copies nobody edited, so it passed while fetch_pull_request,
+// run_integrate and run_reconcile all shipped in v0.9.16 registered at runtime
+// but rejected by admission, and therefore unusable (#1482).
+//
+// With construction here, main.go has no list to drift from, and
+// TestBuildAllMatchesCatalog derives one side of the comparison from these real
+// constructors rather than from a mirror. Adding a tool to this function
+// without adding its name to catalog fails that test, and the reverse fails too.
+//
+// Why this package rather than catalog: catalog is a deliberate zero-import
+// leaf so the operator's Agent admission webhook can validate spec.tools
+// without linking Kubernetes clients, GitHub clients and the slicer. The
+// dependency has to run tools -> catalog, never the other way.
+func BuildAll(deps ToolDeps) []Tool {
+	return []Tool{
+		&ReadFileTool{Workspace: deps.Workspace},
+		&WriteFileTool{Workspace: deps.Workspace},
+		&StrReplaceTool{Workspace: deps.Workspace},
+		&GrepTool{Workspace: deps.Workspace},
+		&BashTool{Workspace: deps.Workspace, Timeout: deps.BashTimeout},
+		SubmitResultTool{},
+		&RunGateJobTool{
+			Client: deps.Client,
+			Cfg: RunGateJobToolConfig{
+				Namespace: deps.ForemanNamespace,
+				LogTailFn: deps.LogTailFn,
+			},
+		},
+		// fetch_issue: read-only GitHub issue surface for the reviewer. The
+		// same token the foreman-agent already loads at startup reaches GitHub
+		// through one bounded Go-side call instead of being inherited by every
+		// bash subprocess via $GH_TOKEN. Closes #580.
+		&FetchIssueTool{
+			Fetcher: githubissue.NewClient(),
+			Token:   deps.Token,
+		},
+		// fetch_pull_request: read-only GitHub PR surface for the coder, same
+		// reasoning as fetch_issue. Closes #1434.
+		&FetchPullRequestTool{
+			Fetcher: githubprfetch.NewClient(),
+			Token:   deps.Token,
+		},
+		// run_integrate: deterministic tool for a sliced Workload's integrate
+		// step. Unions the disjoint slice branches onto the current base and
+		// pushes the integration branch (#1033).
+		&RunIntegrateTool{
+			Workspace: deps.Workspace,
+			Token:     deps.Token,
+		},
+		// run_reconcile: deterministic tool for a sliced Workload's reconcile
+		// step. Checks the integrated union against the pinned shared
+		// identifiers for cross-slice interface drift (#1033).
+		&RunReconcileTool{
+			Workspace: deps.Workspace,
+			Token:     deps.Token,
+		},
+	}
+}
+
+// ToolDeps carries everything the native tool set needs from the process that
+// hosts it. Passing a struct rather than a long parameter list means adding a
+// dependency for one tool does not churn every call site.
+type ToolDeps struct {
+	// Workspace is the per-task clone directory. File tools resolve every
+	// relative path against it and refuse to escape it.
+	Workspace string
+
+	// BashTimeout bounds a single bash invocation.
+	BashTimeout time.Duration
+
+	// Client and ForemanNamespace let run_gate_job create and watch the gate
+	// Job in the operator's namespace.
+	Client           client.Client
+	ForemanNamespace string
+
+	// LogTailFn reads a finished gate Job's pod logs back for the model.
+	LogTailFn func(ctx context.Context, namespace, jobName string) string
+
+	// Token resolves the GitHub credential at call time rather than at
+	// startup, so a rotated token is picked up without restarting the agent.
+	Token func() (string, error)
+}

--- a/pkg/foreman/agent/tools/buildall_test.go
+++ b/pkg/foreman/agent/tools/buildall_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/tools/catalog"
+)
+
+// The webhook allow-list must match the tools that actually exist.
+//
+// A tool registered at runtime but missing from catalog is unusable in both
+// directions: naming it in spec.tools is rejected by admission, and omitting it
+// means the runtime Filter() never surfaces it to the model. v0.9.16 shipped
+// three tools in exactly that state (#1482).
+//
+// The previous guard could not catch it. It compared catalog against a
+// hand-written canonicalToolSet() in the test, while the real registration
+// lived in a third copy inside cmd/foreman-agent/main.go. Both mirrors stayed
+// stale together and the test kept passing.
+//
+// This derives one side from BuildAll, the same function main.go calls, so the
+// comparison is against reality rather than against a copy of it.
+func TestBuildAllMatchesCatalog(t *testing.T) {
+	built := BuildAll(ToolDeps{Workspace: t.TempDir()})
+
+	got := make([]string, 0, len(built))
+	for _, tool := range built {
+		got = append(got, tool.Name())
+	}
+	sort.Strings(got)
+
+	want := catalog.CanonicalToolNames()
+	sort.Strings(want)
+
+	if len(got) != len(want) {
+		t.Fatalf("BuildAll exposes %d tools, catalog allows %d\n  built:   %v\n  catalog: %v",
+			len(got), len(want), got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("tool set differs at index %d: built %q, catalog %q\n"+
+				"  built:   %v\n  catalog: %v\n"+
+				"a tool present in one and not the other is unusable: admission "+
+				"rejects an unknown name, and an unregistered name never reaches "+
+				"the model", i, got[i], want[i], got, want)
+		}
+	}
+}
+
+// Duplicate names would let one tool silently shadow another in the registry,
+// and the length check above would still pass if a name were repeated while
+// another went missing.
+func TestBuildAllNamesAreUnique(t *testing.T) {
+	seen := map[string]int{}
+	for _, tool := range BuildAll(ToolDeps{Workspace: t.TempDir()}) {
+		seen[tool.Name()]++
+	}
+	for name, n := range seen {
+		if n > 1 {
+			t.Errorf("tool name %q is registered %d times", name, n)
+		}
+	}
+}
+
+// Every tool type in the package must appear in BuildAll.
+//
+// This is the remaining hole the two tests above cannot close: a new tool type
+// that nobody wires into BuildAll is consistent with catalog (both omit it) and
+// therefore invisible. Counting Tool implementations in the package and
+// comparing against what BuildAll returns makes that omission fail here rather
+// than in production.
+//
+// Deliberately compares counts rather than names: the goal is to notice that a
+// type exists and is unwired, which is exactly the case where its name is not
+// yet anywhere to compare against.
+func TestBuildAllWiresEveryToolType(t *testing.T) {
+	built := len(BuildAll(ToolDeps{Workspace: t.TempDir()}))
+	declared := len(toolTypeNames(t))
+
+	if built != declared {
+		t.Errorf("the package declares %d Tool implementations but BuildAll wires %d.\n"+
+			"A tool type that is never constructed cannot be reached by any Agent; "+
+			"add it to BuildAll and to catalog.canonicalToolNames.\n"+
+			"declared: %v", declared, built, toolTypeNames(t))
+	}
+}
+
+// toolTypeNames returns every type in this package that implements Name()
+// string, parsed from the package source rather than matched with a regex so
+// the guard cannot be fooled by formatting.
+func toolTypeNames(t *testing.T) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+
+	// ParseFile per entry rather than ParseDir: ParseDir is deprecated, and
+	// the alternative (go/tools/go/packages) is far more machinery than a
+	// guard test needs. This package has no build-tagged files, which is the
+	// only thing ParseDir would have handled differently.
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	var files []*ast.File
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, n, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", n, err)
+		}
+		files = append(files, f)
+	}
+
+	var names []string
+	for _, file := range files {
+		{
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Name.Name != "Name" || fn.Recv == nil || len(fn.Recv.List) == 0 {
+					continue
+				}
+				if fn.Type.Results == nil || len(fn.Type.Results.List) != 1 {
+					continue
+				}
+				if id, ok := fn.Type.Results.List[0].Type.(*ast.Ident); !ok || id.Name != "string" {
+					continue
+				}
+				switch rt := fn.Recv.List[0].Type.(type) {
+				case *ast.StarExpr:
+					if id, ok := rt.X.(*ast.Ident); ok {
+						names = append(names, id.Name)
+					}
+				case *ast.Ident:
+					names = append(names, rt.Name)
+				}
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/foreman/agent/tools/catalog/catalog.go
+++ b/pkg/foreman/agent/tools/catalog/catalog.go
@@ -29,15 +29,26 @@ limitations under the License.
 // "names cannot silently drift from the registry" contract.
 package catalog
 
-// canonicalToolNames is the sorted set of every tool name the v0.1 surface
-// exposes. Keep it sorted and in sync with the real tool constructors in
-// the parent package (enforced by catalog_drift_test.go there).
+// canonicalToolNames is the sorted set of every tool name the agent exposes.
+//
+// Keep it sorted. It is checked against the real constructors in
+// tools.BuildAll by TestBuildAllMatchesCatalog, which derives its side of the
+// comparison from that function rather than from a hand-written mirror. Three
+// tools once shipped registered-but-unusable because the previous guard
+// compared two mirrors and neither had been updated (#1482).
+//
+// This package deliberately imports nothing: the operator's Agent admission
+// webhook links it to validate spec.tools, and must not pull in Kubernetes
+// clients, GitHub clients or the slicer.
 var canonicalToolNames = []string{
 	"bash",
 	"fetch_issue",
+	"fetch_pull_request",
 	"grep",
 	"read_file",
 	"run_gate_job",
+	"run_integrate",
+	"run_reconcile",
 	"str_replace",
 	"submit_result",
 	"write_file",

--- a/pkg/foreman/agent/tools/catalog_drift_test.go
+++ b/pkg/foreman/agent/tools/catalog_drift_test.go
@@ -50,15 +50,11 @@ func TestCatalogNamesMatchConstructors(t *testing.T) {
 // mirroring makeRegistryFactory in cmd/foreman-agent. The constructors
 // take a zero workspace + nil collaborators on purpose: this set exists
 // only to read Name() for the drift check above, never to Dispatch().
+// canonicalToolSet is now derived from the same function production uses.
+//
+// It was previously a hand-written list, which is why the drift guard passed
+// while three tools shipped unusable: it compared this mirror against catalog,
+// and the real registration lived in a third copy in cmd/foreman-agent (#1482).
 func canonicalToolSet() []Tool {
-	return []Tool{
-		&ReadFileTool{},
-		&WriteFileTool{},
-		&StrReplaceTool{},
-		&GrepTool{},
-		&BashTool{},
-		SubmitResultTool{},
-		&RunGateJobTool{},
-		&FetchIssueTool{},
-	}
+	return BuildAll(ToolDeps{})
 }


### PR DESCRIPTION
## What

Collapses the agent's tool list to one place, so a tool cannot ship registered
but unusable again.

## Why

Fixes #1482

**The drift is wider than reported.** Three tools shipped in v0.9.16 registered
at runtime but rejected by admission, not one:

| Tool | Runtime registry | Catalog allow-list |
|---|---|---|
| `fetch_pull_request` | yes | **missing** |
| `run_integrate` | yes | **missing** |
| `run_reconcile` | yes | **missing** |

Each is unreachable in both directions: naming it in `spec.tools` fails the
webhook, and omitting it means `Filter()` never surfaces it to the model.
`run_integrate` and `run_reconcile` had simply not been tried yet.

@joryirving's diagnosis of the cause is exactly right. The same list lived in
three places, and the guard compared the two nobody had edited.

## How

`tools.BuildAll` becomes the single construction site and `main.go` calls it, so
there is no second list to drift from. 49 lines of inline construction in
`cmd/foreman-agent/main.go` become one call.

`catalog` deliberately stays a zero-import leaf. The operator's Agent admission
webhook links it to validate `spec.tools`, and must not pull in Kubernetes
clients, GitHub clients or the slicer, so the dependency has to run
`tools -> catalog` and not the reverse. That rules out having catalog derive
itself from the constructors, which is why the invariant is enforced by a test
rather than by the type system.

## The guards, and how I know they work

Three, each verified by deliberately breaking it rather than assumed:

**Names must match catalog, both directions.** Removing `fetch_pull_request`
from catalog, which is precisely the #1482 shape:

```
--- FAIL: TestBuildAllMatchesCatalog
    BuildAll exposes 11 tools, catalog allows 10
```

Adding a name with no constructor fails too.

**Names must be unique**, so one tool cannot shadow another while another goes
missing and the count still matches.

**Every Tool implementation must be wired into BuildAll**, parsed from the
package source. This is the case the first two cannot see: a new tool type
wired nowhere is consistent with catalog, because both omit it. Removing
`RunReconcileTool` from `BuildAll`:

```
--- FAIL: TestBuildAllWiresEveryToolType
    the package declares 11 Tool implementations but BuildAll wires 10
```

The old `canonicalToolSet()` in `catalog_drift_test.go` now returns
`BuildAll(ToolDeps{})`, so its reference side is production code rather than a
copy of it. A drift test whose reference is hand-maintained guards nothing,
which is the lesson of this bug.

## Testing

`pkg/foreman/...` passes, `make lint` 0 issues.

Not added: the startup assertion I floated in discussion (agent refuses to boot
if a registered tool is missing from catalog). It is now redundant, since the
condition cannot reach a build, and it would fail the fleet at boot for a
problem CI already catches.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance (if any) is disclosed above
- [x] Documentation updated (if user-facing change) — no doc enumerates the tool set

Assisted-by: Claude Code (verified the issue's claims against the source, found
the two additional missing tools, wrote the refactor and the guards, and ran the
break-it checks and suites)
