### PR TITLE
fix(controller): let draft-mtp accept an optional draftModelRef

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -73,7 +73,7 @@ type SpeculativeDecodingType string
 // does not: MTP is self-speculation carried by the target model itself. The
 // ngram-* family speculates from the prompt and likewise needs no weights.
 // +kubebuilder:validation:XValidation:rule="!(self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark']) || (has(self.draftModelRef) && self.draftModelRef.size() > 0)",message="this speculative decoding type needs draft weights: set draftModelRef to a Model in the same namespace"
-// +kubebuilder:validation:XValidation:rule="(self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark']) || !has(self.draftModelRef) || self.draftModelRef.size() == 0",message="draftModelRef is only valid for the draft-model types (draft-simple, draft-eagle3, draft-dflash, draft-dspark); draft-mtp is self-speculation and the ngram types need no draft weights"
+// +kubebuilder:validation:XValidation:rule="(self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark','draft-mtp']) || !has(self.draftModelRef) || self.draftModelRef.size() == 0",message="draftModelRef is only valid for the draft-model types (draft-simple, draft-eagle3, draft-dflash, draft-dspark, draft-mtp); the ngram types need no draft weights"
 type SpeculativeDecodingSpec struct {
 	// Type is the speculative decoding method (--spec-type). The aliases map
 	// as: "mtp" to draft-mtp, "draft" to draft-simple, and "disabled" to no

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -5303,9 +5303,9 @@ spec:
                   rule: '!(self.type in [''draft'',''draft-simple'',''draft-eagle3'',''draft-dflash'',''draft-dspark''])
                     || (has(self.draftModelRef) && self.draftModelRef.size() > 0)'
                 - message: draftModelRef is only valid for the draft-model types (draft-simple,
-                    draft-eagle3, draft-dflash, draft-dspark); draft-mtp is self-speculation
-                    and the ngram types need no draft weights
-                  rule: (self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark'])
+                    draft-eagle3, draft-dflash, draft-dspark, draft-mtp); the ngram
+                    types need no draft weights
+                  rule: (self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark','draft-mtp'])
                     || !has(self.draftModelRef) || self.draftModelRef.size() == 0
               suspend:
                 default: false

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -5299,9 +5299,9 @@ spec:
                   rule: '!(self.type in [''draft'',''draft-simple'',''draft-eagle3'',''draft-dflash'',''draft-dspark''])
                     || (has(self.draftModelRef) && self.draftModelRef.size() > 0)'
                 - message: draftModelRef is only valid for the draft-model types (draft-simple,
-                    draft-eagle3, draft-dflash, draft-dspark); draft-mtp is self-speculation
-                    and the ngram types need no draft weights
-                  rule: (self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark'])
+                    draft-eagle3, draft-dflash, draft-dspark, draft-mtp); the ngram
+                    types need no draft weights
+                  rule: (self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark','draft-mtp'])
                     || !has(self.draftModelRef) || self.draftModelRef.size() == 0
               suspend:
                 default: false

--- a/internal/controller/runtime_llamacpp_args.go
+++ b/internal/controller/runtime_llamacpp_args.go
@@ -216,14 +216,17 @@ var specTypeAliases = map[string]string{
 	"disabled": "none",
 }
 
-// draftWeightSpecTypes are the resolved --spec-type values that need a
-// separate draft model on disk. draft-mtp is absent on purpose: MTP is
-// self-speculation carried by the target model.
+// draftWeightSpecTypes are the resolved --spec-type values that can take a
+// separate draft model on disk. draft-mtp is included because some MTP heads
+// ship as a separate GGUF; whether -md is actually emitted is decided by the
+// resolved draft being non-nil, not by membership here (see
+// appendSpeculativeDecodingArgs).
 var draftWeightSpecTypes = map[string]struct{}{
 	"draft-simple": {},
 	"draft-eagle3": {},
 	"draft-dflash": {},
 	"draft-dspark": {},
+	"draft-mtp":    {},
 }
 
 // resolveSpecType maps an alias to its llama.cpp spelling, or returns the

--- a/internal/controller/runtime_llamacpp_test.go
+++ b/internal/controller/runtime_llamacpp_test.go
@@ -808,16 +808,24 @@ func TestAppendSpeculativeDecodingArgs(t *testing.T) {
 			want:      []string{"--spec-type", "ngram-cache", "--spec-draft-n-max", "2"},
 		},
 		{
-			name:      "mtp alias takes no -md even if a path is present",
+			name:      "mtp alias with no draft takes no -md",
 			spec:      &inferencev1alpha1.SpeculativeDecodingSpec{Type: "mtp"},
-			draftPath: "/models/stale/model.gguf",
+			draftPath: "",
 			want:      []string{"--spec-type", "draft-mtp"},
 		},
 		{
-			name:      "literal draft-mtp takes no -md even if a path is present",
+			name:      "literal draft-mtp with no draft takes no -md",
 			spec:      &inferencev1alpha1.SpeculativeDecodingSpec{Type: "draft-mtp"},
-			draftPath: "/models/stale/model.gguf",
+			draftPath: "",
 			want:      []string{"--spec-type", "draft-mtp"},
+		},
+		{
+			name: "literal draft-mtp with a resolved draft emits -md",
+			spec: &inferencev1alpha1.SpeculativeDecodingSpec{
+				Type: "draft-mtp", DraftModelRef: "d",
+			},
+			draftPath: "/models/d/model.gguf",
+			want:      []string{"--spec-type", "draft-mtp", "-md", "/models/d/model.gguf"},
 		},
 	}
 

--- a/internal/controller/speculative_decoding_validation_test.go
+++ b/internal/controller/speculative_decoding_validation_test.go
@@ -87,6 +87,17 @@ var _ = Describe("speculativeDecoding CRD validation", func() {
 		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
 	})
 
+	// Some MTP heads ship as a separate GGUF (e.g. ggml-org/Qwen3.8-27B-GGUF),
+	// so draft-mtp must also accept an explicit draftModelRef. draft-mtp is the
+	// one type where the field is genuinely optional.
+	It("admits draft-mtp with a draftModelRef", func() {
+		isvc := newSpecISvc("sd-draftmtp-withdraft", &inferencev1alpha1.SpeculativeDecodingSpec{
+			Type: "draft-mtp", DraftModelRef: "mtp-draft",
+		})
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
 	It("admits an ngram type alone", func() {
 		isvc := newSpecISvc("sd-ngram-alone", &inferencev1alpha1.SpeculativeDecodingSpec{
 			Type: "ngram-cache",


### PR DESCRIPTION
## What

`speculativeDecoding.type: draft-mtp` now accepts an **optional** `draftModelRef`, instead of rejecting it outright.

## Why

Fixes #1542

The CEL rule added in #1533 assumed MTP is always self-speculation carried by the target weights, and rejected `draftModelRef` for `draft-mtp` on that basis. That holds for the Qwopus MTP builds it was validated against. It is not true in general.

`ggml-org/Qwen3.8-27B-GGUF`, published 2026-08-14, ships the MTP head as its own file. The repo's `convert.log` records the command that produced the primary GGUF:

```
convert_hf_to_gguf.py ./model-temp-Qwen3.8_27B-PRIMARY \
  --outtype bf16 --outfile ./upload-Qwen3.8_27B/Qwen3.8-27B-BF16.gguf \
  --no-mtp --model-name Qwen3.8-27B
```

`--no-mtp`: the weights were deliberately built without the MTP tensors, which were exported separately. Serving that model with speculation requires `-md`, which the rule forbade — so the only route was to bypass `spec.speculativeDecoding` entirely and hand-write `extraArgs`, which is the hand-wiring #1528 existed to remove, and which forfeits the draft readiness gating #1533 added.

## How

`draft-mtp` becomes the one type where `draftModelRef` is genuinely optional:

- the "needs draft weights" rule is unchanged, so `draft-mtp` with no draft stays valid
- the "only valid for draft-model types" rule no longer rejects `draft-mtp`, so `draft-mtp` with a draft is also valid

`-md` emission stays driven by the resolved draft being non-nil rather than by membership in `draftWeightSpecTypes`, so a `draft-mtp` service without a draft still emits no `-md`.

The upgrade direction is safe: existing `mtp` and `draft-mtp` services set no `draftModelRef`, so relaxing a rejection cannot invalidate anything already applied.

## Verification

- Full `./internal/controller/` suite on this branch: **pass**, 259s
- `go build ./...` clean
- CRD regeneration included, since CEL rules live in the generated YAML

Both shapes are covered: `draft-mtp` with no draft (valid, no `-md`) and with a draft (valid, `-md` at the staged path). The first is the regression guard — without it, "allow a draft" could be satisfied by making `draft-mtp` require one.

## Checklist

- [x] Tests added/updated - both shapes, including the no-draft regression guard
- [x] `make test` passes locally - full controller suite, 259s
- [x] `make lint` passes locally - build clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) - PR title carries the conventional prefix; the commit subject does not
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - CEL messages and field godoc regenerate into the CRD

*Assisted-by: DeepSeek-V4-Flash (MXFP4) on two DGX Sparks via LLMKube, dispatched by Foreman; reviewed by Nemotron-49B on a Strix Halo node. I found the defect while staging Qwen3.8-27B into our model store, confirmed it from the converter's own command line rather than from file names, wrote the intent, ran the suite, and reviewed the diff before opening this.*
