### PR TITLE
feat(foreman): opt-in archival of task audit records and transcripts

### DIFF
--- a/charts/foreman/templates/operator-deployment.yaml
+++ b/charts/foreman/templates/operator-deployment.yaml
@@ -65,6 +65,14 @@ spec:
             # reaper entirely without redeploying.
             - --audit-retention={{ .Values.operator.audit.retention }}
             - --audit-retention-interval={{ .Values.operator.audit.interval }}
+            {{- if .Values.foreman.archive.enabled }}
+            # Terminal-task archival (#1654). One flag carries both the
+            # switch and the destination: empty (the default, rendered
+            # by omitting the flag entirely) disables archival in the
+            # operator. Bundles hold source code, issue text and tool
+            # output, so this is opt-in only.
+            - --archive-dir={{ .Values.foreman.archive.dir }}
+            {{- end }}
           ports:
             - name: health
               containerPort: {{ .Values.operator.health.port }}
@@ -110,6 +118,10 @@ spec:
               mountPath: /tmp/k8s-webhook-server/serving-certs
               readOnly: true
             {{- end }}
+            {{- if .Values.foreman.archive.enabled }}
+            - name: archive
+              mountPath: {{ .Values.foreman.archive.dir }}
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -117,6 +129,10 @@ spec:
         - name: webhook-certs
           secret:
             secretName: {{ include "foreman.webhook.secretName" . }}
+        {{- end }}
+        {{- if .Values.foreman.archive.enabled }}
+        - name: archive
+          {{- toYaml .Values.foreman.archive.volume | nindent 10 }}
         {{- end }}
       {{- with .Values.operator.nodeSelector }}
       nodeSelector:

--- a/charts/foreman/templates/operator-deployment.yaml
+++ b/charts/foreman/templates/operator-deployment.yaml
@@ -29,8 +29,25 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "foreman.operator.serviceAccountName" . }}
+      {{- /*
+        Archival (#1654) is the only thing the operator writes to a volume it
+        does not own, so fsGroup is added ONLY when archival is enabled and
+        only from the archive block. The operator image runs as 65532 with
+        runAsNonRoot, and a PVC arrives root-owned on most provisioners, so
+        without a matching fsGroup every terminal task increments
+        foreman_archive_failures_total{reason="write"} and no bundle lands.
+        Applying it unconditionally would change the pod security context of
+        every install, archival or not, and OpenShift's restricted-v2 SCC
+        rejects a pod naming an fsGroup outside the namespace's allocated
+        range. archive.fsGroup: 0 renders none at all, which is what that SCC
+        needs. An fsGroup the operator sets itself in podSecurityContext wins.
+      */}}
+      {{- $podSecurityContext := deepCopy (default dict .Values.operator.podSecurityContext) }}
+      {{- if and .Values.foreman.archive.enabled (gt (int (default 0 .Values.foreman.archive.fsGroup)) 0) }}
+      {{- $podSecurityContext = merge $podSecurityContext (dict "fsGroup" (int .Values.foreman.archive.fsGroup)) }}
+      {{- end }}
       securityContext:
-        {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
+        {{- toYaml $podSecurityContext | nindent 8 }}
       containers:
         - name: manager
           image: {{ include "foreman.operator.image" . }}

--- a/charts/foreman/templates/operator-deployment.yaml
+++ b/charts/foreman/templates/operator-deployment.yaml
@@ -149,7 +149,23 @@ spec:
         {{- end }}
         {{- if .Values.foreman.archive.enabled }}
         - name: archive
+          {{- /*
+            The emptyDir fallback lives HERE, not in values.yaml, because Helm
+            deep-merges an operator's values onto the chart's. A chart default
+            of {emptyDir: {}} can never be replaced, only added to:
+            --set foreman.archive.volume.persistentVolumeClaim.claimName=x
+            rendered emptyDir AND the claim, and the API server refuses that
+            with "may not specify more than 1 volume type", so helm upgrade
+            failed and no rollout happened. hostPath behaved the same way.
+            That is the exact path values.yaml tells operators to take, so the
+            default has to be an empty map and the safety floor has to be a
+            template branch (#1654).
+          */}}
+          {{- if .Values.foreman.archive.volume }}
           {{- toYaml .Values.foreman.archive.volume | nindent 10 }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- end }}
       {{- with .Values.operator.nodeSelector }}
       nodeSelector:

--- a/charts/foreman/tests/archive_test.yaml
+++ b/charts/foreman/tests/archive_test.yaml
@@ -1,0 +1,122 @@
+suite: foreman operator terminal-task archival (#1654)
+templates:
+  - operator-deployment.yaml
+
+tests:
+  # ---- Off by default ----
+  #
+  # Archival writes source code, issue text and tool output to a volume,
+  # so a default install must render byte-identically to what it rendered
+  # before this feature existed. The operator's own default is the empty
+  # string, and the chart expresses "off" by omitting the flag entirely
+  # rather than passing --archive-dir="".
+
+  - it: renders no archive flag, mount or volume when disabled
+    asserts:
+      # NOTE: do NOT reach for notMatchRegexRaw here. On a template that
+      # parses as a k8s manifest, helm-unittest hands the *Raw matchers a
+      # nil document, so matchRegexRaw always fails and notMatchRegexRaw
+      # always passes. It is a vacuous assertion, not a strong one.
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --archive-dir=/var/lib/foreman/archive
+      # Pins the arg COUNT so an unguarded flag is caught even if it
+      # renders a value this suite does not name (a bare --archive-dir=,
+      # say). Adding an unrelated operator flag will fail this line: that
+      # is deliberate, bump the number in the same commit.
+      - lengthEqual:
+          path: spec.template.spec.containers[0].args
+          count: 9
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: archive
+      - notContains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: archive
+
+  - it: leaves the pre-existing tmp volume and mount untouched when disabled
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir: {}
+
+  # ---- On ----
+
+  - it: renders the flag, the mount and the volume when enabled
+    set:
+      foreman.archive.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --archive-dir=/var/lib/foreman/archive
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: archive
+            mountPath: /var/lib/foreman/archive
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: archive
+            emptyDir: {}
+
+  # This case exists because the two above would both pass if the template
+  # hardcoded the default path and ignored `dir`. The flag the operator
+  # reads and the path the volume is mounted at must move together: a
+  # bundle written to an unmounted path is lost on pod restart.
+
+  - it: mounts the volume at the configured dir, not the default
+    set:
+      foreman.archive.enabled: true
+      foreman.archive.dir: /mnt/elsewhere
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --archive-dir=/mnt/elsewhere
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: archive
+            mountPath: /mnt/elsewhere
+      # The default path must be gone from BOTH places, not just present
+      # at the new one: a template that renders the flag from `dir` but
+      # hardcodes the mount (or vice versa) still splits them apart.
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --archive-dir=/var/lib/foreman/archive
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: archive
+            mountPath: /var/lib/foreman/archive
+
+  # The emptyDir default is a safety floor, not the intended production
+  # source. If the template hardcoded emptyDir instead of passing the
+  # value through, every enabled install would silently lose its bundles
+  # on pod restart and the two enabled cases above would still pass.
+
+  - it: passes the volume source through verbatim so any volume type works
+    set:
+      foreman.archive.enabled: true
+      foreman.archive.volume:
+        emptyDir: null
+        persistentVolumeClaim:
+          claimName: foreman-archive
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: archive
+            persistentVolumeClaim:
+              claimName: foreman-archive

--- a/charts/foreman/tests/archive_test.yaml
+++ b/charts/foreman/tests/archive_test.yaml
@@ -101,6 +101,44 @@ tests:
             name: archive
             mountPath: /var/lib/foreman/archive
 
+  # Archival must not be coupled to any OTHER flag's guard. webhook.enabled
+  # false is a documented, supported install (values.yaml:24), and under it
+  # a mount guard that also tested .Values.webhook.enabled would render the
+  # --archive-dir flag with NO volume behind it: the operator would then
+  # write bundles into the container's writable layer, where they die with
+  # the pod. Green chart, zero archives. Assert the webhook-certs entries
+  # are actually gone too, otherwise a `set:` that silently failed would
+  # make this case a duplicate of the plain enabled case above.
+
+  - it: renders the mount and the volume even when the webhook is disabled
+    set:
+      webhook.enabled: false
+      foreman.archive.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: webhook-certs
+      - notContains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: webhook-certs
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --archive-dir=/var/lib/foreman/archive
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: archive
+            mountPath: /var/lib/foreman/archive
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: archive
+            emptyDir: {}
+
   # The emptyDir default is a safety floor, not the intended production
   # source. If the template hardcoded emptyDir instead of passing the
   # value through, every enabled install would silently lose its bundles

--- a/charts/foreman/tests/archive_test.yaml
+++ b/charts/foreman/tests/archive_test.yaml
@@ -139,6 +139,77 @@ tests:
             name: archive
             emptyDir: {}
 
+  # ---- fsGroup ----
+  #
+  # values.yaml tells operators to point the volume at a PVC for real use,
+  # and without an fsGroup that instruction cannot work. The operator image
+  # runs as UID 65532 under runAsNonRoot (Dockerfile.foreman-operator), and
+  # most provisioners hand out a freshly-bound PVC owned root:root 0755, so
+  # MkdirAll fails EACCES and every terminal task increments
+  # foreman_archive_failures_total{reason="write"} with zero bundles on
+  # disk. The emptyDir default hides it completely: the kubelet creates an
+  # emptyDir already owned by the pod, so the only configuration the chart
+  # ships out of the box is the one configuration that does not need this.
+
+  - it: renders no fsGroup when archival is disabled
+    asserts:
+      # A default install's pod security context must be byte-identical to
+      # what it was before archival existed. isSubset alone would not catch
+      # an added key, so the whole map is pinned.
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+
+  - it: renders the fsGroup when archival is enabled
+    set:
+      foreman.archive.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 65532
+      # The pre-existing hardening must survive the merge, not be replaced
+      # by a context that carries only fsGroup.
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: renders no fsGroup when archival is enabled but fsGroup is 0
+    set:
+      foreman.archive.enabled: true
+      foreman.archive.fsGroup: 0
+    asserts:
+      # 0 is the OpenShift escape hatch: the restricted-v2 SCC injects
+      # fsGroup from the namespace's allocated range and rejects a pod that
+      # names a value outside it. Rendering "fsGroup: 0" instead of omitting
+      # the key would make the operator pod unadmittable there, so this
+      # pins the whole map rather than just the absence of 65532.
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+
+  - it: lets an explicit operator podSecurityContext fsGroup win
+    set:
+      foreman.archive.enabled: true
+      operator.podSecurityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+    asserts:
+      # The archive default must not overwrite a value the operator chose
+      # deliberately, which is how a cluster with its own UID/GID policy
+      # (or an injecting admission controller) stays in control.
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+
   # The emptyDir default is a safety floor, not the intended production
   # source. If the template hardcoded emptyDir instead of passing the
   # value through, every enabled install would silently lose its bundles

--- a/charts/foreman/tests/archive_test.yaml
+++ b/charts/foreman/tests/archive_test.yaml
@@ -210,22 +210,74 @@ tests:
           path: spec.template.spec.securityContext.fsGroup
           value: 1000
 
-  # The emptyDir default is a safety floor, not the intended production
-  # source. If the template hardcoded emptyDir instead of passing the
-  # value through, every enabled install would silently lose its bundles
-  # on pod restart and the two enabled cases above would still pass.
+  # ---- The volume source ----
+  #
+  # emptyDir is a safety floor, not the intended production source, and it
+  # is rendered by the TEMPLATE rather than defaulted in values.yaml. Helm
+  # deep-merges an operator's values onto the chart's, so a values default
+  # of `emptyDir: {}` is ADDED to whatever source the operator names rather
+  # than replaced by it, and the API server refuses the resulting Volume
+  # with "may not specify more than 1 volume type": helm upgrade fails and
+  # nothing rolls out. That is the path values.yaml tells operators to take.
+  #
+  # These cases therefore set the source the way an operator would, with no
+  # `emptyDir: null` incantation to cancel the merge, and pin the WHOLE
+  # rendered element. `equal` on the element is what proves there is exactly
+  # one source: an extra `emptyDir` key breaks the equality. Asserting only
+  # that the claim is present would pass on the broken two-source render.
+  #
+  # volumes[2] is tmp, webhook-certs, archive under default values. The
+  # `contains` line alongside it is index-free and would survive a reorder.
 
-  - it: passes the volume source through verbatim so any volume type works
+  - it: falls back to emptyDir when no volume source is configured
+    set:
+      foreman.archive.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[2]
+          value:
+            name: archive
+            emptyDir: {}
+
+  - it: renders a persistentVolumeClaim as the volume's only source
     set:
       foreman.archive.enabled: true
       foreman.archive.volume:
-        emptyDir: null
         persistentVolumeClaim:
           claimName: foreman-archive
     asserts:
+      - equal:
+          path: spec.template.spec.volumes[2]
+          value:
+            name: archive
+            persistentVolumeClaim:
+              claimName: foreman-archive
       - contains:
           path: spec.template.spec.volumes
           content:
             name: archive
             persistentVolumeClaim:
               claimName: foreman-archive
+
+  - it: renders a hostPath as the volume's only source
+    set:
+      foreman.archive.enabled: true
+      foreman.archive.volume:
+        hostPath:
+          path: /data/foreman-archive
+          type: DirectoryOrCreate
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[2]
+          value:
+            name: archive
+            hostPath:
+              path: /data/foreman-archive
+              type: DirectoryOrCreate
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: archive
+            hostPath:
+              path: /data/foreman-archive
+              type: DirectoryOrCreate

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -89,6 +89,34 @@ foreman:
       additionalLabels:
         prometheus: kube-prometheus-stack-prometheus
 
+  # Terminal-task archival (#1654). Off by default.
+  #
+  # When enabled the operator writes one immutable bundle per terminal
+  # task to `dir`, containing the audit record and the agent transcript.
+  # READ THIS BEFORE ENABLING: those two artifacts contain source code,
+  # issue text, and whatever appeared in tool output, so turning this on
+  # writes all of that to the volume below, in plain text, outside the
+  # 7 day audit retention window. That is a deliberate operator decision
+  # about where your code and issue text come to rest, not a detail.
+  #
+  # The operator only writes files. Getting bundles off the node is a
+  # separate concern: run a CronJob that syncs `dir` to durable storage.
+  # Both storage classes in a typical install are RWO and reclaim with
+  # Delete, so a bundle that is never shipped is one PVC deletion from
+  # gone.
+  archive:
+    enabled: false
+    # Absolute path the operator writes bundles to, and the mount path of
+    # the volume below. The two are always the same path by construction.
+    dir: /var/lib/foreman/archive
+    # Volume mounted at `dir` when enabled. Any volume source works; the
+    # operator never learns what is behind it. The emptyDir default keeps
+    # a mistaken `enabled: true` from silently filling a node disk that
+    # something else depends on, but it also means bundles die with the
+    # pod: point this at a persistentVolumeClaim for real use.
+    volume:
+      emptyDir: {}
+
 # agents is the multi-fleet map (#994). Leave it UNSET for a single
 # agent (the legacy `agent:` block above is used as-is and renders
 # exactly the resources it always has, so an existing install is

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -104,19 +104,50 @@ foreman:
   # Both storage classes in a typical install are RWO and reclaim with
   # Delete, so a bundle that is never shipped is one PVC deletion from
   # gone.
+  #
+  # AGENT VERSION SKEW: archival captures transcripts only from agents at
+  # the same version as this chart. The `transcriptRef` lift that
+  # publishes a transcript ships in foreman-agent; the archiver that reads
+  # it ships in foreman-operator. Metal agents are commonly updated out of
+  # band from the chart, so skew is normal. Against an older agent
+  # `status.transcriptRef` stays empty, the archiver takes neither the
+  # transcript_read nor the transcript_empty branch, every bundle records
+  # `hasTranscript: false`, and foreman_archive_failures_total stays at
+  # zero. That is indistinguishable from a fleet of deterministic runs, so
+  # there is no failure signal at all: bring the agents to this version
+  # before you trust a transcript to be there.
+  #
+  # ROLLBACK: use `helm rollback` (or `kubectl rollout undo`), which
+  # reverts the operator's args and its image together. Rolling the image
+  # back on its own while this stays enabled, as in
+  # `helm upgrade --set operator.image.tag=<old>`, crashloops the
+  # operator: the older binary does not define -archive-dir, Go's flag
+  # package exits 2 on a flag it does not know, and the pod lands in
+  # CrashLoopBackOff. Set `enabled: false` in the same command if you
+  # really must roll only the image.
   archive:
     enabled: false
     # Absolute path the operator writes bundles to, and the mount path of
     # the volume below. The two are always the same path by construction.
     dir: /var/lib/foreman/archive
     # Volume mounted at `dir` when enabled. Any volume source works; the
-    # operator never learns what is behind it. The emptyDir default keeps
-    # a mistaken `enabled: true` from silently filling a node disk that
-    # something else depends on, but it also means bundles die with the
-    # pod: point this at a persistentVolumeClaim for real use. Read the
+    # operator never learns what is behind it. Empty here on purpose: the
+    # chart renders `emptyDir: {}` when you name no source, which keeps a
+    # mistaken `enabled: true` from silently filling a node disk that
+    # something else depends on. It also means bundles die with the pod,
+    # so point this at a persistentVolumeClaim for real use. Read the
     # fsGroup note below before you do.
-    volume:
-      emptyDir: {}
+    #
+    #   volume:
+    #     persistentVolumeClaim:
+    #       claimName: foreman-archive
+    #
+    # Do NOT put `emptyDir: {}` back here as the default. Helm deep-merges
+    # your values onto the chart's, so a default source is ADDED to the one
+    # you name rather than replaced, and a Volume carrying two sources is
+    # rejected by the API server with "may not specify more than 1 volume
+    # type": helm upgrade fails and nothing rolls out.
+    volume: {}
     # fsGroup applied to the operator pod, but ONLY while archival is
     # enabled, so a default install's pod security context is unchanged.
     #

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -113,9 +113,26 @@ foreman:
     # operator never learns what is behind it. The emptyDir default keeps
     # a mistaken `enabled: true` from silently filling a node disk that
     # something else depends on, but it also means bundles die with the
-    # pod: point this at a persistentVolumeClaim for real use.
+    # pod: point this at a persistentVolumeClaim for real use. Read the
+    # fsGroup note below before you do.
     volume:
       emptyDir: {}
+    # fsGroup applied to the operator pod, but ONLY while archival is
+    # enabled, so a default install's pod security context is unchanged.
+    #
+    # This is what makes the persistentVolumeClaim above actually usable.
+    # The operator image runs as UID 65532 with runAsNonRoot, and most
+    # provisioners hand out a freshly-bound PVC owned root:root 0755. With
+    # no fsGroup the operator cannot create its bundle directory, every
+    # terminal task increments
+    # foreman_archive_failures_total{reason="write"}, and not one bundle is
+    # written. The emptyDir default hides this completely, because the
+    # kubelet creates an emptyDir already owned by the pod.
+    #
+    # Set to 0 to render no fsGroup at all. That is what OpenShift needs:
+    # the restricted-v2 SCC injects fsGroup from the namespace's allocated
+    # range and rejects a pod that names a value outside it.
+    fsGroup: 65532
 
 # agents is the multi-fleet map (#994). Leave it UNSET for a single
 # agent (the legacy `agent:` block above is used as-is and renders

--- a/cmd/foreman-operator/main.go
+++ b/cmd/foreman-operator/main.go
@@ -35,6 +35,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -153,11 +154,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := (&foremancontroller.AgenticTaskReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		ArchiveDir: archiveDir,
-	}).SetupWithManager(mgr); err != nil {
+	if err := agenticTaskReconciler(mgr.GetClient(), mgr.GetScheme(), archiveDir).
+		SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AgenticTask")
 		os.Exit(1)
 	}
@@ -252,4 +250,21 @@ func webhookCertsPresent(certDir string) bool {
 		}
 	}
 	return true
+}
+
+// agenticTaskReconciler builds the AgenticTask reconciler. It exists as a
+// seam so a test can assert that archiveDir actually reaches
+// AgenticTaskReconciler.ArchiveDir. Without it, dropping the ArchiveDir
+// assignment still compiles, vets and passes every test in the repo while
+// silently making archival inert on a real cluster: the operator would log
+// nothing, the chart would render the flag and the volume, and no bundle
+// would ever be written.
+func agenticTaskReconciler(
+	c client.Client, s *runtime.Scheme, archiveDir string,
+) *foremancontroller.AgenticTaskReconciler {
+	return &foremancontroller.AgenticTaskReconciler{
+		Client:     c,
+		Scheme:     s,
+		ArchiveDir: archiveDir,
+	}
 }

