### PR TITLE
fix(foreman): carry the in-pod result extras on every Job-mode branch

### DIFF
--- a/pkg/foreman/agent/executor_coderjob.go
+++ b/pkg/foreman/agent/executor_coderjob.go
@@ -327,14 +327,20 @@ func coderJobResultToResult(kind string, start time.Time, cjr CoderJobResult) *R
 		} else {
 			r.FailureReason = foremanv1alpha1.FailureMaxTurnsExhausted
 		}
-		r.Extra = map[string]any{
+		// jobExtra, not a fresh map: the in-pod run's extras must survive every
+		// terminal branch, not only GO and NO-GO (#1656). transcriptRef is the
+		// one that bites, since watcher.go lifts it onto status and the archiver
+		// reaches the transcript through it; dropping it is silent because an
+		// absent ref is also the legitimate deterministic-run shape. The
+		// supervisor keys below still win, so the forced outcome stands.
+		r.Extra = jobExtra(cjr, map[string]any{
 			"outcome":        "INCOMPLETE",
 			"intendedBranch": cjr.Branch,
 			"executionMode":  "Job",
 			"jobName":        cjr.JobName,
 			"namespace":      cjr.Namespace,
 			"logTail":        cjr.LogTail,
-		}
+		})
 		return r
 	default:
 		// "ERROR" or any unrecognized verdict: the Job failed before
@@ -346,14 +352,17 @@ func coderJobResultToResult(kind string, start time.Time, cjr CoderJobResult) *R
 		}
 		r := NewResult(kind, foremanv1alpha1.AgenticTaskVerdictNoGo, summary, time.Since(start))
 		r.FailureReason = foremanv1alpha1.FailureInfrastructureError
-		r.Extra = map[string]any{
+		// jobExtra for the same reason as the INCOMPLETE branch above: a Job
+		// that died after the model wrote its envelope still carries extras
+		// worth keeping, and the supervisor keys below still override them.
+		r.Extra = jobExtra(cjr, map[string]any{
 			"outcome":       "JOB-ERROR",
 			"executionMode": "Job",
 			"jobName":       cjr.JobName,
 			"namespace":     cjr.Namespace,
 			"reason":        cjr.FailureReason,
 			"logTail":       cjr.LogTail,
-		}
+		})
 		return r
 	}
 }

--- a/pkg/foreman/agent/executor_coderjob_envelope_test.go
+++ b/pkg/foreman/agent/executor_coderjob_envelope_test.go
@@ -127,3 +127,81 @@ func TestCoderJobResultToResult_PreservesPromotedOutcome(t *testing.T) {
 		}
 	})
 }
