### PR TITLE
fix(controller): let ModelTransferHealthy recover after a retried download succeeds

### DIFF
--- a/internal/controller/model_transfer_diag.go
+++ b/internal/controller/model_transfer_diag.go
@@ -198,6 +198,13 @@ func findModelTransferFailure(pods []corev1.Pod) (nodeName, reason, matchedLine 
 			if !isGeneratedInitContainer(cs.Name) {
 				continue
 			}
+			// A container whose CURRENT termination is success has staged its
+			// weights. LastTerminationState still holds any earlier failed attempt
+			// for the life of the pod, so consulting it here would pin the
+			// condition False forever after a retry that succeeded (#1536).
+			if cs.State.Terminated != nil && cs.State.Terminated.ExitCode == 0 {
+				continue
+			}
 			for _, term := range []*corev1.ContainerStateTerminated{
 				cs.State.Terminated,
 				cs.LastTerminationState.Terminated,

--- a/internal/controller/model_transfer_diag_test.go
+++ b/internal/controller/model_transfer_diag_test.go
@@ -179,4 +179,47 @@ func TestFindModelTransferFailure(t *testing.T) {
 			t.Error("a completed init container must not be reported as failing")
 		}
 	})
+
+	// A retried download that has since succeeded keeps the failed attempt in
+	// LastTerminationState for the life of the pod. The current state is exit 0,
+	// so the stale failure must not pin the condition False forever (#1536).
+	t.Run("ignores a recovered retry whose last termination still failed", func(t *testing.T) {
+		cs := terminatedInit("model-downloader", 0, "")
+		cs.LastTerminationState = corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 1,
+				Message:  "curl: (7) Failed to connect to 10.0.0.5 port 9000: Connection refused",
+			},
+		}
+		pods := []corev1.Pod{initPod("node-a", cs)}
+		if _, _, _, found := findModelTransferFailure(pods); found {
+			t.Error("a container whose current termination is success must not be diagnosed from its last termination")
+		}
+	})
+
+	// The crash-loop path the last-termination scan exists for must keep
+	// working: current state is NOT a successful termination, so the failed
+	// last termination is still a live signal.
+	t.Run("still diagnoses a genuine crash loop from last termination", func(t *testing.T) {
+		cs := corev1.ContainerStatus{
+			Name: "model-downloader",
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+			},
+			LastTerminationState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					ExitCode: 1,
+					Message:  "curl: (7) Failed to connect to 10.0.0.5 port 9000: Connection refused",
+				},
+			},
+		}
+		pods := []corev1.Pod{initPod("node-b", cs)}
+		node, reason, line, found := findModelTransferFailure(pods)
+		if !found {
+			t.Fatal("a crash-looping container must still be diagnosed from its last termination")
+		}
+		if node != "node-b" || reason != ReasonModelSourceUnreachable || line == "" {
+			t.Errorf("got node=%q reason=%q line=%q", node, reason, line)
+		}
+	})
 }


### PR DESCRIPTION
## What

Stops `ModelTransferHealthy` from being pinned `False` for the life of a pod once its weight-staging init container has failed a single attempt, even after a later attempt succeeds and the service serves normally.

Seven lines in `findModelTransferFailure`, plus two regression tests.

## Why

Fixes #1536

`findModelTransferFailure` scans both terminated states of each generated init container:

```go
for _, term := range []*corev1.ContainerStateTerminated{
    cs.State.Terminated,
    cs.LastTerminationState.Terminated,
} {
```

Scanning `LastTerminationState` is right for a container that is *currently* crash-looping, which is what the existing comment describes. It is wrong once a container has retried and succeeded: `LastTerminationState` retains the failed attempt for the life of the pod, so `found` stays true forever. That makes the `!found` recovery branch in `reconcileModelTransferCondition` unreachable, and the condition never returns to `True`.

Observed live, not inferred. An InferenceService that had been serving for 26 hours:

```
Available=True             at 05:28:54Z   "Inference service is ready and serving requests"
ModelTransferHealthy=False at 04:21:01Z   ModelSourceUnreachable
```

with the init container in exactly the recovered-failure shape:

```
model-downloader: restartCount=22
  state.terminated:     exit=0 reason=Completed
  lastState.terminated: exit=1 reason=Error
```

Forcing a reconcile did not clear it.

The practical cost is not the false alarm. It is that a condition which cannot recover carries no information about the present, so it cannot be trusted in either direction: anything alerting on `ModelTransferHealthy` fires permanently after one transient blip during staging.

## How

A generated init container whose **current** termination is exit 0 has staged its weights, so its `LastTerminationState` is history rather than a live signal:

```go
if cs.State.Terminated != nil && cs.State.Terminated.ExitCode == 0 {
    continue
}
```

The last-termination scan is deliberately kept for the genuine `CrashLoopBackOff` case, where the current state is *not* a successful termination. That case is what the scan was written for and it keeps working.

Two regression tests, mirroring the table style already in `model_transfer_diag_test.go`:

- a recovered retry (current exit 0, last exit 1 carrying a matched message) is **not** diagnosed
- a genuine crash loop (current state `Waiting: CrashLoopBackOff`, last exit 1) **is** still diagnosed, with node, reason and matched line asserted

The second test is the load-bearing one: without it, "fix the false positive" could be satisfied by blinding the crash-loop path entirely.

## Verification

- `go test ./internal/controller/ -run 'ModelTransfer' -count=1`: pass
- **Mutation-verified.** Reverting only the seven-line guard, with the tests left in place, fails exactly one test:

  ```
  --- FAIL: TestFindModelTransferFailure/ignores_a_recovered_retry_whose_last_termination_still_failed
      a container whose current termination is success must not be diagnosed from its last termination
  ```

  The crash-loop test still passes there, confirming the new coverage is specific and that the fix does not blind the path it was written for.
- Full deterministic gate on this branch: **GATE-PASS** (`make fmt`, `vet`, `lint`, `test`, `manifests`, `chart-crds`, `foreman-chart-crds`, `test-chart`, plus the bite check)
- `gofmt` clean; `golangci-lint run ./internal/controller/...` native and `GOOS=linux`: 0 issues

Scope is two files and 50 added lines, no deletions. The message-composition path and `modelTransferSignatures` are untouched.

## Known limitation

The condition message quality is a separate defect, left for its own change. Because the matcher takes the first line matching a signature, a curl progress meter can be selected over the actual error, which is how the live example surfaced as:

```
Model transfer failed: 0      0   0      0   0      0      0      0     ...
(node shadowstack). check the endpoint address, cluster DNS, and any
NetworkPolicy or egress restriction
```

This PR does not change that. It is noted in #1536.

## Checklist

- [x] Tests added/updated - two regression tests, mutation-verified
- [x] `make test` passes locally - via the full gate on this branch (GATE-PASS)
- [x] `make lint` passes locally - 0 issues, native and `GOOS=linux`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - n/a, no user-facing surface changes

*Assisted-by: DeepSeek-V4-Flash (MXFP4) running on two DGX Sparks via LLMKube, dispatched by Foreman from a written intent that named the file and the exact guard; reviewed by Nemotron-49B on a Strix Halo node. I wrote the issue analysis and the intent, independently mutation-verified the diff rather than relying on the agents' verdicts, and reviewed the change before opening this.*
