### PR TITLE
fix(foreman): wire the reviewer diff gate so an ungrounded GO is recorded

### DIFF
--- a/.golangci-deadcode.yml
+++ b/.golangci-deadcode.yml
@@ -37,8 +37,6 @@ linters:
         linters: [unused]
       - path: pkg/foreman/agent/mutation_check\.go # Refs #1555
         linters: [unused]
-      - path: pkg/foreman/agent/reviewer_diff_gate\.go # Refs #1570
-        linters: [unused]
       # Whole file is unreferenced: the proposal-1075 work-class buckets
       # (classifyFile, classifyFootprint and their tables) landed in #1254
       # and nothing calls them.

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -983,6 +983,16 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// the model paraphrased the issue ask (#744).
 			verdict = enforceReviewerIssueAsk(log, loopRes.Terminal.Extra, verdict,
 				scopeDriftDetected, scopeMatched)
+			// Ungrounded-review rail (#1570): a GO whose transcript carries no
+			// evidence the reviewer ever obtained the branch diff is uncorrelated
+			// with the code it approves. This is a FLAG, not a block: it records
+			// the finding on the result's extra (surfacing in status.result) and
+			// logs it; the verdict stands as the model returned it. It runs after
+			// the demote rails (empty-claim, grounded-finding, verdict-from-
+			// findings, scope-overlap, issueAsk) so it reports on the verdict
+			// those rails produced, and it is the last reviewer rail before the
+			// findings summary so its log line is the last rail signal recorded.
+			applyReviewerDiffGateForTask(log, loopRes, verdict)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 		}
 		r := e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
@@ -3305,6 +3315,42 @@ func logReviewerFindings(log logr.Logger, extra map[string]any) {
 		"minor", counts[reviewer.SeverityMinor],
 		"hasBlockers", reviewer.HasBlockers(findings),
 	)
+}
+
+// applyReviewerDiffGateForTask runs the ungrounded-review rail (#1570) over
+// the reviewer's stored transcript and records the finding on the terminal
+// result when the reviewer returned GO without ever obtaining the branch
+// diff. It is a FLAG, not a block: the verdict is passed through unchanged
+// (ungroundedReviewFinding returns a finding + note, not a verdict rewrite),
+// so a GO that never read the diff stands as GO but is visibly marked
+// ungroundedReview=true with the reason, and the finding is logged. The
+// marker lives in status.result so operators and any downstream consumer
+// (escalation, PR, audit) can tell the approval was ungrounded. It runs
+// after the demote rails in the reviewer settle path so it reports on the
+// verdict those rails produced, and before logReviewerFindings so the rail's
+// log line precedes the findings summary.
+//
+// The finding is written onto loopRes.Terminal.Extra (the same map the other
+// reviewer rails mutate), which modelDecidedResult nests under "modelExtra"
+// in the Result, so it lands in AgenticTask.status.result. It is extracted
+// out of runLLMPath so the call site there is a single statement rather than
+// a branch, keeping runLLMPath's cyclomatic complexity budget untouched
+// (mirrors applyCoderGroundingRailForTask).
+func applyReviewerDiffGateForTask(log logr.Logger, loopRes *LoopResult, verdict foremanv1alpha1.AgenticTaskVerdict) {
+	if loopRes == nil || loopRes.Terminal == nil {
+		return
+	}
+	failed, note := ungroundedReviewFinding(loopRes.Transcript, string(verdict))
+	if !failed {
+		return
+	}
+	log.Info("reviewer diff gate: GO returned without ever obtaining the branch diff; marking ungrounded (verdict stands)",
+		"note", note)
+	if loopRes.Terminal.Extra == nil {
+		loopRes.Terminal.Extra = map[string]any{}
+	}
+	loopRes.Terminal.Extra["ungroundedReview"] = true
+	loopRes.Terminal.Extra["ungroundedReviewReason"] = note
 }
 
 // fetchIssueBodyIfNeeded populates task.Spec.Payload.Prompt from the

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -1308,6 +1308,75 @@ func TestNativeExecutor_ReviewerGoIsApproveNotCommit(t *testing.T) {
 	}
 }
 
