### PR TITLE
ci: guard against production code referenced only by its own tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,5 +24,14 @@ jobs:
         with:
           version: v2.12.2
 
+      - name: Dead production code guard
+        # Re-runs `unused` with test files dropped from the graph, so a symbol
+        # referenced only by its own tests is reported. The step above cannot
+        # see that class of bug: the tests make the code look used.
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2
+          args: --config=.golangci-deadcode.yml ./...
+
       - name: Check reviewer prompt sync
         run: make check-reviewer-prompts

--- a/.golangci-deadcode.yml
+++ b/.golangci-deadcode.yml
@@ -1,0 +1,67 @@
+# Dead-production-code guard.
+#
+# The main .golangci.yml analyses test files, so a symbol referenced ONLY by
+# its own tests counts as used. That is how eight fully unit-tested rails
+# merged into pkg/foreman/agent without a single production caller: the tests
+# kept `unused` quiet, and every gate passed. This config drops test files
+# from the graph, so a symbol that nothing in production calls is reported.
+#
+# Run it with `make lint-deadcode`.
+#
+# The two registers below are debt, not policy. Both should shrink to empty.
+version: "2"
+run:
+  # The whole point. Test-only references must not count as uses.
+  tests: false
+linters:
+  default: none
+  enable:
+    - unused
+  exclusions:
+    rules:
+      # ---------------------------------------------------------------
+      # REGISTER A: merged, unit-tested, never wired into the pipeline.
+      # The code exists and does nothing. Delete the entry in the same PR
+      # that wires the rail up; that deletion is the proof it is live.
+      # Do NOT add entries here. A new file in this list is new dead code.
+      # ---------------------------------------------------------------
+      - path: pkg/foreman/agent/mcp_audit\.go # Refs #1331
+        linters: [unused]
+      - path: pkg/foreman/agent/cross_stage\.go # Refs #1549
+        linters: [unused]
+      - path: pkg/foreman/agent/staleness_check\.go # Refs #1550
+        linters: [unused]
+      - path: pkg/foreman/agent/deleted_reference_gate\.go # Refs #1553
+        linters: [unused]
+      - path: pkg/foreman/agent/issue_clauses\.go # Refs #1554
+        linters: [unused]
+      - path: pkg/foreman/agent/mutation_check\.go # Refs #1555
+        linters: [unused]
+      - path: pkg/foreman/agent/reviewer_diff_gate\.go # Refs #1570
+        linters: [unused]
+      - path: pkg/foreman/agent/test_layout\.go # Refs #1579
+        linters: [unused]
+      # Whole file is unreferenced: the proposal-1075 work-class buckets
+      # (classifyFile, classifyFootprint and their tables) landed in #1254
+      # and nothing calls them.
+      - path: pkg/foreman/agent/workclass\.go # Refs #1075
+        linters: [unused]
+
+      # ---------------------------------------------------------------
+      # REGISTER B: pre-existing dead symbols found when this guard was
+      # introduced. Each needs a decision (delete, or wire up); none has
+      # been made yet. Tracked for triage in #1602 rather than silently
+      # deleted. Removing an entry here is the deliverable of that issue.
+      # ---------------------------------------------------------------
+      - path: internal/controller/inferenceservice_controller\.go
+        linters: [unused]
+        text: metalReadyEndpoints
+      - path: internal/foreman/controller/workload_coder_escalation\.go
+        linters: [unused]
+        text: isNeedsVerificationCoder
+      - path: internal/router/budget\.go
+        linters: [unused]
+        text: parseMaxUSD
+      - path: pkg/cli/dispatch\.go
+        linters: [unused]
+        text: taskSucceeded

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,11 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 .PHONY: lint-config
 lint-config: golangci-lint ## Verify golangci-lint linter configuration
 	$(GOLANGCI_LINT) config verify
+	$(GOLANGCI_LINT) config verify -c .golangci-deadcode.yml
+
+.PHONY: lint-deadcode
+lint-deadcode: golangci-lint ## Fail on production code referenced only by its own tests.
+	$(GOLANGCI_LINT) run -c .golangci-deadcode.yml ./...
 
 .PHONY: validate-samples
 validate-samples: ## Validate config/samples against CRD schemas (catch hallucinated manifests).

