### PR TITLE
feat(helm): support cert-manager for the webhook serving cert

### DIFF
--- a/charts/llmkube/README.md
+++ b/charts/llmkube/README.md
@@ -307,6 +307,18 @@ hand-imported.
 |-----------|-------------|---------|
 | `pyrra.enabled` | Enable Pyrra SLO integration | `false` |
 
+### Webhook Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `webhook.enabled` | Render all webhook resources (cert Secret, Service, `ValidatingWebhookConfiguration`) and start the operator's webhook server. | `true` |
+| `webhook.failurePolicy` | What happens when the webhook is unreachable. `Fail` rejects the apply; `Ignore` admits unvalidated. | `Fail` |
+| `webhook.port` | Port the webhook server listens on. | `9443` |
+| `webhook.certValidityDays` | Serving-cert lifetime. Applies to both certificate sources: the chart-generated cert, and the cert-manager `Certificate`'s `duration` (with `renewBefore` at a third of it). | `3650` |
+| `webhook.certManager.enabled` | Hand the webhook serving cert to cert-manager instead of the chart's self-generated one. Needed for ArgoCD, which does not support Helm lookups (see #1601). The render fails with an actionable message if cert-manager is not installed. See `values.yaml` for the install-order caveat with slow external issuers. | `false` |
+| `webhook.certManager.issuerRef` | cert-manager `ObjectReference` for the signing issuer: `{name, kind, group}`. Empty renders the chart's own self-signed `Issuer`. `name` is required once any field is set. | `{}` |
+| `webhook.certManager.issuerRef.group` | API group of the issuer. Defaults to `cert-manager.io`; required for an external issuer (AWS PCA, google-cas, step, Venafi). | unset |
+
 ## Examples
 
 ### Basic Installation

