### PR TITLE
fix(test): make the archival failure-injection tests uid-independent

### DIFF
--- a/internal/foreman/controller/agentictask_archive_test.go
+++ b/internal/foreman/controller/agentictask_archive_test.go
@@ -172,9 +172,13 @@ func TestArchiveTerminalTask_MissingTranscriptStillArchives(t *testing.T) {
 // dropping records, which makes counting the failure load-bearing rather than
 // decorative.
 func TestArchiveTerminalTask_FailureDoesNotPanicAndCounts(t *testing.T) {
-	root := filepath.Join(t.TempDir(), "ro")
-	if err := os.Mkdir(root, 0o500); err != nil {
-		t.Fatalf("mkdir: %v", err)
+	// A regular file, not a chmod 0500 directory: root ignores permission
+	// bits, so a mode-based unwritable root is writable for uid 0 and the
+	// write this test needs to fail would succeed. See the note in
+	// pkg/foreman/archive/bundle_test.go.
+	root := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(root, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
 	}
 	before := archiveFailureCount(t, "write")
 	task := terminalTask()

--- a/pkg/foreman/archive/bundle_test.go
+++ b/pkg/foreman/archive/bundle_test.go
@@ -314,12 +314,19 @@ func TestWriteBundle_PartialWriteLeavesNoBundleSoItRetries(t *testing.T) {
 }
 
 func TestWriteBundle_UnwritableRootFails(t *testing.T) {
-	root := filepath.Join(t.TempDir(), "read-only")
-	if err := os.Mkdir(root, 0o500); err != nil {
-		t.Fatalf("mkdir: %v", err)
+	// A regular file standing where the root directory should be, rather than
+	// a chmod 0500 directory. Root ignores POSIX permission bits, so a mode-
+	// based unwritable directory is writable for uid 0 and this assertion
+	// inverted under any root container: CI runs unprivileged and stayed
+	// green while the Foreman gate Job, which runs as root, failed every run.
+	// ENOTDIR is refused for every uid, so the test now means the same thing
+	// wherever it runs.
+	root := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(root, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
 	}
 	if err := WriteBundle(root, testRecord(), nil); err == nil {
-		t.Fatal("WriteBundle into an unwritable root = nil error, want a failure")
+		t.Fatal("WriteBundle into a root that is not a directory = nil error, want a failure")
 	}
 }
 


### PR DESCRIPTION
## What

Replace the permission-based failure injection in the two archival tests with a
structural one, so they mean the same thing when the test process runs as root.

## Why

Refs #1638. Refs #1654.

`TestWriteBundle_UnwritableRootFails` and
`TestArchiveTerminalTask_FailureDoesNotPanicAndCounts` both created an
unwritable directory with `os.Mkdir(root, 0o500)` and asserted the write
failed. Root ignores POSIX permission bits, so under uid 0 the write succeeds
and both assertions invert.

GitHub Actions runs unprivileged, so CI stayed green and the tests merged in
0.9.20. The Foreman gate Job runs as root, so from that release on every gate
run failed `make test`, returned GATE-FAIL, and cascade-failed its dependent
review with `INCOMPLETE`. The effect was fleet-wide: no Foreman work could
reach a reviewer.

The history is unambiguous. 33 gate runs before the 0.9.20 deploy: zero
GATE-FAIL. The first two runs after it: both GATE-FAIL, both on the same two
tests, on unrelated branches.

```
bundle_test.go:322: WriteBundle into an unwritable root = nil error, want a failure
agentictask_archive_test.go:185: foreman_archive_failures_total = 0, want an increment after a failed write
```

## How

A regular file where the root directory belongs. `MkdirAll` and `Lstat` then
fail with `ENOTDIR`, which is a structural property of the path rather than a
permission check, so the kernel refuses it for every uid.

Verified the returned error is `ENOTDIR` and not `EACCES`/`EPERM`, which is
what makes it uid-independent:

```
ENOTDIR=true  EACCES=false  EPERM=false
```

Skipping the tests under root was the alternative. It was rejected because it
would silently drop the coverage in exactly the environment where archival
actually runs.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)

AI assistance: diagnosed and authored with Claude Code (band 3); the failure
was located from the gate Job's pod logs and the fix verified locally.
