### PR TITLE
fix(controller): AND the arch requirement into nodeAffinity instead of ORing a new term

### DIFF
--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -606,12 +606,36 @@ func applyArchAffinity(deployment *appsv1.Deployment, backend RuntimeBackend, is
 	}
 }
 
-// applyArchNodeAffinity adds a required kubernetes.io/arch nodeAffinity term to
-// the pod spec, restricting scheduling to nodes whose architecture is in archs.
-// It merges into any existing affinity (user-provided or otherwise) rather than
-// overwriting it, so the user's other affinity rules keep applying.
+// applyArchNodeAffinity restricts scheduling to nodes whose architecture is in
+// archs, ANDing that requirement into whatever nodeAffinity is already present.
+//
+// nodeSelectorTerms are ORed and the matchExpressions within a single term are
+// ANDed, so the architecture requirement has to go *into* each existing term.
+// Appending a term of its own would widen placement instead of narrowing it:
+// the user's spec.affinity would become one of two alternatives and the pod
+// could schedule on any node of the right architecture, ignoring their pin
+// (#1583). preferredDuringScheduling is deliberately untouched, since it
+// expresses a preference rather than a constraint.
 func applyArchNodeAffinity(deployment *appsv1.Deployment, archs []string) {
-	affinity := deployment.Spec.Template.Spec.Affinity
+	values := make([]string, 0, len(archs))
+	for _, a := range archs {
+		if a != "" {
+			values = append(values, a)
+		}
+	}
+	if len(values) == 0 {
+		return
+	}
+	req := corev1.NodeSelectorRequirement{
+		Key:      corev1.LabelArchStable,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   values,
+	}
+
+	// Deep-copy before mutating: the pod spec's Affinity is assigned straight
+	// from isvc.Spec.Affinity, so editing terms in place would write into the
+	// cached InferenceService and re-append this requirement on every reconcile.
+	affinity := deployment.Spec.Template.Spec.Affinity.DeepCopy()
 	if affinity == nil {
 		affinity = &corev1.Affinity{}
 	}
@@ -622,29 +646,19 @@ func applyArchNodeAffinity(deployment *appsv1.Deployment, archs []string) {
 		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
 	}
 
-	values := make([]string, 0, len(archs))
-	for _, a := range archs {
-		if a != "" {
-			values = append(values, a)
+	selector := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if len(selector.NodeSelectorTerms) == 0 {
+		// No terms means every node qualifies, so the requirement stands alone
+		// as the only term. This still narrows rather than widens.
+		selector.NodeSelectorTerms = []corev1.NodeSelectorTerm{
+			{MatchExpressions: []corev1.NodeSelectorRequirement{req}},
+		}
+	} else {
+		for i := range selector.NodeSelectorTerms {
+			selector.NodeSelectorTerms[i].MatchExpressions = append(
+				selector.NodeSelectorTerms[i].MatchExpressions, req)
 		}
 	}
-	if len(values) == 0 {
-		return
-	}
-
-	term := corev1.NodeSelectorTerm{
-		MatchExpressions: []corev1.NodeSelectorRequirement{
-			{
-				Key:      corev1.LabelArchStable,
-				Operator: corev1.NodeSelectorOpIn,
-				Values:   values,
-			},
-		},
-	}
-	affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-		term,
-	)
 	deployment.Spec.Template.Spec.Affinity = affinity
 }
 

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1172,6 +1173,168 @@ func TestConstructDeployment_ArchAffinity(t *testing.T) {
 		pod := r.constructDeployment(isvc, model, nil, 1).Spec.Template.Spec
 		if got := archAffinityTerms(pod); got != nil {
 			t.Errorf("arch affinity values = %v, want none for multi-arch backend", got)
+		}
+	})
+
+	// nodeSelectorTerms are ORed, so the arch requirement must be ANDed into
+	// each of the user's existing terms as a matchExpression. Appending a term
+	// instead would make the user's own pin one of two alternatives and let the
+	// pod schedule anywhere of the right architecture (#1583).
+	t.Run("arch requirement is ANDed into the user's own affinity", func(t *testing.T) {
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Runtime: "llamacpp",
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
+									Key:      "nodepool",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"gpu-dedicated"},
+								}},
+							}},
+						},
+					},
+				},
+			},
+		}
+		r := &InferenceServiceReconciler{ModelCachePath: "/models", ModelCacheMode: ModelCacheModePerService}
+		orig := resolveBackend
+		resolveBackend = func(*inferencev1alpha1.InferenceService) RuntimeBackend { return &archAwareBackend{} }
+		defer func() { resolveBackend = orig }()
+
+		pod := r.constructDeployment(isvc, model, nil, 1).Spec.Template.Spec
+		terms := pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+		if len(terms) != 1 {
+			t.Fatalf("nodeSelectorTerms = %d, want 1; extra terms are ORed and make the "+
+				"user's nodepool pin optional: %+v", len(terms), terms)
+		}
+		var gotPool, gotArch bool
+		for _, expr := range terms[0].MatchExpressions {
+			switch expr.Key {
+			case "nodepool":
+				gotPool = true
+			case corev1.LabelArchStable:
+				gotArch = true
+				if !equalStrings(expr.Values, []string{"amd64"}) {
+					t.Errorf("arch values = %v, want [amd64]", expr.Values)
+				}
+			}
+		}
+		if !gotPool || !gotArch {
+			t.Errorf("term must AND both requirements; nodepool=%v arch=%v, expressions=%+v",
+				gotPool, gotArch, terms[0].MatchExpressions)
+		}
+	})
+
+	// With no user affinity there is nothing to AND into, so the constraint
+	// still has to materialise as its own term.
+	t.Run("arch requirement stands alone when the user set no affinity", func(t *testing.T) {
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+			Spec:       inferencev1alpha1.InferenceServiceSpec{Runtime: "llamacpp"},
+		}
+		r := &InferenceServiceReconciler{ModelCachePath: "/models", ModelCacheMode: ModelCacheModePerService}
+		orig := resolveBackend
+		resolveBackend = func(*inferencev1alpha1.InferenceService) RuntimeBackend { return &archAwareBackend{} }
+		defer func() { resolveBackend = orig }()
+
+		pod := r.constructDeployment(isvc, model, nil, 1).Spec.Template.Spec
+		terms := pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+		if len(terms) != 1 || len(terms[0].MatchExpressions) != 1 ||
+			terms[0].MatchExpressions[0].Key != corev1.LabelArchStable {
+			t.Fatalf("want a single term carrying only the arch expression, got %+v", terms)
+		}
+	})
+
+	// A user who pins placement with two alternative pools must keep both
+	// alternatives, each independently narrowed to the supported architecture.
+	t.Run("every user term is narrowed, not just the first", func(t *testing.T) {
+		userTerm := func(pool string) corev1.NodeSelectorTerm {
+			return corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key: "nodepool", Operator: corev1.NodeSelectorOpIn, Values: []string{pool},
+				}},
+			}
+		}
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Runtime: "llamacpp",
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{userTerm("pool-a"), userTerm("pool-b")},
+						},
+					},
+				},
+			},
+		}
+		r := &InferenceServiceReconciler{ModelCachePath: "/models", ModelCacheMode: ModelCacheModePerService}
+		orig := resolveBackend
+		resolveBackend = func(*inferencev1alpha1.InferenceService) RuntimeBackend { return &archAwareBackend{} }
+		defer func() { resolveBackend = orig }()
+
+		pod := r.constructDeployment(isvc, model, nil, 1).Spec.Template.Spec
+		terms := pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+		if len(terms) != 2 {
+			t.Fatalf("nodeSelectorTerms = %d, want the user's 2 alternatives preserved: %+v", len(terms), terms)
+		}
+		for i, term := range terms {
+			var hasArch bool
+			for _, expr := range term.MatchExpressions {
+				if expr.Key == corev1.LabelArchStable {
+					hasArch = true
+				}
+			}
+			if !hasArch {
+				t.Errorf("term[%d] has no arch requirement, so it is an unconstrained "+
+					"alternative: %+v", i, term.MatchExpressions)
+			}
+		}
+	})
+
+	// The pod spec's Affinity is assigned straight from isvc.Spec.Affinity, so
+	// ANDing the requirement in place would write into the cached
+	// InferenceService and stack another copy on every reconcile.
+	t.Run("does not mutate the InferenceService across repeated builds", func(t *testing.T) {
+		isvc := &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Runtime: "llamacpp",
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
+									Key:      "nodepool",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"gpu-dedicated"},
+								}},
+							}},
+						},
+					},
+				},
+			},
+		}
+		want := isvc.Spec.Affinity.DeepCopy()
+		r := &InferenceServiceReconciler{ModelCachePath: "/models", ModelCacheMode: ModelCacheModePerService}
+		orig := resolveBackend
+		resolveBackend = func(*inferencev1alpha1.InferenceService) RuntimeBackend { return &archAwareBackend{} }
+		defer func() { resolveBackend = orig }()
+
+		for i := range 3 {
+			pod := r.constructDeployment(isvc, model, nil, 1).Spec.Template.Spec
+			terms := pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			if len(terms) != 1 || len(terms[0].MatchExpressions) != 2 {
+				t.Fatalf("build %d: want 1 term of 2 expressions, got %+v", i+1, terms)
+			}
+		}
+		if !reflect.DeepEqual(isvc.Spec.Affinity, want) {
+			t.Errorf("constructDeployment mutated isvc.Spec.Affinity:\n got %+v\nwant %+v",
+				isvc.Spec.Affinity, want)
 		}
 	})
 }


