### PR TITLE
fix(controller): inject the DRI render GID into Vulkan pod supplementalGroups

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -127,6 +127,7 @@ func main() {
 	var caCertConfigMap string
 	var initContainerImage string
 	var defaultFSGroup int64
+	var driRenderGID int64
 	var emitScrapeAnnotations bool
 	var routerProxyImage string
 	var defaultLiteLLMURL string
@@ -184,6 +185,17 @@ func main() {
 			"write to a freshly-provisioned PVC. Set to 0 to disable on OpenShift, "+
 			"where the restricted-v2 SCC injects fsGroup from the namespace's allocated "+
 			"range and rejects pods with explicit values outside that range.")
+	flag.Int64Var(&driRenderGID, "dri-render-gid", 44,
+		"GID of the node's DRI render group (the group that owns /dev/dri/renderD128), "+
+			"added to a Vulkan InferenceService pod's supplementalGroups so the serving "+
+			"container can open the render node. fsGroup does nothing for device access, "+
+			"so without this the Vulkan container cannot open /dev/dri/renderD128 and "+
+			"llama.cpp fails open, serving from CPU at roughly half speed with no status "+
+			"condition (#1560). The GID is node-local and not knowable at admission, so it "+
+			"is a single operator-wide value: set it to the render GID of your GPU nodes. "+
+			"44 is the conventional Linux render group; set to 0 to disable (e.g. on "+
+			"OpenShift). Applied only on the Vulkan path, never to a user-supplied "+
+			"Spec.PodSecurityContext.")
 	flag.StringVar(&routerProxyImage, "router-proxy-image", "",
 		"Default container image for ModelRouter-managed router-proxy pods. "+
 			"Empty falls back to the controller's compiled-in default. "+
@@ -449,6 +461,7 @@ func main() {
 		CACertConfigMap:       caCertConfigMap,
 		InitContainerImage:    initContainerImage,
 		DefaultFSGroup:        defaultFSGroup,
+		DRIRenderGID:          driRenderGID,
 		EmitScrapeAnnotations: emitScrapeAnnotations,
 		AllowedHostPathRoots:  allowedHostPathRootList,
 		GPUSharingSharedPool:  gpuSharingSharedPool,

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -168,10 +168,24 @@ func resolveEnableServiceLinks(backend RuntimeBackend) *bool {
 // the namespace's allocated range and rejects pods with explicit values
 // outside that range.
 //
+// Vulkan render GID. fsGroup is a cache-volume-ownership control and does
+// nothing for device access: a Vulkan serving container must also carry the
+// node's render GID in supplementalGroups to open /dev/dri/renderD128, or
+// llama.cpp fails open and serves from CPU at roughly half speed with no
+// status condition (#1560). When the resolved runtime is Vulkan (vulkan) and
+// driRenderGID > 0, that GID is appended to supplementalGroups. The GID is
+// node-local and not knowable at admission, so it comes from the operator's
+// --dri-render-gid flag (default 44, the conventional Linux render group; set
+// to 0 to disable, e.g. on OpenShift). This is applied only on the Vulkan
+// path; the CUDA and Metal paths are untouched. A user-supplied
+// Spec.PodSecurityContext is returned as-is, so setting it takes full
+// ownership of supplementalGroups (the per-service workaround for a node
+// whose render GID differs from the operator default).
+//
 // Operators using a custom init container image (--init-container-image) with
 // a different UID/GID should override Spec.PodSecurityContext or set
 // --default-fsgroup to match the new image's group.
-func inferPodSecurityContext(isvc *inferencev1alpha1.InferenceService, defaultFSGroup int64) *corev1.PodSecurityContext {
+func inferPodSecurityContext(isvc *inferencev1alpha1.InferenceService, defaultFSGroup, driRenderGID int64, vulkan bool) *corev1.PodSecurityContext {
 	if isvc.Spec.PodSecurityContext != nil {
 		return isvc.Spec.PodSecurityContext
 	}
@@ -183,6 +197,9 @@ func inferPodSecurityContext(isvc *inferencev1alpha1.InferenceService, defaultFS
 	if defaultFSGroup > 0 {
 		fsGroup := defaultFSGroup
 		psc.FSGroup = &fsGroup
+	}
+	if vulkan && driRenderGID > 0 {
+		psc.SupplementalGroups = append(psc.SupplementalGroups, driRenderGID)
 	}
 	return psc
 }
@@ -449,6 +466,13 @@ func (r *InferenceServiceReconciler) constructDeployment(
 	}
 	gpuResourceName := sharing.resourceName
 
+	// The Vulkan path requests the generic-device-plugin /dev/dri resource
+	// (devic.es/dri-render). The container still needs the host render GID in
+	// supplementalGroups to open /dev/dri/renderD128, so the security context
+	// injects it only when this service schedules that resource. CUDA and Metal
+	// request other resources (or none) and are left untouched (#1560).
+	vulkan := gpuResourceName == vulkanDRIResourceName
+
 	container.Resources = buildContainerResources(isvc, model, gpuCount, gpuResourceName)
 
 	deployment := &appsv1.Deployment{
@@ -472,7 +496,7 @@ func (r *InferenceServiceReconciler) constructDeployment(
 					Annotations: buildPodAnnotations(isvc, r.EmitScrapeAnnotations, port),
 				},
 				Spec: corev1.PodSpec{
-					SecurityContext:    inferPodSecurityContext(isvc, r.DefaultFSGroup),
+					SecurityContext:    inferPodSecurityContext(isvc, r.DefaultFSGroup, r.DRIRenderGID, vulkan),
 					InitContainers:     storageConfig.initContainers,
 					Containers:         []corev1.Container{container},
 					Volumes:            storageConfig.volumes,

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -1175,3 +1175,79 @@ func TestConstructDeployment_ArchAffinity(t *testing.T) {
 		}
 	})
 }
+
+// TestInferPodSecurityContext_VulkanDRIRenderGID pins the #1560 fix at the
+// function level: the DRI render GID is injected into supplementalGroups only
+// on the Vulkan path, and fsGroup behaviour is unchanged in both cases. This
+// is a pure-function unit test so it runs without envtest (unlike the Ginkgo
+// suite, which needs etcd).
+func TestInferPodSecurityContext_VulkanDRIRenderGID(t *testing.T) {
+	const (
+		defaultFSGroup = int64(102)
+		renderGID      = int64(991)
+	)
+	emptyISVC := &inferencev1alpha1.InferenceService{}
+
+	t.Run("vulkan adds the render GID to supplementalGroups", func(t *testing.T) {
+		psc := inferPodSecurityContext(emptyISVC, defaultFSGroup, renderGID, true)
+		if psc == nil {
+			t.Fatal("inferPodSecurityContext returned nil")
+		}
+		if psc.SupplementalGroups == nil {
+			t.Fatal("vulkan: SupplementalGroups is nil; want it to contain the render GID")
+		}
+		found := false
+		for _, g := range psc.SupplementalGroups {
+			if g == renderGID {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("vulkan: SupplementalGroups = %v, want it to contain %d", psc.SupplementalGroups, renderGID)
+		}
+	})
+
+	t.Run("vulkan keeps fsGroup unchanged", func(t *testing.T) {
+		psc := inferPodSecurityContext(emptyISVC, defaultFSGroup, renderGID, true)
+		if psc.FSGroup == nil || *psc.FSGroup != defaultFSGroup {
+			t.Errorf("vulkan: FSGroup = %v, want %d", psc.FSGroup, defaultFSGroup)
+		}
+	})
+
+	t.Run("cuda does not add the render GID", func(t *testing.T) {
+		psc := inferPodSecurityContext(emptyISVC, defaultFSGroup, renderGID, false)
+		if psc.SupplementalGroups != nil {
+			t.Errorf("cuda: SupplementalGroups = %v, want empty/nil", psc.SupplementalGroups)
+		}
+	})
+
+	t.Run("cuda keeps fsGroup unchanged", func(t *testing.T) {
+		psc := inferPodSecurityContext(emptyISVC, defaultFSGroup, renderGID, false)
+		if psc.FSGroup == nil || *psc.FSGroup != defaultFSGroup {
+			t.Errorf("cuda: FSGroup = %v, want %d", psc.FSGroup, defaultFSGroup)
+		}
+	})
+
+	t.Run("vulkan with render GID disabled (0) adds nothing", func(t *testing.T) {
+		psc := inferPodSecurityContext(emptyISVC, defaultFSGroup, 0, true)
+		if psc.SupplementalGroups != nil {
+			t.Errorf("disabled: SupplementalGroups = %v, want empty/nil", psc.SupplementalGroups)
+		}
+	})
+
+	t.Run("user-supplied podSecurityContext is returned verbatim (vulkan)", func(t *testing.T) {
+		user := &corev1.PodSecurityContext{SupplementalGroups: []int64{777}}
+		got := inferPodSecurityContext(&inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{PodSecurityContext: user},
+		}, defaultFSGroup, renderGID, true)
+		if got != user {
+			t.Errorf("user-supplied PodSecurityContext not returned verbatim: got %v, want %v", got, user)
+		}
+		// The operator's render GID must not be merged into a user override.
+		for _, g := range got.SupplementalGroups {
+			if g == renderGID {
+				t.Errorf("user override must not gain the operator render GID %d", renderGID)
+			}
+		}
+	})
+}

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -75,6 +75,17 @@ type InferenceServiceReconciler struct {
 	// on OpenShift, where the restricted-v2 SCC injects fsGroup from the
 	// namespace's allocated range). Set via --default-fsgroup; default 102.
 	DefaultFSGroup int64
+	// DRIRenderGID is the node-local GID of the DRI render group
+	// (/dev/dri/renderD128) added to a Vulkan InferenceService pod's
+	// supplementalGroups so the container can open the render node; without it
+	// llama.cpp fails open and serves from CPU at roughly half speed with no
+	// status condition (#1560). The GID is node-local and not knowable at
+	// admission, so it comes from the operator's --dri-render-gid flag. Values
+	// <= 0 disable the default (e.g. on OpenShift); the field applies only on
+	// the Vulkan path and never to a user-supplied Spec.PodSecurityContext.
+	// Set via --dri-render-gid; default 44 (the conventional Linux render
+	// group).
+	DRIRenderGID int64
 	// EmitScrapeAnnotations, when true, adds Prometheus annotation-discovery
 	// hints (prometheus.io/scrape, /path, /port) to every inference Pod, with
 	// port set to the resolved endpoint port, so annotation-based scrapers

--- a/internal/controller/inferenceservice_deployment_test.go
+++ b/internal/controller/inferenceservice_deployment_test.go
@@ -5080,6 +5080,169 @@ var _ = Describe("AMD Vulkan Deployment Construction", func() {
 	})
 })
 
+var _ = Describe("Vulkan DRI render GID in supplementalGroups (#1560)", func() {
+	var (
+		reconciler *InferenceServiceReconciler
+		replicas   int32
+	)
+
+	BeforeEach(func() {
+		// DRIRenderGID 991 mirrors the node in the #1560 report (a non-default
+		// render GID), so the test proves the operator flag value is what lands
+		// in the pod, not an assumption.
+		reconciler = &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			DefaultFSGroup:     102,
+			DRIRenderGID:       991,
+		}
+		replicas = 1
+	})
+
+	vulkanModel := func() *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "vulkan-model", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:       "https://example.com/model.gguf",
+				Format:       "gguf",
+				Quantization: "Q4_K_M",
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					GPU: &inferencev1alpha1.GPUSpec{
+						Enabled: true,
+						Count:   1,
+						Vendor:  "amd",
+						Runtime: "vulkan",
+					},
+				},
+			},
+			Status: inferencev1alpha1.ModelStatus{
+				Phase: "Ready",
+				Path:  "/tmp/llmkube/models/test-model.gguf",
+			},
+		}
+	}
+
+	cudaModel := func() *inferencev1alpha1.Model {
+		return &inferencev1alpha1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "cuda-model", Namespace: "default"},
+			Spec: inferencev1alpha1.ModelSpec{
+				Source:       "https://example.com/model.gguf",
+				Format:       "gguf",
+				Quantization: "Q4_K_M",
+				Hardware: &inferencev1alpha1.HardwareSpec{
+					Accelerator: "cuda",
+					GPU: &inferencev1alpha1.GPUSpec{
+						Enabled: true,
+						Count:   1,
+						Vendor:  "nvidia",
+					},
+				},
+			},
+			Status: inferencev1alpha1.ModelStatus{
+				Phase: "Ready",
+				Path:  "/tmp/llmkube/models/test-model.gguf",
+			},
+		}
+	}
+
+	It("adds the DRI render GID to supplementalGroups on a Vulkan service", func() {
+		model := vulkanModel()
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "vulkan-sg", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "vulkan-model",
+				Replicas:  &replicas,
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+			},
+		}
+
+		deployment := reconciler.constructDeployment(isvc, model, nil, 1)
+		podSecCtx := deployment.Spec.Template.Spec.SecurityContext
+		Expect(podSecCtx).NotTo(BeNil())
+		// The render GID the operator flagged must be a supplementary group so
+		// the container can open /dev/dri/renderD128 (fsGroup does not do this).
+		Expect(podSecCtx.SupplementalGroups).To(ContainElement(int64(991)))
+		// fsGroup behaviour is unchanged: the cache-volume default is still set.
+		Expect(podSecCtx.FSGroup).NotTo(BeNil())
+		Expect(*podSecCtx.FSGroup).To(Equal(int64(102)))
+	})
+
+	It("does not add the DRI render GID to supplementalGroups on a CUDA service", func() {
+		model := cudaModel()
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "cuda-sg", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "cuda-model",
+				Replicas:  &replicas,
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+			},
+		}
+
+		deployment := reconciler.constructDeployment(isvc, model, nil, 1)
+		podSecCtx := deployment.Spec.Template.Spec.SecurityContext
+		Expect(podSecCtx).NotTo(BeNil())
+		// CUDA does not request the DRI render node, so no render GID is added.
+		Expect(podSecCtx.SupplementalGroups).NotTo(ContainElement(int64(991)))
+		// fsGroup behaviour is unchanged: the cache-volume default is still set.
+		Expect(podSecCtx.FSGroup).NotTo(BeNil())
+		Expect(*podSecCtx.FSGroup).To(Equal(int64(102)))
+	})
+
+	It("omits the DRI render GID when --dri-render-gid is 0 (disabled)", func() {
+		// Mirrors the OpenShift case: the operator disables the default and lets
+		// the SCC / a per-service override supply the render group.
+		disabledReconciler := &InferenceServiceReconciler{
+			Client:             k8sClient,
+			Scheme:             k8sClient.Scheme(),
+			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			DefaultFSGroup:     102,
+			DRIRenderGID:       0,
+		}
+		model := vulkanModel()
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "vulkan-sg-disabled", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "vulkan-model",
+				Replicas:  &replicas,
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+			},
+		}
+
+		deployment := disabledReconciler.constructDeployment(isvc, model, nil, 1)
+		podSecCtx := deployment.Spec.Template.Spec.SecurityContext
+		Expect(podSecCtx).NotTo(BeNil())
+		Expect(podSecCtx.SupplementalGroups).To(BeEmpty())
+		// fsGroup is unaffected by disabling the render GID.
+		Expect(podSecCtx.FSGroup).NotTo(BeNil())
+		Expect(*podSecCtx.FSGroup).To(Equal(int64(102)))
+	})
+
+	It("does not override a user-supplied PodSecurityContext on a Vulkan service", func() {
+		model := vulkanModel()
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "vulkan-sg-override", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "vulkan-model",
+				Replicas:  &replicas,
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{GPU: 1},
+				// Per-service workaround for a node whose render GID differs from
+				// the operator default (#1560): the user owns supplementalGroups.
+				PodSecurityContext: &corev1.PodSecurityContext{
+					SupplementalGroups: []int64{777},
+				},
+			},
+		}
+
+		deployment := reconciler.constructDeployment(isvc, model, nil, 1)
+		podSecCtx := deployment.Spec.Template.Spec.SecurityContext
+		Expect(podSecCtx).NotTo(BeNil())
+		// The user's group is respected verbatim; the operator's default is not
+		// merged in.
+		Expect(podSecCtx.SupplementalGroups).To(Equal([]int64{777}))
+	})
+})
+
 var _ = Describe("constructDeployment model cache PVC wiring (#728, Task 3)", func() {
 	newModel := func() *inferencev1alpha1.Model {
 		return &inferencev1alpha1.Model{


### PR DESCRIPTION
## What

The operator injects the node's DRI render GID into `supplementalGroups` for Vulkan serving pods, so the container can actually open `/dev/dri/renderD128`.

## Why

Refs #1560

A Vulkan InferenceService can be scheduled, hold its `devic.es/dri-render` device, report `Ready`, and still serve entirely from CPU at roughly half speed.

The render node is group-owned (`root:991 rw-rw----` on our Strix box) and the pod securityContext only sets `fsGroup`, which is a cache-volume-ownership control and does nothing for device access. With capabilities dropped and no matching supplementary group, the open fails, llama.cpp logs one `no usable GPU found` line at startup and carries on.

It fails open. Measured on the same manifest, only the securityContext differing: **5.50 tok/s on CPU against 11.27 with the GID granted**. Nothing in the CR indicates which one you got.

## How

When the resolved runtime is Vulkan and `driRenderGID > 0`, the GID is appended to `supplementalGroups`. The CUDA and Metal paths are untouched.

The GID is node-local and unknowable at admission, so it comes from a new operator flag `--dri-render-gid`, defaulting to **44** (the conventional Linux render group), with `0` to disable, e.g. on OpenShift where the SCC injects its own.

**A user-supplied `Spec.PodSecurityContext` is returned as-is.** That is deliberate and load-bearing: every existing Vulkan service on our cluster already sets `supplementalGroups: [991]` by hand, and this change must not disturb them. Setting the field takes full ownership, which also remains the per-service escape hatch for a node whose render GID differs from the operator default.

**Note for anyone deploying this:** the default of 44 will not match every node. On our Strix box the render GID is 991, so the operator there needs `--dri-render-gid=991`. The default is the convention, not a guarantee.

## Verification

Run on this branch, not inherited from the agent's verdict:

- `go test ./internal/controller/ -count=1` -> **ok, 269.819s**
- `golangci-lint run ./internal/... ./cmd/...` -> **0 issues**
- `GOOS=linux golangci-lint run ./internal/... ./cmd/...` -> **0 issues**
- `go build ./...` -> clean
- `make manifests && make chart-crds` then `git status --porcelain` -> **empty**

The regression guard that matters is present: `deployment_builder_test.go:1217`, `cuda does not add the render GID`, asserting `SupplementalGroups` stays empty on the CUDA path. Without it this change could silently alter every GPU pod, not just Vulkan ones.

**Not done:** no live redeploy of a Vulkan service with the operator flag set, confirming the pod comes up on `Vulkan0` rather than CPU. That end-to-end check is the one worth doing before merge, and it is why this says `Refs #1560` rather than `Fixes`.

## Sign-off

**Bot-only sign-off** (`Signed-off-by: Foreman Bot`). Per CONTRIBUTING.md that is not accepted, so this needs a human sign-off before merge:

```
git commit --amend -s --no-edit && git push --force-with-lease
```

Not added on the maintainer's behalf: the DCO attests that a person understands and takes responsibility for the change.

## AI assistance

`Assisted-by: Qwen3.8-27B via the Foreman harness` (wrote the injection, the flag plumbing and the tests unsupervised, dispatched as an overnight batch).

`Reviewed-by: Claude` (read the full diff, confirmed the change is confined to the Vulkan path, confirmed a user-supplied podSecurityContext is passed through so the existing hand-configured services are unaffected, verified the CUDA regression guard exists and asserts, ran the controller suite, both lint passes and generator cleanliness on the branch).

Worth disclosing the provenance: this bug was found by hand on the cluster this agent runs on, filed as #1560, and then fixed by the agent overnight. Nobody has yet redeployed a Vulkan service with the flag set to confirm the fix works in the situation that produced the bug.

A human has not yet read this diff. Offered for review, not as verified-by-a-person work.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (affected package)
- [x] `make lint` passes locally (host and `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) - PR title carries the prefix; the commit subject does not
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **bot-only, see Sign-off above**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - the flag is self-documenting; the deployment note above should probably land in the AMD/Strix guide as a follow-up
