### PR TITLE
feat(foreman): vouch modified test files on their added lines

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -891,11 +891,19 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 				scopeReadFile := func(relPath string) ([]byte, error) {
 					return os.ReadFile(filepath.Join(workspace, relPath))
 				}
+				// The modified-file vouch (#1616) checks a modified test file on
+				// the lines this branch ADDED to it, so a test that gained the
+				// import vouches while one that merely already had it does not.
+				// Like scopeAdded, a failure degrades the probe to absent — the
+				// rail never demotes on a read error, so this stays best-effort.
+				scopeReadAddedLines := func(relPath string) (string, error) {
+					return repo.DiffAddedLines(ctx, workspace, reviewBase, relPath)
+				}
 				verdict = enforceReviewerScopeOverlap(log, loopRes.Terminal.Extra,
 					extractFetchIssueBody(loopRes.Transcript), reviewDiff, verdict,
 					resolvedGate.SourceExtensions,
 					testLayoutFrom(resolvedGate.TestLayout),
-					scopeAdded, scopeReadFile)
+					scopeAdded, scopeReadFile, scopeReadAddedLines)
 				scopeDriftDetected, _ = loopRes.Terminal.Extra["scopeDriftDetected"].(bool)
 				scopeMatched, _ = loopRes.Terminal.Extra["scopeMatched"].([]string)
 			} else {

--- a/pkg/foreman/agent/repo/diff.go
+++ b/pkg/foreman/agent/repo/diff.go
@@ -79,6 +79,59 @@ func DiffAdded(ctx context.Context, workspace, base string) ([]string, error) {
 	return parseNameStatusAdded(out), nil
 }
 
+// DiffAddedLines returns the lines the branch ADDED to a single file, using
+// `git diff -U0 base...HEAD -- file`. It is the content source for the
+// modified-file half of the content-based test-coverage vouch (#1616): a test
+// file this branch merely modified may have imported the module under test
+// long before the branch touched it, so the file's whole content is not
+// evidence of new coverage. The added LINES are: a test that gains
+// `from pkg.module import ...` in this diff is evidence; one that merely
+// already contained it is not.
+//
+// The three-dot form matches DiffNameOnly / DiffAdded, so the base boundary
+// agrees. `-U0` drops context lines so the result is exactly the additions.
+// Each `+` line is stripped of its leading `+`; the `+++ b/<file>` header is
+// skipped. Returns the added lines joined by newlines ("" when the file has
+// no additions, e.g. a pure deletion). An empty result is not an error.
+func DiffAddedLines(ctx context.Context, workspace, base, file string) (string, error) {
+	if workspace == "" {
+		return "", fmt.Errorf("DiffAddedLines: workspace is required")
+	}
+	if base == "" {
+		return "", fmt.Errorf("DiffAddedLines: base ref is required")
+	}
+	if file == "" {
+		return "", fmt.Errorf("DiffAddedLines: file path is required")
+	}
+	out, err := runGit(ctx, workspace, baseEnv(), "diff", "-U0", base+"...HEAD", "--", file)
+	if err != nil {
+		return "", err
+	}
+	return parseAddedLines(out), nil
+}
+
+// parseAddedLines collects the added lines from a unified diff: every line
+// starting with `+` (minus the `+++` new-file header), with the leading `+`
+// removed and CRLF line endings normalized. Returns "" when there are no
+// additions.
+func parseAddedLines(diff string) string {
+	if diff == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(diff, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, "+++") {
+			continue
+		}
+		if len(line) > 1 && strings.HasPrefix(line, "+") {
+			b.WriteString(line[1:])
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
 // parseNameStatusAdded keeps only the ADDED ("A") paths from tab-separated
 // `git diff --name-status` output. Rename/copy rows ("R..", "C..") are not
 // additions of a new path and are excluded: a renamed test file's coverage was

--- a/pkg/foreman/agent/repo/diff_test.go
+++ b/pkg/foreman/agent/repo/diff_test.go
@@ -75,6 +75,69 @@ func TestParseNameStatusAdded(t *testing.T) {
 	}
 }
 
+func TestParseAddedLines(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{
+			"single-add",
+			"diff --git a/tests/test_x.py b/tests/test_x.py\n" +
+				"index 000..111 100644\n" +
+				"--- a/tests/test_x.py\n" +
+				"+++ b/tests/test_x.py\n" +
+				"@@ -0,0 +1,1 @@\n" +
+				"+from pr_reviewer.platform import Client\n",
+			"from pr_reviewer.platform import Client",
+		},
+		{
+			"header-and-minus-ignored",
+			"--- a/f.py\n" +
+				"+++ b/f.py\n" +
+				"@@ -1 +1,2 @@\n" +
+				"-old line\n" +
+				"+new line one\n" +
+				"+new line two\n",
+			"new line one\nnew line two",
+		},
+		{
+			"added-line-whose-content-starts-with-plus",
+			"+++ b/f.py\n" +
+				"@@ -1,0 +1 @@\n" +
+				"++ not a header line\n",
+			"+ not a header line",
+		},
+		{"no-additions-pure-deletion", "--- a/f.py\n+++ b/f.py\n@@ -1 +0 @@\n-removed\n", ""},
+		{
+			"trailing-newline-normalized",
+			"+++ b/f.py\n@@ -0,0 +1 @@\n+only line\n\n",
+			"only line",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseAddedLines(tc.in); got != tc.want {
+				t.Errorf("parseAddedLines(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiffAddedLines_RejectsEmptyArgs(t *testing.T) {
+	ctx := context.Background()
+	if _, err := DiffAddedLines(ctx, "", "main", "f.py"); err == nil {
+		t.Error("DiffAddedLines: empty workspace should error")
+	}
+	if _, err := DiffAddedLines(ctx, "/tmp", "", "f.py"); err == nil {
+		t.Error("DiffAddedLines: empty base should error")
+	}
+	if _, err := DiffAddedLines(ctx, "/tmp", "main", ""); err == nil {
+		t.Error("DiffAddedLines: empty file should error")
+	}
+}
+
 func TestParseNameOnly(t *testing.T) {
 	cases := []struct {
 		name string
@@ -199,6 +262,84 @@ func TestDiffAdded_RoundTrip(t *testing.T) {
 	}
 	if len(empty) != 0 {
 		t.Errorf("HEAD == base should yield no added files; got %v", empty)
+	}
+}
+
+// TestDiffAddedLines_RoundTrip exercises DiffAddedLines against a real git
+// workspace: a test file already present on main gains appended import lines
+// on a feature branch, and DiffAddedLines must return exactly those added
+// lines — not the pre-existing body, not the removed line. This is the
+// content source for the modified-file half of the content vouch (#1616), so
+// the append shape (the #438 reproduction) must be proven end to end. Skipped
+// if `git` is not on PATH.
+func TestDiffAddedLines_RoundTrip(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ws := t.TempDir()
+	ctx := context.Background()
+
+	run := func(args ...string) {
+		t.Helper()
+		if _, err := runGit(ctx, ws, baseEnv(), args...); err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+	}
+
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(ws, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdirall %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	// init repo + initial commit on main with an existing test file.
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+	mustWrite("tests/test_platform.py", "import base_module\n\n\ndef test_existing():\n    pass\n")
+	run("add", ".")
+	run("commit", "-m", "initial")
+
+	// branch off and APPEND import lines to the existing test file, removing
+	// one line so the minus side is present and must be excluded.
+	run("checkout", "-b", "feature")
+	featureBody := "import base_module\n" +
+		"from pr_reviewer.platform import ForgejoClient\n\n\n" +
+		"def test_existing():\n    pass\n"
+	mustWrite("tests/test_platform.py", featureBody)
+	run("add", ".")
+	run("commit", "-m", "append import")
+
+	got, err := DiffAddedLines(ctx, ws, "main", "tests/test_platform.py")
+	if err != nil {
+		t.Fatalf("DiffAddedLines: %v", err)
+	}
+	if want := "from pr_reviewer.platform import ForgejoClient"; got != want {
+		t.Errorf("DiffAddedLines = %q, want exactly the appended import line %q", got, want)
+	}
+
+	// A file the branch did not touch yields no additions (not an error).
+	untouched, err := DiffAddedLines(ctx, ws, "main", "README.md")
+	if err != nil {
+		t.Fatalf("DiffAddedLines on untouched path: %v", err)
+	}
+	if untouched != "" {
+		t.Errorf("untouched file should yield no added lines; got %q", untouched)
+	}
+
+	// Back on main, HEAD == base, so nothing was added to the file.
+	run("checkout", "main")
+	empty, err := DiffAddedLines(ctx, ws, "main", "tests/test_platform.py")
+	if err != nil {
+		t.Fatalf("DiffAddedLines main vs HEAD: %v", err)
+	}
+	if empty != "" {
+		t.Errorf("HEAD == base should yield no added lines; got %q", empty)
 	}
 }
 

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -264,44 +264,86 @@ func testTargetsForPath(p string) []string {
 	return nil
 }
 
-// testContentReferencesModule reports whether any of the diff-ADDED test files
-// whose content can be read references modulePath. It is the content-based
-// half of the #1610 vouch: name-based folding (testTargetsForPath /
-// testTargetsWithLayout) folds the test file's NAME to its subject, which
-// fails for a test named after a feature or behaviour. This instead reads the
-// file's body and asks whether it imports the module under test
-// (contentReferencesModule), which is the deterministic, model-free signal
-// that a feature-named test really does cover the module.
+// contentProbe pairs a test file's workspace-relative diff path with the
+// content to check: the file's whole body when the branch ADDED it, or only
+// the lines the branch added when it merely MODIFIED it.
+type contentProbe struct {
+	path    string
+	content string
+}
+
+// testContentReferencesModule reports whether any probe's content references
+// modulePath. It is the content-based half of the #1610 vouch: name-based
+// folding (testTargetsForPath / testTargetsWithLayout) folds the test file's
+// NAME to its subject, which fails for a test named after a feature or
+// behaviour. This instead checks the test's content and asks whether it
+// imports the module under test (contentReferencesModule), the deterministic,
+// model-free signal that a feature-named test really does cover the module.
 //
-// Only addedFiles are read, and the reason is soundness, not cost: a test
-// file this branch merely MODIFIED may have imported the module long before
-// the branch touched it, so vouching on a modified file's whole content
-// would let a coder earn a scope pass by editing any test that happens to
-// import the named module, without adding coverage for it. Restricting to
-// files the branch created means the import evidence cannot predate the
-// work. The price is a real out-of-scope class: a branch that APPENDS tests
-// to an existing test file is not vouched even when the appended lines
-// import the module (misospace/pr-reviewer-action#438 is exactly this
-// shape). Covering it needs the added LINES as the discriminator, not the
-// file: see the follow-up filed from the #1614 review.
+// The probe content is chosen for soundness, not cost. A test file this branch
+// ADDED is checked on its whole body: a new test's imports cannot predate the
+// work. A test file this branch merely MODIFIED is checked on its added LINES
+// ONLY (#1616): the file may have imported the module long before the branch
+// touched it, so vouching on its whole content would let a coder earn a scope
+// pass by editing any test that happens to import the named module, without
+// adding coverage for it. The added lines are the sound discriminator — a test
+// that gains `from pkg.module import ...` in this diff is evidence; one that
+// merely already contained it is not. This now covers the append-to-an-existing
+// test-file shape (misospace/pr-reviewer-action#438) the #1614 slice left out.
 //
-// A file whose content cannot be read is simply not a vouch: a read failure
-// must never flip a ref from unmatched to matched, so the rail degrades to
-// name-based behaviour rather than inventing coverage it cannot verify.
-func testContentReferencesModule(addedFiles []string, modulePath string, readFile func(string) ([]byte, error)) bool {
-	for _, f := range addedFiles {
-		if !isTestFile(f) {
+// A probe whose content is empty (an unreadable added file, a modified file
+// with no added lines) is simply not a vouch: a read failure must never flip a
+// ref from unmatched to matched, so the rail degrades to name-based behaviour
+// rather than inventing coverage it cannot verify.
+func testContentReferencesModule(probes []contentProbe, modulePath string) bool {
+	for _, p := range probes {
+		if !isTestFile(p.path) {
 			continue
 		}
-		content, err := readFile(f)
-		if err != nil {
-			continue
-		}
-		if contentReferencesModule(string(content), modulePath) {
+		if contentReferencesModule(p.content, modulePath) {
 			return true
 		}
 	}
 	return false
+}
+
+// buildContentProbes assembles the content probes for the vouch. diff-ADDED
+// test files are probed on their whole body (readFile); diff-MODIFIED test
+// files are probed on their added lines only (readAddedLines). A nil readFile
+// disables the added-file probes and a nil readAddedLines disables the
+// modified-file probes, so passing nil for both reproduces the pre-#1616
+// name-only behaviour exactly.
+func buildContentProbes(
+	diffFiles, addedFiles []string,
+	readFile func(relPath string) ([]byte, error),
+	readAddedLines func(relPath string) (string, error),
+) []contentProbe {
+	added := make(map[string]bool, len(addedFiles))
+	for _, f := range addedFiles {
+		added[f] = true
+	}
+	var probes []contentProbe
+	if readFile != nil {
+		for _, f := range addedFiles {
+			if !isTestFile(f) {
+				continue
+			}
+			if content, err := readFile(f); err == nil {
+				probes = append(probes, contentProbe{path: f, content: string(content)})
+			}
+		}
+	}
+	if readAddedLines != nil {
+		for _, f := range diffFiles {
+			if !isTestFile(f) || added[f] {
+				continue
+			}
+			if lines, err := readAddedLines(f); err == nil {
+				probes = append(probes, contentProbe{path: f, content: lines})
+			}
+		}
+	}
+	return probes
 }
 
 // isTestFile reports whether p is a test file under any of the recognized
@@ -336,12 +378,16 @@ func isTestFile(p string) bool {
 // a false drift flag costs one escalation review, while a missed match
 // would demote a legitimate branch.
 // addedFiles carries the subset of the branch's diff that was ADDED (git
-// status "A"), and readFile resolves a workspace-relative diff path to its
-// bytes. Both are only used by the content-based vouch (#1610): a test file
-// named for a feature (test_dedup.py) defeats name-based folding, but its body
-// imports the module it covers, and reading that import is the deterministic
-// signal name-folding cannot express. Pass nil for both to disable the vouch
-// and keep the pure name-based behaviour (every existing test does).
+// status "A"), readFile resolves an ADDED workspace-relative diff path to its
+// bytes, and readAddedLines resolves a MODIFIED workspace-relative diff path
+// to the lines the branch added to it (via repo.DiffAddedLines). All three
+// are only used by the content-based vouch (#1610, extended to modified files
+// in #1616): a test file named for a feature (test_dedup.py) defeats name-based
+// folding, but its body — or, for a modified file, the lines this branch added
+// to it — imports the module it covers, and reading that import is the
+// deterministic signal name-folding cannot express. Pass nil for all three to
+// disable the vouch and keep the pure name-based behaviour (every existing
+// name-only test does).
 func enforceReviewerScopeOverlap(
 	log logr.Logger,
 	extra map[string]any,
@@ -352,6 +398,7 @@ func enforceReviewerScopeOverlap(
 	testLayout TestLayout,
 	addedFiles []string,
 	readFile func(relPath string) ([]byte, error),
+	readAddedLines func(relPath string) (string, error),
 ) foremanv1alpha1.AgenticTaskVerdict {
 	if extra == nil {
 		return verdict
@@ -405,21 +452,23 @@ func enforceReviewerScopeOverlap(
 		}
 	}
 
-	// Content-based vouch (#1610): name-based folding fails for a test file
-	// named for a feature or behaviour (test_dedup.py,
-	// test_platform_gh_api_forgejo.py) because its name does not derive from
-	// the module it covers. For each ref the name fold left unmatched, fall
-	// back to reading the diff-ADDED test files: a file whose content imports
-	// the module it covers vouches for it. Ordering is load-bearing — the
-	// content check runs only on the refs name matching left unmatched, so a
-	// path match is never re-derived from content, and the two signals stay
-	// distinguishable in the record.
-	if len(matched) < len(refs) && len(addedFiles) > 0 && readFile != nil {
+	// Content-based vouch (#1610, extended to modified files in #1616):
+	// name-based folding fails for a test file named for a feature or
+	// behaviour (test_dedup.py, test_platform_gh_api_forgejo.py) because its
+	// name does not derive from the module it covers. For each ref the name
+	// fold left unmatched, fall back to checking the test content probes: an
+	// ADDED test file probed on its whole body, or a MODIFIED test file probed
+	// on its added lines, vouches when it imports the module it covers.
+	// Ordering is load-bearing — the content check runs only on the refs name
+	// matching left unmatched, so a path match is never re-derived from
+	// content, and the two signals stay distinguishable in the record.
+	probes := buildContentProbes(diffFiles, addedFiles, readFile, readAddedLines)
+	if len(matched) < len(refs) && len(probes) > 0 {
 		for _, r := range refs {
 			if matchedByName[r] {
 				continue
 			}
-			if testContentReferencesModule(addedFiles, r, readFile) {
+			if testContentReferencesModule(probes, r) {
 				matched = append(matched, r)
 				matchedByName[r] = true
 				if extra[scopeMatchedViaContentKey] == nil {

--- a/pkg/foreman/agent/scope_overlap_failopen_test.go
+++ b/pkg/foreman/agent/scope_overlap_failopen_test.go
@@ -14,7 +14,7 @@ import (
 func TestScopeOverlap_NoIssueBodyIsRecorded(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, "",
-		[]string{"pkg/foreman/agent/foo.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		[]string{"pkg/foreman/agent/foo.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("verdict must not change, got %v", got)
@@ -32,7 +32,7 @@ func TestScopeOverlap_NoDiffFilesIsRecorded(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/executor_native.go`.", nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("verdict must not change, got %v", got)
@@ -51,7 +51,7 @@ func TestScopeOverlap_RanAndMatchedIsNotMarkedSkipped(t *testing.T) {
 	extra := map[string]any{}
 	enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/foo.go`.", []string{"pkg/foreman/agent/foo.go"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 
 	if _, ok := skippedFor(extra, railScopeOverlap); ok {
 		t.Errorf("a check that ran must not be marked skipped, extra=%v", extra)
@@ -63,7 +63,7 @@ func TestScopeOverlap_RanAndDriftedIsNotMarkedSkipped(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/executor_native.go`.",
 		[]string{"pkg/foreman/agent/unrelated.go"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Errorf("real drift must still demote, got %v", got)
@@ -75,7 +75,7 @@ func TestScopeOverlap_RanAndDriftedIsNotMarkedSkipped(t *testing.T) {
 
 func TestScopeOverlap_NilExtraDoesNotPanic(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), nil, "body", []string{"a.go"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("verdict must not change, got %v", got)
 	}
@@ -89,7 +89,7 @@ func TestScopeOverlap_NoPathRefsIsRecorded(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Make the reviewer stop approving work it never looked at.",
 		[]string{"pkg/foreman/agent/foo.go"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("verdict must not change, got %v", got)
@@ -111,7 +111,7 @@ func TestScopeOverlap_DriftNotDemotedRecordsWhich(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/executor_native.go`.", []string{"README.md"},
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("docs-only diff must not demote, got %v", got)
 	}
@@ -123,7 +123,7 @@ func TestScopeOverlap_DriftNotDemotedRecordsWhich(t *testing.T) {
 	extra = map[string]any{}
 	enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `pkg/foreman/agent/executor_native.go`.", []string{"pkg/foreman/agent/other.go"},
-		foremanv1alpha1.AgenticTaskVerdictNoGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nil, TestLayout{}, nil, nil, nil)
 	if r, _ := extra["scopeDriftNotDemoted"].(string); r != scopeNotDemotedAlreadyNonGo {
 		t.Errorf("want %q, got %q (extra=%v)", scopeNotDemotedAlreadyNonGo, r, extra)
 	}

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -151,7 +151,7 @@ func TestEnforceReviewerScopeOverlap_GodotRefMatchVouches(t *testing.T) {
 	diff := []string{"scripts/main.gd", "tests/test_tick_integration.gd"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, godotIssueBody, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".gd"}, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".gd"}, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a diff touching issue-named .gd files must not demote; got %v", got)
 	}
@@ -172,7 +172,7 @@ func TestEnforceReviewerScopeOverlap_GodotBlindWithoutExtensions(t *testing.T) {
 	diff := []string{"scripts/main.gd", "tests/test_tick_integration.gd"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, godotIssueBody, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("no refs must pass through; got %v", got)
 	}
@@ -189,7 +189,7 @@ func TestEnforceReviewerScopeOverlap_Issue379DriftDemotesGo(t *testing.T) {
 	}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("zero scope overlap on GO must demote to NO-GO; got %v", got)
 	}
@@ -219,7 +219,7 @@ func TestEnforceReviewerScopeOverlap_MatchedRefStands(t *testing.T) {
 	diff := []string{"AGENTS.md"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue510Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a diff touching a referenced file must not demote; got %v", got)
 	}
@@ -239,7 +239,7 @@ func TestEnforceReviewerScopeOverlap_BasenameMatch(t *testing.T) {
 	diff := []string{"config/rbac/role.yaml"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("basename match must not demote; got %v", got)
 	}
@@ -250,7 +250,7 @@ func TestEnforceReviewerScopeOverlap_NoRefsObserveOnly(t *testing.T) {
 	diff := []string{"pkg/agent/agent.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("no path refs in issue must not demote; got %v", got)
 	}
@@ -263,7 +263,7 @@ func TestEnforceReviewerScopeOverlap_DriftOnNoGoAnnotatesOnly(t *testing.T) {
 	diff := []string{"internal/foreman/controller/agentictask_controller.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictNoGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictNoGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("NO-GO must stay NO-GO; got %v", got)
 	}
@@ -283,7 +283,7 @@ func TestEnforceReviewerScopeOverlap_ZeroGoFilesSkipsScopeCheck(t *testing.T) {
 	diff := []string{"README.md", "config/crd/bases/inference.llmkube.dev_models.yaml"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("zero-Go-file diff must not demote GO; got %v", got)
 	}
@@ -300,7 +300,7 @@ func TestEnforceReviewerScopeOverlap_RealDriftStillBites(t *testing.T) {
 	diff := []string{"internal/foreman/controller/agentictask_controller.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("real drift with Go files must still demote GO; got %v", got)
 	}
@@ -311,13 +311,13 @@ func TestEnforceReviewerScopeOverlap_RealDriftStillBites(t *testing.T) {
 
 func TestEnforceReviewerScopeOverlap_NilOrEmptyInputsPassThrough(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), nil, issue379Body,
-		[]string{"x.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		[]string{"x.go"}, foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("nil extra must pass through; got %v", got)
 	}
 	extra := map[string]any{}
 	if got := enforceReviewerScopeOverlap(logr.Discard(), extra, "", nil,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil); got != foremanv1alpha1.AgenticTaskVerdictGo {
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil); got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("empty body and diff must pass through; got %v", got)
 	}
 }
@@ -385,7 +385,7 @@ func TestEnforceReviewerScopeOverlap_PythonExtensions(t *testing.T) {
 	diff := []string{"README.md", "docs/guide.md"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue379Body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"}, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"}, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("with .py extensions and no .py diff, scope check should skip; got %v", got)
 	}
@@ -426,7 +426,8 @@ func TestEnforceReviewerScopeOverlap_LineCitedRefVouches(t *testing.T) {
 	extra := map[string]any{}
 	body := "Buffered alerts are dropped on restart; see `main.go:135` and `main.go:80`."
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body,
-		[]string{"main.go", "main_test.go"}, foremanv1alpha1.AgenticTaskVerdictGo, []string{".go"}, TestLayout{}, nil, nil)
+		[]string{"main.go", "main_test.go"}, foremanv1alpha1.AgenticTaskVerdictGo,
+		[]string{".go"}, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("a diff touching the line-cited file must keep GO, got %v", got)
 	}
@@ -539,7 +540,7 @@ func TestEnforceReviewerScopeOverlap_TestFileMapsToModule(t *testing.T) {
 	diff := []string{"src/lib/automation-sync.test.ts"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a diff that creates the test for the named module must not demote; got %v", got)
 	}
@@ -563,7 +564,7 @@ func TestEnforceReviewerScopeOverlap_GoTestFileMapsToModule(t *testing.T) {
 	diff := []string{"internal/foo/bar_test.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a diff adding bar_test.go must not demote an issue naming bar.go; got %v", got)
 	}
@@ -580,7 +581,7 @@ func TestEnforceReviewerScopeOverlap_TestFileBareRefMapsToModule(t *testing.T) {
 	diff := []string{"internal/foo/bar_test.go"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, nil, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a bare ref to bar.go must match the bar_test.go diff; got %v", got)
 	}
@@ -626,7 +627,7 @@ func TestEnforceReviewerScopeOverlap_Issue654ConcreteExample(t *testing.T) {
 	// stands and all three modules match.
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue654Ask, issue654Diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("the #654 test-coverage diff must not demote a GO; got %v (reason: %v)",
 			got, extra["demotionReason"])
@@ -666,7 +667,7 @@ func TestEnforceReviewerScopeOverlap_Issue654ModulesDriftStillDemotes(t *testing
 	diff := []string{"src/lib/unrelated-helper.ts"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, issue654Ask, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("a diff touching none of the #654 modules must still demote GO; got %v", got)
 	}
@@ -695,7 +696,7 @@ func TestEnforceReviewerScopeOverlap_RealDriftStillBitesAfterFix(t *testing.T) {
 	diff := []string{"totally-unrelated.ts"}
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("genuine drift must still demote GO; got %v", got)
 	}

--- a/pkg/foreman/agent/test_content_vouch_test.go
+++ b/pkg/foreman/agent/test_content_vouch_test.go
@@ -150,6 +150,17 @@ type readErr struct{ path string }
 
 func (e *readErr) Error() string { return "fakeReader: no such file " + e.path }
 
+// fakeAddedLines backs the readAddedLines seam with an in-memory map of
+// modified-test-file path -> added lines, so the modified-file vouch (#1616)
+// tests need no workspace. A path with no entry returns an empty string and
+// no error, mirroring repo.DiffAddedLines on a file with no additions (the
+// caller treats an empty result as "no vouch from this probe").
+type fakeAddedLines map[string]string
+
+func (f fakeAddedLines) lines(relPath string) (string, error) {
+	return f[relPath], nil
+}
+
 // TestScopeOverlap_ContentVouchFeatureNamedTestIs the end-to-end #1610 case:
 // the issue names pr_reviewer/platform.py, the diff adds a test named for the
 // feature (test_platform_gh_api_forgejo.py) that does not fold to the module,
@@ -171,7 +182,7 @@ func TestScopeOverlap_ContentVouchFeatureNamedTest(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
 		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
 		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
-		added, reader.read)
+		added, reader.read, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a feature-named test whose body imports the named module must keep GO; got %v (reason: %v)",
 			got, extra["demotionReason"])
@@ -210,7 +221,7 @@ func TestScopeOverlap_ContentVouchNoMatchingImportStillDemotes(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
 		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
 		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
-		added, reader.read)
+		added, reader.read, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("a feature-named test that imports a different module must not vouch; got %v", got)
 	}
@@ -240,7 +251,7 @@ func TestScopeOverlap_ContentVouchOnlyReadsAddedTestFiles(t *testing.T) {
 		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
 		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
 		[]string{}, // nothing added: the vouch cannot read anything
-		reader.read)
+		reader.read, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("a test file outside the added set must not vouch; got %v", got)
 	}
@@ -262,7 +273,7 @@ func TestScopeOverlap_ContentVouchReadErrorDegradesToName(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
 		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
 		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
-		added, reader.read)
+		added, reader.read, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("an unreadable test file must not vouch; got %v", got)
 	}
@@ -288,7 +299,7 @@ func TestScopeOverlap_NameMatchNotReattributedToContent(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
 		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
 		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
-		added, reader.read)
+		added, reader.read, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("a name match must keep GO; got %v", got)
 	}
@@ -311,7 +322,7 @@ func TestScopeOverlap_NilAddedOrReaderKeepsNameBehaviour(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
 		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"}, TestLayout{},
-		nil, reader.read)
+		nil, reader.read, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("nil added set must keep name-only behaviour (demote); got %v", got)
 	}
@@ -323,11 +334,147 @@ func TestScopeOverlap_NilAddedOrReaderKeepsNameBehaviour(t *testing.T) {
 	extra = map[string]any{}
 	got = enforceReviewerScopeOverlap(logr.Discard(), extra, body, added,
 		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"}, TestLayout{},
-		added, nil)
+		added, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("nil reader must keep name-only behaviour (demote); got %v", got)
 	}
 	if _, ok := extra[scopeMatchedViaContentKey]; ok {
 		t.Errorf("nil reader must not record a content vouch; extra=%v", extra)
+	}
+}
+
+// TestScopeOverlap_ContentVouchModifiedTestAddedLinesVouch is the positive
+// case of the #1616 extension: a test file the branch MODIFIED (it is in the
+// diff but not in the added set) vouches when the lines this branch ADDED to
+// it import the named module. The file is probed on its added lines, not its
+// whole body.
+func TestScopeOverlap_ContentVouchModifiedTestAddedLinesVouch(t *testing.T) {
+	body := "Add Forgejo API support to `pr_reviewer/platform.py` and cover it with tests."
+	// The test file is MODIFIED: it is in the diff, but not in the added set.
+	modified := "tests/test_platform_gh_api_forgejo.py"
+	// The lines the branch appended import the module under test.
+	addedLines := fakeAddedLines{
+		modified: "from pr_reviewer.platform import ForgejoClient\n\ndef test_forgejo_round_trip():\n    pass\n",
+	}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body,
+		[]string{modified}, // the diff touches the modified test file only
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
+		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
+		[]string{}, // nothing added: the only probe is the modified file's added lines
+		nil, addedLines.lines)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("a modified test whose added lines import the named module must keep GO; got %v (reason: %v)",
+			got, extra["demotionReason"])
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); v {
+		t.Errorf("scopeDriftDetected must be false when the modified test vouches by added lines; extra=%v", extra)
+	}
+	via, ok := extra[scopeMatchedViaContentKey].([]string)
+	if !ok || len(via) != 1 || via[0] != "pr_reviewer/platform.py" {
+		t.Errorf("scopeMatchedViaContent = %v, want the module vouched by the modified test's added lines", via)
+	}
+}
+
+// TestScopeOverlap_ContentVouchModifiedTestPreExistingImportDoesNotVouch is the
+// soundness case the #1616 design exists for: a test file the branch MODIFIED
+// may have imported the module BEFORE the branch touched it. When the import
+// lives only in UNCHANGED lines (the added lines do not import the module),
+// the vouch must not fire, so a GO on a diff that touches none of the named
+// files is still demoted.
+func TestScopeOverlap_ContentVouchModifiedTestPreExistingImportDoesNotVouch(t *testing.T) {
+	body := "Add Forgejo API support to `pr_reviewer/platform.py` and cover it with tests."
+	modified := "tests/test_platform_gh_api_forgejo.py"
+	// The WHOLE file imports the module (an unchanged line present on base), so
+	// whole-content matching would vouch. But the lines this branch ADDED only
+	// add an unrelated test — they do not import the module. Probing a modified
+	// file on added lines only must therefore not vouch, even though the whole
+	// file would: that is the false-positive class the design rejects.
+	reader := fakeReader{
+		modified: "from pr_reviewer.platform import ForgejoClient\n\n\ndef test_preexisting():\n    pass\n",
+	}
+	addedLines := fakeAddedLines{
+		modified: "def test_new_unrelated():\n    pass\n",
+	}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body,
+		[]string{modified},
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
+		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
+		[]string{},
+		reader.read, addedLines.lines)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("a modified test whose import predates the branch must NOT vouch; got %v", got)
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); !v {
+		t.Errorf("scopeDriftDetected must be true when the modified test does not vouch; extra=%v", extra)
+	}
+	if _, ok := extra[scopeMatchedViaContentKey]; ok {
+		t.Errorf("scopeMatchedViaContent must not be recorded for a pre-existing import; extra=%v", extra)
+	}
+}
+
+// TestScopeOverlap_ContentVouchAddedFileWholeContentNoRegression locks in that
+// the #1616 change did not disturb the #1610 added-file path: a test file the
+// branch ADDED is still vouched on its whole content, and the vouch fires
+// even when no modified-file probe is available (readAddedLines nil).
+func TestScopeOverlap_ContentVouchAddedFileWholeContentNoRegression(t *testing.T) {
+	body := "Add Forgejo API support to `pr_reviewer/platform.py` and cover it with tests."
+	added := "tests/test_platform_gh_api_forgejo.py"
+	reader := fakeReader{
+		added: "from pr_reviewer.platform import ForgejoClient\n\n\ndef test_forgejo_round_trip():\n    pass\n",
+	}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body,
+		[]string{added},
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
+		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
+		[]string{added},
+		reader.read, nil) // readAddedLines nil: the added-file probe still fires
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("an ADDED test whose body imports the module must still vouch (no regression); got %v", got)
+	}
+	via, ok := extra[scopeMatchedViaContentKey].([]string)
+	if !ok || len(via) != 1 || via[0] != "pr_reviewer/platform.py" {
+		t.Errorf("scopeMatchedViaContent = %v, want the module vouched by the added test's whole content", via)
+	}
+}
+
+// TestScopeOverlap_ContentVouchModifiedTest438Repro is the end-to-end
+// misospace/pr-reviewer-action#438 shape the #1616 slice exists to win: the
+// correct diff APPENDS import lines to an existing test file, touching nothing
+// else. Name-based folding cannot match the feature-named test file, so without
+// the added-lines vouch the GO would be demoted as scope drift. With it, the
+// GO stands and the vouch is recorded under scopeMatchedViaContent.
+func TestScopeOverlap_ContentVouchModifiedTest438Repro(t *testing.T) {
+	body := "Cover `pr_reviewer/platform.py`'s Forgejo API handling with tests."
+	testFile := "tests/test_platform_gh_api_forgejo.py"
+	// The diff touches ONLY the existing test file (an append), not the module —
+	// exactly the "unwinnable" shape: the module is named but the diff does not
+	// touch it.
+	appended := "from pr_reviewer.platform import ForgejoClient\n" +
+		"\n\ndef test_forgejo_round_trip():\n" +
+		"    client = ForgejoClient()\n    assert client is not None\n"
+	addedLines := fakeAddedLines{testFile: appended}
+	extra := map[string]any{}
+	got := enforceReviewerScopeOverlap(logr.Discard(), extra, body,
+		[]string{testFile},
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".py"},
+		TestLayout{TestRoot: "tests", SourceRoot: "pr_reviewer"},
+		[]string{},
+		nil, addedLines.lines)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("the #438 append-to-existing-test-file shape must keep GO; got %v (reason: %v)",
+			got, extra["demotionReason"])
+	}
+	if v, _ := extra["scopeDriftDetected"].(bool); v {
+		t.Errorf("scopeDriftDetected must be false for the #438 append shape; extra=%v", extra)
+	}
+	if v, _ := extra["verdictDemoted"].(bool); v {
+		t.Errorf("the #438 append shape must not be demoted; extra=%v", extra)
+	}
+	via, ok := extra[scopeMatchedViaContentKey].([]string)
+	if !ok || len(via) != 1 || via[0] != "pr_reviewer/platform.py" {
+		t.Errorf("scopeMatchedViaContent = %v, want the module vouched by the appended import lines", via)
 	}
 }

--- a/pkg/foreman/agent/test_layout_wiring_test.go
+++ b/pkg/foreman/agent/test_layout_wiring_test.go
@@ -38,7 +38,7 @@ func TestScopeLayout_LanguageConventions(t *testing.T) {
 			extra := map[string]any{}
 			got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 				"Add tests for `"+c.issueRef+"`.", []string{c.testFile},
-				foremanv1alpha1.AgenticTaskVerdictGo, []string{c.ext}, c.layout, nil, nil)
+				foremanv1alpha1.AgenticTaskVerdictGo, []string{c.ext}, c.layout, nil, nil, nil)
 			if got != foremanv1alpha1.AgenticTaskVerdictGo {
 				t.Errorf("%s demoted: matched=%v refs=%v", c.lang,
 					extra["scopeMatched"], extra["scopeRefs"])
@@ -52,7 +52,7 @@ func TestScopeLayout_ZeroLayoutPreservesBesideTheCode(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Add tests for `src/lib/foo.ts`.", []string{"src/lib/foo.test.ts"},
-		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil)
+		foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, TestLayout{}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Errorf("beside-the-code must still match, matched=%v", extra["scopeMatched"])
 	}
@@ -70,7 +70,7 @@ func TestScopeLayout_Issue1447StaysGreen(t *testing.T) {
 	for _, l := range []TestLayout{{}, {TestRoot: "tests", SourceRoot: "src"}} {
 		extra := map[string]any{}
 		got := enforceReviewerScopeOverlap(logr.Discard(), extra, body, diff,
-			foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, l, nil, nil)
+			foremanv1alpha1.AgenticTaskVerdictGo, []string{".ts"}, l, nil, nil, nil)
 		if got != foremanv1alpha1.AgenticTaskVerdictGo {
 			t.Errorf("#1447 regressed with layout %+v: matched=%v", l, extra["scopeMatched"])
 		}
@@ -83,7 +83,7 @@ func TestScopeLayout_RealDriftStillDemotes(t *testing.T) {
 	got := enforceReviewerScopeOverlap(logr.Discard(), extra,
 		"Fix `src/main/java/Foo.java`.", []string{"src/main/java/Unrelated.java"},
 		foremanv1alpha1.AgenticTaskVerdictGo, []string{".java"},
-		TestLayout{TestRoot: "src/test/java", SourceRoot: "src/main/java"}, nil, nil)
+		TestLayout{TestRoot: "src/test/java", SourceRoot: "src/main/java"}, nil, nil, nil)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Errorf("real drift must demote, got %v", got)
 	}


### PR DESCRIPTION
## What

Extend the content-based test-coverage vouch (#1614) to test files a branch **modified**: they now match against the diff's **added lines only**, while added files keep whole-content matching.

## Why

Fixes #1616

The #1614 review established the boundary this closes: appending tests to an existing test file — the `misospace/pr-reviewer-action#438` shape, a 25-line append whose added lines import the named module — was structurally excluded by the added-files gate. The gate's reason is soundness (a modified file may have imported the module all along), so the sound discriminator for modified files is the lines the branch added, not the file.

## How

`DiffAddedLines` in `repo/diff.go` (`git diff -U0`, `+` lines, table-tested against a real temp repo) feeds a `contentProbe` abstraction: added test files probe on whole body, modified test files on added lines only, and nil readers reproduce pre-#1616 behavior exactly. Ordering and `scopeMatchedViaContent` recording unchanged. The gate comment now describes the covered case instead of pointing at this issue.

## Provenance and verification

Foreman-authored (`wl-1616-added-lines`); pipeline: coder GO → gate GATE-PASS → reviewer APPROVE, verdict standing, scope rail grounding on all three named files, `onTrust` disclosed. Independently judged before opening:

- All four demanded behaviors tested, including the end-to-end #438 reproduction and the soundness case (**a pre-existing import in unchanged lines must not vouch**)
- **Mutation-verified**: leaking whole content for modified files fails three tests, including the soundness case — the false-positive class the design defends against is fenced by load-bearing tests
- `make lint-deadcode` → 0; `GOOS=linux golangci-lint` → 0; `Refs #1616` in the commit

The `Fixes` is earned: the acceptance case is the live reproduction from the #1614 review, encoded as `TestScopeOverlap_ContentVouchModifiedTest438Repro` and executed.

## Checklist

- [x] Tests added/updated - including soundness and end-to-end reproduction cases, mutation-verified
- [x] `make test` passes locally - full agent tree on the branch
- [x] `make lint` passes locally - 0 issues
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - rail-internal; gate comment updated in place

Foreman-authored per the AI-assisted contribution policy; human-reviewed and accountable.
