### PR TITLE
fix: name the cause when a model cache PV can never bind

### DIFF
--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -141,6 +141,14 @@ func (r *InferenceServiceReconciler) getPodSchedulingInfo(ctx context.Context, i
 						gpuCount = isvc.Spec.Resources.GPU
 					}
 					info.WaitingFor = fmt.Sprintf("%s: %d", gpuResourceName, gpuCount)
+				} else if pvName, nodeName, ok := detectUnbindableVolume(condition.Message); ok {
+					// Checked before the generic "Insufficient" branch: this
+					// message contains neither that word nor anything else that
+					// hints at storage, so it would otherwise reach the user as
+					// the scheduler's raw text, which blames node affinity and
+					// sends you looking at the scheduler. See #1509.
+					info.Status = "UnbindableModelCache"
+					info.Message = unbindableVolumeMessage(pvName, nodeName, podModelCacheClaim(&pod))
 				} else if strings.Contains(condition.Message, "Insufficient") {
 					info.Status = "InsufficientResources"
 				}

--- a/internal/controller/volume_affinity.go
+++ b/internal/controller/volume_affinity.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Emitted by the scheduler's VolumeBinding PreBind plugin when a pod's bound PV
+// carries a node affinity that the chosen node does not satisfy.
+const (
+	volumeBindingPreBindHint = `running PreBind plugin "VolumeBinding"`
+	volumeAffinityHint       = "node affinity doesn't match node"
+)
+
+// detectUnbindableVolume recognises a pod that cannot start because one of its
+// PersistentVolumes has a node affinity matching no node, and returns the PV
+// name and the node the scheduler had chosen.
+//
+// This is worth special-casing because the scheduler's own wording sends you to
+// the wrong place. It names a node and says affinity does not match, which reads
+// like the pod is mis-scheduled -- but the scheduler picked correctly and the
+// PVC's selected-node annotation agrees with it. The fault is upstream: the
+// provisioner never stamped the volume's affinity, so the PV was published with
+// an unsatisfiable term (in practice `kubernetes.io/hostname In [""]`).
+//
+// The trigger seen in the field is a provisioner whose helper pod cannot
+// schedule onto the target node -- microk8s-hostpath spawns a helper carrying
+// only the two default NoExecute tolerations, so any NoSchedule taint (a GPU
+// taint, for instance) blocks provisioning while still creating a PV. See
+// defilantech/LLMKube#1509.
+func detectUnbindableVolume(message string) (pvName string, nodeName string, ok bool) {
+	if !strings.Contains(message, volumeAffinityHint) {
+		return "", "", false
+	}
+	// Require the PreBind context too, so an unrelated message that happens to
+	// quote this phrase does not get reclassified.
+	if !strings.Contains(message, volumeBindingPreBindHint) && !strings.Contains(message, "binding volumes") {
+		return "", "", false
+	}
+
+	pvName = quotedAfter(message, `pv `)
+	nodeName = quotedAfter(message[strings.Index(message, volumeAffinityHint):], volumeAffinityHint+` `)
+
+	return pvName, nodeName, true
+}
+
+// quotedAfter returns the double-quoted token immediately following prefix, or
+// "" when prefix is absent or is not followed by a quoted token. Kept local
+// rather than reaching for a regexp: the scheduler's format is fixed, and the
+// failure mode we care about is "no match", not partial parsing.
+func quotedAfter(s, prefix string) string {
+	i := strings.Index(s, prefix)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(prefix):]
+	if !strings.HasPrefix(rest, `"`) {
+		return ""
+	}
+	rest = rest[1:]
+	j := strings.Index(rest, `"`)
+	if j < 0 {
+		return ""
+	}
+	return rest[:j]
+}
+
+// podModelCacheClaim returns the PVC name backing the pod's model cache, or ""
+// when the pod has no claim-backed volume. The scheduler's message names the PV
+// (a generated pvc-<uuid> string), which is not something anyone recognises;
+// the claim name is.
+func podModelCacheClaim(pod *corev1.Pod) string {
+	for _, v := range pod.Spec.Volumes {
+		if v.PersistentVolumeClaim != nil {
+			return v.PersistentVolumeClaim.ClaimName
+		}
+	}
+	return ""
+}
+
+// unbindableVolumeMessage explains the failure in terms of the thing the user
+// can act on. The scheduler blames node affinity; this names the claim, the
+// volume and the node, and says provisioning is what actually failed.
+func unbindableVolumeMessage(pvName, nodeName, claimName string) string {
+	var b strings.Builder
+	b.WriteString("model cache volume was never provisioned: ")
+	if pvName != "" {
+		b.WriteString(fmt.Sprintf("PersistentVolume %q ", pvName))
+	} else {
+		b.WriteString("the bound PersistentVolume ")
+	}
+	b.WriteString("has a node affinity that matches no node")
+	if nodeName != "" {
+		b.WriteString(fmt.Sprintf(", so the pod cannot start on %q", nodeName))
+	}
+	b.WriteString(".")
+
+	if claimName != "" {
+		b.WriteString(fmt.Sprintf(" Claim: %s.", claimName))
+	}
+
+	b.WriteString(" The scheduler chose the node correctly; the storage provisioner" +
+		" failed to stamp the volume, which usually means its helper pod could not" +
+		" schedule onto that node (for example, a taint the provisioner does not" +
+		" tolerate). Delete the claim and use a storage class whose provisioner can" +
+		" run there.")
+
+	return b.String()
+}

