### PR TITLE
feat(cli): llmkube foreman run, the unattended orchestration loop

### DIFF
--- a/pkg/cli/dispatch.go
+++ b/pkg/cli/dispatch.go
@@ -102,6 +102,8 @@ heterogeneous executors. These subcommands create and watch those tasks.`,
 	}
 	cmd.AddCommand(newDispatchCommand())
 	cmd.AddCommand(newSliceCommand())
+	cmd.AddCommand(newRunCommand())
+	cmd.AddCommand(newDecisionsCommand())
 	return cmd
 }
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -194,7 +194,8 @@ func newDecisionsCommand() *cobra.Command {
 // flattenCell keeps one table cell on one line. Reason arrives from verify
 // output and stall evidence and Answer from a shell argument, so either can
 // carry a newline or a tab, and either one shifts every row that follows it
-// out of alignment.
+// out of alignment. Every cell goes through it rather than only those two: a
+// decision file is human-editable YAML, so any field can come back mangled.
 func flattenCell(s string) string {
 	return strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace(s)
 }
@@ -213,28 +214,44 @@ func decisionOptions(d Decision) string {
 	return strings.Join(d.Options, "|")
 }
 
+// orDash renders an empty cell as a dash. tabwriter pads an empty cell out to
+// the column width, so an omitted value is indistinguishable from a row that
+// has slipped a column; a dash says "nothing here" out loud.
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
 // renderDecisions prints the parked-decision queue as a table.
 //
-// OPTIONS is the column that makes the listing actionable: without it the
-// only way to learn what an answer may be is to read the YAML or guess and
+// WORKLOAD is the only column that says which run to go and look at: ISSUE
+// names the work, but a human wanting the logs, the branch or the transcript
+// needs the Workload, and without the column the only way to get it is to open
+// the YAML. OPTIONS is the column that makes the listing actionable: without it
+// the only way to learn what an answer may be is to read the YAML or guess and
 // wait for the rejection. REASON comes last because it is the one free-form
 // column, and leading with it would push the actionable ones off the right
 // of a narrow terminal.
+//
+// Decision.Stage is deliberately NOT a column. Every park the machine produces
+// today already names its stage in REASON ("stalled" only comes from watch,
+// both verify reasons say "verify"), so a STAGE column would spend width
+// repeating what the row already says and push the actionable columns further
+// right. The field stays in the YAML for anyone who needs it.
 func renderDecisions(w io.Writer, ds []Decision) {
 	if len(ds) == 0 {
 		fprintln(w, "No parked decisions.")
 		return
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fprintln(tw, "ISSUE\tKIND\tOPENED\tOPTIONS\tANSWER\tREASON")
+	fprintln(tw, "ISSUE\tWORKLOAD\tKIND\tOPENED\tOPTIONS\tANSWER\tREASON")
 	for _, d := range ds {
-		answer := d.Answer
-		if answer == "" {
-			answer = "-"
-		}
-		fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\n",
-			d.Issue, flattenCell(d.Kind), d.Opened.Format("2006-01-02 15:04"),
-			flattenCell(decisionOptions(d)), flattenCell(answer), flattenCell(d.Reason))
+		fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			d.Issue, flattenCell(orDash(d.Workload)), flattenCell(d.Kind),
+			d.Opened.Format("2006-01-02 15:04"),
+			flattenCell(decisionOptions(d)), flattenCell(orDash(d.Answer)), flattenCell(d.Reason))
 	}
 	_ = tw.Flush()
 }

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -117,6 +118,8 @@ func newDecisionsCommand() *cobra.Command {
 			if err := AnswerDecision(dir, int32(issue), args[1], args[2]); err != nil {
 				return err
 			}
+			// The parsed issue, not the argument: the confirmation should
+			// name the decision that was actually written.
 			fprintf(cmd.OutOrStdout(), "answered %d/%s: %s\n", issue, args[1], args[2])
 			return nil
 		},
@@ -125,21 +128,50 @@ func newDecisionsCommand() *cobra.Command {
 	return cmd
 }
 
+// flattenCell keeps one table cell on one line. Reason arrives from verify
+// output and stall evidence and Answer from a shell argument, so either can
+// carry a newline or a tab, and either one shifts every row that follows it
+// out of alignment.
+func flattenCell(s string) string {
+	return strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace(s)
+}
+
+// decisionOptions renders the answers a decision will accept. An unanswered
+// decision that offers no options accepts anything, since AnswerDecision only
+// enforces the list when there is one, and saying so beats a bare placeholder
+// that reads as "nothing you can do here".
+func decisionOptions(d Decision) string {
+	if d.Answer != "" {
+		return "-"
+	}
+	if len(d.Options) == 0 {
+		return "any"
+	}
+	return strings.Join(d.Options, "|")
+}
+
 // renderDecisions prints the parked-decision queue as a table.
+//
+// OPTIONS is the column that makes the listing actionable: without it the
+// only way to learn what an answer may be is to read the YAML or guess and
+// wait for the rejection. REASON comes last because it is the one free-form
+// column, and leading with it would push the actionable ones off the right
+// of a narrow terminal.
 func renderDecisions(w io.Writer, ds []Decision) {
 	if len(ds) == 0 {
 		fprintln(w, "No parked decisions.")
 		return
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fprintln(tw, "ISSUE\tKIND\tOPENED\tREASON\tANSWER")
+	fprintln(tw, "ISSUE\tKIND\tOPENED\tOPTIONS\tANSWER\tREASON")
 	for _, d := range ds {
 		answer := d.Answer
 		if answer == "" {
 			answer = "-"
 		}
-		fprintf(tw, "%d\t%s\t%s\t%s\t%s\n",
-			d.Issue, d.Kind, d.Opened.Format("2006-01-02 15:04"), d.Reason, answer)
+		fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\n",
+			d.Issue, flattenCell(d.Kind), d.Opened.Format("2006-01-02 15:04"),
+			flattenCell(decisionOptions(d)), flattenCell(answer), flattenCell(d.Reason))
 	}
 	_ = tw.Flush()
 }

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -45,11 +45,13 @@ func newRunCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Drive a queue of issues through Foreman unattended",
-		Long: `Drive a prepared queue of issues through the Foreman pipeline.
+		// The default directory is interpolated rather than spelled out, so
+		// the help cannot drift from the flag.
+		Long: fmt.Sprintf(`Drive a prepared queue of issues through the Foreman pipeline.
 
 The loop does the mechanical work (preflight skips, dispatch, watching for
 stalls, independent verification, finalizing a PR) and parks judgment calls
-as files under .foreman/decisions for you to review with
+as files under %s for you to review with
 'llmkube foreman decisions'. It never blocks: a parked decision releases the
 slot and the loop moves to the next item.
 
@@ -57,7 +59,7 @@ Intents are yours to write; the queue points at them.
 
 Example:
 
-  llmkube foreman run --queue queue.yaml --coder-agent qwen38-coder`,
+  llmkube foreman run --queue queue.yaml --coder-agent qwen38-coder`, defaultDecisionsDir),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("not implemented: the driver lands in task 8")
 		},

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+const defaultDecisionsDir = ".foreman/decisions"
+
+type runOptions struct {
+	queueFile    string
+	decisionsDir string
+	namespace    string
+	coderAgent   string
+	stallFactor  float64
+	dryRun       bool
+}
+
+// newRunCommand drives a prepared queue through the Foreman pipeline,
+// parking judgment calls instead of blocking on them.
+func newRunCommand() *cobra.Command {
+	opts := &runOptions{}
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Drive a queue of issues through Foreman unattended",
+		Long: `Drive a prepared queue of issues through the Foreman pipeline.
+
+The loop does the mechanical work (preflight skips, dispatch, watching for
+stalls, independent verification, finalizing a PR) and parks judgment calls
+as files under .foreman/decisions for you to review with
+'llmkube foreman decisions'. It never blocks: a parked decision releases the
+slot and the loop moves to the next item.
+
+Intents are yours to write; the queue points at them.
+
+Example:
+
+  llmkube foreman run --queue queue.yaml --coder-agent qwen38-coder`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fmt.Errorf("not implemented: the driver lands in task 8")
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&opts.queueFile, "queue", "", "Path to the work queue YAML (required)")
+	f.StringVar(&opts.decisionsDir, "decisions-dir", defaultDecisionsDir, "Where parked decisions are written")
+	f.StringVarP(&opts.namespace, "namespace", "n", "default", "Namespace for Workloads")
+	f.StringVar(&opts.coderAgent, "coder-agent", "", "Coder Agent name (required)")
+	f.Float64Var(&opts.stallFactor, "stall-factor", DefaultStallFactor,
+		"Kill a run with no branch after this multiple of baseline")
+	f.BoolVar(&opts.dryRun, "dry-run", false, "Print what would happen without applying anything")
+	// Both are documented as required and neither has a defensible default:
+	// a queue-less run has nothing to do, and an agent-less run would have to
+	// guess which box does the work.
+	_ = cmd.MarkFlagRequired("queue")
+	_ = cmd.MarkFlagRequired("coder-agent")
+	return cmd
+}
+
+// newDecisionsCommand lists and answers parked decisions.
+func newDecisionsCommand() *cobra.Command {
+	dir := defaultDecisionsDir
+	cmd := &cobra.Command{
+		Use:   "decisions",
+		Short: "List and answer decisions the run loop parked",
+		// Without this a stray argument is silently ignored and the full
+		// queue is listed, which reads as "nothing matched".
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ds, err := ListDecisions(dir)
+			// Render first. ListDecisions returns what it could parse
+			// alongside an error naming what it could not, and this command
+			// exists to show a human what is parked: one truncated file must
+			// not hide the rest. Returning the error afterwards still exits
+			// non-zero and names the file. Nothing is rendered when nothing
+			// was listed, so "No parked decisions." never appears next to an
+			// error and reads as reassurance.
+			if len(ds) > 0 || err == nil {
+				renderDecisions(cmd.OutOrStdout(), ds)
+			}
+			return err
+		},
+	}
+	cmd.PersistentFlags().StringVar(&dir, "decisions-dir", defaultDecisionsDir, "Where parked decisions live")
+
+	answer := &cobra.Command{
+		Use:   "answer ISSUE KIND ANSWER",
+		Short: "Answer one parked decision",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// ParseInt, not Sscanf: Sscanf("1602x", "%d") succeeds with 1602
+			// and no error, so a typo would silently answer a decision the
+			// human did not name.
+			issue, err := strconv.ParseInt(args[0], 10, 32)
+			if err != nil {
+				return fmt.Errorf("ISSUE must be a number: %w", err)
+			}
+			if err := AnswerDecision(dir, int32(issue), args[1], args[2]); err != nil {
+				return err
+			}
+			fprintf(cmd.OutOrStdout(), "answered %d/%s: %s\n", issue, args[1], args[2])
+			return nil
+		},
+	}
+	cmd.AddCommand(answer)
+	return cmd
+}
+
+// renderDecisions prints the parked-decision queue as a table.
+func renderDecisions(w io.Writer, ds []Decision) {
+	if len(ds) == 0 {
+		fprintln(w, "No parked decisions.")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fprintln(tw, "ISSUE\tKIND\tOPENED\tREASON\tANSWER")
+	for _, d := range ds {
+		answer := d.Answer
+		if answer == "" {
+			answer = "-"
+		}
+		fprintf(tw, "%d\t%s\t%s\t%s\t%s\n",
+			d.Issue, d.Kind, d.Opened.Format("2006-01-02 15:04"), d.Reason, answer)
+	}
+	_ = tw.Flush()
+}

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -80,6 +80,56 @@ Example:
 	return cmd
 }
 
+// printRunPlan loads the queue the human prepared, checks every intent is
+// readable, and prints what a run would do.
+//
+// A live run is refused rather than half-attempted: the cluster-backed Effects
+// (dispatch, watch, verify, kill) are a follow-up to this plan, so there is
+// nothing to drive the loop with yet. Validating the queue is real work that
+// needs no cluster and it catches the mistakes a human actually makes, so it
+// happens BEFORE the refusal: answering a queue with a missing intent by
+// talking about unwired effects helps nobody.
+func printRunPlan(w io.Writer, opts *runOptions) error {
+	data, err := os.ReadFile(opts.queueFile)
+	if err != nil {
+		return fmt.Errorf("read queue: %w", err)
+	}
+	q, err := ParseQueue(data)
+	if err != nil {
+		return err
+	}
+	intents := make([]string, len(q.Items))
+	for i, item := range q.Items {
+		s, err := q.IntentFor(item)
+		if err != nil {
+			return err
+		}
+		intents[i] = s
+	}
+	if !opts.dryRun {
+		return fmt.Errorf("the queue is valid, but a live run cannot start yet: dispatch, "+
+			"watch and verify against the cluster are not wired up. Re-run with --dry-run "+
+			"to see what %d item(s) would do", len(q.Items))
+	}
+	// Labelled with the flag names that produced them, so the plan reads back
+	// as the command that made it.
+	fprintln(w, "dry run, nothing is applied.")
+	fprintf(w, "queue: %s\n", opts.queueFile)
+	fprintf(w, "coder-agent: %s\n", opts.coderAgent)
+	fprintf(w, "namespace: %s\n", opts.namespace)
+	fprintf(w, "decisions-dir: %s\n", opts.decisionsDir)
+	fprintf(w, "stall-factor: %g\n", opts.stallFactor)
+	fprintf(w, "items: %d\n", len(q.Items))
+	for i, item := range q.Items {
+		// The reserved name: nothing has dispatched, so there is no returned
+		// Workload name to build the branch from.
+		fprintf(w, "  issue %d (%s): branch %s, intent %s (%d bytes)\n",
+			item.Issue, item.Repo, taskBranch(plannedWorkloadName(item.Issue), item.Issue),
+			item.IntentPath, len(intents[i]))
+	}
+	return nil
+}
+
 // newDecisionsCommand lists and answers parked decisions.
 func newDecisionsCommand() *cobra.Command {
 	dir := defaultDecisionsDir

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -90,6 +91,12 @@ Example:
 // happens BEFORE the refusal: answering a queue with a missing intent by
 // talking about unwired effects helps nobody.
 func printRunPlan(w io.Writer, opts *runOptions) error {
+	// Before the queue: a bad --stall-factor is a typo in the command that was
+	// just typed, and reporting a queue problem first would have the human
+	// editing a file when the fix is on the command line.
+	if err := checkStallFactor(opts.stallFactor); err != nil {
+		return err
+	}
 	data, err := os.ReadFile(opts.queueFile)
 	if err != nil {
 		return fmt.Errorf("read queue: %w", err)
@@ -126,6 +133,24 @@ func printRunPlan(w io.Writer, opts *runOptions) error {
 		fprintf(w, "  issue %d (%s): branch %s, intent %s (%d bytes)\n",
 			item.Issue, item.Repo, taskBranch(plannedWorkloadName(item.Issue), item.Issue),
 			item.IntentPath, len(intents[i]))
+	}
+	return nil
+}
+
+// checkStallFactor refuses a stall budget that would kill every run.
+//
+// pflag parses the value with strconv.ParseFloat, which happily accepts "NaN",
+// "Inf" and "-1", and IsStalled compares elapsed against factor x baseline: at
+// zero or below the threshold is zero or negative and the first watch tick
+// declares a run that has been going for a second stalled, and NaN converts to
+// a Duration that every elapsed time is greater than, which does the same. The
+// flag is the place to say so, because the human can see which flag is wrong
+// before anything is dispatched. IsStalled defends itself as well, for callers
+// that never went through this command.
+func checkStallFactor(f float64) error {
+	if math.IsNaN(f) || math.IsInf(f, 0) || f <= 0 {
+		return fmt.Errorf("--stall-factor must be a finite number greater than 0, got %g: "+
+			"anything else kills every run on its first watch tick", f)
 	}
 	return nil
 }

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -60,8 +60,8 @@ Intents are yours to write; the queue points at them.
 Example:
 
   llmkube foreman run --queue queue.yaml --coder-agent qwen38-coder`, defaultDecisionsDir),
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fmt.Errorf("not implemented: the driver lands in task 8")
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return printRunPlan(cmd.OutOrStdout(), opts)
 		},
 	}
 	f := cmd.Flags()

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -87,6 +88,16 @@ func newDecisionsCommand() *cobra.Command {
 		// queue is listed, which reads as "nothing matched".
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// A missing default directory means nothing has parked yet,
+			// which is the normal state and not worth an error. A missing
+			// directory the human typed is a typo, and answering a typo with
+			// "No parked decisions." turns it into a confident "nothing to
+			// do" while the real queue sits unread somewhere else.
+			if cmd.Flags().Changed("decisions-dir") {
+				if _, err := os.Stat(dir); err != nil {
+					return fmt.Errorf("--decisions-dir %s: %w", dir, err)
+				}
+			}
 			ds, err := ListDecisions(dir)
 			// Render first. ListDecisions returns what it could parse
 			// alongside an error naming what it could not, and this command

--- a/pkg/cli/run_baseline.go
+++ b/pkg/cli/run_baseline.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	"github.com/defilantech/llmkube/pkg/foreman/audit"
 )
 
@@ -68,7 +69,10 @@ func BaselineFor(ctx context.Context, c client.Client, namespace, agent string) 
 		if rec.Agent == nil || rec.Agent.Name != agent {
 			continue
 		}
-		if rec.Task.Kind != "issue-fix" {
+		// audit.TaskRef.Kind is a plain string on the wire, so the constant is
+		// converted rather than the comparison reshaped: the record carries
+		// whatever the writer serialised, not a typed kind.
+		if rec.Task.Kind != string(foremanv1alpha1.AgenticTaskKindIssueFix) {
 			continue
 		}
 		// SucceededOnTarget is this exact predicate, precomputed by

--- a/pkg/cli/run_baseline.go
+++ b/pkg/cli/run_baseline.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/defilantech/llmkube/pkg/foreman/audit"
+)
+
+// BaselineFor returns the median wall-clock duration of an agent's recent
+// cleanly-successful issue-fix tasks, read from the durable audit-record
+// ConfigMaps the controller already writes. With no history it returns
+// DefaultBaseline: a fleet with no track record should not have its first
+// run declared stalled.
+func BaselineFor(ctx context.Context, c client.Client, namespace, agent string) (time.Duration, error) {
+	var list corev1.ConfigMapList
+	if err := c.List(ctx, &list,
+		client.InNamespace(namespace),
+		client.MatchingLabels{audit.AuditLabel: "true"},
+	); err != nil {
+		return 0, err
+	}
+	var secs []float64
+	for i := range list.Items {
+		raw, ok := list.Items[i].Data["audit.json"]
+		if !ok {
+			continue
+		}
+		var rec audit.Record
+		if err := json.Unmarshal([]byte(raw), &rec); err != nil {
+			continue // a malformed record is not a reason to fail the run
+		}
+		if rec.Agent == nil || rec.Agent.Name != agent {
+			continue
+		}
+		if rec.Task.Kind != "issue-fix" {
+			continue
+		}
+		if rec.Verdict != "GO" && rec.Verdict != "GATE-PASS" {
+			continue
+		}
+		if rec.ElapsedSec > 0 {
+			secs = append(secs, rec.ElapsedSec)
+		}
+	}
+	if len(secs) == 0 {
+		return DefaultBaseline, nil
+	}
+	sort.Float64s(secs)
+	med := secs[len(secs)/2]
+	return time.Duration(med * float64(time.Second)), nil
+}

--- a/pkg/cli/run_baseline.go
+++ b/pkg/cli/run_baseline.go
@@ -28,11 +28,25 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/audit"
 )
 
-// BaselineFor returns the median wall-clock duration of an agent's recent
+// BaselineFor returns the median wall-clock duration of an agent's
 // cleanly-successful issue-fix tasks, read from the durable audit-record
 // ConfigMaps the controller already writes. With no history it returns
 // DefaultBaseline: a fleet with no track record should not have its first
 // run declared stalled.
