### PR TITLE
fix(foreman): guard issue rendering in reviewer prompt when issue is unset

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -2651,11 +2651,18 @@ func buildUserPrompt(task *foremanv1alpha1.AgenticTask) string {
 		// it, but parity across the local reviewer fleet matters.
 		// Empirical: rerun-7 review-510-1 (devstral) failed turn 1
 		// with that exact 400 before this case existed.
-		fmt.Fprintf(&b, "You are reviewing the branch the coder produced for issue #%d of %s.\n\n",
-			p.Issue, p.Repo)
-		fmt.Fprintf(&b, "- repo: %s\n", p.Repo)
-		fmt.Fprintf(&b, "- issue: %d\n", p.Issue)
-		fmt.Fprintf(&b, "- branch: %s\n", p.Branch)
+		if p.Issue > 0 {
+			fmt.Fprintf(&b, "You are reviewing the branch the coder produced for issue #%d of %s.\n\n",
+				p.Issue, p.Repo)
+			fmt.Fprintf(&b, "- repo: %s\n", p.Repo)
+			fmt.Fprintf(&b, "- issue: %d\n", p.Issue)
+			fmt.Fprintf(&b, "- branch: %s\n", p.Branch)
+		} else {
+			fmt.Fprintf(&b, "You are reviewing the branch %s of %s.\n\n",
+				p.Branch, p.Repo)
+			fmt.Fprintf(&b, "- repo: %s\n", p.Repo)
+			fmt.Fprintf(&b, "- branch: %s\n", p.Branch)
+		}
 		b.WriteString("\nFollow Step 1 of your system prompt to navigate to ")
 		b.WriteString("the branch under review before forming any judgment, ")
 		b.WriteString("then apply the Step 2 review checklist, then call ")

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -966,6 +966,39 @@ func TestBuildUserPrompt_ReviewerCaseProducesNonEmptyContent(t *testing.T) {
 	}
 }
 
+// TestBuildUserPrompt_ReviewerCase_ZeroIssue_OmitsIssueLine guards against
+// rendering "issue #0" into reviewer prompts when the workload pipeline
+// omits the issue key (#1570).
+func TestBuildUserPrompt_ReviewerCase_ZeroIssue_OmitsIssueLine(t *testing.T) {
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindReview,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Issue:  0,
+				Branch: "foreman/custom-pipeline-branch",
+			},
+		},
+	}
+	got := buildUserPrompt(task)
+	if got == "" {
+		t.Fatal("reviewer user prompt must not be empty")
+	}
+	if strings.Contains(got, "#0") || strings.Contains(got, "issue: 0") {
+		t.Errorf("reviewer prompt must not mention issue #0 when issue is unset, got:\n%s", got)
+	}
+	for _, want := range []string{
+		"You are reviewing the branch foreman/custom-pipeline-branch of defilantech/LLMKube.",
+		"- repo: defilantech/LLMKube",
+		"- branch: foreman/custom-pipeline-branch",
+		"Step 1 of your system prompt",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("reviewer prompt missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 // TestFileListsEqual_TypeShapes covers the two ways the model's
 // claim shows up in extra: as []string (the executor's own writes)
 // or as []any (the standard shape after a json.Unmarshal pass over


### PR DESCRIPTION
## Problem
When a pipeline dispatch payload omits the `issue` key (or passes `issue: 0`), `buildUserPrompt` on `AgenticTaskKindReview` rendered `You are reviewing the branch the coder produced for issue #0 of <repo>` and `- issue: 0`. This instructed reviewer models to evaluate an issue number that does not exist (#1570).

## Solution
- In `pkg/foreman/agent/executor_native.go`, check `p.Issue > 0` before emitting issue references in the review prompt header; when `Issue` is 0 or unset, render `You are reviewing the branch <branch> of <repo>.` without referencing issue `#0`.
- Add unit test `TestBuildUserPrompt_ReviewerCase_ZeroIssue_OmitsIssueLine` in `pkg/foreman/agent/executor_native_internal_test.go` verifying that unset or zero issues omit issue lines.

Fixes #1570
