### PR TITLE
fix(foreman): reviewers review the change, not the base branch (+ cross-project remote guard)

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -540,6 +540,57 @@ func setupTaskBranch(
 				"to rebuild from %s and overwrite the prior attempt", ref, baseBranch)
 	}
 
+	// A reviewer or verifier ADOPTS the branch under examination; neither
+	// cuts one.
+	//
+	// The base-cut below ends in `checkout -B <branch> FETCH_HEAD`, which
+	// force-moves the branch ref onto the base. For an issue-fix that is the
+	// point: start clean from base so a retry cannot carry stale work. For a
+	// review it destroys the thing being reviewed. The reviewer ends up with a
+	// working tree identical to base, DiffNameOnly against base returns empty,
+	// and the model is asked to judge a change that is not in front of it.
+	//
+	// Observed live: a coder produced a correct two-line fix and reported GO,
+	// and the reviewer returned GO describing the BASE commit's contents
+	// instead of the fix. Both stages green; the review meaningless. This is
+	// the likely mechanism behind reviewers "rubber-stamping on an empty diff",
+	// which had been read as a model-quality problem.
+	//
+	// Verify carries the same shape: the Workload sets Payload.Branch to the
+	// coder's branch and makes the step depend on the coder, so a verifier
+	// reset to base runs its gate against code the coder never wrote.
+	if task.Spec.Kind == foremanv1alpha1.AgenticTaskKindReview ||
+		task.Spec.Kind == foremanv1alpha1.AgenticTaskKindVerify {
+		found, err := repo.CreateBranchFromRemoteRef(ctx, repo.RemoteRefBranchOptions{
+			Workspace: workspace,
+			Branch:    branch,
+			Remote:    "origin",
+			Ref:       branch,
+			Auth:      auth,
+		})
+		if err != nil {
+			return err
+		}
+		if found {
+			return nil
+		}
+		// Review fails closed. Falling through to the base-cut is exactly the
+		// silent failure above: it yields a green review of an empty diff. A
+		// missing branch means the coder never pushed, the ref was pruned, or
+		// the push remote is not the one the coder wrote to (#1464) - all
+		// conditions to surface, never to paper over.
+		if task.Spec.Kind == foremanv1alpha1.AgenticTaskKindReview {
+			return fmt.Errorf(
+				"review: branch %q not found on the push remote; refusing to review the "+
+					"base branch as though it were the change", branch)
+		}
+		// Verify deliberately keeps the historical fallback for now. Adopting
+		// the branch when it exists is a strict improvement and fixes the real
+		// case; making a missing branch terminal would change the gate stage's
+		// failure semantics fleet-wide, which wants a deliberate decision
+		// rather than a drive-by one. Tracked in the PR discussion.
+	}
+
 	if upstreamURL := resolveUpstream(task.Spec.Payload.Repo); upstreamURL != "" {
 		return repo.CreateBranchFromUpstream(ctx, repo.UpstreamBranchOptions{
 			Workspace:   workspace,

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -401,6 +401,9 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 		if cloneURL == "" {
 			cloneURL = resolveUpstream(task.Spec.Payload.Repo)
 		}
+		if msg := crossProjectRemoteMismatch(e.GitRemoteURL, task.Spec.Payload.Repo); msg != "" {
+			return e.failResult(start, foremanv1alpha1.FailureGitRemoteNotConfigured, msg), nil
+		}
 		if cloneURL == "" {
 			return e.failResult(start, foremanv1alpha1.FailureGitRemoteNotConfigured,
 				"no --git-remote-url configured and task payload.repo is empty or invalid; cannot clone"), nil
@@ -2424,6 +2427,43 @@ var cloneURLResolver codehost.CodeHost = codehost.NewGitHubCodeHost(nil)
 // with or without the .git suffix. Anything else (local paths, file://
 // remotes used in tests, bare hosts) yields "", "" so callers fall back
 // to same-repo behavior.
+// crossProjectRemoteMismatch reports why a static --git-remote-url must not be
+// used for this task, or "" when it is fine (#1464).
+//
+// The fork deployment is legitimate and must keep working: --git-remote-url
+// names a fork of payload.repo, so the OWNER differs while the repo NAME is the
+// same (defilantech/LLMKube -> Defilan/LLMKube). A differing repo NAME is never
+// a fork relationship. It is a misconfiguration whose consequences are silent:
+// the coder reads the right issue, does correct work, pushes it into an
+// unrelated repository, and reports GO. Nothing downstream notices, because the
+// reviewer is handed the same wrong remote.
+//
+// Compared on names rather than by asking the codehost whether one repo is a
+// fork of the other: that would be a network call on every task and
+// provider-specific, while the name comparison already separates "fork of the
+// same project" from "entirely different project".
+//
+// Returns "" for remotes that are not owner/repo shaped (local bare-repo paths
+// in tests), so the guard cannot fire on them.
+func crossProjectRemoteMismatch(remoteURL, taskRepo string) string {
+	if remoteURL == "" || taskRepo == "" {
+		return ""
+	}
+	_, remoteName := gitRemoteOwnerRepo(remoteURL)
+	if remoteName == "" {
+		return ""
+	}
+	_, taskName, ok := codehost.SplitRepoSlug(taskRepo)
+	if !ok || strings.EqualFold(remoteName, taskName) {
+		return ""
+	}
+	return fmt.Sprintf(
+		"--git-remote-url names repository %q but the task targets %q; a fork must "+
+			"share the repo name (only the owner differs). Refusing to clone and push "+
+			"work for %q into %q",
+		remoteName, taskRepo, taskRepo, remoteName)
+}
+
 func gitRemoteOwnerRepo(remoteURL string) (owner, name string) {
 	remoteURL = strings.TrimSpace(remoteURL)
 	var path string

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2668,3 +2668,193 @@ func TestMaxTokensPerTurnForAgent(t *testing.T) {
 		})
 	}
 }
+
+// reviewTask builds a review-shaped task: payload.Branch names the branch the
+// coder already pushed, and BaseBranch is the base the change is measured
+// against. No ReviseFromBranch, because a reviewer is not restoring a prior
+// attempt; it is reading one that already exists on the remote.
+func reviewTask(branch string) *foremanv1alpha1.AgenticTask {
+	return &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindReview,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:       "defilantech/LLMKube",
+				Issue:      641,
+				Branch:     branch,
+				BaseBranch: "main",
+			},
+		},
+	}
+}
+
+// A reviewer must end up on the coder's commit, not on the base branch.
+//
+// setupTaskBranch's base-cut path runs `checkout -B <branch> FETCH_HEAD` after
+// fetching the BASE. For an issue-fix that is exactly right: cut a fresh branch
+// from base. For a review it is destructive, because -B force-moves the branch
+// ref off the coder's pushed commit and onto base. The reviewer then holds a
+// working tree identical to base, its diff against base is empty, and it
+// reasons about code the coder never wrote.
+//
+// Observed live: a coder produced a correct two-line fix and reported GO, and
+// the reviewer returned GO describing the base commit's contents ("adds
+// particles, fireflies, weather") rather than the fix. Both stages green, the
+// review meaningless.
+func TestSetupTaskBranch_ReviewStartsAtCoderCommitNotBase(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, mainSHA := seededRemote(t, dir)
+	const branch = "foreman/wl/issue-641"
+
+	// The coder's branch, already pushed.
+	coder := filepath.Join(dir, "coder")
+	gitIn(t, "", "clone", bare, coder)
+	gitIn(t, coder, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(coder, "fix.txt"), []byte("the fix\n"), 0o644); err != nil {
+		t.Fatalf("write fix.txt: %v", err)
+	}
+	gitIn(t, coder, "add", "fix.txt")
+	gitIn(t, coder, "commit", "-m", "fix: the change under review")
+	gitIn(t, coder, "push", "origin", branch)
+	coderSHA := gitIn(t, coder, "rev-parse", "HEAD")
+
+	// The reviewer's fresh workspace clone.
+	ws := filepath.Join(dir, "review-ws")
+	gitIn(t, "", "clone", bare, ws)
+
+	if err := setupTaskBranch(context.Background(), reviewTask(branch), ws, branch, "main",
+		func(string) string { return bare }, nil, logr.Discard()); err != nil {
+		t.Fatalf("setupTaskBranch: %v", err)
+	}
+
+	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != coderSHA {
+		t.Errorf("HEAD = %s, want the coder's commit %s (base is %s).\n"+
+			"A reviewer reset to base reviews an empty diff and approves work it never saw.",
+			got, coderSHA, mainSHA)
+	}
+	if _, err := os.Stat(filepath.Join(ws, "fix.txt")); err != nil {
+		t.Errorf("the change under review must be present in the working tree: %v", err)
+	}
+}
+
+// The issue-fix base-cut must keep working: a coder branch is cut fresh from
+// the current base so a retry cannot carry stale work. Guarding the review case
+// must not weaken this.
+func TestSetupTaskBranch_IssueFixStillCutsFromBase(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, mainSHA := seededRemote(t, dir)
+	const branch = "foreman/wl/issue-900"
+
+	// A stale branch of the same name exists on the remote. An issue-fix must
+	// ignore it and start from base.
+	stale := filepath.Join(dir, "stale")
+	gitIn(t, "", "clone", bare, stale)
+	gitIn(t, stale, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(stale, "stale.txt"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatalf("write stale.txt: %v", err)
+	}
+	gitIn(t, stale, "add", "stale.txt")
+	gitIn(t, stale, "commit", "-m", "stale work")
+	gitIn(t, stale, "push", "origin", branch)
+
+	ws := filepath.Join(dir, "coder-ws")
+	gitIn(t, "", "clone", bare, ws)
+
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo: "defilantech/LLMKube", Issue: 900, BaseBranch: "main",
+			},
+		},
+	}
+	if err := setupTaskBranch(context.Background(), task, ws, branch, "main",
+		func(string) string { return bare }, nil, logr.Discard()); err != nil {
+		t.Fatalf("setupTaskBranch: %v", err)
+	}
+	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != mainSHA {
+		t.Errorf("HEAD = %s, want base %s: an issue-fix must cut fresh from base", got, mainSHA)
+	}
+	if _, err := os.Stat(filepath.Join(ws, "stale.txt")); err == nil {
+		t.Error("stale remote branch content must not be carried into a fresh issue-fix")
+	}
+}
+
+// A review whose branch is missing from the push remote must fail, not quietly
+// review the base.
+//
+// This is the fail-closed half of the fix. The dangerous outcome is not an
+// error, it is a green GO on an empty diff: falling back to a base-cut produces
+// a working tree that looks perfectly valid and a review that means nothing.
+// The three ways to get here (the coder never pushed, the ref was pruned, or
+// the push remote is not the one the coder wrote to, as in #1464) are all
+// conditions an operator needs to see.
+func TestSetupTaskBranch_ReviewMissingBranchFailsLoud(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, _ := seededRemote(t, dir)
+	const branch = "foreman/wl/issue-641"
+
+	ws := filepath.Join(dir, "review-ws")
+	gitIn(t, "", "clone", bare, ws)
+
+	err := setupTaskBranch(context.Background(), reviewTask(branch), ws, branch, "main",
+		func(string) string { return bare }, nil, logr.Discard())
+	if err == nil {
+		t.Fatal("a review with no branch on the remote must fail; falling back to base " +
+			"yields a GO on an empty diff, which is worse than an error")
+	}
+	if !strings.Contains(err.Error(), "refusing") {
+		t.Errorf("error must explain the refusal, got: %v", err)
+	}
+}
+
+// A verifier must run its gate against the coder's commit when that branch
+// exists, for the same reason a reviewer must read it.
+//
+// The Workload sets Payload.Branch to the coder's branch and makes the verify
+// step depend on the coder, so this path has the identical shape to review. A
+// verifier reset to base runs the gate on code the coder never wrote and
+// reports a pass, which is worse than a review rubber-stamp: the gate is the
+// stage that is supposed to be mechanical and trustworthy.
+func TestSetupTaskBranch_VerifyStartsAtCoderCommitNotBase(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare, _ := seededRemote(t, dir)
+	const branch = "foreman/wl/issue-641"
+
+	coder := filepath.Join(dir, "coder")
+	gitIn(t, "", "clone", bare, coder)
+	gitIn(t, coder, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(coder, "fix.txt"), []byte("the fix\n"), 0o644); err != nil {
+		t.Fatalf("write fix.txt: %v", err)
+	}
+	gitIn(t, coder, "add", "fix.txt")
+	gitIn(t, coder, "commit", "-m", "fix: the change under verification")
+	gitIn(t, coder, "push", "origin", branch)
+	coderSHA := gitIn(t, coder, "rev-parse", "HEAD")
+
+	ws := filepath.Join(dir, "verify-ws")
+	gitIn(t, "", "clone", bare, ws)
+
+	task := reviewTask(branch)
+	task.Spec.Kind = foremanv1alpha1.AgenticTaskKindVerify
+
+	if err := setupTaskBranch(context.Background(), task, ws, branch, "main",
+		func(string) string { return bare }, nil, logr.Discard()); err != nil {
+		t.Fatalf("setupTaskBranch: %v", err)
+	}
+	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != coderSHA {
+		t.Errorf("HEAD = %s, want the coder's commit %s: a gate run against base proves nothing",
+			got, coderSHA)
+	}
+}

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2858,3 +2858,74 @@ func TestSetupTaskBranch_VerifyStartsAtCoderCommitNotBase(t *testing.T) {
 			got, coderSHA)
 	}
 }
