### PR TITLE
fix(foreman): fill the transcript budget when truncating

### DIFF
--- a/pkg/foreman/agent/transcript.go
+++ b/pkg/foreman/agent/transcript.go
@@ -109,7 +109,18 @@ func WriteTranscript(
 		return corev1.ObjectReference{}, fmt.Errorf("WriteTranscript: marshal: %w", err)
 	}
 	if len(docBytes) > transcriptCapBytes {
-		doc.Messages = truncateMessages(doc.Messages, loopResult.Turns)
+		// fits reports whether the document would still be under the cap
+		// with this message set. Marshalling the real doc (rather than
+		// summing message sizes) keeps the envelope, escaping and the
+		// marker in the accounting, so the search cannot overshoot.
+		fits := func(candidate []oai.Message) bool {
+			probe := doc
+			probe.Messages = candidate
+			probe.Truncated = true
+			b, err := json.Marshal(probe)
+			return err == nil && len(b) <= transcriptCapBytes
+		}
+		doc.Messages = truncateMessages(doc.Messages, loopResult.Turns, fits)
 		doc.Truncated = true
 		docBytes, err = json.Marshal(doc)
 		if err != nil {
@@ -199,31 +210,68 @@ func ownerRefForTask(task *foremanv1alpha1.AgenticTask) metav1.OwnerReference {
 	}
 }
 
-// truncateMessages keeps the first message (system prompt) and as much
-// of the tail as fits. It inserts a synthetic system marker noting how
-// many turns were dropped so a reader can tell at a glance.
+// truncateMessages keeps the head (system prompt + first user message), a
+// marker naming how much was dropped, and the LARGEST tail that still fits
+// under the caller's budget.
 //
-// v0.1 uses a fixed split: keep system + first user message + last 10
-// messages. That covers the typical "what was the task" + "how did it
-// end" pair and is bounded regardless of input size.
-func truncateMessages(msgs []oai.Message, totalTurns int) []oai.Message {
+// It used to keep a fixed last-10 tail regardless of budget, so a transcript
+// one byte over the cap was cut to 13 messages and stored ~1% of the space it
+// was allowed (#1672). Only long runs exceed the cap and long runs are
+// disproportionately the failures, so the fixed split gutted exactly the
+// transcripts worth keeping.
+//
+// fits reports whether a candidate message set still fits; the caller supplies
+// it so the real document envelope is what gets measured. minTailMessages is
+// the floor: this never retains less than the old fixed split did, so a
+// pathological transcript degrades to the previous behaviour rather than worse.
+// The head-and-tail shape is deliberate -- the start ("what was the task") and
+// the end ("how did it finish", where submit_result lives) are the high-signal
+// parts, and the middle is what a reader can most afford to lose.
+func truncateMessages(msgs []oai.Message, totalTurns int, fits func([]oai.Message) bool) []oai.Message {
 	if len(msgs) <= 12 {
 		// Nothing meaningful to drop.
 		return msgs
 	}
+	const minTailMessages = 10
 	head := msgs[:2] // system + first user prompt
-	tail := msgs[len(msgs)-10:]
-	dropped := len(msgs) - len(head) - len(tail)
-	marker := oai.Message{
-		Role: oai.RoleSystem,
-		Content: fmt.Sprintf(
-			"[transcript truncated: %d middle messages dropped to fit "+
-				"the 1 MiB ConfigMap budget; %d turns total]",
-			dropped, totalTurns),
+
+	build := func(tailN int) []oai.Message {
+		if tailN > len(msgs)-len(head) {
+			tailN = len(msgs) - len(head)
+		}
+		tail := msgs[len(msgs)-tailN:]
+		dropped := len(msgs) - len(head) - len(tail)
+		if dropped < 0 {
+			dropped = 0
+		}
+		marker := oai.Message{
+			Role: oai.RoleSystem,
+			Content: fmt.Sprintf(
+				"[transcript truncated: %d middle messages dropped to fit "+
+					"the 1 MiB ConfigMap budget; %d turns total]",
+				dropped, totalTurns),
+		}
+		out := make([]oai.Message, 0, len(head)+1+len(tail))
+		out = append(out, head...)
+		out = append(out, marker)
+		out = append(out, tail...)
+		return out
 	}
-	out := make([]oai.Message, 0, len(head)+1+len(tail))
-	out = append(out, head...)
-	out = append(out, marker)
-	out = append(out, tail...)
-	return out
+
+	// Binary search the largest tail that fits. Falling back to the floor
+	// when even that is over budget preserves the old behaviour; the caller's
+	// final guard handles the pathological single-huge-message case.
+	best := build(minTailMessages)
+	lo, hi := minTailMessages+1, len(msgs)-len(head)
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		candidate := build(mid)
+		if fits(candidate) {
+			best = candidate
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	return best
 }

--- a/pkg/foreman/agent/transcript_truncate_test.go
+++ b/pkg/foreman/agent/transcript_truncate_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// truncScheme is a package-internal scheme: the shared newScheme helper lives
+// in executor_native_test.go, which is package agent_test and therefore not
+// importable from these internal tests.
+func truncScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgo scheme: %v", err)
+	}
+	if err := foremanv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("foreman scheme: %v", err)
+	}
+	return s
+}
+
+// bigTranscript builds a transcript of n turns whose marshalled size comfortably
+// exceeds transcriptCapBytes, mirroring the shape of a real coder run: an
+// alternating assistant/tool sequence with reasoning content.
+func bigTranscript(n, msgBytes int) []oai.Message {
+	msgs := []oai.Message{
+		{Role: oai.RoleSystem, Content: "you are a coder"},
+		{Role: oai.RoleUser, Content: "fix the bug"},
+	}
+	filler := strings.Repeat("x", msgBytes)
+	for i := 0; i < n; i++ {
+		msgs = append(msgs,
+			oai.Message{Role: oai.RoleAssistant, Content: fmt.Sprintf("turn-%d %s", i, filler)},
+			oai.Message{Role: oai.RoleTool, ToolCallID: fmt.Sprintf("c%d", i), Content: filler},
+		)
+	}
+	return msgs
+}
+
+// TestWriteTranscript_TruncationFillsTheBudget is the regression for #1672.
+//
+// truncateMessages was a FIXED split -- system + first user + last 10 -- so a
+// transcript one byte over the 1008 KiB cap was cut to 13 messages regardless
+// of how far over it was. Measured on a real run (wl-1331-ornith-v3-code-1331,
+// 198 turns): 13 messages and 95 KB stored against a 1032192-byte cap, 9.5%
+// utilisation, while two runs that fit under the cap kept 220 and 241 messages.
+//
+// The bias is systematic: only long runs exceed the cap, and long runs are
+// disproportionately the failures, so this gutted exactly the transcripts worth
+// keeping.
+func TestWriteTranscript_TruncationFillsTheBudget(t *testing.T) {
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "trunc-budget", Namespace: "default"},
+		Spec:       foremanv1alpha1.AgenticTaskSpec{Kind: foremanv1alpha1.AgenticTaskKindIssueFix},
+	}
+	c := fake.NewClientBuilder().WithScheme(truncScheme(t)).WithObjects(task).Build()
+
+	// ~2400 messages of ~1 KB: several times over the cap, like a long run.
+	msgs := bigTranscript(1200, 1000)
+	ref, err := WriteTranscript(context.Background(), c, task, &LoopResult{
+		Turns: 1200, Transcript: msgs,
+	})
+	if err != nil {
+		t.Fatalf("WriteTranscript: %v", err)
+	}
+
+	var cm corev1.ConfigMap
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: ref.Name, Namespace: ref.Namespace}, &cm); err != nil {
+		t.Fatalf("get transcript ConfigMap: %v", err)
+	}
+	stored := len(cm.Data[transcriptDataKey])
+
+	var doc TranscriptDoc
+	if err := json.Unmarshal([]byte(cm.Data[transcriptDataKey]), &doc); err != nil {
+		t.Fatalf("unmarshal transcript: %v", err)
+	}
+	if !doc.Truncated {
+		t.Fatalf("fixture did not exceed the cap; stored=%d cap=%d", stored, transcriptCapBytes)
+	}
+
+	// Must still fit.
+	if stored > transcriptCapBytes {
+		t.Fatalf("stored %d exceeds cap %d", stored, transcriptCapBytes)
+	}
+
+	utilisation := float64(stored) / float64(transcriptCapBytes) * 100
+	t.Logf("retained %d messages, %d bytes, %.1f%% of the %d-byte budget",
+		len(doc.Messages), stored, utilisation, transcriptCapBytes)
+
+	// The defect: a fixed 13-message split. A budget-aware truncator should
+	// fill most of the space it is allowed.
+	if utilisation < 50 {
+		t.Errorf("truncation used only %.1f%% of the budget (%d bytes of %d); "+
+			"a marginally-over transcript should lose middle messages, not 90%% of them",
+			utilisation, stored, transcriptCapBytes)
+	}
+	if len(doc.Messages) <= 13 {
+		t.Errorf("retained %d messages; the fixed head+marker+10-tail split is still in effect",
+			len(doc.Messages))
+	}
+}
+
+// TestWriteTranscript_TruncationKeepsHeadMarkerAndTail pins the structure the
+// budget-aware truncator must preserve: the system prompt and first user
+// message at the head, a marker naming how much was dropped, and the final
+// messages (where submit_result lives) at the tail.
+func TestWriteTranscript_TruncationKeepsHeadMarkerAndTail(t *testing.T) {
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "trunc-shape", Namespace: "default"},
+		Spec:       foremanv1alpha1.AgenticTaskSpec{Kind: foremanv1alpha1.AgenticTaskKindIssueFix},
+	}
+	c := fake.NewClientBuilder().WithScheme(truncScheme(t)).WithObjects(task).Build()
+
+	msgs := bigTranscript(1200, 1000)
+	msgs[len(msgs)-1] = oai.Message{Role: oai.RoleTool, Content: "SUBMIT_RESULT_SENTINEL"}
+
+	ref, err := WriteTranscript(context.Background(), c, task, &LoopResult{
+		Turns: 1200, Transcript: msgs,
+	})
+	if err != nil {
+		t.Fatalf("WriteTranscript: %v", err)
+	}
+	var cm corev1.ConfigMap
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: ref.Name, Namespace: ref.Namespace}, &cm); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var doc TranscriptDoc
+	if err := json.Unmarshal([]byte(cm.Data[transcriptDataKey]), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if doc.Messages[0].Role != oai.RoleSystem {
+		t.Errorf("head[0]: want the system prompt, got role %q", doc.Messages[0].Role)
+	}
+	last := doc.Messages[len(doc.Messages)-1]
+	if !strings.Contains(last.Content, "SUBMIT_RESULT_SENTINEL") {
+		t.Errorf("tail must end at the final message; got %q", last.Content)
+	}
+	marker := false
+	for _, m := range doc.Messages {
+		if strings.Contains(m.Content, "transcript truncated") {
+			marker = true
+			break
+		}
+	}
+	if !marker {
+		t.Error("no truncation marker naming the dropped middle")
+	}
+}


