### PR TITLE
docs: fix guide instructions that fail against the shipped API

### DIFF
--- a/docs/MODEL-CACHE.md
+++ b/docs/MODEL-CACHE.md
@@ -257,8 +257,8 @@ remove depends on the cache mode:
 
 | Cache mode | Deleting the InferenceService clears it |
 | --- | --- |
-| `perService` (default) | Yes, the claim is owner-ref'd and garbage-collected with it |
-| `shared` | No, the shared claim intentionally outlives any one service |
+| `perService` | Yes, the claim is owner-ref'd and garbage-collected with it |
+| `shared` (default) | No, the shared claim intentionally outlives any one service |
 | `claimName` (bring your own) | No, LLMKube never deletes a user-owned claim |
 
 In the latter two cases the unusable volume survives the InferenceService, so
@@ -415,19 +415,47 @@ For air-gapped environments:
    llmkube cache preload mistral-7b
    ```
 
-2. **Export the PVC** (or use external storage):
-   ```bash
-   # Option 1: Copy from PVC to local storage
-   kubectl cp llmkube-system/llmkube-controller-manager:/models ./model-cache
+2. **Export the PVC.** The weights live in the cache PVC of the namespace you
+   preloaded into, not in the controller pod. The controller's own `/models` is
+   scratch space, and it never mounts a workload namespace's claim, so copying
+   out of `llmkube-system` cannot reach them.
 
-   # Option 2: Use a storage system that can be transported
+   Find the claim first. In `shared` mode (the default) it is
+   `llmkube-model-cache`; in `perService` mode it is `<inferenceservice>-model-cache`:
+
+   ```bash
+   kubectl -n <namespace> get pvc
    ```
 
-3. **On the air-gapped cluster**, import the cache:
+   Then mount it in a throwaway pod and copy from there:
+
    ```bash
-   # Copy to the new PVC
-   kubectl cp ./model-cache llmkube-system/llmkube-controller-manager:/models
+   kubectl -n <namespace> run cache-export --restart=Never --image=busybox:1.36 \
+     --overrides='{"spec":{"containers":[{"name":"cache-export","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"cache","mountPath":"/models"}]}],"volumes":[{"name":"cache","persistentVolumeClaim":{"claimName":"llmkube-model-cache"}}]}}'
+
+   kubectl -n <namespace> wait --for=condition=Ready pod/cache-export --timeout=120s
+   kubectl cp <namespace>/cache-export:/models ./model-cache
+   kubectl -n <namespace> delete pod cache-export
    ```
