### PR TITLE
fix(foreman-agent): keep claiming in pollOnce until a slot is full

### DIFF
--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -427,10 +427,21 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 			logf.FromContext(ctx).WithName("agentictask-watcher").Error(err, "claim failed", "task", t.Name)
 			continue
 		}
-		// Took it. Launch the executor and return to the polling loop;
-		// the next poll re-checks capacity before claiming anything else.
+		// Took it. Launch the executor and keep scanning the rest of the
+		// candidates in this same pass instead of returning: in-process and
+		// Job-mode runs draw on different slots, so a node with free capacity
+		// in more than one of them would otherwise leave the others idle for
+		// a whole poll interval (#1638). Continuing is safe because
+		// launchExecutor reserves the slot it takes SYNCHRONOUSLY -- it
+		// takes inflightMu and sets inflight / increments supervised before
+		// the goroutine is even started -- so the hasCapacityFor check at the
+		// top of the next iteration already observes the slot the previous
+		// iteration reserved, and the loop stops claiming on its own once the
+		// relevant slot is full and falls out when the candidate list is
+		// exhausted. Run calls pollOnce sequentially and the executor
+		// goroutines only ever release, so this longer pass does not break
+		// the check-then-reserve invariant above.
 		w.launchExecutor(ctx, t, res.agent, res.supervise)
-		return nil
 	}
 	return nil
 }

--- a/pkg/foreman/agent/watcher_concurrency_test.go
+++ b/pkg/foreman/agent/watcher_concurrency_test.go
@@ -466,6 +466,102 @@ func TestLaunchExecutor_ReleasesSlotOnError(t *testing.T) {
 	}
 }
 
+// TestPollOnce_ClaimsAcrossSlotsInOnePass: in-process and Job-mode runs draw
+// on different slots, so a node with free capacity in both must fill them in a
+// SINGLE pollOnce pass instead of claiming one task and leaving the rest idle
+// for a whole poll interval (#1638). Regression: the loop used to return after
+// the first successful claim, so this pass would claim only one.
+func TestPollOnce_ClaimsAcrossSlotsInOnePass(t *testing.T) {
+	inproc := taskForAgent("inproc", "local", 3*time.Hour)
+	jobA := taskForAgent("job-a", "coder", 2*time.Hour)
+	jobB := taskForAgent("job-b", "coder", time.Hour)
+	exec := newModeExecutor(t, map[string]bool{"coder": true})
+	w := &AgenticTaskWatcher{
+		Client: newRecoveryClient(t,
+			inproc, jobA, jobB, agentCR("local", false), agentCR("coder", true)),
+		NodeName:             "node-1",
+		TaskLivenessInterval: time.Hour, // no watchdog interference
+		Executor:             exec,
+		MaxSupervisedTasks:   2,
+	}
+
+	if err := w.pollOnce(context.Background(), "default"); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+
+	if got := countPhase(t, w, foremanv1alpha1.AgenticTaskPhaseRunning,
+		"inproc", "job-a", "job-b"); got != 3 {
+		t.Fatalf("Running tasks after one pass: want 3 (one in-process, two job-mode) got %d", got)
+	}
+	exec.waitStarted(t, 3)
+}
+
+// TestPollOnce_InProcessSlotStillSerializes: continuing the candidate loop
+// after a claim must not let the single in-process slot be double-booked -- a
+// second in-process candidate in a pass where the slot is already held stays
+// Scheduled, while a job-mode candidate in the same pass is still claimed.
+func TestPollOnce_InProcessSlotStillSerializes(t *testing.T) {
+	inproc1 := taskForAgent("inproc1", "local", 3*time.Hour)
+	inproc2 := taskForAgent("inproc2", "local", 2*time.Hour)
+	job := taskForAgent("job", "coder", time.Hour)
+	exec := newModeExecutor(t, map[string]bool{"coder": true})
+	w := &AgenticTaskWatcher{
+		Client: newRecoveryClient(t,
+			inproc1, inproc2, job, agentCR("local", false), agentCR("coder", true)),
+		NodeName:             "node-1",
+		TaskLivenessInterval: time.Hour, // no watchdog interference
+		Executor:             exec,
+	}
+
+	// One pass must claim inproc1 and job, but leave inproc2 Scheduled: the
+	// in-process slot was taken by inproc1 earlier in the same pass, so the
+	// per-candidate check holds it back, while the job-mode candidate still
+	// draws on its (separate) supervision slot.
+	if err := w.pollOnce(context.Background(), "default"); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+
+	if got := getTask(t, w.Client, "inproc2").Status.Phase; got != foremanv1alpha1.AgenticTaskPhaseScheduled {
+		t.Fatalf("second in-process task while the slot is held: want Scheduled got %s", got)
+	}
+	if got := getTask(t, w.Client, "job").Status.Phase; got != foremanv1alpha1.AgenticTaskPhaseRunning {
+		t.Fatalf("job-mode task should have been claimed in the same pass: want Running got %s", got)
+	}
+	exec.waitStarted(t, 2)
+}
+
+// TestPollOnce_SupervisionBoundEnforcedInOnePass: the supervision budget caps
+// how many job-mode tasks a pass claims -- once it is spent, the remaining
+// job-mode candidates stay Scheduled even though the loop keeps scanning them
+// in the same pass (#1638).
+func TestPollOnce_SupervisionBoundEnforcedInOnePass(t *testing.T) {
+	jobA := taskForAgent("job-a", "coder", 3*time.Hour)
+	jobB := taskForAgent("job-b", "coder", 2*time.Hour)
+	jobC := taskForAgent("job-c", "coder", time.Hour)
+	exec := newModeExecutor(t, map[string]bool{"coder": true})
+	w := &AgenticTaskWatcher{
+		Client: newRecoveryClient(t,
+			jobA, jobB, jobC, agentCR("coder", true)),
+		NodeName:             "node-1",
+		TaskLivenessInterval: time.Hour, // no watchdog interference
+		Executor:             exec,
+		MaxSupervisedTasks:   2,
+	}
+
+	if err := w.pollOnce(context.Background(), "default"); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+
+	if got := countPhase(t, w, foremanv1alpha1.AgenticTaskPhaseRunning,
+		"job-a", "job-b", "job-c"); got != 2 {
+		t.Fatalf("Running tasks after one pass: want 2 (the budget) got %d", got)
+	}
+	if got := getTask(t, w.Client, "job-c").Status.Phase; got != foremanv1alpha1.AgenticTaskPhaseScheduled {
+		t.Fatalf("third job-mode task over the budget: want Scheduled got %s", got)
+	}
+	exec.waitStarted(t, 2)
+}
+
 // TestPollOnce_MixedExecutionModes is the case the slot split exists for, and
 // the one a uniform fleet cannot show: the two modes draw on DIFFERENT slots,
 // so a busy one must not block the other. Both directions are asserted --


