### PR TITLE
fix(foreman): remap unsupported emptiness claims to ERROR instead of NO-GO

### DIFF
--- a/pkg/foreman/agent/empty_claim_gate.go
+++ b/pkg/foreman/agent/empty_claim_gate.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Empty-claim rail (#1552): an emptiness or unreadability claim a reviewer
+// makes about the branch under review ("branch has no commits", "no code
+// changes", "commit history is unreadable") is an EVIDENCE claim, not a
+// review finding. It is not something the reviewer can assert on a checklist
+// pass; it must be backed by the command output that supports it. A reviewer
+// that emits such a claim and returns NO-GO with no supporting evidence is
+// asserting the branch is empty when it demonstrably is not (the ground-truth
+// diff is non-empty), and that false NO-GO has burned review iterations and
+// discarded a correct, gate-passed fix (#1552).
+//
+// The ERROR verdict exists for exactly this ("commit history is unreadable"
+// is one of the reviewer prompt's own ERROR definitions) but nothing enforced
+// it. This rail enforces it: when the ground-truth branch diff is non-empty
+// (so the emptiness claim is contradicted on its face) and the reviewer
+// carried no grounded blocking finding to support a rejection, the NO-GO is
+// remapped to ERROR (INCOMPLETE + ModelReportedError), which routes to a
+// human and preserves the branch, instead of consuming the workload's
+// remaining iterations and failing it.
+//
+// The rail must run BEFORE the grounded-finding demote rail: an ungrounded
+// NO-GO that carries an emptiness claim would otherwise be demoted to GO and
+// this rail would see GO and no-op.
+//
+// Degrades open: when the ground-truth diff is unavailable or the reviewer
+// cites a grounded blocking finding (real supporting evidence), the verdict
+// is left untouched.
+//
+// Disabled by FOREMAN_EMPTY_CLAIM=0.
+package agent
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
+)
+
+// emptyClaimPatterns are the phrasings a reviewer uses to assert the branch
+// under review is empty, missing, or unreadable. They are intentionally
+// narrow: a vague "looks empty" must not trip the rail, only a claim that the
+// branch carries no commits / no code changes / unreadable history.
+var emptyClaimPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)no\s+commits?`),
+	regexp.MustCompile(`(?i)no\s+code\s+changes?`),
+	regexp.MustCompile(`(?i)no\s+(commits|changes|diff)\s+(ahead|at\s+all|present)`),
+	regexp.MustCompile(`(?i)empty\s+(branch|diff|commit|history|repository)`),
+	regexp.MustCompile(`(?i)branch\s+(is\s+)?empty`),
+	regexp.MustCompile(`(?i)nothing\s+to\s+review`),
+	regexp.MustCompile(`(?i)commit\s+history\s+is\s+(unreadable|empty)`),
+	regexp.MustCompile(`(?i)cannot\s+(read|see|find|clone)\s+(the\s+)?(commit|history|branch|code|repo)`),
+	regexp.MustCompile(`(?i)history\s+is\s+unreadable`),
+}
+
+// emptyClaimDisabled reports whether the rail is off via
+// FOREMAN_EMPTY_CLAIM=0. Default (unset) is enabled.
+func emptyClaimDisabled() bool {
+	return os.Getenv("FOREMAN_EMPTY_CLAIM") == "0"
+}
+
+// assertsEmptyBranch reports whether the reviewer's free-text (summary and
+// finding messages) asserts the branch is empty, missing, or unreadable.
+func assertsEmptyBranch(texts ...string) bool {
+	joined := strings.ToLower(strings.Join(texts, "\n"))
+	for _, re := range emptyClaimPatterns {
+		if re.MatchString(joined) {
+			return true
+		}
+	}
+	return false
+}
+
+// emptyClaimTexts collects the reviewer's summary plus every finding message
+// so assertsEmptyBranch can scan the reviewer's own words.
+func emptyClaimTexts(summary string, extra map[string]any) []string {
+	findings, _ := reviewer.ParseFindings(extra)
+	out := make([]string, 0, 1+len(findings))
+	out = append(out, summary)
+	for _, f := range findings {
+		out = append(out, f.Message)
+	}
+	return out
+}
+
+// runEmptyClaimRail resolves the ground-truth changed-lines closure for the
+// empty-claim rail and applies it. It is the wiring helper runLLMPath calls
+// so the rail's diff resolution stays out of the executor's hot path. When
+// the ground-truth diff is unavailable (reviewDiffErr non-nil) the closure is
+// nil and the rail degrades open.
+func runEmptyClaimRail(
+	ctx context.Context, log logr.Logger, workspace, base string,
+	diff []string, diffErr error, extra map[string]any, summary string,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+) (foremanv1alpha1.AgenticTaskVerdict, foremanv1alpha1.AgenticTaskFailureReason) {
+	var changed func(string) map[int]bool
+	if diffErr == nil {
+		changed = reviewerGroundedChangedLines(ctx, log, workspace, base, diff, diffErr)
+	}
+	return enforceReviewerEmptyClaim(log, extra, summary, verdict, changed)
+}
+
+// enforceReviewerEmptyClaim remaps an unsupported emptiness / unreadability
+// NO-GO to ERROR (INCOMPLETE + ModelReportedError).
+//
+// It fires only when ALL of:
+//   - the verdict is NO-GO,
+//   - the reviewer's text asserts the branch is empty/unreadable,
+//   - the ground-truth branch diff is non-empty (changedLines non-nil: the
+//     claim is contradicted on its face), and
+//   - the reviewer carried no grounded blocking finding (no supporting
+//     evidence for a rejection).
+//
+// On a hit it returns (INCOMPLETE, ModelReportedError) so the caller stores
+// the ERROR-shaped verdict and routes the branch to a human. On every other
+// input it returns (verdict, "") and the caller proceeds unchanged.
+func enforceReviewerEmptyClaim(
+	log logr.Logger,
+	extra map[string]any,
+	summary string,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+	changedLines func(string) map[int]bool,
+) (foremanv1alpha1.AgenticTaskVerdict, foremanv1alpha1.AgenticTaskFailureReason) {
+	if emptyClaimDisabled() ||
+		verdict != foremanv1alpha1.AgenticTaskVerdictNoGo ||
+		extra == nil || changedLines == nil {
+		return verdict, ""
+	}
+	if !assertsEmptyBranch(emptyClaimTexts(summary, extra)...) {
+		return verdict, ""
+	}
+	// The reviewer cited a grounded blocking finding: that is real supporting
+	// evidence for a rejection, so the NO-GO stands (regression guard).
+	findings, _ := reviewer.ParseFindings(extra)
+	grounded, _ := groundedBlockingFindings(findings, changedLines)
+	if len(grounded) >= 1 {
+		return verdict, ""
+	}
+
+	if extra != nil {
+		extra["emptyClaimRemappedToError"] = true
+		extra["emptyClaimReason"] = "unsupported branch-emptiness/unreadability " +
+			"claim contradicted by a non-empty ground-truth diff"
+	}
+	log.Info("reviewer empty-claim: unsupported emptiness/unreadability NO-GO "+
+		"remapped to ERROR (non-empty diff, no grounded finding)",
+		"summary", summary)
+	return foremanv1alpha1.AgenticTaskVerdictIncomplete, foremanv1alpha1.FailureModelReportedError
+}

--- a/pkg/foreman/agent/empty_claim_gate_test.go
+++ b/pkg/foreman/agent/empty_claim_gate_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// nonEmptyChanged simulates a ground-truth branch diff that touched a.go
+// lines 10 and 11 (i.e. the branch is demonstrably non-empty).
+func nonEmptyChanged() func(string) map[int]bool {
+	return func(f string) map[int]bool {
+		if f == "a.go" {
+			return map[int]bool{10: true, 11: true}
+		}
+		return nil
+	}
+}
+
+// TestEmptyClaim_UnsupportedYieldsError is the #1552 case: the reviewer
+// asserts the branch is empty with no supporting evidence, the ground-truth
+// diff is non-empty, and the reviewer carries no grounded finding. The NO-GO
+// must be remapped to ERROR (INCOMPLETE + ModelReportedError) so the branch
+// routes to a human instead of failing the workload.
+func TestEmptyClaim_UnsupportedYieldsError(t *testing.T) {
+	extra := map[string]any{"reviewOutcome": "REQUEST-CHANGES"}
+	got, reason := enforceReviewerEmptyClaim(logr.Discard(), extra,
+		"NO-GO: branch has no commits and no code changes",
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nonEmptyChanged())
+	if got != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Fatalf("unsupported emptiness claim must remap to INCOMPLETE(ERROR), got %s", got)
+	}
+	if reason != foremanv1alpha1.FailureModelReportedError {
+		t.Fatalf("remapped ERROR must carry ModelReportedError, got %s", reason)
+	}
+	if extra["emptyClaimRemappedToError"] != true {
+		t.Fatal("expected emptyClaimRemappedToError=true")
+	}
+}
+
+// TestEmptyClaim_EvidencedFindingKeepsNoGo is the regression guard: a
+// reviewer that makes an emptiness claim BUT carries a grounded blocking
+// finding (real supporting evidence) must still yield NO-GO, not ERROR.
+func TestEmptyClaim_EvidencedFindingKeepsNoGo(t *testing.T) {
+	extra := map[string]any{
+		"reviewOutcome": "REQUEST-CHANGES",
+		"findings": []any{
+			map[string]any{"severity": "blocker", "area": "scope", "message": "branch empty", "file": "a.go", "line": 10},
+		},
+	}
+	got, reason := enforceReviewerEmptyClaim(logr.Discard(), extra,
+		"NO-GO: branch has no commits and no code changes",
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nonEmptyChanged())
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("an evidenced emptiness claim must keep NO-GO, got %s", got)
+	}
+	if reason != "" {
+		t.Fatalf("evidenced emptiness claim must not set a failure reason, got %s", reason)
+	}
+	if _, remapped := extra["emptyClaimRemappedToError"]; remapped {
+		t.Fatal("evidenced emptiness claim must not be marked remapped")
+	}
+}
+
+// TestEmptyClaim_NoClaimKeepsNoGo: a genuine NO-GO that never asserts the
+// branch is empty is left untouched even though the diff is non-empty.
+func TestEmptyClaim_NoClaimKeepsNoGo(t *testing.T) {
+	extra := map[string]any{
+		"reviewOutcome": "REQUEST-CHANGES",
+		"findings": []any{
+			map[string]any{"severity": "blocker", "area": "scope", "message": "scope drift", "file": "a.go", "line": 11},
+		},
+	}
+	got, reason := enforceReviewerEmptyClaim(logr.Discard(), extra,
+		"NO-GO: diff addresses a different bug than the issue",
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nonEmptyChanged())
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("a non-emptiness NO-GO must stay NO-GO, got %s", got)
+	}
+	if reason != "" {
+		t.Fatalf("a non-emptiness NO-GO must not set a failure reason, got %s", reason)
+	}
+}
+
+// TestEmptyClaim_GoUntouched: the rail only acts on NO-GO.
+func TestEmptyClaim_GoUntouched(t *testing.T) {
+	extra := map[string]any{}
+	got, reason := enforceReviewerEmptyClaim(logr.Discard(), extra,
+		"branch is empty", foremanv1alpha1.AgenticTaskVerdictGo, nonEmptyChanged())
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("rail must leave GO untouched, got %s", got)
+	}
+	if reason != "" {
+		t.Fatalf("rail must not set a failure reason on GO, got %s", reason)
+	}
+}
+
+// TestEmptyClaim_GitUnavailableDegradesOpen: with no ground-truth diff
+// (changedLines nil) the claim cannot be contradicted, so the verdict is left
+// untouched (degrade open).
+func TestEmptyClaim_GitUnavailableDegradesOpen(t *testing.T) {
+	extra := map[string]any{}
+	got, reason := enforceReviewerEmptyClaim(logr.Discard(), extra,
+		"branch is empty", foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("nil changedLines must leave the verdict untouched, got %s", got)
+	}
+	if reason != "" {
+		t.Fatalf("nil changedLines must not set a failure reason, got %s", reason)
+	}
+}
+
+// TestEmptyClaim_ToggleOff: FOREMAN_EMPTY_CLAIM=0 disables the rail.
+func TestEmptyClaim_ToggleOff(t *testing.T) {
+	t.Setenv("FOREMAN_EMPTY_CLAIM", "0")
+	extra := map[string]any{}
+	got, reason := enforceReviewerEmptyClaim(logr.Discard(), extra,
+		"branch is empty", foremanv1alpha1.AgenticTaskVerdictNoGo, nonEmptyChanged())
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("toggle off must leave the verdict untouched, got %s", got)
+	}
+	if reason != "" {
+		t.Fatalf("toggle off must not set a failure reason, got %s", reason)
+	}
+}
+
+// TestAssertsEmptyBranch checks the claim detector on the reviewer's own
+// words: positive cases trip, ordinary findings do not.
+func TestAssertsEmptyBranch(t *testing.T) {
+	positives := []string{
+		"branch has no commits and no code changes",
+		"the branch is empty",
+		"commit history is unreadable",
+		"nothing to review",
+		"cannot read the history",
+	}
+	for _, s := range positives {
+		if !assertsEmptyBranch(s) {
+			t.Errorf("assertsEmptyBranch(%q) = false, want true", s)
+		}
+	}
+	negatives := []string{
+		"diff addresses a different bug",
+		"missing regression test",
+		"scope drift on the touched file",
+		"empty error message is not handled",
+	}
+	for _, s := range negatives {
+		if assertsEmptyBranch(s) {
+			t.Errorf("assertsEmptyBranch(%q) = true, want false", s)
+		}
+	}
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -813,6 +813,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// instead of resolving and shelling out for them a second time.
 		var reviewBase string
 		var reviewDiff []string
+		// reviewerErrorReason carries the ModelReportedError a reviewer rail
+		// remapped into an ERROR verdict (#1552); attached to the Result after
+		// modelDecidedResult so the branch routes to a human.
+		var reviewerErrorReason foremanv1alpha1.AgenticTaskFailureReason
 		if agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer &&
 			loopRes.Terminal != nil {
 			// Ground-truth filesTouched against the actual diff before
@@ -841,6 +845,15 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// below (grounded-finding + scope-overlap).
 			var reviewDiffErr error
 			reviewDiff, reviewDiffErr = repo.DiffNameOnly(ctx, workspace, reviewBase)
+			// Empty-claim rail (#1552): an unsupported branch-emptiness /
+			// unreadability NO-GO (contradicted by a non-empty ground-truth
+			// diff, with no grounded finding) is remapped to ERROR so it
+			// routes to a human instead of burning review iterations. Runs
+			// BEFORE the grounded-finding demote rail, which would otherwise
+			// turn the ungrounded NO-GO into GO and defeat the remap.
+			verdict, reviewerErrorReason = runEmptyClaimRail(ctx, log, workspace,
+				reviewBase, reviewDiff, reviewDiffErr, loopRes.Terminal.Extra,
+				loopRes.Terminal.Summary, verdict)
 			// Grounded-finding rail: a NO-GO must be earned by >=1 blocking
 			// finding citing a line the diff changed; otherwise demote it to GO
 			// and archive the rejected findings. Mirror of scope-overlap, in the
@@ -899,8 +912,12 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// modelDecidedResult() and here sets r.FailureReason today, but
 		// future reason-setting paths (e.g. additional enforcement passes)
 		// should not be silently clobbered.
-		if normalizedReason != "" && r.FailureReason == "" {
-			r.FailureReason = normalizedReason
+		if r.FailureReason == "" {
+			if reviewerErrorReason != "" {
+				r.FailureReason = reviewerErrorReason
+			} else if normalizedReason != "" {
+				r.FailureReason = normalizedReason
+			}
 		}
 		return r, nil
 	}


### PR DESCRIPTION
## What

An unsupported emptiness claim from a reviewer is remapped from `NO-GO` to `ERROR`, so unevidenced assertions that a branch is empty or unreadable stop destroying good work.

## Why

Refs #1552

A reviewer can kill a workload by asserting the branch is empty or unreadable with no evidence, and nothing downstream can tell that apart from a genuine blocking finding. The `ERROR` verdict exists for exactly this case ("commit history is unreadable" is one of the reviewer prompt's own `ERROR` definitions) but nothing enforced it.

Part of #1548.

## How

New `pkg/foreman/agent/empty_claim_gate.go`. When a reviewer returns `NO-GO`, the free text asserts the branch is empty or unreadable, and the claim carries no grounded blocking finding, the verdict is remapped to `ERROR` (`INCOMPLETE` + `ModelReportedError`), which routes to a retry rather than a rejection.

This is a code-level verdict remap, not a change to reviewer prompt text.

An escape hatch exists: `FOREMAN_EMPTY_CLAIM=0` disables the remap. On by default.

## Verification

Run on this branch, not inherited from the agent's verdict:

- `go test ./pkg/foreman/agent/ -count=1` -> **ok, 36.212s**
- `golangci-lint run ./pkg/...` -> **0 issues**
- `GOOS=linux golangci-lint run ./pkg/...` -> **0 issues**
- `go build ./...` -> clean

The regression guard is present and is the test that matters most: an emptiness claim that *does* carry supporting evidence must still yield `NO-GO`, must not set a failure reason, and must not be marked remapped (`empty_claim_gate_test.go:61-79`). Without that, this change would convert real rejections into retries.

**Not done:** no live workload exercised through the remap path. Unit-verified only, hence `Refs #1552` rather than `Fixes`.