--- a/internal/controller/volume_affinity_test.go
+++ b/internal/controller/volume_affinity_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+func TestDetectUnbindableVolume(t *testing.T) {
+	// Verbatim from a pod blocked by defilantech/LLMKube#1509: the microk8s
+	// hostpath provisioner's helper could not schedule onto a GPU-tainted node,
+	// so it never stamped the PV, and the PV was published with a node affinity
+	// matching no node.
+	const realMessage = `running PreBind plugin "VolumeBinding": binding volumes: ` +
+		`pv "pvc-7d8e47dd-1b2c-4a3e-9f10-2c3d4e5f6a7b" node affinity doesn't match node "ahazidgx2": no matching NodeSelectorTerms`
+
+	t.Run("detects the PreBind volume affinity failure", func(t *testing.T) {
+		pv, node, ok := detectUnbindableVolume(realMessage)
+		if !ok {
+			t.Fatalf("detectUnbindableVolume() ok = false, want true")
+		}
+		if pv != "pvc-7d8e47dd-1b2c-4a3e-9f10-2c3d4e5f6a7b" {
+			t.Fatalf("detectUnbindableVolume() pv = %q, want the pvc- name", pv)
+		}
+		if node != "ahazidgx2" {
+			t.Fatalf("detectUnbindableVolume() node = %q, want %q", node, "ahazidgx2")
+		}
+	})
+
+	t.Run("ignores an ordinary insufficient-resource message", func(t *testing.T) {
+		if _, _, ok := detectUnbindableVolume("0/4 nodes are available: 1 Insufficient nvidia.com/gpu."); ok {
+			t.Fatalf("detectUnbindableVolume() ok = true, want false for a GPU shortage")
+		}
+	})
+
+	t.Run("ignores an ordinary taint message", func(t *testing.T) {
+		msg := "0/4 nodes are available: 2 node(s) had untolerated taint(s)."
+		if _, _, ok := detectUnbindableVolume(msg); ok {
+			t.Fatalf("detectUnbindableVolume() ok = true, want false for a taint mismatch")
+		}
+	})
+
+	t.Run("does not fire on a volume message that is not the affinity failure", func(t *testing.T) {
+		msg := `running PreBind plugin "VolumeBinding": binding volumes: timed out waiting for the condition`
+		if _, _, ok := detectUnbindableVolume(msg); ok {
+			t.Fatalf("detectUnbindableVolume() ok = true, want false for an unrelated VolumeBinding error")
+		}
+	})
+
+	t.Run("tolerates a missing node name", func(t *testing.T) {
+		msg := `binding volumes: pv "pvc-abc" node affinity doesn't match node: no matching NodeSelectorTerms`
+		pv, node, ok := detectUnbindableVolume(msg)
+		if !ok {
+			t.Fatalf("detectUnbindableVolume() ok = false, want true")
+		}
+		if pv != "pvc-abc" {
+			t.Fatalf("detectUnbindableVolume() pv = %q, want %q", pv, "pvc-abc")
+		}
+		if node != "" {
+			t.Fatalf("detectUnbindableVolume() node = %q, want empty", node)
+		}
+	})
+}
+
+func TestUnbindableVolumeMessage(t *testing.T) {
+	msg := unbindableVolumeMessage("pvc-123", "ahazidgx2", "spark-cache")
+
+	// The whole point of the change is that the operator says something the
+	// scheduler's own text does not: that this is a provisioning failure, and
+	// which claim it belongs to. Assert on that, not on exact prose.
+	for _, want := range []string{"pvc-123", "ahazidgx2", "spark-cache"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("unbindableVolumeMessage() = %q, want it to mention %q", msg, want)
+		}
+	}
+	if !strings.Contains(strings.ToLower(msg), "provision") {
+		t.Fatalf("unbindableVolumeMessage() = %q, want it to name provisioning as the cause", msg)
+	}
+}
+
+// The classifier is only useful if it survives the path a real reconcile takes:
+// a Pending pod with PodScheduled=False must come back as UnbindableModelCache
+// rather than the scheduler's raw text.
+func TestGetPodSchedulingInfoReportsUnbindableModelCache(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1.AddToScheme: %v", err)
+	}
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("inferencev1alpha1.AddToScheme: %v", err)
+	}
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "spark-svc", Namespace: "default"},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spark-svc-abc",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":                           "spark-svc",
+				"inference.llmkube.dev/service": "spark-svc",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name: "model-cache",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "spark-svc-model-cache",
+					},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionFalse,
+				Reason: "SchedulerError",
+				Message: `running PreBind plugin "VolumeBinding": binding volumes: ` +
+					`pv "pvc-7d8e47dd" node affinity doesn't match node "ahazidgx2": no matching NodeSelectorTerms`,
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(isvc, pod).Build()
+	r := &InferenceServiceReconciler{Client: c, Scheme: scheme}
+
+	info, err := r.getPodSchedulingInfo(context.Background(), isvc)
+	if err != nil {
+		t.Fatalf("getPodSchedulingInfo() error = %v", err)
+	}
+	if info == nil {
+		t.Fatalf("getPodSchedulingInfo() = nil, want scheduling info")
+	}
+	if info.Status != "UnbindableModelCache" {
+		t.Fatalf("Status = %q, want %q", info.Status, "UnbindableModelCache")
+	}
+	if !strings.Contains(info.Message, "spark-svc-model-cache") {
+		t.Fatalf("Message = %q, want it to name the claim", info.Message)
+	}
+	// The raw scheduler wording is what misled us for two days; it must not be
+	// what the user is left holding.
+	if strings.Contains(info.Message, "no matching NodeSelectorTerms") {
+		t.Fatalf("Message = %q, should not pass through the raw scheduler text", info.Message)
+	}
+}


