### PR TITLE
fix(foreman): map test files to their modules in scope-overlap, and dedupe issue file refs

### DIFF
--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -120,7 +120,49 @@ func extractIssuePathRefs(body string, sourceExtensions []string) []string {
 			refs = append(refs, tok)
 		}
 	}
-	return refs
+	return dedupRefs(refs)
+}
+
+// dedupRefs collapses refs that resolve to the same file so the count of
+// issue-named files is not inflated (#1447). A bare filename that is a path
+// suffix of a fuller ref (automation-sync.ts vs src/lib/automation-sync.ts)
+// names the same module and must not be counted as two distinct files; the
+// more specific (longer) ref is kept. Refs that are not suffix-related (e.g.
+// a/foo.ts and b/foo.ts) are distinct and are all preserved.
+func dedupRefs(refs []string) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		replaced := false
+		for i, k := range out {
+			if samePathRef(k, r) {
+				// Prefer the more specific (longer) of the two.
+				if len(r) > len(k) {
+					out[i] = r
+				}
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// samePathRef reports whether two refs resolve to the same file: either they
+// are equal, or one is a path suffix of the other aligned on a path boundary
+// (a bare filename that ends a fuller path, or vice versa). The "/" boundary
+// guard keeps, e.g., x-automation-sync.ts from matching automation-sync.ts.
+func samePathRef(a, b string) bool {
+	if a == b {
+		return true
+	}
+	full, short := a, b
+	if len(full) < len(short) {
+		full, short = short, full
+	}
+	return len(short) < len(full) && strings.HasSuffix(full, "/"+short)
 }
 
 // hasSourceFile reports whether any path in paths ends with one of the
@@ -159,6 +201,67 @@ func isPathRef(tok string, extraExts map[string]bool) bool {
 		}
 	}
 	return true
+}
+
+// joinDir recombines a path.Dir result with a basename without emitting a
+// redundant "/." for bare filenames.
+func joinDir(dir, base string) string {
+	if dir == "." || dir == "" {
+		return base
+	}
+	return dir + "/" + base
+}
+
+// testTargetsForPath returns the module path(s) a diff path could be testing.
+// A diff that creates or edits a test file counts as touching the module
+// under test (#1447): an "add tests for X" issue names X.ts, the correct
+// change creates X.test.ts, and without this mapping the scope-overlap rail
+// reports the diff touches none of the named files and the issue is
+// unwinnable.
+//
+// The directory is preserved; only the basename is mapped. Recognized
+// conventions:
+//   - X.test.{ts,tsx,js,jsx} -> X.{ts,tsx,js,jsx}
+//   - X.spec.{ts,tsx,js,jsx} -> X.{ts,tsx,js,jsx}
+//   - X_test.go              -> X.go
+//   - test_X.py              -> X.py
+//   - X_test.py              -> X.py
+//
+// Returns nil when the path is not a test file under any of those
+// conventions.
+func testTargetsForPath(p string) []string {
+	base := path.Base(p)
+	ext := path.Ext(base)
+	if ext == "" {
+		return nil
+	}
+	stem := strings.TrimSuffix(base, ext)
+	dir := path.Dir(p)
+
+	// JS/TS: X.test.ts / X.spec.ts -> X.ts (extension preserved).
+	for _, marker := range []string{".test", ".spec"} {
+		if strings.HasSuffix(stem, marker) {
+			module := strings.TrimSuffix(stem, marker) + ext
+			return []string{joinDir(dir, module)}
+		}
+	}
+	// Go: X_test.go -> X.go.
+	if ext == ".go" && strings.HasSuffix(stem, "_test") {
+		module := strings.TrimSuffix(stem, "_test") + ext
+		return []string{joinDir(dir, module)}
+	}
+	// Python: test_X.py -> X.py and X_test.py -> X.py.
+	if ext == ".py" {
+		var modules []string
+		if strings.HasPrefix(stem, "test_") {
+			modules = append(modules, joinDir(dir, strings.TrimPrefix(stem, "test_")+ext))
+		}
+		if strings.HasSuffix(stem, "_test") {
+			modules = append(modules, joinDir(dir, strings.TrimSuffix(stem, "_test")+ext))
+		}
+		return modules
+	}
+	return nil
 }
 
 // enforceReviewerScopeOverlap is the computable half of scope-drift
