### PR TITLE
fix: stop discarding a coder's diff when submit_result omits a message

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1095,9 +1095,26 @@ func (e *NativeAgentLoopExecutor) commitPushAttempt(
 
 	envtestTouched = len(changedEnvtestPackages(ctx, workspace, execCommandRunner)) > 0
 
+	// A submit_result that carries edits but no commit message used to fail
+	// repo.Commit ("Commit: Message is required"), which discarded the whole
+	// diff and recorded NO-GO. The work is real and the branch is resolved by
+	// this point, so synthesize a subject the same way the gate-failed path
+	// below does rather than throwing it away. Refs (not Fixes) because a
+	// message we invented should not auto-close the issue on merge.
+	commitMessage := lr.Terminal.CommitMessage
+	if strings.TrimSpace(commitMessage) == "" {
+		commitMessage = fmt.Sprintf(
+			"fix: resolve issue #%d\n\n%s\n\nRefs #%d",
+			task.Spec.Payload.Issue,
+			strings.TrimSpace(lr.Terminal.Summary),
+			task.Spec.Payload.Issue)
+		log.Info("submit_result carried no commit message; synthesized one",
+			"issue", task.Spec.Payload.Issue)
+	}
+
 	sha, commitErr := repo.Commit(ctx, repo.CommitOptions{
 		Workspace: workspace,
-		Message:   lr.Terminal.CommitMessage,
+		Message:   commitMessage,
 		Author:    e.CommitAuthor,
 		Committer: e.CommitCommitter,
 	})

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -2135,3 +2135,83 @@ func TestNativeExecutor_ModelNoGoAlreadyResolved_PromotesOutcome(t *testing.T) {
 		t.Errorf("modelExtra should keep the nested outcome for observability, got %v", res.Extra["modelExtra"])
 	}
 }
+
+// Issue #1526: a submit_result carrying edits but an empty CommitMessage used
+// to fail repo.Commit ("Commit: Message is required"), discarding the diff and
+// recording NO-GO "commit rejected" — indistinguishable from the model
+// declining the work. Four occurrences in a 40h window on our fleet, each
+// after 1-2 hours of coder runtime. The executor now synthesizes a message.
+func TestNativeExecutor_SynthesizesCommitMessageWhenModelOmitsIt(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+
+	agent, task := taskAndAgent("nomsg")
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(agent, task).
+		Build()
+
+	// GO with real edits but no CommitMessage — the shape that used to be
+	// thrown away.
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true, Verdict: "GO",
+				Summary:       "Added graceful shutdown and a regression test",
+				CommitMessage: "",
+			},
+		},
+		touch: func(name string, ws string) {
+			if name == "submit_result" {
+				_ = os.WriteFile(filepath.Join(ws, "fix.txt"), []byte("real work\n"), 0o644)
+			}
+		},
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("verdict: want GO got %s; result=%+v", res.Verdict, res)
+	}
+	if got := res.Extra["commitSHA"]; got == nil || got == "" {
+		t.Fatalf("work was discarded: commitSHA missing in Extra: %+v", res.Extra)
+	}
+
+	// The synthesized message must reference the issue without auto-closing it.
+	out, err := exec.Command("git", "-C", bare, "log", "-1", "--format=%B",
+		"foreman/issue-9999").CombinedOutput()
+	if err != nil {
+		t.Fatalf("read commit message: %v: %s", err, out)
+	}
+	msg := string(out)
+	if strings.TrimSpace(msg) == "" {
+		t.Error("synthesized commit message is empty")
+	}
+	if !strings.Contains(msg, "#9999") {
+		t.Errorf("message should reference the issue: %q", msg)
+	}
+	if strings.Contains(msg, "Fixes #") {
+		t.Errorf("a synthesized message must not auto-close the issue: %q", msg)
+	}
+}

