### PR TITLE
fix(foreman): do not reserve a FleetNode for Job-mode AgenticTasks

### DIFF
--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -327,6 +327,14 @@ func (r *AgenticTaskReconciler) allDepsSucceeded(ctx context.Context, task *fore
 // is an optimistic-lock status patch, so at most one wins; the loser (Conflict,
 // or a node already reserved for a live task) falls through to the next
 // candidate. Without this, every task funnels onto one node. See #977.
+//
+// In Job mode the task's work runs in an ephemeral Job pod, not on the claiming
+// node, so the node must NOT be reserved: stamping CurrentTask would hold a
+// one-task-per-node slot for the Job's whole lifetime while the node itself
+// does nothing but wait, starving in-process tasks that could run there. A
+// Job-mode task is still assigned to a node (so the Job is created there), but
+// the node's CurrentTask is left untouched and stays free for in-process work.
+// See #1496.
 func (r *AgenticTaskReconciler) reserveFirstFitNode(ctx context.Context, task *foremanv1alpha1.AgenticTask, required foremanv1alpha1.RequiredCapability, requiredModel string, jobMode bool) (string, error) {
 	var nodes foremanv1alpha1.FleetNodeList
 	if err := r.List(ctx, &nodes); err != nil {
@@ -344,6 +352,13 @@ func (r *AgenticTaskReconciler) reserveFirstFitNode(ctx context.Context, task *f
 		}
 		if !capabilitySatisfies(required, requiredModel, n, jobMode) {
 			continue
+		}
+		if jobMode {
+			// Job-mode work runs in an ephemeral Job pod, not on this node, so
+			// the node must not be claimed. Pick the first eligible node and
+			// leave its CurrentTask untouched so it stays free for in-process
+			// tasks. See #1496.
+			return n.Name, nil
 		}
 		reserved, err := r.reserveNode(ctx, n, key)
 		if err != nil {

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -445,6 +445,63 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 			To(ConsistOf("default/spread-t1", "default/spread-t2"))
 	})
 
+	It("schedules a Job-mode task without reserving the node's CurrentTask", func() {
+		// Regression for defilantech/LLMKube#1496: a Job-mode task's work runs
+		// in an ephemeral Job pod, not on the claiming node, so the node must
+		// not be claimed via Status.CurrentTask. The node stays free so an
+		// in-process task can still be dispatched to it while the Job runs.
+		agent := newAgent("job-coder")
+		agent.Spec.Execution = &foremanv1alpha1.ExecutionSpec{
+			Mode: foremanv1alpha1.ExecutionModeJob,
+		}
+		Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, agent) })
+
+		task := newTask("job-target")
+		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		node := newFleetNode("job-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
+
+		// The node must NOT be claimed by the Job-mode task.
+		var unclaimed foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, &unclaimed)).To(Succeed())
+		Expect(unclaimed.Status.CurrentTask).To(BeEmpty())
+
+		// An in-process task can still be dispatched to the same node while
+		// the Job-mode task is assigned to it.
+		ipTask := newTask("job-inprocess")
+		Expect(k8sClient.Create(ctx, ipTask)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, ipTask) })
+		setPhase(ipTask, foremanv1alpha1.AgenticTaskPhasePending)
+		_, err = reconciler.Reconcile(ctx, reqFor(ipTask))
+		Expect(err).NotTo(HaveOccurred())
+
+		var ipFresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(ipTask), &ipFresh)).To(Succeed())
+		Expect(ipFresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(ipFresh.Status.AssignedNode).To(Equal(node.Name))
+
+		var claimed foremanv1alpha1.FleetNode
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, &claimed)).To(Succeed())
+		Expect(claimed.Status.CurrentTask).To(Equal("default/job-inprocess"))
+	})
+
 	It("leaves a second task Pending when the only matching node is busy", func() {
 		// One node, two tasks: the second must wait (requeue) rather than
 		// double-book the node.


### PR DESCRIPTION
## What

Job-mode AgenticTasks no longer reserve the FleetNode they are assigned to. The task is still placed on an eligible node so its Job is created there, but the node's `CurrentTask` is left untouched.

## Why

Fixes #1496

A Job-mode task's work runs in an ephemeral Job pod, not on the claiming node. Stamping `Status.CurrentTask` held a one-task-per-node slot at the CONTROLLER level for the Job's entire lifetime while the node itself did nothing but wait. Reserving a resource you do not use is wrong on its own terms, and it is a prerequisite for ever running in-process work alongside a Job.

## What this does NOT do

**This alone does not enable concurrent execution.** @joryirving caught that the original version of this description overclaimed, and the correction is worth stating plainly rather than quietly editing away.

Emptying `CurrentTask` lets the controller schedule a second task onto the node. The agent still will not run it, because the node's `AgenticTaskWatcher` keeps one process-wide in-flight slot:

- `pkg/foreman/agent/watcher.go:251-254` returns from `pollOnce` as soon as `inflight != nil`.
- `pkg/foreman/agent/watcher.go:314` sets the slot; the deferred clear at `:323` only runs once `Executor.Execute` returns.
- For Job mode, `Execute` blocks: `executeCoderJob` calls `CoderJobSubmitter.Submit` (`RunCoderJob.Run`), which creates the Job and then polls in a `for` loop until `job.Status.Succeeded >= 1` or `job.Status.Failed >= 1`.

So a Job-mode task still occupies its node for the Job's whole lifetime. The watcher fix is tracked separately in #1559.

This is a necessary but not sufficient step. Both are needed for Job-mode concurrency, and they can land in either order.

## How

`reserveFirstFitNode` returns the chosen node without writing the reservation when the task is Job-mode:

```go
if jobMode {
    return n.Name, nil
}
```

Node selection and eligibility filtering are unchanged, so the Job still lands where it would have. In-process scheduling is untouched.

## Scope note

This is a **latent** fix rather than an observed one. No Agent in our deployment currently sets `execution.mode`, so nothing here runs in Job mode today and this changes nothing for us in practice.

The superficially similar starvation we hit on 2026-08-14, four concurrent reviews consuming every node while coder tasks sat Pending, was **in-process** contention and is not addressed by this change. That one needs a per-Agent concurrency bound, which is #1497 (and #1546).

Note that #1546's `maxConcurrentTasks` is also controller-side. It bounds how many tasks the controller schedules for an Agent and does not touch `watcher.go`, so it does not address #1559 either.

## Verification

- `./internal/foreman/...` with `KUBEBUILDER_ASSETS` set: **pass** (18.3s), matching unmodified `main` (17.0s)
- Merges cleanly onto current `main` (`6694d0b0`)
- `go build ./...` clean

**What the added test actually proves:** that a Job-mode task and an in-process task can both be marked `Scheduled` on the same node, and that the in-process reservation path is unchanged. It does **not** prove they execute concurrently, and cannot, because that is gated by the watcher (#1559). The test names should be read with that scope in mind.

Note for anyone running these locally: without `KUBEBUILDER_ASSETS` the suite fails in ~0.03s on envtest setup, which looks like a real assertion failure and is not.

The branch shares `agentictask_controller.go` and its test with the #1497 work, but `git merge-tree` confirms they touch different regions and do not conflict, so the two can land in either order.

## Checklist

- [x] Tests added/updated - 57 lines covering the Job-mode reservation path and the unchanged in-process path
- [x] `make test` passes locally - foreman suites pass with envtest assets
- [x] `make lint` passes locally - build clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) - PR title carries the conventional prefix; the commit subject does not
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
