### PR TITLE
fix(router-proxy): reject colliding listener addresses at startup

### DIFF
--- a/cmd/router-proxy/listenaddr.go
+++ b/cmd/router-proxy/listenaddr.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// metricsDisabled reports whether a --metrics-bind-address value means "do not
+// serve metrics".
+//
+// "" is this binary's documented sentinel, but "0" is what the manager uses
+// (cmd/main.go defaults --metrics-bind-address to "0" and documents "leave as 0
+// to disable"). Carrying the manager's value here used to produce a listener
+// that failed with `address 0: missing port in address` AFTER a log line
+// claiming it was listening, so the operator's last signal said the opposite of
+// what happened. Accepting both makes the two binaries agree.
+func metricsDisabled(addr string) bool {
+	switch strings.ToLower(strings.TrimSpace(addr)) {
+	case "", "0", "none":
+		return true
+	default:
+		return false
+	}
+}
+
+// listenConflict returns a non-nil error when two listen addresses would race
+// for the same port.
+//
+// Configuring both listeners onto one address is not a stable failure: whichever
+// binds first wins, and the loser's treatment differs by which one it is. The
+// data plane's error is fatal, so the process crash-loops; the metrics server's
+// is logged and execution continues without metrics. Measured over 15 runs that
+// came out 14 crash-loops to 1 silent metrics loss, so the same configuration
+// produced two different outcomes.
+//
+// Detecting it before either listener binds turns a coin flip into one
+// deterministic startup error that names the conflict.
+//
+// Host comparison is deliberately conservative. Equal ports conflict when the
+// hosts are equal or when either side is a wildcard, because a wildcard bind
+// covers every specific address on that port. Two different specific hosts on
+// the same port do not conflict and are left alone: that is a legitimate
+// configuration on a multi-homed node, and refusing it would be worse than the
+// bug being fixed.
+func listenConflict(dataPlane, metrics string) error {
+	dHost, dPort, err := splitListen(dataPlane)
+	if err != nil {
+		// A malformed data-plane address is the data plane's problem to report
+		// when it binds; this check declines to speak for it.
+		return nil
+	}
+	mHost, mPort, err := splitListen(metrics)
+	if err != nil {
+		return nil
+	}
+
+	if dPort != mPort {
+		return nil
+	}
+	if !hostsOverlap(dHost, mHost) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"--listen (%s) and --metrics-bind-address (%s) resolve to the same address; "+
+			"the two listeners would race for port %s and the loser's failure differs by "+
+			"which one loses (the data plane exits, the metrics server does not). "+
+			"Give them different ports, or disable metrics with --metrics-bind-address=0",
+		dataPlane, metrics, dPort)
+}
+
+// splitListen accepts the forms a Go listener accepts, including the bare
+// ":9090" that omits the host.
+func splitListen(addr string) (host, port string, err error) {
+	host, port, err = net.SplitHostPort(strings.TrimSpace(addr))
+	if err != nil {
+		return "", "", err
+	}
+	if port == "" {
+		return "", "", fmt.Errorf("no port in %q", addr)
+	}
+	return host, port, nil
+}
+
+// hostsOverlap reports whether two listener hosts can contend for one port.
+// The empty host, 0.0.0.0 and [::] all mean "every interface" and therefore
+// overlap with anything.
+func hostsOverlap(a, b string) bool {
+	if isWildcardHost(a) || isWildcardHost(b) {
+		return true
+	}
+	return strings.EqualFold(a, b)
+}
+
+func isWildcardHost(h string) bool {
+	switch strings.TrimSpace(h) {
+	case "", "0.0.0.0", "::", "[::]":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/router-proxy/listenaddr_test.go
+++ b/cmd/router-proxy/listenaddr_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMetricsDisabled(t *testing.T) {
+	disabled := []string{"", "0", "none", "  0  ", "None"}
+	for _, addr := range disabled {
+		if !metricsDisabled(addr) {
+			t.Errorf("metricsDisabled(%q) = false, want true", addr)
+		}
+	}
+
+	// "0" is the manager's disable sentinel (cmd/main.go). Before #1517 the
+	// proxy treated it as an address, logged "metrics server listening", then
+	// failed to bind with "address 0: missing port in address".
+	enabled := []string{":9090", "0.0.0.0:9090", "127.0.0.1:9090", ":0"}
+	for _, addr := range enabled {
+		if metricsDisabled(addr) {
+			t.Errorf("metricsDisabled(%q) = true, want false", addr)
+		}
+	}
+}
+
+func TestListenConflict(t *testing.T) {
+	conflicting := []struct{ data, metrics string }{
+		{":8080", ":8080"},
+		{":8080", "0.0.0.0:8080"},
+		{"0.0.0.0:8080", ":8080"},
+		// A wildcard bind covers every specific address on that port, so it
+		// contends with a loopback bind on the same one.
+		{":8080", "127.0.0.1:8080"},
+		{"127.0.0.1:8080", ":8080"},
+		{"127.0.0.1:8080", "127.0.0.1:8080"},
+	}
+	for _, c := range conflicting {
+		err := listenConflict(c.data, c.metrics)
+		if err == nil {
+			t.Errorf("listenConflict(%q, %q) = nil, want an error", c.data, c.metrics)
+			continue
+		}
+		// The message has to name the conflict, since the whole point is that
+		// an operator currently sees either a crash-loop or missing metrics
+		// with nothing pointing at the cause.
+		for _, want := range []string{c.data, c.metrics, "--listen", "--metrics-bind-address"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("listenConflict(%q, %q) error = %q, want it to mention %q",
+					c.data, c.metrics, err, want)
+			}
+		}
+	}
+
+	ok := []struct{ data, metrics string }{
+		{":8080", ":9090"},
+		{"127.0.0.1:8080", "127.0.0.1:9090"},
+		// Different specific hosts on one port is legitimate on a multi-homed
+		// node; refusing it would be worse than the bug being fixed.
+		{"127.0.0.1:8080", "192.168.1.10:8080"},
+		// A malformed address is the binding listener's error to report, not
+		// this check's to pre-empt.
+		{"not-an-address", ":9090"},
+		{":8080", "not-an-address"},
+	}
+	for _, c := range ok {
+		if err := listenConflict(c.data, c.metrics); err != nil {
+			t.Errorf("listenConflict(%q, %q) = %v, want nil", c.data, c.metrics, err)
+		}
+	}
+}

--- a/cmd/router-proxy/main.go
+++ b/cmd/router-proxy/main.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"flag"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -49,8 +50,9 @@ func main() {
 	metricsListen := flag.String("metrics-bind-address", ":9090",
 		"Address the Prometheus metrics server binds to (host:port). Serves "+
 			"the controller-runtime registry at /metrics, including the ModelPool "+
-			"swap/residency/hold metrics. Empty or 0 disables the metrics "+
-			"server, matching the manager's --metrics-bind-address.")
+			"swap/residency/hold metrics. Empty, 0 or none disables the metrics "+
+			"server, matching the manager's --metrics-bind-address. Must not "+
+			"resolve to the same address as --listen.")
 	logFormat := flag.String("log-format", "json",
 		"Structured log format: json or text.")
 	shutdownTimeout := flag.Duration("shutdown-timeout", 30*time.Second,
@@ -77,6 +79,17 @@ func main() {
 
 	logger := newLogger(*logFormat)
 	slog.SetDefault(logger)
+
+	// Checked before anything binds. Two listeners on one address is otherwise
+	// a race whose outcome depends on which one loses, so the same flags can
+	// produce either a crash-loop or a running proxy with no metrics. Failing
+	// here makes it one deterministic error that names the conflict.
+	if !metricsDisabled(*metricsListen) {
+		if err := listenConflict(*listen, *metricsListen); err != nil {
+			logger.Error("invalid listener configuration", "error", err)
+			os.Exit(1)
+		}
+	}
 
 	cfg, err := router.LoadConfig(*configPath)
 	if err != nil {
@@ -129,10 +142,10 @@ func main() {
 	// held-request depth) are registered on the controller-runtime registry
 	// from internal/metrics; without this endpoint they are collected but never
 	// scrapeable. A separate port keeps metrics off the inference listener and
-	// lets a ServiceMonitor target it independently. Empty or 0 disables the
-	// server, so the value the manager uses to turn metrics off works here too.
+	// lets a ServiceMonitor target it independently. Empty, "0" or "none"
+	// disables the server; see metricsDisabled for why "0" is accepted.
 	var metricsSrv *http.Server
-	if addr := *metricsListen; addr != "" && addr != "0" {
+	if addr := *metricsListen; !metricsDisabled(addr) {
 		metricsMux := http.NewServeMux()
 		metricsMux.Handle("GET /metrics", newMetricsHandler())
 		metricsSrv = &http.Server{
@@ -140,12 +153,30 @@ func main() {
 			Handler:           metricsMux,
 			ReadHeaderTimeout: 5 * time.Second,
 		}
-		go func() {
-			logger.Info("starting metrics server", "address", addr)
-			if err := metricsSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				logger.Error("metrics server failed", "error", err)
-			}
-		}()
+		// Bind synchronously rather than letting ListenAndServe do it inside
+		// the goroutine. The bind is the step that fails, and doing it here
+		// means the success line is logged only once the port is actually
+		// held. It also lets the log name the resolved address, so a ":0"
+		// request reports the port it actually got instead of ":0".
+		metricsLn, lnErr := net.Listen("tcp", addr)
+		if lnErr != nil {
+			// Not fatal, deliberately: metrics are observability, and killing
+			// the data plane because a scrape endpoint could not bind would
+			// trade a monitoring gap for an outage. The conflict that used to
+			// land here most often is now caught by listenConflict above.
+			logger.Error("metrics server failed to bind; continuing without metrics",
+				"address", addr, "error", lnErr)
+			metricsSrv = nil
+		} else {
+			logger.Info("metrics server listening", "address", metricsLn.Addr().String())
+			go func() {
+				if err := metricsSrv.Serve(metricsLn); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					logger.Error("metrics server failed", "error", err)
+				}
+			}()
+		}
+	} else {
+		logger.Info("metrics server disabled", "metrics-bind-address", addr)
 	}
 
 	// Run the data-plane server in a goroutine so the main goroutine can wait


### PR DESCRIPTION
## What

Rejects `--listen` and `--metrics-bind-address` resolving to the same address, as a startup error raised before either listener binds. Also makes the metrics listener bind synchronously so its success line is only logged once the port is actually held.

Rebased onto `main` now that #1519 has landed. This PR is narrowed to **item 1 of #1517** only. Items 2, 3 and 4 (the `0` guard, the pinned port test, the dashboard catalog) all merged in #1519, and my earlier versions of those have been dropped rather than merged, so there is no duplicate coverage. Diff is 5 files down to 3.

## Why

Fixes #1517

Pointing both listeners at one address is a race, not a fixed failure. Whichever binds first wins, and the loser is treated very differently depending on which one it is:

- data plane loses, its error reaches `serverErr`, which is fatal, so the process crash-loops
- metrics loses, it is logged and the proxy serves on happily with no metrics

Over 15 runs with both flags on one address that came out **14 crash-loops to 1 silent metrics loss**. The same configuration produced two different outcomes, so an operator-facing misconfiguration resolved either as a hard crash or as silent observability loss, decided by scheduling.

## How

`listenConflict` compares both addresses before anything binds and exits 1 with a message that names the conflict.

Host comparison is deliberately conservative. Equal ports conflict when the hosts are equal or when either side is a wildcard, because a wildcard bind covers every specific address on that port. Two different specific hosts on the same port do **not** conflict and are left alone: that is legitimate on a multi-homed node, and refusing it would be worse than the bug being fixed.

Two smaller changes ride along because they are the same code path:

- **Synchronous bind.** The bind is the step that fails, so doing it outside the goroutine means `metrics server listening` is logged only once the port is held, and the log can name the *resolved* address. `--metrics-bind-address=:0` now reports the port it actually got instead of `:0`. A bind failure stays non-fatal, because killing the data plane over a scrape endpoint trades a monitoring gap for an outage.
- **`metricsDisabled`** replaces the inline `addr != "" && addr != "0"` guard from #1519 with a single helper, so the startup check and the serve path cannot drift. It additionally accepts `none` and trims whitespace, so a Helm value rendering as `"0 "` disables the listener instead of taking the bind-and-fail path.

### Verification

Behaviour, on a local build rather than by inspection:

| invocation | result |
| --- | --- |
| `--listen 127.0.0.1:18914 --metrics-bind-address 127.0.0.1:18914` | exit code **1**, one error naming the conflict, before either bind |
| `--metrics-bind-address 0` | `metrics server disabled` |
| `--metrics-bind-address ' 0 '` | `metrics server disabled` |
| `--metrics-bind-address 127.0.0.1:0` | `metrics server listening address=127.0.0.1:53745`, the resolved port |

Gate on this branch against current `main`:

- `go build ./...` clean
- `go vet ./cmd/...` clean
- `go test ./cmd/...` pass, including `cmd/router-proxy`
- `go test ./internal/controller/ -run TestRouterDeploymentMetricsPort` pass, so #1519's pinned-port test is unaffected
- `make lint` 0 issues, and `GOOS=linux golangci-lint run ./cmd/...` 0 issues
- `gofmt -l cmd/ internal/` clean

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran `go test ./cmd/...` plus the router builder test; no controller code is touched by this PR)
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - the dashboard catalog line landed in #1519; the flag help text is updated here

*Assisted-by: Claude Code (wrote the commit, ran the gate and the behaviour table above; I reviewed the diff before pushing.)*
