### PR TITLE
feat(chart): alert when an engine is up but not serving

### DIFF
--- a/charts/llmkube/README.md
+++ b/charts/llmkube/README.md
@@ -142,7 +142,7 @@ The following table lists the configurable parameters of the LLMKube chart and t
 | `prometheus.serviceMonitor.interval` | Scrape interval | `30s` |
 | `prometheus.serviceMonitor.namespace` | ServiceMonitor namespace (defaults to release namespace) | `""` |
 | `prometheus.serviceMonitor.additionalLabels` | Additional labels for ServiceMonitor | See values.yaml |
-| `prometheus.prometheusRule.enabled` | Enable PrometheusRule for alerts | `false` |
+| `prometheus.prometheusRule.enabled` | Enable PrometheusRule for alerts. Also required by the queue-wait panels on the vLLM and SGLang dashboards, which read the `llmkube:inference:queue_time_seconds:p95_5m` recording rule; without it those panels render blank. | `false` |
 | `prometheus.prometheusRule.namespace` | PrometheusRule namespace | `monitoring` |
 | `prometheus.prometheusRule.rules.gpu.enabled` | Enable GPU alerts | `true` |
 | `prometheus.prometheusRule.rules.gpu.highUtilizationThreshold` | GPU high utilization threshold (%) | `90` |

--- a/charts/llmkube/README.md
+++ b/charts/llmkube/README.md
@@ -150,6 +150,10 @@ The following table lists the configurable parameters of the LLMKube chart and t
 | `prometheus.prometheusRule.rules.gpu.memoryPressureThreshold` | GPU memory pressure threshold (%) | `90` |
 | `prometheus.prometheusRule.rules.gpu.powerLimitThreshold` | GPU power limit threshold (W) | `250` |
 | `prometheus.prometheusRule.rules.inference.enabled` | Enable inference alerts | `true` |
+| `prometheus.prometheusRule.rules.serving.enabled` | Enable serving-quality alerts (also requires `prometheus.inferencePodMonitor.enabled`) | `true` |
+| `prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold` | Mean per-pod queue wait threshold (s) | `30` |
+| `prometheus.prometheusRule.rules.serving.kvOffload.enabled` | Enable the KV-offload-slow alert (requires an OffloadingConnector) | `false` |
+| `prometheus.prometheusRule.rules.serving.kvOffload.loadSecondsThreshold` | Mean async KV-offload load threshold (s) | `10` |
 
 #### Scrape labels
 

--- a/charts/llmkube/dashboards/sglang-dashboard.json
+++ b/charts/llmkube/dashboards/sglang-dashboard.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "LLMKube SGLang runtime observability. Throughput, TTFT / E2E / inter-token latency, queue depth, KV pool utilization, scheduler backpressure, prefix cache hit rate, queue wait, per-stage latency, new token ratio, prompt length distribution and request rate, grouped by service / namespace from the sglang: metrics the chart's inference PodMonitor scrapes. TTFT and end-to-end p95 / p50 read the chart's llmkube:inference: recording rules. Mamba, HiCache host and HiCache L3 rows are collapsed because those pools only exist on hybrid-attention models, with --hicache enabled, and with --hicache-storage-backend enabled respectively.",
+  "description": "LLMKube SGLang runtime observability. Throughput, TTFT / E2E / inter-token latency, queue depth, KV pool utilization, scheduler backpressure, prefix cache hit rate, queue wait, per-stage latency, new token ratio, prompt length distribution and request rate, grouped by service / namespace from the sglang: metrics the chart's inference PodMonitor scrapes. TTFT, end-to-end, and queue-wait p95 / p50 read the chart's llmkube:inference: recording rules, per pod. Mamba, HiCache host and HiCache L3 rows are collapsed because those pools only exist on hybrid-attention models, with --hicache enabled, and with --hicache-storage-backend enabled respectively.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -459,13 +459,13 @@
         {
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "expr": "llmkube:inference:queue_time_seconds:p95_5m{runtime=\"sglang\", service=~\"$service\"}",
-          "legendFormat": "{{service}} ({{namespace}}) p95",
+          "legendFormat": "{{service}}/{{pod}} p95",
           "refId": "A"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "expr": "llmkube:inference:queue_time_seconds:p50_5m{runtime=\"sglang\", service=~\"$service\"}",
-          "legendFormat": "{{service}} ({{namespace}}) p50",
+          "legendFormat": "{{service}}/{{pod}} p50",
           "refId": "B"
         }
       ],

--- a/charts/llmkube/dashboards/vllm-dashboard.json
+++ b/charts/llmkube/dashboards/vllm-dashboard.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "LLMKube vLLM runtime observability. Throughput, TTFT / E2E / inter-token latency, queue depth, KV cache utilization, prefix cache hit rate and scheduler backpressure (preemptions, aborts), grouped by service / namespace from the vllm: metrics the chart's inference PodMonitor scrapes. TTFT and end-to-end p95/p50 read the chart's llmkube:inference: recording rules. Request-phase timing (prefill / decode / queue) is in a collapsed row.",
+  "description": "LLMKube vLLM runtime observability. Throughput, TTFT / E2E / inter-token latency, queue depth, KV cache utilization, prefix cache hit rate and scheduler backpressure (preemptions, aborts), grouped by service / namespace from the vllm: metrics the chart's inference PodMonitor scrapes. TTFT, end-to-end, and queue-wait p95/p50 read the chart's llmkube:inference: recording rules, per pod. Request-phase timing (prefill / decode / queue) is in a collapsed row.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -412,8 +412,8 @@
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-              "expr": "histogram_quantile(0.95, sum by (service, namespace, le) (rate(vllm:request_queue_time_seconds_bucket{service=~\"$service\"}[5m])))",
-              "legendFormat": "{{service}} ({{namespace}}) p95",
+              "expr": "llmkube:inference:queue_time_seconds:p95_5m{runtime=\"vllm\", service=~\"$service\"}",
+              "legendFormat": "{{service}}/{{pod}} p95",
               "refId": "A"
             }
           ],

--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -253,8 +253,10 @@ spec:
       labels:
         latency_kind: ttft
 
-    # Queue wait over 5m, covers vLLM and SGLang. By pod, not just service: a
-    # service-wide percentile would dilute one stalled replica out of it.
+    # Queue wait over 5m, covers vLLM and SGLang. By pod, not just service (unlike
+    # the request_latency/ttft_seconds records above): a service-wide percentile
+    # would dilute one stalled replica out of it, and InferenceQueueTimeHigh
+    # alerts straight off this one.
     - record: llmkube:inference:queue_time_seconds:p95_5m
       expr: histogram_quantile(0.95, sum by (service, namespace, runtime, pod, le) (rate(vllm:request_queue_time_seconds_bucket[5m]) or rate(sglang:queue_time_seconds_bucket[5m])))
       labels:

--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -86,15 +86,9 @@ spec:
   - name: llmkube-serving
     interval: 30s
     rules:
-    # TGI has no queued-count metric to pair with tgi_batch_current_size, and
-    # PersonaPlex/Generic/LlamaCppRouter export no queue metrics at all, so
-    # they're left out.
-    #
-    # A single scrape where running momentarily ticks above the ceiling
-    # resets an instantaneous `== 0` check's pending timer, so this averages
-    # over the window instead. "<= 1" is a small-constant ceiling, not zero,
-    # because a partial stall (e.g. running pinned at 1 while waiting queues
-    # up) is still a stall.
+    # TGI, PersonaPlex, Generic and LlamaCppRouter export no queue metrics, so
+    # they're left out. avg_over_time and a "<= 1" ceiling (not "== 0") catch
+    # a partial stall and survive a single scrape ticking above it.
     - alert: InferenceAdmissionStalled
       expr: |
         (avg_over_time(vllm:num_requests_waiting[10m]) > 0 and avg_over_time(vllm:num_requests_running[10m]) <= 1)
@@ -110,10 +104,8 @@ spec:
         summary: "Inference engine is queuing requests but running almost none"
         description: "{{`{{ $labels.service }}`}} in {{`{{ $labels.namespace }}`}} has {{`{{ $value }}`}} requests queued while running almost none. The process is up; it is not admitting work."
 
-    # The utilization series dropping out (not dropping to zero) reads as an
-    # idle-but-healthy engine, same silent no-op class as GPUMetricsMissing /
-    # ControllerMetricsMissing: a selector that stops matching or a job-label
-    # drift is indistinguishable from nothing running.
+    # Same silent no-op class as GPUMetricsMissing/ControllerMetricsMissing: a
+    # dead selector reads as an idle-but-healthy engine, not a gap.
     - alert: InferenceMetricsMissing
       expr: absent(vllm:num_requests_running) and absent(sglang:num_running_reqs) and absent(llamacpp:requests_processing)
       for: 15m
@@ -124,24 +116,18 @@ spec:
         summary: "Inference serving metrics are not being scraped"
         description: "No vLLM, SGLang, or llama.cpp request-count series for 15 minutes. Check the inference PodMonitor selector and pod labels."
 
-    # vLLM/SGLang only, llama.cpp and TGI don't export a queue-duration metric.
-    # Per-pod (not per-service): a service-wide mean weights by completed-request
-    # count, so healthy replicas dilute one stalled replica out of the average.
-    # The count>5 guard keeps a single slow request after a cold start (one
-    # sample averaging 45s) from paging on an otherwise idle, healthy pod.
-    # warning, not critical: a busy but healthy batch deployment can
-    # legitimately sit above this for a while; InferenceAdmissionStalled is
-    # the alert for actual non-admission.
+    # Reuses the per-pod p95 record below instead of re-deriving the ratio, so
+    # a third runtime is a one-line record edit. count>5 guards against a
+    # single slow request after a cold start reading as a sustained breach.
     - alert: InferenceQueueTimeHigh
       expr: |
         (
-          (sum by (service, namespace, runtime, pod) (increase(vllm:request_queue_time_seconds_sum[15m]))
-           / sum by (service, namespace, runtime, pod) (increase(vllm:request_queue_time_seconds_count[15m]))
-           and sum by (service, namespace, runtime, pod) (increase(vllm:request_queue_time_seconds_count[15m])) > 5)
-          or
-          (sum by (service, namespace, runtime, pod) (increase(sglang:queue_time_seconds_sum[15m]))
-           / sum by (service, namespace, runtime, pod) (increase(sglang:queue_time_seconds_count[15m]))
-           and sum by (service, namespace, runtime, pod) (increase(sglang:queue_time_seconds_count[15m])) > 5)
+          llmkube:inference:queue_time_seconds:p95_5m
+          and (
+            sum by (service, namespace, runtime, pod) (increase(vllm:request_queue_time_seconds_count[15m]))
+            or
+            sum by (service, namespace, runtime, pod) (increase(sglang:queue_time_seconds_count[15m]))
+          ) > 5
         ) > {{ .Values.prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold }}
       for: 15m
       labels:
@@ -152,10 +138,8 @@ spec:
         description: "{{`{{ $labels.service }}`}} pod {{`{{ $labels.pod }}`}} in {{`{{ $labels.namespace }}`}} is queuing requests {{`{{ $value | printf \"%.0f\" }}`}}s before they start (threshold: {{ .Values.prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold }}s)."
 
     {{- if .Values.prometheus.prometheusRule.rules.serving.kvOffload.enabled }}