+
+   A ReadWriteOnce claim can only be mounted where it is already attached, so
+   scale the InferenceService to zero first if the export pod will not schedule.
+
+3. **On the air-gapped cluster**, import the cache by reversing the copy against
+   a helper pod mounting the destination claim:
+
+   ```bash
+   kubectl -n <namespace> run cache-import --restart=Never --image=busybox:1.36 \
+     --overrides='{"spec":{"containers":[{"name":"cache-import","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"cache","mountPath":"/models"}]}],"volumes":[{"name":"cache","persistentVolumeClaim":{"claimName":"llmkube-model-cache"}}]}}'
+
+   kubectl -n <namespace> wait --for=condition=Ready pod/cache-import --timeout=120s
+   kubectl cp ./model-cache/. <namespace>/cache-import:/models
+   kubectl -n <namespace> delete pod cache-import
+   ```
+
+   The destination claim must exist before the copy. Deploy the model once and
+   let it fail to download, or create the PVC yourself, so the operator has a
+   claim to bind.
 
 4. **Deploy models** (they'll be found in cache):
    ```bash

--- a/docs/air-gapped-quickstart.md
+++ b/docs/air-gapped-quickstart.md
@@ -12,7 +12,7 @@ Deploy LLMKube in environments without internet access. This guide covers deploy
 
 ## Prerequisites
 
-- Kubernetes cluster (v1.11.3+) with no internet access
+- Kubernetes cluster (v1.25+) with no internet access. The CRDs carry CEL validation rules, which need 1.25 or newer to be enforced
 - LLMKube operator installed (see [offline installation](#offline-operator-installation))
 - Pre-downloaded GGUF model file(s)
 - `llmkube` CLI installed on a workstation with cluster access
@@ -201,13 +201,22 @@ python3 -m http.server 8080
 
 ```bash
 # Pull images
-docker pull ghcr.io/defilantech/llmkube:v0.4.9
-docker pull ghcr.io/ggml-org/llama.cpp:server-cuda13
+docker pull ghcr.io/defilantech/llmkube-controller:v0.9.19
+docker pull ghcr.io/ggml-org/llama.cpp:server-cuda-b10068
+docker pull ghcr.io/ggml-org/llama.cpp:server
 
 # Save to tar files
-docker save ghcr.io/defilantech/llmkube:v0.4.9 > llmkube-controller.tar
-docker save ghcr.io/ggml-org/llama.cpp:server-cuda13 > llama-server-cuda.tar
+docker save ghcr.io/defilantech/llmkube-controller:v0.9.19 > llmkube-controller.tar
+docker save ghcr.io/ggml-org/llama.cpp:server-cuda-b10068 > llama-server-cuda.tar
+docker save ghcr.io/ggml-org/llama.cpp:server > llama-server-cpu.tar
 ```
+
+`server-cuda-b10068` is the tag the operator substitutes for NVIDIA GPU Models
+when the InferenceService sets no `image`, so a YAML-driven GPU deploy fails to
+pull without it. `:server` is the CPU-only default for Models with no GPU
+section. AMD and Intel tiers pull different images again: see
+[amd-rocm-quickstart.md](amd-rocm-quickstart.md) and
+[intel-gpu-quickstart.md](intel-gpu-quickstart.md).
 
 2. Transfer tar files to the air-gapped environment
 
@@ -217,11 +226,12 @@ docker save ghcr.io/ggml-org/llama.cpp:server-cuda13 > llama-server-cuda.tar
 # Load directly on nodes
 docker load < llmkube-controller.tar
 docker load < llama-server-cuda.tar
+docker load < llama-server-cpu.tar
 
 # Or push to private registry
 docker load < llmkube-controller.tar
-docker tag ghcr.io/defilantech/llmkube:v0.4.9 registry.internal/llmkube:v0.4.9
-docker push registry.internal/llmkube:v0.4.9
+docker tag ghcr.io/defilantech/llmkube-controller:v0.9.19 registry.internal/llmkube-controller:v0.9.19
+docker push registry.internal/llmkube-controller:v0.9.19
 ```
 
 ### Option 2: Helm with Private Registry

--- a/docs/dgx-spark-microk8s.md
+++ b/docs/dgx-spark-microk8s.md
@@ -153,9 +153,12 @@ The community has working Dockerfiles; see the upstream
 and the NVIDIA developer forum thread
 [Building llama.cpp container images for Spark/GB10](https://forums.developer.nvidia.com/t/building-llama-cpp-container-images-for-spark-gb10/353664).
 
-Either way, set the image explicitly on the `InferenceService` (the operator's
-default serving image is not the CUDA-13 tag, so a GPU model with no `image` set
-will not accelerate here):
+Either way, set the image explicitly on the `InferenceService`. A GPU Model
+with no `image` set does not fall back to a CPU tag: the operator substitutes
+`ghcr.io/ggml-org/llama.cpp:server-cuda-b10068` for NVIDIA Models. That build
+carries no `sm_121` cubins, so on GB10 it works but pays a one-time JIT
+compile on first load. Pinning `image` yourself is how you choose a build that
+targets `sm_121` directly:
 
 ```yaml
 apiVersion: inference.llmkube.dev/v1alpha1
@@ -163,7 +166,7 @@ kind: InferenceService
 metadata:
   name: llama-3b
 spec:
-  modelRef: llama-3-2-3b
+  modelRef: llama-3.2-3b
   replicas: 1
   image: ghcr.io/ggml-org/llama.cpp:server-cuda13   # or your GB10-built image if this fails
   resources:

--- a/docs/gpu-setup-guide.md
+++ b/docs/gpu-setup-guide.md
@@ -297,7 +297,7 @@ kubectl scale deployment -n kube-system --replicas=0 $(kubectl get deploy -n kub
 ## Next Steps
 
 1. **Set up monitoring**: Prometheus, Grafana, and DCGM exporter for GPU metrics. See the [observability docs](../README.md#observability).
-2. **Use the CLI**: `llmkube deploy <model> --gpu 1` provisions a GPU-backed InferenceService in one command.
+2. **Use the CLI**: `llmkube deploy <model> --gpu` provisions a GPU-backed InferenceService in one command. `--gpu` is a boolean, so it takes no value; use `--gpu-count N` to request more than one GPU.
 3. **Try multi-GPU**: shard 13B-70B+ models across multiple GPUs on a single node. See [MULTI-GPU-DEPLOYMENT.md](./MULTI-GPU-DEPLOYMENT.md).
 4. **Optimize costs**: spot instances, scale-to-zero, and per-model GPU queues are all configurable on the InferenceService CRD.
 

--- a/docs/minikube-quickstart.md
+++ b/docs/minikube-quickstart.md
@@ -188,7 +188,7 @@ llmkube deploy tinyllama \
 llmkube list services
 
 # Check detailed status
-llmkube status tinyllama-service
+llmkube status tinyllama
 ```
 
 ### Option B: Using kubectl (Advanced)
@@ -259,6 +259,11 @@ kubectl logs $POD -c llama-server -f       # Server startup
 ```
 
 ## Step 4: Test the Inference Endpoint
+
+> **Which name?** The commands below use `tinyllama-service`, the name from
+> Option B. If you deployed with the CLI in Option A, every resource is named
+> after the argument you passed, so the Service is `tinyllama`. Substitute
+> accordingly, or run `kubectl get svc` to see which one you have.
 
 ### Port Forward to Access API
 

--- a/docs/operations/runbooks/controller-hot-spin-on-file-source.md
+++ b/docs/operations/runbooks/controller-hot-spin-on-file-source.md
@@ -8,7 +8,11 @@ The LLMKube controller-manager pod is consuming an entire CPU core continuously 
 
 One or more of:
 
-- Alert: `ControllerHighCPU` on the LLMKube controller-manager Deployment (sustained > 80% CPU on a single replica for > 5 minutes)
+- Alert: none. The chart's `PrometheusRule` ships `ControllerDown` and
+  `ControllerMetricsMissing`, but no controller CPU alert, so a hot-spin does
+  not page on its own. If you want one, add a rule on
+  `rate(process_cpu_seconds_total{job="llmkube-controller"}[5m])`;
+  otherwise this is caught by the two signals below
 - Operator notices: `kubectl --context <ctx> top pods -n llmkube-system` shows controller-manager CPU > 1000m steady
 - Log signal: the controller-manager log shows the same `Reconciler error` repeating thousands of times per second:
 

--- a/docs/operations/runbooks/upgrade-rollback.md
+++ b/docs/operations/runbooks/upgrade-rollback.md
@@ -76,8 +76,20 @@ The chart bundles the CRDs in `templates/crds/`, so CRD updates ride the chart u
 
 If the release notes call out an out-of-band CRD update (e.g., a hotfix that changes only the CRD), apply just the CRDs first, verify, then run the standard chart upgrade:
 
+`raw.githubusercontent.com` serves files, not directories, so pointing `-f` at
+`config/crd/bases/` returns a 404. Fetch the chart's CRD templates from the
+release you are moving to and apply the ones you need:
+
 ```bash
-kubectl apply --server-side -f https://raw.githubusercontent.com/defilantech/LLMKube/v<target>/config/crd/bases/
+helm pull llmkube/llmkube --version <target-version> --untar --untardir /tmp/llmkube-crds
+kubectl apply --server-side -f /tmp/llmkube-crds/llmkube/templates/crds/
+```
+
+To pin a single CRD, apply it by name from the tag instead:
+
+```bash
+kubectl apply --server-side \
+  -f https://raw.githubusercontent.com/defilantech/LLMKube/v<target>/config/crd/bases/inference.llmkube.dev_models.yaml
 ```
 
 ## Verify the upgrade
@@ -104,19 +116,23 @@ kubectl apply --server-side -f https://raw.githubusercontent.com/defilantech/LLM
      | grep -E "Reconciling|ERROR" | head -20
    ```
 
-   Look for `Reconciling Model` / `Reconciling InferenceService` lines without `ERROR` companions.
+   Look for `Reconciling Model` lines without `ERROR` companions. The InferenceService controller does not log a matching `Reconciling` line, so judge it by the absence of errors and by the phases in step 2 rather than by a positive log signal.
 
-4. **Functional smoke: deploy a TinyLlama and hit the endpoint.**
+4. **Functional smoke: deploy the smallest catalog model and hit the endpoint.**
+
+   `llmkube deploy` takes a catalog id. `tinyllama-1.1b` is not one; run
+   `llmkube catalog list` to see the 17 that ship. `llama-3.2-3b` is the
+   smallest and is the cheapest smoke test:
 
    ```bash
-   llmkube deploy tinyllama-1.1b
-   # wait for Ready, then:
-   kubectl port-forward svc/tinyllama-1.1b 8080:8080 &
+   llmkube deploy llama-3.2-3b
+   # wait for Ready, then (dots become dashes in the Service name):
+   kubectl port-forward svc/llama-3-2-3b 8080:8080 &
    curl -s http://localhost:8080/v1/chat/completions \
      -H 'Content-Type: application/json' \
-     -d '{"model":"tinyllama-1.1b","messages":[{"role":"user","content":"hi"}],"max_tokens":16}' \
+     -d '{"model":"llama-3.2-3b","messages":[{"role":"user","content":"hi"}],"max_tokens":16}' \
      | jq '.choices[0].message.content'
-   llmkube delete tinyllama-1.1b
+   llmkube delete llama-3.2-3b
    ```
 
 5. **Helm history reflects the new revision.**
@@ -148,9 +164,13 @@ Some failure modes need extra cleanup:
 
 - **CRD storage version regression** (the new minor changed the storage version and the rollback target predates that change): apply the older CRDs back from the git tag of the rollback target and run a `kubectl get inferenceservice -A` to confirm `spec` parses correctly.
 
+  Same directory-URL caveat as above: pull the rollback target's chart and
+  apply its CRD templates.
+
   ```bash
+  helm pull llmkube/llmkube --version <rollback-target> --untar --untardir /tmp/llmkube-rollback-crds
   kubectl apply --server-side --force-conflicts \
-    -f https://raw.githubusercontent.com/defilantech/LLMKube/v<rollback-target>/config/crd/bases/
+    -f /tmp/llmkube-rollback-crds/llmkube/templates/crds/
   ```
 
 - **Webhook config left from the new version**: if the new version installed a validating or mutating admission webhook the older version did not have, `helm rollback` may not remove the webhook config. Manually delete:

--- a/docs/site/concepts/architecture.md
+++ b/docs/site/concepts/architecture.md
@@ -24,8 +24,9 @@ All three live in `inference.llmkube.dev/v1alpha1`.
   what runtime can consume it, and any hardware preferences
   (Metal vs CUDA, multi-GPU sharding hints).
 - **`InferenceService`** declares a serving deployment: a
-  reference to a `Model`, a runtime (`llamacpp`, `vllm`, `tgi`,
-  `ollama`), replicas, resources, an OpenAI-compatible endpoint.
+  reference to a `Model`, a runtime (`llamacpp`, `vllm`, `sglang`,
+  `tgi`, `generic`), replicas, resources, an OpenAI-compatible
+  endpoint.
   Two `InferenceService` objects can share a `Model`.
 - **`ModelRouter`** declares a policy-aware HTTP router in front
   of one or more `InferenceService` and / or external
@@ -54,7 +55,7 @@ model.
 │   Runtime pods (NVIDIA / CPU)         router-proxy Deployment   │
 │   ┌─────────────────┐                  ┌─────────────────┐      │
 │   │ llama.cpp / vLLM│  ◄──policy──     │  ModelRouter    │      │
-│   │ TGI / Ollama    │                  │  data plane     │      │
+│   │ TGI / SGLang    │                  │  data plane     │      │
 │   └─────────────────┘                  └─────────────────┘      │
 └─────────────────────────────────────────────────────────────────┘
                                           ▲

--- a/docs/site/concepts/comparison.md
+++ b/docs/site/concepts/comparison.md
@@ -28,7 +28,7 @@ Honest comparison, not a sales pitch. We use vLLM, llama.cpp, and TGI as runtime
 
 | Project | K8s-native | Apple Silicon | Memory-pressure protection | Engines | Multi-GPU | License |
 |---|---|---|---|---|---|---|
-| **LLMKube** | ✓ operator + Model and InferenceService CRDs | ✓ native via the metal-agent (no containers) | ✓ watchdog, priority-based eviction, per-service opt-out | llama.cpp, vLLM, TGI, oMLX, Ollama | Layer-based sharding across GPUs on a node | Apache 2.0 |
+| **LLMKube** | ✓ operator + Model and InferenceService CRDs | ✓ native via the metal-agent (no containers) | ✓ watchdog, priority-based eviction, per-service opt-out | llama.cpp, vLLM, SGLang, TGI, PersonaPlex, generic; llama-server / mlx-server / vllm-swift via the metal-agent | Layer-based sharding across GPUs on a node | Apache 2.0 |
 | **KubeAI** | ✓ operator + Model CRD | — Linux containers only | — | vLLM, Ollama, Faster-Whisper, Infinity (embeddings) | Multi-GPU pods via `resourceProfile`, tensor-parallel args passed to vLLM | Apache 2.0 |
 | **llm-d** | ✓ Helm + Gateway API + `InferencePool` | — datacenter accelerators only (NVIDIA, AMD, Intel, TPU) | — | vLLM (primary), SGLang | Wide expert parallelism + disaggregated multi-node serving | Apache 2.0 |
 | **Ollama** | — single binary on a host | ✓ native (its sweet spot) | — | Forked llama.cpp (GGUF), MLX engine (Safetensors, macOS) | Automatic spreading across GPUs on one node | MIT |
@@ -40,7 +40,7 @@ Verified against project repos and official docs. If you spot anything inaccurat
 
 **Pick Ollama if** you have one developer machine, you want chat in 90 seconds, and you don't need Kubernetes-style operations (RBAC, NetworkPolicy, multi-tenant namespaces, a Service mesh, a fleet of nodes). Ollama is the right answer here and we use it during development. It also now ships an MLX engine for Safetensor models on Apple Silicon and a hosted-cloud option for models that don't fit locally.
 
-**Pick llm-d if** you're standing up a multi-node vLLM serving fleet with disaggregated prefill/decode, wide expert parallelism, or tiered KV-cache offload, and you want the Red Hat / IBM / Google production lineage. llm-d's prefill-decode disaggregation, KV-cache tiering, and inference-aware routing are deeper than what we offer for that specific topology. We're the better answer for mixed runtimes (llama.cpp + vLLM + Ollama under one CRD) and for Apple Silicon.
+**Pick llm-d if** you're standing up a multi-node vLLM serving fleet with disaggregated prefill/decode, wide expert parallelism, or tiered KV-cache offload, and you want the Red Hat / IBM / Google production lineage. llm-d's prefill-decode disaggregation, KV-cache tiering, and inference-aware routing are deeper than what we offer for that specific topology. We're the better answer for mixed runtimes (llama.cpp + vLLM + SGLang under one CRD) and for Apple Silicon.
 
 **Pick KubeAI if** you want a Kubernetes operator that ships with embeddings (Infinity), reranking, speech (Faster-Whisper), and LoRA hot-loading alongside LLM serving, and you don't need Apple Silicon or per-process memory protection. KubeAI's scale-to-zero with request queuing, prefix-hash load balancing for KV-cache locality, and Kafka-trigger autoscaling are more operationally polished than ours today.
 

--- a/docs/site/guides/air-gapped.md
+++ b/docs/site/guides/air-gapped.md
@@ -109,8 +109,10 @@ helm install llmkube ./llmkube \
 The `initContainer.repository` / `initContainer.tag` overrides
 matter: by default the InferenceService Pod schedules an init
 container that pulls model weights via HTTP(S). In an air-gapped
-environment that container still runs (even when reading from a
-`pvc://` or local file source — it sets up the on-disk layout). If
+environment that container still runs for every source that has to
+be fetched or staged, including a `file://` path on the node. A
+`pvc://` source is the exception: those weights are pre-staged and
+mounted read-only, so no downloader runs at all. If
 your registry mirror requires a different image (your own distroless
 curl, for example), point it here. The chart consumes these as two
 separate fields, not a single `image` value (see
@@ -268,18 +270,46 @@ selector, taint/toleration, or affinity). The operator does not
 distribute the file across nodes; that's the operator's
 responsibility.
 
-### Option D: HuggingFace repo ID (Ollama / vLLM only)
+### Option D: `s3://` internal object store
 
-vLLM and Ollama runtimes can resolve HF repo IDs at runtime from a
-mirror. Point your runtime image's `HF_ENDPOINT` environment
-variable at your internal mirror (e.g. an Artifactory or Sonatype
-Nexus repository) and use:
+If you already run MinIO, Ceph RGW, or any S3-compatible store
+inside the perimeter, point the Model at it directly. Credentials
+and the endpoint come from a Secret in the Model's namespace, wired
+into the downloader as env:
+
+```bash
+kubectl -n default create secret generic minio-creds \
+  --from-literal=AWS_ACCESS_KEY_ID=<key> \
+  --from-literal=AWS_SECRET_ACCESS_KEY=<secret> \
+  --from-literal=AWS_REGION=us-east-1 \
+  --from-literal=AWS_ENDPOINT_URL=https://minio.internal:9000
+```
 
 ```yaml
 spec:
-  source: meta-llama/Meta-Llama-3.1-8B-Instruct
-  format: hf-repo
+  source: s3://models/meta-llama/Llama-3.1-8B-Instruct-GGUF/Llama-3.1-8B-Instruct-Q4_K_M.gguf
+  format: gguf
+  sourceSecretRef:
+    name: minio-creds
 ```
+
+`spec.source` may also name a bucket **prefix** instead of a single
+object, in which case `spec.files` selects which artifacts to stage
+and `files[0]` is the primary file handed to the runtime. That is how
+a sharded GGUF, an `mmproj`, or draft weights are expressed:
+
+```yaml
+spec:
+  source: s3://models/org/Repo-GGUF
+  files:
+    - Model-00001-of-00002.gguf
+    - Model-00002-of-00002.gguf
+  mmproj: mmproj-model-f16.gguf
+```
+
+> There is no HuggingFace-repo-ID source format. `spec.format` accepts
+> `gguf`, `mlx`, `safetensors`, `pytorch`, or `custom`, and a Model that
+> sets anything else is rejected at apply time.
 
 ## Step 5: Verify
 

--- a/docs/site/guides/karpenter-gpu-autoscaling.md
+++ b/docs/site/guides/karpenter-gpu-autoscaling.md
@@ -104,12 +104,9 @@ spec:
   modelRef: llama-3-8b
   runtime: llamacpp
   resources:
-    limits:
-      nvidia.com/gpu: "1"
-    requests:
-      nvidia.com/gpu: "1"
-      memory: "16Gi"
-      cpu: "4"
+    gpu: 1
+    memory: "16Gi"
+    cpu: "4"
   tolerations:
     - key: nvidia.com/gpu
       operator: Equal

--- a/docs/site/guides/macos-metal.md
+++ b/docs/site/guides/macos-metal.md
@@ -245,7 +245,7 @@ Defaults are tuned by total system RAM:
 | 36 GB | 67% | ~24.1 GB |
 | 48 GB | 75% | 36 GB |
 | 64 GB | 75% | 48 GB |
-| 128 GB | 90% | 115 GB |
+| 128 GB | 75% | 96 GB |
 
 Override the fraction with `--memory-fraction 0.9` for a dedicated
 inference machine, or `0.5` if the Mac is also your daily-driver

--- a/docs/site/guides/metrics-driven-autoscaling.md
+++ b/docs/site/guides/metrics-driven-autoscaling.md
@@ -75,26 +75,36 @@ pod metrics.
 
 ### Expose the metrics to the HPA
 
-The llama.cpp server exposes raw Prometheus gauges with underscores
-(`llamacpp_requests_processing`, etc.). `prometheus-adapter` maps them
-to the colon-form names the HPA expects. Add these rules to your
-`prometheus-adapter` ConfigMap:
+The llama.cpp server already emits colon-form names
+(`llamacpp:requests_processing`, `llamacpp:prompt_tokens_total`, and so
+on), which is exactly what the HPA metric refers to, so no renaming rule
+is needed. vLLM and SGLang are the same: `vllm:num_requests_running` and
+`sglang:num_running_reqs` are the names those servers publish.
+
+What `prometheus-adapter` does provide is the `custom.metrics.k8s.io` API
+itself. Without it the HPA has nowhere to read a Pods metric from and
+reports `FailedGetPodsMetric`.
+
+Expose the series as-is:
 
 ```yaml
 rules:
-  - seriesQuery: '{__name__=~"llamacpp_.+",namespace!="",pod!=""}'
+  - seriesQuery: '{__name__=~"llamacpp:.+",namespace!="",pod!=""}'
     resources:
       overrides:
         namespace: {resource: namespace}
         pod: {resource: pod}
     name:
-      matches: "^llamacpp_(.*)$"
-      as: "llamacpp:$1"
+      matches: "^(.*)$"
+      as: "$1"
     metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
 ```
 
-The managed `spec.autoscaling` path does not need this — the
-controller handles the mapping internally.
+The managed `spec.autoscaling` path needs this too. The controller
+writes the HPA object and fills in the runtime's default metric name;
+it does not serve the metric, so `prometheus-adapter` (or another
+custom-metrics API provider) still has to be installed and scraping
+the inference pods.
 
 ### Hand-authored HPAs (advanced / custom metrics)
 
@@ -143,8 +153,16 @@ default for each runtime backend:
 |-----------|------------------------------|----------------------------------------------------|
 | `llamacpp`| `llamacpp:requests_processing`| Requests currently in flight on the llama.cpp pod. |
 | `vllm`    | `vllm:num_requests_running`   | Requests currently in flight on the vLLM pod.      |
-| `tgi`     | `tgi_batch_current_size`      | Tokens currently in the TGI batch.                 |
+| `tgi`     | `tgi:queue_size`              | See the TGI caveat below.                          |
 | `sglang`  | `sglang:num_running_reqs`     | Requests currently in flight on the SGLang pod.    |
+
+> **TGI caveat.** Unlike the other three, TGI does not publish a
+> `tgi:queue_size` series; its own gauge is `tgi_batch_current_size`
+> (which is what the drain-before-roll idle check reads). If you scale a
+> TGI service on the default metric, add a `prometheus-adapter` rule that
+> renames or computes `tgi:queue_size`, or set an explicit metric name in
+> `spec.autoscaling.metrics[]`, otherwise the HPA reports
+> `FailedGetPodsMetric`.
 
 For SGLang, the controller also emits `--enable-metrics` and the
 inference-pod template's port is named `http`, so the chart's

--- a/docs/site/guides/model-matrix.md
+++ b/docs/site/guides/model-matrix.md
@@ -33,7 +33,7 @@ For most chat workloads at 8K to 16K context, **add 20 to 30 percent to the file
 | 5: Workstation | 96 to 128 GB | MacBook Pro M3/M4 Max 96/128GB, Mac Studio M2 Ultra, 2x RTX 4090/5090, RTX 6000 Pro 96GB |
 | 6: Multi-GPU / Ultra | 192 GB and up | Mac Studio M3/M4 Ultra 192/256/512GB, 4x RTX 5090, multi-RTX 6000 Pro, DGX-class |
 
-In LLMKube specifically, **multi-GPU sharding** lets you span tiers by adding GPUs. A 70B at Q4_K_M (about 40 GB) does not fit a single 24 GB RTX 4090, but it shards cleanly across 2x RTX 4090 with `gpuCount: 2`. See [Multi-GPU sharding](/docs/guides/multi-gpu).
+In LLMKube specifically, **multi-GPU sharding** lets you span tiers by adding GPUs. A 70B at Q4_K_M (about 40 GB) does not fit a single 24 GB RTX 4090, but it shards cleanly across 2x RTX 4090 with `hardware.gpu.count: 2` on the Model. See [Multi-GPU sharding](/docs/guides/multi-gpu).
 
 ## Mac unified memory: usable vs advertised
 
@@ -91,7 +91,7 @@ LLMKube exposes the KV cache dtype as a Model CRD field; see [KV cache types](/d
 
 ## Multi-GPU notes
 
-llama.cpp supports multi-GPU inference via layer splitting. LLMKube wraps that with `gpuCount` on the Model CRD.
+llama.cpp supports multi-GPU inference via layer splitting. LLMKube wraps that with `spec.hardware.gpu.count` on the Model CRD.
 
 - **Two 12 GB cards** can run a 20B to 24B model (10 to 12 GB of weights per GPU plus KV).
 - **Two 24 GB cards** comfortably hold a 70B at Q4_K_M (about 40 GB of weights split across two devices).

--- a/docs/strix-halo-onboarding.md
+++ b/docs/strix-halo-onboarding.md
@@ -196,11 +196,13 @@ spec:
   source: https://huggingface.co/microsoft/Phi-4-mini-instruct-gguf/resolve/main/Phi-4-mini-instruct-q4_0.gguf
   format: gguf
   hardware:
-    accelerator: amd
+    accelerator: vulkan
     gpu:
       enabled: true
       count: 1
       vendor: amd
+      runtime: vulkan
+      resourceName: amd.com/gpu
       layers: -1
   resources:
     cpu: "2"
@@ -223,6 +225,25 @@ spec:
     runAsGroup: 0
     fsGroup: 0
 ```
+
+Three fields here are load-bearing and easy to get wrong:
+
+- `accelerator: vulkan`. The enum is `cpu;metal;cuda;rocm;intel;vulkan`. There
+  is no `amd` value, so a Model that sets one is rejected at apply time.
+- `gpu.runtime: vulkan`. This, together with `vendor: amd`, is what selects
+  LLMKube's hardware-validated Vulkan image. With the runtime left unset the
+  Model still applies and the pod still reaches Ready, but it is served by the
+  upstream CPU-only `llama.cpp:server` tag, so none of the `Vulkan0` log
+  markers in Step 5 appear and throughput is roughly half what the GPU
+  delivers.
+- `gpu.resourceName: amd.com/gpu`. Setting `runtime: vulkan` normally switches
+  the request to the shared `devic.es/dri-render` resource, which the device
+  plugin installed in Step 2 does not advertise, so the pod would sit Pending.
+  An explicit `resourceName` always wins, and keeps this guide on the
+  `amd.com/gpu` plugin it just set up. On a cluster running the generic
+  device plugin instead, drop this field and see the
+  [AMD ROCm quickstart](amd-rocm-quickstart.md) for the `devic.es/dri-render`
+  path.
 
 Apply:
 


### PR DESCRIPTION
## What

Corrects the documentation that actively breaks a reader who follows it: commands that error, manifests the API server rejects, and steps that silently do the wrong thing. 15 files, no code changes.

This is the first of three PRs from a docs audit run against `api/`, `internal/`, `pkg/`, `charts/`, and `catalog/`. Every replacement value was read out of the code rather than remembered.

## Why

No issue; these were found by audit rather than reported. `Refs` nothing deliberately, since each item was verified against the tree rather than reproduced on a cluster.

The worst of them is `docs/strix-halo-onboarding.md`. It fails twice over:

1. `accelerator: amd` is not in the enum (`cpu;metal;cuda;rocm;intel;vulkan`), so the Model never applies.
2. Even corrected, the guide never set `gpu.runtime: vulkan`. `isVulkanAMDModel` requires vendor **and** runtime, so the Model fell through `resolveRuntimeImage` to the CPU-only `llama.cpp:server` tag. The pod reaches Ready, none of the `Vulkan0` markers in Step 5 appear, and throughput is roughly half what the GPU delivers. A silent CPU fallback is the worst failure mode a hardware onboarding guide can have.

The fix needed a third field. Setting `runtime: vulkan` switches the request to `devic.es/dri-render`, which the device plugin the guide installs in Step 2 does not advertise, so the pod would sit Pending. An explicit `gpu.resourceName: amd.com/gpu` keeps it on the plugin the guide just set up. This mirrors what `amd-rocm-quickstart.md` already documents.

## How

**Manifests the API server rejects**

| File | Was | Is |
|---|---|---|
| `strix-halo-onboarding.md` | `accelerator: amd`, no runtime | `accelerator: vulkan` + `runtime: vulkan` + `resourceName: amd.com/gpu` |
| `site/guides/karpenter-gpu-autoscaling.md` | `resources.limits/requests` | `resources: {gpu, cpu, memory}` |
| `site/guides/air-gapped.md` | `format: hf-repo`, Ollama runtime | the `s3://` path, with `sourceSecretRef` and the `spec.files` prefix form |
| `site/guides/model-matrix.md` | `gpuCount` | `spec.hardware.gpu.count` |

**Commands that error or address the wrong object**

- `gpu-setup-guide.md`: `--gpu 1`. The flag is boolean; count is `--gpu-count N`.
- `minikube-quickstart.md`: `llmkube status tinyllama-service`. The CLI names both Model and InferenceService after the argument. The `-service` suffix exists only on the Option B path, and Step 4 is shared, so it now says which name belongs to which path.
- `upgrade-rollback.md`: `-f .../config/crd/bases/` 404s, because raw.githubusercontent serves files, not directories. Now does a `helm pull` of the target version and applies its CRD templates, in both the upgrade and rollback directions. The smoke test used `tinyllama-1.1b`, not a catalog id; switched to `llama-3.2-3b`.
- `MODEL-CACHE.md`: the air-gapped export ran `kubectl cp` against `llmkube-system/llmkube-controller-manager`, a Deployment name. Even addressed correctly it cannot work, since the controller's `/models` is scratch and it never mounts a workload namespace's claim. Replaced with a helper pod mounting the cache PVC.

**Claims that are not true of the current code**

- `MODEL-CACHE.md` called `perService` the default cache mode. It is `shared`, as the same file says 120 lines earlier.
- `dgx-spark-microk8s.md`: a GPU Model with no `image` does not fall back to a CPU tag; the operator substitutes `server-cuda-b10068`. Also `modelRef: llama-3-2-3b` pointed at nothing, since dots become dashes in the Service name, not the Model name.
- `controller-hot-spin-on-file-source.md` triggers on `ControllerHighCPU`, which the shipped `PrometheusRule` does not define.
- `air-gapped-quickstart.md`: image was `ghcr.io/defilantech/llmkube:v0.4.9`; the repo is `llmkube-controller` at 0.9.19. The pre-pull list omitted `server-cuda-b10068`, so a YAML-driven GPU deploy fails to pull air-gapped. The `v1.11.3+` floor was kubebuilder boilerplate; CEL validation in the CRDs makes it 1.25+.
- `site/guides/macos-metal.md`: no 90% tier exists. `DefaultMemoryFraction` is 0.67 at or below 36 GiB and 0.75 above, so 128 GB is 96 GB.
- `site/concepts/architecture.md` and `comparison.md`: `ollama` is not in the runtime enum, in prose, in the diagram, or in the table.
- `site/guides/metrics-driven-autoscaling.md` had the adapter story backwards. It claimed llama.cpp emits underscore names that prometheus-adapter renames to colon form, and that the managed `spec.autoscaling` path needs no adapter. Both inverted: llama.cpp, vLLM, and SGLang publish colon-form names natively, so the sample regex matched nothing, and the managed path still needs the adapter because the controller writes the HPA but does not serve the metric.

## One thing worth a maintainer's eye

While correcting that last file: `TGIBackend.DefaultHPAMetric()` returns `tgi:queue_size`, but TGI publishes `tgi_batch_current_size`, which is what `runtime_tgi.go`'s own drain check parses. So a TGI service scaled on the default metric looks like it should work and reports `FailedGetPodsMetric`. I documented the gap rather than changing the default, since that is a behaviour change and belongs in its own PR. Happy to file it.

One claim here is not verifiable from this repo: the note in `dgx-spark-microk8s.md` that `server-cuda-b10068` carries no `sm_121` cubins and pays a one-time JIT on GB10. That comes from a measurement on the Spark, not from the tree. Drop it if you would rather the guide only assert what the code proves.

## Not in this PR

Two section-1 items need rewrites rather than corrections, and would swamp this diff:

- `docs/operations/runbooks/metal-agent-memory-pressure.md`, six wrong claims including the pressure-level formula (computed from the available-memory fraction, not RSS over total) and `memoryBudget` living on Model `spec.hardware`, not InferenceService.
- `docs/MULTI-GPU-DEPLOYMENT.md`, which still reads as the pre-merge Issue #2 validation plan.

## Checklist

- [x] Tests added/updated (n/a, documentation only)
- [x] `make test` passes locally (n/a, no code changed)
- [x] `make lint` passes locally (n/a, no Go changed)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed below
- [x] Documentation updated (this is the documentation update)

Assisted-by: Claude Code (Opus 5)
