### PR TITLE
feat(foreman): mutation-check decision logic (revert the fix, require a test to fail)

### DIFF
--- a/pkg/foreman/agent/mutation_check.go
+++ b/pkg/foreman/agent/mutation_check.go
@@ -1,0 +1,130 @@
+package agent
+
+// mutation_check.go holds the pure decision logic for the gate's mutation
+// check (#1555): a test added alongside a fix must actually constrain that
+// fix. The mechanical test is that reverting the non-test hunks must break at
+// least one new or modified test; zero failures means the tests are inert.
+//
+// This file is deliberately free of any I/O. It does not run git, does not
+// execute tests, and does not touch the gate Job template. The revert step and
+// test execution live in the gate Job; this package only turns the Job's
+// outputs (a diff's file list and the names of tests that failed on revert)
+// into a decision. Keeping it a pure function of its inputs is what makes it
+// unit-testable without a workspace, and it is the seam a later, larger change
+// can wire into the Job.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// jsTestSuffixes are the JS/TS test and spec file suffixes the gate profile
+// cares about. They are matched as full suffixes against the base name, never
+// with a substring contains check: "contest.go" must not be mistaken for a
+// test file just because it contains the letters "test".
+var jsTestSuffixes = []string{
+	".test.ts",
+	".test.tsx",
+	".test.js",
+	".test.jsx",
+	".spec.ts",
+	".spec.tsx",
+	".spec.js",
+	".spec.jsx",
+}
+
+// isTestPath reports whether p names a test file, following the Go, JS/TS, and
+// Python conventions the gate already knows about:
+//
+//   - Go:    *_test.go
+//   - JS/TS: *.test.{ts,tsx,js,jsx} and *.spec.{ts,tsx,js,jsx}
+//   - Python: test_*.py and *_test.py
+//
+// Matching is done on the base name with strict suffix/prefix checks, so a file
+// like "contest.go" (which contains "test" but is not a test file) is
+// correctly rejected.
+func isTestPath(p string) bool {
+	base := filepath.Base(p)
+
+	// Go test files. The full "_test.go" suffix (including the underscore) is
+	// what distinguishes a test file from something like "contest.go".
+	if strings.HasSuffix(base, "_test.go") {
+		return true
+	}
+
+	// JS/TS test and spec files.
+	for _, suf := range jsTestSuffixes {
+		if strings.HasSuffix(base, suf) {
+			return true
+		}
+	}
+
+	// Python test files: leading "test_" or trailing "_test_", both on a .py.
+	if strings.HasSuffix(base, ".py") {
+		if strings.HasPrefix(base, "test_") || strings.HasSuffix(base, "_test.py") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// splitDiffPaths partitions a diff's file list into test files and everything
+// else. Both returned slices are sorted and are non-nil even when the input is
+// nil or empty, so callers can compare lengths without guarding against nil.
+func splitDiffPaths(paths []string) (testPaths, nonTestPaths []string) {
+	testPaths = []string{}
+	nonTestPaths = []string{}
+	for _, p := range paths {
+		if isTestPath(p) {
+			testPaths = append(testPaths, p)
+		} else {
+			nonTestPaths = append(nonTestPaths, p)
+		}
+	}
+	sort.Strings(testPaths)
+	sort.Strings(nonTestPaths)
+	return testPaths, nonTestPaths
+}
+
+// mutationCheckApplicable reports whether the mutation check is meaningful for
+// this diff. It is meaningful only when the branch changed BOTH production
+// code and tests: there must be something to revert (non-test changes) and
+// something to verify against that revert (test changes). When either side is
+// empty the check would produce a false positive, so it is reported as
+// not-applicable with a short reason rather than as a finding.
+func mutationCheckApplicable(testPaths, nonTestPaths []string) (bool, string) {
+	if len(nonTestPaths) == 0 {
+		return false, "diff changes no production code; nothing to revert, so the mutation check is not applicable"
+	}
+	if len(testPaths) == 0 {
+		return false, "diff changes no tests; nothing to verify against the revert, so the mutation check is not applicable"
+	}
+	return true, "diff changes both production code and tests; the mutation check applies"
+}
+
+// mutationFindingFromResults turns the names of the tests that failed after the
+// non-test hunks were reverted into the check's verdict.
+//
+//   - At least one failure: the tests are load-bearing (ok=true). The note
+//     names WHICH test(s) failed so the result shows what is actually
+//     constraining the fix, not merely that something is.
+//   - Zero failures: the new tests pass with the fix reverted, which means they
+//     do not constrain it. That is a finding (ok=false), stated plainly.
+func mutationFindingFromResults(failures []string) (ok bool, note string) {
+	if len(failures) == 0 {
+		return false, "new tests pass with the fix reverted; they do not constrain the change"
+	}
+	return true, fmt.Sprintf("test(s) failed with the fix reverted and are load-bearing: %s", strings.Join(failures, ", "))
+}
+
+// mutationCheckDisabled reports whether the mutation check has been explicitly
+// turned off via the FOREMAN_MUTATION_CHECK environment variable. The default
+// (unset or any value other than "0") is ENABLED; only the literal "0"
+// disables it, so a stray "1" or empty value never silences the check.
+func mutationCheckDisabled() bool {
+	return os.Getenv("FOREMAN_MUTATION_CHECK") == "0"
+}

--- a/pkg/foreman/agent/mutation_check_test.go
+++ b/pkg/foreman/agent/mutation_check_test.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIsTestPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"foo_test.go", true},
+		{"a/b/x.test.ts", true},
+		{"x.spec.tsx", true},
+		{"test_x.py", true},
+		{"x_test.py", true},
+		{"foo.go", false},
+		{"testdata/x.go", false},
+		{"contest.go", false}, // substring trap: contains "test" but is not a test file
+		{"README.md", false},
+		// additional coverage
+		{"x.test.tsx", true},
+		{"x.test.js", true},
+		{"x.test.jsx", true},
+		{"x.spec.ts", true},
+		{"x.spec.js", true},
+		{"x.spec.jsx", true},
+		{"test.py", false},    // no "test_" prefix, no "_test.py" suffix
+		{"contest.go", false}, // repeated to be explicit
+		{"mytest.go", false},  // ends in "test.go" but not "_test.go"
+	}
+	for _, tc := range cases {
+		if got := isTestPath(tc.path); got != tc.want {
+			t.Errorf("isTestPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestSplitDiffPathsPartitionsAndSorts(t *testing.T) {
+	input := []string{
+		"zeta.go",
+		"a_test.go",
+		"beta/b.test.ts",
+		"gamma.py",
+		"delta_test.go",
+		"epsilon/x_test.py",
+	}
+	tests, nonTests := splitDiffPaths(input)
+
+	wantTests := []string{"a_test.go", "beta/b.test.ts", "delta_test.go", "epsilon/x_test.py"}
+	wantNonTests := []string{"gamma.py", "zeta.go"}
+
+	if !reflect.DeepEqual(tests, wantTests) {
+		t.Errorf("testPaths = %v, want %v", tests, wantTests)
+	}
+	if !reflect.DeepEqual(nonTests, wantNonTests) {
+		t.Errorf("nonTestPaths = %v, want %v", nonTests, wantNonTests)
+	}
+
+	// partition: every input accounted for exactly once
+	if len(tests)+len(nonTests) != len(input) {
+		t.Errorf("partition lost files: got %d total, want %d", len(tests)+len(nonTests), len(input))
+	}
+}
+
+func TestSplitDiffPathsNilInput(t *testing.T) {
+	tests, nonTests := splitDiffPaths(nil)
+	if tests == nil {
+		t.Error("testPaths is nil; want an empty non-nil slice")
+	}
+	if nonTests == nil {
+		t.Error("nonTestPaths is nil; want an empty non-nil slice")
+	}
+	if len(tests) != 0 || len(nonTests) != 0 {
+		t.Errorf("splitDiffPaths(nil) = %v, %v; want both empty", tests, nonTests)
+	}
+}
+
+func TestMutationCheckApplicable(t *testing.T) {
+	if ok, _ := mutationCheckApplicable([]string{"a_test.go"}, []string{}); ok {
+		t.Error("applicable = true for test-only diff; want false (nothing to revert)")
+	}
+	if ok, _ := mutationCheckApplicable([]string{}, []string{"a.go"}); ok {
+		t.Error("applicable = true for no-new-tests diff; want false (nothing to verify)")
+	}
+	if ok, reason := mutationCheckApplicable([]string{"a_test.go"}, []string{"a.go"}); !ok {
+		t.Errorf("applicable = false, want true when both sides present (reason: %q)", reason)
+	}
+}
+
+func TestMutationFindingFromResults(t *testing.T) {
+	// One failure: ok, and the note names that test.
+	ok, note := mutationFindingFromResults([]string{"TestCalc_Add"})
+	if !ok {
+		t.Fatalf("ok = false, want true when a test failed on revert")
+	}
+	if note != "test(s) failed with the fix reverted and are load-bearing: TestCalc_Add" {
+		t.Errorf("note = %q, want it to name TestCalc_Add", note)
+	}
+
+	// Zero failures: finding, and the note states the tests pass with the fix reverted.
+	ok, note = mutationFindingFromResults(nil)
+	if ok {
+		t.Error("ok = true, want false when no test failed on revert")
+	}
+	if note != "new tests pass with the fix reverted; they do not constrain the change" {
+		t.Errorf("note = %q, want it to state the tests pass with the fix reverted", note)
+	}
+}
+
+func TestMutationCheckDisabled(t *testing.T) {
+	t.Setenv("FOREMAN_MUTATION_CHECK", "0")
+	if !mutationCheckDisabled() {
+		t.Error("mutationCheckDisabled() = false, want true when FOREMAN_MUTATION_CHECK=0")
+	}
+
+	t.Setenv("FOREMAN_MUTATION_CHECK", "1")
+	if mutationCheckDisabled() {
+		t.Error("mutationCheckDisabled() = true, want false when FOREMAN_MUTATION_CHECK=1 (default enabled)")
+	}
+}


### PR DESCRIPTION
## What

Pure decision logic for a mutation check: given a diff's file list and the results of running its tests with the fix reverted, decide whether the new tests actually constrain the change.

## Why

Refs #1555

Part of #1548.

A branch can add substantial test code that never exercises the behaviour it claims to cover. The gate reports the tests pass, which is true and uninformative. If reverting the fix does not break the new tests, the tests do not test the fix.

The issue calls this "the single check most often applied by hand when auditing agent output", and that matches experience here: it was applied by hand to four pull requests on 2026-08-15/16. It is fully mechanical and should not be manual.

It also targets a measured weakness. Across two days of agent-authored branches on this fleet, every defect found by a human reviewer was a variant of the same thing: tests that confirm the implementation rather than constrain it. One rail shipped seven tests, none covering the defect class the rail exists for. Another added a guard whose test asserted only the quiet case, so it would have passed if the function returned empty unconditionally, which is precisely the regression the guard prevents.

## How

New `pkg/foreman/agent/mutation_check.go`, four pure functions plus a toggle:

- `isTestPath(p string) bool` for Go, JS/TS and Python conventions.
- `splitDiffPaths(paths []string) (testPaths, nonTestPaths []string)`, stable-sorted, nil-safe.
- `mutationCheckApplicable(testPaths, nonTestPaths []string) (bool, string)` returns false with a distinct reason when either side is empty. This is the guard that keeps the check honest: a docs-only or test-only branch has nothing to mutate, and reporting a finding there would be a false positive.
- `mutationFindingFromResults(failures []string) (ok bool, note string)`. At least one failure means the tests are load-bearing, and the note names **which** test failed so the result shows what is load-bearing rather than merely that something is. Zero failures is a finding, and the note says plainly that the tests pass with the fix reverted.
- `mutationCheckDisabled()` reads `FOREMAN_MUTATION_CHECK=0`. Default enabled.

**On `isTestPath`:** the obvious wrong implementation is `strings.Contains(p, "test")`, which passes almost everything and then classifies `contest.go` as a test file. The implementation matches the full `_test.go` suffix and says so:

```go
// The full "_test.go" suffix (including the underscore) is what
// distinguishes a test file from something like "contest.go".
```

`contest.go` and `testdata/x.go` both have explicit false assertions.

## Scope note

Gate-Job wiring is deliberately **not** included. Performing the revert inside the Job (compute non-test hunks, revert them, run only the branch's new or modified tests, restore) is a substantially larger change to `run_gate_job.go` and the Job template, and bundling it here would make the diff unreviewable against the issue. This PR is the decision logic that change would call.

## Verification

- `go test ./pkg/foreman/agent/ -count=1` -> **ok, 39.6s**
- `gofmt` and `go vet` clean

Six test functions: `isTestPath` across 14 paths including both substring traps; partitioning with stable sort; nil input without panic; applicability false for test-only and false for no-new-tests and true when both present; finding-from-results in both directions with the failing test named; and the toggle.

Both files are new, so the tests cannot compile without the implementation.

## Checklist

- [x] Tests added/updated - 6 functions, including the `contest.go` substring trap
- [x] `make test` passes locally - `./pkg/foreman/agent/`
- [x] `make lint` passes locally - `gofmt` and `go vet` clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) - **bot-only, see below**
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - n/a, no wiring yet so no user-visible behaviour change

## Sign-off

Commits carry `Signed-off-by: Foreman Bot`. Per CONTRIBUTING.md a human sign-off is required before merge:

```
git commit --amend -s --no-edit && git push --force-with-lease
```

*Assisted-by: Qwen3.8-27B via the Foreman harness. The `contest.go` case was named in the dispatch intent precisely because a Contains-based implementation passes every other case and fails only that one; the model handled it, documented the reasoning in a comment, and added variants that were not asked for. Reviewed-by: Claude, which read the full diff, confirmed the scope held, verified the trap assertion, and ran the package suite. The automated reviewer returned GO, but its transcript shows it never diffed the branch (`diff --git: 0`), so that verdict was not treated as evidence; see #1570. The maintainer scoped this batch and directed the PR to be opened.*
