### PR TITLE
fix: detect the scheduler's other wording for an unusable cache volume

### DIFF
--- a/charts/llmkube/templates/clusterrole.yaml
+++ b/charts/llmkube/templates/clusterrole.yaml
@@ -74,6 +74,17 @@ rules:
   - patch
   - update
   - watch
+# Read-only, and only to tell a volume the provisioner never stamped from one
+# that is legitimately pinned elsewhere: both produce the same scheduler
+# wording, and the operator should not assert a cause it has not established.
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,6 +23,7 @@ rules:
   resources:
   - namespaces
   - nodes
+  - persistentvolumes
   - pods
   - secrets
   verbs:

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -157,6 +157,7 @@ func initContainerSecurityContext(isvc *inferencev1alpha1.InferenceService) *cor
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods/eviction,verbs=create
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch

--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -152,7 +152,7 @@ func (r *InferenceServiceReconciler) getPodSchedulingInfo(ctx context.Context, i
 						gpuCount = isvc.Spec.Resources.GPU
 					}
 					info.WaitingFor = fmt.Sprintf("%s: %d", gpuResourceName, gpuCount)
-				} else if pvName, nodeName, ok := detectUnbindableVolume(condition.Message); ok {
+				} else if pvName, nodeName, ok := r.classifyUnbindableVolume(ctx, &pod, condition.Message); ok {
 					// Checked before the generic "Insufficient" branch: this
 					// message contains neither that word nor anything else that
 					// hints at storage, so it would otherwise reach the user as

--- a/internal/controller/volume_affinity.go
+++ b/internal/controller/volume_affinity.go
@@ -17,17 +17,30 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Emitted by the scheduler's VolumeBinding PreBind plugin when a pod's bound PV
 // carries a node affinity that the chosen node does not satisfy.
+// The scheduler reports the same underlying fault with two different wordings,
+// depending on where the pod was in its lifecycle when the unusable PV appeared.
+//
+//   - PreBind: the pod had already been assigned a node, so binding is what
+//     fails. Names the PV and the node.
+//   - Filter: the pod had not been scheduled yet, so the volume's affinity is
+//     just another predicate that no node satisfies. Names neither.
+//
+// The Filter form is what a freshly created InferenceService produces, and it
+// was missed by the first cut of this code, which only knew the PreBind form.
 const (
 	volumeBindingPreBindHint = `running PreBind plugin "VolumeBinding"`
 	volumeAffinityHint       = "node affinity doesn't match node"
+	volumeAffinityFilterHint = "didn't match PersistentVolume's node affinity"
 )
 
 // detectUnbindableVolume recognises a pod that cannot start because one of its
@@ -47,19 +60,63 @@ const (
 // taint, for instance) blocks provisioning while still creating a PV. See
 // defilantech/LLMKube#1509.
 func detectUnbindableVolume(message string) (pvName string, nodeName string, ok bool) {
-	if !strings.Contains(message, volumeAffinityHint) {
-		return "", "", false
-	}
-	// Require the PreBind context too, so an unrelated message that happens to
-	// quote this phrase does not get reclassified.
-	if !strings.Contains(message, volumeBindingPreBindHint) && !strings.Contains(message, "binding volumes") {
-		return "", "", false
+	if strings.Contains(message, volumeAffinityHint) {
+		// Require the PreBind context too, so an unrelated message that happens
+		// to quote this phrase does not get reclassified.
+		if !strings.Contains(message, volumeBindingPreBindHint) && !strings.Contains(message, "binding volumes") {
+			return "", "", false
+		}
+		pvName = quotedAfter(message, `pv `)
+		nodeName = quotedAfter(message[strings.Index(message, volumeAffinityHint):], volumeAffinityHint+` `)
+		return pvName, nodeName, true
 	}
 
-	pvName = quotedAfter(message, `pv `)
-	nodeName = quotedAfter(message[strings.Index(message, volumeAffinityHint):], volumeAffinityHint+` `)
+	// Filter form carries no names; the caller resolves the PV from the pod.
+	if strings.Contains(message, volumeAffinityFilterHint) {
+		return "", "", true
+	}
 
-	return pvName, nodeName, true
+	return "", "", false
+}
+
+// unsatisfiableNodeAffinity reports whether pv carries a node affinity that no
+// node can satisfy, which is the fingerprint of a volume the provisioner
+// created but never stamped: `kubernetes.io/hostname In [""]`.
+//
+// This is what separates the provisioning bug from an ordinary mistake. A PV
+// legitimately pinned to one node while the pod is pinned to another produces
+// the same scheduler wording, but its values are real hostnames, and telling
+// that user their provisioner failed would send them somewhere useless.
+func unsatisfiableNodeAffinity(pv *corev1.PersistentVolume) bool {
+	na := pv.Spec.NodeAffinity
+	if na == nil || na.Required == nil || len(na.Required.NodeSelectorTerms) == 0 {
+		return false
+	}
+
+	for _, term := range na.Required.NodeSelectorTerms {
+		for _, expr := range term.MatchExpressions {
+			if expr.Operator != corev1.NodeSelectorOpIn {
+				continue
+			}
+			// An In with no values, or whose only values are empty strings,
+			// can never match: node label values are non-empty.
+			if len(expr.Values) == 0 {
+				return true
+			}
+			allEmpty := true
+			for _, v := range expr.Values {
+				if strings.TrimSpace(v) != "" {
+					allEmpty = false
+					break
+				}
+			}
+			if allEmpty {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // quotedAfter returns the double-quoted token immediately following prefix, or
@@ -124,4 +181,66 @@ func unbindableVolumeMessage(pvName, nodeName, claimName string) string {
 		" run there.")
 
 	return b.String()
+}
+
+// confirmUnbindableModelCache resolves the pod's claim to its PersistentVolume
+// and reports the PV name when that volume can never be scheduled anywhere.
+//
+// Returning ok=false is the safe outcome: the caller then leaves the scheduler's
+// own message alone rather than asserting a cause it has not established. That
+// covers the PVC that has no volume yet (provisioning still in flight) and the
+// genuinely mis-pinned PV, neither of which is this bug.
+func (r *InferenceServiceReconciler) confirmUnbindableModelCache(ctx context.Context, pod *corev1.Pod) (pvName string, ok bool) {
+	claimName := podModelCacheClaim(pod)
+	if claimName == "" {
+		return "", false
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: claimName}, pvc); err != nil {
+		return "", false
+	}
+	if pvc.Spec.VolumeName == "" {
+		return "", false
+	}
+
+	pv := &corev1.PersistentVolume{}
+	if err := r.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, pv); err != nil {
+		return "", false
+	}
+	if !unsatisfiableNodeAffinity(pv) {
+		return "", false
+	}
+
+	return pv.Name, true
+}
+
+// classifyUnbindableVolume decides whether a pending pod's scheduling failure is
+// the never-provisioned-cache case, combining the scheduler's wording with the
+// state of the volume itself.
+//
+// The message alone is not enough. The Filter wording carries no PV name and is
+// equally produced by a PV that is legitimately pinned to another node, so the
+// PV is read to confirm the fingerprint before the operator asserts a cause. The
+// PreBind wording does name the volume, but is confirmed the same way so both
+// paths make the same claim on the same evidence.
+func (r *InferenceServiceReconciler) classifyUnbindableVolume(ctx context.Context, pod *corev1.Pod, message string) (pvName string, nodeName string, ok bool) {
+	msgPV, msgNode, matched := detectUnbindableVolume(message)
+	if !matched {
+		return "", "", false
+	}
+
+	confirmedPV, confirmed := r.confirmUnbindableModelCache(ctx, pod)
+	if !confirmed {
+		return "", "", false
+	}
+
+	if msgPV != "" {
+		confirmedPV = msgPV
+	}
+	if msgNode == "" {
+		msgNode = pod.Spec.NodeName
+	}
+
+	return confirmedPV, msgNode, true
 }

--- a/internal/controller/volume_affinity_test.go
+++ b/internal/controller/volume_affinity_test.go
@@ -149,7 +149,8 @@ func TestGetPodSchedulingInfoReportsUnbindableModelCache(t *testing.T) {
 		},
 	}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(isvc, pod).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(isvc, pod, unstampedClaim(), unstampedPV()).Build()
 	r := &InferenceServiceReconciler{Client: c, Scheme: scheme}
 
 	info, err := r.getPodSchedulingInfo(context.Background(), isvc)
@@ -222,7 +223,8 @@ func TestDeterminePhaseSurfacesUnbindableModelCache(t *testing.T) {
 		},
 	}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(isvc, pod).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(isvc, pod, unstampedClaim(), unstampedPV()).Build()
 	r := &InferenceServiceReconciler{Client: c, Scheme: scheme}
 
 	_, info := r.determinePhase(context.Background(), isvc, 0, 1, false, &appsv1.Deployment{}, nil)
@@ -234,5 +236,116 @@ func TestDeterminePhaseSurfacesUnbindableModelCache(t *testing.T) {
 	}
 	if !strings.Contains(info.Message, "spark-svc-model-cache") {
 		t.Fatalf("Message = %q, want it to name the claim", info.Message)
+	}
+}
+
+// unstampedClaim/unstampedPV mirror the objects observed on the cluster while
+// reproducing #1509: the claim is bound to a volume the provisioner created but
+// never stamped, so its hostname term holds a single empty string.
+func unstampedClaim() *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "spark-svc-model-cache", Namespace: "default"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "pvc-7d8e47dd"},
+	}
+}
+
+func unstampedPV() *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-7d8e47dd"},
+		Spec: corev1.PersistentVolumeSpec{
+			NodeAffinity: &corev1.VolumeNodeAffinity{
+				Required: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+						MatchExpressions: []corev1.NodeSelectorRequirement{{
+							Key:      "kubernetes.io/hostname",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{""},
+						}},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func TestUnsatisfiableNodeAffinity(t *testing.T) {
+	t.Run("empty hostname value is unsatisfiable", func(t *testing.T) {
+		if !unsatisfiableNodeAffinity(unstampedPV()) {
+			t.Fatalf("unsatisfiableNodeAffinity() = false, want true for values [\"\"]")
+		}
+	})
+
+	t.Run("a real hostname is satisfiable", func(t *testing.T) {
+		pv := unstampedPV()
+		pv.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions[0].Values = []string{"ahazidgx1"}
+		if unsatisfiableNodeAffinity(pv) {
+			t.Fatalf("unsatisfiableNodeAffinity() = true, want false for a real hostname")
+		}
+	})
+
+	t.Run("no affinity at all is satisfiable", func(t *testing.T) {
+		if unsatisfiableNodeAffinity(&corev1.PersistentVolume{}) {
+			t.Fatalf("unsatisfiableNodeAffinity() = true, want false when there is no affinity")
+		}
+	})
+}
+
+// The wording a freshly created InferenceService actually produces, captured
+// verbatim from the cluster while reproducing #1509. The first cut of this code
+// only knew the PreBind form and stayed silent on this one.
+func TestFilterFormIsClassified(t *testing.T) {
+	const filterMessage = "0/4 nodes are available: 1 node(s) didn't match PersistentVolume's node affinity, " +
+		"3 node(s) didn't match Pod's node affinity/selector. no new claims to deallocate, " +
+		"preemption: 0/4 nodes are available: 4 Preemption is not helpful for scheduling."
+
+	if _, _, ok := detectUnbindableVolume(filterMessage); !ok {
+		t.Fatalf("detectUnbindableVolume() ok = false, want true for the Filter wording")
+	}
+}
+
+// A PV pinned to a real node produces the same scheduler wording but is a
+// different problem; asserting a provisioning failure there would mislead.
+func TestGenuinelyPinnedVolumeIsNotReclassified(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, appsv1.AddToScheme, inferencev1alpha1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("AddToScheme: %v", err)
+		}
+	}
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "spark-svc", Namespace: "default"},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-svc-abc", Namespace: "default",
+			Labels: map[string]string{"app": "spark-svc", "inference.llmkube.dev/service": "spark-svc"},
+		},
+		Spec: corev1.PodSpec{Volumes: []corev1.Volume{{
+			Name: "model-cache",
+			VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: "spark-svc-model-cache",
+			}},
+		}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type: corev1.PodScheduled, Status: corev1.ConditionFalse, Reason: "Unschedulable",
+				Message: "0/4 nodes are available: 1 node(s) didn't match PersistentVolume's node affinity.",
+			}},
+		},
+	}
+	pinned := unstampedPV()
+	pinned.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions[0].Values = []string{"ahazidgx2"}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(isvc, pod, unstampedClaim(), pinned).Build()
+	r := &InferenceServiceReconciler{Client: c, Scheme: scheme}
+
+	info, err := r.getPodSchedulingInfo(context.Background(), isvc)
+	if err != nil {
+		t.Fatalf("getPodSchedulingInfo() error = %v", err)
+	}
+	if info != nil && info.Status == "UnbindableModelCache" {
+		t.Fatalf("a PV pinned to a real node was reported as a provisioning failure: %q", info.Message)
 	}
 }


