### PR TITLE
fix: EnsurePR treats a closed unmerged PR as satisfied — retried work ends with no PR (#1476)

### DIFF
--- a/pkg/foreman/agent/githubpr/ensure.go
+++ b/pkg/foreman/agent/githubpr/ensure.go
@@ -138,9 +138,16 @@ func (c *Client) findByHead(ctx context.Context, owner, repo, head, token string
 	}
 	target := fmt.Sprintf("%s/repos/%s/%s/pulls?state=all&head=%s",
 		c.base(), owner, repo, url.QueryEscape(filter))
+	// merged_at, not merged: the LIST endpoint returns GitHub's
+	// "pull request simple" object, which carries merged_at but has no
+	// merged field at all. Decoding `merged` here always yields false, so
+	// every merged PR would fall through to the closed-unmerged path and
+	// be duplicated. Verified against the live API: /pulls?state=all has
+	// merged_at and no merged key; only /pulls/{number} carries merged.
 	var prs []struct {
-		HTMLURL string `json:"html_url"`
-		State   string `json:"state"`
+		HTMLURL  string  `json:"html_url"`
+		State    string  `json:"state"`
+		MergedAt *string `json:"merged_at"`
 	}
 	if err := c.getJSON(ctx, target, token, &prs); err != nil {
 		return "", fmt.Errorf("githubpr: list by head: %w", err)
@@ -152,10 +159,15 @@ func (c *Client) findByHead(ctx context.Context, owner, repo, head, token string
 			return pr.HTMLURL, nil
 		}
 	}
-	if len(prs) == 0 {
-		return "", nil
+	// A merged PR is a terminal artifact — nothing to do.
+	for _, pr := range prs {
+		if pr.MergedAt != nil {
+			return pr.HTMLURL, nil
+		}
 	}
-	return prs[0].HTMLURL, nil
+	// Only closed-unmerged PRs exist; treat as absent so EnsurePR
+	// creates a fresh PR (the branch still exists, so GitHub allows it).
+	return "", nil
 }
 
 func (c *Client) create(ctx context.Context, owner, repo, head, base, title, body, token string) (string, error) {

--- a/pkg/foreman/agent/githubpr/ensure_test.go
+++ b/pkg/foreman/agent/githubpr/ensure_test.go
@@ -37,7 +37,7 @@ func prServer(t *testing.T, existing []string, createStatus int, createBody stri
 		}
 		items := make([]map[string]string, 0, len(existing))
 		for _, u := range existing {
-			items = append(items, map[string]string{"html_url": u})
+			items = append(items, map[string]string{"html_url": u, "state": "open"})
 		}
 		_ = json.NewEncoder(w).Encode(items)
 	})
@@ -136,37 +136,73 @@ func TestEnsurePR_ForkQualifiedHeadUsedVerbatim(t *testing.T) {
 	}
 }
 
-// TestEnsurePR_FindByHeadPrefersOpen: state=all carries no open-first
-// ordering guarantee; when a closed PR and an open one share the head,
-// the open one is the artifact to link.
-func TestEnsurePR_FindByHeadPrefersOpen(t *testing.T) {
-	var posts int
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`[
-			{"html_url":"https://github.com/o/r/pull/3","state":"closed"},
-			{"html_url":"https://github.com/o/r/pull/8","state":"open"}
-		]`))
-	})
-	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
-		posts++
-		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{}`))
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+// TestEnsurePR_FindByHeadStateLogic covers the three-way state logic:
+// open PR preferred, merged PR reused, closed-unmerged triggers a new PR.
+func TestEnsurePR_FindByHeadStateLogic(t *testing.T) {
+	tests := []struct {
+		name        string
+		listBody    string
+		wantURL     string
+		wantCreated bool
+		wantPosts   int
+	}{
+		{
+			name: "open preferred over closed",
+			listBody: `[
+				{"html_url":"https://github.com/o/r/pull/3","state":"closed"},
+				{"html_url":"https://github.com/o/r/pull/8","state":"open"}
+			]`,
+			wantURL:     "https://github.com/o/r/pull/8",
+			wantCreated: false,
+			wantPosts:   0,
+		},
+		{
+			name: "merged reused",
+			listBody: `[
+				{"html_url":"https://github.com/o/r/pull/42","state":"closed","merged_at":"2026-07-30T00:00:00Z"}
+			]`,
+			wantURL:     "https://github.com/o/r/pull/42",
+			wantCreated: false,
+			wantPosts:   0,
+		},
+		{
+			name: "closed unmerged creates new",
+			listBody: `[
+				{"html_url":"https://github.com/o/r/pull/444","state":"closed","merged_at":null}
+			]`,
+			wantURL:     "https://github.com/o/r/pull/500",
+			wantCreated: true,
+			wantPosts:   1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var posts int
+			mux := http.NewServeMux()
+			mux.HandleFunc("GET /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.listBody))
+			})
+			mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+				posts++
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"html_url":"https://github.com/o/r/pull/500"}`))
+			})
+			srv := httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
+			c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 
-	res, err := c.EnsurePR(context.Background(), "o", "r",
-		"foreman/wl-x/issue-7", "main", "t", "b", "tok")
-	if err != nil {
-		t.Fatalf("EnsurePR: %v", err)
-	}
-	if res.Created || res.URL != "https://github.com/o/r/pull/8" {
-		t.Fatalf("want open PR 8 preferred over closed PR 3, got %+v", res)
-	}
-	if posts != 0 {
-		t.Fatalf("must not POST when a PR exists; got %d posts", posts)
+			res, err := c.EnsurePR(context.Background(), "o", "r",
+				"foreman/wl-x/issue-7", "main", "t", "b", "tok")
+			if err != nil {
+				t.Fatalf("EnsurePR: %v", err)
+			}
+			if res.Created != tt.wantCreated || res.URL != tt.wantURL {
+				t.Fatalf("got %+v, want Created=%v URL=%s", res, tt.wantCreated, tt.wantURL)
+			}
+			if posts != tt.wantPosts {
+				t.Fatalf("want %d create POSTs, got %d", tt.wantPosts, posts)
+			}
+		})
 	}
 }
 
