### PR TITLE
fix(foreman): skip the NoSystemPrompt floor for deterministic agents

### DIFF
--- a/api/foreman/v1alpha1/agent_configfloor.go
+++ b/api/foreman/v1alpha1/agent_configfloor.go
@@ -41,6 +41,25 @@ var agentRoleRequiredTools = map[AgentRole][]string{
 	AgentRoleReviewer: {"fetch_issue"},
 }
 
+// isDeterministicSpec mirrors pkg/foreman/agent.IsDeterministicAgent: it
+// reports whether the Agent runs the model-free branch, i.e. the executor
+// routes it by ENDPOINT ABSENCE (no LLM at all), not by tool shape. A
+// deterministic agent never renders a system prompt, so the
+// NoSystemPrompt floor requirement does not apply to it.
+//
+// Kept as a private copy rather than importing the agent package because
+// the api package is the leaf both sides depend on; importing
+// pkg/foreman/agent here would invert the dependency (the executor imports
+// this package for AgentSpec). The two implementations are asserted
+// equivalent by the equivalence test in pkg/foreman/agent, following the
+// same pattern the admission webhook uses.
+func (s *AgentSpec) isDeterministicSpec() bool {
+	if s.Provider != "" && s.Provider != AgentProviderLocal {
+		return false
+	}
+	return s.InferenceServiceRef.Name == ""
+}
+
 // ConfigFloor reports whether the spec meets the minimum an agent of this
 // role needs to produce groundable work, with a machine reason and a
 // human message when it does not. It is a warning surface, not an
