### PR TITLE
fix(foreman): route all three consumers through the provider seams

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -384,7 +384,18 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	// remote is configured (#915) and cuts the task branch from the
 	// upstream base below (#813). The test override lets envtest inject a
 	// local remote.
-	resolveUpstream := upstreamURLForRepo
+	//
+	// The injected CodeHost seam wins when set (#1298). Reading the
+	// package-level default here instead would make a Forgejo or GitLab
+	// CodeHost compile, satisfy the interface, be injected, and still hand
+	// back https://github.com/<slug>.git, which is the failure this seam
+	// exists to prevent.
+	resolveUpstream := func(repoSlug string) string {
+		if e.CodeHost != nil {
+			return e.CodeHost.ResolveCloneURL(repoSlug)
+		}
+		return upstreamURLForRepo(repoSlug)
+	}
 	if e.UpstreamURLForRepo != nil {
 		resolveUpstream = e.UpstreamURLForRepo
 	}

--- a/pkg/foreman/agent/executor_upstream_test.go
+++ b/pkg/foreman/agent/executor_upstream_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -141,5 +142,58 @@ func TestBuildDeterministicArgs_ThreadsBaseBranch(t *testing.T) {
 				t.Errorf("args[baseBranch] = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// recordingCodeHost answers with a non-GitHub URL so a github.com result
+// proves the injected seam was bypassed.
+type recordingCodeHost struct{ asked []string }
+
+func (r *recordingCodeHost) ResolveCloneURL(repoSlug string) string {
+	r.asked = append(r.asked, repoSlug)
+	return "https://forge.example.org/" + repoSlug + ".git"
+}
+
+func (r *recordingCodeHost) EnsureChangeRequest(
+	context.Context, string, string, string, string, string,
+) (string, bool, error) {
+	return "", false, nil
+}
+
+func (r *recordingCodeHost) HeadCommitSubject(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+// TestResolveUpstreamPrefersInjectedCodeHost pins the clone-URL half of #1298.
+// Execute used to bind resolveUpstream to upstreamURLForRepo, which reads a
+// package-level GitHub resolver, so an injected Forgejo/GitLab CodeHost
+// compiled, satisfied the interface, was injected, and still produced
+// https://github.com/<slug>.git.
+//
+// This exercises the same selection the executor performs, without standing up
+// a full Execute run: injected seam wins, package default otherwise.
+func TestResolveUpstreamPrefersInjectedCodeHost(t *testing.T) {
+	ch := &recordingCodeHost{}
+	e := &NativeAgentLoopExecutor{CodeHost: ch}
+
+	resolve := func(slug string) string {
+		if e.CodeHost != nil {
+			return e.CodeHost.ResolveCloneURL(slug)
+		}
+		return upstreamURLForRepo(slug)
+	}
+
+	got := resolve("group/sub/project")
+	if want := "https://forge.example.org/group/sub/project.git"; got != want {
+		t.Errorf("clone URL = %q, want %q (injected CodeHost bypassed)", got, want)
+	}
+	if len(ch.asked) != 1 {
+		t.Errorf("injected CodeHost was not consulted: %v", ch.asked)
+	}
+
+	// With no seam injected the GitHub default must be unchanged.
+	e.CodeHost = nil
+	if got := resolve("owner/name"); got != "https://github.com/owner/name.git" {
+		t.Errorf("default path changed: %q", got)
 	}
 }

--- a/pkg/foreman/agent/tools/buildall.go
+++ b/pkg/foreman/agent/tools/buildall.go
@@ -22,8 +22,10 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubprfetch"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/worktracker"
 )
 
 // BuildAll is the single place the agent's native tool set is constructed.
@@ -57,6 +59,7 @@ func BuildAll(deps ToolDeps) []Tool {
 			Cfg: RunGateJobToolConfig{
 				Namespace: deps.ForemanNamespace,
 				LogTailFn: deps.LogTailFn,
+				CodeHost:  deps.CodeHost,
 			},
 		},
 		// fetch_issue: read-only GitHub issue surface for the reviewer. The
@@ -64,8 +67,11 @@ func BuildAll(deps ToolDeps) []Tool {
 		// through one bounded Go-side call instead of being inherited by every
 		// bash subprocess via $GH_TOKEN. Closes #580.
 		&FetchIssueTool{
-			Fetcher: githubissue.NewClient(),
-			Token:   deps.Token,
+			// WorkItems wins when injected; Fetcher/Token remain the
+			// GitHub default so nothing changes for a GitHub fleet.
+			WorkItems: deps.WorkItems,
+			Fetcher:   githubissue.NewClient(),
+			Token:     deps.Token,
 		},
 		// fetch_pull_request: read-only GitHub PR surface for the coder, same
 		// reasoning as fetch_issue. Closes #1434.
@@ -112,4 +118,15 @@ type ToolDeps struct {
 	// Token resolves the GitHub credential at call time rather than at
 	// startup, so a rotated token is picked up without restarting the agent.
 	Token func() (string, error)
+
+	// WorkItems is the provider-neutral work-item seam (#1158). Nil keeps
+	// the GitHub default. Set it and fetch_issue reaches the injected
+	// provider instead of holding its own GitHub client, which is the tool
+	// half of #1298.
+	WorkItems worktracker.WorkItems
+
+	// CodeHost is the provider-neutral code-host seam (#1158). Nil keeps
+	// the GitHub default. run_gate_job derives its clone URL from this
+	// rather than a hardcoded https://github.com.
+	CodeHost codehost.CodeHost
 }

--- a/pkg/foreman/agent/tools/fetch_issue.go
+++ b/pkg/foreman/agent/tools/fetch_issue.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tools
 
 import (
+	"strconv"
+
 	"context"
 	"encoding/json"
 	"errors"
@@ -25,6 +27,7 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/agent"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/worktracker"
 )
 
 // TokenSource resolves a GitHub PAT at FetchIssueTool.Execute time.
@@ -72,9 +75,16 @@ type TokenSource func() (string, error)
 //     instead of also a per-user `gh` config or per-process env var
 //     inherited by every bash subprocess.
 type FetchIssueTool struct {
-	// Fetcher is the GitHub client. Required. Production wires
-	// githubissue.NewClient(); tests pass a fake or an httptest-backed
-	// Client.
+	// WorkItems is the provider-neutral seam (#1158). When set it is used
+	// verbatim and Fetcher/Token are ignored for the fetch itself: a
+	// Forgejo or GitLab implementation carries its own auth. Injecting it
+	// is the only way a non-GitHub provider reaches this tool, which is
+	// what #1298 fixes.
+	WorkItems worktracker.WorkItems
+
+	// Fetcher is the GitHub client backing the default seam when WorkItems
+	// is not injected. Production wires githubissue.NewClient(); tests pass
+	// a fake or an httptest-backed Client.
 	Fetcher githubissue.Fetcher
 	// Token resolves the GitHub PAT at Execute time. Required.
 	Token TokenSource
@@ -123,11 +133,28 @@ func (t *FetchIssueTool) Schema() oai.ToolSchemaDef {
 //     or out of scope.
 //   - 5xx / network: generic transient failure; the model can retry
 //     once or call submit_result with verdict=ERROR.
-func (t *FetchIssueTool) Execute(ctx context.Context, args json.RawMessage) (*agent.ToolResult, error) {
-	if t.Fetcher == nil {
-		return nil, fmt.Errorf("fetch_issue: tool not configured (Fetcher is nil)")
+//
+// workItems returns the effective WorkItems seam: the injected one when set,
+// else a GitHubWorkItems built from Fetcher and the just-resolved token. The
+// token is resolved per call rather than baked in at construction so a rotated
+// credential is picked up without restarting the agent, which is why this
+// cannot simply be a field set in BuildAll. Mirrors the executor's accessor of
+// the same name.
+func (t *FetchIssueTool) workItems(token string) worktracker.WorkItems {
+	if t.WorkItems != nil {
+		return t.WorkItems
 	}
-	if t.Token == nil {
+	if t.Fetcher != nil {
+		return &worktracker.GitHubWorkItems{Fetcher: t.Fetcher, Token: token}
+	}
+	return nil
+}
+
+func (t *FetchIssueTool) Execute(ctx context.Context, args json.RawMessage) (*agent.ToolResult, error) {
+	if t.WorkItems == nil && t.Fetcher == nil {
+		return nil, fmt.Errorf("fetch_issue: tool not configured (WorkItems and Fetcher are both nil)")
+	}
+	if t.WorkItems == nil && t.Token == nil {
 		return nil, fmt.Errorf("fetch_issue: tool not configured (Token resolver is nil)")
 	}
 	var a fetchIssueArgs
@@ -140,18 +167,24 @@ func (t *FetchIssueTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 	if a.Number <= 0 {
 		return nil, fmt.Errorf("fetch_issue: number must be a positive integer (got %d)", a.Number)
 	}
-	owner, name, err := githubissue.ParseRepo(a.Repo)
-	if err != nil {
+	if _, _, err := githubissue.ParseRepo(a.Repo); err != nil {
 		return nil, fmt.Errorf("fetch_issue: %w", err)
 	}
-	token, err := t.Token()
-	if err != nil {
-		return nil, fmt.Errorf(
-			"fetch_issue: no GitHub token "+
-				"(set GITHUB_TOKEN env or populate "+
-				"~/.config/foreman/github-token on the FleetNode): %w", err)
+	// Only the default GitHub seam needs a token here; an injected
+	// WorkItems carries its own auth, so a non-GitHub provider must not be
+	// blocked by a missing GITHUB_TOKEN.
+	var token string
+	if t.WorkItems == nil {
+		var err error
+		token, err = t.Token()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"fetch_issue: no GitHub token "+
+					"(set GITHUB_TOKEN env or populate "+
+					"~/.config/foreman/github-token on the FleetNode): %w", err)
+		}
 	}
-	issue, err := t.Fetcher.Fetch(ctx, owner, name, a.Number, token)
+	item, err := t.workItems(token).Get(ctx, a.Repo, strconv.Itoa(a.Number))
 	if err != nil {
 		var herr *githubissue.HTTPError
 		if errors.As(err, &herr) {
@@ -171,11 +204,11 @@ func (t *FetchIssueTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 	return &agent.ToolResult{
 		Output: map[string]any{
 			"repo":   a.Repo,
-			"number": issue.Number,
-			"title":  issue.Title,
-			"body":   issue.Body,
-			"state":  issue.State,
-			"labels": issue.Labels,
+			"number": a.Number,
+			"title":  item.Title,
+			"body":   item.Body,
+			"state":  item.State,
+			"labels": item.Labels,
 		},
 	}, nil
 }

--- a/pkg/foreman/agent/tools/fetch_issue_test.go
+++ b/pkg/foreman/agent/tools/fetch_issue_test.go
@@ -201,7 +201,14 @@ func TestFetchIssueTool_NilDepsFailLoud(t *testing.T) {
 		tool *FetchIssueTool
 		want string
 	}{
-		{"nil-fetcher", &FetchIssueTool{Fetcher: nil, Token: staticToken("t")}, "Fetcher is nil"},
+		// The tool now accepts either a provider-neutral WorkItems seam or
+		// the GitHub Fetcher (#1298), so "unconfigured" means neither is
+		// present rather than Fetcher alone.
+		{
+			"no-source",
+			&FetchIssueTool{Fetcher: nil, WorkItems: nil, Token: staticToken("t")},
+			"WorkItems and Fetcher are both nil",
+		},
 		{"nil-token", &FetchIssueTool{Fetcher: &fakeFetcher{}, Token: nil}, "Token resolver is nil"},
 	}
 	for _, tc := range cases {

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -36,6 +36,8 @@ import (
 
 	"github.com/defilantech/llmkube/pkg/foreman/agent"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
 )
 
 // gateJobTemplate is the YAML template the tool renders for each call.
@@ -117,6 +119,14 @@ type RunGateJobToolConfig struct {
 	// Image is the container image the Job runs. Defaults to
 	// "golang:1.26". Override for offline mirrors or pinned shas.
 	Image string
+
+	// CodeHost is the provider-neutral seam (#1158). When set, the gate
+	// Job's clone URL is derived from it rather than from CloneURLBase, so
+	// a Forgejo or GitLab fleet clones from its own host. Nil keeps the
+	// GitHub default below. This is the gate-Job half of #1298: the seam
+	// was injectable everywhere except here, so a third-party CodeHost
+	// still produced a github.com clone inside the Job.
+	CodeHost codehost.CodeHost
 
 	// CloneURLBase is prepended to {repo}.git when the Job clones the
 	// fork. Defaults to "https://github.com". Override for GHE or
@@ -316,7 +326,7 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 		MemRequest:              cfg.MemRequest,
 		MemLimit:                cfg.MemLimit,
 		CloneURLBase:            cfg.CloneURLBase,
-		CloneURL:                a.CloneURL,
+		CloneURL:                resolveGateCloneURL(cfg, a.Repo, a.CloneURL),
 		UpstreamURL:             a.UpstreamURL,
 		TaskNamespace:           a.TaskRef.Namespace,
 		TaskName:                a.TaskRef.Name,
@@ -522,6 +532,27 @@ func renderGateJob(in rendererInput) (*batchv1.Job, error) {
 
 // applyConfigDefaults fills in every empty field with the documented
 // default. Kept separate from the struct definition so the zero-value
+// resolveGateCloneURL picks the URL the gate Job clones from.
+//
+// Precedence: an explicit cloneURL argument wins (it is how a fork-style push
+// target reaches the Job), then the injected CodeHost seam, then the template's
+// CloneURLBase + repo fallback, which is GitHub.
+//
+// The seam returns a whole URL rather than a base because provider URL shapes
+// differ: a nested Forgejo or GitLab path is not "base/owner/name.git", so
+// composing one from a base would be wrong for exactly the providers this seam
+// exists to support. Returning "" leaves the template on its CloneURLBase path
+// so a malformed slug degrades to today's behavior rather than an empty clone.
+func resolveGateCloneURL(cfg RunGateJobToolConfig, repoSlug, explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if cfg.CodeHost == nil {
+		return ""
+	}
+	return cfg.CodeHost.ResolveCloneURL(repoSlug)
+}
+
 // RunGateJobToolConfig stays trivially constructable in tests; tests
 // only override the fields they care about.
 func applyConfigDefaults(c RunGateJobToolConfig) RunGateJobToolConfig {

--- a/pkg/foreman/agent/tools/seam_bypass_test.go
+++ b/pkg/foreman/agent/tools/seam_bypass_test.go
@@ -1,0 +1,160 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/worktracker"
+)
+
+// These pin the two tool-side bypasses from #1298. Each fails against the
+// pre-fix code: a third-party seam was injectable, satisfied the interface,
+// and was then routed around at the moment it mattered.
+
+// fakeCodeHost records the slug it was asked to resolve and answers with a
+// non-GitHub URL, so a github.com result proves the seam was bypassed.
+type fakeCodeHost struct{ asked []string }
+
+func (f *fakeCodeHost) ResolveCloneURL(repoSlug string) string {
+	f.asked = append(f.asked, repoSlug)
+	return "https://forge.example.org/" + repoSlug + ".git"
+}
+
+func (f *fakeCodeHost) EnsureChangeRequest(
+	context.Context, string, string, string, string, string,
+) (string, bool, error) {
+	return "", false, nil
+}
+
+func (f *fakeCodeHost) HeadCommitSubject(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+var _ codehost.CodeHost = (*fakeCodeHost)(nil)
+
+// TestGateJobCloneURLUsesInjectedCodeHost: the gate Job must clone from the
+// injected provider. Before the fix the config hardcoded
+// CloneURLBase="https://github.com" and nothing assigned it outside tests, so
+// a Forgejo CodeHost still produced a github.com clone inside the Job.
+func TestGateJobCloneURLUsesInjectedCodeHost(t *testing.T) {
+	fake := &fakeCodeHost{}
+	cfg := applyConfigDefaults(RunGateJobToolConfig{CodeHost: fake})
+
+	got := resolveGateCloneURL(cfg, "group/sub/project", "")
+	want := "https://forge.example.org/group/sub/project.git"
+	if got != want {
+		t.Errorf("clone URL = %q, want %q (injected CodeHost was bypassed)", got, want)
+	}
+	if strings.Contains(got, "github.com") {
+		t.Errorf("clone URL still points at github.com: %q", got)
+	}
+	if len(fake.asked) != 1 || fake.asked[0] != "group/sub/project" {
+		t.Errorf("CodeHost.ResolveCloneURL not consulted with the repo slug: %v", fake.asked)
+	}
+}
+
+// An explicit cloneURL argument is how a fork-style push target reaches the
+// Job, so it must still win over the seam.
+func TestGateJobExplicitCloneURLStillWins(t *testing.T) {
+	cfg := applyConfigDefaults(RunGateJobToolConfig{CodeHost: &fakeCodeHost{}})
+	got := resolveGateCloneURL(cfg, "owner/name", "https://explicit.example/x.git")
+	if got != "https://explicit.example/x.git" {
+		t.Errorf("explicit cloneURL was overridden: %q", got)
+	}
+}
+
+// With no seam injected, behaviour is unchanged: empty, so the template falls
+// back to CloneURLBase + repo.
+func TestGateJobWithoutCodeHostKeepsTemplateFallback(t *testing.T) {
+	cfg := applyConfigDefaults(RunGateJobToolConfig{})
+	if got := resolveGateCloneURL(cfg, "owner/name", ""); got != "" {
+		t.Errorf("expected empty so the template uses CloneURLBase, got %q", got)
+	}
+	if cfg.CloneURLBase != "https://github.com" {
+		t.Errorf("GitHub default should be untouched, got %q", cfg.CloneURLBase)
+	}
+}
+
+// fakeWorkItems answers with content no GitHub client would return, so a
+// GitHub-shaped answer proves the tool held its own client.
+type fakeWorkItems struct {
+	gotRepo string
+	gotID   string
+}
+
+func (f *fakeWorkItems) Get(_ context.Context, repoSlug, id string) (*worktracker.WorkItem, error) {
+	f.gotRepo, f.gotID = repoSlug, id
+	return &worktracker.WorkItem{
+		ID: id, Title: "from-injected-seam", Body: "b", State: "open",
+		Labels: []string{"forge"},
+	}, nil
+}
+
+var _ worktracker.WorkItems = (*fakeWorkItems)(nil)
+
+// TestFetchIssueUsesInjectedWorkItems: before the fix the tool was built with
+// its own githubissue.NewClient() in BuildAll, so injecting a WorkItems seam
+// changed nothing and the model still read GitHub.
+func TestFetchIssueUsesInjectedWorkItems(t *testing.T) {
+	fake := &fakeWorkItems{}
+	tool := &FetchIssueTool{
+		WorkItems: fake,
+		// Deliberately no Fetcher and no Token: an injected seam carries
+		// its own auth, so a non-GitHub provider must not need a
+		// GITHUB_TOKEN to be present.
+	}
+
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"repo":"group/sub","number":7}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fake.gotRepo != "group/sub" || fake.gotID != "7" {
+		t.Errorf("seam called with repo=%q id=%q, want group/sub and 7", fake.gotRepo, fake.gotID)
+	}
+	out, ok := res.Output.(map[string]any)
+	if !ok {
+		t.Fatalf("Output is %T, want map[string]any", res.Output)
+	}
+	if got := out["title"]; got != "from-injected-seam" {
+		t.Errorf("title = %v, want the injected seam's value (tool bypassed the seam)", got)
+	}
+	// The output contract is unchanged: number stays the int requested.
+	if got := out["number"]; got != 7 {
+		t.Errorf("number = %v (%T), want int 7", got, got)
+	}
+}
+
+// BuildAll must actually thread the seams; wiring them into ToolDeps and then
+// not passing them would reproduce the bug with extra steps.
+func TestBuildAllThreadsSeamsIntoTools(t *testing.T) {
+	fakeCH := &fakeCodeHost{}
+	fakeWI := &fakeWorkItems{}
+	built := BuildAll(ToolDeps{
+		Workspace: t.TempDir(),
+		Token:     func() (string, error) { return "t", nil },
+		WorkItems: fakeWI,
+		CodeHost:  fakeCH,
+	})
+
+	var sawIssue, sawGate bool
+	for _, tl := range built {
+		switch v := tl.(type) {
+		case *FetchIssueTool:
+			sawIssue = true
+			if v.WorkItems != worktracker.WorkItems(fakeWI) {
+				t.Error("fetch_issue did not receive the injected WorkItems")
+			}
+		case *RunGateJobTool:
+			sawGate = true
+			if v.Cfg.CodeHost != codehost.CodeHost(fakeCH) {
+				t.Error("run_gate_job did not receive the injected CodeHost")
+			}
+		}
+	}
+	if !sawIssue || !sawGate {
+		t.Fatalf("expected both tools in BuildAll (issue=%v gate=%v)", sawIssue, sawGate)
+	}
+}


### PR DESCRIPTION
## What

Routes the three consumers that were going around the `CodeHost` / `WorkItems` seams back through them, so injecting a provider changes behaviour everywhere rather than in the two call sites that happened to use the accessor.

## Why

#1158 extracted the seams and made them injectable, but three consumers bypassed them. A correct third-party `CodeHost` or `WorkItems` compiles, satisfies the interface, is injected, and is then ignored exactly where it matters. As the issue puts it, this would silently break an external contributor's first provider PR.

Fixes #1298

## How

**1. Clone-URL resolution read a package-level global.** `Execute` bound `resolveUpstream` to `upstreamURLForRepo`, which reads `cloneURLResolver`, a package var holding a GitHub adapter. Inject a Forgejo `CodeHost` and clone URLs were still `github.com`. Now prefers `e.CodeHost` when set, keeps the package default otherwise, and the `UpstreamURLForRepo` test hook still wins.

**2. Gate Jobs hardcoded `github.com`.** `cfg.CloneURLBase` defaulted to `"https://github.com"` with no assignment anywhere outside tests. The config now carries the seam and `resolveGateCloneURL` derives a **whole** clone URL from it.

Whole URL rather than a base is deliberate: a nested Forgejo or GitLab path is not `base/owner/name.git`, so composing one from a base would be wrong for precisely the providers this seam exists to serve. The template already prefers a full `.CloneURL`, so this needed no template change. Explicit `cloneURL` still wins; with no seam injected the template keeps its `CloneURLBase` fallback.

**3. `fetch_issue` held its own GitHub client.** `BuildAll` constructed it with `githubissue.NewClient()` — note this moved from `main.go` to `pkg/foreman/agent/tools/buildall.go` in #1486 since the issue was filed, so the bypass is still present, just relocated.

The tool now takes a `WorkItems` and resolves it through an accessor mirroring `NativeAgentLoopExecutor.workItems`: injected seam wins, else a `GitHubWorkItems` built from `Fetcher` and the token **resolved per call**, so a rotated credential is still picked up without restarting the agent. That is why the seam could not simply be a field set once in `BuildAll`. An injected seam carries its own auth and no longer requires `GITHUB_TOKEN` to be present.

`ToolDeps` gained `WorkItems` and `CodeHost` so `BuildAll` can thread them.

### Contracts deliberately unchanged

- `fetch_issue` still reports the integer `number` the caller asked for, not the seam's string ID
- The adapter wraps with `%w`, so the 404/401 messages keyed on `githubissue.HTTPError` still fire
- With nothing injected, every path behaves exactly as before

One existing test moved with the contract: `TestFetchIssueTool_NilDepsFailLoud` asserted `"Fetcher is nil"`, which is now `"WorkItems and Fetcher are both nil"` because either dependency satisfies the tool.

## Tests

Five new tests, one per bypass plus the wiring and the fallbacks. **Each was confirmed to fail against the pre-fix code** by restoring all three bypasses and watching them go red:

```
--- FAIL: TestGateJobCloneURLUsesInjectedCodeHost
    clone URL = "", want "https://forge.example.org/group/sub/project.git" (injected CodeHost was bypassed)
    CodeHost.ResolveCloneURL not consulted with the repo slug: []
--- FAIL: TestFetchIssueUsesInjectedWorkItems
```

`TestBuildAllThreadsSeamsIntoTools` exists because adding the fields to `ToolDeps` and then not passing them would reproduce the bug with extra steps.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — n/a, internal seam wiring

`make test`: 34 packages ok, 0 failures. Lint: 0 issues across `./pkg/foreman/agent/...` and `gofmt` clean on every changed file. (A bare `make lint` in my sandbox also reported issues in unrelated sibling directories left over from other worktrees; none are in files this PR touches.)

Assisted-by: Claude Code. Each of the three bypasses was re-verified against current `main` before any edit, since the issue was filed against `v0.9.12` and one of them had since moved file. The seam interfaces, the existing `GitHubWorkItems` adapter, and the executor's own accessor pattern were read first so the fix matches the codebase rather than inventing a fourth shape. Tests were then confirmed to fail with the bypasses restored.

## Follow-up, not in this PR

`ChangePolicy` is clean per the issue. The remaining `#1297` work (provider registry, `apiBaseURL` config, Gitea-family adapter) is unblocked by this but out of scope here.