### PR DESCRIPTION
## What

Classify the scheduler's "node affinity doesn't match node" PreBind failure and
replace it, in `InferenceService` status, with a message that names the claim,
the volume, the node, and provisioning as the cause.

## Why

Fixes #1509

A model cache PV whose node affinity matches no node produces this:

```
running PreBind plugin "VolumeBinding": binding volumes: pv "pvc-7d8e47dd-..."
node affinity doesn't match node "ahazidgx2": no matching NodeSelectorTerms
```

That wording sends you to the scheduler, which is the wrong place. The
scheduler chose correctly, and the PVC's `volume.kubernetes.io/selected-node`
annotation agrees with it. What failed was provisioning: the provisioner never
stamped the volume, so the PV was published with `kubernetes.io/hostname In [""]`,
which no node satisfies. The operator passed the scheduler's text through
unchanged, so the status blamed affinity and the reader went looking at nodes
and taints.

The trigger observed in the field is a provisioner whose helper pod cannot
schedule onto the target node. `microk8s-hostpath` spawns a helper carrying only
the two default `NoExecute` tolerations, and `cdkbot/hostpath-provisioner`
exposes no configuration surface to add more, so any `NoSchedule` taint (a GPU
taint, say) blocks provisioning while still creating a PV. It cost two separate
pieces of work on this fleet before the cause was identified, and it presents as
an unrelated scheduling failure every time.

This is the "fail loudly" half of the issue. The environment half (using a
provisioner whose helper tolerates the taint) is a cluster configuration change
and is not in this PR.

## How

`detectUnbindableVolume` recognises the message and extracts the PV and node
names, following the existing `detectInsufficientGPUResource` pattern in this
package: a string classifier over the scheduler's fixed wording, needing no
additional RBAC.

Two details worth review:

- It is checked **before** the generic `Insufficient` branch. This message
  contains neither that word nor any other storage hint, so it would otherwise
  fall through to the raw text.
- It requires both the affinity phrase *and* the `VolumeBinding`/`binding volumes`
  context, so an unrelated message quoting the phrase is not reclassified.

`podModelCacheClaim` adds the claim name to the message, since the scheduler
names only the generated `pvc-<uuid>` PV, which nobody recognises.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)

Verification: full `./internal/controller/` package passes (243s), and
`GOOS=linux golangci-lint run ./internal/controller/...` reports 0 issues. Tests
cover the classifier (including three negative cases that must not reclassify)
and the path through `getPodSchedulingInfo`, asserting the raw scheduler text
does not survive into status.

Assisted-by: Claude Opus 5 (1M context)
