### PR TITLE
fix(foreman): gate the make-invoked CI checks, and pin them against the workflows

### DIFF
--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -65,9 +65,17 @@ const MaxLogTailBytes = 32 * 1024
 // DefaultGateChecks is the make-target list every gate run executes
 // when the caller does not override it. Mirrors what the autofix gate
 // pipeline ran across hundreds of coder-to-verifier runs.
+//
+// It must remain a SUPERSET of what CI blocks on. A GATE-PASS is read by
+// operators, and by the verdict and escalation machinery, as "this branch
+// is expected to pass CI"; that claim only holds while this list covers
+// every check a pull request has to clear. TestDefaultGateChecksCoverCI
+// pins that against .github/workflows, and gateExemptCIChecks records the
+// deliberate omissions with their reasons (#1637).
 var DefaultGateChecks = []string{
-	"fmt", "vet", "lint", "test",
-	"manifests", "chart-crds", "foreman-chart-crds", ChartCheck,
+	"fmt", "vet", "lint", "lint-deadcode", "test",
+	"generate", "manifests", "chart-crds", "foreman-chart-crds",
+	"check-helm-rbac", "check-reviewer-prompts", ChartCheck,
 }
 
 // ChartCheck is the make target that lints and unit-tests the Helm charts.

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -66,16 +66,23 @@ const MaxLogTailBytes = 32 * 1024
 // when the caller does not override it. Mirrors what the autofix gate
 // pipeline ran across hundreds of coder-to-verifier runs.
 //
-// It must remain a SUPERSET of what CI blocks on. A GATE-PASS is read by
-// operators, and by the verdict and escalation machinery, as "this branch
-// is expected to pass CI"; that claim only holds while this list covers
-// every check a pull request has to clear. TestDefaultGateChecksCoverCI
-// pins that against .github/workflows, and gateExemptCIChecks records the
-// deliberate omissions with their reasons (#1637).
+// A GATE-PASS is read by operators, and by the verdict and escalation
+// machinery, as "this branch is expected to pass CI". This list is what
+// backs that reading, and it must remain a superset of the make-invoked
+// subset of CI, plus the golangci configs a workflow names explicitly
+// with --config=. TestDefaultGateChecksCoverCI pins exactly that against
+// .github/workflows, and gateExemptCIChecks records the deliberate
+// omissions from it with their reasons (#1637).
+//
+// The claim stops there. A CI check added as a direct `run:` step is NOT
+// covered by that test: security.yml runs `govulncheck ./...` on every
+// pull request and the test does not see it, and most of helm-chart.yml
+// drives helm and ct the same way. Widening the gate to such a check is
+// a manual decision; nothing here will prompt for it.
 var DefaultGateChecks = []string{
 	"fmt", "vet", "lint", "lint-deadcode", "test",
 	"generate", "manifests", "chart-crds", "foreman-chart-crds",
-	"check-helm-rbac", "check-reviewer-prompts", ChartCheck,
+	"check-reviewer-prompts", ChartCheck,
 }
 
 // ChartCheck is the make target that lints and unit-tests the Helm charts.