+// TestNativeExecutor_ReviewerGoWithoutDiffIsFlaggedUngrounded drives the
+// PRODUCTION reviewer settle path (NativeAgentLoopExecutor.Execute) for the
+// #1570 rail. The reviewer returns GO but its transcript contains no
+// tool result carrying a diff (it only called submit_result, like the
+// observed runs that ran `ls -l` + read a Dockerfile), so the
+// ungrounded-review rail must mark the result. It is a FLAG, not a block:
+// the verdict stays GO, but modelExtra must carry ungroundedReview=true and
+// a non-empty reason. Commenting out the applyReviewerDiffGateForTask call
+// site makes this fail: the flag would be absent.
+func TestNativeExecutor_ReviewerGoWithoutDiffIsFlaggedUngrounded(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+
+	agent, task := reviewerTaskAndAgent("ungrounded-go")
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+
+	// The reviewer's only tool call is submit_result: no bash tool result
+	// carries a diff, so the transcript is ungrounded.
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true,
+				Verdict:  "GO",
+				Summary:  "APPROVE: looks fine.",
+				Extra:    map[string]any{"reviewOutcome": "APPROVE"},
+			},
+		},
+	}
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Bot", Email: "b@x"},
+		CommitCommitter:          repo.Identity{Name: "Bot", Email: "b@x"},
+		RegistryFactory: func(
+			_ context.Context, _ string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+	res, err := execWithAgent(t, e, task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// It is a FLAG, not a block: the verdict stands as the model returned it.
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("verdict must stay GO (the rail is a flag, not a block); got %s; result=%+v", res.Verdict, res)
+	}
+
+	// The finding must land on modelExtra (the path the controller reads).
+	mx, ok := res.Extra["modelExtra"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelExtra: missing or wrong type; res.Extra=%+v", res.Extra)
+	}
+	if got := mx["ungroundedReview"]; got != true {
+		t.Errorf("ungroundedReview: want true (GO without any diff in the transcript) got %v; modelExtra=%+v",
+			mx["ungroundedReview"], mx)
+	}
+	if reason, _ := mx["ungroundedReviewReason"].(string); strings.TrimSpace(reason) == "" {
+		t.Errorf("ungroundedReviewReason: want a non-empty explanation, got %q", mx["ungroundedReviewReason"])
+	}
+}
+
 // TestNativeExecutor_ReviewerERRORMapsToIncompleteWithModelReportedError checks
 // that a reviewer-role Agent emitting verdict=ERROR is correctly wired
 // through normalizeModelVerdict. The CRD has no ERROR verdict; the harness


### PR DESCRIPTION
## What

Wires `reviewer_diff_gate.go` into the reviewer settle path and removes its
dead-code suppression, so a reviewer GO whose transcript shows no evidence it
ever obtained the branch diff is recorded as ungrounded.

## Why

Refs #1570.

The rail has existed since it was written, fully unit-tested, and was never
called. `.golangci-deadcode.yml` suppressed `unused` for the whole file, so CI
stayed green while the detector never ran.

This is not hypothetical. On 2026-08-24 a review on this repo returned **GO in
five turns**, having run only `git log -1` and `git diff --stat` against a
stale `main`, never reading a line of the change under review. Its claimed
`filesTouched` named files the branch does not contain. A second review the
same day showed the same pattern and was only caught because a different rail
(`issueAsk`) happened to fire.

## How

`applyReviewerDiffGateForTask` is called once from `runLLMPath`, after the
demote rails (empty-claim, grounded-finding, verdict-from-findings,
scope-overlap, issueAsk) so it reports on the verdict those produced, and
before `logReviewerFindings`. It is extracted into a wrapper so the call site
stays a single statement and `runLLMPath`'s complexity budget is untouched,
mirroring `applyCoderGroundingRailForTask`.

**It is a flag, not a block.** The verdict passes through unchanged; the rail
records `ungroundedReview=true` and `ungroundedReviewReason` on the terminal
extra, which `modelDecidedResult` nests under `modelExtra` so it lands in
`AgenticTask.status.result` for operators, escalation and audit.

## Verification

- `make lint-deadcode` -> `0 issues.` **with the suppression deleted**, which
  is the acceptance criterion that cannot be faked: it is only green if the
  function is genuinely reachable from production.
- `go test ./pkg/foreman/agent/...` green, `gofmt` and `go vet` clean.
- **Mutation-checked.** Commenting out the call site fails the new test:

```
executor_native_test.go:1372: ungroundedReview: want true (GO without any diff
  in the transcript) got <nil>
executor_native_test.go:1376: ungroundedReviewReason: want a non-empty
  explanation, got %!q(<nil>)
--- FAIL: TestNativeExecutor_ReviewerGoWithoutDiffIsFlaggedUngrounded
```

The failure output also confirms the test drives the real production path
rather than calling the detector directly: the surrounding `modelExtra` carries
genuine rail output (`railsSkipped`, `reviewOutcome:APPROVE`).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)

Assisted-by: Foreman (in-cluster coder agent, qwen38-coder) for the
implementation; independently reviewed and mutation-checked by hand before
this PR was opened. The in-loop reviewer's GO was not treated as sufficient,
which is the same failure mode this PR exists to detect.
