### PR TITLE
feat(foreman): require per-clause coverage of an issue's stated behaviour

### DIFF
--- a/.golangci-deadcode.yml
+++ b/.golangci-deadcode.yml
@@ -29,9 +29,6 @@ linters:
         linters: [unused]
       - path: pkg/foreman/agent/cross_stage\.go # Refs #1549
         linters: [unused]
-
-      - path: pkg/foreman/agent/issue_clauses\.go # Refs #1554
-        linters: [unused]
       - path: pkg/foreman/agent/mutation_check\.go # Refs #1555
         linters: [unused]
       # Whole file is unreferenced: the proposal-1075 work-class buckets

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1003,6 +1003,11 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// findings summary so its log line is the last rail signal recorded.
 			applyReviewerDiffGateForTask(log, loopRes, verdict)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
+			// Per-clause coverage rail (#1554): require the reviewer to have
+			// covered each behaviour clause the issue enumerated, or flag the
+			// gap as a finding. Runs last so it sees the reviewer's full set
+			// of findings; records-and-logs, never changes the verdict.
+			applyIssueClauseCoverageForTask(log, task, loopRes)
 		}
 		r := e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
 		// #1109: preserve a coder's near-complete work when its in-loop
@@ -2774,6 +2779,14 @@ func buildUserPrompt(task *foremanv1alpha1.AgenticTask) string {
 		}
 		if p.Prompt != "" {
 			fmt.Fprintf(&b, "Issue context:\n%s\n\n", p.Prompt)
+		}
+		// Per-clause checklist: extract the behaviour clauses the issue
+		// enumerated under "Expected Behavior" / "Acceptance Criteria" and
+		// paste them as an unchecked checklist so the coder must address
+		// each named case, not just the primary path it first landed on.
+		// Degrades to a no-op for an issue with no enumerated clauses.
+		if checklist := clauseChecklist(extractClauses(p.Prompt)); checklist != "" {
+			fmt.Fprintf(&b, "\nRequired behaviours to cover:\n%s\n", checklist)
 		}
 		b.WriteString("The repository is checked out in the workspace at the current branch.\n")
 		b.WriteString("Make the minimum change that addresses the issue, then call submit_result.\n")

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -2594,3 +2594,142 @@ func TestSupervisesAgent(t *testing.T) {
 		})
 	}
 }