--- a/pkg/foreman/agent/tools/run_gate_job_ci_sync_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_ci_sync_test.go
@@ -27,9 +27,12 @@ import (
 // workflowDir is the CI definition this gate is meant to mirror.
 const workflowDir = "../../../../.github/workflows"
 
-// workflowGlob matches both spellings GitHub honours. A workflow file
-// named .yaml runs exactly like a .yml one, so a glob that saw only
-// *.yml would let an entire file of CI checks pass these tests unread.
+// workflowGlob is deliberately *.y*ml and not the tidier *.yml. GitHub
+// honours .yaml and .yml equally, so a workflow named .yaml runs its
+// checks exactly like any other. Narrowing this pattern does not fail
+// anything: it makes that entire file invisible to the tests below, which
+// keep passing while covering less CI than they claim to. If you are here
+// to simplify it, that is the failure you would be introducing.
 const workflowGlob = "*.y*ml"
 
 // gateExemptCIChecks are make targets CI runs that DefaultGateChecks
@@ -197,6 +200,27 @@ func TestGateExemptionsAreLive(t *testing.T) {
 	for target := range gateExemptCIChecks {
 		if _, ok := ci[target]; !ok {
 			t.Errorf("gateExemptCIChecks has %q but no workflow runs it; drop the stale exemption", target)
+		}
+	}
+}
+
+// TestGateChecksAndExemptionsAreDisjoint catches the inverse of the gap
+// TestDefaultGateChecksCoverCI looks for. That test only asks whether a CI
+// target is missing from the gate, so a target listed in BOTH
+// DefaultGateChecks and gateExemptCIChecks passes every test in this file
+// while the two lists say opposite things about it: one runs the check,
+// the other records a reason it cannot be run. That is the same shape of
+// bug as #1637 itself, a gate configuration that reads plausibly and is
+// wrong with nothing to catch it. check-helm-rbac is the live example: it
+// is exempt because the gate image has no PyYAML, and adding it back to
+// DefaultGateChecks without removing the exemption would turn every gate
+// run red again, silently.
+func TestGateChecksAndExemptionsAreDisjoint(t *testing.T) {
+	for _, c := range DefaultGateChecks {
+		if reason, ok := gateExemptCIChecks[c]; ok {
+			t.Errorf("%q is in DefaultGateChecks AND in gateExemptCIChecks (%q): a target is "+
+				"either gated or exempt, never both. Run it and drop the exemption, or keep the "+
+				"exemption and drop it from DefaultGateChecks.", c, reason)
 		}
 	}
 }

--- a/pkg/foreman/agent/tools/run_gate_job_ci_sync_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_ci_sync_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// workflowDir is the CI definition this gate is meant to mirror.
+const workflowDir = "../../../../.github/workflows"
+
+// gateExemptCIChecks are make targets CI runs that DefaultGateChecks
+// deliberately omits. Each entry is a DECISION with a stated reason, not
+// a formality: an unexplained omission is how a gate quietly stops
+// meaning what its name says (#1637).
+var gateExemptCIChecks = map[string]string{
+	"validate-samples": "requires python3 + the jsonschema package; the gate image is a plain golang " +
+		"image and the target hard-exits when they are absent, so adding it would fail every gate run",
+	"setup-test-e2e":                "provisions an e2e cluster; lifecycle, not a branch check",
+	"cleanup-test-e2e":              "tears down an e2e cluster; lifecycle, not a branch check",
+	"test-e2e":                      "needs a live cluster the gate Job does not own",
+	"docker-build":                  "image build, not a branch check",
+	"docker-build-foreman-agent":    "image build, not a branch check",
+	"docker-build-foreman-operator": "image build, not a branch check",
+}
+
+// golangciConfigTargets maps a golangci-lint --config= value used by a
+// workflow to the make target that runs the same check, so a
+// GitHub-Action-invoked lint is compared against the gate like any other.
+var golangciConfigTargets = map[string]string{
+	".golangci-deadcode.yml": "lint-deadcode",
+	".golangci.yml":          "lint",
+}
+
+var (
+	// A make invocation is either `run: make ...` on one line, or a bare
+	// `make ...` line inside a `run: |` block. Both forms are live in
+	// this repo (test.yml runs `make test` inside a block), and matching
+	// only the first would under-report the gap this test exists to
+	// close.
+	makeLineRe  = regexp.MustCompile(`^(?:-\s*)?(?:run:\s*)?make\s+(.*)$`)
+	golangciRe  = regexp.MustCompile(`--config=(\S+)`)
+	makeTargetR = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+)
+
+// makeTargetsIn returns the target names from a make invocation's
+// argument tail, stopping at the first token that is a variable
+// assignment or otherwise not a target (e.g. `IMG="${IMG}"`).
+func makeTargetsIn(tail string) []string {
+	var out []string
+	for _, tok := range strings.Fields(tail) {
+		if !makeTargetR.MatchString(tok) {
+			break
+		}
+		out = append(out, tok)
+	}
+	return out
+}
+
+// ciBlockingChecks returns every make target CI invokes across all
+// workflow files, plus the make-target equivalent of any golangci-lint
+// action run with an explicit config.
+func ciBlockingChecks(t *testing.T) map[string]string {
+	t.Helper()
+	entries, err := filepath.Glob(filepath.Join(workflowDir, "*.yml"))
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("no workflow files under %s (err=%v)", workflowDir, err)
+	}
+	found := map[string]string{}
+	for _, f := range entries {
+		buf, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		base := filepath.Base(f)
+		for _, line := range strings.Split(string(buf), "\n") {
+			trimmed := strings.TrimSpace(line)
+			// Comments mention targets in prose ("the tests make the code
+			// look used", "Run 'make generate ...'"); they invoke nothing.
+			if strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if m := makeLineRe.FindStringSubmatch(trimmed); m != nil {
+				for _, target := range makeTargetsIn(m[1]) {
+					found[target] = base
+				}
+			}
+			for _, m := range golangciRe.FindAllStringSubmatch(trimmed, -1) {
+				if target, ok := golangciConfigTargets[m[1]]; ok {
+					found[target] = base
+				}
+			}
+		}
+	}
+	return found
+}
+
+// TestDefaultGateChecksCoverCI pins the Foreman gate against CI. A
+// GATE-PASS is read by operators, and by the verdict machinery, as "this
+// branch is expected to pass CI"; that is only true while the gate's
+// check list is a superset of what CI blocks on.
+func TestDefaultGateChecksCoverCI(t *testing.T) {
+	gate := map[string]bool{}
+	for _, c := range DefaultGateChecks {
+		gate[c] = true
+	}
+
+	for target, workflow := range ciBlockingChecks(t) {
+		if gate[target] {
+			continue
+		}
+		if reason, ok := gateExemptCIChecks[target]; ok {
+			if strings.TrimSpace(reason) == "" {
+				t.Errorf("%q is exempt from DefaultGateChecks with an empty reason; state why", target)
+			}
+			continue
+		}
+		t.Errorf("CI (%s) blocks on `make %s` but DefaultGateChecks does not run it: "+
+			"a branch can earn GATE-PASS and still fail CI. Add it to DefaultGateChecks, "+
+			"or add it to gateExemptCIChecks with a reason.", workflow, target)
+	}
+}
+
+// TestGateExemptionsAreLive stops the exemption list from outliving the
+// CI steps it excuses. A stale entry silently widens the next real gap.
+func TestGateExemptionsAreLive(t *testing.T) {
+	ci := ciBlockingChecks(t)
+	for target := range gateExemptCIChecks {
+		if _, ok := ci[target]; !ok {
+			t.Errorf("gateExemptCIChecks has %q but no workflow runs it; drop the stale exemption", target)
+		}
+	}
+}

