### PR TITLE
fix(foreman): make the CustomResourceState config produce usable metrics

### DIFF
--- a/charts/foreman/templates/crs-configmap.yaml
+++ b/charts/foreman/templates/crs-configmap.yaml
@@ -163,6 +163,9 @@ data:
                     current_task: [status, currentTask]
                     version: [status, agentVersion]
                     agent_kind: [status, agentKind]
+                    # The machine as a property, not the identity (#1640).
+                    # Empty for off-cluster agents.
+                    kubernetes_node: [status, kubernetesNode]
 
             # foreman_fleetnode_role_info{name,node,role} -- ONE SERIES PER
             # ROLE. spec.roles is a list, so the Info metric targets the array

--- a/charts/foreman/templates/crs-configmap.yaml
+++ b/charts/foreman/templates/crs-configmap.yaml
@@ -15,181 +15,203 @@ metadata:
     {{- include "foreman.labels" . | nindent 4 }}
 data:
   {{ .Values.foreman.crs.configMapKey }}: |
-    resources:
-      # -- AgenticTask -------------------------------------------------------
-      - groupVersionKind:
-          group: foreman.llmkube.dev
-          version: v1alpha1
-          kind: AgenticTask
-        metricNamePrefix: foreman_agentictask
-        metrics:
-          # foreman_agentictask_info{namespace,name,workload,agent,phase,verdict}
-          - name: info
-            help: "AgenticTask phase and verdict"
-            each:
-              type: Info
-              info:
-                labelsFromPath:
-                  phase: [status, phase]
-                  verdict: [status, verdict]
-                  workload: [metadata, labels, "foreman.llmkube.dev/workload"]
-                  agent: [spec, agentRef, name]
+    kind: CustomResourceStateMetrics
+    spec:
+      resources:
+        # -- AgenticTask -------------------------------------------------------
+        - groupVersionKind:
+            group: foreman.llmkube.dev
+            version: v1alpha1
+            kind: AgenticTask
+          metricNamePrefix: foreman_agentictask
+          # Without this every series is anonymous: you can count
+          # AgenticTasks by phase but cannot name the one that is stuck.
+          labelsFromPath:
+            name: [metadata, name]
+          metrics:
+            # foreman_agentictask_info{namespace,name,workload,agent,phase,verdict}
+            - name: info
+              help: "AgenticTask phase and verdict"
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    phase: [status, phase]
+                    verdict: [status, verdict]
+                    workload: [metadata, labels, "foreman.llmkube.dev/workload"]
+                    agent: [spec, agentRef, name]
+                    # The node actually running it. Without this a running task
+                    # cannot be joined to the FleetNode supervising it, which is
+                    # the join a fleet view is built on.
+                    node: [status, assignedNode]
+                    kind: [spec, kind]
 
-          # Enum-style gauges: one series per state, value=1 on the active
-          # state. Easy to alert on (e.g. sum by (namespace) of the Pending
-          # series = pending task count).
-          - name: phase
-            help: "AgenticTask phase (1 = active)"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
+            # Enum-style gauges: one series per state, value=1 on the active
+            # state. Easy to alert on (e.g. sum by (namespace) of the Pending
+            # series = pending task count).
+            - name: phase
+              help: "AgenticTask phase (1 = active)"
+              each:
+                type: StateSet
+                stateSet:
+                  labelName: phase
                   path: [status, phase]
-                labelsMapping:
-                  Pending: pending
-                  Scheduled: scheduled
-                  Running: running
-                  Verifying: verifying
-                  Succeeded: succeeded
-                  Failed: failed
+                  list: [Pending, Scheduled, Running, Verifying, Succeeded, Failed]
 
-          - name: verdict
-            help: "AgenticTask verdict (1 = active)"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
+            - name: verdict
+              help: "AgenticTask verdict (1 = active)"
+              each:
+                type: StateSet
+                stateSet:
+                  labelName: verdict
                   path: [status, verdict]
-                labelsMapping:
-                  GO: go
-                  "NO-GO": no-go
-                  INCOMPLETE: incomplete
-                  "GATE-PASS": gate-pass
-                  "GATE-FAIL": gate-fail
-                  "GATE-ERROR": gate-error
-                  Skipped: skipped
+                  list: [GO, NO-GO, INCOMPLETE, GATE-PASS, GATE-FAIL, GATE-ERROR, Skipped]
 
