### PR TITLE
fix(foreman): honour Workload spec.repo for gate, push and PR, not just clone

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -401,19 +401,19 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	}
 
 	branch := branchNameForTask(task)
+	// Resolve the clone+push target ONCE so every downstream caller — the
+	// clone itself, the deterministic gate path, the post-push envtest gate,
+	// and PR opening — uses the SAME repository the Workload asked for
+	// (#1464). Precedence: payload.repo wins when set (a single agent serves
+	// many repos instead of being pinned to one --git-remote-url); the
+	// statically configured fork remote is the fallback, and stays the target
+	// when it is a fork of payload.repo (same repo name, different owner): the
+	// fork deployment pushes to the fork, not upstream (#915).
+	cloneURL := ""
 	if needsRepo {
-		// Clone target: the statically configured fork remote when set,
-		// otherwise the task's own repo (#915). Deriving the clone+push
-		// target from payload.repo lets a single agent serve many repos
-		// instead of being pinned to one --git-remote-url; the branch
-		// still pushes to this clone's origin, which in that case is the
-		// task's repo itself.
-		cloneURL := e.GitRemoteURL
-		if cloneURL == "" {
-			cloneURL = resolveUpstream(task.Spec.Payload.Repo)
-		}
-		if msg := crossProjectRemoteMismatch(e.GitRemoteURL, task.Spec.Payload.Repo); msg != "" {
-			return e.failResult(start, foremanv1alpha1.FailureGitRemoteNotConfigured, msg), nil
+		cloneURL = resolveUpstream(task.Spec.Payload.Repo)
+		if cloneURL == "" || isForkOf(e.GitRemoteURL, task.Spec.Payload.Repo) {
+			cloneURL = e.GitRemoteURL
 		}
 		if cloneURL == "" {
 			return e.failResult(start, foremanv1alpha1.FailureGitRemoteNotConfigured,
@@ -452,13 +452,13 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	// first tool directly with the task payload as JSON arguments. The
 	// gate Agent uses this; M5+ reviewer agents use the LLM path.
 	if deterministic {
-		return e.executeDeterministic(ctx, task, &agent, branch, registry, start), nil
+		return e.executeDeterministic(ctx, task, &agent, branch, registry, cloneURL, start), nil
 	}
 
 	// 6+. LLM-driven path: extracted to keep Execute below the
 	// cyclomatic-complexity threshold. runLLMPath owns OAI + loop +
 	// transcript + commit/push.
-	return e.runLLMPath(ctx, task, &agent, endpoint, workspace, branch, registry, auth, needsRepo, start)
+	return e.runLLMPath(ctx, task, &agent, endpoint, workspace, branch, registry, auth, needsRepo, cloneURL, start)
 }
 
 // setupTaskBranch cuts the task's working branch in the freshly cloned
@@ -631,6 +631,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	registry ToolRegistry,
 	auth *repo.Auth,
 	needsRepo bool,
+	cloneURL string,
 	start time.Time,
 ) (*Result, error) {
 	log := logf.FromContext(ctx).WithName("native-agent-loop").WithValues("task", task.Name, "ns", task.Namespace)
@@ -891,7 +892,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// record it under r.Extra. Coder-role only (reviewers are read-only).
 		e.maybePreserveGateFailedBranch(ctx, log, agent, task, workspace, branch, auth, loopRes, r)
 		e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r,
-			workspace, reviewBase, reviewDiff)
+			workspace, reviewBase, reviewDiff, cloneURL)
 		// Attach the normalized failure reason from the model-to-CRD
 		// mapping (e.g. ERROR→INCOMPLETE + ModelReportedError for #649). Only
 		// set when the normalizer produced a reason AND the result does
@@ -939,7 +940,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// coder with feedback.
 		settled, done, feedback := e.postPushGateDecision(
 			ctx, envtestTouched, task, branch, sha, attempt, maxEnvtestIters,
-			start, transcriptRef, loopRes, gateAdvisories)
+			start, transcriptRef, loopRes, gateAdvisories, cloneURL)
 		if settled {
 			break
 		}
@@ -969,7 +970,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		verdict, normReason := normalizeModelVerdict(loopRes.Terminal.Verdict)
 		if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
 			return e.retryCoderTerminalResult(ctx, log, agent, task,
-				workspace, branch, auth, start, transcriptRef, loopRes, verdict, normReason), nil
+				workspace, branch, auth, start, transcriptRef, loopRes, verdict, normReason, cloneURL), nil
 		}
 	}
 