--- a/charts/llmkube/templates/_helpers.tpl
+++ b/charts/llmkube/templates/_helpers.tpl
@@ -179,6 +179,25 @@ ValidatingWebhookConfiguration name.
 {{- end }}
 
 {{/*
+cert-manager Certificate name (webhook.certManager.enabled). Its spec.secretName
+points at llmkube.webhook.secretName, so the deployment mount is unchanged, and
+the webhook configs' cert-manager.io/inject-ca-from annotation references
+<namespace>/<this name>.
+*/}}
+{{- define "llmkube.webhook.certName" -}}
+{{- printf "%s-webhook-cert" (include "llmkube.fullname" .) -}}
+{{- end }}
+
+{{/*
+Self-signed cert-manager Issuer name, rendered only when
+webhook.certManager.issuerRef is empty. Skipped when the operator brings their
+own Issuer or ClusterIssuer via issuerRef.
+*/}}
+{{- define "llmkube.webhook.issuerName" -}}
+{{- printf "%s-webhook-issuer" (include "llmkube.fullname" .) -}}
+{{- end }}
+
+{{/*
 llmkube.webhook.certs resolves the serving cert + CA bundle for the webhook,
 reusing the existing Secret's material when present so the cert and the injected
 caBundle stay STABLE across `helm upgrade`. Returns a dict with keys "ca",

--- a/charts/llmkube/templates/webhook-certmanager.yaml
+++ b/charts/llmkube/templates/webhook-certmanager.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.webhook.enabled }}
+{{- $cm := (.Values.webhook.certManager | default dict).enabled | default false }}
+{{- if $cm }}
+{{- /*
+cert-manager owns the webhook serving cert. Rendered only when
+webhook.certManager.enabled, which is mutually exclusive with the chart's
+self-generated cert: webhook.yaml skips its cert Secret + lookup in this mode
+and cert-manager injects the CA bundle via annotation instead.
+
+The Certificate's secretName is the SAME Secret the deployment mounts
+(llmkube.webhook.secretName), so the controller needs no change: cert-manager
+populates tls.crt + tls.key there and the serving webhook picks them up.
+*/}}
+{{- if not (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
+{{- fail "webhook.certManager.enabled=true but cert-manager.io/v1 is not installed in this cluster. Install cert-manager first, or leave webhook.certManager.enabled=false to use the chart's self-signed cert." }}
+{{- end }}
+{{- $svc := include "llmkube.webhook.serviceName" . }}
+{{- $ns := include "llmkube.namespace" . }}
+{{- /* A user writing `issuerRef:` with nothing under it deletes the chart
+       default, so `index` on it fails the whole render with a raw nil
+       pointer error. Normalise to a dict once, here. */}}
+{{- $issuerRef := .Values.webhook.certManager.issuerRef | default dict }}
+{{- $altNames := list (printf "%s.%s.svc" $svc $ns) (printf "%s.%s.svc.cluster.local" $svc $ns) }}
+{{- if and (not (empty $issuerRef)) (not $issuerRef.name) }}
+{{- fail "webhook.certManager.issuerRef requires a name. Setting only kind/group leaves the Certificate pointing at the chart's self-signed Issuer, which is not rendered when issuerRef is set, so cert-manager reports IssuerNotFound and the webhook never gets a cert." }}
+{{- end }}
+{{- if empty $issuerRef }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "llmkube.webhook.issuerName" . }}
+  namespace: {{ include "llmkube.namespace" . }}
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "llmkube.webhook.certName" . }}
+  namespace: {{ include "llmkube.namespace" . }}
+  labels:
+    {{- include "llmkube.labels" . | nindent 4 }}
+spec:
+  # Same Secret name webhook.yaml's chart-generated cert used, so the
+  # deployment's volume mount is unchanged across modes.
+  secretName: {{ include "llmkube.webhook.secretName" . }}
+  {{- /* No commonName: it is capped at 64 bytes by X.509 and cert-manager
+         enforces it, and a 53-character release name (Helm's documented
+         maximum) already overflows. The dnsNames below carry the identity
+         the API server validates against, which is why the kubebuilder
+         scaffold omits commonName too. */}}
+  dnsNames:
+    {{- range $altNames }}
+    - {{ . }}
+    {{- end }}
+  {{- /* Honour webhook.certValidityDays here too. Without it the knob stays
+         settable and documented while cert-manager silently issues its own
+         90-day default. renewBefore is a third of the lifetime. */}}
+  duration: {{ mul .Values.webhook.certValidityDays 24 }}h
+  renewBefore: {{ div (mul .Values.webhook.certValidityDays 24) 3 }}h
+  {{- /* Keep the Secret owned by Helm so `helm uninstall` removes it.
+         cert-manager only sets an owner reference with
+         --enable-certificate-owner-ref (off by default), so without this the
+         Secret outlives the release and blocks a later reinstall in the
+         chart-generated mode with "exists and cannot be imported". */}}
+  secretTemplate:
+    labels:
+      {{- include "llmkube.labels" . | nindent 6 }}
+    annotations:
+      meta.helm.sh/release-name: {{ .Release.Name | quote }}
+      meta.helm.sh/release-namespace: {{ include "llmkube.namespace" . | quote }}
+  issuerRef:
+    name: {{ $issuerRef.name | default (include "llmkube.webhook.issuerName" .) }}
+    {{- with $issuerRef.kind }}
+    kind: {{ . }}
+    {{- end }}
+    {{- /* group defaults to cert-manager.io; an external issuer (AWS PCA,
+           google-cas, step, Venafi) lives in its own API group and is
+           unreachable without it. */}}
+    {{- with $issuerRef.group }}
+    group: {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/llmkube/templates/webhook.yaml
+++ b/charts/llmkube/templates/webhook.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.webhook.enabled }}
+{{- $cm := (.Values.webhook.certManager | default dict).enabled | default false }}
+{{- $certs := dict }}
+{{- if not $cm }}
 {{- /*
 Compute the serving cert + CA bundle ONCE so the Secret and the
 ValidatingWebhookConfiguration below are guaranteed to use matching material.
@@ -6,7 +9,20 @@ llmkube.webhook.certs reuses the existing Secret on upgrade (lookup-reuse), so
 the cert stays stable and the injected caBundle never drifts from the served
 cert.
 */}}