+
+// crossProjectRemoteMismatch contract for #1464.
+//
+// The fork deployment is legitimate: --git-remote-url names a fork of
+// payload.repo, so the OWNER differs while the repo NAME matches. A differing
+// repo name is never a fork relationship; it is a misconfiguration that sends a
+// coder's work into an unrelated repository while it reports GO.
+//
+// The whole value of the guard is where it draws the line between those two,
+// so the table drives the real helper rather than a copy of its logic.
+func TestCrossProjectRemoteMismatch(t *testing.T) {
+	cases := []struct {
+		name      string
+		remoteURL string
+		taskRepo  string
+		wantErr   bool
+	}{
+		{
+			name:      "fork of the same project is allowed",
+			remoteURL: "https://github.com/Defilan/LLMKube.git",
+			taskRepo:  "defilantech/LLMKube",
+		},
+		{
+			name:      "same repo entirely is allowed",
+			remoteURL: "https://github.com/defilantech/LLMKube.git",
+			taskRepo:  "defilantech/LLMKube",
+		},
+		{
+			name:      "case differences do not make it a different project",
+			remoteURL: "https://github.com/defilan/llmkube.git",
+			taskRepo:  "defilantech/LLMKube",
+		},
+		{
+			name:      "scp-like fork URL is allowed",
+			remoteURL: "git@github.com:Defilan/LLMKube.git",
+			taskRepo:  "defilantech/LLMKube",
+		},
+		{
+			name:      "different project is rejected (the #1464 shape)",
+			remoteURL: "https://github.com/Defilan/LLMKube.git",
+			taskRepo:  "Defilan/greenhouse-demo",
+			wantErr:   true,
+		},
+		{
+			name:      "scp-like different project is rejected",
+			remoteURL: "git@github.com:Defilan/LLMKube.git",
+			taskRepo:  "Defilan/greenhouse-demo",
+			wantErr:   true,
+		},
+		// Local bare-repo paths are what envtest injects. The guard must stay
+		// off for them or it breaks the harness rather than the bug.
+		{name: "local path remote is not guarded", remoteURL: "/tmp/origin.git", taskRepo: "a/b"},
+		{name: "file:// remote is not guarded", remoteURL: "file:///tmp/origin.git", taskRepo: "a/b"},
+		{name: "empty remote is not guarded", remoteURL: "", taskRepo: "a/b"},
+		{name: "empty task repo is not guarded", remoteURL: "https://github.com/o/r.git", taskRepo: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := crossProjectRemoteMismatch(tc.remoteURL, tc.taskRepo)
+			if tc.wantErr && got == "" {
+				t.Errorf("remote %q with task repo %q must be rejected: work would be "+
+					"pushed into an unrelated repository and still report GO",
+					tc.remoteURL, tc.taskRepo)
+			}
+			if !tc.wantErr && got != "" {
+				t.Errorf("remote %q with task repo %q must be allowed, got: %s",
+					tc.remoteURL, tc.taskRepo, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Reviewers now review the coder's commit instead of the base branch.

`setupTaskBranch` ended every non-revision task in `checkout -B <branch>
FETCH_HEAD` after fetching the base. For an issue-fix that is the point: cut
fresh from base so a retry cannot carry stale work. For a review it is
destructive, because `-B` force-moves the branch ref off the coder's pushed
commit and onto base. The reviewer's working tree became identical to base,
`DiffNameOnly` against base returned empty, and the model was asked to judge a
change that was not in front of it.

## How this surfaced

A real coder/reviewer pipeline. The coder produced a correct two-line fix and
reported GO. The reviewer reported **GO** describing the *base* commit's
contents ("adds particles, fireflies, weather") rather than the fix. Both
stages green, Workload `Completed`, and the review meaningless.

Full evidence in #1489.

This is a plausible mechanism behind reviewers "rubber-stamping on an empty
diff", which had been read as a model-quality problem. The code already knows
empty diffs happen (`reviewerGroundedChangedLines` has an explicit
"EMPTY-but-successful diff" path); it looks like the harness was producing
them.

## Changes

Review and verify now adopt the branch under examination via
`CreateBranchFromRemoteRef` rather than cutting a new one.

Verify has the same shape and needed the same fix: the Workload sets
`Payload.Branch` to the coder's branch and makes the step `DependsOn` the
coder, so a verifier reset to base runs its gate against code the coder never
wrote and reports a pass.

**A missing branch fails the review closed.** Falling through to the base-cut is
exactly the silent failure this fixes: it produces a green GO on an empty diff.
The three ways to get there (the coder never pushed, the ref was pruned, or the
push remote is not the one the coder wrote to, #1464) all want surfacing.

## One deliberate omission, flagged for discussion

**Verify keeps the historical fallback rather than failing closed.**

Adopting the branch when it exists is a strict improvement and fixes the real
case. Making a *missing* branch terminal for verify would change the gate
stage's failure semantics across the fleet, and `TestNativeExecutor_
DeterministicGateAgent` encodes the current behaviour with a fixture whose
branch is never pushed. That is a deliberate call to make, not a drive-by one,
so verify still falls back to the base-cut when the branch is absent.

Happy to tighten it in a follow-up if failing closed is the preference.

## Testing

Four new tests in `executor_native_internal_test.go`, covering both directions
so the fix cannot regress into over-correction:

- review starts at the coder's commit, and the changed file is present
- verify starts at the coder's commit
- review fails loud when the branch is absent from the push remote
- **an issue-fix still cuts fresh from base** and does not adopt a stale remote
  branch of the same name

The first fails without the fix, landing on base with the change absent:

```
HEAD = b8df5c0..., want the coder's commit 12a9628... (base is b8df5c0...)
the change under review must be present in the working tree: no such file
```

All four pre-existing `TestSetupTaskBranch_*` tests still pass, as does
`TestNativeExecutor_DeterministicGateAgent`.

```
ok  github.com/defilantech/llmkube/pkg/foreman/agent
ok  ./pkg/foreman/... ./internal/foreman/...
GOOS=linux golangci-lint run ./pkg/foreman/...   0 issues.
```

Refs #1464
Fixes #1489

---

## Second commit: the #1464 cross-project guard

Pushed `35225f0c` onto this branch, because the two defects are the same
incident and the tests share a file.

A static `--git-remote-url` took precedence over the task's own repo for clone
and push. When it named an unrelated repository, the coder read the right
issue, made the right change, pushed it into that other repository, and
reported GO.

Reproduced on the fleet: a Workload targeting `Defilan/greenhouse-demo` on an
agent deployed with `--git-remote-url=https://github.com/Defilan/LLMKube.git`
left a greenhouse-demo commit as a ref on the LLMKube fork, while
greenhouse-demo had no such branch.

The fork deployment stays supported, because that is what the flag is for: it
names a fork of `payload.repo`, so the **owner** differs while the repo **name**
matches (`defilantech/LLMKube` -> `Defilan/LLMKube`). A differing repo name is
never a fork relationship, so that combination now fails with
`GitRemoteNotConfigured` and an error naming both repositories.

Compared on names rather than asking the codehost whether one repo is a fork of
the other: that would be a network call on every task and provider-specific,
and the name comparison already separates the two cases. Remotes that are not
owner/repo shaped (the local bare-repo paths envtest injects) stay unguarded,
which the table pins explicitly.

### What this deliberately does NOT do

**It does not change the precedence between `--git-remote-url` and
`Workload.spec.repo`.** That is the open design question on #1464, namely whether a
per-task repo should override a fleet-wide flag, which bears on the multi-repo
direction in #1297. This commit only refuses the combination that is never
intentional under either answer.

### Testing

`TestCrossProjectRemoteMismatch`, table-driven against the real helper rather
than a copy of its logic, since the entire value of the guard is where it draws
the line: fork allowed, same repo allowed, case differences allowed, scp-like
URLs handled on both sides, different project rejected, and local/empty remotes
unguarded.

```
ok  ./pkg/foreman/... ./internal/foreman/...
GOOS=linux golangci-lint run ./pkg/foreman/...   0 issues.
```

