### PR TITLE
feat(foreman): operator-emitted task outcome counters

### DIFF
--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
@@ -35,6 +36,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
 	"github.com/defilantech/llmkube/pkg/foreman/audit"
 )
 
@@ -113,6 +115,15 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// then nothing left to do.
 	if task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded ||
 		task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed {
+		// Emit the operator-side outcome metrics once, gated on the same
+		// audited annotation RecordTerminal stamps, so a task that stays
+		// terminal across reconciles is counted exactly once (#1491). The
+		// guard runs before RecordTerminal: if the annotation is already set
+		// we have emitted (or the audit wrote) before, so skip.
+		if task.Annotations[audit.AuditedAnnotation] != "true" {
+			agent, kind, verdict, outcome, elapsedSec, turns := taskOutcomeLabels(&task)
+			llmkubemetrics.RecordTaskOutcome(agent, kind, verdict, outcome, elapsedSec, turns)
+		}
 		if err := audit.RecordTerminal(ctx, r.Client, &task, r.AuditNamespace, log); err != nil {
 			log.Error(err, "audit: failed to record terminal run (continuing)")
 		}
@@ -205,6 +216,40 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
+}
+
+// taskOutcomeLabels extracts the bounded label values the operator emits for a
+// terminal Foreman task (#1491): the Agent name (from spec.agentRef; "" when
+// unset), the task kind, the verdict, and the machine outcome carried at
+// result.extra.outcome ("" when the run has none). It also returns the
+// executor's elapsedSec and the agent-loop turn count from result.extra.
+//
+// The task NAME is deliberately never a label: it is unbounded and would break
+// cardinality. A missing or unparseable result envelope yields zero elapsedSec
+// and zero turns (RecordTaskOutcome skips observing zeros) and an empty
+// outcome — never a fabricated value.
+func taskOutcomeLabels(task *foremanv1alpha1.AgenticTask) (agent, kind, verdict, outcome string, elapsedSec float64, turns int) {
+	agent = ""
+	if task.Spec.AgentRef != nil {
+		agent = task.Spec.AgentRef.Name
+	}
+	kind = string(task.Spec.Kind)
+	verdict = string(task.Status.Verdict)
+	if task.Status.Result != nil && len(task.Status.Result.Raw) > 0 {
+		var env struct {
+			ElapsedSec float64 `json:"elapsedSec"`
+			Extra      struct {
+				Outcome   string `json:"outcome"`
+				TurnCount int    `json:"turnCount"`
+			} `json:"extra"`
+		}
+		if err := json.Unmarshal(task.Status.Result.Raw, &env); err == nil {
+			outcome = env.Extra.Outcome
+			elapsedSec = env.ElapsedSec
+			turns = env.Extra.TurnCount
+		}
+	}
+	return agent, kind, verdict, outcome, elapsedSec, turns
 }
 
 // effectiveRequiredCapability returns the capability the scheduler should

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -115,17 +115,28 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// then nothing left to do.
 	if task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded ||
 		task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseFailed {
-		// Emit the operator-side outcome metrics once, gated on the same
-		// audited annotation RecordTerminal stamps, so a task that stays
-		// terminal across reconciles is counted exactly once (#1491). The
-		// guard runs before RecordTerminal: if the annotation is already set
-		// we have emitted (or the audit wrote) before, so skip.
-		if task.Annotations[audit.AuditedAnnotation] != "true" {
-			agent, kind, verdict, outcome, elapsedSec, turns := taskOutcomeLabels(&task)
-			llmkubemetrics.RecordTaskOutcome(agent, kind, verdict, outcome, elapsedSec, turns)
-		}
-		if err := audit.RecordTerminal(ctx, r.Client, &task, r.AuditNamespace, log); err != nil {
-			log.Error(err, "audit: failed to record terminal run (continuing)")
+		// Emit the operator-side outcome metric exactly once, gated on the
+		// audited annotation actually being PERSISTED by RecordTerminal
+		// (#1491). RecordTerminal returns nil in two cases: it just wrote the
+		// record and stamped the annotation (first terminal reconcile), or the
+		// annotation was already set and it was a no-op (a later reconcile of
+		// an already-counted task). We only emit on the first case — the
+		// annotation was unset on entry AND RecordTerminal succeeded — so a
+		// failed audit write means no metric rather than a metric that a later
+		// reconcile (periodic resync or any update) would pass the guard and
+		// repeat. Under-counting on that rare failure path is the better
+		// trade: rates stay correct, whereas a repeated increment would inflate
+		// exactly the agents that are having trouble.
+		firstTerminal := task.Annotations[audit.AuditedAnnotation] != "true"
+		if firstTerminal {
+			if err := audit.RecordTerminal(ctx, r.Client, &task, r.AuditNamespace, log); err != nil {
+				// The dedup marker was not persisted, so the metric must not
+				// be emitted either: a later reconcile will retry both.
+				log.Error(err, "audit: failed to record terminal run; skipping outcome metric (continuing)")
+			} else {
+				agent, kind, verdict, outcome, elapsedSec, turns := taskOutcomeLabels(&task)
+				llmkubemetrics.RecordTaskOutcome(agent, kind, verdict, outcome, elapsedSec, turns)
+			}
 		}
 		// Release the node reservation so the scheduler can dispatch the next
 		// task there. Guarded on taskKey, so a node already reserved for a

--- a/internal/foreman/controller/task_outcome_metrics_test.go
+++ b/internal/foreman/controller/task_outcome_metrics_test.go
@@ -17,12 +17,19 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 
+	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
 )
 
 // TestTaskOutcomeLabels verifies the bounded label extraction the operator uses
@@ -95,4 +102,79 @@ func TestTaskOutcomeLabels(t *testing.T) {
 				outcome, elapsed, turns)
 		}
 	})
