### PR TITLE
chore(deadcode): triage Register B for #1602

### DIFF
--- a/.golangci-deadcode.yml
+++ b/.golangci-deadcode.yml
@@ -46,20 +46,31 @@ linters:
         linters: [unused]
 
       # ---------------------------------------------------------------
-      # REGISTER B: pre-existing dead symbols found when this guard was
-      # introduced. Each needs a decision (delete, or wire up); none has
-      # been made yet. Tracked for triage in #1602 rather than silently
-      # deleted. Removing an entry here is the deliverable of that issue.
+      # REGISTER B: symbols the guard reports that are staged rather than
+      # reachable. #1602 triaged the four originally recorded here:
+      # metalReadyEndpoints, isNeedsVerificationCoder and taskSucceeded
+      # were deleted (each duplicated logic already inlined at its call
+      # site, or was test-only by construction); parseMaxUSD stays, below.
       # ---------------------------------------------------------------
-      - path: internal/controller/inferenceservice_controller\.go
-        linters: [unused]
-        text: metalReadyEndpoints
-      - path: internal/foreman/controller/workload_coder_escalation\.go
-        linters: [unused]
-        text: isNeedsVerificationCoder
-      - path: internal/router/budget\.go
+      # internal/router/budget.go is an entirely dead file: nothing in
+      # production constructs a router.BudgetRule, so BudgetStore,
+      # NewBudgetStore and Charge have no non-test callers. It is staged
+      # for the ModelRouter budget work (#434, #440).
+      #
+      # parseMaxUSD is the only symbol in it the `unused` linter reports.
+      # The file's other unexported symbols (bucket, bucketDuration,
+      # usedInWindow, charge) are reachable from the exported entry points,
+      # so the linter counts them used even though nothing outside the file
+      # calls those either. Do NOT delete parseMaxUSD to clear this entry:
+      # `unused` does not report exported identifiers, so removing the one
+      # symbol it does report would leave the whole dead file invisible.
+      #
+      # Scoped to the SYMBOL, not the file, on purpose. Verified: with a
+      # file-wide rule, adding a dead unexported helper to budget.go gives
+      # 0 issues; with this symbol-scoped rule it is reported. A file-wide
+      # suppression would swallow exactly the debt this guard exists to
+      # surface, for instance a helper left dead when #434/#440 partially
+      # wires the engine.
+      - path: internal/router/budget\.go  # Refs #434, #440
         linters: [unused]
         text: parseMaxUSD
-      - path: pkg/cli/dispatch\.go
-        linters: [unused]
-        text: taskSucceeded

--- a/internal/controller/inferenceservice_controller.go
+++ b/internal/controller/inferenceservice_controller.go
@@ -778,9 +778,9 @@ type metalSnapshot struct {
 
 // metalEndpointSnapshot lists the EndpointSlices for isvc and returns a
 // metalSnapshot summarising both the ready-replica count and the heartbeat
-// state. It is the single source of truth for the metal path; both
-// metalReadyEndpoints and metalHeartbeatRequeueDuration are thin wrappers
-// around it.
+// state. It is the single source of truth for the metal path: it makes the
+// one List call, and metalHeartbeatRequeueDuration then derives the requeue
+// interval from the snapshot it returns without calling the API again.
 //
 // Slices are listed by the well-known kubernetes.io/service-name label rather
 // than fetched by name because there can be more than one: the metal-agent
@@ -873,13 +873,6 @@ func (r *InferenceServiceReconciler) metalEndpointSnapshot(ctx context.Context, 
 		kind = metalHBFresh
 	}
 	return &metalSnapshot{ReadyReplicas: ready, Kind: kind, RawHeartbeat: rawHeartbeat}
-}
-
-// metalReadyEndpoints is a convenience wrapper that returns only the
-// ready-replica count for callers that do not need the full snapshot (e.g.,
-// unit tests). Production reconcile paths use metalEndpointSnapshot directly.
-func (r *InferenceServiceReconciler) metalReadyEndpoints(ctx context.Context, isvc *inferencev1alpha1.InferenceService) int32 {
-	return r.metalEndpointSnapshot(ctx, isvc).ReadyReplicas
 }
 
 // metalHeartbeatRequeueDuration returns the RequeueAfter duration to use after