### PR DESCRIPTION
## What

Makes transcript truncation budget-aware. `truncateMessages` kept a fixed
last-10 tail regardless of how far over the 1008 KiB cap a transcript was.

## Why

A transcript one byte over the cap was cut to 13 messages, storing a fraction of
the space it was allowed. Measured on a real coder run
(`wl-1331-ornith-v3-code-1331`, 198 turns):

| task | turns | verdict | stored | messages |
|---|---|---|---|---|
| wl-1550-ornith-v3-code-1550 | 112 | GO | 633 KB | 241 |
| wl-1554-ornith-v3-code-1554 | 100 | GO | 586 KB | 220 |
| wl-1331-ornith-v3-code-1331 | 198 | INCOMPLETE | **95 KB** | **13** |

The bias is systematic, not random: only long runs exceed the cap, and long runs
are disproportionately the failures. So this discarded precisely the transcripts
worth studying, and the archival work in #1654 was faithfully preserving the
gutted version.

Fixes #1672

## How

Binary-search the largest tail that fits, measuring the **real marshalled
document** via a `fits` closure supplied by `WriteTranscript` rather than summing
message sizes, so the envelope, JSON escaping and the marker are all in the
accounting and the search cannot overshoot the cap.

The old fixed split becomes the **floor** (`minTailMessages = 10`): this never
retains less than before, so a pathological transcript degrades to the previous
behaviour rather than worse. The existing single-huge-message guard in
`WriteTranscript` is untouched, as is the head-and-tail shape — the start ("what
was the task") and the end ("how did it finish", where `submit_result` lives)
are the high-signal parts.

## Verification

TDD: the regression test was written and watched fail before the fix.

```
before:  retained 13 messages,  10789 bytes,   1.0% of the 1032192-byte budget
after:   retained 988 messages, 1032008 bytes, 100.0% of the budget
```

184 bytes under cap, and the test asserts the result still fits.

**Mutation check:** replacing the binary search with the old
`build(minTailMessages)` reproduces `13 messages, 1.0%` and fails
`TestWriteTranscript_TruncationFillsTheBudget`. A second test pins the structure
(system prompt at the head, marker naming the dropped middle, final message at
the tail) and passes both before and after — it is a shape pin, not a new
requirement.

`go test ./pkg/foreman/agent/... -count=1` green; `make lint-deadcode` 0 issues;
build, vet, gofmt clean.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — internal behaviour, no user-facing surface

## AI assistance

Written with Claude Code. The measurements come from live Foreman runs on the
shadowstack cluster, not from estimates. A human owns this review conversation.
