### PR TITLE
fix(foreman): round-robin Job-mode placement across eligible nodes

### DIFF
--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -519,16 +519,20 @@ func (r *AgenticTaskReconciler) reserveFirstFitNode(ctx context.Context, task *f
 		// the node must not be claimed: leave its CurrentTask untouched so
 		// it stays free for in-process tasks. See #1496.
 		//
-		// The eligible list is sorted by name, so pick the eligible node at
-		// the round-robin index (live job-mode task count mod eligible
-		// count). Reserving would undo #1496, but the reservation is what
-		// used to make the scan advance; without a rotation every Job-mode
-		// task lands on the alphabetically first node, so a fleet of N nodes
-		// can supervise only one Job at a time. See #1634.
+		// Reserving would undo #1496, but the reservation is what used to
+		// make the scan advance; without it every Job-mode task lands on the
+		// alphabetically first node, so a fleet of N nodes can supervise only
+		// one Job at a time. See #1634.
+		//
+		// Pick the eligible node currently supervising the fewest live
+		// Job-mode tasks. An earlier revision rotated on a scalar count of
+		// live tasks (count % len(eligible)); that spreads a burst but
+		// collapses to index 0 -- first-fit -- whenever nothing else is in
+		// flight, which is the common serial case.
 		if len(eligible) == 0 {
 			return "", nil
 		}
-		return nodes.Items[eligible[r.jobModeRotation(ctx, eligible, task)]].Name, nil
+		return nodes.Items[r.leastLoadedJobModeNode(ctx, nodes.Items, eligible, task)].Name, nil
 	}
 	for _, i := range eligible {
 		n := &nodes.Items[i]
@@ -545,47 +549,64 @@ func (r *AgenticTaskReconciler) reserveFirstFitNode(ctx context.Context, task *f
 	return "", nil
 }
 
-// jobModeRotation returns the eligible-node index to dispatch a Job-mode task
-// to, so successive assignments rotate across the eligible nodes instead of
-// always landing on the alphabetically first one (see #1634). eligible is the
-// eligible-node index slice as built by reserveFirstFitNode (sorted by name);
-// the caller guarantees it is non-empty.
-func (r *AgenticTaskReconciler) jobModeRotation(ctx context.Context, eligible []int, task *foremanv1alpha1.AgenticTask) int {
-	return r.liveJobModeTasks(ctx, task) % len(eligible)
+// leastLoadedJobModeNode returns the index into nodes of the eligible node
+// supervising the fewest live Job-mode tasks, so successive assignments spread
+// across the fleet instead of stacking on the alphabetically first node
+// (see #1634). eligible is the eligible-node index slice built by
+// reserveFirstFitNode (sorted by name); the caller guarantees it is non-empty.
+//
+// Ties break toward the earlier eligible node, so with an idle fleet this is
+// still deterministic. Unlike a scalar rotation it cannot collapse to index 0
+// when nothing is in flight, and it distinguishes a node already supervising
+// three Jobs from an idle one.
+func (r *AgenticTaskReconciler) leastLoadedJobModeNode(
+	ctx context.Context, nodes []foremanv1alpha1.FleetNode, eligible []int, task *foremanv1alpha1.AgenticTask,
+) int {
+	load := r.jobModeLoadByNode(ctx, task)
+	best := eligible[0]
+	bestLoad := load[nodes[best].Name]
+	for _, i := range eligible[1:] {
+		if l := load[nodes[i].Name]; l < bestLoad {
+			best, bestLoad = i, l
+		}
+	}
+	return best
 }
 
-// liveJobModeTasks counts the in-flight Job-mode AgenticTasks for the given
-// task's agent in the same namespace: those with a Scheduled (or later) phase
-// and an AssignedNode, regardless of whether the node is reserved. Job-mode
-// tasks are never reserved (#1496), so they cannot be counted by CurrentTask;
-// the assigned-node assignment is the only durable record of which Job a node
-// currently supervises. The count is a proxy for "how far round the rotation we
-// are" — exactly enough state for round-robin, and nothing least-loaded needs
-// (which would require a real load signal the controller does not have for
-// Job-mode work). The task being scheduled is still Pending, so it does not
-// count against itself.
-func (r *AgenticTaskReconciler) liveJobModeTasks(ctx context.Context, task *foremanv1alpha1.AgenticTask) int {
+// jobModeLoadByNode tallies the in-flight Job-mode AgenticTasks in the task's
+// namespace per assigned node: those in a Scheduled (or later) phase that carry
+// an AssignedNode, regardless of whether the node is reserved. Job-mode tasks
+// are never reserved (#1496), so they cannot be counted via CurrentTask; the
+// assigned-node stamp is the only durable record of which Jobs a node currently
+// supervises, and it is a real per-node load signal.
+//
+// Every agent's Job-mode work counts toward a node's load, not just the
+// scheduling task's own agent: two agents dispatching concurrently are
+// competing for the same node capacity, and filtering by AgentRef would let
+// each of them independently pick the same "idle" node.
+//
+// The task being scheduled is still Pending, so it does not count against
+// itself.
+func (r *AgenticTaskReconciler) jobModeLoadByNode(ctx context.Context, task *foremanv1alpha1.AgenticTask) map[string]int {
+	load := map[string]int{}
 	var tasks foremanv1alpha1.AgenticTaskList
-	// A failing list must not wedge scheduling; fall back to zero (the first
-	// eligible node) so the task still dispatches rather than stalling.
+	// A failing list must not wedge scheduling; an empty tally falls back to
+	// the first eligible node so the task still dispatches rather than
+	// stalling.
 	if err := r.List(ctx, &tasks, client.InNamespace(task.Namespace)); err != nil {
-		return 0
+		return load
 	}
-	count := 0
 	for i := range tasks.Items {
 		t := &tasks.Items[i]
-		if t.Spec.AgentRef == nil || t.Spec.AgentRef.Name != task.Spec.AgentRef.Name {
-			continue
-		}
 		if !holdsInFlightSlot(t.Status.Phase) {
 			continue
 		}
 		if t.Status.AssignedNode == "" {
 			continue
 		}
-		count++
+		load[t.Status.AssignedNode]++
 	}
-	return count
+	return load
 }
 
 // reserveNode stamps node.Status.CurrentTask with taskKey via an optimistic-

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -499,6 +499,11 @@ func (r *AgenticTaskReconciler) reserveFirstFitNode(ctx context.Context, task *f
 	})
 	now := time.Now()
 	key := taskKey(task)
+	// eligible holds the sorted indices of nodes that are schedulable and
+	// satisfy the capability. A first pass collects them so the jobMode
+	// branch can index into the eligible list directly (the index of the
+	// eligible node being considered must be known before it is returned).
+	var eligible []int
 	for i := range nodes.Items {
 		n := &nodes.Items[i]
 		if !nodeSchedulable(n, now) {
@@ -507,13 +512,26 @@ func (r *AgenticTaskReconciler) reserveFirstFitNode(ctx context.Context, task *f
 		if !capabilitySatisfies(required, requiredModel, n, jobMode) {
 			continue
 		}
-		if jobMode {
-			// Job-mode work runs in an ephemeral Job pod, not on this node, so
-			// the node must not be claimed. Pick the first eligible node and
-			// leave its CurrentTask untouched so it stays free for in-process
-			// tasks. See #1496.
-			return n.Name, nil
+		eligible = append(eligible, i)
+	}
+	if jobMode {
+		// Job-mode work runs in an ephemeral Job pod, not on this node, so
+		// the node must not be claimed: leave its CurrentTask untouched so
+		// it stays free for in-process tasks. See #1496.
+		//
+		// The eligible list is sorted by name, so pick the eligible node at
+		// the round-robin index (live job-mode task count mod eligible
+		// count). Reserving would undo #1496, but the reservation is what
+		// used to make the scan advance; without a rotation every Job-mode
+		// task lands on the alphabetically first node, so a fleet of N nodes
+		// can supervise only one Job at a time. See #1634.
+		if len(eligible) == 0 {
+			return "", nil
 		}
+		return nodes.Items[eligible[r.jobModeRotation(ctx, eligible, task)]].Name, nil
+	}
+	for _, i := range eligible {
+		n := &nodes.Items[i]
 		reserved, err := r.reserveNode(ctx, n, key)
 		if err != nil {
 			return "", err
@@ -525,6 +543,49 @@ func (r *AgenticTaskReconciler) reserveFirstFitNode(ctx context.Context, task *f
 		// first; try the next candidate.
 	}
 	return "", nil
+}
+
+// jobModeRotation returns the eligible-node index to dispatch a Job-mode task
+// to, so successive assignments rotate across the eligible nodes instead of
+// always landing on the alphabetically first one (see #1634). eligible is the
+// eligible-node index slice as built by reserveFirstFitNode (sorted by name);
+// the caller guarantees it is non-empty.
+func (r *AgenticTaskReconciler) jobModeRotation(ctx context.Context, eligible []int, task *foremanv1alpha1.AgenticTask) int {
+	return r.liveJobModeTasks(ctx, task) % len(eligible)
+}
+
+// liveJobModeTasks counts the in-flight Job-mode AgenticTasks for the given
+// task's agent in the same namespace: those with a Scheduled (or later) phase
+// and an AssignedNode, regardless of whether the node is reserved. Job-mode
+// tasks are never reserved (#1496), so they cannot be counted by CurrentTask;
+// the assigned-node assignment is the only durable record of which Job a node
+// currently supervises. The count is a proxy for "how far round the rotation we
+// are" — exactly enough state for round-robin, and nothing least-loaded needs
+// (which would require a real load signal the controller does not have for
+// Job-mode work). The task being scheduled is still Pending, so it does not
+// count against itself.
+func (r *AgenticTaskReconciler) liveJobModeTasks(ctx context.Context, task *foremanv1alpha1.AgenticTask) int {
+	var tasks foremanv1alpha1.AgenticTaskList
+	// A failing list must not wedge scheduling; fall back to zero (the first
+	// eligible node) so the task still dispatches rather than stalling.
+	if err := r.List(ctx, &tasks, client.InNamespace(task.Namespace)); err != nil {
+		return 0
+	}
+	count := 0
+	for i := range tasks.Items {
+		t := &tasks.Items[i]
+		if t.Spec.AgentRef == nil || t.Spec.AgentRef.Name != task.Spec.AgentRef.Name {
+			continue
+		}
+		if !holdsInFlightSlot(t.Status.Phase) {
+			continue
+		}
+		if t.Status.AssignedNode == "" {
+			continue
+		}
+		count++
+	}
+	return count
 }
 
 // reserveNode stamps node.Status.CurrentTask with taskKey via an optimistic-

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -582,6 +582,131 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		}
 	})
 
+	// Raised in review of PR #1669 (thanks @joryirving). The first fix
+	// rotated on a SCALAR count of the scheduling agent's own live Job-mode
+	// tasks: index = count % len(eligible). Two consequences that a scalar
+	// cannot express, each covered by a spec below.
+	//
+	// Note the serial trickle -- every task finishing before the next is
+	// scheduled -- is deliberately NOT asserted on. With nothing in flight
+	// every node is genuinely idle, so landing on the first one is correct,
+	// not a regression. What matters is that a node already carrying Jobs is
+	// not treated the same as an idle one.
+	It("prefers an idle node over one already supervising Jobs (#1634)", func() {
+		nodeA := newFleetNode("dep-aaa-a")
+		Expect(k8sClient.Create(ctx, nodeA)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeA) })
+		setNodeReady(nodeA, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+		nodeB := newFleetNode("dep-mmm-b")
+		Expect(k8sClient.Create(ctx, nodeB)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeB) })
+		setNodeReady(nodeB, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+		nodeC := newFleetNode("dep-zzz-c")
+		Expect(k8sClient.Create(ctx, nodeC)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeC) })
+		setNodeReady(nodeC, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+
+		agent := newAgent("job-coder-depth")
+		agent.Spec.Execution = &foremanv1alpha1.ExecutionSpec{
+			Mode: foremanv1alpha1.ExecutionModeJob,
+		}
+		Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, agent) })
+
+		// Stack three live Job-mode tasks on nodeA. Three is chosen so the
+		// old scalar rotation computes 3 % 3 == 0 and returns eligible[0],
+		// which IS nodeA -- the most loaded node in the fleet.
+		for i := 0; i < 3; i++ {
+			t := newTask(fmt.Sprintf("job-depth-live-%d", i))
+			t.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+			Expect(k8sClient.Create(ctx, t)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, t) })
+			setPhase(t, foremanv1alpha1.AgenticTaskPhasePending)
+			var live foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, nn(t), &live)).To(Succeed())
+			live.Status.Phase = foremanv1alpha1.AgenticTaskPhaseRunning
+			live.Status.AssignedNode = nodeA.Name
+			Expect(k8sClient.Status().Update(ctx, &live)).To(Succeed())
+		}
+
+		task := newTask("job-depth-next")
+		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.AssignedNode).NotTo(Equal(nodeA.Name),
+			"scheduled onto the node already supervising three Jobs while two sat idle")
+	})
+
+	It("counts another agent's Job-mode load on a node (#1634)", func() {
+		nodeA := newFleetNode("xag-aaa-a")
+		Expect(k8sClient.Create(ctx, nodeA)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeA) })
+		setNodeReady(nodeA, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+		nodeB := newFleetNode("xag-mmm-b")
+		Expect(k8sClient.Create(ctx, nodeB)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeB) })
+		setNodeReady(nodeB, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+
+		agentOne := newAgent("job-coder-x1")
+		agentOne.Spec.Execution = &foremanv1alpha1.ExecutionSpec{
+			Mode: foremanv1alpha1.ExecutionModeJob,
+		}
+		Expect(k8sClient.Create(ctx, agentOne)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, agentOne) })
+		agentTwo := newAgent("job-coder-x2")
+		agentTwo.Spec.Execution = &foremanv1alpha1.ExecutionSpec{
+			Mode: foremanv1alpha1.ExecutionModeJob,
+		}
+		Expect(k8sClient.Create(ctx, agentTwo)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, agentTwo) })
+
+		// agentOne is already supervising a Job on nodeA (the alphabetically
+		// first eligible node). The old count filtered by AgentRef, so
+		// agentTwo saw zero live tasks, computed index 0, and landed on the
+		// very node agentOne was using.
+		busy := newTask("job-x1-live")
+		busy.Spec.AgentRef = &corev1.LocalObjectReference{Name: agentOne.Name}
+		Expect(k8sClient.Create(ctx, busy)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, busy) })
+		setPhase(busy, foremanv1alpha1.AgenticTaskPhasePending)
+		var live foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(busy), &live)).To(Succeed())
+		live.Status.Phase = foremanv1alpha1.AgenticTaskPhaseRunning
+		live.Status.AssignedNode = nodeA.Name
+		Expect(k8sClient.Status().Update(ctx, &live)).To(Succeed())
+
+		task := newTask("job-x2-next")
+		task.Spec.AgentRef = &corev1.LocalObjectReference{Name: agentTwo.Name}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.AssignedNode).To(Equal(nodeB.Name),
+			"a second Job-mode agent ignored the first agent's load and reused its node")
+	})
+
 	It("leaves a second task Pending when the only matching node is busy", func() {
 		// One node, two tasks: the second must wait (requeue) rather than
 		// double-book the node.

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -500,6 +501,85 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		var claimed foremanv1alpha1.FleetNode
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, &claimed)).To(Succeed())
 		Expect(claimed.Status.CurrentTask).To(Equal("default/job-inprocess"))
