### PR TITLE
fix(controller): carry Model tolerations onto the prefetch Job

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -103,6 +103,16 @@ type ModelSpec struct {
 	// +optional
 	Prefetch bool `json:"prefetch,omitempty"`
 
+	// PrefetchTolerations are applied to the prefetch Job's pod, and govern
+	// nothing else: they say where the download may run, not where the model
+	// will be served. A fleet whose GPU nodes are tainted needs the prefetch
+	// download to schedule onto those nodes when the shared cache lives on
+	// node-local storage (#1621). Inheriting from an InferenceService would
+	// be ill-defined here: prefetch runs before the first InferenceService
+	// exists by design.
+	// +optional
+	PrefetchTolerations []corev1.Toleration `json:"prefetchTolerations,omitempty"`
+
 	// Format specifies the model file format.
 	// "gguf" is used with the llama-server runtime; "mlx" is used with the oMLX runtime;
 	// "safetensors", "pytorch", and "custom" are used with the generic runtime.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1482,6 +1482,13 @@ func (in *ModelSpec) DeepCopyInto(out *ModelSpec) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.PrefetchTolerations != nil {
+		in, out := &in.PrefetchTolerations, &out.PrefetchTolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Hardware != nil {
 		in, out := &in.Hardware, &out.Hardware
 		*out = new(HardwareSpec)

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -340,6 +340,53 @@ spec:
                   source remains the alternative there. Ignored for local and pvc://
                   sources, which need no remote fetch.
                 type: boolean
+              prefetchTolerations:
+                description: |-
+                  PrefetchTolerations are applied to the prefetch Job's pod, and govern
+                  nothing else: they say where the download may run, not where the model
+                  will be served. A fleet whose GPU nodes are tainted needs the prefetch
+                  download to schedule onto those nodes when the shared cache lives on
+                  node-local storage (#1621). Inheriting from an InferenceService would
+                  be ill-defined here: prefetch runs before the first InferenceService
+                  exists by design.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               quantization:
                 description: Quantization describes the quantization level (e.g.,
                   Q4_0, Q5_K_M, F16)

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -336,6 +336,53 @@ spec:
                   source remains the alternative there. Ignored for local and pvc://
                   sources, which need no remote fetch.
                 type: boolean
+              prefetchTolerations:
+                description: |-
+                  PrefetchTolerations are applied to the prefetch Job's pod, and govern
+                  nothing else: they say where the download may run, not where the model
+                  will be served. A fleet whose GPU nodes are tainted needs the prefetch
+                  download to schedule onto those nodes when the shared cache lives on
+                  node-local storage (#1621). Inheriting from an InferenceService would
+                  be ill-defined here: prefetch runs before the first InferenceService
+                  exists by design.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               quantization:
                 description: Quantization describes the quantization level (e.g.,
                   Q4_0, Q5_K_M, F16)

--- a/internal/controller/model_prefetch.go
+++ b/internal/controller/model_prefetch.go
@@ -271,7 +271,11 @@ func (r *ModelReconciler) buildPrefetchJob(model *inferencev1alpha1.Model) (*bat
 				Spec: corev1.PodSpec{
 					RestartPolicy:   corev1.RestartPolicyNever,
 					SecurityContext: podSecurity,
-					InitContainers:  storage.initContainers,
+					// The Model's own tolerations, so the download can reach
+					// tainted nodes whose local storage backs the shared
+					// cache (#1621).
+					Tolerations:    model.Spec.PrefetchTolerations,
+					InitContainers: storage.initContainers,
 					Containers: []corev1.Container{{
 						Name:    "prefetch-done",
 						Image:   image,

--- a/internal/controller/model_prefetch_test.go
+++ b/internal/controller/model_prefetch_test.go
@@ -89,6 +89,36 @@ var _ = Describe("Model Prefetch", func() {
 		})
 	})
 
+	Describe("buildPrefetchJob scheduling", func() {
+		// #1621: a fleet whose GPU nodes are tainted needs the prefetch Job
+		// to tolerate them, because the shared cache can live on node-local
+		// storage pinned to exactly those nodes. The Model carries its own
+		// tolerations: inheriting from an InferenceService is ill-defined
+		// here, since prefetch runs before the first one exists by design.
+		It("carries the Model's tolerations onto the Job pod", func() {
+			m := newPrefetchModel("tolerated")
+			m.Spec.PrefetchTolerations = []corev1.Toleration{{
+				Key:      "nvidia.com/gpu",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "present",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}}
+			seedPrefetchCacheKey(m)
+			job, err := prefetchReconciler().buildPrefetchJob(m)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.Tolerations).To(HaveLen(1))
+			Expect(job.Spec.Template.Spec.Tolerations[0].Key).To(Equal("nvidia.com/gpu"))
+		})
+
+		It("emits no tolerations when the Model declares none", func() {
+			m := newPrefetchModel("plain")
+			seedPrefetchCacheKey(m)
+			job, err := prefetchReconciler().buildPrefetchJob(m)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.Tolerations).To(BeEmpty())
+		})
+	})
+
 	Describe("reconcilePrefetch", func() {
 		It("does not handle models without prefetch", func() {
 			m := newPrefetchModel("no-prefetch")
@@ -222,3 +252,8 @@ var _ = Describe("Model Prefetch", func() {
 		})
 	})
 })
+
+// #1621: a fleet whose GPU nodes are tainted needs the prefetch Job to
+// tolerate them. Inheriting from an InferenceService is ill-defined here,
+// because prefetch runs BEFORE the first InferenceService by design, so the
+// Model carries its own tolerations and the Job inherits those.


### PR DESCRIPTION
## What

`Model.spec.prefetchTolerations`, applied to the prefetch Job's pod. Prefetch-scoped by name after review discussion: an unscoped `tolerations` on Model would be ambiguous to consumers, since storage topology is not part of the Model spec.

## Why

Refs #1621

@rouke-broersma's report: GPU nodes are tainted, every other LLMKube resource can declare tolerations, but the prefetch Job's pod spec carries none, so on a fleet whose shared model cache lives on node-local storage pinned to those nodes, prefetch sits Pending forever.

## How

The report suggested inheriting the InferenceService's tolerations. That would be ill-defined at exactly the moment it matters: prefetch's purpose is to run **before** the first InferenceService exists, so there may be nothing to inherit from when the Job is built. Instead the Model declares `prefetchTolerations`, and `buildPrefetchJob` threads them onto the pod. No declaration means no tolerations emitted, byte-identical to today's spec.

`nodeSelector` was deliberately left out: for node-local storage the PV's own node affinity already pins the pod's placement at bind time; the taint was the only blocker.

## Verification

- Ginkgo specs, watched fail first: a Model with tolerations produces a Job carrying them; a Model without produces a clean spec
- Full `internal/controller` suite passes (324s, envtest)
- `make generate manifests chart-crds` run; the field is in both CRD copies
- `GOOS=linux golangci-lint` and the dead-code guard: 0 issues

`Refs` rather than `Fixes` per house discipline: unit-verified, not yet reproduced against a live tainted node. @rouke-broersma, if you can confirm on your cluster once this merges, that closes it with real evidence; the field is exactly:

```yaml
apiVersion: inference.llmkube.dev/v1alpha1
kind: Model
spec:
  source: https://...
  prefetch: true
  prefetchTolerations:
    - key: nvidia.com/gpu
      operator: Equal
      value: present
      effect: NoSchedule
```

## Checklist

- [x] Tests added/updated - watched fail before implementing
- [x] `make test` passes locally - full controller suite
- [x] `make lint` passes locally - 0 issues
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) - field documented on the API type

`Assisted-by: Claude Opus 5` (root-caused against buildPrefetchJob, chose the Model-field design over ISvc inheritance, implemented with TDD).