-    # A slow async KV load holds its blocks for the whole transfer, gating admission.
-    # Names the cause; InferenceQueueTimeHigh only reports it as a symptom.
-    # Same min-sample guard as InferenceQueueTimeHigh, same reason: one slow
-    # load on an otherwise idle pod shouldn't page.
+    # A slow async KV load holds its blocks for the whole transfer, gating
+    # admission; names the cause where InferenceQueueTimeHigh only sees the symptom.
     - alert: KVOffloadLoadSlow
       expr: |
         (
@@ -269,14 +253,15 @@ spec:
       labels:
         latency_kind: ttft
 
-    # Queue wait over 5m. Now covers vLLM too, via vllm:request_queue_time_seconds.
+    # Queue wait over 5m, covers vLLM and SGLang. By pod, not just service: a
+    # service-wide percentile would dilute one stalled replica out of it.
     - record: llmkube:inference:queue_time_seconds:p95_5m
-      expr: histogram_quantile(0.95, sum by (service, namespace, runtime, le) (rate(vllm:request_queue_time_seconds_bucket[5m]) or rate(sglang:queue_time_seconds_bucket[5m])))
+      expr: histogram_quantile(0.95, sum by (service, namespace, runtime, pod, le) (rate(vllm:request_queue_time_seconds_bucket[5m]) or rate(sglang:queue_time_seconds_bucket[5m])))
       labels:
         latency_kind: queue_wait
 
     - record: llmkube:inference:queue_time_seconds:p50_5m
-      expr: histogram_quantile(0.50, sum by (service, namespace, runtime, le) (rate(vllm:request_queue_time_seconds_bucket[5m]) or rate(sglang:queue_time_seconds_bucket[5m])))
+      expr: histogram_quantile(0.50, sum by (service, namespace, runtime, pod, le) (rate(vllm:request_queue_time_seconds_bucket[5m]) or rate(sglang:queue_time_seconds_bucket[5m])))
       labels:
         latency_kind: queue_wait
   {{- end }}

--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -86,16 +86,32 @@ spec:
   - name: llmkube-serving
     interval: 30s
     rules:
-    # TGI, PersonaPlex, Generic and LlamaCppRouter export no queue metrics, so
-    # they're left out. avg_over_time and a "<= 1" ceiling (not "== 0") catch
-    # a partial stall and survive a single scrape ticking above it.
+    # TGI, PersonaPlex and Generic export no queue metrics under these
+    # selectors, so they're left out. LlamaCppRouter is NOT excluded: it runs
+    # llama-server and runtime_llamacpp_router.go appends --metrics, so router
+    # pods emit llamacpp:* and are covered by the third arm.
+    #
+    # avg_over_time and a "<= 1" ceiling (not "== 0") catch a partial stall and
+    # survive a single scrape ticking above it.
+    #
+    # The llama.cpp arm gates on THROUGHPUT rather than a running-count ceiling,
+    # because that ceiling is meaningless there. executor.go omits --parallel
+    # when ParallelSlots <= 1 (one slot is llama-server's own default), so
+    # requests_processing is only ever 0 or 1 and the "<= 1" test is permanently
+    # true: a healthy single-slot engine at processing=1, deferred=3 would page
+    # at severity critical. A ceiling is also unstable around its own boundary --
+    # with running oscillating 0/1/2 the 10m average lands either side of 1 on
+    # consecutive evaluations, so `for: 10m` is never satisfied and a REAL stall
+    # hovering there never fires either. Zero predicted tokens while a queue
+    # persists is the honest definition of "not admitting work", and it holds
+    # for one slot and for many.
     - alert: InferenceAdmissionStalled
       expr: |
         (avg_over_time(vllm:num_requests_waiting[10m]) > 0 and avg_over_time(vllm:num_requests_running[10m]) <= 1)
         or
         (avg_over_time(sglang:num_queue_reqs[10m]) > 0 and avg_over_time(sglang:num_running_reqs[10m]) <= 1)
         or
-        (avg_over_time(llamacpp:requests_deferred[10m]) > 0 and avg_over_time(llamacpp:requests_processing[10m]) <= 1)
+        (avg_over_time(llamacpp:requests_deferred[10m]) > 0 and rate(llamacpp:tokens_predicted_total[10m]) == 0)
       for: 10m
       labels:
         severity: critical
@@ -119,11 +135,19 @@ spec:
     # Reuses the per-pod p95 record below instead of re-deriving the ratio, so
     # a third runtime is a one-line record edit. count>5 guards against a
     # single slow request after a cold start reading as a sustained breach.
+    # `and on (...)` below is load-bearing, not stylistic. The p95 record stamps
+    # latency_kind="queue_wait" via its labels: block, while the min-sample guard
+    # is a bare sum by (service, namespace, runtime, pod) and carries no such
+    # label. A plain `and` matches on the FULL label set, so the two sides never
+    # join and the alert cannot fire on any input. Naming the join keys keeps it
+    # alive. KVOffloadLoadSlow uses the bare form safely because both of its
+    # sides are sum by (...) with identical labels, which is what makes this
+    # invisible on a read-through.
     - alert: InferenceQueueTimeHigh
       expr: |
         (
           llmkube:inference:queue_time_seconds:p95_5m
-          and (
+          and on (service, namespace, runtime, pod) (
             sum by (service, namespace, runtime, pod) (increase(vllm:request_queue_time_seconds_count[15m]))
             or
             sum by (service, namespace, runtime, pod) (increase(sglang:queue_time_seconds_count[15m]))

--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -82,6 +82,62 @@ spec:
         description: "No DCGM, amdgpu-sysfs, or drm-exporter utilization series for 15 minutes. Check that a GPU metrics exporter is running."
   {{- end }}
 
+  {{- if .Values.prometheus.prometheusRule.rules.serving.enabled }}
+  - name: llmkube-serving
+    interval: 30s
+    rules:
+    # TGI has no queued-count metric to pair with tgi_batch_current_size, so it's left out.
+    - alert: InferenceAdmissionStalled
+      expr: |
+        (vllm:num_requests_waiting > 0 and vllm:num_requests_running == 0)
+        or
+        (sglang:num_queue_reqs > 0 and sglang:num_running_reqs == 0)
+        or
+        (llamacpp:requests_deferred > 0 and llamacpp:requests_processing == 0)
+      for: 10m
+      labels:
+        severity: critical
+        component: inference
+      annotations:
+        summary: "Inference engine is queuing requests but running none"
+        description: "{{`{{ $labels.service }}`}} in {{`{{ $labels.namespace }}`}} has {{`{{ $value }}`}} requests queued with none running. The process is up; it is not admitting work."
+
+    # vLLM/SGLang only, llama.cpp and TGI don't export a queue-duration metric.
+    - alert: InferenceQueueTimeHigh
+      expr: |
+        (sum by (service, namespace, runtime) (increase(vllm:request_queue_time_seconds_sum[15m]))
+         / sum by (service, namespace, runtime) (increase(vllm:request_queue_time_seconds_count[15m]))
+         or
+         sum by (service, namespace, runtime) (increase(sglang:queue_time_seconds_sum[15m]))
+         / sum by (service, namespace, runtime) (increase(sglang:queue_time_seconds_count[15m]))
+        ) > {{ .Values.prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold }}
+      for: 15m
+      labels:
+        severity: critical
+        component: inference
+      annotations:
+        summary: "Inference requests are waiting a long time before starting"
+        description: "{{`{{ $labels.service }}`}} in {{`{{ $labels.namespace }}`}} is queuing requests {{`{{ $value | printf \"%.0f\" }}`}}s before they start (threshold: {{ .Values.prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold }}s)."
+
+    {{- if .Values.prometheus.prometheusRule.rules.serving.kvOffload.enabled }}
+    # A slow async KV load holds its blocks for the whole transfer, gating admission.
+    # Names the cause; InferenceQueueTimeHigh only reports it as a symptom.
+    - alert: KVOffloadLoadSlow
+      expr: |
+        sum by (service, namespace, runtime) (increase(vllm:kv_offload_lookup_async_delay_seconds_sum[30m]))
+        /
+        sum by (service, namespace, runtime) (increase(vllm:kv_offload_lookup_async_delay_seconds_count[30m]))
+        > {{ .Values.prometheus.prometheusRule.rules.serving.kvOffload.loadSecondsThreshold }}
+      for: 15m
+      labels:
+        severity: warning
+        component: inference
+      annotations:
+        summary: "KV offload loads are slow enough to gate admission"
+        description: "{{`{{ $labels.service }}`}} in {{`{{ $labels.namespace }}`}} is averaging {{`{{ $value | printf \"%.0f\" }}`}}s per async KV-offload load (threshold: {{ .Values.prometheus.prometheusRule.rules.serving.kvOffload.loadSecondsThreshold }}s)."
+    {{- end }}
+  {{- end }}
+
   {{- if .Values.prometheus.prometheusRule.rules.inference.enabled }}
   - name: llmkube-inference
     interval: 30s
@@ -177,14 +233,14 @@ spec:
       labels:
         latency_kind: ttft
 
-    # Queue wait over 5m. SGLang-only for now; no vllm equivalent metric.
+    # Queue wait over 5m. Now covers vLLM too, via vllm:request_queue_time_seconds.
     - record: llmkube:inference:queue_time_seconds:p95_5m
-      expr: histogram_quantile(0.95, sum by (service, namespace, runtime, le) (rate(sglang:queue_time_seconds_bucket[5m])))
+      expr: histogram_quantile(0.95, sum by (service, namespace, runtime, le) (rate(vllm:request_queue_time_seconds_bucket[5m]) or rate(sglang:queue_time_seconds_bucket[5m])))
       labels:
         latency_kind: queue_wait
 
     - record: llmkube:inference:queue_time_seconds:p50_5m
-      expr: histogram_quantile(0.50, sum by (service, namespace, runtime, le) (rate(sglang:queue_time_seconds_bucket[5m])))
+      expr: histogram_quantile(0.50, sum by (service, namespace, runtime, le) (rate(vllm:request_queue_time_seconds_bucket[5m]) or rate(sglang:queue_time_seconds_bucket[5m])))
       labels:
         latency_kind: queue_wait
   {{- end }}

--- a/charts/llmkube/templates/prometheusrule.yaml
+++ b/charts/llmkube/templates/prometheusrule.yaml
@@ -82,59 +82,95 @@ spec:
         description: "No DCGM, amdgpu-sysfs, or drm-exporter utilization series for 15 minutes. Check that a GPU metrics exporter is running."
   {{- end }}
 
-  {{- if .Values.prometheus.prometheusRule.rules.serving.enabled }}
+  {{- if and .Values.prometheus.prometheusRule.rules.serving.enabled .Values.prometheus.inferencePodMonitor.enabled }}
   - name: llmkube-serving
     interval: 30s
     rules:
-    # TGI has no queued-count metric to pair with tgi_batch_current_size, so it's left out.
+    # TGI has no queued-count metric to pair with tgi_batch_current_size, and
+    # PersonaPlex/Generic/LlamaCppRouter export no queue metrics at all, so
+    # they're left out.
+    #
+    # A single scrape where running momentarily ticks above the ceiling
+    # resets an instantaneous `== 0` check's pending timer, so this averages
+    # over the window instead. "<= 1" is a small-constant ceiling, not zero,
+    # because a partial stall (e.g. running pinned at 1 while waiting queues
+    # up) is still a stall.
     - alert: InferenceAdmissionStalled
       expr: |
-        (vllm:num_requests_waiting > 0 and vllm:num_requests_running == 0)
+        (avg_over_time(vllm:num_requests_waiting[10m]) > 0 and avg_over_time(vllm:num_requests_running[10m]) <= 1)
         or
-        (sglang:num_queue_reqs > 0 and sglang:num_running_reqs == 0)
+        (avg_over_time(sglang:num_queue_reqs[10m]) > 0 and avg_over_time(sglang:num_running_reqs[10m]) <= 1)
         or
-        (llamacpp:requests_deferred > 0 and llamacpp:requests_processing == 0)
+        (avg_over_time(llamacpp:requests_deferred[10m]) > 0 and avg_over_time(llamacpp:requests_processing[10m]) <= 1)
       for: 10m
       labels:
         severity: critical
         component: inference
       annotations:
-        summary: "Inference engine is queuing requests but running none"
-        description: "{{`{{ $labels.service }}`}} in {{`{{ $labels.namespace }}`}} has {{`{{ $value }}`}} requests queued with none running. The process is up; it is not admitting work."
+        summary: "Inference engine is queuing requests but running almost none"
+        description: "{{`{{ $labels.service }}`}} in {{`{{ $labels.namespace }}`}} has {{`{{ $value }}`}} requests queued while running almost none. The process is up; it is not admitting work."
+
+    # The utilization series dropping out (not dropping to zero) reads as an
+    # idle-but-healthy engine, same silent no-op class as GPUMetricsMissing /
+    # ControllerMetricsMissing: a selector that stops matching or a job-label
+    # drift is indistinguishable from nothing running.
+    - alert: InferenceMetricsMissing
+      expr: absent(vllm:num_requests_running) and absent(sglang:num_running_reqs) and absent(llamacpp:requests_processing)
+      for: 15m
+      labels:
+        severity: warning
+        component: inference
+      annotations:
+        summary: "Inference serving metrics are not being scraped"
+        description: "No vLLM, SGLang, or llama.cpp request-count series for 15 minutes. Check the inference PodMonitor selector and pod labels."
 
     # vLLM/SGLang only, llama.cpp and TGI don't export a queue-duration metric.
+    # Per-pod (not per-service): a service-wide mean weights by completed-request
+    # count, so healthy replicas dilute one stalled replica out of the average.
+    # The count>5 guard keeps a single slow request after a cold start (one
+    # sample averaging 45s) from paging on an otherwise idle, healthy pod.
+    # warning, not critical: a busy but healthy batch deployment can
+    # legitimately sit above this for a while; InferenceAdmissionStalled is
+    # the alert for actual non-admission.
     - alert: InferenceQueueTimeHigh
       expr: |
-        (sum by (service, namespace, runtime) (increase(vllm:request_queue_time_seconds_sum[15m]))
-         / sum by (service, namespace, runtime) (increase(vllm:request_queue_time_seconds_count[15m]))
-         or
-         sum by (service, namespace, runtime) (increase(sglang:queue_time_seconds_sum[15m]))
-         / sum by (service, namespace, runtime) (increase(sglang:queue_time_seconds_count[15m]))
+        (
+          (sum by (service, namespace, runtime, pod) (increase(vllm:request_queue_time_seconds_sum[15m]))
+           / sum by (service, namespace, runtime, pod) (increase(vllm:request_queue_time_seconds_count[15m]))
+           and sum by (service, namespace, runtime, pod) (increase(vllm:request_queue_time_seconds_count[15m])) > 5)
+          or
+          (sum by (service, namespace, runtime, pod) (increase(sglang:queue_time_seconds_sum[15m]))
+           / sum by (service, namespace, runtime, pod) (increase(sglang:queue_time_seconds_count[15m]))
+           and sum by (service, namespace, runtime, pod) (increase(sglang:queue_time_seconds_count[15m])) > 5)
         ) > {{ .Values.prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold }}
       for: 15m
       labels:
-        severity: critical
+        severity: warning
         component: inference
       annotations:
         summary: "Inference requests are waiting a long time before starting"
-        description: "{{`{{ $labels.service }}`}} in {{`{{ $labels.namespace }}`}} is queuing requests {{`{{ $value | printf \"%.0f\" }}`}}s before they start (threshold: {{ .Values.prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold }}s)."
+        description: "{{`{{ $labels.service }}`}} pod {{`{{ $labels.pod }}`}} in {{`{{ $labels.namespace }}`}} is queuing requests {{`{{ $value | printf \"%.0f\" }}`}}s before they start (threshold: {{ .Values.prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold }}s)."
 
     {{- if .Values.prometheus.prometheusRule.rules.serving.kvOffload.enabled }}
     # A slow async KV load holds its blocks for the whole transfer, gating admission.
     # Names the cause; InferenceQueueTimeHigh only reports it as a symptom.
+    # Same min-sample guard as InferenceQueueTimeHigh, same reason: one slow
+    # load on an otherwise idle pod shouldn't page.
     - alert: KVOffloadLoadSlow
       expr: |
-        sum by (service, namespace, runtime) (increase(vllm:kv_offload_lookup_async_delay_seconds_sum[30m]))
-        /
-        sum by (service, namespace, runtime) (increase(vllm:kv_offload_lookup_async_delay_seconds_count[30m]))
-        > {{ .Values.prometheus.prometheusRule.rules.serving.kvOffload.loadSecondsThreshold }}
+        (
+          sum by (service, namespace, runtime, pod) (increase(vllm:kv_offload_lookup_async_delay_seconds_sum[30m]))
+          /
+          sum by (service, namespace, runtime, pod) (increase(vllm:kv_offload_lookup_async_delay_seconds_count[30m]))
+          and sum by (service, namespace, runtime, pod) (increase(vllm:kv_offload_lookup_async_delay_seconds_count[30m])) > 5
+        ) > {{ .Values.prometheus.prometheusRule.rules.serving.kvOffload.loadSecondsThreshold }}
       for: 15m
       labels:
         severity: warning
         component: inference
       annotations:
         summary: "KV offload loads are slow enough to gate admission"
-        description: "{{`{{ $labels.service }}`}} in {{`{{ $labels.namespace }}`}} is averaging {{`{{ $value | printf \"%.0f\" }}`}}s per async KV-offload load (threshold: {{ .Values.prometheus.prometheusRule.rules.serving.kvOffload.loadSecondsThreshold }}s)."
+        description: "{{`{{ $labels.service }}`}} pod {{`{{ $labels.pod }}`}} in {{`{{ $labels.namespace }}`}} is averaging {{`{{ $value | printf \"%.0f\" }}`}}s per async KV-offload load (threshold: {{ .Values.prometheus.prometheusRule.rules.serving.kvOffload.loadSecondsThreshold }}s)."
     {{- end }}
   {{- end }}
 

--- a/charts/llmkube/tests/prometheusrule_test.yaml
+++ b/charts/llmkube/tests/prometheusrule_test.yaml
@@ -204,6 +204,8 @@ tests:
           pattern: llmkube-slo
 
   # --- serving-quality group: an engine that is up but not admitting work ---
+  # Rules group by (service, runtime, pod), which only inferencePodMonitor's
+  # relabelings add, so every test below turns it on alongside serving.enabled.
 
   - it: should cover both runtimes in the queue-wait recording rule
     template: prometheusrule.yaml
@@ -216,11 +218,31 @@ tests:
       - matchRegex:
           path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:queue_time_seconds:p95_5m")].expr
           pattern: sglang:queue_time_seconds_bucket
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:queue_time_seconds:p50_5m")].expr
+          pattern: vllm:request_queue_time_seconds_bucket
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:queue_time_seconds:p50_5m")].expr
+          pattern: sglang:queue_time_seconds_bucket
 
-  - it: should alert on queued-with-nothing-running for every runtime exporting the pair
+  - it: should default to 3 serving rules, with KVOffloadLoadSlow off
     template: prometheusrule.yaml
     set:
       prometheus.prometheusRule.enabled: true
+      prometheus.inferencePodMonitor.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules
+          count: 3
+      - notMatchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[*].alert
+          pattern: KVOffloadLoadSlow
+
+  - it: should alert on queued-with-almost-nothing-running for every runtime exporting the pair
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+      prometheus.inferencePodMonitor.enabled: true
     asserts:
       - matchRegex:
           path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceAdmissionStalled")].expr
@@ -231,46 +253,77 @@ tests:
       - matchRegex:
           path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceAdmissionStalled")].expr
           pattern: llamacpp:requests_deferred
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceAdmissionStalled")].expr
+          pattern: 'avg_over_time\(vllm:num_requests_running\[10m\]\) <= 1'
 
-  - it: should render the queue-time threshold into both expr and description
+  - it: should AND absence across every runtime's running-count metric in InferenceMetricsMissing
     template: prometheusrule.yaml
     set:
       prometheus.prometheusRule.enabled: true
+      prometheus.inferencePodMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceMetricsMissing")].expr
+          value: absent(vllm:num_requests_running) and absent(sglang:num_running_reqs) and absent(llamacpp:requests_processing)
+
+  - it: should render the queue-time threshold into both expr and description, grouped per pod
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+      prometheus.inferencePodMonitor.enabled: true
       prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold: 45
     asserts:
       - matchRegex:
           path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].expr
           pattern: "> 45"
       - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].expr
+          pattern: "by \\(service, namespace, runtime, pod\\)"
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].expr
+          pattern: "increase\\(vllm:request_queue_time_seconds_count\\[15m\\]\\)\\) > 5"
+      - equal:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].labels.severity
+          value: warning
+      - matchRegex:
           path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].annotations.description
           pattern: "threshold: 45s"
 