@@ -1018,12 +1019,12 @@ func (e *NativeAgentLoopExecutor) postPushGateDecision(
 	ctx context.Context, envtestTouched bool, task *foremanv1alpha1.AgenticTask,
 	branch, sha string, attempt, maxEnvtestIters int,
 	start time.Time, transcriptRef corev1.ObjectReference, loopRes *LoopResult,
-	gateAdvisories *[]advisory,
+	gateAdvisories *[]advisory, cloneURL string,
 ) (settled bool, done *Result, feedback string) {
 	gate, fb := evaluatePostPushEnvtest(
 		ctx, envtestTouched, e.EnvtestJobRunner,
 		task.Namespace, task.Name,
-		task.Spec.Payload.Repo, branch, e.GitRemoteURL,
+		task.Spec.Payload.Repo, branch, cloneURL,
 	)
 	if gate == envtestGateOK || (gate == envtestGateUnverified && attempt == 0) {
 		return true, nil, ""
@@ -1138,6 +1139,17 @@ func (e *NativeAgentLoopExecutor) commitPushAttempt(
 		return sha, envtestTouched, e.pushFailedResult(start, tref, lr, branch, sha, err)
 	}
 
+	// Assert-after-push guard (#1464): the branch must have landed on the
+	// repository the Workload asked for, not an unrelated one the static
+	// --git-remote-url happened to name. The clone+push target is derived
+	// from payload.repo above, so this is a belt-and-suspenders check that
+	// the push remote matches the task's repo when both are known. A push
+	// to an unexpected repository must never be reportable as GO.
+	if msg := pushedRemoteMismatch(ctx, workspace, task.Spec.Payload.Repo); msg != "" {
+		return sha, envtestTouched, e.pushFailedResult(start, tref, lr, branch, sha,
+			fmt.Errorf("%s", msg))
+	}
+
 	return sha, envtestTouched, nil
 }
 
@@ -1179,13 +1191,14 @@ func (e *NativeAgentLoopExecutor) retryCoderTerminalResult(
 	workspace, branch string, auth *repo.Auth,
 	start time.Time, tref corev1.ObjectReference, lr *LoopResult,
 	verdict foremanv1alpha1.AgenticTaskVerdict, normReason foremanv1alpha1.AgenticTaskFailureReason,
+	cloneURL string,
 ) *Result {
 	r := e.modelDecidedResult(start, tref, lr, verdict)
 	e.maybePreserveGateFailedBranch(ctx, log, agent, task, workspace, branch, auth, lr, r)
 	// No reviewer rails ran on this path, so there is no resolved review base
 	// to ground the summary against; #1411's check degrades open on the empty
 	// base rather than grounding against a base it had to guess at.
-	e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r, workspace, "", nil)
+	e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r, workspace, "", nil, cloneURL)
 	if normReason != "" && r.FailureReason == "" {
 		r.FailureReason = normReason
 	}
