### PR TITLE
refactor(controller): delete the pod-template normaliser, treat a missing hash as changed

### DIFF
--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -405,8 +405,9 @@ var _ = Describe("RolloutPolicy drain-before-rollout", func() {
 			mu.Lock()
 			callsAfterSecond := idleCheckCalled
 			mu.Unlock()
-			// podTemplatesDiffer should report no change for an unchanged InferenceService,
-			// so no idle check should fire on second reconcile.
+			// The stored desired-template-hash matches the freshly computed one,
+			// so no template change is detected and no idle check should fire on
+			// the second reconcile.
 			Expect(callsAfterSecond).To(Equal(callsAfterFirst))
 		})
 
@@ -477,6 +478,83 @@ var _ = Describe("RolloutPolicy drain-before-rollout", func() {
 			calls := idleCheckCalled
 			mu.Unlock()
 			Expect(calls).To(BeNumerically(">", 0))
+		})
+
+		It("should treat a missing desired-template-hash as changed and drain", func() {
+			// A legacy Deployment that predates the annotation has no stored hash.
+			// The reconciler must treat that as changed (assume changed, drain)
+			// rather than unchanged, so the idle check fires on that reconcile.
+			modelName := "model-missing-hash"
+			isvcName := "isvc-missing-hash"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server",
+					RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+						WaitForIdle:        true,
+						IdleTimeoutSeconds: 30,
+						Force:              false,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+				RolloutIdleBaseURL: testServer.URL,
+			}
+
+			// First reconcile creates the Deployment and stamps the hash.
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+			Expect(dep.Annotations[AnnotationDesiredTemplateHash]).NotTo(BeEmpty())
+
+			// Simulate a legacy Deployment: strip the annotation so the next
+			// reconcile has no stored hash to compare against.
+			delete(dep.Annotations, AnnotationDesiredTemplateHash)
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			mu.Lock()
+			callsBefore := idleCheckCalled
+			mu.Unlock()
+
+			// With no stored hash the template is treated as changed, so the
+			// idle check must fire (drain before roll).
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			mu.Lock()
+			calls := idleCheckCalled
+			mu.Unlock()
+			Expect(calls).To(BeNumerically(">", callsBefore),
+				"missing desired-template-hash must be treated as changed and drain")
 		})
 	})
 
@@ -674,8 +752,9 @@ var _ = Describe("RolloutPolicy drain-before-rollout", func() {
 
 			countBeforeSecond := idleCheckCount
 
-			// Second reconcile: InferenceService spec unchanged, podTemplatesDiffer
-			// should report no change after normalization. No idle check needed.
+			// Second reconcile: InferenceService spec unchanged, the stored
+			// desired-template-hash still matches the freshly computed one, so no
+			// template change is detected. No idle check needed.
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
 			})
@@ -797,49 +876,6 @@ var _ = Describe("RolloutPolicy drain-before-rollout", func() {
 			}
 			Expect(isvc.ShouldDeferRollout()).To(BeTrue())
 		})
-	})
-})
-
-var _ = Describe("podTemplatesDiffer input immutability (#922)", func() {
-	newPrepTemplate := func() corev1.PodTemplateSpec {
-		root := int64(0)
-		return corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				InitContainers: []corev1.Container{{
-					Name:  "model-cache-prep",
-					Image: "curl:8.18.0",
-					SecurityContext: &corev1.SecurityContext{
-						RunAsUser: &root,
-						Capabilities: &corev1.Capabilities{
-							Add:  []corev1.Capability{"CHOWN", "FOWNER"},
-							Drop: []corev1.Capability{"ALL"},
-						},
-					},
-				}},
-			},
-		}
-	}
-
-	It("does not mutate the desired template's init container SecurityContext", func() {
-		desired := newPrepTemplate()
-		existing := newPrepTemplate()
-		// A rollout-worthy difference so the function runs its full
-		// normalization path before returning.
-		existing.Spec.InitContainers[0].Image = "curl:8.17.0"
-
-		changed := podTemplatesDiffer(existing, desired)
-
-		Expect(changed).To(BeTrue(), "an image change should still be detected")
-		sc := desired.Spec.InitContainers[0].SecurityContext
-		Expect(sc).NotTo(BeNil())
-		Expect(sc.RunAsUser).NotTo(BeNil(), "RunAsUser must survive the diff (see #922)")
-		Expect(*sc.RunAsUser).To(Equal(int64(0)))
-		Expect(sc.Capabilities).NotTo(BeNil())
-		Expect(sc.Capabilities.Add).To(ContainElement(corev1.Capability("CHOWN")))
-	})
-
-	It("reports no difference for identical templates", func() {
-		Expect(podTemplatesDiffer(newPrepTemplate(), newPrepTemplate())).To(BeFalse())
 	})
 })
 

