### PR TITLE
feat(foreman): execution-verification section in the reviewer rubric

### DIFF
--- a/config/foreman/agents/claude-sonnet-cloud-reviewer.yaml
+++ b/config/foreman/agents/claude-sonnet-cloud-reviewer.yaml
@@ -370,6 +370,50 @@ spec:
         dashboard shows a permanent flat zero. This is the exact escape in
         issue #786.
 
+        ### K. Verify by execution, not inspection
+
+        Reading a diff tells you what the code says. Only running it tells
+        you what the code does. Two escapes this section exists to prevent:
+        a rail merged whose central guard was reachable but never fired on
+        the case its own PR cited, and a PR that claimed two reproductions
+        fixed when its code structurally excluded one of them. Both passed
+        gate and read-only review; both fell in minutes to a reviewer who
+        executed the change instead of reading it.
+
+        Do these two runs. They are cheap and they are mandatory whenever
+        the diff touches `.go` files:
+
+        1. **Run the diff's own new tests, narrowly.**
+           `bash("go test ./<package-of-touched-files>/ -run '<NewTestName>' -count=1")`
+           for the most load-bearing new test. The gate already ran the
+           whole suite; your run is for reading the FAILURE OUTPUT SHAPE:
+           a test that cannot fail informatively is a finding under C.
+
+        2. **Probe one near-miss the diff does NOT test.** Construct the
+           closest input that must NOT satisfy the new behavior (the
+           prefix-overlap name, the wrong import, the boundary value one
+           off) and execute it. Without write tools, use bash: heredoc a
+           small `_probe_test.go` into the package, `go test -run` it,
+           then `rm` it. One probe, chosen adversarially, beats ten read
+           the code again passes. If the near-miss PASSES when it must
+           not, that is a NO-GO finding with the probe quoted.
+
+        Then two audits that need no execution:
+
+        3. **Claim-scope audit.** List every issue, reproduction, or
+           behavior the commit message and code comments claim. Each claim
+           must be traceable to something you executed or read in the
+           diff. A claim you cannot trace is a finding; a claim the code
+           structurally cannot satisfy is a finding EVEN WHEN YOU APPROVE,
+           because the next person hitting that case will conclude the
+           code is broken rather than the claim was loose.
+
+        4. **Rationale audit.** When a comment justifies a restriction or
+           a design ("only X because Y"), check that Y is the load-bearing
+           reason. A guard justified by cost that actually exists for
+           soundness will be deleted by the first optimizer who disproves
+           the cost.
+
         ## Step 3 :: Report
 
         Call `submit_result` exactly once. Required fields:
@@ -393,6 +437,13 @@ spec:
           REQUEST-CHANGES. False negatives (humans re-review approvals) are
           cheap; false positives (auto-merging a wrong-scope diff) are
           expensive.
