### PR TITLE
fix(foreman): mount the agent's own gate-cache PVC, and honour an empty name

### DIFF
--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -76,6 +76,10 @@ spec:
             {{- end }}
             {{- /* Always set: the binary default is "foreman-system", a namespace the chart never creates, so gate Jobs would land where the cache PVC does not exist. */}}
             - --foreman-namespace={{ $agent.foremanNamespace | default (include "foreman.namespace" $) }}
+            {{- /* Thread the per-agent gate-cache PVC (foreman.gateCache.pvcName) so the gate Job mounts the claim the chart actually creates. gateCache.enabled=false leaves it empty, preserving the no-volume-mount behavior (#1538). */}}
+            {{- if $agent.gateCache.enabled }}
+            - --gate-cache-pvc={{ include "foreman.gateCache.pvcName" $ctx }}
+            {{- end }}
             {{- if $agent.accelerator }}
             - --accelerator={{ $agent.accelerator }}
             {{- end }}

--- a/charts/foreman/tests/agents_test.yaml
+++ b/charts/foreman/tests/agents_test.yaml
@@ -211,6 +211,34 @@ tests:
           content:
             name: GITHUB_TOKEN
 
+  # ---- #1538: gate-cache PVC threaded to the agent flag ----
+
+  - it: --gate-cache-pvc renders from the same helper that names the PVC
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-default-agent
+      matchMany: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --gate-cache-pvc=RELEASE-NAME-foreman-default-gate-cache
+
+  - it: --gate-cache-pvc is absent when gateCache.enabled is false
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --gate-cache-pvc=
+
   # ---- Accelerator flag (#1242) ----
 
   - it: --accelerator flag renders when agent.accelerator is set

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -154,6 +154,7 @@ func main() {
 
 		// M4 gate-tool flags
 		foremanNamespace     string
+		gateCachePVC         string
 		commitAuthorName     string
 		commitAuthorEmail    string
 		commitCommitterName  string
@@ -239,6 +240,10 @@ func main() {
 		"Preserve the per-task clone workspace after the run. Useful for debugging; default removes it.")
 	flag.StringVar(&foremanNamespace, "foreman-namespace", "foreman-system",
 		"Namespace the M4 run_gate_job tool submits gate Jobs into. Defaults to foreman-system.")
+	flag.StringVar(&gateCachePVC, "gate-cache-pvc", "",
+		"Name of the gate-cache PVC the run_gate_job tool mounts at /cache. Empty disables the "+
+			"volume mount. The chart renders the per-agent claim (foreman.gateCache.pvcName) here "+
+			"so named agent pools mount the PVC that actually exists (#1538).")
 	flag.StringVar(&coderGitSecret, "coder-git-secret", "foreman-git-credentials",
 		"Name of the Secret the coder Job projects as GITHUB_TOKEN for the clone + push (#620). "+
 			"Point this at an existing git Secret (e.g. foreman-github) to reuse it instead of "+
@@ -436,7 +441,7 @@ func main() {
 				Email: committerEmail(commitCommitterEmail, commitAuthorEmail),
 			},
 			KeepWorkspace:   keepWorkspace,
-			RegistryFactory: makeRegistryFactory(kc, kcs, foremanNamespace),
+			RegistryFactory: makeRegistryFactory(kc, kcs, foremanNamespace, gateCachePVC),
 			CodeHost:        githubCodeHost(),
 			WorkItems:       githubWorkItems(),
 			ChangePolicy:    changepolicy.NewDefaultPolicy(),
@@ -537,6 +542,7 @@ func runTaskCommand(args []string) {
 		commitCommitterName      string
 		commitCommitterEmail     string
 		foremanNamespace         string
+		gateCachePVC             string
 		keepWorkspace            bool
 	)
 	fs.StringVar(&taskName, "task", "",
@@ -566,6 +572,9 @@ func runTaskCommand(args []string) {
 			"--commit-author-email so existing deployments are unchanged.")
 	fs.StringVar(&foremanNamespace, "foreman-namespace", "foreman-system",
 		"Namespace deterministic tools (e.g. run_gate_job) submit Jobs into.")
+	fs.StringVar(&gateCachePVC, "gate-cache-pvc", "",
+		"Name of the gate-cache PVC the run_gate_job tool mounts at /cache. Empty disables the "+
+			"volume mount (#1538).")
 	fs.BoolVar(&keepWorkspace, "keep-workspace", false,
 		"Preserve the per-task clone workspace after the run.")
 
@@ -614,7 +623,7 @@ func runTaskCommand(args []string) {
 			Email: committerEmail(commitCommitterEmail, commitAuthorEmail),
 		},
 		KeepWorkspace:   keepWorkspace,
-		RegistryFactory: makeRegistryFactory(kc, kcs, foremanNamespace),
+		RegistryFactory: makeRegistryFactory(kc, kcs, foremanNamespace, gateCachePVC),
 		CodeHost:        githubCodeHost(),
 		WorkItems:       githubWorkItems(),
 		ChangePolicy:    changepolicy.NewDefaultPolicy(),
@@ -776,7 +785,7 @@ func assembleAgentRegistry(
 // gate being closed runs the loop with native tools only, exactly like
 // before MCP existed.
 func makeRegistryFactory(
-	kc client.Client, kcs kubernetes.Interface, foremanNamespace string,
+	kc client.Client, kcs kubernetes.Interface, foremanNamespace, gateCachePVC string,
 ) func(
 	ctx context.Context, workspace string, ag *foremanv1alpha1.Agent, workloadMCPEnabled bool,
 ) (foremanagent.ToolRegistry, error) {
@@ -796,6 +805,7 @@ func makeRegistryFactory(
 			BashTimeout:      bashTimeout,
 			Client:           kc,
 			ForemanNamespace: foremanNamespace,
+			GateCachePVC:     gateCachePVC,
 			LogTailFn:        logTail,
 			Token:            repo.TokenFromEnvOrFile,
 		})

--- a/pkg/foreman/agent/tools/buildall.go
+++ b/pkg/foreman/agent/tools/buildall.go
@@ -58,6 +58,7 @@ func BuildAll(deps ToolDeps) []Tool {
 			Client: deps.Client,
 			Cfg: RunGateJobToolConfig{
 				Namespace: deps.ForemanNamespace,
+				PVCName:   deps.GateCachePVC,
 				LogTailFn: deps.LogTailFn,
 				CodeHost:  deps.CodeHost,
 			},
@@ -111,6 +112,12 @@ type ToolDeps struct {
 	// Job in the operator's namespace.
 	Client           client.Client
 	ForemanNamespace string
+
+	// GateCachePVC is the submitting agent's gate-cache PVC name, threaded
+	// from --gate-cache-pvc so the gate Job mounts the per-agent claim the
+	// chart creates (foreman.gateCache.pvcName). Empty keeps the historical
+	// "no volume mount" behavior (#1538).
+	GateCachePVC string
 
 	// LogTailFn reads a finished gate Job's pod logs back for the model.
 	LogTailFn func(ctx context.Context, namespace, jobName string) string

--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -311,9 +311,11 @@ spec:
               value: /cache/gobuild
             - name: XDG_DATA_HOME
               value: /cache/xdg
+          {{- if .PVCName }}
           volumeMounts:
             - name: cache
               mountPath: /cache
+          {{- end }}
           resources:
             requests:
               cpu: "{{ .CPURequest }}"
@@ -321,7 +323,9 @@ spec:
             limits:
               cpu: "{{ .CPULimit }}"
               memory: {{ .MemLimit }}
+      {{- if .PVCName }}
       volumes:
         - name: cache
           persistentVolumeClaim:
             claimName: {{ .PVCName }}
+      {{- end }}

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -113,7 +113,10 @@ type RunGateJobToolConfig struct {
 
 	// PVCName is the persistent volume claim mounted at /cache for
 	// GOMODCACHE / GOCACHE / XDG_DATA_HOME reuse across runs. Empty
-	// disables the volume mount. Defaults to "foreman-gate-cache".
+	// disables the volume mount entirely: the Job renders no cache
+	// volume and no /cache volumeMount, so the gate runs cold rather
+	// than mounting a claim nobody created. There is deliberately NO
+	// default -- a hardcoded name is what #1538 was about.
 	// The foreman-agent threads the submitting agent's per-agent claim
 	// (foreman.gateCache.pvcName) here via --gate-cache-pvc so named
 	// agent pools mount the PVC the chart actually creates (#1538).
@@ -561,9 +564,6 @@ func resolveGateCloneURL(cfg RunGateJobToolConfig, repoSlug, explicit string) st
 func applyConfigDefaults(c RunGateJobToolConfig) RunGateJobToolConfig {
 	if c.Namespace == "" {
 		c.Namespace = "foreman-system"
-	}
-	if c.PVCName == "" {
-		c.PVCName = "foreman-gate-cache"
 	}
 	if c.Image == "" {
 		c.Image = "golang:1.26"

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -114,6 +114,9 @@ type RunGateJobToolConfig struct {
 	// PVCName is the persistent volume claim mounted at /cache for
 	// GOMODCACHE / GOCACHE / XDG_DATA_HOME reuse across runs. Empty
 	// disables the volume mount. Defaults to "foreman-gate-cache".
+	// The foreman-agent threads the submitting agent's per-agent claim
+	// (foreman.gateCache.pvcName) here via --gate-cache-pvc so named
+	// agent pools mount the PVC the chart actually creates (#1538).
 	PVCName string
 
 	// Image is the container image the Job runs. Defaults to

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -306,8 +306,16 @@ func TestRunGateJob_DuplicateCreateProducesGATEERROR(t *testing.T) {
 
 func TestApplyConfigDefaults_FillsEveryField(t *testing.T) {
 	c := applyConfigDefaults(RunGateJobToolConfig{})
-	if c.Namespace == "" || c.PVCName == "" || c.Image == "" || c.CloneURLBase == "" {
+	if c.Namespace == "" || c.Image == "" || c.CloneURLBase == "" {
 		t.Errorf("string defaults missing: %#v", c)
+	}
+	// PVCName is deliberately NOT defaulted (#1538). A hardcoded claim name
+	// is what broke named agent pools: the chart creates the claim per agent
+	// as foreman-<agentKey>-gate-cache, so any fixed fallback names a claim
+	// that need not exist. Empty means "no cache volume", which the renderer
+	// honours, and the chart supplies the real name via --gate-cache-pvc.
+	if c.PVCName != "" {
+		t.Errorf("PVCName must not be defaulted, got %q", c.PVCName)
 	}
 	if c.ActiveDeadlineSeconds == 0 || c.TTLSecondsAfterFinished == 0 {
 		t.Errorf("deadline defaults missing: %#v", c)
@@ -1217,5 +1225,84 @@ func TestNeedsHelm(t *testing.T) {
 	}
 	if !needsHelm(DefaultGateChecks) {
 		t.Error("DefaultGateChecks must include the chart check (#1441)")
+	}
+}
+
+// TestGateJobCacheVolumeOmittedWhenPVCNameEmpty asserts that an empty PVCName
+// renders NO cache volume and NO /cache volumeMount.
+//
+// Regression for #1538. The field's contract has always said "empty disables
+// the volume mount", but the template rendered `claimName: {{ .PVCName }}`
+// unconditionally and the config defaulted an empty name back to a hardcoded
+// "foreman-gate-cache". With named agent pools that claim does not exist, so
+// the Job mounted a PVC nobody created: the pod never binds, never schedules,
+// and the Job dies at activeDeadlineSeconds looking like a slow gate rather
+// than a misconfigured one.
+func TestGateJobCacheVolumeOmittedWhenPVCNameEmpty(t *testing.T) {
+	job, err := renderGateJob(rendererInput{
+		Name:                    "foreman-gate-nocache",
+		Namespace:               "foreman-system",
+		Image:                   "golang:1.26",
+		Repo:                    "defilantech/LLMKube",
+		Branch:                  "foreman/issue-1538",
+		Checks:                  []string{"fmt"},
+		ActiveDeadlineSeconds:   1800,
+		TTLSecondsAfterFinished: 86400,
+		CPURequest:              "2",
+		CPULimit:                "4",
+		MemRequest:              "4Gi",
+		MemLimit:                "8Gi",
+		CloneURLBase:            "https://github.com",
+		PVCName:                 "",
+	})
+	if err != nil {
+		t.Fatalf("renderGateJob: %v", err)
+	}
+	if n := len(job.Spec.Template.Spec.Volumes); n != 0 {
+		t.Errorf("empty PVCName must render no volumes, got %d: %+v",
+			n, job.Spec.Template.Spec.Volumes)
+	}
+	for _, m := range job.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if m.MountPath == "/cache" {
+			t.Errorf("empty PVCName must render no /cache volumeMount, got %+v", m)
+		}
+	}
+}
+
+// TestGateJobCacheVolumeUsesGivenPVCName is the positive half: a set PVCName
+// mounts exactly that claim, and never a hardcoded fallback (#1538).
+func TestGateJobCacheVolumeUsesGivenPVCName(t *testing.T) {
+	job, err := renderGateJob(rendererInput{
+		Name:                    "foreman-gate-cached",
+		Namespace:               "foreman-system",
+		Image:                   "golang:1.26",
+		Repo:                    "defilantech/LLMKube",
+		Branch:                  "foreman/issue-1538",
+		Checks:                  []string{"fmt"},
+		ActiveDeadlineSeconds:   1800,
+		TTLSecondsAfterFinished: 86400,
+		CPURequest:              "2",
+		CPULimit:                "4",
+		MemRequest:              "4Gi",
+		MemLimit:                "8Gi",
+		CloneURLBase:            "https://github.com",
+		PVCName:                 "foreman-multirepo-gate-cache",
+	})
+	if err != nil {
+		t.Fatalf("renderGateJob: %v", err)
+	}
+	vols := job.Spec.Template.Spec.Volumes
+	if len(vols) != 1 || vols[0].PersistentVolumeClaim == nil ||
+		vols[0].PersistentVolumeClaim.ClaimName != "foreman-multirepo-gate-cache" {
+		t.Fatalf("want the per-agent claim mounted, got %+v", vols)
+	}
+	var found bool
+	for _, m := range job.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if m.MountPath == "/cache" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a set PVCName must render the /cache volumeMount")
 	}
 }


### PR DESCRIPTION
## What

Threads the submitting agent's gate-cache PVC name into `run_gate_job`, so a gate Job mounts the claim the chart actually created, and makes an empty name mean **no cache volume** rather than a hardcoded fallback.

Two commits: the threading, then the disabled-path fix.

## Why

Fixes #1538

`run_gate_job.go` hardcoded the claim name `foreman-gate-cache` with nothing to populate it — no flag, no env, no chart value — while `charts/foreman` creates the claim **per agent** as `foreman-<agentKey>-gate-cache`. Those agree only for the legacy singleton agent. Opting into named `agents:` pools renamed the chart's claims, and every gate Job then mounted a claim that existed nowhere.

The failure is indistinguishable from a slow gate: the pod never binds, so no pod appears, nothing runs, and after `activeDeadlineSeconds` the Job reports `DeadlineExceeded`, surfaced as `GATE-FAIL` with an empty `logTail`. Three consecutive workloads failed this way on a cluster where the branch under test was independently verified as correct. A coder's own self-gate fails identically and still returns `GO`, so the pipeline reported a passing coder and a failing gate for a branch where neither statement had been evaluated.

## How

**Threading.** A `--gate-cache-pvc` flag sets `cfg.PVCName`, rendered in `agent-deployment.yaml` from the same `foreman.gateCache.pvcName` helper that names the PVC, so the two cannot drift. Present on both the main agent and `runTaskCommand`.

**The disabled path.** The flag alone left `gateCache.enabled: false` still broken: the chart omits the flag, `PVCName` arrives empty, and `applyConfigDefaults` rewrote it back to the hardcoded name — the original bug. The field's doc had always claimed "empty disables the volume mount", which was never true: the template rendered `claimName` unconditionally, and the default meant empty never reached it.

So: guard both the `volumes` and `volumeMounts` blocks on `PVCName`, and drop the default. An install that configures nothing now runs the gate with no cache — slower, but it runs — rather than failing on a claim nobody created.

`TestApplyConfigDefaults_FillsEveryField` asserted the old contract and now asserts the new one, since *not* defaulting `PVCName` is the fix.

## Verification

Both paths checked by rendering the chart, not by reading it:

```
helm template t charts/foreman --set agents.a.enabled=true
  -> --gate-cache-pvc=t-foreman-a-gate-cache

helm template t charts/foreman --set agents.a.enabled=true \
  --set agents.a.gateCache.enabled=false
  -> --gate-cache-pvc occurrences: 0
```

- `./pkg/foreman/...`: **pass**
- **Mutation-verified:** removing the `volumes` guard fails exactly `TestGateJobCacheVolumeOmittedWhenPVCNameEmpty` and nothing else
- `gofmt` clean, `go build ./...` clean

Also confirmed live before the fix: creating the missing claim by hand took a gate Job from "no pod, DeadlineExceeded" to a running pod executing `make test`, which is what identified the root cause.

## Checklist

- [x] Tests added/updated - both cache-volume shapes, mutation-verified, plus the updated defaults contract
- [x] `make test` passes locally - foreman suites pass
- [x] `make lint` passes locally - `gofmt` clean, build clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) - the second commit does; the first (`Thread per-agent gate-cache PVC...`) does not, and the PR title carries the prefix for the squash
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - the `PVCName` doc comment now states the real contract

*Assisted-by: DeepSeek-V4-Flash (MXFP4) on two DGX Sparks via LLMKube wrote the threading commit, dispatched by Foreman; reviewed by Nemotron-49B on a Strix Halo node, which returned GO. I diagnosed the original root cause on the live cluster, found the disabled path still broken by rendering the chart both ways, and wrote the second commit by hand after an automated revision pass died on a transport error.*