-          # Counter for failed children, derived from the AgenticTask's own
-          # phase (a task is either failed or it isn't).
-          - name: tasks_failed
-            help: "AgenticTasks in Failed phase (gauge=1 per failed task)"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
+        # -- Workload ----------------------------------------------------------
+        - groupVersionKind:
+            group: foreman.llmkube.dev
+            version: v1alpha1
+            kind: Workload
+          metricNamePrefix: foreman_workload
+          # Without this every series is anonymous: you can count
+          # Workloads by phase but cannot name the one that is stuck.
+          labelsFromPath:
+            name: [metadata, name]
+          metrics:
+            # foreman_workload_info{namespace,name,phase,repo}
+            - name: info
+              help: "Workload phase and repo"
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    phase: [status, phase]
+                    repo: [spec, repo]
+
+            # foreman_workload_succeeded_tasks / _failed_tasks / _incomplete_tasks
+            # (integer gauges = status.<field>)
+            - name: succeeded_tasks
+              help: "Succeeded child AgenticTasks for this Workload"
+              each:
+                type: Gauge
+                gauge:
+                  # valueFrom is RELATIVE to path, and path is required: with
+                  # an absolute valueFrom and no path kube-state-metrics emits
+                  # nothing at all, silently.
+                  path: [status]
+                  valueFrom: [succeededTasks]
+
+            - name: failed_tasks
+              help: "Failed child AgenticTasks for this Workload"
+              each:
+                type: Gauge
+                gauge:
+                  # valueFrom is RELATIVE to path, and path is required: with
+                  # an absolute valueFrom and no path kube-state-metrics emits
+                  # nothing at all, silently.
+                  path: [status]
+                  valueFrom: [failedTasks]
+
+            - name: incomplete_tasks
+              help: "Incomplete child AgenticTasks for this Workload"
+              each:
+                type: Gauge
+                gauge:
+                  # valueFrom is RELATIVE to path, and path is required: with
+                  # an absolute valueFrom and no path kube-state-metrics emits
+                  # nothing at all, silently.
+                  path: [status]
+                  valueFrom: [incompleteTasks]
+
+            # Enum-style phase gauges for Workload (Planning / Planned /
+            # Dispatched / Completed / Failed).
+            - name: phase
+              help: "Workload phase (1 = active)"
+              each:
+                type: StateSet
+                stateSet:
+                  labelName: phase
                   path: [status, phase]
-                labelsMapping:
-                  Failed: failed
+                  list: [Planning, Planned, Dispatched, Completed, Failed]
 
-      # -- Workload ----------------------------------------------------------
-      - groupVersionKind:
-          group: foreman.llmkube.dev
-          version: v1alpha1
-          kind: Workload
-        metricNamePrefix: foreman_workload
-        metrics:
-          # foreman_workload_info{namespace,name,phase,repo}
-          - name: info
-            help: "Workload phase and repo"
-            each:
-              type: Info
-              info:
-                labelsFromPath:
-                  phase: [status, phase]
-                  repo: [spec, repo]
+        # -- FleetNode ---------------------------------------------------------
+        - groupVersionKind:
+            group: foreman.llmkube.dev
+            version: v1alpha1
+            kind: FleetNode
+          metricNamePrefix: foreman_fleetnode
+          # Without this every series is anonymous: you can count
+          # FleetNodes by phase but cannot name the one that is stuck.
+          labelsFromPath:
+            name: [metadata, name]
+          metrics:
+            # foreman_fleetnode_info{name,node,accelerator,os,arch,
+            #                        current_task,version,agent_kind}
+            - name: info
+              help: "FleetNode identity and capability"
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    node: [spec, nodeName]
+                    accelerator: [status, capability, accelerator]
+                    os: [status, os]
+                    arch: [status, arch]
+                    # What the node is doing right now. Empty when it holds no
+                    # in-process reservation; see the CurrentTask godoc, empty
+                    # does not mean idle.
+                    current_task: [status, currentTask]
+                    version: [status, agentVersion]
+                    agent_kind: [status, agentKind]
 