--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -29,7 +29,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -40,20 +39,23 @@ import (
 )
 
 // AnnotationDesiredTemplateHash stores a SHA-256 hash of the desired pod template
-// on the Deployment. The reconciler uses this to detect meaningful template changes
-// without being fooled by API-server-applied defaults that differ between the
-// in-memory object and the persisted object.
+// on the Deployment. The reconciler stamps the hash of the freshly built desired
+// template and compares it against the stored value on each reconcile to detect
+// operator-driven changes. Both sides are derived from the desired template (not
+// the persisted live object), so API-server defaulting on the live object cannot
+// produce a false positive. A Deployment missing the annotation predates it and
+// is treated as changed (drain before roll).
 const AnnotationDesiredTemplateHash = "llmkube.ai/desired-template-hash"
 
 var errIdleUnsupported = errors.New("runtime does not implement idle detection")
 
 // desiredTemplateHash computes a deterministic hash of the pod template for the
-// purpose of detecting operator-driven changes. It serializes the normalized
-// template to JSON and hashes it, so API-server defaulting differences don't
-// produce false positives on subsequent reconciles.
+// purpose of detecting operator-driven changes. It serializes the template to
+// JSON and hashes it. The reconciler stamps this hash on the Deployment and
+// compares it against a freshly computed hash to detect real changes; a missing
+// stored hash means the pre-annotation legacy path and is treated as changed.
 func desiredTemplateHash(template corev1.PodTemplateSpec) string {
-	normalized := computePodTemplateForComparison(template)
-	data, _ := json.Marshal(normalized)
+	data, _ := json.Marshal(template)
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("%x", h[:8])
 }