### PR DESCRIPTION
## What

Add the `kubernetes.io/arch` requirement as a `matchExpression` on every existing `nodeSelectorTerm` rather than appending a term of its own, and deep-copy the affinity before mutating it.

## Why

Refs #1583

Kubernetes ORs `nodeSelectorTerms` and ANDs the `matchExpressions` within a single term. `applyArchNodeAffinity` appended a term, so it widened placement rather than narrowing it: a user's `spec.affinity` became one of two alternatives and the pod could schedule on any node of the right architecture, ignoring their pin. The doc comment asserted the opposite of what the code did ("the user's other affinity rules keep applying").

The path is directly reachable. `spec.affinity` is a user-settable field (`inferenceservice_types.go:327`) and is assigned to the Deployment at `deployment_builder.go:586`, immediately before `applyArchAffinity` runs at line 589.

Measured on `main` (827cad8c), with a user pinning to `nodepool In [gpu-dedicated]`:

```
resulting nodeSelectorTerms = 2 (ORed)
  term[0]: nodepool In [gpu-dedicated]
  term[1]: kubernetes.io/arch In [amd64]
```

**Not reachable in a release today.** All seven `RuntimeBackend` implementations return `nil` from `SupportedArchitectures()`, so `applyArchAffinity` is a no-op and 0.9.18 ships no behaviour change from #1544. This lands the correct semantics before a backend declares an architecture and makes the seam live, because the symptom then is a workload quietly ignoring its node pinning rather than anything that reads as an affinity bug.

