### PR TITLE
fix(foreman): do not open a fix iteration for an empty demoted NO-GO

### DIFF
--- a/internal/foreman/controller/workload_gateless_test.go
+++ b/internal/foreman/controller/workload_gateless_test.go
@@ -162,7 +162,7 @@ func TestReviewIterationSteps_GatelessReviewDependsOnCode(t *testing.T) {
 		child("review-641-0", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo),
 	}
 
-	steps, iterated := reviewIterationSteps(w, children)
+	steps, iterated, _ := reviewIterationSteps(w, children)
 	want := []string{"code-641-r1", "review-641-0-r1"}
 	if len(steps) != len(want) {
 		t.Fatalf("got %d steps, want %d (%v)", len(steps), len(want), want)

--- a/internal/foreman/controller/workload_intent_test.go
+++ b/internal/foreman/controller/workload_intent_test.go
@@ -107,7 +107,7 @@ func TestReviewIterationSteps_CarriesIntent(t *testing.T) {
 	children := []foremanv1alpha1.AgenticTask{
 		child("code-641", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGo),
 		child("verify-641", foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictGatePass),
-		noGoChild("review-641-0", "needs work", "[]"),
+		noGoChild("needs work", "[]"),
 	}
 
 	steps, _ := reviewIterationSteps(w, children)

--- a/internal/foreman/controller/workload_intent_test.go
+++ b/internal/foreman/controller/workload_intent_test.go
@@ -110,7 +110,7 @@ func TestReviewIterationSteps_CarriesIntent(t *testing.T) {
 		noGoChild("needs work", "[]"),
 	}
 
-	steps, _ := reviewIterationSteps(w, children)
+	steps, _, _ := reviewIterationSteps(w, children)
 
 	var found bool
 	for _, s := range steps {

--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -40,6 +40,14 @@ import (
 // chained behind it.
 const conditionTypeReviewIterationTriggered = "ReviewIterationTriggered"
 
+// conditionTypeReviewIterationSuppressed reports that a terminal NO-GO did
+// NOT open a fix iteration because the issueAsk rail manufactured it out of
+// the reviewer's own GO and it carries no findings (#1636). The demoted
+// NO-GO still counts as incomplete in the rollup, so without this the
+// operator sees a Failed Workload on a branch the reviewer approved and
+// nothing anywhere says why no iteration ran.
+const conditionTypeReviewIterationSuppressed = "ReviewIterationSuppressed"
+
 // defaultMaxReviewIterations is the per-issue fix-iteration bound when
 // Workload.spec.maxReviewIterations is unset. One iteration mirrors
 // what a human does with a single request-changes round; an explicit 0
@@ -136,55 +144,97 @@ func issueStepIteration(step string, n int32) (int, bool) {
 	return reviewIterationOf(step, n)
 }
 
-// isInertDemotion reports whether a NO-GO was manufactured by a harness
-// rail rather than asserted by the reviewer, AND carries nothing to act
-// on (#1636).
+// suppressedDemotion records one review child whose inert demotion kept a
+// fix iteration from opening, so emitReviewIterations can say so. Without
+// it the demoted NO-GO still lands in the incomplete bucket
+// (classifyChildren, workload_controller.go) and rolls the Workload to
+// Failed on a branch the reviewer approved, with nothing anywhere
+// explaining why no iteration ran (#1636).
+type suppressedDemotion struct {
+	// step is the review child's step label (e.g. review-641-0), falling
+	// back to its object name when the label is missing.
+	step string
+	// reason is the rail's demotionReason, verbatim.
+	reason string
+}
+
+// taskStepLabel names a child for operator-facing prose: its step label
+// when it carries one, its object name otherwise.
+func taskStepLabel(t *foremanv1alpha1.AgenticTask) string {
+	if label := t.Labels[labelStep]; label != "" {
+		return label
+	}
+	return t.Name
+}
+
+// inertDemotion reports whether a NO-GO was manufactured by the issueAsk
+// rail rather than asserted by the reviewer, AND carries nothing to act on
+// (#1636). It returns the rail's demotionReason so the caller can record
+// why the fix iteration did not run.
 //
-// applyIssueAskIntegrity (pkg/foreman/agent) rewrites a reviewer's GO to
-// NO-GO when it cannot verify that the stated issue ask covers the
-// fetched issue body, stamping extra.verdictDemoted. That is a statement
-// about verification confidence, not about the change. Treating it as a
-// rejection opens a fix iteration whose feedback body is the reviewer's
-// own approval followed by an empty findings list, and re-running the
-// coder cannot make an unverifiable issueAsk verify, so the loop has no
-// terminating condition.
+// enforceReviewerIssueAsk (pkg/foreman/agent/executor_native.go) rewrites a
+// reviewer's GO to NO-GO when it cannot verify that the stated issue ask
+// covers the fetched issue body. That is a statement about verification
+// confidence, not about the change. Treating it as a rejection opens a fix
+// iteration whose feedback body is the reviewer's own approval followed by
+// an empty findings list, and re-running the coder cannot make an
+// unverifiable issueAsk verify, so the loop has no terminating condition.
 //
-// The predicate is deliberately narrow: a demotion that DOES carry
-// findings still iterates, because those findings are real work, and an
-// undemoted NO-GO always iterates, because that is the reviewer's own
-// judgement. Only the empty-handed rewrite is suppressed.
-func isInertDemotion(t *foremanv1alpha1.AgenticTask) bool {
+// Three conditions are required, and each one excludes a NO-GO the coder
+// CAN act on:
+//
+//   - verdictDemotedBy is the issueAsk rail. enforceReviewerScopeOverlap
+//     (scope_overlap.go) also demotes, but its verdict says the diff
+//     touches none of the files the issue names, which is real work.
+//     Keying off the bare verdictDemoted flag would suppress those too.
+//   - verdictClaimed is GO, i.e. the rail really did rewrite the verdict.
+//     enforceReviewerIssueAsk stamps the demotion fields on a path where
+//     it does NOT: an unverified non-GO review is marked untrusted and the
+//     reviewer's OWN NO-GO is returned. Suppressing that would discard a
+//     genuine rejection whose feedback lives in the summary.
+//   - no findings. A demotion carrying findings is real work either way.
+//
+// Every field is read from extra.modelExtra. The executor's
+// modelDecidedResult nests the rails' whole map there and
+// promoteTerminalOutcome lifts only outcome / unverified / resolvedBy to
+// the top level, so reading these keys from extra directly (as this
+// predicate first shipped) never matched anything the executor emits.
+func inertDemotion(t *foremanv1alpha1.AgenticTask) (reason string, inert bool) {
 	if t.Status.Result == nil || len(t.Status.Result.Raw) == 0 {
-		return false
+		return "", false
 	}
 	var envelope struct {
 		Extra struct {
-			VerdictDemoted bool           `json:"verdictDemoted"`
-			ModelExtra     map[string]any `json:"modelExtra"`
+			ModelExtra map[string]any `json:"modelExtra"`
 		} `json:"extra"`
 	}
 	// Malformed results are not our call to suppress; let them iterate.
 	if err := json.Unmarshal(t.Status.Result.Raw, &envelope); err != nil {
-		return false
+		return "", false
 	}
-	if !envelope.Extra.VerdictDemoted {
-		return false
+	modelExtra := envelope.Extra.ModelExtra
+	if by, _ := modelExtra["verdictDemotedBy"].(string); by != reviewer.RailIssueAsk {
+		return "", false
 	}
-	if findings, _ := reviewer.ParseFindings(envelope.Extra.ModelExtra); len(findings) > 0 {
-		return false
+	if claimed, _ := modelExtra["verdictClaimed"].(string); claimed != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+		return "", false
+	}
+	if findings, _ := reviewer.ParseFindings(modelExtra); len(findings) > 0 {
+		return "", false
 	}
 	// Mirror reviewFeedbackSection's fallback: a non-conforming findings
 	// shape still reaches the coder as raw JSON, so it is not inert.
-	if raw, ok := envelope.Extra.ModelExtra["findings"]; ok {
+	if raw, ok := modelExtra["findings"]; ok {
 		if buf, err := json.Marshal(raw); err == nil {
 			switch string(buf) {
 			case "null", "[]", "{}", "":
 			default:
-				return false
+				return "", false
 			}
 		}
 	}
-	return true
+	reason, _ = modelExtra["demotionReason"].(string)
+	return reason, true
 }
 
 // noGoReviewRound inspects issue n's reviewer fan-out for fix
@@ -196,11 +246,18 @@ func isInertDemotion(t *foremanv1alpha1.AgenticTask) bool {
 // triggers a fix iteration. Scanning what exists (rather than the
 // expected reviewer count) keeps cloud-suppressed reviewers from
 // permanently blocking the trigger, mirroring escalationSteps.
+//
+// The second return carries the round's inert demotions (#1636): NO-GO
+// children this function refused to count, so the caller can report them
+// instead of leaving the Workload to fail unexplained. It is populated
+// only once the round is complete, because an in-flight round may still
+// produce a NO-GO that iterates anyway.
 func noGoReviewRound(
 	children []foremanv1alpha1.AgenticTask, n int32, k int,
-) []*foremanv1alpha1.AgenticTask {
+) ([]*foremanv1alpha1.AgenticTask, []suppressedDemotion) {
 	var total, terminal int
 	var noGo []*foremanv1alpha1.AgenticTask
+	var suppressed []suppressedDemotion
 	for i := range children {
 		iter, ok := reviewIterationOf(children[i].Labels[labelStep], n)
 		if !ok || iter != k {
@@ -212,15 +269,25 @@ func noGoReviewRound(
 			phase == foremanv1alpha1.AgenticTaskPhaseFailed {
 			terminal++
 		}
-		if children[i].Status.Verdict == foremanv1alpha1.AgenticTaskVerdictNoGo &&
-			!isInertDemotion(&children[i]) {
-			noGo = append(noGo, &children[i])
+		if children[i].Status.Verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
+			continue
 		}
+		if reason, inert := inertDemotion(&children[i]); inert {
+			suppressed = append(suppressed, suppressedDemotion{
+				step:   taskStepLabel(&children[i]),
+				reason: reason,
+			})
+			continue
+		}
+		noGo = append(noGo, &children[i])
 	}
-	if total == 0 || terminal < total || len(noGo) == 0 {
-		return nil
+	if total == 0 || terminal < total {
+		return nil, nil
 	}
-	return noGo
+	if len(noGo) == 0 {
+		return nil, suppressed
+	}
+	return noGo, suppressed
 }
 
 // reviewIterationSteps decides which code-<n>-r<k> / verify-<n>-r<k> /
@@ -249,19 +316,23 @@ func noGoReviewRound(
 // forcing profile — and falls back to spec.coderAgentRef otherwise
 // (the caller emits the RevisionUnderIssueFixProfile warning).
 //
+// The third return lists the NO-GO reviews whose inert demotion (#1636)
+// kept a round from iterating, for the caller to report; see
+// suppressedDemotion.
+//
 // Pure function: no API calls, no status writes. The caller owns
 // MaxTasks accounting, sovereignty filtering, and creation, and must
 // restrict invocation to issue-batch mode (user-authored Pipeline step
 // names could false-match the synthesized naming scheme).
 func reviewIterationSteps(
 	w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
-) (steps []foremanv1alpha1.PipelineStep, iterated []int32) {
+) (steps []foremanv1alpha1.PipelineStep, iterated []int32, suppressed []suppressedDemotion) {
 	maxIter := effectiveMaxReviewIterations(w)
 	if maxIter <= 0 ||
 		len(w.Spec.ReviewerAgentRefs) == 0 ||
 		len(w.Spec.Issues) == 0 ||
 		w.Spec.CoderAgentRef == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	existing := make(map[string]struct{}, len(children))
@@ -280,7 +351,8 @@ func reviewIterationSteps(
 		branch := fmt.Sprintf("foreman/%s/issue-%d", w.Name, n)
 		issueIterated := false
 		for k := 1; k <= maxIter; k++ {
-			noGo := noGoReviewRound(children, n, k-1)
+			noGo, inert := noGoReviewRound(children, n, k-1)
+			suppressed = append(suppressed, inert...)
 			if len(noGo) == 0 {
 				break
 			}
@@ -352,12 +424,20 @@ func reviewIterationSteps(
 				})
 				issueIterated = true
 			}
+			if k == maxIter {
+				// Last round in the budget: no k+1 pass will ever look at
+				// the reviews this round produces, so scan them here or an
+				// inert demotion in the FINAL round goes unreported and the
+				// Workload fails unexplained after all.
+				_, inert := noGoReviewRound(children, n, k)
+				suppressed = append(suppressed, inert...)
+			}
 		}
 		if issueIterated {
 			iterated = append(iterated, n)
 		}
 	}
-	return steps, iterated
+	return steps, iterated, suppressed
 }
 
 // reviewFeedbackPrompt distills the NO-GO reviewers' structured
@@ -395,10 +475,7 @@ func reviewFeedbackPrompt(noGo []*foremanv1alpha1.AgenticTask) string {
 // legacy map-shaped findings ("scope_creep" + "*_details" keys) still
 // reach the coder, and a result-less task degrades to a one-liner.
 func reviewFeedbackSection(t *foremanv1alpha1.AgenticTask) string {
-	label := t.Labels[labelStep]
-	if label == "" {
-		label = t.Name
-	}
+	label := taskStepLabel(t)
 
 	var envelope struct {
 		Summary string `json:"summary"`
@@ -533,6 +610,63 @@ func countReviewIterations(w *foremanv1alpha1.Workload, stepNames map[string]str
 	return total
 }
 
+// recordSuppressedDemotions reports the inert demotions that kept a fix
+// iteration from opening (#1636), naming each review task and the rail's
+// demotionReason. Same contract as the MaxTasks cap twenty lines below: no
+// silent skip. The Workload still rolls to Failed on the demoted NO-GO, so
+// the condition is what turns "Failed with no explanation" into "Failed
+// because the issueAsk rail could not verify the reviewer read the issue".
+//
+// The condition carries the record because it survives; the paired event
+// surfaces it in `kubectl describe` while the operator is looking. Both are
+// skipped when the stored condition already says exactly this, so a
+// steady-state reconcile neither churns LastTransitionTime nor re-fires the
+// event.
+func (r *WorkloadReconciler) recordSuppressedDemotions(
+	ctx context.Context, w *foremanv1alpha1.Workload, suppressed []suppressedDemotion,
+) error {
+	if len(suppressed) == 0 {
+		return nil
+	}
+
+	parts := make([]string, 0, len(suppressed))
+	for _, s := range suppressed {
+		if s.reason == "" {
+			parts = append(parts, s.step)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", s.step, s.reason))
+	}
+	msg := fmt.Sprintf(
+		"no fix iteration for %d NO-GO review task(s): the issueAsk rail rewrote the reviewer's GO and the review carries no findings, so the iteration would hand the coder an approval it cannot act on (%s)",
+		len(suppressed), strings.Join(parts, "; "))
+
+	cond := metav1.Condition{
+		Type:    conditionTypeReviewIterationSuppressed,
+		Status:  metav1.ConditionTrue,
+		Reason:  "InertDemotion",
+		Message: msg,
+	}
+	if existing := apimeta.FindStatusCondition(
+		w.Status.Conditions, conditionTypeReviewIterationSuppressed,
+	); existing != nil && existing.Status == cond.Status &&
+		existing.Reason == cond.Reason && existing.Message == cond.Message {
+		return nil
+	}
+	cond.LastTransitionTime = metav1.Now()
+
+	patch := client.MergeFrom(w.DeepCopy())
+	setCondition(&w.Status.Conditions, cond)
+	if err := r.Status().Patch(ctx, w, patch); err != nil {
+		return fmt.Errorf("patch review-iteration suppression condition: %w", err)
+	}
+	if r.Recorder != nil {
+		r.Recorder.Eventf(w, nil, corev1.EventTypeWarning,
+			conditionTypeReviewIterationSuppressed, "Reconcile", "%s", msg)
+	}
+	return nil
+}
+
 // emitReviewIterations is the fix-iteration emission hook (#946):
 // called from Reconcile's children-exist branch after the advisory
 // wiring and before escalation + rollup. Synthesizes the due
@@ -554,7 +688,15 @@ func (r *WorkloadReconciler) emitReviewIterations(
 		return children, nil
 	}
 
-	steps, iterated := reviewIterationSteps(w, children)
+	steps, iterated, inert := reviewIterationSteps(w, children)
+
+	// Before the no-op short-circuit: a round that suppressed an inert
+	// demotion usually emits NO steps at all, and that is exactly the case
+	// an operator needs told about.
+	if err := r.recordSuppressedDemotions(ctx, w, inert); err != nil {
+		return children, err
+	}
+
 	if len(steps) == 0 {
 		return children, nil
 	}

--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -136,6 +136,57 @@ func issueStepIteration(step string, n int32) (int, bool) {
 	return reviewIterationOf(step, n)
 }
 
+// isInertDemotion reports whether a NO-GO was manufactured by a harness
+// rail rather than asserted by the reviewer, AND carries nothing to act
+// on (#1636).
+//
+// applyIssueAskIntegrity (pkg/foreman/agent) rewrites a reviewer's GO to
+// NO-GO when it cannot verify that the stated issue ask covers the
+// fetched issue body, stamping extra.verdictDemoted. That is a statement
+// about verification confidence, not about the change. Treating it as a
+// rejection opens a fix iteration whose feedback body is the reviewer's
+// own approval followed by an empty findings list, and re-running the
+// coder cannot make an unverifiable issueAsk verify, so the loop has no
+// terminating condition.
+//
+// The predicate is deliberately narrow: a demotion that DOES carry
+// findings still iterates, because those findings are real work, and an
+// undemoted NO-GO always iterates, because that is the reviewer's own
+// judgement. Only the empty-handed rewrite is suppressed.
+func isInertDemotion(t *foremanv1alpha1.AgenticTask) bool {
+	if t.Status.Result == nil || len(t.Status.Result.Raw) == 0 {
+		return false
+	}
+	var envelope struct {
+		Extra struct {
+			VerdictDemoted bool           `json:"verdictDemoted"`
+			ModelExtra     map[string]any `json:"modelExtra"`
+		} `json:"extra"`
+	}
+	// Malformed results are not our call to suppress; let them iterate.
+	if err := json.Unmarshal(t.Status.Result.Raw, &envelope); err != nil {
+		return false
+	}
+	if !envelope.Extra.VerdictDemoted {
+		return false
+	}
+	if findings, _ := reviewer.ParseFindings(envelope.Extra.ModelExtra); len(findings) > 0 {
+		return false
+	}
+	// Mirror reviewFeedbackSection's fallback: a non-conforming findings
+	// shape still reaches the coder as raw JSON, so it is not inert.
+	if raw, ok := envelope.Extra.ModelExtra["findings"]; ok {
+		if buf, err := json.Marshal(raw); err == nil {
+			switch string(buf) {
+			case "null", "[]", "{}", "":
+			default:
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // noGoReviewRound inspects issue n's reviewer fan-out for fix
 // iteration k. It returns the NO-GO review tasks when the round is
 // complete — at least one review child exists, every one is terminal
@@ -161,7 +212,8 @@ func noGoReviewRound(
 			phase == foremanv1alpha1.AgenticTaskPhaseFailed {
 			terminal++
 		}
-		if children[i].Status.Verdict == foremanv1alpha1.AgenticTaskVerdictNoGo {
+		if children[i].Status.Verdict == foremanv1alpha1.AgenticTaskVerdictNoGo &&
+			!isInertDemotion(&children[i]) {
 			noGo = append(noGo, &children[i])
 		}
 	}

--- a/internal/foreman/controller/workload_iteration_envtest_test.go
+++ b/internal/foreman/controller/workload_iteration_envtest_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
 )
 
 // Reviewer NO-GO fix iteration (#946): instead of terminally failing
@@ -74,6 +75,23 @@ var _ = Describe("WorkloadReconciler review fix iteration (#946)", func() {
 		`"summary":"scope creep beyond the issue ask","extra":{"outcome":"MODEL-DECIDED","modelExtra":{"findings":` +
 		`[{"severity":"blocker","area":"scope","message":"reduces ACCESS_TOKEN_EXPIRE_MINUTES from 10080 to 30",` +
 		`"file":"config/auth.py","line":12,"suggestion":"revert the unrelated change"}]}}}`
+
+	// The result an issueAsk demotion really produces: the reviewer's own
+	// APPROVE summary, no findings, and the rails' markers nested under
+	// extra.modelExtra where modelDecidedResult puts them. Built through
+	// reviewResultRaw (workload_iteration_test.go) so the shape comes from
+	// the real agent.Result rather than a hand-written string (#1641).
+	inertDemotedResult := string(reviewResultRaw(
+		foremanv1alpha1.AgenticTaskVerdictNoGo,
+		"APPROVE: the change is minimal and matches the issue",
+		map[string]any{
+			"issueAskVerified": false,
+			"verdictDemoted":   true,
+			"verdictDemotedBy": reviewer.RailIssueAsk,
+			"verdictClaimed":   string(foremanv1alpha1.AgenticTaskVerdictGo),
+			"demotionReason":   demotionReasonIssueAsk,
+			"findings":         []any{},
+		}).Raw)
 
 	It("re-dispatches the coder with the review feedback on NO-GO and completes when the retry converges", func() {
 		wl := newWorkload("iterate-happy", foremanv1alpha1.WorkloadSpec{
@@ -263,6 +281,73 @@ var _ = Describe("WorkloadReconciler review fix iteration (#946)", func() {
 		Expect(completed).NotTo(BeNil())
 		Expect(completed.Reason).To(Equal("ChildrenIncomplete"))
 		Expect(fresh.Status.ReviewIterations).To(Equal(int32(1)))
+	})
+
+	// #1636/#1641: the issueAsk rail rewrote the reviewer's GO into a NO-GO
+	// carrying no findings. No fix iteration opens (the coder would be handed
+	// an approval it cannot act on), but the demoted NO-GO still counts as
+	// incomplete and fails the Workload. The suppression therefore has to be
+	// recorded, or the operator sees a Failed Workload on a branch the
+	// reviewer approved with nothing anywhere saying why.
+	It("records the suppression when an inert issueAsk demotion blocks the iteration", func() {
+		wl := newWorkload("iterate-inert", foremanv1alpha1.WorkloadSpec{
+			Intent:           "inert demotion suppression",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{753},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+			ReviewerAgentRefs: []corev1.LocalObjectReference{
+				{Name: "reviewer"},
+			},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		reconcile(wl)
+		markTerminal("iterate-inert-code-753", foremanv1alpha1.AgenticTaskVerdictGo, "")
+		markTerminal("iterate-inert-verify-753", foremanv1alpha1.AgenticTaskVerdictGatePass, "")
+		markTerminal("iterate-inert-review-753-0",
+			foremanv1alpha1.AgenticTaskVerdictNoGo, inertDemotedResult)
+		reconcile(wl)
+
+		var r1 foremanv1alpha1.AgenticTask
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "iterate-inert-code-753-r1"}, &r1)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+			"an empty-handed issueAsk demotion must not open a fix iteration")
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseFailed),
+			"the demoted NO-GO still rolls the Workload to Failed; that is what needs explaining")
+
+		suppressed := findCondition(fresh.Status.Conditions, conditionTypeReviewIterationSuppressed)
+		Expect(suppressed).NotTo(BeNil(),
+			"a skipped fix iteration must be reported, not silent")
+		Expect(suppressed.Status).To(Equal(metav1.ConditionTrue))
+		Expect(suppressed.Reason).To(Equal("InertDemotion"))
+		Expect(suppressed.Message).To(ContainSubstring("review-753-0"),
+			"the condition must name the review task it suppressed")
+		Expect(suppressed.Message).To(ContainSubstring(demotionReasonIssueAsk),
+			"the condition must carry the rail's demotionReason")
+
+		Expect(recorder.Events).To(Receive(And(
+			ContainSubstring("Warning"),
+			ContainSubstring(conditionTypeReviewIterationSuppressed),
+			ContainSubstring("review-753-0"),
+		)))
+
+		// Steady state: a re-reconcile must not churn the condition or
+		// re-fire the event on every pass.
+		before := *suppressed
+		reconcile(wl)
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		after := findCondition(fresh.Status.Conditions, conditionTypeReviewIterationSuppressed)
+		Expect(after).NotTo(BeNil())
+		Expect(after.LastTransitionTime).To(Equal(before.LastTransitionTime))
+		Expect(recorder.Events).NotTo(Receive())
 	})
 
 	It("does not iterate when the reviewer says GO", func() {

--- a/internal/foreman/controller/workload_iteration_test.go
+++ b/internal/foreman/controller/workload_iteration_test.go
@@ -46,10 +46,31 @@ func iterationWorkload(issues []int32, reviewers int, maxIter *int32) *foremanv1
 	return w
 }
 
+// demotedNoGoChild is a terminal NO-GO review child whose NO-GO was
+// MANUFACTURED by a harness rail rather than asserted by the reviewer:
+// extra.verdictDemoted marks the rewrite (see applyIssueAskIntegrity in
+// pkg/foreman/agent). findingsJSON lets a case carry real findings or
+// none, which is the distinction that decides whether a fix iteration
+// has anything to act on (#1636).
+func demotedNoGoChild(summary, findingsJSON string) foremanv1alpha1.AgenticTask {
+	c := child(reviewStep, foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo)
+	raw := `{"schemaVersion":"foreman.v1","kind":"review","verdict":"NO-GO","summary":"` + summary + `",` +
+		`"extra":{"verdictDemoted":true,"verdictClaimed":"GO",` +
+		`"demotionReason":"issueAsk could not be verified as covering the fetched issue body",` +
+		`"modelExtra":{"findings":` + findingsJSON + `}}}`
+	c.Status.Result = &runtime.RawExtension{Raw: []byte(raw)}
+	return c
+}
+
+// reviewStep is the single reviewer's step label used throughout these
+// tests. Both review-child builders below stamp it, so it lives here
+// rather than being threaded through every call site.
+const reviewStep = "review-641-0"
+
 // noGoChild is a terminal NO-GO review child carrying a structured
 // review result so the feedback-prompt path is exercised end to end.
-func noGoChild(step, summary, findingsJSON string) foremanv1alpha1.AgenticTask {
-	c := child(step, foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo)
+func noGoChild(summary, findingsJSON string) foremanv1alpha1.AgenticTask {
+	c := child(reviewStep, foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo)
 	raw := `{"schemaVersion":"foreman.v1","kind":"review","verdict":"NO-GO","summary":"` + summary + `",` +
 		`"extra":{"outcome":"MODEL-DECIDED","modelExtra":{"findings":` + findingsJSON + `}}}`
 	c.Status.Result = &runtime.RawExtension{Raw: []byte(raw)}
@@ -91,6 +112,47 @@ func TestReviewIterationSteps(t *testing.T) {
 			name:     "reviewer GO converges: no iteration",
 			w:        iterationWorkload([]int32{641}, 1, nil),
 			children: baseRound(goVerdict),
+		},
+		{
+			// #1636: the issueAsk rail rewrites an approved verdict to
+			// NO-GO. With no findings the coder is handed a rejection it
+			// cannot act on, and re-running cannot make an unverifiable
+			// issueAsk verify, so the loop has no terminating condition.
+			name: "demoted NO-GO carrying no findings does not iterate",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+				child("verify-641", succeeded, gatePass),
+				demotedNoGoChild("APPROVE: changes are minimal and well-tested", `[]`),
+			},
+		},
+		{
+			// Narrowness guard: a demotion is only inert when it carries
+			// nothing to fix. Real findings still deserve an iteration.
+			name: "demoted NO-GO carrying findings still iterates",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+				child("verify-641", succeeded, gatePass),
+				demotedNoGoChild("mixed",
+					`[{"severity":"major","area":"correctness","message":"nil deref on empty strategy"}]`),
+			},
+			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
+			wantIterated: []int32{641},
+		},
+		{
+			// Narrowness guard: an UNdemoted NO-GO is the reviewer's own
+			// judgement. Absent structured findings it still iterates, as
+			// it did before #1636; the summary carries the feedback.
+			name: "genuine NO-GO with no findings still iterates",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+				child("verify-641", succeeded, gatePass),
+				noGoChild("rejected: the fix does not address the issue", `[]`),
+			},
+			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
+			wantIterated: []int32{641},
 		},
 		{
 			name: "waits for every reviewer in the round to be terminal",
@@ -278,7 +340,7 @@ func TestReviewIterationCoderRef(t *testing.T) {
 }
 
 func TestReviewFeedbackPrompt(t *testing.T) {
-	structured := noGoChild("review-641-0", "scope creep beyond the issue ask",
+	structured := noGoChild("scope creep beyond the issue ask",
 		`[{"severity":"blocker","area":"scope","message":"reduces ACCESS_TOKEN_EXPIRE_MINUTES from 10080 to 30, unrelated to the issue","file":"config/auth.py","line":12,"suggestion":"revert the unrelated change"}]`)
 	prompt := reviewFeedbackPrompt([]*foremanv1alpha1.AgenticTask{&structured})
 	for _, want := range []string{
@@ -304,7 +366,7 @@ func TestReviewFeedbackPrompt(t *testing.T) {
 	// Legacy map-shaped findings (the boolean + *_details shape from the
 	// issue report) fail the strict schema and must fall back to raw JSON
 	// rather than vanishing.
-	legacy := noGoChild("review-641-0", "missing tests",
+	legacy := noGoChild("missing tests",
 		`{"missing_tests":true,"missing_tests_details":"no unit test covers the new branch"}`)
 	prompt = reviewFeedbackPrompt([]*foremanv1alpha1.AgenticTask{&legacy})
 	if !strings.Contains(prompt, "no unit test covers the new branch") {

--- a/internal/foreman/controller/workload_iteration_test.go
+++ b/internal/foreman/controller/workload_iteration_test.go
@@ -17,14 +17,18 @@ limitations under the License.
 package controller
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
 )
 
 // iterationWorkload builds the issue-batch spec reviewIterationSteps
@@ -46,34 +50,108 @@ func iterationWorkload(issues []int32, reviewers int, maxIter *int32) *foremanv1
 	return w
 }
 
-// demotedNoGoChild is a terminal NO-GO review child whose NO-GO was
-// MANUFACTURED by a harness rail rather than asserted by the reviewer:
-// extra.verdictDemoted marks the rewrite (see applyIssueAskIntegrity in
-// pkg/foreman/agent). findingsJSON lets a case carry real findings or
-// none, which is the distinction that decides whether a fix iteration
-// has anything to act on (#1636).
-func demotedNoGoChild(summary, findingsJSON string) foremanv1alpha1.AgenticTask {
+// reviewStep is the single reviewer's step label used throughout these
+// tests. Every review-child builder below stamps it, so it lives here
+// rather than being threaded through every call site.
+const reviewStep = "review-641-0"
+
+// demotionReasonIssueAsk / demotionReasonScopeDrift are the two rails'
+// demotionReason strings, copied from enforceReviewerIssueAsk
+// (pkg/foreman/agent/executor_native.go) and enforceReviewerScopeOverlap
+// (pkg/foreman/agent/scope_overlap.go). Only the prose is copied; the
+// verdictDemotedBy values that actually drive the predicate come from the
+// shared reviewer constants both sides compile against.
+const (
+	demotionReasonIssueAsk = "issueAsk could not be verified as covering the " +
+		"fetched issue body; review verdict is untrusted"
+	demotionReasonScopeDrift = "scope drift: the issue names 1 file(s) " +
+		"(internal/foreman/controller/workload_iteration.go) and the diff touches none of them"
+)
+
+// reviewResultRaw renders the status.result a reviewer task really carries,
+// by marshalling an actual agent.Result rather than hand-writing JSON. The
+// Extra map mirrors NativeAgentLoopExecutor.modelDecidedResult
+// (pkg/foreman/agent/executor_native.go): the rails stamp their keys into
+// LoopResult.Terminal.Extra, and modelDecidedResult nests that WHOLE map one
+// level down under "modelExtra", promoting only outcome / unverified /
+// resolvedBy to the top level. modelDecidedResult is an unexported method,
+// so the controller test cannot call it; the nesting is pinned against the
+// real executor by TestIssueAskDemotionLandsUnderModelExtra in
+// pkg/foreman/agent, which runs the actual rail and the actual
+// modelDecidedResult and asserts the JSON path this predicate reads.
+//
+// #1641: the first cut of these fixtures hand-wrote verdictDemoted as a
+// SIBLING of modelExtra, a shape the executor never emits, so the suppression
+// predicate passed its tests and did nothing in production.
+func reviewResultRaw(
+	verdict foremanv1alpha1.AgenticTaskVerdict, summary string, modelExtra map[string]any,
+) *runtime.RawExtension {
+	res := agent.NewResult("review", verdict, summary, 42*time.Second)
+	res.Extra = map[string]any{
+		"outcome":       "MODEL-DECIDED",
+		"transcriptRef": map[string]any{"kind": "ConfigMap", "name": "wl-" + reviewStep + "-transcript"},
+		"turnCount":     7,
+		"modelExtra":    modelExtra,
+	}
+	raw, err := json.Marshal(res)
+	if err != nil {
+		panic("marshal review result fixture: " + err.Error())
+	}
+	return &runtime.RawExtension{Raw: raw}
+}
+
+// railDemotedNoGoChild is a terminal NO-GO review child whose NO-GO a
+// harness rail MANUFACTURED rather than the reviewer asserting it: the rail
+// stamped verdictDemoted plus verdictDemotedBy naming itself, and
+// verdictClaimed archiving the verdict it rewrote (#1636).
+//
+// rail and claimed are parameters because the predicate turns on both: only
+// the issueAsk rail rewriting a GO is inert. findingsJSON decides whether the
+// demotion carries anything the coder could act on.
+func railDemotedNoGoChild(
+	rail, claimed, reason, summary, findingsJSON string,
+) foremanv1alpha1.AgenticTask {
 	c := child(reviewStep, foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo)
-	raw := `{"schemaVersion":"foreman.v1","kind":"review","verdict":"NO-GO","summary":"` + summary + `",` +
-		`"extra":{"verdictDemoted":true,"verdictClaimed":"GO",` +
-		`"demotionReason":"issueAsk could not be verified as covering the fetched issue body",` +
-		`"modelExtra":{"findings":` + findingsJSON + `}}}`
-	c.Status.Result = &runtime.RawExtension{Raw: []byte(raw)}
+	var findings any
+	if err := json.Unmarshal([]byte(findingsJSON), &findings); err != nil {
+		panic("bad findings fixture JSON: " + err.Error())
+	}
+	c.Status.Result = reviewResultRaw(foremanv1alpha1.AgenticTaskVerdictNoGo, summary, map[string]any{
+		"issueAskVerified": false,
+		"verdictDemoted":   true,
+		"verdictDemotedBy": rail,
+		"verdictClaimed":   claimed,
+		"demotionReason":   reason,
+		"findings":         findings,
+	})
 	return c
 }
 
-// reviewStep is the single reviewer's step label used throughout these
-// tests. Both review-child builders below stamp it, so it lives here
-// rather than being threaded through every call site.
-const reviewStep = "review-641-0"
+// demotedNoGoChild is the inert case: the issueAsk rail rewrote the
+// reviewer's GO.
+func demotedNoGoChild(summary, findingsJSON string) foremanv1alpha1.AgenticTask {
+	return railDemotedNoGoChild(reviewer.RailIssueAsk, string(foremanv1alpha1.AgenticTaskVerdictGo),
+		demotionReasonIssueAsk, summary, findingsJSON)
+}
+
+// withStep re-labels a review child for a later fix iteration, so a case can
+// place one of the builders above in round r1 instead of the base round.
+func withStep(c foremanv1alpha1.AgenticTask, step string) foremanv1alpha1.AgenticTask {
+	c.Name = "wl-" + step
+	c.Labels[labelStep] = step
+	return c
+}
 
 // noGoChild is a terminal NO-GO review child carrying a structured
 // review result so the feedback-prompt path is exercised end to end.
 func noGoChild(summary, findingsJSON string) foremanv1alpha1.AgenticTask {
 	c := child(reviewStep, foremanv1alpha1.AgenticTaskPhaseSucceeded, foremanv1alpha1.AgenticTaskVerdictNoGo)
-	raw := `{"schemaVersion":"foreman.v1","kind":"review","verdict":"NO-GO","summary":"` + summary + `",` +
-		`"extra":{"outcome":"MODEL-DECIDED","modelExtra":{"findings":` + findingsJSON + `}}}`
-	c.Status.Result = &runtime.RawExtension{Raw: []byte(raw)}
+	var findings any
+	if err := json.Unmarshal([]byte(findingsJSON), &findings); err != nil {
+		panic("bad findings fixture JSON: " + err.Error())
+	}
+	c.Status.Result = reviewResultRaw(foremanv1alpha1.AgenticTaskVerdictNoGo, summary,
+		map[string]any{"findings": findings})
 	return c
 }
 
@@ -100,6 +178,9 @@ func TestReviewIterationSteps(t *testing.T) {
 		children     []foremanv1alpha1.AgenticTask
 		wantSteps    []string // expected step names, in order
 		wantIterated []int32
+		// wantSuppressed lists the step labels reviewIterationSteps must
+		// report as inert demotions, in order. nil asserts none.
+		wantSuppressed []string
 	}{
 		{
 			name:         "reviewer NO-GO triggers the full r1 triple",
@@ -118,24 +199,61 @@ func TestReviewIterationSteps(t *testing.T) {
 			// NO-GO. With no findings the coder is handed a rejection it
 			// cannot act on, and re-running cannot make an unverifiable
 			// issueAsk verify, so the loop has no terminating condition.
-			name: "demoted NO-GO carrying no findings does not iterate",
+			name: "issueAsk demotion of a GO carrying no findings does not iterate",
 			w:    iterationWorkload([]int32{641}, 1, nil),
 			children: []foremanv1alpha1.AgenticTask{
 				child("code-641", succeeded, goVerdict),
 				child("verify-641", succeeded, gatePass),
 				demotedNoGoChild("APPROVE: changes are minimal and well-tested", `[]`),
 			},
+			wantSuppressed: []string{reviewStep},
 		},
 		{
 			// Narrowness guard: a demotion is only inert when it carries
 			// nothing to fix. Real findings still deserve an iteration.
-			name: "demoted NO-GO carrying findings still iterates",
+			name: "issueAsk demotion carrying findings still iterates",
 			w:    iterationWorkload([]int32{641}, 1, nil),
 			children: []foremanv1alpha1.AgenticTask{
 				child("code-641", succeeded, goVerdict),
 				child("verify-641", succeeded, gatePass),
 				demotedNoGoChild("mixed",
-					`[{"severity":"major","area":"correctness","message":"nil deref on empty strategy"}]`),
+					`[{"severity":"major","area":"scope","message":"nil deref on empty strategy"}]`),
+			},
+			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
+			wantIterated: []int32{641},
+		},
+		{
+			// Rail-identity guard (#1641): enforceReviewerScopeOverlap also
+			// demotes a GO to NO-GO and also stamps verdictDemoted, but its
+			// verdict says the diff touches none of the files the issue
+			// names. That IS actionable, so it must iterate even with no
+			// structured findings. A predicate keyed off the bare
+			// verdictDemoted flag would swallow it.
+			name: "scope-overlap demotion of a GO with no findings still iterates",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+				child("verify-641", succeeded, gatePass),
+				railDemotedNoGoChild(reviewer.RailScopeOverlap, string(goVerdict),
+					demotionReasonScopeDrift, "APPROVE: looks good to me", `[]`),
+			},
+			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
+			wantIterated: []int32{641},
+		},
+		{
+			// Claimed-verdict guard (#1641): enforceReviewerIssueAsk stamps
+			// the demotion fields on the path where it does NOT rewrite the
+			// verdict, marking an unverified NON-GO review untrusted and
+			// returning the reviewer's own NO-GO (verdictClaimed=NO-GO).
+			// That is a genuine rejection whose feedback lives in the
+			// summary; suppressing it would discard the reviewer's prose.
+			name: "issueAsk marking an untrusted NO-GO it did not rewrite still iterates",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+				child("verify-641", succeeded, gatePass),
+				railDemotedNoGoChild(reviewer.RailIssueAsk, string(noGo),
+					demotionReasonIssueAsk, "REJECT: the fix papers over the race instead of fixing it", `[]`),
 			},
 			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
 			wantIterated: []int32{641},
@@ -209,6 +327,20 @@ func TestReviewIterationSteps(t *testing.T) {
 			),
 		},
 		{
+			// The LAST round in the budget is never revisited by a k+1 walk,
+			// so its suppression has to be scanned where the walk ends or the
+			// Workload fails with no explanation after all (#1636).
+			name: "inert demotion in the final round is still reported",
+			w:    iterationWorkload([]int32{641}, 1, nil), // nil -> 1 iteration
+			children: append(baseRound(noGo),
+				child("code-641-r1", succeeded, goVerdict),
+				child("verify-641-r1", succeeded, gatePass),
+				withStep(demotedNoGoChild("APPROVE: the revision addresses every point", `[]`),
+					"review-641-0-r1"),
+			),
+			wantSuppressed: []string{"review-641-0-r1"},
+		},
+		{
 			name:     "explicit 0 disables iteration",
 			w:        iterationWorkload([]int32{641}, 1, ptr.To(int32(0))),
 			children: baseRound(noGo),
@@ -241,7 +373,25 @@ func TestReviewIterationSteps(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			steps, iterated := reviewIterationSteps(tc.w, tc.children)
+			steps, iterated, suppressed := reviewIterationSteps(tc.w, tc.children)
+
+			var gotSuppressed []string
+			for _, s := range suppressed {
+				gotSuppressed = append(gotSuppressed, s.step)
+				// A suppression the controller cannot explain is the gap
+				// #1636 opened: the demoted NO-GO still fails the Workload.
+				if s.reason == "" {
+					t.Errorf("suppressed %s carries no demotionReason; the condition would name no cause", s.step)
+				}
+			}
+			if len(gotSuppressed) != len(tc.wantSuppressed) {
+				t.Fatalf("suppressed = %v, want %v", gotSuppressed, tc.wantSuppressed)
+			}
+			for i := range tc.wantSuppressed {
+				if gotSuppressed[i] != tc.wantSuppressed[i] {
+					t.Fatalf("suppressed = %v, want %v", gotSuppressed, tc.wantSuppressed)
+				}
+			}
 
 			var gotNames []string
 			for _, s := range steps {
@@ -321,7 +471,7 @@ func TestReviewIterationCoderRef(t *testing.T) {
 			w := iterationWorkload([]int32{641}, 1, nil)
 			w.Spec.RevisionCoderAgentRef = tc.revisionRef
 
-			steps, _ := reviewIterationSteps(w, noGoRound)
+			steps, _, _ := reviewIterationSteps(w, noGoRound)
 			refs := map[string]string{}
 			for _, s := range steps {
 				refs[s.Name] = s.AgentRef.Name

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -3127,7 +3127,14 @@ func enforceReviewerIssueAsk(
 		return verdict
 	}
 
+	// verdictDemotedBy is written with the flag, never apart from it: a
+	// consumer that finds verdictDemoted must always be able to ask which
+	// rail set it (#1636). It says the issueAsk rail ACTED on this verdict,
+	// not that the verdict changed: the two branches below stamp the same
+	// marker while returning the reviewer's own verdict. verdictClaimed is
+	// what distinguishes an actual GO to NO-GO rewrite from those.
 	extra["verdictDemoted"] = true
+	extra["verdictDemotedBy"] = railIssueAsk
 	extra["verdictClaimed"] = string(verdict)
 
 	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1481,6 +1481,10 @@ func TestEnforceReviewerIssueAsk_UnverifiedGoDemotedToNoGo(t *testing.T) {
 	if v, _ := extra["verdictDemoted"].(bool); !v {
 		t.Errorf("demotion must set verdictDemoted=true; got %v", extra["verdictDemoted"])
 	}
+	if extra["verdictDemotedBy"] != railIssueAsk {
+		t.Errorf("demotion must name this rail in verdictDemotedBy=%q; got %v",
+			railIssueAsk, extra["verdictDemotedBy"])
+	}
 	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
 		t.Errorf("verdictClaimed should archive the original GO; got %v", extra["verdictClaimed"])
 	}
@@ -1498,8 +1502,94 @@ func TestEnforceReviewerIssueAsk_UnverifiedNoGoKeptButMarked(t *testing.T) {
 	if v, _ := extra["verdictDemoted"].(bool); !v {
 		t.Errorf("unverified NO-GO must still be marked verdictDemoted=true so the escalation reviewer knows the base verdict is untrusted")
 	}
+	// verdictDemotedBy travels with the flag on every path that sets it, or
+	// a consumer finding verdictDemoted cannot say which rail set it. On THIS
+	// path the rail marked the verdict without rewriting it; verdictClaimed
+	// is what records that, and the controller's inertDemotion keys off it so
+	// this genuine rejection still opens a fix iteration (#1636).
+	if extra["verdictDemotedBy"] != railIssueAsk {
+		t.Errorf("marker must name this rail in verdictDemotedBy=%q; got %v",
+			railIssueAsk, extra["verdictDemotedBy"])
+	}
 	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictNoGo) {
 		t.Errorf("verdictClaimed should archive the original NO-GO; got %v", extra["verdictClaimed"])
+	}
+}
+
+// TestIssueAskDemotionLandsUnderModelExtra is the cross-package shape
+// contract for #1636/#1641. It drives the REAL rail and the REAL envelope
+// builder (enforceReviewerIssueAsk stamps LoopResult.Terminal.Extra, and
+// modelDecidedResult wraps it into the Result the watcher stores in
+// AgenticTask.status.result), then asserts the JSON path the
+// controller's inertDemotion (internal/foreman/controller/
+// workload_iteration.go, not imported here) reads.
+//
+// The bug this pins: modelDecidedResult nests the rails' WHOLE map one
+// level down under "modelExtra", and promoteTerminalOutcome lifts only
+// outcome / unverified / resolvedBy to the top level. The suppression
+// predicate shipped reading extra.verdictDemoted, a key nothing ever
+// writes, so it returned false on every production result while its own
+// hand-written fixture (extra.verdictDemoted as a sibling of modelExtra)
+// made it look correct. Any future change to the nesting fails here.
+func TestIssueAskDemotionLandsUnderModelExtra(t *testing.T) {
+	// What the reviewer's submit_result carried, before the rails ran: an
+	// approval the harness could not tie back to the fetched issue body.
+	terminalExtra := map[string]any{"issueAskVerified": false}
+	verdict := enforceReviewerIssueAsk(logr.Discard(), terminalExtra,
+		foremanv1alpha1.AgenticTaskVerdictGo, true, nil)
+	if verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("precondition: rail must demote GO to NO-GO; got %v", verdict)
+	}
+
+	lr := &LoopResult{
+		Terminal: &ToolResult{
+			Terminal: true,
+			Verdict:  string(foremanv1alpha1.AgenticTaskVerdictGo),
+			Summary:  "APPROVE: the change is minimal and well covered",
+			Extra:    terminalExtra,
+		},
+		Turns: 7,
+	}
+	e := &NativeAgentLoopExecutor{}
+	res := e.modelDecidedResult(time.Now(), corev1.ObjectReference{Name: "t"}, lr, verdict)
+	raw, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+
+	// Mirrors inertDemotion's envelope, plus the top-level keys it must NOT
+	// find, so a regression that flattens the nesting is caught here too.
+	var envelope struct {
+		Extra struct {
+			VerdictDemoted   bool           `json:"verdictDemoted"`
+			VerdictDemotedBy string         `json:"verdictDemotedBy"`
+			ModelExtra       map[string]any `json:"modelExtra"`
+		} `json:"extra"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if envelope.Extra.ModelExtra["verdictDemotedBy"] != railIssueAsk {
+		t.Errorf("extra.modelExtra.verdictDemotedBy = %v, want %q (the path the controller reads)",
+			envelope.Extra.ModelExtra["verdictDemotedBy"], railIssueAsk)
+	}
+	if envelope.Extra.ModelExtra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+		t.Errorf("extra.modelExtra.verdictClaimed = %v, want GO",
+			envelope.Extra.ModelExtra["verdictClaimed"])
+	}
+	if v, _ := envelope.Extra.ModelExtra["verdictDemoted"].(bool); !v {
+		t.Errorf("extra.modelExtra.verdictDemoted = %v, want true",
+			envelope.Extra.ModelExtra["verdictDemoted"])
+	}
+	if reason, _ := envelope.Extra.ModelExtra["demotionReason"].(string); reason == "" {
+		t.Error("extra.modelExtra.demotionReason is empty; the controller's suppression condition would name no cause")
+	}
+	if envelope.Extra.VerdictDemoted || envelope.Extra.VerdictDemotedBy != "" {
+		t.Errorf("the demotion markers must NOT appear at the TOP level of extra "+
+			"(promoteTerminalOutcome lifts only outcome/unverified/resolvedBy); "+
+			"got verdictDemoted=%v verdictDemotedBy=%q",
+			envelope.Extra.VerdictDemoted, envelope.Extra.VerdictDemotedBy)
 	}
 }
 

--- a/pkg/foreman/agent/rail_skip.go
+++ b/pkg/foreman/agent/rail_skip.go
@@ -1,5 +1,7 @@
 package agent
 
+import "github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
+
 // Rail-skip observability (#1605).
 //
 // A single `repo.DiffNameOnly` call feeds four reviewer rails. When it fails
@@ -18,9 +20,14 @@ package agent
 // this verdict?" and answering it should not require knowing every rail's name.
 const railsSkippedKey = "railsSkipped"
 
-// Rail names used in railsSkipped entries.
+// Rail names. Used in railsSkipped entries and, for the two rails that can
+// rewrite a verdict, in the verdictDemotedBy marker those rails stamp. The
+// demoting rails take their names from pkg/foreman/agent/reviewer so the
+// controller, which reads verdictDemotedBy back out of the result envelope
+// and cannot import this package, compares against the same strings (#1636).
 const (
-	railScopeOverlap        = "scope-overlap"
+	railIssueAsk            = reviewer.RailIssueAsk
+	railScopeOverlap        = reviewer.RailScopeOverlap
 	railVerdictFromFindings = "verdict-from-findings"
 	railEmptyClaim          = "empty-claim"
 	railGroundedFinding     = "grounded-finding"

--- a/pkg/foreman/agent/reviewer/demotion.go
+++ b/pkg/foreman/agent/reviewer/demotion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reviewer
+
+// Verdict-demotion markers.
+//
+// A harness rail may rewrite a reviewer's verdict. When one touches a
+// verdict it stamps the reviewer's submit_result extra with verdictDemoted
+// (true), verdictClaimed (the archived original verdict), demotionReason
+// (prose), and verdictDemotedBy: the name of the rail that made the call.
+//
+// verdictDemotedBy exists because the bare flag cannot say WHICH rail acted,
+// and the consumers do not want the same answer from each (#1636). The
+// issueAsk rail demotes when it cannot prove the reviewer read the issue:
+// that is a statement about verification confidence, and re-running the
+// coder cannot change it. The scope-overlap rail demotes when the diff
+// touches none of the files the issue names: that is a statement about the
+// diff, and the coder CAN act on it. A consumer keying off verdictDemoted
+// alone conflates the two.
+//
+// The names live here, in the leaf package that already defines the
+// reviewer's submit_result.extra contract, because the producer
+// (pkg/foreman/agent's rails) and the consumer (internal/foreman/controller)
+// both need the same strings and neither imports the other.
+const (
+	// RailIssueAsk names enforceReviewerIssueAsk in
+	// pkg/foreman/agent/executor_native.go.
+	RailIssueAsk = "issueAsk"
+	// RailScopeOverlap names enforceReviewerScopeOverlap in
+	// pkg/foreman/agent/scope_overlap.go.
+	RailScopeOverlap = "scope-overlap"
+)

--- a/pkg/foreman/agent/scope_overlap.go
+++ b/pkg/foreman/agent/scope_overlap.go
@@ -502,7 +502,11 @@ func enforceReviewerScopeOverlap(
 			"verdict", verdict, "scopeRefs", refs)
 		return verdict
 	}
+	// Named alongside the flag so a consumer can tell this demotion apart
+	// from the issueAsk rail's (#1636): scope drift is a statement about the
+	// diff, which a fix iteration can act on.
 	extra["verdictDemoted"] = true
+	extra["verdictDemotedBy"] = railScopeOverlap
 	extra["verdictClaimed"] = string(verdict)
 	extra["demotionReason"] = fmt.Sprintf(
 		"scope drift: the issue names %d file(s) (%s) and the diff touches none of them",

--- a/pkg/foreman/agent/scope_overlap_test.go
+++ b/pkg/foreman/agent/scope_overlap_test.go
@@ -199,6 +199,14 @@ func TestEnforceReviewerScopeOverlap_Issue379DriftDemotesGo(t *testing.T) {
 	if v, _ := extra["verdictDemoted"].(bool); !v {
 		t.Errorf("demotion must set verdictDemoted=true")
 	}
+	// #1636: the controller suppresses the empty fix iteration that follows
+	// an issueAsk demotion but must still iterate on scope drift, which is
+	// actionable. It tells them apart by this marker alone, so a scope
+	// demotion that does not name itself is silently swallowed downstream.
+	if extra["verdictDemotedBy"] != railScopeOverlap {
+		t.Errorf("scope demotion must set verdictDemotedBy=%q; got %v",
+			railScopeOverlap, extra["verdictDemotedBy"])
+	}
 	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
 		t.Errorf("verdictClaimed should archive GO; got %v", extra["verdictClaimed"])
 	}


### PR DESCRIPTION
## What

Stop the Workload reconciler opening a fix iteration for a NO-GO that a harness
rail manufactured and that carries no findings.

## Why

Refs #1636

`enforceReviewerIssueAsk` (`pkg/foreman/agent/executor_native.go`) rewrites a
reviewer's GO to NO-GO when it cannot verify that the reviewer's stated issue ask
covers the fetched issue body. That is a statement about verification confidence,
not about the change under review, but `noGoReviewRound` could not tell the two
apart.

The result is a fix iteration whose prompt says "the reviewer rejected the
previous attempt (verdict NO-GO) ... address this feedback", followed by the
reviewer's own approval and `- findings: []`. There is nothing to act on, and
re-running the coder cannot make an unverifiable issueAsk verify, so the loop has
no terminating condition.

Observed twice on one branch while working through the Tier 1 backlog. Each
occurrence costs a full coder run, which on a local 27B is roughly an hour of GPU
time. The second occurrence is recorded in the issue: two rails flipped the
verdict in sequence (NO-GO to GO to NO-GO) and the value that survived was
asserted by nobody.

## How

`isInertDemotion` reads `extra.verdictDemoted` and the findings already present
on the task, and `noGoReviewRound` skips a NO-GO that is both demoted and
empty-handed. The predicate keys off a new `verdictDemotedBy` marker that names the rail, because `verdictDemoted` alone is set by several rails: `enforceReviewerIssueAsk` already stamps
`verdictDemoted` and `demotionReason`, and nothing read them.

The predicate is deliberately narrow, and two of the three new test cases exist
to hold that line:

- a demotion **carrying findings** still iterates, because those findings are
  real work
- an **undemoted** NO-GO always iterates, even with no structured findings,
  because that is the reviewer's own judgement and the summary carries the
  feedback

Malformed result JSON is not suppressed either; it falls through and iterates as
before.

The non-conforming findings fallback mirrors `reviewFeedbackSection`, so anything
that would actually reach the coder as raw JSON counts as feedback rather than
inertness.

A drive-by from `unparam`: `noGoChild`'s `step` parameter always received the same
value, so it is now a shared const, removing the argument from four call sites.

## Verification

- `make test` passes (RC=0, 0 FAIL lines); `internal/foreman/controller` at 83.7%
- `make lint` and `make lint-all` both report 0 issues
- `make lint-deadcode` reports 0 issues
- Watched the new suppression case fail first, for the right reason (the
  iteration was produced when it should not have been), then pass

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — no user-facing surface changes

Assisted-by: Claude Code (wrote the tests and the implementation under TDD, and
reproduced the failure from the live audit records; I reviewed the change and ran
`make test`, `make lint`, `make lint-all` and `make lint-deadcode` before
submitting).