@@ -383,165 +385,4 @@ func (r *InferenceServiceReconciler) reconcileRolloutPolicy(
 
 	log.Info("Deferring rollout, backend slots are busy", "requeueAfter", requeueAfter)
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
-}
-
-// computePodTemplateForComparison returns the PodTemplateSpec for comparison
-// purposes. Exposed as a function so the comparison logic in the reconciler
-// remains readable and can be extended if needed (e.g., stripping transient
-// fields injected by the API server).
-func computePodTemplateForComparison(t corev1.PodTemplateSpec) corev1.PodTemplateSpec {
-	return t
-}
-
-// podTemplatesDiffer reports whether two PodTemplateSpecs differ in fields
-// that would trigger a Deployment rollout. It compares operator-controlled
-// fields (containers, init containers, volumes, labels, annotations, and
-// scheduling fields) while ignoring API-server-applied defaults like
-// TerminationGracePeriodSeconds that cause false positives on full DeepEqual.
-func podTemplatesDiffer(existing, desired corev1.PodTemplateSpec) bool {
-	// Deep-copy both templates up front. The normalization below mutates
-	// container SecurityContexts and other fields in place, and a shallow
-	// struct copy still shares the underlying slices and pointers with the
-	// caller's templates. Without this, normalizing `desired` for comparison
-	// nils out the real desired template's SecurityContext (e.g. the
-	// model-cache-prep init container's RunAsUser/Capabilities), which then
-	// gets applied to the Deployment. See #922.
-	existing = *existing.DeepCopy()
-	desired = *desired.DeepCopy()
-	if !apiequality.Semantic.DeepEqual(existing.Labels, desired.Labels) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(existing.Annotations, desired.Annotations) {
-		return true
-	}
-	a, b := existing.Spec, desired.Spec
-	// Compare fields the operator controls and that trigger rollouts.
-	// Skip server-side defaulted fields that cause false positives:
-	//   TerminationGracePeriodSeconds (default 30s), DNSPolicy (default ClusterFirst),
-	//   RestartPolicy (default Always), ServiceAccountName (default "default"),
-	//   AutomountServiceAccountToken, SchedulerName (default "default-scheduler").
-	a.TerminationGracePeriodSeconds = nil
-	b.TerminationGracePeriodSeconds = nil
-	a.DNSPolicy = ""
-	b.DNSPolicy = ""
-	a.RestartPolicy = ""
-	b.RestartPolicy = ""
-	a.ServiceAccountName = ""
-	b.ServiceAccountName = ""
-	a.AutomountServiceAccountToken = nil
-	b.AutomountServiceAccountToken = nil
-	a.SchedulerName = ""
-	b.SchedulerName = ""
-	// Additional pod-level fields defaulted by the API server.
-	a.HostNetwork = false
-	b.HostNetwork = false
-	a.HostPID = false
-	b.HostPID = false
-	a.HostIPC = false
-	b.HostIPC = false
-	a.ShareProcessNamespace = nil
-	b.ShareProcessNamespace = nil
-	a.Hostname = ""
-	b.Hostname = ""
-	a.Subdomain = ""
-	b.Subdomain = ""
-	a.SetHostnameAsFQDN = nil
-	b.SetHostnameAsFQDN = nil
-	a.DNSConfig = nil
-	b.DNSConfig = nil
-	a.ImagePullSecrets = nil
-	b.ImagePullSecrets = nil
-	a.HostAliases = nil
-	b.HostAliases = nil
-	// Normalize pod-level SecurityContext (API server defaults seccompProfile).
-	if a.SecurityContext != nil {
-		a.SecurityContext.SeccompProfile = nil
-	}
-	if b.SecurityContext != nil {
-		b.SecurityContext.SeccompProfile = nil
-	}
-	// Normalize containers to strip API-server-applied defaults.
-	normalizeContainers(a.Containers)
-	normalizeContainers(b.Containers)
-	normalizeContainers(a.InitContainers)
-	normalizeContainers(b.InitContainers)
-	if !apiequality.Semantic.DeepEqual(a.Containers, b.Containers) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.InitContainers, b.InitContainers) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.EphemeralContainers, b.EphemeralContainers) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.Volumes, b.Volumes) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.SecurityContext, b.SecurityContext) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.EnableServiceLinks, b.EnableServiceLinks) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.NodeSelector, b.NodeSelector) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.Affinity, b.Affinity) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.TopologySpreadConstraints, b.TopologySpreadConstraints) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.PriorityClassName, b.PriorityClassName) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.RuntimeClassName, b.RuntimeClassName) {
-		return true
-	}
-	if !apiequality.Semantic.DeepEqual(a.ResourceClaims, b.ResourceClaims) {
-		return true
-	}
-	return false
-}
-
-// normalizeContainers strips API-server-applied defaults from container fields
-// so that comparison doesn't produce false positives.
-func normalizeContainers(containers []corev1.Container) {
-	for i := range containers {
-		c := &containers[i]
-		c.TerminationMessagePath = ""
-		// TerminationMessagePolicy is NOT stripped: the operator sets it on
-		// every container it generates (runtime container since #1425, init
-		// containers since #1437), so it is an owned field rather than
-		// API-server defaulting, and drift in it should be comparable.
-		c.ImagePullPolicy = ""
-		c.WorkingDir = ""
-		// SecurityContext is NOT stripped: the operator sets AllowPrivilegeEscalation,
-		// Capabilities, and (for init containers) ReadOnlyRootFilesystem and
-		// RunAsUser/RunAsGroup. An empty SecurityContext submitted to the API server
-		// comes back unchanged, so removing this stripping does not introduce phantom
-		// drift. Keeping it comparable means real drift in operator-owned fields is
-		// detected rather than normalised away. See #1462.
-		for j := range c.Ports {
-			if c.Ports[j].Protocol == "" {
-				c.Ports[j].Protocol = corev1.ProtocolTCP
-			}
-		}
-		// Normalize resource requirements: empty and nil are semantically identical.
-		if len(c.Resources.Limits) == 0 {
-			c.Resources.Limits = nil
-		}
-		if len(c.Resources.Requests) == 0 {
-			c.Resources.Requests = nil
-		}
-		// Normalize env var field/ref defaults (FieldPath API version).
-		for j := range c.Env {
-			if c.Env[j].ValueFrom != nil && c.Env[j].ValueFrom.FieldRef != nil {
-				c.Env[j].ValueFrom.FieldRef.APIVersion = ""
-			}
-		}
-	}
 }

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -552,14 +552,17 @@ func (r *InferenceServiceReconciler) reconcileDeployment(ctx context.Context, is
 		Spec: deployment.Spec.Template.Spec,
 	}
 