@@ -49,8 +68,14 @@ var agentRoleRequiredTools = map[AgentRole][]string{
 // an empty system message while task prompts said "follow Step 1 of your
 // system prompt", and every verdict it minted was uninstructed with
 // nothing anywhere saying so.
+//
+// A deterministic agent (no endpoint; the executor runs its first
+// non-terminal tool directly, no model loop) never renders a system
+// prompt, so the NoSystemPrompt requirement is skipped for it (#1613).
+// The role-required tools check still applies: a deterministic reviewer
+// that cannot fetch the issue it is reviewing is still misconfigured.
 func (s *AgentSpec) ConfigFloor() (ok bool, reason, message string) {
-	if strings.TrimSpace(s.SystemPrompt) == "" {
+	if strings.TrimSpace(s.SystemPrompt) == "" && !s.isDeterministicSpec() {
 		return false, AgentConfigReasonNoSystemPrompt,
 			"spec.systemPrompt is empty: the model runs uninstructed while task prompts reference its steps"
 	}

--- a/api/foreman/v1alpha1/agent_configfloor_test.go
+++ b/api/foreman/v1alpha1/agent_configfloor_test.go
@@ -1,30 +1,122 @@
 package v1alpha1
 
-import "testing"
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 // The config floor is shared: the Agent controller publishes it as the
 // Validated condition, and the executor stamps failing runs' task records
 // (#1609). One implementation, so the two surfaces cannot drift.
 func TestAgentSpecConfigFloor(t *testing.T) {
-	ok, reason, _ := (&AgentSpec{
+	complete := &AgentSpec{
 		Role: AgentRoleReviewer, SystemPrompt: "# p",
 		Tools: []string{"fetch_issue", "submit_result"},
-	}).ConfigFloor()
+	}
+	ok, reason, _ := complete.ConfigFloor()
 	if !ok || reason != AgentConfigReasonComplete {
 		t.Fatalf("complete config must pass, got ok=%v reason=%q", ok, reason)
 	}
 
-	ok, reason, msg := (&AgentSpec{
-		Role: AgentRoleReviewer, Tools: []string{"submit_result"},
-	}).ConfigFloor()
+	// LLM agent (endpoint set): an empty prompt must fail NoSystemPrompt.
+	// The prompt requirement applies to the model path, not the
+	// deterministic path (#1613).
+	emptyPrompt := &AgentSpec{
+		Role: AgentRoleReviewer, Provider: AgentProviderLocal,
+		InferenceServiceRef: corev1.LocalObjectReference{Name: "svc"},
+		Tools:               []string{"fetch_issue", "submit_result"},
+	}
+	ok, reason, msg := emptyPrompt.ConfigFloor()
 	if ok || reason != AgentConfigReasonNoSystemPrompt || msg == "" {
 		t.Fatalf("empty prompt must fail with reason+message, got ok=%v reason=%q msg=%q", ok, reason, msg)
 	}
 
-	ok, reason, _ = (&AgentSpec{
+	missingTool := &AgentSpec{
 		Role: AgentRoleReviewer, SystemPrompt: "# p", Tools: []string{"bash", "submit_result"},
-	}).ConfigFloor()
+	}
+	ok, reason, _ = missingTool.ConfigFloor()
 	if ok || reason != AgentConfigReasonMissingRoleTools {
 		t.Fatalf("reviewer without fetch_issue must fail, got ok=%v reason=%q", ok, reason)
+	}
+}
+
+// TestAgentSpecConfigFloorDeterministic pins the #1613 fix: the floor skips
+// the NoSystemPrompt requirement for a deterministic agent (no endpoint),
+// because the executor routes it by endpoint absence and never renders a
+// prompt. The role-required-tools check still applies, and an LLM-path
+// agent (cloud-proxy) still needs a prompt even when its endpoint is empty.
+func TestAgentSpecConfigFloorDeterministic(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    *AgentSpec
+		wantOK  bool
+		wantWhy string
+	}{
+		{
+			// Gate-shaped: no provider, no inferenceServiceRef, no prompt.
+			// Deterministic, so the empty prompt is fine.
+			name:    "gate-shaped (no provider, no isvc) passes with empty prompt",
+			spec:    &AgentSpec{Role: AgentRoleVerifier, Tools: []string{"run_gate_job"}},
+			wantOK:  true,
+			wantWhy: AgentConfigReasonComplete,
+		},
+		{
+			// Explicit local provider, empty endpoint: still deterministic.
+			name:    "local provider, empty isvc, empty prompt passes",
+			spec:    &AgentSpec{Role: AgentRoleVerifier, Provider: AgentProviderLocal, Tools: []string{"run_gate_job"}},
+			wantOK:  true,
+			wantWhy: AgentConfigReasonComplete,
+		},
+		{
+			// cloud-proxy is never deterministic, so the prompt is required.
+			name:    "cloud-proxy reviewer with empty prompt still fails NoSystemPrompt",
+			spec:    &AgentSpec{Role: AgentRoleReviewer, Provider: AgentProviderCloudProxy, Tools: []string{"fetch_issue", "submit_result"}},
+			wantOK:  false,
+			wantWhy: AgentConfigReasonNoSystemPrompt,
+		},
+		{
+			// Deterministic, but a reviewer without fetch_issue cannot ground
+			// its verdicts: the role-required-tools check still applies.
+			name:    "deterministic reviewer missing fetch_issue fails MissingRoleTools",
+			spec:    &AgentSpec{Role: AgentRoleReviewer, Tools: []string{"submit_result"}},
+			wantOK:  false,
+			wantWhy: AgentConfigReasonMissingRoleTools,
+		},
+		{
+			// Local provider WITH an endpoint is an LLM agent: it needs a
+			// prompt even though its provider is local.
+			name:    "local provider with isvc, empty prompt fails NoSystemPrompt",
+			spec:    &AgentSpec{Role: AgentRoleVerifier, Provider: AgentProviderLocal, InferenceServiceRef: corev1.LocalObjectReference{Name: "svc"}, Tools: []string{"run_gate_job"}},
+			wantOK:  false,
+			wantWhy: AgentConfigReasonNoSystemPrompt,
+		},
+		{
+			// A whitespace-only prompt on a deterministic agent is irrelevant:
+			// no prompt is rendered either way, and the floor must not fail.
+			name:    "deterministic agent with whitespace-only prompt passes",
+			spec:    &AgentSpec{Role: AgentRoleVerifier, SystemPrompt: "   ", Tools: []string{"run_gate_job"}},
+			wantOK:  true,
+			wantWhy: AgentConfigReasonComplete,
+		},
+		{
+			// A whitespace-only prompt on an LLM agent is still "empty": the
+			// deterministic carve-out must not accept it as a present prompt.
+			name:    "local provider with isvc, whitespace-only prompt fails NoSystemPrompt",
+			spec:    &AgentSpec{Role: AgentRoleVerifier, Provider: AgentProviderLocal, InferenceServiceRef: corev1.LocalObjectReference{Name: "svc"}, SystemPrompt: "   ", Tools: []string{"run_gate_job"}},
+			wantOK:  false,
+			wantWhy: AgentConfigReasonNoSystemPrompt,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, reason, msg := tc.spec.ConfigFloor()
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (reason=%q)", ok, tc.wantOK, reason)
+			}
+			if reason != tc.wantWhy {
+				t.Fatalf("reason = %q, want %q (msg=%q)", reason, tc.wantWhy, msg)
+			}
+		})
 	}
 }

