### PR TITLE
feat(foreman): content-based test-coverage vouch for feature-named test files

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -883,10 +883,19 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			var scopeMatched []string
 			if reviewDiffErr == nil {
 				resolvedGate := task.Spec.GateProfile.Resolve()
+				// The content-based vouch (#1610) reads diff-ADDED test files
+				// from the workspace checkout. A failure to compute the added
+				// set or to read a file degrades the vouch to name-only — the
+				// rail must never demote on a read error, so this stays best-effort.
+				scopeAdded, _ := repo.DiffAdded(ctx, workspace, reviewBase)
+				scopeReadFile := func(relPath string) ([]byte, error) {
+					return os.ReadFile(filepath.Join(workspace, relPath))
+				}
 				verdict = enforceReviewerScopeOverlap(log, loopRes.Terminal.Extra,
 					extractFetchIssueBody(loopRes.Transcript), reviewDiff, verdict,
 					resolvedGate.SourceExtensions,
-					testLayoutFrom(resolvedGate.TestLayout))
+					testLayoutFrom(resolvedGate.TestLayout),
+					scopeAdded, scopeReadFile)
 				scopeDriftDetected, _ = loopRes.Terminal.Extra["scopeDriftDetected"].(bool)
 				scopeMatched, _ = loopRes.Terminal.Extra["scopeMatched"].([]string)
 			} else {

--- a/pkg/foreman/agent/repo/diff.go
+++ b/pkg/foreman/agent/repo/diff.go
@@ -55,6 +55,57 @@ func DiffNameOnly(ctx context.Context, workspace, base string) ([]string, error)
 	return parseNameOnly(out), nil
 }
 
+// DiffAdded returns the subset of the branch's diff whose status is ADDED
+// (git status "A"), using `git diff --name-status base...HEAD`. The three-dot
+// form matches DiffNameOnly, so the two agree on which files the branch
+// touched; this only narrows to the additions.
+//
+// The content-based test-coverage vouch (#1610) reads the body of a diff-ADDED
+// test file to check it imports the module it covers. Reading only added files
+// keeps the vouch scoped to what this branch created — a test the branch added
+// is the coverage we are vouching for — and bounds the file reads to the diff
+// rather than the whole tree. An empty result is not an error.
+func DiffAdded(ctx context.Context, workspace, base string) ([]string, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("DiffAdded: workspace is required")
+	}
+	if base == "" {
+		return nil, fmt.Errorf("DiffAdded: base ref is required")
+	}
+	out, err := runGit(ctx, workspace, baseEnv(), "diff", "--name-status", base+"...HEAD")
+	if err != nil {
+		return nil, err
+	}
+	return parseNameStatusAdded(out), nil
+}
+
+// parseNameStatusAdded keeps only the ADDED ("A") paths from tab-separated
+// `git diff --name-status` output. Rename/copy rows ("R..", "C..") are not
+// additions of a new path and are excluded: a renamed test file's coverage was
+// already present on the base, so it is not the new coverage the vouch targets.
+// Returns nil (not []string{}) when nothing was added, so a DeepEqual against
+// a nil expectation works in callers and tests.
+func parseNameStatusAdded(out string) []string {
+	if out == "" {
+		return nil
+	}
+	var added []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		f := strings.Split(line, "\t")
+		if len(f) < 2 {
+			continue
+		}
+		if f[0] == "A" {
+			added = append(added, f[len(f)-1])
+		}
+	}
+	return added
+}
+
 // parseNameOnly splits a `git diff --name-only` output into a clean
 // slice of paths. Strips empty lines and trims surrounding whitespace
 // off each entry. Returns nil (not []string{}) when the output yields

--- a/pkg/foreman/agent/repo/diff_test.go
+++ b/pkg/foreman/agent/repo/diff_test.go
@@ -27,6 +27,54 @@ import (
 	"testing"
 )
 