-{{- $certs := include "llmkube.webhook.certs" . | fromYaml }}
+{{- $certs = include "llmkube.webhook.certs" . | fromYaml }}
+{{- else }}
+{{- /*
+cert-manager owns the webhook serving cert (#1601). The chart does NOT
+self-generate it and does NOT call llmkube.webhook.certs, whose lookup-reuse is
+exactly what breaks ArgoCD syncs: ArgoCD does not support Helm lookups, so every
+re-render regenerated the cert, and ArgoCD's server-side-apply dry-run against
+the API server (with the webhook active) then failed the sync. Instead the
+Certificate in webhook-certmanager.yaml populates the SAME Secret the deployment
+mounts, and the CA bundle is injected into the webhook configurations below via
+the cert-manager.io/inject-ca-from annotation (leaving caBundle unset).
+*/}}
+{{- end }}
+{{- if not $cm }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,6 +36,7 @@ data:
   tls.key: {{ $certs.key }}
   ca.crt: {{ $certs.ca }}
 ---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -42,6 +59,10 @@ metadata:
   name: {{ include "llmkube.webhook.configName" . }}
   labels:
     {{- include "llmkube.labels" . | nindent 4 }}
+  {{- if $cm }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ include "llmkube.namespace" . }}/{{ include "llmkube.webhook.certName" . }}
+  {{- end }}
 webhooks:
   - name: vmodelrouter.inference.llmkube.dev
     admissionReviewVersions: ["v1"]
@@ -52,7 +73,9 @@ webhooks:
         name: {{ include "llmkube.webhook.serviceName" . }}
         namespace: {{ include "llmkube.namespace" . }}
         path: /validate-inference-llmkube-dev-v1alpha1-modelrouter
+      {{- if not $cm }}
       caBundle: {{ $certs.ca }}
+      {{- end }}
     rules:
       - apiGroups: ["inference.llmkube.dev"]
         apiVersions: ["v1alpha1"]
@@ -69,7 +92,9 @@ webhooks:
         name: {{ include "llmkube.webhook.serviceName" . }}
         namespace: {{ include "llmkube.namespace" . }}
         path: /validate-inference-llmkube-dev-v1alpha1-inferenceservice-quota
+      {{- if not $cm }}
       caBundle: {{ $certs.ca }}
+      {{- end }}
     rules:
       - apiGroups: ["inference.llmkube.dev"]
         apiVersions: ["v1alpha1"]
@@ -84,6 +109,10 @@ metadata:
   name: {{ include "llmkube.webhook.configName" . }}-mutating
   labels:
     {{- include "llmkube.labels" . | nindent 4 }}
+  {{- if $cm }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ include "llmkube.namespace" . }}/{{ include "llmkube.webhook.certName" . }}
+  {{- end }}
 webhooks:
   - name: mmodel.inference.llmkube.dev
     admissionReviewVersions: ["v1"]
@@ -96,7 +125,9 @@ webhooks:
         name: {{ include "llmkube.webhook.serviceName" . }}
         namespace: {{ include "llmkube.namespace" . }}
         path: /mutate-inference-llmkube-dev-v1alpha1-model
+      {{- if not $cm }}
       caBundle: {{ $certs.ca }}
+      {{- end }}
     rules:
       - apiGroups: ["inference.llmkube.dev"]
         apiVersions: ["v1alpha1"]

--- a/charts/llmkube/tests/values-certmanager-null-issuerref.yaml
+++ b/charts/llmkube/tests/values-certmanager-null-issuerref.yaml
@@ -1,0 +1,8 @@
+# The natural way to copy the documented block from values.yaml and leave it
+# blank: an explicit `issuerRef:` with nothing under it. Helm treats that as a
+# key DELETION, removing the chart's `issuerRef: {}` default, so any `index`
+# on it fails the whole render with a raw nil-pointer error naming no pool.
+webhook:
+  certManager:
+    enabled: true
+    issuerRef:

--- a/charts/llmkube/tests/webhook_test.yaml
+++ b/charts/llmkube/tests/webhook_test.yaml
@@ -1,17 +1,39 @@
 suite: modelrouter validating webhook
