### PR TITLE
fix(foreman): bound grep match lines so one minified file cannot end a run

### DIFF
--- a/pkg/foreman/agent/tools/grep.go
+++ b/pkg/foreman/agent/tools/grep.go
@@ -36,23 +36,70 @@ import (
 // pattern if it wants more.
 const defaultGrepMaxMatches = 200
 
+// defaultGrepMaxLineChars bounds the text of a single match.
+//
+// Capping the match COUNT alone does not bound the output, because nothing
+// bounded a match's length: the scanner accepts lines up to 1 MiB, so 200
+// matches could return ~200 MiB and the result still reported
+// "truncated": false, since truncated only ever described the match count.
+//
+// Minified bundles make that the common case rather than a corner case. A
+// coder searching a repo with a vendored three.min.js for "stats" got back
+// 649,467 bytes from a handful of matches, because the whole bundle is one
+// line. That single tool result pushed the transcript past the stuck-loop
+// detector's 140k hard cap and the run was force-terminated at turn 8 with
+// verdict INCOMPLETE, having never found the file it was looking for.
+//
+// 512 chars is far more than enough to identify a hit and decide whether to
+// read the file, and it bounds a full result at roughly 200*512 = 100 KiB.
+const defaultGrepMaxLineChars = 512
+
 // GrepTool runs a regex search across files under a workspace subtree.
 // Skips .git aggressively (only directory, not the .gitignore file).
 type GrepTool struct {
 	Workspace  string
 	MaxMatches int // 0 falls back to defaultGrepMaxMatches
+	// MaxLineChars bounds each match's text. 0 falls back to
+	// defaultGrepMaxLineChars.
+	MaxLineChars int
+}
+
+// clipMatchText shortens a match line to at most maxChars characters and
+// reports whether it did. The marker matters: an unmarked clip is
+// indistinguishable from a genuinely short line, and a model that cannot see
+// that its evidence was cut will reason from a partial line as if it were
+// whole.
+//
+// Counts runes rather than bytes so a cut never lands mid-character and hands
+// the model invalid UTF-8.
+func clipMatchText(s string, maxChars int) (string, bool) {
+	if maxChars <= 0 {
+		maxChars = defaultGrepMaxLineChars
+	}
+	runes := []rune(s)
+	if len(runes) <= maxChars {
+		return s, false
+	}
+	return fmt.Sprintf("%s... [clipped, line is %d chars]",
+		string(runes[:maxChars]), len(runes)), true
 }
 
 type grepArgs struct {
 	Pattern string `json:"pattern"`
 	Path    string `json:"path"`
 	Max     int    `json:"max"`
+	// MaxLineChars lets the model widen the per-line cap when it genuinely
+	// needs more of a long line, rather than being stuck with the default.
+	MaxLineChars int `json:"maxLineChars"`
 }
 
 type grepMatch struct {
 	File string `json:"file"`
 	Line int    `json:"line"`
 	Text string `json:"text"`
+	// Clipped marks this individual match as shortened, so a model reading
+	// one match in isolation is not misled by the aggregate count.
+	Clipped bool `json:"clipped,omitempty"`
 }
 
 // Name returns the tool name as advertised to the model.
@@ -68,7 +115,8 @@ func (t *GrepTool) Schema() oai.ToolSchemaDef {
 "properties": {
   "pattern": {"type": "string", "description": "Go regexp syntax."},
   "path":    {"type": "string", "description": "Workspace-relative root to search (default \".\")."},
-  "max":     {"type": "integer", "minimum": 1, "description": "Cap on returned matches."}
+  "max":     {"type": "integer", "minimum": 1, "description": "Cap on returned matches."},
+  "maxLineChars": {"type": "integer", "minimum": 1, "description": "Cap on each match's text length (default 512). Long lines are clipped and marked."}
 },
 "required": ["pattern"]
 }`),
@@ -108,7 +156,15 @@ func (t *GrepTool) Execute(ctx context.Context, args json.RawMessage) (*agent.To
 			limit = defaultGrepMaxMatches
 		}
 	}
+	lineLimit := a.MaxLineChars
+	if lineLimit <= 0 {
+		lineLimit = t.MaxLineChars
+		if lineLimit <= 0 {
+			lineLimit = defaultGrepMaxLineChars
+		}
+	}
 	matches := make([]grepMatch, 0, limit)
+	clipped := 0
 
 	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, inErr error) error {
 		if inErr != nil {
@@ -139,7 +195,11 @@ func (t *GrepTool) Execute(ctx context.Context, args json.RawMessage) (*agent.To
 		for sc.Scan() {
 			lineNo++
 			if re.Match(sc.Bytes()) {
-				matches = append(matches, grepMatch{File: rel, Line: lineNo, Text: sc.Text()})
+				text, wasClipped := clipMatchText(sc.Text(), lineLimit)
+				if wasClipped {
+					clipped++
+				}
+				matches = append(matches, grepMatch{File: rel, Line: lineNo, Text: text, Clipped: wasClipped})
 				if len(matches) >= limit {
 					return errStopWalk
 				}
@@ -152,9 +212,14 @@ func (t *GrepTool) Execute(ctx context.Context, args json.RawMessage) (*agent.To
 	}
 	return &agent.ToolResult{
 		Output: map[string]any{
-			"pattern":   a.Pattern,
-			"matches":   matches,
-			"truncated": len(matches) >= limit,
+			"pattern": a.Pattern,
+			"matches": matches,
+			// truncated keeps its original meaning: the match LIST was cut
+			// short. clippedLines is reported separately so a model can tell
+			// "there are more matches" from "these matches are abridged",
+			// which call for different next steps.
+			"truncated":    len(matches) >= limit,
+			"clippedLines": clipped,
 		},
 	}, nil
 }

--- a/pkg/foreman/agent/tools/grep.go
+++ b/pkg/foreman/agent/tools/grep.go
@@ -116,7 +116,10 @@ func (t *GrepTool) Schema() oai.ToolSchemaDef {
   "pattern": {"type": "string", "description": "Go regexp syntax."},
   "path":    {"type": "string", "description": "Workspace-relative root to search (default \".\")."},
   "max":     {"type": "integer", "minimum": 1, "description": "Cap on returned matches."},
-  "maxLineChars": {"type": "integer", "minimum": 1, "description": "Cap on each match's text length (default 512). Long lines are clipped and marked."}
+  "maxLineChars": {
+    "type": "integer", "minimum": 1,
+    "description": "Cap on each match's text length (default 512). Long lines are clipped and marked."
+  }
 },
 "required": ["pattern"]
 }`),