--- a/internal/foreman/controller/agent_validation_test.go
+++ b/internal/foreman/controller/agent_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -52,10 +53,15 @@ func TestValidateAgentConfig(t *testing.T) {
 			wantValid: true,
 		},
 		{
+			// An LLM agent (endpoint set) still needs a prompt; the
+			// NoSystemPrompt floor applies to the model path, not the
+			// deterministic path (#1613).
 			name: "empty systemPrompt fails for any role",
 			spec: foremanv1alpha1.AgentSpec{
-				Role:  "coder",
-				Tools: []string{"read_file", "bash", "submit_result"},
+				Role:                "coder",
+				Provider:            foremanv1alpha1.AgentProviderLocal,
+				InferenceServiceRef: corev1.LocalObjectReference{Name: "svc"},
+				Tools:               []string{"read_file", "bash", "submit_result"},
 			},
 			wantValid:  false,
 			wantReason: foremanv1alpha1.AgentConfigReasonNoSystemPrompt,
@@ -63,9 +69,11 @@ func TestValidateAgentConfig(t *testing.T) {
 		{
 			name: "whitespace-only systemPrompt fails",
 			spec: foremanv1alpha1.AgentSpec{
-				Role:         "reviewer",
-				SystemPrompt: "  \n\t ",
-				Tools:        []string{"fetch_issue", "submit_result"},
+				Role:                "reviewer",
+				Provider:            foremanv1alpha1.AgentProviderLocal,
+				InferenceServiceRef: corev1.LocalObjectReference{Name: "svc"},
+				SystemPrompt:        "  \n\t ",
+				Tools:               []string{"fetch_issue", "submit_result"},
 			},
 			wantValid:  false,
 			wantReason: foremanv1alpha1.AgentConfigReasonNoSystemPrompt,
@@ -81,10 +89,14 @@ func TestValidateAgentConfig(t *testing.T) {
 			wantReason: foremanv1alpha1.AgentConfigReasonMissingRoleTools,
 		},
 		{
+			// LLM reviewer (endpoint set) missing both prompt and
+			// fetch_issue: the prompt failure is reported first.
 			name: "missing prompt reported before missing tools",
 			spec: foremanv1alpha1.AgentSpec{
-				Role:  "reviewer",
-				Tools: []string{"bash", "submit_result"},
+				Role:                "reviewer",
+				Provider:            foremanv1alpha1.AgentProviderLocal,
+				InferenceServiceRef: corev1.LocalObjectReference{Name: "svc"},
+				Tools:               []string{"bash", "submit_result"},
 			},
 			wantValid:  false,
 			wantReason: foremanv1alpha1.AgentConfigReasonNoSystemPrompt,
@@ -130,11 +142,18 @@ func TestAgentReconcilerWritesValidatedCondition(t *testing.T) {
 	if err := foremanv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
 	}
+	// The incident: a hand-created LLM reviewer ran with no systemPrompt
+	// and no fetch_issue, so every verdict it minted was uninstructed and
+	// it could not read the issue under review (#1609). An LLM reviewer
+	// (endpoint set), not a deterministic one, so the prompt requirement
+	// applies (#1613).
 	agent := &foremanv1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{Name: "blind-reviewer", Namespace: "default", Generation: 3},
 		Spec: foremanv1alpha1.AgentSpec{
-			Role:  "reviewer",
-			Tools: []string{"read_file", "grep", "bash", "submit_result"},
+			Role:                "reviewer",
+			Provider:            foremanv1alpha1.AgentProviderLocal,
+			InferenceServiceRef: corev1.LocalObjectReference{Name: "svc"},
+			Tools:               []string{"read_file", "grep", "bash", "submit_result"},
 		},
 	}
 	cl := fake.NewClientBuilder().WithScheme(scheme).

--- a/pkg/foreman/agent/predicate_equivalence_test.go
+++ b/pkg/foreman/agent/predicate_equivalence_test.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"testing"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestConfigFloorDeterministicMatchesIsDeterministicAgent is the
+// private-copy-plus-equivalence-test guard for the api package's
+// isDeterministicSpec (#1613). The api package cannot import this package
+// (the executor imports it for AgentSpec), so ConfigFloor keeps a private
+// copy of the deterministic predicate — exactly the pattern the admission
+// webhook uses for the same constraint.
+//
+// The api copy is private, so we assert behavioral equivalence through the
+// public surface: for an empty-prompt verifier (a role with no required
+// tools), ConfigFloor passes if and only if the executor would route the
+// agent down the deterministic path. If someone edits isDeterministicSpec
+// to diverge from IsDeterministicAgent, this table fails the moment the two
+// disagree.
+func TestConfigFloorDeterministicMatchesIsDeterministicAgent(t *testing.T) {
+	cases := []struct {
+		name string
+		spec foremanv1alpha1.AgentSpec
+		want bool
+	}{
+		{
+			name: "empty spec (v0.1 shape) -\u003e deterministic",
+			spec: foremanv1alpha1.AgentSpec{},
+			want: true,
+		},
+		{
+			name: "gate-shaped (local, no isvc) -\u003e deterministic",
+			spec: foremanv1alpha1.AgentSpec{
+				Provider: foremanv1alpha1.AgentProviderLocal,
+			},
+			want: true,
+		},
+		{
+			name: "cloud-proxy provider -\u003e LLM (not deterministic)",
+			spec: foremanv1alpha1.AgentSpec{
+				Provider: foremanv1alpha1.AgentProviderCloudProxy,
+			},
+			want: false,
+		},
+		{
+			name: "local provider with inferenceServiceRef set -\u003e LLM",
+			spec: foremanv1alpha1.AgentSpec{
+				Provider:            foremanv1alpha1.AgentProviderLocal,
+				InferenceServiceRef: corev1.LocalObjectReference{Name: "svc"},
+			},
+			want: false,
+		},
+		{
+			name: "local without inferenceServiceRef -\u003e deterministic",
+			spec: foremanv1alpha1.AgentSpec{
+				Provider: foremanv1alpha1.AgentProviderLocal,
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Verifier has no role-required tools, so ConfigFloor reduces
+			// to the deterministic check alone: an empty-prompt verifier
+			// passes iff the spec is deterministic.
+			spec := tc.spec
+			spec.Role = foremanv1alpha1.AgentRoleVerifier
+			spec.SystemPrompt = ""
+
+			want := IsDeterministicAgent(spec)
+			if want != tc.want {
+				t.Fatalf("test setup broken: IsDeterministicAgent(%+v) = %v, want %v", spec, want, tc.want)
+			}
+
+			ok, reason, _ := spec.ConfigFloor()
+			if ok != tc.want {
+				t.Fatalf("ConfigFloor() = %v/%q, want deterministic=%v (api copy drifted)", ok, reason, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Stop the `Validated` condition false-positiving on deterministic agents: `ConfigFloor` now skips the `NoSystemPrompt` requirement for a spec the executor would route down its model-free path, where no prompt is ever rendered.

## Why

Refs #1613

The floor shipped in #1611 requires a `systemPrompt` for every role. The fleet's `gate` verifier (single `run_gate_job` tool, no model loop) showed `Validated=False / NoSystemPrompt` beside genuinely mis-configured agents on the first deploy, diluting the signal the column exists to give. `Refs` rather than `Fixes` because the live confirmation is one step away: after deploy, the placeholder prompt shimmed onto the `gate` CR comes off and `VALIDATED` must stay `True`.

## How

`isDeterministicSpec` in the api package mirrors the executor's routing predicate (`IsDeterministicAgent` in `pkg/foreman/agent/predicate.go`): provider empty-or-local AND no `inferenceServiceRef`. The api package cannot import the agent package (the executor imports it for `AgentSpec`), so this follows the codebase's documented private-copy pattern — the same one the admission webhook uses for the same constraint — with a **behavioral equivalence test** in `pkg/foreman/agent`: an empty-prompt verifier passes the floor iff the executor would route it deterministic, across empty, gate-shaped, cloud-proxy, and local-with/without-inferenceServiceRef specs. Role-required-tools checks are unchanged and still apply to deterministic agents.

## Provenance and verification

Foreman-authored across a review cycle (`wl-1613-detfloor` → finding → `wl-1613-r3`): the first pass implemented a tool-shape proxy predicate; independent review caught the divergence from the executor's real routing and fed it back; this branch is the corrected result. Pipeline: coder GO → gate GATE-PASS → reviewer APPROVE with the verdict standing and the scope rail vouching (`scopeMatched` carries both touched files). Independently judged before opening:

- All three affected packages pass on the branch
- **Mutation-verified**: diverging the api predicate from `IsDeterministicAgent` fails the equivalence test on exactly the diverging case
- `make lint-deadcode` → 0 issues; `GOOS=linux golangci-lint` → 0 issues

## Checklist

- [x] Tests added/updated - floor table expanded, equivalence test added, mutation-verified
- [x] `make test` passes locally - api, agent, and controller packages
- [x] `make lint` passes locally - 0 issues
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - condition semantics documented on ConfigFloor

Foreman-authored per the AI-assisted contribution policy; human-reviewed and accountable.
