### PR TITLE
feat(foreman): pre-flight staleness detection for already-addressed issues

### DIFF
--- a/pkg/foreman/agent/staleness_check.go
+++ b/pkg/foreman/agent/staleness_check.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Staleness pre-flight check.
+//
+// Issues go stale. The tree moves, a fix lands, and the issue text still
+// describes the original symptom. An agent handed that text will faithfully
+// implement it — including by REMOVING the fix that superseded it. Observed in
+// this fleet: an issue was queued whose fix was already on the default branch;
+// the live code carried a comment citing that very issue number and explaining
+// the trade-off it resolved. The coder deleted the field and its comment,
+// reintroducing the regression the comment warned about, and rewrote the tests
+// to match. Coder, gate and reviewer all passed it. A second issue in the same
+// batch had been fully superseded by a merged PR; it was caught only because a
+// human checked before queueing.
+//
+// This file detects the staleness. It is deliberately built as PURE functions
+// that take already-gathered text (git-log output, grep output) and return
+// findings. Nothing here shells out: taking strings makes every signal
+// unit-testable without a repository, which is the whole point. Where the
+// gather actually runs (dispatch time, wired to the executor or controller) is
+// a decision for a human; this package owns only the detection.
+package agent
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// stalenessToggleEnv toggles the pre-flight staleness check off. Setting it to
+// "0" disables; any other value (including unset) leaves it ENABLED.
+const stalenessToggleEnv = "FOREMAN_STALENESS_CHECK"
+
+// stalenessSignals carries what the pre-flight check found for a single issue.
+// Each field holds deduplicated, stably-sorted evidence: the commits that
+// reference the issue and the live-code locations that cite it.
+type stalenessSignals struct {
+	// Issue is the issue number the signals were gathered for.
+	Issue int
+	// Commits are commit references (short SHAs) whose subject references the
+	// issue, gathered from `git log --oneline --grep="#N"` on the base branch.
+	Commits []string
+	// CodeRefs are "file:line" entries in live code or comments that cite the
+	// issue, gathered from `grep -rn "#N"` across the tree.
+	CodeRefs []string
+}
+
+// found reports whether the check surfaced any staleness evidence at all.
+func (s stalenessSignals) found() bool {
+	return len(s.Commits) > 0 || len(s.CodeRefs) > 0
+}
+
+// commitsReferencingIssue parses the output of
+// `git log --oneline --grep="#N"` into commit references. Each non-empty line
+// is one commit; its first whitespace-delimited field (the short SHA) is the
+// reference returned. An empty input yields an empty slice, never nil, and
+// never panics. Results are deduplicated and returned in stable sorted order.
+func commitsReferencingIssue(gitLogOutput string, issue int) []string {
+	_ = issue // the grep already filtered; the number is retained for symmetry.
+	refs := make([]string, 0, 4)
+	for _, line := range strings.Split(gitLogOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		refs = append(refs, fields[0])
+	}
+	return dedupeSorted(refs)
+}
+
+// codeCitingIssue parses the output of `grep -rn "#N"` into "file:line"
+// entries. A line contributes its "file:line" prefix when it cites the issue.
+//
+// The match is exact: it must match `#1550` but NOT `#15500` (a longer number
+// sharing a numeric prefix) and NOT `#155` (a shorter number). The guard is on
+// the right edge of the number — the character following the digits must not
+// itself be a digit — so `#15500` is never mistaken for `#1550`.
+//
+// An empty input yields an empty slice, never nil, and never panics. Results
+// are deduplicated and returned in stable sorted order.
+func codeCitingIssue(grepOutput string, issue int) []string {
+	refs := make([]string, 0, 4)
+	for _, line := range strings.Split(grepOutput, "\n") {
+		if line == "" {
+			continue
+		}
+		if !lineCitesIssue(line, issue) {
+			continue
+		}
+		refs = append(refs, fileLineOf(line))
+	}
+	return dedupeSorted(refs)
+}
+
+// lineCitesIssue reports whether line cites `#<issue>` as a complete number:
+// the `#` is immediately followed by exactly the issue's digits, and the
+// character after those digits (if any) is not a digit. This is what keeps
+// `#15500` from matching `#1550` and `#155` from matching `#1550`.
+func lineCitesIssue(line string, issue int) bool {
+	target := fmt.Sprintf("#%d", issue)
+	for i := 0; i+len(target) <= len(line); i++ {
+		if line[i] != '#' {
+			continue
+		}
+		if !strings.HasPrefix(line[i:], target) {
+			continue
+		}
+		end := i + len(target)
+		if end < len(line) && isDigit(line[end]) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// fileLineOf extracts the "file:line" prefix from a `grep -rn` output line,
+// whose shape is "file:line:content". It returns the first two
+// colon-separated fields joined by a colon. A line with no colon is returned
+// as-is so the caller still records something for it.
+func fileLineOf(grepLine string) string {
+	parts := strings.SplitN(grepLine, ":", 3)
+	switch len(parts) {
+	case 0:
+		return grepLine
+	case 1:
+		return parts[0]
+	default:
+		return parts[0] + ":" + parts[1]
+	}
+}
+
+// stalenessDisabled reports whether the pre-flight staleness check has been
+// turned off via FOREMAN_STALENESS_CHECK=="0". Default (unset or any other
+// value) is ENABLED, so this returns false.
+func stalenessDisabled() bool {
+	return os.Getenv(stalenessToggleEnv) == "0"
+}
+
+// gatherStaleness assembles the pure signals from already-gathered text. It is
+// the single entry point a future call site uses: it never shells out and is
+// safe to call with empty strings (which yields an empty, non-founding result).
+func gatherStaleness(issue int, gitLogOutput, grepOutput string) stalenessSignals {
+	return stalenessSignals{
+		Issue:    issue,
+		Commits:  commitsReferencingIssue(gitLogOutput, issue),
+		CodeRefs: codeCitingIssue(grepOutput, issue),
+	}
+}
+
+// checkStaleness is the end-to-end assembly a future call site would use: it
+// respects the FOREMAN_STALENESS_CHECK toggle and returns the note to attach
+// to a task — an empty string when the check is disabled or when nothing was
+// found. It is pure with respect to its text inputs and safe to call with
+// empty strings. Where the gather actually runs is a decision for a human;
+// this function is the reusable seam between the gathered text and the note.
+func checkStaleness(issue int, gitLogOutput, grepOutput string) string {
+	if stalenessDisabled() {
+		return ""
+	}
+	return stalenessNote(gatherStaleness(issue, gitLogOutput, grepOutput))
+}
+
+// stalenessNote renders the signals into a short human-readable note suitable
+// for attaching to a task's extra map. It names what was found so the coder
+// must read the citing code before editing and the reviewer receives the same
+// references as required context for its regression check. An empty note is
+// returned when nothing was found (or, by the caller, when the check is
+// disabled).
+func stalenessNote(s stalenessSignals) string {
+	if !s.found() {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Staleness pre-flight for #%d: the tree may already address this issue.", s.Issue)
+	if len(s.Commits) > 0 {
+		fmt.Fprintf(&b, " %d commit(s) reference it: %s.", len(s.Commits), strings.Join(s.Commits, ", "))
+	}
+	if len(s.CodeRefs) > 0 {
+		fmt.Fprintf(&b, " Live code cites it at: %s.", strings.Join(s.CodeRefs, ", "))
+	}
+	b.WriteString(" Read these before editing; declare whether this work extends or replaces the cited code.")
+	return b.String()
+}
+
+// isDigit reports whether c is an ASCII decimal digit.
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+// dedupeSorted removes duplicate strings and returns them in stable sorted
+// order. It always returns a non-nil slice (empty input yields an empty, not
+// nil, slice).
+func dedupeSorted(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/foreman/agent/staleness_check_test.go
+++ b/pkg/foreman/agent/staleness_check_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// setToggle sets FOREMAN_STALENESS_CHECK for the duration of a test and
+// restores the prior value on cleanup.
+func setToggle(t *testing.T, val string) {
+	t.Helper()
+	t.Setenv(stalenessToggleEnv, val)
+}
+
+func TestCommitsReferencingIssue_TwoCommits(t *testing.T) {
+	out := `a1b2c3d fix: handle case from #1550
+e4f5g6h revert: #1550 workaround`
+	got := commitsReferencingIssue(out, 1550)
+	want := []string{"a1b2c3d", "e4f5g6h"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("commitsReferencingIssue = %q, want %q", got, want)
+	}
+}
+
+func TestCommitsReferencingIssue_Empty(t *testing.T) {
+	got := commitsReferencingIssue("", 1550)
+	if got == nil {
+		t.Fatalf("commitsReferencingIssue(\"\") = nil, want an empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("commitsReferencingIssue(\"\") = %q, want empty", got)
+	}
+}
+
+func TestCodeCitingIssue_FourteenTwo(t *testing.T) {
+	out := "internal/foo/bar.go:42: // see #1550"
+	got := codeCitingIssue(out, 1550)
+	want := []string{"internal/foo/bar.go:42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("codeCitingIssue = %q, want %q", got, want)
+	}
+}
+
+func TestCodeCitingIssue_NoLongerNumberPrefix(t *testing.T) {
+	// #15500 shares the numeric prefix 1550 but is a different issue number.
+	out := "pkg/foo.go:10: // see #15500 for the real fix"
+	got := codeCitingIssue(out, 1550)
+	if len(got) != 0 {
+		t.Fatalf("codeCitingIssue matched #15500 for issue 1550 = %q, want empty", got)
+	}
+}
+
+func TestCodeCitingIssue_NoShorterNumberSuffix(t *testing.T) {
+	// #155 is a different issue number; it must not match issue 1550.
+	out := "pkg/foo.go:10: // see #155 for context"
+	got := codeCitingIssue(out, 1550)
+	if len(got) != 0 {
+		t.Fatalf("codeCitingIssue matched #155 for issue 1550 = %q, want empty", got)
+	}
+}
+
+func TestCodeCitingIssue_DuplicatesCollapse(t *testing.T) {
+	out := "internal/foo/bar.go:42: // see #1550\n" +
+		"internal/foo/bar.go:42: // see #1550\n" +
+		"internal/foo/bar.go:42: // again #1550"
+	got := codeCitingIssue(out, 1550)
+	want := []string{"internal/foo/bar.go:42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("codeCitingIssue duplicates = %q, want %q", got, want)
+	}
+}
+
+func TestStalenessStableOrder(t *testing.T) {
+	// Deduplication and sorted order must be stable: the same multiset of input
+	// lines, in different orders, yields identical output.
+	logA := "zeta111 fix: #1550\nalpha000 fix: #1550\nzeta111 fix: #1550\n"
+	logB := "alpha000 fix: #1550\nzeta111 fix: #1550\nalpha000 fix: #1550\n"
+	if got := commitsReferencingIssue(logA, 1550); !reflect.DeepEqual(got, []string{"alpha000", "zeta111"}) {
+		t.Fatalf("commitsReferencingIssue order (A) = %q, want [alpha000 zeta111]", got)
+	}
+	if got := commitsReferencingIssue(logB, 1550); !reflect.DeepEqual(got, []string{"alpha000", "zeta111"}) {
+		t.Fatalf("commitsReferencingIssue order (B) = %q, want [alpha000 zeta111]", got)
+	}
+
+	grepA := "zzz.go:9: #1550\naaa.go:1: #1550\nzzz.go:9: #1550\n"
+	grepB := "aaa.go:1: #1550\nzzz.go:9: #1550\naaa.go:1: #1550\n"
+	want := []string{"aaa.go:1", "zzz.go:9"}
+	if got := codeCitingIssue(grepA, 1550); !reflect.DeepEqual(got, want) {
+		t.Fatalf("codeCitingIssue order (A) = %q, want %q", got, want)
+	}
+	if got := codeCitingIssue(grepB, 1550); !reflect.DeepEqual(got, want) {
+		t.Fatalf("codeCitingIssue order (B) = %q, want %q", got, want)
+	}
+}
+
+func TestStalenessDisabledReportsNothing(t *testing.T) {
+	setToggle(t, "0")
+	log := "a1b2c3d fix: #1550"
+	grep := "internal/foo/bar.go:42: // see #1550"
+	if got := checkStaleness(1550, log, grep); got != "" {
+		t.Fatalf("checkStaleness with toggle=0 = %q, want empty string", got)
+	}
+}
+
+func TestCheckStalenessEnabledReportsNote(t *testing.T) {
+	setToggle(t, "")
+	log := "a1b2c3d fix: #1550"
+	grep := "internal/foo/bar.go:42: // see #1550"
+	got := checkStaleness(1550, log, grep)
+	if got == "" {
+		t.Fatalf("checkStaleness with evidence returned empty, want a non-empty note")
+	}
+}
+
+func TestStalenessNote_NamesFindings(t *testing.T) {
+	sig := stalenessSignals{
+		Issue:    1550,
+		Commits:  []string{"a1b2c3d"},
+		CodeRefs: []string{"internal/foo/bar.go:42"},
+	}
+	note := stalenessNote(sig)
+	for _, want := range []string{"#1550", "a1b2c3d", "internal/foo/bar.go:42"} {
+		if !strings.Contains(note, want) {
+			t.Fatalf("note missing %q; got:\n%s", want, note)
+		}
+	}
+}
+
+func TestStalenessNote_EmptyWhenNothingFound(t *testing.T) {
+	if got := stalenessNote(stalenessSignals{Issue: 1550}); got != "" {
+		t.Fatalf("stalenessNote with no evidence = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## What

Pure-function detection for whether the target repository already addressed an issue, so stale work can be flagged before a coder starts.

## Why

Refs #1550

Part of #1548.

Issues go stale. The tree moves, a fix lands, and the issue text still describes the original symptom. An agent handed that text will faithfully implement it, including by removing the fix that superseded it.

The issue records exactly that: a coder deleted a field whose comment cited the very issue number and explained the trade-off it resolved, reintroducing the regression the comment warned about, and rewrote the tests to match. Coder, gate and reviewer all passed it.

Not hypothetical for this fleet. On 2026-08-15 two issues in one batch had already been fixed by merged PRs. Both were caught only because a human checked before queueing, and each would otherwise have consumed a coder slot.

## How

New `pkg/foreman/agent/staleness_check.go`. The detection is built as **pure functions taking already-gathered command output**, not as code that shells out to git. That is deliberate: taking strings makes the logic unit-testable without a repository, which is where the real risk lives.

- `commitsReferencingIssue(gitLogOutput string, issue int) []string` parses `git log --oneline --grep` output.
- `codeCitingIssue(grepOutput string, issue int) []string` parses `grep -rn` output into `file:line` entries.
- `stalenessDisabled()` reads `FOREMAN_STALENESS_CHECK=0`. Default enabled.
- A note assembler turns the signals into a short human-readable summary naming what was found.

**The interesting part is the matcher.** A naive substring search for `#1550` also matches `#15500`, and a search for `#155` matches inside `#1550`. `lineCitesIssue` requires the `#` to be followed by exactly the issue's digits, with the next character (if any) not a digit:

```go
// This is what keeps `#15500` from matching `#1550` and `#155` from
// matching `#1550`.
```

Both directions have their own test.

## Scope note

Dispatch-time wiring is deliberately **not** included. Where the gather runs (operator, agent, or queueing tooling) is a design decision, and threading it through would have made this diff hard to review against the issue. The pure functions plus tests are the reusable half and stand alone.

## Verification

- `go test ./pkg/foreman/agent/ -count=1` -> **ok, 30.0s**
- `gofmt` and `go vet` clean

11 test functions: two-commit and empty git-log parsing, `file:line` extraction, the longer-number guard (`#15500`), the shorter-number guard (`#155`), duplicate collapse, stable ordering, the toggle, and note assembly both populated and empty.

Both new files are new, so the tests cannot compile without the implementation; coupling is inherent rather than incidental.

## Checklist

- [x] Tests added/updated - 11 cases including both numeric-prefix guards
- [x] `make test` passes locally - `./pkg/foreman/agent/`
- [x] `make lint` passes locally - `gofmt` and `go vet` clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **bot-only, see below**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - n/a, no wiring yet so no user-visible behaviour change

## Sign-off

Commits carry `Signed-off-by: Foreman Bot`. Per CONTRIBUTING.md a human sign-off is required before merge:

```
git commit --amend -s --no-edit && git push --force-with-lease
```

*Assisted-by: Qwen3.8-27B via the Foreman harness, on two DGX Sparks behind one LLMKube InferenceService. Reviewed-by: Claude, which read the full diff, confirmed the scope, checked the numeric-prefix matcher against both traps, and ran the package suite. The automated reviewer returned GO, but its transcript shows it never diffed the branch (`diff --git: 0`), so that verdict was not treated as evidence; see #1570. The maintainer scoped this batch and directed the PR to be opened.*
