### PR TITLE
fix(foreman): do not let an unavailable diff disable the grounded-finding rail

### DIFF
--- a/pkg/foreman/agent/grounded_finding_gate.go
+++ b/pkg/foreman/agent/grounded_finding_gate.go
@@ -128,7 +128,7 @@ func enforceReviewerGroundedFindings(
 ) foremanv1alpha1.AgenticTaskVerdict {
 	if groundedFindingsDisabled() ||
 		verdict != foremanv1alpha1.AgenticTaskVerdictNoGo ||
-		extra == nil || changedLines == nil {
+		extra == nil {
 		return verdict
 	}
 
@@ -138,6 +138,39 @@ func enforceReviewerGroundedFindings(
 	}
 
 	findings, _ := reviewer.ParseFindings(extra)
+
+	// A rejection carrying NO findings at all is unearned whether or not the
+	// diff is readable: there is nothing to ground, so grounding data cannot
+	// change the answer. This runs BEFORE the changedLines guard on purpose.
+	//
+	// #1570: one upstream failure (the branch diff unavailable at review time)
+	// does two things at once. It starves the reviewer, so it judges from
+	// partial file reads, AND it nils changedLines, which used to no-op this
+	// rail. The safety net was disabled by the same condition that created the
+	// hazard. Observed on wl-1447-review-1447-0, which returned NO-GO with
+	// result.extra = [outcome, transcriptRef, turnCount] -- not one cited line
+	// -- and stood, costing a retry cycle that regenerated correct work.
+	if len(findings) == 0 {
+		extra["groundedFindingDemotion"] = true
+		extra["groundedFindingReason"] =
+			"NO-GO demoted to GO: the rejection cited no findings at all"
+		log.Info("reviewer grounded-finding: NO-GO demoted to GO; rejection cited no findings")
+		return foremanv1alpha1.AgenticTaskVerdictGo
+	}
+
+	// Past this point grounding requires the diff. When it is unavailable the
+	// verdict stands, but say so in extra: a verdict that could not be checked
+	// must be distinguishable afterwards from one that was checked and passed.
+	// Silently returning the model's verdict is what made #1570 hard to see.
+	if changedLines == nil {
+		extra["groundingUnavailable"] = true
+		extra["groundingUnavailableReason"] =
+			"branch diff unavailable; grounded-finding rail could not evaluate this NO-GO"
+		log.Info("reviewer grounded-finding: branch diff unavailable; verdict left unchecked",
+			"findingCount", len(findings))
+		return verdict
+	}
+
 	grounded, ungrounded := groundedBlockingFindings(findings, changedLines)
 
 	if len(grounded) >= 1 {

--- a/pkg/foreman/agent/grounded_finding_gate_test.go
+++ b/pkg/foreman/agent/grounded_finding_gate_test.go
@@ -481,3 +481,72 @@ func TestGroundedBlockingFindings_PathNormalization(t *testing.T) {
 		})
 	}
 }
+
+// --- #1570: the rail must not be disabled by the same failure it guards ---
+//
+// The branch diff being unavailable at review time starves the reviewer AND
+// nils changedLines. Before this fix the nil no-oped the whole rail, so an
+// evidence-free NO-GO stood unchallenged. Observed on wl-1447-review-1447-0.
+
+func TestGroundedFindings_NoFindingsDemotesEvenWithoutDiff(t *testing.T) {
+	// The exact production shape: extra carries no findings key at all, and
+	// the diff is unavailable so changedLines is nil.
+	extra := map[string]any{"outcome": "MODEL-DECIDED", "turnCount": 3}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("a NO-GO citing no findings is unearned regardless of diff availability; got %s", got)
+	}
+	if demoted, _ := extra["groundedFindingDemotion"].(bool); !demoted {
+		t.Error("demotion must be recorded in extra for auditability")
+	}
+}
+
+func TestGroundedFindings_NoFindingsDemotesWithDiff(t *testing.T) {
+	// Same rejection, diff available: the answer must not depend on that.
+	extra := map[string]any{"outcome": "MODEL-DECIDED"}
+	fix := map[string]map[int]bool{"pkg/cli/cache.go": {42: true}}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, changed(fix))
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("no-findings NO-GO must demote with the diff too, got %s", got)
+	}
+}
+
+func TestGroundedFindings_UncheckableNoGoIsRecorded(t *testing.T) {
+	// Findings exist but the diff is unavailable, so grounding cannot be
+	// judged. The verdict stands (no overreach) but must be marked so a
+	// verdict that could not be checked is distinguishable afterwards.
+	extra := findingExtra("blocker", "pkg/cli/cache.go", 42)
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("an uncheckable NO-GO carrying findings must stand, got %s", got)
+	}
+	if unavailable, _ := extra["groundingUnavailable"].(bool); !unavailable {
+		t.Error("an unchecked verdict must be marked groundingUnavailable")
+	}
+	if _, demoted := extra["groundedFindingDemotion"]; demoted {
+		t.Error("an uncheckable verdict must not be reported as a demotion")
+	}
+}
+
+func TestGroundedFindings_RejectExemptionSurvivesNilDiff(t *testing.T) {
+	// A do-not-retry rejection stays NO-GO even with no findings and no diff:
+	// the new zero-findings path must not overturn the REJECT exemption.
+	extra := map[string]any{"reviewOutcome": "REJECT"}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("REJECT must stay NO-GO, got %s", got)
+	}
+}
+
+func TestGroundedFindings_GoWithNilDiffUntouched(t *testing.T) {
+	// The rail only ever acts on NO-GO. A GO with no diff is left alone and
+	// must not be marked, or every clean review would carry the flag.
+	extra := map[string]any{"outcome": "MODEL-DECIDED"}
+	got := enforceReviewerGroundedFindings(logr.Discard(), extra, foremanv1alpha1.AgenticTaskVerdictGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("GO must be untouched, got %s", got)
+	}
+	if _, marked := extra["groundingUnavailable"]; marked {
+		t.Error("a GO must not be marked groundingUnavailable")
+	}
+}