+# Two mutually exclusive certificate sources (#1601): the chart self-generates
+# a stable serving cert by default, or cert-manager owns it.
+#
+# Absence claims are the fragile ones here: in helm-unittest a notExists or
+# notMatchRegex over a path that resolves to nothing passes vacuously. Where a
+# test's POINT is that something is absent, it pins the document set
+# (hasDocuments/documentSelector) so the assertion can actually fail. Tests
+# that only assert positive content do not need that and do not carry it.
+#
+# The cert-manager cases declare capabilities.apiVersions: the chart fails the
+# render outright when cert-manager.io/v1 is missing, which is deliberate (a
+# clear message beats an unknown-kind error after half the release applied).
 templates:
   - webhook.yaml
+  - webhook-certmanager.yaml
 
 tests:
   # Default ON: the chart self-generates a stable serving cert, so the webhook
-  # is wired by default (matches foreman). Four documents: cert Secret, webhook
-  # Service, and the validating + mutating configurations.
+  # is wired by default (matches foreman). webhook.yaml renders four documents:
+  # cert Secret, webhook Service, and the validating + mutating configurations.
+  # cert-manager resources are NOT rendered in this mode.
   - it: should render Secret + Service + both webhook configurations by default
+    template: webhook.yaml
     asserts:
       - hasDocuments:
           count: 4
 
+  - it: should render no cert-manager resources by default
+    template: webhook-certmanager.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should render a kubernetes.io/tls cert Secret
+    template: webhook.yaml
     documentIndex: 0
     asserts:
       - isKind:
@@ -27,6 +49,7 @@ tests:
           path: data["ca.crt"]
 
   - it: should render a webhook Service exposing the named webhook port
+    template: webhook.yaml
     documentIndex: 1
     asserts:
       - isKind:
@@ -39,6 +62,7 @@ tests:
           value: webhook
 
   - it: should render a ValidatingWebhookConfiguration for modelrouters
+    template: webhook.yaml
     documentIndex: 2
     asserts:
       - isKind:
@@ -64,8 +88,14 @@ tests:
       - equal:
           path: webhooks[0].failurePolicy
           value: Fail
+      # The default mode injects the chart CA bundle, not a cert-manager annotation.
+      - isNotNullOrEmpty:
+          path: webhooks[0].clientConfig.caBundle
+      - notExists:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
 
   - it: should render a MutatingWebhookConfiguration for models
+    template: webhook.yaml
     documentIndex: 3
     asserts:
       - isKind:
@@ -83,9 +113,15 @@ tests:
       - equal:
           path: webhooks[0].failurePolicy
           value: Ignore
+      # The default mode injects the chart CA bundle, not a cert-manager annotation.
+      - isNotNullOrEmpty:
+          path: webhooks[0].clientConfig.caBundle
+      - notExists:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
 
   # failurePolicy is wired from values.
   - it: should honor a custom failurePolicy
+    template: webhook.yaml
     set:
       webhook.failurePolicy: Ignore
     documentIndex: 2
@@ -94,11 +130,319 @@ tests:
           path: webhooks[0].failurePolicy
           value: Ignore
 
-  # Disabled renders NOTHING: existing installs that set webhook.enabled=false
-  # are completely unaffected.
+  # Disabled renders NOTHING from either template: existing installs that set
+  # webhook.enabled=false are completely unaffected.
   - it: should render nothing when the webhook is disabled
