### PR TITLE
docs(runbook): correct the metal-agent memory-pressure runbook against pkg/agent

### DIFF
--- a/docs/operations/runbooks/metal-agent-memory-pressure.md
+++ b/docs/operations/runbooks/metal-agent-memory-pressure.md
@@ -18,24 +18,41 @@ One or more of:
   kubectl get inferenceservice <name> -o jsonpath='{.status.conditions[?(@.type=="MemoryPressure")]}{"\n"}'
   ```
 
-- Metric: `evictions_skipped_total` increments (visible in the metal-agent's `/metrics` endpoint).
+- Metric: `llmkube_metal_agent_evictions_skipped_total` increments (visible in the metal-agent's `/metrics` endpoint). Its companions are `llmkube_metal_agent_evictions_total` and the `llmkube_metal_agent_memory_pressure_level` gauge (0 Normal, 1 Warning, 2 Critical).
 - Operator notices: free memory on the host drops, or applications connected to the inference endpoint report sudden hangs or 5xx responses.
 
 ## Diagnose
 
 1. **Determine current pressure level and which process the watchdog is tracking.**
 
-   The metal-agent emits `[longctx]`-style telemetry lines in its log including memory state. Check the most recent event:
+   Check the most recent event:
 
    ```bash
    kubectl get events -A --field-selector reason=MemoryPressureLevelChanged \
      --sort-by=.lastTimestamp | tail -5
    ```
 
-   The event message includes `totalRSS=XX.X GB of YY.Y GB`. Determine the level:
-   - **Normal**: `totalRSS / totalMemory < warningThreshold` (default `< 0.20` of available)
-   - **Warning**: between thresholds (default `0.20` to `0.10` available)
-   - **Critical**: `totalRSS / totalMemory > 1 - criticalThreshold` (default `> 0.90` of total RSS)
+   For the full picture, read the agent's own log. At Warning or above it
+   logs `memory pressure detected` with `level`, `available`, `total`,
+   `wired`, and `totalRSS` fields:
+
+   ```bash
+   grep 'memory pressure detected' /tmp/llmkube-metal-agent.log | tail -5
+   ```
+
+   The level is computed from **available** memory as a fraction of total,
+   not from RSS. Lower is worse:
+
+   | Level | Condition | Default |
+   |---|---|---|
+   | Normal | `available / total` at or above the warning threshold | `>= 0.20` |
+   | Warning | below warning, at or above critical | `0.10` to `0.20` |
+   | Critical | below the critical threshold | `< 0.10` |
+
+   Both thresholds are agent flags: `--memory-pressure-warning` (default
+   `0.20`) and `--memory-pressure-critical` (default `0.10`). `totalRSS`
+   appears in the messages because it feeds the friendly-fire guard in step
+   4, not because it sets the level.
 
 2. **List managed processes and their priorities.**
 
@@ -56,6 +73,17 @@ One or more of:
    ```
 
 4. **Verify the friendly-fire guard is not the blocker.** When `totalRSS` from managed processes is < 50% of system total RSS, the watchdog refuses to evict (the pressure is from somewhere else, not us). You will see `EvictionSkipped` with `skip-reason=below_guard`. This is the correct behavior; do not disable the guard.
+
+5. **Read the skip reason.** `disabled` and `below_guard` are not the only ones. When the watchdog is Critical, eviction is enabled, and the guard passes, it can still find no eligible target:
+
+   | `skip-reason` | Meaning | What to do |
+   |---|---|---|
+   | `disabled` | `--eviction-enabled` is off | expected unless you opted in |
+   | `below_guard` | managed processes hold under 50% of system RSS | correct refusal, look elsewhere for the hog |
+   | `empty` | no managed processes at all | nothing for the agent to evict |
+   | `floor` | refused to evict the last managed process | single-tenant host by design |
+   | `all_protected` | every candidate has `evictionProtection: true` | review your protection settings |
+   | `runtime_ineligible` | every managed process is on a shared daemon (oMLX / Ollama) the agent does not own at the OS level | killing them here would not free memory |
 
 ## Mitigate (immediate)
 