+
+// #1656: every terminal branch must carry the in-pod extras, not just the
+// two that already did. transcriptRef is the field that made this visible:
+// the operator archives a bundle per terminal task and reaches the
+// transcript through status.transcriptRef, which watcher.go lifts out of
+// Result.Extra. A branch that rebuilds Extra from scratch drops it, and the
+// loss is silent because an absent transcriptRef is also the legitimate
+// deterministic-run shape.
+func TestCoderJobResultToResult_CarriesResultExtraOnEveryBranch(t *testing.T) {
+	start := time.Now()
+
+	transcript := map[string]any{
+		"kind":       "ConfigMap",
+		"apiVersion": "v1",
+		"namespace":  "default",
+		"name":       "foreman-transcript-coder-1656",
+	}
+
+	cases := []struct {
+		name    string
+		verdict string
+	}{
+		{"GO", string(foremanv1alpha1.AgenticTaskVerdictGo)},
+		{"NO-GO", string(foremanv1alpha1.AgenticTaskVerdictNoGo)},
+		{"INCOMPLETE", string(foremanv1alpha1.AgenticTaskVerdictIncomplete)},
+		{"ERROR", "ERROR"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" carries transcriptRef", func(t *testing.T) {
+			cjr := CoderJobResult{
+				Verdict: tc.verdict,
+				JobName: "coder-job-1656",
+				ResultExtra: map[string]any{
+					"transcriptRef": transcript,
+					"turnCount":     42,
+				},
+			}
+			r := coderJobResultToResult("issue-fix", start, cjr)
+
+			ref, ok := r.Extra["transcriptRef"].(map[string]any)
+			if !ok {
+				t.Fatalf("transcriptRef dropped on the %s branch: Extra = %v", tc.name, r.Extra)
+			}
+			if ref["name"] != "foreman-transcript-coder-1656" {
+				t.Errorf("transcriptRef.name = %v, want the transcript ConfigMap name", ref["name"])
+			}
+			if r.Extra["turnCount"] != 42 {
+				t.Errorf("turnCount dropped on the %s branch: %v", tc.name, r.Extra["turnCount"])
+			}
+			// The supervisor's own stamps must still win over anything of the
+			// same name in ResultExtra.
+			if r.Extra["executionMode"] != "Job" || r.Extra["jobName"] != "coder-job-1656" {
+				t.Errorf("supervisor fields missing on the %s branch: %v", tc.name, r.Extra)
+			}
+		})
+	}
+
+	// Only these two branches force an outcome of their own; GO and NO-GO
+	// deliberately let the pod's envelope win, which #1077 already pins.
+	t.Run("the supervisor's forced outcome still overrides the pod's", func(t *testing.T) {
+		forced := map[string]string{
+			string(foremanv1alpha1.AgenticTaskVerdictIncomplete): "INCOMPLETE",
+			"ERROR": "JOB-ERROR",
+		}
+		for verdict, want := range forced {
+			cjr := CoderJobResult{
+				Verdict:     verdict,
+				ResultExtra: map[string]any{"outcome": "MODEL-DECIDED"},
+			}
+			r := coderJobResultToResult("issue-fix", start, cjr)
+			if r.Extra["outcome"] != want {
+				t.Errorf("verdict %s: outcome = %v, want %q to win over the pod's MODEL-DECIDED",
+					verdict, r.Extra["outcome"], want)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## What

Route the `INCOMPLETE` and `ERROR` branches of `coderJobResultToResult` through `jobExtra`, so the in-pod run's `ResultExtra` survives on every terminal branch instead of only `GO` and `NO-GO`.

## Why

`transcriptRef` is the field that made this visible. `watcher.go` lifts it onto `status.transcriptRef`, and the archiver added in #1655 reaches the transcript ConfigMap through it. On the two branches that rebuilt `Extra` from scratch, the key never reached the envelope, so a turn-exhausted Job-mode run archived a bundle with no transcript.

The loss was silent by construction. An absent `transcriptRef` is also the legitimate deterministic-run shape, so `archiveTerminalTask` took neither the `transcript_read` nor the `transcript_empty` branch: `foreman_archive_failures_total` stayed at zero and nothing was logged. A fleet dropping every turn-exhausted transcript looked identical to a fleet of deterministic runs.

Turn-exhausted runs are the recovery trajectories the archive exists to capture: the coder hits a failing gate, works the problem, and runs out of budget. Bundles are immutable and `WriteBundle` skips any directory already holding its `meta.json` sentinel, so anything archived before this fix cannot be repaired by re-reconciling. That is why this is worth a standalone change rather than waiting.

Refs #1656

## How

Both branches now call `jobExtra(cjr, map[string]any{...})` like `GO` and `NO-GO` already did. `jobExtra` copies `cjr.ResultExtra` first and overlays the supervisor map, so the supervisor's keys still win and the forced `INCOMPLETE` and `JOB-ERROR` outcomes are unchanged. The only behaviour difference is that the pod's extras are no longer discarded.

## Testing

`TestCoderJobResultToResult_CarriesResultExtraOnEveryBranch` asserts `transcriptRef` and `turnCount` survive on all four verdict branches, that the supervisor's `executionMode` and `jobName` still land, and that the forced outcomes still override a `MODEL-DECIDED` coming from the pod.

Written before the fix: it failed on exactly `INCOMPLETE` and `ERROR` and passed on `GO` and `NO-GO`, which is the bug's precise shape. After the fix, reverting the `INCOMPLETE` branch to a fresh map fails only that subtest; restored, the package is green.

`go build ./...`, `go vet`, `gofmt`, and `golangci-lint run ./...` clean natively and under `GOOS=linux`. All 19 `pkg/foreman/...` and `internal/foreman/...` packages pass.

The existing envelope tests from #1077 cover `NO-GO` thoroughly and never exercised `INCOMPLETE` or `ERROR`, which is why this survived.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — behaviour fix, no user-facing surface change

Assisted-by: Claude Code (wrote the failing test and the fix; I reviewed the result and ran the gates locally)
