### PR TITLE
fix(controller): bound the prefetch Job read and stop one Model stalling the rest

### DIFF
--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -113,6 +114,9 @@ type ModelReconciler struct {
 	// RevalidateInterval is the minimum time between upstream revalidation
 	// checks for a Model. Zero means DefaultRevalidateInterval.
 	RevalidateInterval time.Duration
+	// PrefetchJobReadTimeout bounds the read of a prefetch Job. Zero means
+	// DefaultPrefetchJobReadTimeout. See reconcilePrefetch (#1597).
+	PrefetchJobReadTimeout time.Duration
 	// AllowedHostPathRoots is the operator-configured allowlist of absolute
 	// path prefixes under which local (/abs and file://) model sources are
 	// permitted. Empty (the secure default) disables all local sources; see
@@ -1418,9 +1422,22 @@ func computeFileSHA256(path string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
+// ModelReconcileConcurrency is how many Models reconcile at once. The
+// controller-runtime default is 1, which makes every slow reconcile a
+// head-of-line block for every other Model: a Model waiting on a network
+// metadata read, or on a dependency that cannot be read at all (#1597),
+// stalls the queue behind it.
+//
+// Safe to raise here: controller-runtime never reconciles the same object
+// concurrently, and ModelReconciler carries no mutable shared state. Its
+// fields are configuration set once at startup, and the one lazily-built
+// value (metadataHTTPClient) is guarded by a sync.Once.
+const ModelReconcileConcurrency = 4
+
 func (r *ModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&inferencev1alpha1.Model{}).
 		Named("model").
+		WithOptions(controller.Options{MaxConcurrentReconciles: ModelReconcileConcurrency}).
 		Complete(r)
 }

--- a/internal/controller/model_prefetch.go
+++ b/internal/controller/model_prefetch.go
@@ -84,6 +84,20 @@ func prefetchEligible(model *inferencev1alpha1.Model) bool {
 	return hasSchemeFold(normalized, "https://") || hasSchemeFold(normalized, "http://")
 }
 
+// DefaultPrefetchJobReadTimeout bounds the read of the prefetch Job. Generous
+// enough that a legitimate first-time informer sync on a cluster with many
+// Jobs completes well inside it, short enough that a permanently unsyncable
+// informer cannot monopolise a reconcile worker (#1597).
+const DefaultPrefetchJobReadTimeout = 30 * time.Second
+
+// prefetchJobReadTimeout returns the configured bound, or the default.
+func (r *ModelReconciler) prefetchJobReadTimeout() time.Duration {
+	if r.PrefetchJobReadTimeout > 0 {
+		return r.PrefetchJobReadTimeout
+	}
+	return DefaultPrefetchJobReadTimeout
+}
+
 // reconcilePrefetch drives the prefetch state machine. handled=true means
 // the prefetch path owns this reconcile and Reconcile should return its
 // result; handled=false means fall through to the normal source dispatch
@@ -102,8 +116,20 @@ func (r *ModelReconciler) reconcilePrefetch(ctx context.Context, model *inferenc
 
 	logger := logf.FromContext(ctx)
 
+	// Bounded read. The controller does not watch Jobs (see the polling
+	// comment below), so this is the first touch of the type and
+	// controller-runtime starts the informer lazily and waits for it to sync.
+	// When that informer can never list -- an RBAC denial like #1593, a
+	// partitioned API server -- the reflector retries forever and an unbounded
+	// Get holds the worker. The Model controller's workers are a shared
+	// resource, so that stalls every other Model, not just this one (#1597).
+	// A timeout turns it into a prompt error and an ordinary backoff requeue,
+	// which self-heals once the informer can sync.
+	getCtx, cancel := context.WithTimeout(ctx, r.prefetchJobReadTimeout())
+	defer cancel()
+
 	job := &batchv1.Job{}
-	err := r.Get(ctx, types.NamespacedName{Name: prefetchJobName(model), Namespace: model.Namespace}, job)
+	err := r.Get(getCtx, types.NamespacedName{Name: prefetchJobName(model), Namespace: model.Namespace}, job)
 	switch {
 	case apierrors.IsNotFound(err):
 		result, startErr := r.startPrefetch(ctx, model)

--- a/internal/controller/model_prefetch_timeout_test.go
+++ b/internal/controller/model_prefetch_timeout_test.go
@@ -1,0 +1,72 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// hangingGetClient models the #1593 failure: controller-runtime starts an
+// informer lazily on first Get of a type, and when that informer can never
+// list (RBAC denial, missing CRD, partitioned API server) the reflector
+// retries forever and the Get blocks instead of failing. Get here blocks
+// until its context is done, which is exactly what the real client does.
+type hangingGetClient struct {
+	client.Client
+}
+
+func (c *hangingGetClient) Get(ctx context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// A prefetch-eligible Model: remote source, prefetch on, not already complete.
+func prefetchModelForTimeout() *inferencev1alpha1.Model {
+	return &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+		Spec: inferencev1alpha1.ModelSpec{
+			Source:   "https://example.invalid/model.gguf",
+			Format:   "gguf",
+			Prefetch: true,
+		},
+	}
+}
+
+// The reconcile worker must not be held by a dependency that cannot be read.
+// The Model controller runs a single worker, so a blocked Get stalls every
+// other Model on the cluster, not just this one (#1597).
+func TestReconcilePrefetch_DoesNotBlockOnUnreadableJob(t *testing.T) {
+	const timeout = 50 * time.Millisecond
+	r := &ModelReconciler{Client: &hangingGetClient{}, PrefetchJobReadTimeout: timeout}
+
+	// Generous budget: the point is bounded-vs-unbounded, not the exact value.
+	budget := timeout + 10*time.Second
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, _, err := r.reconcilePrefetch(context.Background(), prefetchModelForTimeout())
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("want an error when the Job cannot be read, got nil")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("want a deadline-exceeded error, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed < timeout {
+			t.Fatalf("returned after %v, before the %v timeout could have elapsed",
+				elapsed, timeout)
+		}
+	case <-time.After(budget):
+		t.Fatalf("reconcilePrefetch still blocked after %v: the worker is held "+
+			"indefinitely by an unreadable Job", budget)
+	}
+}


### PR DESCRIPTION
## What

Bound the prefetch Job read with its own timeout, and raise the Model controller's reconcile concurrency to 4.

## Why

Refs #1597

`reconcilePrefetch` reads the prefetch Job with the reconcile's own context. The controller does not watch Jobs — deliberately, per the polling comment in `model_prefetch.go` — so that `Get` is the first touch of the type, and controller-runtime starts the informer lazily and waits for it to sync. When the informer can never list (the #1593 RBAC denial, a missing CRD, a partitioned API server) the reflector retries forever and the `Get` never returns.

The Model controller ran a **single** reconcile worker, so that blocked `Get` stalled every other Model on the cluster, not just the prefetching one. That amplification is what made #1593 worse than "prefetch is broken".

## How

Two independent bounds, either of which contains the blast radius:

**1. Bounded read.** The Job `Get` runs under its own timeout, so an unreadable dependency becomes a prompt error and an ordinary backoff requeue, self-healing once the informer can sync. The bound is injectable via `PrefetchJobReadTimeout`, mirroring the existing `RevalidateInterval` zero-means-default idiom, so the test doesn't have to burn the real 30s.

**2. `MaxConcurrentReconciles: 4`.** A slow reconcile for any reason is no longer head-of-line for the queue. Safe here, and I checked rather than assumed: controller-runtime never reconciles the same object concurrently, and `ModelReconciler` holds no mutable shared state — its fields are startup configuration, and the one lazily-built value (`metadataHTTPClient`) is behind a `sync.Once`.

**Deliberately not adding `Owns(&batchv1.Job{})`.** `model_prefetch.go` documents that polling was chosen on purpose: *"The Job's completion does not generate a Model event, so a modest requeue keeps the status honest without watching Jobs from this controller."* A watch would also start the informer at manager boot on every install including those that never prefetch, converting today's degraded-prefetch into a controller that cannot start against a stale ClusterRole. #1593 was exactly a stale ClusterRole in the wild, so that trade looks wrong.

Nothing else in the repo sets `MaxConcurrentReconciles`. I scoped this to the controller with the demonstrated problem rather than changing every controller; whether to do it repo-wide is worth its own decision.

## Verification

Run on this branch:

- `KUBEBUILDER_ASSETS=... go test ./internal/controller/ -count=1` -> **ok, 325.660s**
- `golangci-lint run ./internal/... ./cmd/...` -> **0 findings**, host and `GOOS=linux`
- `gofmt -l`, `go build ./...` -> clean

`TestReconcilePrefetch_DoesNotBlockOnUnreadableJob` drives `reconcilePrefetch` with a client whose `Get` blocks until its context is done, which is what the real client does behind an unsyncable informer.

**Mutation-checked.** Replacing the bounded context with `context.WithCancel(ctx)` — removing the bound while keeping both variables used, so it's a behaviour change and not a compile error — makes the test hang and fail:

```
--- FAIL: TestReconcilePrefetch_DoesNotBlockOnUnreadableJob (10.05s)
    reconcilePrefetch still blocked after 10.05s: the worker is held
    indefinitely by an unreadable Job
```

With the bound it returns in 0.05s. My first mutation attempt produced only a `declared and not used` compile error, which would have been a vacuous pass — worth stating since that's the failure mode this repo's own mutation gate exists to catch.

**Not done:** no live cluster run. The starvation is reproduced in a unit test rather than observed on a cluster, which is why this says `Refs #1597`.

## AI assistance

`Assisted-by: Claude Opus 5` (diagnosed the amplification while fixing #1593, wrote the fix and the test, ran the verification and mutation check above).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (ran `./internal/controller/` with envtest assets)
- [x] `make lint` passes locally (host and `GOOS=linux`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - no user-facing surface; rationale is inline