+}
+
+// TestTerminalMetricEmittedAtMostOnceOnAuditFailure proves the "exactly once"
+// guarantee holds on the audit FAILURE path, not only the happy path (#1491).
+// The metric must be emitted only when the dedup marker (the audited
+// annotation) is actually persisted by RecordTerminal. When the audit write
+// fails the marker is never stamped, so a later reconcile of the same terminal
+// task (periodic resync or any update) would otherwise pass the guard and
+// increment the counter a second time. A failed audit write therefore means no
+// metric (under-count: rates stay correct) rather than a repeating one
+// (double-count: inflates exactly the agents that are having trouble).
+//
+// This test must FAIL against the ordering where the metric is emitted before
+// RecordTerminal: there, both reconciles pass the unset-annotation guard and
+// each emits, so the counter moves by 2 across the two passes.
+func TestTerminalMetricEmittedAtMostOnceOnAuditFailure(t *testing.T) {
+	// Foreman-only scheme (no corev1.ConfigMap registered). This is deliberate:
+	// audit.RecordTerminal writes its durable record to a ConfigMap, and with
+	// the type absent from the scheme that write fails ("no kind registered
+	// for v1.ConfigMap"), so RecordTerminal returns an error and never stamps
+	// the audited annotation — exactly the audit-failure path under test.
+	scheme := runtime.NewScheme()
+	if err := foremanv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add foreman scheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	task := newTask("dedup-audit-fail")
+	task.Spec.Kind = foremanv1alpha1.AgenticTaskKindIssueFix
+	task.Spec.AgentRef = &corev1.LocalObjectReference{Name: "dedup-agent"}
+	// Terminal state the FleetAgent would have written. A populated result
+	// envelope makes the emitted labels deterministic and distinct from the
+	// label set used by TestTaskOutcomeLabels.
+	finished := metav1.Now()
+	task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictGo
+	task.Status.FinishedAt = &finished
+	task.Status.Result = &runtime.RawExtension{Raw: []byte(
+		`{"elapsedSec":42.5,"extra":{"outcome":"MODEL-DECIDED","turnCount":17}}`)}
+	// No audited annotation: this is the first terminal reconcile.
+	if err := fakeClient.Create(context.Background(), task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	r := &AgenticTaskReconciler{Client: fakeClient, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(task)}
+
+	labels := []string{"dedup-agent", "issue-fix", "GO", "MODEL-DECIDED"}
+	readCounter := func() float64 {
+		t.Helper()
+		var m dto.Metric
+		if err := llmkubemetrics.ForemanTaskCompletedTotal.WithLabelValues(labels...).Write(&m); err != nil {
+			t.Fatalf("read counter: %v", err)
+		}
+		return m.GetCounter().GetValue()
+	}
+
+	before := readCounter()
+
+	// First terminal reconcile: the audit write fails, so the metric must not
+	// be emitted (the dedup marker is never persisted).
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first reconcile returned an error: %v", err)
+	}
+	// Second reconcile of the same terminal task (periodic resync / update).
+	// The annotation is still unset, so without the fix this pass re-emits.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second reconcile returned an error: %v", err)
+	}
+
+	after := readCounter()
+	if got := after - before; got > 1 {
+		t.Errorf("counter must increment at most once across both passes, got +%v (audit write failed both times)", got)
+	}
 }