-          # foreman_workload_succeeded_tasks / _failed_tasks / _incomplete_tasks
-          # (integer gauges = status.<field>)
-          - name: succeeded_tasks
-            help: "Succeeded child AgenticTasks for this Workload"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
-                  path: [status, succeededTasks]
+            # foreman_fleetnode_role_info{name,node,role} -- ONE SERIES PER
+            # ROLE. spec.roles is a list, so the Info metric targets the array
+            # and `role: []` names each element; a node registered as
+            # [worker, coder, verifier] yields three series. Joining them into a
+            # single label instead would make "which nodes can review?" an
+            # unanswerable substring match.
+            - name: role_info
+              help: "FleetNode advertised role (one series per role)"
+              each:
+                type: Info
+                info:
+                  path: [spec, roles]
+                  labelsFromPath:
+                    role: []
 
-          - name: failed_tasks
-            help: "Failed child AgenticTasks for this Workload"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
-                  path: [status, failedTasks]
+            # foreman_fleetnode_heartbeat_timestamp_seconds (gauge = unix seconds
+            # of LastHeartbeatTime, 0 when absent).
+            - name: heartbeat_timestamp_seconds
+              help: "FleetNode last heartbeat unix timestamp (0 = no heartbeat)"
+              each:
+                type: Gauge
+                gauge:
+                  # valueFrom is RELATIVE to path, and path is required: with
+                  # an absolute valueFrom and no path kube-state-metrics emits
+                  # nothing at all, silently.
+                  path: [status]
+                  valueFrom: [lastHeartbeatTime]
 
-          - name: incomplete_tasks
-            help: "Incomplete child AgenticTasks for this Workload"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
-                  path: [status, incompleteTasks]
+            # foreman_fleetnode_ram_gigabytes (gauge = status.capability.totalRAMGB)
+            - name: ram_gigabytes
+              help: "FleetNode total RAM in GiB"
+              each:
+                type: Gauge
+                gauge:
+                  # valueFrom is RELATIVE to path, and path is required: with
+                  # an absolute valueFrom and no path kube-state-metrics emits
+                  # nothing at all, silently.
+                  path: [status, capability]
+                  valueFrom: [totalRAMGB]
 
-          # Enum-style phase gauges for Workload (Planning / Planned /
-          # Dispatched / Completed / Failed).
-          - name: phase
-            help: "Workload phase (1 = active)"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
+            # Enum-style phase gauges (Ready / Draining / NotReady / Unknown).
+            - name: phase
+              help: "FleetNode phase (1 = active)"
+              each:
+                type: StateSet
+                stateSet:
+                  labelName: phase
                   path: [status, phase]
-                labelsMapping:
-                  Planning: planning
-                  Planned: planned
-                  Dispatched: dispatched
-                  Completed: completed
-                  Failed: failed
-
-      # -- FleetNode ---------------------------------------------------------
-      - groupVersionKind:
-          group: foreman.llmkube.dev
-          version: v1alpha1
-          kind: FleetNode
-        metricNamePrefix: foreman_fleetnode
-        metrics:
-          # foreman_fleetnode_info{node,accelerator,os,arch}
-          - name: info
-            help: "FleetNode identity and capability"
-            each:
-              type: Info
-              info:
-                labelsFromPath:
-                  node: [spec, nodeName]
-                  accelerator: [status, capability, accelerator]
-                  os: [status, os]
-                  arch: [status, arch]
-
-          # foreman_fleetnode_heartbeat_timestamp_seconds (gauge = unix seconds
-          # of LastHeartbeatTime, 0 when absent).
-          - name: heartbeat_timestamp_seconds
-            help: "FleetNode last heartbeat unix timestamp (0 = no heartbeat)"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
-                  path: [status, lastHeartbeatTime]
-
-          # foreman_fleetnode_ram_gigabytes (gauge = status.capability.totalRAMGB)
-          - name: ram_gigabytes
-            help: "FleetNode total RAM in GiB"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
-                  path: [status, capability, totalRAMGB]
-
-          # Enum-style phase gauges (Ready / Draining / NotReady / Unknown).
-          - name: phase
-            help: "FleetNode phase (1 = active)"
-            each:
-              type: Gauge
-              gauge:
-                valueFrom:
-                  path: [status, phase]
-                labelsMapping:
-                  Ready: ready
-                  Draining: draining
-                  NotReady: not-ready
-                  Unknown: unknown
+                  list: [Ready, Draining, NotReady, Unknown]
 ---
 {{- end }}