--- a/cmd/foreman-operator/main.go
+++ b/cmd/foreman-operator/main.go
@@ -71,6 +71,7 @@ func main() {
 	var webhookPort int
 	var auditRetention time.Duration
 	var auditRetentionInterval time.Duration
+	var archiveDir string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8081",
 		"The address the metrics endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8082",
@@ -105,6 +106,12 @@ func main() {
 		"How often the audit reaper sweeps. Defaults to 1h. Lower values are "+
 			"only useful in tests; raising it past a few hours delays the "+
 			"first cleanup pass proportionally.")
+	flag.StringVar(&archiveDir, "archive-dir", "",
+		"Directory for terminal-task archive bundles. Empty (the default) "+
+			"disables archival entirely. Bundles contain the audit record and "+
+			"the agent transcript, which include source code, issue text, and "+
+			"tool output; enabling this writes all of that to the mounted "+
+			"volume in plain text.")
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -147,8 +154,9 @@ func main() {
 	}
 
 	if err := (&foremancontroller.AgenticTaskReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		ArchiveDir: archiveDir,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AgenticTask")
 		os.Exit(1)

--- a/cmd/foreman-operator/main_test.go
+++ b/cmd/foreman-operator/main_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestAgenticTaskReconciler_CarriesArchiveDir pins the one assignment that
+// makes --archive-dir do anything. Deleting `ArchiveDir: archiveDir` from
+// the constructed struct still compiles and still passes every other test
+// in this repo, while archival goes silently inert on a real cluster: the
+// chart renders the flag and mounts the volume, the operator starts
+// cleanly, and no bundle is ever written.
+//
+// Note for whoever maintains this: gofmt is NOT a backstop here. Removing
+// the longest key collapses the struct's field alignment, so `gofmt -l`
+// flags the file, but a single `gofmt -w` clears that and everything else
+// goes green. Only this assertion catches it.
+func TestAgenticTaskReconciler_CarriesArchiveDir(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		archiveDir string
+	}{
+		{"an absolute dir reaches the reconciler", "/x"},
+		{"a non-default dir is not rewritten", "/mnt/elsewhere"},
+		// Empty must stay empty. A seam that substituted a default here
+		// would turn archival ON for every install that never asked for
+		// it, writing source code and issue text to disk by surprise.
+		{"empty stays empty so archival stays off", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := agenticTaskReconciler(nil, nil, tc.archiveDir)
+			if r.ArchiveDir != tc.archiveDir {
+				t.Fatalf("ArchiveDir = %q, want %q", r.ArchiveDir, tc.archiveDir)
+			}
+		})
+	}
+}
+
+// TestAgenticTaskReconciler_CarriesClientAndScheme keeps the seam honest
+// about the other two fields, so it cannot become a function that returns
+// a reconciler wired to nothing but the archive dir.
+func TestAgenticTaskReconciler_CarriesClientAndScheme(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+	s := runtime.NewScheme()
+
+	r := agenticTaskReconciler(c, s, "/x")
+
+	if r.Client != c {
+		t.Errorf("Client = %v, want the client passed in (%v)", r.Client, c)
+	}
+	if r.Scheme != s {
+		t.Errorf("Scheme = %v, want the scheme passed in (%v)", r.Scheme, s)
+	}
+}

--- a/docs/proposals/1654-foreman-trajectory-archival.md
+++ b/docs/proposals/1654-foreman-trajectory-archival.md
@@ -25,7 +25,7 @@ go when the task goes.
 
 Audit records are deliberately owner-unbound so they outlive their task, but
 `--audit-retention` defaults to seven days
-(`cmd/foreman-operator/main.go:99`).
+(`cmd/foreman-operator/main.go:101`).
 
 Git keeps the destination but not the journey. A merged diff shows what landed;
 it cannot show that the first attempt failed `go vet`, what the coder did next,
@@ -50,14 +50,16 @@ that no longer exists and cannot be reconstructed.
 ### Hook point: `audit.RecordTerminal`
 
 The archiver runs where `audit.RecordTerminal` is already called, in
-`internal/foreman/controller/agentictask_controller.go:132`.
+`internal/foreman/controller/agentictask_controller.go:139`.
 
 That instant is the only one where everything needed is simultaneously true:
 
 - the verdict is final;
 - the audit record is fully populated, including the `Gate`, `ScopeGuard`,
   `IssueAsk` and `Reviewer` outcome structs;