--- a/internal/foreman/controller/task_outcome_metrics_test.go
+++ b/internal/foreman/controller/task_outcome_metrics_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// TestTaskOutcomeLabels verifies the bounded label extraction the operator uses
+// to emit terminal-task outcome metrics (#1491): agent name from spec.agentRef,
+// kind, verdict, and the machine outcome / elapsedSec / turns carried in the
+// result envelope. A missing or unparseable result yields empty outcome and
+// zero numeric fields, never a fabricated value. The task NAME is deliberately
+// never returned — it is unbounded and would break cardinality.
+func TestTaskOutcomeLabels(t *testing.T) {
+	t.Run("full envelope with agentRef", func(t *testing.T) {
+		task := &foremanv1alpha1.AgenticTask{}
+		task.Spec.Kind = foremanv1alpha1.AgenticTaskKindIssueFix
+		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: "coder"}
+		task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		task.Status.Result = &runtime.RawExtension{Raw: []byte(
+			`{"elapsedSec":42.5,"extra":{"outcome":"ALREADY-RESOLVED","turnCount":17}}`)}
+
+		agent, kind, verdict, outcome, elapsed, turns := taskOutcomeLabels(task)
+		if agent != "coder" {
+			t.Errorf("agent = %q, want %q", agent, "coder")
+		}
+		if kind != "issue-fix" {
+			t.Errorf("kind = %q, want %q", kind, "issue-fix")
+		}
+		if verdict != "NO-GO" {
+			t.Errorf("verdict = %q, want %q", verdict, "NO-GO")
+		}
+		if outcome != "ALREADY-RESOLVED" {
+			t.Errorf("outcome = %q, want %q", outcome, "ALREADY-RESOLVED")
+		}
+		if elapsed != 42.5 {
+			t.Errorf("elapsed = %f, want 42.5", elapsed)
+		}
+		if turns != 17 {
+			t.Errorf("turns = %d, want 17", turns)
+		}
+	})
+
+	t.Run("no agentRef and no result envelope", func(t *testing.T) {
+		task := &foremanv1alpha1.AgenticTask{}
+		task.Spec.Kind = foremanv1alpha1.AgenticTaskKindVerify
+		task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictGatePass
+
+		agent, kind, verdict, outcome, elapsed, turns := taskOutcomeLabels(task)
+		if agent != "" {
+			t.Errorf("agent = %q, want empty for unset agentRef", agent)
+		}
+		if kind != "verify" {
+			t.Errorf("kind = %q, want %q", kind, "verify")
+		}
+		if verdict != "GATE-PASS" {
+			t.Errorf("verdict = %q, want %q", verdict, "GATE-PASS")
+		}
+		if outcome != "" || elapsed != 0 || turns != 0 {
+			t.Errorf("missing envelope must yield empty/zero, got outcome=%q elapsed=%f turns=%d",
+				outcome, elapsed, turns)
+		}
+	})
+
+	t.Run("unparseable result yields no fabricated values", func(t *testing.T) {
+		task := &foremanv1alpha1.AgenticTask{}
+		task.Spec.Kind = foremanv1alpha1.AgenticTaskKindFreeform
+		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: "freeform-agent"}
+		task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictIncomplete
+		task.Status.Result = &runtime.RawExtension{Raw: []byte(`{not-json`)}
+
+		_, _, _, outcome, elapsed, turns := taskOutcomeLabels(task)
+		if outcome != "" || elapsed != 0 || turns != 0 {
+			t.Errorf("unparseable envelope must yield empty/zero, got outcome=%q elapsed=%f turns=%d",
+				outcome, elapsed, turns)
+		}
+	})
+}

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -34,6 +34,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
 )
 
 // WorkloadReconciler turns a Workload into a set of AgenticTask objects
