### PR TITLE
fix(controller): clear the controller's own schedulingStatus once a service is Ready

### DIFF
--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -307,6 +307,21 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		r.reconcileAccelerationStatus(ctx, inferenceService)
 	}
 
+	// Clear the scheduling diagnosis this controller wrote once the service is
+	// actually serving. determinePhase returns a nil SchedulingInfo at Ready,
+	// and the status builder deliberately no-ops on nil so it cannot clobber
+	// agent-written scheduling fields (#643). That preserve is correct for the
+	// metal path, where the agent owns these fields and clears them itself
+	// (#777), but it also froze the controller's own InsufficientGPU /
+	// UnbindableModelCache: a recovered service kept advertising a resource it
+	// was no longer waiting on (#1632). Deployment path only, so the metal
+	// path's ownership is untouched.
+	if !isMetal && phase == PhaseReady {
+		inferenceService.Status.SchedulingStatus = ""
+		inferenceService.Status.SchedulingMessage = ""
+		inferenceService.Status.WaitingFor = ""
+	}
+
 	finalResult, statusErr := r.updateStatusWithSchedulingInfo(ctx, inferenceService, phase, modelReady, readyReplicas, desiredReplicas, endpoint, "", schedulingInfo)
 	if statusErr != nil {
 		return finalResult, statusErr

--- a/internal/controller/inferenceservice_reconcile_test.go
+++ b/internal/controller/inferenceservice_reconcile_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1097,6 +1098,140 @@ var _ = Describe("Reconcile lifecycle", func() {
 			// The controller must not clobber the agent-written scheduling fields.
 			Expect(updated.Status.SchedulingStatus).To(Equal("MemoryCheckFailed"))
 			Expect(updated.Status.SchedulingMessage).To(Equal("host memory insufficient for model"))
+		})
+
+		It("should clear the controller's own schedulingStatus once the service is Ready", func() {
+			modelName := "model-sched-clear"
+			isvcName := "isvc-sched-clear"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server",
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, isvc)
+				dep := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep); err == nil {
+					_ = k8sClient.Delete(ctx, dep)
+				}
+				svc := &corev1.Service{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, svc); err == nil {
+					_ = k8sClient.Delete(ctx, svc)
+				}
+			}()
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+			key := types.NamespacedName{Name: isvcName, Namespace: "default"}
+
+			// First pass creates the Deployment.
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			// envtest runs no kubelet, so drive the Deployment to Ready by hand.
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, key, dep)).To(Succeed())
+			dep.Status.Replicas = 1
+			dep.Status.ReadyReplicas = 1
+			dep.Status.AvailableReplicas = 1
+			Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+			// Seed the diagnosis the controller itself writes on the deployment
+			// path, as if the pods had been unschedulable before recovering.
+			Expect(k8sClient.Get(ctx, key, isvc)).To(Succeed())
+			isvc.Status.SchedulingStatus = "InsufficientGPU"
+			isvc.Status.SchedulingMessage = "0/4 nodes are available: 1 Insufficient nvidia.com/gpu"
+			isvc.Status.WaitingFor = "nvidia.com/gpu: 1"
+			Expect(k8sClient.Status().Update(ctx, isvc)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			recovered := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, key, recovered)).To(Succeed())
+			Expect(recovered.Status.Phase).To(Equal(PhaseReady))
+			// A serving service must not advertise a resource it is no longer
+			// waiting on (#1632).
+			Expect(recovered.Status.SchedulingStatus).To(BeEmpty())
+			Expect(recovered.Status.SchedulingMessage).To(BeEmpty())
+			Expect(recovered.Status.WaitingFor).To(BeEmpty())
+		})
+
+		It("should preserve agent-written schedulingStatus on a Ready metal service", func() {
+			modelName := "model-sched-metal-ready"
+			isvcName := "isvc-sched-metal-ready"
+
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/metal-model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "metal"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+			// A fresh heartbeat with a ready endpoint puts the metal service at Ready.
+			slice := metalEndpoints(isvcName, time.Now().UTC().Format(time.RFC3339))
+			Expect(k8sClient.Create(ctx, slice)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, slice) }()
+
+			key := types.NamespacedName{Name: isvcName, Namespace: "default"}
+			Expect(k8sClient.Get(ctx, key, isvc)).To(Succeed())
+			isvc.Status.SchedulingStatus = "InsufficientMemory"
+			isvc.Status.SchedulingMessage = "model exceeds the host memory budget"
+			Expect(k8sClient.Status().Update(ctx, isvc)).To(Succeed())
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedMetal := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, key, updatedMetal)).To(Succeed())
+			// The agent owns these on the metal path and clears them itself
+			// (#777); the #1632 clear must not reach across and do it here.
+			Expect(updatedMetal.Status.SchedulingStatus).To(Equal("InsufficientMemory"))
+			Expect(updatedMetal.Status.SchedulingMessage).To(Equal("model exceeds the host memory budget"))
 		})
 	})
 })


