### PR TITLE
docs: make spec.files discoverable from spec.source for multi-artifact models

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -35,6 +35,16 @@ type ModelSpec struct {
 	//   - s3://my-bucket/models/llama-3.1-8b-q4_k_m.gguf (S3-compatible object store)
 	//   - /mnt/models/Llama-3.2-3B-Instruct-4bit (MLX model directory)
 	//
+	// Source may also name a repository or bucket PREFIX rather than a single
+	// object. In that case spec.files selects which artifacts to stage from it,
+	// and files[0] is the primary file handed to the runtime. This is how a
+	// sharded GGUF, an mmproj, or draft weights are expressed. Example:
+	//
+	//   source: s3://models/org/Repo-GGUF
+	//   files:
+	//     - Model-00001-of-00002.gguf
+	//     - Model-00002-of-00002.gguf
+	//
 	// file:// caveat for hybrid topologies: the controller pod must be
 	// able to read the path. In Mac kind / k3s / GKE deployments where
 	// the metal-agent runs on the host and the controller runs inside a
@@ -115,7 +125,8 @@ type ModelSpec struct {
 
 	// Files lists model weight artifacts to stage from Source. Entries are
 	// repo-relative for repository sources. The first entry is the primary model
-	// file passed to the runtime.
+	// file passed to the runtime. When Files is empty, Source must name a single
+	// object directly.
 	// +optional
 	Files []string `json:"files,omitempty"`
 

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -66,7 +66,8 @@ spec:
                 description: |-
                   Files lists model weight artifacts to stage from Source. Entries are
                   repo-relative for repository sources. The first entry is the primary model
-                  file passed to the runtime.
+                  file passed to the runtime. When Files is empty, Source must name a single
+                  object directly.
                 items:
                   type: string
                 type: array
@@ -392,6 +393,16 @@ spec:
                     - pvc://my-models-pvc/path/to/model.gguf (pre-staged on a PersistentVolumeClaim)
                     - s3://my-bucket/models/llama-3.1-8b-q4_k_m.gguf (S3-compatible object store)
                     - /mnt/models/Llama-3.2-3B-Instruct-4bit (MLX model directory)
+
+                  Source may also name a repository or bucket PREFIX rather than a single
+                  object. In that case spec.files selects which artifacts to stage from it,
+                  and files[0] is the primary file handed to the runtime. This is how a
+                  sharded GGUF, an mmproj, or draft weights are expressed. Example:
+
+                    source: s3://models/org/Repo-GGUF
+                    files:
+                      - Model-00001-of-00002.gguf
+                      - Model-00002-of-00002.gguf
 
                   file:// caveat for hybrid topologies: the controller pod must be
                   able to read the path. In Mac kind / k3s / GKE deployments where

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -62,7 +62,8 @@ spec:
                 description: |-
                   Files lists model weight artifacts to stage from Source. Entries are
                   repo-relative for repository sources. The first entry is the primary model
-                  file passed to the runtime.
+                  file passed to the runtime. When Files is empty, Source must name a single
+                  object directly.
                 items:
                   type: string
                 type: array
@@ -388,6 +389,16 @@ spec:
                     - pvc://my-models-pvc/path/to/model.gguf (pre-staged on a PersistentVolumeClaim)
                     - s3://my-bucket/models/llama-3.1-8b-q4_k_m.gguf (S3-compatible object store)
                     - /mnt/models/Llama-3.2-3B-Instruct-4bit (MLX model directory)
+
+                  Source may also name a repository or bucket PREFIX rather than a single
+                  object. In that case spec.files selects which artifacts to stage from it,
+                  and files[0] is the primary file handed to the runtime. This is how a
+                  sharded GGUF, an mmproj, or draft weights are expressed. Example:
+
+                    source: s3://models/org/Repo-GGUF
+                    files:
+                      - Model-00001-of-00002.gguf
+                      - Model-00002-of-00002.gguf
 
                   file:// caveat for hybrid topologies: the controller pod must be
                   able to read the path. In Mac kind / k3s / GKE deployments where

--- a/docs/model-storage.md
+++ b/docs/model-storage.md
@@ -60,3 +60,17 @@ Strict-taint users can use `spec.modelCache.claimName` with a pre-provisioned, n
 ## Metadata
 
 In `perService` mode the operator reads GGUF metadata (architecture, layer count, context length, etc.) for `Model.Status` by reading **only the file header** over HTTP range requests — it never downloads the whole model itself. The full model bytes are fetched only by the init container, on the serving node. `pvc://` and HuggingFace-repo sources are resolved at pod runtime and are unaffected.
+
+## Multi-artifact staging
+
+`spec.source` may name a repository or bucket **prefix** rather than a single object. In that case `spec.files` selects which artifacts to stage from it, and `files[0]` is the primary file handed to the runtime. This is how a sharded GGUF, an `mmproj`, or draft weights are expressed. All listed files land in **one cache directory**, so a sharded GGUF resolves its siblings by path.
+
+```yaml
+source: s3://models/org/Repo-GGUF
+files:
+  - Model-00001-of-00002.gguf
+  - Model-00002-of-00002.gguf
+mmproj: mmproj-model-f16.gguf
+```
+
+When `spec.files` is empty, `spec.source` must name a single object directly.


### PR DESCRIPTION
## What

Makes `spec.files` discoverable from the field that sends people looking for it.

`ModelSpec.Source`'s godoc gains a paragraph stating that `source` may name a repository or bucket **prefix**, that `spec.files` selects artifacts within it, and that `files[0]` is the primary file handed to the runtime, with a sharded-GGUF example. `ModelSpec.Files` gains the converse sentence. `docs/model-storage.md` gains a `## Multi-artifact staging` section. The generated CRD descriptions are regenerated so `kubectl explain model.spec.source` carries it too.

## Why

Fixes #1537

`Source`'s godoc enumerated every supported scheme and gave seven examples, all of them single files. `Files` existed and did exactly the right thing, but the two fields never referenced each other and nothing in `docs/` mentioned `spec.files`. The behaviour also splits into two entirely different init containers depending on whether `files` is set (single-key `curl --aws-sigv4 .../${S3_KEY}` versus `multiFileInitEnvVars` staging a list), so reading one deployed pod gives a confident but wrong picture of what the API supports.

That cost real work. Staging DeepSeek-V4-Flash (2 shards, 144.3 GiB) from MinIO, the single-key init container led to the conclusion that `s3://` could not express a multi-shard model, and the shards were merged with `llama-gguf-split --merge`, uploaded as a 144 GiB derived object, and renamed server-side. Roughly 64 minutes of transfer plus a write credential that did not need to exist. The supported spelling was `source` + `files`, and the original shards were already in the bucket.

## How

The `Source` paragraph is placed immediately before the existing `file://` caveat, so the scheme list, the new prefix note, and the caveat read in order. Both godoc edits change CRD field descriptions, so `make manifests` and `make chart-crds` were run and their output is included in the commit.

Scope is deliberately narrow: no controller logic, and none of `ResolveFileSet` / `multiFileInitEnvVars` / `usesMultiFileStaging`, whose behaviour is already correct. The optional validation guard floated in #1537 (surface a condition when `source` names a prefix with no `files`) is **not** included; adding a new Model condition is a larger change than the discoverability fix and belongs in its own PR.

Verified beyond the automated gate: re-running `make manifests && make chart-crds` on this branch leaves the tree **clean**, confirming the regenerated CRDs in the commit are complete and matching what CI's CRD Sync Check enforces. `gofmt -l api/` is clean and `go build ./...` succeeds. The full deterministic gate passed on this branch (`fmt`, `vet`, `lint`, `test`, `manifests`, `chart-crds`, `foreman-chart-crds`, `test-chart`, plus the bite check).

## Checklist

- [x] Tests added/updated - n/a, documentation and generated-description change only, no behaviour change
- [x] `make test` passes locally - via the full gate on this branch (GATE-PASS)
- [x] `make lint` passes locally - `gofmt -l api/` clean, `go build ./...` clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - `docs/model-storage.md` gains `## Multi-artifact staging`; the CRD field descriptions are regenerated

*Assisted-by: DeepSeek-V4-Flash (MXFP4) running on two DGX Sparks via LLMKube, dispatched by Foreman from a written intent that named the files and the exact edits; reviewed by Nemotron-49B on a Strix Halo node, and opened automatically by Foreman on review GO. I wrote the issue analysis and the intent, independently re-ran the CRD regeneration to confirm the commit was complete rather than relying on the agents' verdicts, and reviewed the diff.*

<sub>This body was filled in after the fact: Foreman opens PRs with the reviewer's summary and issue link only, not the repo's PR template. Tracked separately so future agent-opened PRs comply automatically.</sub>
