### PR TITLE
feat(foreman): implement the Agent Validated condition and stamp under-configured runs

### DIFF
--- a/api/foreman/v1alpha1/agent_configfloor.go
+++ b/api/foreman/v1alpha1/agent_configfloor.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Config-floor reasons (#1609). Shared here because two surfaces publish
+// the same judgment and must not drift: the Agent controller writes it as
+// the Validated condition, and the executor stamps a failing Agent's task
+// records so a verdict minted by an under-configured agent carries the
+// fact in its own record.
+const (
+	AgentConfigReasonComplete         = "ConfigComplete"
+	AgentConfigReasonNoSystemPrompt   = "NoSystemPrompt"
+	AgentConfigReasonMissingRoleTools = "MissingRoleTools"
+)
+
+// agentRoleRequiredTools names tools a role cannot meaningfully run
+// without. A reviewer without fetch_issue cannot read the issue it is
+// reviewing against: the issue-ask and scope-overlap rails depend on the
+// fetched body, and without the tool they can only ever record a skip.
+var agentRoleRequiredTools = map[AgentRole][]string{
+	AgentRoleReviewer: {"fetch_issue"},
+}
+
+// ConfigFloor reports whether the spec meets the minimum an agent of this
+// role needs to produce groundable work, with a machine reason and a
+// human message when it does not. It is a warning surface, not an
+// admission gate. The incident behind it (#1609): a hand-created reviewer
+// Agent ran for days with no systemPrompt and no fetch_issue, receiving
+// an empty system message while task prompts said "follow Step 1 of your
+// system prompt", and every verdict it minted was uninstructed with
+// nothing anywhere saying so.
+func (s *AgentSpec) ConfigFloor() (ok bool, reason, message string) {
+	if strings.TrimSpace(s.SystemPrompt) == "" {
+		return false, AgentConfigReasonNoSystemPrompt,
+			"spec.systemPrompt is empty: the model runs uninstructed while task prompts reference its steps"
+	}
+	for _, required := range agentRoleRequiredTools[s.Role] {
+		if !slices.Contains(s.Tools, required) {
+			return false, AgentConfigReasonMissingRoleTools,
+				fmt.Sprintf("role %q requires tool %q in spec.tools: without it the %s cannot ground its verdicts",
+					s.Role, required, s.Role)
+		}
+	}
+	return true, AgentConfigReasonComplete, "systemPrompt present and role-required tools advertised"
+}

--- a/api/foreman/v1alpha1/agent_configfloor_test.go
+++ b/api/foreman/v1alpha1/agent_configfloor_test.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+import "testing"
+
+// The config floor is shared: the Agent controller publishes it as the
+// Validated condition, and the executor stamps failing runs' task records
+// (#1609). One implementation, so the two surfaces cannot drift.
+func TestAgentSpecConfigFloor(t *testing.T) {
+	ok, reason, _ := (&AgentSpec{
+		Role: AgentRoleReviewer, SystemPrompt: "# p",
+		Tools: []string{"fetch_issue", "submit_result"},
+	}).ConfigFloor()
+	if !ok || reason != AgentConfigReasonComplete {
+		t.Fatalf("complete config must pass, got ok=%v reason=%q", ok, reason)
+	}
+
+	ok, reason, msg := (&AgentSpec{
+		Role: AgentRoleReviewer, Tools: []string{"submit_result"},
+	}).ConfigFloor()
+	if ok || reason != AgentConfigReasonNoSystemPrompt || msg == "" {
+		t.Fatalf("empty prompt must fail with reason+message, got ok=%v reason=%q msg=%q", ok, reason, msg)
+	}
+
+	ok, reason, _ = (&AgentSpec{
+		Role: AgentRoleReviewer, SystemPrompt: "# p", Tools: []string{"bash", "submit_result"},
+	}).ConfigFloor()
+	if ok || reason != AgentConfigReasonMissingRoleTools {
+		t.Fatalf("reviewer without fetch_issue must fail, got ok=%v reason=%q", ok, reason)
+	}
+}

--- a/api/foreman/v1alpha1/agent_types.go
+++ b/api/foreman/v1alpha1/agent_types.go
@@ -492,6 +492,7 @@ type AgentStatus struct {
 // +kubebuilder:printcolumn:name="Role",type=string,JSONPath=`.spec.role`
 // +kubebuilder:printcolumn:name="Model",type=string,JSONPath=`.spec.model`
 // +kubebuilder:printcolumn:name="InferenceService",type=string,JSONPath=`.spec.inferenceServiceRef.name`
+// +kubebuilder:printcolumn:name="Validated",type=string,JSONPath=`.status.conditions[?(@.type=="Validated")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Agent is the reusable role definition referenced by AgenticTasks via

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .spec.inferenceServiceRef.name
       name: InferenceService
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Validated")].status
+      name: Validated
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.inferenceServiceRef.name
       name: InferenceService
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Validated")].status
+      name: Validated
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/internal/foreman/controller/agent_controller.go
+++ b/internal/foreman/controller/agent_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,9 +64,38 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		"toolCount", len(agent.Spec.Tools),
 	)
 
-	// M3 stub: no status mutation. The scheduler reads Agent.spec
-	// directly when an AgenticTask references it; status fields are
-	// reserved for v0.2.
+	// Publish the config floor as the Validated condition the M3 stub
+	// reserved (#1609). Warn, do not refuse: an Agent that fails the floor
+	// still schedules, but its state is visible in status and in
+	// `kubectl get agents` instead of only in the verdicts it mints. The
+	// incident behind this: a hand-created reviewer Agent ran for days
+	// with no systemPrompt and no fetch_issue tool, and every review it
+	// produced was uninstructed with nothing anywhere saying so.
+	valid, reason, message := validateAgentConfig(&agent.Spec)
+	condStatus := metav1.ConditionTrue
+	if !valid {
+		condStatus = metav1.ConditionFalse
+		log.Info("Agent config below the role floor",
+			"agent", agent.Name, "reason", reason, "message", message)
+	}
+	// SetStatusCondition reports whether anything changed, so a no-op
+	// reconcile writes nothing.
+	changed := apimeta.SetStatusCondition(&agent.Status.Conditions, metav1.Condition{
+		Type:               conditionValidated,
+		Status:             condStatus,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: agent.Generation,
+	})
+	if agent.Status.ObservedGeneration != agent.Generation {
+		agent.Status.ObservedGeneration = agent.Generation
+		changed = true
+	}
+	if changed {
+		if err := r.Status().Update(ctx, &agent); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/foreman/controller/agent_validation.go
+++ b/internal/foreman/controller/agent_validation.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// Validated-condition plumbing (#1609). The judgment itself lives on
+// AgentSpec.ConfigFloor in the api package, shared with the executor's
+// task-record stamp so the two surfaces cannot drift.
+// conditionValidated is the condition type the M3 stub reserved.
+const conditionValidated = "Validated"
+
+// validateAgentConfig is the config floor behind the Validated condition;
+// see AgentSpec.ConfigFloor for the rules and the incident behind them.
+func validateAgentConfig(spec *foremanv1alpha1.AgentSpec) (valid bool, reason, message string) {
+	return spec.ConfigFloor()
+}

--- a/internal/foreman/controller/agent_validation_test.go
+++ b/internal/foreman/controller/agent_validation_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// validateAgentConfig is the config-floor check behind the Validated
+// condition (#1609). A hand-created reviewer Agent ran for 3+ days with no
+// systemPrompt and no fetch_issue tool: every verdict it produced came from
+// an uninstructed model that structurally could not read the issue under
+// review, and nothing anywhere said so.
+func TestValidateAgentConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		spec       foremanv1alpha1.AgentSpec
+		wantValid  bool
+		wantReason string
+	}{
+		{
+			name: "reviewer with prompt and full tools is valid",
+			spec: foremanv1alpha1.AgentSpec{
+				Role:         "reviewer",
+				SystemPrompt: "# reviewer instructions",
+				Tools:        []string{"read_file", "grep", "bash", "fetch_issue", "submit_result"},
+			},
+			wantValid: true,
+		},
+		{
+			name: "empty systemPrompt fails for any role",
+			spec: foremanv1alpha1.AgentSpec{
+				Role:  "coder",
+				Tools: []string{"read_file", "bash", "submit_result"},
+			},
+			wantValid:  false,
+			wantReason: foremanv1alpha1.AgentConfigReasonNoSystemPrompt,
+		},
+		{
+			name: "whitespace-only systemPrompt fails",
+			spec: foremanv1alpha1.AgentSpec{
+				Role:         "reviewer",
+				SystemPrompt: "  \n\t ",
+				Tools:        []string{"fetch_issue", "submit_result"},
+			},
+			wantValid:  false,
+			wantReason: foremanv1alpha1.AgentConfigReasonNoSystemPrompt,
+		},
+		{
+			name: "reviewer without fetch_issue fails",
+			spec: foremanv1alpha1.AgentSpec{
+				Role:         "reviewer",
+				SystemPrompt: "# reviewer instructions",
+				Tools:        []string{"read_file", "grep", "bash", "submit_result"},
+			},
+			wantValid:  false,
+			wantReason: foremanv1alpha1.AgentConfigReasonMissingRoleTools,
+		},
+		{
+			name: "missing prompt reported before missing tools",
+			spec: foremanv1alpha1.AgentSpec{
+				Role:  "reviewer",
+				Tools: []string{"bash", "submit_result"},
+			},
+			wantValid:  false,
+			wantReason: foremanv1alpha1.AgentConfigReasonNoSystemPrompt,
+		},
+		{
+			name: "coder does not need fetch_issue",
+			spec: foremanv1alpha1.AgentSpec{
+				Role:         "coder",
+				SystemPrompt: "# coder instructions",
+				Tools:        []string{"read_file", "write_file", "bash", "submit_result"},
+			},
+			wantValid: true,
+		},
+		{
+			name: "verifier role has no tool floor",
+			spec: foremanv1alpha1.AgentSpec{
+				Role:         "verifier",
+				SystemPrompt: "# gate",
+				Tools:        []string{"run_gate_job"},
+			},
+			wantValid: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			valid, reason, msg := validateAgentConfig(&c.spec)
+			if valid != c.wantValid {
+				t.Fatalf("valid=%v want %v (reason=%q msg=%q)", valid, c.wantValid, reason, msg)
+			}
+			if !valid && reason != c.wantReason {
+				t.Fatalf("reason=%q want %q", reason, c.wantReason)
+			}
+			if !valid && msg == "" {
+				t.Fatal("an invalid result must carry a human-readable message")
+			}
+		})
+	}
+}
+
+// The reconciler must publish the result as the reserved Validated condition.
+func TestAgentReconcilerWritesValidatedCondition(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := foremanv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	agent := &foremanv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "blind-reviewer", Namespace: "default", Generation: 3},
+		Spec: foremanv1alpha1.AgentSpec{
+			Role:  "reviewer",
+			Tools: []string{"read_file", "grep", "bash", "submit_result"},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(agent).WithStatusSubresource(agent).Build()
+	r := &AgentReconciler{Client: cl, Scheme: scheme}
+
+	if _, err := r.Reconcile(context.Background(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: "blind-reviewer", Namespace: "default"}}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var got foremanv1alpha1.Agent
+	if err := cl.Get(context.Background(),
+		types.NamespacedName{Name: "blind-reviewer", Namespace: "default"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, conditionValidated)
+	if cond == nil {
+		t.Fatal("want a Validated condition, got none")
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != foremanv1alpha1.AgentConfigReasonNoSystemPrompt {
+		t.Fatalf("want False/%s, got %s/%s", foremanv1alpha1.AgentConfigReasonNoSystemPrompt, cond.Status, cond.Reason)
+	}
+	if got.Status.ObservedGeneration != 3 {
+		t.Fatalf("want observedGeneration=3, got %d", got.Status.ObservedGeneration)
+	}
+
+	// Fixing the spec flips the condition on the next reconcile.
+	got.Spec.SystemPrompt = "# instructions"
+	got.Spec.Tools = append(got.Spec.Tools, "fetch_issue")
+	if err := cl.Update(context.Background(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Reconcile(context.Background(),
+		ctrl.Request{NamespacedName: types.NamespacedName{Name: "blind-reviewer", Namespace: "default"}}); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if err := cl.Get(context.Background(),
+		types.NamespacedName{Name: "blind-reviewer", Namespace: "default"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if cond = apimeta.FindStatusCondition(got.Status.Conditions, conditionValidated); cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("want Validated=True after fix, got %+v", cond)
+	}
+}

--- a/pkg/foreman/agent/agent_config_stamp.go
+++ b/pkg/foreman/agent/agent_config_stamp.go
@@ -1,0 +1,28 @@
+package agent
+
+import (
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// stampAgentConfigWarnings records in the terminal extra that the agent
+// producing this result runs below its role's config floor (#1609). The
+// Validated condition on the Agent CR covers the control plane; this covers
+// the artifact, so a verdict minted by an uninstructed or under-tooled
+// agent is self-incriminating in its own task record. A complete config
+// stamps nothing: a warning on every record is noise. Owns initializing a
+// nil Extra map, because this stamp exists precisely for mis-configured
+// setups and must not depend on the model having sent the optional field.
+func stampAgentConfigWarnings(terminal *ToolResult, spec *foremanv1alpha1.AgentSpec) {
+	if terminal == nil || spec == nil {
+		return
+	}
+	ok, reason, message := spec.ConfigFloor()
+	if ok {
+		return
+	}
+	if terminal.Extra == nil {
+		terminal.Extra = map[string]any{}
+	}
+	existing, _ := terminal.Extra["agentConfigWarnings"].([]string)
+	terminal.Extra["agentConfigWarnings"] = append(existing, reason+": "+message)
+}

--- a/pkg/foreman/agent/agent_config_stamp_test.go
+++ b/pkg/foreman/agent/agent_config_stamp_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"testing"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// A verdict minted by an under-configured agent must carry that fact in its
+// own task record (#1609). The Validated condition covers the control plane;
+// this covers the artifact, so an uninstructed review is self-incriminating
+// even if nobody looked at `kubectl get agents`.
+func TestStampAgentConfigWarnings(t *testing.T) {
+	blind := foremanv1alpha1.AgentSpec{
+		Role:  foremanv1alpha1.AgentRoleReviewer,
+		Tools: []string{"read_file", "grep", "bash", "submit_result"},
+	}
+	terminal := &ToolResult{}
+	stampAgentConfigWarnings(terminal, &blind)
+	warnings, _ := terminal.Extra["agentConfigWarnings"].([]string)
+	if len(warnings) != 1 {
+		t.Fatalf("want 1 warning (and a nil Extra initialized), got %v", terminal.Extra)
+	}
+
+	// A complete config stamps nothing: a warning on every record is noise.
+	complete := foremanv1alpha1.AgentSpec{
+		Role: foremanv1alpha1.AgentRoleReviewer, SystemPrompt: "# p",
+		Tools: []string{"fetch_issue", "submit_result"},
+	}
+	terminal = &ToolResult{Extra: map[string]any{}}
+	stampAgentConfigWarnings(terminal, &complete)
+	if _, present := terminal.Extra["agentConfigWarnings"]; present {
+		t.Fatalf("complete config must not stamp, got %v", terminal.Extra)
+	}
+
+	// Nil terminal must not panic.
+	stampAgentConfigWarnings(nil, &blind)
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -785,6 +785,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			"loop returned nil error but no terminal result"), nil
 	}
 
+	// Stamp the record when this agent runs below its role's config floor
+	// (#1609), before any rail reads or writes extra.
+	stampAgentConfigWarnings(loopRes.Terminal, &agent.Spec)
+
 	verdict, normalizedReason := normalizeModelVerdict(loopRes.Terminal.Verdict)
 
 	// 9. Non-GO verdicts: no commit, no push, just record the model's


### PR DESCRIPTION
## What

Implement the `Validated` condition the Agent controller's M3 stub promised, backed by a shared config floor, and stamp every task record produced by an under-configured agent.

## Why

Fixes #1609

An `Agent` with no `systemPrompt` and a truncated toolset is accepted, dispatches, and mints verdicts indistinguishable from configured ones. Observed live during the #1607 verification: a hand-created reviewer Agent ran **3+ days** uninstructed and unable to fetch the issue it was reviewing, while its task prompts said "follow Step 1 of your system prompt". The controller was a 79-line stub whose own comment deferred Validated "to v0.2".

## How

One judgment, two surfaces, one implementation so they cannot drift:

- **`AgentSpec.ConfigFloor()`** (api): `systemPrompt` required for every role; `role: reviewer` additionally requires `fetch_issue` in `spec.tools`, because the issue-ask and scope-overlap rails depend on the fetched body and can only record a skip without it
- **Controller**: publishes the result as `Validated` with reason/message, `observedGeneration`, and a `VALIDATED` printer column. **Warn, not refuse** — a failing Agent still schedules, but the state is visible in `kubectl get agents` instead of only in its verdicts
- **Executor**: `agentConfigWarnings` stamped into the terminal extra of every task a failing agent completes, so the verdict's own record carries the fact. Complete configs stamp nothing. The helper owns initializing a nil `Extra`, since it exists precisely for mis-configured setups

## Verification

- TDD throughout: floor table tests, a fake-client reconciler test proving the condition flips False→True when the spec is fixed, stamp tests including nil-Extra initialization; all watched fail first
- `go test ./pkg/foreman/agent/... ./internal/... ./api/...` → pass
- `make manifests` + `make foreman-chart-crds` run; printer column in both CRD copies
- `GOOS=linux golangci-lint run ./...` → 0 issues; `make lint-deadcode` → 0 issues

Both quality gates bit during development and each caught a real defect: the dead-code guard flagged two constants that became test-only after a refactor, and `gocyclo` rejected my first wiring for pushing `runLLMPath` to 31 — the final shape moves the branch into the helper instead.

## Checklist

- [x] Tests added/updated - watched fail before implementing
- [x] `make test` passes locally - agent, controller, and api packages
- [x] `make lint` passes locally - 0 issues, fresh cache
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - condition and column documented on the API type

`Assisted-by: Claude Opus 5` (diagnosed the live incident during the #1607 verification, filed #1609, implemented the shared floor, condition, and stamp with TDD).
