### PR TITLE
feat(chart): foreman.crs.namespace — render the CRS ConfigMap where kube-state-metrics can mount it

### DIFF
--- a/charts/foreman/templates/crs-configmap.yaml
+++ b/charts/foreman/templates/crs-configmap.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "foreman.fullname" . }}-crs
-  namespace: {{ include "foreman.namespace" . }}
+  namespace: {{ .Values.foreman.crs.namespace | default (include "foreman.namespace" .) }}
   labels:
     {{- include "foreman.labels" . | nindent 4 }}
 data:

--- a/charts/foreman/tests/crs_test.yaml
+++ b/charts/foreman/tests/crs_test.yaml
@@ -1,0 +1,37 @@
+suite: CRS ConfigMap namespace override (#1491)
+templates:
+  - crs-configmap.yaml
+
+tests:
+  - it: renders into the release namespace by default
+    set:
+      foreman.crs.enabled: true
+    release:
+      namespace: llm
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: llm
+
+  - it: foreman.crs.namespace renders the ConfigMap into that namespace
+    set:
+      foreman.crs.enabled: true
+      foreman.crs.namespace: observability
+    release:
+      namespace: llm
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: observability
+
+  - it: foreman.crs.namespace does not affect the chart-wide namespace helper
+    set:
+      foreman.crs.enabled: true
+      foreman.crs.namespace: observability
+      namespace: custom-ns
+    release:
+      namespace: llm
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: observability

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -64,6 +64,10 @@ foreman:
     # Matches the kube-prometheus-stack default (`/etc/ksm-cmaps/...`) so
     # the stack picks it up without extra wiring.
     configMapKey: foreman-crs.yaml
+    # Namespace to render the CRS ConfigMap into. kube-state-metrics can
+    # only mount ConfigMaps from its own namespace, so set this when it
+    # runs elsewhere (e.g. observability). Empty = the release namespace.
+    namespace: ""
     # Example PrometheusRule alerts shipped alongside the CRS config.
     # Disable when you prefer to author your own alerts against the same
     # metric series.


### PR DESCRIPTION
## What

Adds `foreman.crs.namespace`: when set, the CRS ConfigMap renders into that namespace instead of the release namespace. Empty default preserves existing behavior byte-for-byte.

## Why

Refs #1491 (addendum). The values comment tells operators to point their kube-state-metrics at this ConfigMap, but pods can only mount ConfigMaps from their own namespace — and kube-state-metrics typically lives in an observability namespace, not Foreman's. Today that leaves consumers two bad options: maintain a verbatim copy of the CRS definitions in kube-state-metrics values (drifts on every chart bump), or run a dedicated CRS-only kube-state-metrics deployment next to Foreman. Helm creates cross-namespace resources without complaint; only the pod mount is namespace-bound, so a one-line namespace override closes the gap.

Scope note: only `crs-configmap.yaml` honors the value. The PrometheusRule is discovered by label selectors cross-namespace, and the Grafana dashboard ConfigMap serves sidecar-based setups where placement needs differ — both left as-is deliberately.

## Testing

New `charts/foreman/tests/crs_test.yaml`: default renders into the release namespace, override renders into the target namespace, and the override is independent of the chart-wide `namespace` value. `helm unittest charts/foreman` — 35/35 across both suites; `helm lint` clean with the override set.

## Checklist

- [x] Tests added/updated
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [x] AI assistance disclosed: Claude Code wrote the change and tests from my design and ran `helm unittest` (35/35) and `helm lint` in my environment
- [x] Human review: diff walked through and approved
- [x] Documentation: the new value is documented in values.yaml alongside the existing crs comment block
