### PR TITLE
fix(foreman): free the agent's in-process slot while a Job-mode task runs

### DIFF
--- a/api/foreman/v1alpha1/fleetnode_types.go
+++ b/api/foreman/v1alpha1/fleetnode_types.go
@@ -154,9 +154,16 @@ type FleetNodeStatus struct {
 	// +optional
 	Capability FleetNodeCapability `json:"capability,omitempty"`
 
-	// CurrentTask is the namespaced name of the AgenticTask the agent is
-	// running, or empty if idle. The scheduler skips nodes with a non-empty
-	// CurrentTask (v0.1 concurrency is one task per node).
+	// CurrentTask is the namespaced name of the in-process AgenticTask this
+	// node is reserved for, or empty if no reservation is held. The scheduler
+	// skips nodes with a non-empty CurrentTask when placing in-process work.
+	//
+	// Empty does NOT mean idle. A Job-mode task (Agent
+	// spec.execution.mode=Job) runs in an ephemeral Job pod rather than on the
+	// node, so the scheduler deliberately leaves CurrentTask untouched for it,
+	// and one agent supervises several such tasks concurrently (bounded by its
+	// --max-supervised-tasks). A node with an empty CurrentTask can therefore
+	// be supervising coder Jobs; it is free for in-process work, not idle.
 	// +optional
 	CurrentTask string `json:"currentTask,omitempty"`
 

--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -26,9 +26,12 @@ metadata:
     {{- include "foreman.agent.poolLabels" $ctx | nindent 4 }}
 spec:
   replicas: {{ $agent.replicaCount }}
-  # Each foreman-agent claims one task at a time. The Recreate
-  # strategy stops a rolling update from briefly running two agents
-  # that race for the same Scheduled tasks.
+  # The Recreate strategy stops a rolling update from briefly running two
+  # agents that race for the same Scheduled tasks. Note the blast radius: an
+  # agent holds one in-process task plus up to --max-supervised-tasks Job-mode
+  # supervisions (#1559), and on restart recoverOrphanedTasks resets EVERY
+  # Running task on the node back to Pending, so an upgrade can yank back more
+  # than one run at a time and each is re-dispatched from the start.
   strategy:
     type: Recreate
   # Pool-scoped, via $ctx rather than the chart root: passing $ here gave

--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -26,12 +26,12 @@ metadata:
     {{- include "foreman.agent.poolLabels" $ctx | nindent 4 }}
 spec:
   replicas: {{ $agent.replicaCount }}
-  # The Recreate strategy stops a rolling update from briefly running two
-  # agents that race for the same Scheduled tasks. Note the blast radius: an
-  # agent holds one in-process task plus up to --max-supervised-tasks Job-mode
-  # supervisions (#1559), and on restart recoverOrphanedTasks resets EVERY
-  # Running task on the node back to Pending, so an upgrade can yank back more
-  # than one run at a time and each is re-dispatched from the start.
+  # Recreate: never runs two agents for this pool at once. Note the blast
+  # radius: an agent holds one in-process task plus up to
+  # --max-supervised-tasks Job-mode supervisions (#1559), and on restart
+  # recoverOrphanedTasks resets EVERY Running task on the node back to
+  # Pending, so an upgrade can yank back more than one run at a time and
+  # each is re-dispatched from the start.
   strategy:
     type: Recreate
   # Pool-scoped, via $ctx rather than the chart root: passing $ here gave

--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -74,6 +74,9 @@ spec:
             {{- if $agent.taskNamespace }}
             - --task-namespace={{ $agent.taskNamespace }}
             {{- end }}
+            {{- if $agent.maxSupervisedTasks }}
+            - --max-supervised-tasks={{ $agent.maxSupervisedTasks }}
+            {{- end }}
             {{- /* Always set: the binary default is "foreman-system", a namespace the chart never creates, so gate Jobs would land where the cache PVC does not exist. */}}
             - --foreman-namespace={{ $agent.foremanNamespace | default (include "foreman.namespace" $) }}
             {{- /* Thread the per-agent gate-cache PVC (foreman.gateCache.pvcName) so the gate Job mounts the claim the chart actually creates. gateCache.enabled=false leaves it empty, preserving the no-volume-mount behavior (#1538). */}}

--- a/charts/foreman/templates/crds/fleetnodes.yaml
+++ b/charts/foreman/templates/crds/fleetnodes.yaml
@@ -223,9 +223,16 @@ spec:
                 x-kubernetes-list-type: map
               currentTask:
                 description: |-
-                  CurrentTask is the namespaced name of the AgenticTask the agent is
-                  running, or empty if idle. The scheduler skips nodes with a non-empty
-                  CurrentTask (v0.1 concurrency is one task per node).
+                  CurrentTask is the namespaced name of the in-process AgenticTask this
+                  node is reserved for, or empty if no reservation is held. The scheduler
+                  skips nodes with a non-empty CurrentTask when placing in-process work.
+
+                  Empty does NOT mean idle. A Job-mode task (Agent
+                  spec.execution.mode=Job) runs in an ephemeral Job pod rather than on the
+                  node, so the scheduler deliberately leaves CurrentTask untouched for it,
+                  and one agent supervises several such tasks concurrently (bounded by its
+                  --max-supervised-tasks). A node with an empty CurrentTask can therefore
+                  be supervising coder Jobs; it is free for in-process work, not idle.
                 type: string
               lastHeartbeatTime:
                 description: |-

--- a/charts/foreman/tests/agents_test.yaml
+++ b/charts/foreman/tests/agents_test.yaml
@@ -239,6 +239,43 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --gate-cache-pvc=
 
+  # ---- Job-mode supervision bound (#1559) ----
+
+  - it: --max-supervised-tasks renders per pool when maxSupervisedTasks is set
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-default-agent
+      matchMany: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --max-supervised-tasks=2
+
+  - it: --max-supervised-tasks is absent for a pool that leaves it unset
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --max-supervised-tasks=
+
+  - it: --max-supervised-tasks is absent by default on the legacy agent block
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --max-supervised-tasks=
+
   # ---- Accelerator flag (#1242) ----
 
   - it: --accelerator flag renders when agent.accelerator is set

--- a/charts/foreman/tests/values-multi.yaml
+++ b/charts/foreman/tests/values-multi.yaml
@@ -14,6 +14,7 @@ agents:
     replicaCount: 3
     roles: [worker, coder, verifier]
     gitRemoteURL: ""
+    maxSupervisedTasks: 2
   llmkube-fork:
     enabled: true
     replicaCount: 1

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -330,6 +330,17 @@ agent:
   # tenants that should not see each other's tasks.
   taskNamespace: ""
 
+  # --max-supervised-tasks flag. How many Job-mode AgenticTasks this node
+  # supervises at once. A Job-mode task's loop runs in an ephemeral coder
+  # Job pod, so the agent only submits it, polls Job.Status and tails logs;
+  # those tasks are therefore accounted separately from the single
+  # in-process slot (#1559). Each one is still an outstanding coder Job
+  # competing for pods, cache volumes and inference capacity, so lower it
+  # on a cluster where those are tight. 1 serializes Job-mode work the way
+  # it behaved before #1559. Unset (0) leaves the agent's built-in default
+  # of 4 in place.
+  maxSupervisedTasks: 0
+
   # --foreman-namespace flag. Namespace the agent submits gate Jobs
   # into. Defaults to the release namespace, which is where the chart
   # creates the foreman-gate-cache PVC. Override only when the PVC

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -141,6 +141,7 @@ func main() {
 		heartbeat        time.Duration
 		taskPollInterval time.Duration
 		taskNamespace    string
+		maxSupervised    int
 		stubSleep        time.Duration
 		maxCtx           int
 		tokensPerSec     int
@@ -196,6 +197,9 @@ func main() {
 		"How often the AgenticTask watcher polls the cluster for new assignments.")
 	flag.StringVar(&taskNamespace, "task-namespace", "default",
 		"Namespace the AgenticTask watcher reads from.")
+	flag.IntVar(&maxSupervised, "max-supervised-tasks", foremanagent.DefaultMaxSupervisedTasks,
+		"How many Job-mode tasks this node supervises concurrently. Their work runs "+
+			"in a coder Job pod, so they do not hold the single in-process slot.")
 	flag.DurationVar(&stubSleep, "stub-sleep", foremanagent.DefaultStubSleep,
 		"How long the StubExecutor blocks per task. Only used when --executor=stub (the only v0.1 option).")
 	flag.IntVar(&maxCtx, "max-context-tokens", 0,
@@ -478,11 +482,12 @@ func main() {
 	}
 
 	watcher := &foremanagent.AgenticTaskWatcher{
-		Client:    kc,
-		NodeName:  fleetNodeName,
-		Namespace: taskNamespace,
-		Interval:  taskPollInterval,
-		Executor:  executor,
+		Client:             kc,
+		NodeName:           fleetNodeName,
+		Namespace:          taskNamespace,
+		Interval:           taskPollInterval,
+		Executor:           executor,
+		MaxSupervisedTasks: maxSupervised,
 	}
 
 	cap := provider.Capability()
@@ -494,6 +499,7 @@ func main() {
 		"totalRAMGB", cap.TotalRAMGB,
 		"heartbeat", heartbeat.String(),
 		"taskPollInterval", taskPollInterval.String(),
+		"maxSupervisedTasks", maxSupervised,
 		"taskNamespace", taskNamespace,
 		"executor", executor.Kind(),
 	)

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -199,7 +199,9 @@ func main() {
 		"Namespace the AgenticTask watcher reads from.")
 	flag.IntVar(&maxSupervised, "max-supervised-tasks", foremanagent.DefaultMaxSupervisedTasks,
 		"How many Job-mode tasks this node supervises concurrently. Their work runs "+
-			"in a coder Job pod, so they do not hold the single in-process slot.")
+			"in a coder Job pod, so they do not hold the single in-process slot. "+
+			"0 (or less) means unset and keeps the default; pass 1 to serialize "+
+			"Job-mode work.")
 	flag.DurationVar(&stubSleep, "stub-sleep", foremanagent.DefaultStubSleep,
 		"How long the StubExecutor blocks per task. Only used when --executor=stub (the only v0.1 option).")
 	flag.IntVar(&maxCtx, "max-context-tokens", 0,

--- a/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
@@ -222,9 +222,16 @@ spec:
                 x-kubernetes-list-type: map
               currentTask:
                 description: |-
-                  CurrentTask is the namespaced name of the AgenticTask the agent is
-                  running, or empty if idle. The scheduler skips nodes with a non-empty
-                  CurrentTask (v0.1 concurrency is one task per node).
+                  CurrentTask is the namespaced name of the in-process AgenticTask this
+                  node is reserved for, or empty if no reservation is held. The scheduler
+                  skips nodes with a non-empty CurrentTask when placing in-process work.
+
+                  Empty does NOT mean idle. A Job-mode task (Agent
+                  spec.execution.mode=Job) runs in an ephemeral Job pod rather than on the
+                  node, so the scheduler deliberately leaves CurrentTask untouched for it,
+                  and one agent supervises several such tasks concurrently (bounded by its
+                  --max-supervised-tasks). A node with an empty CurrentTask can therefore
+                  be supervising coder Jobs; it is free for in-process work, not idle.
                 type: string
               lastHeartbeatTime:
                 description: |-

--- a/docs/site/foreman/README.md
+++ b/docs/site/foreman/README.md
@@ -76,9 +76,12 @@ GitHub for human review.
 ### How many tasks a node runs at once
 
 A FleetNode runs **one in-process task at a time**. That task executes the
-native Go loop inside the foreman-agent process, so it owns the host's CPU,
-memory and workspace directory; running two would have them fight over the
-same workspace.
+native Go loop inside the foreman-agent process: it clones, runs the host's
+toolchain and drives the inference endpoint from this process, so a second
+concurrent run would compete for the same host CPU and RAM and the same
+toolchain. Workspaces are not the reason — each run gets its own
+(`<workspace-root>/<namespace>/<task-name>`, reset before the run and torn
+down after), so two in-process runs would not collide on a directory.
 
 An Agent with `spec.execution.mode: Job` is different. Its loop runs in an
 ephemeral Job pod, and the agent process only submits the Job, polls its

--- a/docs/site/foreman/README.md
+++ b/docs/site/foreman/README.md
@@ -98,6 +98,11 @@ Agent and enforced by the controller before a task is ever `Scheduled` — use
 that one to protect an inference backend shared with other consumers. When both
 are set, whichever is tighter wins.
 
+Set the per-node bound through the chart with `agent.maxSupervisedTasks` (or
+`agents.<pool>.maxSupervisedTasks` for one pool). `0` means unset and keeps the
+default of 4 — to serialize Job-mode work the way it behaved before this split,
+pass `1`.
+
 ## Pipeline shape (v0.1)
 
 v0.1 ships the linear pipeline:

--- a/docs/site/foreman/README.md
+++ b/docs/site/foreman/README.md
@@ -73,6 +73,31 @@ host runs the native Go loop against the local inference endpoint.
 Verdicts cascade to the parent Workload. Fork branches land on
 GitHub for human review.
 
+### How many tasks a node runs at once
+
+A FleetNode runs **one in-process task at a time**. That task executes the
+native Go loop inside the foreman-agent process, so it owns the host's CPU,
+memory and workspace directory; running two would have them fight over the
+same workspace.
+
+An Agent with `spec.execution.mode: Job` is different. Its loop runs in an
+ephemeral Job pod, and the agent process only submits the Job, polls its
+status and tails its logs. Those tasks are therefore accounted separately and
+several can be supervised concurrently, bounded by `--max-supervised-tasks`
+(default 4). The bound exists because each supervised task is an outstanding
+Job competing for pods, cache volumes and inference capacity — not because the
+agent is busy.
+
+The two limits are independent: a node supervising Job-mode tasks can still
+pick up an in-process review or gate task. Note that `FleetNode.status.currentTask`
+reports only the in-process task, so a node supervising Jobs looks idle in
+`kubectl get fleetnode`.
+
+`--max-supervised-tasks` is per node. `Agent.spec.maxConcurrentTasks` is per
+Agent and enforced by the controller before a task is ever `Scheduled` — use
+that one to protect an inference backend shared with other consumers. When both
+are set, whichever is tighter wins.
+
 ## Pipeline shape (v0.1)
 
 v0.1 ships the linear pipeline:

--- a/pkg/foreman/agent/executor.go
+++ b/pkg/foreman/agent/executor.go
@@ -40,16 +40,44 @@ type Executor interface {
 	// GATE-FAIL verdict). A non-nil error is a system failure: the
 	// executor did not complete, and the watcher patches the task as
 	// Failed with the error in the Completed condition.
-	Execute(ctx context.Context, task *foremanv1alpha1.AgenticTask) (*Result, error)
+	//
+	// agent is the task's already-resolved spec.agentRef target, read ONCE
+	// by the caller. Execute must not re-read it: the dispatch loop derives
+	// this task's slot accounting from the same value (see
+	// SupervisingExecutor), and a second independent read can disagree with
+	// the first -- an Agent edited between the two would be counted against
+	// one slot while burning the other (#1635 review).
+	//
+	// A nil agent means the reference could not be resolved to an Agent:
+	// either the task carries no spec.agentRef, or the Agent was deleted
+	// between scheduling and the claim. Implementations that need an Agent
+	// must produce a terminal outcome for it rather than retry.
+	Execute(
+		ctx context.Context,
+		task *foremanv1alpha1.AgenticTask,
+		agent *foremanv1alpha1.Agent,
+	) (*Result, error)
 }
 
 // SupervisingExecutor is an optional Executor capability: it reports whether
-// a task's real work will happen OUTSIDE this process. The watcher runs one
+// an Agent's work will happen OUTSIDE this process. The watcher runs one
 // in-process task at a time, but a supervised run leaves the agent idle --
 // it only submits the work, waits, and reports the outcome -- so holding the
 // single in-process slot for its whole lifetime blocks the node for nothing
 // (#1559). An Executor that does not implement this interface is treated as
 // always running in-process.
+//
+// SupervisesAgent does NO I/O: it answers over the Agent the dispatch loop
+// already resolved, and that same value is handed to Execute. That is what
+// makes "the slot accounting cannot drift from the path actually taken" true
+// -- one predicate applied to one value, not two independent reads that can
+// disagree.
+//
+// It stays an interface rather than a static executor property because the
+// predicate is a conjunction of a static fact (is a submitter wired on this
+// executor?) and a per-Agent one (does this Agent select Job mode?). A static
+// property answers only the first half, and computing the second half in the
+// watcher would leak executor wiring into the dispatch loop.
 type SupervisingExecutor interface {
-	SupervisesExternally(ctx context.Context, task *foremanv1alpha1.AgenticTask) bool
+	SupervisesAgent(agent *foremanv1alpha1.Agent) bool
 }

--- a/pkg/foreman/agent/executor.go
+++ b/pkg/foreman/agent/executor.go
@@ -42,3 +42,14 @@ type Executor interface {
 	// Failed with the error in the Completed condition.
 	Execute(ctx context.Context, task *foremanv1alpha1.AgenticTask) (*Result, error)
 }
+
+// SupervisingExecutor is an optional Executor capability: it reports whether
+// a task's real work will happen OUTSIDE this process. The watcher runs one
+// in-process task at a time, but a supervised run leaves the agent idle --
+// it only submits the work, waits, and reports the outcome -- so holding the
+// single in-process slot for its whole lifetime blocks the node for nothing
+// (#1559). An Executor that does not implement this interface is treated as
+// always running in-process.
+type SupervisingExecutor interface {
+	SupervisesExternally(ctx context.Context, task *foremanv1alpha1.AgenticTask) bool
+}

--- a/pkg/foreman/agent/executor_coderjob.go
+++ b/pkg/foreman/agent/executor_coderjob.go
@@ -134,6 +134,29 @@ func (e *NativeAgentLoopExecutor) useCoderJobPath(agent *foremanv1alpha1.Agent) 
 	return agent.Spec.Execution.Mode == foremanv1alpha1.ExecutionModeJob
 }
 
+// SupervisesExternally implements SupervisingExecutor: a Job-mode task's
+// loop, workspace and toolchain live in the coder Job's pod, so Execute here
+// only submits, polls Job.Status and tails logs. It resolves the Agent and
+// reuses useCoderJobPath -- the same predicate Execute dispatches on -- so
+// the watcher's slot accounting cannot drift from the path actually taken.
+// A missing agentRef or a failed lookup answers false, the conservative
+// direction: the task keeps the in-process slot it would have held before,
+// and Execute fails it on the same error a moment later.
+func (e *NativeAgentLoopExecutor) SupervisesExternally(
+	ctx context.Context,
+	task *foremanv1alpha1.AgenticTask,
+) bool {
+	if task.Spec.AgentRef == nil || task.Spec.AgentRef.Name == "" {
+		return false
+	}
+	var agent foremanv1alpha1.Agent
+	key := types.NamespacedName{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
+	if err := e.Client.Get(ctx, key, &agent); err != nil {
+		return false
+	}
+	return e.useCoderJobPath(&agent)
+}
+
 // executeCoderJob submits the per-task coder Job via the wired
 // CoderJobSubmitter, waits for it to finish, and folds the parsed result
 // into a *Result. It is the Job-mode counterpart to runLLMPath /

--- a/pkg/foreman/agent/executor_coderjob.go
+++ b/pkg/foreman/agent/executor_coderjob.go
@@ -134,27 +134,21 @@ func (e *NativeAgentLoopExecutor) useCoderJobPath(agent *foremanv1alpha1.Agent) 
 	return agent.Spec.Execution.Mode == foremanv1alpha1.ExecutionModeJob
 }
 
-// SupervisesExternally implements SupervisingExecutor: a Job-mode task's
-// loop, workspace and toolchain live in the coder Job's pod, so Execute here
-// only submits, polls Job.Status and tails logs. It resolves the Agent and
-// reuses useCoderJobPath -- the same predicate Execute dispatches on -- so
-// the watcher's slot accounting cannot drift from the path actually taken.
-// A missing agentRef or a failed lookup answers false, the conservative
-// direction: the task keeps the in-process slot it would have held before,
-// and Execute fails it on the same error a moment later.
-func (e *NativeAgentLoopExecutor) SupervisesExternally(
-	ctx context.Context,
-	task *foremanv1alpha1.AgenticTask,
-) bool {
-	if task.Spec.AgentRef == nil || task.Spec.AgentRef.Name == "" {
+// SupervisesAgent implements SupervisingExecutor: a Job-mode task's loop,
+// workspace and toolchain live in the coder Job's pod, so Execute here only
+// submits, polls Job.Status and tails logs. It is useCoderJobPath -- literally
+// the predicate Execute dispatches on, over the Agent Execute will be handed
+// -- so the watcher's slot accounting cannot drift from the path actually
+// taken.
+//
+// A nil Agent (no agentRef, or deleted between scheduling and the claim) is
+// not supervised: Execute turns it into a terminal failure in this process
+// without ever reaching the Job path.
+func (e *NativeAgentLoopExecutor) SupervisesAgent(agent *foremanv1alpha1.Agent) bool {
+	if agent == nil {
 		return false
 	}
-	var agent foremanv1alpha1.Agent
-	key := types.NamespacedName{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
-	if err := e.Client.Get(ctx, key, &agent); err != nil {
-		return false
-	}
-	return e.useCoderJobPath(&agent)
+	return e.useCoderJobPath(agent)
 }
 
 // executeCoderJob submits the per-task coder Job via the wired

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -271,10 +271,45 @@ var ErrNoAgentRef = errors.New("native-agent-loop: task.spec.agentRef is require
 // an empty or wrong-workspace tool set.
 var ErrRegistryFactoryNotSet = errors.New("native-agent-loop: RegistryFactory is required")
 
+// resolveTaskAgent reads the Agent a task points at. It is the single Agent
+// read per dispatched task: the caller derives the task's execution mode from
+// the returned value (SupervisingExecutor.SupervisesAgent) and hands the SAME
+// value to Executor.Execute, so the slot the watcher reserves and the path the
+// executor takes cannot disagree (#1635 review).
+//
+// A nil Agent and a nil error is the ABSENT case, and it is deliberately not
+// an error: either the task carries no agentRef, or the Agent is gone. Both
+// deserve a verdict from Execute rather than a retry -- a task whose Agent was
+// deleted would otherwise sit at Scheduled forever with nothing saying why. A
+// non-nil error is the AMBIGUOUS case (apiserver blip, 429, reset): the
+// execution mode is unknown, so the caller must not claim on a guess.
+func resolveTaskAgent(
+	ctx context.Context,
+	c client.Client,
+	task *foremanv1alpha1.AgenticTask,
+) (*foremanv1alpha1.Agent, error) {
+	if task.Spec.AgentRef == nil || task.Spec.AgentRef.Name == "" {
+		return nil, nil
+	}
+	var agent foremanv1alpha1.Agent
+	key := types.NamespacedName{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
+	if err := c.Get(ctx, key, &agent); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("resolve agent: %w", err)
+	}
+	return &agent, nil
+}
+
 // Execute is the Executor implementation. See the package-level docs on
 // NativeAgentLoopExecutor for the high-level flow; this method drives
 // it step by step.
-func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1alpha1.AgenticTask) (*Result, error) {
+func (e *NativeAgentLoopExecutor) Execute(
+	ctx context.Context,
+	task *foremanv1alpha1.AgenticTask,
+	agent *foremanv1alpha1.Agent,
+) (*Result, error) {
 	log := logf.FromContext(ctx).WithName("native-agent-loop").WithValues("task", task.Name, "ns", task.Namespace)
 	start := time.Now()
 
@@ -285,17 +320,15 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 		return nil, ErrNoAgentRef
 	}
 
-	// 1. Resolve the Agent CR.
-	var agent foremanv1alpha1.Agent
-	agentKey := types.NamespacedName{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
-	if err := e.Client.Get(ctx, agentKey, &agent); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Scheduler should have caught this; if we got here the
-			// Agent was deleted between scheduling and execution.
-			return e.failResult(start, foremanv1alpha1.FailureAgentNotFound,
-				fmt.Sprintf("Agent %q not found in namespace %q", agentKey.Name, agentKey.Namespace)), nil
-		}
-		return nil, fmt.Errorf("resolve agent: %w", err)
+	// 1. The Agent was resolved by the caller (resolveTaskAgent), once, and
+	// the same value already decided this run's slot accounting -- see the
+	// Executor.Execute contract. A nil Agent with an agentRef set means the
+	// Agent is gone: the scheduler should have caught it, so it was deleted
+	// between scheduling and execution.
+	if agent == nil {
+		return e.failResult(start, foremanv1alpha1.FailureAgentNotFound,
+			fmt.Sprintf("Agent %q not found in namespace %q",
+				task.Spec.AgentRef.Name, task.Namespace)), nil
 	}
 
 	// 1b. Job-mode dispatch (#620). When the Agent selects spec.execution.
@@ -307,8 +340,8 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	// (RunTask wires no submitter, so useCoderJobPath is false there). The
 	// InProcess path (Execution nil or mode==InProcess, or no submitter
 	// wired) is left byte-for-byte unchanged below.
-	if e.useCoderJobPath(&agent) {
-		return e.executeCoderJob(ctx, task, &agent, start), nil
+	if e.useCoderJobPath(agent) {
+		return e.executeCoderJob(ctx, task, agent, start), nil
 	}
 
 	// 2. Resolve the model-serving endpoint. Three branches:
@@ -323,11 +356,11 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	//   - Local Agent (default): resolveInferenceBaseURL reads
 	//     InferenceService.status.endpoint and optionally rewrites the
 	//     host (per #540).
-	deterministic := isDeterministicAgent(&agent)
+	deterministic := isDeterministicAgent(agent)
 	var endpoint providerEndpoint
 	if !deterministic {
 		var err error
-		endpoint, err = e.resolveProviderEndpoint(ctx, task.Namespace, &agent)
+		endpoint, err = e.resolveProviderEndpoint(ctx, task.Namespace, agent)
 		if err != nil {
 			return e.failResult(start, foremanv1alpha1.FailureInferenceServiceUnavailable, err.Error()), nil
 		}
@@ -439,7 +472,7 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 
 	// 5. Build tool registry pinned to this workspace + filtered by the
 	// Agent's tool whitelist.
-	registry, err := e.RegistryFactory(ctx, workspace, &agent, mcpEnabledForTask(task))
+	registry, err := e.RegistryFactory(ctx, workspace, agent, mcpEnabledForTask(task))
 	if err != nil {
 		// Registry build failure is an operator config issue (bad
 		// whitelist name, duplicate tool); not a runtime model
@@ -452,13 +485,13 @@ func (e *NativeAgentLoopExecutor) Execute(ctx context.Context, task *foremanv1al
 	// first tool directly with the task payload as JSON arguments. The
 	// gate Agent uses this; M5+ reviewer agents use the LLM path.
 	if deterministic {
-		return e.executeDeterministic(ctx, task, &agent, branch, registry, cloneURL, start), nil
+		return e.executeDeterministic(ctx, task, agent, branch, registry, cloneURL, start), nil
 	}
 
 	// 6+. LLM-driven path: extracted to keep Execute below the
 	// cyclomatic-complexity threshold. runLLMPath owns OAI + loop +
 	// transcript + commit/push.
-	return e.runLLMPath(ctx, task, &agent, endpoint, workspace, branch, registry, auth, needsRepo, cloneURL, start)
+	return e.runLLMPath(ctx, task, agent, endpoint, workspace, branch, registry, auth, needsRepo, cloneURL, start)
 }
 
 // setupTaskBranch cuts the task's working branch in the freshly cloned

--- a/pkg/foreman/agent/executor_native_envtest_loop_test.go
+++ b/pkg/foreman/agent/executor_native_envtest_loop_test.go
@@ -173,7 +173,7 @@ func (tc envtestLoopCase) run(t *testing.T) (*foremanagent.Result, int) {
 	reg := &seqEnvtestRegistry{verdicts: tc.regVerdicts}
 	runner := &scriptedEnvtestRunner{results: tc.gate}
 	e := envtestLoopExecutor(t, root, bare, oaiSrv.URL, c, runner, reg)
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -45,6 +45,29 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
 )
 
+// execWithAgent mirrors what the dispatch loop does around Execute: resolve
+// the task's Agent exactly once, then hand that value in. A task with no
+// agentRef, or one whose Agent is missing from the client, passes nil --
+// the same "absent" signal the watcher sends when an Agent has been deleted.
+func execWithAgent(
+	t *testing.T, e *foremanagent.NativeAgentLoopExecutor, task *foremanv1alpha1.AgenticTask,
+) (*foremanagent.Result, error) {
+	t.Helper()
+	var agent *foremanv1alpha1.Agent
+	if task.Spec.AgentRef != nil && task.Spec.AgentRef.Name != "" {
+		var got foremanv1alpha1.Agent
+		key := types.NamespacedName{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
+		err := e.Client.Get(context.Background(), key, &got)
+		switch {
+		case err == nil:
+			agent = &got
+		case !apierrors.IsNotFound(err):
+			t.Fatalf("resolve agent %s: %v", key, err)
+		}
+	}
+	return e.Execute(context.Background(), task, agent)
+}
+
 // gitOrSkip mirrors the helper in the repo subpackage: skip when git is
 // not on PATH so the suite stays healthy on minimal containers.
 func gitOrSkip(t *testing.T) {
@@ -266,7 +289,7 @@ func TestNativeExecutor_AgentNotFound(t *testing.T) {
 		},
 		AuthFactory: fakeAuth(t),
 	}
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -299,7 +322,7 @@ func TestNativeExecutor_NoAgentRefIsHardError(t *testing.T) {
 			return &fakeRegistry{}, nil
 		},
 	}
-	if _, err := e.Execute(context.Background(), task); !errors.Is(err, foremanagent.ErrNoAgentRef) {
+	if _, err := execWithAgent(t, e, task); !errors.Is(err, foremanagent.ErrNoAgentRef) {
 		t.Errorf("expected ErrNoAgentRef, got %v", err)
 	}
 }
@@ -356,7 +379,7 @@ func TestNativeExecutor_FreeformNoRepoSkipsAuthAndClone(t *testing.T) {
 		// No GitRemoteURL: proves clone is skipped.
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -438,7 +461,7 @@ func TestNativeExecutor_HappyPathPushesBranch(t *testing.T) {
 		AuthFactory: fakeAuth(t),
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -539,7 +562,7 @@ func TestNativeExecutor_TruncatedMapsToIncomplete(t *testing.T) {
 		AuthFactory: fakeAuth(t),
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute returned a hard error; truncation must map to INCOMPLETE: %v", err)
 	}
@@ -605,7 +628,7 @@ func TestNativeExecutor_MultiRepoClonesTaskRepoWhenNoStaticRemote(t *testing.T) 
 		AuthFactory: fakeAuth(t),
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -653,7 +676,7 @@ func TestNativeExecutor_NoStaticRemoteAndNoRepoIsHardError(t *testing.T) {
 		},
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute returned a system error, want a data-shaped fail: %v", err)
 	}
@@ -700,7 +723,7 @@ func TestNativeExecutor_ModelEmitsGoButNoChanges(t *testing.T) {
 		},
 		AuthFactory: fakeAuth(t),
 	}
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -777,7 +800,7 @@ func TestNativeExecutor_ModelEmitsNoGo(t *testing.T) {
 		},
 		AuthFactory: fakeAuth(t),
 	}
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -907,7 +930,7 @@ func executeCoderTask(
 		},
 		AuthFactory: fakeAuth(t),
 	}
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -1242,7 +1265,7 @@ func TestNativeExecutor_ReviewerGoIsApproveNotCommit(t *testing.T) {
 		},
 		AuthFactory: fakeAuth(t),
 	}
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -1324,7 +1347,7 @@ func TestNativeExecutor_ReviewerERRORMapsToIncompleteWithModelReportedError(t *t
 		},
 		AuthFactory: fakeAuth(t),
 	}
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -1481,7 +1504,7 @@ func TestNativeExecutor_CoderPromptHasRepoMapPrefix(t *testing.T) {
 		AuthFactory: fakeAuth(t),
 	}
 
-	if _, err := e.Execute(context.Background(), task); err != nil {
+	if _, err := execWithAgent(t, e, task); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 
@@ -1608,7 +1631,7 @@ func TestNativeExecutor_FetchesIssueBodyWhenPromptEmpty(t *testing.T) {
 		IssueFetcher: fetcher,
 	}
 
-	if _, err := e.Execute(context.Background(), task); err != nil {
+	if _, err := execWithAgent(t, e, task); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 
@@ -1687,7 +1710,7 @@ func TestNativeExecutor_NoFetcherFallsBackToEmptyBody(t *testing.T) {
 		// IssueFetcher intentionally nil.
 	}
 
-	if _, err := e.Execute(context.Background(), task); err != nil {
+	if _, err := execWithAgent(t, e, task); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if len(captured) == 0 {
@@ -1767,7 +1790,7 @@ func TestNativeExecutor_DeterministicGateAgent(t *testing.T) {
 		AuthFactory: fakeAuth(t),
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -1880,7 +1903,7 @@ func TestNativeExecutor_JobModeDispatchesToCoderJob(t *testing.T) {
 		CoderJobSubmitter: sub,
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -1989,7 +2012,7 @@ func TestNativeExecutor_JobModeStampsJobNameWhileRunning(t *testing.T) {
 		},
 	}
 
-	if _, err := e.Execute(context.Background(), task); err != nil {
+	if _, err := execWithAgent(t, e, task); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 
@@ -2102,7 +2125,7 @@ func TestNativeExecutor_JobModeWithoutSubmitterRunsInProcess(t *testing.T) {
 		// state. The Job path must not activate.
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2283,7 +2306,7 @@ func TestNativeExecutor_ModelNoGoAlreadyResolved_PromotesOutcome(t *testing.T) {
 		},
 		AuthFactory: fakeAuth(t),
 	}
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2353,7 +2376,7 @@ func TestNativeExecutor_SynthesizesCommitMessageWhenModelOmitsIt(t *testing.T) {
 		AuthFactory: fakeAuth(t),
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2436,7 +2459,7 @@ func TestNativeExecutor_SynthesizedMessageOmitsIssueWhenTaskHasNone(t *testing.T
 		AuthFactory: fakeAuth(t),
 	}
 
-	res, err := e.Execute(context.Background(), task)
+	res, err := execWithAgent(t, e, task)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2461,5 +2484,44 @@ func TestNativeExecutor_SynthesizedMessageOmitsIssueWhenTaskHasNone(t *testing.T
 	}
 	if !strings.Contains(msg, "Tighten the SSRF allowlist") {
 		t.Errorf("message should carry the model's summary: %q", msg)
+	}
+}
+
+// TestSupervisesAgent: the watcher's slot question must be answered by the
+// same predicate Execute dispatches on, over the same resolved Agent, so the
+// accounting cannot drift from the path actually taken (#1559). It does no
+// I/O, which is what lets one Agent read serve both.
+func TestSupervisesAgent(t *testing.T) {
+	jobAgent := &foremanv1alpha1.Agent{}
+	jobAgent.Name = "coder"
+	jobAgent.Spec.Execution = &foremanv1alpha1.ExecutionSpec{
+		Mode: foremanv1alpha1.ExecutionModeJob,
+	}
+	inProcAgent := &foremanv1alpha1.Agent{}
+	inProcAgent.Name = "inproc"
+
+	tests := []struct {
+		name          string
+		agent         *foremanv1alpha1.Agent
+		withSubmitter bool
+		want          bool
+	}{
+		{name: "job-mode agent with submitter", agent: jobAgent, withSubmitter: true, want: true},
+		// The recursion guard: the executor RunTask builds inside the coder
+		// Job pod wires no submitter, so it supervises nothing.
+		{name: "job-mode agent without submitter", agent: jobAgent},
+		{name: "in-process agent", agent: inProcAgent, withSubmitter: true},
+		{name: "unresolvable agent", agent: nil, withSubmitter: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &foremanagent.NativeAgentLoopExecutor{}
+			if tc.withSubmitter {
+				e.CoderJobSubmitter = &fakeCoderJobSubmitter{}
+			}
+			if got := e.SupervisesAgent(tc.agent); got != tc.want {
+				t.Fatalf("SupervisesAgent: want %v got %v", tc.want, got)
+			}
+		})
 	}
 }

--- a/pkg/foreman/agent/executor_stub.go
+++ b/pkg/foreman/agent/executor_stub.go
@@ -50,8 +50,13 @@ func (s *StubExecutor) Kind() string { return "stub" }
 
 // Execute sleeps for SleepDuration (or default) and returns a Result that
 // labels the task as a stub run. Cancellation via ctx returns
-// immediately with ctx.Err().
-func (s *StubExecutor) Execute(ctx context.Context, task *foremanv1alpha1.AgenticTask) (*Result, error) {
+// immediately with ctx.Err(). The resolved Agent is unused: the stub runs no
+// loop, so nothing about the task's Agent changes what it does.
+func (s *StubExecutor) Execute(
+	ctx context.Context,
+	task *foremanv1alpha1.AgenticTask,
+	_ *foremanv1alpha1.Agent,
+) (*Result, error) {
 	dur := s.SleepDuration
 	if dur <= 0 {
 		dur = DefaultStubSleep

--- a/pkg/foreman/agent/runtask.go
+++ b/pkg/foreman/agent/runtask.go
@@ -240,7 +240,16 @@ func RunTask(ctx context.Context, cfg RunTaskConfig) (RunTaskResult, error) {
 		UpstreamURLForRepo:           cfg.UpstreamURLForRepo,
 	}
 
-	res, execErr := exec.Execute(ctx, &task)
+	// Resolve the Agent here rather than inside Execute so the in-pod path
+	// and the watcher path share one contract: exactly one Agent read per
+	// run, whose value Execute is handed.
+	agent, err := resolveTaskAgent(ctx, cfg.Client, &task)
+	if err != nil {
+		emitSentinel(out, RunTaskSentinelError, err.Error())
+		return RunTaskResult{}, fmt.Errorf("execute task %s: %w", cfg.Task, err)
+	}
+
+	res, execErr := exec.Execute(ctx, &task, agent)
 	if execErr != nil {
 		// System / transport failure. Mirror the executor's contract:
 		// these are the cases the watcher records as ExecutorError.

--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -152,6 +152,17 @@ func (w *AgenticTaskWatcher) hasCapacityFor(supervise bool) bool {
 	return w.inflight == nil
 }
 
+// agentRefKey identifies the Agent a task points at, namespace-qualified
+// because the watcher may be polling every namespace. It is the memo key for
+// the execution-mode lookup in pollOnce; tasks with no agentRef share the
+// empty-name key, which every Executor answers the same way.
+func agentRefKey(t *foremanv1alpha1.AgenticTask) string {
+	if t.Spec.AgentRef == nil {
+		return t.Namespace + "/"
+	}
+	return t.Namespace + "/" + t.Spec.AgentRef.Name
+}
+
 // supervises reports whether this task's work will run outside this process,
 // by asking the Executor. An Executor that does not implement
 // SupervisingExecutor (the stub) always runs in-process.
@@ -303,9 +314,14 @@ func sortTasksDepthFirst(tasks []*foremanv1alpha1.AgenticTask) {
 // this node that is in phase=Scheduled, preferring downstream tasks
 // (review, verify) over new issue-fix work — see sortTasksDepthFirst.
 func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) error {
-	// Skip the List entirely when neither slot can take work: the
-	// in-process run is busy AND the supervision budget is spent.
-	if !w.hasCapacityFor(false) && !w.hasCapacityFor(true) {
+	// Skip the List entirely when no slot can take work. The supervision
+	// budget only counts when this Executor can actually supervise: for one
+	// that cannot (the stub, or any Executor that does not implement
+	// SupervisingExecutor) the budget is permanently idle, so testing it
+	// would keep the guard from ever firing and turn every tick into a full
+	// uncached namespace List that then skips every candidate.
+	_, canSupervise := w.Executor.(SupervisingExecutor)
+	if !w.hasCapacityFor(false) && (!canSupervise || !w.hasCapacityFor(true)) {
 		return nil
 	}
 
@@ -327,6 +343,13 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 	}
 	sortTasksDepthFirst(candidates)
 
+	// A task's execution mode is a property of its Agent, and the candidates
+	// queued on one node nearly always share a single Agent, so memoize the
+	// answer for this pass: w.supervises is an uncached GET, and without this
+	// a node with several queued candidates pays one per candidate per tick
+	// even for candidates it cannot claim.
+	modes := make(map[string]bool, 2)
+
 	for _, t := range candidates {
 		// Capacity is checked per candidate because the two execution modes
 		// draw on different slots: with the in-process slot busy, a Job-mode
@@ -334,7 +357,12 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 		// slots (Run calls pollOnce sequentially) and the executor goroutines
 		// only ever release, so a check here cannot be invalidated by the
 		// time launchExecutor reserves below.
-		supervise := w.supervises(ctx, t)
+		modeKey := agentRefKey(t)
+		supervise, cached := modes[modeKey]
+		if !cached {
+			supervise = w.supervises(ctx, t)
+			modes[modeKey] = supervise
+		}
 		if !w.hasCapacityFor(supervise) {
 			continue
 		}

--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -110,8 +110,12 @@ type AgenticTaskWatcher struct {
 	// DefaultTaskLivenessInterval.
 	TaskLivenessInterval time.Duration
 
-	// MaxSupervisedTasks bounds concurrent Job-mode supervisions. Zero
-	// defaults to DefaultMaxSupervisedTasks. This is a per-NODE bound on
+	// MaxSupervisedTasks bounds concurrent Job-mode supervisions. Zero (or
+	// negative) means UNSET and takes DefaultMaxSupervisedTasks, the same
+	// zero-value-means-default convention as Interval and
+	// TaskLivenessInterval above; 0 is not "supervise nothing", which would
+	// wedge every Job-mode task on the node. Set it to 1 to serialize
+	// Job-mode work the way it behaved before #1559. This is a per-NODE bound on
 	// outstanding coder Jobs; Agent.spec.maxConcurrentTasks is a per-Agent
 	// bound the controller enforces before a task is ever Scheduled, so the
 	// two compose (whichever is tighter wins) rather than overlap.
@@ -128,7 +132,8 @@ type AgenticTaskWatcher struct {
 	supervised int
 }
 
-// maxSupervised is MaxSupervisedTasks with its default applied.
+// maxSupervised is MaxSupervisedTasks with its default applied. See the
+// field's doc for why <= 0 means "unset" rather than "none".
 func (w *AgenticTaskWatcher) maxSupervised() int {
 	if w.MaxSupervisedTasks <= 0 {
 		return DefaultMaxSupervisedTasks

--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -57,6 +57,17 @@ const DefaultTaskLivenessInterval = 10 * time.Second
 // partition from being mistaken for a deletion and killing a healthy run.
 const maxTaskLivenessMisses = 3
 
+// DefaultMaxSupervisedTasks bounds how many Job-mode tasks one agent
+// supervises concurrently (#1559). A supervised task's loop runs in its own
+// Job pod, so the agent only submits, polls Job.Status and tails logs for it
+// -- cheap enough that serializing them behind the in-process slot only
+// starves the node. It is still bounded: each supervision holds a goroutine
+// and a liveness probe, and every one of them is an outstanding coder Job
+// competing for pods, cache volumes and inference capacity. Four keeps a
+// node's Workload pipeline moving (a coder Job plus the review/verify work
+// queued behind it) without letting one node fan out without limit.
+const DefaultMaxSupervisedTasks = 4
+
 // ErrWatcherStalled is returned from Run when consecutive List() failures
 // exceed the configured threshold; the supervisor (launchd / systemd /
 // the harness) is expected to recycle the process to rebuild the client.
@@ -67,8 +78,10 @@ var ErrWatcherStalled = errors.New("foreman agentictask watcher stalled: consecu
 // phase=Scheduled, hands them to the configured Executor, and patches
 // the final phase/verdict/result when the executor returns.
 //
-// v0.1 runs one task at a time per node (single Executor.Execute in
-// flight, controlled by a mutex). v0.2 may introduce a worker pool.
+// One IN-PROCESS Executor.Execute runs at a time per node: it owns this
+// process's CPU, memory and workspace. Job-mode runs are accounted
+// separately (see MaxSupervisedTasks): their work happens in an ephemeral
+// Job pod, so they must not hold the in-process slot (#1559).
 type AgenticTaskWatcher struct {
 	// Client is the Kubernetes client. Required.
 	Client client.Client
@@ -97,9 +110,49 @@ type AgenticTaskWatcher struct {
 	// DefaultTaskLivenessInterval.
 	TaskLivenessInterval time.Duration
 
-	// inflightMu guards inflight. Exactly one task at a time in v0.1.
+	// MaxSupervisedTasks bounds concurrent Job-mode supervisions. Zero
+	// defaults to DefaultMaxSupervisedTasks. This is a per-NODE bound on
+	// outstanding coder Jobs; Agent.spec.maxConcurrentTasks is a per-Agent
+	// bound the controller enforces before a task is ever Scheduled, so the
+	// two compose (whichever is tighter wins) rather than overlap.
+	MaxSupervisedTasks int
+
+	// inflightMu guards inflight and supervised.
 	inflightMu sync.Mutex
-	inflight   *foremanv1alpha1.AgenticTask
+	// inflight is the in-process run, if any. At most one: it uses this
+	// process's CPU, memory and workspace.
+	inflight *foremanv1alpha1.AgenticTask
+	// supervised counts Job-mode runs in flight. The agent is idle while
+	// they run, so they get their own budget instead of the single
+	// in-process slot (#1559).
+	supervised int
+}
+
+// maxSupervised is MaxSupervisedTasks with its default applied.
+func (w *AgenticTaskWatcher) maxSupervised() int {
+	if w.MaxSupervisedTasks <= 0 {
+		return DefaultMaxSupervisedTasks
+	}
+	return w.MaxSupervisedTasks
+}
+
+// hasCapacityFor reports whether the slot a task of this execution mode
+// needs is free.
+func (w *AgenticTaskWatcher) hasCapacityFor(supervise bool) bool {
+	w.inflightMu.Lock()
+	defer w.inflightMu.Unlock()
+	if supervise {
+		return w.supervised < w.maxSupervised()
+	}
+	return w.inflight == nil
+}
+
+// supervises reports whether this task's work will run outside this process,
+// by asking the Executor. An Executor that does not implement
+// SupervisingExecutor (the stub) always runs in-process.
+func (w *AgenticTaskWatcher) supervises(ctx context.Context, t *foremanv1alpha1.AgenticTask) bool {
+	se, ok := w.Executor.(SupervisingExecutor)
+	return ok && se.SupervisesExternally(ctx, t)
 }
 
 // Run blocks, polling every Interval until ctx is cancelled. Returns
@@ -245,12 +298,9 @@ func sortTasksDepthFirst(tasks []*foremanv1alpha1.AgenticTask) {
 // this node that is in phase=Scheduled, preferring downstream tasks
 // (review, verify) over new issue-fix work — see sortTasksDepthFirst.
 func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) error {
-	// If a task is already in flight, skip until it completes; v0.1 is
-	// one-task-per-node.
-	w.inflightMu.Lock()
-	busy := w.inflight != nil
-	w.inflightMu.Unlock()
-	if busy {
+	// Skip the List entirely when neither slot can take work: the
+	// in-process run is busy AND the supervision budget is spent.
+	if !w.hasCapacityFor(false) && !w.hasCapacityFor(true) {
 		return nil
 	}
 
@@ -273,6 +323,16 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 	sortTasksDepthFirst(candidates)
 
 	for _, t := range candidates {
+		// Capacity is checked per candidate because the two execution modes
+		// draw on different slots: with the in-process slot busy, a Job-mode
+		// task can still start (and vice versa). Only this goroutine reserves
+		// slots (Run calls pollOnce sequentially) and the executor goroutines
+		// only ever release, so a check here cannot be invalidated by the
+		// time launchExecutor reserves below.
+		supervise := w.supervises(ctx, t)
+		if !w.hasCapacityFor(supervise) {
+			continue
+		}
 		if err := w.claim(ctx, t); err != nil {
 			// Patch race or transient apiserver error; let the next
 			// poll retry. Do not count toward the stall threshold
@@ -281,8 +341,8 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 			continue
 		}
 		// Took it. Launch the executor and return to the polling loop;
-		// the next poll will see inflight!=nil and skip.
-		w.launchExecutor(ctx, t)
+		// the next poll re-checks capacity before claiming anything else.
+		w.launchExecutor(ctx, t, supervise)
 		return nil
 	}
 	return nil
@@ -307,20 +367,32 @@ func (w *AgenticTaskWatcher) claim(ctx context.Context, t *foremanv1alpha1.Agent
 	return w.Client.Status().Patch(ctx, t, patch)
 }
 
-// launchExecutor runs Execute in a goroutine, patches the terminal
-// status when it returns, and clears the inflight slot.
-func (w *AgenticTaskWatcher) launchExecutor(ctx context.Context, t *foremanv1alpha1.AgenticTask) {
+// launchExecutor runs Execute in a goroutine, patches the terminal status
+// when it returns, and releases the slot it took. supervise selects which
+// slot: the single in-process one, or a Job-mode supervision budget slot.
+// The release is deferred inside the goroutine so it happens on every exit
+// path -- error, ctx cancellation, or panic.
+func (w *AgenticTaskWatcher) launchExecutor(ctx context.Context, t *foremanv1alpha1.AgenticTask, supervise bool) {
 	w.inflightMu.Lock()
-	w.inflight = t
+	if supervise {
+		w.supervised++
+	} else {
+		w.inflight = t
+	}
 	w.inflightMu.Unlock()
 
-	log := logf.FromContext(ctx).WithName("agentictask-watcher").WithValues("task", t.Name, "kind", t.Spec.Kind)
+	log := logf.FromContext(ctx).WithName("agentictask-watcher").
+		WithValues("task", t.Name, "kind", t.Spec.Kind, "supervised", supervise)
 	log.Info("dispatching to executor")
 
 	go func() {
 		defer func() {
 			w.inflightMu.Lock()
-			w.inflight = nil
+			if supervise {
+				w.supervised--
+			} else {
+				w.inflight = nil
+			}
 			w.inflightMu.Unlock()
 		}()
 

--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -163,12 +163,41 @@ func agentRefKey(t *foremanv1alpha1.AgenticTask) string {
 	return t.Namespace + "/" + t.Spec.AgentRef.Name
 }
 
-// supervises reports whether this task's work will run outside this process,
+// agentResolution is one Agent read plus the slot decision derived from it,
+// memoized for the duration of a pollOnce pass.
+type agentResolution struct {
+	// agent is the resolved Agent, or nil when the task has no agentRef or
+	// its Agent is gone. Handed to Executor.Execute as-is.
+	agent *foremanv1alpha1.Agent
+	// supervise is which slot this task needs, derived from agent by the
+	// same predicate Execute dispatches on.
+	supervise bool
+	// err is set only for an ambiguous read failure. The candidate is
+	// skipped: its mode, and so its slot, is unknown.
+	err error
+}
+
+// resolveCandidateAgent reads a candidate's Agent once and derives which slot
+// it would occupy.
+func (w *AgenticTaskWatcher) resolveCandidateAgent(
+	ctx context.Context, t *foremanv1alpha1.AgenticTask,
+) agentResolution {
+	agent, err := resolveTaskAgent(ctx, w.Client, t)
+	if err != nil {
+		return agentResolution{err: err}
+	}
+	return agentResolution{agent: agent, supervise: w.supervises(agent)}
+}
+
+// supervises reports whether this Agent's work will run outside this process,
 // by asking the Executor. An Executor that does not implement
-// SupervisingExecutor (the stub) always runs in-process.
-func (w *AgenticTaskWatcher) supervises(ctx context.Context, t *foremanv1alpha1.AgenticTask) bool {
+// SupervisingExecutor (the stub) always runs in-process. A nil Agent is never
+// supervised -- Execute fails it in this process without reaching the Job
+// path -- so it charges the in-process slot it would have held before #1559,
+// which it releases again as soon as the failure is patched.
+func (w *AgenticTaskWatcher) supervises(agent *foremanv1alpha1.Agent) bool {
 	se, ok := w.Executor.(SupervisingExecutor)
-	return ok && se.SupervisesExternally(ctx, t)
+	return ok && se.SupervisesAgent(agent)
 }
 
 // Run blocks, polling every Interval until ctx is cancelled. Returns
@@ -320,6 +349,17 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 	// SupervisingExecutor) the budget is permanently idle, so testing it
 	// would keep the guard from ever firing and turn every tick into a full
 	// uncached namespace List that then skips every candidate.
+	//
+	// The type assertion asks whether the TYPE has the method, which is a
+	// proxy for whether THIS INSTANCE can ever answer true. The two agree
+	// today by wiring, not by construction: a nil-submitter
+	// NativeAgentLoopExecutor does exist (RunTask builds one inside the coder
+	// Job pod so a Job cannot recurse into another Job --
+	// cmd/foreman-agent/main.go:454) and it would answer false for every
+	// Agent, but it never meets a watcher, because RunTask constructs none
+	// and the only watcher gets the submitter-wired executor. If they ever
+	// diverge the cost is that this guard stops firing and the pointless
+	// Lists come back: API load, not incorrect dispatch.
 	_, canSupervise := w.Executor.(SupervisingExecutor)
 	if !w.hasCapacityFor(false) && (!canSupervise || !w.hasCapacityFor(true)) {
 		return nil
@@ -345,10 +385,12 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 
 	// A task's execution mode is a property of its Agent, and the candidates
 	// queued on one node nearly always share a single Agent, so memoize the
-	// answer for this pass: w.supervises is an uncached GET, and without this
-	// a node with several queued candidates pays one per candidate per tick
-	// even for candidates it cannot claim.
-	modes := make(map[string]bool, 2)
+	// read for this pass. The claimed candidate is resolved once, but the
+	// ones ahead of it in the queue still have to be resolved to know which
+	// slot they want, and the agent's client is uncached: without this a node
+	// with several queued candidates pays one GET per candidate per tick,
+	// including for candidates it has no slot for.
+	resolved := make(map[string]agentResolution, 2)
 
 	for _, t := range candidates {
 		// Capacity is checked per candidate because the two execution modes
@@ -358,12 +400,24 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 		// only ever release, so a check here cannot be invalidated by the
 		// time launchExecutor reserves below.
 		modeKey := agentRefKey(t)
-		supervise, cached := modes[modeKey]
+		res, cached := resolved[modeKey]
 		if !cached {
-			supervise = w.supervises(ctx, t)
-			modes[modeKey] = supervise
+			res = w.resolveCandidateAgent(ctx, t)
+			resolved[modeKey] = res
 		}
-		if !w.hasCapacityFor(supervise) {
+		if res.err != nil {
+			// The read failed ambiguously, so which slot this task needs is
+			// unknown, and claiming on a guess is the bug this accounting
+			// exists to fix: guess in-process for a Job-mode task and the
+			// node holds its only slot for the Job's whole lifetime (#1559).
+			// Leave it Scheduled and retry next tick. A DELETED Agent is a
+			// different case -- resolveTaskAgent reports it as a nil Agent,
+			// so the task is still claimed and Execute gives it a verdict.
+			logf.FromContext(ctx).WithName("agentictask-watcher").
+				Error(res.err, "could not resolve candidate's Agent; retrying next poll", "task", t.Name)
+			continue
+		}
+		if !w.hasCapacityFor(res.supervise) {
 			continue
 		}
 		if err := w.claim(ctx, t); err != nil {
@@ -375,7 +429,7 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 		}
 		// Took it. Launch the executor and return to the polling loop;
 		// the next poll re-checks capacity before claiming anything else.
-		w.launchExecutor(ctx, t, supervise)
+		w.launchExecutor(ctx, t, res.agent, res.supervise)
 		return nil
 	}
 	return nil
@@ -405,7 +459,16 @@ func (w *AgenticTaskWatcher) claim(ctx context.Context, t *foremanv1alpha1.Agent
 // slot: the single in-process one, or a Job-mode supervision budget slot.
 // The release is deferred inside the goroutine so it happens on every exit
 // path -- error, ctx cancellation, or panic.
-func (w *AgenticTaskWatcher) launchExecutor(ctx context.Context, t *foremanv1alpha1.AgenticTask, supervise bool) {
+//
+// agent is the Agent resolved for this task, and supervise was derived from
+// it; both come from the same read, so the executor cannot take a path the
+// accounting did not budget for.
+func (w *AgenticTaskWatcher) launchExecutor(
+	ctx context.Context,
+	t *foremanv1alpha1.AgenticTask,
+	agent *foremanv1alpha1.Agent,
+	supervise bool,
+) {
 	w.inflightMu.Lock()
 	if supervise {
 		w.supervised++
@@ -440,7 +503,7 @@ func (w *AgenticTaskWatcher) launchExecutor(ctx context.Context, t *foremanv1alp
 		// watchdog shares execCtx, so it exits when the run finishes.
 		go w.watchTaskLiveness(execCtx, cancel, t)
 
-		res, execErr := w.Executor.Execute(execCtx, t)
+		res, execErr := w.Executor.Execute(execCtx, t, agent)
 		if patchErr := w.patchTerminal(ctx, t, res, execErr); patchErr != nil {
 			log.Error(patchErr, "patching terminal status failed")
 		}

--- a/pkg/foreman/agent/watcher_concurrency_test.go
+++ b/pkg/foreman/agent/watcher_concurrency_test.go
@@ -48,6 +48,13 @@ type blockingExecutor struct {
 	execErr  error
 	stopOnce sync.Once
 
+	// agentsMu guards agents.
+	agentsMu sync.Mutex
+	// agents records the Agent value handed to each Execute call, so a test
+	// can assert the dispatch loop passed on the Agent it resolved instead
+	// of leaving the executor to read its own.
+	agents []*foremanv1alpha1.Agent
+
 	// wg joins the Execute calls the watcher launched. Without it the test
 	// body can return while an Execute goroutine is still running, and it
 	// then logs (and patches) against a finished test.
@@ -96,10 +103,13 @@ func (e *blockingExecutor) waitStarted(t *testing.T, n int) {
 func (*blockingExecutor) Kind() string { return "test-mode" }
 
 func (e *blockingExecutor) Execute(
-	ctx context.Context, _ *foremanv1alpha1.AgenticTask,
+	ctx context.Context, _ *foremanv1alpha1.AgenticTask, agent *foremanv1alpha1.Agent,
 ) (*Result, error) {
 	e.wg.Add(1)
 	defer e.wg.Done()
+	e.agentsMu.Lock()
+	e.agents = append(e.agents, agent)
+	e.agentsMu.Unlock()
 	e.started <- struct{}{}
 
 	if e.execErr != nil {
@@ -118,26 +128,55 @@ func (e *blockingExecutor) Execute(
 	}, nil
 }
 
+// executedAgents returns the Agent handed to each Execute call so far, in
+// call order.
+func (e *blockingExecutor) executedAgents() []*foremanv1alpha1.Agent {
+	e.agentsMu.Lock()
+	defer e.agentsMu.Unlock()
+	return append([]*foremanv1alpha1.Agent(nil), e.agents...)
+}
+
 // modeExecutor is a blockingExecutor that also answers the watcher's
 // execution-mode question, so slot accounting can be driven without a real
-// coder Job. modeCalls counts the answers, which is what the memoization in
-// pollOnce is about.
+// coder Job. It answers PER AGENT, keyed by name, because that is what the
+// real predicate does: mode is a property of the Agent, so a node's fleet can
+// be mixed. An Agent not in the map (and a nil Agent) runs in-process.
 type modeExecutor struct {
 	*blockingExecutor
-	supervise bool
-	modeCalls atomic.Int32
+	jobMode map[string]bool
 }
 
-func newModeExecutor(t *testing.T, supervise bool) *modeExecutor {
+func newModeExecutor(t *testing.T, jobMode map[string]bool) *modeExecutor {
 	t.Helper()
-	return &modeExecutor{blockingExecutor: newBlockingExecutor(t), supervise: supervise}
+	return &modeExecutor{blockingExecutor: newBlockingExecutor(t), jobMode: jobMode}
 }
 
-func (e *modeExecutor) SupervisesExternally(
-	_ context.Context, _ *foremanv1alpha1.AgenticTask,
-) bool {
-	e.modeCalls.Add(1)
-	return e.supervise
+func (e *modeExecutor) SupervisesAgent(agent *foremanv1alpha1.Agent) bool {
+	if agent == nil {
+		return false
+	}
+	return e.jobMode[agent.Name]
+}
+
+// agentCR builds an Agent whose spec.execution.mode matches what the
+// modeExecutor double will answer for it, so the fixture and the double do
+// not tell two different stories.
+func agentCR(name string, jobMode bool) *foremanv1alpha1.Agent {
+	a := &foremanv1alpha1.Agent{}
+	a.Name = name
+	a.Namespace = "default"
+	if jobMode {
+		a.Spec.Execution = &foremanv1alpha1.ExecutionSpec{Mode: foremanv1alpha1.ExecutionModeJob}
+	}
+	return a
+}
+
+// taskForAgent is scheduledTask plus the agentRef the dispatch loop resolves
+// before it can decide which slot the task wants.
+func taskForAgent(name, agentName string, age time.Duration) *foremanv1alpha1.AgenticTask {
+	task := scheduledTask(name, "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, age)
+	task.Spec.AgentRef = &corev1.LocalObjectReference{Name: agentName}
+	return task
 }
 
 // countPhase reports how many of the named tasks are in the given phase.
@@ -217,11 +256,11 @@ func TestPollOnce_SlotAccountingByExecutionMode(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			first := scheduledTask("first", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Hour)
-			second := scheduledTask("second", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Minute)
-			exec := newModeExecutor(t, tc.supervise)
+			first := taskForAgent("first", "coder", time.Hour)
+			second := taskForAgent("second", "coder", time.Minute)
+			exec := newModeExecutor(t, map[string]bool{"coder": tc.supervise})
 			w := &AgenticTaskWatcher{
-				Client:   newRecoveryClient(t, first, second),
+				Client:   newRecoveryClient(t, first, second, agentCR("coder", tc.supervise)),
 				NodeName: "node-1",
 				Executor: exec,
 			}
@@ -248,16 +287,13 @@ func TestPollOnce_SlotAccountingByExecutionMode(t *testing.T) {
 // caps how many coder Jobs one node has outstanding.
 func TestPollOnce_SupervisionBoundEnforced(t *testing.T) {
 	names := []string{"job-1", "job-2", "job-3"}
-	objs := make([]*foremanv1alpha1.AgenticTask, 0, len(names))
+	objs := []client.Object{agentCR("coder", true)}
 	for i, name := range names {
-		objs = append(objs, scheduledTask(
-			name, "node-1", foremanv1alpha1.AgenticTaskKindIssueFix,
-			time.Duration(len(names)-i)*time.Hour,
-		))
+		objs = append(objs, taskForAgent(name, "coder", time.Duration(len(names)-i)*time.Hour))
 	}
-	exec := newModeExecutor(t, true)
+	exec := newModeExecutor(t, map[string]bool{"coder": true})
 	w := &AgenticTaskWatcher{
-		Client:             newRecoveryClient(t, objs[0], objs[1], objs[2]),
+		Client:             newRecoveryClient(t, objs...),
 		NodeName:           "node-1",
 		Executor:           exec,
 		MaxSupervisedTasks: 2,
@@ -328,26 +364,41 @@ func TestPollOnce_SkipsListWhenNoSlotCanTakeWork(t *testing.T) {
 	}
 }
 
-// TestPollOnce_ResolvesExecutionModeOncePerAgent: the mode question is an
-// uncached Agent GET, so a pass that walks several candidates behind one Agent
-// must ask once, not once per candidate (#1635 review).
-func TestPollOnce_ResolvesExecutionModeOncePerAgent(t *testing.T) {
+// TestPollOnce_ResolvesAgentOncePerPass: resolving a candidate's execution
+// mode costs an uncached Agent GET, and a pass has to resolve the candidates
+// AHEAD of the one it claims too, since it cannot know which slot they want
+// without asking. Candidates queued on one node nearly always share a single
+// Agent, so a pass must read it once, not once per candidate (#1635 review).
+func TestPollOnce_ResolvesAgentOncePerPass(t *testing.T) {
 	names := []string{"job-1", "job-2", "job-3", "job-4"}
-	objs := make([]client.Object, 0, len(names))
+	objs := []client.Object{agentCR("coder", true)}
 	for i, name := range names {
-		task := scheduledTask(
-			name, "node-1", foremanv1alpha1.AgenticTaskKindIssueFix,
-			time.Duration(len(names)-i)*time.Hour,
-		)
-		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: "coder"}
-		objs = append(objs, task)
+		objs = append(objs, taskForAgent(name, "coder", time.Duration(len(names)-i)*time.Hour))
 	}
-	exec := newModeExecutor(t, true)
+	var agentGets atomic.Int32
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objs...).
+		WithStatusSubresource(&foremanv1alpha1.AgenticTask{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(
+				ctx context.Context, cl client.WithWatch,
+				key client.ObjectKey, obj client.Object, opts ...client.GetOption,
+			) error {
+				if _, ok := obj.(*foremanv1alpha1.Agent); ok {
+					agentGets.Add(1)
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	exec := newModeExecutor(t, map[string]bool{"coder": true})
 	w := &AgenticTaskWatcher{
-		Client:             newRecoveryClient(t, objs...),
-		NodeName:           "node-1",
-		Executor:           exec,
-		MaxSupervisedTasks: 1,
+		Client:               c,
+		NodeName:             "node-1",
+		TaskLivenessInterval: time.Hour, // no watchdog interference
+		Executor:             exec,
+		MaxSupervisedTasks:   1,
 	}
 
 	// Spend the whole budget, so the next pass walks every remaining
@@ -357,12 +408,12 @@ func TestPollOnce_ResolvesExecutionModeOncePerAgent(t *testing.T) {
 	}
 	exec.waitStarted(t, 1)
 
-	exec.modeCalls.Store(0)
+	agentGets.Store(0)
 	if err := w.pollOnce(context.Background(), "default"); err != nil {
 		t.Fatalf("pollOnce: %v", err)
 	}
-	if got := exec.modeCalls.Load(); got != 1 {
-		t.Fatalf("execution mode resolved %d time(s) for %d candidates sharing one Agent; want 1",
+	if got := agentGets.Load(); got != 1 {
+		t.Fatalf("Agent read %d time(s) for %d candidates sharing one Agent; want 1",
 			got, len(names)-1)
 	}
 }
@@ -386,11 +437,11 @@ func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
 			// ownership guard after the fake client's round-trip.
 			claimedAt := metav1.NewTime(time.Unix(time.Now().Unix(), 0))
 			task := claimedRunningTask("boom", "node-1", claimedAt)
-			next := scheduledTask("next", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Minute)
-			exec := newModeExecutor(t, tc.supervise)
+			next := taskForAgent("next", "coder", time.Minute)
+			exec := newModeExecutor(t, map[string]bool{"coder": tc.supervise})
 			exec.execErr = errors.New("executor exploded")
 			w := &AgenticTaskWatcher{
-				Client:               newRecoveryClient(t, task, next),
+				Client:               newRecoveryClient(t, task, next, agentCR("coder", tc.supervise)),
 				NodeName:             "node-1",
 				TaskLivenessInterval: time.Hour, // no watchdog interference
 				Executor:             exec,
@@ -399,7 +450,7 @@ func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
 				MaxSupervisedTasks: 1,
 			}
 
-			w.launchExecutor(context.Background(), task, tc.supervise)
+			w.launchExecutor(context.Background(), task, agentCR("coder", tc.supervise), tc.supervise)
 
 			if !waitPhase(t, w, "boom", foremanv1alpha1.AgenticTaskPhaseFailed, 2*time.Second) {
 				t.Fatalf("task phase after executor error: want Failed got %s",
@@ -411,56 +462,4 @@ func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
 			exec.waitStarted(t, 2)
 		})
 	}
-}
-
-// TestSupervisesExternally: the watcher's mode question must be answered by
-// the same predicate Execute dispatches on, so slot accounting cannot drift
-// from the path actually taken (#1559).
-func TestSupervisesExternally(t *testing.T) {
-	jobAgent := &foremanv1alpha1.Agent{}
-	jobAgent.Name = "coder"
-	jobAgent.Namespace = "default"
-	jobAgent.Spec.Execution = &foremanv1alpha1.ExecutionSpec{
-		Mode: foremanv1alpha1.ExecutionModeJob,
-	}
-	inProcAgent := &foremanv1alpha1.Agent{}
-	inProcAgent.Name = "inproc"
-	inProcAgent.Namespace = "default"
-
-	tests := []struct {
-		name          string
-		agentRef      string
-		withSubmitter bool
-		want          bool
-	}{
-		{name: "job-mode agent with submitter", agentRef: "coder", withSubmitter: true, want: true},
-		{name: "job-mode agent without submitter", agentRef: "coder", want: false},
-		{name: "in-process agent", agentRef: "inproc", withSubmitter: true, want: false},
-		{name: "missing agent", agentRef: "gone", withSubmitter: true, want: false},
-		{name: "no agentRef", agentRef: "", withSubmitter: true, want: false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			e := &NativeAgentLoopExecutor{Client: newRecoveryClient(t, jobAgent, inProcAgent)}
-			if tc.withSubmitter {
-				e.CoderJobSubmitter = stubCoderJobSubmitter{}
-			}
-			task := claimedRunningTask("t", "node-1", metav1.Now())
-			if tc.agentRef != "" {
-				task.Spec.AgentRef = &corev1.LocalObjectReference{Name: tc.agentRef}
-			}
-			if got := e.SupervisesExternally(context.Background(), task); got != tc.want {
-				t.Fatalf("SupervisesExternally: want %v got %v", tc.want, got)
-			}
-		})
-	}
-}
-
-// stubCoderJobSubmitter satisfies CoderJobSubmitter for the wiring checks
-// above; it is never invoked. (executor_native_test.go has an equivalent
-// double, but it lives in package agent_test and cannot be reached from here.)
-type stubCoderJobSubmitter struct{}
-
-func (stubCoderJobSubmitter) Submit(context.Context, CoderJobRequest) (CoderJobResult, error) {
-	return CoderJobResult{}, errors.New("not called")
 }

--- a/pkg/foreman/agent/watcher_concurrency_test.go
+++ b/pkg/foreman/agent/watcher_concurrency_test.go
@@ -20,11 +20,15 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
@@ -35,30 +39,29 @@ import (
 // Job-mode supervisions run concurrently up to MaxSupervisedTasks, and both
 // slots are released on the error path.
 
-// modeExecutor blocks in Execute until release is closed and reports whichever
-// execution mode a test needs, so slot accounting can be driven without a real
-// coder Job.
-type modeExecutor struct {
-	supervise bool
-	release   chan struct{}
-	execErr   error
-
+// blockingExecutor blocks in Execute until release is closed, so a test can
+// hold a slot for as long as it needs one. It deliberately does NOT implement
+// SupervisingExecutor: it stands in for the stub executor, and for any node
+// whose Executor cannot supervise at all.
+type blockingExecutor struct {
+	release  chan struct{}
+	execErr  error
 	stopOnce sync.Once
-	// wg joins the Execute calls the watcher launched. Without it a test
+
+	// wg joins the Execute calls the watcher launched. Without it the test
 	// body can return while an Execute goroutine is still running, and it
-	// then patches status and logs against a finished test.
+	// then logs (and patches) against a finished test.
 	wg sync.WaitGroup
 	// started takes one send per Execute entry, so waitStarted can prove
-	// every launched goroutine has reached Execute -- and so has already
-	// done its wg.Add -- before the cleanup Waits on the group.
+	// every launched goroutine has reached Execute (and so has already done
+	// its wg.Add) before the cleanup Waits on the group.
 	started chan struct{}
 }
 
-func newModeExecutor(t *testing.T, supervise bool) *modeExecutor {
+func newBlockingExecutor(t *testing.T) *blockingExecutor {
 	t.Helper()
-	e := &modeExecutor{
-		supervise: supervise,
-		release:   make(chan struct{}),
+	e := &blockingExecutor{
+		release: make(chan struct{}),
 		// Buffered so Execute never blocks on a test that does not read
 		// every send; deeper than any task count these tests use.
 		started: make(chan struct{}, 8),
@@ -72,14 +75,14 @@ func newModeExecutor(t *testing.T, supervise bool) *modeExecutor {
 	return e
 }
 
-// stop unblocks every in-flight Execute. Idempotent, so the cleanup can call
-// it whether or not a test already did.
-func (e *modeExecutor) stop() {
+// stop unblocks every in-flight Execute. Idempotent: the cleanup calls it even
+// when a test already did.
+func (e *blockingExecutor) stop() {
 	e.stopOnce.Do(func() { close(e.release) })
 }
 
 // waitStarted blocks until n Execute calls have entered.
-func (e *modeExecutor) waitStarted(t *testing.T, n int) {
+func (e *blockingExecutor) waitStarted(t *testing.T, n int) {
 	t.Helper()
 	for i := range n {
 		select {
@@ -90,10 +93,10 @@ func (e *modeExecutor) waitStarted(t *testing.T, n int) {
 	}
 }
 
-func (*modeExecutor) Kind() string { return "test-mode" }
+func (*blockingExecutor) Kind() string { return "test-mode" }
 
-func (e *modeExecutor) Execute(
-	ctx context.Context, task *foremanv1alpha1.AgenticTask,
+func (e *blockingExecutor) Execute(
+	ctx context.Context, _ *foremanv1alpha1.AgenticTask,
 ) (*Result, error) {
 	e.wg.Add(1)
 	defer e.wg.Done()
@@ -115,10 +118,40 @@ func (e *modeExecutor) Execute(
 	}, nil
 }
 
+// modeExecutor is a blockingExecutor that also answers the watcher's
+// execution-mode question, so slot accounting can be driven without a real
+// coder Job. modeCalls counts the answers, which is what the memoization in
+// pollOnce is about.
+type modeExecutor struct {
+	*blockingExecutor
+	supervise bool
+	modeCalls atomic.Int32
+}
+
+func newModeExecutor(t *testing.T, supervise bool) *modeExecutor {
+	t.Helper()
+	return &modeExecutor{blockingExecutor: newBlockingExecutor(t), supervise: supervise}
+}
+
 func (e *modeExecutor) SupervisesExternally(
 	_ context.Context, _ *foremanv1alpha1.AgenticTask,
 ) bool {
+	e.modeCalls.Add(1)
 	return e.supervise
+}
+
+// countPhase reports how many of the named tasks are in the given phase.
+func countPhase(
+	t *testing.T, w *AgenticTaskWatcher, phase foremanv1alpha1.AgenticTaskPhase, names ...string,
+) int {
+	t.Helper()
+	n := 0
+	for _, name := range names {
+		if getTask(t, w.Client, name).Status.Phase == phase {
+			n++
+		}
+	}
+	return n
 }
 
 // pollUntilLeavesScheduled polls until the named task is claimed, or the
@@ -160,20 +193,6 @@ func waitPhase(
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-}
-
-// countPhase reports how many of the named tasks are in the given phase.
-func countPhase(
-	t *testing.T, w *AgenticTaskWatcher, phase foremanv1alpha1.AgenticTaskPhase, names ...string,
-) int {
-	t.Helper()
-	n := 0
-	for _, name := range names {
-		if getTask(t, w.Client, name).Status.Phase == phase {
-			n++
-		}
-	}
-	return n
 }
 
 // TestPollOnce_SlotAccountingByExecutionMode: with one task already running,
@@ -259,10 +278,99 @@ func TestPollOnce_SupervisionBoundEnforced(t *testing.T) {
 	exec.waitStarted(t, 2)
 }
 
+// TestPollOnce_SkipsListWhenNoSlotCanTakeWork: an Executor that cannot
+// supervise has no supervision budget to spend, so a busy in-process slot must
+// short-circuit the poll BEFORE the List. The agent's client is uncached, so a
+// guard that never fires means a full namespace List every tick for the whole
+// run, which then skips every candidate (#1635 review).
+func TestPollOnce_SkipsListWhenNoSlotCanTakeWork(t *testing.T) {
+	var lists atomic.Int32
+	held := scheduledTask("held", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Hour)
+	queued := scheduledTask("queued", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Minute)
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(held, queued).
+		WithStatusSubresource(&foremanv1alpha1.AgenticTask{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(
+				ctx context.Context, cl client.WithWatch,
+				list client.ObjectList, opts ...client.ListOption,
+			) error {
+				lists.Add(1)
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	exec := newBlockingExecutor(t)
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "node-1",
+		TaskLivenessInterval: time.Hour, // no watchdog interference
+		Executor:             exec,
+	}
+
+	if err := w.pollOnce(context.Background(), "default"); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	exec.waitStarted(t, 1)
+	if got := getTask(t, w.Client, "held").Status.Phase; got != foremanv1alpha1.AgenticTaskPhaseRunning {
+		t.Fatalf("first poll did not claim the in-process slot: phase %s", got)
+	}
+
+	before := lists.Load()
+	for range 3 {
+		if err := w.pollOnce(context.Background(), "default"); err != nil {
+			t.Fatalf("pollOnce: %v", err)
+		}
+	}
+	if got := lists.Load() - before; got != 0 {
+		t.Fatalf("pollOnce issued %d List(s) with the only slot busy; want 0", got)
+	}
+}
+
+// TestPollOnce_ResolvesExecutionModeOncePerAgent: the mode question is an
+// uncached Agent GET, so a pass that walks several candidates behind one Agent
+// must ask once, not once per candidate (#1635 review).
+func TestPollOnce_ResolvesExecutionModeOncePerAgent(t *testing.T) {
+	names := []string{"job-1", "job-2", "job-3", "job-4"}
+	objs := make([]client.Object, 0, len(names))
+	for i, name := range names {
+		task := scheduledTask(
+			name, "node-1", foremanv1alpha1.AgenticTaskKindIssueFix,
+			time.Duration(len(names)-i)*time.Hour,
+		)
+		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: "coder"}
+		objs = append(objs, task)
+	}
+	exec := newModeExecutor(t, true)
+	w := &AgenticTaskWatcher{
+		Client:             newRecoveryClient(t, objs...),
+		NodeName:           "node-1",
+		Executor:           exec,
+		MaxSupervisedTasks: 1,
+	}
+
+	// Spend the whole budget, so the next pass walks every remaining
+	// candidate instead of claiming the first one and returning.
+	if err := w.pollOnce(context.Background(), "default"); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	exec.waitStarted(t, 1)
+
+	exec.modeCalls.Store(0)
+	if err := w.pollOnce(context.Background(), "default"); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	if got := exec.modeCalls.Load(); got != 1 {
+		t.Fatalf("execution mode resolved %d time(s) for %d candidates sharing one Agent; want 1",
+			got, len(names)-1)
+	}
+}
+
 // TestLaunchExecutor_ReleasesSlotOnError: an executor that returns an error
 // must release whichever slot it took, or the node wedges after one failure.
-// The release is asserted through its observable consequence -- a follow-up
-// poll can claim another task -- rather than by reading the counters.
+// The release is asserted through its observable consequence — a follow-up
+// poll can claim another task — rather than by reading the counters.
 func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -286,8 +394,8 @@ func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
 				NodeName:             "node-1",
 				TaskLivenessInterval: time.Hour, // no watchdog interference
 				Executor:             exec,
-				// One supervision slot, so a leaked one blocks the follow-up
-				// claim instead of hiding under the default of 4.
+				// One supervision slot, so a leaked one blocks the
+				// follow-up claim instead of hiding under the default of 4.
 				MaxSupervisedTasks: 1,
 			}
 

--- a/pkg/foreman/agent/watcher_concurrency_test.go
+++ b/pkg/foreman/agent/watcher_concurrency_test.go
@@ -19,6 +19,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,14 +42,52 @@ type modeExecutor struct {
 	supervise bool
 	release   chan struct{}
 	execErr   error
+
+	stopOnce sync.Once
+	// wg joins the Execute calls the watcher launched. Without it a test
+	// body can return while an Execute goroutine is still running, and it
+	// then patches status and logs against a finished test.
+	wg sync.WaitGroup
+	// started takes one send per Execute entry, so waitStarted can prove
+	// every launched goroutine has reached Execute -- and so has already
+	// done its wg.Add -- before the cleanup Waits on the group.
+	started chan struct{}
 }
 
 func newModeExecutor(t *testing.T, supervise bool) *modeExecutor {
 	t.Helper()
-	e := &modeExecutor{supervise: supervise, release: make(chan struct{})}
-	// Unblock any still-running Execute goroutines when the test ends.
-	t.Cleanup(func() { close(e.release) })
+	e := &modeExecutor{
+		supervise: supervise,
+		release:   make(chan struct{}),
+		// Buffered so Execute never blocks on a test that does not read
+		// every send; deeper than any task count these tests use.
+		started: make(chan struct{}, 8),
+	}
+	// Unblock any still-running Execute goroutines when the test ends, then
+	// join them.
+	t.Cleanup(func() {
+		e.stop()
+		e.wg.Wait()
+	})
 	return e
+}
+
+// stop unblocks every in-flight Execute. Idempotent, so the cleanup can call
+// it whether or not a test already did.
+func (e *modeExecutor) stop() {
+	e.stopOnce.Do(func() { close(e.release) })
+}
+
+// waitStarted blocks until n Execute calls have entered.
+func (e *modeExecutor) waitStarted(t *testing.T, n int) {
+	t.Helper()
+	for i := range n {
+		select {
+		case <-e.started:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d Execute call(s) started; want %d", i, n)
+		}
+	}
 }
 
 func (*modeExecutor) Kind() string { return "test-mode" }
@@ -56,6 +95,10 @@ func (*modeExecutor) Kind() string { return "test-mode" }
 func (e *modeExecutor) Execute(
 	ctx context.Context, task *foremanv1alpha1.AgenticTask,
 ) (*Result, error) {
+	e.wg.Add(1)
+	defer e.wg.Done()
+	e.started <- struct{}{}
+
 	if e.execErr != nil {
 		return nil, e.execErr
 	}
@@ -78,14 +121,38 @@ func (e *modeExecutor) SupervisesExternally(
 	return e.supervise
 }
 
-// waitSupervised polls w.supervised (under its mutex) until it equals want.
-func waitSupervised(w *AgenticTaskWatcher, want int, timeout time.Duration) bool {
+// pollUntilLeavesScheduled polls until the named task is claimed, or the
+// timeout expires. Retrying is deliberate: the slot a finished run held is
+// released after its terminal status patch, so the first poll after a failure
+// can legitimately still see it held.
+func pollUntilLeavesScheduled(
+	t *testing.T, w *AgenticTaskWatcher, name string, timeout time.Duration,
+) bool {
+	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for {
-		w.inflightMu.Lock()
-		got := w.supervised
-		w.inflightMu.Unlock()
-		if got == want {
+		if err := w.pollOnce(context.Background(), "default"); err != nil {
+			t.Fatalf("pollOnce: %v", err)
+		}
+		if getTask(t, w.Client, name).Status.Phase != foremanv1alpha1.AgenticTaskPhaseScheduled {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// waitPhase waits for the named task to reach phase.
+func waitPhase(
+	t *testing.T, w *AgenticTaskWatcher, name string,
+	phase foremanv1alpha1.AgenticTaskPhase, timeout time.Duration,
+) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if getTask(t, w.Client, name).Status.Phase == phase {
 			return true
 		}
 		if time.Now().After(deadline) {
@@ -133,10 +200,11 @@ func TestPollOnce_SlotAccountingByExecutionMode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			first := scheduledTask("first", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Hour)
 			second := scheduledTask("second", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Minute)
+			exec := newModeExecutor(t, tc.supervise)
 			w := &AgenticTaskWatcher{
 				Client:   newRecoveryClient(t, first, second),
 				NodeName: "node-1",
-				Executor: newModeExecutor(t, tc.supervise),
+				Executor: exec,
 			}
 
 			for range 2 {
@@ -149,6 +217,9 @@ func TestPollOnce_SlotAccountingByExecutionMode(t *testing.T) {
 			if got != tc.wantRunning {
 				t.Fatalf("Running tasks: want %d got %d", tc.wantRunning, got)
 			}
+			// Every claimed task has an Execute goroutine; join them all
+			// before the test body returns.
+			exec.waitStarted(t, tc.wantRunning)
 		})
 	}
 }
@@ -165,10 +236,11 @@ func TestPollOnce_SupervisionBoundEnforced(t *testing.T) {
 			time.Duration(len(names)-i)*time.Hour,
 		))
 	}
+	exec := newModeExecutor(t, true)
 	w := &AgenticTaskWatcher{
 		Client:             newRecoveryClient(t, objs[0], objs[1], objs[2]),
 		NodeName:           "node-1",
-		Executor:           newModeExecutor(t, true),
+		Executor:           exec,
 		MaxSupervisedTasks: 2,
 	}
 
@@ -184,10 +256,13 @@ func TestPollOnce_SupervisionBoundEnforced(t *testing.T) {
 	if got := countPhase(t, w, foremanv1alpha1.AgenticTaskPhaseScheduled, names...); got != 1 {
 		t.Fatalf("Scheduled tasks: want 1 (held back by the bound) got %d", got)
 	}
+	exec.waitStarted(t, 2)
 }
 
 // TestLaunchExecutor_ReleasesSlotOnError: an executor that returns an error
 // must release whichever slot it took, or the node wedges after one failure.
+// The release is asserted through its observable consequence -- a follow-up
+// poll can claim another task -- rather than by reading the counters.
 func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -203,26 +278,29 @@ func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
 			// ownership guard after the fake client's round-trip.
 			claimedAt := metav1.NewTime(time.Unix(time.Now().Unix(), 0))
 			task := claimedRunningTask("boom", "node-1", claimedAt)
+			next := scheduledTask("next", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Minute)
 			exec := newModeExecutor(t, tc.supervise)
 			exec.execErr = errors.New("executor exploded")
 			w := &AgenticTaskWatcher{
-				Client:               newRecoveryClient(t, task),
+				Client:               newRecoveryClient(t, task, next),
 				NodeName:             "node-1",
 				TaskLivenessInterval: time.Hour, // no watchdog interference
 				Executor:             exec,
+				// One supervision slot, so a leaked one blocks the follow-up
+				// claim instead of hiding under the default of 4.
+				MaxSupervisedTasks: 1,
 			}
 
 			w.launchExecutor(context.Background(), task, tc.supervise)
 
-			if !waitSupervised(w, 0, 2*time.Second) {
-				t.Fatal("supervision slot leaked after executor error")
+			if !waitPhase(t, w, "boom", foremanv1alpha1.AgenticTaskPhaseFailed, 2*time.Second) {
+				t.Fatalf("task phase after executor error: want Failed got %s",
+					getTask(t, w.Client, "boom").Status.Phase)
 			}
-			if !waitInflight(w, false, 2*time.Second) {
-				t.Fatal("in-process slot leaked after executor error")
+			if !pollUntilLeavesScheduled(t, w, "next", 2*time.Second) {
+				t.Fatal("slot leaked after the executor error: no further task could be claimed")
 			}
-			if got := getTask(t, w.Client, "boom").Status.Phase; got != foremanv1alpha1.AgenticTaskPhaseFailed {
-				t.Fatalf("task phase after executor error: want Failed got %s", got)
-			}
+			exec.waitStarted(t, 2)
 		})
 	}
 }
@@ -271,7 +349,8 @@ func TestSupervisesExternally(t *testing.T) {
 }
 
 // stubCoderJobSubmitter satisfies CoderJobSubmitter for the wiring checks
-// above; it is never invoked.
+// above; it is never invoked. (executor_native_test.go has an equivalent
+// double, but it lives in package agent_test and cannot be reached from here.)
 type stubCoderJobSubmitter struct{}
 
 func (stubCoderJobSubmitter) Submit(context.Context, CoderJobRequest) (CoderJobResult, error) {

--- a/pkg/foreman/agent/watcher_concurrency_test.go
+++ b/pkg/foreman/agent/watcher_concurrency_test.go
@@ -287,7 +287,8 @@ func TestPollOnce_SlotAccountingByExecutionMode(t *testing.T) {
 // caps how many coder Jobs one node has outstanding.
 func TestPollOnce_SupervisionBoundEnforced(t *testing.T) {
 	names := []string{"job-1", "job-2", "job-3"}
-	objs := []client.Object{agentCR("coder", true)}
+	objs := make([]client.Object, 0, 1+len(names))
+	objs = append(objs, agentCR("coder", true))
 	for i, name := range names {
 		objs = append(objs, taskForAgent(name, "coder", time.Duration(len(names)-i)*time.Hour))
 	}
@@ -371,7 +372,8 @@ func TestPollOnce_SkipsListWhenNoSlotCanTakeWork(t *testing.T) {
 // Agent, so a pass must read it once, not once per candidate (#1635 review).
 func TestPollOnce_ResolvesAgentOncePerPass(t *testing.T) {
 	names := []string{"job-1", "job-2", "job-3", "job-4"}
-	objs := []client.Object{agentCR("coder", true)}
+	objs := make([]client.Object, 0, 1+len(names))
+	objs = append(objs, agentCR("coder", true))
 	for i, name := range names {
 		objs = append(objs, taskForAgent(name, "coder", time.Duration(len(names)-i)*time.Hour))
 	}
@@ -461,5 +463,155 @@ func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
 			}
 			exec.waitStarted(t, 2)
 		})
+	}
+}
+
+// TestPollOnce_MixedExecutionModes is the case the slot split exists for, and
+// the one a uniform fleet cannot show: the two modes draw on DIFFERENT slots,
+// so a busy one must not block the other. Both directions are asserted --
+// #1559 itself (a Job-mode task claimed while an in-process run holds
+// inflight) and the claim in docs/site/foreman/README.md that a node already
+// supervising Job-mode work can still pick up in-process work.
+func TestPollOnce_MixedExecutionModes(t *testing.T) {
+	tests := []struct {
+		name string
+		// firstClaimed is the older task, so sortTasksDepthFirst offers it
+		// first and it takes its slot before the other is considered.
+		firstClaimed string
+	}{
+		{
+			name:         "job-mode task claimed while an in-process run holds the slot",
+			firstClaimed: "inproc",
+		},
+		{
+			name:         "in-process task claimed while a supervision is outstanding",
+			firstClaimed: "jobbed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ages := map[string]time.Duration{tc.firstClaimed: time.Hour}
+			inproc := taskForAgent("inproc", "local", ages["inproc"]+time.Minute)
+			jobbed := taskForAgent("jobbed", "coder", ages["jobbed"]+time.Minute)
+			exec := newModeExecutor(t, map[string]bool{"coder": true})
+			w := &AgenticTaskWatcher{
+				Client: newRecoveryClient(t,
+					inproc, jobbed, agentCR("local", false), agentCR("coder", true)),
+				NodeName:             "node-1",
+				TaskLivenessInterval: time.Hour, // no watchdog interference
+				Executor:             exec,
+			}
+
+			// Neither Execute ever returns (blockingExecutor holds until
+			// cleanup), so the second claim happens with the first task's
+			// slot still occupied.
+			for range 2 {
+				if err := w.pollOnce(context.Background(), "default"); err != nil {
+					t.Fatalf("pollOnce: %v", err)
+				}
+			}
+
+			got := countPhase(t, w, foremanv1alpha1.AgenticTaskPhaseRunning, "inproc", "jobbed")
+			if got != 2 {
+				t.Fatalf("Running tasks: want 2 (one per slot) got %d", got)
+			}
+			exec.waitStarted(t, 2)
+
+			// Each run must have been handed the Agent the dispatch loop
+			// resolved for it -- that shared value is what keeps the slot
+			// reserved and the path taken from disagreeing.
+			seen := map[string]bool{}
+			for _, a := range exec.executedAgents() {
+				if a == nil {
+					t.Fatal("Execute was handed a nil Agent for a task whose Agent exists")
+				}
+				seen[a.Name] = true
+			}
+			if !seen["local"] || !seen["coder"] {
+				t.Fatalf("Agents handed to Execute: want local+coder got %v", seen)
+			}
+		})
+	}
+}
+
+// TestPollOnce_DeletedAgentIsStillClaimed: an Agent deleted between scheduling
+// and the claim resolves to nil, NOT to an error, so the task is claimed and
+// handed to the executor, which stamps FailureAgentNotFound (asserted at the
+// executor level by TestNativeExecutor_AgentNotFound). Skipping it instead
+// would leave it at Scheduled forever with nothing saying why (#1635 review).
+func TestPollOnce_DeletedAgentIsStillClaimed(t *testing.T) {
+	orphan := taskForAgent("orphan", "gone", time.Hour)
+	exec := newModeExecutor(t, nil)
+	w := &AgenticTaskWatcher{
+		Client:               newRecoveryClient(t, orphan),
+		NodeName:             "node-1",
+		TaskLivenessInterval: time.Hour, // no watchdog interference
+		Executor:             exec,
+	}
+
+	if err := w.pollOnce(context.Background(), "default"); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	if got := getTask(t, w.Client, "orphan").Status.Phase; got == foremanv1alpha1.AgenticTaskPhaseScheduled {
+		t.Fatal("task with a deleted Agent was left at Scheduled; it must be claimed and failed")
+	}
+	exec.waitStarted(t, 1)
+	agents := exec.executedAgents()
+	if len(agents) != 1 || agents[0] != nil {
+		t.Fatalf("Execute must be handed a nil Agent for a deleted one; got %v", agents)
+	}
+}
+
+// TestPollOnce_TransientAgentReadErrorHoldsCandidate: when the Agent read
+// fails ambiguously the execution mode is unknown, so the candidate is left
+// Scheduled and retried. Claiming on a guess is what reintroduces #1559 --
+// guess in-process for a Job-mode task and the node holds its only slot for
+// the coder Job's whole lifetime.
+func TestPollOnce_TransientAgentReadErrorHoldsCandidate(t *testing.T) {
+	var failing atomic.Bool
+	failing.Store(true)
+	task := taskForAgent("queued", "coder", time.Hour)
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(task, agentCR("coder", true)).
+		WithStatusSubresource(&foremanv1alpha1.AgenticTask{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(
+				ctx context.Context, cl client.WithWatch,
+				key client.ObjectKey, obj client.Object, opts ...client.GetOption,
+			) error {
+				if _, ok := obj.(*foremanv1alpha1.Agent); ok && failing.Load() {
+					return errors.New("apiserver blip")
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	exec := newModeExecutor(t, map[string]bool{"coder": true})
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "node-1",
+		TaskLivenessInterval: time.Hour, // no watchdog interference
+		Executor:             exec,
+	}
+
+	if err := w.pollOnce(context.Background(), "default"); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	if got := getTask(t, w.Client, "queued").Status.Phase; got != foremanv1alpha1.AgenticTaskPhaseScheduled {
+		t.Fatalf("candidate phase after an unresolvable Agent: want Scheduled got %s", got)
+	}
+	if got := exec.executedAgents(); len(got) != 0 {
+		t.Fatalf("dispatched %d task(s) without knowing the execution mode; want 0", len(got))
+	}
+
+	failing.Store(false)
+	if !pollUntilLeavesScheduled(t, w, "queued", 2*time.Second) {
+		t.Fatal("candidate was not retried once its Agent became readable")
+	}
+	exec.waitStarted(t, 1)
+	agents := exec.executedAgents()
+	if len(agents) != 1 || agents[0] == nil || agents[0].Name != "coder" {
+		t.Fatalf("Agent handed to Execute after the retry: want coder got %v", agents)
 	}
 }

--- a/pkg/foreman/agent/watcher_concurrency_test.go
+++ b/pkg/foreman/agent/watcher_concurrency_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// #1559: a Job-mode task's work runs in an ephemeral Job pod, so it must not
+// hold the agent's single in-process slot for the Job's whole lifetime. These
+// tests pin the resulting slot accounting: in-process runs still serialize,
+// Job-mode supervisions run concurrently up to MaxSupervisedTasks, and both
+// slots are released on the error path.
+
+// modeExecutor blocks in Execute until release is closed and reports whichever
+// execution mode a test needs, so slot accounting can be driven without a real
+// coder Job.
+type modeExecutor struct {
+	supervise bool
+	release   chan struct{}
+	execErr   error
+}
+
+func newModeExecutor(t *testing.T, supervise bool) *modeExecutor {
+	t.Helper()
+	e := &modeExecutor{supervise: supervise, release: make(chan struct{})}
+	// Unblock any still-running Execute goroutines when the test ends.
+	t.Cleanup(func() { close(e.release) })
+	return e
+}
+
+func (*modeExecutor) Kind() string { return "test-mode" }
+
+func (e *modeExecutor) Execute(
+	ctx context.Context, task *foremanv1alpha1.AgenticTask,
+) (*Result, error) {
+	if e.execErr != nil {
+		return nil, e.execErr
+	}
+	select {
+	case <-e.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return &Result{
+		SchemaVersion: ResultSchemaVersion,
+		Kind:          e.Kind(),
+		Verdict:       foremanv1alpha1.AgenticTaskVerdictGo,
+		Summary:       "test",
+	}, nil
+}
+
+func (e *modeExecutor) SupervisesExternally(
+	_ context.Context, _ *foremanv1alpha1.AgenticTask,
+) bool {
+	return e.supervise
+}
+
+// waitSupervised polls w.supervised (under its mutex) until it equals want.
+func waitSupervised(w *AgenticTaskWatcher, want int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		w.inflightMu.Lock()
+		got := w.supervised
+		w.inflightMu.Unlock()
+		if got == want {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// countPhase reports how many of the named tasks are in the given phase.
+func countPhase(
+	t *testing.T, w *AgenticTaskWatcher, phase foremanv1alpha1.AgenticTaskPhase, names ...string,
+) int {
+	t.Helper()
+	n := 0
+	for _, name := range names {
+		if getTask(t, w.Client, name).Status.Phase == phase {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPollOnce_SlotAccountingByExecutionMode: with one task already running,
+// a second in-process task must wait, but a second Job-mode task must be
+// claimed — the agent is idle while it supervises (#1559).
+func TestPollOnce_SlotAccountingByExecutionMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		supervise   bool
+		wantRunning int
+	}{
+		{
+			name:        "in-process runs serialize on the single slot",
+			supervise:   false,
+			wantRunning: 1,
+		},
+		{
+			name:        "job-mode supervisions run concurrently",
+			supervise:   true,
+			wantRunning: 2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			first := scheduledTask("first", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Hour)
+			second := scheduledTask("second", "node-1", foremanv1alpha1.AgenticTaskKindIssueFix, time.Minute)
+			w := &AgenticTaskWatcher{
+				Client:   newRecoveryClient(t, first, second),
+				NodeName: "node-1",
+				Executor: newModeExecutor(t, tc.supervise),
+			}
+
+			for range 2 {
+				if err := w.pollOnce(context.Background(), "default"); err != nil {
+					t.Fatalf("pollOnce: %v", err)
+				}
+			}
+
+			got := countPhase(t, w, foremanv1alpha1.AgenticTaskPhaseRunning, "first", "second")
+			if got != tc.wantRunning {
+				t.Fatalf("Running tasks: want %d got %d", tc.wantRunning, got)
+			}
+		})
+	}
+}
+
+// TestPollOnce_SupervisionBoundEnforced: Job-mode tasks do not hold the
+// in-process slot, but they are not unbounded either — MaxSupervisedTasks
+// caps how many coder Jobs one node has outstanding.
+func TestPollOnce_SupervisionBoundEnforced(t *testing.T) {
+	names := []string{"job-1", "job-2", "job-3"}
+	objs := make([]*foremanv1alpha1.AgenticTask, 0, len(names))
+	for i, name := range names {
+		objs = append(objs, scheduledTask(
+			name, "node-1", foremanv1alpha1.AgenticTaskKindIssueFix,
+			time.Duration(len(names)-i)*time.Hour,
+		))
+	}
+	w := &AgenticTaskWatcher{
+		Client:             newRecoveryClient(t, objs[0], objs[1], objs[2]),
+		NodeName:           "node-1",
+		Executor:           newModeExecutor(t, true),
+		MaxSupervisedTasks: 2,
+	}
+
+	for range len(names) {
+		if err := w.pollOnce(context.Background(), "default"); err != nil {
+			t.Fatalf("pollOnce: %v", err)
+		}
+	}
+
+	if got := countPhase(t, w, foremanv1alpha1.AgenticTaskPhaseRunning, names...); got != 2 {
+		t.Fatalf("Running tasks: want 2 (the bound) got %d", got)
+	}
+	if got := countPhase(t, w, foremanv1alpha1.AgenticTaskPhaseScheduled, names...); got != 1 {
+		t.Fatalf("Scheduled tasks: want 1 (held back by the bound) got %d", got)
+	}
+}
+
+// TestLaunchExecutor_ReleasesSlotOnError: an executor that returns an error
+// must release whichever slot it took, or the node wedges after one failure.
+func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
+	tests := []struct {
+		name      string
+		supervise bool
+	}{
+		{name: "in-process", supervise: false},
+		{name: "job-mode", supervise: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Second-precision claimedAt: metav1.Time JSON-encodes to
+			// seconds, so a sub-second value would fail patchTerminal's
+			// ownership guard after the fake client's round-trip.
+			claimedAt := metav1.NewTime(time.Unix(time.Now().Unix(), 0))
+			task := claimedRunningTask("boom", "node-1", claimedAt)
+			exec := newModeExecutor(t, tc.supervise)
+			exec.execErr = errors.New("executor exploded")
+			w := &AgenticTaskWatcher{
+				Client:               newRecoveryClient(t, task),
+				NodeName:             "node-1",
+				TaskLivenessInterval: time.Hour, // no watchdog interference
+				Executor:             exec,
+			}
+
+			w.launchExecutor(context.Background(), task, tc.supervise)
+
+			if !waitSupervised(w, 0, 2*time.Second) {
+				t.Fatal("supervision slot leaked after executor error")
+			}
+			if !waitInflight(w, false, 2*time.Second) {
+				t.Fatal("in-process slot leaked after executor error")
+			}
+			if got := getTask(t, w.Client, "boom").Status.Phase; got != foremanv1alpha1.AgenticTaskPhaseFailed {
+				t.Fatalf("task phase after executor error: want Failed got %s", got)
+			}
+		})
+	}
+}
+
+// TestSupervisesExternally: the watcher's mode question must be answered by
+// the same predicate Execute dispatches on, so slot accounting cannot drift
+// from the path actually taken (#1559).
+func TestSupervisesExternally(t *testing.T) {
+	jobAgent := &foremanv1alpha1.Agent{}
+	jobAgent.Name = "coder"
+	jobAgent.Namespace = "default"
+	jobAgent.Spec.Execution = &foremanv1alpha1.ExecutionSpec{
+		Mode: foremanv1alpha1.ExecutionModeJob,
+	}
+	inProcAgent := &foremanv1alpha1.Agent{}
+	inProcAgent.Name = "inproc"
+	inProcAgent.Namespace = "default"
+
+	tests := []struct {
+		name          string
+		agentRef      string
+		withSubmitter bool
+		want          bool
+	}{
+		{name: "job-mode agent with submitter", agentRef: "coder", withSubmitter: true, want: true},
+		{name: "job-mode agent without submitter", agentRef: "coder", want: false},
+		{name: "in-process agent", agentRef: "inproc", withSubmitter: true, want: false},
+		{name: "missing agent", agentRef: "gone", withSubmitter: true, want: false},
+		{name: "no agentRef", agentRef: "", withSubmitter: true, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &NativeAgentLoopExecutor{Client: newRecoveryClient(t, jobAgent, inProcAgent)}
+			if tc.withSubmitter {
+				e.CoderJobSubmitter = stubCoderJobSubmitter{}
+			}
+			task := claimedRunningTask("t", "node-1", metav1.Now())
+			if tc.agentRef != "" {
+				task.Spec.AgentRef = &corev1.LocalObjectReference{Name: tc.agentRef}
+			}
+			if got := e.SupervisesExternally(context.Background(), task); got != tc.want {
+				t.Fatalf("SupervisesExternally: want %v got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+// stubCoderJobSubmitter satisfies CoderJobSubmitter for the wiring checks
+// above; it is never invoked.
+type stubCoderJobSubmitter struct{}
+
+func (stubCoderJobSubmitter) Submit(context.Context, CoderJobRequest) (CoderJobResult, error) {
+	return CoderJobResult{}, errors.New("not called")
+}

--- a/pkg/foreman/agent/watcher_liveness_test.go
+++ b/pkg/foreman/agent/watcher_liveness_test.go
@@ -145,7 +145,8 @@ func TestLaunchExecutor_AbortsInflightRunOnDelete(t *testing.T) {
 		Executor:             &StubExecutor{SleepDuration: time.Hour}, // blocks until ctx cancelled
 	}
 
-	w.launchExecutor(context.Background(), task, false)
+	// The stub executor ignores the Agent, so nil is the honest value here.
+	w.launchExecutor(context.Background(), task, nil, false)
 
 	// Confirm the run is actually in flight before deleting.
 	if !waitInflight(w, true, time.Second) {

--- a/pkg/foreman/agent/watcher_liveness_test.go
+++ b/pkg/foreman/agent/watcher_liveness_test.go
@@ -145,7 +145,7 @@ func TestLaunchExecutor_AbortsInflightRunOnDelete(t *testing.T) {
 		Executor:             &StubExecutor{SleepDuration: time.Hour}, // blocks until ctx cancelled
 	}
 
-	w.launchExecutor(context.Background(), task)
+	w.launchExecutor(context.Background(), task, false)
 
 	// Confirm the run is actually in flight before deleting.
 	if !waitInflight(w, true, time.Second) {


### PR DESCRIPTION
## What

Stop a Job-mode AgenticTask from holding the agent's single in-process execution
slot for the lifetime of its Job.

## Why

Fixes #1559

#1558 stopped the controller reserving a FleetNode for Job-mode tasks. That was
necessary but not sufficient: the controller can now place a second task on the
node, but the agent will not pick it up, because `AgenticTaskWatcher` holds one
process-wide `inflight` slot for every task it claims regardless of execution
mode.

Observed on an 8-node fleet: one node ran a Job-mode coder task with two further
tasks stuck in `Scheduled` behind it while the other seven FleetNodes sat `Ready`
with nothing assigned. The supervising agent process was idle throughout — the
coder loop, workspace and toolchain all run inside the Job pod.

## How

In-process runs keep the strict one-at-a-time slot: they own the agent process's
CPU, memory and workspace directory, which is what the slot was for.

Job-mode runs get a separate budget, `MaxSupervisedTasks`, default 4, settable
with `--max-supervised-tasks`. Bounded rather than unbounded because each
supervision holds a goroutine and a liveness probe, and more importantly each is
an outstanding coder Job competing for pods, cache volumes and inference
capacity. Nothing else caps that per node.

The bound is per node and composes with `Agent.spec.maxConcurrentTasks` (#1497),
which is per Agent and enforced by the controller before a task is ever
`Scheduled`. Different axes; whichever is tighter wins. A task the controller
declines never reaches the watcher.

The watcher learns a task's mode by asking the Executor, through a new optional
`SupervisingExecutor` interface implemented over the same `useCoderJobPath`
predicate `Execute` already dispatches on, so slot accounting cannot drift from
the path actually taken. This is deliberately not a watcher-side
`spec.execution.mode` check: a Job-mode Agent whose executor has no wired
`CoderJobSubmitter` runs in-process, and a mode check would hand out a slot it
isn't holding. Executors that don't implement the interface (`StubExecutor`)
are treated as in-process, so stub mode stays strictly serialised.

The reservation happens before the goroutine starts and the release is a `defer`
registered first inside it, so the slot is returned on every exit path —
executor error, context cancellation, or panic.

### Out of scope

`reserveFirstFitNode` returns the alphabetically first eligible node for
Job-mode tasks and, correctly per #1496, does not reserve it — so Job-mode tasks
concentrate on a single node (measured: 10 of 11 in one day, with seven nodes
idle). This change raises that node's concurrency from 1 to
`MaxSupervisedTasks`, but does not spread work across the fleet, which means the
per-node bound currently behaves like a fleet-wide cap. Filed separately as
#1634. Happy to fold the two together if you'd rather they land as one change.

Also worth knowing: `FleetNode.status.currentTask` still reports only the
in-process task, so a node supervising Jobs looks idle in `kubectl get
fleetnode`. That follows from #1558's design rather than this change, and is now
documented.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

`make lint-all` also passes (`GOOS=darwin` and `GOOS=linux`, 0 issues).

Tests: `pkg/foreman/agent` covers in-process serialisation, Job-mode
concurrency, the supervision bound holding a third task at `Scheduled`, slot
release on the executor-error path for both modes, and a 5-case table on
`SupervisesExternally` (submitter wired, no submitter, in-process Agent, missing
Agent, no `agentRef`). Verified the new tests fail with the fix reverted:
stubbing the mode check to always return in-process gives
`want 2 got 1` on both concurrency tests.

Not manually exercised in a cluster yet — the fleet behaviour above is the
observation that motivated the fix, not a verification of it.

Assisted-by: Claude Opus (wrote the implementation, tests and docs; I reviewed
the diff, confirmed the tests fail without the fix, and ran make test / lint /
lint-all)