@@ -104,16 +132,28 @@ If memory pressure is recurring on this host:
 
    Compare each to the model's expected memory footprint. If a process is dramatically over its expected footprint, that is a separate bug in the runtime; file a focused issue.
 
-2. **Lower `--memory-fraction` on the metal-agent.** Defaults to `0.67` on most hosts (auto-detected). If you are trying to leave more headroom for non-LLMKube workloads, drop it to `0.5`.
+2. **Lower `--memory-fraction` on the metal-agent.** The flag defaults to `0`, which means auto-detect, and auto is tiered by host RAM: `0.67` at or below 36 GiB, `0.75` above it. A 128 GB Studio therefore budgets ~96 GB, not ~86 GB. If you are trying to leave more headroom for non-LLMKube workloads, set it explicitly to `0.5`.
 
-3. **Add memory budget to specific InferenceServices.**
+3. **Add a memory budget to specific models.** The budget lives on the
+   **Model**, under `spec.hardware`, not on the InferenceService:
 
    ```yaml
+   apiVersion: inference.llmkube.dev/v1alpha1
+   kind: Model
    spec:
-     memoryBudget: "16Gi"
+     hardware:
+       memoryBudget: "16Gi"     # absolute
+       # or, instead:
+       # memoryFraction: 0.4    # fraction of this host's total RAM
    ```
 
-   The metal-agent enforces this at spawn time and refuses to start a process that would exceed it. Prevents the failure mode upstream of the watchdog.
+   The precedence chain is `spec.hardware.memoryBudget`, then
+   `spec.hardware.memoryFraction`, then the agent's `--memory-fraction`.
+   The metal-agent enforces the resolved budget at spawn time and refuses
+   to start a process whose estimate exceeds it, which heads off the
+   failure mode upstream of the watchdog. If the pre-flight estimate cannot
+   be computed at all, `--memory-check-mode` decides what happens:
+   `enforce` (the default) fails closed, `warn` starts the process anyway.
 
 4. **Move heavy models to a host with more memory.** If the same M2 Pro keeps hitting Critical with a 30B model, that is a sizing problem, not a runbook problem.
 
@@ -133,18 +173,27 @@ If memory pressure is recurring on this host:
    kubectl get inferenceservice -A
    ```
 
-   If a service was evicted, its replicas are 0 and the MemoryPressure condition has reason `Evicted`. The watchdog will allow respawn once the pressure drops back to Normal (the agent emits a level-changed event when it returns to Normal).
+   An eviction does **not** change the InferenceService spec. The agent kills
+   the local process and sets the `MemoryPressure` condition with reason
+   `Evicted`; `spec.replicas` is left exactly as you set it, so a service
+   showing `replicas: 1` with no running process is the expected shape after
+   an eviction, not a stuck reconcile. The agent keeps that key blocked
+   in-memory so a controller event cannot respawn it mid-teardown, and clears
+   every block the moment pressure returns to Normal.
 
-3. **`evictions_skipped_total` is not climbing** unless eviction is intentionally disabled:
+3. **`llmkube_metal_agent_evictions_skipped_total` is not climbing** unless eviction is intentionally disabled:
 
    ```bash