+    template: webhook.yaml
     set:
       webhook.enabled: false
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should render no cert-manager resources when the webhook is disabled
+    template: webhook-certmanager.yaml
+    set:
+      webhook.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # --- cert-manager mode (#1601) ---
+  # webhook.certManager.enabled=true is mutually exclusive with the chart's
+  # self-generated cert: webhook.yaml renders the Service + both webhook
+  # configurations (NO cert Secret, NO caBundle) and cert-manager injects the
+  # CA bundle via the cert-manager.io/inject-ca-from annotation; the
+  # Certificate populates the SAME Secret the deployment mounts.
+
+  - it: should skip the chart-generated cert Secret when cert-manager is enabled
+    template: webhook.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+    asserts:
+      # Three docs (Service, validating, mutating) — the cert Secret is gone.
+      - hasDocuments:
+          count: 3
+
+  - it: should render a self-signed Issuer + Certificate when cert-manager is enabled
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+    asserts:
+      # Two docs: the self-signed Issuer (issuerRef empty) + the Certificate.
+      - hasDocuments:
+          count: 2
+
+  - it: should name the Certificate after the chart's serving Secret
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+    documentSelector:
+      path: kind
+      value: Certificate
+    asserts:
+      - isKind:
+          of: Certificate
+      - isAPIVersion:
+          of: cert-manager.io/v1
+      # Same Secret the deployment mounts, so the controller needs no change.
+      - equal:
+          path: spec.secretName
+          value: RELEASE-NAME-llmkube-webhook-cert
+      # Empty issuerRef renders the chart's own self-signed Issuer.
+      - equal:
+          path: spec.issuerRef.name
+          value: RELEASE-NAME-llmkube-webhook-issuer
+
+  - it: should render a self-signed Issuer by default in cert-manager mode
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+    documentSelector:
+      path: kind
+      value: Issuer
+    asserts:
+      - isKind:
+          of: Issuer
+      - isAPIVersion:
+          of: cert-manager.io/v1
+      - equal:
+          path: spec.selfSigned
+          value: {}
+
+  # The cert-manager.io/inject-ca-from value is <namespace>/<certificate name>.
+  # The namespace defaults to the release namespace; pin it so the assertion is
+  # deterministic (the chart's values.yaml sets it to llmkube-system in practice).
+  - it: should inject the cert-manager CA via annotation on both webhook configs
+    template: webhook.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+    release:
+      namespace: llmkube-system
+    documentSelector:
+      path: kind
+      value: ValidatingWebhookConfiguration
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
+          value: llmkube-system/RELEASE-NAME-llmkube-webhook-cert
+      - notExists:
+          path: webhooks[0].clientConfig.caBundle
+
+  - it: should leave caBundle unset on the mutating webhook in cert-manager mode
+    template: webhook.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+    release:
+      namespace: llmkube-system
+    documentSelector:
+      path: kind
+      value: MutatingWebhookConfiguration
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
+          value: llmkube-system/RELEASE-NAME-llmkube-webhook-cert
+      - notExists:
+          path: webhooks[0].clientConfig.caBundle
+
+  # A set issuerRef skips the chart's self-signed Issuer and references the
+  # operator's own Issuer or ClusterIssuer instead.
+  - it: should skip the self-signed Issuer when issuerRef is set
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+      webhook.certManager.issuerRef.name: my-issuer
+      webhook.certManager.issuerRef.kind: ClusterIssuer
+    asserts:
+      # One doc: only the Certificate (the self-signed Issuer is skipped).
+      - hasDocuments:
+          count: 1
+
+  - it: should reference the operator's ClusterIssuer when issuerRef is set
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+      webhook.certManager.issuerRef.name: my-issuer
+      webhook.certManager.issuerRef.kind: ClusterIssuer
+    documentSelector:
+      path: kind
+      value: Certificate
+    asserts:
+      - equal:
+          path: spec.issuerRef.name
+          value: my-issuer
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+      # The Secret the deployment mounts is unchanged regardless of issuer.
+      - equal:
+          path: spec.secretName
+          value: RELEASE-NAME-llmkube-webhook-cert
+
+  # The SANs are what the API server validates the serving cert against. A typo
+  # here breaks every admission call, and nothing pinned them: the suite checked
+  # caBundle and the inject annotation but never the identity being certified.
+  - it: the Certificate carries both service SANs and lives in the release namespace
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+    documentSelector:
+      path: kind
+      value: Certificate
+    asserts:
+      - equal:
+          path: spec.dnsNames[0]
+          value: RELEASE-NAME-llmkube-webhook.NAMESPACE.svc
+      - equal:
+          path: spec.dnsNames[1]
+          value: RELEASE-NAME-llmkube-webhook.NAMESPACE.svc.cluster.local
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      # commonName is capped at 64 bytes by X.509 and cert-manager enforces it;
+      # a 53-character release name overflows it. The SANs carry the identity.
+      - notExists:
+          path: spec.commonName
+
+  - it: the self-signed Issuer lives in the release namespace
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+    documentSelector:
+      path: kind
+      value: Issuer
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: certValidityDays drives the Certificate duration
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+      webhook.certValidityDays: 30
+    documentSelector:
+      path: kind
+      value: Certificate
+    asserts:
+      # Without this the knob stays settable and documented while cert-manager
+      # silently issues its own 90-day default.
+      - equal:
+          path: spec.duration
+          value: 720h
+      - equal:
+          path: spec.renewBefore
+          value: 240h
+
+  - it: the issued Secret is labelled as Helm-owned so uninstall removes it
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+    documentSelector:
+      path: kind
+      value: Certificate
+    asserts:
+      # cert-manager only sets an owner reference with
+      # --enable-certificate-owner-ref (off by default), so without this the
+      # Secret outlives the release and blocks a later reinstall in the
+      # chart-generated mode with "exists and cannot be imported".
+      - equal:
+          path: spec.secretTemplate.annotations["meta.helm.sh/release-name"]
+          value: RELEASE-NAME
+
+  - it: an external issuer's API group reaches the Certificate
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+      webhook.certManager.issuerRef.name: pca
+      webhook.certManager.issuerRef.kind: AWSPCAClusterIssuer
+      webhook.certManager.issuerRef.group: awspca.cert-manager.io
+    documentSelector:
+      path: kind
+      value: Certificate
+    asserts:
+      # Without group every external issuer (AWS PCA, google-cas, step, Venafi)
+      # is unreachable, which defeats the point of issuerRef.
+      - equal:
+          path: spec.issuerRef.group
+          value: awspca.cert-manager.io
+
+  - it: issuerRef without a name fails the render rather than dangling
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      webhook.certManager.enabled: true
+      webhook.certManager.issuerRef.kind: ClusterIssuer
+    asserts:
+      # Setting only kind leaves the Certificate pointing at the self-signed
+      # Issuer's NAME while that Issuer is not rendered (and is an Issuer, not
+      # a ClusterIssuer), so cert-manager reports IssuerNotFound forever and
+      # the webhook never gets a cert.
+      - failedTemplate:
+          errorMessage: "webhook.certManager.issuerRef requires a name. Setting only kind/group leaves the Certificate pointing at the chart's self-signed Issuer, which is not rendered when issuerRef is set, so cert-manager reports IssuerNotFound and the webhook never gets a cert."
+
+  - it: cert-manager mode fails clearly when cert-manager is not installed
+    template: webhook-certmanager.yaml
+    set:
+      webhook.certManager.enabled: true
+    asserts:
+      # No capabilities block here on purpose. Without the guard this renders a
+      # Certificate the API server rejects with an unknown-kind error, AFTER
+      # the rest of the release has applied.
+      - failedTemplate:
+          errorMessage: "webhook.certManager.enabled=true but cert-manager.io/v1 is not installed in this cluster. Install cert-manager first, or leave webhook.certManager.enabled=false to use the chart's self-signed cert."
+
+  - it: an empty issuerRef key falls back to the self-signed Issuer, not a nil panic
+    template: webhook-certmanager.yaml
+    capabilities:
+      apiVersions:
+        - cert-manager.io/v1
+    values:
+      - ./values-certmanager-null-issuerref.yaml
+    asserts:
+      # Two documents: the self-signed Issuer and the Certificate. Pinning the
+      # count is what makes this fail if the render breaks instead of silently
+      # producing fewer documents.
+      - hasDocuments:
+          count: 2

