### PR TITLE
fix(operator): apply nodeSelector and tolerations to non-GPU services

### DIFF
--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -468,6 +468,11 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	}
 	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, isvc.Spec.ExtraVolumes...)
 
+	// GPU-only scheduling: the device taint toleration and the shared-pool
+	// selector. Both are meaningless without a GPU request, so they stay gated.
+	var gpuTolerations []corev1.Toleration
+	gpuNodeSelector := map[string]string{}
+
 	if gpuCount > 0 {
 		// Use Recreate strategy for GPU workloads to prevent deadlock:
 		// RollingUpdate requires the new pod to be Ready before terminating the old,
@@ -476,7 +481,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 			Type: appsv1.RecreateDeploymentStrategyType,
 		}
 
-		tolerations := []corev1.Toleration{
+		gpuTolerations = []corev1.Toleration{
 			{
 				// Keyed off the sharing-resolved name so a partitioned pod
 				// tolerates the MIG resource's taint, not the whole-GPU one.
@@ -487,25 +492,40 @@ func (r *InferenceServiceReconciler) constructDeployment(
 			},
 		}
 
-		if len(isvc.Spec.Tolerations) > 0 {
-			tolerations = append(tolerations, isvc.Spec.Tolerations...)
+		// The pool label steers shared pods away from exclusive nodes that
+		// advertise the same extended resource.
+		for k, v := range sharing.nodeSelector {
+			gpuNodeSelector[k] = v
 		}
+	}
 
+	// The user's own nodeSelector and tolerations are general pod-scheduling
+	// passthrough with no GPU semantics, so they apply to EVERY service.
+	//
+	// They used to live inside the gpuCount > 0 branch above, which meant a CPU
+	// or Vulkan-served model silently got neither: the field was accepted,
+	// stored, visible in `kubectl get isvc -o yaml`, and dropped (#1503). The
+	// pod then scheduled anywhere, and the scheduler's failure message named
+	// nodes the user had never asked for. TopologySpreadConstraints and Affinity
+	// just below were already unconditional for exactly this reason.
+	//
+	// GPU-specific entries go first so the user's win on key conflict, matching
+	// the previous behaviour for GPU workloads.
+	tolerations := append([]corev1.Toleration{}, gpuTolerations...)
+	tolerations = append(tolerations, isvc.Spec.Tolerations...)
+	if len(tolerations) > 0 {
 		deployment.Spec.Template.Spec.Tolerations = tolerations
+	}
 
-		// Shared-pool selector first, then the user's own nodeSelector so the
-		// user wins on key conflict; the pool label steers shared pods away
-		// from exclusive nodes that advertise the same extended resource.
-		if len(sharing.nodeSelector) > 0 || len(isvc.Spec.NodeSelector) > 0 {
-			nodeSelector := make(map[string]string, len(sharing.nodeSelector)+len(isvc.Spec.NodeSelector))
-			for k, v := range sharing.nodeSelector {
-				nodeSelector[k] = v
-			}
-			for k, v := range isvc.Spec.NodeSelector {
-				nodeSelector[k] = v
-			}
-			deployment.Spec.Template.Spec.NodeSelector = nodeSelector
+	if len(gpuNodeSelector) > 0 || len(isvc.Spec.NodeSelector) > 0 {
+		nodeSelector := make(map[string]string, len(gpuNodeSelector)+len(isvc.Spec.NodeSelector))
+		for k, v := range gpuNodeSelector {
+			nodeSelector[k] = v
 		}
+		for k, v := range isvc.Spec.NodeSelector {
+			nodeSelector[k] = v
+		}
+		deployment.Spec.Template.Spec.NodeSelector = nodeSelector
 	}
 
 	// DRA: apply nodeSelector and tolerations (no auto GPU taint for DRA)

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -183,6 +183,69 @@ var _ = Describe("Multi-GPU Deployment Construction", func() {
 			}
 		})
 
+		// #1503: spec.nodeSelector and spec.tolerations lived inside the
+		// gpuCount > 0 branch, so a service that requested no GPU silently got
+		// neither. The field was accepted, stored, and dropped, and the pod then
+		// scheduled anywhere. These pin both halves: the user's constraints
+		// always apply, and the GPU-only pieces stay GPU-only.
+		It("applies nodeSelector and tolerations to a non-GPU service", func() {
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "cpu-model", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf", Format: "gguf", Quantization: "Q4_K_M",
+				},
+				Status: inferencev1alpha1.ModelStatus{Phase: "Ready", Path: "/tmp/m.gguf"},
+			}
+			replicas := int32(1)
+			isvc = &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "cpu-service", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef:     "cpu-model",
+					Replicas:     &replicas,
+					NodeSelector: map[string]string{"accelerator": "amd"},
+					Tolerations: []corev1.Toleration{{
+						Key: "devic.es/dri-render", Operator: corev1.TolerationOpExists,
+						Effect: corev1.TaintEffectNoSchedule,
+					}},
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 0)
+
+			Expect(deployment.Spec.Template.Spec.NodeSelector).To(
+				HaveKeyWithValue("accelerator", "amd"),
+				"a service with no GPU request must still get its nodeSelector")
+			Expect(deployment.Spec.Template.Spec.Tolerations).To(HaveLen(1),
+				"a service with no GPU request must still get its tolerations")
+			Expect(deployment.Spec.Template.Spec.Tolerations[0].Key).To(Equal("devic.es/dri-render"))
+		})
+
+		It("does not add the GPU taint toleration to a non-GPU service", func() {
+			model = &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "cpu-model-2", Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source: "https://example.com/model.gguf", Format: "gguf", Quantization: "Q4_K_M",
+				},
+				Status: inferencev1alpha1.ModelStatus{Phase: "Ready", Path: "/tmp/m.gguf"},
+			}
+			replicas := int32(1)
+			isvc = &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "cpu-service-2", Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "cpu-model-2", Replicas: &replicas,
+				},
+			}
+
+			deployment := reconciler.constructDeployment(isvc, model, 0)
+
+			for _, tol := range deployment.Spec.Template.Spec.Tolerations {
+				Expect(tol.Key).NotTo(ContainSubstring("nvidia.com/gpu"),
+					"the GPU taint toleration is meaningless without a GPU request")
+			}
+			Expect(deployment.Spec.Strategy.Type).NotTo(Equal(appsv1.RecreateDeploymentStrategyType),
+				"Recreate exists to avoid GPU-hold deadlock and should stay GPU-only")
+		})
+
 		It("should include multi-GPU args for 2 GPU model", func() {
 			model = &inferencev1alpha1.Model{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

`spec.nodeSelector` and `spec.tolerations` were applied inside the
`gpuCount > 0` branch, so a service that requested no GPU silently got neither.
The fields are accepted, stored, and visible in `kubectl get isvc -o yaml`, and
did nothing.

## How it surfaced

Bringing up a Vulkan-served model. Vulkan requests `devic.es/dri-render` rather
than a GPU resource, so it took the non-GPU path. The ISvc had the pin:

```
$ kubectl get isvc muse-glimmer-strix -o jsonpath='{.spec.nodeSelector}'
{"kubernetes.io/hostname":"shadowstrix"}
```

The pod did not:

```
$ kubectl get pod ... -o json | jq .spec.nodeSelector
null

PodScheduled=False reason=Unschedulable
  0/4 nodes are available: 2 Insufficient memory, 2 node(s) had untolerated taint(s)
```

The scheduler evaluated all four nodes because the pin was dropped, so the
message describes nodes the user never asked for and says nothing about the
constraint they actually wrote.

Worth noting the quieter case: if a node happens to fit, the pod schedules
somewhere the user did not choose and runs. That failure never surfaces as an
error at all, only as unexplained performance differences.

## Changes

The user's passthrough becomes unconditional. This is what
`TopologySpreadConstraints` and `Affinity` immediately below already do, with a
comment noting they are general pod-scheduling passthrough and not GPU-specific.

GPU-only pieces stay gated:

- the device taint toleration keyed off `sharing.tolerationKey`
- the shared-pool `sharing.nodeSelector`
- the `Recreate` strategy, which exists to avoid GPU-hold deadlock

Merge order is preserved, so GPU entries are applied first and the user's win on
key conflict, exactly as before for GPU workloads.

## Testing

Two specs pinning both directions, because a fix here can fail by over-applying
as easily as by under-applying:

- a non-GPU service receives its `nodeSelector` and `tolerations`
- a non-GPU service does **not** receive the GPU taint toleration or `Recreate`

Verified they fail without the fix rather than merely passing with it. Re-gating
the constraints reproduces the bug:

```
• [FAILED] [0.000 seconds]
  [FAILED] a service with no GPU request must still get its nodeSelector
  [It] applies nodeSelector and tolerations to a non-GPU service

FAIL! -- 715 Passed | 1 Failed | 0 Pending | 0 Skipped
```

Restored, the suite is green:

```
ok  github.com/defilantech/llmkube/internal/controller  28.140s
GOOS=linux golangci-lint run ./internal/controller/   0 issues.
```

## Note on provenance

A Foreman coder run on this issue produced a working alternative: an `else`
branch duplicating the logic for non-GPU services. It passed the gate and fixed
the symptom, but it leaves the same scheduling logic in two places, which is the
shape that caused the bug. This PR does the move instead.

Fixes #1503
