### PR TITLE
fix: Empty payload.repo silently defeats the upstream-base fetch: task branches cut from a stale fork HEAD (#1625)

### DIFF
--- a/pkg/foreman/agent/claim_gate.go
+++ b/pkg/foreman/agent/claim_gate.go
@@ -77,7 +77,9 @@ var claimDocsPathspec = []string{"*.md", "docs", "examples"}
 //   - Fork-lag false positive: in a fork-based deployment, --git-remote-url
 //     points origin at a fork that can lag the upstream project by an
 //     arbitrary amount, while setupTaskBranch always cuts the task branch
-//     from the CURRENT upstream tip (repo.CreateBranchFromUpstream, #813).
+//     from the CURRENT upstream tip (repo.CreateBranchFromUpstream, #813) —
+//     for repo-bearing kinds an empty payload.repo is now a configuration
+//     error (#1625), so the stale fork-HEAD fallback cannot produce one.
 //     Deriving the anchor from `git merge-base HEAD origin/<baseBranch>`
 //     inside the workspace landed on the STALE fork tip, so AddedLines swept
 //     the entire upstream lag delta into the diff and flagged other

--- a/pkg/foreman/agent/codehost/codehost.go
+++ b/pkg/foreman/agent/codehost/codehost.go
@@ -78,8 +78,11 @@ func SplitRepoSlug(slug string) (namespace, name string, ok bool) {
 type CodeHost interface {
 	// ResolveCloneURL derives the HTTPS git clone URL from a repo slug
 	// like "owner/name" (GitHub) or "group/subgroup/project" (GitLab /
-	// nested Forgejo). Returns "" for an empty or malformed slug so
-	// callers fall back to the cloned fork's HEAD.
+	// nested Forgejo). Returns "" for an empty or malformed slug; the
+	// executor's fork-HEAD fallback then applies to freeform tasks
+	// (which carry no slug by design), while repo-bearing kinds (issue-
+	// fix, verify, review) refuse an empty slug as a configuration
+	// error (#1625) rather than basing on a possibly-stale fork HEAD.
 	ResolveCloneURL(repoSlug string) string
 
 	// EnsureChangeRequest ensures a pull request exists for head → base,

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -479,7 +479,11 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 //     base ref from the upstream project and branch from that (the reset path),
 //     so a stale fork default branch cannot produce a stale-base branch. Origin
 //     stays the fork; the branch still pushes there.
-//  3. Clone-HEAD checkout for freeform tasks without a repo slug.
+//  3. Repo-bearing kind (issue-fix, verify, review) WITHOUT a repo slug:
+//     a configuration error (#1625). The fork-HEAD fallback below is
+//     unsafe for these kinds — it bases on a fork tip that drifts from
+//     upstream — so the missing slug is refused, not papered over.
+//  4. Clone-HEAD checkout for freeform tasks without a repo slug.
 func setupTaskBranch(
 	ctx context.Context,
 	task *foremanv1alpha1.AgenticTask,
@@ -613,6 +617,31 @@ func setupTaskBranch(
 			BaseBranch:  baseBranch,
 			Auth:        auth,
 		})
+	}
+	// Repo-bearing kinds (issue-fix, verify, review) must cut from the
+	// current upstream tip (#813). An empty or malformed payload.repo
+	// resolves no upstream, and falling through to the cloned fork's
+	// HEAD here is exactly the hazard #813 removed: a fork's default
+	// branch drifts from upstream silently, so the task branch (and any
+	// diff or claim-evidence anchor built on it) bases on a stale tip
+	// with nothing to surface it (#1625). The fix is the payload, not a
+	// workaround, so fail the task instead of guessing a base. This
+	// keys on the SLUG, not the resolved URL: a valid slug whose
+	// resolver (test override or degraded host) yields "" is a distinct,
+	// deliberately fail-open path (see
+	// TestNativeExecutor_WorkClassPolicy_FailsOpenWhenBaseUnresolved),
+	// not the stale-fork hazard. Freeform tasks carry no repo slug by
+	// design (ResolveCloneURL contract) and keep the fork-HEAD fallback.
+	if !codehost.IsValidRepoSlug(task.Spec.Payload.Repo) {
+		switch task.Spec.Kind {
+		case foremanv1alpha1.AgenticTaskKindIssueFix,
+			foremanv1alpha1.AgenticTaskKindVerify,
+			foremanv1alpha1.AgenticTaskKindReview:
+			return fmt.Errorf(
+				"task %s: payload.repo is empty but this task kind (%s) requires an upstream base; "+
+					"set payload.repo so the branch bases on the current upstream tip",
+				task.Name, task.Spec.Kind)
+		}
 	}
 	return repo.CreateAndCheckoutBranch(ctx, workspace, branch)
 }
@@ -2306,9 +2335,11 @@ func (e *NativeAgentLoopExecutor) resolveUpstreamForRun(task *foremanv1alpha1.Ag
 // origin/<baseBranch>` inside the workspace: in a fork-based deployment
 // origin can lag the upstream project the branch was actually cut from by
 // an arbitrary amount (setupTaskBranch always cuts from the CURRENT
-// upstream tip, #813), so that derivation swept the whole upstream lag
-// delta into the diff as unproven "claims," and failed closed outright
-// when origin/<baseBranch> was absent (an unsynced release branch).
+// upstream tip, #813, and refuses an empty payload.repo for repo-bearing
+// kinds rather than falling back to the fork's HEAD, #1625), so that
+// derivation swept the whole upstream lag delta into the diff as unproven
+// "claims," and failed closed outright when origin/<baseBranch> was absent
+// (an unsynced release branch).
 // Resolving the literal SHA here, once, from a real fetch against the
 // upstream project (not the fork), and holding it in memory removes both
 // failure modes: gate time now runs `git merge-base HEAD <this literal

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -2860,6 +2860,155 @@ func TestSetupTaskBranch_VerifyStartsAtCoderCommitNotBase(t *testing.T) {
 	}
 }
 
+// #1625: an issue-fix task with an empty payload.repo used to fall through
+// to the cloned fork's HEAD, silently basing on a fork tip that drifts from
+// upstream. The task must now fail with a configuration error and create
+// NO branch: the fix is the payload (set payload.repo), not a guess at a
+// base, and the claim-evidence gate's anchor assumption (#813) must hold.
+func TestSetupTaskBranch_IssueFixEmptyRepoRefusesStaleForkHead(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	seededRemote(t, dir) // upstream main at A
+	const branch = "foreman/wl/issue-641"
+
+	// A STALE fork clone taken before upstream advanced: its local "main"
+	// is the pre-advance tip — exactly what the old fallback would base on.
+	ws := filepath.Join(dir, "fork-ws")
+	gitIn(t, "", "clone", filepath.Join(dir, "origin.git"), ws)
+	forkSHA := gitIn(t, ws, "rev-parse", "HEAD")
+
+	// Advance upstream AFTER the fork was cloned, so the fork is stale.
+	adv := filepath.Join(dir, "adv")
+	gitIn(t, "", "clone", filepath.Join(dir, "origin.git"), adv)
+	if err := os.WriteFile(filepath.Join(adv, "UPSTREAM.md"), []byte("intervening upstream delta\n"), 0o644); err != nil {
+		t.Fatalf("write UPSTREAM.md: %v", err)
+	}
+	gitIn(t, adv, "add", "UPSTREAM.md")
+	gitIn(t, adv, "commit", "-m", "intervening upstream commit")
+	gitIn(t, adv, "push", "origin", "main")
+	upstreamSHA := gitIn(t, adv, "rev-parse", "HEAD")
+	if forkSHA == upstreamSHA {
+		t.Fatal("test setup wrong: the fork tip must predate the upstream advance")
+	}
+
+	// Empty Repo: the #1625 hazard. The default resolver yields "" for it.
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "code-641"},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind:    foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{Issue: 641},
+		},
+	}
+	err := setupTaskBranch(context.Background(), task, ws, branch, "main",
+		upstreamURLForRepo, nil, logr.Discard())
+	if err == nil {
+		t.Fatal("an issue-fix with an empty payload.repo must fail, not fall back to the fork HEAD")
+	}
+	for _, want := range []string{"payload.repo", "set payload.repo", "current upstream tip"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must name the remedy (%q), got: %v", want, err)
+		}
+	}
+	// No branch was created: the workspace is still on its original branch,
+	// and the refused branch does not exist locally.
+	if got := gitIn(t, ws, "branch", "--show-current"); got != "main" {
+		t.Errorf("current branch = %q, want the fork's original branch (no branch may be cut)", got)
+	}
+	// show-ref --verify --quiet exits non-zero when the ref is ABSENT, which
+	// is the desired outcome here; gitIn would fatal on that exit code, so
+	// probe with exec directly. A zero exit means the branch was created —
+	// the bug we are guarding against.
+	probe := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	probe.Dir = ws
+	if probe.Run() == nil {
+		t.Errorf("branch %q unexpectedly exists after refusal", branch)
+	}
+}
+
+// #1625: a freeform task with an empty payload.repo keeps the fork-HEAD
+// fallback — freeform tasks carry no repo slug by design (the
+// ResolveCloneURL contract), so nothing has drifted by construction.
+func TestSetupTaskBranch_FreeformEmptyRepoKeepsForkHeadFallback(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	_, mainSHA := seededRemote(t, dir)
+	const branch = "foreman/freeform"
+
+	ws := filepath.Join(dir, "ws")
+	gitIn(t, "", "clone", filepath.Join(dir, "origin.git"), ws)
+
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "freeform-1"},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind:    foremanv1alpha1.AgenticTaskKindFreeform,
+			Payload: foremanv1alpha1.AgenticTaskPayload{Prompt: "just do a thing"},
+		},
+	}
+	if err := setupTaskBranch(context.Background(), task, ws, branch, "main",
+		upstreamURLForRepo, nil, logr.Discard()); err != nil {
+		t.Fatalf("freeform with an empty payload.repo must keep the fork-HEAD fallback: %v", err)
+	}
+	if got := gitIn(t, ws, "branch", "--show-current"); got != branch {
+		t.Errorf("current branch = %q, want %q", got, branch)
+	}
+	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != mainSHA {
+		t.Errorf("HEAD = %s, want the fork HEAD %s", got, mainSHA)
+	}
+}
+
+// #1625: an issue-fix task with a valid payload.repo still takes the
+// CreateBranchFromUpstream path, basing on the CURRENT upstream tip even
+// though the fork clone is stale.
+func TestSetupTaskBranch_IssueFixValidRepoBasesOnUpstreamTip(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	_, forkSHA := seededRemote(t, dir)
+	const branch = "foreman/wl/issue-641"
+
+	ws := filepath.Join(dir, "fork-ws")
+	gitIn(t, "", "clone", filepath.Join(dir, "origin.git"), ws)
+
+	// Upstream advances AFTER the fork was cloned, so the fork is stale.
+	adv := filepath.Join(dir, "adv")
+	gitIn(t, "", "clone", filepath.Join(dir, "origin.git"), adv)
+	if err := os.WriteFile(filepath.Join(adv, "UPSTREAM.md"), []byte("intervening upstream delta\n"), 0o644); err != nil {
+		t.Fatalf("write UPSTREAM.md: %v", err)
+	}
+	gitIn(t, adv, "add", "UPSTREAM.md")
+	gitIn(t, adv, "commit", "-m", "intervening upstream commit")
+	gitIn(t, adv, "push", "origin", "main")
+	upstreamSHA := gitIn(t, adv, "rev-parse", "HEAD")
+	if upstreamSHA == forkSHA {
+		t.Fatal("test setup wrong: upstream tip must differ from the fork tip")
+	}
+
+	// A valid slug resolves an upstream URL; the branch must land on the
+	// upstream tip, not the stale fork HEAD.
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "code-641"},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind:    foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{Repo: "defilantech/LLMKube", Issue: 641},
+		},
+	}
+	if err := setupTaskBranch(context.Background(), task, ws, branch, "main",
+		func(string) string { return filepath.Join(dir, "origin.git") }, nil, logr.Discard()); err != nil {
+		t.Fatalf("setupTaskBranch with a valid slug: %v", err)
+	}
+	if got := gitIn(t, ws, "rev-parse", "HEAD"); got != upstreamSHA {
+		t.Errorf("HEAD = %s, want the upstream tip %s (not the stale fork tip %s)", got, upstreamSHA, forkSHA)
+	}
+	if got := gitIn(t, ws, "branch", "--show-current"); got != branch {
+		t.Errorf("current branch = %q, want %q", got, branch)
+	}
+}
+
 // isForkOf contract for #1464: a fork shares the repo NAME (owner may
 // differ); a differing repo name is an unrelated repository, not a fork.
 func TestIsForkOf(t *testing.T) {


### PR DESCRIPTION
## What

Repo-bearing task kinds (`issue-fix`, `verify`, `review`) with an empty or malformed `payload.repo` now fail with a configuration error at branch setup instead of silently basing the task branch on the cloned fork's HEAD. Freeform tasks keep the fork-HEAD fallback unchanged.

## Why

Refs #1625

The fork a deployment clones can lag upstream by an arbitrary amount (observed live: a month), and the empty-slug fallback silently defeated the #813 upstream-base fetch — five overnight workloads based on a July tree before the pattern was caught. The fix is the payload, not a workaround, so a missing slug is refused with a message naming the remedy.

## How

`setupTaskBranch` keys the refusal on `codehost.IsValidRepoSlug(payload.repo)`, not on the resolved URL: a valid slug whose resolver degrades to "" keeps its existing, deliberate fail-open path (covered by `TestNativeExecutor_WorkClassPolicy_FailsOpenWhenBaseUnresolved`). Doc comments in `codehost.go` (ResolveCloneURL contract) and `claim_gate.go` (stale-base assumption) updated to state the new invariant. Explicitly out of scope: fork-parent resolution, upstream config knobs, webhook validation (they overlap #1297/#1300).

## Verification

- Three new tests, all passing: issue-fix with empty repo refuses and creates no branch; freeform with empty repo falls back exactly as before; issue-fix with a valid slug still cuts from the upstream tip
- Full `pkg/foreman/...` suite green; `GOOS=linux golangci-lint` and the dead-code guard: 0 issues
- Pipeline: coder GO, gate GATE-PASS (fresh-clone envtest), reviewer GO; the branch itself was cut from current upstream main via the exact code path this PR hardens

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off per DCO
- [x] AI assistance is disclosed below, per CONTRIBUTING.md
- [x] Documentation updated (doc comments carry the new invariant)

Assisted-by: Foreman (qwen38-coder) authored the change from the issue's mandated design; gate-verified, reviewer-approved (Nemotron), and human-reviewed pre-PR (diff, tests re-run, lints) by the maintainer's session.
