### PR TITLE
docs: how to recognise a cache volume the provisioner never stamped

### DIFF
--- a/docs/MODEL-CACHE.md
+++ b/docs/MODEL-CACHE.md
@@ -207,6 +207,102 @@ Strict-taint choices:
 - Use a provisioner whose helper configuration supports the taint.
 - Apply a narrowly scoped cluster-level policy maintained by the cluster administrator.
 
+#### Recognising a volume the provisioner never stamped
+
+The failure above is worth calling out separately because it does not look like a
+storage failure. Some provisioners publish a PersistentVolume even when their
+helper never ran, carrying a node affinity that no node satisfies:
+
+```console
+$ kubectl get pv <pv> -o jsonpath='{.spec.nodeAffinity}'
+{"required":{"nodeSelectorTerms":[{"matchExpressions":[
+  {"key":"kubernetes.io/hostname","operator":"In","values":[""]}]}]}}
+```
+
+An empty value in that `In` term is the fingerprint: node label values are never
+empty, so the volume can never be scheduled anywhere. The PVC still reports
+`Bound`, which is why this reads as success.
+
+The consuming pod then sits `Pending` forever, and the scheduler describes it in
+one of two ways depending on whether the pod had already been assigned a node:
+
+```text
+0/4 nodes are available: 1 node(s) didn't match PersistentVolume's node affinity
+```
+
+```text
+running PreBind plugin "VolumeBinding": binding volumes: pv "pvc-..."
+node affinity doesn't match node "gpu-node-1": no matching NodeSelectorTerms
+```
+
+Both name node affinity, which sends you to the scheduler. The scheduler is not
+at fault: it chose correctly, and the PVC's `volume.kubernetes.io/selected-node`
+annotation agrees with it. Provisioning is what failed.
+
+LLMKube reports this directly rather than passing the scheduler's wording
+through:
+
+```console
+$ kubectl get inferenceservice <name> -o jsonpath='{.status.schedulingStatus}'
+UnbindableModelCache
+
+$ kubectl get inferenceservice <name> -o jsonpath='{.status.schedulingMessage}'
+model cache volume was never provisioned: PersistentVolume "pvc-..." has a node
+affinity that matches no node. Claim: <name>-model-cache. ...
+```
+
+To recover, delete the claim so its volume is released, then provision on a
+storage class whose helper can run on the tainted node. Which objects you have to
+remove depends on the cache mode:
+
+| Cache mode | Deleting the InferenceService clears it |
+| --- | --- |
+| `perService` (default) | Yes, the claim is owner-ref'd and garbage-collected with it |
+| `shared` | No, the shared claim intentionally outlives any one service |
+| `claimName` (bring your own) | No, LLMKube never deletes a user-owned claim |
+
+In the latter two cases the unusable volume survives the InferenceService, so
+delete the claim explicitly before retrying. Recreating the service against a
+claim that is still bound to a broken volume reproduces the same `Pending` state.
+
+#### Choosing a provisioner that tolerates taints
+
+Whether this is fixable by configuration depends on the provisioner:
+
+| Provisioner | Helper tolerations configurable |
+| --- | --- |
+| `rancher.io/local-path` | Yes, via `helperPod.yaml` in its ConfigMap |
+| `microk8s.io/hostpath` | No, the helper template is built into the image |
+
+For `local-path`, add tolerations to the helper template so it can run wherever a
+volume is legitimately requested. This mirrors what a CSI node plugin does:
+
+```yaml
+# local-path-config ConfigMap, helperPod.yaml key
+apiVersion: v1
+kind: Pod
+metadata:
+  name: helper-pod
+spec:
+  priorityClassName: system-node-critical
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: helper-pod
+      image: busybox
+```
+
+Then point model caches at it:
+
+```yaml
+modelCache:
+  storageClass: local-path
+```
+
+`microk8s.io/hostpath` exposes no equivalent knob, so on a tainted node the
+remaining options are the pre-provisioned `claimName` route above or a different
+storage class.
+
 ### Per-InferenceService Cache PVC (Bring Your Own)
 
 The cache backend above is an operator-global choice. To point a *single*