-  # The connector is upstream-experimental and its series are absent without it,
-  # so the rule must not ship unless it is asked for.
-  - it: should omit the KV-offload alert by default
+  - it: should include the KV-offload alert when explicitly enabled, at 4 serving rules
     template: prometheusrule.yaml
     set:
       prometheus.prometheusRule.enabled: true
-    asserts:
-      - notMatchRegex:
-          path: spec.groups[?(@.name=="llmkube-serving")].rules[*].alert
-          pattern: KVOffloadLoadSlow
-
-  - it: should include the KV-offload alert when explicitly enabled
-    template: prometheusrule.yaml
-    set:
-      prometheus.prometheusRule.enabled: true
+      prometheus.inferencePodMonitor.enabled: true
       prometheus.prometheusRule.rules.serving.kvOffload.enabled: true
     asserts:
+      - lengthEqual:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules
+          count: 4
       - matchRegex:
           path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="KVOffloadLoadSlow")].expr
           pattern: kv_offload_lookup_async_delay_seconds
 
-  - it: should omit the serving group entirely when disabled
+  - it: should omit the serving group entirely when serving.enabled is false
     template: prometheusrule.yaml
     set:
       prometheus.prometheusRule.enabled: true
+      prometheus.inferencePodMonitor.enabled: true
       prometheus.prometheusRule.rules.serving.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: spec.groups[*].name