### PR DESCRIPTION
## What

Clears `schedulingStatus`, `schedulingMessage`, and `waitingFor` when a deployment-path InferenceService reaches Ready, so a recovered service stops advertising the failure that is no longer true.

Four lines of production code plus two tests.

## Why

Found on the live cluster. Two healthy services were reporting as GPU-starved:

```
NAMESPACE   NAME                 PHASE   MODEL                REPLICAS   REASON
default     qwen38-coder         Ready   qwen38-27b           2          InsufficientGPU
default     nemotron-49b-strix   Ready   nemotron-49b-strix   1          InsufficientGPU
```

`qwen38-coder` at the time:

```yaml
phase: Ready
readyReplicas: 2
desiredReplicas: 2
lastUpdated: "2026-08-22T17:42:47Z"      # current, so the controller IS reconciling
conditions:
  - type: Available
    status: "True"
    lastTransitionTime: "2026-08-21T01:45:25Z"
schedulingStatus: InsufficientGPU
waitingFor: "nvidia.com/gpu: 1"
```

Both pods Running, zero restarts, 40h uptime, one per node. The `Reason` printcolumn reads `.status.schedulingStatus` (`inferenceservice_types.go:1441`), so `kubectl get` reports a serving service as starved indefinitely.

This is not cosmetic. `waitingFor` advertises a pending resource request that does not exist, and any consumer treating a non-empty `schedulingStatus` as unhealthy gets a false negative on a service that is fine.

## Root cause

A gap between two individually correct changes:

1. `determinePhase` (`scheduling.go:74`) returns `PhaseReady, nil`. Scheduling info goes nil on recovery, by design.
2. `status_builder.go:215` writes the fields only `if schedulingInfo != nil`.
3. The `else` is an intentional no-op: *"preserve agent-written scheduling fields ... so the controller does not clobber them (#643)."*

The preserve is correct for agent-owned values but unconditional, so it also froze controller-owned ones. #777 reached the matching conclusion for the other half of this bug and fixed the agent side at `agent.go:1589-1596`:

> The agent owns these fields (the controller preserves them post-#774), so the agent must own clearing them.

By the same reasoning the controller owns `InsufficientGPU` and `UnbindableModelCache`, written in the `!isMetal` branch, and must clear them. That half was never done. This is it.

## How

The clear sits in the main reconcile path next to the existing `if !isMetal` guard for `reconcileAccelerationStatus`, which is the same pattern of mutating status before the write:

```go
if !isMetal && phase == PhaseReady {
    inferenceService.Status.SchedulingStatus = ""
    inferenceService.Status.SchedulingMessage = ""
    inferenceService.Status.WaitingFor = ""
}
```

Deployment path only, so metal ownership is untouched.

I considered two alternatives and rejected both:

- **Allowlisting the controller's status strings.** Incomplete: besides `InsufficientGPU` and `UnbindableModelCache`, `getPodSchedulingInfo` can also emit `InsufficientResources` and the scheduler's raw `condition.Reason`. The allowlist would silently miss those and need updating whenever a new one is added.
- **Threading `isMetal` into `updateStatusWithSchedulingInfo`.** It matches house style (`reconcileDeployment`, `reconcileService`, `reconcilePodLifetime`, and `determinePhase` all take it), but there are 11 call sites and only the main one can ever produce `PhaseReady`; the other ten pass `Failed` or `Pending`. Ten signature changes to reach one decision point was not worth it.

## Tests

One per direction, both in `inferenceservice_reconcile_test.go`:

- **Clears on recovery.** envtest runs no kubelet, so the Deployment is driven to ready by hand, `InsufficientGPU` is seeded as if the pods had been unschedulable, and after a reconcile all three fields must be empty and the phase Ready.
- **Metal still preserved.** A metal service is put at Ready with a fresh heartbeat, an agent-written `InsufficientMemory` is seeded, and it must survive the reconcile, so this clear cannot grow into the agent's fields and reintroduce #643.

**It bites.** Reverting the four-line change fails the first test:

```
[FAILED] in [It] - inferenceservice_reconcile_test.go:1177
[FAILED] Expected
    <string>: InsufficientGPU
FAIL! -- 2 Passed | 1 Failed
```

The two preserve tests pass with and without the fix, which is the point: they guard #643 rather than depending on this change.

Full suite green (`go test $(go list ./... | grep -v /e2e)`), and `GOOS=linux golangci-lint run ./...` reports zero issues in either changed file.

## Verification status

`Refs #1632` rather than `Fixes`. The bug is reproduced live and the fix is proven under envtest, but I have not yet watched a real InsufficientGPU-to-Ready recovery clear the field on the cluster. Worth confirming on the next real recovery before closing the issue.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance is disclosed below
- [x] Documentation updated (n/a, no user-facing API or behaviour change beyond the status field correcting itself)

Assisted-by: Claude Code (Opus 5)
