### PR TITLE
fix(foreman): restore the coder grounding rail's MCP prefix after the #1527 rename

### DIFF
--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -739,7 +739,7 @@ func clampInt32(n int) int32 {
 // (best-effort), never fatal.
 //
 // Ordering matters: Filter is an allow-list intersection, and MCP tools
-// are named dynamically (mcp/<server>/<tool>), so no real Agent's
+// are named dynamically (mcp__<server>__<tool>), so no real Agent's
 // spec.tools whitelist ever names one. Filtering the MCP tools alongside
 // the native ones (the pre-fix behavior) silently dropped every MCP tool
 // for every agent -- the feature was inert. Filtering native first, then

--- a/cmd/foreman-agent/main_test.go
+++ b/cmd/foreman-agent/main_test.go
@@ -67,7 +67,7 @@ func schemaNames(t *testing.T, r agent.ToolRegistry) []string {
 // for the v0.3 Foreman MCP fix: a non-empty Agent.spec.tools whitelist
 // must not drop MCP tools. Before the fix, makeRegistryFactory appended
 // MCP tools to the native slice and then ran Filter(ag.Spec.Tools) over
-// the combined set -- since MCP tool names (mcp/<server>/<tool>) are
+// the combined set -- since MCP tool names (mcp__<server>__<tool>) are
 // dynamic, no real whitelist ever names one, so Filter silently removed
 // every MCP tool. This test builds a whitelist that keeps read_file and
 // drops bash, and asserts the MCP tool survives regardless.
@@ -78,7 +78,7 @@ func TestAssembleAgentRegistry_MCPBypassesWhitelist(t *testing.T) {
 	}
 	whitelist := []string{"read_file"}
 	mcpTools := []foremantools.Tool{
-		&fakeAssembleTool{name: "mcp/context7/get-docs"},
+		&fakeAssembleTool{name: "mcp__context7__get-docs"},
 	}
 
 	r, err := assembleAgentRegistry(logr.Discard(), native, whitelist, mcpTools)
@@ -87,7 +87,7 @@ func TestAssembleAgentRegistry_MCPBypassesWhitelist(t *testing.T) {
 	}
 
 	got := schemaNames(t, r)
-	want := []string{"mcp/context7/get-docs", "read_file"}
+	want := []string{"mcp__context7__get-docs", "read_file"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("advertised tools = %v, want %v (bash must be filtered by the whitelist; "+
 			"the MCP tool must survive despite not being named in it)", got, want)
@@ -99,12 +99,12 @@ func TestAssembleAgentRegistry_MCPBypassesWhitelist(t *testing.T) {
 	}
 
 	// The MCP tool must be reachable, not just advertised.
-	res, err := r.Dispatch(context.Background(), "mcp/context7/get-docs", json.RawMessage(`{}`))
+	res, err := r.Dispatch(context.Background(), "mcp__context7__get-docs", json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Dispatch(mcp tool): %v", err)
 	}
-	if res.Output != "mcp/context7/get-docs result" {
-		t.Fatalf("Dispatch(mcp tool).Output = %q, want %q", res.Output, "mcp/context7/get-docs result")
+	if res.Output != "mcp__context7__get-docs result" {
+		t.Fatalf("Dispatch(mcp tool).Output = %q, want %q", res.Output, "mcp__context7__get-docs result")
 	}
 }
 
@@ -117,7 +117,7 @@ func TestAssembleAgentRegistry_EmptyWhitelistKeepsAllPlusMCP(t *testing.T) {
 		&fakeAssembleTool{name: "bash"},
 	}
 	mcpTools := []foremantools.Tool{
-		&fakeAssembleTool{name: "mcp/context7/get-docs"},
+		&fakeAssembleTool{name: "mcp__context7__get-docs"},
 	}
 
 	r, err := assembleAgentRegistry(logr.Discard(), native, nil, mcpTools)
@@ -126,7 +126,7 @@ func TestAssembleAgentRegistry_EmptyWhitelistKeepsAllPlusMCP(t *testing.T) {
 	}
 
 	got := schemaNames(t, r)
-	want := []string{"bash", "mcp/context7/get-docs", "read_file"}
+	want := []string{"bash", "mcp__context7__get-docs", "read_file"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("advertised tools = %v, want %v", got, want)
 	}

--- a/config/foreman/system-prompts/coder.md
+++ b/config/foreman/system-prompts/coder.md
@@ -56,9 +56,9 @@ when you call the terminal `submit_result` tool.
 - `submit_result(verdict, summary, commit_message?, extra?)` —
   terminal. The loop exits after this call.
 
-Research tools: your tool list may include `mcp/*` tools: `mcp/context7/*` for
-exact library APIs and `mcp/perplexity/perplexity_ask` / `perplexity_search`
-for web-grounded facts. See "Verify external facts" in Step 2 for when to use
+Research tools: your tool list may include `mcp__*` tools: `mcp__context7__*`
+for exact library APIs and `mcp__perplexity__perplexity_ask` /
+`mcp__perplexity__perplexity_search` for web-grounded facts. See "Verify external facts" in Step 2 for when to use
 them. When asking research tools about versions or "latest" anything, phrase
 queries as "as of today" or "the current latest" — never name a specific year
 from memory. Treat the date given in the task prompt as the current date;
@@ -101,8 +101,9 @@ Do not edit any files.
   external specific that is version sensitive or you are not certain is
   current (a runtime or CLI flag name/value, an API route or wire/URL format,
   a config key, a tool invocation, a library's current behavior), you MUST
-  confirm it with `mcp/perplexity/perplexity_ask` or `perplexity_search` (or
-  `mcp/context7/*` for exact library APIs) BEFORE writing code or a test that
+  confirm it with `mcp__perplexity__perplexity_ask` or
+  `mcp__perplexity__perplexity_search` (or `mcp__context7__*` for exact
+  library APIs) BEFORE writing code or a test that
   assumes it, and cite what you found. Guessing an external fact and shipping
   a test that matches your guess is a failure even if the gate goes green.
   Skip this only for stable, well established specifics you are already

--- a/pkg/foreman/agent/coder_grounding_gate.go
+++ b/pkg/foreman/agent/coder_grounding_gate.go
@@ -58,10 +58,11 @@ type groundingViolation struct {
 	RetrievedAlternatives []string
 }
 
-// context7Evidence gathers the content of every mcp/* tool result in the
-// transcript into an evidence corpus. The tool message's Name is the function
-// name; when a backend leaves Name empty we recover it from the assistant's
-// tool_call by ToolCallID.
+// context7Evidence gathers the content of every MCP tool result in the
+// transcript into an evidence corpus, matching on MCPToolNamePrefix so this
+// cannot drift from the name the mcp package actually registers. The tool
+// message's Name is the function name; when a backend leaves Name empty we
+// recover it from the assistant's tool_call by ToolCallID.
 func context7Evidence(transcript []oai.Message) []string {
 	callName := make(map[string]string)
 	for _, m := range transcript {
@@ -80,7 +81,7 @@ func context7Evidence(transcript []oai.Message) []string {
 		if name == "" {
 			name = callName[m.ToolCallID]
 		}
-		if strings.HasPrefix(name, "mcp/") {
+		if strings.HasPrefix(name, MCPToolNamePrefix) {
 			ev = append(ev, m.Content)
 		}
 	}

--- a/pkg/foreman/agent/coder_grounding_gate_test.go
+++ b/pkg/foreman/agent/coder_grounding_gate_test.go
@@ -16,9 +16,9 @@ func TestContext7Evidence_CollectsMCPToolResults(t *testing.T) {
 		{Role: oai.RoleUser, Content: "fix it"},
 		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{
 			{ID: "c1", Type: "function",
-				Function: oai.ToolCallFunction{Name: "mcp/context7/query-docs"}},
+				Function: oai.ToolCallFunction{Name: "mcp__context7__query-docs"}},
 		}},
-		{Role: oai.RoleTool, ToolCallID: "c1", Name: "mcp/context7/query-docs",
+		{Role: oai.RoleTool, ToolCallID: "c1", Name: "mcp__context7__query-docs",
 			Content: "vllm:request_success_total{finished_reason}"},
 		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{
 			{ID: "c2", Type: "function", Function: oai.ToolCallFunction{Name: "read_file"}},
@@ -37,7 +37,7 @@ func TestContext7Evidence_CollectsMCPToolResults(t *testing.T) {
 func TestContext7Evidence_CorrelatesByToolCallIDWhenNameEmpty(t *testing.T) {
 	tr := []oai.Message{
 		{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{
-			{ID: "c1", Type: "function", Function: oai.ToolCallFunction{Name: "mcp/context7/resolve-library-id"}},
+			{ID: "c1", Type: "function", Function: oai.ToolCallFunction{Name: "mcp__context7__resolve-library-id"}},
 		}},
 		{Role: oai.RoleTool, ToolCallID: "c1", Content: "/websites/vllm"},
 	}
@@ -118,13 +118,13 @@ func TestApplyCoderGroundingRail_RecordsViolation(t *testing.T) {
 	}
 	queryCall := oai.ToolCall{
 		ID: "c1", Type: "function",
-		Function: oai.ToolCallFunction{Name: "mcp/context7/query-docs"},
+		Function: oai.ToolCallFunction{Name: "mcp__context7__query-docs"},
 	}
 	lr := &LoopResult{
 		Transcript: []oai.Message{
 			{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{queryCall}},
 			{
-				Role: oai.RoleTool, ToolCallID: "c1", Name: "mcp/context7/query-docs",
+				Role: oai.RoleTool, ToolCallID: "c1", Name: "mcp__context7__query-docs",
 				Content: "vllm:request_success_total{finished_reason}",
 			},
 		},
@@ -155,10 +155,10 @@ func TestApplyCoderGroundingRailForTask_GatesOnIssueFixKind(t *testing.T) {
 		return &LoopResult{
 			Transcript: []oai.Message{
 				{Role: oai.RoleAssistant, ToolCalls: []oai.ToolCall{
-					{ID: "c1", Type: "function", Function: oai.ToolCallFunction{Name: "mcp/context7/query-docs"}},
+					{ID: "c1", Type: "function", Function: oai.ToolCallFunction{Name: "mcp__context7__query-docs"}},
 				}},
 				{
-					Role: oai.RoleTool, ToolCallID: "c1", Name: "mcp/context7/query-docs",
+					Role: oai.RoleTool, ToolCallID: "c1", Name: "mcp__context7__query-docs",
 					Content: "vllm:request_success_total{finished_reason}",
 				},
 			},

--- a/pkg/foreman/agent/mcp/registry.go
+++ b/pkg/foreman/agent/mcp/registry.go
@@ -31,7 +31,7 @@ import (
 // enabled is false or servers is empty, it returns base unchanged and a
 // no-op closer. The per-call record hook is built internally from log
 // (V(1) debug visibility); the authoritative audit is the run transcript,
-// where every MCP call already appears as a normal mcp/<server>/<tool> call.
+// where every MCP call already appears as a normal mcp__<server>__<tool> call.
 func Register(
 	ctx context.Context, log logr.Logger, base []tools.Tool, servers []ServerConfig, opts Options, enabled bool,
 ) (all []tools.Tool, closer func() error) {

--- a/pkg/foreman/agent/mcp/tool.go
+++ b/pkg/foreman/agent/mcp/tool.go
@@ -115,11 +115,11 @@ func newTools(
 	return out
 }
 
-// nameSeparator joins the namespace segments. It is "__" rather than "/"
-// because the OAI tool-call spec constrains function.name to
-// ^[a-zA-Z0-9_-]+$: a "/" makes every request carrying an MCP tool
-// malformed, and providers that validate reject it before the model runs.
-const nameSeparator = "__"
+// nameSeparator joins the namespace segments. It is defined in the agent
+// package, not here, so that transcript consumers there (the coder grounding
+// rail) match on the same prefix this builds rather than a hand-copied
+// literal that can drift out of step (#1527).
+const nameSeparator = agent.MCPNameSeparator
 
 // sanitizeNameSegment maps any character outside the OAI function-name set
 // to an underscore, so a server or tool advertising a dot, slash or space
@@ -142,7 +142,7 @@ func sanitizeNameSegment(s string) string {
 // used as the registry key. The remote tool is still called by its bare
 // name; see Execute.
 func (t *mcpTool) Name() string {
-	return "mcp" + nameSeparator + sanitizeNameSegment(t.server) +
+	return agent.MCPToolNamePrefix + sanitizeNameSegment(t.server) +
 		nameSeparator + sanitizeNameSegment(t.toolName)
 }
 

--- a/pkg/foreman/agent/mcp/tool_test.go
+++ b/pkg/foreman/agent/mcp/tool_test.go
@@ -448,3 +448,16 @@ func TestToolNameSanitisesSegments(t *testing.T) {
 		t.Errorf("Name() = %q, want %q", got, want)
 	}
 }
+
+// The coder grounding rail in the agent package identifies MCP results by
+// MCPToolNamePrefix. #1527 changed the separator here and left that literal
+// behind, so the rail matched nothing and silently collected no evidence on
+// every run. Pin the two together so a future rename cannot go one-sided.
+func TestToolNameCarriesAgentPackagePrefix(t *testing.T) {
+	tl := newTool(nil, "context7", "query-docs", Options{}, nil)
+	if got := tl.Name(); !strings.HasPrefix(got, agent.MCPToolNamePrefix) {
+		t.Errorf("Name() = %q, want prefix %q; transcript consumers in the agent "+
+			"package will not recognise this as an MCP tool result",
+			got, agent.MCPToolNamePrefix)
+	}
+}

--- a/pkg/foreman/agent/mcp_names.go
+++ b/pkg/foreman/agent/mcp_names.go
@@ -1,0 +1,18 @@
+package agent
+
+// MCPNameSeparator joins the segments of an MCP tool's namespaced name. It is
+// "__" rather than "/" because the OAI tool-call spec constrains function.name
+// to ^[a-zA-Z0-9_-]+$: a "/" makes every request carrying an MCP tool
+// malformed, and providers that validate reject it before the model runs
+// (#1527).
+const MCPNameSeparator = "__"
+
+// MCPToolNamePrefix is the prefix every MCP-provided tool name carries, so a
+// transcript consumer can tell an MCP result from a native tool's.
+//
+// It lives here rather than in pkg/foreman/agent/mcp because that package
+// already imports this one, and the two must not drift apart again: #1527
+// changed the separator in the mcp package but left this package's own "mcp/"
+// literal behind in the coder grounding rail, which then matched nothing and
+// silently collected no evidence on every run.
+const MCPToolNamePrefix = "mcp" + MCPNameSeparator

--- a/pkg/foreman/agent/tools/tools_test.go
+++ b/pkg/foreman/agent/tools/tools_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 // fakeMCPTool is a minimal Tool double standing in for a dynamically
-// discovered MCP tool (mcp/<server>/<tool>) in registry tests that
+// discovered MCP tool (mcp__<server>__<tool>) in registry tests that
 // exercise Add() without dialing a real MCP server.
 type fakeMCPTool struct {
 	name string
@@ -182,7 +182,7 @@ func TestRegistry_Dispatch_UnfilteredRegistryNoFalsePositives(t *testing.T) {
 // TestRegistry_FilterThenAdd pins the v0.3 Foreman MCP fix: MCP tools
 // must be appended AFTER the Agent.spec.tools whitelist Filter, not
 // before it. Filter is an allow-list intersection, and MCP tools are
-// named dynamically (mcp/<server>/<tool>), so no real Agent's
+// named dynamically (mcp__<server>__<tool>), so no real Agent's
 // spec.tools whitelist ever names one -- filtering them would silently
 // drop every MCP tool for every agent. Add() is the bypass: it's called
 // on the already-filtered registry, so MCP tools reach the model
@@ -201,13 +201,13 @@ func TestRegistry_FilterThenAdd(t *testing.T) {
 	}
 
 	// MCP tool is added AFTER Filter, so it bypasses the whitelist.
-	mcpTool := &fakeMCPTool{name: "mcp/context7/get-docs"}
+	mcpTool := &fakeMCPTool{name: "mcp__context7__get-docs"}
 	if err := filtered.Add(mcpTool); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 
 	got := filtered.Names()
-	want := []string{"mcp/context7/get-docs", "read_file", "submit_result"}
+	want := []string{"mcp__context7__get-docs", "read_file", "submit_result"}
 	if len(got) != len(want) {
 		t.Fatalf("Names() = %v, want %v", got, want)
 	}
@@ -226,7 +226,7 @@ func TestRegistry_FilterThenAdd(t *testing.T) {
 
 	// The mcp tool must actually be dispatchable, not just visible in
 	// Names() -- Add wires it into the same tools map Dispatch reads.
-	res, err := filtered.Dispatch(context.Background(), "mcp/context7/get-docs", json.RawMessage(`{}`))
+	res, err := filtered.Dispatch(context.Background(), "mcp__context7__get-docs", json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Dispatch(mcp tool): %v", err)
 	}
@@ -247,7 +247,7 @@ func TestRegistry_Add_SkipsDuplicatesReportsError(t *testing.T) {
 	}
 
 	dup := &fakeMCPTool{name: "read_file"} // collides with the native tool
-	fresh := &fakeMCPTool{name: "mcp/context7/get-docs"}
+	fresh := &fakeMCPTool{name: "mcp__context7__get-docs"}
 
 	err = r.Add(dup, fresh)
 	if err == nil {
@@ -260,7 +260,7 @@ func TestRegistry_Add_SkipsDuplicatesReportsError(t *testing.T) {
 	names := r.Names()
 	foundFresh := false
 	for _, n := range names {
-		if n == "mcp/context7/get-docs" {
+		if n == "mcp__context7__get-docs" {
 			foundFresh = true
 		}
 	}


### PR DESCRIPTION
## What

Point the coder grounding rail and the coder system prompt at the MCP tool names #1527 actually produces (`mcp__<server>__<tool>`), and share the prefix between the two packages so they cannot drift apart again.

## Why

Refs #1581

#1527 renamed MCP tool names from `mcp/<server>/<tool>` to `mcp__<server>__<tool>`, correctly: the OAI tool-call spec constrains `function.name` to `^[a-zA-Z0-9_-]+$`, and a `/` makes every request carrying an MCP tool malformed. It updated the `mcp` package and its tests, but not two consumers of the name.

**The grounding rail went dark.** `coder_grounding_gate.go` matched `strings.HasPrefix(name, "mcp/")`. No tool has carried that prefix since #1527, so `context7Evidence` returned an empty corpus and `applyCoderGroundingRail` returned early at its `len(evidence) == 0` guard. It is wired live on the coder path (`executor_native.go:1005`). The rail is advisory, so no verdict was affected, but a coder that queries context7 and then writes an identifier absent from the retrieved docs has not been flagged since #1527 merged.

Measured on `main` (827cad8c) by feeding `context7Evidence` both names:

```
tool name "mcp__context7__query-docs"  -> evidence items: 0
tool name "mcp/context7/query-docs"    -> evidence items: 1
```

**The system prompt advertised dead names.** `config/foreman/system-prompts/coder.md` told the coder to call `mcp/perplexity/perplexity_ask`, `perplexity_search` and `mcp/context7/*`. The registry cannot dispatch any of those, so a model following the prompt literally emits a call that fails.

## How

The root cause is that the prefix was a hand-copied literal in two packages, so a rename could land on one side only. `pkg/foreman/agent/mcp` already imports `pkg/foreman/agent`, so the constants go in the latter:

- New `pkg/foreman/agent/mcp_names.go` exports `MCPNameSeparator` and `MCPToolNamePrefix`.
- `mcp/tool.go` builds `Name()` from them instead of its own `"mcp"` + local separator.
- `coder_grounding_gate.go` matches on `MCPToolNamePrefix`.

A one-sided rename is now a compile error rather than a silent behaviour change. `TestToolNameCarriesAgentPackagePrefix` in the `mcp` package pins `Name()` to the agent package's prefix, which is the check that would have caught this originally: it can only live on the `mcp` side, since the import direction forbids `agent` from reaching into `mcp`.

The rest is the same drift: the `perplexity`/`context7` names in the coder prompt, and stale `mcp/<server>/<tool>` in comments and test fixtures across `mcp/registry.go`, `cmd/foreman-agent`, and `agent/tools`. A repo-wide grep for the old pattern is now clean.

No behaviour change for anyone not running MCP servers, and no API or CRD surface is touched.

## Verification

Run on this branch:

- `go test ./pkg/foreman/agent/... ./cmd/foreman-agent/... -count=1` -> **all ok** (16 packages). The four pre-existing grounding-gate tests were switched to the real tool names first and observed to fail (`context7Evidence = []`), then pass with the fix.
- `./bin/golangci-lint run ./...` -> **0 issues**
- `GOOS=linux ./bin/golangci-lint run ./...` -> **0 issues**
- `gofmt -l ./pkg ./cmd ./internal ./api` -> clean
- `go build ./...` -> clean

**Not done:** no live cluster run. This is unit-verified only, which is why the commit says `Refs #1581` rather than `Fixes`. Confirming the rail fires again on a real coder task needs a dispatch against a live agent with an MCP server attached.

`config/foreman/agents/*-coder.yaml` were checked for pasted copies of the affected prompt text; none contain it, so no manifest re-paste is needed.

## AI assistance

`Assisted-by: Claude Opus 5` (found the drift while auditing the 0.9.18 release diff for breaking changes, wrote the fix and the guard test, ran the verification above).

A human has not yet read this diff. It is offered for review.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran the affected packages: `./pkg/foreman/agent/...`, `./cmd/foreman-agent/...`)
- [x] `make lint` passes locally (host and `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - the coder system prompt is the user-facing surface here and is updated