-	// Use annotation-based hash comparison to avoid false positives from
-	// API-server-applied defaults that differ between in-memory and persisted objects.
+	// Use annotation-based hash comparison to detect real changes. A missing
+	// stored hash (a legacy Deployment that predates the annotation) is
+	// treated as changed: draining unnecessarily costs a little latency, while
+	// skipping a needed drain drops in-flight requests. After the first
+	// reconcile the annotation is stamped and the hash path takes over.
 	desiredHash := desiredTemplateHash(desiredPodTemplate)
 	storedHash := ""
 	if existingDeployment.Annotations != nil {
 		storedHash = existingDeployment.Annotations[AnnotationDesiredTemplateHash]
 	}
-	templateChanged := podTemplatesDiffer(existingDeployment.Spec.Template, desiredPodTemplate)
+	templateChanged := true
 	if storedHash != "" {
 		templateChanged = desiredHash != storedHash
 	}

--- a/internal/controller/init_container_diagnostics_test.go
+++ b/internal/controller/init_container_diagnostics_test.go
@@ -33,10 +33,9 @@ import (
 // container most likely to fail (bad credentials, 404, disk full, evicted for
 // exceeding an emptyDir sizeLimit), and it reported nothing.
 //
-// Setting it on every generated init container also removes the asymmetry that
-// made normalizeContainers unable to stop stripping the field: with the
-// operator setting it everywhere it generates a container, desired and live
-// agree and there is nothing to normalise away.
+// Setting it on every generated init container makes the policy self-describing
+// everywhere, so a failed downloader is diagnosable the same way the runtime
+// container is.
 
 func storageConfigModel(source string) *inferencev1alpha1.Model {
 	m := &inferencev1alpha1.Model{
@@ -77,98 +76,5 @@ func TestInitContainersCarryTerminationMessagePolicy(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// normalizeContainers must stop blanking the field, so drift in something the
-// operator now sets deliberately is comparable rather than normalised away.
-func TestNormalizeContainersKeepsTerminationMessagePolicy(t *testing.T) {
-	containers := []corev1.Container{{
-		Name:                     "c",
-		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-		TerminationMessagePath:   "/dev/termination-log",
-		ImagePullPolicy:          corev1.PullAlways,
-	}}
-	normalizeContainers(containers)
-
-	if got := containers[0].TerminationMessagePolicy; got != corev1.TerminationMessageFallbackToLogsOnError {
-		t.Errorf("TerminationMessagePolicy = %q, want it preserved", got)
-	}
-	// The genuinely-defaulted neighbours must still be stripped; this is the
-	// line between "the operator sets it" and "the API server defaults it".
-	if containers[0].TerminationMessagePath != "" {
-		t.Error("TerminationMessagePath should still be normalised away")
-	}
-	if containers[0].ImagePullPolicy != "" {
-		t.Error("ImagePullPolicy should still be normalised away")
-	}
-}
-
-// normalizeContainers must not strip SecurityContext fields the operator owns.
-// Two containers differing only in an operator-owned SecurityContext field must
-// still compare as different after normalization. Under the old code they
-// normalised to equal (the bug); this test fails if the stripping block is
-// restored. See #1462.
-func TestNormalizeContainersKeepsSecurityContextDifferences(t *testing.T) {
-	// inferContainerSecurityContext sets AllowPrivilegeEscalation and Capabilities;
-	// initContainerSecurityContext also sets ReadOnlyRootFilesystem and
-	// RunAsUser/RunAsGroup. Use those fields in the test.
-	containers := []corev1.Container{
-		{
-			Name: "c1",
-			SecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: boolPtr(false),
-				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{"ALL"},
-				},
-			},
-		},
-		{
-			Name: "c2",
-			SecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: boolPtr(true), // differs from c1
-				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{"ALL"},
-				},
-			},
-		},
-	}
-	normalizeContainers(containers)
-
-	if containers[0].SecurityContext.AllowPrivilegeEscalation == containers[1].SecurityContext.AllowPrivilegeEscalation {
-		t.Error("AllowPrivilegeEscalation difference was normalised away: the operator-owned field was stripped")
-	}
-}
-
-// The property that keeping the field comparable could plausibly break: a
-// desired template compared against itself must report no drift. If the
-// operator ever leaves the policy unset on a container it generates, the live
-// object gets the API-server default and every reconcile sees a difference.
-func TestPodTemplatesDoNotDifferFromThemselves(t *testing.T) {
-	cfg := buildModelStorageConfig(
-		storageConfigModel("https://example.com/model.gguf"), nil, "default", true,
-		ModelCacheModeShared, "", "docker.io/curlimages/curl:8.18.0", 102, nil)
-
-	// Live objects come back from the API server with the policy defaulted on
-	// any container that did not set one. Simulate that on a copy.
-	desired := corev1.PodTemplateSpec{Spec: corev1.PodSpec{
-		InitContainers: append([]corev1.Container(nil), cfg.initContainers...),
-		Containers:     []corev1.Container{{Name: "server", TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError}},
-	}}
-	live := *desired.DeepCopy()
-	for i := range live.Spec.InitContainers {
-		if live.Spec.InitContainers[i].TerminationMessagePolicy == "" {
-			live.Spec.InitContainers[i].TerminationMessagePolicy = corev1.TerminationMessageReadFile
-		}
-	}
-	for i := range live.Spec.Containers {
-		if live.Spec.Containers[i].TerminationMessagePolicy == "" {
-			live.Spec.Containers[i].TerminationMessagePolicy = corev1.TerminationMessageReadFile
-		}
-	}
-
-	if podTemplatesDiffer(live, desired) {
-		t.Error("a template differs from itself once the API server defaults " +
-			"TerminationMessagePolicy: the operator left it unset on a container it generates")
 	}
 }


