### PR TITLE
fix(foreman): wire the pre-flight staleness check into coder dispatch

### DIFF
--- a/.golangci-deadcode.yml
+++ b/.golangci-deadcode.yml
@@ -29,8 +29,7 @@ linters:
         linters: [unused]
       - path: pkg/foreman/agent/cross_stage\.go # Refs #1549
         linters: [unused]
-      - path: pkg/foreman/agent/staleness_check\.go # Refs #1550
-        linters: [unused]
+
       - path: pkg/foreman/agent/issue_clauses\.go # Refs #1554
         linters: [unused]
       - path: pkg/foreman/agent/mutation_check\.go # Refs #1555

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -742,6 +742,15 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	// "#510" with no knowledge of what #510 is about. Best-effort: a
 	// failed fetch logs and the loop runs with the pre-#571 behavior.
 	fetchIssueBodyIfNeeded(ctx, e.workItems(authToken(auth)), task, log)
+	// Staleness pre-flight (#1550): before the coder starts, cheaply check
+	// whether the tree already addresses this issue. The pure check takes
+	// git-log and grep output as strings (see staleness_check.go); here we
+	// run those two commands once in the task workspace against the base
+	// branch the executor just cut, and prepend the returned note to the
+	// prompt so the coder reads the citing code before editing. Runs before
+	// buildUserPrompt so the note is in the coder's first turn. Best-effort:
+	// a git/grep error logs and skips, never blocking the task.
+	applyStalenessCheckForTask(ctx, log, task, workspace)
 	userPrompt := buildUserPrompt(task)
 	// issueText ranks files for both the repo-map prefix (coder Agents) and the
 	// scope-overlap guard in the coder gate verifier (#782).

--- a/pkg/foreman/agent/staleness_check.go
+++ b/pkg/foreman/agent/staleness_check.go
@@ -219,13 +219,20 @@ func applyStalenessCheckForTask(
 	// case (the issue is not cited in live code), not a failure, so its
 	// output is empty rather than a reason to skip. Anything else is logged
 	// and skipped so an unexpected git error never blocks the task.
+	//
+	// --include=*.go is load-bearing and matches the sibling rails
+	// (caller_impact_gate.go, grounding/inert.go). Unscoped, this grep also
+	// reads .golangci-deadcode.yml, whose entries cite "# Refs #N" for every
+	// rail that is NOT yet wired -- exactly the issues a staleness check must
+	// not call stale. Scoping to Go source keeps the register out of the
+	// signal.
 	gitArgs := []string{"log", "--oneline", "--grep=#" + strconv.Itoa(issue), base}
 	gitLog, gitErr := execCommandRunner(ctx, workspace, nil, "git", gitArgs...)
 	if gitErr != nil {
 		log.Info("staleness pre-flight: git log failed; skipping", "issue", issue, "err", gitErr.Error())
 		return
 	}
-	grep, grepErr := execCommandRunner(ctx, workspace, nil, "grep", "-rn", "#"+strconv.Itoa(issue), ".")
+	grep, grepErr := execCommandRunner(ctx, workspace, nil, "grep", "-rn", "--include=*.go", "#"+strconv.Itoa(issue), ".")
 	if grepErr != nil {
 		if exitErr, ok := grepErr.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			grepErr = nil

--- a/pkg/foreman/agent/staleness_check.go
+++ b/pkg/foreman/agent/staleness_check.go
@@ -36,10 +36,17 @@ limitations under the License.
 package agent
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"sort"
+	"strconv"
 	"strings"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
 
 // stalenessToggleEnv toggles the pre-flight staleness check off. Setting it to
@@ -178,6 +185,61 @@ func checkStaleness(issue int, gitLogOutput, grepOutput string) string {
 		return ""
 	}
 	return stalenessNote(gatherStaleness(issue, gitLogOutput, grepOutput))
+}
+
+// applyStalenessCheckForTask is the production entry point that wires the
+// pre-flight staleness check (#1550) into the coder's pre-dispatch path. It is
+// the command seam between the pure checkStaleness entry point and the real
+// workspace: it gathers the two text inputs the check needs by shelling out
+// once (git log on the base branch, grep across the tree), feeds them to
+// checkStaleness, and, when the check found something, prepends the returned
+// note to the task's prompt so the coder reads the citing code before editing.
+//
+// It runs once per issue-fix task, before buildUserPrompt assembles the prompt,
+// so the note lands in the coder's first turn rather than after a model has
+// already started (and could delete the very fix it should have left alone).
+// The git log and grep are run in the task workspace against the branch the
+// executor just cut from the base, so `git log --grep` sees the base branch's
+// history and `grep -rn` sees the live tree. Best-effort: any git/grep error
+// is logged and the check is skipped, so an unreachable repo never blocks a
+// task. It gates to issue-fix tasks (the only kind that carries an issue
+// number worth checking), mirroring the sibling apply*ForTask wrappers.
+func applyStalenessCheckForTask(
+	ctx context.Context, log logr.Logger, task *foremanv1alpha1.AgenticTask, workspace string,
+) {
+	if task.Spec.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
+		return
+	}
+	if task.Spec.Payload.Issue <= 0 {
+		return
+	}
+	issue := int(task.Spec.Payload.Issue)
+	base := baseBranchOrDefault(task.Spec.Payload.BaseBranch)
+	// grep exits 1 when it finds no matches; that is the common, healthy
+	// case (the issue is not cited in live code), not a failure, so its
+	// output is empty rather than a reason to skip. Anything else is logged
+	// and skipped so an unexpected git error never blocks the task.
+	gitArgs := []string{"log", "--oneline", "--grep=#" + strconv.Itoa(issue), base}
+	gitLog, gitErr := execCommandRunner(ctx, workspace, nil, "git", gitArgs...)
+	if gitErr != nil {
+		log.Info("staleness pre-flight: git log failed; skipping", "issue", issue, "err", gitErr.Error())
+		return
+	}
+	grep, grepErr := execCommandRunner(ctx, workspace, nil, "grep", "-rn", "#"+strconv.Itoa(issue), ".")
+	if grepErr != nil {
+		if exitErr, ok := grepErr.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			grepErr = nil
+		} else {
+			log.Info("staleness pre-flight: grep failed; skipping", "issue", issue, "err", grepErr.Error())
+			return
+		}
+	}
+	note := checkStaleness(issue, gitLog, grep)
+	if note == "" {
+		return
+	}
+	log.Info("staleness pre-flight: tree may already address this issue", "issue", issue)
+	task.Spec.Payload.PromptPrefix = note + "\n\n" + task.Spec.Payload.PromptPrefix
 }
 
 // stalenessNote renders the signals into a short human-readable note suitable