--- a/pkg/foreman/agent/tools/grep_test.go
+++ b/pkg/foreman/agent/tools/grep_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runGrep executes the tool against a workspace and returns its output map.
+func runGrep(t *testing.T, ws string, args map[string]any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	res, err := (&GrepTool{Workspace: ws}).Execute(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("grep execute: %v", err)
+	}
+	out, ok := res.Output.(map[string]any)
+	if !ok {
+		t.Fatalf("grep output is %T, want map[string]any", res.Output)
+	}
+	return out
+}
+
+// writeWorkspace builds a temp workspace from name -> contents.
+func writeWorkspace(t *testing.T, files map[string]string) string {
+	t.Helper()
+	ws := t.TempDir()
+	for name, body := range files {
+		full := filepath.Join(ws, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return ws
+}
+
+// A single match on a minified bundle must not be able to flood the transcript.
+//
+// This is the regression for a real force-terminated coder run. The repo had a
+// vendored three.min.js, the model grepped for "stats", and the tool returned
+// 649,467 bytes from a handful of matches because the whole bundle is one line.
+// That one result pushed the transcript past the stuck-loop detector's 140k
+// hard cap, and the run ended at turn 8 with verdict INCOMPLETE without ever
+// finding the file it was looking for.
+//
+// The match cap did not help: capping how MANY matches come back does nothing
+// when one of them is half a megabyte.
+func TestGrepClipsLongMatchLines(t *testing.T) {
+	minified := "!function(t,e){" + strings.Repeat("stats.update();", 50_000) + "}"
+	ws := writeWorkspace(t, map[string]string{
+		"vendor/three.min.js": minified,
+		"js/app.js":           "// stats panel\nconst stats = init();\n",
+	})
+
+	out := runGrep(t, ws, map[string]any{"pattern": "stats"})
+
+	matches, ok := out["matches"].([]grepMatch)
+	if !ok {
+		t.Fatalf("matches is %T, want []grepMatch", out["matches"])
+	}
+	if len(matches) == 0 {
+		t.Fatal("expected matches in both files")
+	}
+
+	total := 0
+	sawClipped := false
+	for _, m := range matches {
+		if n := len([]rune(m.Text)); n > defaultGrepMaxLineChars+64 {
+			t.Errorf("match %s:%d is %d chars; the per-line cap is %d "+
+				"(+ room for the marker). An unbounded match line is what "+
+				"blew the transcript budget.", m.File, m.Line, n, defaultGrepMaxLineChars)
+		}
+		if m.Clipped {
+			sawClipped = true
+		}
+		total += len(m.Text)
+	}
+
+	if !sawClipped {
+		t.Error("the minified line should have been clipped and marked; " +
+			"an unmarked clip is indistinguishable from a short line")
+	}
+	if n, _ := out["clippedLines"].(int); n < 1 {
+		t.Errorf("clippedLines = %d, want at least 1", n)
+	}
+	// The real failure was 649,467 bytes. Bound the whole result generously
+	// and still catch anything of that order.
+	if total > 200*defaultGrepMaxLineChars+4096 {
+		t.Errorf("total match text is %d bytes; the point of the cap is that a "+
+			"full result stays near %d", total, 200*defaultGrepMaxLineChars)
+	}
+}
+
+// A clipped line must say so in the payload, because the model decides what to
+// read next based on what it thinks it saw.
+func TestGrepMarksClippedTextVisibly(t *testing.T) {
+	ws := writeWorkspace(t, map[string]string{
+		"big.js": strings.Repeat("x", 5000) + "needle",
+	})
+
+	out := runGrep(t, ws, map[string]any{"pattern": "needle"})
+	matches := out["matches"].([]grepMatch)
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1", len(matches))
+	}
+	if !strings.Contains(matches[0].Text, "clipped") {
+		t.Errorf("clipped text carries no marker: %q", matches[0].Text[:80])
+	}
+	if !matches[0].Clipped {
+		t.Error("Clipped flag not set on a shortened match")
+	}
+}
+
+// Short lines must pass through byte-for-byte. A cap that quietly rewrites
+// ordinary results would be worse than the bug it fixes.
+func TestGrepLeavesShortLinesIntact(t *testing.T) {
+	ws := writeWorkspace(t, map[string]string{
+		"js/ui.js": "const label = 'Health';\nconst value = '80%';\n",
+	})
+
+	out := runGrep(t, ws, map[string]any{"pattern": "Health"})
+	matches := out["matches"].([]grepMatch)
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1", len(matches))
+	}
+	if matches[0].Text != "const label = 'Health';" {
+		t.Errorf("short line was altered: %q", matches[0].Text)
+	}
+	if matches[0].Clipped {
+		t.Error("Clipped set on a line that fits")
+	}
+	if n, _ := out["clippedLines"].(int); n != 0 {
+		t.Errorf("clippedLines = %d, want 0", n)
+	}
+}
+
+// truncated and clippedLines answer different questions, and conflating them
+// would tell a model to re-grep when it should widen instead.
+func TestGrepTruncatedAndClippedAreIndependent(t *testing.T) {
+	ws := writeWorkspace(t, map[string]string{
+		"a.js": strings.Repeat("hit short line\n", 10),
+	})
+
+	out := runGrep(t, ws, map[string]any{"pattern": "hit", "max": 3})
+	if tr, _ := out["truncated"].(bool); !tr {
+		t.Error("truncated should be true when the match list hit its cap")
+	}
+	if n, _ := out["clippedLines"].(int); n != 0 {
+		t.Errorf("clippedLines = %d, want 0: these lines are short", n)
+	}
+}
+
+// Clipping counts runes so a cut never emits invalid UTF-8.
+func TestGrepClipDoesNotSplitRunes(t *testing.T) {
+	body := strings.Repeat("こんにちは", 500) + "needle"
+	ws := writeWorkspace(t, map[string]string{"u.txt": body})
+
+	out := runGrep(t, ws, map[string]any{"pattern": "needle"})
+	matches := out["matches"].([]grepMatch)
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1", len(matches))
+	}
+	if !json.Valid([]byte(strconvQuote(matches[0].Text))) {
+		t.Error("clipped text is not valid UTF-8; the cut landed mid-rune")
+	}
+}
+
+// strconvQuote renders a string as a JSON string so validity can be checked
+// the same way the wire encoder would see it.
+func strconvQuote(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return `""`
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Summary

Bounds each `grep` match to 512 characters so one minified file cannot flood a
transcript and end an agent run.

The tool capped how *many* matches came back (200) but never how *long* one
was. With the scanner accepting 1 MiB lines, a result could reach ~200 MiB, and
it still reported `"truncated": false`, because `truncated` only ever described
the match count.

## How this surfaced

Found while running a real Foreman coder/reviewer pipeline. The run was
force-terminated:

```
stuck-loop detector intervened: ContextHardCap
approximate wire-token count 163689 >= hard cap 140000 at turn 8
```

The repo had a vendored `three.min.js`. A grep for `stats` matched inside it,
and since the whole bundle is one line, that single result was **649,467
bytes**. The transcript went from a few KB to 650 KB in one turn and blew the
140k hard cap.

The stuck-loop detector was right. The tool lied to it.

## Changes

- Clip each match to 512 chars (`maxLineChars` to widen), marked per match
  (`"clipped": true`) and in aggregate (`"clippedLines": N`).
- `truncated` keeps its existing meaning, so "there are more matches" stays
  distinguishable from "these matches are abridged". Those call for different
  next steps: re-grep tighter versus widen the line cap.
- Clip on runes, not bytes, so a cut never emits invalid UTF-8.

A full result is now bounded at roughly 200 * 512 = 100 KiB.

## Testing

Five tests in `pkg/foreman/agent/tools/grep_test.go`, the first reproducing the
exact shape that caused this (a one-line minified bundle beside a normal source
file).

Verified they fail without the fix rather than merely passing with it. With the
clip reverted:

```
--- FAIL: TestGrepClipsLongMatchLines
    match vendor/three.min.js:1 is 750016 chars; the per-line cap is 512
    the minified line should have been clipped and marked
    clippedLines = 0, want at least 1
    total match text is 750051 bytes; ... stays near 102400
--- FAIL: TestGrepMarksClippedTextVisibly
    clipped text carries no marker
    Clipped flag not set on a shortened match
```

Restored, the package passes:

```
ok  github.com/defilantech/llmkube/pkg/foreman/agent/tools  0.352s
```

The other tests cover the things a cap could plausibly break: short lines pass
through byte-for-byte, `truncated` and `clippedLines` stay independent, and a
multibyte line survives clipping as valid UTF-8.

Fixes #1487
