### PR TITLE
docs(operations): document ModelPool in the GPU-sharing guide

### DIFF
--- a/docs/operations/gpu-sharing.md
+++ b/docs/operations/gpu-sharing.md
@@ -121,6 +121,94 @@ co-scheduling for workloads that already trust each other, and reach for
 `partitioned` when you need a boundary that holds between tenants, since a
 MIG partition is enforced by the hardware.
 
+## ModelPool: many models, one slot
+
+`exclusive`, `partitioned` and `shared` all divide a device between workloads
+that run *at the same time*. A ModelPool solves the opposite problem: several
+models that each want the whole slot, but are not needed simultaneously. At most
+one member is resident; the rest are held at `Stopped` with `replicas: 0`, and
+the slot changes hands on demand.
+
+```yaml
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelPool
+metadata:
+  name: coder-pool
+spec:
+  gpu: 1
+  nodeSelector:
+    kubernetes.io/hostname: gpu-node-1
+  swapPolicy: sticky
+  swapBudget: 300s
+  default: coder-small
+  members:
+    - inferenceServiceRef: {name: coder-small}
+    - inferenceServiceRef: {name: coder-large}
+```
+
+Each member is an ordinary single-model InferenceService with its own image,
+context size and runtime. `spec.gpu` is informational: members declare their own
+resource requests, and this only records the slot size so the pool invariant is
+visible at a glance. `nodeSelector` pins the slot, and every member is expected
+to land on that node so they genuinely contend for the same device memory.
+
+### What it looks like when it is working
+
+```
+$ kubectl get modelpool coder-pool
+NAME          POLICY   RESIDENT      PHASE   AGE
+coder-pool    sticky   coder-small   Ready   4m
+
+$ kubectl get isvc coder-small coder-large
+NAME          PHASE     ...
+coder-small   Ready               # owns the slot, replicas 1
+coder-large   Stopped             # held by the operator, replicas 0
+```
+
+The operator sets `replicas: 0` on the non-resident members itself. Do not
+"fix" a member that shows `Stopped`: in a pool that is the normal held state,
+not a failure.
+
+Four conditions report the pool's health:
+
+| Condition | Meaning |
+| --- | --- |
+| `MembersValid` | every `inferenceServiceRef` resolves. `False` / `MissingMembers` lists the names that do not exist, and the pool sits `Degraded` |
+| `SlotAllocated` | `True` / `Resident` names the owner. `False` / `Swapping` means no member is resident yet |
+| `SwapDeferred` | a swap is being held off rather than performed |
+| `MetalSupported` | whether the members are Kubernetes GPU-gated or Apple-metal backed |
+
+### Sticky is the only policy, and it means what it says
+
+`swapPolicy: sticky` (the default and the only value in v1) keeps the incumbent
+until a *different* member is requested. A priority-based reclaim policy is a
+planned follow-up.
+
+One consequence surprises operators, so it is worth stating plainly: **editing
+`spec.default` on a warm pool does not move the slot.** `default` names the
+member to warm on a *cold* pool, before anything has picked an owner. Once a
+member is resident, sticky keeps it there and the `default` edit is inert until
+the pool next goes cold. Verified on-cluster: after repointing `default` at the
+other member, the incumbent still owned the slot two minutes later.
+
+### swapBudget, and why it is separate from the request timeout
+
+`swapBudget` (default `300s`) bounds how long the router holds a cross-model
+request open while it drains the incumbent and cold-loads the target. It is
+deliberately decoupled from the router's response-header timeout so a large
+model can take minutes to load without loosening the per-request generation cap
+for every request on the fleet. If the budget elapses before the target is
+resident, the held request fails with `503` and a `Retry-After`; the caller can
+retry, and the now-warm member serves the next one.
+
+### A pooled router runs one replica
+
+When any backend resolves to a ModelPool member, the operator pins the router
+to a single replica regardless of what the spec asks for. Pool activation
+serialises swaps through an in-process lock, so a second proxy replica would
+race it and thrash the slot. Cross-replica swap coordination is a follow-up, so
+do not plan a highly-available pooled router yet.
+
 ## Fleet configuration
 
 GPU sharing requires fleet-level configuration so the operator knows where