### PR DESCRIPTION
## What

Recognise the second wording the scheduler uses for an unusable cache volume, and
confirm the diagnosis by reading the PersistentVolume rather than trusting the
message.

## Why

Refs #1509

I reproduced #1509 against the deployed operator (#1511 + #1512) and **it never
fired**. The scheduler describes this fault two ways, depending on where the pod
was when the unusable PV appeared:

**PreBind** — pod already had a node, so binding fails. Names the PV and node:

```
running PreBind plugin "VolumeBinding": binding volumes: pv "pvc-..."
node affinity doesn't match node "ahazidgx1": no matching NodeSelectorTerms
```

**Filter** — pod not yet scheduled, so the volume is just a predicate nothing
satisfies. Names neither:

```
0/4 nodes are available: 1 node(s) didn't match PersistentVolume's node affinity,
3 node(s) didn't match Pod's node affinity/selector.
```

Only the PreBind form was recognised. The Filter form is what a freshly created
InferenceService produces, so the common case stayed silent. The original issue
happened to capture the PreBind text, which is why the earlier wording looked
complete — and why two rounds of unit tests agreed with it.

## How

The Filter message names no volume, and a PV legitimately pinned to another node
produces the same text. Matching on the string alone would let the operator
assert a provisioning failure it has not established, and send that user
somewhere useless.

So the classifier now confirms from the cluster: resolve the pod's claim to its
PV and check for the fingerprint of a volume the provisioner created but never
stamped — an `In` term whose values are empty, which no node label can satisfy.
Both wordings rest on the same evidence, and an unconfirmed match leaves the
scheduler's own message untouched.

That needs read-only `persistentvolumes` RBAC, added to the markers and to
`charts/llmkube/templates/clusterrole.yaml`. `make check-helm-rbac` caught the
drift and now reports 263 rules covered.

Test data is taken from the live reproduction: the broken PV really does carry
`values: [""]`, and a healthy local-path PV alongside it carries `['ahazidgx1']`.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)

New coverage: the Filter wording; the unsatisfiable-affinity predicate (empty,
real hostname, absent); and a negative case asserting a genuinely pinned PV is
**not** reported as a provisioning failure. Full `./internal/controller/` passes
(252s), `GOOS=linux golangci-lint` reports 0 issues, `make check-helm-rbac` passes.

Note this still wants live confirmation after deploy — that is how the previous
two gaps were found, and I would not call #1509 closed until the message is
observed on a real stuck service.

Assisted-by: Claude Opus 5 (1M context)
