### PR TITLE
feat: fetch_pull_request: include check-run output (title/summary/text) for failed runs (#1481)

### DIFF
--- a/pkg/foreman/agent/githubprfetch/fetch.go
+++ b/pkg/foreman/agent/githubprfetch/fetch.go
@@ -51,6 +51,12 @@ import (
 // with a marker so the model knows there is more.
 const DefaultBodyCap = 16 * 1024
 
+// DefaultOutputCap bounds each check-run output field (title, summary, text)
+// so a chatty CI runner does not bloat the tool result. 4 KiB per field is
+// enough for the actual error message and annotated lines from common CI
+// setups (Go test annotations, pytest summaries, linters, scanners).
+const DefaultOutputCap = 4 * 1024
+
 // DefaultTimeout caps a single fetch. The GitHub API is fast; if the
 // network is slow we'd rather skip the fetch than hold up the loop.
 const DefaultTimeout = 10 * time.Second
@@ -96,11 +102,15 @@ type ReviewComment struct {
 	Body         string `json:"body"`
 }
 
-// CheckRun is a single check run result.
+// CheckRun is a single check run result. Output fields are populated only
+// for non-success conclusions so a green PR does not bloat the tool result.
 type CheckRun struct {
-	Name       string `json:"name"`
-	Conclusion string `json:"conclusion"`
-	DetailsURL string `json:"details_url"`
+	Name          string `json:"name"`
+	Conclusion    string `json:"conclusion"`
+	DetailsURL    string `json:"details_url"`
+	OutputTitle   string `json:"output_title,omitempty"`
+	OutputSummary string `json:"output_summary,omitempty"`
+	OutputText    string `json:"output_text,omitempty"`
 }
 
 // Fetcher is the seam between the executor and the GitHub API. The
@@ -376,6 +386,11 @@ func (c *Client) fetchCheckRuns(
 			Name       string `json:"name"`
 			Conclusion string `json:"conclusion"`
 			DetailsURL string `json:"details_url"`
+			Output     struct {
+				Title   string `json:"title"`
+				Summary string `json:"summary"`
+				Text    string `json:"text"`
+			} `json:"output"`
 		} `json:"check_runs"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
@@ -384,11 +399,19 @@ func (c *Client) fetchCheckRuns(
 
 	out := make([]CheckRun, 0, len(raw.CheckRuns))
 	for _, r := range raw.CheckRuns {
-		out = append(out, CheckRun{
+		cr := CheckRun{
 			Name:       r.Name,
 			Conclusion: r.Conclusion,
 			DetailsURL: r.DetailsURL,
-		})
+		}
+		// Populate output fields only for non-success conclusions so a green
+		// PR does not bloat the tool result.
+		if !isSuccessConclusion(r.Conclusion) {
+			cr.OutputTitle = truncateOutput(r.Output.Title, DefaultOutputCap)
+			cr.OutputSummary = truncateOutput(r.Output.Summary, DefaultOutputCap)
+			cr.OutputText = truncateOutput(r.Output.Text, DefaultOutputCap)
+		}
+		out = append(out, cr)
 	}
 	return out, nil
 }
@@ -442,6 +465,27 @@ func truncateBody(body string, cap int) string {
 		keep = 0
 	}
 	return body[:keep] + marker
+}
+
+// isSuccessConclusion returns true when the check run conclusion indicates
+// success. Only non-success conclusions carry output fields so a green PR
+// does not bloat the tool result.
+func isSuccessConclusion(conclusion string) bool {
+	return conclusion == "success" || conclusion == "skipped" || conclusion == "neutral"
+}
+
+// truncateOutput bounds a single check-run output field. The marker is
+// parseable by both humans and models: a clear note that more text exists.
+func truncateOutput(s string, cap int) string {
+	if len(s) <= cap {
+		return s
+	}
+	const marker = "\n... [output truncated]"
+	keep := cap - len(marker)
+	if keep < 0 {
+		keep = 0
+	}
+	return s[:keep] + marker
 }
 
 // ParseRepo splits a repo slug into its owner (namespace) and repo

--- a/pkg/foreman/agent/githubprfetch/fetch_test.go
+++ b/pkg/foreman/agent/githubprfetch/fetch_test.go
@@ -301,6 +301,119 @@ func TestTruncateBody(t *testing.T) {
 	}
 }
 
+func TestCheckRun_OutputFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case isPRDetailsPath(r.URL.Path):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+		  "number": 42,
+		  "title": "fix: something",
+		  "body": "PR body text",
+		  "state": "open",
+		  "merged": false,
+		  "head": {"ref": "fix/something", "sha": "abc123def456"},
+		  "base": {"ref": "main"}
+		}`)
+		case strings.Contains(r.URL.Path, "/reviews"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		case strings.Contains(r.URL.Path, "/comments"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+		  "check_runs": [
+		    {
+		      "name": "lint",
+		      "conclusion": "success",
+		      "details_url": "https://example.com/lint",
+		      "output": {"title": "Lint passed", "summary": "", "text": ""}
+		    },
+		    {
+		      "name": "test",
+		      "conclusion": "failure",
+		      "details_url": "https://example.com/test",
+		      "output": {
+		        "title": "Test failure",
+		        "summary": "1 test failed",
+		        "text": "--- FAIL: TestFoo (0.01s)\n    foo_test.go:42: expected 1, got 2"
+		      }
+		    },
+		    {
+		      "name": "security",
+		      "conclusion": "timed_out",
+		      "details_url": "https://example.com/security",
+		      "output": {"title": "Timeout", "summary": "", "text": ""}
+		    }
+		  ]
+		}`)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL}
+	pr, err := c.Fetch(context.Background(), "defilantech", "LLMKube", 42, "t")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if len(pr.CheckRuns) != 3 {
+		t.Fatalf("CheckRuns: want 3 got %d", len(pr.CheckRuns))
+	}
+
+	// Successful run: output fields must be empty (omitted).
+	lint := pr.CheckRuns[0]
+	if lint.Name != "lint" || lint.Conclusion != "success" {
+		t.Errorf("lint: name=%q conclusion=%q", lint.Name, lint.Conclusion)
+	}
+	if lint.OutputTitle != "" || lint.OutputSummary != "" || lint.OutputText != "" {
+		t.Errorf("lint output should be empty for success: %v", lint)
+	}
+
+	// Failed run: output fields must be populated.
+	test := pr.CheckRuns[1]
+	if test.Name != "test" || test.Conclusion != "failure" {
+		t.Errorf("test: name=%q conclusion=%q", test.Name, test.Conclusion)
+	}
+	if test.OutputTitle != "Test failure" {
+		t.Errorf("test OutputTitle: want 'Test failure' got %q", test.OutputTitle)
+	}
+	if test.OutputSummary != "1 test failed" {
+		t.Errorf("test OutputSummary: want '1 test failed' got %q", test.OutputSummary)
+	}
+	if !strings.Contains(test.OutputText, "TestFoo") {
+		t.Errorf("test OutputText should contain 'TestFoo': %q", test.OutputText)
+	}
+
+	// Timed out run: output fields populated even when summary/text are empty.
+	sec := pr.CheckRuns[2]
+	if sec.Name != "security" || sec.Conclusion != "timed_out" {
+		t.Errorf("security: name=%q conclusion=%q", sec.Name, sec.Conclusion)
+	}
+	if sec.OutputTitle != "Timeout" {
+		t.Errorf("security OutputTitle: want 'Timeout' got %q", sec.OutputTitle)
+	}
+}
+
+func TestTruncateOutput(t *testing.T) {
+	// Short output: no truncation.
+	short := "short output"
+	if got := truncateOutput(short, 1024); got != short {
+		t.Errorf("short output: got %q, want %q", got, short)
+	}
+	// Long output: truncated with marker.
+	long := strings.Repeat("x", 8192)
+	got := truncateOutput(long, 4096)
+	if len(got) > 4096 {
+		t.Errorf("truncated output too long: %d bytes", len(got))
+	}
+	if !strings.Contains(got, "[output truncated]") {
+		t.Errorf("truncated output missing marker: %q", got)
+	}
+}
+
 // The two contract bugs this package shipped with, pinned explicitly rather
 // than left to the happy-path mock: head/base arrive as nested objects, and
 // check runs are addressed per commit ref. Both passed review and a full test


### PR DESCRIPTION
## What

`fetch_pull_request` now returns each check run's `output.title`, `output.summary` and `output.text`, so a coder asked to fix a failing PR can read why CI failed rather than only that it did. Output is populated only for non-success conclusions, and each field is capped at 4 KiB.

## Why

A coder handed a red PR previously saw `{name, conclusion, details_url}`. The conclusion says "failure"; the reason lives in the check run's output, which was never fetched. The only recourse was `details_url`, which an agent cannot open.

Fixes #1481

## How

- `CheckRun` gains `OutputTitle` / `OutputSummary` / `OutputText`, all `omitempty`.
- `fetchCheckRuns` decodes the `output` object the API already returns on the same request, so this adds no extra API call.
- Gated on conclusion: `success`, `skipped` and `neutral` are treated as success and carry no output, so a green PR does not bloat the tool result.
- `DefaultOutputCap` is 4 KiB per field, with a `... [output truncated]` marker so a clipped field stays distinguishable from a genuinely short one.

**Known limitation, deliberately not fixed here.** `truncateOutput` slices bytes, so a cut can land mid-rune. That matches `truncateBody` directly above it, so this PR stays consistent with its neighbour rather than fixing one of two. The grep tool's `clipMatchText` already counts runes; making both truncators in this package rune-safe is worth a separate change.

**Not verified:** the live GitHub API, and a coder consuming the enriched output in a real loop. The decode is exercised against a fixture of the documented response shape.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — n/a, internal tool surface

`make lint`: 0 issues. `make test`: 34 packages ok, 0 failures.

The tests were confirmed to actually fail on a regression rather than merely pass: with the success-gating removed (`if !isSuccessConclusion(...)` forced true), `TestCheckRun_OutputFields` goes red with `lint output should be empty for success`. A test that cannot fail is not coverage.

Assisted-by: LLMKube Foreman (Qwopus-Fusion 27B coder on Strix Halo) generated the implementation and tests; reviewed by Nemotron-49B, then verified by hand before submission: read the diff, checked the tests assert the success-vs-failure gating rather than shape, ran `make test` and `make lint`, and confirmed the tests fail when the gating is broken.