--- a/charts/llmkube/values.schema.json
+++ b/charts/llmkube/values.schema.json
@@ -467,6 +467,24 @@
         "certValidityDays": {
           "type": "integer",
           "minimum": 1
+        },
+        "certManager": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Hand the webhook serving cert to cert-manager instead of the chart's self-generated one (#1601).",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "issuerRef": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "description": "cert-manager ObjectReference {name, kind, group} for the signing issuer; empty renders the chart's self-signed Issuer. name is required once any field is set. May be written as an explicit null to mean the default.",
+              "properties": {
+                "name": { "type": "string" },
+                "kind": { "type": "string" },
+                "group": { "type": "string", "description": "API group of the issuer. Defaults to cert-manager.io; required for an external issuer (AWS PCA, google-cas, step, Venafi)." }
+              }
+            }
+          }
         }
       }
     },

--- a/charts/llmkube/values.yaml
+++ b/charts/llmkube/values.yaml
@@ -485,6 +485,54 @@ webhook:
   # force regeneration before expiry).
   certValidityDays: 3650
 
+  # certManager hands the webhook serving cert to cert-manager instead of the
+  # chart's self-generated one (#1601). Required for ArgoCD: ArgoCD does not
+  # support Helm lookups, so every re-render ran the lookup-reuse path and
+  # regenerated the cert, and ArgoCD's server-side-apply dry-run against the API
+  # server (webhook active) then failed the sync until the operator reloaded.
+  # With this on, the chart renders a cert-manager Certificate that populates the
+  # SAME Secret the deployment mounts (so the controller needs no change), and
+  # the webhook configurations' CA bundle is injected via the
+  # cert-manager.io/inject-ca-from annotation instead of a chart-generated
+  # caBundle. The chart-generated cert Secret is NOT rendered in this mode.
+  # Defaults false: the self-generated path (no cert-manager dependency) stays
+  # the default. Requires cert-manager to be installed.
+  certManager:
+    # Hand the webhook serving cert to cert-manager instead of the chart's
+    # self-generated one. Requires cert-manager to be installed; the chart
+    # fails the render with an actionable message if cert-manager.io/v1 is
+    # not present, rather than applying half the release and then hitting an
+    # unknown-kind error.
+    #
+    # certValidityDays above applies in this mode too: it is rendered as the
+    # Certificate's duration, with renewBefore at a third of it.
+    #
+    # INSTALL ORDER, worth knowing before you use an external issuer. The
+    # controller mounts the serving Secret as a REQUIRED volume, because a
+    # webhook with no cert cannot serve and the operator only registers the
+    # webhook when the cert is present. cert-manager creates that Secret
+    # asynchronously, AFTER this release applies, so on a first install the
+    # controller pod sits in ContainerCreating until issuance completes.
+    # With the chart's self-signed Issuer that is seconds. With a slow
+    # external issuer (ACME, AWS PCA, Venafi, step) it can be minutes, and
+    # `helm install --wait --atomic` will time out and roll back, deleting
+    # the Certificate so the install can never converge. Either drop
+    # --atomic on the first install, raise --timeout past your issuer's
+    # issuance time, or pre-create the Certificate.
+    #
+    # The volume is deliberately NOT optional: marking it optional would let
+    # the controller start with admission silently disabled, which is worse
+    # than a pod that visibly waits.
+    enabled: false
+    # issuerRef is cert-manager's ObjectReference: {name, kind, group}.
+    # Empty (default) renders the chart's own self-signed Issuer. name is
+    # REQUIRED once any field is set, otherwise the Certificate points at the
+    # self-signed Issuer's name while that Issuer is not rendered, and
+    # cert-manager reports IssuerNotFound forever. group defaults to
+    # cert-manager.io and must be set for an external issuer, e.g.
+    #   issuerRef: {name: pca, kind: AWSPCAClusterIssuer, group: awspca.cert-manager.io}
+    issuerRef: {}
+
 # multitenancy gates the opt-in multi-tenant admission + RBAC surface (#416).
 # Default off: the InferenceService quota ValidatingWebhookConfiguration entry is
 # NOT rendered (so InferenceService admission is never intercepted) and no tenant


