### PR TITLE
feat(controller): speculativeDecoding.draftModel for companion-file drafters

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -66,14 +66,17 @@ type SpeculativeDecodingType string
 
 // SpeculativeDecodingSpec configures speculative decoding for the llama.cpp
 // runtime. It maps to --spec-type (Type), --spec-draft-n-max (NDraftMax),
-// --spec-draft-p-min (PMin) and -md (DraftModelRef). Only the "llamacpp"
-// runtime supports this field; other runtimes must not set it.
+// --spec-draft-p-min (PMin) and -md (DraftModelRef / DraftModel). Only the
+// "llamacpp" runtime supports this field; other runtimes must not set it.
 //
-// The draft-model types need weights and so require DraftModelRef. draft-mtp
-// does not: MTP is self-speculation carried by the target model itself. The
-// ngram-* family speculates from the prompt and likewise needs no weights.
-// +kubebuilder:validation:XValidation:rule="!(self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark']) || (has(self.draftModelRef) && self.draftModelRef.size() > 0)",message="this speculative decoding type needs draft weights: set draftModelRef to a Model in the same namespace"
-// +kubebuilder:validation:XValidation:rule="(self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark','draft-mtp']) || !has(self.draftModelRef) || self.draftModelRef.size() == 0",message="draftModelRef is only valid for the draft-model types (draft-simple, draft-eagle3, draft-dflash, draft-dspark, draft-mtp); the ngram types need no draft weights"
+// The draft-model types need weights and so require exactly one of DraftModelRef
+// (a separate Model CR) or DraftModel (a companion file staged alongside the
+// target in Model.files). draft-mtp does not require weights: MTP is
+// self-speculation carried by the target model itself. The ngram-* family
+// speculates from the prompt and likewise needs no weights.
+// +kubebuilder:validation:XValidation:rule="!(self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark']) || ((has(self.draftModelRef) && self.draftModelRef.size() > 0) || (has(self.draftModel) && self.draftModel.size() > 0))",message="this speculative decoding type needs draft weights: set draftModelRef to a Model in the same namespace, or draftModel to a file in Model.files"
+// +kubebuilder:validation:XValidation:rule="(self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark','draft-mtp']) || ((!has(self.draftModelRef) || self.draftModelRef.size() == 0) && (!has(self.draftModel) || self.draftModel.size() == 0))",message="draft weights (draftModelRef or draftModel) are only valid for the draft-model types (draft-simple, draft-eagle3, draft-dflash, draft-dspark, draft-mtp); the ngram types need no draft weights"
+// +kubebuilder:validation:XValidation:rule="!((has(self.draftModelRef) && self.draftModelRef.size() > 0) && (has(self.draftModel) && self.draftModel.size() > 0))",message="set only one of draftModelRef (a separate Model CR) and draftModel (a file in Model.files), not both"
 type SpeculativeDecodingSpec struct {
 	// Type is the speculative decoding method (--spec-type). The aliases map
 	// as: "mtp" to draft-mtp, "draft" to draft-simple, and "disabled" to no
@@ -82,7 +85,8 @@ type SpeculativeDecodingSpec struct {
 
 	// DraftModelRef names the Model CR holding the draft weights, resolved in
 	// the InferenceService's own namespace and mounted into the serving pod
-	// alongside the target model. Required for the draft-model types.
+	// alongside the target model. Required for the draft-model types when the
+	// drafter ships as its own model rather than a companion file.
 	//
 	// Deliberately a Model reference rather than the raw in-container path
 	// SGLang's block uses (SpeculativeConfig.DraftModelPath): the operator
@@ -90,6 +94,22 @@ type SpeculativeDecodingSpec struct {
 	// has no readiness to gate on.
 	// +optional
 	DraftModelRef string `json:"draftModelRef,omitempty"`
+
+	// DraftModel names a file already present in the target model's spec.files
+	// that holds the draft weights (e.g. the dflash-kquant.gguf companion
+	// drafter Meta ships next to the main GGUF for Muse Glimmer). The operator
+	// resolves its staged in-container path the same way it does for
+	// Model.mmproj and passes it to llama.cpp as -md, so the manifest never
+	// has to name a content-hash cache directory that is unknowable before the
+	// first reconcile and moves whenever the file set changes (#1495).
+	//
+	// Use DraftModel when the drafter is a companion file in the same Model and
+	// DraftModelRef when it is a separate Model CR; the two are mutually
+	// exclusive.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
+	// +optional
+	DraftModel string `json:"draftModel,omitempty"`
 
 	// NDraftMax is the maximum number of draft tokens to propose per step
 	// (--spec-draft-n-max). Only emitted when set; llama.cpp uses its own default

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -5242,11 +5242,28 @@ spec:
                   Maps to llama.cpp --spec-type and --spec-draft-n-max flags. Only the
                   "llamacpp" runtime supports this field; other runtimes must not set it.
                 properties:
+                  draftModel:
+                    description: |-
+                      DraftModel names a file already present in the target model's spec.files
+                      that holds the draft weights (e.g. the dflash-kquant.gguf companion
+                      drafter Meta ships next to the main GGUF for Muse Glimmer). The operator
+                      resolves its staged in-container path the same way it does for
+                      Model.mmproj and passes it to llama.cpp as -md, so the manifest never
+                      has to name a content-hash cache directory that is unknowable before the
+                      first reconcile and moves whenever the file set changes (#1495).
+
+                      Use DraftModel when the drafter is a companion file in the same Model and
+                      DraftModelRef when it is a separate Model CR; the two are mutually
+                      exclusive.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
                   draftModelRef:
                     description: |-
                       DraftModelRef names the Model CR holding the draft weights, resolved in
                       the InferenceService's own namespace and mounted into the serving pod
-                      alongside the target model. Required for the draft-model types.
+                      alongside the target model. Required for the draft-model types when the
+                      drafter ships as its own model rather than a companion file.
 
                       Deliberately a Model reference rather than the raw in-container path
                       SGLang's block uses (SpeculativeConfig.DraftModelPath): the operator
@@ -5299,14 +5316,21 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: 'this speculative decoding type needs draft weights: set
-                    draftModelRef to a Model in the same namespace'
+                    draftModelRef to a Model in the same namespace, or draftModel
+                    to a file in Model.files'
                   rule: '!(self.type in [''draft'',''draft-simple'',''draft-eagle3'',''draft-dflash'',''draft-dspark''])
-                    || (has(self.draftModelRef) && self.draftModelRef.size() > 0)'
-                - message: draftModelRef is only valid for the draft-model types (draft-simple,
-                    draft-eagle3, draft-dflash, draft-dspark, draft-mtp); the ngram
-                    types need no draft weights
+                    || ((has(self.draftModelRef) && self.draftModelRef.size() > 0)
+                    || (has(self.draftModel) && self.draftModel.size() > 0))'
+                - message: draft weights (draftModelRef or draftModel) are only valid
+                    for the draft-model types (draft-simple, draft-eagle3, draft-dflash,
+                    draft-dspark, draft-mtp); the ngram types need no draft weights
                   rule: (self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark','draft-mtp'])
-                    || !has(self.draftModelRef) || self.draftModelRef.size() == 0
+                    || ((!has(self.draftModelRef) || self.draftModelRef.size() ==
+                    0) && (!has(self.draftModel) || self.draftModel.size() == 0))
+                - message: set only one of draftModelRef (a separate Model CR) and
+                    draftModel (a file in Model.files), not both
+                  rule: '!((has(self.draftModelRef) && self.draftModelRef.size() >
+                    0) && (has(self.draftModel) && self.draftModel.size() > 0))'
               suspend:
                 default: false
                 description: |-

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -5238,11 +5238,28 @@ spec:
                   Maps to llama.cpp --spec-type and --spec-draft-n-max flags. Only the
                   "llamacpp" runtime supports this field; other runtimes must not set it.
                 properties:
+                  draftModel:
+                    description: |-
+                      DraftModel names a file already present in the target model's spec.files
+                      that holds the draft weights (e.g. the dflash-kquant.gguf companion
+                      drafter Meta ships next to the main GGUF for Muse Glimmer). The operator
+                      resolves its staged in-container path the same way it does for
+                      Model.mmproj and passes it to llama.cpp as -md, so the manifest never
+                      has to name a content-hash cache directory that is unknowable before the
+                      first reconcile and moves whenever the file set changes (#1495).
+
+                      Use DraftModel when the drafter is a companion file in the same Model and
+                      DraftModelRef when it is a separate Model CR; the two are mutually
+                      exclusive.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
                   draftModelRef:
                     description: |-
                       DraftModelRef names the Model CR holding the draft weights, resolved in
                       the InferenceService's own namespace and mounted into the serving pod
-                      alongside the target model. Required for the draft-model types.
+                      alongside the target model. Required for the draft-model types when the
+                      drafter ships as its own model rather than a companion file.
 
                       Deliberately a Model reference rather than the raw in-container path
                       SGLang's block uses (SpeculativeConfig.DraftModelPath): the operator
@@ -5295,14 +5312,21 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: 'this speculative decoding type needs draft weights: set
-                    draftModelRef to a Model in the same namespace'
+                    draftModelRef to a Model in the same namespace, or draftModel
+                    to a file in Model.files'
                   rule: '!(self.type in [''draft'',''draft-simple'',''draft-eagle3'',''draft-dflash'',''draft-dspark''])
-                    || (has(self.draftModelRef) && self.draftModelRef.size() > 0)'
-                - message: draftModelRef is only valid for the draft-model types (draft-simple,
-                    draft-eagle3, draft-dflash, draft-dspark, draft-mtp); the ngram
-                    types need no draft weights
+                    || ((has(self.draftModelRef) && self.draftModelRef.size() > 0)
+                    || (has(self.draftModel) && self.draftModel.size() > 0))'
+                - message: draft weights (draftModelRef or draftModel) are only valid
+                    for the draft-model types (draft-simple, draft-eagle3, draft-dflash,
+                    draft-dspark, draft-mtp); the ngram types need no draft weights
                   rule: (self.type in ['draft','draft-simple','draft-eagle3','draft-dflash','draft-dspark','draft-mtp'])
-                    || !has(self.draftModelRef) || self.draftModelRef.size() == 0
+                    || ((!has(self.draftModelRef) || self.draftModelRef.size() ==
+                    0) && (!has(self.draftModel) || self.draftModel.size() == 0))
+                - message: set only one of draftModelRef (a separate Model CR) and
+                    draftModel (a file in Model.files), not both
+                  rule: '!((has(self.draftModelRef) && self.draftModelRef.size() >
+                    0) && (has(self.draftModel) && self.draftModel.size() > 0))'
               suspend:
                 default: false
                 description: |-

--- a/internal/controller/runtime_llamacpp.go
+++ b/internal/controller/runtime_llamacpp.go
@@ -145,18 +145,11 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 	args = appendBatchSizeArgs(args, isvc.Spec.BatchSize)
 	args = appendUBatchSizeArgs(args, isvc.Spec.UBatchSize)
 	args = appendNoWarmupArgs(args, isvc.Spec.NoWarmup)
+	draftPath, mmprojPath := resolveStagedCompanions(isvc, model, modelPath, draftPath)
+
 	args = appendSpeculativeDecodingArgs(args, isvc.Spec.SpeculativeDecoding, draftPath)
 	args = appendReasoningBudgetArgs(args, isvc.Spec.ReasoningBudget, isvc.Spec.ReasoningBudgetMessage)
-	if model != nil && model.Spec.Mmproj != "" && modelPath != "" {
-		if plan, err := ResolveFileSet(model.Spec.Files, model.Spec.Mmproj, nil); err == nil && plan != nil && plan.Primary != "" {
-			mmprojDir := path.Dir(modelPath)
-			suffix := "/" + plan.Primary
-			if strings.HasSuffix(modelPath, suffix) {
-				mmprojDir = modelPath[:len(modelPath)-len(suffix)]
-			}
-			args = appendMmprojArgs(args, stagedCachePath(mmprojDir, model.Spec.Mmproj), isvc.Spec.ExtraArgs)
-		}
-	}
+	args = appendMmprojArgs(args, mmprojPath, isvc.Spec.ExtraArgs)
 	args = appendMetadataOverrideArgs(args, isvc.Spec.MetadataOverrides)
 	args = appendModeArgs(args, isvc.Spec.Mode, isvc.Spec.ExtraArgs)
 	if len(isvc.Spec.ExtraArgs) > 0 {
@@ -173,6 +166,48 @@ func (b *LlamaCppBackend) BuildArgs(isvc *inferencev1alpha1.InferenceService, mo
 	}
 
 	return args
+}
+
+// resolveStagedCompanions resolves the absolute in-container paths of the two
+// companion files the operator stages alongside the primary model: the
+// multimodal projector (Model.mmproj) and a file-based draft
+// (spec.speculativeDecoding.draftModel, #1495). Both resolve against the
+// model's cache base dir — the directory holding the primary file — so the
+// manifest never names a content-hash path that is unknowable before the
+// first reconcile.
+//
+// It returns the draft path to hand to appendSpeculativeDecodingArgs and the
+// mmproj path to hand to appendMmprojArgs. The draft path is left as passed
+// when a Model-CR draft (draftModelRef) already supplied one; a file-based
+// draft only fills the gap when the base dir is resolvable. Each path is ""
+// when its source is unset or the file set is invalid, in which case the
+// corresponding append* helper emits nothing.
+func resolveStagedCompanions(isvc *inferencev1alpha1.InferenceService, model *inferencev1alpha1.Model, modelPath, draftPath string) (draftPathOut, mmprojPath string) {
+	draftPathOut = draftPath
+	if model == nil || modelPath == "" {
+		return
+	}
+
+	baseDir := ""
+	if plan, err := ResolveFileSet(model.Spec.Files, model.Spec.Mmproj, nil); err == nil && plan != nil && plan.Primary != "" {
+		baseDir = path.Dir(modelPath)
+		if suffix := "/" + plan.Primary; strings.HasSuffix(modelPath, suffix) {
+			baseDir = modelPath[:len(modelPath)-len(suffix)]
+		}
+	}
+	if baseDir == "" {
+		return
+	}
+
+	if model.Spec.Mmproj != "" {
+		mmprojPath = stagedCachePath(baseDir, model.Spec.Mmproj)
+	}
+	if draftPathOut == "" {
+		if sd := isvc.Spec.SpeculativeDecoding; sd != nil && sd.DraftModel != "" {
+			draftPathOut = stagedCachePath(baseDir, sd.DraftModel)
+		}
+	}
+	return
 }
 
 func (b *LlamaCppBackend) BuildProbes(port int32) (startup, liveness, readiness *corev1.Probe) {

--- a/internal/controller/runtime_llamacpp_test.go
+++ b/internal/controller/runtime_llamacpp_test.go
@@ -865,3 +865,122 @@ func TestLlamaCppBuildArgs_EmitsDraftModelPath(t *testing.T) {
 		}
 	}
 }
+
+// TestLlamaCppBuildArgs_FileBasedDraftModel covers the file-based draft path
+// (#1495): spec.speculativeDecoding.draftModel names a companion file in
+// Model.files (e.g. a dflash drafter) and the operator resolves its staged
+// in-container path the way it does for Model.mmproj, so the manifest never
+// names a content-hash cache directory.
+func TestLlamaCppBuildArgs_FileBasedDraftModel(t *testing.T) {
+	n := func(i int32) *int32 { return &i }
+	backend := &LlamaCppBackend{}
+
+	cases := []struct {
+		name        string
+		modelSpec   inferencev1alpha1.ModelSpec
+		modelPath   string
+		spec        *inferencev1alpha1.SpeculativeDecodingSpec
+		contains    []FlagCheck
+		notContains []string
+	}{
+		{
+			name: "draft-dflash companion file emits resolved -md",
+			modelSpec: inferencev1alpha1.ModelSpec{
+				Format: "gguf",
+				Files:  []string{"main.gguf", "dflash-kquant.gguf"},
+			},
+			modelPath: "/models/main.gguf",
+			spec: &inferencev1alpha1.SpeculativeDecodingSpec{
+				Type:       "draft-dflash",
+				DraftModel: "dflash-kquant.gguf",
+				NDraftMax:  n(3),
+			},
+			contains: []FlagCheck{
+				{"--spec-type", "draft-dflash"},
+				{"-md", "/models/dflash-kquant.gguf"},
+				{"--spec-draft-n-max", "3"},
+			},
+		},
+		{
+			name: "draft file in subdirectory resolves against cache root",
+			modelSpec: inferencev1alpha1.ModelSpec{
+				Format: "gguf",
+				Files:  []string{"subdir/main.gguf", "subdir/dflash.gguf"},
+			},
+			modelPath: "/models/cache/subdir/main.gguf",
+			spec: &inferencev1alpha1.SpeculativeDecodingSpec{
+				Type:       "draft-dflash",
+				DraftModel: "subdir/dflash.gguf",
+			},
+			contains: []FlagCheck{
+				{"--spec-type", "draft-dflash"},
+				{"-md", "/models/cache/subdir/dflash.gguf"},
+			},
+		},
+		{
+			name: "draftModel without files does not emit -md (cannot resolve)",
+			modelSpec: inferencev1alpha1.ModelSpec{
+				Format: "gguf",
+			},
+			modelPath: "/models/main.gguf",
+			spec: &inferencev1alpha1.SpeculativeDecodingSpec{
+				Type:       "draft-dflash",
+				DraftModel: "dflash.gguf",
+			},
+			contains:    []FlagCheck{{"--spec-type", "draft-dflash"}},
+			notContains: []string{"-md"},
+		},
+		{
+			name: "draftModel not emitted for ngram type (needs no weights)",
+			modelSpec: inferencev1alpha1.ModelSpec{
+				Format: "gguf",
+				Files:  []string{"main.gguf", "dflash.gguf"},
+			},
+			modelPath: "/models/main.gguf",
+			spec: &inferencev1alpha1.SpeculativeDecodingSpec{
+				Type:       "ngram-cache",
+				DraftModel: "dflash.gguf",
+				NDraftMax:  n(2),
+			},
+			contains: []FlagCheck{
+				{"--spec-type", "ngram-cache"},
+				{"--spec-draft-n-max", "2"},
+			},
+			notContains: []string{"-md"},
+		},
+		{
+			name: "draftModel not emitted for mtp (self-speculation)",
+			modelSpec: inferencev1alpha1.ModelSpec{
+				Format: "gguf",
+				Files:  []string{"main.gguf"},
+			},
+			modelPath: "/models/main.gguf",
+			spec:      &inferencev1alpha1.SpeculativeDecodingSpec{Type: "mtp"},
+			contains:  []FlagCheck{{"--spec-type", "draft-mtp"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "isvc-" + strings.ReplaceAll(tc.name, " ", "-"), Namespace: "default"},
+				Spec:       inferencev1alpha1.InferenceServiceSpec{Runtime: "llamacpp", SpeculativeDecoding: tc.spec},
+			}
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+				Spec:       tc.modelSpec,
+			}
+			args := backend.BuildArgs(isvc, model, tc.modelPath, "", 8080)
+			for _, fc := range tc.contains {
+				if !containsArg(args, fc.flag, fc.value) {
+					t.Errorf("expected %q %q in args, got: %v", fc.flag, fc.value, args)
+				}
+			}
+			for _, f := range tc.notContains {
+				if containsArg(args, f, "") {
+					t.Errorf("expected %q NOT in args, got: %v", f, args)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/speculative_decoding_validation_test.go
+++ b/internal/controller/speculative_decoding_validation_test.go
@@ -113,4 +113,45 @@ var _ = Describe("speculativeDecoding CRD validation", func() {
 		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
 	})
+
+	// draftModel is the file-based draft path (#1495): a companion file in
+	// Model.files (e.g. a dflash drafter) rather than a separate Model CR.
+	It("admits a draft-model type with a draftModel file", func() {
+		isvc := newSpecISvc("sd-dflash-file", &inferencev1alpha1.SpeculativeDecodingSpec{
+			Type:       "draft-dflash",
+			DraftModel: "dflash-kquant.gguf",
+		})
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	It("rejects a draft-model type with neither draftModelRef nor draftModel", func() {
+		isvc := newSpecISvc("sd-dflash-nodeither", &inferencev1alpha1.SpeculativeDecodingSpec{
+			Type: "draft-dflash",
+		})
+		err := k8sClient.Create(ctx, isvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("needs draft weights"))
+	})
+
+	It("rejects setting both draftModelRef and draftModel", func() {
+		isvc := newSpecISvc("sd-dflash-both", &inferencev1alpha1.SpeculativeDecodingSpec{
+			Type:          "draft-dflash",
+			DraftModelRef: "dflash-model",
+			DraftModel:    "dflash-kquant.gguf",
+		})
+		err := k8sClient.Create(ctx, isvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("only one of"))
+	})
+
+	It("rejects a draftModel file on a type that needs no draft weights", func() {
+		isvc := newSpecISvc("sd-ngram-file", &inferencev1alpha1.SpeculativeDecodingSpec{
+			Type:       "ngram-cache",
+			DraftModel: "dflash.gguf",
+		})
+		err := k8sClient.Create(ctx, isvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("only valid for the draft-model types"))
+	})
 })


### PR DESCRIPTION
## What

Add `speculativeDecoding.draftModel`, naming a draft-weights file that is already staged as part of the target `Model.spec.files`, as an alternative to `draftModelRef` (a separate Model CR).

## Why

Refs #1495

Some models ship their drafter as a companion file next to the main GGUF rather than as a separate artifact: Meta's `dflash-kquant.gguf` alongside Muse Glimmer is the case that motivated this. Before this change there was no way to point llama.cpp at such a file.

Naming it by path in the manifest is not an option. Staged paths are content-hashed (`/models/<hash>/...`), so the directory is unknowable before the first reconcile and moves whenever the file set changes. The operator has to resolve it, exactly as it already does for `Model.mmproj`.

## How

`DraftModel` is a new optional string on `SpeculativeDecodingSpec`. `resolveStagedCompanions` resolves its in-container path through `stagedCachePath`, the same mechanism used for `mmproj`, and passes it to llama.cpp as `-md`. It defers when a Model-CR draft (`draftModelRef`) already supplied one.

Three CEL rules keep the two ways of naming a drafter coherent:

1. The draft-model types need weights from **either** `draftModelRef` **or** `draftModel`.
2. Draft weights of either kind are only valid for the draft-model types; the ngram family needs none.
3. `draftModelRef` and `draftModel` are **mutually exclusive**.

Additive and optional, so existing manifests are unaffected: a config setting only `draftModelRef` still validates and still emits the same argv.

## Verification

Run on this branch, not inherited from the agent's verdict:

- `go test ./internal/controller/ -count=1` -> **ok, 271.280s**
- `golangci-lint run ./internal/... ./api/...` -> **0 issues**
- `GOOS=linux golangci-lint run ./internal/... ./api/...` -> **0 issues**
- `go build ./...` -> clean
- `make manifests && make chart-crds` then `git status --porcelain` -> **empty**, so the committed CRDs in both `config/crd/bases/` and `charts/llmkube/templates/crds/` match a fresh regeneration

**Not done:** no live serve of a model using a companion-file drafter. The `-md` argv construction is unit-tested but has not been exercised end to end against llama.cpp, hence `Refs #1495` rather than `Fixes`.

## Sign-off

**Bot-only sign-off** (`Signed-off-by: Foreman Bot`). Per CONTRIBUTING.md that is not accepted, so this needs a human sign-off before merge:

```
git commit --amend -s --no-edit && git push --force-with-lease
```

Not added on the maintainer's behalf: the DCO attests that a person understands and takes responsibility for the change.

## AI assistance

`Assisted-by: Qwen3.8-27B via the Foreman harness` (wrote the API change, CEL rules, runtime resolution and tests unsupervised, dispatched as an overnight batch).

`Reviewed-by: Claude` (read the full diff, checked the three CEL rules cover needs-weights / type-restriction / mutual-exclusion without contradicting each other, confirmed the change is additive so existing `draftModelRef` configs still validate, verified `resolveStagedCompanions` uses the same staging mechanism the doc comment claims, confirmed the committed CRDs match a fresh regeneration, ran the suite and both lint passes).

A human has not yet read this diff. Offered for review, not as verified-by-a-person work.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran the affected package)
- [x] `make lint` passes locally (host and `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) - PR title carries the prefix; the commit subject does not
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **bot-only, see Sign-off above**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - the new field is documented in its CRD doc comment; no separate guide covers speculative decoding fields