+	})
+
+	// Regression for defilantech/LLMKube#1634. Without a rotation the
+	// jobMode branch of reserveFirstFitNode returns the alphabetically first
+	// eligible node every time, so every Job-mode task lands on the same
+	// node. This drives the production path (Reconcile) with several Job-mode
+	// tasks over several eligible nodes and asserts the assignments rotate
+	// across the nodes rather than repeating one.
+	It("rotates Job-mode assignments across eligible nodes (#1634)", func() {
+		// Three eligible nodes, created out of alphabetical order so the
+		// scheduler's sort-by-name actually orders them a/b/c.
+		nodeC := newFleetNode("zzz-c")
+		Expect(k8sClient.Create(ctx, nodeC)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeC) })
+		setNodeReady(nodeC, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+		nodeA := newFleetNode("aaa-a")
+		Expect(k8sClient.Create(ctx, nodeA)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeA) })
+		setNodeReady(nodeA, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+		nodeB := newFleetNode("mmm-b")
+		Expect(k8sClient.Create(ctx, nodeB)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, nodeB) })
+		setNodeReady(nodeB, foremanv1alpha1.FleetNodeCapability{
+			Accelerator: foremanv1alpha1.FleetNodeAccelerator("metal"),
+		})
+
+		// A Job-mode agent: the eligible set is derived from the agent's
+		// RequiredCapability, and jobMode is read from its execution mode.
+		agent := newAgent("job-coder-rot")
+		agent.Spec.Execution = &foremanv1alpha1.ExecutionSpec{
+			Mode: foremanv1alpha1.ExecutionModeJob,
+		}
+		Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, agent) })
+
+		const n = 5
+		assigned := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			task := newTask(fmt.Sprintf("job-rot-%d", i))
+			task.Spec.AgentRef = &corev1.LocalObjectReference{Name: agent.Name}
+			Expect(k8sClient.Create(ctx, task)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+			setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+			_, err := reconciler.Reconcile(ctx, reqFor(task))
+			Expect(err).NotTo(HaveOccurred())
+
+			var fresh foremanv1alpha1.AgenticTask
+			Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+			Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+			assigned = append(assigned, fresh.Status.AssignedNode)
+
+			// The node must never be claimed by a Job-mode task.
+			var node foremanv1alpha1.FleetNode
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: fresh.Status.AssignedNode}, &node)).To(Succeed())
+			Expect(node.Status.CurrentTask).To(BeEmpty())
+		}
+
+		// Spread across the three nodes rather than all on the first.
+		unique := map[string]bool{}
+		for _, a := range assigned {
+			Expect(a).NotTo(BeEmpty())
+			unique[a] = true
+		}
+		Expect(len(unique)).To(BeNumerically(">", 1))
+		// Five tasks over three nodes: no node can carry more than two.
+		for _, a := range assigned {
+			count := 0
+			for _, b := range assigned {
+				if a == b {
+					count++
+				}
+			}
+			Expect(count).To(BeNumerically("<=", 2))
+		}
 	})
 
 	It("leaves a second task Pending when the only matching node is busy", func() {


### PR DESCRIPTION
## What

Job-mode AgenticTasks now rotate across the eligible FleetNodes instead of
always landing on the alphabetically first one.

## Why

Refs #1634.

`reserveFirstFitNode` sorts nodes by name, and the Job-mode branch returned the
first eligible node without reserving it:

```go
if jobMode {
    return n.Name, nil
}
```

Not reserving is correct and deliberate (#1496): Job-mode work runs in an
ephemeral Job pod, not on the claiming node, so the node must stay free for
in-process tasks. The bug is that "first eligible" became a **constant** rather
than a rotation, because the reservation was what previously made the scan
advance. Measured on the fleet: 10 of 11 Job-mode tasks landed on one node
while seven other Ready nodes sat idle.

## How

A first pass collects the eligible node indices. The Job-mode branch then picks
`eligible[liveJobModeTasks(...) % len(eligible)]`, so successive assignments
advance across the eligible set. The in-process path is unchanged and still
reserves exactly as before.

Two deliberate properties:

- **`#1496` is preserved.** Job-mode placement still does not reserve the node.
  Reintroducing reservation would bring back the bug where one node holds its
  only slot for a Job's whole lifetime (#1559).
- **A failed List degrades to index 0 rather than wedging.** If the rotation
  count cannot be read, the task still dispatches to the first eligible node
  instead of stalling.

Round-robin rather than least-loaded, because the controller has no load signal
for Job-mode work: the node is deliberately not claimed, so `currentTask` is
empty by design. Round-robin is the smallest change that makes the choice
advance.

## Verification

- `go test ./internal/foreman/controller/...` green (104 specs)
- `make lint-deadcode` -> `0 issues.`; `gofmt` and `go vet` clean
- **Mutation-checked.** Replacing the rotation with `eligible[0]` (the old
  always-first behaviour) fails exactly the new spec and nothing else:

```
[FAIL] rotates Job-mode assignments across eligible nodes (#1634)
103 Passed | 1 Failed
```

One targeted failure out of 104 confirms the test is specific to the behaviour
it claims, and the other 103 confirm the refactor did not disturb existing
scheduling.

The spec creates three eligible nodes **out of alphabetical order** (so the
sort-by-name genuinely orders them), a Job-mode agent, and five tasks, then
drives `Reconcile` and asserts the assignments spread rather than repeating.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change)

Assisted-by: Foreman (in-cluster coder agent running Ornith-1.5-35B-A3B) for
the implementation; independently reviewed and mutation-checked by hand before
this PR was opened. The in-loop reviewer's verdict was not treated as
sufficient.