@@ -201,9 +304,22 @@ func enforceReviewerScopeOverlap(
 	for _, f := range diffFiles {
 		diffPaths[f] = true
 		diffBases[path.Base(f)] = true
+		// A test file also counts as touching the module it tests (#1447).
+		// Index the mapped target under both full path and basename so a
+		// ref that names either the module's directory or just its file
+		// matches the test file that covers it.
+		for _, t := range testTargetsForPath(f) {
+			diffPaths[t] = true
+			diffBases[path.Base(t)] = true
+		}
 	}
 	matched := []string{}
 	for _, r := range refs {
+		// A ref is satisfied when the diff touches the module it names
+		// directly, or when the diff touches a test file that targets it:
+		// testTargetsForPath has folded each test file's subject into
+		// diffPaths/diffBases, so an "add tests for X" issue (naming X)
+		// matches the X.test file the diff creates (#1447).
 		if diffPaths[r] || diffBases[path.Base(r)] {
 			matched = append(matched, r)
 		}

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -456,3 +456,152 @@ func TestExtractIssuePathRefs_ProseIsNotAPathRef(t *testing.T) {
 		t.Errorf("prose must not extract as path refs; got %v", got)
 	}
 }
+
+// --- Issue #1447: test-coverage issues must be winnable. -------------------
+// The scope-overlap rail demoted a GO when the diff touched none of the
+// files the issue names literally. For "add tests for X" that is
+// unsatisfiable: the issue names X, the correct change creates X.test, and
+// the check reported the diff touched none of them. Two defects were fixed:
+// (1) a test file now maps to the module it covers, and (2) a bare filename
+// and its full path no longer both count as distinct files.
+
+// TestTestTargetsForPath is the pure helper that maps a diff path to the
+// module(s) it tests, across the conventions the repo cares about.
+func TestTestTargetsForPath(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{in: "src/lib/automation-sync.test.ts", want: []string{"src/lib/automation-sync.ts"}},
+		{in: "src/lib/resolve-actor.spec.ts", want: []string{"src/lib/resolve-actor.ts"}},
+		{in: "src/lib/Component.test.tsx", want: []string{"src/lib/Component.tsx"}},
+		{in: "src/lib/widget.test.js", want: []string{"src/lib/widget.js"}},
+		{in: "src/lib/widget.test.jsx", want: []string{"src/lib/widget.jsx"}},
+		{in: "internal/foo/bar_test.go", want: []string{"internal/foo/bar.go"}},
+		{in: "pkg/agent/loop_test.go", want: []string{"pkg/agent/loop.go"}},
+		{in: "src/calculators/test_math.py", want: []string{"src/calculators/math.py"}},
+		{in: "src/calculators/math_test.py", want: []string{"src/calculators/math.py"}},
+		// Non-test files map to nothing.
+		{in: "src/lib/automation-sync.ts", want: nil},
+		{in: "internal/foo/bar.go", want: nil},
+		{in: "src/math.py", want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := testTargetsForPath(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("testTargetsForPath(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractIssuePathRefs_DedupsBasenameAndFullPath is defect (2) in #1447:
+// an issue that names a module both bare and by path reported six files
+// instead of three. Dedup by resolved path must collapse each pair to one,
+// keeping the more specific (full) ref.
+func TestExtractIssuePathRefs_DedupsBasenameAndFullPath(t *testing.T) {
+	body := "Add unit tests covering the main execution paths for " +
+		"`automation-sync.ts`, `groomer-lock.ts`, and `resolve-actor.ts` " +
+		"(see `src/lib/automation-sync.ts`, `src/lib/groomer/groomer-lock.ts`, " +
+		"and `src/lib/resolve-actor.ts`)."
+	got := extractIssuePathRefs(body, []string{".ts"})
+	want := []string{
+		"src/lib/automation-sync.ts",
+		"src/lib/groomer/groomer-lock.ts",
+		"src/lib/resolve-actor.ts",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("dedup extraction = %v, want %v", got, want)
+	}
+}
+
+// TestExtractIssuePathRefs_DistinctSameBasenameKept guards the boundary of
+// the dedup: two files with the same basename in DIFFERENT directories are
+// distinct modules and must both survive. The "/"+short boundary check keeps
+// x-automation-sync.ts from matching automation-sync.ts too.
+func TestExtractIssuePathRefs_DistinctSameBasenameKept(t *testing.T) {
+	body := "Compare `a/foo.ts` and `b/foo.ts` before refactoring."
+	got := extractIssuePathRefs(body, []string{".ts"})
+	want := []string{"a/foo.ts", "b/foo.ts"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("distinct same-basename refs must both survive; got %v, want %v", got, want)
+	}
+}
+
+// TestEnforceReviewerScopeOverlap_TestFileMapsToModule is defect (1) in
+// #1447: the diff creates the test files for the modules the issue names, so
+// the verdict must stay GO (not be demoted as scope drift).
+func TestEnforceReviewerScopeOverlap_TestFileMapsToModule(t *testing.T) {
+	body := "Add unit tests covering the main execution paths and error " +
+		"conditions for `src/lib/automation-sync.ts`."
+	diff := []string{"src/lib/automation-sync.test.ts"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"})
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("a diff that creates the test for the named module must not demote; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); v {
+		t.Errorf("scopeDriftDetected should be false when the test file maps to the named module")
+	}
+	if v, _ := extra["verdictDemoted"].(bool); v {
+		t.Errorf("must not claim demotion for a test-coverage diff")
+	}
+	matched, _ := extra["scopeMatched"].([]string)
+	if !reflect.DeepEqual(matched, []string{"src/lib/automation-sync.ts"}) {
+		t.Errorf("scopeMatched = %v, want the module the test covers", matched)
+	}
+}
+
+// TestEnforceReviewerScopeOverlap_GoTestFileMapsToModule is the Go-flavored
+// version of the same case: a diff that adds `bar_test.go` satisfies an
+// issue naming `bar.go`.
+func TestEnforceReviewerScopeOverlap_GoTestFileMapsToModule(t *testing.T) {
+	body := "Add tests for `internal/foo/bar.go` covering the error path."
+	diff := []string{"internal/foo/bar_test.go"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("a diff adding bar_test.go must not demote an issue naming bar.go; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); v {
+		t.Errorf("scopeDriftDetected should be false for a _test.go diff covering the named .go file")
+	}
+}
+
+// TestEnforceReviewerScopeOverlap_TestFileBareRefMapsToModule covers the
+// direction where the issue names the module bare and the diff path is
+// fully-qualified: `bar.go` must still match `internal/foo/bar_test.go`.
+func TestEnforceReviewerScopeOverlap_TestFileBareRefMapsToModule(t *testing.T) {
+	body := "Add tests for `bar.go`."
+	diff := []string{"internal/foo/bar_test.go"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("a bare ref to bar.go must match the bar_test.go diff; got %v", got)
+	}
+}
+
+// TestEnforceReviewerScopeOverlap_RealDriftStillBitesAfterFix is the
+// regression guard for #1447: a diff that touches none of the modules the
+// issue names — and is not a test file mapping to any of them — must STILL
+// be flagged as scope drift and demote a GO. The fix must not disable the
+// rail.
+func TestEnforceReviewerScopeOverlap_RealDriftStillBitesAfterFix(t *testing.T) {
+	body := "Tighten error handling in `a.ts`."
+	diff := []string{"totally-unrelated.ts"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"})
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("genuine drift must still demote GO; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); !v {
+		t.Errorf("scopeDriftDetected must be true for genuine drift")
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("genuine drift must set verdictDemoted")
+	}
+}

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -24,6 +24,7 @@ package agent
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -581,6 +582,105 @@ func TestEnforceReviewerScopeOverlap_TestFileBareRefMapsToModule(t *testing.T) {
 		foremanv1alpha1.AgenticTaskVerdictGo, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a bare ref to bar.go must match the bar_test.go diff; got %v", got)
+	}
+}
+
+// issue654Ask mirrors misospace/dispatch#654 ("[P3] Add tests for high-risk
+// untested modules"), the concrete run that motivated #1447: the issueAsk
+// names three modules, each once bare and once with its path, and the
+// correct diff creates the three test files. Pre-fix this demoted a GO
+// ("the issue names 6 file(s) ... and the diff touches none of them").
+const issue654Ask = "Add unit tests covering the main execution paths and error " +
+	"conditions for these three modules. See `automation-sync.ts`, `groomer-lock.ts`, " +
+	"and `resolve-actor.ts` (the full paths are `src/lib/automation-sync.ts`, " +
+	"`src/lib/groomer/groomer-lock.ts`, and `src/lib/resolve-actor.ts`)."
+
+// issue654Diff is the finished, correct diff from #654: one new test file per
+// module. Each is a test file that maps to the module it covers.
+var issue654Diff = []string{
+	"src/lib/automation-sync.test.ts",
+	"src/lib/groomer/groomer-lock.test.ts",
+	"src/lib/resolve-actor.test.ts",
+}
+
+// TestEnforceReviewerScopeOverlap_Issue654ConcreteExample is the end-to-end
+// reproduction of the exact run that motivated #1447. The issue names all
+// three modules (six raw refs, deduplicated to three) and the diff creates
+// the three test files. After the fix: the GO stands, scopeDriftDetected is
+// false, all three modules are matched via their test files, and the
+// extracted ref list carries three entries (not the inflated six).
+func TestEnforceReviewerScopeOverlap_Issue654ConcreteExample(t *testing.T) {
+	// Defect (2): the issue names each module bare and by path; the
+	// extracted list must deduplicate to the three modules.
+	refs := extractIssuePathRefs(issue654Ask, []string{".ts"})
+	if want := []string{
+		"src/lib/automation-sync.ts",
+		"src/lib/groomer/groomer-lock.ts",
+		"src/lib/resolve-actor.ts",
+	}; !reflect.DeepEqual(refs, want) {
+		t.Fatalf("the #654 issue must dedup to 3 refs; got %v", refs)
+	}
+
+	// Defect (1): each test file maps to the module it covers, so the GO
+	// stands and all three modules match.
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue654Ask, issue654Diff,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"})
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("the #654 test-coverage diff must not demote a GO; got %v (reason: %v)",
+			got, extra["demotionReason"])
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); v {
+		t.Errorf("scopeDriftDetected should be false for the #654 diff")
+	}
+	if v, _ := extra["verdictDemoted"].(bool); v {
+		t.Errorf("the #654 diff must not be demoted")
+	}
+	if v, _ := extra["demotionReason"].(string); v != "" {
+		t.Errorf("the #654 diff must not carry a demotion reason; got %q", v)
+	}
+	savedRefs, _ := extra["scopeRefs"].([]string)
+	if len(savedRefs) != 3 {
+		t.Errorf("scopeRefs should carry 3 deduplicated refs, not 6; got %v", savedRefs)
+	}
+	matched, _ := extra["scopeMatched"].([]string)
+	if !reflect.DeepEqual(matched, []string{
+		"src/lib/automation-sync.ts",
+		"src/lib/groomer/groomer-lock.ts",
+		"src/lib/resolve-actor.ts",
+	}) {
+		t.Errorf("scopeMatched = %v, want the three modules the test files cover", matched)
+	}
+}
+
+// TestEnforceReviewerScopeOverlap_Issue654ModulesDriftStillDemotes is the
+// #654-specific scope-drift guard: the same issueAsk that names all three
+// modules, but a diff that touches none of them (and no test file mapping
+// to any of them) is genuine drift and must still demote a GO. This is the
+// flip side of TestEnforceReviewerScopeOverlap_Issue654ConcreteExample and
+// proves the test-file mapping does not let an unrelated change ride along.
+func TestEnforceReviewerScopeOverlap_Issue654ModulesDriftStillDemotes(t *testing.T) {
+	// A diff with a .ts source file (so hasSourceFile admits the check) but
+	// that touches none of the three named modules — not even their tests.
+	diff := []string{"src/lib/unrelated-helper.ts"}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue654Ask, diff,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"})
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("a diff touching none of the #654 modules must still demote GO; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); !v {
+		t.Errorf("scopeDriftDetected must be true when the diff touches none of the named modules")
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("genuine #654 drift must set verdictDemoted")
+	}
+	if reason, _ := extra["demotionReason"].(string); !strings.Contains(reason, "3 file(s)") {
+		t.Errorf("demotionReason should name the 3 deduplicated files; got %q", reason)
+	}
+	matched, _ := extra["scopeMatched"].([]string)
+	if len(matched) != 0 {
+		t.Errorf("scopeMatched should be empty for a diff touching none of the named modules; got %v", matched)
 	}
 }
 


### PR DESCRIPTION
## What

Makes the reviewer's scope-overlap rail recognise test files as touching the modules they cover, and stops the extracted issue-file list from double-counting the same file.

## Why

Refs #1447

The rail demotes a reviewer GO when the diff touches none of the files the issue names. That makes an entire class of issue unwinnable: an "add tests for X" issue names `X.ts`, the correct change creates `X.test.ts`, and the check reports the diff "touches none of them". The task then burns its full attempt budget and the frontier escalation every time, and no PR is ever opened.

The issue records a real instance: a coder returned GO twice with typecheck and lint passing, 1104 lines across three correct new test files, and was demoted both times.

Second, smaller defect: `extractIssuePathRefs` returned both the bare filename and the full path as separate entries, so an issue naming three modules reported six files. That inflates the denominator of any overlap ratio and makes the demotion message misleading.

## How

Two changes in `pkg/foreman/agent/scope_overlap.go`:

- **`testTargetsForPath`** maps a diff path to the module path(s) it could be testing: `X.test.ts` and `X.spec.ts` to `X.ts` (extension preserved, so `.tsx`/`.js`/`.jsx` work too), and `X_test.go` to `X.go`. Direct matches are unaffected: a diff touching `X.ts` still satisfies `X.ts`.
- **`dedupRefs` / `samePathRef`** collapse references that resolve to the same file, so `automation-sync.ts` and `src/lib/automation-sync.ts` count once.

`enforceReviewerScopeOverlap`'s signature and its call site in `executor_native.go` are unchanged, and no other rail was touched.

## Verification

Run on this branch, not inherited from an agent verdict:

- `go test ./pkg/foreman/agent/ -count=1` -> **ok, 29.6s**
- **Falsifiability proved.** Applying this branch's `scope_overlap_test.go` to unmodified `main` fails to build with `undefined: testTargetsForPath`, so the new tests cannot pass without the implementation.

Coverage includes the issue's concrete example (`TestEnforceReviewerScopeOverlap_Issue654ConcreteExample` with `automation-sync`, `groomer-lock` and `resolve-actor`), the dedup case, the Go `_test.go` mapping, and a regression guard (`TestEnforceReviewerScopeOverlap_RealDriftStillBitesAfterFix`) proving genuine scope drift is still demoted. That last one matters: the fix must not pass by disabling the rail.

## A reviewer NO-GO on this branch was wrong

Recorded rather than quietly dropped, because it is evidence for #1570.

The automated reviewer returned NO-GO twice, stating the changes "lack tests for the issue's concrete example files (automation-sync.ts, groomer-lock.ts, etc.)". The branch contains a test named `TestEnforceReviewerScopeOverlap_Issue654ConcreteExample` using exactly those files. The claim is false on its face, and it triggered a retry cycle that regenerated already-correct work.

This is the mirror image of the failure in #1570, where two reviews returned GO without ever reading the diff. Same root cause, opposite direction. Per #1552, an unsupported NO-GO destroys good work, and here it did.

The diff was verified by hand instead. Reviewers should judge the code, not this note.

## Checklist

- [x] Tests added/updated - 9 new cases, including the issue's concrete example and a drift regression guard
- [x] `make test` passes locally - `./pkg/foreman/agent/` suite
- [x] `make lint` passes locally - `go vet` clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **bot-only sign-off, see below**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - n/a, internal rail behaviour

## Sign-off

Commits carry `Signed-off-by: Foreman Bot`. Per CONTRIBUTING.md a human sign-off is required before merge:

```
git commit --amend -s --no-edit && git push --force-with-lease
```

Not added on the maintainer's behalf: the DCO attests that a person takes responsibility for the change.

*Assisted-by: Qwen3.8-27B via the Foreman harness, on two DGX Sparks behind one LLMKube InferenceService. Its automated reviewer returned NO-GO; that verdict was checked against the diff and found false (see above), so it was not acted on. Reviewed-by: Claude, which read the full diff, confirmed both defects are addressed, ran the package suite, and proved the tests fail against unmodified main. The maintainer scoped this batch, reviewed the findings in conversation (including the false NO-GO recorded above), and directed this PR to be opened. DCO sign-off is still outstanding, per the checklist.*