+          pattern: llmkube-serving
+
+  # service/runtime/pod only exist on series scraped by inferencePodMonitor's
+  # relabelings (finding #3): without it, a foreign scrape config collapses
+  # every pod in a namespace into one empty-label series.
+  - it: should omit the serving group when inferencePodMonitor is disabled, even with serving.enabled
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+      prometheus.prometheusRule.rules.serving.enabled: true
+      prometheus.inferencePodMonitor.enabled: false
     asserts:
       - notMatchRegex:
           path: spec.groups[*].name

--- a/charts/llmkube/tests/prometheusrule_test.yaml
+++ b/charts/llmkube/tests/prometheusrule_test.yaml
@@ -202,3 +202,76 @@ tests:
       - notMatchRegex:
           path: spec.groups[*].name
           pattern: llmkube-slo
+
+  # --- serving-quality group: an engine that is up but not admitting work ---
+
+  - it: should cover both runtimes in the queue-wait recording rule
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:queue_time_seconds:p95_5m")].expr
+          pattern: vllm:request_queue_time_seconds_bucket
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:queue_time_seconds:p95_5m")].expr
+          pattern: sglang:queue_time_seconds_bucket
+
+  - it: should alert on queued-with-nothing-running for every runtime exporting the pair
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceAdmissionStalled")].expr
+          pattern: vllm:num_requests_waiting
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceAdmissionStalled")].expr
+          pattern: sglang:num_queue_reqs
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceAdmissionStalled")].expr
+          pattern: llamacpp:requests_deferred
+
+  - it: should render the queue-time threshold into both expr and description
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+      prometheus.prometheusRule.rules.serving.queueTimeSecondsThreshold: 45
+    asserts:
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].expr
+          pattern: "> 45"
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].annotations.description
+          pattern: "threshold: 45s"
+
+  # The connector is upstream-experimental and its series are absent without it,
+  # so the rule must not ship unless it is asked for.
+  - it: should omit the KV-offload alert by default
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[*].alert
+          pattern: KVOffloadLoadSlow
+
+  - it: should include the KV-offload alert when explicitly enabled
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+      prometheus.prometheusRule.rules.serving.kvOffload.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="KVOffloadLoadSlow")].expr
+          pattern: kv_offload_lookup_async_delay_seconds
+
+  - it: should omit the serving group entirely when disabled
+    template: prometheusrule.yaml
+    set:
+      prometheus.prometheusRule.enabled: true
+      prometheus.prometheusRule.rules.serving.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: spec.groups[*].name
+          pattern: llmkube-serving