--- a/pkg/foreman/agent/tools/submit_result.go
+++ b/pkg/foreman/agent/tools/submit_result.go
@@ -118,12 +118,14 @@ func (SubmitResultTool) Schema() oai.ToolSchemaDef {
 "properties": {
   "verdict":        {"type": "string", "enum": ["GO", "NO-GO", "ERROR"]},
   "summary":        {"type": "string", "description": "One-sentence outcome summary (1-280 chars)."},
-  "commit_message": {"type": "string",
-    "description": "Full commit message including subject, body, and Fixes #N if applicable."},
+  "commit_message": {
+    "type": "string",
+    "description":
+      "Full commit message: subject, body, and Fixes #N if applicable. The executor commits your edits with it."},
   "extra": {"type": "object",
     "description": "Structured extra fields the executor may surface in status.result.extra."}
 },
-"required": ["verdict", "summary"]
+"required": ["verdict", "summary", "commit_message"]
 }`),
 	}
 }

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -1192,3 +1192,25 @@ func TestTruncateRuneSafe_DottedIdentifierIsNotASentenceEnd(t *testing.T) {
 		t.Errorf("dotted identifier treated as a sentence end: %q", got)
 	}
 }
+
+// Issue #1526: commit_message must be required so a model cannot reach the
+// executor with edits and no message. The executor still synthesizes a
+// fallback, but the schema is what stops it happening.
+func TestSubmitResultRequiresCommitMessage(t *testing.T) {
+	var schema struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(SubmitResultTool{}.Schema().Parameters, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	want := map[string]bool{"verdict": true, "summary": true, "commit_message": true}
+	got := map[string]bool{}
+	for _, r := range schema.Required {
+		got[r] = true
+	}
+	for k := range want {
+		if !got[k] {
+			t.Errorf("schema required is missing %q; got %v", k, schema.Required)
+		}
+	}
+}


### PR DESCRIPTION
## What

- `commitAndPush` synthesizes a commit message when `submit_result` carries none.
- `commit_message` becomes required in the `submit_result` schema.

## Why

`repo.Commit` rejects an empty message and `commitAndPush` had no fallback, so a coder that edited files and reached `submit_result` without a commit message had its entire diff discarded:

```json
{"verdict":"NO-GO","summary":"commit rejected",
 "branch":"foreman/wl-misospace-windowstead-333/issue-333",
 "extra":{"error":"Commit: Message is required"}}
```

`branch` is set and `commitSHA` is empty — the work existed, the branch was resolved, and nothing was committed. Because the verdict is a plain `NO-GO`, it is indistinguishable from the model declining the work, so it reads as a model-quality problem rather than a harness one.

Four occurrences in a 40-hour window on our fleet, each after 1–2 hours of coder runtime:

```
2026-08-12T01:05  miso-gallery#387
2026-08-12T11:06  miso-gallery#402
2026-08-12T14:41  foreman-dispatch-bridge#97
2026-08-13T17:28  windowstead#333
```

Fixes #1526

## How

**The fallback** follows the shape already used by the gate-failed preserve path a few hundred lines below, which synthesizes a WIP subject rather than losing the branch. It uses the model's own `Summary` as the body and `Refs #N` rather than `Fixes #N` — a message we invented should not auto-close an issue on merge.

**The schema change** is the actual cause. `commit_message` was declared but absent from `required`, so a model could legally omit it.

Both, deliberately: the schema stops it happening, the fallback stops it costing an hour when a model omits it anyway. Either alone leaves a gap — schema-only turns a recoverable case into a rejected tool call, fallback-only silently accepts sloppy submissions.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — n/a, no user-facing surface changes

Two regression tests, both run against unmodified upstream first. `TestNativeExecutor_SynthesizesCommitMessageWhenModelOmitsIt` drives the real executor through `initBareWithSeed` + `fakeRegistry` and reproduces the production failure exactly before the fix:

```
verdict: want GO got NO-GO
Summary:commit rejected  Extra:[error:Commit: Message is required outcome:COMMIT-REJECTED ...]
```

It then asserts `commitSHA` is present and reads the message back off the bare remote to confirm it references the issue and does **not** contain `Fixes #`. `TestSubmitResultRequiresCommitMessage` covers the schema; before the change it reports `schema required is missing "commit_message"; got [verdict summary]`.

I first wrote the executor test against a copy of the synthesis logic, which would have passed with the production code broken, and replaced it with the harness above.

`Assisted-by: Claude Code (diagnosed the bug from four production occurrences, wrote the fix and tests; I reviewed the change and ran make fmt, make vet, make lint and make test locally before submitting)`