### PR DESCRIPTION
## What

Stops the grounded-finding rail from being disabled by the same failure it exists to guard against, and makes an unverifiable verdict visible instead of silent.

## Why

Refs #1570

The rail demotes a reviewer NO-GO to GO when no blocking finding cites a changed line. Its guard returned early on `changedLines == nil`, which is set whenever the branch diff errors or comes back empty.

That is the **same condition** that starves the reviewer of the diff in the first place. One upstream failure therefore did two things at once: it produced an ungrounded verdict, and it disabled the net that catches ungrounded verdicts.

Observed on `wl-1447-review-1447-0`. It returned NO-GO claiming the branch lacked tests for the issue's example files, when the branch contains `TestEnforceReviewerScopeOverlap_Issue654ConcreteExample` using exactly those files. Its entire `result.extra` was:

```
['outcome', 'transcriptRef', 'turnCount']
```

Not one cited line, no `groundedFindingDemotion` marker. The rejection stood and cost a retry cycle that regenerated already-correct work. A same-pod control ten minutes earlier (`wl-1553-review-1553-0`) had the diff available, logged `groundTruth: [...]`, and behaved correctly, which is what isolated the variable.

Full diagnosis in [this comment](https://github.com/defilantech/LLMKube/issues/1570#issuecomment-5306204376).

## How

Two changes in `pkg/foreman/agent/grounded_finding_gate.go`:

**1. A rejection carrying no findings at all is demoted before the `changedLines` guard.** Grounding data cannot change that answer, because there is nothing to ground. This is the minimal fix for the observed case and introduces no new failure mode: it only fires where the reviewer cited nothing whatsoever.

The REJECT do-not-retry exemption still takes precedence, so a wrong-issue rejection is not overturnable by this path.

**2. When findings exist but the diff is unavailable, the verdict stands and `extra` records why.** No overreach: an unverifiable NO-GO carrying real findings is left alone. But `groundingUnavailable` plus a reason is now recorded, so a verdict that *could not be checked* is distinguishable afterwards from one that *was checked and passed*. Silently returning the model's verdict is what made this hard to see.

Deliberately **not** in scope: turning an ungrounded verdict into `INCOMPLETE`. That subsumes both failure directions but is a behaviour change worth deciding on its own merits, and it is item 3 in the issue comment. Nor is the underlying diff-acquisition bug fixed here; this is the backstop, and item 4 is the cause.

## Verification

- `go test ./pkg/foreman/agent/... -count=1` -> **ok** (agent 41.2s, all subpackages)
- **Falsifiability proved.** With the test file kept and `grounded_finding_gate.go` reverted to `main`, both new assertions fail:
  ```
  --- FAIL: TestGroundedFindings_NoFindingsDemotesEvenWithoutDiff
  --- FAIL: TestGroundedFindings_UncheckableNoGoIsRecorded
  ```

Five new cases: no-findings demotes without the diff (the production shape, `extra` with no findings key and nil `changedLines`); no-findings demotes with the diff, so the answer does not depend on availability; an uncheckable NO-GO carrying findings stands and is marked; the REJECT exemption survives a nil diff; and a GO with a nil diff is untouched and unmarked, so clean reviews do not all carry the flag.

The pre-existing `TestGroundedFindings_GitUnavailableDegradesOpen` continues to pass unchanged. It carries a finding, so it exercises the preserved path, which is the regression guard that this change did not widen the demotion.

## Checklist

- [x] Tests added/updated - 5 cases, proven to fail against main
- [x] `make test` passes locally - `./pkg/foreman/agent/...`
- [x] `make lint` passes locally - `gofmt` clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **see the note below before merging**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - n/a, internal rail behaviour

## Sign-off note

Unlike the sibling PRs in this batch, this commit is **not** bot-signed: it was authored directly in the maintainer's checkout, so `git commit -s` used the maintainer's configured identity. The change was written by Claude, not by the maintainer. This was raised explicitly before merge, with the option to strip and re-sign; the maintainer confirmed the sign-off stands. The DCO attestation is therefore deliberate rather than an accident of whose checkout the work happened in.

*Assisted-by: Claude Opus 5, which diagnosed the mechanism from the task extras, transcripts and reviewer pod logs, wrote the change and its tests, and proved the tests fail against unmodified main. Written by hand rather than dispatched to the Foreman coder deliberately: using an unreliable reviewer to validate a fix to reviewer reliability is circular.*

