### PR TITLE
fix: surface the unbindable-cache diagnosis instead of dropping it

### DIFF
--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -85,8 +85,19 @@ func (r *InferenceServiceReconciler) determinePhase(ctx context.Context, isvc *i
 		if err != nil {
 			log.Error(err, "Failed to get pod scheduling info")
 		}
-		if schedulingInfo != nil && schedulingInfo.Status == "InsufficientGPU" {
-			return PhaseWaitingForGPU, schedulingInfo
+		if schedulingInfo != nil {
+			switch schedulingInfo.Status {
+			case "InsufficientGPU":
+				return PhaseWaitingForGPU, schedulingInfo
+			case "UnbindableModelCache":
+				// Phase stays Creating: the deployment is healthy and nothing
+				// about the InferenceService is wrong, so calling it Failed
+				// would misattribute a storage fault and change how rollout
+				// treats it. The diagnosis rides the message instead, which is
+				// the part that was missing -- this branch previously fell
+				// through and dropped it.
+				return PhaseCreating, schedulingInfo
+			}
 		}
 	}
 	if isMetal {

--- a/internal/controller/volume_affinity_test.go
+++ b/internal/controller/volume_affinity_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -168,5 +169,70 @@ func TestGetPodSchedulingInfoReportsUnbindableModelCache(t *testing.T) {
 	// what the user is left holding.
 	if strings.Contains(info.Message, "no matching NodeSelectorTerms") {
 		t.Fatalf("Message = %q, should not pass through the raw scheduler text", info.Message)
+	}
+}
+
+// Regression for the gap that shipped in #1511: getPodSchedulingInfo classified
+// the failure correctly, but determinePhase forwarded scheduling info only for
+// InsufficientGPU, so the diagnosis was computed and then dropped. Asserting at
+// the determinePhase level is what catches that; the earlier test could not.
+func TestDeterminePhaseSurfacesUnbindableModelCache(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1.AddToScheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("appsv1.AddToScheme: %v", err)
+	}
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("inferencev1alpha1.AddToScheme: %v", err)
+	}
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "spark-svc", Namespace: "default"},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spark-svc-abc",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":                           "spark-svc",
+				"inference.llmkube.dev/service": "spark-svc",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name: "model-cache",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "spark-svc-model-cache",
+					},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionFalse,
+				Reason: "SchedulerError",
+				Message: `running PreBind plugin "VolumeBinding": binding volumes: ` +
+					`pv "pvc-7d8e47dd" node affinity doesn't match node "ahazidgx2": no matching NodeSelectorTerms`,
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(isvc, pod).Build()
+	r := &InferenceServiceReconciler{Client: c, Scheme: scheme}
+
+	_, info := r.determinePhase(context.Background(), isvc, 0, 1, false, &appsv1.Deployment{}, nil)
+	if info == nil {
+		t.Fatalf("determinePhase() scheduling info = nil; the diagnosis was computed and dropped")
+	}
+	if info.Status != "UnbindableModelCache" {
+		t.Fatalf("Status = %q, want %q", info.Status, "UnbindableModelCache")
+	}
+	if !strings.Contains(info.Message, "spark-svc-model-cache") {
+		t.Fatalf("Message = %q, want it to name the claim", info.Message)
 	}
 }


### PR DESCRIPTION
## What

Forward the `UnbindableModelCache` scheduling info out of `determinePhase` so it
reaches `InferenceService` status. Without this, #1511's diagnosis is computed
and then discarded.

## Why

Refs #1509

#1511 shipped incomplete, and I missed it in review of my own change.
`getPodSchedulingInfo` classified the failure correctly, but `determinePhase`
forwards scheduling info only for `InsufficientGPU`:

```go
if schedulingInfo != nil && schedulingInfo.Status == "InsufficientGPU" {
    return PhaseWaitingForGPU, schedulingInfo
}
...
return PhaseCreating, nil   // <- UnbindableModelCache landed here
```

`updateStatusWithSchedulingInfo` only acts `if schedulingInfo != nil`, so the
message naming the claim, the volume and the provisioning fault never reached
status. Observable behaviour was unchanged from before #1511.

The test in #1511 called `getPodSchedulingInfo` directly. That is why it passed
against code that did not work end to end, and it is the reason this PR asserts
one level up.

## How

Replace the equality check with a switch that also forwards
`UnbindableModelCache`.

Phase deliberately stays `Creating` rather than becoming `Failed`: the Deployment
is healthy and nothing about the InferenceService spec is wrong, so reporting
`Failed` would misattribute a storage fault and change how rollout logic treats
the object. The diagnosis rides the message, which is the part that was missing.

Worth a reviewer's opinion: if you would rather this be a terminal phase, that is
a defensible reading of "fail loudly" in #1509, but it is a semantic change to
rollout handling and I did not want to make it silently.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)

Verification: the new test fails on `main` with "the diagnosis was computed and
dropped" and passes with the change. Full `./internal/controller/` package passes
(259s); `GOOS=linux golangci-lint run ./internal/controller/...` reports 0 issues.

Assisted-by: Claude Opus 5 (1M context)