@@ -575,12 +576,27 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 	patch := client.MergeFrom(w.DeepCopy())
 	now := metav1.Now()
 
+	// Capture the prior phase before computeTerminalState mutates it, so the
+	// outcome metric fires exactly once per terminal transition (#1491) and
+	// not on every steady-state re-reconcile of an already-terminal Workload.
+	prevPhase := w.Status.Phase
+
 	w.Status.SucceededTasks = cls.succeeded
 	w.Status.FailedTasks = cls.failed
 	w.Status.IncompleteTasks = cls.incomplete
 
 	computeTerminalState(w, cls, now)
 	r.emitAlreadyResolvedCondition(w, cls, now)
+
+	if (w.Status.Phase == foremanv1alpha1.WorkloadPhaseCompleted ||
+		w.Status.Phase == foremanv1alpha1.WorkloadPhaseFailed) &&
+		w.Status.Phase != prevPhase {
+		outcome := "completed"
+		if w.Status.Phase == foremanv1alpha1.WorkloadPhaseFailed {
+			outcome = "failed"
+		}
+		llmkubemetrics.RecordWorkloadOutcome(outcome)
+	}
 
 	if err := r.Status().Patch(ctx, w, patch); err != nil {
 		return ctrl.Result{}, fmt.Errorf("patch workload status during rollup: %w", err)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -280,6 +280,59 @@ var (
 		},
 		[]string{"router", "pool", "member"},
 	)
+
+	// Foreman task metrics (#1491): per-Agent verdict rates, task duration, and
+	// turn counts. Task outcomes live only on AgenticTask/Workload CRs, which are
+	// deleted with their Workload on every retry, so the operator emits them at
+	// terminal-phase transition to survive CR deletion by construction. Labels
+	// are bounded (Agent names, task kinds, verdict/outcome enums) — never task
+	// names — so cardinality stays trivial.
+
+	// ForemanTaskCompletedTotal counts tasks reaching a terminal phase, by the
+	// Agent that ran them, the task kind, the verdict, and the machine outcome
+	// carried in result.extra.outcome ("" when the run has none).
+	ForemanTaskCompletedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "foreman_task_completed_total",
+			Help: "Total number of Foreman tasks reaching a terminal phase, by agent, kind, verdict, and outcome.",
+		},
+		[]string{"agent", "kind", "verdict", "outcome"},
+	)
+
+	// ForemanTaskDurationSeconds measures wall-clock task duration, from the
+	// executor's result.elapsedSec. Buckets cover the 2700s task timeout.
+	ForemanTaskDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "foreman_task_duration_seconds",
+			Help:    "Wall-clock duration of a Foreman task, from the executor's result.elapsedSec.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 12), // 1s to ~4096s
+		},
+		[]string{"agent", "kind", "verdict"},
+	)
+
+	// ForemanTaskTurns measures agent-loop turns consumed, from
+	// result.extra.turnCount.
+	ForemanTaskTurns = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "foreman_task_turns",
+			Help:    "Number of agent-loop turns a Foreman task used, from result.extra.turnCount.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 10), // 1 to ~512
+		},
+		[]string{"agent", "kind"},
+	)
+
+	// ForemanWorkloadCompletedTotal counts workloads reaching a terminal phase,
+	// by outcome (completed / failed), derived from status.phase. The operator
+	// does not observe the PR state a Workload produced (the ephemeral agent
+	// opens the PR via githubpr.EnsurePR), so the split is by terminal phase,
+	// not by whether a PR landed.
+	ForemanWorkloadCompletedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "foreman_workload_completed_total",
+			Help: "Total number of Foreman workloads reaching a terminal phase, by outcome.",
+		},
+		[]string{"outcome"},
+	)
 )
 
 // AllCollectors is every metric this operator registers. init() registers