-- `TranscriptRef` still resolves, because the task has not been deleted;
+- `TranscriptRef` still resolves, because the task has not been deleted (this
+  turned out to require a fix; see "The transcript reference was never on
+  status" below);
 - `Branch`, `CommitSHA` and `Issue` are set, which are the join keys into git.
 
 Archiving here needs no finalizer and races nothing. An archiver that instead
@@ -67,8 +69,8 @@ race. A stuck finalizer blocks task deletion indefinitely, which is a worse
 failure than a missed archive.
 
 Note that the transcript is written by a different process at a different time:
-the agent writes it during execution (`pkg/foreman/agent/executor_native.go:800`
-and `:1031`). The controller is the only party that later sees both halves.
+the agent writes it during execution (`pkg/foreman/agent/executor_native.go:833`
+and `:1064`). The controller is the only party that later sees both halves.
 
 ### Bundle layout
 
@@ -98,7 +100,7 @@ failed attempt is training data in its own right, and re-running a task must
 never destroy the evidence of why it was re-run.
 
 **A missing transcript is normal, not an error.** A deterministic run writes no
-transcript at all (`pkg/foreman/agent/executor_native.go:1524`). The archiver
+transcript at all (`pkg/foreman/agent/executor_native.go:1557`). The archiver
 records the audit half and moves on, without logging an error for every
 deterministic task.
 
@@ -120,7 +122,7 @@ write path.
 
 ## As built: what moved during implementation
 
-Five review rounds changed the design in ways this document originally did not
+Review rounds changed the design in ways this document originally did not
 describe. They are recorded here rather than left as a gap between the proposal
 and the code.
 
@@ -131,10 +133,22 @@ return success. The shipped writer resolves the root with `filepath.EvalSymlinks
 uses `filepath.Rel` rather than a string prefix, and **re-verifies containment
 after `MkdirAll`**, because a pre-create check cannot see a symlink planted on a
 segment it has not created yet. Containment runs before any bytes are written,
-so a refused bundle never receives content. This mirrors `resolveInside` in
-`pkg/foreman/agent/tools/workspace.go`; the duplication is deliberate for now,
-since that function sits in the coder's live write path and lifting it into a
-shared helper is its own change.
+so a refused bundle never receives content.
+
+The archive check is **stronger than** `resolveInside` in
+`pkg/foreman/agent/tools/workspace.go`, not a copy of it. `resolveInside` skips
+symlink resolution entirely when the target does not yet exist
+(`workspace.go:85`), which is the normal case for a file the coder is about to
+create, and `write_file.go` then calls `os.MkdirAll` (`:74`) and `os.WriteFile`
+(`:79`) with no re-check. A symlinked ancestor inside the workspace is followed
+out. The archive writer re-verifies after `MkdirAll` (`pkg/foreman/archive/bundle.go:173`),
+which is exactly the hole `resolveInside` leaves open.
+
+So unification must go **upward**: lifting `resolveInside` into a shared helper
+as-is would regress the archive to the weaker check. If the two are ever merged,
+the archive's post-`MkdirAll` re-verification is the behaviour that has to
+survive, and moving it into the coder's live write path is its own change with
+its own risk.
 
 **The bundle key falls back to the task UID.** `RecordedAt` is only populated
 when `task.Status.FinishedAt` is non-nil, and an empty value made the key
@@ -161,6 +175,26 @@ or `no-repo` and a reader should expect variable depth. NUL bytes and an empty
 skips a complete bundle, so the repeat costs one `stat` and gives a failed write
 a free retry. Gating it on the first terminal pass would turn a transient failure
 into permanent loss for that task.
+
+**The transcript reference was never on status.** This proposal assumed
+`Status.TranscriptRef` was populated. It was not, and never had been:
+`pkg/foreman/agent/watcher.go` lifted `branch`, `commitSHA` and `jobName` out of
+the executor's `Result.Extra` but not `transcriptRef`, which the executor stamps
+there as an `ObjectReference` map. The field therefore had one reader and zero
+assignments across the whole repository. Left unfixed, the archiver would have
+gated its entire transcript path on an always-empty field: every bundle
+`hasTranscript:false`, both transcript failure counters flat, and nothing logged,
+because an empty reference is the deterministic-run path this design deliberately
+made silent. A fleet dropping every transcript would have been
+byte-indistinguishable from a fleet of deterministic runs. Fixed at the root, in
+the watcher, beside the three existing lifts; `audit.Record.TranscriptRef`, empty
+since the field was introduced, is repaired as a side effect.
+
+**The node reservation is released before archival, not after.** Archival writes
+to a mounted volume and takes no timeout, and the AgenticTask controller runs
+with concurrency 1. An archive stalled on a hung mount ahead of the release would
+hold a finished task's node reserved and wedge every other AgenticTask reconcile
+behind it. Releasing first bounds a bad mount to "no bundles are being written".
 
 **Known residual.** An empty regular `meta.json`, produced by a torn write of
 the sentinel itself, passes the completion check but cannot be parsed. The window
@@ -288,12 +322,16 @@ remains the source of truth; the archive is a side effect.
 But non-blocking plus log-only means discovering six weeks later that there is no
 data. So failures are counted and surfaced:
 
-- a Prometheus counter, `foreman_archive_failures_total`, labelled by reason;
-- an event on the AgenticTask.
+- a Prometheus counter, `foreman_archive_failures_total`, labelled by reason.
 
 That makes "archival has been failing for 15m" a single recording rule away, in
 a chart that already alerts on this shape, and turns silent data loss into a
 page.
+
+An earlier draft of this section also promised an event on the AgenticTask.
+Nothing emits one: `AgenticTaskReconciler` has no `Recorder` field and
+`archiveTerminalTask` does not record events. The counter is the whole of the
+failure signal today. See "Follow-ups".
 
 ## Retention stays independent
 
@@ -337,6 +375,10 @@ edge nodes.
    archived lossy.
 2. **Backfill from git.** Merged issue-to-PR pairs are permanent and can be
    harvested retroactively at any time, independent of this proposal.
+3. **An event on the AgenticTask for an archive failure.** Promised by an
+   earlier draft of "Failure handling" and never built. It needs a `Recorder`
+   on `AgenticTaskReconciler`, which no Foreman controller has today, so it is
+   a wiring change of its own rather than a line in the archiver.
 
 ## Testing
 

--- a/docs/proposals/1654-foreman-trajectory-archival.md
+++ b/docs/proposals/1654-foreman-trajectory-archival.md
@@ -1,0 +1,315 @@
+# Foreman trajectory archival
+
+**Status:** proposed
+**Issue:** #1654
+**Scope:** sub-project 1 of 4 in the lab model-training effort. This proposal
+covers durable capture only. Dataset building, training, and A/B evaluation are
+separate proposals and are explicitly out of scope here.
+
+## Why now
+
+The data with the highest training signal is the data with the shortest life,
+and nothing is currently preserving it.
+
+| Artifact | Lifetime today | Contains |
+|---|---|---|
+| Transcript ConfigMap | Deleted with its AgenticTask | Full coder trajectory: turns, tool calls, the gate output the coder actually saw |
+| Audit ConfigMap | 7 days | Verdict, gate/scope/issueAsk/reviewer outcomes, branch, commit SHA, issue |
+| Git | Permanent | Final merged diff |
+
+Transcripts carry `OwnerReferences: []metav1.OwnerReference{ownerRefForTask(task)}`
+(`pkg/foreman/agent/transcript.go`), so Kubernetes garbage-collects them the
+moment their AgenticTask is deleted. Nothing reaps them separately; they simply
+go when the task goes.
+
+Audit records are deliberately owner-unbound so they outlive their task, but
+`--audit-retention` defaults to seven days
+(`cmd/foreman-operator/main.go:99`).
+
+Git keeps the destination but not the journey. A merged diff shows what landed;
+it cannot show that the first attempt failed `go vet`, what the coder did next,
+or why the reviewer demoted a GO. Those live only in the two perishable
+artifacts above.
+
+Every day of Foreman activity that passes without archival is trajectory data
+that no longer exists and cannot be reconstructed.
+
+## Non-goals
+
+- Building the training dataset. That is a separate proposal; this one produces
+  its raw input.
+- Changing what the harness decides. Archival is a side effect and never
+  influences a verdict.
+- Replacing the audit retention sweep, or making deletion conditional on
+  archival. See "Retention stays independent".
+- Archiving from the agent. v1 is controller-only. See "Deliberate v1 limits".
+
+## Design
+
+### Hook point: `audit.RecordTerminal`
+
+The archiver runs where `audit.RecordTerminal` is already called, in
+`internal/foreman/controller/agentictask_controller.go:132`.
+
+That instant is the only one where everything needed is simultaneously true:
+
+- the verdict is final;
+- the audit record is fully populated, including the `Gate`, `ScopeGuard`,
+  `IssueAsk` and `Reviewer` outcome structs;
+- `TranscriptRef` still resolves, because the task has not been deleted;
+- `Branch`, `CommitSHA` and `Issue` are set, which are the join keys into git.
+
+Archiving here needs no finalizer and races nothing. An archiver that instead
+watched for terminal tasks from outside the reconcile would be racing Kubernetes
+garbage collection for the transcript, and would need a finalizer to close that
+race. A stuck finalizer blocks task deletion indefinitely, which is a worse
+failure than a missed archive.
+
+Note that the transcript is written by a different process at a different time:
+the agent writes it during execution (`pkg/foreman/agent/executor_native.go:800`
+and `:1031`). The controller is the only party that later sees both halves.
+
+### Bundle layout
+
+One immutable bundle per terminal task:
+
+```
+<archive-dir>/<repo>/<issue>/<taskName>-<recordedAt>/
+  audit.json        # the audit.Record, verbatim
+  transcript.json   # the transcript ConfigMap payload, when one exists
+  meta.json         # bundle schema version, archiver version, audit namespace
+```
+
+`<repo>` is `audit.Record.Repo`, which is an owner/name slug such as
+`defilantech/LLMKube`. Its slash is kept, so a repo occupies two key levels and
+a prefix listing for one repo works naturally. `<issue>` is the integer, or the
+literal `no-issue` when `Record.Issue` is zero, so that every bundle has a
+well-formed key. `<recordedAt>` is the record's own timestamp, colons replaced
+with hyphens so the key is portable across tools that dislike them.
+
+**Partitioned by repo and issue on purpose.** The dataset builder then reads a
+prefix rather than scanning a bucket, and one issue's entire history collects
+under a single prefix: first attempt, gate failure, retry, final GO. That is
+exactly the shape the "gate failure to successful retry" training pair needs.
+
+**Immutable, never updated in place.** A retried task writes a new bundle. The
+failed attempt is training data in its own right, and re-running a task must
+never destroy the evidence of why it was re-run.
+
+**A missing transcript is normal, not an error.** A deterministic run writes no
+transcript at all (`pkg/foreman/agent/executor_native.go:1524`). The archiver
+records the audit half and moves on, without logging an error for every
+deterministic task.
+
+### Idempotency
+
+`RecordTerminal` is at-least-once; a re-reconcile calls it again.
+
+The bundle key uses the record's own `RecordedAt`, never `time.Now()` at archive
+time. `RecordedAt` is assigned from `FinishedAt` and is documented as
+deterministic (`pkg/foreman/audit/record.go:143`), so a repeat call rewrites the
+same key with identical bytes instead of minting a duplicate bundle the dataset
+builder would later have to dedupe.
+
+### Size
+
+Both objects originate as ConfigMaps, so a bundle is bounded at roughly 1 MB by
+construction. No multipart, no streaming, no chunking: a plain PUT is the entire
+write path.
+
+## Opt-in
+
+The feature is off unless configured, and there is no half-on state. A single
+operator flag carries both the switch and the destination:
+
+```
+--archive-dir=/var/lib/foreman/archive       # empty (default) disables the feature
+```
+
+An empty `--archive-dir` means the archiver is never constructed, no directory
+is touched, no additional API reads occur, and `RecordTerminal` behaves exactly
+as it does today.
+
+The chart mirrors this as `foreman.archive.*`, defaulting off, and mounts a
+volume at that path **only when the feature is enabled**. A disabled install
+gets no volume, no PVC and no new RBAC. One switch rather than a matrix of
+flags that can disagree with each other.
+
+There are no credentials, no endpoint and no bucket in the operator's
+configuration, because the operator does not talk to object storage. Whatever
+ships bundles onward owns that configuration.
+
+**Privacy note, which belongs in the flag's help text and the chart values
+comment:** transcripts contain source code, issue text, and whatever appeared in
+tool output. Enabling this writes all of that to a volume, and any shipper
+configured against it moves that content off-cluster. That is a deliberate
+operator decision and the documentation must say so plainly.
+
+### Write path: the filesystem, not object storage
+
+The archiver writes bundles to a mounted directory using `os.MkdirAll` and
+`os.WriteFile`. It adds **no new dependency**, and the operator never learns
+what the underlying storage is.
+
+This matters because the feature is opt-in. The repository currently has no Go
+S3 client at all: model fetching is done by init containers shelling
+`curl --aws-sigv4` against `${AWS_ENDPOINT_URL}`
+(`internal/controller/model_storage.go`). Making the operator speak S3 would tax
+every user who never enables archival.
+
+The cost of a client was measured rather than estimated. The
+`foreman-operator` binary currently builds 94 third-party module roots.
+`minio-go` adds 13 of them: `dustin/go-humanize`,
+`klauspost/{compress,cpuid,crc32}`, `minio/{crc64nvme,md5-simd,minio-go}`,
+`philhofer/fwd`, `rs/xid`, `tinylib/msgp`, `zeebo/xxh3`,
+`golang.org/x/crypto` and `gopkg.in/ini.v1`. That is roughly a 14% increase in
+module roots, mostly small checksum and compression utilities. It is a real but
+modest tax, and it is not the deciding factor on its own.
+
+The deciding factors are that the filesystem path costs nothing, works with any
+backend the cluster offers, and collapses the test surface: no client
+interface, no fake, no environment-guarded integration test. Tests assert on
+real files under `t.TempDir()`.
+
+Three alternatives were considered and rejected:
+
+- **A Go S3 client in the operator.** Correct and single-moving-part, but taxes
+  every non-user, and requires a fake plus an integration test that CI cannot
+  run.
+- **Hand-rolling a single SigV4 PUT** over `net/http`, roughly 150 lines and no
+  dependency. Rejected because SigV4 is a well-known source of subtle bugs
+  (canonical request construction, payload hashing, clock skew, retries), and a
+  silently broken archiver loses exactly the data this project exists to
+  collect.
+- **Rook or Ceph, to obtain a shared filesystem.** Rejected as a much larger
+  commitment than the problem warrants: it means adopting a distributed storage
+  system with its own operator, CRDs and mon quorum across a four-node lab of
+  mixed architectures, in order to avoid one library. See "Storage reality"
+  below for why it also would not deliver the benefit that motivated it.
+
+### Storage reality, and what it rules out
+
+The target cluster offers two storage classes, both RWO and node-pinned, both
+with a `Delete` reclaim policy:
+
+| Class | Provisioner |
+|---|---|
+| `local-path` | `rancher.io/local-path` |
+| `microk8s-hostpath` (default) | `microk8s.io/hostpath` |
+
+There is no Rook, no Ceph, and **no RWX class at all**. Two consequences:
+
+- **Training jobs cannot mount the archive.** The appealing idea of pointing a
+  training job at the same volume requires RWX. With RWO node-pinning the
+  operator writes on one node and a training job on another cannot read it.
+  Bundles must be shipped, not shared.
+- **The archive directory is one `kubectl delete pvc` from gone**, because both
+  classes reclaim with `Delete`. This is the strongest argument for shipping
+  bundles off-cluster promptly rather than treating the volume as durable.
+
+### Shipping bundles off-node
+
+Getting bundles from the node to durable storage is deliberately **not the
+operator's job**. It is a separate, optional CronJob running `mc mirror` or
+`curl --aws-sigv4` from an image that already carries those tools, which is the
+same idiom the repository already uses for model fetching.
+
+Keeping this outside the operator means the storage decision stays reversible:
+MinIO today, something else later, or nothing at all for a user who only wants
+bundles on disk for debugging.
+
+The trade-off is honest and should be stated: there are two moving parts rather
+than one, and a window during which bundles exist only on a single node's disk
+under a `Delete` reclaim policy. Bundles are at most about 1 MB, so a shipper
+running every few minutes keeps that window small, but it is a real exposure
+that an in-operator S3 write would not have.
+
+## Failure handling
+
+Archive failure must never fail a task that otherwise succeeded. The harness
+remains the source of truth; the archive is a side effect.
+
+But non-blocking plus log-only means discovering six weeks later that there is no
+data. So failures are counted and surfaced:
+
+- a Prometheus counter, `foreman_archive_failures_total`, labelled by reason;
+- an event on the AgenticTask.
+
+That makes "archival has been failing for 15m" a single recording rule away, in
+a chart that already alerts on this shape, and turns silent data loss into a
+page.
+
+## Retention stays independent
+
+The audit sweep keeps its existing timer regardless of archival outcome.
+
+Gating deletion on successful archival is tempting and wrong: it couples a
+cleanup path to an external service, so a MinIO outage would fill etcd with
+ConfigMaps. The failure counter is how a broken archiver is discovered, not a
+quietly growing ConfigMap count.
+
+## Deliberate v1 limits
+
+Both of these are stated here so they are not later mistaken for bugs.
+
+**Truncated transcripts are archived as-is, with the flag preserved.**
+`transcriptCapBytes` is `(1 << 20) - (16 << 10)`, about 1.008 MB, essentially
+the ConfigMap ceiling. Over-budget transcripts are truncated **from the middle**,
+keeping the head and tail. That policy was chosen for a reviewer reading a run
+(`pkg/foreman/agent/transcript.go`), and for that purpose it is correct.
+
+For trajectory training it is adverse: on a long run the middle is precisely
+where the model recovers from a failing gate, which is the highest-value Tier 1
+pair. The consequence is that the longest and hardest runs are archived lossy.
+
+The archiver preserves the `truncated` flag, and the dataset builder must
+exclude truncated transcripts from trajectory training or use only their
+head/tail. Archiving a lossy record is acceptable; training on one as though it
+were complete is not, because the model would learn to jump from a failing gate
+straight to a fix with the intervening reasoning removed.
+
+**The agent does not archive.** v1 has exactly one write point, in the
+controller. This keeps the diff small and keeps S3 credentials off metal and
+edge nodes.
+
+## Follow-ups
+
+1. **Full untruncated transcripts.** Object storage has no 1 MB ceiling, so the
+   agent could archive the complete transcript while the ConfigMap remains the
+   truncated in-cluster view. This is the first follow-up and it is not
+   cosmetic: until it lands, the runs with the most recovery signal are the ones
+   archived lossy.
+2. **Backfill from git.** Merged issue-to-PR pairs are permanent and can be
+   harvested retroactively at any time, independent of this proposal.
+
+## Testing
+
+Tests write to a real directory under `t.TempDir()` and assert on the files
+that appear. There is no client interface, no fake, and no integration test
+that CI cannot run: the filesystem write path is fully exercisable in a unit
+test, which is most of the reason to prefer it.
+
+The tests must pin the behaviours that would otherwise silently no-op. Each must
+fail if the behaviour it names is deleted:
+
+- a disabled archiver writes **nothing** and creates no directory;
+- a failed write (unwritable directory, ENOSPC) does **not** fail the
+  reconcile, and **does** increment `foreman_archive_failures_total`;
+- a task with no transcript still archives its audit record;
+- a second `RecordTerminal` for the same task writes the **same** key;
+- a truncated transcript arrives with its `truncated` flag intact.
+
+A fake that records calls which nothing asserts on would reproduce the exact
+defect class this codebase has repeatedly shipped: a test that passes whether or
+not the code under test works.
+
+## Assumptions
+
+- The operator runs as a single replica, so an RWO volume is sufficient. If it
+  is ever scaled out, bundles would be split across replicas' volumes and the
+  shipper would need to run per-node.
+- A shipper and its destination are lab setup, not part of this proposal.
+  Neither exists today.
+- `ahazidgx2` reporting four allocatable GPUs is time-slicing rather than four
+  physical devices, since GB10 has no MIG. This does not affect archival and is
+  noted only because later training proposals depend on it.

--- a/docs/proposals/1654-foreman-trajectory-archival.md
+++ b/docs/proposals/1654-foreman-trajectory-archival.md
@@ -1,6 +1,7 @@
 # Foreman trajectory archival
 
-**Status:** proposed
+**Status:** Implemented. This document has been reconciled against what shipped;
+the sections below marked "as built" record design that moved during review.
 **Issue:** #1654
 **Scope:** sub-project 1 of 4 in the lab model-training effort. This proposal
 covers durable capture only. Dataset building, training, and A/B evaluation are
@@ -116,6 +117,61 @@ builder would later have to dedupe.
 Both objects originate as ConfigMaps, so a bundle is bounded at roughly 1 MB by
 construction. No multipart, no streaming, no chunking: a plain PUT is the entire
 write path.
+
+## As built: what moved during implementation
+
+Five review rounds changed the design in ways this document originally did not
+describe. They are recorded here rather than left as a gap between the proposal
+and the code.
+
+**Path containment is a real check, not a lexical one.** The original design
+implied a lexical containment test. That is insufficient: a symlink planted on
+an intermediate path segment let a write land outside the archive root and
+return success. The shipped writer resolves the root with `filepath.EvalSymlinks`,
+uses `filepath.Rel` rather than a string prefix, and **re-verifies containment
+after `MkdirAll`**, because a pre-create check cannot see a symlink planted on a
+segment it has not created yet. Containment runs before any bytes are written,
+so a refused bundle never receives content. This mirrors `resolveInside` in
+`pkg/foreman/agent/tools/workspace.go`; the duplication is deliberate for now,
+since that function sits in the coder's live write path and lifting it into a
+shared helper is its own change.
+
+**The bundle key falls back to the task UID.** `RecordedAt` is only populated
+when `task.Status.FinishedAt` is non-nil, and an empty value made the key
+constant across retries, so the skip check made the first attempt win
+permanently. The key now falls back to `Task.UID`, and refuses when both are
+empty. Note the limit: a Kubernetes object UID is constant for an object's
+lifetime, so a re-run of the same task object under the fallback reuses its key.
+
+**`meta.json` is a completion sentinel.** `writeAll` writes it last, so its
+presence means the bundle finished. Without it, a directory created by a process
+that died between `MkdirAll` and the first write would be read as a finished
+bundle forever, losing that record on every subsequent reconcile. An incomplete
+directory is now removed and rewritten rather than skipped or refused: refusing
+would make the debris permanent, which is the same loss by another route. Only a
+**completed** bundle is immutable, and the sentinel is what distinguishes the two.
+
+**Key fields are validated.** An empty or `.`-cleaning `Repo` normalises to a
+`no-repo` segment, mirroring `no-issue`, so the repo portion is the slug verbatim
+or `no-repo` and a reader should expect variable depth. NUL bytes and an empty
+`Task.Name` are rejected at construction rather than failing later with an opaque
+`invalid argument`.
+
+**Archival runs on every terminal reconcile, not only the first.** `WriteBundle`
+skips a complete bundle, so the repeat costs one `stat` and gives a failed write
+a free retry. Gating it on the first terminal pass would turn a transient failure
+into permanent loss for that task.
+
+**Known residual.** An empty regular `meta.json`, produced by a torn write of
+the sentinel itself, passes the completion check but cannot be parsed. The window
+is a crash during the write of a small final file. Closing it means writing the
+sentinel atomically via temp-and-rename.
+
+**Layering.** `pkg/foreman/archive` takes no direct `k8s.io`, `sigs.k8s.io` or
+`internal/` import. A transitive check cannot hold: the package consumes
+`audit.Record`, and `pkg/foreman/audit` already imports controller-runtime, so
+roughly 170 Kubernetes packages arrive transitively regardless. The constraint
+that is enforced, and the one that matters, is on direct imports.
 
 ## Opt-in
 

--- a/docs/proposals/1654-foreman-trajectory-archival.md
+++ b/docs/proposals/1654-foreman-trajectory-archival.md
@@ -190,6 +190,22 @@ byte-indistinguishable from a fleet of deterministic runs. Fixed at the root, in
 the watcher, beside the three existing lifts; `audit.Record.TranscriptRef`, empty
 since the field was introduced, is repaired as a side effect.
 
+**That silence returns under agent version skew, and it is not fixed here.** The
+`transcriptRef` lift ships in `foreman-agent`; the archiver that reads it ships
+in `foreman-operator`. Metal agents in this fleet are updated out of band from
+the chart, so a new operator running against older agents is a normal state, not
+an edge case. Those agents never populate `status.transcriptRef`, so the
+archiver enters neither the `transcript_read` nor the `transcript_empty` branch:
+every bundle records `hasTranscript: false` and `foreman_archive_failures_total`
+stays flat. That is exactly the indistinguishable-from-deterministic failure the
+`transcript_empty` branch was added to prevent, reached by a route no counter
+covers, because an absent reference is the deterministic-run path this design
+deliberately made silent. Archival therefore requires agents at the operator's
+version to capture transcripts at all, and the chart's `foreman.archive` block
+says so where an operator enabling it will read. Detecting skew from the
+operator side needs an agent version on the AgenticTask or the FleetNode that
+the archiver can compare against; that is a follow-up, not a v1 behaviour.
+
 **The node reservation is released before archival, not after.** Archival writes
 to a mounted volume and takes no timeout, and the AgenticTask controller runs
 with concurrency 1. An archive stalled on a hung mount ahead of the release would

--- a/internal/foreman/controller/agentictask_archive_test.go
+++ b/internal/foreman/controller/agentictask_archive_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
+	"github.com/defilantech/llmkube/pkg/foreman/archive"
+	"github.com/defilantech/llmkube/pkg/foreman/audit"
+)
+
+// TestArchiveTerminalTask_DisabledWritesNothing pins the opt-in: an empty
+// ArchiveDir must do nothing at all, not "write somewhere harmless".
+//
+// The assertion runs against the process working directory because that is
+// where a missing guard would actually put the bundle: archive.BundleDir
+// resolves its root with filepath.Abs, and filepath.Abs("") is the working
+// directory. Asserting on a temp dir that was never handed to the reconciler
+// would pass whether or not the guard exists. t.Chdir therefore does double
+// duty here, giving the test something real to observe and keeping a
+// regression from scattering bundles through the source tree.
+func TestArchiveTerminalTask_DisabledWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+
+	task := terminalTask()
+	r := &AgenticTaskReconciler{Client: fakeClientWithTask(t, task), ArchiveDir: ""}
+	r.archiveTerminalTask(context.Background(), task, logr.Discard())
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("disabled archiver created %d entries, want 0", len(entries))
+	}
+}
+
+// TestArchiveTerminalTask_WritesABundle is the happy path: a terminal task
+// with archival enabled lands one bundle at the record's key.
+//
+// The repo/issue path check is a fixture guard. audit.BuildRecord reads
+// Spec.Payload.Repo and Spec.Payload.Issue, so a fixture that set those
+// anywhere else would archive every task under "no-repo/no-issue" and the
+// layout would be asserted against a path production never emits.
+func TestArchiveTerminalTask_WritesABundle(t *testing.T) {
+	root := t.TempDir()
+	task := terminalTask()
+	r := &AgenticTaskReconciler{Client: fakeClientWithTask(t, task), ArchiveDir: root}
+	r.archiveTerminalTask(context.Background(), task, logr.Discard())
+
+	rec := audit.BuildRecord(task, nil)
+	dir, err := archive.BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "audit.json")); err != nil {
+		t.Errorf("audit.json not written: %v", err)
+	}
+	if want := filepath.Join("defilantech", "LLMKube", "1602"); !strings.Contains(dir, want) {
+		t.Errorf("bundle dir %q does not contain %q; the task's repo and issue did not reach the record", dir, want)
+	}
+}
+
+// TestArchiveTerminalTask_WritesTranscriptFromConfigMap pins the ConfigMap
+// contract: Status.TranscriptRef names a ConfigMap in the task's namespace and
+// the transcript bytes live under the "transcript.json" data key. Reading any
+// other key yields an empty transcript, which WriteBundle silently declines to
+// write, so the loss would be invisible without this test.
+func TestArchiveTerminalTask_WritesTranscriptFromConfigMap(t *testing.T) {
+	root := t.TempDir()
+	task := terminalTask()
+	task.Status.TranscriptRef = "foreman-transcript-archive-me"
+	want := `{"turns":[{"role":"user","content":"fix it"}]}`
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: task.Status.TranscriptRef, Namespace: task.Namespace},
+		Data:       map[string]string{"transcript.json": want},
+	}
+	r := &AgenticTaskReconciler{Client: fakeClientWithTask(t, task, cm), ArchiveDir: root}
+	r.archiveTerminalTask(context.Background(), task, logr.Discard())
+
+	rec := audit.BuildRecord(task, nil)
+	dir, err := archive.BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "transcript.json"))
+	if err != nil {
+		t.Fatalf("transcript.json not written: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("transcript.json = %q, want %q", string(got), want)
+	}
+}
+
+// TestArchiveTerminalTask_MissingTranscriptStillArchives: a deterministic run
+// writes no transcript and a transcript ConfigMap can be reaped before this
+// runs. Neither is a reason to drop the compliance record, and both are
+// counted so a broken transcript path is visible rather than silent.
+func TestArchiveTerminalTask_MissingTranscriptStillArchives(t *testing.T) {
+	root := t.TempDir()
+	task := terminalTask()
+	task.Status.TranscriptRef = "cm-that-does-not-exist"
+	before := archiveFailureCount(t, "transcript_read")
+
+	r := &AgenticTaskReconciler{Client: fakeClientWithTask(t, task), ArchiveDir: root}
+	r.archiveTerminalTask(context.Background(), task, logr.Discard())
+
+	rec := audit.BuildRecord(task, nil)
+	dir, err := archive.BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "audit.json")); err != nil {
+		t.Errorf("a task whose transcript is gone must still archive its record: %v", err)
+	}
+	if got := archiveFailureCount(t, "transcript_read"); got <= before {
+		t.Errorf("foreman_archive_failures_total{reason=\"transcript_read\"} = %v, want an increment after an unreadable transcript", got)
+	}
+}
+
+// TestArchiveTerminalTask_FailureDoesNotPanicAndCounts: archival is a side
+// effect and must never change a verdict, so a write failure returns quietly.
+// The counter is then the only signal that a full or misconfigured volume is
+// dropping records, which makes counting the failure load-bearing rather than
+// decorative.
+func TestArchiveTerminalTask_FailureDoesNotPanicAndCounts(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "ro")
+	if err := os.Mkdir(root, 0o500); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	before := archiveFailureCount(t, "write")
+	task := terminalTask()
+	r := &AgenticTaskReconciler{Client: fakeClientWithTask(t, task), ArchiveDir: root}
+	r.archiveTerminalTask(context.Background(), task, logr.Discard())
+
+	if got := archiveFailureCount(t, "write"); got <= before {
+		t.Errorf("foreman_archive_failures_total = %v, want an increment after a failed write", got)
+	}
+}
+
+// TestArchiveTerminalTask_SecondCallDoesNotDuplicate: the archive call is
+// deliberately not gated on firstTerminal, so it runs on every terminal
+// reconcile. That is only safe because the bundle key is derived from the
+// record (FinishedAt, or the task UID) rather than from wall-clock time, so a
+// repeat call resolves to the same directory and WriteBundle skips it.
+func TestArchiveTerminalTask_SecondCallDoesNotDuplicate(t *testing.T) {
+	root := t.TempDir()
+	task := terminalTask()
+	r := &AgenticTaskReconciler{Client: fakeClientWithTask(t, task), ArchiveDir: root}
+	r.archiveTerminalTask(context.Background(), task, logr.Discard())
+	r.archiveTerminalTask(context.Background(), task, logr.Discard())
+
+	rec := audit.BuildRecord(task, nil)
+	dir, err := archive.BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	parent := filepath.Dir(dir)
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("two archive calls produced %d bundles, want 1", len(entries))
+	}
+}
+
+// --- archive test helpers ---
+
+// terminalTask returns a Succeeded AgenticTask carrying exactly the fields the
+// bundle key is built from.
+//
+// Repo and Issue live under Spec.Payload, not directly on Spec: BuildRecord
+// reads task.Spec.Payload.Repo and int(task.Spec.Payload.Issue). FinishedAt is
+// load-bearing for the same reason: BuildRecord sets RecordedAt only when
+// FinishedAt is non-nil, and RecordedAt is the timestamp half of the key. A
+// fixture missing either one still archives, but under a "no-repo/no-issue"
+// or UID-keyed path that production would not produce.
+func terminalTask() *foremanv1alpha1.AgenticTask {
+	finished := metav1.Date(2026, time.August, 23, 17, 4, 5, 0, time.UTC)
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "archive-me",
+			Namespace: "default",
+			UID:       types.UID("11111111-2222-3333-4444-555555555555"),
+		},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:  "defilantech/LLMKube",
+				Issue: int32(1602),
+			},
+		},
+	}
+	task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+	task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictGo
+	task.Status.FinishedAt = &finished
+	return task
+}
+
+// fakeClientWithTask builds a fake client holding the task plus any extra
+// objects a test needs (a transcript ConfigMap, say). corev1 is registered
+// because archiveTerminalTask reads the transcript ConfigMap through it.
+func fakeClientWithTask(
+	t *testing.T,
+	task *foremanv1alpha1.AgenticTask,
+	extra ...client.Object,
+) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := foremanv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add foreman scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	objs := append([]client.Object{task}, extra...)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+// archiveFailureCount reads the archive failure counter for one bounded
+// reason label.
+func archiveFailureCount(t *testing.T, reason string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(llmkubemetrics.ForemanArchiveFailuresTotal.WithLabelValues(reason))
+}

--- a/internal/foreman/controller/agentictask_archive_test.go
+++ b/internal/foreman/controller/agentictask_archive_test.go
@@ -34,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
@@ -53,6 +54,12 @@ import (
 // regression from scattering bundles through the source tree.
 func TestArchiveTerminalTask_DisabledWritesNothing(t *testing.T) {
 	root := t.TempDir()
+	// Safe only as a package-wide invariant: t.Chdir refuses to run in a test
+	// that has called t.Parallel, but it cannot see a t.Parallel anywhere ELSE
+	// in internal/foreman/controller. A parallel test added to this package
+	// would silently run against this directory, and envtest resolves its CRD
+	// paths relative to the working directory, so the failure would land far
+	// from its cause. Nothing in this package is parallel today; keep it so.
 	t.Chdir(root)
 
 	task := terminalTask()
@@ -316,12 +323,96 @@ func TestArchiveTerminalTask_TranscriptPresentButKeyMissingIsCounted(t *testing.
 	}
 }
 
+// TestReconcile_ReleasesTheNodeBeforeArchiving pins the ORDER of the two side
+// effects a terminal reconcile performs.
+//
+// Archival writes to a mounted volume and takes no timeout, so a hung NFS or
+// CSI mount blocks os.MkdirAll indefinitely. This controller runs with
+// concurrency 1 (SetupWithManager sets no MaxConcurrentReconciles), so an
+// archive stalled ahead of the release would hold the node reserved for a task
+// that has already finished AND wedge every other AgenticTask reconcile behind
+// it: one bad mount stops the fleet scheduling. Releasing first bounds the
+// damage to "no bundles are being written".
+//
+// The assertion is made from INSIDE the archive path rather than after
+// Reconcile returns, because both orders leave the same end state and an
+// after-the-fact check would pass either way. The interceptor fires on the
+// transcript ConfigMap read, which is the first thing archiveTerminalTask
+// does, and reads the FleetNode at that instant: the reservation must already
+// be gone.
+func TestReconcile_ReleasesTheNodeBeforeArchiving(t *testing.T) {
+	root := t.TempDir()
+	task := terminalTask()
+	// firstTerminal=false so audit.RecordTerminal is skipped and the only
+	// ConfigMap read on this path is the archiver's transcript fetch.
+	task.Annotations = map[string]string{audit.AuditedAnnotation: "true"}
+	task.Status.AssignedNode = archiveNodeName
+	task.Status.TranscriptRef = "foreman-transcript-archive-me"
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: task.Status.TranscriptRef, Namespace: task.Namespace},
+		Data:       map[string]string{transcriptDataKey: `{"turns":[]}`},
+	}
+	node := &foremanv1alpha1.FleetNode{
+		ObjectMeta: metav1.ObjectMeta{Name: archiveNodeName},
+		Status:     foremanv1alpha1.FleetNodeStatus{CurrentTask: taskKey(task)},
+	}
+
+	var (
+		archiveRan      bool
+		reservationSeen string
+	)
+	c := interceptor.NewClient(fakeClientWithTask(t, task, cm, node), interceptor.Funcs{
+		Get: func(
+			ctx context.Context,
+			inner client.WithWatch,
+			key client.ObjectKey,
+			obj client.Object,
+			opts ...client.GetOption,
+		) error {
+			if _, isCM := obj.(*corev1.ConfigMap); isCM {
+				archiveRan = true
+				var n foremanv1alpha1.FleetNode
+				if err := inner.Get(ctx, client.ObjectKey{Name: archiveNodeName}, &n); err != nil {
+					t.Errorf("reading the node from inside the archive path: %v", err)
+				}
+				reservationSeen = n.Status.CurrentTask
+			}
+			return inner.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &AgenticTaskReconciler{Client: c, ArchiveDir: root}
+	if _, err := r.Reconcile(context.Background(),
+		ctrl.Request{NamespacedName: client.ObjectKeyFromObject(task)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if !archiveRan {
+		t.Fatal("the archiver never read the transcript, so this test observed nothing")
+	}
+	if reservationSeen != "" {
+		t.Errorf("FleetNode.status.currentTask = %q when archival began, want empty: "+
+			"a stalled mount would hold the node reserved and wedge the controller", reservationSeen)
+	}
+
+	// The release must not have cost the bundle.
+	dir, err := archive.BundleDir(root, audit.BuildRecord(task, nil))
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "audit.json")); err != nil {
+		t.Errorf("releasing the node first must not skip the bundle: %v", err)
+	}
+}
+
 // --- archive test helpers ---
 
 const (
 	archiveAgentName     = "archive-coder"
 	archiveAgentModel    = "qwopus-fusion-27b"
 	archiveAgentEndpoint = "http://foundation-router.lan:4000/v1"
+	archiveNodeName      = "archive-coder-node"
 )
 
 // terminalTask returns a Succeeded AgenticTask carrying exactly the fields the
@@ -374,7 +465,7 @@ func fakeClientWithTask(
 	t *testing.T,
 	task *foremanv1alpha1.AgenticTask,
 	extra ...client.Object,
-) client.Client {
+) client.WithWatch {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := foremanv1alpha1.AddToScheme(scheme); err != nil {
@@ -387,7 +478,11 @@ func fakeClientWithTask(
 	if ref := task.Spec.AgentRef; ref != nil && ref.Name != "" {
 		objs = append(objs, archiveAgent(ref.Name, task.Namespace))
 	}
-	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&foremanv1alpha1.FleetNode{}).
+		Build()
 }
 
 // archiveAgent is the Agent terminalTask points at. It is a cloud-proxy agent

--- a/internal/foreman/controller/agentictask_archive_test.go
+++ b/internal/foreman/controller/agentictask_archive_test.go
@@ -99,6 +99,14 @@ func TestArchiveTerminalTask_WritesABundle(t *testing.T) {
 // the transcript bytes live under the "transcript.json" data key. Reading any
 // other key yields an empty transcript, which WriteBundle silently declines to
 // write, so the loss would be invisible without this test.
+//
+// The fixture sets Status.TranscriptRef by hand, which is safe ONLY because a
+// producer-side test now pins that the field is populated at all:
+// TestPatchTerminal_LiftsTranscriptRef in pkg/foreman/agent. Until #1654 it was
+// not, and this file's hand-set field was manufacturing an input production
+// never supplied -- green tests over a feature that archived zero transcripts.
+// The ConfigMap name here is transcriptName(task.Name), the same one
+// pkg/foreman/agent/transcript.go mints, so the two ends stay comparable.
 func TestArchiveTerminalTask_WritesTranscriptFromConfigMap(t *testing.T) {
 	root := t.TempDir()
 	task := terminalTask()

--- a/internal/foreman/controller/agentictask_archive_test.go
+++ b/internal/foreman/controller/agentictask_archive_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -196,7 +198,123 @@ func TestArchiveTerminalTask_SecondCallDoesNotDuplicate(t *testing.T) {
 	}
 }
 
+// TestReconcile_TerminalTaskArchivesOnALaterReconcile is the only test that
+// reaches archiveTerminalTask through Reconcile, and it exists because every
+// other test in this file calls the method directly: without it the call site
+// can be deleted, or moved inside the firstTerminal branch, and the whole
+// feature disconnects with every gate still green.
+//
+// The audited annotation is pre-stamped, so firstTerminal is false on this
+// pass. That is the reconcile a resync produces for an already-recorded task,
+// and it is exactly the pass a firstTerminal gate would skip. Asserting the
+// bundle exists after it pins both the call site and its placement outside
+// that branch, which is what makes a failed write retryable rather than
+// permanent data loss.
+func TestReconcile_TerminalTaskArchivesOnALaterReconcile(t *testing.T) {
+	root := t.TempDir()
+	task := terminalTask()
+	task.Annotations = map[string]string{audit.AuditedAnnotation: "true"}
+
+	r := &AgenticTaskReconciler{Client: fakeClientWithTask(t, task), ArchiveDir: root}
+	if _, err := r.Reconcile(context.Background(),
+		ctrl.Request{NamespacedName: client.ObjectKeyFromObject(task)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	rec := audit.BuildRecord(task, nil)
+	dir, err := archive.BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "audit.json")); err != nil {
+		t.Errorf("Reconcile did not archive a terminal task on a non-first terminal pass: %v", err)
+	}
+}
+
+// TestArchiveTerminalTask_RecordsResolvedAgent pins that the resolved Agent
+// reaches the bundle. Replacing audit.ResolveAgent with a literal nil is
+// otherwise invisible: the record still writes, the bundle still lands, and
+// only the agent block quietly disappears.
+//
+// The endpoint assertion is the point. record.go calls it "the
+// inference-provenance proof", and a bundle that cannot say which model at
+// which endpoint produced the run answers much less of what archival is for.
+func TestArchiveTerminalTask_RecordsResolvedAgent(t *testing.T) {
+	root := t.TempDir()
+	task := terminalTask()
+	r := &AgenticTaskReconciler{Client: fakeClientWithTask(t, task), ArchiveDir: root}
+	r.archiveTerminalTask(context.Background(), task, logr.Discard())
+
+	dir, err := archive.BundleDir(root, audit.BuildRecord(task, nil))
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "audit.json"))
+	if err != nil {
+		t.Fatalf("audit.json not written: %v", err)
+	}
+	var got audit.Record
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode audit.json: %v", err)
+	}
+	if got.Agent == nil {
+		t.Fatalf("audit.json carries no agent block; the resolved Agent never reached the record")
+	}
+	if got.Agent.Name != archiveAgentName {
+		t.Errorf("agent.name = %q, want %q", got.Agent.Name, archiveAgentName)
+	}
+	if got.Agent.Model != archiveAgentModel {
+		t.Errorf("agent.model = %q, want %q", got.Agent.Model, archiveAgentModel)
+	}
+	if got.Agent.Endpoint != archiveAgentEndpoint {
+		t.Errorf("agent.endpoint = %q, want %q; the bundle lost its inference-provenance proof",
+			got.Agent.Endpoint, archiveAgentEndpoint)
+	}
+}
+
+// TestArchiveTerminalTask_TranscriptPresentButKeyMissingIsCounted covers the
+// case between "no ConfigMap" and "a transcript": the ConfigMap resolves and
+// holds nothing under the key we read.
+//
+// Left uncounted this is the worst failure of the three, because it is the
+// only one with no signal at all. meta.json records hasTranscript:false, which
+// is exactly what a deterministic run that produced no transcript writes, so a
+// producer-side key rename would drop every transcript in the fleet and look
+// like normal operation.
+func TestArchiveTerminalTask_TranscriptPresentButKeyMissingIsCounted(t *testing.T) {
+	root := t.TempDir()
+	task := terminalTask()
+	task.Status.TranscriptRef = "foreman-transcript-archive-me"
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: task.Status.TranscriptRef, Namespace: task.Namespace},
+		Data:       map[string]string{"transcript": `{"turns":[]}`},
+	}
+	before := archiveFailureCount(t, "transcript_empty")
+
+	r := &AgenticTaskReconciler{Client: fakeClientWithTask(t, task, cm), ArchiveDir: root}
+	r.archiveTerminalTask(context.Background(), task, logr.Discard())
+
+	dir, err := archive.BundleDir(root, audit.BuildRecord(task, nil))
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "audit.json")); err != nil {
+		t.Errorf("a transcript ConfigMap missing its key must still archive the record: %v", err)
+	}
+	if got := archiveFailureCount(t, "transcript_empty"); got <= before {
+		t.Errorf("foreman_archive_failures_total{reason=\"transcript_empty\"} = %v, want an increment: "+
+			"a resolved ConfigMap with no transcript under %q is silent data loss otherwise",
+			got, "transcript.json")
+	}
+}
+
 // --- archive test helpers ---
+
+const (
+	archiveAgentName     = "archive-coder"
+	archiveAgentModel    = "qwopus-fusion-27b"
+	archiveAgentEndpoint = "http://foundation-router.lan:4000/v1"
+)
 
 // terminalTask returns a Succeeded AgenticTask carrying exactly the fields the
 // bundle key is built from.
@@ -207,6 +325,12 @@ func TestArchiveTerminalTask_SecondCallDoesNotDuplicate(t *testing.T) {
 // FinishedAt is non-nil, and RecordedAt is the timestamp half of the key. A
 // fixture missing either one still archives, but under a "no-repo/no-issue"
 // or UID-keyed path that production would not produce.
+//
+// The AgentRef is load-bearing too, though not for the path: without it
+// audit.ResolveAgent short-circuits to nil and the bundle carries no agent
+// block, so nothing would notice the resolution being dropped. See
+// TestArchiveTerminalTask_RecordsResolvedAgent. fakeClientWithTask seeds the
+// matching Agent.
 func terminalTask() *foremanv1alpha1.AgenticTask {
 	finished := metav1.Date(2026, time.August, 23, 17, 4, 5, 0, time.UTC)
 	task := &foremanv1alpha1.AgenticTask{
@@ -216,7 +340,8 @@ func terminalTask() *foremanv1alpha1.AgenticTask {
 			UID:       types.UID("11111111-2222-3333-4444-555555555555"),
 		},
 		Spec: foremanv1alpha1.AgenticTaskSpec{
-			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Kind:     foremanv1alpha1.AgenticTaskKindIssueFix,
+			AgentRef: &corev1.LocalObjectReference{Name: archiveAgentName},
 			Payload: foremanv1alpha1.AgenticTaskPayload{
 				Repo:  "defilantech/LLMKube",
 				Issue: int32(1602),
@@ -229,9 +354,14 @@ func terminalTask() *foremanv1alpha1.AgenticTask {
 	return task
 }
 
-// fakeClientWithTask builds a fake client holding the task plus any extra
-// objects a test needs (a transcript ConfigMap, say). corev1 is registered
-// because archiveTerminalTask reads the transcript ConfigMap through it.
+// fakeClientWithTask builds a fake client holding the task, the Agent its
+// AgentRef names, and any extra objects a test needs (a transcript ConfigMap,
+// say). corev1 is registered because archiveTerminalTask reads the transcript
+// ConfigMap through it.
+//
+// The Agent is seeded by default so the resolvable path, which is the
+// production-typical one, is what the tests exercise. A test that wants the
+// unresolvable path clears task.Spec.AgentRef before calling.
 func fakeClientWithTask(
 	t *testing.T,
 	task *foremanv1alpha1.AgenticTask,
@@ -246,7 +376,29 @@ func fakeClientWithTask(
 		t.Fatalf("add core scheme: %v", err)
 	}
 	objs := append([]client.Object{task}, extra...)
+	if ref := task.Spec.AgentRef; ref != nil && ref.Name != "" {
+		objs = append(objs, archiveAgent(ref.Name, task.Namespace))
+	}
 	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+// archiveAgent is the Agent terminalTask points at. It is a cloud-proxy agent
+// so ProviderConfig.BaseURL is populated: record.go calls that endpoint "the
+// inference-provenance proof", and for archival it is much of the point of
+// keeping a bundle at all.
+func archiveAgent(name, namespace string) *foremanv1alpha1.Agent {
+	return &foremanv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: foremanv1alpha1.AgentSpec{
+			Role:     foremanv1alpha1.AgentRoleCoder,
+			Model:    archiveAgentModel,
+			Provider: foremanv1alpha1.AgentProviderCloudProxy,
+			ProviderConfig: &foremanv1alpha1.ProviderConfig{
+				BaseURL: archiveAgentEndpoint,
+				Model:   archiveAgentModel,
+			},
+		},
+	}
 }
 
 // archiveFailureCount reads the archive failure counter for one bounded

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -1016,6 +1016,13 @@ func (r *AgenticTaskReconciler) fleetNodeEnqueues(ctx context.Context, obj clien
 	return requests
 }
 
+// transcriptDataKey is the ConfigMap data key the transcript is stored under.
+// It is the only key read, so a producer that renames it silently drops every
+// transcript in the fleet. That is why a ConfigMap which resolves but carries
+// nothing under this key is counted below rather than quietly recorded as a
+// run that produced no transcript.
+const transcriptDataKey = "transcript.json"
+
 // archiveTerminalTask writes one immutable bundle for a terminal task.
 //
 // Deliberately not gated on firstTerminal. WriteBundle skips a bundle that
@@ -1046,8 +1053,17 @@ func (r *AgenticTaskReconciler) archiveTerminalTask(
 			log.V(1).Info("archive: transcript not readable; archiving record only",
 				"transcriptRef", ref, "err", err.Error())
 			llmkubemetrics.RecordArchiveFailure("transcript_read")
+		} else if body := cm.Data[transcriptDataKey]; body == "" {
+			// The ConfigMap resolved but holds nothing we can read. Without
+			// this branch the bundle records hasTranscript:false, which is
+			// indistinguishable from a deterministic run that legitimately
+			// produced no transcript, so a producer-side key rename would
+			// drop every transcript in the fleet with no signal at all.
+			log.V(1).Info("archive: transcript configmap holds no transcript; archiving record only",
+				"transcriptRef", ref, "key", transcriptDataKey)
+			llmkubemetrics.RecordArchiveFailure("transcript_empty")
 		} else {
-			transcript = []byte(cm.Data["transcript.json"])
+			transcript = []byte(body)
 		}
 	}
 

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -145,14 +145,23 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				llmkubemetrics.RecordTaskOutcome(agent, kind, verdict, outcome, elapsedSec, turns)
 			}
 		}
-		r.archiveTerminalTask(ctx, &task, log)
 		// Release the node reservation so the scheduler can dispatch the next
 		// task there. Guarded on taskKey, so a node already reserved for a
 		// different task is untouched.
+		//
+		// This runs BEFORE archival, and the order is load-bearing. Archival
+		// writes to a mounted volume and takes no timeout: a hung NFS or CSI
+		// mount blocks os.MkdirAll indefinitely. This controller runs with
+		// concurrency 1, so an archive stalled ahead of the release would hold
+		// the node reserved for a task that has already finished AND wedge
+		// every other AgenticTask reconcile behind it. Releasing first bounds
+		// a stalled mount to "no bundles are being written" instead of "the
+		// fleet stops scheduling".
 		if err := r.clearNodeCurrentTask(ctx, task.Status.AssignedNode, taskKey(&task)); err != nil {
 			log.Error(err, "failed to release node reservation on terminal task",
 				"node", task.Status.AssignedNode, "task", task.Name)
 		}
+		r.archiveTerminalTask(ctx, &task, log)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +39,7 @@ import (
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	llmkubemetrics "github.com/defilantech/llmkube/internal/metrics"
+	"github.com/defilantech/llmkube/pkg/foreman/archive"
 	"github.com/defilantech/llmkube/pkg/foreman/audit"
 )
 
@@ -69,6 +72,10 @@ type AgenticTaskReconciler struct {
 	// AuditNamespace is where durable audit-record ConfigMaps are written.
 	// Empty means each record lands in its task's own namespace.
 	AuditNamespace string
+
+	// ArchiveDir is where terminal-task bundles are written. Empty disables
+	// archival entirely: no directory is created and no work is done.
+	ArchiveDir string
 }
 
 // requeueNoFit is the backoff when no FleetNode satisfies the task's
@@ -138,6 +145,7 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				llmkubemetrics.RecordTaskOutcome(agent, kind, verdict, outcome, elapsedSec, turns)
 			}
 		}
+		r.archiveTerminalTask(ctx, &task, log)
 		// Release the node reservation so the scheduler can dispatch the next
 		// task there. Guarded on taskKey, so a node already reserved for a
 		// different task is untouched.
@@ -1006,4 +1014,45 @@ func (r *AgenticTaskReconciler) fleetNodeEnqueues(ctx context.Context, obj clien
 		}
 	}
 	return requests
+}
+
+// archiveTerminalTask writes one immutable bundle for a terminal task.
+//
+// Deliberately not gated on firstTerminal. WriteBundle skips a bundle that
+// already exists, so calling this on every terminal reconcile costs one stat
+// and gives a failed write a free retry: a failure leaves no directory behind.
+// Gating on firstTerminal would turn a transient ENOSPC into permanent data
+// loss for that task.
+//
+// Every failure path is non-fatal and counted. Archival must never change a
+// verdict; the harness is the source of truth and this is a side effect.
+func (r *AgenticTaskReconciler) archiveTerminalTask(
+	ctx context.Context,
+	task *foremanv1alpha1.AgenticTask,
+	log logr.Logger,
+) {
+	if r.ArchiveDir == "" {
+		return
+	}
+	rec := audit.BuildRecord(task, audit.ResolveAgent(ctx, r.Client, task, log))
+
+	var transcript []byte
+	if ref := task.Status.TranscriptRef; ref != "" {
+		var cm corev1.ConfigMap
+		key := client.ObjectKey{Namespace: task.Namespace, Name: ref}
+		if err := r.Get(ctx, key, &cm); err != nil {
+			// A deterministic run writes no transcript, and a transcript can be
+			// collected before this runs. Neither is a reason to drop the record.
+			log.V(1).Info("archive: transcript not readable; archiving record only",
+				"transcriptRef", ref, "err", err.Error())
+			llmkubemetrics.RecordArchiveFailure("transcript_read")
+		} else {
+			transcript = []byte(cm.Data["transcript.json"])
+		}
+	}
+
+	if err := archive.WriteBundle(r.ArchiveDir, rec, transcript); err != nil {
+		log.Error(err, "archive: failed to write bundle (continuing)", "task", task.Name)
+		llmkubemetrics.RecordArchiveFailure("write")
+	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -333,6 +333,18 @@ var (
 		},
 		[]string{"outcome"},
 	)
+
+	// ForemanArchiveFailuresTotal counts bundles that could not be written.
+	// Archival is deliberately non-fatal, so this counter is the only signal
+	// that it is broken: without it, a misconfigured or full volume looks
+	// exactly like a cluster that has had no terminal tasks.
+	ForemanArchiveFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "foreman_archive_failures_total",
+			Help: "Total task-archive bundles that failed to write, by reason.",
+		},
+		[]string{"reason"},
+	)
 )
 
 // AllCollectors is every metric this operator registers. init() registers
@@ -370,6 +382,7 @@ var AllCollectors = []prometheus.Collector{
 	ForemanTaskDurationSeconds,
 	ForemanTaskTurns,
 	ForemanWorkloadCompletedTotal,
+	ForemanArchiveFailuresTotal,
 }
 
 func init() {
@@ -492,4 +505,11 @@ func RecordTaskOutcome(agent, kind, verdict, outcome string, elapsedSec float64,
 // terminal transition by the caller, which guards on phase change.
 func RecordWorkloadOutcome(outcome string) {
 	ForemanWorkloadCompletedTotal.WithLabelValues(outcome).Inc()
+}
+
+// RecordArchiveFailure counts one failed archive write. Reason is a bounded
+// classification (for example "transcript_read", "write"), never an error
+// string: error text is unbounded and would break cardinality.
+func RecordArchiveFailure(reason string) {
+	ForemanArchiveFailuresTotal.WithLabelValues(reason).Inc()
 }

--- a/pkg/foreman/agent/runtask.go
+++ b/pkg/foreman/agent/runtask.go
@@ -292,6 +292,26 @@ func stringField(extra map[string]any, key string) string {
 	return ""
 }
 
+// nestedStringField returns extra[key][field] as a string. It is the
+// accessor for the Extra values that are themselves small maps rather than
+// scalars: objRefAsMap stamps an ObjectReference under a key as a
+// map[string]any of kind/apiVersion/namespace/name, so stringField, which
+// only ever sees a scalar, returns "" for it.
+//
+// Every malformed shape yields "" rather than a panic: an absent key, an
+// explicit nil, a scalar where a map was expected, an absent field, or a
+// non-string field. That matters because the map arrives two ways -- built
+// in-process by objRefAsMap, and decoded from JSON after a Job hop, where
+// json.Unmarshal also produces map[string]any but any producer-side drift
+// shows up here as a wrong-shaped value rather than a type error.
+func nestedStringField(extra map[string]any, key, field string) string {
+	inner, ok := extra[key].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return stringField(inner, field)
+}
+
 // firstStringField returns the first non-empty string value among the
 // given keys.
 func firstStringField(extra map[string]any, keys ...string) string {

--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -675,6 +675,21 @@ func (w *AgenticTaskWatcher) patchTerminal(
 		// stamps "jobName" into Extra on every verdict path; the in-process
 		// path never sets it, so this stays empty there.
 		fresh.Status.JobName = stringField(res.Extra, "jobName")
+		// #1654: lift the transcript ConfigMap's NAME out of the Result
+		// envelope onto status. Every executor path that ran a model loop
+		// stamps the reference into Extra["transcriptRef"] as the map
+		// objRefAsMap builds (kind/apiVersion/namespace/name); nothing
+		// wrote status.transcriptRef, so the field had been empty since it
+		// was introduced and every consumer of it -- the audit record, and
+		// now the archiver -- saw a fleet that looked entirely
+		// deterministic. Status.TranscriptRef is a bare name resolved
+		// against the task's own namespace, so only "name" is lifted.
+		//
+		// A deterministic run writes no transcript and leaves the key
+		// absent, which correctly leaves the field empty; so does any
+		// malformed value, because nestedStringField refuses rather than
+		// panicking on a status-write path that must not take the run down.
+		fresh.Status.TranscriptRef = nestedStringField(res.Extra, "transcriptRef", "name")
 	}
 	raw, err := json.Marshal(res)
 	if err != nil {

--- a/pkg/foreman/agent/watcher_transcriptref_test.go
+++ b/pkg/foreman/agent/watcher_transcriptref_test.go
@@ -162,19 +162,22 @@ func TestPatchTerminal_LiftsTranscriptRefAfterJSONRoundTrip(t *testing.T) {
 // task never reaches a terminal phase at all.
 func TestPatchTerminal_TranscriptRefEmptyWhenAbsentOrMalformed(t *testing.T) {
 	cases := []struct {
-		name  string
+		// task is also the subtest name, so each case gets its own fake
+		// client and the six cannot share state.
+		task  string
+		why   string
 		extra map[string]any
 	}{
-		{"deterministic run: no key at all", map[string]any{"outcome": ""}},
-		{"explicit nil, as objRefAsMap returns for an unnamed ref", map[string]any{"transcriptRef": nil}},
-		{"flattened to a scalar", map[string]any{"transcriptRef": "foreman-transcript-code-x"}},
-		{"map with no name field", map[string]any{"transcriptRef": map[string]any{"kind": "ConfigMap"}}},
-		{"name is not a string", map[string]any{"transcriptRef": map[string]any{"name": 42}}},
-		{"nil Extra entirely", nil},
+		{"det-absent", "deterministic run: no key at all", map[string]any{"outcome": ""}},
+		{"det-nil", "explicit nil, as objRefAsMap returns for an unnamed ref", map[string]any{"transcriptRef": nil}},
+		{"det-scalar", "flattened to a scalar", map[string]any{"transcriptRef": "foreman-transcript-code-x"}},
+		{"det-nokey", "map with no name field", map[string]any{"transcriptRef": map[string]any{"kind": "ConfigMap"}}},
+		{"det-nonstring", "name is not a string", map[string]any{"transcriptRef": map[string]any{"name": 42}}},
+		{"det-noextra", "nil Extra entirely", nil},
 	}
-	for i, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			name := taskNameForCase(i)
+	for _, tc := range cases {
+		t.Run(tc.task, func(t *testing.T) {
+			name := tc.task
 			c := newRecoveryClient(t, pendingTask(name))
 			w := &AgenticTaskWatcher{Client: c, NodeName: "coder", Namespace: "default"}
 
@@ -186,14 +189,8 @@ func TestPatchTerminal_TranscriptRefEmptyWhenAbsentOrMalformed(t *testing.T) {
 				t.Fatalf("patchTerminal: %v", err)
 			}
 			if got := getTask(t, c, name).Status.TranscriptRef; got != "" {
-				t.Errorf("status.transcriptRef = %q, want empty", got)
+				t.Errorf("status.transcriptRef = %q, want empty (%s)", got, tc.why)
 			}
 		})
 	}
-}
-
-// taskNameForCase gives each subtest its own task so the fake clients cannot
-// share state.
-func taskNameForCase(i int) string {
-	return "det-" + string(rune('a'+i))
 }

--- a/pkg/foreman/agent/watcher_transcriptref_test.go
+++ b/pkg/foreman/agent/watcher_transcriptref_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// transcriptRefExtra returns the Result.Extra map a real run produces for a
+// task that wrote a transcript, by driving the actual producer chain rather
+// than by asserting a shape from memory.
+//
+// This is the whole point of the fixture. Status.TranscriptRef went unassigned
+// in production for its entire life, and the reason nothing caught it is that
+// the consumer-side tests hand-set the field, manufacturing an input no
+// producer supplies. So this helper calls WriteTranscript, which creates the
+// ConfigMap and returns the ObjectReference, then objRefAsMap, which is what
+// every executor path stamps into Extra["transcriptRef"]. If either end of
+// that chain changes shape -- a renamed key, a flattened reference, a
+// namespaced name -- these tests fail rather than continuing to pass against
+// a fixture that has drifted away from the code.
+func transcriptRefExtra(t *testing.T, c client.Client, task *foremanv1alpha1.AgenticTask) (map[string]any, string) {
+	t.Helper()
+	tref, err := WriteTranscript(context.Background(), c, task, &LoopResult{
+		Turns: 2,
+		Transcript: []oai.Message{
+			{Role: oai.RoleUser, Content: "fix the bug"},
+			{Role: oai.RoleAssistant, Content: "fixed it"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteTranscript: %v", err)
+	}
+	if tref.Name == "" {
+		t.Fatalf("WriteTranscript returned an unnamed reference; the fixture cannot prove anything")
+	}
+	return map[string]any{
+		"outcome":       "",
+		"branch":        "foreman/issue-1654",
+		"commitSHA":     "abc1234def5678",
+		"transcriptRef": objRefAsMap(tref),
+	}, tref.Name
+}
+
+// patchTerminal must lift the transcript ConfigMap's name out of the Result
+// envelope and onto AgenticTask.status.transcriptRef.
+//
+// Regression for defilantech/LLMKube#1654. The executor stamps the reference
+// into Result.Extra as an ObjectReference map; nothing lifted it, so
+// status.transcriptRef was empty on every task ever run. Both readers of the
+// field -- audit.BuildRecord and the terminal-task archiver -- take the empty
+// value as "this run wrote no transcript", which is exactly what a
+// deterministic run looks like. A fleet losing 100% of its transcripts was
+// therefore byte-indistinguishable from a fleet of deterministic runs.
+//
+// The assertion resolves the lifted name through the fake client the way the
+// archiver does, because a name that lands on status but does not resolve to
+// the ConfigMap is the same data loss one step later.
+func TestPatchTerminal_LiftsTranscriptRef(t *testing.T) {
+	c := newRecoveryClient(t, pendingTask("code-1654"))
+	w := &AgenticTaskWatcher{Client: c, NodeName: "coder", Namespace: "default"}
+
+	extra, wantName := transcriptRefExtra(t, c, pendingTask("code-1654"))
+	res := NewResult("issue-fix", foremanv1alpha1.AgenticTaskVerdictGo,
+		"fixed the bug", time.Second)
+	res.Extra = extra
+
+	if err := w.patchTerminal(context.Background(), pendingTask("code-1654"), res, nil); err != nil {
+		t.Fatalf("patchTerminal: %v", err)
+	}
+
+	got := getTask(t, c, "code-1654")
+	if got.Status.TranscriptRef != wantName {
+		t.Fatalf("status.transcriptRef = %q, want %q; the transcript reference never reached status, "+
+			"so every archived bundle records hasTranscript:false", got.Status.TranscriptRef, wantName)
+	}
+
+	// The archiver resolves the field as a bare name in the task's own
+	// namespace (agentictask_controller.go archiveTerminalTask). Lifting
+	// "namespace/name", or the ObjectReference's Kind, would satisfy the
+	// comparison above only if the fixture were hand-written; here it would
+	// still fail this Get.
+	var cm corev1.ConfigMap
+	key := client.ObjectKey{Namespace: got.Namespace, Name: got.Status.TranscriptRef}
+	if err := c.Get(context.Background(), key, &cm); err != nil {
+		t.Fatalf("status.transcriptRef %q does not resolve to a ConfigMap in %s: %v",
+			got.Status.TranscriptRef, got.Namespace, err)
+	}
+	if cm.Data[transcriptDataKey] == "" {
+		t.Errorf("the referenced ConfigMap holds nothing under %q", transcriptDataKey)
+	}
+}
+
+// The Job-mode executor carries Result.Extra through a JSON hop
+// (coderJobResultToResult seeds it from the in-pod envelope, which arrives
+// decoded), so the transcriptRef value the watcher sees there is
+// json.Unmarshal's map[string]any, not the one objRefAsMap built in this
+// process. The two are the same shape, and this pins that: a lift written
+// against a concrete corev1.ObjectReference type assertion would pass the
+// in-process test above and drop every Job-mode transcript.
+func TestPatchTerminal_LiftsTranscriptRefAfterJSONRoundTrip(t *testing.T) {
+	c := newRecoveryClient(t, pendingTask("code-1654-job"))
+	w := &AgenticTaskWatcher{Client: c, NodeName: "coder", Namespace: "default"}
+
+	extra, wantName := transcriptRefExtra(t, c, pendingTask("code-1654-job"))
+	raw, err := json.Marshal(extra)
+	if err != nil {
+		t.Fatalf("marshal extra: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal extra: %v", err)
+	}
+
+	res := NewResult("issue-fix", foremanv1alpha1.AgenticTaskVerdictGo,
+		"fixed in a Job", time.Second)
+	res.Extra = decoded
+
+	if err := w.patchTerminal(context.Background(), pendingTask("code-1654-job"), res, nil); err != nil {
+		t.Fatalf("patchTerminal: %v", err)
+	}
+
+	got := getTask(t, c, "code-1654-job")
+	if got.Status.TranscriptRef != wantName {
+		t.Fatalf("status.transcriptRef = %q, want %q after a JSON round-trip",
+			got.Status.TranscriptRef, wantName)
+	}
+}
+
+// A deterministic run writes no transcript ConfigMap, so objRefAsMap returns
+// nil and the key is absent. status.transcriptRef must stay empty rather than
+// naming a ConfigMap that does not exist, which the archiver would count as a
+// transcript_read failure on every deterministic task in the fleet.
+//
+// The malformed cases are here because Extra is a map[string]any that survives
+// a JSON hop: a producer-side change that flattens the reference to a string,
+// or emits an explicit null, must leave the field empty rather than panic on a
+// status-write path. A panic there takes down the watcher goroutine and the
+// task never reaches a terminal phase at all.
+func TestPatchTerminal_TranscriptRefEmptyWhenAbsentOrMalformed(t *testing.T) {
+	cases := []struct {
+		name  string
+		extra map[string]any
+	}{
+		{"deterministic run: no key at all", map[string]any{"outcome": ""}},
+		{"explicit nil, as objRefAsMap returns for an unnamed ref", map[string]any{"transcriptRef": nil}},
+		{"flattened to a scalar", map[string]any{"transcriptRef": "foreman-transcript-code-x"}},
+		{"map with no name field", map[string]any{"transcriptRef": map[string]any{"kind": "ConfigMap"}}},
+		{"name is not a string", map[string]any{"transcriptRef": map[string]any{"name": 42}}},
+		{"nil Extra entirely", nil},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name := taskNameForCase(i)
+			c := newRecoveryClient(t, pendingTask(name))
+			w := &AgenticTaskWatcher{Client: c, NodeName: "coder", Namespace: "default"}
+
+			res := NewResult("gate", foremanv1alpha1.AgenticTaskVerdictGo,
+				"deterministic", time.Second)
+			res.Extra = tc.extra
+
+			if err := w.patchTerminal(context.Background(), pendingTask(name), res, nil); err != nil {
+				t.Fatalf("patchTerminal: %v", err)
+			}
+			if got := getTask(t, c, name).Status.TranscriptRef; got != "" {
+				t.Errorf("status.transcriptRef = %q, want empty", got)
+			}
+		})
+	}
+}
+
+// taskNameForCase gives each subtest its own task so the fake clients cannot
+// share state.
+func taskNameForCase(i int) string {
+	return "det-" + string(rune('a'+i))
+}

--- a/pkg/foreman/archive/bundle.go
+++ b/pkg/foreman/archive/bundle.go
@@ -33,6 +33,11 @@ import (
 // a change a reader cannot handle transparently.
 const BundleSchemaVersion = "foreman.archive.v1"
 
+// metaFile is written last by writeAll, which makes its presence the sentinel
+// for a completed bundle. A directory without it is crash debris, not an
+// archive. Keep it last.
+const metaFile = "meta.json"
+
 // BundleMeta is meta.json. It carries only what the writer can know without
 // reaching outside its arguments, so the writer stays a pure function.
 type BundleMeta struct {
@@ -70,8 +75,12 @@ func BundleDir(root string, rec audit.Record) (string, error) {
 		issue = fmt.Sprintf("%d", rec.Issue)
 	}
 
+	// Clean, not a literal comparison: "", ".", "./", "./.", "a/.." and
+	// "./x/.." all name the same nothing, and any of them slipping past this
+	// would drop the repo level entirely and collide with each other under
+	// <root>/<issue>/<leaf>.
 	repo := rec.Repo
-	if repo == "" || repo == "." {
+	if filepath.Clean(repo) == "." {
 		repo = "no-repo"
 	}
 
@@ -104,12 +113,23 @@ func BundleDir(root string, rec audit.Record) (string, error) {
 // Kubernetes object UID is constant for the object's lifetime, so a re-run of
 // the same task object reuses the key and the first bundle stands.
 //
+// "Existing" means complete, not merely present. meta.json is written last, so
+// a directory without it is the debris of an interrupted write rather than a
+// bundle, and it is removed and rewritten. The alternative, refusing it, would
+// reproduce the exact failure this check was hardened against: the debris is
+// permanent, so every retry would fail on it and the record would be lost.
+// Nothing readable is discarded, because a bundle with no meta.json cannot be
+// read as one.
+//
 // A failed write removes the partial directory, so the next reconcile is not
 // suppressed by a half-written bundle that the skip check would mistake for a
 // finished one. A partial MkdirAll failure can leave empty parent directories
-// behind, but never the leaf, so the retry is not suppressed there either.
-// Whether that retry then succeeds depends on the cause: a permission error or
-// a full disk fails again. What is guaranteed is only that it is attempted.
+// behind, but never the leaf, so the retry is not suppressed there either. A
+// crash between MkdirAll and the last write, by SIGKILL, eviction or a node
+// reboot, gets no cleanup at all and does leave the leaf: that is the case the
+// meta.json sentinel covers. Whether the retry then succeeds depends on the
+// cause: a permission error or a full disk fails again. What is guaranteed is
+// only that it is attempted.
 func WriteBundle(root string, rec audit.Record, transcript []byte) error {
 	dir, err := BundleDir(root, rec)
 	if err != nil {
@@ -135,9 +155,18 @@ func WriteBundle(root string, rec audit.Record, transcript []byte) error {
 		if err := verifyContained(root, dir); err != nil {
 			return err
 		}
-		return nil
-	}
-	if !os.IsNotExist(err) {
+		complete, err := isComplete(dir)
+		if err != nil {
+			return err
+		}
+		if complete {
+			return nil
+		}
+		// Incomplete: crash debris. Clear it and write the bundle properly.
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("archive: remove incomplete bundle %q: %w", dir, err)
+		}
+	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("archive: stat bundle dir %q: %w", dir, err)
 	}
 
@@ -148,6 +177,14 @@ func WriteBundle(root string, rec audit.Record, transcript []byte) error {
 	// Re-check containment against the filesystem as it actually is, before any
 	// bytes are written: filepath.Join cleans lexically and cannot see a
 	// symlink planted on any segment of the path.
+	//
+	// Known and accepted: this check is path-based, so between it and writeAll
+	// another writer on the same mount could swap the leaf for a symlink. The
+	// archive root is a shared PVC or hostPath, so the window is real, but
+	// closing it needs openat2(RESOLVE_BENEATH) or an O_NOFOLLOW walk held open
+	// across every write, which is a larger change than this writer justifies
+	// and is not portable to the Metal agent's darwin path. It is recorded here
+	// so the next reader knows it was weighed rather than missed.
 	if err := verifyContained(root, dir); err != nil {
 		_ = os.RemoveAll(dir)
 		return err
@@ -160,6 +197,21 @@ func WriteBundle(root string, rec audit.Record, transcript []byte) error {
 		return err
 	}
 	return nil
+}
+
+// isComplete reports whether dir holds a finished bundle, which is to say a
+// regular meta.json. Anything else (an empty directory, an audit.json with no
+// meta.json, a meta.json that is a symlink or a directory) is the debris of an
+// interrupted write and must not be mistaken for an archived record.
+func isComplete(dir string) (bool, error) {
+	fi, err := os.Lstat(filepath.Join(dir, metaFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("archive: stat %s in %q: %w", metaFile, dir, err)
+	}
+	return fi.Mode().IsRegular(), nil
 }
 
 // resolveRoot returns root as an absolute, symlink-free path. A root that does
@@ -201,6 +253,14 @@ func verifyContained(root, dir string) error {
 // already be absolute. Every failure is a refusal, never a pass: filepath.Rel
 // yields "" on error, and "" would satisfy the ".." test below.
 func contained(resolvedRoot, path string) error {
+	// Layer the guard. resolveRoot and EvalSymlinks both yield "" alongside
+	// their errors, so if either error were ever dropped upstream this function
+	// would be handed "" and filepath.Rel(".", ".") would answer ".", nil: a
+	// containment check that passes everything. An empty or relative argument
+	// here means the caller does not actually know where the path is.
+	if !filepath.IsAbs(resolvedRoot) || !filepath.IsAbs(path) {
+		return fmt.Errorf("archive: containment needs absolute paths, got root %q and path %q", resolvedRoot, path)
+	}
 	rel, err := filepath.Rel(resolvedRoot, path)
 	if err != nil {
 		return fmt.Errorf("archive: cannot relate bundle path %q to root %q: %w", path, resolvedRoot, err)
@@ -245,7 +305,9 @@ func writeAll(dir string, rec audit.Record, transcript []byte) error {
 			return fmt.Errorf("archive: write %s: %w", p, err)
 		}
 	}
-	return writeJSON(filepath.Join(dir, "meta.json"), BundleMeta{
+	// meta.json last, always: WriteBundle reads its presence as the proof that
+	// this function ran to completion.
+	return writeJSON(filepath.Join(dir, metaFile), BundleMeta{
 		SchemaVersion: BundleSchemaVersion,
 		TaskName:      rec.Task.Name,
 		RecordedAt:    rec.RecordedAt,

--- a/pkg/foreman/archive/bundle.go
+++ b/pkg/foreman/archive/bundle.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package archive
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/defilantech/llmkube/pkg/foreman/audit"
+)
+
+// BundleSchemaVersion identifies the on-disk bundle layout. Bump it only for
+// a change a reader cannot handle transparently.
+const BundleSchemaVersion = "foreman.archive.v1"
+
+// BundleMeta is meta.json. It carries only what the writer can know without
+// reaching outside its arguments, so the writer stays a pure function.
+type BundleMeta struct {
+	SchemaVersion string `json:"schemaVersion"`
+	TaskName      string `json:"taskName"`
+	RecordedAt    string `json:"recordedAt"`
+	HasTranscript bool   `json:"hasTranscript"`
+}
+
+// BundleDir returns the directory a record's bundle belongs in.
+//
+// The layout is <root>/<repo>/<issue>/<taskName>-<recordedAt>. Repo keeps its
+// slash, so an owner/name slug occupies two levels and a prefix listing for one
+// repo works naturally. Colons are stripped from the timestamp because they are
+// awkward in paths on some tools and filesystems.
+//
+// Every segment is validated against path traversal. Record fields come from a
+// cluster object and an operator could set Repo to anything; a bundle must
+// never land outside root. This is the same class of defect as issue #1625,
+// where an unvalidated repo slug silently changed which base a branch was cut
+// from.
+func BundleDir(root string, rec audit.Record) (string, error) {
+	if filepath.IsAbs(rec.Repo) {
+		return "", fmt.Errorf("archive: repo %q must be relative", rec.Repo)
+	}
+	issue := "no-issue"
+	if rec.Issue != 0 {
+		issue = fmt.Sprintf("%d", rec.Issue)
+	}
+	stamp := strings.ReplaceAll(rec.RecordedAt, ":", "-")
+	rel := filepath.Join(rec.Repo, issue, rec.Task.Name+"-"+stamp)
+
+	dir := filepath.Join(root, rel)
+	// filepath.Join cleans, so a traversing segment shows up as a path that no
+	// longer sits under root. Compare with a trailing separator so /arch-evil
+	// does not pass a prefix test against /arch.
+	if !strings.HasPrefix(dir, filepath.Clean(root)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("archive: bundle path %q escapes root %q", dir, root)
+	}
+	return dir, nil
+}
+
+// WriteBundle writes audit.json, meta.json, and transcript.json (when
+// transcript is non-empty) into the record's bundle directory.
+//
+// An existing bundle is left untouched: bundles are immutable, and a retried
+// task writes a different bundle because its RecordedAt differs. A failed write
+// removes the partial directory so the next reconcile retries rather than
+// finding a half-written bundle and skipping it.
+func WriteBundle(root string, rec audit.Record, transcript []byte) error {
+	dir, err := BundleDir(root, rec)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(dir); err == nil {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("archive: create bundle dir: %w", err)
+	}
+
+	if err := writeAll(dir, rec, transcript); err != nil {
+		// Leave nothing behind: a partial bundle would look complete to the
+		// skip check above and the run would never be archived.
+		_ = os.RemoveAll(dir)
+		return err
+	}
+	return nil
+}
+
+func writeAll(dir string, rec audit.Record, transcript []byte) error {
+	if err := writeJSON(filepath.Join(dir, "audit.json"), rec); err != nil {
+		return err
+	}
+	if len(transcript) > 0 {
+		p := filepath.Join(dir, "transcript.json")
+		if err := os.WriteFile(p, transcript, 0o640); err != nil {
+			return fmt.Errorf("archive: write %s: %w", p, err)
+		}
+	}
+	return writeJSON(filepath.Join(dir, "meta.json"), BundleMeta{
+		SchemaVersion: BundleSchemaVersion,
+		TaskName:      rec.Task.Name,
+		RecordedAt:    rec.RecordedAt,
+		HasTranscript: len(transcript) > 0,
+	})
+}
+
+func writeJSON(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("archive: marshal %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, b, 0o640); err != nil {
+		return fmt.Errorf("archive: write %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/foreman/archive/bundle.go
+++ b/pkg/foreman/archive/bundle.go
@@ -3,8 +3,20 @@ Copyright 2025.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
+// Package archive writes durable task execution records as immutable on-disk
+// bundles for compliance and debugging. Each bundle is a directory containing
+// audit.json (the Record), transcript.json (optional), and meta.json.
 package archive
 
 import (
@@ -32,34 +44,71 @@ type BundleMeta struct {
 
 // BundleDir returns the directory a record's bundle belongs in.
 //
-// The layout is <root>/<repo>/<issue>/<taskName>-<recordedAt>. Repo keeps its
-// slash, so an owner/name slug occupies two levels and a prefix listing for one
-// repo works naturally. Colons are stripped from the timestamp because they are
-// awkward in paths on some tools and filesystems.
+// The layout is <root>/<repo>/<issue>/<taskName>-<recordedAt> (or
+// <taskName>-<taskUID> if RecordedAt is empty). Repo keeps its slash, so an
+// owner/name slug occupies two levels and a prefix listing for one repo works
+// naturally; an empty repo is normalized to "no-repo". Colons are stripped
+// from the timestamp because they are awkward in paths on some tools and
+// filesystems.
 //
-// Every segment is validated against path traversal. Record fields come from a
-// cluster object and an operator could set Repo to anything; a bundle must
-// never land outside root. This is the same class of defect as issue #1625,
-// where an unvalidated repo slug silently changed which base a branch was cut
-// from.
+// Every segment is validated against path traversal and symlink escape.
+// Record fields come from a cluster object and an operator could set Repo to
+// anything; a bundle must never land outside root. This is the same class of
+// defect as issue #1625, where an unvalidated repo slug silently changed which
+// base a branch was cut from.
 func BundleDir(root string, rec audit.Record) (string, error) {
+	if err := validateKey(rec); err != nil {
+		return "", err
+	}
+
 	if filepath.IsAbs(rec.Repo) {
 		return "", fmt.Errorf("archive: repo %q must be relative", rec.Repo)
 	}
+
 	issue := "no-issue"
 	if rec.Issue != 0 {
 		issue = fmt.Sprintf("%d", rec.Issue)
 	}
-	stamp := strings.ReplaceAll(rec.RecordedAt, ":", "-")
-	rel := filepath.Join(rec.Repo, issue, rec.Task.Name+"-"+stamp)
 
-	dir := filepath.Join(root, rel)
-	// filepath.Join cleans, so a traversing segment shows up as a path that no
-	// longer sits under root. Compare with a trailing separator so /arch-evil
-	// does not pass a prefix test against /arch.
-	if !strings.HasPrefix(dir, filepath.Clean(root)+string(os.PathSeparator)) {
-		return "", fmt.Errorf("archive: bundle path %q escapes root %q", dir, root)
+	repo := rec.Repo
+	if repo == "" || repo == "." {
+		repo = "no-repo"
 	}
+
+	timestamp := rec.RecordedAt
+	if timestamp == "" {
+		timestamp = rec.Task.UID
+	}
+	stamp := strings.ReplaceAll(timestamp, ":", "-")
+
+	rel := filepath.Join(repo, issue, rec.Task.Name+"-"+stamp)
+
+	// Resolve root to its canonical form. Use Abs which doesn't require the
+	// path to exist, then EvalSymlinks if it does to catch symlink escapes.
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("archive: abs root: %w", err)
+	}
+
+	resolvedRoot := absRoot
+	if _, err := os.Stat(absRoot); err == nil {
+		// Root exists, resolve symlinks.
+		resolvedRoot, err = filepath.EvalSymlinks(absRoot)
+		if err != nil {
+			return "", fmt.Errorf("archive: resolve root symlinks: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		// Stat failed for a reason other than not-exist.
+		return "", fmt.Errorf("archive: stat root: %w", err)
+	}
+
+	// Check containment using filepath.Rel instead of string prefix.
+	dir := filepath.Join(resolvedRoot, rel)
+	relPath, err := filepath.Rel(resolvedRoot, dir)
+	if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("archive: bundle path %q escapes root %q", dir, resolvedRoot)
+	}
+
 	return dir, nil
 }
 
@@ -67,17 +116,29 @@ func BundleDir(root string, rec audit.Record) (string, error) {
 // transcript is non-empty) into the record's bundle directory.
 //
 // An existing bundle is left untouched: bundles are immutable, and a retried
-// task writes a different bundle because its RecordedAt differs. A failed write
-// removes the partial directory so the next reconcile retries rather than
-// finding a half-written bundle and skipping it.
+// task writes a different bundle because its RecordedAt or UID differs. A
+// failed write removes the partial directory so the next reconcile retries
+// rather than finding a half-written bundle and skipping it. A partial
+// MkdirAll failure leaves orphaned directories, but the leaf is never created
+// and the retry still succeeds.
 func WriteBundle(root string, rec audit.Record, transcript []byte) error {
 	dir, err := BundleDir(root, rec)
 	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(dir); err == nil {
+
+	// Check if the bundle directory already exists and is a directory.
+	fi, err := os.Stat(dir)
+	if err == nil {
+		if !fi.IsDir() {
+			return fmt.Errorf("archive: bundle path %q is not a directory", dir)
+		}
 		return nil
 	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("archive: stat bundle dir: %w", err)
+	}
+
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("archive: create bundle dir: %w", err)
 	}
@@ -87,6 +148,47 @@ func WriteBundle(root string, rec audit.Record, transcript []byte) error {
 		// skip check above and the run would never be archived.
 		_ = os.RemoveAll(dir)
 		return err
+	}
+
+	// Post-create verification: ensure the directory we wrote to is still under root.
+	finalResolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		// Directory was created but verification failed; clean up.
+		_ = os.RemoveAll(dir)
+		return fmt.Errorf("archive: verify bundle containment: %w", err)
+	}
+
+	// Re-check containment of the final resolved path.
+	absRoot, _ := filepath.Abs(root)
+	resolvedRoot := absRoot
+	if _, err := os.Stat(absRoot); err == nil {
+		resolvedRoot, _ = filepath.EvalSymlinks(absRoot)
+	}
+
+	relPath, _ := filepath.Rel(resolvedRoot, finalResolved)
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+		// A symlink escape occurred post-create; clean up.
+		_ = os.RemoveAll(dir)
+		return fmt.Errorf("archive: bundle escaped root after creation at %q", finalResolved)
+	}
+
+	return nil
+}
+
+// validateKey checks for impossible or unsafe values in the record fields
+// that form the bundle path key.
+func validateKey(rec audit.Record) error {
+	if strings.ContainsRune(rec.Repo, '\x00') {
+		return fmt.Errorf("archive: repo contains NUL byte")
+	}
+	if strings.ContainsRune(rec.Task.Name, '\x00') {
+		return fmt.Errorf("archive: task name contains NUL byte")
+	}
+	if strings.ContainsRune(rec.RecordedAt, '\x00') {
+		return fmt.Errorf("archive: recordedAt contains NUL byte")
+	}
+	if rec.RecordedAt == "" && rec.Task.UID == "" {
+		return fmt.Errorf("archive: neither recordedAt nor task UID provided; no stable key")
 	}
 	return nil
 }

--- a/pkg/foreman/archive/bundle.go
+++ b/pkg/foreman/archive/bundle.go
@@ -75,72 +75,82 @@ func BundleDir(root string, rec audit.Record) (string, error) {
 		repo = "no-repo"
 	}
 
-	timestamp := rec.RecordedAt
-	if timestamp == "" {
-		timestamp = rec.Task.UID
+	stamp := rec.RecordedAt
+	if stamp == "" {
+		stamp = rec.Task.UID
 	}
-	stamp := strings.ReplaceAll(timestamp, ":", "-")
+	stamp = strings.ReplaceAll(stamp, ":", "-")
 
-	rel := filepath.Join(repo, issue, rec.Task.Name+"-"+stamp)
-
-	// Resolve root to its canonical form. Use Abs which doesn't require the
-	// path to exist, then EvalSymlinks if it does to catch symlink escapes.
-	absRoot, err := filepath.Abs(root)
+	resolvedRoot, err := resolveRoot(root)
 	if err != nil {
-		return "", fmt.Errorf("archive: abs root: %w", err)
+		return "", err
 	}
 
-	resolvedRoot := absRoot
-	if _, err := os.Stat(absRoot); err == nil {
-		// Root exists, resolve symlinks.
-		resolvedRoot, err = filepath.EvalSymlinks(absRoot)
-		if err != nil {
-			return "", fmt.Errorf("archive: resolve root symlinks: %w", err)
-		}
-	} else if !os.IsNotExist(err) {
-		// Stat failed for a reason other than not-exist.
-		return "", fmt.Errorf("archive: stat root: %w", err)
+	// filepath.Join cleans, so a traversing segment shows up as a path that no
+	// longer sits under root.
+	dir := filepath.Join(resolvedRoot, repo, issue, rec.Task.Name+"-"+stamp)
+	if err := contained(resolvedRoot, dir); err != nil {
+		return "", err
 	}
-
-	// Check containment using filepath.Rel instead of string prefix.
-	dir := filepath.Join(resolvedRoot, rel)
-	relPath, err := filepath.Rel(resolvedRoot, dir)
-	if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
-		return "", fmt.Errorf("archive: bundle path %q escapes root %q", dir, resolvedRoot)
-	}
-
 	return dir, nil
 }
 
 // WriteBundle writes audit.json, meta.json, and transcript.json (when
 // transcript is non-empty) into the record's bundle directory.
 //
-// An existing bundle is left untouched: bundles are immutable, and a retried
-// task writes a different bundle because its RecordedAt or UID differs. A
-// failed write removes the partial directory so the next reconcile retries
-// rather than finding a half-written bundle and skipping it. A partial
-// MkdirAll failure leaves orphaned directories, but the leaf is never created
-// and the retry still succeeds.
+// An existing bundle is left untouched, because bundles are immutable. When
+// RecordedAt is set a retried task writes a different bundle, since the
+// timestamp differs. When the key falls back to Task.UID it does not: a
+// Kubernetes object UID is constant for the object's lifetime, so a re-run of
+// the same task object reuses the key and the first bundle stands.
+//
+// A failed write removes the partial directory, so the next reconcile is not
+// suppressed by a half-written bundle that the skip check would mistake for a
+// finished one. A partial MkdirAll failure can leave empty parent directories
+// behind, but never the leaf, so the retry is not suppressed there either.
+// Whether that retry then succeeds depends on the cause: a permission error or
+// a full disk fails again. What is guaranteed is only that it is attempted.
 func WriteBundle(root string, rec audit.Record, transcript []byte) error {
 	dir, err := BundleDir(root, rec)
 	if err != nil {
 		return err
 	}
 
-	// Check if the bundle directory already exists and is a directory.
-	fi, err := os.Stat(dir)
+	// Lstat, not Stat. Stat resolves a symlink at the bundle path, so a symlink
+	// pointing at any existing directory would report IsDir and this function
+	// would return nil having archived nothing. That loss is permanent, because
+	// the same check fires identically on every retry, and silently dropping a
+	// compliance record is worse than the escape the check guards against.
+	fi, err := os.Lstat(dir)
 	if err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("archive: bundle path %q is a symlink, not a bundle directory", dir)
+		}
 		if !fi.IsDir() {
-			return fmt.Errorf("archive: bundle path %q is not a directory", dir)
+			return fmt.Errorf("archive: bundle path %q exists and is not a directory", dir)
+		}
+		// The leaf is a real directory, but an intermediate symlink can still
+		// have put it outside the root. Without this the containment check
+		// never runs at all for a path that already exists.
+		if err := verifyContained(root, dir); err != nil {
+			return err
 		}
 		return nil
 	}
 	if !os.IsNotExist(err) {
-		return fmt.Errorf("archive: stat bundle dir: %w", err)
+		return fmt.Errorf("archive: stat bundle dir %q: %w", dir, err)
 	}
 
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("archive: create bundle dir: %w", err)
+	}
+
+	// Re-check containment against the filesystem as it actually is, before any
+	// bytes are written: filepath.Join cleans lexically and cannot see a
+	// symlink planted on any segment of the path.
+	if err := verifyContained(root, dir); err != nil {
+		_ = os.RemoveAll(dir)
+		return err
 	}
 
 	if err := writeAll(dir, rec, transcript); err != nil {
@@ -149,29 +159,55 @@ func WriteBundle(root string, rec audit.Record, transcript []byte) error {
 		_ = os.RemoveAll(dir)
 		return err
 	}
+	return nil
+}
 
-	// Post-create verification: ensure the directory we wrote to is still under root.
-	finalResolved, err := filepath.EvalSymlinks(dir)
+// resolveRoot returns root as an absolute, symlink-free path. A root that does
+// not exist yet is returned absolute but unresolved, which is safe: nothing is
+// under it yet, and verifyContained resolves it again once it has been created.
+func resolveRoot(root string) (string, error) {
+	absRoot, err := filepath.Abs(root)
 	if err != nil {
-		// Directory was created but verification failed; clean up.
-		_ = os.RemoveAll(dir)
-		return fmt.Errorf("archive: verify bundle containment: %w", err)
+		return "", fmt.Errorf("archive: absolute path for root %q: %w", root, err)
 	}
-
-	// Re-check containment of the final resolved path.
-	absRoot, _ := filepath.Abs(root)
-	resolvedRoot := absRoot
-	if _, err := os.Stat(absRoot); err == nil {
-		resolvedRoot, _ = filepath.EvalSymlinks(absRoot)
+	if _, err := os.Lstat(absRoot); err != nil {
+		if os.IsNotExist(err) {
+			return absRoot, nil
+		}
+		return "", fmt.Errorf("archive: stat root %q: %w", absRoot, err)
 	}
-
-	relPath, _ := filepath.Rel(resolvedRoot, finalResolved)
-	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
-		// A symlink escape occurred post-create; clean up.
-		_ = os.RemoveAll(dir)
-		return fmt.Errorf("archive: bundle escaped root after creation at %q", finalResolved)
+	resolved, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return "", fmt.Errorf("archive: resolve root %q: %w", absRoot, err)
 	}
+	return resolved, nil
+}
 
+// verifyContained resolves dir through any symlinks on its segments and checks
+// that what it actually points at still sits under root.
+func verifyContained(root, dir string) error {
+	resolvedRoot, err := resolveRoot(root)
+	if err != nil {
+		return err
+	}
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return fmt.Errorf("archive: resolve bundle path %q: %w", dir, err)
+	}
+	return contained(resolvedRoot, resolvedDir)
+}
+
+// contained reports whether path sits inside resolvedRoot, both of which must
+// already be absolute. Every failure is a refusal, never a pass: filepath.Rel
+// yields "" on error, and "" would satisfy the ".." test below.
+func contained(resolvedRoot, path string) error {
+	rel, err := filepath.Rel(resolvedRoot, path)
+	if err != nil {
+		return fmt.Errorf("archive: cannot relate bundle path %q to root %q: %w", path, resolvedRoot, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("archive: bundle path %q escapes root %q", path, resolvedRoot)
+	}
 	return nil
 }
 
@@ -184,8 +220,14 @@ func validateKey(rec audit.Record) error {
 	if strings.ContainsRune(rec.Task.Name, '\x00') {
 		return fmt.Errorf("archive: task name contains NUL byte")
 	}
+	if strings.ContainsRune(rec.Task.UID, '\x00') {
+		return fmt.Errorf("archive: task UID contains NUL byte")
+	}
 	if strings.ContainsRune(rec.RecordedAt, '\x00') {
 		return fmt.Errorf("archive: recordedAt contains NUL byte")
+	}
+	if rec.Task.Name == "" {
+		return fmt.Errorf("archive: task name is empty; no stable key")
 	}
 	if rec.RecordedAt == "" && rec.Task.UID == "" {
 		return fmt.Errorf("archive: neither recordedAt nor task UID provided; no stable key")
@@ -211,6 +253,10 @@ func writeAll(dir string, rec audit.Record, transcript []byte) error {
 	})
 }
 
+// writeJSON writes v as two-space-indented JSON with no trailing newline. The
+// exact bytes are part of the bundle contract: bundles are immutable and may be
+// checksummed by an external compliance reader, so the encoding is pinned by
+// TestWriteBundle_JSONByteFormatIsPinned rather than left to the caller's taste.
 func writeJSON(path string, v any) error {
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {

--- a/pkg/foreman/archive/bundle_test.go
+++ b/pkg/foreman/archive/bundle_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package archive
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/audit"
+)
+
+func testRecord() audit.Record {
+	return audit.Record{
+		SchemaVersion: "foreman.audit.v1",
+		RecordedAt:    "2026-08-23T18:44:22Z",
+		Repo:          "defilantech/LLMKube",
+		Issue:         1602,
+		Verdict:       "GO",
+		Task:          audit.TaskRef{Name: "wl-1602-code", Kind: "issue-fix"},
+	}
+}
+
+func TestBundleDir_LayoutAndTimestampSanitising(t *testing.T) {
+	got, err := BundleDir("/arch", testRecord())
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	want := "/arch/defilantech/LLMKube/1602/wl-1602-code-2026-08-23T18-44-22Z"
+	if got != want {
+		t.Errorf("BundleDir = %q, want %q", got, want)
+	}
+}
+
+func TestBundleDir_ZeroIssueGetsAWellFormedKey(t *testing.T) {
+	rec := testRecord()
+	rec.Issue = 0
+	got, err := BundleDir("/arch", rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if !strings.Contains(got, "/no-issue/") {
+		t.Errorf("BundleDir = %q, want a no-issue segment", got)
+	}
+}
+
+func TestBundleDir_RefusesToEscapeTheRoot(t *testing.T) {
+	cases := map[string]string{
+		"traversing repo": "../../etc",
+		"absolute repo":   "/etc/passwd",
+		"dot-dot segment": "a/../../b",
+	}
+	for name, repo := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec := testRecord()
+			rec.Repo = repo
+			if _, err := BundleDir("/arch", rec); err == nil {
+				t.Errorf("BundleDir(repo=%q) = nil error, want a refusal", repo)
+			}
+		})
+	}
+}
+
+func TestWriteBundle_WritesAuditTranscriptAndMeta(t *testing.T) {
+	root := t.TempDir()
+	if err := WriteBundle(root, testRecord(), []byte(`{"truncated":true}`)); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	dir, err := BundleDir(root, testRecord())
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+
+	var rec audit.Record
+	readJSON(t, filepath.Join(dir, "audit.json"), &rec)
+	if rec.Task.Name != "wl-1602-code" || rec.Verdict != "GO" {
+		t.Errorf("audit.json round-trip = %+v, want the record we wrote", rec)
+	}
+
+	tr, err := os.ReadFile(filepath.Join(dir, "transcript.json"))
+	if err != nil {
+		t.Fatalf("read transcript.json: %v", err)
+	}
+	if string(tr) != `{"truncated":true}` {
+		t.Errorf("transcript.json = %q, want the bytes verbatim including the truncated flag", tr)
+	}
+
+	var meta BundleMeta
+	readJSON(t, filepath.Join(dir, "meta.json"), &meta)
+	if meta.SchemaVersion != BundleSchemaVersion || !meta.HasTranscript {
+		t.Errorf("meta.json = %+v, want schema %q and hasTranscript true", meta, BundleSchemaVersion)
+	}
+}
+
+func TestWriteBundle_NoTranscriptStillArchivesTheRecord(t *testing.T) {
+	root := t.TempDir()
+	if err := WriteBundle(root, testRecord(), nil); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	dir, _ := BundleDir(root, testRecord())
+	if _, err := os.Stat(filepath.Join(dir, "audit.json")); err != nil {
+		t.Errorf("audit.json missing for a transcript-less run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "transcript.json")); !os.IsNotExist(err) {
+		t.Errorf("transcript.json exists for a run that had none (err=%v)", err)
+	}
+	var meta BundleMeta
+	readJSON(t, filepath.Join(dir, "meta.json"), &meta)
+	if meta.HasTranscript {
+		t.Error("meta.hasTranscript = true for a run with no transcript")
+	}
+}
+
+func TestWriteBundle_ExistingBundleIsNotRewritten(t *testing.T) {
+	root := t.TempDir()
+	if err := WriteBundle(root, testRecord(), []byte(`original`)); err != nil {
+		t.Fatalf("first WriteBundle: %v", err)
+	}
+	if err := WriteBundle(root, testRecord(), []byte(`REPLACED`)); err != nil {
+		t.Fatalf("second WriteBundle: %v", err)
+	}
+	dir, _ := BundleDir(root, testRecord())
+	tr, err := os.ReadFile(filepath.Join(dir, "transcript.json"))
+	if err != nil {
+		t.Fatalf("read transcript.json: %v", err)
+	}
+	if string(tr) != "original" {
+		t.Errorf("transcript.json = %q, want the first write preserved; bundles are immutable", tr)
+	}
+}
+
+func TestWriteBundle_PartialWriteLeavesNoBundleSoItRetries(t *testing.T) {
+	root := t.TempDir()
+	rec := testRecord()
+	// json.Marshal refuses a non-finite float, so the bundle directory is
+	// created and then audit.json fails to write. That is the only path that
+	// exercises the cleanup, and without it a half-written bundle would look
+	// complete to the skip check and never be retried.
+	rec.ElapsedSec = math.Inf(1)
+
+	if err := WriteBundle(root, rec, nil); err == nil {
+		t.Fatal("WriteBundle with a non-finite ElapsedSec = nil error, want a marshal failure")
+	}
+	dir, err := BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if _, err := os.Stat(dir); err == nil {
+		t.Error("a failed write left a bundle directory behind, which would suppress the retry")
+	}
+}
+
+func TestWriteBundle_UnwritableRootFails(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "read-only")
+	if err := os.Mkdir(root, 0o500); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := WriteBundle(root, testRecord(), nil); err == nil {
+		t.Fatal("WriteBundle into an unwritable root = nil error, want a failure")
+	}
+}
+
+func readJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(b, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+}

--- a/pkg/foreman/archive/bundle_test.go
+++ b/pkg/foreman/archive/bundle_test.go
@@ -39,12 +39,16 @@ func testRecord() audit.Record {
 }
 
 func TestBundleDir_LayoutAndTimestampSanitising(t *testing.T) {
+	// "/arch" is absolute and does not exist, so Abs is a no-op and the root is
+	// never symlink-resolved. The full path can therefore be pinned exactly,
+	// which keeps the root prefix and the number of path levels under test.
 	got, err := BundleDir("/arch", testRecord())
 	if err != nil {
 		t.Fatalf("BundleDir: %v", err)
 	}
-	if !strings.HasSuffix(got, "defilantech/LLMKube/1602/wl-1602-code-2026-08-23T18-44-22Z") {
-		t.Errorf("BundleDir = %q, want suffix %q", got, "defilantech/LLMKube/1602/wl-1602-code-2026-08-23T18-44-22Z")
+	want := "/arch/defilantech/LLMKube/1602/wl-1602-code-2026-08-23T18-44-22Z"
+	if got != want {
+		t.Errorf("BundleDir = %q, want %q", got, want)
 	}
 }
 
@@ -123,27 +127,33 @@ func TestBundleDir_RejectsEmptyRecordedAtAndUID(t *testing.T) {
 	}
 }
 
-func TestBundleDir_RejectsNULInRepo(t *testing.T) {
+func TestBundleDir_RejectsEmptyTaskName(t *testing.T) {
 	rec := testRecord()
-	rec.Repo = "foo\x00bar"
+	rec.Task.Name = ""
 	if _, err := BundleDir("/arch", rec); err == nil {
-		t.Fatal("BundleDir with NUL in repo = nil error, want a rejection")
+		t.Fatal("BundleDir with an empty task name = nil error, want a rejection; " +
+			"the key would degenerate to a leading-dash segment such as -2026-08-23T18-44-22Z")
 	}
 }
 
-func TestBundleDir_RejectsNULInTaskName(t *testing.T) {
-	rec := testRecord()
-	rec.Task.Name = "task\x00name"
-	if _, err := BundleDir("/arch", rec); err == nil {
-		t.Fatal("BundleDir with NUL in task name = nil error, want a rejection")
+func TestBundleDir_RejectsNULInKeyFields(t *testing.T) {
+	// Every field that becomes a path component must be checked: a NUL reaches
+	// the syscall layer and fails there with an opaque "invalid argument",
+	// which is exactly what this validation exists to turn into a real message.
+	cases := map[string]func(*audit.Record){
+		"repo":       func(r *audit.Record) { r.Repo = "foo\x00bar" },
+		"task name":  func(r *audit.Record) { r.Task.Name = "task\x00name" },
+		"task UID":   func(r *audit.Record) { r.RecordedAt = ""; r.Task.UID = "uid\x00evil" },
+		"recordedAt": func(r *audit.Record) { r.RecordedAt = "2026-08-23T18:44:22\x00Z" },
 	}
-}
-
-func TestBundleDir_RejectsNULInRecordedAt(t *testing.T) {
-	rec := testRecord()
-	rec.RecordedAt = "2026-08-23T18:44:22\x00Z"
-	if _, err := BundleDir("/arch", rec); err == nil {
-		t.Fatal("BundleDir with NUL in recordedAt = nil error, want a rejection")
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec := testRecord()
+			mutate(&rec)
+			if _, err := BundleDir("/arch", rec); err == nil {
+				t.Errorf("BundleDir with a NUL byte in %s = nil error, want a rejection", name)
+			}
+		})
 	}
 }
 
@@ -187,12 +197,51 @@ func TestWriteBundle_WritesAuditTranscriptAndMeta(t *testing.T) {
 	}
 }
 
+func TestWriteBundle_JSONByteFormatIsPinned(t *testing.T) {
+	// The bundle is immutable and an external reader may checksum it, so the
+	// on-disk encoding is part of the contract, not an implementation detail.
+	// Without this, swapping MarshalIndent for Marshal survives the suite.
+	root := t.TempDir()
+	if err := WriteBundle(root, testRecord(), []byte(`{"x":1}`)); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	dir, err := BundleDir(root, testRecord())
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatalf("read meta.json: %v", err)
+	}
+	want := `{
+  "schemaVersion": "foreman.archive.v1",
+  "taskName": "wl-1602-code",
+  "recordedAt": "2026-08-23T18:44:22Z",
+  "hasTranscript": true
+}`
+	if string(got) != want {
+		t.Errorf("meta.json bytes =\n%s\n\nwant\n%s", got, want)
+	}
+
+	auditBytes, err := os.ReadFile(filepath.Join(dir, "audit.json"))
+	if err != nil {
+		t.Fatalf("read audit.json: %v", err)
+	}
+	if !strings.HasPrefix(string(auditBytes), "{\n  \"schemaVersion\": \"foreman.audit.v1\",\n") {
+		t.Errorf("audit.json is not two-space-indented JSON:\n%s", auditBytes)
+	}
+}
+
 func TestWriteBundle_NoTranscriptStillArchivesTheRecord(t *testing.T) {
 	root := t.TempDir()
 	if err := WriteBundle(root, testRecord(), nil); err != nil {
 		t.Fatalf("WriteBundle: %v", err)
 	}
-	dir, _ := BundleDir(root, testRecord())
+	dir, err := BundleDir(root, testRecord())
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
 	if _, err := os.Stat(filepath.Join(dir, "audit.json")); err != nil {
 		t.Errorf("audit.json missing for a transcript-less run: %v", err)
 	}
@@ -214,7 +263,10 @@ func TestWriteBundle_ExistingBundleIsNotRewritten(t *testing.T) {
 	if err := WriteBundle(root, testRecord(), []byte(`REPLACED`)); err != nil {
 		t.Fatalf("second WriteBundle: %v", err)
 	}
-	dir, _ := BundleDir(root, testRecord())
+	dir, err := BundleDir(root, testRecord())
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
 	tr, err := os.ReadFile(filepath.Join(dir, "transcript.json"))
 	if err != nil {
 		t.Fatalf("read transcript.json: %v", err)
@@ -227,7 +279,10 @@ func TestWriteBundle_ExistingBundleIsNotRewritten(t *testing.T) {
 func TestWriteBundle_StrayFileRefusesBundle(t *testing.T) {
 	root := t.TempDir()
 	rec := testRecord()
-	dir, _ := BundleDir(root, rec)
+	dir, err := BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(dir), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -276,26 +331,175 @@ func TestWriteBundle_FileModes(t *testing.T) {
 	if err := WriteBundle(root, testRecord(), []byte("test")); err != nil {
 		t.Fatalf("WriteBundle: %v", err)
 	}
-	dir, _ := BundleDir(root, testRecord())
+	dir, err := BundleDir(root, testRecord())
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
 
-	// Check directory mode.
-	dirInfo, _ := os.Stat(dir)
-	dirMode := dirInfo.Mode().Perm()
-	if dirMode != 0o750 {
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat bundle dir: %v", err)
+	}
+	if dirMode := dirInfo.Mode().Perm(); dirMode != 0o750 {
 		t.Errorf("bundle dir mode = %03o, want 0750", dirMode)
 	}
 
-	// Check file modes.
+	// This record was written with a transcript, so all three files must exist.
+	// Skipping a missing one would let a lost file pass as a clean loop.
 	for _, name := range []string{"audit.json", "transcript.json", "meta.json"} {
 		path := filepath.Join(dir, name)
 		fi, err := os.Stat(path)
 		if err != nil {
-			continue // transcript might not exist for some tests
+			t.Errorf("stat %s: %v", name, err)
+			continue
 		}
-		fileMode := fi.Mode().Perm()
-		if fileMode != 0o640 {
+		if fileMode := fi.Mode().Perm(); fileMode != 0o640 {
 			t.Errorf("%s mode = %03o, want 0640", name, fileMode)
 		}
+	}
+}
+
+// TestWriteBundle_RefusesASymlinkAtTheBundlePath covers the skip check reading
+// through a symlink. The symlink target is inside the archive root, so the
+// containment check alone cannot catch it: only refusing a non-directory at the
+// bundle path does. os.Stat here means WriteBundle returns nil having archived
+// nothing, permanently, because the retry hits the same check.
+func TestWriteBundle_RefusesASymlinkAtTheBundlePath(t *testing.T) {
+	root := t.TempDir()
+	rec := testRecord()
+	dir, err := BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+
+	decoy := filepath.Join(root, "decoy")
+	if err := os.Mkdir(decoy, 0o750); err != nil {
+		t.Fatalf("mkdir decoy: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dir), 0o750); err != nil {
+		t.Fatalf("mkdir bundle parents: %v", err)
+	}
+	mustSymlink(t, decoy, dir)
+
+	if err := WriteBundle(root, rec, []byte(`{"x":1}`)); err == nil {
+		t.Fatal("WriteBundle onto a symlinked bundle path = nil error; " +
+			"the record was silently dropped and every retry drops it too")
+	}
+	entries, err := os.ReadDir(decoy)
+	if err != nil {
+		t.Fatalf("read decoy: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("wrote %d entries through the symlink into %q, want none", len(entries), decoy)
+	}
+}
+
+// TestWriteBundle_RefusesASymlinkedSegmentHoldingTheBundle covers the shape the
+// leaf check cannot see: an intermediate segment is a symlink whose target
+// already holds the matching sub-path, so the leaf really is a directory and
+// the write is skipped without the containment check ever running.
+func TestWriteBundle_RefusesASymlinkedSegmentHoldingTheBundle(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	rec := testRecord()
+	dir, err := BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+
+	// Reproduce the bundle's sub-path under the symlink target, so a stat
+	// through the symlink reports a finished bundle.
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve root: %v", err)
+	}
+	rel, err := filepath.Rel(filepath.Join(resolvedRoot, "defilantech"), dir)
+	if err != nil {
+		t.Fatalf("rel: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(outside, rel), 0o750); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	mustSymlink(t, outside, filepath.Join(root, "defilantech"))
+
+	if err := WriteBundle(root, rec, []byte(`{"x":1}`)); err == nil {
+		t.Fatal("WriteBundle through a symlinked segment holding the bundle = nil error, want a refusal")
+	}
+	assertNoFilesUnder(t, outside)
+}
+
+// TestWriteBundle_RefusesASymlinkedSegment is the plain escape: an intermediate
+// symlink sends MkdirAll outside the archive root entirely.
+func TestWriteBundle_RefusesASymlinkedSegment(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	mustSymlink(t, outside, filepath.Join(root, "defilantech"))
+
+	if err := WriteBundle(root, testRecord(), []byte(`{"x":1}`)); err == nil {
+		t.Fatal("WriteBundle through a symlinked segment = nil error, want a refusal")
+	}
+	assertNoFilesUnder(t, outside)
+}
+
+// TestVerifyContained_RefusesAPathItCannotResolve pins the failure direction of
+// the containment verdict. filepath.EvalSymlinks and filepath.Rel both return a
+// value that passes a naive check when they fail (Rel returns ""), so
+// discarding their errors turns the security check of this file into a no-op.
+func TestVerifyContained_RefusesAPathItCannotResolve(t *testing.T) {
+	root := t.TempDir()
+	if err := verifyContained(root, filepath.Join(root, "never-created")); err == nil {
+		t.Fatal("verifyContained on a path it cannot resolve = nil error; " +
+			"a containment check that cannot answer must refuse, never pass")
+	}
+}
+
+// TestContained_RefusesWhenItCannotRelateThePaths forces the filepath.Rel
+// failure on its own. Rel yields "" alongside its error, and "" is neither ".."
+// nor ".."-prefixed, so discarding that error turns the escape test into a
+// guaranteed pass.
+func TestContained_RefusesWhenItCannotRelateThePaths(t *testing.T) {
+	if err := contained("/arch", "relative/path"); err == nil {
+		t.Fatal("contained on paths it cannot relate = nil error, want a refusal")
+	}
+}
+
+func TestVerifyContained_RefusesAnUnresolvableRoot(t *testing.T) {
+	base := t.TempDir()
+	loop := filepath.Join(base, "loop")
+	mustSymlink(t, loop, loop)
+
+	if err := verifyContained(loop, filepath.Join(loop, "bundle")); err == nil {
+		t.Fatal("verifyContained with an unresolvable root = nil error, want a refusal")
+	}
+}
+
+func mustSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		// Not a skip. These are the only regression tests for the symlink
+		// escape, and a silent skip reads exactly like a pass.
+		t.Fatalf("symlink %q -> %q: %v; this platform cannot run the symlink "+
+			"containment regression tests, which must not be mistaken for them passing", link, target, err)
+	}
+}
+
+func assertNoFilesUnder(t *testing.T, dir string) {
+	t.Helper()
+	var leaked []string
+	if err := filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			leaked = append(leaked, p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	if len(leaked) != 0 {
+		t.Errorf("files written outside the archive root: %v", leaked)
 	}
 }
 
@@ -307,31 +511,5 @@ func readJSON(t *testing.T, path string, v any) {
 	}
 	if err := json.Unmarshal(b, v); err != nil {
 		t.Fatalf("unmarshal %s: %v", path, err)
-	}
-}
-
-func TestWriteBundle_RefusesASymlinkedSegment(t *testing.T) {
-	root := t.TempDir()
-	outside := t.TempDir()
-
-	// The bundle path starts <root>/defilantech/LLMKube/... , so a symlink at
-	// the first segment sends MkdirAll outside the archive root entirely.
-	if err := os.Symlink(outside, filepath.Join(root, "defilantech")); err != nil {
-		t.Skipf("symlink creation failed: %v (platform limitation)", err)
-	}
-
-	if err := WriteBundle(root, testRecord(), []byte(`{"x":1}`)); err == nil {
-		t.Fatal("WriteBundle through a symlinked segment = nil error, want a refusal")
-	}
-
-	var leaked []string
-	_ = filepath.WalkDir(outside, func(p string, d os.DirEntry, err error) error {
-		if err == nil && !d.IsDir() {
-			leaked = append(leaked, p)
-		}
-		return nil
-	})
-	if len(leaked) != 0 {
-		t.Errorf("files written outside the archive root: %v", leaked)
 	}
 }

--- a/pkg/foreman/archive/bundle_test.go
+++ b/pkg/foreman/archive/bundle_test.go
@@ -3,6 +3,15 @@ Copyright 2025.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package archive
@@ -25,7 +34,7 @@ func testRecord() audit.Record {
 		Repo:          "defilantech/LLMKube",
 		Issue:         1602,
 		Verdict:       "GO",
-		Task:          audit.TaskRef{Name: "wl-1602-code", Kind: "issue-fix"},
+		Task:          audit.TaskRef{Name: "wl-1602-code", Kind: "issue-fix", UID: "task-123"},
 	}
 }
 
@@ -34,9 +43,8 @@ func TestBundleDir_LayoutAndTimestampSanitising(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BundleDir: %v", err)
 	}
-	want := "/arch/defilantech/LLMKube/1602/wl-1602-code-2026-08-23T18-44-22Z"
-	if got != want {
-		t.Errorf("BundleDir = %q, want %q", got, want)
+	if !strings.HasSuffix(got, "defilantech/LLMKube/1602/wl-1602-code-2026-08-23T18-44-22Z") {
+		t.Errorf("BundleDir = %q, want suffix %q", got, "defilantech/LLMKube/1602/wl-1602-code-2026-08-23T18-44-22Z")
 	}
 }
 
@@ -49,6 +57,30 @@ func TestBundleDir_ZeroIssueGetsAWellFormedKey(t *testing.T) {
 	}
 	if !strings.Contains(got, "/no-issue/") {
 		t.Errorf("BundleDir = %q, want a no-issue segment", got)
+	}
+}
+
+func TestBundleDir_EmptyRepoNormalizesToNoRepo(t *testing.T) {
+	rec := testRecord()
+	rec.Repo = ""
+	got, err := BundleDir("/arch", rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if !strings.Contains(got, "/no-repo/") {
+		t.Errorf("BundleDir with empty repo = %q, want /no-repo/ segment", got)
+	}
+}
+
+func TestBundleDir_DotRepoNormalizesToNoRepo(t *testing.T) {
+	rec := testRecord()
+	rec.Repo = "."
+	got, err := BundleDir("/arch", rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if !strings.Contains(got, "/no-repo/") {
+		t.Errorf("BundleDir with dot repo = %q, want /no-repo/ segment", got)
 	}
 }
 
@@ -66,6 +98,52 @@ func TestBundleDir_RefusesToEscapeTheRoot(t *testing.T) {
 				t.Errorf("BundleDir(repo=%q) = nil error, want a refusal", repo)
 			}
 		})
+	}
+}
+
+func TestBundleDir_EmptyRecordedAtFallsBackToUID(t *testing.T) {
+	rec := testRecord()
+	rec.RecordedAt = ""
+	rec.Task.UID = "stable-uid-123"
+	got, err := BundleDir("/arch", rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if !strings.Contains(got, "stable-uid-123") {
+		t.Errorf("BundleDir with empty RecordedAt = %q, want to contain UID", got)
+	}
+}
+
+func TestBundleDir_RejectsEmptyRecordedAtAndUID(t *testing.T) {
+	rec := testRecord()
+	rec.RecordedAt = ""
+	rec.Task.UID = ""
+	if _, err := BundleDir("/arch", rec); err == nil {
+		t.Fatal("BundleDir with no RecordedAt or UID = nil error, want a rejection")
+	}
+}
+
+func TestBundleDir_RejectsNULInRepo(t *testing.T) {
+	rec := testRecord()
+	rec.Repo = "foo\x00bar"
+	if _, err := BundleDir("/arch", rec); err == nil {
+		t.Fatal("BundleDir with NUL in repo = nil error, want a rejection")
+	}
+}
+
+func TestBundleDir_RejectsNULInTaskName(t *testing.T) {
+	rec := testRecord()
+	rec.Task.Name = "task\x00name"
+	if _, err := BundleDir("/arch", rec); err == nil {
+		t.Fatal("BundleDir with NUL in task name = nil error, want a rejection")
+	}
+}
+
+func TestBundleDir_RejectsNULInRecordedAt(t *testing.T) {
+	rec := testRecord()
+	rec.RecordedAt = "2026-08-23T18:44:22\x00Z"
+	if _, err := BundleDir("/arch", rec); err == nil {
+		t.Fatal("BundleDir with NUL in recordedAt = nil error, want a rejection")
 	}
 }
 
@@ -95,8 +173,17 @@ func TestWriteBundle_WritesAuditTranscriptAndMeta(t *testing.T) {
 
 	var meta BundleMeta
 	readJSON(t, filepath.Join(dir, "meta.json"), &meta)
-	if meta.SchemaVersion != BundleSchemaVersion || !meta.HasTranscript {
-		t.Errorf("meta.json = %+v, want schema %q and hasTranscript true", meta, BundleSchemaVersion)
+	if meta.SchemaVersion != "foreman.archive.v1" {
+		t.Errorf("meta.schemaVersion = %q, want literal \"foreman.archive.v1\"", meta.SchemaVersion)
+	}
+	if !meta.HasTranscript {
+		t.Error("meta.hasTranscript = false, want true")
+	}
+	if meta.TaskName != "wl-1602-code" {
+		t.Errorf("meta.taskName = %q, want wl-1602-code", meta.TaskName)
+	}
+	if meta.RecordedAt != "2026-08-23T18:44:22Z" {
+		t.Errorf("meta.recordedAt = %q, want 2026-08-23T18:44:22Z", meta.RecordedAt)
 	}
 }
 
@@ -137,6 +224,22 @@ func TestWriteBundle_ExistingBundleIsNotRewritten(t *testing.T) {
 	}
 }
 
+func TestWriteBundle_StrayFileRefusesBundle(t *testing.T) {
+	root := t.TempDir()
+	rec := testRecord()
+	dir, _ := BundleDir(root, rec)
+	if err := os.MkdirAll(filepath.Dir(dir), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(dir, []byte("stray"), 0o640); err != nil {
+		t.Fatalf("create stray file: %v", err)
+	}
+
+	if err := WriteBundle(root, rec, nil); err == nil {
+		t.Fatal("WriteBundle with stray regular file at path = nil error, want error")
+	}
+}
+
 func TestWriteBundle_PartialWriteLeavesNoBundleSoItRetries(t *testing.T) {
 	root := t.TempDir()
 	rec := testRecord()
@@ -165,6 +268,34 @@ func TestWriteBundle_UnwritableRootFails(t *testing.T) {
 	}
 	if err := WriteBundle(root, testRecord(), nil); err == nil {
 		t.Fatal("WriteBundle into an unwritable root = nil error, want a failure")
+	}
+}
+
+func TestWriteBundle_FileModes(t *testing.T) {
+	root := t.TempDir()
+	if err := WriteBundle(root, testRecord(), []byte("test")); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	dir, _ := BundleDir(root, testRecord())
+
+	// Check directory mode.
+	dirInfo, _ := os.Stat(dir)
+	dirMode := dirInfo.Mode().Perm()
+	if dirMode != 0o750 {
+		t.Errorf("bundle dir mode = %03o, want 0750", dirMode)
+	}
+
+	// Check file modes.
+	for _, name := range []string{"audit.json", "transcript.json", "meta.json"} {
+		path := filepath.Join(dir, name)
+		fi, err := os.Stat(path)
+		if err != nil {
+			continue // transcript might not exist for some tests
+		}
+		fileMode := fi.Mode().Perm()
+		if fileMode != 0o640 {
+			t.Errorf("%s mode = %03o, want 0640", name, fileMode)
+		}
 	}
 }
 

--- a/pkg/foreman/archive/bundle_test.go
+++ b/pkg/foreman/archive/bundle_test.go
@@ -64,27 +64,24 @@ func TestBundleDir_ZeroIssueGetsAWellFormedKey(t *testing.T) {
 	}
 }
 
-func TestBundleDir_EmptyRepoNormalizesToNoRepo(t *testing.T) {
-	rec := testRecord()
-	rec.Repo = ""
-	got, err := BundleDir("/arch", rec)
-	if err != nil {
-		t.Fatalf("BundleDir: %v", err)
-	}
-	if !strings.Contains(got, "/no-repo/") {
-		t.Errorf("BundleDir with empty repo = %q, want /no-repo/ segment", got)
-	}
-}
-
-func TestBundleDir_DotRepoNormalizesToNoRepo(t *testing.T) {
-	rec := testRecord()
-	rec.Repo = "."
-	got, err := BundleDir("/arch", rec)
-	if err != nil {
-		t.Fatalf("BundleDir: %v", err)
-	}
-	if !strings.Contains(got, "/no-repo/") {
-		t.Errorf("BundleDir with dot repo = %q, want /no-repo/ segment", got)
+func TestBundleDir_RepoThatNamesNothingNormalizesToNoRepo(t *testing.T) {
+	// Every one of these cleans to ".". A literal `repo == "" || repo == "."`
+	// lets the rest through, which drops the repo level entirely and lands the
+	// bundle at <root>/<issue>/<leaf>, where they all collide with each other.
+	repos := []string{"", ".", "./", "./.", "a/..", "./x/.."}
+	want := "/arch/no-repo/1602/wl-1602-code-2026-08-23T18-44-22Z"
+	for _, repo := range repos {
+		t.Run("repo="+repo, func(t *testing.T) {
+			rec := testRecord()
+			rec.Repo = repo
+			got, err := BundleDir("/arch", rec)
+			if err != nil {
+				t.Fatalf("BundleDir: %v", err)
+			}
+			if got != want {
+				t.Errorf("BundleDir(repo=%q) = %q, want %q", repo, got, want)
+			}
+		})
 	}
 }
 
@@ -469,8 +466,147 @@ func TestVerifyContained_RefusesAnUnresolvableRoot(t *testing.T) {
 	loop := filepath.Join(base, "loop")
 	mustSymlink(t, loop, loop)
 
-	if err := verifyContained(loop, filepath.Join(loop, "bundle")); err == nil {
+	// The bundle path given here resolves cleanly, so root resolution is the
+	// only thing that can fail. Passing a path under the loop instead would let
+	// this pass through the EvalSymlinks(dir) guard without ever reaching the
+	// root.
+	if err := verifyContained(loop, base); err == nil {
 		t.Fatal("verifyContained with an unresolvable root = nil error, want a refusal")
+	}
+}
+
+func TestResolveRoot_RefusesARootItCannotResolve(t *testing.T) {
+	base := t.TempDir()
+	loop := filepath.Join(base, "loop")
+	mustSymlink(t, loop, loop)
+
+	if _, err := resolveRoot(loop); err == nil {
+		t.Fatal("resolveRoot on a symlink loop = nil error; EvalSymlinks returns \"\" " +
+			"with its error, and \"\" as a root passes every containment test")
+	}
+}
+
+// TestContained_RefusesNonAbsolutePaths pins the layered guard. resolveRoot and
+// EvalSymlinks both hand back "" with their errors, so if either error were
+// dropped upstream this function would be asked to relate "" to "", which
+// filepath.Rel answers with ".", nil: containment would pass for everything.
+func TestContained_RefusesNonAbsolutePaths(t *testing.T) {
+	cases := map[string][2]string{
+		"both empty":    {"", ""},
+		"empty root":    {"", "/arch/bundle"},
+		"empty path":    {"/arch", ""},
+		"relative root": {"arch", "/arch/bundle"},
+	}
+	for name, pair := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := contained(pair[0], pair[1]); err == nil {
+				t.Errorf("contained(%q, %q) = nil error, want a refusal", pair[0], pair[1])
+			}
+		})
+	}
+}
+
+// TestWriteBundle_IncompleteDirectoryIsRewritten covers the failure mode of
+// Critical 1 reached without a symlink. A crash between MkdirAll and the last
+// write leaves a directory with no cleanup, and treating any directory as a
+// finished bundle drops the record on that reconcile and on every one after it.
+func TestWriteBundle_IncompleteDirectoryIsRewritten(t *testing.T) {
+	debris := map[string][]string{
+		"empty leaf":               nil,
+		"audit.json but no meta":   {"audit.json"},
+		"audit and transcript":     {"audit.json", "transcript.json"},
+		"meta.json is a directory": {"meta.json/"},
+	}
+	for name, files := range debris {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			rec := testRecord()
+			dir, err := BundleDir(root, rec)
+			if err != nil {
+				t.Fatalf("BundleDir: %v", err)
+			}
+			if err := os.MkdirAll(dir, 0o750); err != nil {
+				t.Fatalf("mkdir leaf: %v", err)
+			}
+			for _, f := range files {
+				if strings.HasSuffix(f, "/") {
+					if err := os.Mkdir(filepath.Join(dir, strings.TrimSuffix(f, "/")), 0o750); err != nil {
+						t.Fatalf("mkdir %s: %v", f, err)
+					}
+					continue
+				}
+				if err := os.WriteFile(filepath.Join(dir, f), []byte("debris"), 0o640); err != nil {
+					t.Fatalf("write %s: %v", f, err)
+				}
+			}
+
+			if err := WriteBundle(root, rec, []byte(`{"truncated":true}`)); err != nil {
+				t.Fatalf("WriteBundle over %s: %v", name, err)
+			}
+
+			var meta BundleMeta
+			readJSON(t, filepath.Join(dir, metaFile), &meta)
+			if meta.SchemaVersion != BundleSchemaVersion || !meta.HasTranscript {
+				t.Errorf("meta.json = %+v, want a completed bundle", meta)
+			}
+			tr, err := os.ReadFile(filepath.Join(dir, "transcript.json"))
+			if err != nil {
+				t.Fatalf("read transcript.json: %v", err)
+			}
+			if string(tr) != `{"truncated":true}` {
+				t.Errorf("transcript.json = %q, want the record we passed; the debris was not replaced", tr)
+			}
+		})
+	}
+}
+
+// TestWriteBundle_RepeatedReconcilesOverDebrisDoNotLoseTheRecord is the shape
+// the reviewer ran: three consecutive reconciles against a pre-created empty
+// leaf. All three returning nil means the record is gone for good.
+func TestWriteBundle_RepeatedReconcilesOverDebrisDoNotLoseTheRecord(t *testing.T) {
+	root := t.TempDir()
+	rec := testRecord()
+	dir, err := BundleDir(root, rec)
+	if err != nil {
+		t.Fatalf("BundleDir: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir leaf: %v", err)
+	}
+
+	for i := 1; i <= 3; i++ {
+		if err := WriteBundle(root, rec, []byte(`original`)); err != nil {
+			t.Fatalf("reconcile %d: %v", i, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, metaFile)); err != nil {
+		t.Fatalf("no bundle after three reconciles over an empty leaf: %v", err)
+	}
+	// The first reconcile completed the bundle; the two after it must respect
+	// immutability rather than rewriting it.
+	tr, err := os.ReadFile(filepath.Join(dir, "transcript.json"))
+	if err != nil {
+		t.Fatalf("read transcript.json: %v", err)
+	}
+	if string(tr) != "original" {
+		t.Errorf("transcript.json = %q, want the completed bundle left alone", tr)
+	}
+}
+
+// TestWriteAll_MetaIsWrittenLast pins the ordering the sentinel depends on. If
+// meta.json were written first, an interrupted write would leave a directory
+// that WriteBundle reads as a finished bundle, which is the whole defect.
+func TestWriteAll_MetaIsWrittenLast(t *testing.T) {
+	dir := t.TempDir()
+	rec := testRecord()
+	rec.ElapsedSec = math.Inf(1) // audit.json, the first write, fails to marshal
+
+	if err := writeAll(dir, rec, []byte(`{"x":1}`)); err == nil {
+		t.Fatal("writeAll with a non-finite ElapsedSec = nil error, want a marshal failure")
+	}
+	if _, err := os.Lstat(filepath.Join(dir, metaFile)); !os.IsNotExist(err) {
+		t.Errorf("%s exists after an interrupted writeAll (err=%v); it is the completion "+
+			"sentinel and must be written last", metaFile, err)
 	}
 }
 

--- a/pkg/foreman/archive/bundle_test.go
+++ b/pkg/foreman/archive/bundle_test.go
@@ -309,3 +309,29 @@ func readJSON(t *testing.T, path string, v any) {
 		t.Fatalf("unmarshal %s: %v", path, err)
 	}
 }
+
+func TestWriteBundle_RefusesASymlinkedSegment(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	// The bundle path starts <root>/defilantech/LLMKube/... , so a symlink at
+	// the first segment sends MkdirAll outside the archive root entirely.
+	if err := os.Symlink(outside, filepath.Join(root, "defilantech")); err != nil {
+		t.Skipf("symlink creation failed: %v (platform limitation)", err)
+	}
+
+	if err := WriteBundle(root, testRecord(), []byte(`{"x":1}`)); err == nil {
+		t.Fatal("WriteBundle through a symlinked segment = nil error, want a refusal")
+	}
+
+	var leaked []string
+	_ = filepath.WalkDir(outside, func(p string, d os.DirEntry, err error) error {
+		if err == nil && !d.IsDir() {
+			leaked = append(leaked, p)
+		}
+		return nil
+	})
+	if len(leaked) != 0 {
+		t.Errorf("files written outside the archive root: %v", leaked)
+	}
+}

--- a/pkg/foreman/audit/writer.go
+++ b/pkg/foreman/audit/writer.go
@@ -40,6 +40,28 @@ const (
 // AuditConfigMapName returns the ConfigMap name for a task's audit record.
 func AuditConfigMapName(taskName string) string { return auditNamePrefix + taskName }
 
+// ResolveAgent returns the task's Agent, or nil when there is no agentRef or
+// the object cannot be read. A missing Agent is not an error: the record is
+// written without the agent block rather than lost.
+func ResolveAgent(
+	ctx context.Context,
+	c client.Client,
+	task *foremanv1alpha1.AgenticTask,
+	log logr.Logger,
+) *foremanv1alpha1.Agent {
+	if task.Spec.AgentRef == nil || task.Spec.AgentRef.Name == "" {
+		return nil
+	}
+	var a foremanv1alpha1.Agent
+	key := client.ObjectKey{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
+	if err := c.Get(ctx, key, &a); err != nil {
+		log.Info("audit: agent not resolvable; recording without agent block",
+			"agent", task.Spec.AgentRef.Name, "err", err.Error())
+		return nil
+	}
+	return &a
+}
+
 // WriteRecord upserts a durable, NON-owner-ref'd ConfigMap holding rec, plus
 // emits the record as a single structured log line. The absence of an owner
 // reference is deliberate: the record must outlive the AgenticTask so it
@@ -111,17 +133,7 @@ func RecordTerminal(
 		ns = task.Namespace
 	}
 
-	var agent *foremanv1alpha1.Agent
-	if task.Spec.AgentRef != nil && task.Spec.AgentRef.Name != "" {
-		var a foremanv1alpha1.Agent
-		key := client.ObjectKey{Namespace: task.Namespace, Name: task.Spec.AgentRef.Name}
-		if err := c.Get(ctx, key, &a); err == nil {
-			agent = &a
-		} else {
-			log.Info("audit: agent not resolvable; recording without agent block",
-				"agent", task.Spec.AgentRef.Name, "err", err.Error())
-		}
-	}
+	agent := ResolveAgent(ctx, c, task, log)
 
 	rec := BuildRecord(task, agent)
 	if err := WriteRecord(ctx, c, ns, rec, log); err != nil {


### PR DESCRIPTION
## What

Opt-in archival of Foreman task data. When an AgenticTask reaches a terminal state, the operator writes its audit record and agent transcript to disk as an immutable bundle:

```
<archive-dir>/<repo>/<issue>/<taskName>-<recordedAt>/
  audit.json        # the audit.Record verbatim
  transcript.json   # when one exists
  meta.json         # completion sentinel
```

Off unless `--archive-dir` is set. A disabled install renders byte-identically to before: no flag, no volume, no mount, no directory, no API read, no metric series.

## Why

The data with the most signal has the shortest life, and nothing preserved it:

| Artifact | Lifetime | Contains |
|---|---|---|
| Transcript ConfigMap | deleted with its AgenticTask | the full trajectory: turns, tool calls, the gate output the coder saw |
| Audit ConfigMap | 7 days (`--audit-retention`) | verdict, gate/scope/issueAsk/reviewer outcomes, branch, commit SHA |
| Git | permanent | the final merged diff |

Git keeps the destination but not the journey. A merged diff cannot show that the first attempt failed `go vet`, what the coder did next, or why a reviewer demoted a GO.

Refs #1654. Design: `docs/proposals/1654-foreman-trajectory-archival.md`, committed here and reconciled against what shipped.

## How

`audit.RecordTerminal`'s call site is the only moment where the verdict is final, the record is fully populated, the transcript still resolves, and the git join keys are set. Archival hooks there, after the node reservation is released.

Decisions worth calling out, several of which came out of review rather than design:

- **Containment is symlink-aware, not lexical.** The root is resolved with `EvalSymlinks`, containment uses `filepath.Rel` rather than a string prefix, and it is **re-verified after `MkdirAll`** because a pre-create check cannot see a symlink planted on a segment it has not created yet. Containment runs before any bytes are written. Note this is *stronger* than `resolveInside` in `pkg/foreman/agent/tools`, which skips symlink resolution for paths that do not exist yet; unifying the two must go upward.
- **`meta.json` is a completion sentinel**, written last. A directory without it is debris from an interrupted write and is removed and rewritten, not skipped. Refusing would make the debris permanent, which is the same data loss by another route. Only a *completed* bundle is immutable.
- **The bundle key falls back to `Task.UID`** when `RecordedAt` is empty, which happens whenever `Status.FinishedAt` is nil. Without it the key is constant across retries and the first attempt wins permanently.
- **Archival runs on every terminal reconcile**, not only the first, so a failed write retries rather than being lost.
- **`Status.TranscriptRef` was never assigned anywhere in production.** One read, one test fixture, zero writes. `watcher.go` lifted `branch`, `commitSHA` and `jobName` out of the result envelope but not `transcriptRef`, so this feature would have archived zero transcripts silently, with both failure counters flat, indistinguishable from a fleet of deterministic runs. Fixed at the root; this also repairs `audit.Record.TranscriptRef`, empty in every audit record since the field was introduced.

## Testing

- `go test ./...` (minus `/e2e`, matching `make test`): green. Affected packages also green under `-race` and `-shuffle=on`.
- `golangci-lint run ./...`: 0 issues, natively and under `GOOS=linux`.
- `helm lint` clean; `helm unittest charts/foreman` 52/52.
- No new module dependencies; `go.mod` and `go.sum` untouched across all 17 commits.

Roughly 130 mutations were applied across four task reviews, nine fix rounds, and a whole-branch review. Several tests were found to pass whether or not the code worked and were rewritten to bite: an inert cleanup test, a tautological schema assertion, a `notMatchRegexRaw` assertion that passes unconditionally on a parsed manifest, and a disabled-case test that asserted on a directory the code never received.

## Known gaps, deliberately not fixed here

- **`coderJobResultToResult` drops `transcriptRef` on the `INCOMPLETE` and `ERROR` branches** (`executor_coderjob.go`), so Job-mode turn-exhausted runs still archive `hasTranscript: false`. Those are precisely the recovery trajectories this feature exists to capture. Pre-existing, producer-side, needs its own change.
- The `"transcriptRef"` Extra key is a hand-written literal in producer and consumer; renaming it at all seven producer sites leaves the package green. A shared constant would close it.
- An empty regular `meta.json` from a torn write of the sentinel itself passes the completion check but cannot be parsed. Closing it needs an atomic sentinel write.
- `archiveTerminalTask` is synchronous and untimed inside `Reconcile`. Releasing the node reservation first bounds the blast radius, but a stalled network mount still blocks that controller.
- `fsGroup: 65532` is hand-matched to the image's `USER`; a Dockerfile change silently restores the EACCES failure mode. Helm cannot read the image at render time.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

Assisted-by: Claude Code (implemented the four planned tasks and their fix rounds under per-task and whole-branch review; I reviewed the result and ran `make test` and `make lint` locally)