## How

The requirement goes into each existing term, so every alternative the user expressed is independently narrowed:

```
  term[0]: nodepool In [gpu-dedicated] AND kubernetes.io/arch In [amd64]
```

With no terms present it stands alone as the only term, which still narrows, since an empty term list matches every node. `preferredDuringScheduling` is deliberately untouched: it is a preference, not a constraint, and ANDing into it would change its meaning.

One thing the in-place AND forces: the pod spec's `Affinity` is assigned straight from `isvc.Spec.Affinity` by pointer, so editing terms in place would write into the cached InferenceService and stack another copy of the requirement on every reconcile. The fix deep-copies first. That aliasing is pre-existing (the old `append` already reassigned fields on the shared `NodeAffinity`), but it becomes load-bearing here, so it is fixed and pinned rather than left implicit.

## Verification

Run on this branch:

- `KUBEBUILDER_ASSETS=... go test ./internal/controller/ -count=1` -> **ok, 258.935s** (738 envtest specs plus the plain unit tests)
- `./bin/golangci-lint run ./...` -> **0 issues**
- `GOOS=linux ./bin/golangci-lint run ./...` -> **0 issues**
- `gofmt -l ./internal ./api ./pkg ./cmd` -> clean
- `go build ./...` -> clean

Four subtests were added to `TestConstructDeployment_ArchAffinity` and observed to fail before the fix:

- `arch requirement is ANDed into the user's own affinity` -> was `nodeSelectorTerms = 2, want 1`
- `every user term is narrowed, not just the first` -> was `nodeSelectorTerms = 3, want 2`
- `arch requirement stands alone when the user set no affinity` -> guards the empty-terms path against regressing to a no-op
- `does not mutate the InferenceService across repeated builds` -> builds three times and compares `isvc.Spec.Affinity` against a pre-build deep copy

The three pre-existing subtests (`operator image gets arch affinity`, `user image bypasses arch affinity`, `no declared arch means no constraint`) pass unchanged.

**Not done:** no live cluster run, which is why the commit says `Refs #1583` rather than `Fixes`. Nothing in a live cluster exercises this until a backend declares an architecture, so there is currently no e2e path to observe.

## AI assistance

`Assisted-by: Claude Opus 5` (found the OR semantics while auditing the 0.9.18 release diff for breaking changes, wrote the fix and the tests, ran the verification above).

A human has not yet read this diff. It is offered for review.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran `./internal/controller/` with envtest assets, the affected package)
- [x] `make lint` passes locally (host and `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - no user-facing surface changes; the field is unreachable until a backend declares an architecture