### PR DESCRIPTION
## What

`webhook.certManager.enabled`: hand the webhook serving cert to cert-manager
instead of the chart's self-generated one.

## Why

Refs #1601

ArgoCD does not support Helm lookups, so every re-render runs the chart's
lookup-reuse path and regenerates the serving cert. ArgoCD's server-side-apply
dry-run then fails with a certificate error and the sync stays broken until the
operator reloads. Reported with four reference implementations (KEDA, cilium,
envoy ai-gateway, and others).

## How

A cert-manager `Certificate` whose `secretName` is the **same** Secret the
deployment already mounts, plus a self-signed `Issuer` when `issuerRef` is empty.
In that mode `webhook.yaml` skips the chart-generated Secret, never calls the
lookup helper, and leaves `caBundle` unset, relying on the `inject-ca-from`
annotation. The two modes are mutually exclusive and **the default render is
byte-for-byte unchanged** (verified against `upstream/main`).

### Guards, each for a failure that is otherwise silent or opaque

| Condition | Without the guard |
|---|---|
| cert-manager not installed | `no matches for kind "Certificate"` **after** the rest of the release has applied |
| `issuerRef.kind` set, `name` unset | Certificate points at the self-signed Issuer's *name* while that Issuer is not rendered (and is an `Issuer`, not a `ClusterIssuer`) → `IssuerNotFound` forever, webhook never gets a cert |
| explicit empty `issuerRef:` | Helm treats it as deleting the chart default, so indexing it fails the whole render with a raw nil-pointer error |