@@ -1444,6 +1457,7 @@ func (e *NativeAgentLoopExecutor) executeDeterministic(
 	agent *foremanv1alpha1.Agent,
 	branch string,
 	registry ToolRegistry,
+	cloneURL string,
 	start time.Time,
 ) *Result {
 	toolName := pickDeterministicTool(agent.Spec.Tools)
@@ -1455,11 +1469,11 @@ func (e *NativeAgentLoopExecutor) executeDeterministic(
 	// The task payload becomes the tool's arguments. For the gate
 	// Agent's run_gate_job tool, this means {repo, branch, checks,
 	// cloneURL} surface from spec.payload via well-known fields. The
-	// cloneURL override carries the executor's --git-remote-url so the
-	// gate Job clones from the fork the upstream coder pushed to,
-	// rather than the upstream payload.repo where the branch does not
-	// yet exist.
-	args := buildDeterministicArgs(task, branch, e.GitRemoteURL)
+	// cloneURL override carries the resolved clone+push target (the
+	// repository the Workload asked for, #1464) so the gate Job clones
+	// from the same repo the coder pushed to, rather than the upstream
+	// payload.repo where the branch does not yet exist.
+	args := buildDeterministicArgs(task, branch, cloneURL)
 
 	result, dispatchErr := registry.Dispatch(ctx, toolName, args)
 	if dispatchErr != nil {
@@ -1526,13 +1540,13 @@ func pickDeterministicTool(tools []string) string {
 // {repo, branch, cloneURL} from this; other deterministic tools can
 // extend the shape as needed.
 //
-// cloneURL is the executor's --git-remote-url passed through verbatim.
-// When set, the gate Job clones from this URL instead of constructing
-// one from CloneURLBase + payload.repo. v0.1 needs this because the
-// upstream coder task pushes to a fork (the foreman-agent's
-// --git-remote-url) and the gate must verify that branch on the fork,
-// not on the upstream payload.repo where the branch does not yet
-// exist. Empty cloneURL preserves the M4 default (upstream + repo).
+// cloneURL is the resolved clone+push target (the repository the Workload
+// asked for, #1464). When set, the gate Job clones from this URL instead of
+// constructing one from CloneURLBase + payload.repo. v0.1 needs this because
+// the upstream coder task pushes to a fork (the foreman-agent's
+// --git-remote-url) and the gate must verify that branch on the fork, not on
+// the upstream payload.repo where the branch does not yet exist. Empty
+// cloneURL preserves the M4 default (upstream + repo).
 func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL string) json.RawMessage {
 	// Resolve once. Resolve() is nil-safe: a nil GateProfile yields the go
 	// preset (image golang:1.26, the make-target checks), so a Go task stays
@@ -1860,7 +1874,7 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 	ctx context.Context, log logr.Logger,
 	task *foremanv1alpha1.AgenticTask, auth *repo.Auth,
 	verdict foremanv1alpha1.AgenticTaskVerdict, r *Result,
-	workspace, reviewBase string, reviewDiff []string,
+	workspace, reviewBase string, reviewDiff []string, cloneURL string,
 ) {
 	if verdict != foremanv1alpha1.AgenticTaskVerdictGo ||
 		task.Spec.Kind != foremanv1alpha1.AgenticTaskKindReview ||
@@ -1869,7 +1883,7 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 		return
 	}
 	body := e.groundPRSummary(ctx, log, r, workspace, reviewBase, reviewDiff)
-	if prURL, prErr := e.openPullRequest(ctx, task, auth, body); prErr != nil {
+	if prURL, prErr := e.openPullRequest(ctx, task, auth, body, cloneURL); prErr != nil {
 		log.Error(prErr, "review GO: opening pull request failed",
 			"repo", task.Spec.Payload.Repo, "branch", task.Spec.Payload.Branch)
 		r.Extra["pullRequestError"] = prErr.Error()
@@ -1936,7 +1950,7 @@ func (e *NativeAgentLoopExecutor) groundPRSummary(
 // owner — or one that is not an owner/repo-shaped URL at all (local
 // paths in tests) — keeps the same-repo shape.
 func (e *NativeAgentLoopExecutor) openPullRequest(
-	ctx context.Context, task *foremanv1alpha1.AgenticTask, auth *repo.Auth, summaryBody string,
+	ctx context.Context, task *foremanv1alpha1.AgenticTask, auth *repo.Auth, summaryBody, cloneURL string,
 ) (string, error) {
 	p := task.Spec.Payload
 	owner, _, ok := codehost.SplitRepoSlug(p.Repo)
@@ -1944,12 +1958,18 @@ func (e *NativeAgentLoopExecutor) openPullRequest(
 		return "", fmt.Errorf("openPullRequest: payload.repo %q is not a valid repo slug", p.Repo)
 	}
 	ch := e.codeHost(authToken(auth))
-	// The coder pushed the branch to e.GitRemoteURL, which may be a fork of
-	// payload.repo. For a cross-fork PR the head is qualified "forkOwner:branch"
-	// and the head commit is read from the fork (headSlug), where the ref lives.
+	// The coder pushed the branch to the resolved clone+push target, which may
+	// be a fork of payload.repo. For a cross-fork PR the head is qualified
+	// "forkOwner:branch" and the head commit is read from the fork (headSlug),
+	// where the ref lives. cloneURL is the resolved target; when it is empty
+	// (e.g. a caller that did not resolve one) fall back to the static
+	// --git-remote-url so the fork deployment keeps working.
+	if cloneURL == "" {
+		cloneURL = e.GitRemoteURL
+	}
 	head := p.Branch
 	headSlug := p.Repo
-	if forkOwner, forkRepo := gitRemoteOwnerRepo(e.GitRemoteURL); forkOwner != "" &&
+	if forkOwner, forkRepo := gitRemoteOwnerRepo(cloneURL); forkOwner != "" &&
 		!strings.EqualFold(forkOwner, owner) {
 		head = forkOwner + ":" + p.Branch
 		headSlug = forkOwner + "/" + forkRepo
@@ -2509,6 +2529,57 @@ func crossProjectRemoteMismatch(remoteURL, taskRepo string) string {
 			"share the repo name (only the owner differs). Refusing to clone and push "+
 			"work for %q into %q",
 		remoteName, taskRepo, taskRepo, remoteName)
+}
+
+// isForkOf reports whether remoteURL names a fork of taskRepo: the repo NAME
+// matches (case-insensitively) while the OWNER may differ. A fork shares the
+// repo name by definition, so a name match is the fork relationship; a name
+// mismatch is an unrelated repository (#1464). Returns false for remotes that
+// are not owner/repo shaped (local bare-repo paths in tests) or when either
+// input is empty, so the fork deployment and the multi-repo mode both fall
+// through to the normal precedence.
+func isForkOf(remoteURL, taskRepo string) bool {
+	if remoteURL == "" || taskRepo == "" {
+		return false
+	}
+	_, remoteName := gitRemoteOwnerRepo(remoteURL)
+	if remoteName == "" {
+		return false
+	}
+	_, taskName, ok := codehost.SplitRepoSlug(taskRepo)
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(remoteName, taskName)
+}
+
+// pushedRemoteMismatch reports why the branch's push remote does not match the
+// task's payload.repo, or "" when it does (or cannot be determined). It reads
+// the workspace's origin URL after a push and compares its repo name against
+// the task's repo name, so a push that landed in an unrelated repository is
+// caught even though git push exited 0 (#1464). Returns "" when the remote is
+// not owner/repo shaped (local bare-repo paths in tests) or when either side is
+// empty, so the multi-repo and fork deployments are not falsely flagged.
+func pushedRemoteMismatch(ctx context.Context, workspace, taskRepo string) string {
+	if taskRepo == "" {
+		return ""
+	}
+	remoteURL, err := repo.RemoteURL(ctx, workspace, "origin")
+	if err != nil {
+		return ""
+	}
+	_, remoteName := gitRemoteOwnerRepo(remoteURL)
+	if remoteName == "" {
+		return ""
+	}
+	_, taskName, ok := codehost.SplitRepoSlug(taskRepo)
+	if !ok || strings.EqualFold(remoteName, taskName) {
+		return ""
+	}
+	return fmt.Sprintf(
+		"pushed branch to repository %q but the task targets %q; a push to an "+
+			"unexpected repository must not be reported as GO",
+		remoteName, taskRepo)
 }
 
 func gitRemoteOwnerRepo(remoteURL string) (owner, name string) {

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -2494,43 +2494,6 @@ var cloneURLResolver codehost.CodeHost = codehost.NewGitHubCodeHost(nil)
 // with or without the .git suffix. Anything else (local paths, file://
 // remotes used in tests, bare hosts) yields "", "" so callers fall back
 // to same-repo behavior.
-// crossProjectRemoteMismatch reports why a static --git-remote-url must not be
-// used for this task, or "" when it is fine (#1464).
-//
-// The fork deployment is legitimate and must keep working: --git-remote-url
-// names a fork of payload.repo, so the OWNER differs while the repo NAME is the
-// same (defilantech/LLMKube -> Defilan/LLMKube). A differing repo NAME is never
-// a fork relationship. It is a misconfiguration whose consequences are silent:
-// the coder reads the right issue, does correct work, pushes it into an
-// unrelated repository, and reports GO. Nothing downstream notices, because the
-// reviewer is handed the same wrong remote.
-//
-// Compared on names rather than by asking the codehost whether one repo is a
-// fork of the other: that would be a network call on every task and
-// provider-specific, while the name comparison already separates "fork of the
-// same project" from "entirely different project".
-//
-// Returns "" for remotes that are not owner/repo shaped (local bare-repo paths
-// in tests), so the guard cannot fire on them.
-func crossProjectRemoteMismatch(remoteURL, taskRepo string) string {
-	if remoteURL == "" || taskRepo == "" {
-		return ""
-	}
-	_, remoteName := gitRemoteOwnerRepo(remoteURL)
-	if remoteName == "" {
-		return ""
-	}
-	_, taskName, ok := codehost.SplitRepoSlug(taskRepo)
-	if !ok || strings.EqualFold(remoteName, taskName) {
-		return ""
-	}
-	return fmt.Sprintf(
-		"--git-remote-url names repository %q but the task targets %q; a fork must "+
-			"share the repo name (only the owner differs). Refusing to clone and push "+
-			"work for %q into %q",
-		remoteName, taskRepo, taskRepo, remoteName)
-}
-
 // isForkOf reports whether remoteURL names a fork of taskRepo: the repo NAME
 // matches (case-insensitively) while the OWNER may differ. A fork shares the
 // repo name by definition, so a name match is the fork relationship; a name

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2929,3 +2929,53 @@ func TestCrossProjectRemoteMismatch(t *testing.T) {
 		})
 	}
 }
+
+// isForkOf contract for #1464: a fork shares the repo NAME (owner may
+// differ); a differing repo name is an unrelated repository, not a fork.
+func TestIsForkOf(t *testing.T) {
+	cases := []struct {
+		name      string
+		remoteURL string
+		taskRepo  string
+		want      bool
+	}{
+		{name: "fork of same project", remoteURL: "https://github.com/Defilan/LLMKube.git", taskRepo: "defilantech/LLMKube", want: true},
+		{name: "same repo", remoteURL: "https://github.com/defilantech/LLMKube.git", taskRepo: "defilantech/LLMKube", want: true},
+		{name: "case-insensitive name", remoteURL: "https://github.com/Defilan/llmkube.git", taskRepo: "defilantech/LLMKube", want: true},
+		{name: "scp-like fork", remoteURL: "git@github.com:Defilan/LLMKube.git", taskRepo: "defilantech/LLMKube", want: true},
+		{name: "different project is not a fork", remoteURL: "https://github.com/Defilan/LLMKube.git", taskRepo: "Defilan/greenhouse-demo", want: false},
+		{name: "local path is not a fork", remoteURL: "/tmp/origin.git", taskRepo: "a/b", want: false},
+		{name: "file:// is not a fork", remoteURL: "file:///tmp/origin.git", taskRepo: "a/b", want: false},
+		{name: "empty remote", remoteURL: "", taskRepo: "a/b", want: false},
+		{name: "empty task repo", remoteURL: "https://github.com/o/r.git", taskRepo: "", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isForkOf(tc.remoteURL, tc.taskRepo); got != tc.want {
+				t.Errorf("isForkOf(%q, %q) = %v, want %v", tc.remoteURL, tc.taskRepo, got, tc.want)
+			}
+		})
+	}
+}
+
+// pushedRemoteMismatch reads the workspace's origin after a push and flags a
+// branch that landed in a repository other than the task's payload.repo.
+func TestPushedRemoteMismatch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	bare := filepath.Join(dir, "origin.git")
+	gitIn(t, "", "init", "--bare", bare)
+	ws := filepath.Join(dir, "ws")
+	gitIn(t, "", "clone", bare, ws)
+
+	// Local bare path is not owner/repo shaped -> no mismatch flagged.
+	if msg := pushedRemoteMismatch(context.Background(), ws, "defilantech/LLMKube"); msg != "" {
+		t.Errorf("local bare remote must not be flagged, got: %s", msg)
+	}
+	// Empty task repo -> no mismatch flagged.
+	if msg := pushedRemoteMismatch(context.Background(), ws, ""); msg != "" {
+		t.Errorf("empty task repo must not be flagged, got: %s", msg)
+	}
+}

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -46,6 +46,7 @@ import (
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/worktracker"
 )
 
@@ -2859,77 +2860,6 @@ func TestSetupTaskBranch_VerifyStartsAtCoderCommitNotBase(t *testing.T) {
 	}
 }
 
-// crossProjectRemoteMismatch contract for #1464.
-//
-// The fork deployment is legitimate: --git-remote-url names a fork of
-// payload.repo, so the OWNER differs while the repo NAME matches. A differing
-// repo name is never a fork relationship; it is a misconfiguration that sends a
-// coder's work into an unrelated repository while it reports GO.
-//
-// The whole value of the guard is where it draws the line between those two,
-// so the table drives the real helper rather than a copy of its logic.
-func TestCrossProjectRemoteMismatch(t *testing.T) {
-	cases := []struct {
-		name      string
-		remoteURL string
-		taskRepo  string
-		wantErr   bool
-	}{
-		{
-			name:      "fork of the same project is allowed",
-			remoteURL: "https://github.com/Defilan/LLMKube.git",
-			taskRepo:  "defilantech/LLMKube",
-		},
-		{
-			name:      "same repo entirely is allowed",
-			remoteURL: "https://github.com/defilantech/LLMKube.git",
-			taskRepo:  "defilantech/LLMKube",
-		},
-		{
-			name:      "case differences do not make it a different project",
-			remoteURL: "https://github.com/defilan/llmkube.git",
-			taskRepo:  "defilantech/LLMKube",
-		},
-		{
-			name:      "scp-like fork URL is allowed",
-			remoteURL: "git@github.com:Defilan/LLMKube.git",
-			taskRepo:  "defilantech/LLMKube",
-		},
-		{
-			name:      "different project is rejected (the #1464 shape)",
-			remoteURL: "https://github.com/Defilan/LLMKube.git",
-			taskRepo:  "Defilan/greenhouse-demo",
-			wantErr:   true,
-		},
-		{
-			name:      "scp-like different project is rejected",
-			remoteURL: "git@github.com:Defilan/LLMKube.git",
-			taskRepo:  "Defilan/greenhouse-demo",
-			wantErr:   true,
-		},
-		// Local bare-repo paths are what envtest injects. The guard must stay
-		// off for them or it breaks the harness rather than the bug.
-		{name: "local path remote is not guarded", remoteURL: "/tmp/origin.git", taskRepo: "a/b"},
-		{name: "file:// remote is not guarded", remoteURL: "file:///tmp/origin.git", taskRepo: "a/b"},
-		{name: "empty remote is not guarded", remoteURL: "", taskRepo: "a/b"},
-		{name: "empty task repo is not guarded", remoteURL: "https://github.com/o/r.git", taskRepo: ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := crossProjectRemoteMismatch(tc.remoteURL, tc.taskRepo)
-			if tc.wantErr && got == "" {
-				t.Errorf("remote %q with task repo %q must be rejected: work would be "+
-					"pushed into an unrelated repository and still report GO",
-					tc.remoteURL, tc.taskRepo)
-			}
-			if !tc.wantErr && got != "" {
-				t.Errorf("remote %q with task repo %q must be allowed, got: %s",
-					tc.remoteURL, tc.taskRepo, got)
-			}
-		})
-	}
-}
-
 // isForkOf contract for #1464: a fork shares the repo NAME (owner may
 // differ); a differing repo name is an unrelated repository, not a fork.
 func TestIsForkOf(t *testing.T) {
@@ -2977,5 +2907,29 @@ func TestPushedRemoteMismatch(t *testing.T) {
 	// Empty task repo -> no mismatch flagged.
 	if msg := pushedRemoteMismatch(context.Background(), ws, ""); msg != "" {
 		t.Errorf("empty task repo must not be flagged, got: %s", msg)
+	}
+
+	// Positive case (#1464): the pushed remote genuinely disagrees with
+	// payload.repo. Point origin at a differently-named repository and assert
+	// the mismatch is flagged. If pushedRemoteMismatch unconditionally returned
+	// "" this would fail, which is exactly the regression that would
+	// reintroduce #1464 (a push to an unrelated repo reported as GO).
+	if err := repo.SetRemote(context.Background(), ws, "origin",
+		"https://github.com/Defilan/greenhouse-demo.git"); err != nil {
+		t.Fatalf("SetRemote origin to a differently-named repo: %v", err)
+	}
+	if msg := pushedRemoteMismatch(context.Background(), ws, "defilantech/LLMKube"); msg == "" {
+		t.Fatalf("remote greenhouse-demo vs task repo defilantech/LLMKube must be " +
+			"flagged as a mismatch; got an empty message")
+	}
+
+	// Control: a fork (same repo name, different owner) is NOT a mismatch —
+	// the legitimate fork deployment must stay off this guard.
+	if err := repo.SetRemote(context.Background(), ws, "origin",
+		"https://github.com/Defilan/LLMKube.git"); err != nil {
+		t.Fatalf("SetRemote origin to a fork of the task repo: %v", err)
+	}
+	if msg := pushedRemoteMismatch(context.Background(), ws, "defilantech/LLMKube"); msg != "" {
+		t.Errorf("a fork of the task repo must not be flagged, got: %s", msg)
 	}
 }

--- a/pkg/foreman/agent/executor_pr_test.go
+++ b/pkg/foreman/agent/executor_pr_test.go
@@ -112,7 +112,7 @@ func TestMaybeOpenPullRequest_Gating(t *testing.T) {
 			task := reviewTaskForPR(tc.kind, tc.openPR)
 			r := &Result{Extra: map[string]any{}}
 
-			e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil, tc.verdict, r, "", "", nil)
+			e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil, tc.verdict, r, "", "", nil, "")
 
 			if called := len(fe.ensures) > 0; called != tc.wantCalled {
 				t.Fatalf("EnsurePR called=%v, want %v (calls=%+v)", called, tc.wantCalled, fe.ensures)
@@ -131,7 +131,7 @@ func TestMaybeOpenPullRequest_NilEnsurerIsDisabled(t *testing.T) {
 	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
 	r := &Result{Extra: map[string]any{}}
 	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil, "")
 	if len(r.Extra) != 0 {
 		t.Fatalf("nil ensurer must be a no-op; extra=%+v", r.Extra)
 	}
@@ -150,7 +150,7 @@ func TestMaybeOpenPullRequest_BodyCarriesReviewSummary(t *testing.T) {
 	}
 
 	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil, "")
 
 	if len(fe.ensures) != 1 {
 		t.Fatalf("want 1 EnsurePR call, got %+v", fe.ensures)
@@ -182,7 +182,7 @@ func TestMaybeOpenPullRequest_ForkRemoteQualifiesHead(t *testing.T) {
 	r := &Result{Extra: map[string]any{}}
 
 	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil, "")
 
 	if len(fe.ensures) != 1 {
 		t.Fatalf("want 1 EnsurePR call, got %+v", fe.ensures)
@@ -224,7 +224,7 @@ func TestMaybeOpenPullRequest_SameRepoRemoteKeepsBareHead(t *testing.T) {
 		r := &Result{Extra: map[string]any{}}
 
 		e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-			foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil)
+			foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil, "")
 
 		if len(fe.ensures) != 1 {
 			t.Fatalf("remote %q: want 1 EnsurePR call, got %+v", remote, fe.ensures)
@@ -292,7 +292,7 @@ func TestMaybeOpenPullRequest_BodyFlagsUngroundedClaim(t *testing.T) {
 	r := &Result{Summary: summary, Extra: map[string]any{}}
 
 	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, r, t.TempDir(), "main", []string{"bridge/app.py"})
+		foremanv1alpha1.AgenticTaskVerdictGo, r, t.TempDir(), "main", []string{"bridge/app.py"}, "")
 
 	if len(fe.ensures) != 1 {
 		t.Fatalf("want 1 EnsurePR call, got %+v", fe.ensures)
@@ -334,7 +334,7 @@ func TestMaybeOpenPullRequest_GroundedSummaryUntouched(t *testing.T) {
 	r := &Result{Summary: summary, Extra: map[string]any{}}
 
 	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, r, t.TempDir(), "main", []string{"bridge/app.py"})
+		foremanv1alpha1.AgenticTaskVerdictGo, r, t.TempDir(), "main", []string{"bridge/app.py"}, "")
 
 	body := fe.ensures[0].body
 	if strings.Contains(body, "Unverified claims") {
@@ -369,7 +369,7 @@ func TestMaybeOpenPullRequest_NoDiffSkipsGrounding(t *testing.T) {
 			r := &Result{Summary: summary, Extra: map[string]any{}}
 
 			e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
-				foremanv1alpha1.AgenticTaskVerdictGo, r, tc.workspace, tc.base, nil)
+				foremanv1alpha1.AgenticTaskVerdictGo, r, tc.workspace, tc.base, nil, "")
 
 			if body := fe.ensures[0].body; strings.Contains(body, "Unverified claims") {
 				t.Errorf("no ground truth must mean no note; got %q", body)

--- a/pkg/foreman/agent/repo/push.go
+++ b/pkg/foreman/agent/repo/push.go
@@ -126,6 +126,24 @@ func replaceRemoteBranch(ctx context.Context, workspace string, env []string, re
 	return err
 }
 
+// RemoteURL returns the URL of the named remote (default "origin") in the
+// workspace, or an error if the remote does not exist or cannot be read.
+// Callers use it to assert, after a push, that the branch landed on the
+// repository the Workload asked for rather than an unrelated one (#1464).
+func RemoteURL(ctx context.Context, workspace, remote string) (string, error) {
+	if workspace == "" {
+		return "", fmt.Errorf("RemoteURL: Workspace is required")
+	}
+	if remote == "" {
+		remote = "origin"
+	}
+	out, err := runGit(ctx, workspace, baseEnv(), "remote", "get-url", remote)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
 // SetRemote adds (or updates) a git remote. Used by callers that clone
 // from upstream and push to a fork: clone with one remote name, then
 // AddRemote("fork", forkURL), then Push(Remote="fork").

--- a/pkg/foreman/agent/repo/push_test.go
+++ b/pkg/foreman/agent/repo/push_test.go
@@ -120,6 +120,43 @@ func TestPush_CleanPush_NeverForces(t *testing.T) {
 	}
 }
 
+// TestRemoteURL reads the URL of a named remote (default "origin") from a
+// workspace, backing the assert-after-push guard (#1464).
+func TestRemoteURL(t *testing.T) {
+	dir := t.TempDir()
+	bare := initBareOrigin(t, dir)
+	seedOrigin(t, bare)
+	work := filepath.Join(dir, "work")
+	mustGit(t, "", "clone", bare, work)
+
+	got, err := RemoteURL(context.Background(), work, "")
+	if err != nil {
+		t.Fatalf("RemoteURL(origin): %v", err)
+	}
+	if got != bare {
+		t.Errorf("RemoteURL(origin) = %q, want %q", got, bare)
+	}
+
+	// A named remote resolves too.
+	mustGit(t, work, "remote", "add", "fork", "https://github.com/Defilan/LLMKube.git")
+	got, err = RemoteURL(context.Background(), work, "fork")
+	if err != nil {
+		t.Fatalf("RemoteURL(fork): %v", err)
+	}
+	if got != "https://github.com/Defilan/LLMKube.git" {
+		t.Errorf("RemoteURL(fork) = %q, want the fork URL", got)
+	}
+
+	// A missing remote is an error.
+	if _, err := RemoteURL(context.Background(), work, "nope"); err == nil {
+		t.Error("RemoteURL of a missing remote must error")
+	}
+	// An empty workspace is an error.
+	if _, err := RemoteURL(context.Background(), "", "origin"); err == nil {
+		t.Error("RemoteURL with empty workspace must error")
+	}
+}
+
 // mustGitOut runs git and returns trimmed stdout, failing the test on error.
 func mustGitOut(t *testing.T, dir string, args ...string) string {
 	t.Helper()


### PR DESCRIPTION
## What

Resolves the clone/push target once in `Execute` and threads it through every downstream caller, so a Workload's `spec.repo` governs the gate, the post-push envtest, and PR opening — not just the clone.

## Why

Fixes #1464

An earlier change inverted precedence so `payload.repo` wins over the static `--git-remote-url`, but only the clone itself used the resolved value. Every other caller still read `e.GitRemoteURL` directly, so a Workload naming repo-B could clone repo-B and then gate, push and open a PR against repo-A. A partial fix here is arguably worse than none: the clone succeeding makes it look like the Workload's repo took effect.

## How

The resolved target is computed once and passed down three paths:

- `executeDeterministic` -> `buildDeterministicArgs` (gate Job clone URL)
- `runLLMPath` -> `postPushGateDecision` -> `evaluatePostPushEnvtest`
- `runLLMPath` / `retryCoderTerminalResult` -> `maybeOpenPullRequest` -> `openPullRequest`, which needs it for cross-fork head qualification

`openPullRequest` falls back to `e.GitRemoteURL` when a caller passes an empty clone URL, so the fork-detection path is unchanged for callers that do not supply one.

## Behaviour change

Called out here because it changes a failure mode, and a reader trying to understand that change should not have to find it in a commit message.

**Before:** `crossProjectRemoteMismatch` ran *before* the clone and failed fast whenever `--git-remote-url` named a different repository than `payload.repo`, with an explicit "refusing to clone and push work for one repo into another" message.

**After:** that pre-check is gone. The static remote is ignored when it is not a fork of `payload.repo`, and the task proceeds against `payload.repo`. The replacement guard, `pushedRemoteMismatch`, runs in `commitPushAttempt` *after* a successful push: it reads the workspace's actual `origin` and fails the task if it disagrees with `payload.repo`.

**Why the swap is an improvement:** checking the actual push outcome is a stronger test than predicting the target from configuration, because a config prediction can disagree with where git actually landed.

**Net effect, stated plainly:** a mismatching `--git-remote-url` no longer fails immediately. It is caught only if a push actually lands in the wrong repository. That is a deliberate trade, not an oversight.

## Also addressed in review round 2

- **Deleted `crossProjectRemoteMismatch` and its contract test.** After this PR nothing in production called it. A guard that reads as live but can no longer fire is worse than no guard, because the next person to touch this path assumes the protection is there.
- **Made the new guard actually testable.** `TestPushedRemoteMismatch` previously contained only the two cases where the guard must stay *quiet* (a local bare-repo path that is not `owner/repo` shaped, and an empty task repo), so it would have passed even if `pushedRemoteMismatch` unconditionally returned `""` — exactly the regression that would reintroduce #1464 silently. Added a positive case that points `origin` at a differently-named repo and asserts a non-empty message, plus a case confirming that a *fork* of the task repo is correctly not flagged.

## Verification

- `./pkg/foreman/...` suite on this branch: **pass** (agent 37s, repo 16.6s, all subpackages ok)
- `go build ./...` clean

Coverage was added at both ends: `executor_native_internal_test.go` for the threading, `repo/push_test.go` for the push target itself.

## Checklist

- [x] Tests added/updated - internal threading tests plus push-target coverage
- [x] `make test` passes locally - full `pkg/foreman/...` suite
- [x] `make lint` passes locally - build clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - n/a, corrects existing documented behaviour

*Assisted-by: DeepSeek-V4-Flash (MXFP4) on two DGX Sparks via LLMKube, dispatched by Foreman; reviewed by Nemotron-49B on a Strix Halo node, which returned NO-GO on the first pass for a missing cloneURL fallback and executor parity, both addressed in the revision. Review round 2 was implemented by Qwen3.8-27B on the same fleet; its automated reviewer returned GO, but that verdict was not grounded in the diff (see #1570), so the three review items were checked against the diff by hand instead. I wrote the intent and reviewed the diff before opening this.*