--- a/charts/foreman/templates/grafana-dashboard.yaml
+++ b/charts/foreman/templates/grafana-dashboard.yaml
@@ -60,7 +60,7 @@ data:
           "title": "Ready Nodes",
           "type": "stat",
           "targets": [
-            { "expr": "sum(foreman_fleetnode_phase{phase=\"ready\"})", "refId": "A" }
+            { "expr": "sum(foreman_fleetnode_phase{phase=\"Ready\"})", "refId": "A" }
           ]
         },
         {
@@ -85,7 +85,7 @@ data:
           "title": "Draining Nodes",
           "type": "stat",
           "targets": [
-            { "expr": "sum(foreman_fleetnode_phase{phase=\"draining\"})", "refId": "A" }
+            { "expr": "sum(foreman_fleetnode_phase{phase=\"Draining\"})", "refId": "A" }
           ]
         },
         {
@@ -109,7 +109,7 @@ data:
           "title": "NotReady Nodes",
           "type": "stat",
           "targets": [
-            { "expr": "sum(foreman_fleetnode_phase{phase=\"not-ready\"})", "refId": "A" }
+            { "expr": "sum(foreman_fleetnode_phase{phase=\"NotReady\"})", "refId": "A" }
           ]
         },
         {
@@ -272,7 +272,7 @@ data:
           "title": "Stuck Tasks (Running > 1h)",
           "type": "stat",
           "targets": [
-            { "expr": "count(foreman_agentictask_phase{phase=\"running\"}) > 0", "refId": "A" }
+            { "expr": "count(foreman_agentictask_phase{phase=\"Running\"}) > 0", "refId": "A" }
           ]
         },
         {
@@ -297,7 +297,7 @@ data:
           "title": "Succeeded Tasks",
           "type": "stat",
           "targets": [
-            { "expr": "sum(foreman_agentictask_phase{phase=\"succeeded\"})", "refId": "A" }
+            { "expr": "sum(foreman_agentictask_phase{phase=\"Succeeded\"})", "refId": "A" }
           ]
         },
         {
@@ -321,7 +321,7 @@ data:
           "title": "Failed Tasks",
           "type": "stat",
           "targets": [
-            { "expr": "sum(foreman_agentictask_phase{phase=\"failed\"})", "refId": "A" }
+            { "expr": "sum(foreman_agentictask_phase{phase=\"Failed\"})", "refId": "A" }
           ]
         },
         {
@@ -345,7 +345,7 @@ data:
           "title": "Incomplete Tasks",
           "type": "stat",
           "targets": [
-            { "expr": "sum(foreman_agentictask_verdict{verdict=\"incomplete\"})", "refId": "A" }
+            { "expr": "sum(foreman_agentictask_verdict{verdict=\"INCOMPLETE\"})", "refId": "A" }
           ]
         }
       ],

--- a/charts/foreman/tests/crs_test.yaml
+++ b/charts/foreman/tests/crs_test.yaml
@@ -35,3 +35,116 @@ tests:
       - equal:
           path: metadata.namespace
           value: observability