### Other corrections

- **`issuerRef` is the full `{name, kind, group}`.** Without `group` every
  external issuer (AWS PCA, google-cas, step, Venafi) is unreachable, which
  defeats the point of the field.
- **No `commonName`.** It is capped at 64 bytes by X.509 and cert-manager
  enforces it; a 53-character release name (Helm's documented maximum) already
  overflows. The `dnsNames` carry the identity the API server validates against,
  which is why the kubebuilder scaffold omits it.
- **`certValidityDays` applies here too**, as the Certificate's `duration` with
  `renewBefore` at a third. It was previously settable and documented while
  cert-manager silently issued its own 90-day default.
- **The issued Secret carries Helm ownership metadata** so `helm uninstall`
  removes it. cert-manager only sets an owner reference with
  `--enable-certificate-owner-ref` (off by default), so otherwise the Secret
  outlives the release and blocks a later reinstall in the chart-generated mode
  with `exists and cannot be imported`.

### One deliberate non-fix

Review suggested marking the serving-Secret volume `optional: true`, because
cert-manager creates the Secret **after** this release applies, so on a first
install the controller sits in `ContainerCreating` until issuance completes —
and with a slow external issuer `helm install --wait --atomic` times out, rolls
back, deletes the Certificate, and can never converge.

I left the volume **required**. `cmd/main.go` only registers the webhook when the
serving cert is present, so `optional: true` would let the controller start with
admission **silently disabled** until someone restarted it. That trades a visible
failure for an invisible one. The install-order consequence is documented in
`values.yaml` instead, with the three ways out (drop `--atomic`, raise
`--timeout`, or pre-create the Certificate).

## Verification

- Default render byte-for-byte identical to `upstream/main`
- `helm unittest`: 95/95 (was 87; +8 covering the guards, `dnsNames`, namespace, `duration`, Secret ownership, and the external-issuer group)
- Mutation-tested: removing the `name` guard fails exactly its own test
- All four modes rendered and inspected: self-signed, external issuer with group, `kind`-without-`name` (fails), empty `issuerRef:` (falls back)
- Schema still rejects unknown keys

The suite header no longer claims *every* test pins its document set. Only the
tests whose point is an absence do, which is where helm-unittest's vacuous-pass
actually bites.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated — `values.yaml` and the chart README's webhook table

Assisted-by: Claude Code via the Foreman harness (an agentic coder produced the
first implementation; an adversarial review found ten defects in it, and I
hand-fixed all ten, made the `optional: true` call above deliberately against the
review's suggestion, and ran the renders, mutation test and full chart suite
before submitting).