--- a/pkg/foreman/agent/staleness_check_wiring_test.go
+++ b/pkg/foreman/agent/staleness_check_wiring_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent_test
+
+// Wiring test for the pre-flight staleness check (#1550). The guard itself
+// (checkStaleness + the pure helpers) is already unit-tested in
+// staleness_check_test.go, but those tests call the guard directly and would
+// pass even if the rail were never invoked by the executor -- the exact defect
+// this file exists to pin down. This test instead drives the PRODUCTION path:
+// Execute -> runLLMPath -> the pre-dispatch prompt assembly, and asserts the
+// staleness note lands in the coder's first OAI user message. It fails if the
+// call site in runLLMPath is removed (mutation check), which a direct-call
+// test cannot catch.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
+)
+
+// staleRefRegistry is a fakeRegistry that records the workspace path so the
+// test can seed a commit citing the issue number into the task branch.
+type staleRefRegistry struct {
+	workspace string
+}
+
+func (r *staleRefRegistry) Schemas() []oai.Tool { return nil }
+
+func (r *staleRefRegistry) Dispatch(
+	_ context.Context, name string, _ json.RawMessage,
+) (*foremanagent.ToolResult, error) {
+	if name != "submit_result" {
+		return nil, &unknownTool{name}
+	}
+	return &foremanagent.ToolResult{
+		Terminal:      true,
+		Verdict:       "GO",
+		Summary:       "fixed",
+		CommitMessage: "fix: trivial change\n",
+	}, nil
+}
+
+// unknownTool is a minimal error type so the fake registry can report an
+// unexpected tool without importing errors just for this helper.
+type unknownTool struct{ name string }
+
+func (e *unknownTool) Error() string { return "unknown tool " + e.name }
+
+// staleRefSeed builds a bare remote whose single commit (on main) has a
+// subject line citing the issue number, so the executor's clone has a base
+// whose `git log --grep` matches. Mirrors drRefSeed in the deleted-reference
+// wiring test.
+func staleRefSeed(t *testing.T, root, issue string) string {
+	t.Helper()
+	bare := filepath.Join(root, "origin.git")
+	if out, err := exec.Command("git", "init", "--bare", "-b", "main", bare).CombinedOutput(); err != nil {
+		t.Fatalf("git init bare: %v: %s", err, out)
+	}
+	seed := filepath.Join(root, "seed")
+	if out, err := exec.Command("git", "clone", bare, seed).CombinedOutput(); err != nil {
+		t.Fatalf("git clone seed: %v: %s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("# seed\n"), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "-c", "user.email=seed@x", "-c", "user.name=seed", "add", "README.md"},
+		{"git", "-c", "user.email=seed@x", "-c", "user.name=seed", "commit", "-m", "seed"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = seed
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+	// A second commit whose subject cites the issue so `git log --oneline
+	// --grep=#N` on the base branch matches. The executor cuts the task
+	// branch from the base, so the fix commit must already be on the base
+	// branch (pushed as main), not added to the task branch.
+	if out, err := exec.Command("git", "-C", seed, "-c", "user.email=seed@x", "-c", "user.name=seed",
+		"commit", "--allow-empty", "-m", "fix: resolve issue #"+issue).CombinedOutput(); err != nil {
+		t.Fatalf("seed cite commit: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", seed, "push", "origin", "main").CombinedOutput(); err != nil {
+		t.Fatalf("seed cite push: %v: %s", err, out)
+	}
+	cur, _ := exec.Command("git", "-C", seed, "branch", "--show-current").Output()
+	if strings.TrimSpace(string(cur)) != "main" {
+		cmd := exec.Command("git", "-C", seed, "branch", "-M", strings.TrimSpace(string(cur)), "main")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("rename main: %v: %s", err, out)
+		}
+	}
+	if out, err := exec.Command("git", "-C", seed, "push", "origin", "main").CombinedOutput(); err != nil {
+		t.Fatalf("seed push: %v: %s", err, out)
+	}
+	return bare
+}
+
+// TestStalenessCheck_WiredNotesCoderPrompt drives the real production coder
+// path and asserts the staleness note lands in the coder's first OAI request.
+// The seed commit cites the task's issue number, so the base-branch `git log
+// --grep` matches and the check returns a non-empty note. Without the call
+// site in runLLMPath the first request carries no such note and this fails.
+func TestStalenessCheck_WiredNotesCoderPrompt(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	issue := "9999"
+	bare := staleRefSeed(t, root, issue)
+
+	var captured []string
+	oaiSrv := recordingOAI(t, []string{submitGoBody}, &captured)
+
+	agent, task := taskAndAgent("staleness")
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+
+	reg := &staleRefRegistry{}
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Bot", Email: "b@x"},
+		CommitCommitter:          repo.Identity{Name: "Bot", Email: "b@x"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	if _, err := execWithAgent(t, e, task); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if len(captured) == 0 {
+		t.Fatal("no OAI requests captured")
+	}
+	first := captured[0]
+	if !strings.Contains(first, "#"+issue) {
+		t.Fatalf("first OAI request missing the staleness note citing #%s: %q", issue, truncForTest(first))
+	}
+	if !strings.Contains(first, "Staleness pre-flight") {
+		t.Fatalf("first OAI request missing the staleness pre-flight note: %q", truncForTest(first))
+	}
+}


### PR DESCRIPTION
## What

Wires the pre-flight staleness check (`pkg/foreman/agent/staleness_check.go`)
into the coder's pre-dispatch path, deletes its dead-code suppression, and adds
a production-path wiring test. Includes a follow-up commit scoping the rail's
grep to Go source.

## Why

`staleness_check.go` held a pure, unit-tested guard with zero production
callers, and `.golangci-deadcode.yml` suppressed `unused` for it so CI stayed
green while the feature never ran.

Refs #1550

## How

`applyStalenessCheckForTask` is the command seam between the pure
`checkStaleness` entry point and the real workspace: it runs `git log --grep`
on the base branch plus a `grep` across the tree via the existing
`execCommandRunner` seam (the same one `coder_grounding_gate.go` and
`deleted_reference_gate.go` use), then prepends the note to
`task.Spec.Payload.PromptPrefix`. It is called immediately before
`buildUserPrompt`, which consumes `PromptPrefix` at `executor_native.go:2762`,
so the note lands in the coder's first turn. Best-effort throughout: any
git/grep error logs and skips, never blocking a task. `grep` exiting 1 (no
matches) is treated as the healthy empty case, not a failure.

The second commit adds `--include=*.go`, matching `caller_impact_gate.go` and
`grounding/inert.go`. Unscoped, the grep also read `.golangci-deadcode.yml`,
whose entries cite `# Refs #N` for every rail that is **not** yet wired —
exactly the issues a staleness check must not report as already-addressed.
Verified against still-open #1555:

```
unscoped:  .golangci-deadcode.yml:38  +  mutation_check.go:4
--include: mutation_check.go:4 only
```

### Verification

Reviewed adversarially before opening, not on the reviewer's verdict alone:

- **Mutation check.** Deleting the `applyStalenessCheckForTask` call site makes
  `TestStalenessCheck_WiredNotesCoderPrompt` **FAIL**. Re-confirmed after the
  scoping commit. The test constrains the wiring, not just the function.
- **`make lint-deadcode` passes with 0 issues** with the suppression deleted —
  no `//nolint`, no fake reference.
- `go test ./pkg/foreman/agent/... -count=1` green; build, vet, gofmt clean.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — internal rail, no user-facing surface

## AI assistance

The implementation commit was authored by a Foreman coder agent
(Ornith-1.5-35B-A3B, in-cluster). The scoping commit and the adversarial review
above were done with Claude Code. A human owns this review conversation.