## Sign-off

**Bot-only sign-off** (`Signed-off-by: Foreman Bot`). Per CONTRIBUTING.md that is not accepted, so this needs a human sign-off before merge:

```
git commit --amend -s --no-edit && git push --force-with-lease
```

Not added on the maintainer's behalf: the DCO attests that a person understands and takes responsibility for the change.

## AI assistance

`Assisted-by: Qwen3.8-27B via the Foreman harness` (wrote the gate and its tests unsupervised, dispatched as an overnight batch).

`Reviewed-by: Claude` (read the full diff, confirmed the change is code rather than prompt text as the issue requires, verified the evidenced-claim regression guard exists and asserts on all three properties, checked the escape hatch defaults to enabled, ran the package suite and both lint passes on the branch).

There is an irony worth flagging to a reviewer: in the same overnight batch, this model produced the mirror-image failure this change guards against. On a different issue it emitted `GO` on a genuinely empty diff, which the harness's empty-diff guard caught. That is not an argument against the change, but it is a reason to read the remap conditions carefully rather than take the author's judgement about emptiness on trust.

A human has not yet read this diff. Offered for review, not as verified-by-a-person work.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran the affected package)
- [x] `make lint` passes locally (host and `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) - PR title carries the prefix; the commit subject does not
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **bot-only, see Sign-off above**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - behaviour is described here; the env escape hatch is documented in the source