@@ -181,7 +217,7 @@ func TestEnsurePR_ResolvesCreateRace(t *testing.T) {
 			_, _ = w.Write([]byte("[]"))
 			return
 		}
-		_, _ = w.Write([]byte(`[{"html_url":"https://github.com/o/r/pull/11"}]`))
+		_, _ = w.Write([]byte(`[{"html_url":"https://github.com/o/r/pull/11","state":"open","merged":false}]`))
 	})
 	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
@@ -262,5 +298,46 @@ func TestHeadCommitSubject_EmptyOnFailure(t *testing.T) {
 	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 	if got := c.HeadCommitSubject(context.Background(), "o", "r", "b", "t"); got != "" {
 		t.Fatalf("want empty on 404, got %q", got)
+	}
+}
+
+// TestEnsurePR_MergedPRUsesMergedAtNotMerged pins the field the LIST endpoint
+// actually returns. GitHub's "pull request simple" object (what
+// GET /repos/{o}/{r}/pulls returns) carries merged_at and has NO merged key;
+// only GET /repos/{o}/{r}/pulls/{number} carries merged. Decoding `merged`
+// from the list response silently yields false for every merged PR, which
+// sends it down the closed-unmerged path and duplicates finished work.
+//
+// The fixture below deliberately omits `merged` exactly as the real API does.
+func TestEnsurePR_MergedPRUsesMergedAtNotMerged(t *testing.T) {
+	created := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"html_url":"https://github.com/o/r/pull/444",` +
+				`"state":"closed","merged_at":"2026-07-30T00:00:00Z"}]`))
+		case http.MethodPost:
+			created = true
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"html_url":"https://github.com/o/r/pull/999"}`))
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL}
+	res, err := c.EnsurePR(context.Background(), "o", "r", "branch", "main", "t", "b", "tok")
+	if err != nil {
+		t.Fatalf("EnsurePR: %v", err)
+	}
+	if created {
+		t.Error("a merged PR was duplicated into a new PR; merged_at was not honoured")
+	}
+	if res.URL != "https://github.com/o/r/pull/444" {
+		t.Errorf("want the merged PR URL, got %s", res.URL)
+	}
+	if res.Created {
+		t.Error("Created should be false for an existing merged PR")
 	}
 }


### PR DESCRIPTION
## What

`EnsurePR` no longer treats a closed, unmerged PR as satisfying "the workload's artifact is a pull request". A merged PR is still returned as-is; a closed-unmerged one is treated as absent so a fresh PR is created.

## Why

Branch names are deterministic (`foreman/<workload>/issue-<n>`), so retrying an issue whose earlier PR was closed pushed reviewed code to the branch, got a review GO, logged `review GO: pull request ensured`, and left no visible PR anywhere. Finished work silently discarded.

Fixes #1476

## How

`findByHead` now classifies three cases instead of two:

1. an **open** PR for the head wins (unchanged)
2. a **merged** PR is a terminal artifact and is returned (unchanged behaviour, now explicit)
3. only **closed-unmerged** PRs exist, so return absent and let `EnsurePR` create a new one

The issue offered reopen-then-create-on-failure as an alternative. Create is simpler, has no 422-handling path, and the branch still exists so GitHub accepts it.

**The part worth reviewing carefully: merged detection reads `merged_at`, not `merged`.**

`findByHead` calls `GET /repos/{owner}/{repo}/pulls`, which returns GitHub's *pull request simple* object. That object carries `merged_at` and has no `merged` key at all; only `GET /pulls/{number}` carries `merged`. A merged PR is `state: "closed"` in both, so `state` alone cannot distinguish it. Decoding `merged` from the list response therefore yields `false` for every merged PR, sending it down the closed-unmerged path and duplicating finished work, reintroducing this bug in a form that looks handled.

Verified against the live API rather than from the docs:

```
GET /repos/defilantech/LLMKube/pulls?state=all  ->  merged_at present, merged ABSENT
GET /repos/defilantech/LLMKube/pulls/1504       ->  both present
```

**Not verified:** a live end-to-end retry against a real closed PR. The classification is exercised against fixtures of the API-confirmed response shape.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — n/a, internal Foreman behaviour

`make lint`: 0 issues. `make test`: 34 packages ok, 0 failures.

`TestEnsurePR_MergedPRUsesMergedAtNotMerged` pins the trap with a fixture that omits `merged` exactly as the real API does, and goes red if the implementation switches back to `merged`.

The pre-existing table fixtures asserted `"merged":true` / `"merged":false`, a field GitHub never sends on that endpoint, so they agreed with the implementation instead of with GitHub and both were wrong together. They now carry `merged_at` and `merged_at: null`.

Assisted-by: LLMKube Foreman (Qwopus-Fusion 27B coder on Strix Halo) generated the classification change and its tests across two passes; reviewed by Nemotron-49B, then verified and corrected by hand before submission. The first attempt duplicated merged PRs outright; the second detected them via `merged`, a field the list endpoint does not return, so it still misclassified every merged PR. The field was changed to `merged_at`, checked against the live API, the fixtures corrected, and a regression test added that fails if `merged` returns. `make test` and `make lint` were run on the final branch.