+//
+// There is deliberately no recency window in v1: every matching record in
+// the namespace counts, so a six-month-old run weighs exactly as much as
+// yesterday's. Audit CMs outlive their tasks on purpose and their retention
+// is operator-tunable (disableable with --audit-retention=0), so the window
+// is really whatever the reaper leaves behind. A real half-life belongs
+// here eventually; it is not v1.
+//
+// The List is intentionally NOT paginated. Scoped to one namespace and the
+// audit label, the result is small in practice. If audit volume ever grows
+// past the apiserver's --max-objects-per-list (default 500) this single
+// call would silently truncate, and a truncated sample shifts the median
+// rather than erroring; if that ever happens, switch to a Continue loop
+// with a per-page limit. Same trade-off the sibling audit.Sweep documents.
 func BaselineFor(ctx context.Context, c client.Client, namespace, agent string) (time.Duration, error) {
 	var list corev1.ConfigMapList
 	if err := c.List(ctx, &list,
@@ -57,7 +71,13 @@ func BaselineFor(ctx context.Context, c client.Client, namespace, agent string) 
 		if rec.Task.Kind != "issue-fix" {
 			continue
 		}
-		if rec.Verdict != "GO" && rec.Verdict != "GATE-PASS" {
+		// SucceededOnTarget is this exact predicate, precomputed by
+		// audit.BuildRecord from AgenticTask.SucceededOnTarget(). It is
+		// stricter than comparing Verdict against GO/GATE-PASS because it
+		// also requires Phase == Succeeded, so a GO verdict on a task that
+		// never finished does not pollute the baseline. Always serialized
+		// (no omitempty), so an absent field reads as false.
+		if !rec.SucceededOnTarget {
 			continue
 		}
 		if rec.ElapsedSec > 0 {
@@ -68,6 +88,14 @@ func BaselineFor(ctx context.Context, c client.Client, namespace, agent string) 
 		return DefaultBaseline, nil
 	}
 	sort.Float64s(secs)
-	med := secs[len(secs)/2]
+	// A true median: average the middle two on an even count. Taking the
+	// upper-middle element instead makes a two-record history return the
+	// slower run, and at DefaultStallFactor a single pathological outlier
+	// would then buy every later run an enormous stall budget.
+	n := len(secs)
+	med := secs[n/2]
+	if n%2 == 0 {
+		med = (secs[n/2-1] + secs[n/2]) / 2
+	}
 	return time.Duration(med * float64(time.Second)), nil
 }

--- a/pkg/cli/run_baseline_test.go
+++ b/pkg/cli/run_baseline_test.go
@@ -65,7 +65,7 @@ func TestBaselineFor_MediansSuccessfulIssueFixRuns(t *testing.T) {
 	c := fake.NewClientBuilder().WithObjects(
 		baselineCM(t, "a", "qwen38-coder", "issue-fix", "GO", 3000),
 		baselineCM(t, "b", "qwen38-coder", "issue-fix", "GO", 3600),
-		baselineCM(t, "c", "qwen38-coder", "issue-fix", "GO", 4200),
+		baselineCM(t, "c", "qwen38-coder", "issue-fix", "GO", 9000),
 		// Excluded: different agent, non-terminal-good verdict, wrong kind.
 		baselineCM(t, "d", "other-coder", "issue-fix", "GO", 60),
 		baselineCM(t, "e", "qwen38-coder", "issue-fix", "NO-GO", 60),
@@ -77,7 +77,7 @@ func TestBaselineFor_MediansSuccessfulIssueFixRuns(t *testing.T) {
 		t.Fatalf("BaselineFor: %v", err)
 	}
 	if got != 3600*time.Second {
-		t.Errorf("BaselineFor = %v, want %v (median of 3000/3600/4200)", got, 3600*time.Second)
+		t.Errorf("BaselineFor = %v, want %v (median of 3000/3600/9000, mean would be 5200)", got, 3600*time.Second)
 	}
 }
 

--- a/pkg/cli/run_baseline_test.go
+++ b/pkg/cli/run_baseline_test.go
@@ -38,9 +38,14 @@ func baselineCMIn(t *testing.T, namespace, name, agent, kind, verdict string, el
 	rec := audit.Record{
 		SchemaVersion: "foreman.audit.v1",
 		Verdict:       verdict,
-		ElapsedSec:    elapsed,
-		Agent:         &audit.AgentRef{Name: agent},
-		Task:          audit.TaskRef{Name: name, Kind: kind},
+		// BuildRecord derives this from AgenticTask.SucceededOnTarget(),
+		// which is true exactly for a Succeeded task whose verdict is GO
+		// or GATE-PASS. Keep the fixture consistent with the verdict so it
+		// still describes a record the writer could actually emit.
+		SucceededOnTarget: verdict == "GO" || verdict == "GATE-PASS",
+		ElapsedSec:        elapsed,
+		Agent:             &audit.AgentRef{Name: agent},
+		Task:              audit.TaskRef{Name: name, Kind: kind},
 	}
 	b, err := json.Marshal(rec)
 	if err != nil {
@@ -160,7 +165,7 @@ func TestBaselineFor_FiltersAreLoadBearing(t *testing.T) {
 		},
 		{
 			name:     "unsuccessful verdicts are excluded",
-			mutation: "delete the verdict guard",
+			mutation: "delete the !rec.SucceededOnTarget guard",
 			objs: []client.Object{
 				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
 				baselineCM(t, "x1", agent, "issue-fix", "NO-GO", 60),
@@ -171,7 +176,7 @@ func TestBaselineFor_FiltersAreLoadBearing(t *testing.T) {
 		},
 		{
 			name:     "GATE-PASS counts as cleanly successful",
-			mutation: "narrow the verdict guard to GO only",
+			mutation: "replace rec.SucceededOnTarget with rec.Verdict == GO",
 			objs: []client.Object{
 				baselineCM(t, "gp", agent, "issue-fix", "GATE-PASS", 1800),
 			},
@@ -212,11 +217,55 @@ func TestBaselineFor_FiltersAreLoadBearing(t *testing.T) {
 			// 60/3600/36000: mean is 13220s, so a mean would fail here, and
 			// so would picking the min or the max.
 			name:     "the middle value is taken, not the mean or an end",
-			mutation: "replace secs[len(secs)/2] with the mean, secs[0], or secs[len(secs)-1]",
+			mutation: "replace secs[n/2] with the mean, secs[0], or secs[len(secs)-1]",
 			objs: []client.Object{
 				baselineCM(t, "m1", agent, "issue-fix", "GO", 36000),
 				baselineCM(t, "m2", agent, "issue-fix", "GO", 60),
 				baselineCM(t, "m3", agent, "issue-fix", "GO", 3600),
+			},
+			want: 3600 * time.Second,
+		},
+		{
+			// Two records is the NORMAL state for a freshly-added agent,
+			// which is exactly when the baseline is load-bearing. The
+			// upper-middle element would return 36000 here, and at
+			// DefaultStallFactor that is a 25-hour stall threshold bought
+			// by one pathological run. The lower-middle would return 60.
+			name:     "an even count averages the middle two, it does not pick a side",
+			mutation: "use secs[len/2] or secs[(len-1)/2] instead of averaging on even n",
+			objs: []client.Object{
+				baselineCM(t, "e1", agent, "issue-fix", "GO", 60),
+				baselineCM(t, "e2", agent, "issue-fix", "GO", 36000),
+			},
+			want: 18030 * time.Second,
+		},
+		{
+			// Four records: upper-middle gives 3600, lower-middle 3000,
+			// the true median 3300. Pins the even branch at a length where
+			// both off-by-one variants are still plausible-looking.
+			name:     "an even count of four averages the middle two",
+			mutation: "use secs[len/2] or secs[(len-1)/2] instead of averaging on even n",
+			objs: []client.Object{
+				baselineCM(t, "f1", agent, "issue-fix", "GO", 60),
+				baselineCM(t, "f2", agent, "issue-fix", "GO", 3000),
+				baselineCM(t, "f3", agent, "issue-fix", "GO", 3600),
+				baselineCM(t, "f4", agent, "issue-fix", "GO", 9000),
+			},
+			want: 3300 * time.Second,
+		},
+		{
+			// The reason SucceededOnTarget beats a Verdict string compare:
+			// a GO verdict on a task that never reached Phase == Succeeded
+			// is not a completed run, and its elapsed time is not evidence
+			// of how long the agent takes. The old string check let these
+			// in. See AgenticTask.SucceededOnTarget().
+			name:     "a GO verdict on a task that never succeeded is excluded",
+			mutation: "replace rec.SucceededOnTarget with the old GO/GATE-PASS string compare",
+			objs: []client.Object{
+				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
+				baselineUnfinishedCM(t, "u1", agent, "issue-fix", "GO", 60),
+				baselineUnfinishedCM(t, "u2", agent, "issue-fix", "GO", 60),
+				baselineUnfinishedCM(t, "u3", agent, "issue-fix", "GATE-PASS", 60),
 			},
 			want: 3600 * time.Second,
 		},
@@ -261,20 +310,37 @@ func TestBaselineFor_FiltersAreLoadBearing(t *testing.T) {
 	}
 }
 
-// agentlessCM builds an audit record with no agent block at all, which is
-// what the writer emits when the Agent could not be resolved.
-func baselineAgentlessCM(t *testing.T, name, kind, verdict string, elapsed float64) *corev1.ConfigMap {
+// baselineUnfinishedCM builds a record whose Verdict reads as a success but
+// whose task never reached Phase == Succeeded, so BuildRecord would have set
+// SucceededOnTarget false. This is the case the verdict-string check got
+// wrong and the record's own flag gets right.
+func baselineUnfinishedCM(t *testing.T, name, agent, kind, verdict string, elapsed float64) *corev1.ConfigMap {
 	t.Helper()
-	cm := baselineCM(t, name, "", kind, verdict, elapsed)
+	cm := baselineCM(t, name, agent, kind, verdict, elapsed)
+	patchRecord(t, cm, func(rec *audit.Record) { rec.SucceededOnTarget = false })
+	return cm
+}
+
+// patchRecord rewrites the audit.json payload of cm through mutate.
+func patchRecord(t *testing.T, cm *corev1.ConfigMap, mutate func(*audit.Record)) {
+	t.Helper()
 	var rec audit.Record
 	if err := json.Unmarshal([]byte(cm.Data["audit.json"]), &rec); err != nil {
 		t.Fatal(err)
 	}
-	rec.Agent = nil
+	mutate(&rec)
 	b, err := json.Marshal(rec)
 	if err != nil {
 		t.Fatal(err)
 	}
 	cm.Data["audit.json"] = string(b)
+}
+
+// agentlessCM builds an audit record with no agent block at all, which is
+// what the writer emits when the Agent could not be resolved.
+func baselineAgentlessCM(t *testing.T, name, kind, verdict string, elapsed float64) *corev1.ConfigMap {
+	t.Helper()
+	cm := baselineCM(t, name, "", kind, verdict, elapsed)
+	patchRecord(t, cm, func(rec *audit.Record) { rec.Agent = nil })
 	return cm
 }

--- a/pkg/cli/run_baseline_test.go
+++ b/pkg/cli/run_baseline_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/defilantech/llmkube/pkg/foreman/audit"
+)
+
+// auditCMIn builds an audit-record ConfigMap in the given namespace, shaped
+// the way pkg/foreman/audit's writer shapes it: the audit label, plus the
+// JSON Record under the audit.json data key.
+func baselineCMIn(t *testing.T, namespace, name, agent, kind, verdict string, elapsed float64) *corev1.ConfigMap {
+	t.Helper()
+	rec := audit.Record{
+		SchemaVersion: "foreman.audit.v1",
+		Verdict:       verdict,
+		ElapsedSec:    elapsed,
+		Agent:         &audit.AgentRef{Name: agent},
+		Task:          audit.TaskRef{Name: name, Kind: kind},
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreman-audit-" + name,
+			Namespace: namespace,
+			Labels:    map[string]string{audit.AuditLabel: "true"},
+		},
+		Data: map[string]string{"audit.json": string(b)},
+	}
+}
+
+func baselineCM(t *testing.T, name, agent, kind, verdict string, elapsed float64) *corev1.ConfigMap {
+	t.Helper()
+	return baselineCMIn(t, "default", name, agent, kind, verdict, elapsed)
+}
+
+func TestBaselineFor_MediansSuccessfulIssueFixRuns(t *testing.T) {
+	c := fake.NewClientBuilder().WithObjects(
+		baselineCM(t, "a", "qwen38-coder", "issue-fix", "GO", 3000),
+		baselineCM(t, "b", "qwen38-coder", "issue-fix", "GO", 3600),
+		baselineCM(t, "c", "qwen38-coder", "issue-fix", "GO", 4200),
+		// Excluded: different agent, non-terminal-good verdict, wrong kind.
+		baselineCM(t, "d", "other-coder", "issue-fix", "GO", 60),
+		baselineCM(t, "e", "qwen38-coder", "issue-fix", "NO-GO", 60),
+		baselineCM(t, "f", "qwen38-coder", "review", "GO", 60),
+	).Build()
+
+	got, err := BaselineFor(context.Background(), c, "default", "qwen38-coder")
+	if err != nil {
+		t.Fatalf("BaselineFor: %v", err)
+	}
+	if got != 3600*time.Second {
+		t.Errorf("BaselineFor = %v, want %v (median of 3000/3600/4200)", got, 3600*time.Second)
+	}
+}
+
+func TestBaselineFor_NoHistoryReturnsDefault(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+	got, err := BaselineFor(context.Background(), c, "default", "qwen38-coder")
+	if err != nil {
+		t.Fatalf("BaselineFor: %v", err)
+	}
+	if got != DefaultBaseline {
+		t.Errorf("BaselineFor = %v, want the default %v", got, DefaultBaseline)
+	}
+}
+
+// TestBaselineFor_FiltersAreLoadBearing pins each selection rule on its own.
+//
+// The happy-path test above cannot do this: its three excluded records all
+// carry elapsed=60, and adding one 60 to {3000,3600,4200} leaves the median
+// at 3600, so dropping any single filter still passes it. Every case here is
+// built so that removing exactly one rule from BaselineFor changes the
+// answer. Each case names the mutation it exists to catch.
+func TestBaselineFor_FiltersAreLoadBearing(t *testing.T) {
+	const agent = "qwen38-coder"
+
+	// A labelled audit ConfigMap holding JSON that is not a Record.
+	malformed := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreman-audit-malformed",
+			Namespace: "default",
+			Labels:    map[string]string{audit.AuditLabel: "true"},
+		},
+		Data: map[string]string{"audit.json": "{ this is not json"},
+	}
+	// A labelled audit ConfigMap with no audit.json key at all.
+	keyless := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreman-audit-keyless",
+			Namespace: "default",
+			Labels:    map[string]string{audit.AuditLabel: "true"},
+		},
+		Data: map[string]string{"other.json": "{}"},
+	}
+	// Well-formed records that are NOT labelled as audit records. Three of
+	// them, so that dropping the label selector drags the median down to 60
+	// rather than leaving it at 3600.
+	unlabelled := func(name string) *corev1.ConfigMap {
+		cm := baselineCM(t, name, agent, "issue-fix", "GO", 60)
+		cm.Labels = nil
+		return cm
+	}
+
+	cases := []struct {
+		name string
+		// mutation names the single production change this case detects.
+		mutation string
+		objs     []client.Object
+		want     time.Duration
+	}{
+		{
+			name:     "records for other agents are excluded",
+			mutation: "delete the rec.Agent.Name != agent guard",
+			objs: []client.Object{
+				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
+				baselineCM(t, "x1", "other-coder", "issue-fix", "GO", 60),
+				baselineCM(t, "x2", "other-coder", "issue-fix", "GO", 60),
+				baselineCM(t, "x3", "other-coder", "issue-fix", "GO", 60),
+			},
+			want: 3600 * time.Second,
+		},
+		{
+			name:     "records with no agent block are excluded",
+			mutation: "delete the rec.Agent == nil guard",
+			objs: []client.Object{
+				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
+				baselineAgentlessCM(t, "n1", "issue-fix", "GO", 60),
+				baselineAgentlessCM(t, "n2", "issue-fix", "GO", 60),
+				baselineAgentlessCM(t, "n3", "issue-fix", "GO", 60),
+			},
+			want: 3600 * time.Second,
+		},
+		{
+			name:     "unsuccessful verdicts are excluded",
+			mutation: "delete the verdict guard",
+			objs: []client.Object{
+				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
+				baselineCM(t, "x1", agent, "issue-fix", "NO-GO", 60),
+				baselineCM(t, "x2", agent, "issue-fix", "CODER-GATE-FAILED", 60),
+				baselineCM(t, "x3", agent, "issue-fix", "NEEDS-VERIFICATION", 60),
+			},
+			want: 3600 * time.Second,
+		},
+		{
+			name:     "GATE-PASS counts as cleanly successful",
+			mutation: "narrow the verdict guard to GO only",
+			objs: []client.Object{
+				baselineCM(t, "gp", agent, "issue-fix", "GATE-PASS", 1800),
+			},
+			want: 1800 * time.Second,
+		},
+		{
+			name:     "non issue-fix kinds are excluded",
+			mutation: "delete the rec.Task.Kind != issue-fix guard",
+			objs: []client.Object{
+				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
+				baselineCM(t, "x1", agent, "review", "GO", 60),
+				baselineCM(t, "x2", agent, "review", "GO", 60),
+				baselineCM(t, "x3", agent, "review", "GO", 60),
+			},
+			want: 3600 * time.Second,
+		},
+		{
+			name:     "other namespaces are excluded",
+			mutation: "drop client.InNamespace(namespace) from the List",
+			objs: []client.Object{
+				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
+				baselineCMIn(t, "other-ns", "x1", agent, "issue-fix", "GO", 60),
+				baselineCMIn(t, "other-ns", "x2", agent, "issue-fix", "GO", 60),
+				baselineCMIn(t, "other-ns", "x3", agent, "issue-fix", "GO", 60),
+			},
+			want: 3600 * time.Second,
+		},
+		{
+			name:     "unlabelled ConfigMaps are excluded",
+			mutation: "drop client.MatchingLabels{audit.AuditLabel: true} from the List",
+			objs: []client.Object{
+				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
+				unlabelled("u1"), unlabelled("u2"), unlabelled("u3"),
+			},
+			want: 3600 * time.Second,
+		},
+		{
+			// 60/3600/36000: mean is 13220s, so a mean would fail here, and
+			// so would picking the min or the max.
+			name:     "the middle value is taken, not the mean or an end",
+			mutation: "replace secs[len(secs)/2] with the mean, secs[0], or secs[len(secs)-1]",
+			objs: []client.Object{
+				baselineCM(t, "m1", agent, "issue-fix", "GO", 36000),
+				baselineCM(t, "m2", agent, "issue-fix", "GO", 60),
+				baselineCM(t, "m3", agent, "issue-fix", "GO", 3600),
+			},
+			want: 3600 * time.Second,
+		},
+		{
+			name:     "records with no elapsed time are ignored, not counted as zero",
+			mutation: "delete the rec.ElapsedSec > 0 guard",
+			objs: []client.Object{
+				baselineCM(t, "z1", agent, "issue-fix", "GO", 0),
+				baselineCM(t, "z2", agent, "issue-fix", "GO", 0),
+				baselineCM(t, "z3", agent, "issue-fix", "GO", 0),
+			},
+			want: DefaultBaseline,
+		},
+		{
+			name:     "a malformed record is skipped, not fatal",
+			mutation: "return the json.Unmarshal error instead of continuing",
+			objs:     []client.Object{malformed, keyless},
+			want:     DefaultBaseline,
+		},
+		{
+			name:     "a malformed record does not suppress the usable ones",
+			mutation: "return the json.Unmarshal error instead of continuing",
+			objs: []client.Object{
+				malformed,
+				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
+			},
+			want: 3600 * time.Second,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithObjects(tc.objs...).Build()
+			got, err := BaselineFor(context.Background(), c, "default", agent)
+			if err != nil {
+				t.Fatalf("BaselineFor: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("BaselineFor = %v, want %v (regression catches: %s)", got, tc.want, tc.mutation)
+			}
+		})
+	}
+}
+
+// agentlessCM builds an audit record with no agent block at all, which is
+// what the writer emits when the Agent could not be resolved.
+func baselineAgentlessCM(t *testing.T, name, kind, verdict string, elapsed float64) *corev1.ConfigMap {
+	t.Helper()
+	cm := baselineCM(t, name, "", kind, verdict, elapsed)
+	var rec audit.Record
+	if err := json.Unmarshal([]byte(cm.Data["audit.json"]), &rec); err != nil {
+		t.Fatal(err)
+	}
+	rec.Agent = nil
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm.Data["audit.json"] = string(b)
+	return cm
+}

--- a/pkg/cli/run_baseline_test.go
+++ b/pkg/cli/run_baseline_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/audit"
 )
 
-// auditCMIn builds an audit-record ConfigMap in the given namespace, shaped
+// baselineCMIn builds an audit-record ConfigMap in the given namespace, shaped
 // the way pkg/foreman/audit's writer shapes it: the audit label, plus the
 // JSON Record under the audit.json data key.
 func baselineCMIn(t *testing.T, namespace, name, agent, kind, verdict string, elapsed float64) *corev1.ConfigMap {
@@ -100,10 +100,11 @@ func TestBaselineFor_NoHistoryReturnsDefault(t *testing.T) {
 // TestBaselineFor_FiltersAreLoadBearing pins each selection rule on its own.
 //
 // The happy-path test above cannot do this: its three excluded records all
-// carry elapsed=60, and adding one 60 to {3000,3600,4200} leaves the median
-// at 3600, so dropping any single filter still passes it. Every case here is
-// built so that removing exactly one rule from BaselineFor changes the
-// answer. Each case names the mutation it exists to catch.
+// carry elapsed=60, and adding a single 60 to its included {3000,3600,9000}
+// leaves the median at 3600, so dropping any one filter still passes it.
+// Every case here is built so that removing exactly one rule from
+// BaselineFor changes the answer, using three excluded records rather than
+// one so the median actually moves. Each case names the mutation it catches.
 func TestBaselineFor_FiltersAreLoadBearing(t *testing.T) {
 	const agent = "qwen38-coder"
 
@@ -157,20 +158,25 @@ func TestBaselineFor_FiltersAreLoadBearing(t *testing.T) {
 			mutation: "delete the rec.Agent == nil guard",
 			objs: []client.Object{
 				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
-				baselineAgentlessCM(t, "n1", "issue-fix", "GO", 60),
-				baselineAgentlessCM(t, "n2", "issue-fix", "GO", 60),
-				baselineAgentlessCM(t, "n3", "issue-fix", "GO", 60),
+				// 12000 appears in no other case, so if these ever leak in
+				// the failure message names them rather than reading like
+				// any other excluded-record leak.
+				baselineAgentlessCM(t, "n1", "issue-fix", "GO", 12000),
+				baselineAgentlessCM(t, "n2", "issue-fix", "GO", 12000),
+				baselineAgentlessCM(t, "n3", "issue-fix", "GO", 12000),
 			},
 			want: 3600 * time.Second,
 		},
 		{
 			name:     "unsuccessful verdicts are excluded",
 			mutation: "delete the !rec.SucceededOnTarget guard",
+			// All three are real AgenticTaskVerdict values. INCOMPLETE is
+			// the common coder failure.
 			objs: []client.Object{
 				baselineCM(t, "mine", agent, "issue-fix", "GO", 3600),
 				baselineCM(t, "x1", agent, "issue-fix", "NO-GO", 60),
-				baselineCM(t, "x2", agent, "issue-fix", "CODER-GATE-FAILED", 60),
-				baselineCM(t, "x3", agent, "issue-fix", "NEEDS-VERIFICATION", 60),
+				baselineCM(t, "x2", agent, "issue-fix", "INCOMPLETE", 60),
+				baselineCM(t, "x3", agent, "issue-fix", "GATE-FAIL", 60),
 			},
 			want: 3600 * time.Second,
 		},
@@ -336,7 +342,7 @@ func patchRecord(t *testing.T, cm *corev1.ConfigMap, mutate func(*audit.Record))
 	cm.Data["audit.json"] = string(b)
 }
 
-// agentlessCM builds an audit record with no agent block at all, which is
+// baselineAgentlessCM builds an audit record with no agent block at all, which is
 // what the writer emits when the Agent could not be resolved.
 func baselineAgentlessCM(t *testing.T, name, kind, verdict string, elapsed float64) *corev1.ConfigMap {
 	t.Helper()

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -148,6 +149,11 @@ func ParkDecision(dir string, d Decision) (string, error) {
 // ListDecisions reads every decision in dir, oldest first. A missing
 // directory is an empty list, not an error: no parked decisions is the
 // normal state.
+//
+// One unreadable file does not hide the rest. The decisions that parsed come
+// back along with an error naming the ones that did not, because the caller is
+// the command whose whole job is showing a human what is parked, and showing
+// nothing at all is the worst answer it can give.
 func ListDecisions(dir string) ([]Decision, error) {
 	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
@@ -157,22 +163,25 @@ func ListDecisions(dir string) ([]Decision, error) {
 		return nil, fmt.Errorf("read decisions dir: %w", err)
 	}
 	var out []Decision
+	var bad []error
 	for _, e := range entries {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
 			continue
 		}
 		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
 		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", e.Name(), err)
+			bad = append(bad, fmt.Errorf("read %s: %w", e.Name(), err))
+			continue
 		}
 		var d Decision
 		if err := yaml.Unmarshal(b, &d); err != nil {
-			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
+			bad = append(bad, fmt.Errorf("parse %s: %w", e.Name(), err))
+			continue
 		}
 		out = append(out, d)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Opened.Before(out[j].Opened) })
-	return out, nil
+	return out, errors.Join(bad...)
 }
 
 // AnswerDecision records a human's answer. The answer must be one of the

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -52,6 +52,12 @@ type Decision struct {
 // decisions directory, and makes AnswerDecision rewrite whatever YAML it lands
 // on as a Decision, dropping every key it did not recognise.
 func checkDecisionKind(kind string) error {
+	// Task 7 feeds this from --kind, and Decision.Kind is not omitempty, so an
+	// empty kind parks a file named "1602-.yaml" carrying a decision with no
+	// kind at all.
+	if kind == "" {
+		return fmt.Errorf("decision kind must not be empty")
+	}
 	if strings.ContainsAny(kind, `/\`) {
 		return fmt.Errorf("decision kind %q must not contain a path separator", kind)
 	}

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -186,9 +186,19 @@ func ListDecisions(dir string) ([]Decision, error) {
 
 // AnswerDecision records a human's answer. The answer must be one of the
 // options the decision offered, so a typo cannot silently become an action.
+//
+// The answer is trimmed, and an answer that is empty once trimmed is rejected:
+// returning nil having recorded nothing reads as success to the human while
+// every consumer still sees the decision as unanswered, and a stored answer of
+// pure whitespace is worse still, since it satisfies the park guard forever and
+// the decision can never be refreshed again.
 func AnswerDecision(dir string, issue int32, kind, answer string) error {
 	if err := checkDecisionKind(kind); err != nil {
 		return err
+	}
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		return fmt.Errorf("decision answer must not be empty")
 	}
 	p := decisionPath(dir, issue, kind)
 	b, err := os.ReadFile(p)

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -45,16 +45,17 @@ type Decision struct {
 	Answer string `json:"answer,omitempty"`
 }
 
-// checkDecisionKind rejects a kind that would steer the path out of dir. Task 7
-// takes the kind from the command line, so this is reachable input, and it is
-// not a privilege boundary so much as a way to avoid silently destroying an
-// unrelated file: a kind with a ".." in it makes ParkDecision write outside the
-// decisions directory, and makes AnswerDecision rewrite whatever YAML it lands
-// on as a Decision, dropping every key it did not recognise.
+// checkDecisionKind rejects a kind that would steer the path out of dir.
+// `foreman decisions answer ISSUE KIND ANSWER` takes the kind straight off the
+// command line, so this is reachable input, and it is not a privilege boundary
+// so much as a way to avoid silently destroying an unrelated file: a kind with
+// a ".." in it makes ParkDecision write outside the decisions directory, and
+// makes AnswerDecision rewrite whatever YAML it lands on as a Decision,
+// dropping every key it did not recognise.
 func checkDecisionKind(kind string) error {
-	// Task 7 feeds this from --kind, and Decision.Kind is not omitempty, so an
-	// empty kind parks a file named "1602-.yaml" carrying a decision with no
-	// kind at all.
+	// A kind typed as a positional argument reaches here, and Decision.Kind is
+	// not omitempty, so an empty kind parks a file named "1602-.yaml" carrying
+	// a decision with no kind at all.
 	if kind == "" {
 		return fmt.Errorf("decision kind must not be empty")
 	}

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Decision is one parked judgment call. Files rather than a CRD: inspectable,
+// diffable, no schema guessed at before the shape is known, and a future
+// Command Center can read the same directory without either side committing
+// to an API.
+type Decision struct {
+	Issue    int32             `json:"issue"`
+	Workload string            `json:"workload,omitempty"`
+	Stage    string            `json:"stage,omitempty"`
+	Kind     string            `json:"kind"`
+	Opened   time.Time         `json:"opened,omitempty"`
+	Reason   string            `json:"reason,omitempty"`
+	Evidence map[string]string `json:"evidence,omitempty"`
+	Options  []string          `json:"options,omitempty"`
+	// Answer is empty until a human answers it.
+	Answer string `json:"answer,omitempty"`
+}
+
+func decisionPath(dir string, issue int32, kind string) string {
+	return filepath.Join(dir, fmt.Sprintf("%d-%s.yaml", issue, kind))
+}
+
+// ParkDecision writes a decision and returns its path. Parking is how the
+// loop declines to block: the caller records this and moves to the next item.
+func ParkDecision(dir string, d Decision) (string, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create decisions dir: %w", err)
+	}
+	if d.Opened.IsZero() {
+		d.Opened = time.Now().UTC()
+	}
+	b, err := yaml.Marshal(d)
+	if err != nil {
+		return "", fmt.Errorf("marshal decision: %w", err)
+	}
+	p := decisionPath(dir, d.Issue, d.Kind)
+	if err := os.WriteFile(p, b, 0o600); err != nil {
+		return "", fmt.Errorf("write decision: %w", err)
+	}
+	return p, nil
+}
+
+// ListDecisions reads every decision in dir, oldest first. A missing
+// directory is an empty list, not an error: no parked decisions is the
+// normal state.
+func ListDecisions(dir string) ([]Decision, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read decisions dir: %w", err)
+	}
+	var out []Decision
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		var d Decision
+		if err := yaml.Unmarshal(b, &d); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
+		}
+		out = append(out, d)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Opened.Before(out[j].Opened) })
+	return out, nil
+}
+
+// AnswerDecision records a human's answer. The answer must be one of the
+// options the decision offered, so a typo cannot silently become an action.
+func AnswerDecision(dir string, issue int32, kind, answer string) error {
+	p := decisionPath(dir, issue, kind)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return fmt.Errorf("read decision: %w", err)
+	}
+	var d Decision
+	if err := yaml.Unmarshal(b, &d); err != nil {
+		return fmt.Errorf("parse decision: %w", err)
+	}
+	ok := len(d.Options) == 0
+	for _, o := range d.Options {
+		if o == answer {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("answer %q is not one of %v", answer, d.Options)
+	}
+	d.Answer = answer
+	out, err := yaml.Marshal(d)
+	if err != nil {
+		return fmt.Errorf("marshal decision: %w", err)
+	}
+	return os.WriteFile(p, out, 0o600)
+}

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -65,13 +65,22 @@ func decisionPath(dir string, issue int32, kind string) string {
 	return filepath.Join(dir, fmt.Sprintf("%d-%s.yaml", issue, kind))
 }
 
+// decisionStagePattern names the file writeDecisionFile stages before renaming
+// it into place. The suffix is load-bearing rather than decorative: a process
+// killed between the create and the rename, which is precisely the crash atomic
+// writes exist for, leaks one of these next to the real decisions, and
+// ListDecisions ignores it only because the extension is not ".yaml". Give it a
+// .yaml name and every such leftover becomes a permanent parse error in the
+// human's queue view, now that a bad file is deliberately surfaced there.
+const decisionStagePattern = ".decision-*.tmp"
+
 // writeDecisionFile replaces p with b atomically. A decision file is
 // human-owned: a truncating write that is interrupted by a crash or a full
 // disk leaves a half-written answer behind, which is exactly the damage the
 // park guard then has to refuse to touch. Staging in the same directory and
 // renaming means a reader sees either the whole old file or the whole new one.
 func writeDecisionFile(p string, b []byte) error {
-	f, err := os.CreateTemp(filepath.Dir(p), ".decision-*.tmp")
+	f, err := os.CreateTemp(filepath.Dir(p), decisionStagePattern)
 	if err != nil {
 		return fmt.Errorf("write decision %s: %w", p, err)
 	}

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/yaml"
@@ -41,6 +42,22 @@ type Decision struct {
 	Options  []string          `json:"options,omitempty"`
 	// Answer is empty until a human answers it.
 	Answer string `json:"answer,omitempty"`
+}
+
+// checkDecisionKind rejects a kind that would steer the path out of dir. Task 7
+// takes the kind from the command line, so this is reachable input, and it is
+// not a privilege boundary so much as a way to avoid silently destroying an
+// unrelated file: a kind with a ".." in it makes ParkDecision write outside the
+// decisions directory, and makes AnswerDecision rewrite whatever YAML it lands
+// on as a Decision, dropping every key it did not recognise.
+func checkDecisionKind(kind string) error {
+	if strings.ContainsAny(kind, `/\`) {
+		return fmt.Errorf("decision kind %q must not contain a path separator", kind)
+	}
+	if kind == "." || kind == ".." {
+		return fmt.Errorf("decision kind %q must be a name, not a path segment", kind)
+	}
+	return nil
 }
 
 func decisionPath(dir string, issue int32, kind string) string {
@@ -81,6 +98,9 @@ func writeDecisionFile(p string, b []byte) error {
 // ParkDecision writes a decision and returns its path. Parking is how the
 // loop declines to block: the caller records this and moves to the next item.
 func ParkDecision(dir string, d Decision) (string, error) {
+	if err := checkDecisionKind(d.Kind); err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("create decisions dir: %w", err)
 	}
@@ -158,6 +178,9 @@ func ListDecisions(dir string) ([]Decision, error) {
 // AnswerDecision records a human's answer. The answer must be one of the
 // options the decision offered, so a typo cannot silently become an action.
 func AnswerDecision(dir string, issue int32, kind, answer string) error {
+	if err := checkDecisionKind(kind); err != nil {
+		return err
+	}
 	p := decisionPath(dir, issue, kind)
 	b, err := os.ReadFile(p)
 	if err != nil {

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -129,6 +129,14 @@ func ParkDecision(dir string, d Decision) (string, error) {
 	// likeliest way one gets truncated is an interrupted write, and the answer
 	// may well still be sitting in it in plain text. Refusing until a human
 	// looks at the file beats destroying what is left of it.
+	//
+	// Every read error other than "no such file" refuses, not just permission
+	// denied: an I/O error on a real file is also a decision that exists and
+	// cannot be read, and falling through on that would overwrite exactly what
+	// this guard is for. The cost is that errors meaning "nothing is there at
+	// all", a name that is too long or a directory sitting at the path, land
+	// here too, so the message names what failed rather than asserting there is
+	// a corrupt decision to go and look at.
 	existing, err := os.ReadFile(p)
 	switch {
 	case err == nil:
@@ -140,7 +148,7 @@ func ParkDecision(dir string, d Decision) (string, error) {
 			return p, nil
 		}
 	case !os.IsNotExist(err):
-		return "", fmt.Errorf("refusing to overwrite unreadable decision %s: %w", p, err)
+		return "", fmt.Errorf("cannot check for an existing decision at %s, refusing to write: %w", p, err)
 	}
 	if d.Opened.IsZero() {
 		d.Opened = time.Now().UTC()

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -53,6 +53,18 @@ func ParkDecision(dir string, d Decision) (string, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("create decisions dir: %w", err)
 	}
+	p := decisionPath(dir, d.Issue, d.Kind)
+	// An answer already on disk is the human's, and nothing consumes it before
+	// the loop re-parks the same item, so writing over it would silently
+	// destroy typed input. The item genuinely is parked either way, so leaving
+	// it alone is not an error for the caller. An unanswered decision is still
+	// refreshed with the current reason and evidence.
+	if existing, err := os.ReadFile(p); err == nil {
+		var prev Decision
+		if err := yaml.Unmarshal(existing, &prev); err == nil && prev.Answer != "" {
+			return p, nil
+		}
+	}
 	if d.Opened.IsZero() {
 		d.Opened = time.Now().UTC()
 	}
@@ -60,7 +72,6 @@ func ParkDecision(dir string, d Decision) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal decision: %w", err)
 	}
-	p := decisionPath(dir, d.Issue, d.Kind)
 	if err := os.WriteFile(p, b, 0o600); err != nil {
 		return "", fmt.Errorf("write decision: %w", err)
 	}

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -59,11 +59,27 @@ func ParkDecision(dir string, d Decision) (string, error) {
 	// destroy typed input. The item genuinely is parked either way, so leaving
 	// it alone is not an error for the caller. An unanswered decision is still
 	// refreshed with the current reason and evidence.
-	if existing, err := os.ReadFile(p); err == nil {
+	//
+	// This narrows the window, it does not close it: a human answering at the
+	// same instant as a park can still lose the answer. That is acceptable for
+	// a single-process loop and is not what this guard claims to prevent.
+	//
+	// A decision that cannot be read or parsed is never overwritten. The
+	// likeliest way one gets truncated is an interrupted write, and the answer
+	// may well still be sitting in it in plain text. Refusing until a human
+	// looks at the file beats destroying what is left of it.
+	existing, err := os.ReadFile(p)
+	switch {
+	case err == nil:
 		var prev Decision
-		if err := yaml.Unmarshal(existing, &prev); err == nil && prev.Answer != "" {
+		if err := yaml.Unmarshal(existing, &prev); err != nil {
+			return "", fmt.Errorf("refusing to overwrite unparseable decision %s: %w", p, err)
+		}
+		if prev.Answer != "" {
 			return p, nil
 		}
+	case !os.IsNotExist(err):
+		return "", fmt.Errorf("refusing to overwrite unreadable decision %s: %w", p, err)
 	}
 	if d.Opened.IsZero() {
 		d.Opened = time.Now().UTC()

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -47,6 +47,37 @@ func decisionPath(dir string, issue int32, kind string) string {
 	return filepath.Join(dir, fmt.Sprintf("%d-%s.yaml", issue, kind))
 }
 
+// writeDecisionFile replaces p with b atomically. A decision file is
+// human-owned: a truncating write that is interrupted by a crash or a full
+// disk leaves a half-written answer behind, which is exactly the damage the
+// park guard then has to refuse to touch. Staging in the same directory and
+// renaming means a reader sees either the whole old file or the whole new one.
+func writeDecisionFile(p string, b []byte) error {
+	f, err := os.CreateTemp(filepath.Dir(p), ".decision-*.tmp")
+	if err != nil {
+		return fmt.Errorf("write decision %s: %w", p, err)
+	}
+	tmp := f.Name()
+	// A no-op once the rename has happened.
+	defer func() { _ = os.Remove(tmp) }()
+	// Pinned here rather than left to how the temp file happened to be made.
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write decision %s: %w", p, err)
+	}
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write decision %s: %w", p, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("write decision %s: %w", p, err)
+	}
+	if err := os.Rename(tmp, p); err != nil {
+		return fmt.Errorf("write decision %s: %w", p, err)
+	}
+	return nil
+}
+
 // ParkDecision writes a decision and returns its path. Parking is how the
 // loop declines to block: the caller records this and moves to the next item.
 func ParkDecision(dir string, d Decision) (string, error) {
@@ -88,8 +119,8 @@ func ParkDecision(dir string, d Decision) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal decision: %w", err)
 	}
-	if err := os.WriteFile(p, b, 0o600); err != nil {
-		return "", fmt.Errorf("write decision: %w", err)
+	if err := writeDecisionFile(p, b); err != nil {
+		return "", err
 	}
 	return p, nil
 }
@@ -151,5 +182,5 @@ func AnswerDecision(dir string, issue int32, kind, answer string) error {
 	if err != nil {
 		return fmt.Errorf("marshal decision: %w", err)
 	}
-	return os.WriteFile(p, out, 0o600)
+	return writeDecisionFile(p, out)
 }

--- a/pkg/cli/run_decisions.go
+++ b/pkg/cli/run_decisions.go
@@ -226,7 +226,11 @@ func AnswerDecision(dir string, issue int32, kind, answer string) error {
 	p := decisionPath(dir, issue, kind)
 	b, err := os.ReadFile(p)
 	if err != nil {
-		return fmt.Errorf("read decision: %w", err)
+		// Named, like every other error here: the common way to reach this is
+		// a mistyped ISSUE or KIND, and "read decision: ... no such file"
+		// without the path reads as an I/O fault rather than "nothing is
+		// parked under that name".
+		return fmt.Errorf("read decision %s: %w", p, err)
 	}
 	var d Decision
 	if err := yaml.Unmarshal(b, &d); err != nil {

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -210,3 +210,72 @@ func TestListDecisions_OldestFirst(t *testing.T) {
 		t.Errorf("order = [%d %d], want [1602 1500] (oldest first)", got[0].Issue, got[1].Issue)
 	}
 }
+
+func TestParkDecision_KeepsAnAnsweredDecision(t *testing.T) {
+	// The driver parks unconditionally and nothing reads a decision before
+	// re-parking it, so a second run of the same item must not overwrite an
+	// answer a human already typed.
+	dir := t.TempDir()
+	first, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate",
+		Reason:  "verify found issues",
+		Options: []string{"accept", "revise"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := AnswerDecision(dir, 1602, "adjudicate", "revise"); err != nil {
+		t.Fatal(err)
+	}
+	again, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate",
+		Reason:   "second pass found more issues",
+		Evidence: map[string]string{"verify": "./evidence/1602-verify-2.txt"},
+		Options:  []string{"accept", "revise"},
+	})
+	if err != nil {
+		t.Fatalf("re-park an answered decision: %v", err)
+	}
+	if again != first {
+		t.Errorf("path = %q, want the existing %q", again, first)
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Answer != "revise" {
+		t.Errorf("Answer = %q, want revise to survive the re-park", got[0].Answer)
+	}
+	if got[0].Reason != "verify found issues" {
+		t.Errorf("Reason = %q, want the answered decision left intact", got[0].Reason)
+	}
+}
+
+func TestParkDecision_RefreshesAnUnansweredDecision(t *testing.T) {
+	// The guard is about answers, not about existence: an unanswered decision
+	// still picks up the current reason.
+	dir := t.TempDir()
+	if _, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate", Reason: "verify found issues",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate", Reason: "second pass found more issues",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Reason != "second pass found more issues" {
+		t.Errorf("Reason = %q, want the refreshed reason", got[0].Reason)
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -324,10 +324,10 @@ func TestAnswerDecision_ErrorsWhenTheWriteFails(t *testing.T) {
 	if err := os.Chmod(p, 0o400); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(dir, 0o500); err != nil { //nolint:gosec // G302: a directory mode, and the test needs the dir non-writable
+	if err := os.Chmod(dir, 0o500); err != nil { //nolint:gosec // G302: directory mode
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) //nolint:gosec // G302: a directory mode, restored so TempDir cleanup works
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) //nolint:gosec // G302: directory mode
 	err := AnswerDecision(dir, 1602, "adjudicate", "revise")
 	if err == nil {
 		t.Fatal("want an error when the decision cannot be written")

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -626,3 +626,40 @@ func TestAnswerDecision_RejectsAnEmptyAnswer(t *testing.T) {
 		t.Errorf("Answer = %q, want the decision still unanswered", got[0].Answer)
 	}
 }
+
+func TestDecisionWritesStageInTheDecisionsDir(t *testing.T) {
+	// The staged file has to be a sibling of the target, not a file in TMPDIR.
+	// os.Rename across filesystems returns EXDEV, and a decisions dir under a
+	// home directory against a /var/folders TMPDIR is exactly that arrangement
+	// on macOS, so staging in TMPDIR would fail every write on a real box while
+	// passing every test on a box where the two happen to share a filesystem.
+	// Pointing TMPDIR at somewhere that does not exist stands in for that: a
+	// write that needs TMPDIR breaks, a write that stages beside the target
+	// does not care.
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", filepath.Join(dir, "no-such-tmpdir"))
+	p, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate", Options: []string{"accept", "revise"},
+	})
+	if err != nil {
+		t.Fatalf("ParkDecision with TMPDIR pointing nowhere: %v", err)
+	}
+	if got := filepath.Dir(p); got != dir {
+		t.Errorf("decision at %s, want it in %s", got, dir)
+	}
+	if err := AnswerDecision(dir, 1602, "adjudicate", "revise"); err != nil {
+		t.Fatalf("AnswerDecision with TMPDIR pointing nowhere: %v", err)
+	}
+}
+
+func TestParkDecision_ChecksTheKindBeforeTouchingTheDisk(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "decisions")
+	if _, err := ParkDecision(dir, Decision{Issue: 1602, Kind: "../x"}); err == nil {
+		t.Fatal("want an error for a kind containing a path separator")
+	}
+	// Rejecting the kind only after MkdirAll would leave the directory behind.
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("%s exists, want nothing created for a rejected kind", dir)
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -256,15 +256,19 @@ func TestParkDecision_KeepsAnAnsweredDecision(t *testing.T) {
 
 func TestParkDecision_RefreshesAnUnansweredDecision(t *testing.T) {
 	// The guard is about answers, not about existence: an unanswered decision
-	// still picks up the current reason.
+	// still picks up the current reason. Options are set here to match the
+	// answered case exactly, so the only difference between the two tests is
+	// the answer itself and the guard cannot be satisfied by anything else.
 	dir := t.TempDir()
 	if _, err := ParkDecision(dir, Decision{
 		Issue: 1602, Kind: "adjudicate", Reason: "verify found issues",
+		Options: []string{"accept", "revise"},
 	}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ParkDecision(dir, Decision{
 		Issue: 1602, Kind: "adjudicate", Reason: "second pass found more issues",
+		Options: []string{"accept", "revise"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -277,5 +281,69 @@ func TestParkDecision_RefreshesAnUnansweredDecision(t *testing.T) {
 	}
 	if got[0].Reason != "second pass found more issues" {
 		t.Errorf("Reason = %q, want the refreshed reason", got[0].Reason)
+	}
+}
+
+// answeredDecisionDir parks one answerable decision and returns its directory
+// and file path. Named for this file to avoid colliding with the package's
+// other test helpers.
+func decisionFixtureDir(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	p, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate", Options: []string{"accept", "revise"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, p
+}
+
+func TestAnswerDecision_ErrorsWhenThereIsNoSuchDecision(t *testing.T) {
+	dir, _ := decisionFixtureDir(t)
+	if err := AnswerDecision(dir, 9999, "adjudicate", "revise"); err == nil {
+		t.Error("want an error for an issue with no parked decision")
+	}
+	if err := AnswerDecision(dir, 1602, "triage", "revise"); err == nil {
+		t.Error("want an error for a kind with no parked decision")
+	}
+	if err := AnswerDecision(filepath.Join(t.TempDir(), "never-created"), 1602, "adjudicate", "revise"); err == nil {
+		t.Error("want an error when the decisions dir does not exist")
+	}
+}
+
+func TestAnswerDecision_ErrorsWhenTheWriteFails(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root, permission bits do not apply")
+	}
+	dir, p := decisionFixtureDir(t)
+	// Read-only file and read-only directory: an in-place rewrite and a
+	// staged replace both have to fail, and the answer must not be reported
+	// as recorded when it was not.
+	if err := os.Chmod(p, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	if err := AnswerDecision(dir, 1602, "adjudicate", "revise"); err == nil {
+		t.Fatal("want an error when the decision cannot be written")
+	}
+}
+
+func TestParkDecision_WritesTheFileUserReadWriteOnly(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root, permission bits do not apply")
+	}
+	_, p := decisionFixtureDir(t)
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A decision can carry evidence paths and a human's answer. Nothing else
+	// on the box needs to read it.
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %04o, want 0600", got)
 	}
 }

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -324,10 +324,10 @@ func TestAnswerDecision_ErrorsWhenTheWriteFails(t *testing.T) {
 	if err := os.Chmod(p, 0o400); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(dir, 0o500); err != nil {
+	if err := os.Chmod(dir, 0o500); err != nil { //nolint:gosec // G302: a directory mode, and the test needs the dir non-writable
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) //nolint:gosec // G302: a directory mode, restored so TempDir cleanup works
 	err := AnswerDecision(dir, 1602, "adjudicate", "revise")
 	if err == nil {
 		t.Fatal("want an error when the decision cannot be written")

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -688,3 +688,21 @@ func TestListDecisions_IgnoresALeakedStageFile(t *testing.T) {
 		t.Errorf("Issue = %d, want 1602", got[0].Issue)
 	}
 }
+
+func TestParkDecision_DoesNotClaimACorruptDecisionWhenNoneExists(t *testing.T) {
+	// A name too long is a read error that is not "no such file", so it lands
+	// in the same refusal branch as a genuinely unreadable decision. It still
+	// has to fail safely, but it must not send a human hunting for a corrupt
+	// file that was never there.
+	dir := t.TempDir()
+	_, err := ParkDecision(dir, Decision{Issue: 1602, Kind: strings.Repeat("k", 300)})
+	if err == nil {
+		t.Fatal("want an error for a decision path that cannot be read or written")
+	}
+	if strings.Contains(err.Error(), "overwrite") {
+		t.Errorf("err = %v, want no claim that an existing decision is in the way", err)
+	}
+	if names := decisionDirNames(t, dir); len(names) != 0 {
+		t.Errorf("dir = %v, want nothing written", names)
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -489,3 +489,55 @@ func decisionDirNames(t *testing.T, dir string) []string {
 	}
 	return names
 }
+
+func TestParkDecision_RejectsAKindThatEscapesTheDir(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "sub", "decisions")
+	// "1602-.." is one path element, so it takes three to climb out of dir.
+	if _, err := ParkDecision(dir, Decision{Issue: 1602, Kind: "../../../x"}); err == nil {
+		t.Error("want an error for a kind that climbs out of the decisions dir")
+	}
+	escaped := filepath.Join(base, "sub", "x.yaml")
+	if _, err := os.Stat(escaped); !os.IsNotExist(err) {
+		t.Errorf("%s exists, want nothing written outside the decisions dir", escaped)
+	}
+}
+
+func TestParkDecision_RejectsAKindWithAPathSeparator(t *testing.T) {
+	dir := t.TempDir()
+	// The subdirectory exists, so without the check this park would succeed
+	// and file the decision somewhere ListDecisions never looks.
+	if err := os.Mkdir(filepath.Join(dir, "1602-nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParkDecision(dir, Decision{Issue: 1602, Kind: "nested/x"}); err == nil {
+		t.Error("want an error for a kind containing a path separator")
+	}
+	buried := filepath.Join(dir, "1602-nested", "x.yaml")
+	if _, err := os.Stat(buried); !os.IsNotExist(err) {
+		t.Errorf("%s exists, want no decision filed in a subdirectory", buried)
+	}
+}
+
+func TestAnswerDecision_RejectsAKindThatEscapesTheDir(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "sub", "decisions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	victim := filepath.Join(base, "sub", "victim.yaml")
+	const unrelated = "unrelated: keep me\n"
+	if err := os.WriteFile(victim, []byte(unrelated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := AnswerDecision(dir, 1602, "../../../victim", "revise"); err == nil {
+		t.Error("want an error for a kind that climbs out of the decisions dir")
+	}
+	after, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != unrelated {
+		t.Errorf("victim = %q, want the unrelated file untouched", string(after))
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -541,3 +541,37 @@ func TestAnswerDecision_RejectsAKindThatEscapesTheDir(t *testing.T) {
 		t.Errorf("victim = %q, want the unrelated file untouched", string(after))
 	}
 }
+
+func TestListDecisions_ReturnsTheGoodOnesAndNamesTheBad(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := ParkDecision(dir, Decision{Issue: 1602, Kind: "adjudicate"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "1500-adjudicate.yaml"),
+		[]byte("answer: revise\noptions: [accept, revise\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unreadable := os.Getuid() != 0
+	if unreadable {
+		if err := os.WriteFile(filepath.Join(dir, "1400-adjudicate.yaml"), []byte("issue: 1400\n"), 0o200); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := ListDecisions(dir)
+	if err == nil {
+		t.Fatal("want an error naming the decisions that could not be read")
+	}
+	if !strings.Contains(err.Error(), "1500-adjudicate.yaml") {
+		t.Errorf("err = %v, want it to name 1500-adjudicate.yaml", err)
+	}
+	if unreadable && !strings.Contains(err.Error(), "1400-adjudicate.yaml") {
+		t.Errorf("err = %v, want it to name 1400-adjudicate.yaml", err)
+	}
+	// The point of the change: the human still sees what is parked.
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want the one decision that parsed", len(got))
+	}
+	if got[0].Issue != 1602 {
+		t.Errorf("Issue = %d, want 1602", got[0].Issue)
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -327,8 +328,12 @@ func TestAnswerDecision_ErrorsWhenTheWriteFails(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
-	if err := AnswerDecision(dir, 1602, "adjudicate", "revise"); err == nil {
+	err := AnswerDecision(dir, 1602, "adjudicate", "revise")
+	if err == nil {
 		t.Fatal("want an error when the decision cannot be written")
+	}
+	if !strings.HasPrefix(err.Error(), "write decision") {
+		t.Errorf("err = %v, want it wrapped like the file's other errors", err)
 	}
 }
 
@@ -398,4 +403,89 @@ func TestParkDecision_RefusesToOverwriteAnUnreadableDecision(t *testing.T) {
 	if len(got) != 1 || got[0].Answer != "revise" {
 		t.Errorf("got %+v, want the answer still on disk", got)
 	}
+}
+
+func TestDecisionWritesReplaceRatherThanTruncate(t *testing.T) {
+	// An in-place truncating write is the mechanism behind a half-written
+	// answer. A staged write plus rename leaves a different file behind, which
+	// is the observable difference between the two.
+	dir, p := decisionFixtureDir(t)
+	before, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := AnswerDecision(dir, 1602, "adjudicate", "revise"); err != nil {
+		t.Fatal(err)
+	}
+	afterAnswer, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(before, afterAnswer) {
+		t.Error("AnswerDecision rewrote the file in place, want an atomic replace")
+	}
+
+	dir2, p2 := decisionFixtureDir(t)
+	before2, err := os.Stat(p2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParkDecision(dir2, Decision{
+		Issue: 1602, Kind: "adjudicate", Reason: "refreshed",
+		Options: []string{"accept", "revise"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	after2, err := os.Stat(p2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(before2, after2) {
+		t.Error("ParkDecision rewrote the file in place, want an atomic replace")
+	}
+}
+
+func TestDecisionWritesLeaveNoTempFiles(t *testing.T) {
+	dir, _ := decisionFixtureDir(t)
+	if err := AnswerDecision(dir, 1602, "adjudicate", "revise"); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "1602-adjudicate.yaml" {
+		t.Errorf("dir = %v, want just the decision file", decisionDirNames(t, dir))
+	}
+
+	// The failing path is the one that matters: a staged file that never got
+	// renamed must not be left lying around for the next run to trip over.
+	blocked := t.TempDir()
+	target := filepath.Join(blocked, "1602-adjudicate.yaml")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "child"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeDecisionFile(target, []byte("issue: 1602\n")); err == nil {
+		t.Fatal("want an error when the staged file cannot be renamed into place")
+	}
+	names := decisionDirNames(t, blocked)
+	if len(names) != 1 || names[0] != "1602-adjudicate.yaml" {
+		t.Errorf("dir = %v, want no staged leftovers", names)
+	}
+}
+
+func decisionDirNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
 }

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestParkAndListDecisions(t *testing.T) {
+	dir := t.TempDir()
+	d := Decision{
+		Issue:    1602,
+		Workload: "wl-1602-deadcode-triage",
+		Stage:    "verify",
+		Kind:     "adjudicate",
+		Opened:   time.Date(2026, 8, 23, 4, 12, 0, 0, time.UTC),
+		Reason:   "verify found issues",
+		Evidence: map[string]string{"verify": "./evidence/1602-verify.txt"},
+		Options:  []string{"accept", "revise", "escalate", "drop"},
+	}
+	path, err := ParkDecision(dir, d)
+	if err != nil {
+		t.Fatalf("ParkDecision: %v", err)
+	}
+	if path == "" {
+		t.Fatal("ParkDecision returned an empty path")
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatalf("ListDecisions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Issue != 1602 || got[0].Kind != "adjudicate" {
+		t.Errorf("got %+v, want issue 1602 / adjudicate", got[0])
+	}
+	if got[0].Answer != "" {
+		t.Errorf("Answer = %q, want empty on a fresh decision", got[0].Answer)
+	}
+	// Every field the caller parked has to survive the write/read, not just
+	// the two that also make up the filename.
+	if got[0].Workload != d.Workload {
+		t.Errorf("Workload = %q, want %q", got[0].Workload, d.Workload)
+	}
+	if got[0].Stage != d.Stage {
+		t.Errorf("Stage = %q, want %q", got[0].Stage, d.Stage)
+	}
+	if !got[0].Opened.Equal(d.Opened) {
+		t.Errorf("Opened = %v, want %v", got[0].Opened, d.Opened)
+	}
+	if got[0].Reason != d.Reason {
+		t.Errorf("Reason = %q, want %q", got[0].Reason, d.Reason)
+	}
+	if got[0].Evidence["verify"] != "./evidence/1602-verify.txt" {
+		t.Errorf("Evidence = %v, want the parked verify path", got[0].Evidence)
+	}
+	if !reflect.DeepEqual(got[0].Options, d.Options) {
+		t.Errorf("Options = %v, want %v", got[0].Options, d.Options)
+	}
+}
+
+func TestAnswerDecision_RoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate", Options: []string{"accept", "revise"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AnswerDecision(dir, 1602, "adjudicate", "revise"); err != nil {
+		t.Fatalf("AnswerDecision: %v", err)
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Answer != "revise" {
+		t.Errorf("Answer = %q, want revise", got[0].Answer)
+	}
+}
+
+func TestAnswerDecision_RejectsAnOptionNotOffered(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate", Options: []string{"accept", "revise"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AnswerDecision(dir, 1602, "adjudicate", "nonsense"); err == nil {
+		t.Fatal("want an error for an answer outside the offered options")
+	}
+}
+
+func TestListDecisions_EmptyDirIsNotAnError(t *testing.T) {
+	got, err := ListDecisions(t.TempDir())
+	if err != nil {
+		t.Fatalf("ListDecisions on an empty dir: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}
+
+func TestParkDecision_CreatesTheDecisionsDir(t *testing.T) {
+	// The loop parks into a directory that does not exist yet on the first
+	// run of a session, so creating it is part of the contract.
+	dir := filepath.Join(t.TempDir(), "decisions")
+	path, err := ParkDecision(dir, Decision{Issue: 1602, Kind: "adjudicate"})
+	if err != nil {
+		t.Fatalf("ParkDecision into a missing dir: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+}
+
+func TestParkDecision_StampsOpenedWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := ParkDecision(dir, Decision{Issue: 1602, Kind: "adjudicate"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Opened.IsZero() {
+		t.Error("Opened is zero, want a stamp from ParkDecision")
+	}
+}
+
+func TestListDecisions_MissingDirIsNotAnError(t *testing.T) {
+	// Distinct from an existing empty dir: nothing has parked yet, so the
+	// directory itself is absent.
+	got, err := ListDecisions(filepath.Join(t.TempDir(), "never-created"))
+	if err != nil {
+		t.Fatalf("ListDecisions on a missing dir: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}
+
+func TestListDecisions_SkipsNonYAMLEntries(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := ParkDecision(dir, Decision{Issue: 1602, Kind: "adjudicate"}); err != nil {
+		t.Fatal(err)
+	}
+	// A stray note that happens to parse as a Decision, and a directory whose
+	// name ends in .yaml. Neither is a parked decision.
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("issue: 999\nkind: bogus\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "archive.yaml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatalf("ListDecisions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].Issue != 1602 {
+		t.Errorf("Issue = %d, want 1602", got[0].Issue)
+	}
+}
+
+func TestListDecisions_OldestFirst(t *testing.T) {
+	dir := t.TempDir()
+	// 1602 is opened earlier but sorts after 1500 by filename, so filename
+	// order and Opened order disagree.
+	if _, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate",
+		Opened: time.Date(2026, 8, 23, 4, 12, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParkDecision(dir, Decision{
+		Issue: 1500, Kind: "adjudicate",
+		Opened: time.Date(2026, 8, 23, 5, 30, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Issue != 1602 || got[1].Issue != 1500 {
+		t.Errorf("order = [%d %d], want [1602 1500] (oldest first)", got[0].Issue, got[1].Issue)
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -575,3 +575,54 @@ func TestListDecisions_ReturnsTheGoodOnesAndNamesTheBad(t *testing.T) {
 		t.Errorf("Issue = %d, want 1602", got[0].Issue)
 	}
 }
+
+func TestAnswerDecision_TrimsTheAnswer(t *testing.T) {
+	dir, _ := decisionFixtureDir(t)
+	if err := AnswerDecision(dir, 1602, "adjudicate", "  revise\n"); err != nil {
+		t.Fatalf("AnswerDecision with surrounding whitespace: %v", err)
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Answer != "revise" {
+		t.Errorf("Answer = %q, want it trimmed", got[0].Answer)
+	}
+
+	// Without options there is no membership check to do the trimming for us,
+	// so this pins the stored value on its own.
+	loose := t.TempDir()
+	if _, err := ParkDecision(loose, Decision{Issue: 1700, Kind: "adjudicate"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AnswerDecision(loose, 1700, "adjudicate", "  accept  "); err != nil {
+		t.Fatal(err)
+	}
+	got, err = ListDecisions(loose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Answer != "accept" {
+		t.Errorf("Answer = %q, want it trimmed", got[0].Answer)
+	}
+}
+
+func TestAnswerDecision_RejectsAnEmptyAnswer(t *testing.T) {
+	// No options, so the permissive branch would otherwise accept anything.
+	dir := t.TempDir()
+	if _, err := ParkDecision(dir, Decision{Issue: 1602, Kind: "adjudicate"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, answer := range []string{"", "   ", "\t\n"} {
+		if err := AnswerDecision(dir, 1602, "adjudicate", answer); err == nil {
+			t.Errorf("AnswerDecision(%q) = nil, want an error", answer)
+		}
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Answer != "" {
+		t.Errorf("Answer = %q, want the decision still unanswered", got[0].Answer)
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -663,3 +663,28 @@ func TestParkDecision_ChecksTheKindBeforeTouchingTheDisk(t *testing.T) {
 		t.Errorf("%s exists, want nothing created for a rejected kind", dir)
 	}
 }
+
+func TestListDecisions_IgnoresALeakedStageFile(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := ParkDecision(dir, Decision{Issue: 1602, Kind: "adjudicate"}); err != nil {
+		t.Fatal(err)
+	}
+	// What a process killed between the create and the rename leaves behind.
+	// Half-written, so if ListDecisions ever looks at it, it does not merely
+	// show up as an extra decision, it becomes a parse error the human cannot
+	// clear without knowing what the file is.
+	leaked := filepath.Join(dir, strings.Replace(decisionStagePattern, "*", "3901215257", 1))
+	if err := os.WriteFile(leaked, []byte("issue: 1602\noptions: [accept, revise\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Errorf("ListDecisions: %v, want a leaked stage file to be invisible", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want just the parked decision: %v", len(got), decisionDirNames(t, dir))
+	}
+	if got[0].Issue != 1602 {
+		t.Errorf("Issue = %d, want 1602", got[0].Issue)
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -347,3 +347,55 @@ func TestParkDecision_WritesTheFileUserReadWriteOnly(t *testing.T) {
 		t.Errorf("mode = %04o, want 0600", got)
 	}
 }
+
+func TestParkDecision_RefusesToOverwriteAnUnparseableDecision(t *testing.T) {
+	// A half-written decision still has the answer in it in plain text. The
+	// likeliest way it got that way is an interrupted write of the answer.
+	dir := t.TempDir()
+	p := filepath.Join(dir, "1602-adjudicate.yaml")
+	truncated := "answer: revise\noptions: [accept, revise\n"
+	if err := os.WriteFile(p, []byte(truncated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate", Reason: "second pass found more issues",
+	}); err == nil {
+		t.Error("want an error rather than an overwrite of an unparseable decision")
+	}
+	after, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != truncated {
+		t.Errorf("file = %q, want the damaged original left alone", string(after))
+	}
+}
+
+func TestParkDecision_RefusesToOverwriteAnUnreadableDecision(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root, permission bits do not apply")
+	}
+	dir, p := decisionFixtureDir(t)
+	if err := AnswerDecision(dir, 1602, "adjudicate", "revise"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(p, 0o200); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(p, 0o600) })
+	if _, err := ParkDecision(dir, Decision{
+		Issue: 1602, Kind: "adjudicate", Reason: "second pass found more issues",
+	}); err == nil {
+		t.Error("want an error rather than an overwrite of an unreadable decision")
+	}
+	if err := os.Chmod(p, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Answer != "revise" {
+		t.Errorf("got %+v, want the answer still on disk", got)
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -706,3 +706,16 @@ func TestParkDecision_DoesNotClaimACorruptDecisionWhenNoneExists(t *testing.T) {
 		t.Errorf("dir = %v, want nothing written", names)
 	}
 }
+
+func TestDecisionKindMustNotBeEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := ParkDecision(dir, Decision{Issue: 1602}); err == nil {
+		t.Error("want an error for an empty kind")
+	}
+	if names := decisionDirNames(t, dir); len(names) != 0 {
+		t.Errorf("dir = %v, want no decision parked without a kind", names)
+	}
+	if err := AnswerDecision(dir, 1602, "", "revise"); err == nil {
+		t.Error("want an error for an empty kind")
+	}
+}

--- a/pkg/cli/run_decisions_test.go
+++ b/pkg/cli/run_decisions_test.go
@@ -300,16 +300,40 @@ func decisionFixtureDir(t *testing.T) (string, string) {
 	return dir, p
 }
 
+// A mistyped ISSUE or KIND is the ordinary way to reach this, so the error has
+// to lead with the decision it went looking for. It is asserted as a PREFIX on
+// purpose: os.ReadFile's own PathError already carries the path, so a bare
+// "read decision: %w" still ends up mentioning the file somewhere inside "open
+// ...: no such file or directory", and any Contains assertion passes without
+// the fix. What changes is what the human reads first, the decision that is not
+// parked or a syscall that failed.
 func TestAnswerDecision_ErrorsWhenThereIsNoSuchDecision(t *testing.T) {
 	dir, _ := decisionFixtureDir(t)
-	if err := AnswerDecision(dir, 9999, "adjudicate", "revise"); err == nil {
-		t.Error("want an error for an issue with no parked decision")
+	cases := []struct {
+		name     string
+		dir      string
+		issue    int32
+		kind     string
+		wantName string
+	}{
+		{"an issue with nothing parked", dir, 9999, "adjudicate", "9999-adjudicate.yaml"},
+		{"a kind with nothing parked", dir, 1602, "triage", "1602-triage.yaml"},
+		{
+			"a decisions dir that was never created",
+			filepath.Join(t.TempDir(), "never-created"), 1602, "adjudicate", "1602-adjudicate.yaml",
+		},
 	}
-	if err := AnswerDecision(dir, 1602, "triage", "revise"); err == nil {
-		t.Error("want an error for a kind with no parked decision")
-	}
-	if err := AnswerDecision(filepath.Join(t.TempDir(), "never-created"), 1602, "adjudicate", "revise"); err == nil {
-		t.Error("want an error when the decisions dir does not exist")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := AnswerDecision(tc.dir, tc.issue, tc.kind, "revise")
+			if err == nil {
+				t.Fatalf("AnswerDecision = nil, want an error naming %s", tc.wantName)
+			}
+			want := "read decision " + filepath.Join(tc.dir, tc.wantName) + ":"
+			if !strings.HasPrefix(err.Error(), want) {
+				t.Errorf("err = %v, want it to lead with %q", err, want)
+			}
+		})
 	}
 }
 

--- a/pkg/cli/run_driver.go
+++ b/pkg/cli/run_driver.go
@@ -50,16 +50,30 @@ type Effects interface {
 	Verify(ctx context.Context, workload, branch string) (clean bool, evidence string, err error)
 }
 
-// taskBranch is the branch Foreman's coder pushes for an item.
+// taskBranch is the branch Foreman's coder pushes for a Workload. It mirrors
+// the controller's own convention, which builds the name from the Workload and
+// the issue: workload_controller.go:379 is "foreman/<workload>/issue-<n>".
 //
-// It has to be derivable BEFORE dispatch, because preflight probes it, so the
-// driver reserves the Workload name "wl-<issue>" and builds the controller's
-// own branch convention on top of it: workload_controller.go:379 names the
-// branch "foreman/<workload>/issue-<n>". Dispatch owes it to preflight to
-// create the Workload under that name; a Dispatch that names it something else
-// makes the loop clear one branch and judge another.
-func taskBranch(issue int32) string {
-	return fmt.Sprintf("foreman/wl-%d/issue-%d", issue, issue)
+// The workload name is a parameter and not derived from the issue on purpose.
+// Effects.Dispatch RETURNS the name it created precisely so the caller does not
+// have to guess it, and a production Dispatch has every reason to return
+// something other than the reserved name: a retry suffix, a collision-avoiding
+// name, a slug carrying the repo. A driver that rebuilt the branch from the
+// issue would then watch and verify a branch nobody pushed and call the verify
+// clean, which is a silent wrong answer in the direction that matters.
+func taskBranch(workload string, issue int32) string {
+	return fmt.Sprintf("foreman/%s/issue-%d", workload, issue)
+}
+
+// plannedWorkloadName is the Workload name the driver reserves for an item.
+//
+// Preflight probes the task branch before any Workload exists, so that one call
+// has no returned name to work from and has to assume this. It is the only
+// place the assumption is unavoidable, and it is a probe rather than a
+// judgment: an open PR on the issue is the stronger of preflight's two signals
+// and does not depend on the name at all.
+func plannedWorkloadName(issue int32) string {
+	return fmt.Sprintf("wl-%d", issue)
 }
 
 // optionsFor is the answer set a parked decision offers. Every park sets one:
@@ -89,7 +103,9 @@ func DriveItem(
 	baseline time.Duration,
 	factor float64,
 ) (Stage, error) {
-	branch := taskBranch(item.Issue)
+	// Preflight has no Workload to name yet; every stage after dispatch uses
+	// the name Dispatch reported.
+	branch := taskBranch(plannedWorkloadName(item.Issue), item.Issue)
 	var workload, evidence string
 	// attempts is inert in v1: nothing routes to StageFeedback, so verify is
 	// only ever reached on the first attempt and NextStage's one-pass rule is
@@ -114,6 +130,9 @@ func DriveItem(
 				return stage, err
 			}
 			workload = w
+			// The branch follows the Workload that actually exists, not the
+			// name reserved for the probe above.
+			branch = taskBranch(workload, item.Issue)
 			attempts++
 		case StageWatch:
 			res, err := e.Watch(ctx, workload, baseline, factor)
@@ -206,8 +225,11 @@ func printRunPlan(w io.Writer, opts *runOptions) error {
 	fprintf(w, "stall-factor: %g\n", opts.stallFactor)
 	fprintf(w, "items: %d\n", len(q.Items))
 	for i, item := range q.Items {
+		// The reserved name: nothing has dispatched, so there is no returned
+		// Workload name to build the branch from.
 		fprintf(w, "  issue %d (%s): branch %s, intent %s (%d bytes)\n",
-			item.Issue, item.Repo, taskBranch(item.Issue), item.IntentPath, len(intents[i]))
+			item.Issue, item.Repo, taskBranch(plannedWorkloadName(item.Issue), item.Issue),
+			item.IntentPath, len(intents[i]))
 	}
 	return nil
 }

--- a/pkg/cli/run_driver.go
+++ b/pkg/cli/run_driver.go
@@ -129,6 +129,15 @@ func DriveItem(
 			if err != nil {
 				return stage, err
 			}
+			// An empty name is the one answer the "trust what Dispatch
+			// returns" contract cannot absorb: it makes the branch
+			// "foreman//issue-<n>", points watch, kill and verify at nothing,
+			// and parks a decision whose Workload field is blank, which is
+			// the only thing telling a human which run to go and look at.
+			// A Workload that cannot be named was not created.
+			if w == "" {
+				return stage, fmt.Errorf("dispatch for issue %d reported no workload name", item.Issue)
+			}
 			workload = w
 			// The branch follows the Workload that actually exists, not the
 			// name reserved for the probe above.

--- a/pkg/cli/run_driver.go
+++ b/pkg/cli/run_driver.go
@@ -19,8 +19,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"time"
 )
 
@@ -243,54 +241,4 @@ func driveLoop(
 		}
 		stage = t.Next
 	}
-}
-
-// printRunPlan loads the queue the human prepared, checks every intent is
-// readable, and prints what a run would do.
-//
-// A live run is refused rather than half-attempted: the cluster-backed Effects
-// (dispatch, watch, verify, kill) are a follow-up to this plan, so there is
-// nothing to drive the loop with yet. Validating the queue is real work that
-// needs no cluster and it catches the mistakes a human actually makes, so it
-// happens BEFORE the refusal: answering a queue with a missing intent by
-// talking about unwired effects helps nobody.
-func printRunPlan(w io.Writer, opts *runOptions) error {
-	data, err := os.ReadFile(opts.queueFile)
-	if err != nil {
-		return fmt.Errorf("read queue: %w", err)
-	}
-	q, err := ParseQueue(data)
-	if err != nil {
-		return err
-	}
-	intents := make([]string, len(q.Items))
-	for i, item := range q.Items {
-		s, err := q.IntentFor(item)
-		if err != nil {
-			return err
-		}
-		intents[i] = s
-	}
-	if !opts.dryRun {
-		return fmt.Errorf("the queue is valid, but a live run cannot start yet: dispatch, "+
-			"watch and verify against the cluster are not wired up. Re-run with --dry-run "+
-			"to see what %d item(s) would do", len(q.Items))
-	}
-	// Labelled with the flag names that produced them, so the plan reads back
-	// as the command that made it.
-	fprintln(w, "dry run, nothing is applied.")
-	fprintf(w, "queue: %s\n", opts.queueFile)
-	fprintf(w, "coder-agent: %s\n", opts.coderAgent)
-	fprintf(w, "namespace: %s\n", opts.namespace)
-	fprintf(w, "decisions-dir: %s\n", opts.decisionsDir)
-	fprintf(w, "stall-factor: %g\n", opts.stallFactor)
-	fprintf(w, "items: %d\n", len(q.Items))
-	for i, item := range q.Items {
-		// The reserved name: nothing has dispatched, so there is no returned
-		// Workload name to build the branch from.
-		fprintf(w, "  issue %d (%s): branch %s, intent %s (%d bytes)\n",
-			item.Issue, item.Repo, taskBranch(plannedWorkloadName(item.Issue), item.Issue),
-			item.IntentPath, len(intents[i]))
-	}
-	return nil
 }

--- a/pkg/cli/run_driver.go
+++ b/pkg/cli/run_driver.go
@@ -85,10 +85,12 @@ func plannedWorkloadName(issue int32) string {
 // `foreman decisions` renders that as "any", so an option-less park hands the
 // human a free-text prompt instead of the answers the loop understands.
 func optionsFor(kind string) []string {
-	if kind == "escalate" {
+	if kind == ParkEscalate {
 		return []string{"requeue", "hand-fix", "drop"}
 	}
-	return []string{"accept", "revise", "escalate", "drop"}
+	// The escalate answer asks for exactly what a ParkEscalate park gets, so it
+	// spells the kind rather than a lookalike of it.
+	return []string{"accept", "revise", ParkEscalate, "drop"}
 }
 
 // maxStageTransitions bounds one item's trip through the loop.

--- a/pkg/cli/run_driver.go
+++ b/pkg/cli/run_driver.go
@@ -88,9 +88,12 @@ func optionsFor(kind string) []string {
 	if kind == ParkEscalate {
 		return []string{"requeue", "hand-fix", "drop"}
 	}
-	// The escalate answer asks for exactly what a ParkEscalate park gets, so it
-	// spells the kind rather than a lookalike of it.
-	return []string{"accept", "revise", ParkEscalate, "drop"}
+	// A literal, NOT ParkEscalate. These are answers a human may type, not park
+	// kinds, and the two vocabularies coincide on "escalate" by coincidence.
+	// Coupling them would make renaming the park kind silently change the
+	// option set that already-parked decisions were written with, and
+	// AnswerDecision validates a typed answer against exactly that stored set.
+	return []string{"accept", "revise", "escalate", "drop"}
 }
 
 // maxStageTransitions bounds one item's trip through the loop.

--- a/pkg/cli/run_driver.go
+++ b/pkg/cli/run_driver.go
@@ -29,8 +29,14 @@ type WatchResult struct {
 	// Stalled is the stall predicate's verdict, IsStalled applied to what the
 	// watcher saw. The driver does not re-derive it.
 	Stalled bool
-	// BranchPushed reports whether the coder pushed anything. It is an input
-	// to Stalled rather than a second signal the driver reads.
+	// BranchPushed reports whether the coder pushed anything.
+	//
+	// Nothing writes or reads it yet. The wiring it is waiting for belongs to
+	// the production Effects: a real Watch would feed it, with the elapsed
+	// time and the baseline, into IsStalled via StallInput.BranchPushed, and
+	// report the verdict as Stalled above. The driver never reads this field,
+	// and the separate StallInput.BranchPushed is the one the predicate
+	// actually uses today.
 	BranchPushed bool
 }
 
@@ -87,6 +93,17 @@ func optionsFor(kind string) []string {
 	return []string{"accept", "revise", "escalate", "drop"}
 }
 
+// maxStageTransitions bounds one item's trip through the loop.
+//
+// The real machine's longest path is five transitions (preflight, dispatch,
+// watch, verify, finalize), or eight once a feedback pass exists, so a healthy
+// run never comes near this. It is a backstop against a cycle: NextStage
+// already maps StageFeedback back to StageWatch, so the loop below has a cycle
+// in it today and is saved only by nothing routing INTO feedback. A hang is
+// the worst failure mode a human-facing loop has, because it is
+// indistinguishable from a slow agent and the CLI never says otherwise.
+const maxStageTransitions = 64
+
 // DriveItem advances one queue item until it reaches a terminal stage: done,
 // or parked. Parking is terminal for this pass by design, so the caller
 // proceeds to the next item rather than blocking on a human.
@@ -95,6 +112,13 @@ func optionsFor(kind string) []string {
 // opening the PR is scripts/foreman-finalize.sh and belongs with the rest of
 // the cluster-backed implementation; until that lands a clean verify falls
 // straight through finalize to done.
+//
+// NOTHING IN PRODUCTION CALLS THIS YET. The Effects implementation that would
+// is deferred to a follow-up plan, and no lint catches the gap: golangci-lint's
+// `unused` treats an exported identifier in a non-main package as used, so
+// neither `make lint` nor `make lint-deadcode` reports this function, IsStalled
+// or the package-level Preflight despite all three having zero non-test
+// callers. Wiring is a human check here, not a gate.
 func DriveItem(
 	ctx context.Context,
 	e Effects,
@@ -103,6 +127,23 @@ func DriveItem(
 	baseline time.Duration,
 	factor float64,
 ) (Stage, error) {
+	return driveLoop(ctx, e, item, intent, decisionsDir, baseline, factor, NextStage)
+}
+
+// driveLoop is DriveItem's body with the stage machine as a parameter.
+//
+// The indirection buys exactly one thing: no input reaches a cycle through the
+// real NextStage, so maxStageTransitions would otherwise be untestable, and an
+// untested guard against a hang is not a guard. Production passes NextStage.
+func driveLoop(
+	ctx context.Context,
+	e Effects,
+	item QueueItem,
+	intent, decisionsDir string,
+	baseline time.Duration,
+	factor float64,
+	next func(Stage, Facts) Transition,
+) (Stage, error) {
 	// Preflight has no Workload to name yet; every stage after dispatch uses
 	// the name Dispatch reported.
 	branch := taskBranch(plannedWorkloadName(item.Issue), item.Issue)
@@ -110,12 +151,23 @@ func DriveItem(
 	// attempts is inert in v1: nothing routes to StageFeedback, so verify is
 	// only ever reached on the first attempt and NextStage's one-pass rule is
 	// never the deciding fact. It is counted anyway because the moment the
-	// feedback effect lands, that rule depends on it, and a driver that always
-	// reported zero would re-adjudicate the same item forever.
+	// feedback effect lands, that rule depends on it.
+	//
+	// READ THIS BEFORE ADDING `case StageFeedback:` BELOW. The increment lives
+	// in case StageDispatch and nowhere else. A feedback case that re-dispatches
+	// is fine. A feedback case that does anything else must increment attempts
+	// itself, or watch -> verify -> feedback -> watch spins with Attempts frozen
+	// at 1, maxAttempts never fires, and only maxStageTransitions stops it.
 	attempts := 0
 	stage := StagePreflight
 
-	for {
+	for i := 0; ; i++ {
+		if i >= maxStageTransitions {
+			return stage, fmt.Errorf(
+				"run loop for issue %d made %d stage transitions without reaching a terminal "+
+					"stage, stuck at %q: the stage machine has a cycle",
+				item.Issue, i, stage)
+		}
 		facts := Facts{Attempts: attempts}
 		switch stage {
 		case StagePreflight:
@@ -162,7 +214,7 @@ func DriveItem(
 			facts.VerifyClean, evidence = clean, ev
 		}
 
-		t := NextStage(stage, facts)
+		t := next(stage, facts)
 		switch t.Next {
 		case StageParked:
 			d := Decision{

--- a/pkg/cli/run_driver.go
+++ b/pkg/cli/run_driver.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// WatchResult is what the watch stage observed.
+type WatchResult struct {
+	// Stalled is the stall predicate's verdict, IsStalled applied to what the
+	// watcher saw. The driver does not re-derive it.
+	Stalled bool
+	// BranchPushed reports whether the coder pushed anything. It is an input
+	// to Stalled rather than a second signal the driver reads.
+	BranchPushed bool
+}
+
+// Effects are the side-effecting operations the driver performs. Kept behind
+// an interface so DriveItem's control flow is testable without a cluster;
+// the production implementation wraps the controller-runtime client and is a
+// follow-up to this plan.
+//
+// Effects.Preflight is a METHOD and is not the package-level Preflight
+// function: that one takes a PreflightProbe and does the forge reads, and the
+// production implementation of this method is what will call it.
+type Effects interface {
+	Preflight(ctx context.Context, item QueueItem, branch string) (string, error)
+	Dispatch(ctx context.Context, item QueueItem, intent string) (workload string, err error)
+	Watch(ctx context.Context, workload string, baseline time.Duration, factor float64) (WatchResult, error)
+	Kill(ctx context.Context, workload string) error
+	Verify(ctx context.Context, workload, branch string) (clean bool, evidence string, err error)
+}
+
+// taskBranch is the branch Foreman's coder pushes for an item.
+//
+// It has to be derivable BEFORE dispatch, because preflight probes it, so the
+// driver reserves the Workload name "wl-<issue>" and builds the controller's
+// own branch convention on top of it: workload_controller.go:379 names the
+// branch "foreman/<workload>/issue-<n>". Dispatch owes it to preflight to
+// create the Workload under that name; a Dispatch that names it something else
+// makes the loop clear one branch and judge another.
+func taskBranch(issue int32) string {
+	return fmt.Sprintf("foreman/wl-%d/issue-%d", issue, issue)
+}
+
+// optionsFor is the answer set a parked decision offers. Every park sets one:
+// AnswerDecision accepts arbitrary text when a decision offers no options and
+// `foreman decisions` renders that as "any", so an option-less park hands the
+// human a free-text prompt instead of the answers the loop understands.
+func optionsFor(kind string) []string {
+	if kind == "escalate" {
+		return []string{"requeue", "hand-fix", "drop"}
+	}
+	return []string{"accept", "revise", "escalate", "drop"}
+}
+
+// DriveItem advances one queue item until it reaches a terminal stage: done,
+// or parked. Parking is terminal for this pass by design, so the caller
+// proceeds to the next item rather than blocking on a human.
+//
+// StageFinalize runs no effect. The Effects interface has no Finalize, because
+// opening the PR is scripts/foreman-finalize.sh and belongs with the rest of
+// the cluster-backed implementation; until that lands a clean verify falls
+// straight through finalize to done.
+func DriveItem(
+	ctx context.Context,
+	e Effects,
+	item QueueItem,
+	intent, decisionsDir string,
+	baseline time.Duration,
+	factor float64,
+) (Stage, error) {
+	branch := taskBranch(item.Issue)
+	var workload, evidence string
+	// attempts is inert in v1: nothing routes to StageFeedback, so verify is
+	// only ever reached on the first attempt and NextStage's one-pass rule is
+	// never the deciding fact. It is counted anyway because the moment the
+	// feedback effect lands, that rule depends on it, and a driver that always
+	// reported zero would re-adjudicate the same item forever.
+	attempts := 0
+	stage := StagePreflight
+
+	for {
+		facts := Facts{Attempts: attempts}
+		switch stage {
+		case StagePreflight:
+			skip, err := e.Preflight(ctx, item, branch)
+			if err != nil {
+				return stage, err
+			}
+			facts.SkipReason = skip
+		case StageDispatch:
+			w, err := e.Dispatch(ctx, item, intent)
+			if err != nil {
+				return stage, err
+			}
+			workload = w
+			attempts++
+		case StageWatch:
+			res, err := e.Watch(ctx, workload, baseline, factor)
+			if err != nil {
+				return stage, err
+			}
+			if res.Stalled {
+				if err := e.Kill(ctx, workload); err != nil {
+					return stage, err
+				}
+			}
+			facts.Stalled = res.Stalled
+		case StageVerify:
+			clean, ev, err := e.Verify(ctx, workload, branch)
+			if err != nil {
+				return stage, err
+			}
+			facts.VerifyClean, evidence = clean, ev
+		}
+
+		t := NextStage(stage, facts)
+		switch t.Next {
+		case StageParked:
+			d := Decision{
+				Issue:    item.Issue,
+				Workload: workload,
+				Stage:    string(stage),
+				Kind:     t.Park,
+				Reason:   t.Reason,
+				Options:  optionsFor(t.Park),
+			}
+			// Only when verify actually produced some: a stall is killed
+			// before verify runs, and an empty "verify" key would claim a
+			// judgment that nothing made.
+			if evidence != "" {
+				d.Evidence = map[string]string{"verify": evidence}
+			}
+			// A park that could not be written is not a park. Returning
+			// StageParked here would tell the caller a human has been asked
+			// when there is nothing on disk to answer.
+			if _, err := ParkDecision(decisionsDir, d); err != nil {
+				return stage, err
+			}
+			return StageParked, nil
+		case StageDone:
+			return StageDone, nil
+		}
+		stage = t.Next
+	}
+}
+
+// printRunPlan loads the queue the human prepared, checks every intent is
+// readable, and prints what a run would do.
+//
+// A live run is refused rather than half-attempted: the cluster-backed Effects
+// (dispatch, watch, verify, kill) are a follow-up to this plan, so there is
+// nothing to drive the loop with yet. Validating the queue is real work that
+// needs no cluster and it catches the mistakes a human actually makes, so it
+// happens BEFORE the refusal: answering a queue with a missing intent by
+// talking about unwired effects helps nobody.
+func printRunPlan(w io.Writer, opts *runOptions) error {
+	data, err := os.ReadFile(opts.queueFile)
+	if err != nil {
+		return fmt.Errorf("read queue: %w", err)
+	}
+	q, err := ParseQueue(data)
+	if err != nil {
+		return err
+	}
+	intents := make([]string, len(q.Items))
+	for i, item := range q.Items {
+		s, err := q.IntentFor(item)
+		if err != nil {
+			return err
+		}
+		intents[i] = s
+	}
+	if !opts.dryRun {
+		return fmt.Errorf("the queue is valid, but a live run cannot start yet: dispatch, "+
+			"watch and verify against the cluster are not wired up. Re-run with --dry-run "+
+			"to see what %d item(s) would do", len(q.Items))
+	}
+	// Labelled with the flag names that produced them, so the plan reads back
+	// as the command that made it.
+	fprintln(w, "dry run, nothing is applied.")
+	fprintf(w, "queue: %s\n", opts.queueFile)
+	fprintf(w, "coder-agent: %s\n", opts.coderAgent)
+	fprintf(w, "namespace: %s\n", opts.namespace)
+	fprintf(w, "decisions-dir: %s\n", opts.decisionsDir)
+	fprintf(w, "stall-factor: %g\n", opts.stallFactor)
+	fprintf(w, "items: %d\n", len(q.Items))
+	for i, item := range q.Items {
+		fprintf(w, "  issue %d (%s): branch %s, intent %s (%d bytes)\n",
+			item.Issue, item.Repo, taskBranch(item.Issue), item.IntentPath, len(intents[i]))
+	}
+	return nil
+}

--- a/pkg/cli/run_driver_test.go
+++ b/pkg/cli/run_driver_test.go
@@ -28,11 +28,17 @@ import (
 )
 
 const (
-	driveIssue    = int32(1602)
-	driveRepo     = "defilantech/LLMKube"
-	driveIntent   = "fix the thing"
+	driveIssue  = int32(1602)
+	driveRepo   = "defilantech/LLMKube"
+	driveIntent = "fix the thing"
+	// The name Dispatch returns. Deliberately not "wl-1602": a driver that
+	// derives the branch from the issue instead of from this cannot be told
+	// apart from a correct one when the two happen to agree.
 	driveWorkload = "wl-test"
-	driveBranch   = "foreman/wl-1602/issue-1602"
+	// What preflight probes, before any Workload exists.
+	drivePlannedBranch = "foreman/wl-1602/issue-1602"
+	// What every stage after dispatch acts on.
+	driveDispatchedBranch = "foreman/wl-test/issue-1602"
 	// Realistic gate output: multi-line, with runs of two spaces. Nothing here
 	// asserts on it through the rendered table, whose column splitter treats
 	// two spaces as a break.
@@ -80,6 +86,9 @@ type fakeEffects struct {
 	watch          WatchResult
 	verifyClean    bool
 	verifyEvidence string
+	// dispatchWorkload is the Workload name Dispatch reports creating.
+	// Empty means driveWorkload.
+	dispatchWorkload string
 
 	preflightErr error
 	dispatchErr  error
@@ -109,6 +118,9 @@ func (f *fakeEffects) Dispatch(ctx context.Context, item QueueItem, intent strin
 	f.dispatched++
 	if f.dispatchErr != nil {
 		return "", f.dispatchErr
+	}
+	if f.dispatchWorkload != "" {
+		return f.dispatchWorkload, nil
 	}
 	return driveWorkload, nil
 }
@@ -300,13 +312,14 @@ func TestDriveItem_ForwardsWhatEachStageNeeds(t *testing.T) {
 			t.Errorf("%s got a context that is not the caller's, so cancellation cannot reach it", site)
 		}
 	}
-	// The branch preflight cleared has to be the branch verify inspects, or
-	// the loop clears one branch and judges another.
-	if got := e.calls["preflight"].branch; got != driveBranch {
-		t.Errorf("Preflight branch = %q, want %q", got, driveBranch)
+	// Preflight runs before any Workload exists, so it probes the name the
+	// driver reserves. Verify runs after, so it acts on the name Dispatch
+	// reported. The two differ here on purpose.
+	if got := e.calls["preflight"].branch; got != drivePlannedBranch {
+		t.Errorf("Preflight branch = %q, want %q", got, drivePlannedBranch)
 	}
-	if got := e.calls["verify"].branch; got != driveBranch {
-		t.Errorf("Verify branch = %q, want %q", got, driveBranch)
+	if got := e.calls["verify"].branch; got != driveDispatchedBranch {
+		t.Errorf("Verify branch = %q, want %q", got, driveDispatchedBranch)
 	}
 	if got := e.calls["preflight"].item.Issue; got != driveIssue {
 		t.Errorf("Preflight issue = %d, want %d", got, driveIssue)
@@ -334,6 +347,28 @@ func TestDriveItem_ForwardsWhatEachStageNeeds(t *testing.T) {
 	}
 	if got := e.calls["watch"].factor; got != driveFactor {
 		t.Errorf("Watch factor = %v, want %v", got, driveFactor)
+	}
+}
+
+// Dispatch returns the Workload name it created precisely so the caller does
+// not have to guess it. A retry suffix, a collision-avoiding name or a slug
+// carrying the repo all produce something other than "wl-<issue>", and a driver
+// that derived the branch from the issue instead would watch and verify a
+// branch nobody pushed, then report a clean verify against work that is not
+// there. Silent, and wrong in the direction that matters.
+func TestDriveItem_TakesTheBranchFromTheWorkloadDispatchCreated(t *testing.T) {
+	e := &fakeEffects{dispatchWorkload: "coder-1602-retry-7", verifyClean: true}
+	if _, err := driveItemUnderTest(context.Background(), e, t.TempDir()); err != nil {
+		t.Fatalf("DriveItem: %v", err)
+	}
+	const want = "foreman/coder-1602-retry-7/issue-1602"
+	if got := e.calls["verify"].branch; got != want {
+		t.Errorf("Verify branch = %q, want %q", got, want)
+	}
+	// The reserved name is only ever an assumption for the one call that has
+	// to happen before the Workload exists.
+	if got := e.calls["preflight"].branch; got != drivePlannedBranch {
+		t.Errorf("Preflight branch = %q, want %q", got, drivePlannedBranch)
 	}
 }
 

--- a/pkg/cli/run_driver_test.go
+++ b/pkg/cli/run_driver_test.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	driveIssue    = int32(1602)
+	driveRepo     = "defilantech/LLMKube"
+	driveIntent   = "fix the thing"
+	driveWorkload = "wl-test"
+	driveBranch   = "foreman/wl-1602/issue-1602"
+	// Realistic gate output: multi-line, with runs of two spaces. Nothing here
+	// asserts on it through the rendered table, whose column splitter treats
+	// two spaces as a break.
+	driveEvidence = "gate FAIL: 2 tests\n  pkg/cli  TestOne\n  pkg/cli  TestTwo"
+	// Deliberately not DefaultBaseline (60m) or DefaultStallFactor (2.5), so
+	// a driver that substitutes a package default for the caller's budget is
+	// visible rather than accidentally right.
+	driveBaseline = 90 * time.Minute
+	driveFactor   = 3.5
+)
+
+// Sentinels, one per effect, so errors.Is can tell which branch surfaced the
+// failure rather than accepting any error at all.
+var (
+	errPreflightDown  = errors.New("forge unreachable")
+	errDispatchRefsd  = errors.New("workload rejected")
+	errWatchLost      = errors.New("watch stream closed")
+	errKillRefused    = errors.New("delete forbidden")
+	errVerifyExploded = errors.New("gate job never scheduled")
+)
+
+// driveCtxKey marks the caller's context. Each effect records the context it
+// was handed, so a stage given a fresh context.Background() is visible.
+type driveCtxKey struct{}
+
+// driveCall is what one effect was handed. Unused fields stay zero: Watch has
+// no branch, Preflight has no workload.
+type driveCall struct {
+	ctx      context.Context
+	item     QueueItem
+	branch   string
+	intent   string
+	workload string
+	baseline time.Duration
+	factor   float64
+}
+
+// fakeEffects answers the driver's side effects from a fixture and records
+// what each one was handed. The recordings are not decoration: every one of
+// them is asserted in TestDriveItem_ForwardsWhatEachStageNeeds, because a
+// driver that hands Verify a blank branch still gets a clean answer back and
+// the ordinary stage assertions cannot see the difference.
+type fakeEffects struct {
+	skip           string
+	watch          WatchResult
+	verifyClean    bool
+	verifyEvidence string
+
+	preflightErr error
+	dispatchErr  error
+	watchErr     error
+	killErr      error
+	verifyErr    error
+
+	calls      map[string]driveCall
+	dispatched int
+	killed     int
+}
+
+func (f *fakeEffects) record(site string, c driveCall) {
+	if f.calls == nil {
+		f.calls = map[string]driveCall{}
+	}
+	f.calls[site] = c
+}
+
+func (f *fakeEffects) Preflight(ctx context.Context, item QueueItem, branch string) (string, error) {
+	f.record("preflight", driveCall{ctx: ctx, item: item, branch: branch})
+	return f.skip, f.preflightErr
+}
+
+func (f *fakeEffects) Dispatch(ctx context.Context, item QueueItem, intent string) (string, error) {
+	f.record("dispatch", driveCall{ctx: ctx, item: item, intent: intent})
+	f.dispatched++
+	if f.dispatchErr != nil {
+		return "", f.dispatchErr
+	}
+	return driveWorkload, nil
+}
+
+func (f *fakeEffects) Watch(ctx context.Context, workload string, baseline time.Duration,
+	factor float64) (WatchResult, error) {
+	f.record("watch", driveCall{ctx: ctx, workload: workload, baseline: baseline, factor: factor})
+	return f.watch, f.watchErr
+}
+
+func (f *fakeEffects) Kill(ctx context.Context, workload string) error {
+	f.record("kill", driveCall{ctx: ctx, workload: workload})
+	f.killed++
+	return f.killErr
+}
+
+func (f *fakeEffects) Verify(ctx context.Context, workload, branch string) (bool, string, error) {
+	f.record("verify", driveCall{ctx: ctx, workload: workload, branch: branch})
+	return f.verifyClean, f.verifyEvidence, f.verifyErr
+}
+
+func driveItemUnderTest(ctx context.Context, e *fakeEffects, dir string) (Stage, error) {
+	return DriveItem(ctx, e,
+		QueueItem{Issue: driveIssue, Repo: driveRepo, IntentPath: "intent.md"},
+		driveIntent, dir, driveBaseline, driveFactor)
+}
+
+// drive runs the driver over one item and fails the test if it errored.
+func drive(t *testing.T, e *fakeEffects, dir string) Stage {
+	t.Helper()
+	end, err := driveItemUnderTest(context.Background(), e, dir)
+	if err != nil {
+		t.Fatalf("DriveItem: %v", err)
+	}
+	return end
+}
+
+// noDecisions asserts nothing was parked. ListDecisions returns what it could
+// parse alongside an error, so both are reported.
+func noDecisions(t *testing.T, dir string) {
+	t.Helper()
+	ds, err := ListDecisions(dir)
+	if len(ds) != 0 {
+		t.Errorf("decisions = %+v, want none", ds)
+	}
+	if err != nil {
+		t.Errorf("ListDecisions: %v", err)
+	}
+}
+
+// onlyDecision returns the single decision parked in dir.
+func onlyDecision(t *testing.T, dir string) Decision {
+	t.Helper()
+	ds, err := ListDecisions(dir)
+	if err != nil {
+		t.Fatalf("ListDecisions: %v (parsed %+v)", err, ds)
+	}
+	if len(ds) != 1 {
+		t.Fatalf("decisions = %+v, want exactly one", ds)
+	}
+	return ds[0]
+}
+
+func TestDriveItem_SkipsAtPreflightWithoutDispatching(t *testing.T) {
+	dir := t.TempDir()
+	e := &fakeEffects{skip: "an open PR already references it"}
+	if got := drive(t, e, dir); got != StageDone {
+		t.Errorf("end stage = %q, want %q", got, StageDone)
+	}
+	if e.dispatched != 0 {
+		t.Errorf("dispatched %d times, want 0", e.dispatched)
+	}
+	// A skip is settled, not a judgment call. Parking one would put a
+	// decision in front of a human that has nothing for them to decide.
+	noDecisions(t, dir)
+}
+
+func TestDriveItem_CleanRunFinishesWithoutParking(t *testing.T) {
+	dir := t.TempDir()
+	// Evidence even on a clean run: a passing gate still prints. Carrying it
+	// must not turn a finished item into a parked one.
+	e := &fakeEffects{verifyClean: true, verifyEvidence: driveEvidence}
+	if got := drive(t, e, dir); got != StageDone {
+		t.Errorf("end stage = %q, want %q", got, StageDone)
+	}
+	// Separates this path from the preflight skip, which also ends at done.
+	if e.dispatched != 1 {
+		t.Errorf("dispatched %d times, want 1", e.dispatched)
+	}
+	if e.killed != 0 {
+		t.Errorf("killed %d times, want 0: a run that never stalled is not killed", e.killed)
+	}
+	noDecisions(t, dir)
+}
+
+func TestDriveItem_StallKillsAndParksToEscalate(t *testing.T) {
+	dir := t.TempDir()
+	e := &fakeEffects{watch: WatchResult{Stalled: true}}
+	if got := drive(t, e, dir); got != StageParked {
+		t.Errorf("end stage = %q, want %q", got, StageParked)
+	}
+	if e.killed != 1 {
+		t.Errorf("killed %d times, want the stalled run killed exactly once", e.killed)
+	}
+	if got := e.calls["kill"].workload; got != driveWorkload {
+		t.Errorf("Kill got workload %q, want %q", got, driveWorkload)
+	}
+	// A stall is decided before verify runs, so verify must not have run.
+	if _, ran := e.calls["verify"]; ran {
+		t.Error("a killed run must not then be verified")
+	}
+	d := onlyDecision(t, dir)
+	if d.Kind != "escalate" {
+		t.Errorf("Kind = %q, want escalate", d.Kind)
+	}
+	if d.Issue != driveIssue {
+		t.Errorf("Issue = %d, want %d", d.Issue, driveIssue)
+	}
+	if d.Workload != driveWorkload {
+		t.Errorf("Workload = %q, want %q: the human needs the run to go look at", d.Workload, driveWorkload)
+	}
+	if d.Stage != string(StageWatch) {
+		t.Errorf("Stage = %q, want %q: the stage that parked, not the park itself", d.Stage, StageWatch)
+	}
+	if !strings.Contains(d.Reason, "stall") {
+		t.Errorf("Reason = %q, want it to say the run stalled", d.Reason)
+	}
+	if want := []string{"requeue", "hand-fix", "drop"}; !slices.Equal(d.Options, want) {
+		t.Errorf("Options = %q, want %q", d.Options, want)
+	}
+	// Nothing verified this run, so claiming verify evidence would be a lie.
+	if len(d.Evidence) != 0 {
+		t.Errorf("Evidence = %v, want none: verify never ran", d.Evidence)
+	}
+}
+
+func TestDriveItem_DirtyVerifyParksAdjudicateWithEvidence(t *testing.T) {
+	dir := t.TempDir()
+	e := &fakeEffects{verifyClean: false, verifyEvidence: driveEvidence}
+	if got := drive(t, e, dir); got != StageParked {
+		t.Errorf("end stage = %q, want %q", got, StageParked)
+	}
+	if e.killed != 0 {
+		t.Errorf("killed %d times, want 0: a dirty verify is not a stall", e.killed)
+	}
+	d := onlyDecision(t, dir)
+	if d.Kind != "adjudicate" {
+		t.Errorf("Kind = %q, want adjudicate", d.Kind)
+	}
+	if d.Stage != string(StageVerify) {
+		t.Errorf("Stage = %q, want %q", d.Stage, StageVerify)
+	}
+	if d.Workload != driveWorkload {
+		t.Errorf("Workload = %q, want %q", d.Workload, driveWorkload)
+	}
+	if !strings.Contains(d.Reason, "verify") {
+		t.Errorf("Reason = %q, want it to name verify", d.Reason)
+	}
+	if want := []string{"accept", "revise", "escalate", "drop"}; !slices.Equal(d.Options, want) {
+		t.Errorf("Options = %q, want %q", d.Options, want)
+	}
+	// Verbatim: a human adjudicates on what the gate actually said, and a
+	// truncated or relabelled copy is not that.
+	if got := d.Evidence["verify"]; got != driveEvidence {
+		t.Errorf("Evidence[verify] = %q, want %q", got, driveEvidence)
+	}
+	// Parking must be durable on disk, not just in memory.
+	if _, err := os.Stat(filepath.Join(dir, "1602-adjudicate.yaml")); err != nil {
+		t.Errorf("decision file not written: %v", err)
+	}
+}
+
+// Every stage acts on something the driver handed it. A dropped or blanked
+// argument leaves each stage answering happily about the wrong thing, which no
+// stage-transition assertion can see.
+func TestDriveItem_ForwardsWhatEachStageNeeds(t *testing.T) {
+	ctx := context.WithValue(context.Background(), driveCtxKey{}, "carried")
+	e := &fakeEffects{verifyClean: true}
+	if _, err := driveItemUnderTest(ctx, e, t.TempDir()); err != nil {
+		t.Fatalf("DriveItem: %v", err)
+	}
+	for _, site := range []string{"preflight", "dispatch", "watch", "verify"} {
+		c, ok := e.calls[site]
+		if !ok {
+			t.Errorf("%s was never called", site)
+			continue
+		}
+		if c.ctx == nil || c.ctx.Value(driveCtxKey{}) != "carried" {
+			t.Errorf("%s got a context that is not the caller's, so cancellation cannot reach it", site)
+		}
+	}
+	// The branch preflight cleared has to be the branch verify inspects, or
+	// the loop clears one branch and judges another.
+	if got := e.calls["preflight"].branch; got != driveBranch {
+		t.Errorf("Preflight branch = %q, want %q", got, driveBranch)
+	}
+	if got := e.calls["verify"].branch; got != driveBranch {
+		t.Errorf("Verify branch = %q, want %q", got, driveBranch)
+	}
+	if got := e.calls["preflight"].item.Issue; got != driveIssue {
+		t.Errorf("Preflight issue = %d, want %d", got, driveIssue)
+	}
+	// An empty repo slug is #1625: the forge answers about nothing and the
+	// task branch gets cut from a stale fork HEAD.
+	if got := e.calls["dispatch"].item.Repo; got != driveRepo {
+		t.Errorf("Dispatch repo = %q, want %q", got, driveRepo)
+	}
+	// The intent, not the path to it: the coder is handed text.
+	if got := e.calls["dispatch"].intent; got != driveIntent {
+		t.Errorf("Dispatch intent = %q, want %q", got, driveIntent)
+	}
+	// Watch, kill and verify must act on the workload dispatch actually
+	// created, not on a name the driver guessed.
+	if got := e.calls["watch"].workload; got != driveWorkload {
+		t.Errorf("Watch workload = %q, want %q", got, driveWorkload)
+	}
+	if got := e.calls["verify"].workload; got != driveWorkload {
+		t.Errorf("Verify workload = %q, want %q", got, driveWorkload)
+	}
+	// The stall budget is the caller's, not a package default.
+	if got := e.calls["watch"].baseline; got != driveBaseline {
+		t.Errorf("Watch baseline = %v, want %v", got, driveBaseline)
+	}
+	if got := e.calls["watch"].factor; got != driveFactor {
+		t.Errorf("Watch factor = %v, want %v", got, driveFactor)
+	}
+}
+
+// A broken effect is not a judgment call: it must abort the item, name the
+// stage it broke at, and park nothing. Each case carries its own sentinel, so
+// an error arriving from some other branch cannot satisfy it.
+func TestDriveItem_SurfacesEffectErrorsAndParksNothing(t *testing.T) {
+	cases := []struct {
+		name      string
+		effects   fakeEffects
+		wantErr   error
+		wantStage Stage
+	}{
+		{"preflight", fakeEffects{preflightErr: errPreflightDown}, errPreflightDown, StagePreflight},
+		{"dispatch", fakeEffects{dispatchErr: errDispatchRefsd}, errDispatchRefsd, StageDispatch},
+		{"watch", fakeEffects{watchErr: errWatchLost}, errWatchLost, StageWatch},
+		{
+			"kill",
+			fakeEffects{watch: WatchResult{Stalled: true}, killErr: errKillRefused},
+			errKillRefused, StageWatch,
+		},
+		{"verify", fakeEffects{verifyErr: errVerifyExploded}, errVerifyExploded, StageVerify},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			e := tc.effects
+			got, err := driveItemUnderTest(context.Background(), &e, dir)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+			if got != tc.wantStage {
+				t.Errorf("stage = %q, want the stage that broke, %q", got, tc.wantStage)
+			}
+			noDecisions(t, dir)
+		})
+	}
+}
+
+// A park that could not be written is not a park. Reporting one anyway would
+// tell the caller a human has been asked when nothing is on disk to answer.
+func TestDriveItem_SurfacesAParkThatCouldNotBeWritten(t *testing.T) {
+	notADir := filepath.Join(t.TempDir(), "decisions")
+	if err := os.WriteFile(notADir, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	e := &fakeEffects{watch: WatchResult{Stalled: true}}
+	got, err := driveItemUnderTest(context.Background(), e, notADir)
+	if err == nil {
+		t.Fatal("DriveItem = nil, want the failed park surfaced")
+	}
+	if got != StageWatch {
+		t.Errorf("stage = %q, want %q: the item is not parked", got, StageWatch)
+	}
+}

--- a/pkg/cli/run_driver_test.go
+++ b/pkg/cli/run_driver_test.go
@@ -102,6 +102,7 @@ type fakeEffects struct {
 	calls      map[string]driveCall
 	dispatched int
 	killed     int
+	watched    int
 }
 
 func (f *fakeEffects) record(site string, c driveCall) {
@@ -134,6 +135,7 @@ func (f *fakeEffects) Dispatch(ctx context.Context, item QueueItem, intent strin
 func (f *fakeEffects) Watch(ctx context.Context, workload string, baseline time.Duration,
 	factor float64) (WatchResult, error) {
 	f.record("watch", driveCall{ctx: ctx, workload: workload, baseline: baseline, factor: factor})
+	f.watched++
 	return f.watch, f.watchErr
 }
 
@@ -403,6 +405,53 @@ func TestDriveItem_RefusesAnEmptyWorkloadNameFromDispatch(t *testing.T) {
 		}
 	}
 	// And it is a broken effect, not a judgment call for a human.
+	noDecisions(t, dir)
+}
+
+// The stage machine already contains a cycle: NextStage(StageFeedback) returns
+// StageWatch, and it is saved today only by nothing routing INTO feedback. The
+// day a `case StageFeedback:` lands that does not re-dispatch, watch -> verify
+// -> feedback -> watch spins with Attempts frozen at 1, so maxAttempts never
+// fires and the CLI hangs, looking exactly like a slow agent.
+//
+// No input reaches that shape through the real NextStage, which is precisely
+// why the backstop needs a test of its own: an untested guard against a hang is
+// not a guard. Hence driveLoop taking the machine as a parameter.
+func TestDriveLoop_StopsRatherThanSpinningOnACycle(t *testing.T) {
+	cycle := func(cur Stage, _ Facts) Transition {
+		switch cur {
+		case StagePreflight:
+			return Transition{Next: StageDispatch}
+		case StageDispatch, StageFeedback:
+			return Transition{Next: StageWatch}
+		case StageWatch:
+			return Transition{Next: StageVerify}
+		}
+		return Transition{Next: StageFeedback}
+	}
+	dir := t.TempDir()
+	e := &fakeEffects{}
+	got, err := driveLoop(context.Background(), e,
+		QueueItem{Issue: driveIssue, Repo: driveRepo, IntentPath: "intent.md"},
+		driveIntent, dir, driveBaseline, driveFactor, cycle)
+	if err == nil {
+		t.Fatal("driveLoop = nil, want a cycling machine refused rather than spun on")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("err = %v, want it to name what went wrong", err)
+	}
+	if got == StageDone || got == StageParked {
+		t.Errorf("stage = %q, want a non-terminal stage: nothing finished", got)
+	}
+	// It really did loop, and it really did stop.
+	if e.watched < 2 {
+		t.Errorf("watch ran %d times, want the loop to have actually cycled", e.watched)
+	}
+	if e.watched >= maxStageTransitions {
+		t.Errorf("watch ran %d times, want the %d-transition bound to have cut it short",
+			e.watched, maxStageTransitions)
+	}
+	// A loop that gave up is not a judgment call for a human.
 	noDecisions(t, dir)
 }
 

--- a/pkg/cli/run_driver_test.go
+++ b/pkg/cli/run_driver_test.go
@@ -89,6 +89,9 @@ type fakeEffects struct {
 	// dispatchWorkload is the Workload name Dispatch reports creating.
 	// Empty means driveWorkload.
 	dispatchWorkload string
+	// dispatchNoName makes Dispatch report ("", nil): it claims to have
+	// created a Workload and does not say which.
+	dispatchNoName bool
 
 	preflightErr error
 	dispatchErr  error
@@ -118,6 +121,9 @@ func (f *fakeEffects) Dispatch(ctx context.Context, item QueueItem, intent strin
 	f.dispatched++
 	if f.dispatchErr != nil {
 		return "", f.dispatchErr
+	}
+	if f.dispatchNoName {
+		return "", nil
 	}
 	if f.dispatchWorkload != "" {
 		return f.dispatchWorkload, nil
@@ -370,6 +376,34 @@ func TestDriveItem_TakesTheBranchFromTheWorkloadDispatchCreated(t *testing.T) {
 	if got := e.calls["preflight"].branch; got != drivePlannedBranch {
 		t.Errorf("Preflight branch = %q, want %q", got, drivePlannedBranch)
 	}
+}
+
+// Dispatch returning ("", nil) is the one input the "trust the name Dispatch
+// returns" contract cannot absorb. Unguarded it is silent: the branch becomes
+// "foreman//issue-1602", watch and verify act on nothing, and the item parks a
+// decision whose Workload field, the one thing telling a human which run to go
+// look at, is blank.
+func TestDriveItem_RefusesAnEmptyWorkloadNameFromDispatch(t *testing.T) {
+	dir := t.TempDir()
+	e := &fakeEffects{dispatchNoName: true}
+	got, err := driveItemUnderTest(context.Background(), e, dir)
+	if err == nil {
+		t.Fatal("DriveItem = nil, want a Workload with no name refused")
+	}
+	if !strings.Contains(err.Error(), "workload") {
+		t.Errorf("err = %v, want it to say the workload name is missing", err)
+	}
+	if got != StageDispatch {
+		t.Errorf("stage = %q, want %q", got, StageDispatch)
+	}
+	// Nothing downstream may run against a name that is not there.
+	for _, site := range []string{"watch", "kill", "verify"} {
+		if _, ran := e.calls[site]; ran {
+			t.Errorf("%s ran against a Workload with no name", site)
+		}
+	}
+	// And it is a broken effect, not a judgment call for a human.
+	noDecisions(t, dir)
 }
 
 // A broken effect is not a judgment call: it must abort the item, name the

--- a/pkg/cli/run_preflight.go
+++ b/pkg/cli/run_preflight.go
@@ -31,6 +31,8 @@ import (
 // implementation that folds a bad slug into ("", nil) or (false, nil)
 // silently defeats the fail-closed guarantee below: an empty slug that
 // answers "no open PR" is how #1625 duplicated work already in flight.
+// Preflight will not hand an implementation an empty slug or branch, but
+// implementations still owe this for every other unresolvable query.
 type PreflightProbe interface {
 	// OpenPRForIssue returns the URL of an open PR referencing the issue,
 	// or "" when there is none.
@@ -40,10 +42,22 @@ type PreflightProbe interface {
 }
 
 // Preflight returns a non-empty skip reason when the item should not be
-// dispatched. It fails CLOSED: a probe error is returned as an error, never
-// treated as "nothing found", because dispatching on a failed lookup risks
-// duplicating work already in flight.
+// dispatched.
+//
+// The item's repo slug and the branch must both be non-empty, and Preflight
+// enforces that before making any forge call: an empty slug or branch probes
+// nothing, and "nothing found" reads as a green light to dispatch (#1625).
+//
+// It fails CLOSED: a probe error is returned as an error, never treated as
+// "nothing found", because dispatching on a failed lookup risks duplicating
+// work already in flight.
 func Preflight(ctx context.Context, p PreflightProbe, item QueueItem, branch string) (string, error) {
+	if item.Repo == "" {
+		return "", fmt.Errorf("preflight: issue %d has no repo slug", item.Issue)
+	}
+	if branch == "" {
+		return "", fmt.Errorf("preflight: issue %d has no branch", item.Issue)
+	}
 	url, err := p.OpenPRForIssue(ctx, item.Repo, item.Issue)
 	if err != nil {
 		return "", fmt.Errorf("preflight: open-PR probe for issue %d: %w", item.Issue, err)

--- a/pkg/cli/run_preflight.go
+++ b/pkg/cli/run_preflight.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"fmt"
+)
+
+// PreflightProbe is the forge-side reads preflight needs. Kept as an
+// interface so the loop is testable without network and so a non-GitHub
+// forge can satisfy it later (#1158).
+type PreflightProbe interface {
+	// OpenPRForIssue returns the URL of an open PR referencing the issue,
+	// or "" when there is none.
+	OpenPRForIssue(ctx context.Context, repoSlug string, issue int32) (string, error)
+	// BranchExists reports whether branch exists on the push remote.
+	BranchExists(ctx context.Context, repoSlug, branch string) (bool, error)
+}
+
+// Preflight returns a non-empty skip reason when the item should not be
+// dispatched. It fails CLOSED: a probe error is returned as an error, never
+// treated as "nothing found", because dispatching on a failed lookup risks
+// duplicating work already in flight.
+func Preflight(ctx context.Context, p PreflightProbe, item QueueItem, branch string) (string, error) {
+	url, err := p.OpenPRForIssue(ctx, item.Repo, item.Issue)
+	if err != nil {
+		return "", fmt.Errorf("preflight: open-PR probe for issue %d: %w", item.Issue, err)
+	}
+	if url != "" {
+		return fmt.Sprintf("an open PR already references it: %s", url), nil
+	}
+	exists, err := p.BranchExists(ctx, item.Repo, branch)
+	if err != nil {
+		return "", fmt.Errorf("preflight: branch probe for %s: %w", branch, err)
+	}
+	if exists {
+		return fmt.Sprintf("branch %s already exists", branch), nil
+	}
+	return "", nil
+}

--- a/pkg/cli/run_preflight.go
+++ b/pkg/cli/run_preflight.go
@@ -24,6 +24,13 @@ import (
 // PreflightProbe is the forge-side reads preflight needs. Kept as an
 // interface so the loop is testable without network and so a non-GitHub
 // forge can satisfy it later (#1158).
+//
+// Implementations must return an error, never a zero value, when the repo
+// slug is empty or unresolvable or the query otherwise could not be answered.
+// Preflight reads a zero value as "nothing found" and dispatches, so an
+// implementation that folds a bad slug into ("", nil) or (false, nil)
+// silently defeats the fail-closed guarantee below: an empty slug that
+// answers "no open PR" is how #1625 duplicated work already in flight.
 type PreflightProbe interface {
 	// OpenPRForIssue returns the URL of an open PR referencing the issue,
 	// or "" when there is none.

--- a/pkg/cli/run_preflight_test.go
+++ b/pkg/cli/run_preflight_test.go
@@ -186,3 +186,54 @@ func TestPreflight_ProbesRunOnTheCallersContext(t *testing.T) {
 		t.Errorf("skipReason = %q, want empty alongside an error", got)
 	}
 }
+
+// Preflight validates its own inputs before making live forge calls. An empty
+// repo slug or branch cannot produce a meaningful probe: the query matches
+// nothing, "nothing found" reads as a green light (#1625), and an empty branch
+// additionally yields a reason naming a branch nobody asked about. ParseQueue
+// rejects an empty slug today, but Preflight is exported and takes the item by
+// value, so it owes its own guard.
+func TestPreflight_RejectsEmptyRepoAndBranchBeforeProbing(t *testing.T) {
+	cases := []struct {
+		name   string
+		item   QueueItem
+		branch string
+		// probe expects exactly the arguments unguarded code would send and
+		// answers with errProbeDown, so reaching a probe at all is visible in
+		// the returned error rather than through a call recorder.
+		probe     fakeProbe
+		wantField string
+	}{
+		{
+			name:      "no repo slug",
+			item:      QueueItem{Issue: preflightIssue, IntentPath: "x.md"},
+			branch:    preflightBranch,
+			probe:     fakeProbe{wantIssue: preflightIssue, wantBranch: preflightBranch, prErr: errProbeDown},
+			wantField: "repo",
+		},
+		{
+			name:      "no branch",
+			item:      preflightItem(),
+			branch:    "",
+			probe:     fakeProbe{wantRepo: preflightRepo, wantIssue: preflightIssue, branchErr: errProbeDown},
+			wantField: "branch",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Preflight(context.Background(), tc.probe, tc.item, tc.branch)
+			if err == nil {
+				t.Fatalf("want an error when the %s is empty", tc.wantField)
+			}
+			if errors.Is(err, errProbeDown) {
+				t.Errorf("err = %v, want validation to reject before any probe runs", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantField) {
+				t.Errorf("err = %v, want it to name the empty field %q", err, tc.wantField)
+			}
+			if got != "" {
+				t.Errorf("skipReason = %q, want empty alongside an error", got)
+			}
+		})
+	}
+}

--- a/pkg/cli/run_preflight_test.go
+++ b/pkg/cli/run_preflight_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeProbe struct {
+	pr        string
+	prErr     error
+	branch    bool
+	branchErr error
+}
+
+func (f fakeProbe) OpenPRForIssue(_ context.Context, _ string, _ int32) (string, error) {
+	return f.pr, f.prErr
+}
+func (f fakeProbe) BranchExists(_ context.Context, _, _ string) (bool, error) {
+	return f.branch, f.branchErr
+}
+
+const (
+	preflightBranch = "foreman/wl/issue-1602"
+	preflightPRURL  = "https://github.com/x/y/pull/9"
+)
+
+func TestPreflight(t *testing.T) {
+	item := QueueItem{Issue: 1602, Repo: "defilantech/LLMKube", IntentPath: "x.md"}
+	cases := []struct {
+		name     string
+		probe    fakeProbe
+		wantSkip string
+		// wantDetail is the identifier the human needs in order to go look
+		// at what already exists. A reason that omits it is not actionable.
+		wantDetail string
+	}{
+		{"clean issue proceeds", fakeProbe{}, "", ""},
+		{"open PR skips", fakeProbe{pr: preflightPRURL}, "open PR", preflightPRURL},
+		{"existing branch skips", fakeProbe{branch: true}, "branch", preflightBranch},
+		// The open PR is decided before the branch is probed, so a broken
+		// branch probe cannot turn a settled skip into a run-ending error.
+		{"open PR short circuits a broken branch probe",
+			fakeProbe{pr: preflightPRURL, branchErr: errors.New("api down")},
+			"open PR", preflightPRURL},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Preflight(context.Background(), tc.probe, item, preflightBranch)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantSkip == "" {
+				if got != "" {
+					t.Errorf("skipReason = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantSkip) {
+				t.Errorf("skipReason = %q, want it to mention %q", got, tc.wantSkip)
+			}
+			if !strings.Contains(got, tc.wantDetail) {
+				t.Errorf("skipReason = %q, want it to name %q", got, tc.wantDetail)
+			}
+		})
+	}
+}
+
+// Preflight must fail closed: a probe error is not "no open PR". Dispatching
+// on a failed lookup risks duplicating work already in flight.
+func TestPreflight_ProbeErrorIsAnErrorNotAGreenLight(t *testing.T) {
+	item := QueueItem{Issue: 1602, Repo: "defilantech/LLMKube", IntentPath: "x.md"}
+	_, err := Preflight(context.Background(),
+		fakeProbe{prErr: errors.New("api down")}, item, preflightBranch)
+	if err == nil {
+		t.Fatal("want an error when the PR probe fails")
+	}
+}
+
+// The branch probe fails closed for the same reason: a lookup that did not
+// answer is not an answer of "no such branch".
+func TestPreflight_BranchProbeErrorIsAnErrorNotAGreenLight(t *testing.T) {
+	item := QueueItem{Issue: 1602, Repo: "defilantech/LLMKube", IntentPath: "x.md"}
+	_, err := Preflight(context.Background(),
+		fakeProbe{branchErr: errors.New("api down")}, item, preflightBranch)
+	if err == nil {
+		t.Fatal("want an error when the branch probe fails")
+	}
+}

--- a/pkg/cli/run_preflight_test.go
+++ b/pkg/cli/run_preflight_test.go
@@ -23,27 +23,71 @@ import (
 	"testing"
 )
 
+const (
+	preflightRepo   = "defilantech/LLMKube"
+	preflightBranch = "foreman/wl/issue-1602"
+	preflightPRURL  = "https://github.com/x/y/pull/9"
+)
+
+const preflightIssue = int32(1602)
+
+// errProbeDown is the transport failure a probe reports when the forge is
+// unreachable. Preflight must wrap it rather than flatten it, so a caller can
+// tell a forge outage from a policy decision.
+var errProbeDown = errors.New("api down")
+
+func preflightItem() QueueItem {
+	return QueueItem{Issue: preflightIssue, Repo: preflightRepo, IntentPath: "x.md"}
+}
+
+// fakeProbe answers only when Preflight forwards the arguments it expects. A
+// mismatch yields the zero value with a nil error, which is what a real forge
+// returns when asked about a repo, issue, or branch that does not exist. That
+// makes argument forwarding observable through Preflight's return value: a
+// dropped or blanked argument turns a skip into a proceed, which the ordinary
+// assertions already catch. No call recording, and nothing asserts on the
+// fake's own state.
 type fakeProbe struct {
+	wantRepo   string
+	wantIssue  int32
+	wantBranch string
+
 	pr        string
 	prErr     error
 	branch    bool
 	branchErr error
 }
 
-func (f fakeProbe) OpenPRForIssue(_ context.Context, _ string, _ int32) (string, error) {
+// probeExpecting fills in the arguments Preflight must forward, so each case
+// declares only the answers it wants back.
+func probeExpecting(answers fakeProbe) fakeProbe {
+	answers.wantRepo = preflightRepo
+	answers.wantIssue = preflightIssue
+	answers.wantBranch = preflightBranch
+	return answers
+}
+
+func (f fakeProbe) OpenPRForIssue(ctx context.Context, repoSlug string, issue int32) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if repoSlug != f.wantRepo || issue != f.wantIssue {
+		return "", nil
+	}
 	return f.pr, f.prErr
 }
-func (f fakeProbe) BranchExists(_ context.Context, _, _ string) (bool, error) {
+
+func (f fakeProbe) BranchExists(ctx context.Context, repoSlug, branch string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if repoSlug != f.wantRepo || branch != f.wantBranch {
+		return false, nil
+	}
 	return f.branch, f.branchErr
 }
 
-const (
-	preflightBranch = "foreman/wl/issue-1602"
-	preflightPRURL  = "https://github.com/x/y/pull/9"
-)
-
 func TestPreflight(t *testing.T) {
-	item := QueueItem{Issue: 1602, Repo: "defilantech/LLMKube", IntentPath: "x.md"}
 	cases := []struct {
 		name     string
 		probe    fakeProbe
@@ -58,12 +102,13 @@ func TestPreflight(t *testing.T) {
 		// The open PR is decided before the branch is probed, so a broken
 		// branch probe cannot turn a settled skip into a run-ending error.
 		{"open PR short circuits a broken branch probe",
-			fakeProbe{pr: preflightPRURL, branchErr: errors.New("api down")},
+			fakeProbe{pr: preflightPRURL, branchErr: errProbeDown},
 			"open PR", preflightPRURL},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Preflight(context.Background(), tc.probe, item, preflightBranch)
+			got, err := Preflight(context.Background(), probeExpecting(tc.probe),
+				preflightItem(), preflightBranch)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -72,6 +117,11 @@ func TestPreflight(t *testing.T) {
 					t.Errorf("skipReason = %q, want empty", got)
 				}
 				return
+			}
+			// Guard against a future edit reintroducing a vacuous case:
+			// strings.Contains is trivially true for an empty needle.
+			if tc.wantDetail == "" {
+				t.Fatal("test bug: a skip case must name the detail its reason has to carry")
 			}
 			if !strings.Contains(got, tc.wantSkip) {
 				t.Errorf("skipReason = %q, want it to mention %q", got, tc.wantSkip)
@@ -86,21 +136,53 @@ func TestPreflight(t *testing.T) {
 // Preflight must fail closed: a probe error is not "no open PR". Dispatching
 // on a failed lookup risks duplicating work already in flight.
 func TestPreflight_ProbeErrorIsAnErrorNotAGreenLight(t *testing.T) {
-	item := QueueItem{Issue: 1602, Repo: "defilantech/LLMKube", IntentPath: "x.md"}
-	_, err := Preflight(context.Background(),
-		fakeProbe{prErr: errors.New("api down")}, item, preflightBranch)
+	got, err := Preflight(context.Background(),
+		probeExpecting(fakeProbe{prErr: errProbeDown}), preflightItem(), preflightBranch)
 	if err == nil {
 		t.Fatal("want an error when the PR probe fails")
+	}
+	if !errors.Is(err, errProbeDown) {
+		t.Errorf("err = %v, want it to wrap the probe's own error", err)
+	}
+	// A caller that logs the reason before checking err would otherwise
+	// report a skip that never happened.
+	if got != "" {
+		t.Errorf("skipReason = %q, want empty alongside an error", got)
 	}
 }
 
 // The branch probe fails closed for the same reason: a lookup that did not
 // answer is not an answer of "no such branch".
 func TestPreflight_BranchProbeErrorIsAnErrorNotAGreenLight(t *testing.T) {
-	item := QueueItem{Issue: 1602, Repo: "defilantech/LLMKube", IntentPath: "x.md"}
-	_, err := Preflight(context.Background(),
-		fakeProbe{branchErr: errors.New("api down")}, item, preflightBranch)
+	got, err := Preflight(context.Background(),
+		probeExpecting(fakeProbe{branchErr: errProbeDown}), preflightItem(), preflightBranch)
 	if err == nil {
 		t.Fatal("want an error when the branch probe fails")
+	}
+	if !errors.Is(err, errProbeDown) {
+		t.Errorf("err = %v, want it to wrap the probe's own error", err)
+	}
+	if got != "" {
+		t.Errorf("skipReason = %q, want empty alongside an error", got)
+	}
+}
+
+// Probes must run on the caller's context. The run loop cancels on its stall
+// deadline, and a probe handed context.Background() outlives the run it
+// belongs to.
+func TestPreflight_ProbesRunOnTheCallersContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// Answers that would otherwise be a clean proceed, so cancellation
+	// reaching the probe is the only thing that can produce an error.
+	got, err := Preflight(ctx, probeExpecting(fakeProbe{}), preflightItem(), preflightBranch)
+	if err == nil {
+		t.Fatal("want the caller's cancellation to reach the probe")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want it to wrap context.Canceled", err)
+	}
+	if got != "" {
+		t.Errorf("skipReason = %q, want empty alongside an error", got)
 	}
 }

--- a/pkg/cli/run_queue.go
+++ b/pkg/cli/run_queue.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// QueueItem is one unit of work: an issue plus the intent the human wrote
+// for it. v1 never authors intents (spec non-goal), so IntentPath is
+// required.
+type QueueItem struct {
+	Issue      int32  `json:"issue"`
+	IntentPath string `json:"intent"`
+	// Repo overrides the queue-level default for this item.
+	Repo string `json:"repo,omitempty"`
+}
+
+// Queue is the prepared work list handed to `llmkube foreman run`.
+type Queue struct {
+	Repo  string      `json:"repo,omitempty"`
+	Items []QueueItem `json:"items"`
+}
+
+// ParseQueue parses queue YAML and resolves each item's repo against the
+// queue default. An item with no resolvable repo is rejected: an empty slug
+// bases the task branch on a possibly-stale fork HEAD (#1625).
+func ParseQueue(data []byte) (Queue, error) {
+	var q Queue
+	if err := sigsyaml.Unmarshal(data, &q); err != nil {
+		return Queue{}, fmt.Errorf("parse queue: %w", err)
+	}
+	if len(q.Items) == 0 {
+		return Queue{}, fmt.Errorf("parse queue: no items")
+	}
+	for i := range q.Items {
+		if q.Items[i].Issue == 0 {
+			return Queue{}, fmt.Errorf("parse queue: item %d has no issue", i)
+		}
+		if q.Items[i].Repo == "" {
+			q.Items[i].Repo = q.Repo
+		}
+		if q.Items[i].Repo == "" {
+			return Queue{}, fmt.Errorf("parse queue: item %d (issue %d) has no repo", i, q.Items[i].Issue)
+		}
+		if q.Items[i].IntentPath == "" {
+			return Queue{}, fmt.Errorf("parse queue: issue %d has no intent path", q.Items[i].Issue)
+		}
+	}
+	return q, nil
+}
+
+// IntentFor reads the item's intent file.
+func (q Queue) IntentFor(item QueueItem) (string, error) {
+	b, err := os.ReadFile(item.IntentPath)
+	if err != nil {
+		return "", fmt.Errorf("read intent for issue %d: %w", item.Issue, err)
+	}
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		return "", fmt.Errorf("intent for issue %d is empty", item.Issue)
+	}
+	return s, nil
+}

--- a/pkg/cli/run_queue_test.go
+++ b/pkg/cli/run_queue_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseQueue(t *testing.T) {
+	data := []byte(`
+repo: defilantech/LLMKube
+items:
+  - issue: 1602
+    intent: ./intents/1602.md
+  - issue: 1601
+    intent: ./intents/1601.md
+    repo: defilantech/other
+`)
+	q, err := ParseQueue(data)
+	if err != nil {
+		t.Fatalf("ParseQueue: %v", err)
+	}
+	if q.Repo != "defilantech/LLMKube" {
+		t.Errorf("Repo = %q, want defilantech/LLMKube", q.Repo)
+	}
+	if len(q.Items) != 2 {
+		t.Fatalf("len(Items) = %d, want 2", len(q.Items))
+	}
+	if q.Items[0].Issue != 1602 {
+		t.Errorf("Items[0].Issue = %d, want 1602", q.Items[0].Issue)
+	}
+	// Per-item repo overrides the queue default; unset inherits it.
+	if q.Items[0].Repo != "defilantech/LLMKube" {
+		t.Errorf("Items[0].Repo = %q, want the queue default", q.Items[0].Repo)
+	}
+	if q.Items[1].Repo != "defilantech/other" {
+		t.Errorf("Items[1].Repo = %q, want the per-item override", q.Items[1].Repo)
+	}
+}
+
+func TestParseQueue_RejectsMissingIssue(t *testing.T) {
+	if _, err := ParseQueue([]byte("repo: a/b\nitems:\n  - intent: ./x.md\n")); err == nil {
+		t.Fatal("want error for an item with no issue")
+	}
+}
+
+func TestParseQueue_RejectsMissingRepo(t *testing.T) {
+	// #1625: an empty repo slug silently bases a branch on a stale fork HEAD.
+	// Refuse it here rather than dispatching work that will be cut wrong.
+	if _, err := ParseQueue([]byte("items:\n  - issue: 1\n    intent: ./x.md\n")); err == nil {
+		t.Fatal("want error when neither queue nor item names a repo")
+	}
+}
+
+func TestIntentFor_ReadsFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "1602.md")
+	if err := os.WriteFile(p, []byte("do the thing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	q := Queue{Repo: "a/b"}
+	got, err := q.IntentFor(QueueItem{Issue: 1602, IntentPath: p, Repo: "a/b"})
+	if err != nil {
+		t.Fatalf("IntentFor: %v", err)
+	}
+	if got != "do the thing" {
+		t.Errorf("IntentFor = %q, want %q", got, "do the thing")
+	}
+}
+
+func TestIntentFor_MissingFileIsAnError(t *testing.T) {
+	q := Queue{Repo: "a/b"}
+	if _, err := q.IntentFor(QueueItem{Issue: 1, IntentPath: "/nope/missing.md", Repo: "a/b"}); err == nil {
+		t.Fatal("want error for a missing intent file")
+	}
+}

--- a/pkg/cli/run_queue_test.go
+++ b/pkg/cli/run_queue_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cli
 
 import (

--- a/pkg/cli/run_stages.go
+++ b/pkg/cli/run_stages.go
@@ -30,6 +30,17 @@ const (
 	StageDone      Stage = "done"
 )
 
+// The kinds a park can carry. Transition.Park and Decision.Kind stay plain
+// strings (Decision.Kind is serialised to YAML and names the file on disk), so
+// nothing but a shared constant keeps the two ends spelling a kind alike:
+// optionsFor keys the answer set a human is offered off this exact value, and a
+// kind introduced here that optionsFor does not recognise silently gets the
+// adjudicate answer set instead of its own.
+const (
+	ParkEscalate   = "escalate"
+	ParkAdjudicate = "adjudicate"
+)
+
 // maxAttempts is the structural one-pass rule: one original attempt plus at
 // most one automatic feedback pass. A third is never reached by any input.
 const maxAttempts = 2
@@ -69,7 +80,7 @@ func NextStage(cur Stage, f Facts) Transition {
 		return Transition{Next: StageWatch}
 	case StageWatch:
 		if f.Stalled {
-			return Transition{Next: StageParked, Park: "escalate", Reason: "stalled"}
+			return Transition{Next: StageParked, Park: ParkEscalate, Reason: "stalled"}
 		}
 		return Transition{Next: StageVerify}
 	case StageVerify:
@@ -77,9 +88,9 @@ func NextStage(cur Stage, f Facts) Transition {
 			return Transition{Next: StageFinalize}
 		}
 		if f.Attempts >= maxAttempts {
-			return Transition{Next: StageParked, Park: "escalate", Reason: "verify failed after the feedback pass"}
+			return Transition{Next: StageParked, Park: ParkEscalate, Reason: "verify failed after the feedback pass"}
 		}
-		return Transition{Next: StageParked, Park: "adjudicate", Reason: "verify found issues"}
+		return Transition{Next: StageParked, Park: ParkAdjudicate, Reason: "verify found issues"}
 	case StageFeedback:
 		return Transition{Next: StageWatch}
 	case StageFinalize:

--- a/pkg/cli/run_stages.go
+++ b/pkg/cli/run_stages.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+// Stage is a queue item's position in the run loop.
+type Stage string
+
+const (
+	StagePreflight Stage = "preflight"
+	StageDispatch  Stage = "dispatch"
+	StageWatch     Stage = "watch"
+	StageVerify    Stage = "verify"
+	StageFeedback  Stage = "feedback"
+	StageFinalize  Stage = "finalize"
+	StageParked    Stage = "parked"
+	StageDone      Stage = "done"
+)
+
+// maxAttempts is the structural one-pass rule: one original attempt plus at
+// most one automatic feedback pass. A third is never reached by any input.
+const maxAttempts = 2
+
+// Facts are the observations the driver gathered for the current stage.
+// NextStage is a pure function of (stage, facts) so the machine is table
+// testable without a cluster.
+type Facts struct {
+	// SkipReason, when non-empty, ends the item at preflight.
+	SkipReason string
+	// Stalled reports the stall predicate's verdict during watch.
+	Stalled bool
+	// VerifyClean reports whether the independent verify stage found nothing.
+	VerifyClean bool
+	// Attempts counts coder attempts made so far, starting at 1.
+	Attempts int
+}
+
+// Transition is the machine's output: the next stage, and when that stage is
+// StageParked, which decision kind to park.
+type Transition struct {
+	Next   Stage
+	Park   string
+	Reason string
+}
+
+// NextStage advances one queue item. Parking is terminal for this pass: the
+// driver records the decision and moves to the next item rather than blocking.
+func NextStage(cur Stage, f Facts) Transition {
+	switch cur {
+	case StagePreflight:
+		if f.SkipReason != "" {
+			return Transition{Next: StageDone, Reason: f.SkipReason}
+		}
+		return Transition{Next: StageDispatch}
+	case StageDispatch:
+		return Transition{Next: StageWatch}
+	case StageWatch:
+		if f.Stalled {
+			return Transition{Next: StageParked, Park: "escalate", Reason: "stalled"}
+		}
+		return Transition{Next: StageVerify}
+	case StageVerify:
+		if f.VerifyClean {
+			return Transition{Next: StageFinalize}
+		}
+		if f.Attempts >= maxAttempts {
+			return Transition{Next: StageParked, Park: "escalate", Reason: "verify failed after the feedback pass"}
+		}
+		return Transition{Next: StageParked, Park: "adjudicate", Reason: "verify found issues"}
+	case StageFeedback:
+		return Transition{Next: StageWatch}
+	case StageFinalize:
+		return Transition{Next: StageDone}
+	}
+	return Transition{Next: StageDone, Reason: "unknown stage"}
+}

--- a/pkg/cli/run_stages_test.go
+++ b/pkg/cli/run_stages_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import "testing"
+
+func TestNextStage(t *testing.T) {
+	cases := []struct {
+		name     string
+		cur      Stage
+		facts    Facts
+		wantNext Stage
+		wantPark string
+	}{
+		{"preflight skip ends the item", StagePreflight,
+			Facts{SkipReason: "open PR #1234 references it"}, StageDone, ""},
+		{"preflight clean dispatches", StagePreflight, Facts{}, StageDispatch, ""},
+		{"dispatch always watches", StageDispatch, Facts{}, StageWatch, ""},
+		{"a stalled run parks for escalation", StageWatch,
+			Facts{Stalled: true}, StageParked, "escalate"},
+		{"a terminal run verifies", StageWatch, Facts{}, StageVerify, ""},
+		{"clean verify on the first attempt finalizes", StageVerify,
+			Facts{VerifyClean: true, Attempts: 1}, StageFinalize, ""},
+		{"dirty verify on the first attempt parks to adjudicate", StageVerify,
+			Facts{VerifyClean: false, Attempts: 1}, StageParked, "adjudicate"},
+		{"clean verify after the one feedback pass finalizes", StageVerify,
+			Facts{VerifyClean: true, Attempts: 2}, StageFinalize, ""},
+		{"finalize ends the item", StageFinalize, Facts{}, StageDone, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NextStage(tc.cur, tc.facts)
+			if got.Next != tc.wantNext {
+				t.Errorf("Next = %q, want %q", got.Next, tc.wantNext)
+			}
+			if got.Park != tc.wantPark {
+				t.Errorf("Park = %q, want %q", got.Park, tc.wantPark)
+			}
+		})
+	}
+}
+
+// The one-pass rule is the invariant, not a convention: after the single
+// feedback attempt a dirty verify must escalate, never revise again.
+func TestNextStage_NeverMakesASecondFeedbackAttempt(t *testing.T) {
+	got := NextStage(StageVerify, Facts{VerifyClean: false, Attempts: 2})
+	if got.Next != StageParked || got.Park != "escalate" {
+		t.Fatalf("second dirty verify = (%q,%q), want (parked,escalate)", got.Next, got.Park)
+	}
+	// And no attempt count beyond that reopens feedback.
+	for n := 3; n < 10; n++ {
+		g := NextStage(StageVerify, Facts{VerifyClean: false, Attempts: n})
+		if g.Next == StageFeedback {
+			t.Fatalf("attempts=%d reopened feedback", n)
+		}
+	}
+}

--- a/pkg/cli/run_stages_test.go
+++ b/pkg/cli/run_stages_test.go
@@ -61,11 +61,11 @@ func TestNextStage_NeverMakesASecondFeedbackAttempt(t *testing.T) {
 	if got.Next != StageParked || got.Park != "escalate" {
 		t.Fatalf("second dirty verify = (%q,%q), want (parked,escalate)", got.Next, got.Park)
 	}
-	// And no attempt count beyond that reopens feedback.
+	// And no attempt count beyond that must always escalate, never adjudicate.
 	for n := 3; n < 10; n++ {
 		g := NextStage(StageVerify, Facts{VerifyClean: false, Attempts: n})
-		if g.Next == StageFeedback {
-			t.Fatalf("attempts=%d reopened feedback", n)
+		if g.Next != StageParked || g.Park != "escalate" {
+			t.Fatalf("attempts=%d = (%q,%q), want (parked,escalate)", n, g.Next, g.Park)
 		}
 	}
 }

--- a/pkg/cli/run_stall.go
+++ b/pkg/cli/run_stall.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import "time"
+
+const (
+	// DefaultStallFactor multiplies the baseline to get the stall threshold.
+	DefaultStallFactor = 2.5
+	// DefaultBaseline applies when there is no audit history to median.
+	DefaultBaseline = 60 * time.Minute
+)
+
+// StallInput is what the stall predicate needs. Turn counts are deliberately
+// absent: reconstructing them today means parsing llama.cpp slot logs, which
+// is forensics rather than a signal. #1628 would make turn accounting a real
+// metric and would sharpen this, but elapsed-vs-baseline with no branch
+// pushed caught both real stalls in the reference batch.
+type StallInput struct {
+	Elapsed      time.Duration
+	Baseline     time.Duration
+	BranchPushed bool
+}
+
+// IsStalled reports whether a run should be killed: nothing pushed, and
+// elapsed past factor x baseline. A run that has pushed a branch is making
+// progress regardless of how long it is taking.
+func IsStalled(in StallInput, factor float64) bool {
+	if in.BranchPushed {
+		return false
+	}
+	base := in.Baseline
+	if base <= 0 {
+		base = DefaultBaseline
+	}
+	return in.Elapsed > time.Duration(float64(base)*factor)
+}

--- a/pkg/cli/run_stall.go
+++ b/pkg/cli/run_stall.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package cli
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 const (
 	// DefaultStallFactor multiplies the baseline to get the stall threshold.
@@ -39,9 +42,23 @@ type StallInput struct {
 // IsStalled reports whether a run should be killed: nothing pushed, and
 // elapsed past factor x baseline. A run that has pushed a branch is making
 // progress regardless of how long it is taking.
+//
+// A factor that is not a positive finite number falls back to the default, the
+// same way a missing baseline does. It is not a theoretical input: the value
+// comes from --stall-factor, which the flag layer checks, but IsStalled is
+// exported and DriveItem forwards whatever factor its caller passed, so the
+// predicate that decides whether to destroy a run in progress does not take
+// that on trust. Zero or negative puts the threshold at or below zero and NaN
+// converts to a Duration below every elapsed time, so both make the first watch
+// tick kill the run. NaN is tested separately because NaN <= 0 is false.
+// Falling back beats returning false: a bogus factor should not quietly disable
+// stall detection either.
 func IsStalled(in StallInput, factor float64) bool {
 	if in.BranchPushed {
 		return false
+	}
+	if math.IsNaN(factor) || math.IsInf(factor, 0) || factor <= 0 {
+		factor = DefaultStallFactor
 	}
 	base := in.Baseline
 	if base <= 0 {

--- a/pkg/cli/run_stall_test.go
+++ b/pkg/cli/run_stall_test.go
@@ -37,6 +37,7 @@ func TestIsStalled(t *testing.T) {
 		{"exactly at the factor is not yet stalled", StallInput{150 * time.Minute, base, false}, false},
 		{"just past the factor", StallInput{151 * time.Minute, base, false}, true},
 		{"zero baseline falls back to the default", StallInput{4 * time.Hour, 0, false}, true},
+		{"zero baseline uses the default threshold, not zero", StallInput{100 * time.Minute, 0, false}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/cli/run_stall_test.go
+++ b/pkg/cli/run_stall_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsStalled(t *testing.T) {
+	base := 60 * time.Minute
+	cases := []struct {
+		name string
+		in   StallInput
+		want bool
+	}{
+		// The two real cases from the 2026-08-22 batch.
+		{"1628: 4h, nothing pushed", StallInput{4 * time.Hour, base, false}, true},
+		{"1601-revise: 3h51m, nothing pushed", StallInput{231 * time.Minute, base, false}, true},
+		// The contrast case that must NOT trip: slow but productive.
+		{"slow run that pushed a branch", StallInput{4 * time.Hour, base, true}, false},
+		{"under the factor", StallInput{2 * time.Hour, base, false}, false},
+		{"exactly at the factor is not yet stalled", StallInput{150 * time.Minute, base, false}, false},
+		{"just past the factor", StallInput{151 * time.Minute, base, false}, true},
+		{"zero baseline falls back to the default", StallInput{4 * time.Hour, 0, false}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsStalled(tc.in, DefaultStallFactor); got != tc.want {
+				t.Errorf("IsStalled(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/run_stall_test.go
+++ b/pkg/cli/run_stall_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cli
 
 import (
+	"fmt"
+	"math"
 	"testing"
 	"time"
 )
@@ -43,6 +45,34 @@ func TestIsStalled(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := IsStalled(tc.in, DefaultStallFactor); got != tc.want {
 				t.Errorf("IsStalled(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// A factor that is not a positive finite number puts the stall threshold at or
+// below zero, and NaN converts to a Duration below every elapsed time, so every
+// run is declared stalled on its first watch tick and killed. --stall-factor is
+// checked at the flag, but IsStalled is exported and DriveItem forwards
+// whatever factor its caller handed it.
+//
+// Both arms are load-bearing. The "not stalled" arm alone would still pass if
+// the guard just returned false for a bad factor, which turns stall detection
+// off rather than correcting it; the "stalled" arm pins that the fallback is
+// the default factor and the predicate still does its job.
+func TestIsStalled_ABadFactorFallsBackToTheDefault(t *testing.T) {
+	base := 60 * time.Minute
+	for _, factor := range []float64{0, -1, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		t.Run(fmt.Sprintf("factor %g", factor), func(t *testing.T) {
+			// Inside the default threshold of 2.5 x 60m.
+			if IsStalled(StallInput{100 * time.Minute, base, false}, factor) {
+				t.Errorf("100m into a 60m baseline reads as stalled at factor %g: "+
+					"every run would be killed on its first watch tick", factor)
+			}
+			// And well past it.
+			if !IsStalled(StallInput{4 * time.Hour, base, false}, factor) {
+				t.Errorf("4h into a 60m baseline does not read as stalled at factor %g: "+
+					"stall detection is off, not corrected", factor)
 			}
 		})
 	}

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -249,6 +249,48 @@ func TestDecisionsCommand_DoesNotClaimEmptyWhenNothingWasListed(t *testing.T) {
 	}
 }
 
+// An empty queue is a real answer and has to be said out loud.
+func TestDecisionsCommand_EmptyDirSaysSo(t *testing.T) {
+	out, err := foremanExec(t, "decisions", "--decisions-dir", t.TempDir())
+	if err != nil {
+		t.Fatalf("Execute() = %v, want no error for an empty decisions dir", err)
+	}
+	if !strings.Contains(out, "No parked decisions.") {
+		t.Errorf("stdout = %q, want the empty queue said out loud", out)
+	}
+}
+
+func TestDecisionsCommand_MissingDir(t *testing.T) {
+	// A directory the human typed and got wrong. Answering a typo with "No
+	// parked decisions." turns it into a confident "nothing to do".
+	t.Run("typed and absent is an error", func(t *testing.T) {
+		typo := filepath.Join(t.TempDir(), "no-such-dir")
+		out, err := foremanExec(t, "decisions", "--decisions-dir", typo)
+		if err == nil {
+			t.Fatal("Execute() = nil, want a typo'd --decisions-dir to be refused")
+		}
+		if !strings.Contains(err.Error(), typo) {
+			t.Errorf("err = %v, want it to name %q", err, typo)
+		}
+		if out != "" {
+			t.Errorf("stdout = %q, want nothing printed for a directory that is not there", out)
+		}
+	})
+	// The default is different: nothing has parked yet is the normal state
+	// on a fresh checkout, and erroring on it would make the command unusable
+	// before the first run.
+	t.Run("the default being absent is not", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		out, err := foremanExec(t, "decisions")
+		if err != nil {
+			t.Fatalf("Execute() = %v, want an absent default dir to be the normal empty state", err)
+		}
+		if !strings.Contains(out, "No parked decisions.") {
+			t.Errorf("stdout = %q, want the empty queue said out loud", out)
+		}
+	})
+}
+
 func TestDecisionsCommand_RejectsStrayArguments(t *testing.T) {
 	_, err := foremanExec(t, "decisions", "1602", "--decisions-dir", t.TempDir())
 	if err == nil {

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -164,9 +164,9 @@ func TestFlattenCell(t *testing.T) {
 }
 
 // A cell carrying a newline or a tab does not just mangle its own row, it
-// shifts every row after it. Task 8 fills Reason from verify output and stall
-// evidence, which is exactly where multi-line strings come from, and Answer
-// is a shell argument.
+// shifts every row after it. The driver fills Reason from verify output and
+// stall evidence, which is exactly where multi-line strings come from, and
+// Answer is a shell argument.
 func TestRenderDecisions_FlattensCellsThatWouldBreakTheTable(t *testing.T) {
 	opened := time.Date(2026, 8, 23, 4, 12, 0, 0, time.UTC)
 	clean := Decision{Issue: 1601, Kind: "escalate", Reason: "stalled", Opened: opened, Answer: "drop"}

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -73,14 +73,20 @@ func tableCells(row string) []string {
 func TestRenderDecisions(t *testing.T) {
 	var buf bytes.Buffer
 	renderDecisions(&buf, []Decision{
-		{Issue: 1602, Kind: "adjudicate", Reason: "verify found issues",
+		// Every Workload is distinct and none is derivable from the issue, so
+		// a column filled from any other field is visible rather than
+		// accidentally right.
+		{Issue: 1602, Kind: "adjudicate", Reason: "verify found issues", Workload: "wl-test",
 			Opened:  time.Date(2026, 8, 23, 4, 12, 0, 0, time.UTC),
 			Options: []string{"accept", "revise"}},
-		{Issue: 1601, Kind: "escalate", Reason: "stalled",
+		{Issue: 1601, Kind: "escalate", Reason: "stalled", Workload: "coder-1601-retry-7",
 			Opened: time.Date(2026, 8, 23, 5, 0, 0, 0, time.UTC), Answer: "drop"},
+		// No Workload: a hand-written decision, or one from before the driver
+		// recorded it. The cell must say so rather than go blank, which
+		// tabwriter pads out into a row that has slipped a column.
 		{Issue: 1600, Kind: "unblock", Reason: "needs a human",
 			Opened: time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC)},
-		{Issue: 1603, Kind: "revise", Reason: "coder pushed a fix",
+		{Issue: 1603, Kind: "revise", Reason: "coder pushed a fix", Workload: "wl-1603-b",
 			Opened:  time.Date(2026, 8, 23, 6, 0, 0, 0, time.UTC),
 			Options: []string{"accept", "revise"}, Answer: "accept"},
 	})
@@ -89,23 +95,26 @@ func TestRenderDecisions(t *testing.T) {
 		lead  string
 		cells []string
 	}{
-		{lead: "ISSUE", cells: []string{"ISSUE", "KIND", "OPENED", "OPTIONS", "ANSWER", "REASON"}},
+		{lead: "ISSUE", cells: []string{
+			"ISSUE", "WORKLOAD", "KIND", "OPENED", "OPTIONS", "ANSWER", "REASON"}},
 		// Unanswered with options: the human can read the valid answers off
 		// the table instead of guessing and reading the rejection.
 		{lead: "1602", cells: []string{
-			"1602", "adjudicate", "2026-08-23 04:12", "accept|revise", "-", "verify found issues"}},
+			"1602", "wl-test", "adjudicate", "2026-08-23 04:12", "accept|revise", "-",
+			"verify found issues"}},
 		// Answered with no options: nothing to suppress.
 		{lead: "1601", cells: []string{
-			"1601", "escalate", "2026-08-23 05:00", "-", "drop", "stalled"}},
+			"1601", "coder-1601-retry-7", "escalate", "2026-08-23 05:00", "-", "drop", "stalled"}},
 		// Answered WITH options, the normal end state of an adjudicate: the
 		// answer is the news and the options are spent. Without this row the
 		// answered arm is only ever exercised on the option-less path, and
 		// suppressing spent options is untested.
 		{lead: "1603", cells: []string{
-			"1603", "revise", "2026-08-23 06:00", "-", "accept", "coder pushed a fix"}},
-		// Unanswered with no options: AnswerDecision accepts anything here.
+			"1603", "wl-1603-b", "revise", "2026-08-23 06:00", "-", "accept", "coder pushed a fix"}},
+		// Unanswered with no options and no workload: AnswerDecision accepts
+		// anything here, and there is no run to point at.
 		{lead: "1600", cells: []string{
-			"1600", "unblock", "2026-08-23 03:00", "any", "-", "needs a human"}},
+			"1600", "-", "unblock", "2026-08-23 03:00", "any", "-", "needs a human"}},
 	}
 	for _, tc := range want {
 		row := decisionRow(out, tc.lead)
@@ -197,6 +206,12 @@ func TestRenderDecisions_FlattensCellsThatWouldBreakTheTable(t *testing.T) {
 			mangled: Decision{Issue: 1602, Kind: "adjudicate", Opened: opened, Reason: "stalled",
 				Options: []string{"acc\nept", "revise"}},
 			wantFlat: "acc ept|revise",
+		},
+		{
+			name: "a newline in WORKLOAD",
+			mangled: Decision{Issue: 1602, Kind: "adjudicate", Opened: opened, Reason: "stalled",
+				Workload: "wl\n1602"},
+			wantFlat: "wl 1602",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -81,6 +81,9 @@ func TestRenderDecisions(t *testing.T) {
 			Opened: time.Date(2026, 8, 23, 5, 0, 0, 0, time.UTC), Answer: "drop"},
 		{Issue: 1600, Kind: "unblock", Reason: "needs a human",
 			Opened: time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC)},
+		{Issue: 1603, Kind: "revise", Reason: "coder pushed a fix",
+			Opened:  time.Date(2026, 8, 23, 6, 0, 0, 0, time.UTC),
+			Options: []string{"accept", "revise"}, Answer: "accept"},
 	})
 	out := buf.String()
 	want := []struct {
@@ -92,9 +95,15 @@ func TestRenderDecisions(t *testing.T) {
 		// the table instead of guessing and reading the rejection.
 		{lead: "1602", cells: []string{
 			"1602", "adjudicate", "2026-08-23 04:12", "accept|revise", "-", "verify found issues"}},
-		// Answered: the answer is the news, the options are spent.
+		// Answered with no options: nothing to suppress.
 		{lead: "1601", cells: []string{
 			"1601", "escalate", "2026-08-23 05:00", "-", "drop", "stalled"}},
+		// Answered WITH options, the normal end state of an adjudicate: the
+		// answer is the news and the options are spent. Without this row the
+		// answered arm is only ever exercised on the option-less path, and
+		// suppressing spent options is untested.
+		{lead: "1603", cells: []string{
+			"1603", "revise", "2026-08-23 06:00", "-", "accept", "coder pushed a fix"}},
 		// Unanswered with no options: AnswerDecision accepts anything here.
 		{lead: "1600", cells: []string{
 			"1600", "unblock", "2026-08-23 03:00", "any", "-", "needs a human"}},
@@ -116,6 +125,33 @@ func TestRenderDecisions_EmptySaysSo(t *testing.T) {
 	renderDecisions(&buf, nil)
 	if !strings.Contains(strings.ToLower(buf.String()), "no parked decisions") {
 		t.Errorf("want an explicit empty message, got %q", buf.String())
+	}
+}
+
+// The table-level flatten test catches a tab only because tabwriter pads with
+// two spaces, so a single space between words cannot be padding. That couples
+// the invariant to a rendering constant: drop the tab arm and set padding to 1
+// and the table test goes quiet. Hold the invariant here, where nothing about
+// the table can reach it.
+func TestFlattenCell(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{name: "a tab", in: "verify\tfailed", want: "verify failed"},
+		{name: "a newline", in: "verify\nfailed", want: "verify failed"},
+		{name: "a carriage return", in: "verify\rfailed", want: "verify failed"},
+		// Documenting current behaviour, not requiring it: each control
+		// character maps to its own space, so CRLF widens to two. Harmless in
+		// a table, and the same reason a tab followed by a space widens.
+		{name: "a CRLF becomes two spaces", in: "verify\r\nfailed", want: "verify  failed"},
+		{name: "text with nothing to flatten", in: "verify failed", want: "verify failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := flattenCell(tc.in); got != tc.want {
+				t.Errorf("flattenCell(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -522,6 +522,35 @@ func TestRunCommand_UsesTheOptionsItWasGiven(t *testing.T) {
 	}
 }
 
+// pflag parses --stall-factor with strconv.ParseFloat, which accepts "0",
+// "-1", "NaN" and "Inf" as readily as "2.5". Every one of those makes IsStalled
+// declare a run stalled on its first watch tick and kill it, which is harmless
+// today only because a live run is refused: the flag has to be refused before
+// the Effects that would act on it are wired up.
+//
+// Each case is a valid queue with --dry-run, the one combination that otherwise
+// succeeds and prints a plan, so the error cannot be arriving from anywhere but
+// the guard. The empty-stdout assertion is what pins that: without the check
+// the command prints "stall-factor: 0" and exits 0.
+func TestRunCommand_RefusesAStallFactorThatWouldKillEveryRun(t *testing.T) {
+	for _, factor := range []string{"0", "-1", "-2.5", "NaN", "Inf", "-Inf"} {
+		t.Run(factor, func(t *testing.T) {
+			queue, _ := runQueueFixture(t)
+			out, err := foremanExec(t, "run", "--dry-run",
+				"--queue", queue, "--coder-agent", "coder-metal", "--stall-factor", factor)
+			if err == nil {
+				t.Fatalf("Execute() = nil, want --stall-factor %s refused", factor)
+			}
+			if !strings.Contains(err.Error(), "--stall-factor") {
+				t.Errorf("err = %v, want it to name the flag that is wrong", err)
+			}
+			if out != "" {
+				t.Errorf("stdout = %q, want no plan printed for a run that cannot watch", out)
+			}
+		})
+	}
+}
+
 // A live run has no cluster-backed effects behind it yet, so it must say so
 // rather than print a plan and exit 0 as though something ran.
 func TestRunCommand_RefusesALiveRunRatherThanPretending(t *testing.T) {

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -186,24 +186,25 @@ func TestRenderDecisions_FlattensCellsThatWouldBreakTheTable(t *testing.T) {
 	}
 }
 
-func TestForemanCommand_RegistersRunAndDecisions(t *testing.T) {
-	cases := []struct {
-		sub, wantInHelp string
-	}{
-		// A flag only the run command declares.
-		{sub: "run", wantInHelp: "--stall-factor"},
-		// The answer subcommand's own Short, which the parent's Short does
-		// not repeat: "answer" alone would match either.
-		{sub: "decisions", wantInHelp: "Answer one parked decision"},
+// Asserts on registered names rather than help text, so rewording a Short
+// does not fail a test about wiring. The two pre-existing registrations are
+// covered here too; nothing else pins them.
+func TestForemanCommand_RegistersItsSubcommands(t *testing.T) {
+	paths := [][]string{
+		{"dispatch"},
+		{"slice"},
+		{"run"},
+		{"decisions"},
+		{"decisions", "answer"},
 	}
-	for _, tc := range cases {
-		t.Run(tc.sub, func(t *testing.T) {
-			out, err := foremanExec(t, tc.sub, "--help")
+	for _, path := range paths {
+		t.Run(strings.Join(path, " "), func(t *testing.T) {
+			c, _, err := NewForemanCommand().Find(path)
 			if err != nil {
-				t.Fatalf("foreman %s --help: %v", tc.sub, err)
+				t.Fatalf("foreman %s: %v", strings.Join(path, " "), err)
 			}
-			if !strings.Contains(out, tc.wantInHelp) {
-				t.Errorf("help for %q missing %q:\n%s", tc.sub, tc.wantInHelp, out)
+			if want := path[len(path)-1]; c.Name() != want {
+				t.Errorf("foreman %s resolved to %q, want %q", strings.Join(path, " "), c.Name(), want)
 			}
 		})
 	}
@@ -316,6 +317,14 @@ func TestDecisionsAnswerCommand(t *testing.T) {
 			wantAnswer: "accept",
 		},
 		{
+			// The confirmation names the decision that was written, not the
+			// string that was typed.
+			name:       "confirms with the parsed issue",
+			args:       []string{"+1602", "adjudicate", "accept"},
+			wantOut:    "answered 1602/adjudicate: accept",
+			wantAnswer: "accept",
+		},
+		{
 			name:    "refuses an option that was not offered",
 			args:    []string{"1602", "adjudicate", "maybe"},
 			wantErr: "is not one of",
@@ -329,6 +338,11 @@ func TestDecisionsAnswerCommand(t *testing.T) {
 			name:    "refuses an issue with trailing garbage",
 			args:    []string{"1602x", "adjudicate", "accept"},
 			wantErr: "ISSUE must be a number",
+		},
+		{
+			name:    "refuses a fourth argument",
+			args:    []string{"1602", "adjudicate", "accept", "revise"},
+			wantErr: "accepts 3 arg(s), received 4",
 		},
 	}
 	for _, tc := range cases {
@@ -363,6 +377,29 @@ func TestDecisionsAnswerCommand(t *testing.T) {
 				t.Errorf("recorded answer = %q, want %q", ds[0].Answer, tc.wantAnswer)
 			}
 		})
+	}
+}
+
+// The loop parks where --decisions-dir says and the human answers where
+// --decisions-dir says, but those are two separate registrations. If their
+// defaults ever drift, the loop parks somewhere the human is not looking.
+func TestDecisionsDirIsNamedInOnePlace(t *testing.T) {
+	run := newRunCommand()
+	runFlag := run.Flags().Lookup("decisions-dir")
+	decFlag := newDecisionsCommand().PersistentFlags().Lookup("decisions-dir")
+	if runFlag == nil || decFlag == nil {
+		t.Fatalf("--decisions-dir registered on run = %v, on decisions = %v", runFlag, decFlag)
+	}
+	if runFlag.DefValue != decFlag.DefValue {
+		t.Errorf("run defaults to %q but decisions defaults to %q; the loop would park "+
+			"where the human is not looking", runFlag.DefValue, decFlag.DefValue)
+	}
+	if runFlag.DefValue != defaultDecisionsDir {
+		t.Errorf("--decisions-dir default = %q, want the package constant %q", runFlag.DefValue, defaultDecisionsDir)
+	}
+	if !strings.Contains(run.Long, defaultDecisionsDir) {
+		t.Errorf("run --help does not name %q, so the help can drift from the flag:\n%s",
+			defaultDecisionsDir, run.Long)
 	}
 }
 

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -451,45 +450,104 @@ func TestRunCommand_RequiresQueueAndCoderAgent(t *testing.T) {
 	}
 }
 
-// The driver lands in task 8. Until then run must say so rather than do half
-// a dispatch: this test is expected to be replaced, not kept.
-func TestRunCommand_ReportsNotImplemented(t *testing.T) {
-	out, err := foremanExec(t, "run", "--queue", "queue.yaml", "--coder-agent", "coder-metal")
-	if err == nil || !strings.Contains(err.Error(), "not implemented") {
-		t.Fatalf("Execute() = %v, want a not-implemented error", err)
+// The old TestRunCommand_FlagDefaults read DefValue and ShorthandLookup and
+// never touched the bound variable, so swapping which struct field --queue and
+// --coder-agent bind to survived the whole package. These run the command and
+// read every option back out of what it did.
+
+// runQueueFixture writes a one-item queue and its intent, and returns both
+// paths.
+func runQueueFixture(t *testing.T) (queuePath, intentPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	intentPath = filepath.Join(dir, "1602.md")
+	if err := os.WriteFile(intentPath, []byte(runFixtureIntent), 0o600); err != nil {
+		t.Fatal(err)
 	}
-	if out != "" {
-		t.Errorf("stdout = %q, want nothing printed by a command that does nothing", out)
+	queuePath = filepath.Join(dir, "queue.yaml")
+	body := "repo: defilantech/LLMKube\nitems:\n  - issue: 1602\n    intent: " + intentPath + "\n"
+	if err := os.WriteFile(queuePath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return queuePath, intentPath
+}
+
+const runFixtureIntent = "fix the thing"
+
+// Every value is distinct and none is a flag default, so a flag bound to the
+// wrong field lands somewhere the assertions can see. The whole labelled line
+// is asserted rather than the bare value, so two options swapping places is a
+// failure and not a coincidence.
+func TestRunCommand_UsesTheOptionsItWasGiven(t *testing.T) {
+	queue, intent := runQueueFixture(t)
+	parked := filepath.Join(t.TempDir(), "parked-here")
+	out, err := foremanExec(t, "run", "--dry-run",
+		"--queue", queue,
+		"--coder-agent", "coder-metal",
+		"--namespace", "foreman-ns",
+		"--decisions-dir", parked,
+		"--stall-factor", "3.5")
+	if err != nil {
+		t.Fatalf("Execute() = %v, want a dry run to succeed", err)
+	}
+	want := []string{
+		"queue: " + queue,
+		"coder-agent: coder-metal",
+		"namespace: foreman-ns",
+		"decisions-dir: " + parked,
+		"stall-factor: 3.5",
+		"items: 1",
+		"issue 1602 (defilantech/LLMKube): branch foreman/wl-1602/issue-1602, intent " +
+			intent + " (13 bytes)",
+	}
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("plan missing %q:\n%s", w, out)
+		}
 	}
 }
 
-// The remaining run flags have no consumer until task 8, so this pins the
-// surface a human types and nothing more. It is a registration assertion, not
-// a behavioural one, and task 8 must REPLACE it with one that runs the driver
-// and observes the effect: swapping which field --queue binds to survives it.
-func TestRunCommand_FlagDefaults(t *testing.T) {
-	cmd := newRunCommand()
-	cases := []struct {
-		flag, want string
-	}{
-		{flag: "queue", want: ""},
-		{flag: "decisions-dir", want: defaultDecisionsDir},
-		{flag: "namespace", want: "default"},
-		{flag: "coder-agent", want: ""},
-		{flag: "stall-factor", want: strconv.FormatFloat(DefaultStallFactor, 'g', -1, 64)},
-		{flag: "dry-run", want: "false"},
+// A live run has no cluster-backed effects behind it yet, so it must say so
+// rather than print a plan and exit 0 as though something ran.
+func TestRunCommand_RefusesALiveRunRatherThanPretending(t *testing.T) {
+	queue, _ := runQueueFixture(t)
+	out, err := foremanExec(t, "run", "--queue", queue, "--coder-agent", "coder-metal")
+	if err == nil {
+		t.Fatal("Execute() = nil, want a live run refused while the effects are unwired")
 	}
-	for _, tc := range cases {
-		f := cmd.Flags().Lookup(tc.flag)
-		if f == nil {
-			t.Errorf("--%s is not registered", tc.flag)
-			continue
+	if !strings.Contains(err.Error(), "--dry-run") {
+		t.Errorf("err = %v, want it to name the flag that does work today", err)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want no plan printed by a run that refused", out)
+	}
+}
+
+// The queue is the human's input and it is where the mistakes are. Both cases
+// run WITHOUT --dry-run: validation has to happen before the run is refused,
+// or `run` answers a broken queue with a message about unwired effects.
+func TestRunCommand_ReportsWhatIsWrongWithTheQueue(t *testing.T) {
+	t.Run("a queue that is not there", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "no-queue.yaml")
+		_, err := foremanExec(t, "run", "--queue", missing, "--coder-agent", "coder-metal")
+		if err == nil {
+			t.Fatal("Execute() = nil, want a missing queue refused")
 		}
-		if f.DefValue != tc.want {
-			t.Errorf("--%s default = %q, want %q", tc.flag, f.DefValue, tc.want)
+		if !strings.Contains(err.Error(), missing) {
+			t.Errorf("err = %v, want it to name %q", err, missing)
 		}
-	}
-	if sh := cmd.Flags().ShorthandLookup("n"); sh == nil || sh.Name != "namespace" {
-		t.Errorf("-n shorthand = %v, want it bound to --namespace", sh)
-	}
+	})
+	t.Run("an intent that is not there", func(t *testing.T) {
+		queue, intent := runQueueFixture(t)
+		if err := os.Remove(intent); err != nil {
+			t.Fatal(err)
+		}
+		_, err := foremanExec(t, "run", "--queue", queue, "--coder-agent", "coder-metal")
+		if err == nil {
+			t.Fatal("Execute() = nil, want an unreadable intent refused")
+		}
+		if !strings.Contains(err.Error(), intent) {
+			t.Errorf("err = %v, want it to name %q", err, intent)
+		}
+	})
 }

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// foremanExec runs args through the real `foreman` command group and returns
+// what the command wrote to stdout. Going through NewForemanCommand rather
+// than calling the constructors directly is deliberate: it exercises the
+// registration and the flag wiring instead of asserting they exist. Cobra
+// writes errors to stderr, which is discarded here so that a stdout
+// assertion cannot be satisfied by an error report.
+func foremanExec(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := NewForemanCommand()
+	// Cobra dumps usage to stdout when a command errors, unless the command
+	// Execute was called on silences it. In production that is
+	// NewRootCommand, which sets SilenceUsage; setting it here models the
+	// same run rather than testing a mode the CLI never has.
+	cmd.SilenceUsage = true
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// decisionRow returns the rendered table row for an issue, or "".
+func decisionRow(out, issue string) string {
+	for _, l := range strings.Split(out, "\n") {
+		if strings.HasPrefix(l, issue) {
+			return l
+		}
+	}
+	return ""
+}
+
+func TestRenderDecisions(t *testing.T) {
+	var buf bytes.Buffer
+	renderDecisions(&buf, []Decision{
+		{Issue: 1602, Kind: "adjudicate", Reason: "verify found issues",
+			Opened:  time.Date(2026, 8, 23, 4, 12, 0, 0, time.UTC),
+			Options: []string{"accept", "revise"}},
+		{Issue: 1601, Kind: "escalate", Reason: "stalled",
+			Opened: time.Date(2026, 8, 23, 5, 0, 0, 0, time.UTC), Answer: "drop"},
+	})
+	out := buf.String()
+	wants := []string{
+		"ISSUE", "KIND", "OPENED", "REASON", "ANSWER",
+		"1602", "adjudicate", "verify found issues", "2026-08-23 04:12",
+		"1601", "escalate", "stalled", "2026-08-23 05:00", "drop",
+	}
+	for _, want := range wants {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	row := decisionRow(out, "1602")
+	if row == "" {
+		t.Fatalf("no rendered row for issue 1602:\n%s", out)
+	}
+	if f := strings.Fields(row); f[len(f)-1] != "-" {
+		t.Errorf("unanswered row = %q, want a placeholder in the ANSWER column", row)
+	}
+}
+
+func TestRenderDecisions_EmptySaysSo(t *testing.T) {
+	var buf bytes.Buffer
+	renderDecisions(&buf, nil)
+	if !strings.Contains(strings.ToLower(buf.String()), "no parked decisions") {
+		t.Errorf("want an explicit empty message, got %q", buf.String())
+	}
+}
+
+func TestForemanCommand_RegistersRunAndDecisions(t *testing.T) {
+	cases := []struct {
+		sub, wantInHelp string
+	}{
+		// A flag only the run command declares.
+		{sub: "run", wantInHelp: "--stall-factor"},
+		// The answer subcommand's own Short, which the parent's Short does
+		// not repeat: "answer" alone would match either.
+		{sub: "decisions", wantInHelp: "Answer one parked decision"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sub, func(t *testing.T) {
+			out, err := foremanExec(t, tc.sub, "--help")
+			if err != nil {
+				t.Fatalf("foreman %s --help: %v", tc.sub, err)
+			}
+			if !strings.Contains(out, tc.wantInHelp) {
+				t.Errorf("help for %q missing %q:\n%s", tc.sub, tc.wantInHelp, out)
+			}
+		})
+	}
+}
+
+// TestDecisionsCommand_RendersTheGoodOnesAndReportsTheBad pins the ordering
+// inside the command: ListDecisions returns partial results alongside an
+// error, so reporting the broken file before rendering would hide every
+// decision that did parse from the human who ran this to see them.
+func TestDecisionsCommand_RendersTheGoodOnesAndReportsTheBad(t *testing.T) {
+	dir, _ := decisionFixtureDir(t)
+	bad := filepath.Join(dir, "1500-adjudicate.yaml")
+	if err := os.WriteFile(bad, []byte("answer: revise\noptions: [accept, revise\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := foremanExec(t, "decisions", "--decisions-dir", dir)
+	if err == nil {
+		t.Fatal("Execute() = nil, want an error naming the file that could not be read")
+	}
+	if !strings.Contains(err.Error(), "1500-adjudicate.yaml") {
+		t.Errorf("err = %v, want it to name 1500-adjudicate.yaml", err)
+	}
+	for _, want := range []string{"1602", "adjudicate"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q; the decision that parsed must still be shown:\n%s", want, out)
+		}
+	}
+}
+
+// A directory that could not be listed at all must not be reported as an
+// empty queue: "No parked decisions." next to an error reads as reassurance.
+func TestDecisionsCommand_DoesNotClaimEmptyWhenNothingWasListed(t *testing.T) {
+	notADir := filepath.Join(t.TempDir(), "decisions")
+	if err := os.WriteFile(notADir, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := foremanExec(t, "decisions", "--decisions-dir", notADir)
+	if err == nil {
+		t.Fatal("Execute() = nil, want an error for an unlistable decisions dir")
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want nothing printed when nothing could be listed", out)
+	}
+}
+
+func TestDecisionsCommand_RejectsStrayArguments(t *testing.T) {
+	_, err := foremanExec(t, "decisions", "1602", "--decisions-dir", t.TempDir())
+	if err == nil {
+		t.Fatal("Execute() = nil, want a stray argument to be refused, not ignored")
+	}
+	if !strings.Contains(err.Error(), `unknown command "1602"`) {
+		t.Errorf("err = %v, want it to name the stray argument", err)
+	}
+}
+
+func TestDecisionsAnswerCommand(t *testing.T) {
+	cases := []struct {
+		name       string
+		args       []string
+		wantErr    string
+		wantOut    string
+		wantAnswer string
+	}{
+		{
+			name:       "records the answer",
+			args:       []string{"1602", "adjudicate", "accept"},
+			wantOut:    "answered 1602/adjudicate: accept",
+			wantAnswer: "accept",
+		},
+		{
+			name:    "refuses an option that was not offered",
+			args:    []string{"1602", "adjudicate", "maybe"},
+			wantErr: "is not one of",
+		},
+		{
+			name:    "refuses a non-numeric issue",
+			args:    []string{"abc", "adjudicate", "accept"},
+			wantErr: "ISSUE must be a number",
+		},
+		{
+			name:    "refuses an issue with trailing garbage",
+			args:    []string{"1602x", "adjudicate", "accept"},
+			wantErr: "ISSUE must be a number",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, _ := decisionFixtureDir(t)
+			args := append([]string{"decisions", "answer"}, tc.args...)
+			args = append(args, "--decisions-dir", dir)
+			out, err := foremanExec(t, args...)
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("Execute() = %v, want no error", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("Execute() = nil, want an error containing %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Errorf("err = %v, want it to contain %q", err, tc.wantErr)
+			}
+			if tc.wantOut == "" {
+				if out != "" {
+					t.Errorf("stdout = %q, want nothing printed for a refused answer", out)
+				}
+			} else if !strings.Contains(out, tc.wantOut) {
+				t.Errorf("stdout = %q, want it to contain %q", out, tc.wantOut)
+			}
+			ds, err := ListDecisions(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ds) != 1 {
+				t.Fatalf("len(decisions) = %d, want the one fixture", len(ds))
+			}
+			if ds[0].Answer != tc.wantAnswer {
+				t.Errorf("recorded answer = %q, want %q", ds[0].Answer, tc.wantAnswer)
+			}
+		})
+	}
+}
+
+func TestRunCommand_RequiresQueueAndCoderAgent(t *testing.T) {
+	_, err := foremanExec(t, "run")
+	if err == nil {
+		t.Fatal("Execute() = nil, want the required flags to be enforced")
+	}
+	for _, want := range []string{"required flag(s)", `"queue"`, `"coder-agent"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %v, want it to contain %q", err, want)
+		}
+	}
+}
+
+// The driver lands in task 8. Until then run must say so rather than do half
+// a dispatch: this test is expected to be replaced, not kept.
+func TestRunCommand_ReportsNotImplemented(t *testing.T) {
+	out, err := foremanExec(t, "run", "--queue", "queue.yaml", "--coder-agent", "coder-metal")
+	if err == nil || !strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("Execute() = %v, want a not-implemented error", err)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want nothing printed by a command that does nothing", out)
+	}
+}
+
+// The remaining run flags have no consumer until task 8, so this pins the
+// surface a human types and nothing more. It is a registration assertion, not
+// a behavioural one, and it should grow teeth when the driver reads them.
+func TestRunCommand_FlagDefaults(t *testing.T) {
+	cmd := newRunCommand()
+	cases := []struct {
+		flag, want string
+	}{
+		{flag: "queue", want: ""},
+		{flag: "decisions-dir", want: defaultDecisionsDir},
+		{flag: "namespace", want: "default"},
+		{flag: "coder-agent", want: ""},
+		{flag: "stall-factor", want: strconv.FormatFloat(DefaultStallFactor, 'g', -1, 64)},
+		{flag: "dry-run", want: "false"},
+	}
+	for _, tc := range cases {
+		f := cmd.Flags().Lookup(tc.flag)
+		if f == nil {
+			t.Errorf("--%s is not registered", tc.flag)
+			continue
+		}
+		if f.DefValue != tc.want {
+			t.Errorf("--%s default = %q, want %q", tc.flag, f.DefValue, tc.want)
+		}
+	}
+	if sh := cmd.Flags().ShorthandLookup("n"); sh == nil || sh.Name != "namespace" {
+		t.Errorf("-n shorthand = %v, want it bound to --namespace", sh)
+	}
+}

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -537,6 +537,26 @@ func TestRunCommand_ReportsWhatIsWrongWithTheQueue(t *testing.T) {
 			t.Errorf("err = %v, want it to name %q", err, missing)
 		}
 	})
