### PR TITLE
feat(chart): expose foreman-agent rollout strategy and grace period per pool

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -872,6 +872,36 @@ jobs:
           fi
           echo "✅ verifier-node overrides render correctly"
 
+      - name: Template foreman multi-pool with a --set numeric override
+        # helm unittest cannot catch this class of bug. Its `set:` block
+        # round-trips values through YAML, so every number reaches the
+        # template as a float64. A real `--set k=60` goes through Helm's
+        # strvals parser and arrives as an int64, and agent-deployment.yaml
+        # deep-copies .Values.agent into each pool WITHOUT a YAML round
+        # trip. A template guard that type-checks for float64 alone
+        # therefore passes the whole unit suite and hard-fails the render
+        # for anyone on the agents: map (#1438 review). Only a real
+        # `helm template --set` bites, so run one here.
+        run: |
+          set -euo pipefail
+          helm template foreman charts/foreman \
+            --namespace foreman-system \
+            -f charts/foreman/tests/values-multi.yaml \
+            --set agent.terminationGracePeriodSeconds=45 \
+            --set agent.strategy.type=RollingUpdate \
+            --set agent.strategy.rollingUpdate.maxSurge=1 \
+            > foreman-multi-set.yaml
+
+          if ! grep -q "terminationGracePeriodSeconds: 45" foreman-multi-set.yaml; then
+            echo "❌ --set grace period did not survive the multi-pool merge"
+            exit 1
+          fi
+          if ! grep -q "maxSurge: 1$" foreman-multi-set.yaml; then
+            echo "❌ --set maxSurge did not survive the multi-pool merge"
+            exit 1
+          fi
+          echo "✅ --set numeric overrides survive the multi-pool merge"
+
       - name: Cache kubeconform schemas
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -26,14 +26,69 @@ metadata:
     {{- include "foreman.agent.poolLabels" $ctx | nindent 4 }}
 spec:
   replicas: {{ $agent.replicaCount }}
-  # Recreate: never runs two agents for this pool at once. Note the blast
-  # radius: an agent holds one in-process task plus up to
-  # --max-supervised-tasks Job-mode supervisions (#1559), and on restart
-  # recoverOrphanedTasks resets EVERY Running task on the node back to
-  # Pending, so an upgrade can yank back more than one run at a time and
-  # each is re-dispatched from the start.
+  {{- /* Recreate is the conservative default: it never runs two agents for a
+         pool at once. The comment this replaced said that stopped them racing
+         for the same Scheduled task; that race is currently unreachable, and
+         only because of a bug. FLEET_NODE_NAME is set from spec.nodeName (the
+         Kubernetes NODE) but read by nothing, so the agent falls back to
+         os.Hostname() -- the POD name -- and pollOnce claims only tasks whose
+         status.assignedNode matches its own FleetNode. Under the intended
+         node-scoped identity two pods on one node WOULD share an identity and
+         race. Tracked as #1640; do not restate the race as a present-tense
+         fact either way. */}}
+  {{- /* Blast radius of replacing an agent, from #1635, and it matters more
+         now that RollingUpdate is selectable rather than less: an agent holds
+         one in-process task plus up to --max-supervised-tasks Job-mode
+         supervisions (#1559), so an upgrade yanks back more than one run at a
+         time and each is re-dispatched from the start. Which mechanism does
+         the yanking depends on how the agent went away. An in-place container
+         restart keeps the hostname, so recoverOrphanedTasks matches
+         status.assignedNode and resets every Running task on the node back to
+         Pending. A Deployment pod replacement mints a new pod name, so that
+         path never matches and it is the operator's claim expiry
+         (agentictask_controller.go) that releases the tasks once the heartbeat
+         goes stale, spending a strike each time. */}}
+  {{- /* `strategy:` written with nothing under it is a null, not a dict, so
+         dereferencing .type panics the render. Normalise once. */}}
+  {{- $strategy := $agent.strategy | default dict }}
+  {{- $st := $strategy.type | default "Recreate" }}
+  {{- if eq $st "Recreate" }}
+  # Recreate: never runs two agents for this pool at once. The conservative
+  # default; see agents.<pool>.strategy in values.yaml for the tradeoff.
+  {{- else }}
+  # RollingUpdate: replaces this pool's agents one at a time instead of
+  # tearing the pool down. See agents.<pool>.strategy in values.yaml.
+  {{- end }}
+  {{- if and (ne $st "Recreate") (ne $st "RollingUpdate") }}
+  {{- fail (printf "agents.%s.strategy.type: %q is not a valid Deployment strategy; use \"Recreate\" or \"RollingUpdate\" (the API server rejects anything else, including case variants like \"rollingUpdate\")" $name $st) }}
+  {{- end }}
+  {{- $tgps := $agent.terminationGracePeriodSeconds | default 30 }}
+  {{- if or (not (kindIs "float64" $tgps)) (lt (float64 $tgps) 0.0) }}
+  {{- fail (printf "agents.%s.terminationGracePeriodSeconds: %v must be a non-negative integer (the API server rejects anything else)" $name $tgps) }}
+  {{- end }}
   strategy:
-    type: Recreate
+    type: {{ $st }}
+    {{- if eq $st "RollingUpdate" }}
+    {{- $ru := $strategy.rollingUpdate | default dict }}
+    {{- /* hasKey, not `default`: Go templates treat 0 as empty, so `| default`
+           silently rewrites a deliberately configured 0 to the fallback. */}}
+    {{- $surge := 0 }}
+    {{- if hasKey $ru "maxSurge" }}{{ $surge = $ru.maxSurge }}{{ end }}
+    {{- $unavail := 1 }}
+    {{- if hasKey $ru "maxUnavailable" }}{{ $unavail = $ru.maxUnavailable }}{{ end }}
+    {{- /* maxSurge 0 with maxUnavailable 0 is rejected by the Deployment
+           validator ("may not be 0 when maxSurge is 0"), so fail at render
+           rather than at apply. Both accept the IntOrString percentage form,
+           which is why this compares the rendered strings. */}}
+    {{- $surgeZero := or (eq (toString $surge) "0") (eq (toString $surge) "0%") }}
+    {{- $unavailZero := or (eq (toString $unavail) "0") (eq (toString $unavail) "0%") }}
+    {{- if and $surgeZero $unavailZero }}
+    {{- fail (printf "agents.%s.strategy.rollingUpdate: maxUnavailable may not be 0 when maxSurge is 0; the Deployment validator rejects that pair" $name) }}
+    {{- end }}
+    rollingUpdate:
+      maxSurge: {{ $surge }}
+      maxUnavailable: {{ $unavail }}
+    {{- end }}
   # Pool-scoped, via $ctx rather than the chart root: passing $ here gave
   # every pool the same selector, so each Deployment adopted the others'
   # pods and fought them over replicaCount (#1523).
@@ -168,6 +223,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ $tgps | int64 }}
 {{- end }}
 {{- end }}

--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -63,7 +63,22 @@ spec:
   {{- fail (printf "agents.%s.strategy.type: %q is not a valid Deployment strategy; use \"Recreate\" or \"RollingUpdate\" (the API server rejects anything else, including case variants like \"rollingUpdate\")" $name $st) }}
   {{- end }}
   {{- $tgps := $agent.terminationGracePeriodSeconds | default 30 }}
-  {{- if or (not (kindIs "float64" $tgps)) (lt (float64 $tgps) 0.0) }}
+  {{- /* Kind, not a single kind: the same value reaches this line as
+         different Go types depending on how it was supplied. Everything
+         routed through `include "foreman.agents" | fromYaml` is float64,
+         but $defaults above is a deepCopy of .Values.agent that is never
+         round-tripped through YAML, and Helm's --set (strvals) parses a
+         bare integer as int64. A float64-only type check therefore passed
+         every helm-unittest case (its `set:` round-trips through YAML) and
+         failed the real `--set agent.terminationGracePeriodSeconds=N`
+         render on any release using the agents: map. Accept every numeric
+         kind here and let the arms below do the actual validation. */}}
+  {{- $tgpsNum := or (kindIs "float64" $tgps) (kindIs "int64" $tgps) (kindIs "int" $tgps) }}
+  {{- $tgpsF := float64 $tgps }}
+  {{- /* Fractions are rejected rather than truncated: terminationGracePeriodSeconds
+         is an int64 in the pod spec, and `| int64` below would silently ship 30 for
+         an input of 30.5, which is a value the operator never asked for. */}}
+  {{- if or (not $tgpsNum) (lt $tgpsF 0.0) (ne $tgpsF (floor $tgpsF)) }}
   {{- fail (printf "agents.%s.terminationGracePeriodSeconds: %v must be a non-negative integer (the API server rejects anything else)" $name $tgps) }}
   {{- end }}
   strategy:
@@ -76,6 +91,14 @@ spec:
     {{- if hasKey $ru "maxSurge" }}{{ $surge = $ru.maxSurge }}{{ end }}
     {{- $unavail := 1 }}
     {{- if hasKey $ru "maxUnavailable" }}{{ $unavail = $ru.maxUnavailable }}{{ end }}
+    {{- /* Same %v exponent trap the grace period hit: values arriving via
+           fromYaml are float64, and fmt switches to exponent form at 1e6, so
+           `maxSurge: 1000000` rendered as `1e+06`, which YAML 1.1 does not
+           resolve as a number. Narrow to int64 for the numeric forms only;
+           the IntOrString percentage form ("25%") is a string and must pass
+           through untouched, because sprig's int64 casts it to 0. */}}
+    {{- if not (kindIs "string" $surge) }}{{ $surge = int64 $surge }}{{ end }}
+    {{- if not (kindIs "string" $unavail) }}{{ $unavail = int64 $unavail }}{{ end }}
     {{- /* maxSurge 0 with maxUnavailable 0 is rejected by the Deployment
            validator ("may not be 0 when maxSurge is 0"), so fail at render
            rather than at apply. Both accept the IntOrString percentage form,

--- a/charts/foreman/tests/agent-rollout_test.yaml
+++ b/charts/foreman/tests/agent-rollout_test.yaml
@@ -200,6 +200,12 @@ tests:
     values:
       - ./values-null-strategy.yaml
     asserts:
+      # Pins the render contract for a null `strategy:`, not the `| default
+      # dict` in isolation. See the header of values-null-strategy.yaml:
+      # deleting that pipe alone leaves this green, because the two-step
+      # `$strategy := $agent.strategy` then `$strategy.type` tolerates a nil.
+      # The mutation this DOES catch is collapsing those two steps into
+      # `$agent.strategy.type`, which nil-pointers the render.
       - equal:
           path: spec.strategy.type
           value: Recreate
@@ -319,3 +325,47 @@ tests:
           value: Recreate
       - notExists:
           path: spec.strategy.rollingUpdate
+
+  - it: a fractional terminationGracePeriodSeconds fails the render rather than truncating
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.terminationGracePeriodSeconds: 30.5
+    asserts:
+      # terminationGracePeriodSeconds is an int64 in the pod spec. Without the
+      # integrality arm the guard passes and `| int64` ships 30, a value the
+      # operator never asked for, while this comment block claims non-integers
+      # fail. Fail loudly instead.
+      - failedTemplate:
+          errorPattern: 'terminationGracePeriodSeconds: 30\.5 must be a non-negative integer'
+
+  - it: a large maxSurge renders as an integer, not an exponent
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1000000
+          maxUnavailable: 1
+    asserts:
+      # Same float64 %v trap already fixed for the grace period: fmt switches
+      # to exponent form at 1e6 and YAML 1.1 does not resolve `1e+06` as a
+      # number, so the API server rejects the Deployment.
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1000000
+
+  - it: a large maxUnavailable renders as an integer, not an exponent
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1000000
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1000000

--- a/charts/foreman/tests/agent-rollout_test.yaml
+++ b/charts/foreman/tests/agent-rollout_test.yaml
@@ -1,0 +1,321 @@
+suite: agent rollout strategy + terminationGracePeriodSeconds (#1438 chart half)
+templates:
+  - agent-deployment.yaml
+
+tests:
+  # ---- Defaults reproduce the previous hardcoded output exactly ----
+
+  - it: default agent renders Recreate and a 30s grace period (no change on upgrade)
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      # Recreate has no rollingUpdate knobs; the field must be absent, not 0.
+      - notExists:
+          path: spec.strategy.rollingUpdate
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 30
+
+  - it: default multi-pool install renders Recreate and 30s for the default pool
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-default-agent
+      matchMany: false
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 30
+
+  - it: default multi-pool install renders Recreate and 30s for the fork pool
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 30
+
+  # ---- Opting into RollingUpdate ----
+
+  - it: a pool opting into RollingUpdate renders the rollingUpdate block and its raised grace period
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    set:
+      agents.default.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+      agents.default.terminationGracePeriodSeconds: 180
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-default-agent
+      matchMany: false
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      # maxSurge MUST stay 0 to preserve the no-two-agents invariant;
+      # assert on the rendered value, not a regex, so it cannot pass vacuously.
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 180
+
+  - it: RollingUpdate with only type set still renders the rollingUpdate block with safe defaults
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.strategy:
+        type: RollingUpdate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      # maxSurge defaults to 0 (no two agents) even when omitted.
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+
+  # ---- #1523 regression: per-pool rollout values must not leak across pools ----
+  # Pin the rollingUpdate absence with a documentSelector on the fork pool so
+  # it cannot pass vacuously on the pool that DOES render one.
+
+  - it: a pool opting into RollingUpdate leaves the sibling pool on Recreate with no rollingUpdate block
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    set:
+      # Only the default pool opts in; the fork pool must keep the defaults.
+      agents.default.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+      agents.default.terminationGracePeriodSeconds: 180
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 30
+
+  - it: the opting-in pool still carries its raised grace period when a sibling opts in
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    set:
+      agents.default.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+      agents.default.terminationGracePeriodSeconds: 180
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-default-agent
+      matchMany: false
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 180
+
+  # ---- Validation: a documented MUST that nothing enforced would silently ship ----
+  # The values doc says maxSurge MUST stay 0 and only Recreate / RollingUpdate
+  # are valid types; the template must fail the render, not ship a manifest the
+  # API server would reject (or a surge that breaks the no-two-agents invariant).
+
+  - it: a non-zero maxSurge renders rather than failing the chart
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+    asserts:
+      # maxSurge 0 is the conservative DEFAULT, not an enforced invariant. The
+      # race it was once said to prevent is currently unreachable, and only
+      # because FLEET_NODE_NAME is dead wiring (#1640), so the chart does not
+      # make an unbypassable policy ruling that depends on a bug staying
+      # unfixed. Operators may raise it knowingly.
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+  - it: an invalid strategy type fails the render, naming the allowed values
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.strategy.type: Rolling
+    asserts:
+      - failedTemplate:
+          errorPattern: 'agents\._implicit_\.strategy\.type: "Rolling" is not a valid Deployment strategy'
+
+  - it: an empty strategy key falls back to Recreate instead of nil-pointering
+    template: agent-deployment.yaml
+    values:
+      - ./values-null-strategy.yaml
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: an explicitly configured maxUnavailable of 0 is preserved, not defaulted
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+    asserts:
+      # Go templates treat 0 as empty, so `| default 1` silently rewrites a
+      # deliberately configured 0. hasKey is what distinguishes unset from 0.
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+
+  - it: a percentage maxSurge renders as the IntOrString the API accepts
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 1
+    asserts:
+      # sprig's `int` casts "25%" to 0, so any numeric comparison on this
+      # silently mis-reads it. The value passes through untouched.
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 25%
+
+  - it: maxSurge 0 with maxUnavailable 0 fails the render, as the API would
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 0%
+    asserts:
+      # "may not be 0 when maxSurge is 0". Failing at render beats an API
+      # error at apply time, and 0% is the spelling that slips past a
+      # numeric check.
+      - failedTemplate:
+          errorPattern: 'maxUnavailable may not be 0 when maxSurge is 0'
+
+  - it: a negative terminationGracePeriodSeconds fails the render
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.terminationGracePeriodSeconds: -5
+    asserts:
+      - failedTemplate:
+          errorPattern: 'terminationGracePeriodSeconds: -5 must be a non-negative integer'
+
+  - it: a non-numeric terminationGracePeriodSeconds fails the render
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.terminationGracePeriodSeconds: forever
+    asserts:
+      - failedTemplate:
+          errorPattern: 'terminationGracePeriodSeconds: forever must be a non-negative integer'
+
+  - it: a large terminationGracePeriodSeconds renders as an integer, not exponent
+    template: agent-deployment.yaml
+    set:
+      agent.enabled: true
+      agent.terminationGracePeriodSeconds: 1000000
+    asserts:
+      # Values arrive via fromYaml, so every number is a float64 and %v
+      # switches to exponent form at 1e6. YAML 1.1 does not resolve 1e+06 as
+      # a number, so the API server rejects the Deployment.
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 1000000
+
+  - it: validation failures name the offending pool, not the legacy key
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    set:
+      agents.llmkube-fork.strategy.type: Nonsense
+    asserts:
+      # `agent.strategy...` is the wrong key to edit in a multi-pool release,
+      # and bisecting a four-pool values file by hand is the alternative.
+      - failedTemplate:
+          errorPattern: 'agents\.llmkube-fork\.strategy\.type'
+
+  - it: a pool forcing Recreate drops an inherited global rollingUpdate block
+    template: agent-deployment.yaml
+    values:
+      - ./values-multi.yaml
+    set:
+      agent.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+      agents.llmkube-fork.strategy.type: Recreate
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-foreman-llmkube-fork-agent
+      matchMany: false
+    asserts:
+      # mustMergeOverwrite deep-merges .Values.agent into each pool, so the
+      # inherited rollingUpdate survives a pool overriding only `type`. The
+      # API server rejects Recreate carrying a rollingUpdate block.
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate

--- a/charts/foreman/tests/values-null-strategy.yaml
+++ b/charts/foreman/tests/values-null-strategy.yaml
@@ -1,5 +1,15 @@
 # "leave this at the default", written the natural way. Helm treats the empty
-# key as a deletion, so dereferencing .type used to nil-pointer the render.
+# key as a deletion, so the merged $agent.strategy is nil.
+#
+# Read this as a fixture pinning a RENDER CONTRACT, not as coverage of the
+# `| default dict` on its own. Removing that pipe alone changes nothing:
+# agent-deployment.yaml assigns `$strategy := $agent.strategy` and only THEN
+# reads `$strategy.type`, and Go templates tolerate a field lookup on a
+# variable holding nil. What this fixture does catch is the tempting
+# one-liner: collapsing those two steps into `$agent.strategy.type` makes the
+# render die with "nil pointer evaluating interface {}.type". The `| default
+# dict` stays as the belt-and-braces normalisation that keeps either spelling
+# safe.
 agents:
   p1:
     enabled: true

--- a/charts/foreman/tests/values-null-strategy.yaml
+++ b/charts/foreman/tests/values-null-strategy.yaml
@@ -1,0 +1,7 @@
+# "leave this at the default", written the natural way. Helm treats the empty
+# key as a deletion, so dereferencing .type used to nil-pointer the render.
+agents:
+  p1:
+    enabled: true
+    roles: [worker]
+    strategy:

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -278,6 +278,48 @@ agent:
   enabled: true
   replicaCount: 1
 
+  # How long the kubelet waits for the agent to finish in-flight work
+  # after sending SIGTERM before force-killing the pod. In-process
+  # (execution.image unset) tasks die with the SIGTERM — the agent has
+  # no drain hook yet — so raising this buys a longer window for a
+  # slow local-model turn to be interrupted cleanly by the scheduler's
+  # retry path. The default of 30s reproduces the previous hardcoded
+  # value so an existing install is unchanged until it opts in.
+  # Must be a non-negative integer; the chart fails the render otherwise,
+  # rather than shipping a manifest the API server rejects.
+  terminationGracePeriodSeconds: 30
+
+  # Pod rollout strategy for this agent Deployment.
+  #
+  # Recreate (default) tears the pool down before starting replacements, so it
+  # never runs two agents for the pool at once. RollingUpdate replaces them one
+  # at a time, so an image bump does not stop the whole pool.
+  #
+  # On the "two agents would race for the same task" reasoning, which the older
+  # comment here stated as fact: that race is currently UNREACHABLE, and only
+  # because of a bug. agent-deployment.yaml sets FLEET_NODE_NAME from
+  # spec.nodeName (the Kubernetes NODE), but no Go code reads it, so the agent
+  # falls back to os.Hostname() -- the POD name -- and each replica registers
+  # its own FleetNode. pollOnce then claims only tasks whose
+  # status.assignedNode matches its own node, so two pods are never offered the
+  # same task. Under the INTENDED node-scoped identity they would share one
+  # FleetNode and the race would be real. Tracked as #1640.
+  #
+  # So maxSurge 0 is the conservative default, not an enforced invariant: the
+  # chart will not hard-fail a non-zero surge, because that would be an
+  # unbypassable policy ruling resting on a bug staying unfixed. Raise it
+  # knowingly, and re-read #1640 first if it has been resolved.
+  #
+  # Worth knowing before opting in: with the chart's default replicaCount of 1,
+  # RollingUpdate with maxSurge 0 is behaviourally IDENTICAL to Recreate. The
+  # pool must scale to zero before the new pod starts, because it can never
+  # exceed `replicas`. This option only buys you anything at replicaCount > 1.
+  #
+  # maxUnavailable may not be 0 when maxSurge is 0; the Deployment validator
+  # rejects that pair and the chart fails the render rather than the apply.
+  strategy:
+    type: Recreate
+
   image:
     # registry: ghcr.io
     # Default: the lean runtime image (alpine + git). To run a coder-enabled

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -278,15 +278,37 @@ agent:
   enabled: true
   replicaCount: 1
 
-  # How long the kubelet waits for the agent to finish in-flight work
-  # after sending SIGTERM before force-killing the pod. In-process
-  # (execution.image unset) tasks die with the SIGTERM — the agent has
-  # no drain hook yet — so raising this buys a longer window for a
-  # slow local-model turn to be interrupted cleanly by the scheduler's
-  # retry path. The default of 30s reproduces the previous hardcoded
-  # value so an existing install is unchanged until it opts in.
-  # Must be a non-negative integer; the chart fails the render otherwise,
-  # rather than shipping a manifest the API server rejects.
+  # How long the kubelet waits after sending SIGTERM before force-killing
+  # the agent pod.
+  #
+  # Raising this does NOT currently lengthen anything. On SIGTERM the
+  # watcher's poll loop returns straight away on ctx.Done()
+  # (pkg/foreman/agent/watcher.go), an in-process task's executor runs in
+  # a goroutine that nothing waits on, and the FleetNode registrar's drain
+  # patch is capped at its own 5s timeout (pkg/foreman/agent/fleetnode.go),
+  # so the process is gone within a few seconds whatever this is set to.
+  # There is no drain hook yet. Treat the knob as forward-wiring for the
+  # drain work tracked in #1438, plus a way to LOWER the value on a pool
+  # that should die fast. It does not buy a slow local-model turn a longer
+  # window to finish or to be interrupted cleanly.
+  #
+  # What recovers the killed task is the operator, not the agent. It is
+  # NOT recoverOrphanedTasks: that matches only tasks whose
+  # status.assignedNode equals the agent's own FleetNode name, and the
+  # replacement pod registers under a different name (the agent falls back
+  # to os.Hostname(), the POD name; see the strategy note below), so it
+  # never sees the dead pod's work. It is checkClaimExpiry in
+  # internal/foreman/controller/agentictask_controller.go, which releases
+  # the task back to Pending once the assigned FleetNode's heartbeat goes
+  # stale and terminal-fails it on the third expiry. The cost is real: a
+  # rollout during a long run spends one of that task's three strikes, so
+  # repeated rollouts can fail a task outright rather than re-queue it.
+  #
+  # Must be a non-negative whole number of seconds. The chart fails the
+  # render on a negative, non-numeric or fractional value, rather than
+  # shipping a manifest the API server rejects or silently truncating a
+  # 30.5 to 30. The default of 30 reproduces the previous hardcoded value
+  # so an existing install is unchanged until it opts in.
   terminationGracePeriodSeconds: 30
 
   # Pod rollout strategy for this agent Deployment.
@@ -309,6 +331,18 @@ agent:
   # chart will not hard-fail a non-zero surge, because that would be an
   # unbypassable policy ruling resting on a bug staying unfixed. Raise it
   # knowingly, and re-read #1640 first if it has been resolved.
+  #
+  # Know what "knowingly" costs. The sharper hazard is not the lost Scheduled
+  # claim, it is recoverOrphanedTasks (pkg/foreman/agent/watcher.go): it runs
+  # once at agent startup and resets EVERY task in phase=Running assigned to
+  # its own FleetNode back to Pending. A surging pod that shared a node-scoped
+  # identity with its still-running sibling would reset that sibling's
+  # in-flight work at boot, the scheduler would re-dispatch a task that is
+  # still executing, and two agents would end up pushing the same branch.
+  # That is worse than losing a Scheduled claim. It is unreachable today for
+  # the same reason the claim race is (the two pods register separate
+  # FleetNodes under pod-name identity), and #1640 is what would make it
+  # reachable.
   #
   # Worth knowing before opting in: with the chart's default replicaCount of 1,
   # RollingUpdate with maxSurge 0 is behaviourally IDENTICAL to Recreate. The


### PR DESCRIPTION
## What

Expose the foreman-agent rollout strategy and termination grace period as
per-pool chart values.

## Why

Refs #1438

`agent-deployment.yaml` hardcoded `strategy: Recreate` and
`terminationGracePeriodSeconds: 30`, so a routine image bump tore down every
replica of a pool at once, and there was no per-pool way to opt into a gentler
rollout.

## Scope: the chart half only

No preStop hook, no operator change, deliberately. A preStop hook runs **before**
SIGTERM and its runtime counts against the grace period, and the agent's executor
dies with the SIGTERM (`fleetnode.go` patches `phase=Draining` on context
cancellation; it does not finish in-flight work). A preStop sleep would look like
a drain without being one. Making the agent outlive SIGTERM is an agent-side
design decision.

## The race the old comment asserted

The comment justifying `Recreate` said it "stops a rolling update from briefly
running two agents that race for the same Scheduled tasks." **That race is
currently unreachable, and only because of a bug.**

`FLEET_NODE_NAME` is set from `spec.nodeName` but read by no Go code, so the
agent falls back to `os.Hostname()` — the pod name — and each replica registers
its own FleetNode. `pollOnce` then claims only tasks whose `status.assignedNode`
matches its own node, so two pods are never offered the same task. Under the
*intended* node-scoped identity they would share one FleetNode and the race would
be real. Filed as #1640.

So **`maxSurge: 0` is the conservative default, not an enforced invariant.** An
earlier revision of this branch hard-failed a non-zero surge; that would be an
unbypassable policy ruling resting on a bug staying unfixed, so it is gone. If
#1640 is resolved toward node-scoped identity, this is worth revisiting.

`values.yaml` also now states something the option's own pitch obscured: at the
chart's default `replicaCount: 1`, RollingUpdate with `maxSurge: 0` is
**behaviourally identical to Recreate** — the pool must scale to zero before the
new pod starts. It only helps at `replicaCount > 1`.

## What the chart does fail the render for

Only values Kubernetes itself rejects, so the error arrives with a message rather
than at apply time:

| Input | Why |
|---|---|
| `strategy.type` other than `Recreate`/`RollingUpdate`, case-exact | the API server rejects `rollingUpdate` too |
| `maxUnavailable: 0` with `maxSurge: 0`, including `0%` | "may not be 0 when maxSurge is 0"; `0%` slips past a numeric check |
| negative or non-numeric `terminationGracePeriodSeconds` | API-rejected |

Messages name the offending pool (`agents.<pool>.strategy.type`), since that is
the key to edit and bisecting a multi-pool values file by hand was the alternative.

## Three silent-bad-manifest fixes

- **Empty `strategy:` key** is a null, not a dict, so dereferencing `.type`
  nil-pointered the entire render — the natural way to write "leave this at the
  default". Now falls back to `Recreate`.
- **`hasKey`, not `| default`**, for maxSurge/maxUnavailable. Go templates treat
  `0` as empty, so `default` silently rewrote a deliberately configured `0`.
- **`terminationGracePeriodSeconds | int64`**. Values arrive via `fromYaml` as
  float64 and `%v` switches to exponent form at 1e6; YAML 1.1 does not resolve
  `1e+06` as a number, so the API server rejects the Deployment.

The rendered comment above `strategy:` is now accurate in both modes. It
previously shipped Recreate's rationale verbatim above a rendered
`type: RollingUpdate`, so every opted-in manifest contradicted itself.

## Verification

- Default and multi-pool renders differ from `upstream/main` **only in comment
  text** (the corrected wording)
- `helm unittest`: 57/57, up from 46
- Mutation-tested: neutering both new guards fails exactly 3 tests
- Negative cases covered: null `strategy:`, `maxUnavailable: 0`, `maxSurge: 25%`,
  `0`+`0%`, negative/non-numeric/1e6 grace periods, per-pool message, and the
  deep-merge leak where a pool forcing Recreate inherits a global `rollingUpdate`

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated — `values.yaml`

Assisted-by: Claude Code via the Foreman harness (an agentic coder produced the
first implementation and one revision; an adversarial review found thirteen
defects including the false race premise, and I hand-fixed all of them, removed
the maxSurge hard-fail after establishing the race is unreachable, and ran the
renders, mutation tests and full chart suite before submitting).