+func TestParseNameStatusAdded(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"blank-only", "\n  \n", nil},
+		{
+			"single-add",
+			"A\ttests/test_dedup.py\n",
+			[]string{"tests/test_dedup.py"},
+		},
+		{
+			"add-among-modify",
+			"M\tsrc/app.py\nA\ttests/test_dedup.py\nM\tREADME.md\nD\told/gone.py\n",
+			[]string{"tests/test_dedup.py"},
+		},
+		{
+			"multiple-adds",
+			"A\ttests/test_a.py\nA\ttests/test_b.py\nM\tsrc/app.py\n",
+			[]string{"tests/test_a.py", "tests/test_b.py"},
+		},
+		{
+			"rename-and-copy-excluded",
+			"A\ttests/test_a.py\nR100\told/test_b.py\tnew/test_b.py\nC75\tsrc/x.py\tsrc/y.py\n",
+			[]string{"tests/test_a.py"},
+		},
+		{
+			"malformed-rows-skipped",
+			"A\ttests/test_a.py\nnotabline\nM\tsrc/app.py\n",
+			[]string{"tests/test_a.py"},
+		},
+		{
+			"crlf-tolerant",
+			"A\ttests/test_a.py\r\nM\tsrc/app.py\r\n",
+			[]string{"tests/test_a.py"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseNameStatusAdded(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseNameStatusAdded(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseNameOnly(t *testing.T) {
 	cases := []struct {
 		name string
@@ -69,6 +117,88 @@ func TestDiffNameOnly_RejectsEmptyArgs(t *testing.T) {
 	}
 	if _, err := DiffNameOnly(ctx, "/tmp", ""); err == nil {
 		t.Error("DiffNameOnly: empty base should error")
+	}
+}
+
+func TestDiffAdded_RejectsEmptyArgs(t *testing.T) {
+	ctx := context.Background()
+	if _, err := DiffAdded(ctx, "", "main"); err == nil {
+		t.Error("DiffAdded: empty workspace should error")
+	}
+	if _, err := DiffAdded(ctx, "/tmp", ""); err == nil {
+		t.Error("DiffAdded: empty base should error")
+	}
+}
+
+// TestDiffAdded_RoundTrip exercises DiffAdded against a real bare git
+// workspace: init a repo with one file on main, branch off, then modify the
+// existing file, add two new files, and assert DiffAdded returns exactly the
+// two additions — not the modification. This is the export the content-based
+// vouch (#1610) reads, so the happy path and the modify-exclusion must both
+// be proven end to end. Skipped if `git` is not on PATH.
+func TestDiffAdded_RoundTrip(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ws := t.TempDir()
+	ctx := context.Background()
+
+	run := func(args ...string) {
+		t.Helper()
+		if _, err := runGit(ctx, ws, baseEnv(), args...); err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+	}
+
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(ws, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdirall %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	// init repo + initial commit on main
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+	mustWrite("app.py", "print('v1')\n")
+	run("add", ".")
+	run("commit", "-m", "initial")
+
+	// branch off: modify app.py, add two test files (leave nothing deleted)
+	run("checkout", "-b", "feature")
+	mustWrite("app.py", "print('v2')\n")
+	mustWrite("tests/test_dedup.py", "from app import dedup\n")
+	mustWrite("tests/test_other.py", "def test_x():\n    pass\n")
+	run("add", ".")
+	run("commit", "-m", "feature work")
+
+	got, err := DiffAdded(ctx, ws, "main")
+	if err != nil {
+		t.Fatalf("DiffAdded: %v", err)
+	}
+	want := map[string]bool{"tests/test_dedup.py": true, "tests/test_other.py": true}
+	if len(got) != len(want) {
+		t.Fatalf("DiffAdded = %v, want exactly the two added files (no modify)", got)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected path %q in added set (a modify must not be added)", p)
+		}
+	}
+
+	// Back on main, HEAD == base, so nothing was added.
+	run("checkout", "main")
+	empty, err := DiffAdded(ctx, ws, "main")
+	if err != nil {
+		t.Fatalf("DiffAdded main vs HEAD: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("HEAD == base should yield no added files; got %v", empty)
 	}
 }
 

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -273,8 +273,18 @@ func testTargetsForPath(p string) []string {
 // (contentReferencesModule), which is the deterministic, model-free signal
 // that a feature-named test really does cover the module.
 //
-// Only addedFiles are read — a test the branch created is the one whose
-// coverage we are vouching for, and reading them bounds the work to the diff.
+// Only addedFiles are read, and the reason is soundness, not cost: a test
+// file this branch merely MODIFIED may have imported the module long before
+// the branch touched it, so vouching on a modified file's whole content
+// would let a coder earn a scope pass by editing any test that happens to
+// import the named module, without adding coverage for it. Restricting to
+// files the branch created means the import evidence cannot predate the
+// work. The price is a real out-of-scope class: a branch that APPENDS tests
+// to an existing test file is not vouched even when the appended lines
+// import the module (misospace/pr-reviewer-action#438 is exactly this
+// shape). Covering it needs the added LINES as the discriminator, not the
+// file: see the follow-up filed from the #1614 review.
+//
 // A file whose content cannot be read is simply not a vouch: a read failure
 // must never flip a ref from unmatched to matched, so the rail degrades to
 // name-based behaviour rather than inventing coverage it cannot verify.

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -264,6 +264,48 @@ func testTargetsForPath(p string) []string {
 	return nil
 }
 
+// testContentReferencesModule reports whether any of the diff-ADDED test files
+// whose content can be read references modulePath. It is the content-based
+// half of the #1610 vouch: name-based folding (testTargetsForPath /
+// testTargetsWithLayout) folds the test file's NAME to its subject, which
+// fails for a test named after a feature or behaviour. This instead reads the
+// file's body and asks whether it imports the module under test
+// (contentReferencesModule), which is the deterministic, model-free signal
+// that a feature-named test really does cover the module.
+//
+// Only addedFiles are read — a test the branch created is the one whose
+// coverage we are vouching for, and reading them bounds the work to the diff.
+// A file whose content cannot be read is simply not a vouch: a read failure
+// must never flip a ref from unmatched to matched, so the rail degrades to
+// name-based behaviour rather than inventing coverage it cannot verify.
+func testContentReferencesModule(addedFiles []string, modulePath string, readFile func(string) ([]byte, error)) bool {
+	for _, f := range addedFiles {
+		if !isTestFile(f) {
+			continue
+		}
+		content, err := readFile(f)
+		if err != nil {
+			continue
+		}
+		if contentReferencesModule(string(content), modulePath) {
+			return true
+		}
+	}
+	return false
+}
+
+// isTestFile reports whether p is a test file under any of the recognized
+// conventions. The content vouch only reads test files: a source file importing
+// a module is not evidence a test covers it, so restricting to test files keeps
+// the vouch scoped to test-coverage issues. It delegates to stripTestDecoration
+// (the broadest recognizer, covering the beside-the-code conventions plus the
+// parallel-tree forms like foo_spec.rb and FooTest.java) rather than
+// testTargetsForPath, so a feature-named test in a parallel tree is still read
+// for its content even when name-folding would not have folded it.
+func isTestFile(p string) bool {
+	return stripTestDecoration(path.Base(p)) != ""
+}
+
 // enforceReviewerScopeOverlap is the computable half of scope-drift
 // detection (#647). The issue body names concrete files; the ground-truth
 // diff says which files actually changed. When the issue names at least
@@ -283,6 +325,13 @@ func testTargetsForPath(p string) []string {
 // Matching is generous on purpose (exact path or basename equality):
 // a false drift flag costs one escalation review, while a missed match
 // would demote a legitimate branch.
+// addedFiles carries the subset of the branch's diff that was ADDED (git
+// status "A"), and readFile resolves a workspace-relative diff path to its
+// bytes. Both are only used by the content-based vouch (#1610): a test file
+// named for a feature (test_dedup.py) defeats name-based folding, but its body
+// imports the module it covers, and reading that import is the deterministic
+// signal name-folding cannot express. Pass nil for both to disable the vouch
+// and keep the pure name-based behaviour (every existing test does).
 func enforceReviewerScopeOverlap(
 	log logr.Logger,
 	extra map[string]any,
@@ -291,6 +340,8 @@ func enforceReviewerScopeOverlap(
 	verdict foremanv1alpha1.AgenticTaskVerdict,
 	sourceExtensions []string,
 	testLayout TestLayout,
+	addedFiles []string,
+	readFile func(relPath string) ([]byte, error),
 ) foremanv1alpha1.AgenticTaskVerdict {
 	if extra == nil {
 		return verdict
@@ -331,6 +382,7 @@ func enforceReviewerScopeOverlap(
 		}
 	}
 	matched := []string{}
+	matchedByName := map[string]bool{}
 	for _, r := range refs {
 		// A ref is satisfied when the diff touches the module it names
 		// directly, or when the diff touches a test file that targets it:
@@ -339,6 +391,33 @@ func enforceReviewerScopeOverlap(
 		// matches the X.test file the diff creates (#1447).
 		if diffPaths[r] || diffBases[path.Base(r)] {
 			matched = append(matched, r)
+			matchedByName[r] = true
+		}
+	}
+
+	// Content-based vouch (#1610): name-based folding fails for a test file
+	// named for a feature or behaviour (test_dedup.py,
+	// test_platform_gh_api_forgejo.py) because its name does not derive from
+	// the module it covers. For each ref the name fold left unmatched, fall
+	// back to reading the diff-ADDED test files: a file whose content imports
+	// the module it covers vouches for it. Ordering is load-bearing — the
+	// content check runs only on the refs name matching left unmatched, so a
+	// path match is never re-derived from content, and the two signals stay
+	// distinguishable in the record.
+	if len(matched) < len(refs) && len(addedFiles) > 0 && readFile != nil {
+		for _, r := range refs {
+			if matchedByName[r] {
+				continue
+			}
+			if testContentReferencesModule(addedFiles, r, readFile) {
+				matched = append(matched, r)
+				matchedByName[r] = true
+				if extra[scopeMatchedViaContentKey] == nil {
+					extra[scopeMatchedViaContentKey] = []string{r}
+				} else {
+					extra[scopeMatchedViaContentKey] = append(extra[scopeMatchedViaContentKey].([]string), r)
+				}
+			}
 		}
 	}
 

--- a/pkg/foreman/agent/scope_overlap_failopen_test.go
+++ b/pkg/foreman/agent/scope_overlap_failopen_test.go
@@ -14,7 +14,7 @@ import (
 func TestScopeOverlap_NoIssueBodyIsRecorded(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, "",
-		[]string{"pkg/foreman/agent/foo.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		[]string{"pkg/foreman/agent/foo.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("verdict must not change, got %v", got)
@@ -32,7 +32,7 @@ func TestScopeOverlap_NoDiffFilesIsRecorded(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/executor_native.go`.", nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("verdict must not change, got %v", got)
@@ -51,7 +51,7 @@ func TestScopeOverlap_RanAndMatchedIsNotMarkedSkipped(t *testing.T) {
 	extra := map[string]any{}
 	enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/foo.go`.", []string{"pkg/foreman/agent/foo.go"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 
 	if _, ok := skippedFor(extra, railScopeOverlap); ok {
 		t.Errorf("a check that ran must not be marked skipped, extra=%v", extra)
@@ -63,7 +63,7 @@ func TestScopeOverlap_RanAndDriftedIsNotMarkedSkipped(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/executor_native.go`.",
 		[]string{"pkg/foreman/agent/unrelated.go"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Errorf("real drift must still demote, got %v", got)
@@ -75,7 +75,7 @@ func TestScopeOverlap_RanAndDriftedIsNotMarkedSkipped(t *testing.T) {
 
 func TestScopeOverlap_NilExtraDoesNotPanic(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), nil, "body", []string{"a.go"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("verdict must not change, got %v", got)
 	}
@@ -89,7 +89,7 @@ func TestScopeOverlap_NoPathRefsIsRecorded(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Make the reviewer stop approving work it never looked at.",
 		[]string{"pkg/foreman/agent/foo.go"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("verdict must not change, got %v", got)
@@ -111,7 +111,7 @@ func TestScopeOverlap_DriftNotDemotedRecordsWhich(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/executor_native.go`.", []string{"README.md"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("docs-only diff must not demote, got %v", got)
 	}
@@ -123,7 +123,7 @@ func TestScopeOverlap_DriftNotDemotedRecordsWhich(t *testing.T) {
 	extra = map[string]any{}
 	enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/executor_native.go`.", []string{"pkg/foreman/agent/other.go"},
-		foremanv1alpha1.AgenticTaskVerdictNoGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nil, TestLayout{}, nil, nil)
 	if r, _ := extra["scopeDriftNotDemoted"].(string); r != scopeNotDemotedAlreadyNonGo {
 		t.Errorf("want %q, got %q (extra=%v)", scopeNotDemotedAlreadyNonGo, r, extra)
 	}

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -151,7 +151,7 @@ func TestEnforceReviewerScopeOverlap_GodotRefMatchVouches(t *testing.T) {
 	diff := []string{"scripts/main.gd", "tests/test_tick_integration.gd"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, godotIssueBody, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".gd"}, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".gd"}, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a diff touching issue-named .gd files must not demote; got %v", got)
 	}
@@ -172,7 +172,7 @@ func TestEnforceReviewerScopeOverlap_GodotBlindWithoutExtensions(t *testing.T) {
 	diff := []string{"scripts/main.gd", "tests/test_tick_integration.gd"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, godotIssueBody, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("no refs must pass through; got %v", got)
 	}
@@ -189,7 +189,7 @@ func TestEnforceReviewerScopeOverlap_Issue379DriftDemotesGo(t *testing.T) {
 	}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("zero scope overlap on GO must demote to NO-GO; got %v", got)
 	}
@@ -219,7 +219,7 @@ func TestEnforceReviewerScopeOverlap_MatchedRefStands(t *testing.T) {
 	diff := []string{"AGENTS.md"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue510Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a diff touching a referenced file must not demote; got %v", got)
 	}
@@ -239,7 +239,7 @@ func TestEnforceReviewerScopeOverlap_BasenameMatch(t *testing.T) {
 	diff := []string{"config/rbac/role.yaml"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("basename match must not demote; got %v", got)
 	}
@@ -250,7 +250,7 @@ func TestEnforceReviewerScopeOverlap_NoRefsObserveOnly(t *testing.T) {
 	diff := []string{"pkg/agent/agent.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("no path refs in issue must not demote; got %v", got)
 	}
@@ -263,7 +263,7 @@ func TestEnforceReviewerScopeOverlap_DriftOnNoGoAnnotatesOnly(t *testing.T) {
 	diff := []string{"internal/foreman/controller/agentictask_controller.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictNoGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("NO-GO must stay NO-GO; got %v", got)
 	}
@@ -283,7 +283,7 @@ func TestEnforceReviewerScopeOverlap_ZeroGoFilesSkipsScopeCheck(t *testing.T) {
 	diff := []string{"README.md", "config/crd/bases/inference.llmkube.dev_models.yaml"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("zero-Go-file diff must not demote GO; got %v", got)
 	}
@@ -300,7 +300,7 @@ func TestEnforceReviewerScopeOverlap_RealDriftStillBites(t *testing.T) {
 	diff := []string{"internal/foreman/controller/agentictask_controller.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("real drift with Go files must still demote GO; got %v", got)
 	}
@@ -311,13 +311,13 @@ func TestEnforceReviewerScopeOverlap_RealDriftStillBites(t *testing.T) {
 
 func TestEnforceReviewerScopeOverlap_NilOrEmptyInputsPassThrough(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), nil, issue379Body,
-		[]string{"x.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		[]string{"x.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("nil extra must pass through; got %v", got)
 	}
 	extra := map[string]any{}
 	if got := enforceReviewerScopeOverlap(logr.Discard(), extra, "", nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}); got != foremanv1alpha1.AgenticTaskVerdictGo {
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil); got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("empty body and diff must pass through; got %v", got)
 	}
 }
@@ -385,7 +385,7 @@ func TestEnforceReviewerScopeOverlap_PythonExtensions(t *testing.T) {
 	diff := []string{"README.md", "docs/guide.md"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"}, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"}, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("with .py extensions and no .py diff, scope check should skip; got %v", got)
 	}
@@ -426,7 +426,7 @@ func TestEnforceReviewerScopeOverlap_LineCitedRefVouches(t *testing.T) {
 	extra := map[string]any{}
 	body := "Buffered alerts are dropped on restart; see `main.go:135` and `main.go:80`."
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body,
-		[]string{"main.go", "main_test.go"}, foremanv1alpha1.AgenticTaskVerdictGo, []string{".go"}, TestLayout{})
+		[]string{"main.go", "main_test.go"}, foremanv1alpha1.AgenticTaskVerdictGo, []string{".go"}, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("a diff touching the line-cited file must keep GO, got %v", got)
 	}
@@ -539,7 +539,7 @@ func TestEnforceReviewerScopeOverlap_TestFileMapsToModule(t *testing.T) {
 	diff := []string{"src/lib/automation-sync.test.ts"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a diff that creates the test for the named module must not demote; got %v", got)
 	}
@@ -563,7 +563,7 @@ func TestEnforceReviewerScopeOverlap_GoTestFileMapsToModule(t *testing.T) {
 	diff := []string{"internal/foo/bar_test.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a diff adding bar_test.go must not demote an issue naming bar.go; got %v", got)
 	}
@@ -580,7 +580,7 @@ func TestEnforceReviewerScopeOverlap_TestFileBareRefMapsToModule(t *testing.T) {
 	diff := []string{"internal/foo/bar_test.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a bare ref to bar.go must match the bar_test.go diff; got %v", got)
 	}
@@ -626,7 +626,7 @@ func TestEnforceReviewerScopeOverlap_Issue654ConcreteExample(t *testing.T) {
 	// stands and all three modules match.
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue654Ask, issue654Diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("the #654 test-coverage diff must not demote a GO; got %v (reason: %v)",
 			got, extra["demotionReason"])
@@ -666,7 +666,7 @@ func TestEnforceReviewerScopeOverlap_Issue654ModulesDriftStillDemotes(t *testing
 	diff := []string{"src/lib/unrelated-helper.ts"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue654Ask, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("a diff touching none of the #654 modules must still demote GO; got %v", got)
 	}
@@ -695,7 +695,7 @@ func TestEnforceReviewerScopeOverlap_RealDriftStillBitesAfterFix(t *testing.T) {
 	diff := []string{"totally-unrelated.ts"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("genuine drift must still demote GO; got %v", got)
 	}

--- a/pkg/foreman/agent/test_content_vouch.go
+++ b/pkg/foreman/agent/test_content_vouch.go
@@ -1,0 +1,121 @@
+package agent
+
+import (
+	"path"
+	"regexp"
+	"strings"
+)
+
+// scopeMatchedViaContentKey is the extra key carrying refs satisfied by the
+// content-based vouch rather than by name-based folding. A content vouch is
+// recorded separately from scopeMatched so a match earned by reading a file's
+// imports is distinguishable in the task record from one earned by path
+// folding (#1605, #1606).
+const scopeMatchedViaContentKey = "scopeMatchedViaContent"
+
+// contentReferencesModule reports whether testContent imports or references
+// the module named by modulePath. It is the deterministic content signal the
+// scope-overlap rail falls back to when name-based folding (testTargetsForPath
+// / testTargetsWithLayout) fails to match a feature- or behaviour-named test
+// file: a test named for what it exercises (test_dedup.py,
+// test_platform_gh_api_forgejo.py) does not fold to the module it covers, but
+// its body imports that module, and the import is a computable, model-free
+// proof of coverage (#1610).
+//
+// The match is on the module's path stem (its last segment with the
+// extension removed), tolerant of package prefixes, so a Python test that
+// does `import pr_reviewer.platform` or `from pr_reviewer.platform import x`
+// vouches for a ref naming `platform.py`, and a JS test that does
+// `import x from './util'` or `require('./util')` vouches for `util.ts`.
+//
+// Per-language reference patterns, applied to the stem:
+//   - Python: `import <stem>` or `from <pkg>.<stem> import ...`
+//   - Go:     an import path whose last path element is the stem
+//   - JS/TS:  `import ... from '<prefix>/<stem>'` or `require('<stem>')`
+//   - Ruby:   `require '<stem>'` or `require_relative '<stem>'`
+//
+// The check is deliberately conservative: it returns false on any input that
+// does not clearly reference the module, because a false vouch defeats the
+// rail the same way a false name match would. A different module's stem that
+// merely shares a prefix (foo vs foo_bar) must not vouch.
+func contentReferencesModule(testContent, modulePath string) bool {
+	base := path.Base(modulePath)
+	stem := base
+	if ext := path.Ext(base); ext != "" {
+		stem = strings.TrimSuffix(base, ext)
+	}
+	if stem == "" {
+		return false
+	}
+	return contentReferencesStem(testContent, stem)
+}
+
+// contentReferencesStem runs the per-language import checks for one stem.
+// Kept separate from contentReferencesModule so the language rules stay
+// readable and so a future language can be added without touching the
+// modulePath-to-stem derivation.
+func contentReferencesStem(content, stem string) bool {
+	// Python: `import <stem>` / `import <pkg>.<stem>`, or
+	// `from <stem> import` / `from <pkg>.<stem> import`.
+	// The trailing \b keeps `import foo` from claiming `foo_bar`.
+	for _, re := range []string{
+		`(?m)^\s*import\s+` + regexp.QuoteMeta(stem) + `\b`,
+		`(?m)^\s*import\s+[\w.]*` + regexp.QuoteMeta(stem) + `(\.|$|\s)`,
+		`(?m)^\s*from\s+` + regexp.QuoteMeta(stem) + `\b`,
+		`(?m)^\s*from\s+[\w.]*\.` + regexp.QuoteMeta(stem) + `(\.|$|\s)`,
+	} {
+		if matched(re, content) {
+			return true
+		}
+	}
+
+	// JS/TS: `import ... from '<stem>'`, `import ... from '<pkg>/<stem>'`,
+	// or `require('<stem>')` / `require('<pkg>/<stem>')`.
+	for _, re := range []string{
+		`(?m)from\s+['"][^'"]*/` + regexp.QuoteMeta(stem) + `['"]`,
+		`(?m)from\s+['"]` + regexp.QuoteMeta(stem) + `['"]`,
+		`(?m)require\s*\(\s*['"][^'"]*/` + regexp.QuoteMeta(stem) + `['"]`,
+		`(?m)require\s*\(\s*['"]` + regexp.QuoteMeta(stem) + `['"]`,
+	} {
+		if matched(re, content) {
+			return true
+		}
+	}
+
+	// Ruby: `require '<stem>'` / `require '<pkg>/<stem>'` and the
+	// require_relative variants.
+	for _, re := range []string{
+		`(?m)^\s*require(_relative)?\s+['"][^'"]*/` + regexp.QuoteMeta(stem) + `['"]`,
+		`(?m)^\s*require(_relative)?\s+['"]` + regexp.QuoteMeta(stem) + `['"]`,
+	} {
+		if matched(re, content) {
+			return true
+		}
+	}
+
+	// Go: an import path whose last element is the stem. Go's import paths
+	// end in the package directory, so a test in the same package references
+	// the module by its directory name (the stem of `foo.go`), not `foo.go`
+	// itself.
+	for _, re := range []string{
+		`(?m)^\s*(?:[\w.]+ )?"[^"]*/` + regexp.QuoteMeta(stem) + `"`,
+		`(?m)^\s*(?:[\w.]+ )?"` + regexp.QuoteMeta(stem) + `"`,
+	} {
+		if matched(re, content) {
+			return true
+		}
+	}
+	return false
+}
+
+// matched reports whether the (precompiled-once) regex pattern matches
+// content. Compiling per call is acceptable: the scope rail reads at most a
+// handful of small test files per run, and keeping the helper stateless keeps
+// the vouch a pure function of (content, module) with no package state.
+func matched(pattern, content string) bool {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(content)
+}

--- a/pkg/foreman/agent/test_content_vouch_test.go
+++ b/pkg/foreman/agent/test_content_vouch_test.go
@@ -1,0 +1,333 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// TestContentReferencesModule covers the deterministic content signal the
+// scope-overlap rail falls back to when a test file is named for a feature
+// rather than the module it covers (#1610). Each case pairs a module ref the
+// issue names with a test body and the expected vouch. The NON-match cases are
+// the load-bearing ones: a test importing a different module must never vouch
+// for X, or the rail loses the drift signal it exists to keep.
+func TestContentReferencesModule(t *testing.T) {
+	tests := []struct {
+		name        string
+		testContent string
+		modulePath  string
+		want        bool
+	}{
+		{
+			name:        "python import with package prefix",
+			testContent: "import pr_reviewer.platform\n\n\ndef test_foo():\n    pass\n",
+			modulePath:  "pr_reviewer/platform.py",
+			want:        true,
+		},
+		{
+			name:        "python from-import with package prefix",
+			testContent: "from pr_reviewer.platform import build_client\n\n\ndef test_foo():\n    pass\n",
+			modulePath:  "pr_reviewer/platform.py",
+			want:        true,
+		},
+		{
+			name:        "python from-import bare module",
+			testContent: "from app import dedup\n\n\ndef test_dedup():\n    pass\n",
+			modulePath:  "app.py",
+			want:        true,
+		},
+		{
+			name:        "python import bare module",
+			testContent: "import app\n\n\ndef test_dedup():\n    pass\n",
+			modulePath:  "app.py",
+			want:        true,
+		},
+		{
+			name:        "js import from relative",
+			testContent: "import { dedup } from './util'\n\nit('dedups', () => {})\n",
+			modulePath:  "src/util.ts",
+			want:        true,
+		},
+		{
+			name:        "js import from package subpath",
+			testContent: "import { buildClient } from '../pr_reviewer/platform'\n\nit('builds', () => {})\n",
+			modulePath:  "pr_reviewer/platform.py",
+			want:        true,
+		},
+		{
+			name:        "js require",
+			testContent: "const { dedup } = require('./util')\n\ntest('dedups', () => {})\n",
+			modulePath:  "src/util.ts",
+			want:        true,
+		},
+		{
+			name:        "ruby require_relative",
+			testContent: "require_relative '../lib/foo'\n\nRSpec.describe Foo do\nend\n",
+			modulePath:  "lib/foo.rb",
+			want:        true,
+		},
+		{
+			name:        "ruby require with package prefix",
+			testContent: "require 'pr_reviewer/platform'\n\nRSpec.describe Platform do\nend\n",
+			modulePath:  "pr_reviewer/platform.py",
+			want:        true,
+		},
+		{
+			name:        "go import path suffix",
+			testContent: "import (\n\t\"example.com/proj/internal/foo\"\n\n\t\"testing\"\n)\n\nfunc TestFoo(t *testing.T) {}\n",
+			modulePath:  "internal/foo/foo.go",
+			want:        true,
+		},
+		{
+			name:        "go import bare package",
+			testContent: "import (\n\t\"foo\"\n\n\t\"testing\"\n)\n\nfunc TestFoo(t *testing.T) {}\n",
+			modulePath:  "foo.go",
+			want:        true,
+		},
+		{
+			name:        "non-match: python imports a different module",
+			testContent: "import other_module\n\n\ndef test_foo():\n    pass\n",
+			modulePath:  "platform.py",
+			want:        false,
+		},
+		{
+			name:        "non-match: prefix overlap must not vouch",
+			testContent: "import foo\n\n\ndef test_foo():\n    pass\n",
+			modulePath:  "foo_bar.py",
+			want:        false,
+		},
+		{
+			name:        "non-match: js requires a different module",
+			testContent: "import { other } from './other'\n\nit('x', () => {})\n",
+			modulePath:  "src/util.ts",
+			want:        false,
+		},
+		{
+			name:        "non-match: body mentions the name but does not import it",
+			testContent: "# the platform module is exercised here\ndef test_foo():\n    pass\n",
+			modulePath:  "platform.py",
+			want:        false,
+		},
+		{
+			name:        "non-match: empty module path",
+			testContent: "import app\n",
+			modulePath:  "",
+			want:        false,
+		},
+		{
+			name:        "non-match: empty test content",
+			testContent: "",
+			modulePath:  "platform.py",
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := contentReferencesModule(tt.testContent, tt.modulePath); got != tt.want {
+				t.Errorf("contentReferencesModule(%q, %q) = %v, want %v", tt.testContent, tt.modulePath, got, tt.want)
+			}
+		})
+	}
+}
+
+// fakeReader backs the readFile seam with an in-memory map so the
+// enforceReviewerScopeOverlap tests need no workspace. A missing path returns
+// an error, mirroring os.ReadFile on an absent file.
+type fakeReader map[string]string
+
+func (f fakeReader) read(relPath string) ([]byte, error) {
+	s, ok := f[relPath]
+	if !ok {
+		return nil, &readErr{path: relPath}
+	}
+	return []byte(s), nil
+}
+
+type readErr struct{ path string }
+
+func (e *readErr) Error() string { return "fakeReader: no such file " + e.path }
+
+// TestScopeOverlap_ContentVouchFeatureNamedTestIs the end-to-end #1610 case:
+// the issue names pr_reviewer/platform.py, the diff adds a test named for the
+// feature (test_platform_gh_api_forgejo.py) that does not fold to the module,
+// and the test's body imports the module. Name-based folding leaves the ref
+// unmatched, the content check reads the added test file and vouches, so the
+// GO stands and the vouch is recorded distinctly under scopeMatchedViaContent.
+func TestScopeOverlap_ContentVouchFeatureNamedTest(t *testing.T) {
+	body := "Add Forgejo API support to `pr_reviewer/platform.py` and cover it with tests."
+	added := []string{"tests/test_platform_gh_api_forgejo.py"}
+	vouching := "from pr_reviewer.platform import ForgejoClient\n" +
+		"\n\n" +
+		"def test_forgejo_round_trip():\n" +
+		"    client = ForgejoClient()\n" +
+		"    assert client is not None\n"
+	reader := fakeReader{
+		"tests/test_platform_gh_api_forgejo.py": vouching,
+	}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
+		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
+		added, reader.read)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("a feature-named test whose body imports the named module must keep GO; got %v (reason: %v)",
+			got, extra["demotionReason"])
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); v {
+		t.Errorf("scopeDriftDetected should be false when the added test vouches by content; extra=%v", extra)
+	}
+	if v, _ := extra["verdictDemoted"].(bool); v {
+		t.Errorf("the feature-named-test diff must not be demoted; extra=%v", extra)
+	}
+	matched, _ := extra["scopeMatched"].([]string)
+	if len(matched) != 1 || matched[0] != "pr_reviewer/platform.py" {
+		t.Errorf("scopeMatched = %v, want the module the test covers", matched)
+	}
+	via, ok := extra[scopeMatchedViaContentKey].([]string)
+	if !ok {
+		t.Fatalf("scopeMatchedViaContent must be recorded; extra=%v", extra)
+	}
+	if len(via) != 1 || via[0] != "pr_reviewer/platform.py" {
+		t.Errorf("scopeMatchedViaContent = %v, want the content-vouched ref", via)
+	}
+}
+
+// TestScopeOverlap_ContentVouchNoMatchingImportStillDemotes is the guard that
+// the vouch does not overreach: a feature-named test that imports a DIFFERENT
+// module must not vouch for the named module, so a GO on a diff that touches
+// none of the named files is still demoted.
+func TestScopeOverlap_ContentVouchNoMatchingImportStillDemotes(t *testing.T) {
+	body := "Add Forgejo API support to `pr_reviewer/platform.py` and cover it with tests."
+	added := []string{"tests/test_platform_gh_api_forgejo.py"}
+	reader := fakeReader{
+		// Named for the feature, but imports a helper, not the module under test.
+		"tests/test_platform_gh_api_forgejo.py": "import unrelated_helper\n\n\ndef test_forgejo_round_trip():\n    pass\n",
+	}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
+		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
+		added, reader.read)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("a feature-named test that imports a different module must not vouch; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); !v {
+		t.Errorf("scopeDriftDetected must be true when no vouch fires; extra=%v", extra)
+	}
+	if v, _ := extra["verdictDemoted"].(bool); !v {
+		t.Errorf("the non-vouching diff must be demoted; extra=%v", extra)
+	}
+	if _, ok := extra[scopeMatchedViaContentKey]; ok {
+		t.Errorf("scopeMatchedViaContent must not be recorded when the content vouch fires; extra=%v", extra)
+	}
+}
+
+// TestScopeOverlap_ContentVouchOnlyReadsAddedTestFiles proves the vouch is
+// scoped to the diff-ADDED set: a test file that references the module but was
+// already present on base (not in addedFiles) is not read, so it cannot vouch.
+func TestScopeOverlap_ContentVouchOnlyReadsAddedTestFiles(t *testing.T) {
+	body := "Add Forgejo API support to `pr_reviewer/platform.py` and cover it with tests."
+	// The reader has the referencing file, but it is NOT in the added set.
+	reader := fakeReader{
+		"tests/test_platform_gh_api_forgejo.py": "from pr_reviewer.platform import ForgejoClient\n",
+	}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body,
+		[]string{"pr_reviewer/other.py"}, // a source diff that touches nothing named
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
+		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
+		[]string{}, // nothing added: the vouch cannot read anything
+		reader.read)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("a test file outside the added set must not vouch; got %v", got)
+	}
+	if _, ok := extra[scopeMatchedViaContentKey]; ok {
+		t.Errorf("scopeMatchedViaContent must not be recorded when no added file is read; extra=%v", extra)
+	}
+}
+
+// TestScopeOverlap_ContentVouchReadErrorDegradesToName proves the vouch degrades
+// to name-only when a file cannot be read: a read error must never flip a ref
+// from unmatched to matched, so the GO is demoted rather than invented as
+// covered.
+func TestScopeOverlap_ContentVouchReadErrorDegradesToName(t *testing.T) {
+	body := "Add Forgejo API support to `pr_reviewer/platform.py` and cover it with tests."
+	added := []string{"tests/test_platform_gh_api_forgejo.py"}
+	// The reader has no entry for the added file, so reading it errors.
+	reader := fakeReader{}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
+		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
+		added, reader.read)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("an unreadable test file must not vouch; got %v", got)
+	}
+	if _, ok := extra[scopeMatchedViaContentKey]; ok {
+		t.Errorf("scopeMatchedViaContent must not be recorded on a read error; extra=%v", extra)
+	}
+}
+
+// TestScopeOverlap_NameMatchNotReattributedToContent proves ordering: when a
+// ref is already satisfied by name-based folding, the content vouch does not
+// also claim it, so scopeMatchedViaContent stays empty.
+func TestScopeOverlap_NameMatchNotReattributedToContent(t *testing.T) {
+	body := "Add Forgejo API support to `pr_reviewer/platform.py` and cover it with tests."
+	// The diff adds the module itself (name match) AND a test importing it.
+	added := []string{
+		"pr_reviewer/platform.py",
+		"tests/test_platform_gh_api_forgejo.py",
+	}
+	reader := fakeReader{
+		"tests/test_platform_gh_api_forgejo.py": "from pr_reviewer.platform import ForgejoClient\n",
+	}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
+		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
+		added, reader.read)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("a name match must keep GO; got %v", got)
+	}
+	if _, ok := extra[scopeMatchedViaContentKey]; ok {
+		t.Errorf("a ref satisfied by name must not be re-attributed to the content vouch; extra=%v", extra)
+	}
+}
+
+// TestScopeOverlap_NilAddedOrReaderKeepsNameBehaviour locks in that the vouch
+// is opt-in: passing nil for the added set or the reader leaves the rail's
+// behaviour identical to the name-only path (no content read, no vouch key).
+func TestScopeOverlap_NilAddedOrReaderKeepsNameBehaviour(t *testing.T) {
+	body := "Add Forgejo API support to `pr_reviewer/platform.py` and cover it with tests."
+	added := []string{"tests/test_platform_gh_api_forgejo.py"}
+	reader := fakeReader{
+		"tests/test_platform_gh_api_forgejo.py": "from pr_reviewer.platform import ForgejoClient\n",
+	}
+
+	// nil added set: the vouch is disabled, the ref stays unmatched, GO demotes.
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"}, TestLayout{},
+		nil, reader.read)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("nil added set must keep name-only behaviour (demote); got %v", got)
+	}
+	if _, ok := extra[scopeMatchedViaContentKey]; ok {
+		t.Errorf("nil added set must not record a content vouch; extra=%v", extra)
+	}
+
+	// nil reader: the vouch is disabled even though the added set is present.
+	extra = map[string]any{}
+	got = enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"}, TestLayout{},
+		added, nil)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("nil reader must keep name-only behaviour (demote); got %v", got)
+	}
+	if _, ok := extra[scopeMatchedViaContentKey]; ok {
+		t.Errorf("nil reader must not record a content vouch; extra=%v", extra)
+	}
+}

--- a/pkg/foreman/agent/test_layout_wiring_test.go
+++ b/pkg/foreman/agent/test_layout_wiring_test.go
@@ -38,7 +38,7 @@ func TestScopeLayout_LanguageConventions(t *testing.T) {
 			extra := map[string]any{}
 			got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 				"Add tests for `"+c.issueRef+"`.", []string{c.testFile},
-				foremanv1alpha1.AgenticTaskVerdictGo, []string{c.ext}, c.layout)
+				foremanv1alpha1.AgenticTaskVerdictGo, []string{c.ext}, c.layout, nil, nil)
 			if got != foremanv1alpha1.AgenticTaskVerdictGo {
 				t.Errorf("%s demoted: matched=%v refs=%v", c.lang,
 					extra["scopeMatched"], extra["scopeRefs"])
@@ -52,7 +52,7 @@ func TestScopeLayout_ZeroLayoutPreservesBesideTheCode(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Add tests for `src/lib/foo.ts`.", []string{"src/lib/foo.test.ts"},
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{})
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("beside-the-code must still match, matched=%v", extra["scopeMatched"])
 	}
@@ -70,7 +70,7 @@ func TestScopeLayout_Issue1447StaysGreen(t *testing.T) {
 	for _, l := range []TestLayout{{}, {TestRoot: "tests", SourceRoot: "src"}} {
 		extra := map[string]any{}
 		got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-			foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, l)
+			foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, l, nil, nil)
 		if got != foremanv1alpha1.AgenticTaskVerdictGo {
 			t.Errorf("#1447 regressed with layout %+v: matched=%v", l, extra["scopeMatched"])
 		}
@@ -83,7 +83,7 @@ func TestScopeLayout_RealDriftStillDemotes(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `src/main/java/Foo.java`.", []string{"src/main/java/Unrelated.java"},
 		foremanv1alpha1.AgenticTaskVerdictGo, []string{".java"},
-		TestLayout{TestRoot: "src/test/java", SourceRoot: "src/main/java"})
+		TestLayout{TestRoot: "src/test/java", SourceRoot: "src/main/java"}, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Errorf("real drift must demote, got %v", got)
 	}