--- a/internal/controller/inferenceservice_metal_heartbeat_test.go
+++ b/internal/controller/inferenceservice_metal_heartbeat_test.go
@@ -67,7 +67,7 @@ func metalEndpoints(name, heartbeat string) *discoveryv1.EndpointSlice {
 	return slice
 }
 
-var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
+var _ = Describe("metalEndpointSnapshot heartbeat expiry", func() {
 	var (
 		reconciler *InferenceServiceReconciler
 		ctx        context.Context
@@ -82,7 +82,7 @@ var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
 		}
 	})
 
-	Context("direct unit tests of metalReadyEndpoints", func() {
+	Context("direct unit tests of metalEndpointSnapshot ready replicas", func() {
 		const namespace = "default"
 
 		It("should return 1 for Endpoints with a fresh heartbeat annotation", func() {
@@ -95,7 +95,13 @@ var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
 			isvc := &inferencev1alpha1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
 			}
-			Expect(reconciler.metalReadyEndpoints(ctx, isvc)).To(Equal(int32(1)))
+			snap := reconciler.metalEndpointSnapshot(ctx, isvc)
+			Expect(snap.ReadyReplicas).To(Equal(int32(1)))
+			// Kind, not just the count: it selects the requeue interval
+			// (metalHeartbeatRequeueDuration) and the SchedulingStatus
+			// message. Stale and unparseable both report 0 ready, so the
+			// count alone cannot tell them apart.
+			Expect(snap.Kind).To(Equal(metalHBFresh))
 		})
 
 		It("should return 0 for Endpoints with a stale heartbeat annotation (10 minutes old)", func() {
@@ -108,7 +114,13 @@ var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
 			isvc := &inferencev1alpha1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
 			}
-			Expect(reconciler.metalReadyEndpoints(ctx, isvc)).To(Equal(int32(0)))
+			snap := reconciler.metalEndpointSnapshot(ctx, isvc)
+			Expect(snap.ReadyReplicas).To(Equal(int32(0)))
+			// Kind, not just the count: it selects the requeue interval
+			// (metalHeartbeatRequeueDuration) and the SchedulingStatus
+			// message. Stale and unparseable both report 0 ready, so the
+			// count alone cannot tell them apart.
+			Expect(snap.Kind).To(Equal(metalHBStale))
 		})
 
 		It("should return 0 for Endpoints with an unparseable heartbeat annotation", func() {
@@ -120,7 +132,13 @@ var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
 			isvc := &inferencev1alpha1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
 			}
-			Expect(reconciler.metalReadyEndpoints(ctx, isvc)).To(Equal(int32(0)))
+			snap := reconciler.metalEndpointSnapshot(ctx, isvc)
+			Expect(snap.ReadyReplicas).To(Equal(int32(0)))
+			// Kind, not just the count: it selects the requeue interval
+			// (metalHeartbeatRequeueDuration) and the SchedulingStatus
+			// message. Stale and unparseable both report 0 ready, so the
+			// count alone cannot tell them apart.
+			Expect(snap.Kind).To(Equal(metalHBUnparseable))
 		})
 
 		It("should return 1 for Endpoints WITHOUT the annotation (legacy agent exemption)", func() {
@@ -132,7 +150,13 @@ var _ = Describe("metalReadyEndpoints heartbeat expiry", func() {
 			isvc := &inferencev1alpha1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: namespace},
 			}
-			Expect(reconciler.metalReadyEndpoints(ctx, isvc)).To(Equal(int32(1)))
+			snap := reconciler.metalEndpointSnapshot(ctx, isvc)
+			Expect(snap.ReadyReplicas).To(Equal(int32(1)))
+			// Kind, not just the count: it selects the requeue interval
+			// (metalHeartbeatRequeueDuration) and the SchedulingStatus
+			// message. Stale and unparseable both report 0 ready, so the
+			// count alone cannot tell them apart.
+			Expect(snap.Kind).To(Equal(metalHBLegacy))
 		})
 	})
 

