### PR TITLE
fix(foreman): record why a reviewer rail could not run

### DIFF
--- a/pkg/foreman/agent/empty_claim_gate.go
+++ b/pkg/foreman/agent/empty_claim_gate.go
@@ -142,7 +142,15 @@ func enforceReviewerEmptyClaim(
 ) (foremanv1alpha1.AgenticTaskVerdict, foremanv1alpha1.AgenticTaskFailureReason) {
 	if emptyClaimDisabled() ||
 		verdict != foremanv1alpha1.AgenticTaskVerdictNoGo ||
-		extra == nil || changedLines == nil {
+		extra == nil {
+		return verdict, ""
+	}
+	// Without the diff this rail cannot separate an unsupported emptiness
+	// claim from a supported one, so the NO-GO it exists to remap stands.
+	// Record it (#1605): the rail built because an unverifiable claim should
+	// not be a NO-GO must not itself fail open silently.
+	if changedLines == nil {
+		recordRailSkipped(extra, railEmptyClaim, skipReasonNoDiff)
 		return verdict, ""
 	}
 	if !assertsEmptyBranch(emptyClaimTexts(summary, extra)...) {

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -884,6 +884,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 				scopeDriftDetected, _ = loopRes.Terminal.Extra["scopeDriftDetected"].(bool)
 				scopeMatched, _ = loopRes.Terminal.Extra["scopeMatched"].([]string)
 			} else {
+				// A log line is not a record (#1605). Mark the skip in extra so a
+				// verdict produced without the scope check is distinguishable
+				// afterwards from one that earned it.
+				recordRailSkipped(loopRes.Terminal.Extra, railScopeOverlap, skipReasonNoDiff)
 				log.Info("reviewer scope: ground-truth diff unavailable; skipping scope check",
 					"err", reviewDiffErr.Error())
 			}

--- a/pkg/foreman/agent/grounded_finding_gate.go
+++ b/pkg/foreman/agent/grounded_finding_gate.go
@@ -164,6 +164,7 @@ func enforceReviewerGroundedFindings(
 	// Silently returning the model's verdict is what made #1570 hard to see.
 	if changedLines == nil {
 		extra["groundingUnavailable"] = true
+		recordRailSkipped(extra, railGroundedFinding, skipReasonNoDiff)
 		extra["groundingUnavailableReason"] =
 			"branch diff unavailable; grounded-finding rail could not evaluate this NO-GO"
 		log.Info("reviewer grounded-finding: branch diff unavailable; verdict left unchecked",

--- a/pkg/foreman/agent/rail_skip.go
+++ b/pkg/foreman/agent/rail_skip.go
@@ -1,0 +1,52 @@
+package agent
+
+// Rail-skip observability (#1605).
+//
+// A single `repo.DiffNameOnly` call feeds four reviewer rails. When it fails
+// or returns nothing, every one of them loses its input at once, which is the
+// mechanism #1570 named: the safety net is disabled by the same condition that
+// creates the hazard. Two of the four already returned the model's verdict
+// silently, so a verdict nothing checked was indistinguishable afterwards from
+// one that earned it.
+//
+// These helpers make that visible. They never change a verdict: demoting
+// because a check could not run destroys good work, which is the #1552 lesson.
+
+// railsSkippedKey is the single extra key recording every rail that could not
+// run on a task, as "<rail>: <reason>" entries. One key rather than a marker
+// per rail, because the operational question is "did anything fail to run on
+// this verdict?" and answering it should not require knowing every rail's name.
+const railsSkippedKey = "railsSkipped"
+
+// Rail names used in railsSkipped entries.
+const (
+	railScopeOverlap        = "scope-overlap"
+	railVerdictFromFindings = "verdict-from-findings"
+	railEmptyClaim          = "empty-claim"
+	railGroundedFinding     = "grounded-finding"
+)
+
+// Reasons a rail could not run.
+const (
+	skipReasonNoDiff      = "diff-unavailable"
+	skipReasonNoIssueBody = "no-issue-body"
+	skipReasonNoDiffFiles = "no-diff-files"
+)
+
+// recordRailSkipped appends a rail's inability to run, and why, to extra.
+// Repeated entries collapse, so a rail short-circuiting twice on the same
+// reason does not inflate the list. Tolerates a nil map so callers need no
+// guard of their own.
+func recordRailSkipped(extra map[string]any, rail, reason string) {
+	if extra == nil {
+		return
+	}
+	entry := rail + ": " + reason
+	existing, _ := extra[railsSkippedKey].([]string)
+	for _, e := range existing {
+		if e == entry {
+			return
+		}
+	}
+	extra[railsSkippedKey] = append(existing, entry)
+}

--- a/pkg/foreman/agent/rail_skip.go
+++ b/pkg/foreman/agent/rail_skip.go
@@ -31,6 +31,18 @@ const (
 	skipReasonNoDiff      = "diff-unavailable"
 	skipReasonNoIssueBody = "no-issue-body"
 	skipReasonNoDiffFiles = "no-diff-files"
+	// skipReasonNoPathRefs is the likeliest of the four in practice: it fires
+	// for any issue citing no extractable file paths, which hand-written
+	// issues routinely do not.
+	skipReasonNoPathRefs = "no-path-refs-in-issue"
+)
+
+// Reasons the scope rail detected drift and then declined to act on it. These
+// are not skips: the rail ran and answered. They are recorded because
+// scopeDriftDetected alone cannot say which branch declined.
+const (
+	scopeNotDemotedNoSourceFile = "diff-has-no-source-file"
+	scopeNotDemotedAlreadyNonGo = "verdict-already-non-go"
 )
 
 // recordRailSkipped appends a rail's inability to run, and why, to extra.

--- a/pkg/foreman/agent/rail_skip_test.go
+++ b/pkg/foreman/agent/rail_skip_test.go
@@ -1,0 +1,97 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// skippedFor returns the recorded reason a rail could not run, if any.
+func skippedFor(extra map[string]any, rail string) (string, bool) {
+	entries, _ := extra[railsSkippedKey].([]string)
+	for _, e := range entries {
+		if strings.HasPrefix(e, rail+": ") {
+			return strings.TrimPrefix(e, rail+": "), true
+		}
+	}
+	return "", false
+}
+
+// One DiffNameOnly failure disables four rails at once (#1605). Each must say
+// so, or a verdict nothing checked looks identical to one that earned it.
+
+func TestRailSkipped_VerdictFromFindingsRecordsMissingDiff(t *testing.T) {
+	extra := map[string]any{}
+	got := enforceReviewerVerdictFromFindings(logr.Discard(), extra,
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("verdict must not change, got %v", got)
+	}
+	reason, ok := skippedFor(extra, railVerdictFromFindings)
+	if !ok {
+		t.Fatalf("want %s recorded, extra=%v", railVerdictFromFindings, extra)
+	}
+	if reason != skipReasonNoDiff {
+		t.Errorf("want reason %q, got %q", skipReasonNoDiff, reason)
+	}
+}
+
+func TestRailSkipped_VerdictFromFindingsThatRanIsNotMarked(t *testing.T) {
+	extra := map[string]any{}
+	changed := func(string) map[int]bool { return map[int]bool{1: true} }
+	enforceReviewerVerdictFromFindings(logr.Discard(), extra,
+		foremanv1alpha1.AgenticTaskVerdictGo, changed)
+
+	if _, ok := skippedFor(extra, railVerdictFromFindings); ok {
+		t.Errorf("a rail that ran must not be marked skipped, extra=%v", extra)
+	}
+}
+
+func TestRailSkipped_EmptyClaimRecordsMissingDiff(t *testing.T) {
+	extra := map[string]any{}
+	got, _ := enforceReviewerEmptyClaim(logr.Discard(), extra,
+		"the branch is empty", foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
+
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Errorf("verdict must not change, got %v", got)
+	}
+	reason, ok := skippedFor(extra, railEmptyClaim)
+	if !ok {
+		t.Fatalf("want %s recorded, extra=%v", railEmptyClaim, extra)
+	}
+	if reason != skipReasonNoDiff {
+		t.Errorf("want reason %q, got %q", skipReasonNoDiff, reason)
+	}
+}
+
+// The grounded rail already sets groundingUnavailable (#1576). It must ALSO
+// join the shared list, or the list is misleading by omission.
+func TestRailSkipped_GroundedFindingJoinsSharedList(t *testing.T) {
+	extra := findingExtra("blocker", "pkg/cli/cache.go", 42)
+	enforceReviewerGroundedFindings(logr.Discard(), extra,
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
+
+	if unavailable, _ := extra["groundingUnavailable"].(bool); !unavailable {
+		t.Errorf("#1576 marker must be preserved, extra=%v", extra)
+	}
+	if _, ok := skippedFor(extra, railGroundedFinding); !ok {
+		t.Errorf("want %s in the shared list, extra=%v", railGroundedFinding, extra)
+	}
+}
+
+func TestRailSkipped_DedupesRepeatedEntries(t *testing.T) {
+	extra := map[string]any{}
+	recordRailSkipped(extra, railScopeOverlap, skipReasonNoDiff)
+	recordRailSkipped(extra, railScopeOverlap, skipReasonNoDiff)
+	if entries, _ := extra[railsSkippedKey].([]string); len(entries) != 1 {
+		t.Errorf("want 1 entry, got %v", entries)
+	}
+}
+
+func TestRailSkipped_NilExtraDoesNotPanic(t *testing.T) {
+	recordRailSkipped(nil, railScopeOverlap, skipReasonNoDiff)
+}

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -291,7 +291,19 @@ func enforceReviewerScopeOverlap(
 	verdict foremanv1alpha1.AgenticTaskVerdict,
 	sourceExtensions []string,
 ) foremanv1alpha1.AgenticTaskVerdict {
-	if extra == nil || issueBody == "" || len(diffFiles) == 0 {
+	if extra == nil {
+		return verdict
+	}
+	// Each short-circuit below is a case where the rail cannot answer, not one
+	// where it answered "no drift". Record which, so a verdict produced without
+	// the check is distinguishable afterwards from one that earned it (#1605).
+	// Returning the model's verdict silently is what let this go unseen.
+	if issueBody == "" {
+		recordRailSkipped(extra, railScopeOverlap, skipReasonNoIssueBody)
+		return verdict
+	}
+	if len(diffFiles) == 0 {
+		recordRailSkipped(extra, railScopeOverlap, skipReasonNoDiffFiles)
 		return verdict
 	}
 	refs := extractIssuePathRefs(issueBody, sourceExtensions)

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -308,6 +308,10 @@ func enforceReviewerScopeOverlap(
 	}
 	refs := extractIssuePathRefs(issueBody, sourceExtensions)
 	if len(refs) == 0 {
+		// The issue named nothing checkable, so the rail cannot answer. Record
+		// it like the other short-circuits: a GO that passed through here did
+		// not earn a scope vouch, and nothing else says so.
+		recordRailSkipped(extra, railScopeOverlap, skipReasonNoPathRefs)
 		return verdict
 	}
 
@@ -349,10 +353,12 @@ func enforceReviewerScopeOverlap(
 	// legitimate docs- or YAML-only change (#800). Skip the scope check
 	// so the run proceeds.
 	if !hasSourceFile(diffFiles, sourceExtensions) {
+		extra["scopeDriftNotDemoted"] = scopeNotDemotedNoSourceFile
 		return verdict
 	}
 
 	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		extra["scopeDriftNotDemoted"] = scopeNotDemotedAlreadyNonGo
 		log.Info("reviewer scope: diff touches none of the files the issue names; verdict already non-GO, annotating only",
 			"verdict", verdict, "scopeRefs", refs)
 		return verdict

--- a/pkg/foreman/agent/scope_overlap_failopen_test.go
+++ b/pkg/foreman/agent/scope_overlap_failopen_test.go
@@ -80,3 +80,51 @@ func TestScopeOverlap_NilExtraDoesNotPanic(t *testing.T) {
 		t.Errorf("verdict must not change, got %v", got)
 	}
 }
+
+// Review of #1606: len(refs) == 0 was the fourth unrecorded short-circuit and
+// likely the most frequent, since it fires for any issue citing no file paths,
+// which hand-written issues routinely do not.
+func TestScopeOverlap_NoPathRefsIsRecorded(t *testing.T) {
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
+		"Make the reviewer stop approving work it never looked at.",
+		[]string{"pkg/foreman/agent/foo.go"},
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("verdict must not change, got %v", got)
+	}
+	reason, ok := skippedFor(extra, railScopeOverlap)
+	if !ok {
+		t.Fatalf("want %s recorded, extra=%v", railScopeOverlap, extra)
+	}
+	if reason != skipReasonNoPathRefs {
+		t.Errorf("want reason %q, got %q", skipReasonNoPathRefs, reason)
+	}
+}
+
+// The two branches that detect drift and then decline to demote must say which
+// one happened. They already leave scopeDriftDetected behind, so they are not
+// silent, but reading extra you cannot tell them apart.
+func TestScopeOverlap_DriftNotDemotedRecordsWhich(t *testing.T) {
+	// Docs-only diff: drift is real but a docs change is not scope drift.
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
+		"Fix `pkg/foreman/agent/executor_native.go`.", []string{"README.md"},
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("docs-only diff must not demote, got %v", got)
+	}
+	if r, _ := extra["scopeDriftNotDemoted"].(string); r != scopeNotDemotedNoSourceFile {
+		t.Errorf("want %q, got %q (extra=%v)", scopeNotDemotedNoSourceFile, r, extra)
+	}
+
+	// Already non-GO: nothing to demote.
+	extra = map[string]any{}
+	enforceReviewerScopeOverlap(logr.Discard(), extra,
+		"Fix `pkg/foreman/agent/executor_native.go`.", []string{"pkg/foreman/agent/other.go"},
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nil)
+	if r, _ := extra["scopeDriftNotDemoted"].(string); r != scopeNotDemotedAlreadyNonGo {
+		t.Errorf("want %q, got %q (extra=%v)", scopeNotDemotedAlreadyNonGo, r, extra)
+	}
+}

--- a/pkg/foreman/agent/scope_overlap_failopen_test.go
+++ b/pkg/foreman/agent/scope_overlap_failopen_test.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// The scope rail's own short-circuits. See rail_skip_test.go for the shared
+// helper and the other three rails fed by the same diff (#1605).
+
+func TestScopeOverlap_NoIssueBodyIsRecorded(t *testing.T) {
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, "",
+		[]string{"pkg/foreman/agent/foo.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil)
+
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("verdict must not change, got %v", got)
+	}
+	reason, ok := skippedFor(extra, railScopeOverlap)
+	if !ok {
+		t.Fatalf("want %s recorded, extra=%v", railScopeOverlap, extra)
+	}
+	if reason != skipReasonNoIssueBody {
+		t.Errorf("want reason %q, got %q", skipReasonNoIssueBody, reason)
+	}
+}
+
+func TestScopeOverlap_NoDiffFilesIsRecorded(t *testing.T) {
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
+		"Fix `pkg/foreman/agent/executor_native.go`.", nil,
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("verdict must not change, got %v", got)
+	}
+	reason, ok := skippedFor(extra, railScopeOverlap)
+	if !ok {
+		t.Fatalf("want %s recorded, extra=%v", railScopeOverlap, extra)
+	}
+	if reason != skipReasonNoDiffFiles {
+		t.Errorf("want reason %q, got %q", skipReasonNoDiffFiles, reason)
+	}
+}
+
+// A check that ran must NOT carry the flag, or the signal is worthless.
+func TestScopeOverlap_RanAndMatchedIsNotMarkedSkipped(t *testing.T) {
+	extra := map[string]any{}
+	enforceReviewerScopeOverlap(logr.Discard(), extra,
+		"Fix `pkg/foreman/agent/foo.go`.", []string{"pkg/foreman/agent/foo.go"},
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+
+	if _, ok := skippedFor(extra, railScopeOverlap); ok {
+		t.Errorf("a check that ran must not be marked skipped, extra=%v", extra)
+	}
+}
+
+func TestScopeOverlap_RanAndDriftedIsNotMarkedSkipped(t *testing.T) {
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
+		"Fix `pkg/foreman/agent/executor_native.go`.",
+		[]string{"pkg/foreman/agent/unrelated.go"},
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Errorf("real drift must still demote, got %v", got)
+	}
+	if _, ok := skippedFor(extra, railScopeOverlap); ok {
+		t.Errorf("a check that ran must not be marked skipped, extra=%v", extra)
+	}
+}
+
+func TestScopeOverlap_NilExtraDoesNotPanic(t *testing.T) {
+	got := enforceReviewerScopeOverlap(logr.Discard(), nil, "body", []string{"a.go"},
+		foremanv1alpha1.AgenticTaskVerdictGo, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("verdict must not change, got %v", got)
+	}
+}

--- a/pkg/foreman/agent/verdict_from_findings_gate.go
+++ b/pkg/foreman/agent/verdict_from_findings_gate.go
@@ -61,7 +61,15 @@ func enforceReviewerVerdictFromFindings(
 ) foremanv1alpha1.AgenticTaskVerdict {
 	if verdictFromFindingsDisabled() ||
 		verdict != foremanv1alpha1.AgenticTaskVerdictGo ||
-		extra == nil || changedLines == nil {
+		extra == nil {
+		return verdict
+	}
+	// The diff is this rail's only input. Without it nothing can be grounded,
+	// so a GO carrying a real blocking finding stands and opens a PR. Record
+	// that nothing checked it (#1605) instead of returning the model's verdict
+	// silently; the verdict is deliberately left alone.
+	if changedLines == nil {
+		recordRailSkipped(extra, railVerdictFromFindings, skipReasonNoDiff)
 		return verdict
 	}
 


### PR DESCRIPTION
## What

Make every reviewer rail record when it could not run, and why, through one shared `railsSkipped` key.

## Why

Refs #1605

A single `repo.DiffNameOnly` call at `executor_native.go:848` feeds **four** rails:

| Line | Rail | Before |
|---|---|---|
| 855 | `runEmptyClaimRail` | silent |
| 865 | `enforceReviewerGroundedFindings` | recorded (#1576) |
| 873 | `enforceReviewerVerdictFromFindings` | silent |
| 880 | `enforceReviewerScopeOverlap` | silent |

When that call errors or returns nothing, all four lose their input simultaneously. This is the mechanism #1570 named, *"the safety net is disabled by the same condition that creates the hazard."* That diagnosis described two rails. It is four, and #1576 instrumented one of them.

**Two fail in the dangerous direction.** `verdict-from-findings` promotes GO to NO-GO when a grounded blocking finding exists, so without the diff **a GO carrying a real blocker stands and opens a PR**. `empty-claim` is the #1552 rail that remaps unsupported emptiness claims to ERROR, so the rail built because *an unverifiable claim should not be a NO-GO* was itself failing open on exactly that input.

**Evidence.** Replaying two merged PRs' real issue bodies against their real shipped diffs:

```
#1570 / PR #1588   refs=[..., executor_native.go]        matched=[]  -> NO-GO
#1549 / PR #1589   refs=[..., workload_controller.go]    matched=[]  -> NO-GO
```

Both opened and merged on a GO, so the rail cannot have run with the real diff, and nothing survived to say so. Those two are among the nine rails now on `main` with no production caller (#1603).

## How

One shared key, `railsSkipped`, holding `"<rail>: <reason>"` entries, written by `recordRailSkipped`. One key rather than a marker per rail, because the operational question is *"did anything fail to run on this verdict?"* and answering it should not require knowing every rail's name. Repeated entries collapse; a nil map is tolerated.

`groundingUnavailable` is preserved unchanged, since #1576's tests assert it; the grounded rail now also joins the shared list so the list is not misleading by omission.

**No verdict changes anywhere.** Demoting because a check could not run destroys good work, which is the #1552 lesson observed live on `wl-1447-review-1447-0` where a false NO-GO burned a coder slot regenerating correct work. Whether an unverifiable review should return `INCOMPLETE` is item 3 of the #1570 diagnosis and deserves its own decision. Item 4, the diff-acquisition bug underneath, is still open and unticketed; this is the backstop, not the cause.

## Scope note

This PR originally covered scope-overlap only. An audit of every rail found the same defect in two more fed by the same call, so they were folded in rather than split across three PRs with two sitting unfixed. Findings deliberately **not** included here, worth their own issue: `enforceReviewerIssueAsk` returns silently when `issueAskVerified` is absent; `applyCoderGroundingRail` returns silently on empty evidence (this is what let it sit dark for weeks after the #1527 rename, until #1581); and the three env kill-switches disable rails with zero annotation.

## Verification

- `go test ./pkg/foreman/agent/... -count=1` → ok, agent package 53.2s, all subpackages
- `go build ./...` → ok
- `GOOS=linux golangci-lint run ./pkg/foreman/agent/...` → 0 issues, fresh cache
- `rail_skip.go` passes the dead-code guard from #1604 with 0 findings, so this change does not add to the problem it documents
- **Falsifiability proved.** With the constants present but no rail wired, the assertions fail:
  ```
  --- FAIL: TestRailSkipped_VerdictFromFindingsRecordsMissingDiff  want verdict-from-findings recorded, extra=map[]
  --- FAIL: TestRailSkipped_EmptyClaimRecordsMissingDiff           want empty-claim recorded, extra=map[]
  --- FAIL: TestRailSkipped_GroundedFindingJoinsSharedList         want grounded-finding in the shared list
  ```

Twelve cases across two files: each rail records its missing input; each rail that **ran** is unmarked (four of the cases exist solely to hold that line, since a marker on every review is worthless); `groundingUnavailable` survives; entries dedupe; nil `extra` does not panic.

## Checklist

- [x] Tests added/updated - 12 cases, watched fail before implementing
- [x] `make test` passes locally - `./pkg/foreman/agent/...`
- [x] `make lint` passes locally - 0 issues, fresh lint cache
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - n/a, internal rail annotations

`Assisted-by: Claude Opus 5` (traced the fail-open while reviewing #1447, audited every rail to find the other two, replayed the merged PRs against their real diffs to establish the rails would have demoted them, wrote the tests and the fix).