--- a/docs/dgx-spark-microk8s.md
+++ b/docs/dgx-spark-microk8s.md
@@ -35,6 +35,22 @@ microk8s status --wait-ready
 microk8s enable dns hostpath-storage helm3
 ```
 
+> **If you taint this node for GPU workloads, do not leave `hostpath-storage` as
+> the class backing model caches.** Its provisioner runs a per-node helper pod
+> that carries only the default not-ready/unreachable tolerations, and the
+> helper template is built into the image, so no configuration can add the GPU
+> toleration. On a `NoSchedule`-tainted node the helper never runs, but a
+> PersistentVolume is still published with an affinity matching no node, and
+> every pod that binds it stays `Pending` while the PVC reports `Bound`.
+>
+> Install a provisioner whose helper you can configure (for example
+> `rancher.io/local-path`, whose `helperPod.yaml` ConfigMap key accepts
+> tolerations) and set `modelCache.storageClass` to it. See
+> [Persistent Model Cache](MODEL-CACHE.md#choosing-a-provisioner-that-tolerates-taints).
+>
+> This applies only if you taint the node. An untainted single-node Spark is
+> unaffected.
+
 ## 2b. GPU support: install the NVIDIA GPU Operator via Helm (NOT the addon)
 
 > **Do not use `microk8s enable gpu` on the DGX Spark.** The MicroK8s `gpu` /


### PR DESCRIPTION
## What

Document how to recognise a model cache volume the provisioner created but never
stamped, and which provisioners can be configured out of the problem.

## Why

Refs #1509

`MODEL-CACHE.md` already warned that a provisioner's helper pod may not schedule
onto a tainted node. What it did not say is that the failure is **silent**: the
PVC still reports `Bound`, a PersistentVolume is published with an affinity
matching no node, and the scheduler's message blames node affinity. The reader
goes looking at nodes and taints, which is the wrong place. On this fleet it cost
two separate pieces of work before the cause was identified.

## How

Two additions to the existing "Strictly tainted GPU nodes" section:

**Recognising it.** The fingerprint (`In` with an empty value, which no node label
can satisfy), both scheduler wordings, and the `UnbindableModelCache` status the
operator now reports after #1511/#1512/#1513. Recovery is broken out per cache
mode, because `perService` claims are owner-ref'd and go with the
InferenceService while `shared` and `claimName` ones do not.

**Choosing a provisioner.** `rancher.io/local-path` exposes `helperPod.yaml` in
its ConfigMap and accepts tolerations; `microk8s.io/hostpath` builds the helper
template into its image and cannot be told to tolerate anything. That distinction
is the actionable part and was not written down anywhere.

Plus a warning in `dgx-spark-microk8s.md` at the point where it runs
`microk8s enable hostpath-storage`, since a tainted single-GPU Spark is where
this is met first. Scoped to "only if you taint the node" so it does not alarm
anyone running untainted.

## Checklist

- [ ] Tests added/updated (documentation only)
- [x] `make test` passes locally (unaffected, no code changes)
- [x] `make lint` passes locally (unaffected, no code changes)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

Every claim was re-checked against the source rather than written from memory:
status field names (`schedulingStatus` / `schedulingMessage`) against
`inferenceservice_types.go`, the `UnbindableModelCache` literal against
`scheduling.go`, the `helperPod.yaml` ConfigMap key against a running
local-path-provisioner, and `modelCache.storageClass` against `values.yaml`. The
cross-doc anchor link resolves.

One correction made during review of my own draft: I had written that deleting
the InferenceService is not enough to clear the bad volume. That is wrong for the
default `perService` mode, where the claim is owner-ref'd and garbage-collected
with the service. The table now states it per mode.

This closes the documentation checklist item left open on #1511, #1512 and #1513.

Assisted-by: Claude Opus 5 (1M context)