--- a/charts/llmkube/tests/prometheusrule_test.yaml
+++ b/charts/llmkube/tests/prometheusrule_test.yaml
@@ -224,6 +224,9 @@ tests:
       - matchRegex:
           path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:queue_time_seconds:p50_5m")].expr
           pattern: sglang:queue_time_seconds_bucket
+      - matchRegex:
+          path: spec.groups[?(@.name=="llmkube-inference-recording")].rules[?(@.record=="llmkube:inference:queue_time_seconds:p95_5m")].expr
+          pattern: "by \\(service, namespace, runtime, pod, le\\)"
 
   - it: should default to 3 serving rules, with KVOffloadLoadSlow off
     template: prometheusrule.yaml
@@ -279,10 +282,10 @@ tests:
           pattern: "> 45"
       - matchRegex:
           path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].expr
-          pattern: "by \\(service, namespace, runtime, pod\\)"
+          pattern: "llmkube:inference:queue_time_seconds:p95_5m"
       - matchRegex:
           path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].expr
-          pattern: "increase\\(vllm:request_queue_time_seconds_count\\[15m\\]\\)\\) > 5"
+          pattern: "by \\(service, namespace, runtime, pod\\) \\(increase\\(vllm:request_queue_time_seconds_count\\[15m\\]\\)\\)"
       - equal:
           path: spec.groups[?(@.name=="llmkube-serving")].rules[?(@.alert=="InferenceQueueTimeHigh")].labels.severity
           value: warning

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -266,6 +266,22 @@
                   "properties": {
                     "enabled": { "type": "boolean" }
                   }
+                },
+                "serving": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "queueTimeSecondsThreshold": { "type": "number", "minimum": 0 },
+                    "kvOffload": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "enabled": { "type": "boolean" },
+                        "loadSecondsThreshold": { "type": "number", "minimum": 0 }
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -297,7 +297,9 @@ prometheus:
       # Inference service alerts
       inference:
         enabled: true
-      # Serving-quality alerts: engine is up and Ready but not admitting work
+      # Serving-quality alerts: engine is up and Ready but not admitting work.
+      # Also gated on prometheus.inferencePodMonitor.enabled: the rules group
+      # by the service/runtime labels only that PodMonitor's relabelings add.
       serving:
         enabled: true
         # Mean queue wait; healthy single-GPU deployments sit in the low single digits

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -297,6 +297,15 @@ prometheus:
       # Inference service alerts
       inference:
         enabled: true
+      # Serving-quality alerts: engine is up and Ready but not admitting work
+      serving:
+        enabled: true
+        # Mean queue wait; healthy single-GPU deployments sit in the low single digits
+        queueTimeSecondsThreshold: 30
+        # Requires a KV connector, off by default since OffloadingConnector is experimental
+        kvOffload:
+          enabled: false
+          loadSecondsThreshold: 10
 
 # Grafana dashboards shipped in charts/llmkube/dashboards/. One ConfigMap holds
 # every dashboard, one key per file; the sidecar label and the grafana-operator

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -321,6 +321,13 @@ grafana:
     # deploy: sglang-dashboard and vllm-dashboard need an InferenceService on
     # that runtime, amd-gpu-observability needs AMD GPUs, llmkube-slo needs
     # pyrra.enabled.
+    #
+    # The queue-wait panels on sglang-dashboard and vllm-dashboard additionally
+    # need prometheus.prometheusRule.enabled: they read the
+    # llmkube:inference:queue_time_seconds:p95_5m recording rule rather than
+    # deriving a quantile from raw buckets. That flag defaults false and is
+    # independent of this one, so those two panels render blank on an install
+    # that enables dashboards alone.
     only: []
     # Additional labels for the ConfigMap. grafana_dashboard is the key the
     # kube-prometheus-stack Grafana sidecar watches for.