-   curl -s http://<metal-agent-host>:9090/metrics | grep evictions_skipped
+   curl -s http://<metal-agent-host>:9090/metrics \
+     | grep -E 'llmkube_metal_agent_(evictions|memory_pressure_level)'
    ```
+
+   `llmkube_metal_agent_memory_pressure_level` should read `0`.
 
 ## Related
 
 - Issue: [#390](https://github.com/defilantech/LLMKube/issues/390) (the K8s events that surface this signal)
 - Fix: [PR #411](https://github.com/defilantech/LLMKube/pull/411) (events emission)
 - Earlier work: PRs #382 + #386 (the watchdog itself, shipped in 0.7.6)
-- Companion runbook: `metal-agent-respawn-blocked.md` (when an evicted service refuses to come back even after pressure clears)
-- Documentation: `Memory.Budget` field on `InferenceService` for upstream enforcement
+- Field reference: `spec.hardware.memoryBudget` and `spec.hardware.memoryFraction` on `Model`, for enforcement upstream of the watchdog
+- Agent setup and log locations: [macOS Metal agent guide](../../site/guides/macos-metal.md)


### PR DESCRIPTION
## What

Rewrites the incorrect parts of `docs/operations/runbooks/metal-agent-memory-pressure.md` against `pkg/agent/`. Documentation only, one file.

Follow-up to #1629, which covered the mechanical guide breakers. This runbook needed a rewrite rather than a patch, so it was split out.

## Why

Six claims did not match the code. Two of them would actively mislead an operator mid-incident.

**The pressure-level formula was inverted.** `computePressure` in `watchdog.go`:

```go
availFraction := float64(stats.AvailableMemory) / float64(stats.TotalMemory)
if availFraction < w.config.CriticalThreshold { return MemoryPressureCritical }
if availFraction < w.config.WarningThreshold  { return MemoryPressureWarning }
```

The level comes from **available** memory as a fraction of total, and lower is worse. The runbook described `totalRSS / totalMemory`, with Critical at "> 0.90 of total RSS". That is the wrong quantity read in the wrong direction, so an operator computing the level by hand during an incident would reach the opposite conclusion. Defaults are `--memory-pressure-warning 0.20` and `--memory-pressure-critical 0.10`, both available fractions.

**`memoryBudget` was on the wrong CRD.** It is `Model.spec.hardware.memoryBudget` (`model_types.go:175`, inside `HardwareSpec`). The runbook put it at `InferenceService.spec.memoryBudget`, so following it produces YAML that is silently dropped, and the operator concludes the budget does not work.

## How

| Claim | Reality |
|---|---|
| Level is `totalRSS / totalMemory`, Critical `> 0.90` | `available / total`, Critical `< 0.10`; thresholds are `--memory-pressure-{warning,critical}` |
| `memoryBudget` on InferenceService | `Model.spec.hardware.memoryBudget`, next to `memoryFraction` |
| Grep for `[longctx]` telemetry lines | no such string anywhere in `pkg/` or `cmd/`; the real line is `memory pressure detected` |
| Evicted service has `replicas: 0` | eviction never writes `spec.replicas`; it kills the process and sets the condition |
| `--memory-fraction` defaults to `0.67` | defaults to `0` (auto); auto is `0.67` at or below 36 GiB, `0.75` above |
| Metric `evictions_skipped_total` | `llmkube_metal_agent_evictions_skipped_total` |

The `replicas` one is worth dwelling on. `pressure.go` marks the key blocked in-memory, sets `MemoryPressure` to reason `Evicted`, and calls `deleteProcess`. The spec is untouched. So a service showing `replicas: 1` with no running process is the *expected* shape after an eviction, and the Verify step was training operators to look for a state the agent never produces.

Also fills a genuine gap rather than only fixing errors. `eviction.go` distinguishes six skip reasons precisely because they imply different operator actions, but the runbook documented only `disabled` and `below_guard`. Anyone landing on `empty`, `floor`, `all_protected`, or `runtime_ineligible` had nothing to go on. All six are now tabulated with the action each implies.

Two dead references fixed: `metal-agent-respawn-blocked.md` was linked as a companion runbook and has never existed, and the `Memory.Budget` field reference pointed at the wrong CRD.

## What I did not change

The Trigger section, the friendly-fire guard description (`> 50%` of system RSS is correct), the `priority` / `evictionProtection` kubectl commands (both are real InferenceService fields, and `critical` is in the priority enum), and the Mitigate structure. Those check out.

## Checklist

- [x] Tests added/updated (n/a, documentation only)
- [x] `make test` passes locally (n/a, no code changed)
- [x] `make lint` passes locally (n/a, no Go changed)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed below
- [x] Documentation updated (this is the documentation update)

Assisted-by: Claude Code (Opus 5)
