### PR TITLE
feat(foreman): report the Kubernetes node on FleetNode.status, not as identity

### DIFF
--- a/api/foreman/v1alpha1/fleetnode_types.go
+++ b/api/foreman/v1alpha1/fleetnode_types.go
@@ -95,8 +95,13 @@ type FleetNodeCapability struct {
 // FleetNode object. Most of the resource's interesting fields live in Status,
 // which the FleetAgent updates on every heartbeat.
 type FleetNodeSpec struct {
-	// NodeName is the human-readable identity of the worker. Conventionally
-	// matches metadata.name; required for the scheduler to address it.
+	// NodeName is the human-readable identity of the WORKER — the agent
+	// process, not the machine it runs on (#1640). Conventionally matches
+	// metadata.name; required for the scheduler to address it. For an
+	// in-cluster agent this is the pod name (the agent falls back to
+	// os.Hostname()); off-cluster agents set it via --fleet-node-name. The
+	// Kubernetes node a pod is scheduled on is reported separately at
+	// status.kubernetesNode.
 	// +kubebuilder:validation:Required
 	NodeName string `json:"nodeName"`
 
@@ -182,6 +187,15 @@ type FleetNodeStatus struct {
 	// (runtime.GOARCH). Used alongside OS for platform artifact selection.
 	// +optional
 	Arch string `json:"arch,omitempty"`
+
+	// KubernetesNode is the Kubernetes node the agent pod is scheduled on,
+	// reported by the agent on heartbeat from the FLEET_NODE_NAME downward-API
+	// env var (fieldRef: spec.nodeName). It is a PROPERTY of the worker, not
+	// its identity: FleetNode identity is the agent process (#1640), and
+	// spec.nodeName holds the worker's own name. Off-cluster agents (metal
+	// Macs) have no Kubernetes node and leave this empty.
+	// +optional
+	KubernetesNode string `json:"kubernetesNode,omitempty"`
 
 	// UpdateRequest is written by the AgentReleaseReconciler when a new
 	// agent version is ready for this node to install. The agent reads

--- a/api/foreman/v1alpha1/fleetnode_types.go
+++ b/api/foreman/v1alpha1/fleetnode_types.go
@@ -220,6 +220,7 @@ type FleetNodeStatus struct {
 // +kubebuilder:printcolumn:name="Accelerator",type=string,JSONPath=`.status.capability.accelerator`
 // +kubebuilder:printcolumn:name="RAM",type=integer,JSONPath=`.status.capability.availableRAMGB`
 // +kubebuilder:printcolumn:name="Current Task",type=string,JSONPath=`.status.currentTask`
+// +kubebuilder:printcolumn:name="K8s Node",type=string,JSONPath=`.status.kubernetesNode`
 // +kubebuilder:printcolumn:name="Heartbeat",type=date,JSONPath=`.status.lastHeartbeatTime`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/charts/foreman/templates/crds/fleetnodes.yaml
+++ b/charts/foreman/templates/crds/fleetnodes.yaml
@@ -69,8 +69,13 @@ spec:
             properties:
               nodeName:
                 description: |-
-                  NodeName is the human-readable identity of the worker. Conventionally
-                  matches metadata.name; required for the scheduler to address it.
+                  NodeName is the human-readable identity of the WORKER — the agent
+                  process, not the machine it runs on (#1640). Conventionally matches
+                  metadata.name; required for the scheduler to address it. For an
+                  in-cluster agent this is the pod name (the agent falls back to
+                  os.Hostname()); off-cluster agents set it via --fleet-node-name. The
+                  Kubernetes node a pod is scheduled on is reported separately at
+                  status.kubernetesNode.
                 type: string
               roles:
                 description: |-
@@ -226,6 +231,15 @@ spec:
                   CurrentTask is the namespaced name of the AgenticTask the agent is
                   running, or empty if idle. The scheduler skips nodes with a non-empty
                   CurrentTask (v0.1 concurrency is one task per node).
+                type: string
+              kubernetesNode:
+                description: |-
+                  KubernetesNode is the Kubernetes node the agent pod is scheduled on,
+                  reported by the agent on heartbeat from the FLEET_NODE_NAME downward-API
+                  env var (fieldRef: spec.nodeName). It is a PROPERTY of the worker, not
+                  its identity: FleetNode identity is the agent process (#1640), and
+                  spec.nodeName holds the worker's own name. Off-cluster agents (metal
+                  Macs) have no Kubernetes node and leave this empty.
                 type: string
               lastHeartbeatTime:
                 description: |-

--- a/charts/foreman/templates/crds/fleetnodes.yaml
+++ b/charts/foreman/templates/crds/fleetnodes.yaml
@@ -33,6 +33,9 @@ spec:
     - jsonPath: .status.currentTask
       name: Current Task
       type: string
+    - jsonPath: .status.kubernetesNode
+      name: K8s Node
+      type: string
     - jsonPath: .status.lastHeartbeatTime
       name: Heartbeat
       type: date

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -276,22 +276,16 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	if fleetNodeName == "" {
-		host, err := os.Hostname()
-		if err != nil || host == "" {
-			setupLog.Error(err, "--fleet-node-name is required; OS hostname unavailable")
-			os.Exit(1)
-		}
-		fleetNodeName = sanitizeName(host)
-	} else {
-		// User-supplied name still needs to be a valid DNS-1123 label.
-		clean := sanitizeName(fleetNodeName)
-		if clean != fleetNodeName {
-			setupLog.Info("fleet-node-name sanitized for DNS-1123 compliance",
-				"input", fleetNodeName, "result", clean)
-			fleetNodeName = clean
-		}
+	resolved, err := resolveFleetNodeName(fleetNodeName, os.Hostname)
+	if err != nil {
+		setupLog.Error(err, "--fleet-node-name is required; OS hostname unavailable")
+		os.Exit(1)
 	}
+	if fleetNodeName != "" && resolved != fleetNodeName {
+		setupLog.Info("fleet-node-name sanitized for DNS-1123 compliance",
+			"input", fleetNodeName, "result", resolved)
+	}
+	fleetNodeName = resolved
 
 	if agentMode == "stub" && workspaceDir == "" && opencodeBin == "" {
 		setupLog.Info(
@@ -410,7 +404,12 @@ func main() {
 		Kind:     "foreman-agent",
 		OS:       goruntime.GOOS,
 		Arch:     goruntime.GOARCH,
-		Updater:  updater,
+		// The chart sets FLEET_NODE_NAME from the downward API
+		// (fieldRef: spec.nodeName). It reports which Kubernetes node this
+		// pod runs on; it is NOT the FleetNode's identity (#1640). Empty
+		// off-cluster.
+		KubernetesNode: os.Getenv("FLEET_NODE_NAME"),
+		Updater:        updater,
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -903,6 +902,26 @@ func makePodLogTailFn(kcs kubernetes.Interface) func(ctx context.Context, namesp
 }
 
 var dns1123Bad = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// resolveFleetNodeName resolves this process's FleetNode identity: the
+// --fleet-node-name flag when set, otherwise the OS hostname (which in a pod
+// is the POD name). Both are sanitized to a DNS-1123 label. The
+// FLEET_NODE_NAME env var — the Kubernetes node, via the downward API — is
+// deliberately not an input: FleetNode identity is the agent process (#1640),
+// and the node it runs on is reported separately at status.kubernetesNode.
+func resolveFleetNodeName(flagValue string, hostname func() (string, error)) (string, error) {
+	if flagValue != "" {
+		return sanitizeName(flagValue), nil
+	}
+	host, err := hostname()
+	if err != nil {
+		return "", fmt.Errorf("resolve fleet node name: %w", err)
+	}
+	if host == "" {
+		return "", fmt.Errorf("resolve fleet node name: empty hostname")
+	}
+	return sanitizeName(host), nil
+}
 
 func sanitizeName(s string) string {
 	s = strings.ToLower(s)

--- a/cmd/foreman-agent/main_test.go
+++ b/cmd/foreman-agent/main_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"reflect"
 	"sort"
@@ -310,3 +311,44 @@ func TestCommitterName_FallbackToAuthor(t *testing.T) {
 		})
 	}
 }
+
+// The identity-source contract from #1640: FleetNode identity is the agent
+// PROCESS. The --fleet-node-name flag wins when set; otherwise identity is the
+// sanitized OS hostname, which in a pod is the POD name. The FLEET_NODE_NAME
+// env var (the Kubernetes node, via downward API) is deliberately NOT an
+// input here — it feeds status.kubernetesNode, never the identity.
+func TestResolveFleetNodeName(t *testing.T) {
+	cases := []struct {
+		name     string
+		flag     string
+		hostname string
+		hostErr  error
+		want     string
+		wantErr  bool
+	}{
+		{"flag wins over hostname", "m5max-coder", "ignored-host", nil, "m5max-coder", false},
+		{"flag is sanitized to a DNS-1123 label", "My_Agent", "ignored", nil, "my-agent", false},
+		{"empty flag falls back to sanitized hostname", "", "coder-agent-ABC12", nil, "coder-agent-abc12", false},
+		{"no flag and no hostname is an error", "", "", nil, "", true},
+		{"hostname error surfaces", "", "", errHostname, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveFleetNodeName(tc.flag, func() (string, error) { return tc.hostname, tc.hostErr })
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveFleetNodeName(%q) = %q, want %q", tc.flag, got, tc.want)
+			}
+		})
+	}
+}
+
+var errHostname = errors.New("hostname unavailable")

--- a/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
@@ -68,8 +68,13 @@ spec:
             properties:
               nodeName:
                 description: |-
-                  NodeName is the human-readable identity of the worker. Conventionally
-                  matches metadata.name; required for the scheduler to address it.
+                  NodeName is the human-readable identity of the WORKER — the agent
+                  process, not the machine it runs on (#1640). Conventionally matches
+                  metadata.name; required for the scheduler to address it. For an
+                  in-cluster agent this is the pod name (the agent falls back to
+                  os.Hostname()); off-cluster agents set it via --fleet-node-name. The
+                  Kubernetes node a pod is scheduled on is reported separately at
+                  status.kubernetesNode.
                 type: string
               roles:
                 description: |-
@@ -225,6 +230,15 @@ spec:
                   CurrentTask is the namespaced name of the AgenticTask the agent is
                   running, or empty if idle. The scheduler skips nodes with a non-empty
                   CurrentTask (v0.1 concurrency is one task per node).
+                type: string
+              kubernetesNode:
+                description: |-
+                  KubernetesNode is the Kubernetes node the agent pod is scheduled on,
+                  reported by the agent on heartbeat from the FLEET_NODE_NAME downward-API
+                  env var (fieldRef: spec.nodeName). It is a PROPERTY of the worker, not
+                  its identity: FleetNode identity is the agent process (#1640), and
+                  spec.nodeName holds the worker's own name. Off-cluster agents (metal
+                  Macs) have no Kubernetes node and leave this empty.
                 type: string
               lastHeartbeatTime:
                 description: |-

--- a/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_fleetnodes.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.currentTask
       name: Current Task
       type: string
+    - jsonPath: .status.kubernetesNode
+      name: K8s Node
+      type: string
     - jsonPath: .status.lastHeartbeatTime
       name: Heartbeat
       type: date

--- a/docs/site/foreman/README.md
+++ b/docs/site/foreman/README.md
@@ -55,7 +55,7 @@ Four CRDs make up the Foreman surface:
 | `Workload` | namespaced | The user-facing intent ("fix these eight issues in this repo"). The reconciler decomposes it into a pipeline of AgenticTasks. |
 | `AgenticTask` | namespaced | One dispatchable unit of work. References an Agent + a payload. The scheduler claims it for a FleetNode whose capability matches. |
 | `Agent` | namespaced | A reusable role definition: system prompt, tool whitelist, model endpoint, required capability. The same Agent can drive many AgenticTasks. |
-| `FleetNode` | cluster-scoped | A node in the fleet. The foreman-agent on each host self-registers and advertises its capability (accelerator family, RAM, context window, roles). |
+| `FleetNode` | cluster-scoped | A worker in the fleet. Identity is the foreman-agent *process*, not the machine: each agent self-registers one FleetNode and advertises its capability (accelerator family, RAM, context window, roles). A host running two agents therefore has two FleetNodes; the machine an in-cluster agent landed on is reported as a property on `status.kubernetesNode`. |
 
 The minimal lifecycle:
 
@@ -113,8 +113,10 @@ helm install foreman llmkube/foreman \
 ```
 
 That installs the foreman-operator (controllers for the four CRDs),
-plus a foreman-agent Deployment that registers a FleetNode for the
-gate-runner role on the Linux/K8s host. Apple Silicon coder /
+plus a foreman-agent Deployment for the gate-runner role on the
+Linux/K8s host. Each agent replica registers its own FleetNode, so a
+pool with `replicaCount: 2` produces two FleetNodes on that one host,
+each reporting the same `status.kubernetesNode`. Apple Silicon coder /
 reviewer nodes run the foreman-agent binary directly via launchd;
 see [the M3 runbook](/docs/foreman/runbook-m3) and
 [the M4 runbook](/docs/foreman/runbook-m4) for hosts-side install.

--- a/pkg/foreman/agent/fleetnode.go
+++ b/pkg/foreman/agent/fleetnode.go
@@ -83,6 +83,12 @@ type Registrar struct {
 	Labels   map[string]string
 	Interval time.Duration // zero defaults to DefaultHeartbeatInterval
 
+	// KubernetesNode is the Kubernetes node this agent's pod runs on, from
+	// the FLEET_NODE_NAME downward-API env var. Reported on FleetNode.status
+	// as a property of the worker; empty off-cluster. Never part of the
+	// FleetNode's identity (#1640).
+	KubernetesNode string
+
 	// Version is the agent binary's version string (e.g. "v0.8.4").
 	// Set from the build-time ldflags var and stamped on FleetNode.status
 	// every heartbeat so the cluster can observe which version is running.
@@ -243,6 +249,9 @@ func (r *Registrar) PatchHeartbeat(ctx context.Context, phase foremanv1alpha1.Fl
 	}
 	if r.Arch != "" {
 		node.Status.Arch = r.Arch
+	}
+	if r.KubernetesNode != "" {
+		node.Status.KubernetesNode = r.KubernetesNode
 	}
 	if err := r.Client.Status().Patch(ctx, &node, patch); err != nil {
 		return nil, fmt.Errorf("patch FleetNode status: %w", err)

--- a/pkg/foreman/agent/fleetnode_test.go
+++ b/pkg/foreman/agent/fleetnode_test.go
@@ -597,8 +597,11 @@ func TestRegistrar_PatchHeartbeat_StampsKubernetesNode(t *testing.T) {
 	}
 }
 
-// Off-cluster agents (the metal Macs) have no Kubernetes node and leave the
-// field empty; an empty value must not be stamped as anything.
+// Off-cluster agents (the metal Macs) have no Kubernetes node, so a node
+// that has never been stamped stays empty. This case alone cannot tell the
+// r.KubernetesNode != "" guard apart from its absence (an unconditional ""
+// write is indistinguishable on a fresh node); the sticky-value test below
+// is the one that pins the guard down.
 func TestRegistrar_PatchHeartbeat_OmitsKubernetesNodeWhenUnset(t *testing.T) {
 	kc := newFakeClient(t)
 	r := &Registrar{
@@ -622,5 +625,54 @@ func TestRegistrar_PatchHeartbeat_OmitsKubernetesNodeWhenUnset(t *testing.T) {
 	}
 	if got.Status.KubernetesNode != "" {
 		t.Errorf("Status.KubernetesNode = %q, want empty", got.Status.KubernetesNode)
+	}
+}
+
+// A Registrar with KubernetesNode empty must not erase a value that is
+// already on status. This is the case that separates the
+// r.KubernetesNode != "" guard from its absence: without the guard, an
+// unconditional "" assignment plus the field's json omitempty tag makes
+// the MergeFrom patch emit kubernetesNode: null and the stored value is
+// lost. The guard makes the property sticky, matching how OS and Arch
+// already behave, so a stamped node keeps its last known machine even if
+// the agent restarts without the FLEET_NODE_NAME downward-API env var.
+func TestRegistrar_PatchHeartbeat_KeepsExistingKubernetesNodeWhenUnset(t *testing.T) {
+	kc := newFakeClient(t)
+	spec := foremanv1alpha1.FleetNodeSpec{
+		NodeName: "coder-agent-abc12",
+		Roles:    []string{"coder"},
+	}
+	stamped := &Registrar{
+		Client:         kc,
+		NodeName:       "coder-agent-abc12",
+		Spec:           spec,
+		Provider:       &fixedCapability{},
+		KubernetesNode: "ahazidgx1",
+	}
+	if err := stamped.Upsert(context.Background()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if _, err := stamped.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
+		t.Fatalf("PatchHeartbeat (stamped): %v", err)
+	}
+
+	// A second Registrar for the same FleetNode with the env var absent.
+	unset := &Registrar{
+		Client:   kc,
+		NodeName: "coder-agent-abc12",
+		Spec:     spec,
+		Provider: &fixedCapability{},
+	}
+	if _, err := unset.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
+		t.Fatalf("PatchHeartbeat (unset): %v", err)
+	}
+
+	var got foremanv1alpha1.FleetNode
+	if err := kc.Get(context.Background(), types.NamespacedName{Name: "coder-agent-abc12"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status.KubernetesNode != "ahazidgx1" {
+		t.Errorf("Status.KubernetesNode = %q, want %q (empty Registrar must not clear a stamped value)",
+			got.Status.KubernetesNode, "ahazidgx1")
 	}
 }

--- a/pkg/foreman/agent/fleetnode_test.go
+++ b/pkg/foreman/agent/fleetnode_test.go
@@ -564,3 +564,63 @@ func TestRegistrar_Run_DrainsAndExitsOnCancel(t *testing.T) {
 		t.Errorf("final phase = %q, want Draining", got.Status.Phase)
 	}
 }
+
+// The #1640 decision: FleetNode identity is the agent process, and the
+// physical machine is a reported PROPERTY. status.kubernetesNode is where
+// that property lands for in-cluster agents (fed from the FLEET_NODE_NAME
+// downward-API env var, which was previously set by the chart but read by
+// nothing).
+func TestRegistrar_PatchHeartbeat_StampsKubernetesNode(t *testing.T) {
+	kc := newFakeClient(t)
+	r := &Registrar{
+		Client:   kc,
+		NodeName: "coder-agent-abc12",
+		Spec: foremanv1alpha1.FleetNodeSpec{
+			NodeName: "coder-agent-abc12",
+			Roles:    []string{"coder"},
+		},
+		Provider:       &fixedCapability{},
+		KubernetesNode: "ahazidgx1",
+	}
+	if err := r.Upsert(context.Background()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if _, err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
+		t.Fatalf("PatchHeartbeat: %v", err)
+	}
+	var got foremanv1alpha1.FleetNode
+	if err := kc.Get(context.Background(), types.NamespacedName{Name: "coder-agent-abc12"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status.KubernetesNode != "ahazidgx1" {
+		t.Errorf("Status.KubernetesNode = %q, want %q", got.Status.KubernetesNode, "ahazidgx1")
+	}
+}
+
+// Off-cluster agents (the metal Macs) have no Kubernetes node and leave the
+// field empty; an empty value must not be stamped as anything.
+func TestRegistrar_PatchHeartbeat_OmitsKubernetesNodeWhenUnset(t *testing.T) {
+	kc := newFakeClient(t)
+	r := &Registrar{
+		Client:   kc,
+		NodeName: "mac-studio-reviewer",
+		Spec: foremanv1alpha1.FleetNodeSpec{
+			NodeName: "mac-studio-reviewer",
+			Roles:    []string{"reviewer"},
+		},
+		Provider: &fixedCapability{},
+	}
+	if err := r.Upsert(context.Background()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if _, err := r.PatchHeartbeat(context.Background(), foremanv1alpha1.FleetNodePhaseReady); err != nil {
+		t.Fatalf("PatchHeartbeat: %v", err)
+	}
+	var got foremanv1alpha1.FleetNode
+	if err := kc.Get(context.Background(), types.NamespacedName{Name: "mac-studio-reviewer"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status.KubernetesNode != "" {
+		t.Errorf("Status.KubernetesNode = %q, want empty", got.Status.KubernetesNode)
+	}
+}


### PR DESCRIPTION
## What

Implement the #1640 decision: FleetNode identity is the agent **process**, and
the Kubernetes node it runs on becomes a reported **property** —
`status.kubernetesNode`.

## Why

Refs #1640

The chart has set `FLEET_NODE_NAME` from the downward API (`fieldRef:
spec.nodeName`) since M4c, but no Go code ever read it. The agent falls back to
`os.Hostname()` — the pod name — so every replica registers its own FleetNode.
The decision on #1640 established that fallback as the correct model:
`spec.nodeName`'s contract was always worker-scoped, and every
`FleetNode.status` mechanism (one `currentTask` reservation, heartbeat-driven
claim expiry and the Draining reaper, `phase`) assumes a single writer. Wiring
the env var into identity would break all of them at once and reintroduce the
two-agents claim race.

What was genuinely missing is the machine as a *property*: nothing recorded
which physical node an in-cluster agent pod runs on. On a fleet of two GB10s, a
Strix and metal Macs, "which box is this agent on?" was unanswerable from the CR.

## How

- **`status.kubernetesNode`**, stamped on heartbeat alongside `os`/`arch`, fed
  from `FLEET_NODE_NAME` — the previously-dead env var, repurposed rather than
  deleted. Off-cluster agents leave it empty (covered by a test).
- **`spec.nodeName` godoc corrected** to state it is the worker's own name (the
  pod name in-cluster) and that the Kubernetes node lives at
  `status.kubernetesNode`. The field is **not** renamed — that is a CRD break,
  deferred per the decision.
- **`resolveFleetNodeName` extracted from `main()` and tested**, pinning the
  identity-source contract (#1640 ask 3): the `--fleet-node-name` flag wins,
  otherwise the sanitized hostname; `FLEET_NODE_NAME` is deliberately not an
  input.
- CRDs regenerated: `make manifests`, `chart-crds`, `foreman-chart-crds`;
  `make check-helm-rbac` green.

The kube-state-metrics CustomResourceState label for the new field rides with
the #1643 CRS fix, where that config file is already being rewritten — adding it
here would guarantee a conflict between the two branches.

## Follow-up

#1648 (StatefulSet stable identity) is the named follow-up for the churn cost
this decision accepts.

## Verification

- Watched both registrar tests and the resolver test fail first (missing field /
  missing function), then pass
- `go test ./pkg/foreman/agent/ ./cmd/foreman-agent/ ./api/foreman/...` green
- `make lint`, `GOOS=linux` cross-arch lint, `make lint-deadcode`: 0 issues
- `make check-helm-rbac`: green; `helm unittest charts/foreman`: 39/39

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — CRD godoc is the user-facing surface here

Assisted-by: Claude Code (implemented under TDD from the #1640 decision I made
after its architecture study; I reviewed the change and ran the tests, both
lints, the RBAC check and the chart suite before submitting).
