### PR TITLE
fix(controller): expose --dri-render-gid through the chart and stop defaulting it to the video group

### DIFF
--- a/charts/llmkube/templates/deployment.yaml
+++ b/charts/llmkube/templates/deployment.yaml
@@ -91,6 +91,12 @@ spec:
         # re-replace the OpenShift preset's deliberate 0 with 102 and break
         # SCC compatibility. Schema in values.schema.json enforces integer >= 0.
         - --default-fsgroup={{ .Values.controllerManager.initContainer.defaultFSGroup }}
+        {{- if .Values.controllerManager.driRenderGID }}
+        # Node-local render GID for Vulkan pods (#1572). Omitted entirely when
+        # 0/unset so the operator's own default (disabled) applies, rather than
+        # passing a value that cannot be correct on an unknown host.
+        - --dri-render-gid={{ .Values.controllerManager.driRenderGID }}
+        {{- end }}
         - --router-proxy-image={{ include "llmkube.routerProxyImage" . }}
         {{- with .Values.controllerManager.routerProxy.defaultLiteLLMURL }}
         - --default-litellm-url={{ . }}

--- a/charts/llmkube/tests/dri-render-gid_test.yaml
+++ b/charts/llmkube/tests/dri-render-gid_test.yaml
@@ -1,0 +1,42 @@
+suite: dri-render-gid operator flag
+templates:
+  - deployment.yaml
+
+tests:
+  # The default must stay off. There is no portable render GID, so shipping a
+  # value here would put a GID that cannot be correct on an unknown host into
+  # every Vulkan pod's supplementalGroups, where the failure is silent CPU
+  # fallback rather than an error (#1560, #1572).
+  - it: does not render --dri-render-gid by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --dri-render-gid=
+
+  - it: renders --dri-render-gid when the node's render group is set
+    set:
+      controllerManager.driRenderGID: 991
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --dri-render-gid=991
+
+  # An explicit 0 means "disabled" and must behave exactly like unset, not
+  # render --dri-render-gid=0.
+  - it: treats an explicit 0 as disabled
+    set:
+      controllerManager.driRenderGID: 0
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --dri-render-gid=0
+
+  # 44 is `video`, not `render`. The chart does not stop an operator setting
+  # it, but it must pass through verbatim rather than being special-cased.
+  - it: passes a non-default GID through verbatim
+    set:
+      controllerManager.driRenderGID: 44
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --dri-render-gid=44

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -98,6 +98,11 @@
             }
           }
         },
