### PR TITLE
fix(chart): scope agent Deployment selectors to their pool

### DIFF
--- a/charts/foreman/templates/_helpers.tpl
+++ b/charts/foreman/templates/_helpers.tpl
@@ -68,10 +68,39 @@ app.kubernetes.io/component: operator
 
 {{/*
 Agent pod labels = base selector + component=agent.
+
+Release-scoped, NOT pool-scoped: the agent ServiceAccount/RBAC and the
+gate-cache PVC are per-release objects and must keep these labels stable.
+Anything that needs to tell one agent pool from another wants
+foreman.agent.poolLabels instead.
 */}}
 {{- define "foreman.agent.labels" -}}
 {{ include "foreman.selectorLabels" . }}
 app.kubernetes.io/component: agent
+{{- end }}
+
+{{/*
+Agent Deployment labels, selector and pod-template labels, scoped to one pool.
+
+Takes the per-agent context ($ctx) built by agent-deployment.yaml, so it can
+read .agentName. Every pool in the multi-fleet form gets an agent-pool label,
+which is what keeps two Deployments from selecting each other's pods (#1523):
+foreman.agent.labels alone is identical for every pool, so without this the
+controllers each count the other's replicas toward their own replicaCount and
+scale down what the other scales up.
+
+The legacy single-agent form is deliberately left alone. Its config is wrapped
+under the "_implicit_" sentinel and renders exactly one Deployment, so there is
+nothing to collide with, and a Deployment's selector is immutable: adding a
+label there would break `helm upgrade` on every existing install. Migrating
+from agent: to agents: already renames the object (foreman-agent becomes
+foreman-<pool>-agent), so the new selector lands on a new object.
+*/}}
+{{- define "foreman.agent.poolLabels" -}}
+{{ include "foreman.agent.labels" . }}
+{{- if ne .agentName "_implicit_" }}
+{{ printf "foreman.llmkube.dev/agent-pool: %s" .agentName }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -23,7 +23,7 @@ metadata:
   name: {{ include "foreman.agent.resourceName" $ctx }}
   namespace: {{ include "foreman.namespace" $ }}
   labels:
-    {{- include "foreman.agent.labels" $ | nindent 4 }}
+    {{- include "foreman.agent.poolLabels" $ctx | nindent 4 }}
 spec:
   replicas: {{ $agent.replicaCount }}
   # Each foreman-agent claims one task at a time. The Recreate
@@ -31,9 +31,12 @@ spec:
   # that race for the same Scheduled tasks.
   strategy:
     type: Recreate
+  # Pool-scoped, via $ctx rather than the chart root: passing $ here gave
+  # every pool the same selector, so each Deployment adopted the others'
+  # pods and fought them over replicaCount (#1523).
   selector:
     matchLabels:
-      {{- include "foreman.agent.labels" $ | nindent 6 }}
+      {{- include "foreman.agent.poolLabels" $ctx | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -42,7 +45,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "foreman.agent.labels" $ | nindent 8 }}
+        {{- include "foreman.agent.poolLabels" $ctx | nindent 8 }}
         {{- with $agent.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/foreman/tests/agents_test.yaml
+++ b/charts/foreman/tests/agents_test.yaml
@@ -409,3 +409,44 @@ tests:
       - equal:
           path: metadata.labels.grafana_dashboard
           value: "true"
+  # ---- #1523: pools must not select each other's pods ----
+
+  - it: each agents entry gets a pool-scoped selector, so pools cannot adopt each other's pods
+    template: agent-deployment.yaml
+    values:
+      - values-multi.yaml
+    asserts:
+      # documentIndex 0 = the "default" pool, 1 = "llmkube-fork" (map order is
+      # alphabetical). Before #1523 both rendered the identical selector
+      # {name, instance, part-of, component}, so each Deployment counted the
+      # other's replicas toward its own replicaCount.
+      - equal:
+          path: spec.selector.matchLabels["foreman.llmkube.dev/agent-pool"]
+          value: default
+        documentIndex: 0
+      - equal:
+          path: spec.selector.matchLabels["foreman.llmkube.dev/agent-pool"]
+          value: llmkube-fork
+        documentIndex: 1
+      # The pod template must carry the same pool label, or the selector
+      # matches nothing and the Deployment never becomes available.
+      - equal:
+          path: spec.template.metadata.labels["foreman.llmkube.dev/agent-pool"]
+          value: default
+        documentIndex: 0
+      - equal:
+          path: spec.template.metadata.labels["foreman.llmkube.dev/agent-pool"]
+          value: llmkube-fork
+        documentIndex: 1
+
+  - it: the legacy single-agent selector is left alone, since Deployment selectors are immutable
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.selector.matchLabels["foreman.llmkube.dev/agent-pool"]
+      - notExists:
+          path: spec.template.metadata.labels["foreman.llmkube.dev/agent-pool"]

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -125,6 +125,25 @@ foreman:
 # Setting `agents:` opts you OUT of the implicit legacy agent: render
 # path; if you need a "default" fleet alongside custom ones, list it
 # explicitly under `agents:` with the name `default` (or any other key).
+#
+# UPGRADE NOTE, existing `agents:` users only (#1523). Every pool's
+# Deployment now carries `foreman.llmkube.dev/agent-pool: <key>` in its
+# selector. Before this, all pools rendered the SAME selector, so each
+# Deployment adopted the others' pods and the controllers fought over
+# replicaCount. A Deployment's selector is immutable, so `helm upgrade`
+# on a release created before this change fails with:
+#
+#   spec.selector: Invalid value: {...}: field is immutable
+#
+# Agent Deployments are stateless, so the fix is to delete them and let
+# the upgrade recreate them. In-flight tasks are re-claimed by a sibling:
+#
+#   kubectl -n <namespace> delete deploy -l app.kubernetes.io/component=agent
+#   helm upgrade ...
+#
+# Installs on the legacy `agent:` block are unaffected: that path renders
+# under the "_implicit_" sentinel with no pool label and its selector is
+# byte-identical across this change.
 
 operator:
   enabled: true


### PR DESCRIPTION
## What

Gives each entry in the multi-fleet `agents:` map its own `foreman.llmkube.dev/agent-pool` label, applied to the Deployment labels, `selector.matchLabels` and the pod template, so pools stop selecting each other's pods. Adds a `helm unittest` case that renders two pools and asserts the selectors differ.

## Why

Fixes #1523

`foreman.agent.labels` resolves to `foreman.selectorLabels` + `component: agent` and contains nothing identifying the pool, and `agent-deployment.yaml` passed the chart root `$` to it for the metadata labels, the selector and the pod template, rather than the per-agent `$ctx` it builds a few lines earlier. Every pool therefore rendered a byte-identical selector:

```
  name: foreman-default-agent      matchLabels: {name, instance, part-of, component}
  name: foreman-multirepo-agent    matchLabels: {name, instance, part-of, component}
```

On a cluster that makes the pools fight: each Deployment's selector matches the other's pods, so both controllers count the same replicas toward their own `replicaCount` and scale down what the other scales up. With `strategy: Recreate` on both, the churn does not settle. `nodeLabels` does not compensate, since it is rendered into the agent's `--node-labels` argument and only affects FleetNode registration; it never reaches the pod labels.

This had a real operational cost. It is why the `foreman-agent-multirepo` pool on our Shadowstack cluster was created by hand instead of through the chart, and because that hand-made Deployment belongs to no Helm release (it carries the `app.kubernetes.io/managed-by: Helm` label but no `meta.helm.sh/release-name` annotation) `helm upgrade` silently skipped it and still reported success. It sat 19 commits behind on `e77d7cf3` across a deploy of `main`, so it was running every coder task without #1521.

## How

`foreman.agent.poolLabels` takes the per-agent context and appends `foreman.llmkube.dev/agent-pool: <name>` for every named pool. `agent-deployment.yaml` now passes `$ctx` at all three sites.

**The legacy single-agent form is deliberately left alone.** Its config is wrapped under the `_implicit_` sentinel and renders exactly one Deployment, so it has nothing to collide with, and a Deployment's `selector` is immutable: adding a label there would fail `helm upgrade` on every existing install. Migrating from `agent:` to `agents:` already renames the object (`foreman-agent` becomes `foreman-<pool>-agent`), so the new selector lands on a new object and the constraint is never hit.

`foreman.agent.labels` stays release-scoped, because `agent-rbac.yaml` and `gate-cache-pvc.yaml` are per-release objects whose labels must remain stable.

### Upgrade note for existing `agents:` users

Deployment selectors are immutable, so a release created **before** this change fails to upgrade. Verified against a live cluster rather than reasoned about:

```
Error: UPGRADE FAILED: Deployment.apps "selftest-foreman-default-agent" is invalid:
spec.selector: Invalid value: {...}: field is immutable
```

Agent Deployments are stateless, so the remediation is to delete and let the upgrade recreate them. In-flight tasks are re-claimed by a sibling agent:

```bash
kubectl -n <namespace> delete deploy -l app.kubernetes.io/component=agent
helm upgrade ...
```

**Legacy `agent:` installs are unaffected**, which is the overwhelming majority. Same live test, legacy values: `STATUS: deployed`, and the rendered selector is byte-identical between `main` and this branch.

Documented on the `agents:` key in `values.yaml` rather than `NOTES.txt`, because Helm only renders NOTES on a successful release and this failure aborts the upgrade before that point.

**Deliberately not marked `BREAKING CHANGE`.** `agents:` is opt-in, shipped three weeks ago, and is broken for its stated purpose today: any install with 2+ pools is currently thrashing, because the two Deployments each adopt the other's pods. The only population with a working setup is single-entry `agents:` users, who have no collision to suffer from. Given `bump-minor-pre-major: true` in the release-please config, a breaking footer would cut 0.10.0 and signal a far larger change than this is to the many unaffected legacy installs. Shipping as `fix:` (0.9.17) with the upgrade path documented in the two places an operator would actually look.

### Verification

Rendered output after the change:

| shape | result |
| --- | --- |
| `agents:` with `default` + `multirepo` | selectors `agent-pool: default` and `agent-pool: multirepo`, pod templates match |
| legacy `agent:` | `foreman-agent`, **no** `agent-pool` label, byte-identical to before |

- `helm unittest charts/foreman` — 37/37 pass
- `helm lint charts/foreman` — 0 failed
- `helm template` renders cleanly for both the legacy and multi-pool shapes

The new selector case is mutation-verified in both directions: it **fails** against the pre-fix template (`1 failed, 36 passed`) and passes after. The existing suite asserted names and document counts but never selectors, which is why this was invisible to it.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (chart-only change; `helm unittest` + `helm lint` + `helm template` for both shapes, no Go code touched)
- [x] `make lint` passes locally (`helm lint`, 0 failed)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - upgrade note added to the `agents:` key in values.yaml; behaviour explained in the template comments; the `agents:` values contract itself is unchanged

*Assisted-by: Claude Code (found the collision while verifying a fleet deploy, wrote the commit, and ran the render/unittest/mutation checks quoted above; I reviewed the diff before pushing.)*