@@ -313,6 +366,10 @@ var AllCollectors = []prometheus.Collector{
 	ModelPoolHoldDuration,
 	ModelPoolCoalescedTotal,
 	ModelPoolHeldRequests,
+	ForemanTaskCompletedTotal,
+	ForemanTaskDurationSeconds,
+	ForemanTaskTurns,
+	ForemanWorkloadCompletedTotal,
 }
 
 func init() {
@@ -401,4 +458,38 @@ func DeleteGPUQuotaSeries(name, namespace string) {
 
 func gpuQuotaLabels(name, namespace string) prometheus.Labels {
 	return prometheus.Labels{"gpuquota": name, nsLabel: namespace}
+}
+
+// RecordTaskOutcome emits the operator-side counters and histograms for one
+// terminal Foreman task (#1491). The operator observes every terminal-phase
+// transition regardless of execution mode, so these series survive CR deletion
+// by construction — the per-Agent verdict rates the audit ConfigMap can only
+// reconstruct after the fact.
+//
+// The caller extracts the bounded label values (agent name, kind, verdict, and
+// the machine outcome carried at result.extra.outcome) from the terminal
+// AgenticTask and passes them here. The task NAME is deliberately never a
+// label: it is unbounded and would break cardinality.
+//
+// The histograms observe only when the executor reported a value (elapsedSec
+// and turns are both 0/absent on a cascade-skip or a run that died before
+// reporting), so a missing value does not skew the distribution.
+func RecordTaskOutcome(agent, kind, verdict, outcome string, elapsedSec float64, turns int) {
+	ForemanTaskCompletedTotal.WithLabelValues(agent, kind, verdict, outcome).Inc()
+	if elapsedSec > 0 {
+		ForemanTaskDurationSeconds.WithLabelValues(agent, kind, verdict).Observe(elapsedSec)
+	}
+	if turns > 0 {
+		ForemanTaskTurns.WithLabelValues(agent, kind).Observe(float64(turns))
+	}
+}
+
+// RecordWorkloadOutcome emits the operator-side counter for one terminal
+// Foreman Workload (#1491). outcome is the bounded terminal bucket the
+// Workload rollup classified it into, derived from status.phase: "completed"
+// or "failed". Counters are monotonically increasing; a Workload that
+// re-reaches the same terminal phase across reconciles is emitted once per
+// terminal transition by the caller, which guards on phase change.
+func RecordWorkloadOutcome(outcome string) {
+	ForemanWorkloadCompletedTotal.WithLabelValues(outcome).Inc()
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -307,6 +307,90 @@ func TestGPUQuotaLabels(t *testing.T) {
 	}
 }
 
+func TestRecordTaskOutcomeCounter(t *testing.T) {
+	// The completed counter is unconditional: every terminal task emits it,
+	// keyed by the bounded label set (agent, kind, verdict, outcome).
+	RecordTaskOutcome("coder", "issue-fix", "GO", "MODEL-DECIDED", 42.0, 17)
+
+	var m dto.Metric
+	obs := ForemanTaskCompletedTotal.WithLabelValues("coder", "issue-fix", "GO", "MODEL-DECIDED")
+	if err := obs.Write(&m); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if got := m.GetCounter().GetValue(); got < 1 {
+		t.Errorf("expected completed counter >= 1, got %f", got)
+	}
+}
+
+func TestRecordTaskOutcomeDuration(t *testing.T) {
+	// A positive elapsedSec must land in the duration histogram.
+	RecordTaskOutcome("coder", "issue-fix", "NO-GO", "ALREADY-RESOLVED", 88.0, 0)
+	m := getHistogramMetric(t, ForemanTaskDurationSeconds, []string{"coder", "issue-fix", "NO-GO"}, 1.0)
+	if m.GetHistogram().GetSampleCount() == 0 {
+		t.Error("expected duration sample count > 0 after a positive observation")
+	}
+}
+
+func TestRecordTaskOutcomeSkipsZeroDurationAndTurns(t *testing.T) {
+	// A cascade-skip / pre-report terminal task has no elapsedSec or turns:
+	// the histograms must NOT observe zero, or the distribution skews low.
+	RecordTaskOutcome("verifier", "verify", "GATE-PASS", "", 0, 0)
+
+	// Read the series directly without observing (getHistogramMetric would
+	// observe its own value and inflate the count).
+	durObs, err := ForemanTaskDurationSeconds.GetMetricWithLabelValues("verifier", "verify", "GATE-PASS")
+	if err != nil {
+		t.Fatalf("failed to get duration metric: %v", err)
+	}
+	var dm dto.Metric
+	if err := durObs.(prometheus.Metric).Write(&dm); err != nil {
+		t.Fatalf("failed to write duration metric: %v", err)
+	}
+	if got := dm.GetHistogram().GetSampleCount(); got != 0 {
+		t.Errorf("zero elapsedSec must not observe duration, got %d samples", got)
+	}
+
+	turnsObs, err := ForemanTaskTurns.GetMetricWithLabelValues("verifier", "verify")
+	if err != nil {
+		t.Fatalf("failed to get turns metric: %v", err)
+	}
+	var tm dto.Metric
+	if err := turnsObs.(prometheus.Metric).Write(&tm); err != nil {
+		t.Fatalf("failed to write turns metric: %v", err)
+	}
+	if got := tm.GetHistogram().GetSampleCount(); got != 0 {
+		t.Errorf("zero turns must not observe the turns histogram, got %d samples", got)
+	}
+}
+
+func TestRecordTaskOutcomeTurns(t *testing.T) {
+	// A positive turn count must land in the turns histogram.
+	RecordTaskOutcome("coder", "issue-fix", "GO", "", 12.0, 9)
+	m := getHistogramMetric(t, ForemanTaskTurns, []string{"coder", "issue-fix"}, 3.0)
+	if m.GetHistogram().GetSampleCount() == 0 {
+		t.Error("expected turns sample count > 0 after a positive observation")
+	}
+}
+
+func TestRecordWorkloadOutcome(t *testing.T) {
+	RecordWorkloadOutcome("completed")
+	RecordWorkloadOutcome("failed")
+
+	var m dto.Metric
+	if err := ForemanWorkloadCompletedTotal.WithLabelValues("completed").Write(&m); err != nil {
+		t.Fatalf("failed to write completed metric: %v", err)
+	}
+	if got := m.GetCounter().GetValue(); got < 1 {
+		t.Errorf("expected completed workload counter >= 1, got %f", got)
+	}
+	if err := ForemanWorkloadCompletedTotal.WithLabelValues("failed").Write(&m); err != nil {
+		t.Fatalf("failed to write failed metric: %v", err)
+	}
+	if got := m.GetCounter().GetValue(); got < 1 {
+		t.Errorf("expected failed workload counter >= 1, got %f", got)
+	}
+}
+
 func TestPublishModelPhase(t *testing.T) {
 	labels := modelLabels("publish-test", "default")
 	ModelStatus.DeletePartialMatch(labels)


### PR DESCRIPTION
## What

Operator-emitted Prometheus counters for Foreman task outcomes, so verdict rates and outcome mix survive the CRs they came from.

## Why

Refs #1491

Task outcomes live only on AgenticTask and Workload CRs, which are deleted with their Workload on every retry or recreate. There is no durable record of per-Agent verdict rates, task duration or outcome mix, so questions about fleet behaviour cannot be answered after the fact.

Tonight is a good example: this batch produced GO, NO-GO, INCOMPLETE and infrastructure failures across ten workloads, and reconstructing that distribution afterwards meant reading CRs before they were garbage collected.

## How

New counters in `internal/metrics/metrics.go`, recorded from the call sites in `internal/foreman/controller/agentictask_controller.go` and `workload_controller.go`, following the naming and registration pattern already used by the existing collectors in that file.

Label sets are deliberately bounded:

```
{"agent", "kind", "verdict", "outcome"}
{"agent", "kind", "verdict"}
{"agent", "kind"}
{"outcome"}
```

No task name or workload name appears in any label, so cardinality stays a function of the fleet's agent count rather than its task history.

**Scope note:** the issue carries an addendum about `foreman.crs.namespace` for the CRS ConfigMap. That is not in this change, and appears to be covered by #1492 already.

## Review round 2: the counter could double-count

Found by reading the failure path rather than the happy path, and fixed in `c04ff393`. Recording it here because it changes the guarantee the code advertises.

**The defect.** The metric was emitted *before* the audit dedup marker was persisted, and `RecordTerminal`'s error was logged and swallowed rather than returned:

```go
if task.Annotations[audit.AuditedAnnotation] != "true" {
    ... RecordTaskOutcome(...)          // emitted HERE
}
if err := audit.RecordTerminal(...); err != nil {
    log.Error(err, "...(continuing)")   // swallowed, no requeue
}
```

So when the audit write failed, the counter had already incremented, the annotation was never stamped, and any later reconcile of that task (periodic resync, or any update to it) passed the guard again and incremented a **second** time. The code's own comment claimed the task "is counted exactly once", which held only on the success path.

**The fix.** Emit only when the dedup marker actually persisted:

```go
if err := audit.RecordTerminal(...); err != nil {
    // The dedup marker was not persisted, so the metric must not
    // be emitted either: a later reconcile will retry both.
    log.Error(err, "...skipping outcome metric (continuing)")
} else {
    llmkubemetrics.RecordTaskOutcome(...)
}
```

Under-counting on a rare failure is the better trade: a counter that occasionally misses a terminal task still gives correct **rates**, while one that double-counts inflates exactly the agents that are having trouble, which is the opposite of useful.

**The regression test.** `TestTerminalMetricEmittedAtMostOnceOnAuditFailure` builds a scheme with `v1.ConfigMap` deliberately absent, so `RecordTerminal` genuinely fails ("no kind registered for v1.ConfigMap") rather than being mocked. It then reconciles the same terminal task **twice** and asserts the counter incremented at most once across both passes. It fails against the previous ordering, where both passes clear the unset-annotation guard.

## Verification

Run on this branch, not inherited from the agent's verdict:

- `go test ./internal/metrics/... -count=1` -> **ok, 0.421s**
- `go test ./internal/foreman/controller/ -count=1` -> **ok, 19.294s**
- `golangci-lint run ./internal/...` -> **0 issues**
- `go build ./...` -> clean

Round 2 (`c04ff393`) was gate-verified on the branch (GATE-PASS) and the reordering plus the new regression test were read line by line before this description was updated. The two package suites above were run on the round-1 commit; they have not been re-run locally against round 2.

**CI note:** the current `Run on Ubuntu` failure is infrastructure, not this change. `setup-envtest` could not fetch its release index (`connection reset by peer` from raw.githubusercontent.com), so no test executed. Worth a re-run.

**Not done:** no scrape against a live Prometheus, and no check that the series render as intended in a dashboard. Unit-verified only, hence `Refs #1491` rather than `Fixes`.

## Sign-off

**Bot-only sign-off** (`Signed-off-by: Foreman Bot`). Per CONTRIBUTING.md that is not accepted, so this needs a human sign-off before merge:

```
git commit --amend -s --no-edit && git push --force-with-lease
```

Not added on the maintainer's behalf: the DCO attests that a person understands and takes responsibility for the change.

## AI assistance

`Assisted-by: Qwen3.8-27B via the Foreman harness` (wrote the counters, call sites and tests unsupervised, dispatched as an overnight batch).

`Reviewed-by: Claude` (read the full diff, confirmed the change is purely additive, checked label cardinality is bounded to agent and verdict rather than task identity, confirmed the CRS addendum was correctly left out of scope, ran both package suites and lint on the branch).

Round 2 was implemented by Qwen3.8-27B on the three-node fleet. Its automated reviewer returned GO, and unlike two sibling runs in the same batch its summary did describe the actual change; that reviewer is nevertheless unreliable (see #1570), so the ordering fix and the regression test were checked against the diff by hand rather than accepted on the verdict.

A human has not yet read this diff. Offered for review, not as verified-by-a-person work.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran the two affected packages)
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) - PR title carries the prefix; the commit subject does not
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **bot-only, see Sign-off above**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - metrics names are described here; no observability doc enumerates them today