--- a/internal/metrics/dashboard_sync_test.go
+++ b/internal/metrics/dashboard_sync_test.go
@@ -79,7 +79,10 @@ var (
 	// Desc keeps fqName unexported; String() is the only accessor.
 	descFQName = regexp.MustCompile(`fqName: "([^"]+)"`)
 	recordRule = regexp.MustCompile(`(?m)^\s*- record:\s*(\S+)`)
+	alertName  = regexp.MustCompile(`(?m)^\s*- alert:\s*(\S+)`)
 	// Every alert has a `for:` right after its expr; that's the terminator.
+	// chartAlertExprs cross-checks this against alertName so a future alert
+	// breaking that assumption fails loudly instead of being silently dropped.
 	alertExprBlock = regexp.MustCompile(`(?ms)^\s*- alert:\s*(\S+).*?\n\s*expr:\s*\|?\s*\n?(.*?)\n\s*for:`)
 
 	labelMatcher    = regexp.MustCompile(`\{[^}]*\}`)
@@ -113,18 +116,25 @@ func declaredNames(t *testing.T) map[string]bool {
 	return names
 }
 
-// chartRecordingRules returns the names the chart's PrometheusRule records.
-// These are the only llmkube: series that exist.
-func chartRecordingRules(t *testing.T) map[string]bool {
+// readPrometheusRuleTpl is the raw, un-rendered chart source both
+// chartRecordingRules and chartAlertExprs regex-scrape.
+func readPrometheusRuleTpl(t *testing.T) string {
 	t.Helper()
 
 	tpl, err := os.ReadFile(prometheusRuleTpl)
 	if err != nil {
 		t.Fatalf("read %s: %v", prometheusRuleTpl, err)
 	}
+	return string(tpl)
+}
+
+// chartRecordingRules returns the names the chart's PrometheusRule records.
+// These are the only llmkube: series that exist.
+func chartRecordingRules(t *testing.T) map[string]bool {
+	t.Helper()
 
 	names := map[string]bool{}
-	for _, m := range recordRule.FindAllStringSubmatch(string(tpl), -1) {
+	for _, m := range recordRule.FindAllStringSubmatch(readPrometheusRuleTpl(t), -1) {
 		names[m[1]] = true
 	}
 	if len(names) == 0 {
@@ -133,23 +143,24 @@ func chartRecordingRules(t *testing.T) map[string]bool {
 	return names
 }
 
-// chartAlertExprs returns each alert's name and expr text, raw source
-// un-rendered. metricNames' noise stripping collapses a Go-templated
-// threshold the same way it collapses a Grafana `$var`.
+// chartAlertExprs returns each alert's name and expr text. metricNames' noise
+// stripping collapses a Go-templated threshold the same way it collapses a
+// Grafana `$var`.
 func chartAlertExprs(t *testing.T) map[string]string {
 	t.Helper()
 
-	tpl, err := os.ReadFile(prometheusRuleTpl)
-	if err != nil {
-		t.Fatalf("read %s: %v", prometheusRuleTpl, err)
-	}
+	tpl := readPrometheusRuleTpl(t)
 
 	exprs := map[string]string{}
-	for _, m := range alertExprBlock.FindAllStringSubmatch(string(tpl), -1) {
+	for _, m := range alertExprBlock.FindAllStringSubmatch(tpl, -1) {
 		exprs[m[1]] = m[2]
 	}
 	if len(exprs) == 0 {
 		t.Fatalf("no alerts in %s", prometheusRuleTpl)
+	}
+	if want := alertName.FindAllStringSubmatch(tpl, -1); len(want) != len(exprs) {
+		t.Fatalf("alertExprBlock matched %d of %d alerts in %s — an alert's expr isn't followed by `for:`",
+			len(exprs), len(want), prometheusRuleTpl)
 	}
 	return exprs
 }
@@ -510,21 +521,30 @@ func TestDashboardsQueryEmittedMetrics(t *testing.T) {
 	}
 
 	for _, dashboard := range dashboards {
-		reported := map[string]bool{}
 		for _, query := range dashboardQueries(t, dashboard) {
-			for _, name := range metricNames(query) {
-				if emitted(name, known) || reported[name] {
-					continue
-				}
-				reported[name] = true
-				t.Errorf("%s queries %q, which no registered collector, chart recording rule or allowlisted exporter emits\n\tquery: %s",
-					dashboard, name, query)
-			}
+			assertQueryEmitted(t, known, dashboard, query)
 		}
 	}
 
 	if t.Failed() {
 		t.Logf("emittable: %v", slices.Sorted(maps.Keys(known)))
+	}
+}
+
+// assertQueryEmitted fails for each metric name in query that nothing in
+// known emits, deduped per query. label identifies the query's source
+// (a dashboard path, or "alert X") in the failure message.
+func assertQueryEmitted(t *testing.T, known map[string]bool, label, query string) {
+	t.Helper()
+
+	reported := map[string]bool{}
+	for _, name := range metricNames(query) {
+		if emitted(name, known) || reported[name] {
+			continue
+		}
+		reported[name] = true
+		t.Errorf("%s queries %q, which no registered collector, chart recording rule or allowlisted exporter emits\n\tquery: %s",
+			label, name, query)
 	}
 }
 
@@ -537,15 +557,7 @@ func TestAlertExprsQueryEmittedMetrics(t *testing.T) {
 	maps.Copy(known, runtimeNames(t))
 
 	for alert, expr := range chartAlertExprs(t) {
-		reported := map[string]bool{}
-		for _, name := range metricNames(expr) {
-			if emitted(name, known) || reported[name] {
-				continue
-			}
-			reported[name] = true
-			t.Errorf("alert %s queries %q, which no registered collector, chart recording rule or allowlisted exporter emits\n\texpr: %s",
-				alert, name, expr)
-		}
+		assertQueryEmitted(t, known, "alert "+alert, expr)
 	}
 
 	if t.Failed() {

--- a/internal/metrics/dashboard_sync_test.go
+++ b/internal/metrics/dashboard_sync_test.go
@@ -47,12 +47,19 @@ var externalPrefixes = []string{
 	// Pyrra generates these from the vLLM histogram; the runtime's own vllm:
 	// metrics are fixture-verified like every other runtime.
 	"vllm:e2e_request_latency_seconds:",
-	"up",           // Prometheus synthesizes this per scrape target; Pyrra's up:sum5m too
+	"up:",          // Pyrra's up:sum5m and friends; bare "up" is in externalExact
 	"DCGM_FI_DEV_", // NVIDIA dcgm-exporter
 	"amdgpu_",      // amdgpu-sysfs exporter
 	"drm_",         // drm-exporter
 	"node_",        // node-exporter
 }
+
+// externalExact are whole metric names owned outside this repo. Matched by
+// equality, NOT prefix: "up" is synthesized by Prometheus per scrape target,
+// but as a prefix it would also allowlist uptime_*, upstream_* and anything
+// else starting with those two letters, which is exactly the typo class this
+// guard exists to catch.
+var externalExact = []string{"up"}
 
 // promqlWords are the identifiers PromQL allows outside a call: operators and
 // modifiers. Function names need no listing, a call is stripped by its "(".
@@ -486,6 +493,11 @@ func emitted(name string, known map[string]bool) bool {
 	// Dashboards select histogram series; the Desc carries only the base name.
 	for _, suffix := range []string{"_bucket", "_sum", "_count"} {
 		if base := strings.TrimSuffix(name, suffix); base != name && known[base] {
+			return true
+		}
+	}
+	for _, exact := range externalExact {
+		if name == exact {
 			return true
 		}
 	}

--- a/internal/metrics/dashboard_sync_test.go
+++ b/internal/metrics/dashboard_sync_test.go
@@ -47,7 +47,7 @@ var externalPrefixes = []string{
 	// Pyrra generates these from the vLLM histogram; the runtime's own vllm:
 	// metrics are fixture-verified like every other runtime.
 	"vllm:e2e_request_latency_seconds:",
-	"up:",          // Pyrra burn-rate rules over scrape liveness
+	"up",           // Prometheus synthesizes this per scrape target; Pyrra's up:sum5m too
 	"DCGM_FI_DEV_", // NVIDIA dcgm-exporter
 	"amdgpu_",      // amdgpu-sysfs exporter
 	"drm_",         // drm-exporter
@@ -79,6 +79,8 @@ var (
 	// Desc keeps fqName unexported; String() is the only accessor.
 	descFQName = regexp.MustCompile(`fqName: "([^"]+)"`)
 	recordRule = regexp.MustCompile(`(?m)^\s*- record:\s*(\S+)`)
+	// Every alert has a `for:` right after its expr; that's the terminator.
+	alertExprBlock = regexp.MustCompile(`(?ms)^\s*- alert:\s*(\S+).*?\n\s*expr:\s*\|?\s*\n?(.*?)\n\s*for:`)
 
 	labelMatcher    = regexp.MustCompile(`\{[^}]*\}`)
 	soleAggregation = regexp.MustCompile(`^(?:sum|count)(?:\s+(?:by|without)\s*\([^)]*\))?\s*\(`)
@@ -129,6 +131,27 @@ func chartRecordingRules(t *testing.T) map[string]bool {
 		t.Fatalf("no recording rules in %s", prometheusRuleTpl)
 	}
 	return names
+}
+
+// chartAlertExprs returns each alert's name and expr text, raw source
+// un-rendered. metricNames' noise stripping collapses a Go-templated
+// threshold the same way it collapses a Grafana `$var`.
+func chartAlertExprs(t *testing.T) map[string]string {
+	t.Helper()
+
+	tpl, err := os.ReadFile(prometheusRuleTpl)
+	if err != nil {
+		t.Fatalf("read %s: %v", prometheusRuleTpl, err)
+	}
+
+	exprs := map[string]string{}
+	for _, m := range alertExprBlock.FindAllStringSubmatch(string(tpl), -1) {
+		exprs[m[1]] = m[2]
+	}
+	if len(exprs) == 0 {
+		t.Fatalf("no alerts in %s", prometheusRuleTpl)
+	}
+	return exprs
 }
 
 // runtimeNames returns the metric names the inference runtimes' own servers
@@ -497,6 +520,31 @@ func TestDashboardsQueryEmittedMetrics(t *testing.T) {
 				t.Errorf("%s queries %q, which no registered collector, chart recording rule or allowlisted exporter emits\n\tquery: %s",
 					dashboard, name, query)
 			}
+		}
+	}
+
+	if t.Failed() {
+		t.Logf("emittable: %v", slices.Sorted(maps.Keys(known)))
+	}
+}
+
+// TestAlertExprsQueryEmittedMetrics is TestDashboardsQueryEmittedMetrics's
+// counterpart for alert rules: a typo'd or renamed metric in an `expr:` ships
+// an alert that never fires.
+func TestAlertExprsQueryEmittedMetrics(t *testing.T) {
+	known := declaredNames(t)
+	maps.Copy(known, chartRecordingRules(t))
+	maps.Copy(known, runtimeNames(t))
+
+	for alert, expr := range chartAlertExprs(t) {
+		reported := map[string]bool{}
+		for _, name := range metricNames(expr) {
+			if emitted(name, known) || reported[name] {
+				continue
+			}
+			reported[name] = true
+			t.Errorf("alert %s queries %q, which no registered collector, chart recording rule or allowlisted exporter emits\n\texpr: %s",
+				alert, name, expr)
 		}
 	}
 

--- a/internal/metrics/testdata/vllm-metrics.txt
+++ b/internal/metrics/testdata/vllm-metrics.txt
@@ -6,6 +6,9 @@ vllm:inter_token_latency_seconds_bucket
 vllm:inter_token_latency_seconds_count
 vllm:inter_token_latency_seconds_sum
 vllm:kv_cache_usage_perc
+vllm:kv_offload_lookup_async_delay_seconds_bucket
+vllm:kv_offload_lookup_async_delay_seconds_count
+vllm:kv_offload_lookup_async_delay_seconds_sum
 vllm:num_preemptions_total
 vllm:num_requests_running
 vllm:num_requests_waiting


### PR DESCRIPTION
`InferenceServiceDown` only catches a dead process. An engine can hold its port open, pass `/health` and report `Ready` while admitting almost no work: requests queue, KV cache sits partly free, prompt throughput reads zero. Nothing in the chart caught that.

Observed on a single-GPU vLLM deployment: three hours of `1/1 Running`, `/health` 200, no chart alert, while the engine sat at `Running: 1, Waiting: 5` with 36% KV free and 0.0 tok/s prompt throughput.

## New `llmkube-serving` group

| alert | expr basis | runtimes | default |
|---|---|---|---|
| `InferenceAdmissionStalled` | queued requests with none running | vllm + sglang | on |
| `InferenceQueueTimeHigh` | mean queue wait > threshold | vllm + sglang | on |
| `KVOffloadLoadSlow` | mean async KV-offload load > threshold | vllm | off |

`KVOffloadLoadSlow` names the likely cause (a slow, non-preemptible async KV load gates admission for everything behind it); `InferenceQueueTimeHigh` only reports the symptom. It's off by default since `OffloadingConnector` is upstream-experimental and its series are absent without a KV connector configured, same pattern as the existing `gpu.memoryPressure` toggle.

## Also fixes a recording rule that only covered SGLang

vLLM exports `vllm:request_queue_time_seconds`, which `charts/llmkube/dashboards/vllm-dashboard.json` already queries. Both queue-wait recording rules now use the same `or` alternation as their `e2e_request_latency` and `ttft_seconds` neighbours.

## Thresholds

Values-driven, set well above the healthy band. Measured on a healthy single-GPU vLLM deployment:

| | healthy | default threshold | headroom |
|---|---|---|---|
| mean queue wait | 1.4s | 30s | ~21x |
| mean async offload load | 0.9s | 10s | ~11x |

## Validation

- `helm unittest`: 83/83 passing, including 6 new cases.
- Rendered expressions run against a live VictoriaMetrics instance: all parse and return the expected series with `service` / `namespace` / `runtime` labels. Confirmed they aren't silent no-ops by lowering thresholds to 0 and checking they then match, the `#1223` failure mode.

## Caveat

Thresholds are backtested against one incident on one deployment. Metric names are stock and rule shapes are runtime-agnostic, but treat the numbers as reasonable defaults rather than fleet-validated. Happy to adjust, or gate `serving.enabled` off by default for a first release.

Assisted-by: OpenCode (helped draft this PR; I reviewed the final change and stand behind it.)
