### PR TITLE
fix: normalizeContainers strips operator-owned SecurityContext fields before drift comparison (#1462)

### DIFF
--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -493,17 +493,12 @@ func normalizeContainers(containers []corev1.Container) {
 		// API-server defaulting, and drift in it should be comparable.
 		c.ImagePullPolicy = ""
 		c.WorkingDir = ""
-		if c.SecurityContext != nil {
-			c.SecurityContext.Privileged = nil
-			c.SecurityContext.RunAsUser = nil
-			c.SecurityContext.RunAsGroup = nil
-			c.SecurityContext.RunAsNonRoot = nil
-			c.SecurityContext.ReadOnlyRootFilesystem = nil
-			c.SecurityContext.AllowPrivilegeEscalation = nil
-			c.SecurityContext.SeccompProfile = nil
-			c.SecurityContext.Capabilities = nil
-			c.SecurityContext.ProcMount = nil
-		}
+		// SecurityContext is NOT stripped: the operator sets AllowPrivilegeEscalation,
+		// Capabilities, and (for init containers) ReadOnlyRootFilesystem and
+		// RunAsUser/RunAsGroup. An empty SecurityContext submitted to the API server
+		// comes back unchanged, so removing this stripping does not introduce phantom
+		// drift. Keeping it comparable means real drift in operator-owned fields is
+		// detected rather than normalised away. See #1462.
 		for j := range c.Ports {
 			if c.Ports[j].Protocol == "" {
 				c.Ports[j].Protocol = corev1.ProtocolTCP

--- a/internal/controller/init_container_diagnostics_test.go
+++ b/internal/controller/init_container_diagnostics_test.go
@@ -104,6 +104,42 @@ func TestNormalizeContainersKeepsTerminationMessagePolicy(t *testing.T) {
 	}
 }
 
+// normalizeContainers must not strip SecurityContext fields the operator owns.
+// Two containers differing only in an operator-owned SecurityContext field must
+// still compare as different after normalization. Under the old code they
+// normalised to equal (the bug); this test fails if the stripping block is
+// restored. See #1462.
+func TestNormalizeContainersKeepsSecurityContextDifferences(t *testing.T) {
+	// inferContainerSecurityContext sets AllowPrivilegeEscalation and Capabilities;
+	// initContainerSecurityContext also sets ReadOnlyRootFilesystem and
+	// RunAsUser/RunAsGroup. Use those fields in the test.
+	containers := []corev1.Container{
+		{
+			Name: "c1",
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: boolPtr(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+			},
+		},
+		{
+			Name: "c2",
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: boolPtr(true), // differs from c1
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+			},
+		},
+	}
+	normalizeContainers(containers)
+
+	if containers[0].SecurityContext.AllowPrivilegeEscalation == containers[1].SecurityContext.AllowPrivilegeEscalation {
+		t.Error("AllowPrivilegeEscalation difference was normalised away: the operator-owned field was stripped")
+	}
+}
+
 // The property that keeping the field comparable could plausibly break: a
 // desired template compared against itself must report no drift. If the
 // operator ever leaves the policy unset on a container it generates, the live


### PR DESCRIPTION
## What

`normalizeContainers` no longer blanks the container `SecurityContext` before the drift comparison, so drift in fields the operator owns is detected instead of normalised away.

## Why

The stripping blanked nine `SecurityContext` fields, including ones the operator sets itself:

- `inferContainerSecurityContext` sets `AllowPrivilegeEscalation` and `Capabilities`
- `initContainerSecurityContext` sets `AllowPrivilegeEscalation`, `ReadOnlyRootFilesystem`, `Capabilities`, plus `RunAsUser` / `RunAsGroup` when the pod security context supplies them

Those are owned values, not API-server defaulting, so the drain decision was blind to security-relevant drift. Same category error #1437 found for `TerminationMessagePolicy`, on a field set where it matters more.

Fixes #1462

## How

The stripping block is removed and replaced with a comment recording why the fields stay comparable.

**The risk worth reviewing is the opposite failure.** If the API server defaults any `SecurityContext` field the operator does not set, comparing it would report permanent drift and roll the Deployment forever, which is the #928 / #1139 oscillation shape.

That was checked against a live cluster rather than reasoned about. A Deployment carrying only the two fields the operator sets was submitted, and the API server stored back exactly that:

```
$ kubectl get deploy sc-defaulting-probe \
    -o jsonpath='{.spec.template.spec.containers[0].securityContext}'
{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}
```

No defaulting of `Privileged`, `RunAsUser`, `RunAsGroup`, `RunAsNonRoot`, `SeccompProfile` or `ProcMount`. There is nothing for the comparison to see that the operator did not put there.

The second commit only moves a doc comment: the new test was originally inserted between `TestPodTemplatesDoNotDifferFromThemselves` and its comment, leaving that test undocumented and mislabelling the new one. No behaviour change.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — n/a, internal controller behaviour

`make lint`: 0 issues. `make test`: 34 packages ok, 0 failures.

`TestNormalizeContainersKeepsSecurityContextDifferences` builds two containers differing only in `AllowPrivilegeEscalation` and asserts they still compare as different after normalisation. Confirmed it discriminates rather than merely passing: with the stripping block temporarily restored it goes red.

```
--- FAIL: TestNormalizeContainersKeepsSecurityContextDifferences (0.00s)
    init_container_diagnostics_test.go:143: AllowPrivilegeEscalation difference was
        normalised away: the operator-owned field was stripped
```

Assisted-by: LLMKube Foreman (Qwopus-Fusion 27B coder on Strix Halo) generated the source change and, on a second pass carrying the review finding, the test; reviewed by Nemotron-49B, then verified by hand before submission: confirmed the test fails with the old behaviour restored, checked API-server defaulting against a live cluster, fixed the misplaced doc comment, and ran `make test` and `make lint`. The first attempt shipped the source change with no test and was rejected for that reason.
