### PR TITLE
fix: namespace MCP tools with __ so names match the OAI pattern

### DIFF
--- a/api/foreman/v1alpha1/mcp_types.go
+++ b/api/foreman/v1alpha1/mcp_types.go
@@ -43,10 +43,10 @@ type MCPConfig struct {
 }
 
 // MCPServer configures one MCP server the agent connects to. Its tools
-// are namespaced as mcp/<name>/<tool> so identically-named tools across
+// are namespaced as mcp__<name>__<tool> so identically-named tools across
 // servers do not collide in the model-facing tool whitelist.
 type MCPServer struct {
-	// Name namespaces this server's tools as mcp/<name>/<tool>.
+	// Name namespaces this server's tools as mcp__<name>__<tool>.
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -309,7 +309,7 @@ spec:
                     items:
                       description: |-
                         MCPServer configures one MCP server the agent connects to. Its tools
-                        are namespaced as mcp/<name>/<tool> so identically-named tools across
+                        are namespaced as mcp__<name>__<tool> so identically-named tools across
                         servers do not collide in the model-facing tool whitelist.
                       properties:
                         allowedTools:
@@ -361,7 +361,7 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: Name namespaces this server's tools as mcp/<name>/<tool>.
+                          description: Name namespaces this server's tools as mcp__<name>__<tool>.
                           type: string
                         transport:
                           description: Transport is the MCP transport. Phase 1 supports

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -308,7 +308,7 @@ spec:
                     items:
                       description: |-
                         MCPServer configures one MCP server the agent connects to. Its tools
-                        are namespaced as mcp/<name>/<tool> so identically-named tools across
+                        are namespaced as mcp__<name>__<tool> so identically-named tools across
                         servers do not collide in the model-facing tool whitelist.
                       properties:
                         allowedTools:
@@ -360,7 +360,7 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: Name namespaces this server's tools as mcp/<name>/<tool>.
+                          description: Name namespaces this server's tools as mcp__<name>__<tool>.
                           type: string
                         transport:
                           description: Transport is the MCP transport. Phase 1 supports

--- a/pkg/foreman/agent/mcp/allowlist_warn_test.go
+++ b/pkg/foreman/agent/mcp/allowlist_warn_test.go
@@ -70,12 +70,12 @@ func TestConnect_WarnsOnUnmatchedAllowlist(t *testing.T) {
 		t.Fatalf("Connect err = %v", err)
 	}
 	// "echo" still registers; "ghost" does not exist.
-	if len(toolz) != 1 || toolz[0].Name() != "mcp/fake/echo" {
+	if len(toolz) != 1 || toolz[0].Name() != "mcp__fake__echo" {
 		names := make([]string, 0, len(toolz))
 		for _, tl := range toolz {
 			names = append(names, tl.Name())
 		}
-		t.Fatalf("want only mcp/fake/echo registered, got %v", names)
+		t.Fatalf("want only mcp__fake__echo registered, got %v", names)
 	}
 	// A warning must name the unmatched entry "ghost".
 	joined := strings.Join(logs, "\n")

--- a/pkg/foreman/agent/mcp/registry_test.go
+++ b/pkg/foreman/agent/mcp/registry_test.go
@@ -75,11 +75,11 @@ func TestRegister_AppendsMCPTools(t *testing.T) {
 	if !names["native_tool"] {
 		t.Fatalf("Register result %v missing base tool native_tool", names)
 	}
-	if !names["mcp/fake/echo"] {
-		t.Fatalf("Register result %v missing discovered mcp/fake/echo", names)
+	if !names["mcp__fake__echo"] {
+		t.Fatalf("Register result %v missing discovered mcp__fake__echo", names)
 	}
-	if !names["mcp/fake/boom"] {
-		t.Fatalf("Register result %v missing discovered mcp/fake/boom", names)
+	if !names["mcp__fake__boom"] {
+		t.Fatalf("Register result %v missing discovered mcp__fake__boom", names)
 	}
 	if len(all) != 3 {
 		t.Fatalf("Register result has %d tools, want 3 (1 base + 2 mcp)", len(all))

--- a/pkg/foreman/agent/mcp/session_test.go
+++ b/pkg/foreman/agent/mcp/session_test.go
@@ -59,14 +59,14 @@ func TestConnect_SkipsUnreachableServer(t *testing.T) {
 	var echoCount, badCount int
 	for _, tl := range toolList {
 		switch {
-		case tl.Name() == "mcp/good/echo":
+		case tl.Name() == "mcp__good__echo":
 			echoCount++
-		case strings.HasPrefix(tl.Name(), "mcp/bad/"):
+		case strings.HasPrefix(tl.Name(), "mcp__bad__"):
 			badCount++
 		}
 	}
 	if echoCount != 1 {
-		t.Fatalf("mcp/good/echo appeared %d times, want exactly 1: %+v", echoCount, names(toolList))
+		t.Fatalf("mcp__good__echo appeared %d times, want exactly 1: %+v", echoCount, names(toolList))
 	}
 	if badCount != 0 {
 		t.Fatalf("bad server contributed %d tools, want 0: %+v", badCount, names(toolList))

--- a/pkg/foreman/agent/mcp/tool.go
+++ b/pkg/foreman/agent/mcp/tool.go
@@ -19,6 +19,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -97,7 +98,7 @@ func newTool(c caller, server, toolName string, opts Options, record func(mcpCal
 }
 
 // newTools adapts every tool discovered on server's Session into a
-// tools.Tool, namespaced as "mcp/<server.Name>/<tool name>" so tools
+// tools.Tool, namespaced as "mcp__<server.Name>__<tool name>" so tools
 // from different MCP servers (or a same-named native tool) never
 // collide in the registry. record is invoked once per Execute call;
 // pass nil if the caller does not need call observations.
@@ -114,10 +115,35 @@ func newTools(
 	return out
 }
 
+// nameSeparator joins the namespace segments. It is "__" rather than "/"
+// because the OAI tool-call spec constrains function.name to
+// ^[a-zA-Z0-9_-]+$: a "/" makes every request carrying an MCP tool
+// malformed, and providers that validate reject it before the model runs.
+const nameSeparator = "__"
+
+// sanitizeNameSegment maps any character outside the OAI function-name set
+// to an underscore, so a server or tool advertising a dot, slash or space
+// cannot produce a name the provider rejects.
+func sanitizeNameSegment(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
+}
+
 // Name returns the namespaced tool name as advertised to the model and
-// used as the registry key.
+// used as the registry key. The remote tool is still called by its bare
+// name; see Execute.
 func (t *mcpTool) Name() string {
-	return "mcp/" + t.server + "/" + t.toolName
+	return "mcp" + nameSeparator + sanitizeNameSegment(t.server) +
+		nameSeparator + sanitizeNameSegment(t.toolName)
 }
 
 // Schema returns the OAI schema advertisement, built from the remote

--- a/pkg/foreman/agent/mcp/tool_test.go
+++ b/pkg/foreman/agent/mcp/tool_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -55,13 +56,13 @@ func TestNewTools_Wiring(t *testing.T) {
 		t.Fatalf("newTools returned %d tools, want 1", len(toolList))
 	}
 	tl := toolList[0]
-	if got, want := tl.Name(), "mcp/fake/echo"; got != want {
+	if got, want := tl.Name(), "mcp__fake__echo"; got != want {
 		t.Fatalf("Name() = %q, want %q", got, want)
 	}
 
 	schema := tl.Schema()
-	if schema.Name != "mcp/fake/echo" {
-		t.Fatalf("Schema().Name = %q, want %q", schema.Name, "mcp/fake/echo")
+	if schema.Name != "mcp__fake__echo" {
+		t.Fatalf("Schema().Name = %q, want %q", schema.Name, "mcp__fake__echo")
 	}
 	if schema.Description != "echoes back" {
 		t.Fatalf("Schema().Description = %q, want %q", schema.Description, "echoes back")
@@ -418,5 +419,32 @@ func TestTruncateUTF8_RuneBoundaries(t *testing.T) {
 					tc.s, tc.max, got, len(got), tc.max)
 			}
 		})
+	}
+}
+
+// Issue #1525: the OAI tool-call spec constrains function.name to
+// ^[a-zA-Z0-9_-]+$. The old "mcp/<server>/<tool>" namespacing embedded a
+// "/", so providers that validate rejected every request carrying an MCP
+// tool at turn 1, before the model ran.
+func TestToolNameMatchesOAIPattern(t *testing.T) {
+	oaiName := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	for _, tc := range []struct{ server, tool string }{
+		{"fake", "echo"},
+		{"context7", "resolve-library-id"},
+		{"weird.server", "tool/with slash"},
+		{"a b", "c.d"},
+	} {
+		tl := newTool(nil, tc.server, tc.tool, Options{}, nil)
+		if got := tl.Name(); !oaiName.MatchString(got) {
+			t.Errorf("Name() = %q for server=%q tool=%q; does not match %s",
+				got, tc.server, tc.tool, oaiName)
+		}
+	}
+}
+
+func TestToolNameSanitisesSegments(t *testing.T) {
+	tl := newTool(nil, "weird.server", "tool/name", Options{}, nil)
+	if got, want := tl.Name(), "mcp__weird_server__tool_name"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## What

Namespace MCP tools as `mcp__<server>__<tool>` instead of `mcp/<server>/<tool>`, and sanitise each segment.

## Why

The OAI tool-call spec constrains `function.name` to `^[a-zA-Z0-9_-]+$`. `/` is not in that set, so every request carrying an MCP tool is malformed. Providers that validate reject it at turn 1, before the model runs:

```
status 400: Invalid 'tools[3].function.name': string does not match pattern.
Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.
```

Providers that don't validate accept it unchanged, which is why this is invisible on a local-only fleet — `llama.cpp` and LM Studio pass the same payload through. It only surfaces when an Agent points at a strict hosted endpoint.

On our fleet it took a coder agent out of service completely: **14 of 22 errored coder pods** failed this way. Because the rejection records as a task error rather than a provider refusal, the agent's verdict record read as poor model quality — we spent most of a day attributing it to the model before tracing the 400.

The upstream names are already valid on their own; context7 advertises `resolve-library-id` and `query-docs`. The namespacing introduced the violation.

Fixes #1525

## How

`nameSeparator` is `"__"`, and `sanitizeNameSegment` maps anything outside the allowed set to `_` — so a server or tool advertising a dot, slash or space also can't produce a rejected name. The remote tool is still invoked by its bare name in `Execute` (`callTool(cctx, t.toolName, args)`), which is untouched.

The `mcp_types.go` doc comments carried the old form, so `make manifests`, `make chart-crds` and `make foreman-chart-crds` were re-run and the regenerated CRDs are included.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — CRD descriptions regenerated

Two regression tests, both run against unmodified upstream first to confirm they fail there:

- `TestToolNameMatchesOAIPattern` — asserts `Name()` matches `^[a-zA-Z0-9_-]+$` across four server/tool shapes. Before the fix: `Name() = "mcp/a b/c.d" ... does not match`.
- `TestToolNameSanitisesSegments` — `weird.server` + `tool/name` → `mcp__weird_server__tool_name`. Before: `"mcp/weird.server/tool/name"`.

The four existing tests that asserted the old separator were updated to the new one.

`Assisted-by: Claude Code (diagnosed the bug from a live 400, wrote the fix and tests; I reviewed the change and ran make fmt, make vet, make lint and make test locally before submitting)`