@@ -331,6 +419,12 @@ mode with separate nodes.
 - **No automatic profile selection**: the operator does not choose a MIG
   profile for you; you must declare it explicitly in the InferenceService
   spec.
-- **No dynamic pool rebalancing**: the shared pool is static. If you need
-  to move workloads between pools, update the node labels and the chart
-  value, then restart affected InferenceServices.
+- **No dynamic pool rebalancing in `shared` mode**: the shared pool is
+  static. If you need to move workloads between pools, update the node
+  labels and the chart value, then restart affected InferenceServices.
+  Note this is a limitation of `shared` mode specifically. If what you
+  want is several models taking turns on one slot rather than co-resident
+  workloads, that is a [ModelPool](#modelpool-many-models-one-slot).
+- **Pooled routers are single-replica**: a router with any ModelPool
+  member as a backend is pinned to one replica, because swap activation
+  serialises through an in-process lock.


### PR DESCRIPTION
## What

Documents ModelPool in `docs/operations/gpu-sharing.md`, and scopes one limitation that had become misleading.

## Why

ModelPool shipped in #1393 (2026-08-09). The GPU-sharing operations guide never mentioned it, so the only prose describing it is the design proposal. An operator reading the guide sees three modes and no hint a fourth pattern exists.

It is a genuinely different shape from the other three: `exclusive`, `partitioned` and `shared` all divide a device between workloads running **at the same time**, while a pool serves several models that each want the whole slot but are not needed simultaneously.

Refs #1393

## How

Adds a `## ModelPool: many models, one slot` section covering the spec, the observed steady state, the four status conditions, sticky semantics, `swapBudget`, and the single-replica router constraint.

Two corrections to the existing text:

- **`No dynamic pool rebalancing`** read as absolute. It is specific to `shared` mode, and it now says so and points at ModelPool for the take-turns case.
- Adds a limitation recording that a router with a pooled backend is pinned to one replica, because swap activation serialises through an in-process lock and a second replica would race it.

### Written from an exercised pool, not from type comments

A real pool was stood up on-cluster:

```
NAME       POLICY   RESIDENT     PHASE   AGE
pooltest   sticky   pooltest-a   Ready   35m

pooltest-a   Ready     replicas 1
pooltest-b   Stopped   replicas 0
```

Observed and now documented:

- a cold pool warms `spec.default`; non-resident members are set to `replicas: 0` by the operator, and `Stopped` is the normal held state rather than a failure
- `SlotAllocated=True/Resident` names the owner; with members missing it reports `False/MissingMembers` and the pool sits `Degraded`
- **editing `spec.default` on a warm pool does not move the slot.** Repointing it at the other member left the incumbent resident two minutes later. This is correct (sticky keeps the incumbent, and `default` only applies to a cold pool) but it is the first thing an operator will try, so it is called out explicitly.

### Not exercised

The demand-driven swap itself, and `swapBudget` expiry returning `503` + `Retry-After`. Those are documented from the API contract. Driving a swap needs a `Proxy` data-plane router, and the cluster's only router runs `dataPlane: Gateway`, so there was no way to exercise it without standing up new infrastructure. Flagging so a reviewer knows which claims are observed and which are read.

## Checklist

- [x] Tests added/updated — n/a, documentation only
- [x] `make test` passes locally — n/a, no code changed
- [x] `make lint` passes locally — n/a, no code changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

Assisted-by: Claude Code (drafted the section). Before writing, the CRD schema and field semantics were read off the live cluster with `kubectl explain`, a ModelPool was created and driven through Degraded, Swapping and Ready, and the warm-pool `default` behaviour was tested rather than assumed. What could not be exercised is labelled above.
