### PR TITLE
fix(chart): heartbeat alert uses time(), not the nonexistent time_seconds()

### DIFF
--- a/charts/foreman/templates/prometheusrule.yaml
+++ b/charts/foreman/templates/prometheusrule.yaml
@@ -47,7 +47,7 @@ spec:
     # fires after `staleHeartbeatDuration` of silence, which must be >
     # 90s to avoid flapping on a single missed beat.
     - alert: ForemanFleetNodeHeartbeatStale
-      expr: foreman_fleetnode_heartbeat_timestamp_seconds > 0 and (time_seconds() - foreman_fleetnode_heartbeat_timestamp_seconds) > {{ .Values.foreman.crs.alerts.staleHeartbeatSeconds }}
+      expr: foreman_fleetnode_heartbeat_timestamp_seconds > 0 and (time() - foreman_fleetnode_heartbeat_timestamp_seconds) > {{ .Values.foreman.crs.alerts.staleHeartbeatSeconds }}
       for: {{ .Values.foreman.crs.alerts.staleHeartbeatDuration }}
       labels:
         severity: critical


### PR DESCRIPTION
## What

One token in the `ForemanFleetNodeHeartbeatStale` alert expression: `time_seconds()` → `time()`.

## Why

Fixes #1493

`time_seconds()` is not a PromQL function, so prometheus-operator's rule-validation webhook rejects the PrometheusRule — and because the rule applies with the release, `foreman.crs.alerts.enabled: true` fails the **entire Helm upgrade** and rolls it back. The alerts feature has been un-installable on any cluster running rule validation since it shipped.

## How

Straight substitution; `time()` returns the evaluation timestamp in seconds, which is exactly what the expression's `(now - heartbeat_timestamp) > threshold` arithmetic assumes. Verified by rendering the rule and parsing every expression through a live Prometheus query API: 2/3 valid before the change (heartbeat rejected), 3/3 after. Like #1482, this shipped unexercised because helm-unittest proves templates render, not that PromQL parses — a `promtool check rules` CI guard is suggested in #1493 but deliberately out of scope for a one-token fix.

## Checklist

- [ ] Tests added/updated — none added: a one-token PromQL fix has no template-shape change for helm-unittest to assert; the durable guard (promtool over rendered rules in CI) is proposed in #1493
- [x] `make test` passes locally
- [x] `make lint` passes locally (0 issues; `make test-chart` also passes, 105/105)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — no docs surface changes; values.yaml comments already describe the alert and are unaffected

Assisted-by: Claude Code (diagnosed the failing webhook admission, made the change, and ran `make test` / `make lint` / `make test-chart` plus live-Prometheus validation of all three rendered expressions; I reviewed the diff and approved submission)