### PR DESCRIPTION
## What

`pollOnce` no longer returns after its first successful claim. It keeps
scanning the remaining candidates in the same pass, stopping when the relevant
slot is full or the candidate list is exhausted.

The production change is one deleted `return nil`.

## Why

Refs #1638.

One claim per tick was correct when a node had a single slot: nothing else
could start anyway. Since #1559 gave Job-mode supervisions their own budget, a
node with free capacity in two different slots leaves one idle for a whole
poll interval. Filling a supervision budget of 4 took about four intervals,
roughly 20 seconds at the default cadence, even when all four tasks were
already `Scheduled`.

It also interacts badly with ordering: `sortTasksDepthFirst` puts review and
verify ahead of issue-fix, so a Job-mode issue-fix claim deferred an in-process
review by a full interval even though the two draw on different slots.

## How

Continuing the loop is safe because `launchExecutor` reserves its slot
**synchronously**: it takes `inflightMu` and sets `inflight` / increments
`supervised` before starting the goroutine, and only the release is deferred
inside it. So the per-candidate `hasCapacityFor` check on the next iteration
already observes the slot the previous iteration took. `Run` calls `pollOnce`
sequentially and executor goroutines only ever release, so a longer pass does
not change the check-then-reserve invariant. No new locking, and `inflightMu`
is not held across the loop.

Three tests in `watcher_concurrency_test.go`:

- a node with a free in-process slot and a supervision budget of 2 claims all
  three candidates in one pass
- a second in-process candidate stays `Scheduled` when the slot is already
  held earlier in the same pass, while a Job-mode candidate is still claimed
- Job-mode candidates past the supervision budget stay `Scheduled`

**Mutation-checked.** Restoring the `return nil` fails all three:

```
--- FAIL: TestPollOnce_ClaimsAcrossSlotsInOnePass
    Running tasks after one pass: want 3 (one in-process, two job-mode) got 1
--- FAIL: TestPollOnce_InProcessSlotStillSerializes
    job-mode task should have been claimed in the same pass: want Running got Scheduled
--- FAIL: TestPollOnce_SupervisionBoundEnforcedInOnePass
    Running tasks after one pass: want 2 (the budget) got 1
```

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)

Assisted-by: Foreman (in-cluster coder agent, qwen38-coder) for the initial
implementation; reviewed, mutation-checked and rebased by hand.
