### PR TITLE
feat(foreman): add optional Agent.spec.maxConcurrentTasks to bound in-flight tasks

### DIFF
--- a/api/foreman/v1alpha1/agent_types.go
+++ b/api/foreman/v1alpha1/agent_types.go
@@ -282,6 +282,15 @@ type AgentSpec struct {
 	// +optional
 	MaxOutputTokens int32 `json:"maxOutputTokens,omitempty"`
 
+	// MaxConcurrentTasks bounds how many of this Agent's tasks may be in
+	// flight at once. When set, the AgenticTask controller does not claim
+	// an (N+1)th task for this Agent until one of its in-flight tasks
+	// completes; excess tasks stay Pending for the next pass. Unset means
+	// unbounded (today's behavior).
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	MaxConcurrentTasks *int32 `json:"maxConcurrentTasks,omitempty"`
+
 	// ChatTemplateKwargs is a free-form map of template-specific keyword
 	// arguments forwarded verbatim on every chat-completions request as
 	// chat_template_kwargs. Each value is a raw JSON blob so booleans stay

--- a/api/foreman/v1alpha1/zz_generated.deepcopy.go
+++ b/api/foreman/v1alpha1/zz_generated.deepcopy.go
@@ -282,6 +282,11 @@ func (in *AgentSpec) DeepCopyInto(out *AgentSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MaxConcurrentTasks != nil {
+		in, out := &in.MaxConcurrentTasks, &out.MaxConcurrentTasks
+		*out = new(int32)
+		**out = **in
+	}
 	if in.ChatTemplateKwargs != nil {
 		in, out := &in.ChatTemplateKwargs, &out.ChatTemplateKwargs
 		*out = make(map[string]apiextensionsv1.JSON, len(*in))

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -236,6 +236,16 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              maxConcurrentTasks:
+                description: |-
+                  MaxConcurrentTasks bounds how many of this Agent's tasks may be in
+                  flight at once. When set, the AgenticTask controller does not claim
+                  an (N+1)th task for this Agent until one of its in-flight tasks
+                  completes; excess tasks stay Pending for the next pass. Unset means
+                  unbounded (today's behavior).
+                format: int32
+                minimum: 1
+                type: integer
               maxEnvtestIterations:
                 description: |-
                   MaxEnvtestIterations bounds how many times the executor re-runs a

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -235,6 +235,16 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              maxConcurrentTasks:
+                description: |-
+                  MaxConcurrentTasks bounds how many of this Agent's tasks may be in
+                  flight at once. When set, the AgenticTask controller does not claim
+                  an (N+1)th task for this Agent until one of its in-flight tasks
+                  completes; excess tasks stay Pending for the next pass. Unset means
+                  unbounded (today's behavior).
+                format: int32
+                minimum: 1
+                type: integer
               maxEnvtestIterations:
                 description: |-
                   MaxEnvtestIterations bounds how many times the executor re-runs a

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -182,6 +182,18 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
+	// Enforce the per-Agent in-flight bound. When the referenced Agent sets
+	// spec.maxConcurrentTasks, count its in-flight tasks in this namespace
+	// (those holding a slot: Scheduled / Running / Verifying) and decline to
+	// claim an (N+1)th one; the task stays Pending for the next pass, exactly
+	// as it does when no node matches. Unset = unbounded.
+	if atLimit, err := r.agentAtConcurrencyLimit(ctx, &task); err != nil {
+		return ctrl.Result{}, err
+	} else if atLimit {
+		log.Info("agent at maxConcurrentTasks; leaving task Pending", "task", task.Name)
+		return ctrl.Result{RequeueAfter: requeueNoFit}, nil
+	}
+
 	// Find a Ready FleetNode that satisfies the effective RequiredCapability
 	// and atomically reserve it. The reservation (stamping the node's
 	// CurrentTask) is what enforces one-task-per-node and spreads work across
@@ -228,6 +240,75 @@ func (r *AgenticTaskReconciler) effectiveRequiredCapability(ctx context.Context,
 	}
 	jobMode := agent.Spec.Execution != nil && agent.Spec.Execution.Mode == foremanv1alpha1.ExecutionModeJob
 	return agent.Spec.RequiredCapability, agentModelIdentity(&agent), jobMode, nil
+}
+
+// agentAtConcurrencyLimit reports whether the task's referenced Agent has
+// reached its spec.maxConcurrentTasks bound. When the Agent sets no bound
+// (nil) the answer is always false (unbounded, today's behavior). Otherwise
+// it lists the Agent's in-flight tasks in the same namespace — those whose
+// phase actually holds a slot (Scheduled / Running / Verifying), not merely
+// those that have not finished — and returns true when their count is
+// already at or above the bound, so the caller leaves this task Pending for
+// the next pass.
+func (r *AgenticTaskReconciler) agentAtConcurrencyLimit(ctx context.Context, task *foremanv1alpha1.AgenticTask) (bool, error) {
+	if task.Spec.AgentRef == nil || task.Spec.AgentRef.Name == "" {
+		return false, nil
+	}
+	var agent foremanv1alpha1.Agent
+	key := types.NamespacedName{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
+	if err := r.Get(ctx, key, &agent); err != nil {
+		if apierrors.IsNotFound(err) {
+			// The Agent is missing; effectiveRequiredCapability fails the task
+			// with AgentNotFound before this point is reached, so treat as
+			// unbounded here.
+			return false, nil
+		}
+		return false, err
+	}
+	if agent.Spec.MaxConcurrentTasks == nil {
+		return false, nil
+	}
+	var tasks foremanv1alpha1.AgenticTaskList
+	if err := r.List(ctx, &tasks, client.InNamespace(task.Namespace)); err != nil {
+		return false, err
+	}
+	inFlight := 0
+	for i := range tasks.Items {
+		t := &tasks.Items[i]
+		if t.Spec.AgentRef == nil || t.Spec.AgentRef.Name != agent.Name {
+			continue
+		}
+		// The task being reconciled is still Pending and not yet in flight;
+		// it must not count against the bound it is trying to claim into.
+		if t.Name == task.Name {
+			continue
+		}
+		if !holdsInFlightSlot(t.Status.Phase) {
+			continue
+		}
+		inFlight++
+	}
+	return inFlight >= int(*agent.Spec.MaxConcurrentTasks), nil
+}
+
+// holdsInFlightSlot reports whether a task phase actually occupies an
+// in-flight slot on its Agent. Only Scheduled, Running and Verifying hold a
+// slot: Pending does NOT, by definition — it is the state a task sits in
+// while waiting for this very dispatch decision. Counting Pending against
+// the bound would deadlock a queued batch: with N Pending tasks and a bound
+// of N or fewer, every task would see the others as "in flight", decline,
+// and nothing would ever start. Counting "what holds a slot" (rather than
+// "what has not finished") matches the field's godoc: the bound caps how
+// many tasks may be *in flight* at once.
+func holdsInFlightSlot(phase foremanv1alpha1.AgenticTaskPhase) bool {
+	switch phase {
+	case foremanv1alpha1.AgenticTaskPhaseScheduled,
+		foremanv1alpha1.AgenticTaskPhaseRunning,
+		foremanv1alpha1.AgenticTaskPhaseVerifying:
+		return true
+	default:
+		return false
+	}
 }
 
 // agentModelIdentity returns the model name used to test installedModels

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -660,6 +660,175 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
 		Expect(fresh.Status.AssignedNode).To(BeEmpty())
 	})
+
+	It("leaves a task Pending when the Agent's maxConcurrentTasks is reached", func() {
+		// An Agent pinned to 1 in-flight task must not claim a second one:
+		// the second task stays Pending for the next pass even though a
+		// Ready FleetNode is free.
+		limit := int32(1)
+		agent := newAgent("bounded-coder")
+		agent.Spec.MaxConcurrentTasks = &limit
+		Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, agent) })
+
+		// One in-flight (Running) task already occupies the Agent's single slot.
+		inflight := newTask("bounded-inflight")
+		inflight.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+		Expect(k8sClient.Create(ctx, inflight)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, inflight) })
+		setPhase(inflight, foremanv1alpha1.AgenticTaskPhaseRunning)
+
+		// A second Pending task for the same Agent.
+		task := newTask("bounded-second")
+		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		node := newFleetNode("bounded-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator:    foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:     128,
+			AvailableRAMGB: 96,
+		})
+
+		res, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		Expect(fresh.Status.AssignedNode).To(BeEmpty())
+	})
+
+	It("schedules a task when the Agent's maxConcurrentTasks has headroom", func() {
+		// With the bound unset (unbounded) or above the current in-flight
+		// count, the task schedules normally.
+		limit := int32(2)
+		agent := newAgent("headroom-coder")
+		agent.Spec.MaxConcurrentTasks = &limit
+		Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, agent) })
+
+		// One in-flight task, bound is 2: headroom remains.
+		inflight := newTask("headroom-inflight")
+		inflight.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+		Expect(k8sClient.Create(ctx, inflight)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, inflight) })
+		setPhase(inflight, foremanv1alpha1.AgenticTaskPhaseRunning)
+
+		task := newTask("headroom-second")
+		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		node := newFleetNode("headroom-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator:    foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:     128,
+			AvailableRAMGB: 96,
+		})
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
+	})
+
+	It("does not count terminal tasks toward maxConcurrentTasks", func() {
+		// A Succeeded task no longer occupies an in-flight slot, so a new
+		// task for the same Agent schedules even at bound=1.
+		limit := int32(1)
+		agent := newAgent("terminal-coder")
+		agent.Spec.MaxConcurrentTasks = &limit
+		Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, agent) })
+
+		done := newTask("terminal-done")
+		done.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+		Expect(k8sClient.Create(ctx, done)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, done) })
+		setPhase(done, foremanv1alpha1.AgenticTaskPhaseSucceeded)
+
+		task := newTask("terminal-next")
+		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		node := newFleetNode("terminal-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator:    foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:     128,
+			AvailableRAMGB: 96,
+		})
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
+	})
+
+	It("admits a task when the Agent's other tasks are all Pending (they hold no slot)", func() {
+		// Pending is the state a task waits in while awaiting THIS dispatch
+		// decision; it does not hold a slot. A batch of Pending tasks queued
+		// behind a small bound must not deadlock: with bound=2 and four
+		// Pending siblings, reconciling any one of them sees zero in-flight
+		// siblings and admits it (the others wait for the next pass).
+		//
+		// This is the shape that a "count non-terminal tasks" predicate
+		// deadlocks: four non-terminal siblings >= 2 bound -> every task
+		// declines on every pass and nothing ever starts.
+		limit := int32(2)
+		agent := newAgent("pending-batch-coder")
+		agent.Spec.MaxConcurrentTasks = &limit
+		Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, agent) })
+
+		// Four Pending tasks for the same Agent.
+		for _, name := range []string{"pending-batch-a", "pending-batch-b", "pending-batch-c", "pending-batch-d"} {
+			t := newTask(name)
+			t.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+			Expect(k8sClient.Create(ctx, t)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, t) })
+			setPhase(t, foremanv1alpha1.AgenticTaskPhasePending)
+		}
+
+		// A free, capable node so the bound (not node fit) is the thing under test.
+		node := newFleetNode("pending-batch-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator:    foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:     128,
+			AvailableRAMGB: 96,
+		})
+
+		task := newTask("pending-batch-a")
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		// Admitted: Pending tasks hold no slot, so the task is scheduled,
+		// not left Pending (which would mean the bound deadlocked the batch).
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
+	})
 })
 
 var _ = Describe("capabilitySatisfies jobMode", func() {


### PR DESCRIPTION
## What

Adds an optional `Agent.spec.maxConcurrentTasks` that bounds how many of an Agent's tasks may be in flight at once. Unset means unbounded, which is today's behaviour.

## Why

Fixes #1497

Without a bound, one Agent can occupy every available FleetNode. Observed live on 2026-08-14: four concurrent reviews consumed all four nodes in a pool while coder tasks sat Pending, leaving the inference box those coders target completely idle with work queued. Raising the replica count lifts the ceiling but does not change the ordering, so a burst of one task kind can still starve another.

## How

Enforced at dispatch in the AgenticTask reconciler, beside the existing node-reservation logic so it composes with FleetNode reservation rather than duplicating it. When the bound is set, the controller counts the Agent's non-terminal tasks in the namespace and declines to claim an (N+1)th, leaving the excess Pending for the next pass.

The task being reconciled is excluded from the count, since it is not yet in flight.

Per-Agent only. No controller-wide global bound: the failure this addresses is one Agent monopolising capacity, and a global cap would throttle unrelated Agents to fix it.

## Verification

- `./pkg/foreman/...`, `./internal/foreman/...`, `./api/foreman/...` on this branch: **pass**
- CRD regeneration confirmed complete: re-running `make manifests` and `make foreman-chart-crds` leaves the tree **clean**, which is what CI's CRD Sync Check enforces. Both `config/crd/bases/` and `charts/foreman/templates/crds/` are included in the commit
- `go build ./...` clean

`make foreman-chart-crds` is a separate target from `make chart-crds`; both generated copies are present.

## Checklist

- [x] Tests added/updated - 122 lines in `agentictask_controller_test.go` covering the bound, the unset case, and exclusion of the reconciled task
- [x] `make test` passes locally - foreman suites pass
- [x] `make lint` passes locally - build clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) - PR title carries the conventional prefix; the commit subject does not
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - new CRD field is documented in its godoc, which `kubectl explain` surfaces

*Assisted-by: DeepSeek-V4-Flash (MXFP4) on two DGX Sparks via LLMKube, dispatched by Foreman; reviewed by Nemotron-49B on a Strix Halo node. I wrote the intent, ran the suites, and independently re-ran both CRD generators to confirm the commit was complete before opening this.*