### PR DESCRIPTION
## What

Delete `podTemplatesDiffer`, `normalizeContainers` and `computePodTemplateForComparison` from `internal/controller/drain_before_rollout.go`, and treat a missing `desired-template-hash` annotation as "changed" rather than "unchanged".

## Why

Refs #1461

`normalizeContainers` was a hand-maintained mirror of API-server defaulting. It had to track Kubernetes defaulting indefinitely for a path that runs at most once per Deployment, and it had already drifted once: `TerminationMessagePolicy` became operator-owned in #1425 while the normaliser still stripped it (#1437).

The comparison was also almost never consulted. Every operator-created Deployment carries the annotation, so the hash path already discards the normalised result.

## How

The legacy fallback becomes the conservative choice: a missing `desired-template-hash` now means assume changed, so we drain before rolling. That is the safe direction, and after the first post-upgrade reconcile the annotation is present and the hash path takes over.

Tests that only existed to exercise the deleted functions are removed. `TestNormalizeContainersKeepsTerminationMessagePolicy` in `init_container_diagnostics_test.go` went with them, since it called `normalizeContainers` directly, and a doc comment there describing the old normalisation asymmetry was updated.

## Verification

Run on this branch, not inherited from the agent's own verdict:

- `go test ./internal/controller/ -count=1` -> **ok, 269.968s**, including the new spec `should treat a missing desired-template-hash as changed and drain` (`drain_before_roll_test.go:483`)
- `golangci-lint run ./internal/...` -> **0 issues**
- `GOOS=linux golangci-lint run ./internal/...` -> **0 issues**
- `go build ./...` -> clean

**Not done:** manual testing in a live Kubernetes cluster. This is unit-verified only, which is why the commit says `Refs #1461` rather than `Fixes`.

**A note on the agent's own gate.** The verify command in the dispatch intent was `-run 'Drain|Rollout|Template'`, which matches no top-level `func Test` in that package because the relevant coverage is Ginkgo specs inside a suite. `go test` exits 0 with `[no tests to run]`, so the harness reported GATE-PASS having executed nothing. The work is genuinely covered, but that verdict was not evidence of it. Filing that gate gap separately.

## Sign-off

**This commit currently carries a bot-only sign-off** (`Signed-off-by: Foreman Bot`). Per CONTRIBUTING.md, bot-only sign-offs are not accepted, so this needs a human sign-off before merge:

```
git commit --amend -s --no-edit && git push --force-with-lease
```

I did not add it on the maintainer's behalf. The DCO is an attestation that a person understands and takes responsibility for the change, and that is not mine to make for someone else.

## AI assistance

`Assisted-by: Qwen3.8-27B via the Foreman harness` (wrote the change and the tests, unsupervised, dispatched as an overnight batch).

`Reviewed-by: Claude` (read the full diff, verified both functions were actually removed, confirmed the out-of-scope test edit was a required consequence rather than scope creep, ran the full package suite and both lint passes on the branch, and caught that the harness's own GATE-PASS was vacuous).

A human has not yet read this diff. It is offered for review, not as verified-by-a-person work.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran `go test ./internal/controller/ -count=1`, the affected package)
- [x] `make lint` passes locally (host and `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) - the PR title carries the prefix; the commit subject does not
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **bot-only, see Sign-off above**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - not user-facing