--- a/pkg/foreman/agent/tools/run_gate_job_ci_sync_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_ci_sync_test.go
@@ -27,13 +27,23 @@ import (
 // workflowDir is the CI definition this gate is meant to mirror.
 const workflowDir = "../../../../.github/workflows"
 
+// workflowGlob matches both spellings GitHub honours. A workflow file
+// named .yaml runs exactly like a .yml one, so a glob that saw only
+// *.yml would let an entire file of CI checks pass these tests unread.
+const workflowGlob = "*.y*ml"
+
 // gateExemptCIChecks are make targets CI runs that DefaultGateChecks
 // deliberately omits. Each entry is a DECISION with a stated reason, not
 // a formality: an unexplained omission is how a gate quietly stops
 // meaning what its name says (#1637).
 var gateExemptCIChecks = map[string]string{
-	"validate-samples": "requires python3 + the jsonschema package; the gate image is a plain golang " +
-		"image and the target hard-exits when they are absent, so adding it would fail every gate run",
+	"validate-samples": "hard-exits when the third-party python3 modules jsonschema and pyyaml are " +
+		"absent; python3 itself IS in the gate image, but it is a plain golang image with no pip3 " +
+		"to add them, so adding this target would fail every gate run",
+	"check-helm-rbac": "scripts/check-helm-rbac.sh exits 2 unless `python3 -c 'import yaml'` " +
+		"succeeds; the gate image is a plain golang image that ships python3 but neither PyYAML " +
+		"nor pip3, so adding this target would fail every gate run. CI clears it only because " +
+		"helm-chart.yml installs PyYAML in a step of its own beforehand",
 	"setup-test-e2e":                "provisions an e2e cluster; lifecycle, not a branch check",
 	"cleanup-test-e2e":              "tears down an e2e cluster; lifecycle, not a branch check",
 	"test-e2e":                      "needs a live cluster the gate Job does not own",
@@ -45,9 +55,13 @@ var gateExemptCIChecks = map[string]string{
 // golangciConfigTargets maps a golangci-lint --config= value used by a
 // workflow to the make target that runs the same check, so a
 // GitHub-Action-invoked lint is compared against the gate like any other.
+//
+// Only a config some workflow actually names with --config= belongs
+// here. lint.yml's plain lint step passes no args at all, so an entry
+// for .golangci.yml would translate nothing and could never be caught
+// being wrong. TestGolangciConfigTargetsAreLive holds that line.
 var golangciConfigTargets = map[string]string{
 	".golangci-deadcode.yml": "lint-deadcode",
-	".golangci.yml":          "lint",
 }
 
 var (
@@ -75,16 +89,24 @@ func makeTargetsIn(tail string) []string {
 	return out
 }
 
-// ciBlockingChecks returns every make target CI invokes across all
-// workflow files, plus the make-target equivalent of any golangci-lint
-// action run with an explicit config.
-func ciBlockingChecks(t *testing.T) map[string]string {
+// workflowLine is one non-comment line of one workflow file, tagged with
+// the file it came from so a failure can name the workflow.
+type workflowLine struct {
+	workflow string
+	text     string
+}
+
+// workflowLines reads every workflow file once and returns their
+// non-comment lines. One reader and one glob for every test in this
+// file: a test that widened its own view of CI would otherwise leave the
+// others reading a smaller CI than the one that runs.
+func workflowLines(t *testing.T) []workflowLine {
 	t.Helper()
-	entries, err := filepath.Glob(filepath.Join(workflowDir, "*.yml"))
+	entries, err := filepath.Glob(filepath.Join(workflowDir, workflowGlob))
 	if err != nil || len(entries) == 0 {
 		t.Fatalf("no workflow files under %s (err=%v)", workflowDir, err)
 	}
-	found := map[string]string{}
+	var out []workflowLine
 	for _, f := range entries {
 		buf, err := os.ReadFile(f)
 		if err != nil {
@@ -98,25 +120,44 @@ func ciBlockingChecks(t *testing.T) map[string]string {
 			if strings.HasPrefix(trimmed, "#") {
 				continue
 			}
-			if m := makeLineRe.FindStringSubmatch(trimmed); m != nil {
-				for _, target := range makeTargetsIn(m[1]) {
-					found[target] = base
-				}
+			out = append(out, workflowLine{workflow: base, text: trimmed})
+		}
+	}
+	return out
+}
+
+// ciBlockingChecks returns every make target CI invokes across all
+// workflow files, plus the make-target equivalent of any golangci-lint
+// action run with an explicit config.
+//
+// It sees make targets and golangci configs, and nothing else. A CI step
+// that runs a tool directly (security.yml's `run: govulncheck ./...`, or
+// helm-chart.yml's helm and ct steps) is invisible here, so every test
+// built on this function bounds its claim to the make-invoked subset.
+func ciBlockingChecks(t *testing.T) map[string]string {
+	t.Helper()
+	found := map[string]string{}
+	for _, wl := range workflowLines(t) {
+		if m := makeLineRe.FindStringSubmatch(wl.text); m != nil {
+			for _, target := range makeTargetsIn(m[1]) {
+				found[target] = wl.workflow
 			}
-			for _, m := range golangciRe.FindAllStringSubmatch(trimmed, -1) {
-				if target, ok := golangciConfigTargets[m[1]]; ok {
-					found[target] = base
-				}
+		}
+		for _, m := range golangciRe.FindAllStringSubmatch(wl.text, -1) {
+			if target, ok := golangciConfigTargets[m[1]]; ok {
+				found[target] = wl.workflow
 			}
 		}
 	}
 	return found
 }
 
-// TestDefaultGateChecksCoverCI pins the Foreman gate against CI. A
-// GATE-PASS is read by operators, and by the verdict machinery, as "this
-// branch is expected to pass CI"; that is only true while the gate's
-// check list is a superset of what CI blocks on.
+// TestDefaultGateChecksCoverCI pins the Foreman gate against the
+// make-invoked subset of CI. A GATE-PASS is read by operators, and by the
+// verdict machinery, as "this branch is expected to pass CI"; that is
+// only true while the gate's check list covers the CI checks this test
+// can see. Checks CI runs as direct `run:` steps are outside its reach,
+// so a green run here is not a promise the pull request is green.
 func TestDefaultGateChecksCoverCI(t *testing.T) {
 	gate := map[string]bool{}
 	for _, c := range DefaultGateChecks {
@@ -141,11 +182,42 @@ func TestDefaultGateChecksCoverCI(t *testing.T) {
 
 // TestGateExemptionsAreLive stops the exemption list from outliving the
 // CI steps it excuses. A stale entry silently widens the next real gap.
+//
+// It is load-bearing for a second reason that is easy to destroy while
+// tidying up. docker-build, docker-build-foreman-agent,
+// docker-build-foreman-operator, test-e2e and setup-test-e2e appear in
+// the workflows ONLY as bare lines inside a `run: |` block, so they are
+// reachable only through makeLineRe's optional `run:` prefix. Drop that
+// half of the pattern and ciBlockingChecks returns a smaller CI:
+// TestDefaultGateChecksCoverCI would still pass, on a gate that had
+// quietly stopped looking. This test fails loudly instead. Keep the
+// block form when simplifying the matcher.
 func TestGateExemptionsAreLive(t *testing.T) {
 	ci := ciBlockingChecks(t)
 	for target := range gateExemptCIChecks {
 		if _, ok := ci[target]; !ok {
 			t.Errorf("gateExemptCIChecks has %q but no workflow runs it; drop the stale exemption", target)
+		}
+	}
+}
+
+// TestGolangciConfigTargetsAreLive applies TestGateExemptionsAreLive's
+// rule to the other hand-maintained map. An entry whose config no
+// workflow passes with --config= translates nothing: it cannot make the
+// coverage test stricter and it can never be caught being wrong, so it
+// reads as coverage these tests do not have. .golangci.yml was exactly
+// that entry until #1642, because lint.yml runs the linter with no args.
+func TestGolangciConfigTargetsAreLive(t *testing.T) {
+	seen := map[string]bool{}
+	for _, wl := range workflowLines(t) {
+		for _, m := range golangciRe.FindAllStringSubmatch(wl.text, -1) {
+			seen[m[1]] = true
+		}
+	}
+	for cfg := range golangciConfigTargets {
+		if !seen[cfg] {
+			t.Errorf("golangciConfigTargets maps %q but no workflow passes --config=%s; "+
+				"the entry matches nothing, drop it", cfg, cfg)
 		}
 	}
 }


### PR DESCRIPTION
## What

Add the make-invoked CI checks the Foreman gate was not running, and add a drift test so
the gate's check list cannot silently fall behind CI again.

## Why

Refs #1637

`DefaultGateChecks` was a strict subset of what CI blocks on, so a branch could
earn `GATE-PASS` and still fail its pull request. Missing: the dead production
code guard, DeepCopy codegen drift, the chart RBAC cross-check, and reviewer
prompt drift.

A `GATE-PASS` is not only read by humans. It feeds the verdict and escalation
machinery, and a coder self-gate uses the same path, so a partial check set makes
every downstream signal weaker than it appears.

The gate template already states the principle, for its helm pins:

> Versions are pinned to CI's so the gate and CI validate charts with the same
> tooling; a gate that disagrees with CI is worse than no gate.

It had never been applied to the check list itself.

This surfaced concretely on #1602, whose entire deliverable is that
`make lint-deadcode` still passes once a suppression register is emptied. The
gate returned `GATE-PASS` without ever running that guard, so it structurally
could not verify the change it was gating.

## How

Added `lint-deadcode` and `check-reviewer-prompts` to `DefaultGateChecks`; these
are the two real gaps. `generate` is added explicitly too, though it already ran
transitively via `test: manifests generate fmt vet setup-envtest`. `check-helm-rbac`
is NOT gated: `scripts/check-helm-rbac.sh` hard-exits without PyYAML and the gate
image is a plain `golang` image with no `pip3`, so gating it would fail every gate
run; it is in `gateExemptCIChecks` with that reason. These run on tooling the gate
image already fetches
(golangci-lint and controller-gen), so this adds no bootstrap cost.

`validate-samples` is deliberately left out and recorded as such: it hard-requires
python3 and the `jsonschema` package and exits non-zero without them, so adding it
naively would fail **every** gate run rather than none.

The durable half is `TestDefaultGateChecksCoverCI`. It scans every workflow for
make invocations and fails when CI gains a check the gate does not run.
Deliberate omissions live in `gateExemptCIChecks` **with a stated reason**, and
`TestGateExemptionsAreLive` fails when an exemption names a CI step that no longer
exists, so the list cannot decay into a blanket waiver.

Two things worth calling out about the extractor, both of which are why the test
is trustworthy rather than decorative:

- It handles `make` invoked inside a `run: |` block, not just `run: make ...`.
  My first version matched only the single-line form and missed `make test` in
  `test.yml`. A matcher that under-reports is precisely the failure mode this
  change is about, so it is worth being explicit that it was caught and fixed.
- It skips comment lines, because CI comments mention targets in prose
  (`# make test writes cover.out`, `Run 'make generate ...'`).

The issue description attributes all five gaps to `lint.yml`; that was wrong and
is corrected in a comment there. Only two block in `lint.yml`; the others are in
`helm-chart.yml` and `test.yml`, which is why the test scans all workflows rather
than one.

## Verification

- `make test` passes (RC=0, 0 FAIL lines)
- `make lint` and `make lint-all` both report 0 issues
- `make lint-deadcode` reports 0 issues
- Tree is clean after `make test` runs `generate`/`manifests`, so the newly gated
  codegen checks pass on current `main`
- Watched the drift test fail first, listing the gaps, and the
  liveness test fail on speculative exemptions until they were pruned to what CI
  actually runs

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — no user-facing surface changes

Note for reviewers: this makes the gate stricter, so the first gate run on any
branch with stale codegen or a dead symbol will now fail where it previously
passed. That is the intent, but it is a behaviour change for in-flight branches.

Assisted-by: Claude Code (wrote the tests and the implementation under TDD; I
reviewed the change, corrected the extractor after finding it under-reported, and
ran `make test`, `make lint`, `make lint-all` and `make lint-deadcode` before
submitting).



---

**Scope correction after review (thanks @joryirving).** The original title claimed the
gate runs *every* CI check. It does not, and the test cannot see the difference: a check
added as a bare `run:` step rather than a make target is invisible to it, and
`security.yml`'s `govulncheck` is exactly that. The doc comment on `DefaultGateChecks` now
claims only what the test can verify. Also fixed: the workflow glob missed `.yaml` files
entirely, a dead `.golangci.yml` config entry, and a new assertion fails when a target is
both gated and exempt, which nothing previously caught.