--- a/internal/foreman/controller/coder_envelope_integration_test.go
+++ b/internal/foreman/controller/coder_envelope_integration_test.go
@@ -69,6 +69,13 @@ func TestRealAgentEnvelope_DrivesClassifiers(t *testing.T) {
 		if shouldEscalateCoder(v, top, model) {
 			t.Fatal("ALREADY-RESOLVED must not escalate")
 		}
+		// Mirror the NEEDS-VERIFICATION subtest below: the opt-in
+		// classifier needs real-envelope coverage too, or an
+		// EscalateOnFailure Workload escalating an ALREADY-RESOLVED task
+		// would go uncaught here.
+		if shouldEscalateCoderOnFailure(v, top) {
+			t.Fatal("ALREADY-RESOLVED must not escalate on failure either")
+		}
 	})
 
 	t.Run("promoted NEEDS-VERIFICATION stands escalation down", func(t *testing.T) {
@@ -80,12 +87,23 @@ func TestRealAgentEnvelope_DrivesClassifiers(t *testing.T) {
 			"modelExtra": map[string]any{"outcome": "NEEDS-VERIFICATION"},
 		}
 		task := realEnvelopeTask(t, r)
-		if !isNeedsVerificationCoder(task) {
-			t.Fatal("real NEEDS-VERIFICATION envelope not recognized")
-		}
 		v, top, model := coderTerminalOutcome(task)
+		// Assert BOTH halves of the classifier's predicate, not just the
+		// outcome string: shouldEscalateCoder also returns false for GO,
+		// INCOMPLETE and an empty verdict, so checking only the top-level
+		// outcome would let this pass vacuously if the verdict ever stops
+		// propagating.
+		if v != foremanv1alpha1.AgenticTaskVerdictNoGo {
+			t.Fatalf("real NEEDS-VERIFICATION envelope: verdict = %s, want NoGo", v)
+		}
+		if top != needsVerificationOutcome {
+			t.Fatalf("real NEEDS-VERIFICATION envelope not recognized: top-level outcome %q", top)
+		}
 		if shouldEscalateCoder(v, top, model) {
 			t.Fatal("NEEDS-VERIFICATION must not escalate")
+		}
+		if shouldEscalateCoderOnFailure(v, top) {
+			t.Fatal("NEEDS-VERIFICATION must not escalate on failure either")
 		}
 	})
 

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -108,17 +108,6 @@ const alreadyResolvedOutcome = "ALREADY-RESOLVED"
 // ground truth (hardware, a live system's output) either.
 const needsVerificationOutcome = "NEEDS-VERIFICATION"
 
-// isNeedsVerificationCoder reports whether the task ended NO-GO because the
-// coder could not ground a load-bearing external fact (extra.outcome ==
-// needsVerificationOutcome). Used by shouldEscalateCoder to skip escalation.
-func isNeedsVerificationCoder(task *foremanv1alpha1.AgenticTask) bool {
-	if task == nil {
-		return false
-	}
-	verdict, topOutcome, _ := coderTerminalOutcome(task)
-	return verdict == foremanv1alpha1.AgenticTaskVerdictNoGo && topOutcome == needsVerificationOutcome
-}
-
 // isAlreadyResolvedCoder reports whether the task ended in the
 // machine outcome for "work is already on the branch/base". Used by
 // shouldEscalateCoder (to skip escalation) and rollup (to keep the