+        "driRenderGID": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "GID of the GPU nodes' DRI render group (owner of /dev/dri/renderD128), added to Vulkan InferenceService pods' supplementalGroups so the serving container can open the render node. 0 disables. No portable default exists: render is allocated dynamically (991 on Ubuntu 26.04) and GID 44 is video, which owns card0 rather than the render node. Read it with: stat -c '%g' /dev/dri/renderD128"
+        },
         "env": {
           "type": "array",
           "items": {

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -90,6 +90,27 @@ controllerManager:
     # values outside that range.
     defaultFSGroup: 102
 
+  # GID of your GPU nodes' DRI render group: the group that owns
+  # /dev/dri/renderD128. It is added to a Vulkan InferenceService pod's
+  # supplementalGroups so the serving container can open the render node.
+  # fsGroup does nothing for device access, so without this llama.cpp cannot
+  # open the render node, fails open, and serves from CPU at roughly half
+  # speed with no status condition (#1560).
+  #
+  # Defaults to 0 (disabled) because there is no portable value. The `render`
+  # group is allocated dynamically and differs per host: it is 991 on Ubuntu
+  # 26.04, and elsewhere something else again. GID 44 is NOT the render group,
+  # it is `video`, which owns card0 rather than the render node (#1572).
+  #
+  # Read the real value from one of your GPU nodes:
+  #
+  #   stat -c '%g' /dev/dri/renderD128
+  #
+  # Only applies on the Vulkan path, and never overrides a service that sets
+  # its own spec.podSecurityContext. On a fleet whose nodes disagree, set this
+  # to the majority value and override the outliers per service.
+  driRenderGID: 0
+
   # Additional environment variables
   env: []
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -213,17 +213,20 @@ func main() {
 			"write to a freshly-provisioned PVC. Set to 0 to disable on OpenShift, "+
 			"where the restricted-v2 SCC injects fsGroup from the namespace's allocated "+
 			"range and rejects pods with explicit values outside that range.")
-	flag.Int64Var(&driRenderGID, "dri-render-gid", 44,
+	flag.Int64Var(&driRenderGID, "dri-render-gid", 0,
 		"GID of the node's DRI render group (the group that owns /dev/dri/renderD128), "+
 			"added to a Vulkan InferenceService pod's supplementalGroups so the serving "+
 			"container can open the render node. fsGroup does nothing for device access, "+
 			"so without this the Vulkan container cannot open /dev/dri/renderD128 and "+
 			"llama.cpp fails open, serving from CPU at roughly half speed with no status "+
 			"condition (#1560). The GID is node-local and not knowable at admission, so it "+
-			"is a single operator-wide value: set it to the render GID of your GPU nodes. "+
-			"44 is the conventional Linux render group; set to 0 to disable (e.g. on "+
-			"OpenShift). Applied only on the Vulkan path, never to a user-supplied "+
-			"Spec.PodSecurityContext.")
+			"is a single operator-wide value: set it to the render GID of your GPU nodes, "+
+			"which you can read by running: stat -c '%g' /dev/dri/renderD128. "+
+			"There is no portable default, so this defaults to 0 (disabled): the render "+
+			"group is allocated dynamically and differs per host (991 on Ubuntu 26.04, "+
+			"for example), and the statically-allocated GID 44 is the video group, which "+
+			"owns card0 rather than the render node (#1572). Applied only on the Vulkan "+
+			"path, never to a user-supplied Spec.PodSecurityContext.")
 	flag.StringVar(&routerProxyImage, "router-proxy-image", "",
 		"Default container image for ModelRouter-managed router-proxy pods. "+
 			"Empty falls back to the controller's compiled-in default. "+

--- a/docs/strix-halo-onboarding.md
+++ b/docs/strix-halo-onboarding.md
@@ -291,6 +291,48 @@ lsmod | grep amdgpu
 dmesg | grep amdgpu
 ```
 
+### Ready, but serving from CPU at roughly half speed
+
+The pod is Ready and reports no error, but throughput is about half what the
+GPU should deliver. The serving container could not open `/dev/dri/renderD128`,
+so llama.cpp fell back to CPU without failing.
+
+`fsGroup` does nothing for device access. The container must carry the node's
+**render** group in `supplementalGroups`. Read the real GID from the node:
+
+```bash
+stat -c '%g' /dev/dri/renderD128
+```
+
+Then set it cluster-wide:
+
+```yaml
+# values.yaml
+controllerManager:
+  driRenderGID: 991   # whatever the command above printed
+```
+
+The GID is node-local and has no portable value, so this defaults to `0`
+(disabled). Two traps worth knowing:
+
+- **44 is not the render group.** It is `video`, which owns `card0`, not the
+  render node. Setting 44 grants access to the wrong device.
+- **`render` is dynamically allocated**, so it differs per host (991 on Ubuntu
+  26.04, other values elsewhere). Always read it rather than assuming.
+
+Confirm it took effect on a running pod:
+
+```bash
+kubectl get pod <pod> -o jsonpath='{.spec.securityContext.supplementalGroups}'
+kubectl exec <pod> -- ls -ln /dev/dri/
+```
+
+The GID in `supplementalGroups` must match the group shown against
+`renderD128`. On a fleet whose nodes disagree, set the chart value to the
+majority and override the outliers with `spec.podSecurityContext` on the
+individual InferenceService, which takes full ownership of
+`supplementalGroups`.
+
 ### Insufficient amd.com/gpu
 
 Device plugin or operator not running on the Strix Halo node. Check pod logs:

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -175,8 +175,9 @@ func resolveEnableServiceLinks(backend RuntimeBackend) *bool {
 // status condition (#1560). When the resolved runtime is Vulkan (vulkan) and
 // driRenderGID > 0, that GID is appended to supplementalGroups. The GID is
 // node-local and not knowable at admission, so it comes from the operator's
-// --dri-render-gid flag (default 44, the conventional Linux render group; set
-// to 0 to disable, e.g. on OpenShift). This is applied only on the Vulkan
+// --dri-render-gid flag, which defaults to 0 (disabled): `render` is allocated
+// dynamically and differs per host, so there is no portable default to ship
+// (#1572). This is applied only on the Vulkan
 // path; the CUDA and Metal paths are untouched. A user-supplied
 // Spec.PodSecurityContext is returned as-is, so setting it takes full
 // ownership of supplementalGroups (the per-service workaround for a node

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -83,8 +83,8 @@ type InferenceServiceReconciler struct {
 	// admission, so it comes from the operator's --dri-render-gid flag. Values
 	// <= 0 disable the default (e.g. on OpenShift); the field applies only on
 	// the Vulkan path and never to a user-supplied Spec.PodSecurityContext.
-	// Set via --dri-render-gid; default 44 (the conventional Linux render
-	// group).
+	// Set via --dri-render-gid; defaults to 0 (disabled) because `render` is
+	// dynamically allocated and has no portable value (#1572).
 	DRIRenderGID int64
 	// EmitScrapeAnnotations, when true, adds Prometheus annotation-discovery
 	// hints (prometheus.io/scrape, /path, /port) to every inference Pod, with


### PR DESCRIPTION
## What

Default `--dri-render-gid` to `0` instead of `44`, and plumb it through the Helm chart as `controllerManager.driRenderGID`.

## Why

Refs #1572

#1569 added the flag so a Vulkan serving container can open `/dev/dri/renderD128`, defaulted it to `44`, and described 44 as "the conventional Linux render group". **44 is the `video` group.** It owns `card0`, not the render node. Debian allocates 44 statically to `video`; `render` is allocated dynamically, so 44 is not the render group on any distro, and this is not a fleet-specific mismatch.

Measured on an Ubuntu 26.04 Strix Halo node, read from inside the running Vulkan serving pod:

```
crw-rw---- 1 0  44  226,   0  card0
crw-rw---- 1 0 991  226, 128  renderD128

$ getent group 44
video:x:44:ubuntu
$ getent group render
(no render group)
```

`renderD128` is `crw-rw---- root:991` with nothing for "other". The serving process is uid 999 with groups `{999, 44}`, so it matches neither owner nor group and gets **no** access. llama.cpp then falls back to CPU at roughly half speed with no status condition, which is precisely the #1560 failure the flag exists to prevent.

Confirmed the operator really computes 44 rather than inferring it, using a suspended probe InferenceService (`suspend: true`, so zero pods were ever scheduled) with no `podSecurityContext`:

```json
{"fsGroup":102,"seccompProfile":{"type":"RuntimeDefault"},"supplementalGroups":[44]}
```

The flag was also unreachable from the chart. #1569 touched no chart files, and the operator's `args:` block hardcodes every flag with no `extraArgs` escape hatch, so there was no supported way to correct the value.

Net effect on `main` today: a fresh Vulkan service gets a GID that cannot work, fails silently, and has no chart-level remedy. The status field that would have surfaced it (#1566) is also inert, filed separately as #1585.

## How

- **Default 0 (disabled).** There is no portable render GID, so shipping one means shipping a wrong one. `0` is the honest state and matches the pre-#1569 status quo rather than regressing it.
- **`controllerManager.driRenderGID`** in `values.yaml` + `values.schema.json` (the schema is `additionalProperties: false`, so the key is required there), rendered behind a conditional matching the neighbouring flags' pattern. `0`/unset omits the flag entirely.
- **Point at the command that gets the right answer** (`stat -c '%g' /dev/dri/renderD128`) from the flag help, the values comment, and a new "Ready, but serving from CPU at roughly half speed" troubleshooting entry in the Strix Halo onboarding guide, which covers both traps: 44 is `video`, and `render` differs per host.

One incidental fix: the flag usage string now carries no backquotes. Go's `flag` package promotes the first backquoted word to the operand name, so the original text turned the usage line into `-dri-render-gid stat -c '%g' /dev/dri/renderD128` instead of `-dri-render-gid int`.

This is Part 1 of #1572 only. Part 2 (per-node GIDs on a heterogeneous fleet, most likely via node labels) is a design decision and stays open.

Existing services are unaffected in either direction: `inferPodSecurityContext` returns a user-supplied `Spec.PodSecurityContext` as-is, so anyone already carrying the manual `supplementalGroups` workaround keeps it.

## Verification

Run on this branch:

- `KUBEBUILDER_ASSETS=... go test ./internal/controller/ -count=1` -> **ok, 265.649s**
- `go test ./cmd/... -count=1` -> **ok**
- `helm unittest charts/llmkube charts/foreman` -> **116 passed, 11 suites**
- `helm lint charts/llmkube charts/foreman` -> **2 linted, 0 failed**
- `golangci-lint run` (host and `GOOS=linux`) -> **0 findings in this tree**
- `gofmt -l`, `go build ./...` -> clean
- `go run ./cmd --help` -> usage line renders as `-dri-render-gid int`, and no other flag has a hijacked operand name

The four new chart cases in `tests/dri-render-gid_test.yaml` were mutation-checked: removing the `{{- if }}` guard from the template makes 2 of the 4 fail (the default case and the explicit-`0` case), confirming they bite rather than passing vacuously. The guard was restored and all four pass.

No existing Go test depended on the old default: the two that exercise this path pass `DRIRenderGID` explicitly (991 and 0).

**Not done:** no live cluster run of the new chart value, which is why the commit says `Refs #1572` rather than `Fixes`. The finding it is based on was measured live, but the fix itself is verified by unit and chart tests only.

## AI assistance

`Assisted-by: Claude Opus 5` (measured the GIDs against the fleet, ran the suspended probe, wrote the fix, docs and tests, and ran the verification above).

A human has not yet read this diff. It is offered for review.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran `./internal/controller/` and `./cmd/...` with envtest assets)
- [x] `make lint` passes locally (host and `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - values comment, flag help, and a Strix Halo troubleshooting entry
