### PR TITLE
fix: omit the issue reference when a task has no issue number

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1103,11 +1103,7 @@ func (e *NativeAgentLoopExecutor) commitPushAttempt(
 	// message we invented should not auto-close the issue on merge.
 	commitMessage := lr.Terminal.CommitMessage
 	if strings.TrimSpace(commitMessage) == "" {
-		commitMessage = fmt.Sprintf(
-			"fix: resolve issue #%d\n\n%s\n\nRefs #%d",
-			task.Spec.Payload.Issue,
-			strings.TrimSpace(lr.Terminal.Summary),
-			task.Spec.Payload.Issue)
+		commitMessage = synthesizedCommitMessage(task, lr.Terminal.Summary)
 		log.Info("submit_result carried no commit message; synthesized one",
 			"issue", task.Spec.Payload.Issue)
 	}
@@ -1154,6 +1150,29 @@ func (e *NativeAgentLoopExecutor) commitPushAttempt(
 // practice (the retry loop is unreachable for read-only reviewers), so no
 // reviewer rails run here. Pulled out as a method so runLLMPath stays under
 // the gocyclo ceiling, mirroring applyWorkClassPolicyForTask above.
+// synthesizedCommitMessage builds a message for a submit_result that carried
+// none, so a real diff is never discarded on "Commit: Message is required".
+//
+// Payload.Issue is int32 with omitempty, so a task with no issue number reads
+// as 0. Freeform, integrate and reconcile tasks carry a repo without an issue
+// and do reach the commit path, so the issue reference is added only when
+// there is one — otherwise the subject names issue #0 and the trailer points
+// at nothing (#1530).
+func synthesizedCommitMessage(task *foremanv1alpha1.AgenticTask, summary string) string {
+	subject := strings.TrimSpace(summary)
+	if i := strings.IndexByte(subject, '\n'); i >= 0 {
+		subject = strings.TrimSpace(subject[:i])
+	}
+	if subject == "" {
+		subject = "apply coder changes for " + task.Name
+	}
+	if issue := task.Spec.Payload.Issue; issue > 0 {
+		return fmt.Sprintf("fix: resolve issue #%d\n\n%s\n\nRefs #%d",
+			issue, strings.TrimSpace(summary), issue)
+	}
+	return "fix: " + subject
+}
+
 func (e *NativeAgentLoopExecutor) retryCoderTerminalResult(
 	ctx context.Context, log logr.Logger,
 	agent *foremanv1alpha1.Agent, task *foremanv1alpha1.AgenticTask,

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -2215,3 +2215,85 @@ func TestNativeExecutor_SynthesizesCommitMessageWhenModelOmitsIt(t *testing.T) {
 		t.Errorf("a synthesized message must not auto-close the issue: %q", msg)
 	}
 }
+
+// Issue #1530: Payload.Issue is int32 with omitempty, so a task carrying a
+// repo but no issue number reads as 0. Freeform, integrate and reconcile
+// tasks have that shape and do reach commitPushAttempt, so the synthesized
+// message used to name issue #0 and emit a "Refs #0" trailer pointing at
+// nothing. The regression test for #1529 cannot catch this, because
+// taskAndAgent hardcodes Issue: 9999.
+func TestNativeExecutor_SynthesizedMessageOmitsIssueWhenTaskHasNone(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+
+	agent, task := taskAndAgent("noissue")
+	// The shape from #1530: repo set, issue unset.
+	task.Spec.Kind = foremanv1alpha1.AgenticTaskKindFreeform
+	task.Spec.Payload.Issue = 0
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(agent, task).
+		Build()
+
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true, Verdict: "GO",
+				Summary:       "Tighten the SSRF allowlist",
+				CommitMessage: "",
+			},
+		},
+		touch: func(name string, ws string) {
+			if name == "submit_result" {
+				_ = os.WriteFile(filepath.Join(ws, "fix.txt"), []byte("real work\n"), 0o644)
+			}
+		},
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	res, err := e.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := res.Extra["commitSHA"]; got == nil || got == "" {
+		t.Fatalf("work was discarded: commitSHA missing in Extra: %+v", res.Extra)
+	}
+
+	branch, _ := res.Extra["branch"].(string)
+	out, err := exec.Command("git", "-C", bare, "log", "-1", "--format=%B", branch).CombinedOutput()
+	if err != nil {
+		t.Fatalf("read commit message from %q: %v: %s", branch, err, out)
+	}
+	msg := string(out)
+	if strings.TrimSpace(msg) == "" {
+		t.Fatal("synthesized commit message is empty")
+	}
+	if strings.Contains(msg, "#0") {
+		t.Errorf("message must not reference issue #0: %q", msg)
+	}
+	if strings.Contains(msg, "Refs #") {
+		t.Errorf("no issue number, so there should be no Refs trailer: %q", msg)
+	}
+	if !strings.Contains(msg, "Tighten the SSRF allowlist") {
+		t.Errorf("message should carry the model's summary: %q", msg)
+	}
+}


### PR DESCRIPTION
## What

Extract the synthesized-commit-message logic into `synthesizedCommitMessage` and add the issue reference only when the task actually has one.

## Why

`Payload.Issue` is `int32` with `omitempty`, so a task carrying a repo but no issue number reads as `0`. The fallback landed in #1529 formatted it unconditionally:

```
fix: resolve issue #0

Tighten the SSRF allowlist

Refs #0
```

A subject naming a non-existent issue, and a trailer pointing at nothing.

Freeform, integrate and reconcile tasks have exactly that shape and do reach `commitPushAttempt` — `freeformGoResult`'s early return is gated on `needsRepo`, and those tasks have a repo.

Fixes #1530

## How

`synthesizedCommitMessage(task, summary)`:

- `Issue > 0` — unchanged: `fix: resolve issue #N` with the summary as body and a `Refs #N` trailer.
- otherwise — `fix: <summary>`, no issue reference and no trailer, matching the shape the gate-failed preserve path already uses for a message with no issue.
- summary also empty — falls back to the task name, so the message can never be blank and re-trip the `Commit: Message is required` failure #1529 fixed. The first line only is used as a subject, since `summary` is spec'd up to 280 chars.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — n/a, no user-facing surface changes

`TestNativeExecutor_SynthesizedMessageOmitsIssueWhenTaskHasNone` drives the real executor with `Kind: Freeform` and `Issue: 0`. Against current `main` it reproduces the report exactly:

```
message must not reference issue #0:
  "fix: resolve issue #0\n\nTighten the SSRF allowlist\n\nRefs #0\n\nSigned-off-by: ..."
no issue number, so there should be no Refs trailer: (same)
```

It also asserts `commitSHA` is present, so the no-issue path still cannot discard a diff.

As #1530 notes, the existing #1529 regression test cannot catch this — `taskAndAgent` hardcodes `Issue: 9999`.

`Assisted-by: Claude Code (wrote the fix and test from the report; I reviewed the change and ran make fmt, make vet, make lint and make test locally before submitting)`
