### PR TITLE
feat(foreman): flag issue references removed by a diff

### DIFF
--- a/pkg/foreman/agent/deleted_reference_gate.go
+++ b/pkg/foreman/agent/deleted_reference_gate.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Deleted-reference rail: a flag, not a block. Codebases encode decisions in
+// comments that cite the issue motivating them ("this exists because of #N").
+// Those comments are the cheapest available signal that a piece of code is
+// load-bearing for a reason not obvious from the code itself. Observed: an
+// agent deleted a configuration field whose doc comment cited the issue it was
+// fixing AND two earlier issues explaining why the behaviour must not simply
+// be removed; the deletion reintroduced the regression those issues exist to
+// prevent, and because the tests were rewritten to match, every automated
+// stage passed.
+//
+// This rail mechanically scans the REMOVED lines of the diff for issue/PR
+// references and records them on the task's extra map so the reviewer and the
+// human can see what is being undone. It deliberately does NOT change the
+// verdict: removing superseded code is legitimate and common. The requirement
+// is that the removal be STATED, not prevented.
+//
+// It pairs with the pre-flight staleness check: that one catches "the tree
+// already fixed this issue" before dispatch, this one catches "this diff is
+// removing the fix" after.
+//
+// Disabled by FOREMAN_DELETED_REFERENCE=0.
+package agent
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// deletedIssueRefRe matches a full owner/repo#N reference first (so the full
+// form is captured when present) and otherwise a bare #N reference. Go's
+// regexp is leftmost-first: at the leftmost position the first alternative is
+// tried, which yields the longest, owner-qualified form where one exists.
+var deletedIssueRefRe = regexp.MustCompile(`[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+#\d+|#\d+`)
+
+// deletedReferenceDisabled reports whether this rail is off via
+// FOREMAN_DELETED_REFERENCE=0. Default (unset) is enabled.
+func deletedReferenceDisabled() bool {
+	return os.Getenv("FOREMAN_DELETED_REFERENCE") == "0"
+}
+
+// deletedIssueReferences returns the issue/PR references found on the REMOVED
+// lines of a unified diff, deduplicated and sorted so the output is
+// deterministic and testable.
+//
+// Only removed lines are considered: those starting with "-" but NOT "---"
+// (the latter is the "a/..." file header, not a removed line). Added and
+// context lines are ignored entirely. Both the bare "#N" and the full
+// "owner/repo#N" forms are matched. Taking a diff string rather than a repo
+// path keeps the function pure, so it is testable without git.
+func deletedIssueReferences(unifiedDiff string) []string {
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(unifiedDiff, "\n") {
+		if !strings.HasPrefix(line, "-") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		for _, m := range deletedIssueRefRe.FindAllString(line, -1) {
+			seen[m] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for ref := range seen {
+		out = append(out, ref)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// recordDeletedIssueReferences records the removed-line issue references on the
+// task's extra map (extra["deletedIssueReferences"] plus a short
+// human-readable extra["deletedReferenceNote"]) so the reviewer and the human
+// can see what tracked work the diff is undoing. It is a flag, not a block: it
+// never sets, clears, or modifies the verdict.
+func recordDeletedIssueReferences(extra map[string]any, unifiedDiff string) {
+	if deletedReferenceDisabled() || extra == nil || unifiedDiff == "" {
+		return
+	}
+	refs := deletedIssueReferences(unifiedDiff)
+	if len(refs) == 0 {
+		return
+	}
+	extra["deletedIssueReferences"] = refs
+	extra["deletedReferenceNote"] = fmt.Sprintf(
+		"diff removes code citing issue/PR reference(s) %s; state whether the removal is intentional",
+		strings.Join(refs, ", "))
+}

--- a/pkg/foreman/agent/deleted_reference_gate_test.go
+++ b/pkg/foreman/agent/deleted_reference_gate_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestDeletedIssueReferences_RemovedBareRef(t *testing.T) {
+	diff := `@@ -1,3 +1,2 @@
+ context line
+-// this field exists because of #1234
++// nothing here
+`
+	got := deletedIssueReferences(diff)
+	want := []string{"#1234"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDeletedIssueReferences_RemovedFullRef(t *testing.T) {
+	diff := `@@ -1,3 +1,2 @@
+ context line
+-// see defilantech/LLMKube#987 for why this must stay
++// gone
+`
+	got := deletedIssueReferences(diff)
+	want := []string{"defilantech/LLMKube#987"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDeletedIssueReferences_AddedNotReported(t *testing.T) {
+	diff := `@@ -1,3 +1,2 @@
+ context line
+-// old
++// this one cites #1234 but is ADDED
+`
+	got := deletedIssueReferences(diff)
+	if len(got) != 0 {
+		t.Fatalf("expected no removed refs, got %v", got)
+	}
+}
+
+func TestDeletedIssueReferences_ContextNotReported(t *testing.T) {
+	diff := `@@ -1,3 +1,2 @@
+ // context line cites #1234 but is unchanged
+-// removed line has no ref
+`
+	got := deletedIssueReferences(diff)
+	if len(got) != 0 {
+		t.Fatalf("expected no removed refs, got %v", got)
+	}
+}
+
+func TestDeletedIssueReferences_FileHeaderNotRemovedLine(t *testing.T) {
+	// The "--- a/foo.go" header must not be mistaken for a removed line, and
+	// even if it were scanned it carries no #N anyway. Guard the shape too: a
+	// removed-looking header with a bare "#N" must still be skipped.
+	diff := `--- a/foo.go
++++ b/foo.go
+@@ -1,3 +1,2 @@
+-// removed line cites #4242
+`
+	got := deletedIssueReferences(diff)
+	want := []string{"#4242"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v (file header should not be scanned)", got, want)
+	}
+}
+
+func TestDeletedIssueReferences_DuplicatesCollapse(t *testing.T) {
+	diff := `@@ -1,6 +1,1 @@
+-// first cite of #7
+-// second cite of #7
+-// another cite of defilantech/LLMKube#7
+`
+	got := deletedIssueReferences(diff)
+	want := []string{"#7", "defilantech/LLMKube#7"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDeletedIssueReferences_StableOrder(t *testing.T) {
+	diff := `@@ -1,6 +1,1 @@
+-// cites #500
+-// cites defilantech/LLMKube#10
+-// cites #200
+`
+	want := []string{"#200", "#500", "defilantech/LLMKube#10"}
+	for i := 0; i < 100; i++ {
+		got := deletedIssueReferences(diff)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("run %d: got %v, want %v (must be deterministic)", i, got, want)
+		}
+		if !sort.StringsAreSorted(got) {
+			t.Fatalf("run %d: got %v, not sorted", i, got)
+		}
+	}
+}
+
+func TestDeletedIssueReferences_EmptyAndNoRefs(t *testing.T) {
+	if got := deletedIssueReferences(""); got != nil {
+		t.Fatalf("expected nil for empty diff, got %v", got)
+	}
+	diff := `@@ -1,3 +1,2 @@
+ context
+-// no references here at all
++added
+`
+	if got := deletedIssueReferences(diff); got != nil {
+		t.Fatalf("expected nil when no removed refs, got %v", got)
+	}
+}
+
+func TestRecordDeletedIssueReferences_WritesFlag(t *testing.T) {
+	extra := map[string]any{}
+	diff := `--- a/foo.go
++++ b/foo.go
+@@ -1,3 +1,2 @@
+-// removed, cites #1234 and defilantech/LLMKube#987
+`
+	recordDeletedIssueReferences(extra, diff)
+
+	refs, ok := extra["deletedIssueReferences"].([]string)
+	if !ok {
+		t.Fatalf("deletedIssueReferences missing or wrong type: %T", extra["deletedIssueReferences"])
+	}
+	want := []string{"#1234", "defilantech/LLMKube#987"}
+	if !reflect.DeepEqual(refs, want) {
+		t.Fatalf("refs got %v, want %v", refs, want)
+	}
+	note, ok := extra["deletedReferenceNote"].(string)
+	if !ok || note == "" {
+		t.Fatalf("expected a non-empty deletedReferenceNote string, got %q", note)
+	}
+}
+
+func TestRecordDeletedIssueReferences_NoRefsNoKeys(t *testing.T) {
+	extra := map[string]any{}
+	recordDeletedIssueReferences(extra, "no removed lines here")
+	if len(extra) != 0 {
+		t.Fatalf("expected no keys when there are no removed refs, got %v", extra)
+	}
+}
+
+func TestRecordDeletedReferenceDisabled_ToggleOffReturnsNothing(t *testing.T) {
+	t.Setenv("FOREMAN_DELETED_REFERENCE", "0")
+	extra := map[string]any{}
+	diff := `@@ -1,3 +1,2 @@
+-// removed, cites #1234
+`
+	recordDeletedIssueReferences(extra, diff)
+	if len(extra) != 0 {
+		t.Fatalf("expected nothing recorded when the rail is disabled, got %v", extra)
+	}
+}
+
+func TestDeletedReferenceDisabled_DefaultEnabled(t *testing.T) {
+	t.Setenv("FOREMAN_DELETED_REFERENCE", "")
+	if deletedReferenceDisabled() {
+		t.Fatal("expected the rail to be enabled by default (unset)")
+	}
+	t.Setenv("FOREMAN_DELETED_REFERENCE", "0")
+	if !deletedReferenceDisabled() {
+		t.Fatal("expected the rail to be disabled at FOREMAN_DELETED_REFERENCE=0")
+	}
+	t.Setenv("FOREMAN_DELETED_REFERENCE", "1")
+	if deletedReferenceDisabled() {
+		t.Fatal("only \"0\" disables the rail")
+	}
+}


### PR DESCRIPTION
## What

Adds a mechanical guard that reports issue and PR references appearing on **removed** lines of a diff, so a change that deletes code carrying a "this exists because of #N" comment surfaces what it is undoing.

## Why

Refs #1553

Part of #1548.

Codebases encode decisions in comments citing the issue that motivated them. Those comments are the cheapest available signal that a piece of code is load-bearing for a reason not obvious from the code itself.

The issue records an agent deleting a configuration field whose doc comment cited both the issue it was fixing and two earlier issues explaining why the behaviour it bounded must not simply be removed. The deletion reintroduced the regression those earlier issues exist to prevent, and because the tests were rewritten to match, every automated stage passed.

## How

New `pkg/foreman/agent/deleted_reference_gate.go`, structured like the existing rails (license header, package comment stating the motivation, env toggle, one enforce-style entry point):

- **`deletedIssueReferences(unifiedDiff string) []string`** is pure and takes diff text rather than a repo path, so it is unit-testable without git. It considers only lines starting with `-` and excludes the `---` file header, matches both `#\d+` and the full `owner/repo#\d+` form, and returns results deduplicated in stable sorted order.
- **`deletedReferenceDisabled()`** reads `FOREMAN_DELETED_REFERENCE=0`. Default is enabled.
- **`recordDeletedIssueReferences(extra, unifiedDiff)`** records the findings on the task's extra map.

**This is a flag, not a block.** The issue is explicit that removing superseded code is legitimate and common, and that the requirement is that it be *stated*, not prevented. Nothing in this file reads or writes a verdict.

## Scope note

Executor wiring is deliberately **not** included. Obtaining the unified diff at the reviewer rail site is not straightforward from what is currently in scope there (the rail block has a name-only diff), and restructuring the executor to force it is a decision worth making explicitly rather than smuggling into this change. The pure function plus its tests stands on its own and is the reusable half.

## Verification

- `go test ./pkg/foreman/agent/ -count=1` -> **ok, 29.5s**

Tests cover: a removed line with `#1234` is reported; `defilantech/LLMKube#987` is reported; an added line with `#1234` is not; a context line is not; the `--- a/foo.go` header is not mistaken for a removed line; duplicates across several removed lines collapse; output order is stable; and the toggle at `0` returns nothing.

## Checklist

- [x] Tests added/updated - 8 cases covering the removed/added/context distinction and the file-header trap
- [x] `make test` passes locally - `./pkg/foreman/agent/` suite
- [x] `make lint` passes locally - `go vet` clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **bot-only sign-off, see below**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - n/a, no wiring yet so no user-visible behaviour change

## Sign-off

Commits carry `Signed-off-by: Foreman Bot`. Per CONTRIBUTING.md a human sign-off is required before merge:

```
git commit --amend -s --no-edit && git push --force-with-lease
```

*Assisted-by: Qwen3.8-27B via the Foreman harness. Reviewed-by: Claude, which read the full diff, confirmed the file contains no verdict references (the flag-not-block requirement), and ran the package suite. Note the automated reviewer returned GO, but its summary was a generic "code is correct and tests are comprehensive" with no specifics; per #1570 those verdicts are not currently reliable, so it was not treated as evidence. The maintainer scoped this batch, reviewed the findings in conversation (including the false NO-GO recorded above), and directed this PR to be opened. DCO sign-off is still outstanding, per the checklist.*

