### PR TITLE
fix(deps): bump the Go toolchain to 1.26.6 for two stdlib advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/defilantech/llmkube
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/go-logr/logr v1.4.4


### PR DESCRIPTION
## What

One line: `go.mod` from `go 1.26.5` to `go 1.26.6`.

## Why

`govulncheck` began failing on **every** branch once two Go standard library advisories were published earlier today:

| advisory | package | fixed in |
| --- | --- | --- |
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url`, quadratic complexity in `resolvePath` | 1.26.6 |
| [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091) | `html/template`, Javascript regexp context tracking | 1.26.6 |

Both are reachable from our code, so `govulncheck` reports them as affecting rather than merely present:

```
#1: internal/router/backend.go:262:26: router.Dispatcher.Dispatch calls http.Client.Do,
    which eventually calls url.URL.Parse
#2: cmd/foreman-agent/main.go:500:6: foreman.main calls errgroup.Group.Go,
    which eventually calls url.URL.ResolveReference
#1: pkg/agent/health.go:233:30: agent.HealthServer.Run calls http.Server.ListenAndServe,
    which eventually calls template.Template.Execute
```

**This is not specific to any one branch.** `main` fails the Security workflow too:

| time (UTC) | branch | result |
| --- | --- | --- |
| 18:02 | `fix/submit-result-commit-message` (#1529) | success |
| 18:30 | `fix/synth-message-no-issue` (#1532) | success |
| 23:26 | `feat/1528-draft-speculative-decoding` (#1533) | **failure** |
| 23:43 | `main`, after #1532 merged | **failure** |

`govulncheck` queries the vulnerability database live, so the advisories landed between 18:30 and 23:26. Every run after that fails regardless of branch, and the green checks on PRs that ran earlier are stale rather than meaningful.

## How

Every workflow resolves its toolchain with `go-version-file: go.mod` (`lint.yml:20`, `test.yml:20`, `security.yml:27`, `foreman-e2e.yml:55`), so bumping the single pin covers all of them.

## Verification

Run locally with the exact govulncheck revision the workflow pins (`v1.1.4`, `d1f380186385b4f64e00313f31743df8e4b89a77`), against this branch:

```
Your code is affected by 0 vulnerabilities.
This scan also found 0 vulnerabilities in packages you import and 2
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
```

Exit 0. The two remaining are require-only, not call-reachable, and were already in that state before this change.

- `go mod tidy` on 1.26.6: no-op, `go.mod` is the only changed file and `go.sum` is untouched
- `go build ./...` and `go vet ./...` on 1.26.6: clean
- `gofmt -l cmd/ internal/ api/ pkg/`: clean

## Additional Context

Worth landing ahead of the open PR queue: #1518, #1527, #1529 and #1533 are approved or mergeable, and merging any of them turns `main` red on Security until this is in.

## Checklist

- [x] Tests added/updated - n/a, toolchain pin only, no code change
- [x] `make test` passes locally - build and vet clean on 1.26.6; no source changed
- [x] `make lint` passes locally - `gofmt` clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - n/a

*Assisted-by: Claude Code (diagnosed the failure against the run timeline, confirmed main fails identically, and verified the fix with the pinned govulncheck revision before opening this.)*