+
+  # The fleet view is only useful if it can say WHAT a node is and WHAT it is
+  # doing. Without these the shipped dashboard renders a node list with no
+  # role, no running job, and unnamed tasks.
+  - it: FleetNode info carries the current task, agent version and kind
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'current_task: \[status, currentTask\]'
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'version: \[status, agentVersion\]'
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'agent_kind: \[status, agentKind\]'
+
+  - it: FleetNode roles are expanded one series per role
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      # spec.roles is a non-map array, so the Info metric targets the array
+      # itself and `role: []` names each element. A node with three roles
+      # yields three series rather than one lossy joined label.
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'path: \[spec, roles\]'
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'role: \[\]'
+
+  - it: AgenticTask info names the task and the node running it
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'node: \[status, assignedNode\]'
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'kind: \[spec, kind\]'
+
+  - it: every resource labels its metrics with the object name
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      # Without a resource-level labelsFromPath the series cannot be traced
+      # back to a specific CR, which is what the Stuck Tasks panel needs.
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'name: \[metadata, name\]'
+
+  - it: the config is a complete CustomResourceStateMetrics document
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      # kube-state-metrics' --custom-resource-state-config-file expects a whole
+      # document. Given a bare `resources:` mapping it parses to an empty
+      # config, logs NOTHING, and serves no custom metrics: a silent no-op that
+      # looks exactly like a working install with no CRs.
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: '^kind: CustomResourceStateMetrics'
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: '\nspec:\n'
+
+  - it: gauge valueFrom is a bare list, relative to a required path
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      # KSM's gauge.valueFrom is []string RELATIVE to gauge.path, and path is
+      # required. The object form (valueFrom: {path: [...]}) crashloops KSM
+      # with "cannot unmarshal !!map into []string"; an absolute valueFrom
+      # with no path parses fine and then emits NOTHING, silently. Verified
+      # against a live kube-state-metrics: absolute form 0 series, this form
+      # 10 series.
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'path: \[status\]\n\s*valueFrom: \[lastHeartbeatTime\]'
+      - notMatchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'valueFrom:\s*\n\s*path:'
+
+  - it: enum status fields are StateSets, not gauges over a string
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      # A Gauge's value must be a number, boolean or RFC3339 string, so a
+      # Gauge over status.phase ("Ready") emits nothing. StateSet is the
+      # construct for enums. `labelsMapping` is not a kube-state-metrics
+      # field at all and was silently ignored.
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'type: StateSet'
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'list: \[Ready, Draining, NotReady, Unknown\]'
+      - notMatchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'labelsMapping'
+
+  - it: FleetNode info reports the Kubernetes node the pod runs on
+    set:
+      foreman.crs.enabled: true
+    asserts:
+      # status.kubernetesNode is the machine as a PROPERTY (#1640): identity
+      # is the agent process, and this is the only place "which box is this
+      # agent on" is answerable from metrics. Empty for off-cluster agents.
+      - matchRegex:
+          path: data["foreman-crs.yaml"]
+          pattern: 'kubernetes_node: \[status, kubernetesNode\]'


### PR DESCRIPTION
## What

Make `foreman.crs.enabled` produce metrics — it has never emitted a single one —
and add the labels a fleet view actually needs.

## Why

Fixes #1643. Refs #1602, #1640.

Four defects, each reproduced against a live kube-state-metrics, detailed in
#1643: the ConfigMap was not a complete `CustomResourceStateMetrics` document
(KSM silently parses an empty config), `gauge.valueFrom` used an object form
that crashloops KSM, `valueFrom` is relative to a required `path` the config
omitted (parses fine, emits nothing), and enum fields used `type: Gauge` with a
fabricated `labelsMapping` key instead of `StateSet`.

## How

- Wrap the config as `kind: CustomResourceStateMetrics` / `spec:`.
- `path` + relative `valueFrom` for the numeric gauges; `StateSet` with the CRs'
  real enum values for phase/verdict.
- The shipped dashboard's queries move with the enum casing
  (`phase="ready"` → `phase="Ready"`).
- Drops `foreman_agentictask_tasks_failed`: with phase a real StateSet it is
  exactly `phase{phase="Failed"}`, nothing queried it, and it cost 630 series.
- **New labels** so the fleet view can say what a node is and what it is doing:
  every resource stamps `name`; FleetNode info gains `current_task`, `version`,
  `agent_kind`, and `kubernetes_node` (the #1640 property, shipped in #1649);
  `role_info` is new, one series per role (`spec.roles` is a list — a joined
  label would make "which nodes can review?" a substring match); AgenticTask
  info gains `node` and `kind`, the join a fleet table is built on.

Deployment notes recorded in #1643: kube-prometheus-stack's explicit
`--resources` list excludes custom resources, and KSM needs RBAC for the
foreman API group — both outside what this chart can ship.

## Verification

Deployed end-to-end on a live cluster: all 14 metric families emit
(`foreman_fleetnode_phase` 40 series, `role_info` 23, heartbeat 10, …) and every
query in the shipped dashboard returns data. `helm unittest`: 47/47, including
regression tests for the document wrapper, the `valueFrom` shape, and the
StateSet conversion.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — values.yaml comments cover the surface

Assisted-by: Claude Code (diagnosed the four defects against a live
kube-state-metrics with a three-way probe, implemented the fixes, and verified
every metric family and dashboard query live before submitting).
