### PR TITLE
docs(foreman): document gateProfile.testLayout

### DIFF
--- a/docs/site/foreman/language-gates.md
+++ b/docs/site/foreman/language-gates.md
@@ -32,6 +32,9 @@ spec:
     language: python          # selects a built-in preset
     image: python:3.13        # container image the gate Job runs in
     sourceExtensions: [".py"] # extensions the scope guard treats as source
+    testLayout:               # where tests live, when not beside the code
+      testRoot: tests
+      sourceRoot: src
     commands:                 # overrides; empty fields keep the preset value
       format: "ruff format --check ."
       lint: "ruff check ."
@@ -67,6 +70,54 @@ spec:
 For a mixed-language pipeline, `pipeline[].gateProfile` overrides the
 workload-level default for that step only. Resolution is step → workload →
 Go preset.
+
+### Declaring where tests live (`testLayout`)
+
+The reviewer's scope-overlap check verifies that a diff touches the files an
+issue names. For "add tests for X" issues, a test file counts as touching the
+module it covers, but only when the check can fold the test file's path back
+to that module. Out of the box it folds the beside-the-code conventions:
+`x.test.ts` and `x.spec.ts` beside `x.ts`, `x_test.go` beside `x.go`,
+`test_x.py` and `x_test.py` beside `x.py`.
+
+That folding preserves the directory, so it cannot express a **parallel test
+tree**, where the directory differs too. `testLayout` declares the
+convention:
+
+```yaml
+gateProfile:
+  language: generic
+  sourceExtensions: [".java"]
+  testLayout:
+    testRoot: src/test/java     # where the tests live
+    sourceRoot: src/main/java   # where the code they cover lives
+```
+
+With a layout declared, a path under `testRoot` is folded by rewriting the
+root and stripping the test decoration from the basename, including the
+suffix forms the beside-the-code rules do not know:
+
+| repository style | test file | folds to |
+|---|---|---|
+| Maven / Gradle | `src/test/java/a/FooTest.java` | `src/main/java/a/Foo.java` |
+| Ruby RSpec | `spec/relnotes_spec.rb` (`testRoot: spec`, `sourceRoot: scripts`) | `scripts/relnotes.rb` |
+| pytest tree | `tests/test_relnotes.py` (`testRoot: tests`, `sourceRoot: scripts`) | `scripts/relnotes.py` |
+| C# / NUnit | `tests/FooTests.cs` (`testRoot: tests`, `sourceRoot: src`) | `src/Foo.cs` |
+
+Without the declaration, each of those diffs reads as touching none of the
+files the issue names: a correct "add tests for X" branch is demoted for
+scope drift and the task burns its attempt budget with no PR
+([#1447](https://github.com/defilantech/LLMKube/issues/1447)). Both fields
+are optional; an unset `testLayout` keeps the beside-the-code behaviour
+exactly, and a path outside `testRoot` falls back to it.
+
+Two boundaries worth knowing. Declaring a layout changes nothing until the
+profile carrying it reaches the task, so a bridge that maintains its own
+gate-profile map must add the field per repository. And the folding is
+name-based: a test file named after a **feature** rather than its module
+(`tests/test_dedup.py` covering `app.py`) cannot be expressed by any layout;
+that class is tracked in
+[#1610](https://github.com/defilantech/LLMKube/issues/1610).
 
 ### Built-in presets
 


### PR DESCRIPTION
## What

Document `gateProfile.testLayout` in the language-gates guide, where `sourceExtensions` and the rest of the profile already live.

## Why

Refs #1579

The #1607 review noted, fairly, that merging the feature changes nothing until an operator declares a layout, and the PR read as though the five language families were fixed when what was fixed is the ability to declare them. There was also nowhere an operator would learn the field exists.

## How

One subsection in `docs/site/foreman/language-gates.md`, in the page's existing voice:

- when the beside-the-code folding suffices and when a parallel tree defeats it
- the declaration, with a folding table for Maven/Gradle, Ruby RSpec, a pytest tree, and C#/NUnit
- the cost of omitting it on a parallel-tree repository: a correct "add tests for X" branch demotes for scope drift and burns its attempt budget (#1447)
- the operational boundary the review raised: a bridge maintaining its own gate-profile map must add the field per repository
- the honest limit: name-based folding cannot express feature-named test files (`tests/test_dedup.py` covering `app.py`); that class is #1610

The Ruby and pytest rows in the table are the shapes from the live A/B verification on the PR thread, so the examples are ones that have actually run.

## Checklist

- [ ] Tests added/updated - n/a, documentation only
- [x] `make test` passes locally - no code changed
- [x] `make lint` passes locally - no Go changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - this is the documentation

`Assisted-by: Claude Opus 5` (wrote the section from the #1607 review feedback and the live verification results).