### PR DESCRIPTION
## What

Content-based test-coverage vouch in the scope-overlap rail: a diff-**added** test file whose content imports the module an issue names now satisfies the scope check for that module, even when the test's *name* derives from a feature or behaviour rather than the module.

## Why

Fixes #1610

Name-based folding (#1573 beside-the-code, #1607 parallel trees) cannot express a test named for a feature or behaviour rather than its module. For that class, a correct "add tests for X" branch demotes for scope drift and burns its attempt budget with no PR.

**Scope, corrected per review:** of the two live reproductions from @joryirving's fleet, this fixes the diff-**added** shape — `misospace/miso-gallery#365` (`tests/test_dedup.py` covering `app.py`), verified vouching on this branch with `scopeMatchedViaContent: [app.py]`. The other, `misospace/pr-reviewer-action#438`, **appended** to an existing test file; the added-files gate deliberately excludes modified files (soundness: a modified file may have imported the module all along), so that shape remains out of scope here and is tracked in #1616 with added *lines* as the discriminator.

## How

`contentReferencesModule` matches per-language import forms (Python, Go, JS/TS, Ruby) against the named module's path stem; `testTargetsWithLayout`-style ordering is preserved — the content check runs **only** for refs name-matching left unmatched, against **only** diff-added test files. Content-vouched matches are recorded distinctly under `scopeMatchedViaContent`. A file whose content cannot be read is not a vouch: a read failure never flips a ref from unmatched to matched. Distinguishing added files required exporting a small `repo` diff helper, covered by its own tests.

## Provenance and verification

Authored by the Foreman coder (`wl-1610-content-vouch`, task records on the fleet) from the issue's spec; pipeline: coder GO → gate GATE-PASS → reviewer APPROVE with the verdict standing under the deterministic rails. Independently judged before this PR was opened:

- Full `pkg/foreman/agent` suite passes on the branch
- **Mutation checks bite at both layers**: forcing `contentReferencesModule` to `false` fails the unit table *and* the integration test; severing the wiring call fails the integration test — the wiring is load-bearing, not decorative
- `make lint-deadcode` → 0 issues (the CI guard added in #1604 fails on unwired code by construction)
- `GOOS=linux golangci-lint` → 0 issues
- Non-match guards present: a test importing a different module must not vouch; prefix overlap must not vouch; `scopeMatchedViaContent` absent when no content vouch fired

## Checklist

- [x] Tests added/updated - 9 test functions including negative cases
- [x] `make test` passes locally - full agent package on the branch
- [x] `make lint` passes locally - 0 issues
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - rail-internal; the language-gates doc gains a cross-reference in the #1610 follow-up if wanted

Foreman-authored per the AI-assisted contribution policy; human-reviewed and accountable (this PR's review conversation is owned by the maintainer).