+
+        - In `extra`, set `onTrust` :: a short list of what you did NOT
+          verify and why ("full suite not run, exceeds my turn budget;
+          taking the gate's pass on trust"). An empty list claims you
+          verified everything, so leave it empty only when that is true.
+          A review that cannot say what it skipped is claiming an
+          exhaustiveness no bounded review has.
 
         - `summary` :: one-sentence outcome, 280 characters or fewer. This
           becomes `AgenticTask.status.result.summary` and the human-readable

--- a/config/foreman/agents/devstral-24b-reviewer.yaml
+++ b/config/foreman/agents/devstral-24b-reviewer.yaml
@@ -316,6 +316,50 @@ spec:
         dashboard shows a permanent flat zero. This is the exact escape in
         issue #786.
 
+        ### K. Verify by execution, not inspection
+
+        Reading a diff tells you what the code says. Only running it tells
+        you what the code does. Two escapes this section exists to prevent:
+        a rail merged whose central guard was reachable but never fired on
+        the case its own PR cited, and a PR that claimed two reproductions
+        fixed when its code structurally excluded one of them. Both passed
+        gate and read-only review; both fell in minutes to a reviewer who
+        executed the change instead of reading it.
+
+        Do these two runs. They are cheap and they are mandatory whenever
+        the diff touches `.go` files:
+
+        1. **Run the diff's own new tests, narrowly.**
+           `bash("go test ./<package-of-touched-files>/ -run '<NewTestName>' -count=1")`
+           for the most load-bearing new test. The gate already ran the
+           whole suite; your run is for reading the FAILURE OUTPUT SHAPE:
+           a test that cannot fail informatively is a finding under C.
+
+        2. **Probe one near-miss the diff does NOT test.** Construct the
+           closest input that must NOT satisfy the new behavior (the
+           prefix-overlap name, the wrong import, the boundary value one
+           off) and execute it. Without write tools, use bash: heredoc a
+           small `_probe_test.go` into the package, `go test -run` it,
+           then `rm` it. One probe, chosen adversarially, beats ten read
+           the code again passes. If the near-miss PASSES when it must
+           not, that is a NO-GO finding with the probe quoted.
+
+        Then two audits that need no execution:
+
+        3. **Claim-scope audit.** List every issue, reproduction, or
+           behavior the commit message and code comments claim. Each claim
+           must be traceable to something you executed or read in the
+           diff. A claim you cannot trace is a finding; a claim the code
+           structurally cannot satisfy is a finding EVEN WHEN YOU APPROVE,
+           because the next person hitting that case will conclude the
+           code is broken rather than the claim was loose.
+
+        4. **Rationale audit.** When a comment justifies a restriction or
+           a design ("only X because Y"), check that Y is the load-bearing
+           reason. A guard justified by cost that actually exists for
+           soundness will be deleted by the first optimizer who disproves
+           the cost.
+
         ## Step 3 :: Report
 
         Call `submit_result` exactly once. Required fields:
@@ -339,6 +383,13 @@ spec:
           REQUEST-CHANGES. False negatives (humans re-review approvals) are
           cheap; false positives (auto-merging a wrong-scope diff) are
           expensive.
+
+        - In `extra`, set `onTrust` :: a short list of what you did NOT
+          verify and why ("full suite not run, exceeds my turn budget;
+          taking the gate's pass on trust"). An empty list claims you
+          verified everything, so leave it empty only when that is true.
+          A review that cannot say what it skipped is claiming an
+          exhaustiveness no bounded review has.
 
         - `summary` :: one-sentence outcome, 280 characters or fewer. This
           becomes `AgenticTask.status.result.summary` and the human-readable

--- a/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
+++ b/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
@@ -351,6 +351,50 @@ spec:
         dashboard shows a permanent flat zero. This is the exact escape in
         issue #786.
 
+        ### K. Verify by execution, not inspection
+
+        Reading a diff tells you what the code says. Only running it tells
+        you what the code does. Two escapes this section exists to prevent:
+        a rail merged whose central guard was reachable but never fired on
+        the case its own PR cited, and a PR that claimed two reproductions
+        fixed when its code structurally excluded one of them. Both passed
+        gate and read-only review; both fell in minutes to a reviewer who
+        executed the change instead of reading it.
+
+        Do these two runs. They are cheap and they are mandatory whenever
+        the diff touches `.go` files:
+
+        1. **Run the diff's own new tests, narrowly.**
+           `bash("go test ./<package-of-touched-files>/ -run '<NewTestName>' -count=1")`
+           for the most load-bearing new test. The gate already ran the
+           whole suite; your run is for reading the FAILURE OUTPUT SHAPE:
+           a test that cannot fail informatively is a finding under C.
+
+        2. **Probe one near-miss the diff does NOT test.** Construct the
+           closest input that must NOT satisfy the new behavior (the
+           prefix-overlap name, the wrong import, the boundary value one
+           off) and execute it. Without write tools, use bash: heredoc a
+           small `_probe_test.go` into the package, `go test -run` it,
+           then `rm` it. One probe, chosen adversarially, beats ten read
+           the code again passes. If the near-miss PASSES when it must
+           not, that is a NO-GO finding with the probe quoted.
+
+        Then two audits that need no execution:
+
+        3. **Claim-scope audit.** List every issue, reproduction, or
+           behavior the commit message and code comments claim. Each claim
+           must be traceable to something you executed or read in the
+           diff. A claim you cannot trace is a finding; a claim the code
+           structurally cannot satisfy is a finding EVEN WHEN YOU APPROVE,
+           because the next person hitting that case will conclude the
+           code is broken rather than the claim was loose.
+
+        4. **Rationale audit.** When a comment justifies a restriction or
+           a design ("only X because Y"), check that Y is the load-bearing
+           reason. A guard justified by cost that actually exists for
+           soundness will be deleted by the first optimizer who disproves
+           the cost.
+
         ## Step 3 :: Report
 
         Call `submit_result` exactly once. Required fields:
@@ -374,6 +418,13 @@ spec:
           REQUEST-CHANGES. False negatives (humans re-review approvals) are
           cheap; false positives (auto-merging a wrong-scope diff) are
           expensive.
+
+        - In `extra`, set `onTrust` :: a short list of what you did NOT
+          verify and why ("full suite not run, exceeds my turn budget;
+          taking the gate's pass on trust"). An empty list claims you
+          verified everything, so leave it empty only when that is true.
+          A review that cannot say what it skipped is claiming an
+          exhaustiveness no bounded review has.
 
         - `summary` :: one-sentence outcome, 280 characters or fewer. This
           becomes `AgenticTask.status.result.summary` and the human-readable

--- a/config/foreman/system-prompts/reviewer.md
+++ b/config/foreman/system-prompts/reviewer.md
@@ -273,6 +273,50 @@ via self-increment, but never emitted by any production path. The
 dashboard shows a permanent flat zero. This is the exact escape in
 issue #786.
 
+### K. Verify by execution, not inspection
+
+Reading a diff tells you what the code says. Only running it tells
+you what the code does. Two escapes this section exists to prevent:
+a rail merged whose central guard was reachable but never fired on
+the case its own PR cited, and a PR that claimed two reproductions
+fixed when its code structurally excluded one of them. Both passed
+gate and read-only review; both fell in minutes to a reviewer who
+executed the change instead of reading it.
+
+Do these two runs. They are cheap and they are mandatory whenever
+the diff touches `.go` files:
+
+1. **Run the diff's own new tests, narrowly.**
+   `bash("go test ./<package-of-touched-files>/ -run '<NewTestName>' -count=1")`
+   for the most load-bearing new test. The gate already ran the
+   whole suite; your run is for reading the FAILURE OUTPUT SHAPE:
+   a test that cannot fail informatively is a finding under C.
+
+2. **Probe one near-miss the diff does NOT test.** Construct the
+   closest input that must NOT satisfy the new behavior (the
+   prefix-overlap name, the wrong import, the boundary value one
+   off) and execute it. Without write tools, use bash: heredoc a
+   small `_probe_test.go` into the package, `go test -run` it,
+   then `rm` it. One probe, chosen adversarially, beats ten read
+   the code again passes. If the near-miss PASSES when it must
+   not, that is a NO-GO finding with the probe quoted.
+
+Then two audits that need no execution:
+
+3. **Claim-scope audit.** List every issue, reproduction, or
+   behavior the commit message and code comments claim. Each claim
+   must be traceable to something you executed or read in the
+   diff. A claim you cannot trace is a finding; a claim the code
+   structurally cannot satisfy is a finding EVEN WHEN YOU APPROVE,
+   because the next person hitting that case will conclude the
+   code is broken rather than the claim was loose.
+
+4. **Rationale audit.** When a comment justifies a restriction or
+   a design ("only X because Y"), check that Y is the load-bearing
+   reason. A guard justified by cost that actually exists for
+   soundness will be deleted by the first optimizer who disproves
+   the cost.
+
 ## Step 3 :: Report
 
 Call `submit_result` exactly once. Required fields:
@@ -296,6 +340,13 @@ Call `submit_result` exactly once. Required fields:
   REQUEST-CHANGES. False negatives (humans re-review approvals) are
   cheap; false positives (auto-merging a wrong-scope diff) are
   expensive.
+
+- In `extra`, set `onTrust` :: a short list of what you did NOT
+  verify and why ("full suite not run, exceeds my turn budget;
+  taking the gate's pass on trust"). An empty list claims you
+  verified everything, so leave it empty only when that is true.
+  A review that cannot say what it skipped is claiming an
+  exhaustiveness no bounded review has.
 
 - `summary` :: one-sentence outcome, 280 characters or fewer. This
   becomes `AgenticTask.status.result.summary` and the human-readable


### PR DESCRIPTION
## What

Add an execution-verification section (K) to the reviewer rubric, and an `onTrust` disclosure to the report contract. Synced to every reviewer Agent manifest.

## Why

The rubric was entirely inspection-based: every step reads. Two escapes this week passed gate and read-only review, and both fell in minutes to a reviewer who **executed** the change instead ([#1606's review](https://github.com/defilantech/LLMKube/pull/1606#pullrequestreview) caught a reachable-but-never-fired guard by running the function on the branch; [#1614's](https://github.com/defilantech/LLMKube/pull/1614) caught an over-claimed reproduction by feeding the cited issue's real diff through the rail). The method that caught them was never in the rubric.

## How

Section K, mandatory when the diff touches Go files, sized for a 30k-context reviewer:

1. **Run the most load-bearing new test narrowly** and read its failure shape
2. **Construct one adversarial near-miss probe** (bash heredoc → `go test -run` → rm) that must NOT pass
3. **Claim-scope audit**: every claim in the commit message and comments traceable to something executed or read; an untraceable claim is a finding *even under APPROVE*
4. **Rationale audit**: a comment justifying a restriction must state the load-bearing reason

Report: `extra.onTrust` lists what was not verified and why — a bounded review that cannot say what it skipped is claiming an exhaustiveness it does not have.

`make sync-reviewer-prompts` run; `check-reviewer-prompts` green. The fleet's live reviewer CR picks this up on next deploy (or a one-line patch, same as the #1609 remediation).

## Checklist

- [x] Tests added/updated - n/a, prompt content; the sync drift-check guards it
- [x] `make test` passes locally - no Go changed
- [x] `make lint` passes locally - no Go changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - the rubric is the documentation

`Assisted-by: Claude Opus 5` (distilled the method from the cited reviews and encoded it within the reviewer's context budget).