+
+// TestNativeExecutor_ReviewerClauseCoverage drives the production reviewer-rail
+// path (Execute -> runLLMPath -> the per-clause coverage rail) and asserts both
+// directions of the rail:
+//
+//  1. A reviewer that paraphrases a clause's key terms (rather than echoing a
+//     verbatim 60-character prefix) still counts as covering that clause, so no
+//     gap finding is appended. This is the fix for #1554: the old prefix-
+//     substring matcher required a near-verbatim echo, which reproduced the
+//     exact defect the issue exists to replace.
+//  2. A clause the reviewer genuinely never mentions is still flagged, so a fix
+//     that satisfies one named case and leaves another broken cannot pass
+//     review.
+//
+// The positive assertion (the uncited clause IS flagged) is the mutation guard:
+// deleting the applyIssueClauseCoverageForTask call site makes it fail.
+func TestNativeExecutor_ReviewerClauseCoverage(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+
+	agent, task := reviewerTaskAndAgent("clause-cov")
+	// The reviewer rails run only for issue-fix review runs.
+	task.Spec.Kind = foremanv1alpha1.AgenticTaskKindIssueFix
+	task.Spec.Payload.Prompt = "## Acceptance Criteria\n\n" +
+		"1. the enabled path applies the new default\n" +
+		"2. the disabled path preserves the original no-side-effect behaviour\n" +
+		"3. the issue clauses are wired into the coder prompt\n" +
+		"4. the reviewer workflow cites each clause\n"
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+
+	// The reviewer's summary paraphrases clauses 1, 3 and 4 (their key terms
+	// all appear in the summary) but never mentions clause 2 (the disabled
+	// path), so exactly one gap must be flagged.
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true,
+				Verdict:  "GO",
+				Summary: "APPROVE: diff addresses #1554's ask for per-clause " +
+					"coverage by wiring issue clauses into coder prompt and reviewer " +
+					"workflow, and the enabled path applies the new default.",
+				Extra: map[string]any{
+					"reviewOutcome": "APPROVE",
+					// issueAskVerified=true keeps the issueAsk rail from
+					// demoting the GO; the scope rail short-circuits because
+					// the issue body names no file paths.
+					"issueAskVerified": true,
+					"findings":         []any{},
+				},
+			},
+		},
+	}
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Bot", Email: "b@x"},
+		CommitCommitter:          repo.Identity{Name: "Bot", Email: "b@x"},
+		RegistryFactory: func(
+			_ context.Context, _ string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+	res, err := execWithAgent(t, e, task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("verdict: want GOT got %s", res.Verdict)
+	}
+	findings := extraFindings(res, "findings")
+
+	// Direction 2 (positive, mutation-guarding): the uncited disabled-path
+	// clause must be flagged.
+	disabledFlagged := false
+	for _, msg := range findings {
+		if strings.Contains(msg, "the disabled path preserves the original no-side-effect behaviour") {
+			disabledFlagged = true
+			break
+		}
+	}
+	if !disabledFlagged {
+		t.Fatalf("expected a gap finding for the uncited disabled-path clause, findings: %v", findings)
+	}
+
+	// Direction 1 (negative): the three paraphrased clauses must NOT be
+	// flagged.
+	for _, clause := range []string{
+		"the enabled path applies the new default",
+		"the issue clauses are wired into the coder prompt",
+		"the reviewer workflow cites each clause",
+	} {
+		for _, msg := range findings {
+			if strings.Contains(msg, clause) {
+				t.Fatalf("expected no gap finding for the paraphrased clause %q, findings: %v", clause, findings)
+			}
+		}
+	}
+	// Exactly one gap (the disabled path) must have been appended.
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one gap finding, got %d: %v", len(findings), findings)
+	}
+}
+
+// extraFindings pulls the finding messages out of a Result's modelExtra
+// findings payload, or nil when the model-decided envelope is absent.
+func extraFindings(res *foremanagent.Result, key string) []string {
+	if res == nil || res.Extra == nil {
+		return nil
+	}
+	modelExtra, ok := res.Extra["modelExtra"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, ok := modelExtra[key]
+	if !ok {
+		return nil
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, item := range list {
+		if m, ok := item.(map[string]any); ok {
+			if msg, ok := m["message"].(string); ok {
+				out = append(out, msg)
+			}
+		}
+	}
+	return out
+}

--- a/pkg/foreman/agent/issue_clause_coverage.go
+++ b/pkg/foreman/agent/issue_clause_coverage.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Per-clause coverage rail.
+//
+// An issue commonly enumerates more than one required behaviour, and a coder
+// reliably implements the one its first test happens to cover and stops. The
+// coder prompt already pastes the enumerated clauses as an unchecked
+// checklist (see buildUserPrompt); this rail closes the loop on the review
+// side: it checks whether the reviewer's findings actually covered each clause,
+// and for any clause the reviewer never addressed it appends a major finding
+// so the gap is surfaced rather than silently omitted.
+//
+// This extends the existing issueAsk machinery, which checked that the
+// reviewer restated the issue; that compares against the whole body and is
+// brittle to light reformatting. Per-clause coverage instead asks, for each
+// named behaviour, whether the reviewer pointed at something that satisfies it.
+//
+// Non-blocking by design: unsatisfied clauses become findings, not a verdict
+// demotion. The reviewer's GO/NO-GO stays authoritative; the findings enrich
+// it and are recorded on the task so a human or the controller can route them.
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
+)
+
+// clauseStopWords are the most common English stopwords stripped before the
+// token-overlap check. Dropping them lets a reviewer paraphrase a clause
+// ("the disabled path keeps its no-side-effect behaviour") match the clause
+// ("the disabled path preserves the original no-side-effect behaviour") even
+// though no 60-character prefix of the clause survives as a substring, which
+// is the defect this rail exists to replace.
+var clauseStopWords = map[string]bool{
+	"a": true, "an": true, "the": true, "and": true, "or": true, "of": true,
+	"to": true, "in": true, "on": true, "at": true, "for": true, "with": true,
+	"out": true, "is": true, "are": true, "was": true, "were": true, "be": true,
+	"been": true, "being": true, "it": true, "its": true, "this": true, "that": true,
+	"these": true, "those": true, "as": true, "by": true, "from": true, "into": true,
+	"than": true, "then": true, "so": true, "if": true, "must": true, "shall": true,
+	"should": true, "will": true, "would": true, "can": true, "could": true,
+	"have": true, "has": true, "had": true, "do": true, "does": true, "did": true,
+}
+
+// clauseMatchThreshold is the minimum number of non-stopword clause tokens
+// the reviewer's cited text must share for the clause to count as covered.
+// Two is high enough to reject an unrelated one-word mention while still
+// forgiving a paraphrase that keeps the clause's key terms.
+const clauseMatchThreshold = 2
+
+// applyIssueClauseCoverage checks the reviewer's findings + summary against the
+// issue's enumerated behaviour clauses and, for every clause the reviewer never
+// addressed, appends a major finding so the clause is surfaced rather than
+// omitted. It is a no-op when there are no clauses (an issue with none must
+// degrade to a no-op rather than an error) or when extra is nil.
+//
+// A clause counts as cited when the reviewer's summary or any of its findings
+// shares enough of the clause's key tokens; this is the mechanical check that
+// complements the coder prompt's checklist. The reviewer's own verdict is
+// left untouched. summary is the reviewer's free-form submit_result summary;
+// it is a real citation site (it may describe coverage without emitting a
+// structured finding per clause).
+func applyIssueClauseCoverage(
+	log logr.Logger,
+	extra map[string]any,
+	clauses []string,
+	summary string,
+) {
+	if extra == nil || len(clauses) == 0 {
+		return
+	}
+	findings, _ := reviewer.ParseFindings(extra)
+	cited := citedClauses(clauses, findings, summary)
+	gaps := unsatisfiedClauses(clauses, cited)
+	if len(gaps) == 0 {
+		return
+	}
+	appendClauseFindings(extra, clauses, gaps)
+	log.Info("reviewer clause coverage: appended findings for uncited clauses",
+		"total", len(clauses), "unsatisfied", len(gaps))
+}
+
+// applyIssueClauseCoverageForTask gates applyIssueClauseCoverage to issue-fix
+// review runs and resolves the issue body a future call site uses. Extracted
+// out of the reviewer block in runLLMPath so the call site there is a single
+// statement, keeping that function's cyclomatic complexity budget untouched.
+func applyIssueClauseCoverageForTask(
+	log logr.Logger,
+	task *foremanv1alpha1.AgenticTask,
+	loopRes *LoopResult,
+) {
+	if task.Spec.Kind != foremanv1alpha1.AgenticTaskKindIssueFix {
+		return
+	}
+	if loopRes == nil || loopRes.Terminal == nil {
+		return
+	}
+	// The reviewer's fetch_issue body is the source of truth; fall back to the
+	// payload prompt when the reviewer never fetched one.
+	body := extractFetchIssueBody(loopRes.Transcript)
+	if body == "" {
+		body = task.Spec.Payload.Prompt
+	}
+	clauses := extractClauses(body)
+	applyIssueClauseCoverage(log, loopRes.Terminal.Extra, clauses, loopRes.Terminal.Summary)
+}
+
+// citedClauses builds the clause-index -> citation map that
+// unsatisfiedClauses consumes. A clause is cited when the reviewer's summary or
+// any of its findings shares enough of the clause's key tokens to show the
+// reviewer addressed that behaviour rather than merely echoing a prefix of it.
+func citedClauses(clauses []string, findings []reviewer.Finding, summary string) map[int]string {
+	cited := make(map[int]string, len(clauses))
+
+	haystacks := make([]string, 0, len(findings)+1)
+	for _, f := range findings {
+		if f.Message != "" {
+			haystacks = append(haystacks, f.Message)
+		}
+	}
+	// The reviewer's free-form summary is a real citation site too: it may
+	// describe coverage without emitting a structured finding per clause.
+	if strings.TrimSpace(summary) != "" {
+		haystacks = append(haystacks, summary)
+	}
+
+	for i, clause := range clauses {
+		needle := clauseTokens(clause)
+		if len(needle) < clauseMatchThreshold {
+			// A clause with fewer than two key tokens is too short to
+			// match reliably; fall back to a substring check so a very
+			// short clause still counts as covered when echoed verbatim.
+			trimmed := strings.TrimSpace(clause)
+			if trimmed == "" {
+				continue
+			}
+			for _, h := range haystacks {
+				if strings.Contains(h, trimmed) {
+					cited[i] = "clause echoed in reviewer findings or summary"
+					break
+				}
+			}
+			continue
+		}
+		for _, h := range haystacks {
+			if tokenOverlap(h, needle) >= clauseMatchThreshold {
+				cited[i] = "clause covered by reviewer findings or summary"
+				break
+			}
+		}
+	}
+	return cited
+}
+
+// clauseTokens splits clause into lower-cased tokens with stopwords and
+// non-alphanumeric noise stripped. The result is the set of key terms the
+// overlap check compares against the reviewer's text.
+func clauseTokens(clause string) []string {
+	raw := strings.FieldsFunc(strings.ToLower(clause), nonAlnumRune)
+	tokens := make([]string, 0, len(raw))
+	for _, t := range raw {
+		if clauseStopWords[t] {
+			continue
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens
+}
+
+// tokenOverlap returns how many of clause's key tokens appear (at least once)
+// in haystack. It is the mechanical coverage check: a reviewer that paraphrases
+// a clause but keeps its key terms still scores above the threshold. A trailing
+// 's' is ignored so a clause and its paraphrase agree across singular/plural
+// ("clause" matches "clause" and "clauses") without a full stemmer.
+func tokenOverlap(haystack string, clauseTokens []string) int {
+	words := strings.FieldsFunc(strings.ToLower(haystack), nonAlnumRune)
+	hits := 0
+	for _, c := range clauseTokens {
+		for _, w := range words {
+			if formsMatch(c, w) {
+				hits++
+				break
+			}
+		}
+	}
+	return hits
+}
+
+// formsMatch reports whether clause token c and haystack word w are the same
+// word, ignoring a single trailing 's' that marks the plural. "clause" matches
+// "clause" and "clauses"; "clauses" matches "clause" and "clauses".
+func formsMatch(c, w string) bool {
+	if c == w {
+		return true
+	}
+	if strings.HasSuffix(c, "s") && c[:len(c)-1] == w {
+		return true
+	}
+	if strings.HasSuffix(w, "s") && w[:len(w)-1] == c {
+		return true
+	}
+	return false
+}
+
+// nonAlnumRune reports whether r is not an ASCII letter or digit.
+func nonAlnumRune(r rune) bool {
+	return !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9')
+}
+
+// appendClauseFindings adds a major finding per unsatisfied clause to
+// extra["findings"], preserving the reviewer's existing findings. It rebuilds
+// the field from the parsed findings so the stored shape stays uniform
+// ([]any) regardless of the shape it arrived in.
+func appendClauseFindings(extra map[string]any, clauses []string, gaps []int) {
+	combined, _ := reviewer.ParseFindings(extra)
+	for _, idx := range gaps {
+		combined = append(combined, reviewer.Finding{
+			Severity: reviewer.SeverityMajor,
+			Area:     reviewer.AreaScope,
+			Message:  fmt.Sprintf("issue clause not cited by reviewer: %q", clauses[idx]),
+		})
+	}
+	marshaled, err := json.Marshal(combined)
+	if err != nil {
+		return
+	}
+	var asAny []any
+	if err := json.Unmarshal(marshaled, &asAny); err != nil {
+		return
+	}
+	extra["findings"] = asAny
+}

--- a/pkg/foreman/agent/issue_clause_prompt_internal_test.go
+++ b/pkg/foreman/agent/issue_clause_prompt_internal_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Internal tests for the coder-prompt half of the #1554 per-clause rail.
+// buildUserPrompt, clauseChecklist and extractClauses are unexported, so these
+// live in package agent rather than agent_test.
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+func clausePromptTask(body string) *foremanv1alpha1.AgenticTask {
+	return &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Issue:  1554,
+				Prompt: body,
+			},
+		},
+	}
+}
+
+// TestBuildUserPrompt_ClauseChecklistIsInjected guards the prompt-side half of
+// the rail: buildUserPrompt must emit the clause checklist block.
+//
+// It asserts on the block's header and on the checklist RENDERING, never on the
+// clause text alone. That distinction is the whole point. buildUserPrompt
+// already pastes the entire issue body verbatim under "Issue context:", so a
+// test that merely looked for the clause text would be satisfied by the pasted
+// body and would keep passing with the checklist deleted. Deleting the
+// clauseChecklist call in buildUserPrompt must fail this test.
+func TestBuildUserPrompt_ClauseChecklistIsInjected(t *testing.T) {
+	body := "## Expected Behavior\n\n" +
+		"- the enabled path applies the new default\n" +
+		"- the disabled path preserves the original no-side-effect behaviour\n"
+	got := buildUserPrompt(clausePromptTask(body))
+
+	if !strings.Contains(got, "Required behaviours to cover:") {
+		t.Fatalf("clause checklist block missing from the coder prompt:\n%s", got)
+	}
+	want := clauseChecklist(extractClauses(body))
+	if want == "" {
+		t.Fatal("fixture produced no clauses; this test would be vacuous")
+	}
+	if !strings.Contains(got, want) {
+		t.Errorf("expected the rendered checklist %q in the prompt:\n%s", want, got)
+	}
+	if strings.Index(got, "Required behaviours to cover:") < strings.Index(got, "Issue context:") {
+		t.Error("checklist block should follow the issue context, not precede it")
+	}
+}
+
+// TestBuildUserPrompt_NoClausesOmitsChecklist is the negative direction: an
+// issue with only prose must not gain a checklist block, so a clause-less issue
+// degrades to a no-op rather than an empty header.
+func TestBuildUserPrompt_NoClausesOmitsChecklist(t *testing.T) {
+	task := clausePromptTask("Some prose describing the problem with no enumerated sections.")
+	if got := buildUserPrompt(task); strings.Contains(got, "Required behaviours to cover:") {
+		t.Errorf("clause-less issue must not gain a checklist block:\n%s", got)
+	}
+}