--- a/pkg/foreman/agent/verdict_policy.go
+++ b/pkg/foreman/agent/verdict_policy.go
@@ -69,7 +69,7 @@ const alreadyResolvedOutcome = "ALREADY-RESOLVED"
 // task.Spec.VerdictPolicy.Resolve(), which falls back to the same value
 // when a Workload never set spec.verdictPolicy; this var remains for the
 // tests in this package that exercise applyVerdictPolicy directly.
-var defaultSelfGO = foremanv1alpha1.DefaultSelfGO
+var defaultSelfGO = foremanv1alpha1.DefaultSelfGO //nolint:unused // test-only by design (see above)
 
 // unverifiedClaimReason and unverifiedClaimHowTo are the fixed
 // whyItMatters/howToVerify strings attached to every claim-evidence


### PR DESCRIPTION
## What

Fail CI when production code is referenced only by its own tests.

Adds `.golangci-deadcode.yml` (only `unused`, with `run.tests: false`), exposes it as `make lint-deadcode`, and runs it as a blocking step in the lint workflow. `make lint-config` now verifies both configs so the new one cannot rot.

## Why

Fixes #1603

The main `golangci-lint` run analyses test files, so a symbol that only its own tests call counts as used. **Nine files in `pkg/foreman/agent` are on `main` right now with full unit coverage and zero production callers**: `cross_stage.go`, `deleted_reference_gate.go`, `issue_clauses.go`, `mcp_audit.go`, `mutation_check.go`, `reviewer_diff_gate.go`, `staleness_check.go`, `test_layout.go`, `workclass.go`.

Every one passed unit tests, `make lint`, and the gate. The tests are what kept `unused` quiet.

Reproduce on `main` without this PR:

```
golangci-lint run --tests=false --no-config --default=none -E unused ./...
```

Six of the nine are children of #1548, "Make agent verdicts verifiable." #1391 names this failure mode from the model side; this mechanises the detection so it does not depend on a reviewer noticing.

## How

No custom tool. `unused` already detects this correctly and simply never had test files removed from its graph.

**Verified against the pattern, not argued.** Injecting a new function plus a passing test and no caller:

| Check | Result |
|---|---|
| `go test ./pkg/foreman/agent/` | pass |
| `make lint` | 0 issues (blind) |
| `make lint-deadcode` | reported |

Removing the probe returns the guard to `0 issues`.

**Two suppression registers**, both of which should shrink to empty:

- **Register A**: the nine merged-but-unwired files, each tagged with its tracking issue (#1075, #1331, #1549, #1550, #1553, #1554, #1555, #1570, #1579). The entry is deleted by the PR that wires the rail up, because that deletion is the proof the code is reachable.
- **Register B**: four pre-existing dead symbols the guard found on its first repo-wide run, tracked in #1602.

One inline `//nolint:unused` covers `defaultSelfGO`, which is deliberate rather than debt: its own comment documents that it exists for tests while the executor reaches the value through `VerdictPolicy.Resolve()`.

**Design decision worth challenging.** Per-symbol `//nolint:unused` would be stronger, because a path-based register entry also suppresses *new* dead code added to an already-dead file. I chose the registers on volume: the known cases produce roughly fifty directives scattered across nine files, which is neither readable nor countable. The registers keep the debt in one place that must be edited to shrink. If Register A stops shrinking, this trade-off should be revisited.

**Scope is repo-wide.** Every package outside `pkg/foreman/agent` was already clean, so `./...` costs nothing today and covers `internal/controller` too.

## Not done

`make test` does not pass on my machine, for a reason unrelated to this change. `TestDefaultProcessHealthChecker_Failure` in `pkg/agent` hardcodes port 19999 with the comment "almost certainly not listening"; a local process is listening on it, so the expected connection error never happens. This commit changes zero lines in `pkg/agent` (`git diff HEAD~1 HEAD -- pkg/agent/` is empty) and the test passes in CI, where nothing occupies that port. Worth its own issue as an environment-fragile test.

Everything else passes: `make lint` clean (0 issues on a fresh lint cache), `make lint-deadcode` clean, `make lint-config` verifies both configs.

## Checklist

- [x] Tests added/updated
- [ ] `make test` passes locally (one unrelated pre-existing failure, see "Not done")
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

`Assisted-by: Claude Opus 5` (found the nine unwired files while triaging the issue backlog, established that `unused` already covers the case so no custom tool was needed, built the config/Makefile/CI wiring, and verified the guard against an injected probe).
