### PR TITLE
fix(foreman): bound edit-free resets earned from bash-shaped writes

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -3221,6 +3221,17 @@ func progressConfigFromAgent(agent *foremanv1alpha1.Agent) ProgressConfig {
 			EditFreeTurnsLimit:    int(s.EditFreeTurnsLimit),
 			ContextSoftCap:        int(s.ContextSoftCap),
 			ContextHardCap:        int(s.ContextHardCap),
+			// Not yet an Agent CR field, so it is taken from the defaults
+			// rather than left at zero. Zero means "unbounded", which is the
+			// pre-#1520 behaviour, and an Agent that sets stuckLoopDetection
+			// at all would otherwise silently opt out of the bound while
+			// appearing to have tightened its detection. The agent in #1520
+			// was exactly that shape: an explicit editFreeTurnsLimit of 30,
+			// and a detector that could never reach it.
+			//
+			// Inert when the edit-free signal is off (EditFreeTurnsLimit 0),
+			// so `stuckLoopDetection: {}` still disables the whole signal.
+			UnverifiedEditResetCap: DefaultProgressConfig.UnverifiedEditResetCap,
 		}
 	}
 	// Role-aware override: reviewers are read-only by design (tool

--- a/pkg/foreman/agent/progress.go
+++ b/pkg/foreman/agent/progress.go
@@ -49,6 +49,25 @@ type ProgressConfig struct {
 	// Zero disables the signal.
 	EditFreeTurnsLimit int
 
+	// UnverifiedEditResetCap bounds how many CONSECUTIVE edit-free resets may
+	// be earned from bash commands that only LOOK like writes, before those
+	// resets stop being honoured.
+	//
+	// bashLikelyMutatesWorkspace is a substring heuristic biased toward
+	// detecting a write, because a false negative force-terminates a model
+	// editing through the shell (#982, #896). That bias is right, but it was
+	// unbounded: a command containing a matching token every turn resets the
+	// streak every turn, so EditFreeTurnsLimit becomes unreachable and the
+	// detector cannot fire at all. Observed in #1520: 85 minutes, tens of
+	// thousands of model operations, a verifiably clean worktree, and no nudge.
+	//
+	// A real edit tool (write_file / str_replace / submit_result) clears this
+	// counter, so a model that edits through tools is never affected. Only a
+	// model whose sole evidence of progress is bash-shaped strings is bounded.
+	//
+	// 0 disables the bound, restoring the pre-#1520 behaviour.
+	UnverifiedEditResetCap int
+
 	// ContextSoftCap and ContextHardCap are token-budget guards.
 	// Crossing the soft cap nudges the model to wrap up; crossing the
 	// hard cap force-terminates regardless of model behavior.
@@ -78,10 +97,11 @@ type ProgressConfig struct {
 // the way through MaxTurns without ever editing. Caps are sized for
 // a 64k-window model with headroom.
 var DefaultProgressConfig = ProgressConfig{
-	RepeatedToolThreshold: 5,
-	EditFreeTurnsLimit:    15,
-	ContextSoftCap:        90000,
-	ContextHardCap:        140000,
+	RepeatedToolThreshold:  5,
+	EditFreeTurnsLimit:     15,
+	UnverifiedEditResetCap: 20,
+	ContextSoftCap:         90000,
+	ContextHardCap:         140000,
 }
 
 // ProgressAction is the recommendation the monitor returns after each
@@ -136,6 +156,11 @@ type LoopProgressMonitor struct {
 	// observing a wide-enough window to detect the pattern.
 	recentCallHashes []string
 	editFreeStreak   int // turns since last edit/submit
+	// unverifiedResets counts consecutive edit-free resets earned from
+	// bash-shaped writes since the last real edit-tool call. Bounded by
+	// UnverifiedEditResetCap so unverifiable evidence cannot hold the streak
+	// at zero forever (#1520).
+	unverifiedResets int
 	// groundedFiles is the set of distinct files read_file'd since the last
 	// edit. Each distinct file beyond the first raises the effective edit-free
 	// limit (grounding-aware guard, #1066): reading real source to ground the
@@ -499,11 +524,23 @@ func (m *LoopProgressMonitor) recordCalls(calls []oai.ToolCall) {
 // commits with `git add -A`, so those changes are real progress.
 func (m *LoopProgressMonitor) updateEditFreeStreak(calls []oai.ToolCall) {
 	for _, tc := range calls {
+		// A real edit tool is self-evidencing: the tool contract says a file was
+		// written. It resets the streak unconditionally and clears the
+		// unverified budget, so a model that edits through tools is never
+		// subject to the bound below.
 		if _, ok := editProducingTools[tc.Function.Name]; ok {
+			m.unverifiedResets = 0
 			m.resetEditFreeStreak()
 			return
 		}
+		// A bash command is only string evidence that a write happened. Honour
+		// it, but not indefinitely: past the cap the streak is allowed to
+		// advance so the detector can still reach its limit (#1520).
 		if tc.Function.Name == "bash" && bashCallMutatesWorkspace(tc.Function.Arguments) {
+			if m.cfg.UnverifiedEditResetCap > 0 && m.unverifiedResets >= m.cfg.UnverifiedEditResetCap {
+				break
+			}
+			m.unverifiedResets++
 			m.resetEditFreeStreak()
 			return
 		}

--- a/pkg/foreman/agent/progress_test.go
+++ b/pkg/foreman/agent/progress_test.go
@@ -704,3 +704,76 @@ func TestProgressMonitor_EditDisarmsNudgedRepeatedTool(t *testing.T) {
 		t.Fatalf("edit-free defiance must still terminate; got %+v", d)
 	}
 }
+
+// TestProgressMonitor_UnverifiedBashResetsAreBounded reproduces #1520: a model
+// whose every turn contains a bash command matching the write heuristic held
+// editFreeStreak at zero indefinitely, so EditFreeTurnsLimit was unreachable
+// and the detector never fired. Observed in the field as 85 minutes and tens of
+// thousands of model operations against a verifiably clean worktree.
+//
+// Each turn here varies the filename so RepeatedToolThreshold does not fire
+// first; the signal under test is the edit-free one alone.
+func TestProgressMonitor_UnverifiedBashResetsAreBounded(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{
+		EditFreeTurnsLimit:     5,
+		UnverifiedEditResetCap: 3,
+	})
+	transcript := []oai.Message{{Role: oai.RoleSystem, Content: "sys"}}
+
+	fired := 0
+	for turn := 1; turn <= 40; turn++ {
+		args := fmt.Sprintf(`{"command":"cp scratch-%d.txt /tmp/x"}`, turn)
+		d := mon.Observe(turn, []oai.ToolCall{makeCall("t", "bash", args)}, transcript)
+		if d.Action != ProgressContinue {
+			fired = turn
+			break
+		}
+	}
+	if fired == 0 {
+		t.Fatal("edit-free signal never fired across 40 bash-shaped turns; " +
+			"unverified resets are still unbounded (#1520)")
+	}
+	// 3 resets are honoured, then the streak advances to the limit of 5.
+	if fired > 12 {
+		t.Errorf("signal fired at turn %d, later than the cap should allow", fired)
+	}
+}
+
+// A model that edits through real tools must be unaffected by the bound: the
+// tool contract is self-evidencing, so its budget resets every time.
+func TestProgressMonitor_RealEditToolClearsUnverifiedBudget(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{
+		EditFreeTurnsLimit:     5,
+		UnverifiedEditResetCap: 3,
+	})
+	transcript := []oai.Message{{Role: oai.RoleSystem, Content: "sys"}}
+
+	// Alternate bash-shaped writes with a genuine str_replace. The real edit
+	// clears the unverified budget, so the cap is never reached.
+	for turn := 1; turn <= 40; turn++ {
+		var call oai.ToolCall
+		if turn%3 == 0 {
+			call = makeCall("e", "str_replace", `{"path":"a.go","old":"x","new":"y"}`)
+		} else {
+			call = makeCall("t", "bash", fmt.Sprintf(`{"command":"cp s-%d.txt /tmp/x"}`, turn))
+		}
+		if d := mon.Observe(turn, []oai.ToolCall{call}, transcript); d.Action != ProgressContinue {
+			t.Fatalf("turn %d: a model making real edits must not be flagged; got %+v", turn, d)
+		}
+	}
+}
+
+// Cap 0 restores the pre-#1520 behaviour, so an operator can opt out.
+func TestProgressMonitor_UnverifiedResetCapZeroIsUnbounded(t *testing.T) {
+	mon := NewLoopProgressMonitor(ProgressConfig{
+		EditFreeTurnsLimit:     5,
+		UnverifiedEditResetCap: 0,
+	})
+	transcript := []oai.Message{{Role: oai.RoleSystem, Content: "sys"}}
+	for turn := 1; turn <= 40; turn++ {
+		args := fmt.Sprintf(`{"command":"cp scratch-%d.txt /tmp/x"}`, turn)
+		if d := mon.Observe(turn, []oai.ToolCall{makeCall("t", "bash", args)}, transcript); d.Action != ProgressContinue {
+			t.Fatalf("turn %d: cap 0 must keep the old unbounded behaviour; got %+v", turn, d)
+		}
+	}
+}


### PR DESCRIPTION
## What

Bound the edit-free resets a run can earn from bash commands that only *look* like writes, so `EditFreeTurnsLimit` stays reachable.

## Why

Refs #1520

The edit-free signal could not fire for a model whose every turn contained a bash command matching the write heuristic. Each such turn reset `editFreeStreak` to zero, so the limit was never approached. Observed in the field as **85 minutes and tens of thousands of model operations against a worktree that never changed**, with no nudge and no force-terminate.

`bashLikelyMutatesWorkspace` is a substring heuristic deliberately biased toward detecting a write, because a false negative force-terminates a model editing through the shell (#982, #896). **That bias is correct and this PR keeps it.** What was wrong is that it was unbounded. The code says a false positive "merely delays the signal", which is true of an occasional match and false of one that recurs every turn. `go install ./...` matches `install ` at a word boundary; any output redirection matches too.

## How

`UnverifiedEditResetCap` (default 20) bounds **consecutive** resets earned from bash alone.

A real edit tool is self-evidencing under its own contract, so `write_file` / `str_replace` / `submit_result` reset the streak unconditionally *and* clear the budget. So:

- a model editing through tools is **never** affected
- a model editing through the shell keeps 20 turns of tolerance before unverified evidence stops counting
- `0` restores the previous unbounded behaviour

Agents that set `stuckLoopDetection` explicitly inherit the cap from the defaults rather than getting a zero value. Without that they would silently opt out while appearing to have *tightened* detection — which is exactly the shape the reported agent had: an explicit `editFreeTurnsLimit: 30`, and a detector that could never reach it.

## Verification

The regression test fails on `main` with the reported symptom and passes with the change:

```
--- FAIL: TestProgressMonitor_UnverifiedBashResetsAreBounded
    edit-free signal never fired across 40 bash-shaped turns;
    unverified resets are still unbounded (#1520)
```

Two guard tests cover the cases that must **not** change: a model alternating bash with real `str_replace` calls runs 40 turns without being flagged, and `UnverifiedEditResetCap: 0` keeps the old unbounded behaviour. Both pass before and after, which is the point.

Full `./pkg/foreman/agent/` passes (35s); `GOOS=linux golangci-lint run` reports 0 issues.

## Scope

This **bounds** the failure rather than removing the guess. The complete fix is a worktree fingerprint the heuristic cannot mask — "no tracked file changed for N turns" — which needs a workspace path threaded from the executor into the monitor, since `progressConfigFromAgent` has none today. Left as a follow-up and noted on the issue.

There is also no Agent CR field for the cap yet, so it is defaults-only. Worth adding if anyone needs to tune it per-agent.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — behaviour change is internal to the detector

Assisted-by: Claude Opus 5 (1M context)