--- a/internal/foreman/controller/workload_coder_escalation_test.go
+++ b/internal/foreman/controller/workload_coder_escalation_test.go
@@ -58,6 +58,12 @@ func TestShouldEscalateCoder(t *testing.T) {
 		{"model gave up / stuck (like #921)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "MODEL-DECIDED", "", false},
 		{"stuck-loop detected", foremanv1alpha1.AgenticTaskVerdictIncomplete, "STUCK-LOOP-DETECTED", "", false},
 		{"NO-GO but no-changes (trivial)", foremanv1alpha1.AgenticTaskVerdictNoGo, "NO-CHANGES", "", false},
+		{"NO-GO + ERROR (not a base capability failure)", foremanv1alpha1.AgenticTaskVerdictNoGo, "ERROR", "", false},
+		// A legacy task, or one whose status.result is nil/unparseable so
+		// coderTerminalOutcome returns empty strings. Without this row a
+		// `verdict == NoGo -> true` default would make every task with an
+		// unreadable envelope escalate to the larger model, silently.
+		{"NO-GO + empty outcome (legacy/unparseable envelope)", foremanv1alpha1.AgenticTaskVerdictNoGo, "", "", false},
 		{"GO", foremanv1alpha1.AgenticTaskVerdictGo, "", "", false},
 	}
 	for _, tc := range cases {
@@ -86,6 +92,7 @@ func TestShouldEscalateCoderOnFailure(t *testing.T) {
 		{"NO-GO + MODEL-DECIDED (capability failure, not opt-in)", foremanv1alpha1.AgenticTaskVerdictNoGo, "MODEL-DECIDED", "", false},
 		{"GO", foremanv1alpha1.AgenticTaskVerdictGo, "", "", false},
 		{"NO-CHANGES", foremanv1alpha1.AgenticTaskVerdictNoGo, "NO-CHANGES", "", false},
+		{"GO + NEEDS-VERIFICATION (defensive, never escalate)", foremanv1alpha1.AgenticTaskVerdictGo, "NEEDS-VERIFICATION", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -475,34 +482,6 @@ func TestIsAlreadyResolvedCoder(t *testing.T) {
 			}
 			if got := isAlreadyResolvedCoder(task); got != tc.want {
 				t.Errorf("isAlreadyResolvedCoder() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestIsNeedsVerificationCoder(t *testing.T) {
-	cases := []struct {
-		name       string
-		verdict    foremanv1alpha1.AgenticTaskVerdict
-		topOutcome string
-		want       bool
-	}{
-		{"NO-GO + NEEDS-VERIFICATION", foremanv1alpha1.AgenticTaskVerdictNoGo, "NEEDS-VERIFICATION", true},
-		{"NO-GO + MODEL-DECIDED (capability failure)", foremanv1alpha1.AgenticTaskVerdictNoGo, "MODEL-DECIDED", false},
-		{"NO-GO + ALREADY-RESOLVED (different outcome)", foremanv1alpha1.AgenticTaskVerdictNoGo, "ALREADY-RESOLVED", false},
-		{"NO-GO + empty outcome (legacy)", foremanv1alpha1.AgenticTaskVerdictNoGo, "", false},
-		{"INCOMPLETE + NEEDS-VERIFICATION (not a NO-GO)", foremanv1alpha1.AgenticTaskVerdictIncomplete, "NEEDS-VERIFICATION", false},
-		{"GO + NEEDS-VERIFICATION (impossible combo, defensive)", foremanv1alpha1.AgenticTaskVerdictGo, "NEEDS-VERIFICATION", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			task := &foremanv1alpha1.AgenticTask{}
-			task.Status.Verdict = tc.verdict
-			if tc.topOutcome != "" {
-				task.Status.Result = resultRaw(tc.topOutcome, "", "", "")
-			}
-			if got := isNeedsVerificationCoder(task); got != tc.want {
-				t.Errorf("isNeedsVerificationCoder() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/pkg/cli/dispatch.go
+++ b/pkg/cli/dispatch.go
@@ -378,21 +378,6 @@ func isTerminalPhase(p foremanv1alpha1.AgenticTaskPhase) bool {
 	return p == foremanv1alpha1.AgenticTaskPhaseSucceeded || p == foremanv1alpha1.AgenticTaskPhaseFailed
 }
 
-// taskSucceeded reports whether a terminal task is a clean success: it reached
-// Succeeded with a GO or GATE-PASS verdict. Anything else (Failed, NO-GO,
-// INCOMPLETE, GATE-FAIL, GATE-ERROR) is a failure for exit-code purposes.
-func taskSucceeded(t *foremanv1alpha1.AgenticTask) bool {
-	if t.Status.Phase != foremanv1alpha1.AgenticTaskPhaseSucceeded {
-		return false
-	}
-	switch t.Status.Verdict {
-	case foremanv1alpha1.AgenticTaskVerdictGo, foremanv1alpha1.AgenticTaskVerdictGatePass:
-		return true
-	default:
-		return false
-	}
-}
-
 // resultFromTask snapshots a task's terminal status into a taskResult.
 func resultFromTask(t *foremanv1alpha1.AgenticTask) taskResult {
 	r := taskResult{

--- a/pkg/cli/dispatch_test.go
+++ b/pkg/cli/dispatch_test.go
@@ -165,29 +165,7 @@ func TestBuildTask(t *testing.T) {
 	}
 }
 
-func TestTaskSucceededAndExitErr(t *testing.T) {
-	mk := func(phase aPhase, v aVerdict) *foremanv1alpha1.AgenticTask {
-		return &foremanv1alpha1.AgenticTask{Status: foremanv1alpha1.AgenticTaskStatus{Phase: phase, Verdict: v}}
-	}
-	cases := []struct {
-		name   string
-		task   *foremanv1alpha1.AgenticTask
-		wantOK bool
-	}{
-		{"succeeded GO", mk(phSucceeded, vGo), true},
-		{"succeeded GATE-PASS", mk(phSucceeded, vGatePass), true},
-		{"succeeded NO-GO", mk(phSucceeded, vNoGo), false},
-		{"succeeded INCOMPLETE", mk(phSucceeded, vIncomplete), false},
-		{"failed", mk(phFailed, ""), false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := taskSucceeded(tc.task); got != tc.wantOK {
-				t.Fatalf("taskSucceeded got %v want %v", got, tc.wantOK)
-			}
-		})
-	}
-
+func TestExitErr(t *testing.T) {
 	// All-good batch -> nil; any bad -> error naming the issue.
 	good := []taskResult{
 		{Issue: 1, Phase: phSucceeded, Verdict: vGo},
@@ -196,13 +174,40 @@ func TestTaskSucceededAndExitErr(t *testing.T) {
 	if err := exitErrFromResults(good); err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
+	// Every non-clean-success shape must be flagged, and each conjunct of
+	// the predicate has a row that fails without it. Verified by deleting
+	// each conjunct in turn and observing which issues stop being named:
+	//
+	//   drop `Phase == Succeeded`  -> #6 escapes  (#3 #4 #5 still caught)
+	//   drop the verdict check     -> #3, #5 escape (#4 #6 still caught)
+	//
+	// So #3 and #5 pin the verdict side, #6 pins the phase side, and #4
+	// (Failed, no verdict) is caught by either and pins neither on its own.
+	// Row #6 is the load-bearing one: a task that reached a non-Succeeded
+	// phase carrying a stale GO verdict. Without the phase conjunct it
+	// flips to good, so a dispatch batch containing a Failed task exits 0
+	// and a CI script gating on the exit code reports green.
 	mixed := []taskResult{
 		{Issue: 1, Phase: phSucceeded, Verdict: vGo},
 		{Issue: 3, Phase: phSucceeded, Verdict: vNoGo},
+		{Issue: 4, Phase: phFailed},
+		{Issue: 5, Phase: phSucceeded, Verdict: vIncomplete},
+		{Issue: 6, Phase: phFailed, Verdict: vGo},
 	}
 	err := exitErrFromResults(mixed)
-	if err == nil || !strings.Contains(err.Error(), "#3") {
-		t.Fatalf("expected error naming #3, got %v", err)
+	if err == nil {
+		t.Fatalf("expected an error for a mixed batch, got nil")
+	}
+	for _, want := range []string{"#3", "#4", "#5", "#6"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error naming %s, got %v", want, err)
+		}
+	}
+	// ...and the clean row must NOT be named. Without this an inverted or
+	// over-broad predicate still satisfies every Contains above, and only
+	// the `good` slice above catches it.
+	if strings.Contains(err.Error(), "#1") {
+		t.Fatalf("clean task #1 must not be reported as failed, got %v", err)
 	}
 }
 

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -2170,10 +2170,14 @@ func (e *NativeAgentLoopExecutor) modelDecidedResult(
 // promoteTerminalOutcome lifts a terminal, non-escalating machine outcome
 // from the loop terminal's Extra (nested under "modelExtra" in the Result)
 // to the Result's top-level Extra["outcome"]. The controller's
-// isNeedsVerificationCoder and isAlreadyResolvedCoder (see
+// shouldEscalateCoder, shouldEscalateCoderOnFailure and
+// isAlreadyResolvedCoder (see
 // internal/foreman/controller/workload_coder_escalation.go; NOT imported
 // here, per the needsVerificationOutcome doc comment in verdict_policy.go)
-// read the TOP-LEVEL outcome to decide whether to skip escalation, so a
+// read the TOP-LEVEL outcome. The first two decide whether to skip
+// escalation; isAlreadyResolvedCoder additionally drives the Workload
+// rollup's alreadyResolved bucket (workload_controller.go) and the
+// Skipped cascade for dependents (agentictask_controller.go), so a
 // NEEDS-VERIFICATION or ALREADY-RESOLVED terminal buried under modelExtra
 // would still classify as a generic MODEL-DECIDED NO-GO and escalate; that
 // gap predates #1075 Task 5 (#970/#1033 shipped with the model-emitted
@@ -2182,10 +2186,12 @@ func (e *NativeAgentLoopExecutor) modelDecidedResult(
 // loop.go).
 //
 // Only the two known terminal non-failure outcomes are promoted; every
-// other terminal keeps the top-level "MODEL-DECIDED". The paired fields
-// the controller and the Workload rollup read alongside each outcome are
-// promoted with it: "unverified" (needs-verification) and "resolvedBy"
-// (already-resolved). The full modelExtra nesting is left untouched for
+// other terminal keeps the top-level "MODEL-DECIDED". The paired field of
+// each outcome is promoted with it: "unverified" (needs-verification) and
+// "resolvedBy" (already-resolved). Of the two, only "resolvedBy" is read
+// by the controller, via coderResolvedBy in workload_controller.go;
+// "unverified" is promoted for parity and observability, and its readers
+// are all in this package (loop.go, verdict_policy.go). The full modelExtra nesting is left untouched for
 // observability (terminalExtra is the same map referenced there).
 func promoteTerminalOutcome(extra, terminalExtra map[string]any) {
 	outcome, _ := terminalExtra["outcome"].(string)

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -920,7 +920,7 @@ func executeCoderTask(
 // executor with a model-emitted NO-GO whose terminal extra carries
 // outcome=NEEDS-VERIFICATION (#1033) plus an unverified list, and asserts
 // the executor promotes both to the TOP-LEVEL Result.Extra, where the
-// controller's isNeedsVerificationCoder (see coderTerminalOutcome in
+// controller's escalation classifier (see shouldEscalateCoder in
 // internal/foreman/controller/workload_coder_escalation.go, not imported
 // here) reads them to skip escalation. Without the promotion the outcome
 // stayed buried under modelExtra and the task classified as a generic


### PR DESCRIPTION
## What

Triage all four Register B symbols in `.golangci-deadcode.yml`: delete three,
keep one with the register entry re-pointed at it and the reason recorded.

## Why

Refs #1602

The dead-code guard reported four symbols in production packages that nothing
outside their own tests called. The register's own banner says each needs a
delete-or-wire decision, and an unbounded suppression list is how a guard stops
meaning anything.

## How

**Deleted**, each because its logic is already inlined at the call site or it was
test-only by construction:

| symbol | why it was dead |
|---|---|
| `isNeedsVerificationCoder` | its NO-GO + NEEDS-VERIFICATION check is inlined in both `shouldEscalateCoder` and `shouldEscalateCoderOnFailure` |
| `metalReadyEndpoints` | its own doc said it existed "for callers that do not need the full snapshot (e.g., unit tests)" |
| `taskSucceeded` | the identical predicate is inlined in `exitErrFromResults` |

**Kept:** `parseMaxUSD`. `internal/router/budget.go` is an entirely dead file
staged for #434/#440 (nothing constructs a `router.BudgetRule`), and `parseMaxUSD`
is the only symbol in it `unused` reports. Deleting it would clear the register
while leaving the whole dead file invisible, because `unused` does not report
exported identifiers.

The suppression is **symbol-scoped, not file-scoped**. Verified: adding a dead
unexported helper to `budget.go` is reported under the symbol-scoped rule and
gives `0 issues` under a file-wide one, so file-scoping would swallow exactly the
debt this guard exists to surface.

**So Register B does not reach zero, and #1602 stays open.** Three of four are
gone; the fourth is recorded as staged debt with its reason. I would rather leave
one honest entry than clear the register by deleting the symbol that keeps a dead
file visible.

### Coverage moved with the deletions

- The metal heartbeat tests retarget `metalEndpointSnapshot` and now assert
  `snapshot.Kind` as well as `ReadyReplicas`. `Kind` selects the requeue interval
  and the `SchedulingStatus` message; stale and unparseable both report zero
  ready, so the count alone could not tell them apart, and nothing in the repo
  pinned it. Verified: returning `metalHBNone` from the unparseable branch now
  fails the suite.
- The NEEDS-VERIFICATION escalation skip is pinned in both classifiers, including
  a NO-GO with an empty outcome (nil or unparseable result envelope), and against
  a real agent envelope rather than only a synthetic table.
- `TestExitErr` covers every non-clean-success shape against `exitErrFromResults`,
  including a `Failed` phase carrying a stale `GO` verdict. That row pins the
  `Phase == Succeeded` conjunct: delete the conjunct and the suite stays green
  today, while a dispatch batch containing a Failed task exits 0 and a CI script
  gating on the exit code reports green.

Three comments that named deleted or wrong symbols are corrected as well:
`promoteTerminalOutcome`'s reader list, its claim that the controller reads
`"unverified"` (nothing outside `pkg/foreman/agent` does), and the description of
`metalHeartbeatRequeueDuration` as a wrapper that makes an API call.

## Follow-up filed

#1644: `NEEDS-VERIFICATION` has no rollup bucket or dependency cascade where
`ALREADY-RESOLVED` has both, so such a task pins its Workload out of `Completed`.
`isNeedsVerificationCoder` was the last marker of that asymmetry in the tree, so
deleting it here without recording the open question would have been the
"silently deleted" outcome the register exists to prevent.

## Verification

- `make lint-deadcode`: 0 issues, with the suppressions the PR leaves in place
- `make lint` and cross-arch `GOOS=linux`: 0 issues
- `internal/router`, `pkg/cli`, `internal/foreman/controller`, `internal/controller`,
  `pkg/foreman/agent`: all pass
- Mutation-tested both new guards (the register scoping and `snapshot.Kind`), and
  each conjunct of `exitErrFromResults` in turn to confirm which row pins which

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — no user-facing surface changes

Assisted-by: Claude Code via the Foreman harness (the initial triage and one
revision were produced by an agentic coder; I reviewed both, corrected three of my
own instructions that were wrong after an adversarial review, hand-fixed the
remainder, and ran the guard, both lints and all affected package tests, plus the
mutation experiments described above, before submitting).