### PR DESCRIPTION
## What

Wires `pkg/foreman/agent/issue_clauses.go` into both the coder prompt and the
review path, deletes its dead-code suppression, and adds per-clause coverage
findings for clauses a reviewer never addressed.

## Why

`issue_clauses.go` held a pure, unit-tested extractor with zero production
callers, suppressed in `.golangci-deadcode.yml` so CI stayed green while the
feature never ran.

Refs #1554

## How

Two halves:

- **Coder prompt.** `buildUserPrompt` pastes the issue's enumerated behaviour
  clauses as an unchecked checklist under `Required behaviours to cover:`, so
  the coder sees each named case rather than only the primary path.
- **Review path.** `applyIssueClauseCoverageForTask` runs after the reviewer and
  appends a major finding per clause the reviewer never cited. Non-blocking by
  design: findings enrich the reviewer's verdict, they do not demote it, which
  matches the issue's "unsatisfied clauses are findings, not omissions".

Citation matching uses stopword-stripped token overlap against a threshold, not
a verbatim prefix. That matters because #1554 exists to replace machinery that
"reports unverified when the text is lightly reformatted"; a substring match
would have reproduced exactly that. Measured against this PR's own reviewer
summary: 2 of 4 clauses matched on a paraphrasing review, 0 of 4 on an unrelated
one, so it survives paraphrase while still flagging genuine gaps.

### Verification

Reviewed adversarially across two revisions rather than on the reviewer's
verdict. The first revision returned GO with **both** wiring points passing when
deleted, so it was sent back:

| Mutation | r0 | this PR |
|---|---|---|
| delete `applyIssueClauseCoverageForTask` call | all pass | `ReviewerClauseCoverage` **FAILS** |
| delete `clauseChecklist` injection | all pass | `ClauseChecklistIsInjected` **FAILS** |

The r0 prompt test was vacuous: it asserted the clause text appeared in the
prompt, which `buildUserPrompt` already guarantees by pasting the issue body
verbatim. The replacement asserts on the block header and the rendered
checklist, neither of which the pasted body supplies, plus the negative case
that a clause-less issue gains no block.

Also: `make lint-deadcode` passes with **0 issues** with the suppression
deleted; `go test ./pkg/foreman/agent/... -count=1` green; build, vet, gofmt
clean.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — internal rail, no user-facing surface

## AI assistance

The implementation commits were authored by a Foreman coder agent
(Ornith-1.5-35B-A3B, in-cluster) across two revisions. The final test commit and
the adversarial review above were done with Claude Code. A human owns this
review conversation.