+	t.Run("a queue that is not YAML", func(t *testing.T) {
+		queue, _ := runQueueFixture(t)
+		// An unbalanced bracket: a parse failure, not a schema complaint, so
+		// this exercises ParseQueue's own error path rather than its
+		// validation. Nothing else in the CLI tests reaches it.
+		body := "repo: defilantech/LLMKube\nitems:\n  - issue: 1602\n    intent: [oops\n"
+		if err := os.WriteFile(queue, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		out, err := foremanExec(t, "run", "--queue", queue, "--coder-agent", "coder-metal")
+		if err == nil {
+			t.Fatal("Execute() = nil, want a malformed queue refused")
+		}
+		if !strings.Contains(err.Error(), "parse queue") {
+			t.Errorf("err = %v, want the parse failure surfaced, not swallowed", err)
+		}
+		if out != "" {
+			t.Errorf("stdout = %q, want no plan printed for a queue that would not parse", out)
+		}
+	})
 	t.Run("an intent that is not there", func(t *testing.T) {
 		queue, intent := runQueueFixture(t)
 		if err := os.Remove(intent); err != nil {

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -49,14 +51,24 @@ func foremanExec(t *testing.T, args ...string) (string, error) {
 	return out.String(), err
 }
 
-// decisionRow returns the rendered table row for an issue, or "".
-func decisionRow(out, issue string) string {
+// decisionRow returns the rendered table row that starts with lead, or "".
+func decisionRow(out, lead string) string {
 	for _, l := range strings.Split(out, "\n") {
-		if strings.HasPrefix(l, issue) {
+		if strings.HasPrefix(l, lead) {
 			return l
 		}
 	}
 	return ""
+}
+
+var tableGap = regexp.MustCompile(` {2,}`)
+
+// tableCells splits a rendered row into its columns. tabwriter pads every
+// aligned cell with at least two spaces, so a run of two or more spaces is a
+// column break while a single space inside a cell survives. Comparing whole
+// rows this way pins column order and content without hand-computing padding.
+func tableCells(row string) []string {
+	return tableGap.Split(strings.TrimRight(row, " "), -1)
 }
 
 func TestRenderDecisions(t *testing.T) {
@@ -67,24 +79,35 @@ func TestRenderDecisions(t *testing.T) {
 			Options: []string{"accept", "revise"}},
 		{Issue: 1601, Kind: "escalate", Reason: "stalled",
 			Opened: time.Date(2026, 8, 23, 5, 0, 0, 0, time.UTC), Answer: "drop"},
+		{Issue: 1600, Kind: "unblock", Reason: "needs a human",
+			Opened: time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC)},
 	})
 	out := buf.String()
-	wants := []string{
-		"ISSUE", "KIND", "OPENED", "REASON", "ANSWER",
-		"1602", "adjudicate", "verify found issues", "2026-08-23 04:12",
-		"1601", "escalate", "stalled", "2026-08-23 05:00", "drop",
+	want := []struct {
+		lead  string
+		cells []string
+	}{
+		{lead: "ISSUE", cells: []string{"ISSUE", "KIND", "OPENED", "OPTIONS", "ANSWER", "REASON"}},
+		// Unanswered with options: the human can read the valid answers off
+		// the table instead of guessing and reading the rejection.
+		{lead: "1602", cells: []string{
+			"1602", "adjudicate", "2026-08-23 04:12", "accept|revise", "-", "verify found issues"}},
+		// Answered: the answer is the news, the options are spent.
+		{lead: "1601", cells: []string{
+			"1601", "escalate", "2026-08-23 05:00", "-", "drop", "stalled"}},
+		// Unanswered with no options: AnswerDecision accepts anything here.
+		{lead: "1600", cells: []string{
+			"1600", "unblock", "2026-08-23 03:00", "any", "-", "needs a human"}},
 	}
-	for _, want := range wants {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q:\n%s", want, out)
+	for _, tc := range want {
+		row := decisionRow(out, tc.lead)
+		if row == "" {
+			t.Errorf("no rendered row leading with %q:\n%s", tc.lead, out)
+			continue
 		}
-	}
-	row := decisionRow(out, "1602")
-	if row == "" {
-		t.Fatalf("no rendered row for issue 1602:\n%s", out)
-	}
-	if f := strings.Fields(row); f[len(f)-1] != "-" {
-		t.Errorf("unanswered row = %q, want a placeholder in the ANSWER column", row)
+		if got := tableCells(row); !slices.Equal(got, tc.cells) {
+			t.Errorf("row %q cells = %q, want %q", tc.lead, got, tc.cells)
+		}
 	}
 }
 
@@ -93,6 +116,73 @@ func TestRenderDecisions_EmptySaysSo(t *testing.T) {
 	renderDecisions(&buf, nil)
 	if !strings.Contains(strings.ToLower(buf.String()), "no parked decisions") {
 		t.Errorf("want an explicit empty message, got %q", buf.String())
+	}
+}
+
+// A cell carrying a newline or a tab does not just mangle its own row, it
+// shifts every row after it. Task 8 fills Reason from verify output and stall
+// evidence, which is exactly where multi-line strings come from, and Answer
+// is a shell argument.
+func TestRenderDecisions_FlattensCellsThatWouldBreakTheTable(t *testing.T) {
+	opened := time.Date(2026, 8, 23, 4, 12, 0, 0, time.UTC)
+	clean := Decision{Issue: 1601, Kind: "escalate", Reason: "stalled", Opened: opened, Answer: "drop"}
+	cases := []struct {
+		name     string
+		mangled  Decision
+		wantFlat string
+	}{
+		{
+			name:     "a newline in REASON",
+			mangled:  Decision{Issue: 1602, Kind: "adjudicate", Opened: opened, Reason: "verify failed\nrerun it"},
+			wantFlat: "verify failed rerun it",
+		},
+		{
+			name:     "a tab in REASON",
+			mangled:  Decision{Issue: 1602, Kind: "adjudicate", Opened: opened, Reason: "verify\tfailed"},
+			wantFlat: "verify failed",
+		},
+		{
+			name:     "a carriage return in REASON",
+			mangled:  Decision{Issue: 1602, Kind: "adjudicate", Opened: opened, Reason: "verify\rfailed"},
+			wantFlat: "verify failed",
+		},
+		{
+			name: "a newline in ANSWER",
+			mangled: Decision{Issue: 1602, Kind: "adjudicate", Opened: opened, Reason: "stalled",
+				Answer: "no\nmaybe"},
+			wantFlat: "no maybe",
+		},
+		{
+			name:     "a newline in KIND",
+			mangled:  Decision{Issue: 1602, Kind: "adjud\nicate", Opened: opened, Reason: "stalled"},
+			wantFlat: "adjud icate",
+		},
+		{
+			name: "a newline in OPTIONS",
+			mangled: Decision{Issue: 1602, Kind: "adjudicate", Opened: opened, Reason: "stalled",
+				Options: []string{"acc\nept", "revise"}},
+			wantFlat: "acc ept|revise",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			renderDecisions(&buf, []Decision{tc.mangled, clean})
+			out := buf.String()
+			lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+			if len(lines) != 3 {
+				t.Fatalf("got %d lines, want a header and one line per decision:\n%s", len(lines), out)
+			}
+			if !strings.Contains(out, tc.wantFlat) {
+				t.Errorf("flattened cell %q missing from:\n%s", tc.wantFlat, out)
+			}
+			// The row after the mangled one must still sit under the header.
+			kind := strings.Index(lines[0], "KIND")
+			row := decisionRow(out, "1601")
+			if len(row) <= kind || !strings.HasPrefix(row[kind:], "escalate") {
+				t.Errorf("the row after the mangled cell is out of alignment:\n%s", out)
+			}
+		})
 	}
 }
 
@@ -260,7 +350,8 @@ func TestRunCommand_ReportsNotImplemented(t *testing.T) {
 
 // The remaining run flags have no consumer until task 8, so this pins the
 // surface a human types and nothing more. It is a registration assertion, not
-// a behavioural one, and it should grow teeth when the driver reads them.
+// a behavioural one, and task 8 must REPLACE it with one that runs the driver
+// and observes the effect: swapping which field --queue binds to survives it.
 func TestRunCommand_FlagDefaults(t *testing.T) {
 	cmd := newRunCommand()
 	cases := []struct {


### PR DESCRIPTION
## What

Implements `llmkube foreman run` and `llmkube foreman decisions`, the unattended orchestration loop from the design proposal merged in #1652.

This is **mechanism-only v1**. There is no production `Effects` implementation yet, so a live run is deliberately refused and only `--dry-run` does anything. What lands here is the machinery, fully tested, ready for the follow-up plan to wire against a real cluster.

Eight pieces, one per commit group:

- **Queue parsing** (`run_queue.go`) — `ParseQueue`, `IntentFor`
- **Stage machine** (`run_stages.go`) — `NextStage`, and the one-pass rule that a queue item gets at most one automatic feedback attempt
- **Stall predicate** (`run_stall.go`) — elapsed past a multiple of baseline with no branch pushed, the signal that caught both real stalls in the 2026-08-22 batch
- **Baseline** (`run_baseline.go`) — median over past audit records, so a run is judged against how long this agent actually takes
- **Decision queue** (`run_decisions.go`) — parked questions as YAML on disk, so the loop never blocks on a human
- **Preflight** (`run_preflight.go`) — skip an issue that already has an open PR or an existing branch
- **CLI surface** (`run.go`) — the two commands and the decisions table
- **Driver** (`run_driver.go`) — preflight, dispatch, watch, kill-if-stalled, verify, then finalize or park

## Why

Orchestrating a Foreman run currently requires a human (or Claude) to babysit it: dispatch, watch for a stall, kill it, read the verify output, decide. This is the mechanism that lets the loop run ahead and queue decisions for a human to answer in a batch instead.

Refs #1651

## How

The design rationale is in `docs/proposals/1651-foreman-run-orchestrator.md` (merged in #1652). Decisions worth calling out:

- **A live run is refused, not faked.** `RunE` parses the queue, validates every intent, and prints a labelled plan under `--dry-run`. Refusing beats pretending when the effects layer does not exist.
- **`StageFinalize` runs no effect**, so a clean verify reaches `StageDone` without opening a PR. `Effects` has no `Finalize` in v1 by design. `done` does not mean "shipped".
- **Parking is non-blocking and durable.** `ParkDecision` refuses to overwrite a decision that already carries an answer, writes atomically via temp+rename, and rejects a `kind` that would steer the path outside the decisions directory.
- **`ListDecisions` returns partial results plus an error**, so one malformed file names itself rather than hiding every other parked decision.
- **The driver takes the task branch from the Workload `Dispatch` returns**, not from the issue number, so a differently-named Workload cannot cause a clean verify against a branch nobody pushed.

Known gaps are enumerated in the plan's deferred section rather than left implicit. The most important: the driver cannot see the `-esc` escalation branch (`workload_coder_escalation.go:292`), and the obvious fix does not work, because escalation is decided from the base coder's verdict long after the Workload is created. The production `Effects` will have to discover the branch from Workload status at verify time.

## Testing

- `go test ./... ` (minus `/e2e`, matching `make test`): green.
- Also green under `-race` and `-shuffle=on`.
- `golangci-lint run ./...`: 0 issues, natively and under `GOOS=linux`.
- Every task was gated by an independent review plus mutation testing. Nine separate tests across the branch were found to be passing tautologies during review and rewritten so they actually fail when the code under test breaks; the last task survived 50 mutations with 49 killed, the single survivor being a field that is inert by design.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — the design doc landed in #1652; user-facing command docs follow when the loop can actually run

Assisted-by: Claude Code (generated the implementation and tests across eight planned tasks, each gated by an independent review and mutation testing; I reviewed the result and ran `make test` and `make lint` locally)
