### PR TITLE
feat(foreman): wire the cross-stage contradiction detector into the reviewer path

### DIFF
--- a/.golangci-deadcode.yml
+++ b/.golangci-deadcode.yml
@@ -27,8 +27,6 @@ linters:
       # ---------------------------------------------------------------
       - path: pkg/foreman/agent/mcp_audit\.go # Refs #1331
         linters: [unused]
-      - path: pkg/foreman/agent/cross_stage\.go # Refs #1549
-        linters: [unused]
       - path: pkg/foreman/agent/mutation_check\.go # Refs #1555
         linters: [unused]
       # Whole file is unreferenced: the proposal-1075 work-class buckets

--- a/pkg/foreman/agent/cross_stage_wiring.go
+++ b/pkg/foreman/agent/cross_stage_wiring.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// branchFactsFromBranch computes the ground-truth BranchFacts for the branch
+// under review, anchored at base (a resolved commit SHA, or a ref like
+// "main"). files is the changed-file list the caller already resolved against
+// base, so it is passed in rather than re-read. It shells out to git via run;
+// any failure degrades to the corresponding zero value so the detector cannot
+// fire on missing ground truth (it errs toward not flagging).
+func branchFactsFromBranch(
+	ctx context.Context, workspace, base string, run commandRunner, files []string,
+) BranchFacts {
+	facts := BranchFacts{FilesChanged: files, BaseSHA: base}
+	if base == "" {
+		return facts
+	}
+	if out, err := run(ctx, workspace, nil, "git", "rev-parse", "HEAD"); err == nil {
+		facts.HeadSHA = strings.TrimSpace(out)
+	}
+	if out, err := run(ctx, workspace, nil, "git", "rev-list", "--count", base+"..HEAD"); err == nil {
+		if n, aerr := strconv.Atoi(strings.TrimSpace(out)); aerr == nil {
+			facts.CommitsAhead = n
+		}
+	}
+	return facts
+}
+
+// applyCrossStageContradictionsForTask is the production wiring for the
+// cross-stage contradiction detector (cross_stage.go). It builds a StageClaim
+// from what the reviewer stage already asserted -- its verdict, its
+// branch-emptiness prose, and the files it named -- and a BranchFacts from the
+// ground-truth diff the caller resolved, then records every contradiction the
+// detector reports onto the terminal result so the next pipeline step (or a
+// human) sees the disagreement.
+//
+// Non-blocking (#1549): it never changes the verdict; it only surfaces the
+// contradiction under Extra["crossStageContradictions"] and logs each one. It
+// degrades open -- a missing ground-truth diff (diffErr non-nil) means the
+// detector cannot separate a supported claim from an unsupported one, so it
+// steps aside, exactly like the other diff-anchored rails.
+//
+// It runs in the reviewer path of runLLMPath, after the reviewer rails, where
+// reviewBase/reviewDiff/reviewDiffErr are already in scope and a
+// contradiction can actually occur (the reviewer claims the branch is empty
+// when the ground-truth diff is non-empty).
+func applyCrossStageContradictionsForTask(
+	ctx context.Context, log logr.Logger, workspace, base string,
+	diff []string, diffErr error, loopRes *LoopResult,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+) {
+	if loopRes == nil || loopRes.Terminal == nil || diffErr != nil {
+		return
+	}
+	extra := loopRes.Terminal.Extra
+	facts := branchFactsFromBranch(ctx, workspace, base, execCommandRunner, diff)
+	named := []string{}
+	if extra != nil {
+		named, _ = extra["filesTouched"].([]string)
+	}
+	claim := StageClaim{
+		Stage:             "reviewer",
+		Verdict:           string(verdict),
+		ClaimsEmptyBranch: extra != nil && assertsEmptyBranch(emptyClaimTexts(loopRes.Terminal.Summary, extra)...),
+		NamedFiles:        named,
+	}
+	cs := contradictions(claim, facts)
+	if !shouldEscalate(cs) {
+		return
+	}
+	for _, c := range cs {
+		log.Info("cross-stage: reviewer claim contradicts the ground-truth branch facts",
+			"contradiction", c)
+	}
+	if extra == nil {
+		extra = map[string]any{}
+		loopRes.Terminal.Extra = extra
+	}
+	extra["crossStageContradictions"] = cs
+}

--- a/pkg/foreman/agent/cross_stage_wiring_test.go
+++ b/pkg/foreman/agent/cross_stage_wiring_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
+)
+
+// csGit runs one git command in dir with a fixed identity, failing the test
+// on error.
+func csGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=seed", "GIT_AUTHOR_EMAIL=seed@example.com",
+		"GIT_COMMITTER_NAME=seed", "GIT_COMMITTER_EMAIL=seed@example.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// csPushNonEmptyBranch clones the bare origin into a temp workdir, adds one
+// committed file on `branch` (so the branch is one commit ahead of main), and
+// pushes it to origin. Returns the bare origin path unchanged.
+func csPushNonEmptyBranch(t *testing.T, root, bare, branch string) {
+	t.Helper()
+	clone := filepath.Join(root, "coder-clone")
+	csGit(t, root, "clone", bare, clone)
+	csGit(t, clone, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(clone, "fix.go"), []byte("package fix\n"), 0o644); err != nil {
+		t.Fatalf("write fix.go: %v", err)
+	}
+	csGit(t, clone, "add", ".")
+	csGit(t, clone, "commit", "-m", "the real fix")
+	csGit(t, clone, "push", "origin", branch)
+}
+
+// TestCrossStageContradiction_WiredIntoRunLLMPath drives the PRODUCTION path:
+// Execute -> runLLMPath -> the reviewer block -> applyCrossStageContradictions
+// ForTask -> contradictions + shouldEscalate. It builds a reviewer task whose
+// branch is NON-empty (one real commit ahead of main) but whose terminal
+// summary asserts the branch is empty -- the #1549 incident where a reviewer
+// reported "no commits" on a branch that demonstrably had them. The detector
+// must fire and record the contradiction on the terminal result.
+//
+// Mutation check: comment out the applyCrossStageContradictionsForTask call in
+// runLLMPath and this test fails, because res.Extra["modelExtra"] no longer
+// carries "crossStageContradictions". A test that called contradictions()
+// directly would still pass with the call site removed -- this one cannot.
+func TestCrossStageContradiction_WiredIntoRunLLMPath(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	const branch = "foreman/review-1"
+	csPushNonEmptyBranch(t, root, bare, branch)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody}) // triggers the submit_result tool call
+
+	// Reviewer-role agent: read-only, so the non-GO path (no commit/push) is
+	// taken and the reviewer rails -- including the cross-stage check -- run.
+	agent := &foremanv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "reviewer-cs", Namespace: "default"},
+		Spec: foremanv1alpha1.AgentSpec{
+			Role:                foremanv1alpha1.AgentRoleReviewer,
+			Model:               "test-model",
+			InferenceServiceRef: corev1.LocalObjectReference{Name: "test-svc"},
+			SystemPrompt:        "you are a test reviewer",
+			Tools:               []string{"read_file", "submit_result"},
+			MaxTurns:            5,
+		},
+	}
+	// Review task that ADOPTS the non-empty branch under review.
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "review-cs", Namespace: "default", UID: types.UID("review-cs-uid"),
+		},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindReview,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Issue:  1549,
+				Branch: branch,
+			},
+			AgentRef: &corev1.LocalObjectReference{Name: agent.Name},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(agent, task).Build()
+
+	// The reviewer's terminal asserts an empty branch even though the ground
+	// truth is one committed file. No findings: the empty-claim rail (#1552)
+	// may remap the verdict, but the cross-stage contradiction is independent
+	// and must be recorded either way.
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true,
+				Verdict:  "NO-GO",
+				Summary:  "Branch has no commits and no code changes; nothing to review.",
+				Extra:    map[string]any{},
+			},
+		},
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	res, err := execWithAgent(t, e, task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	me, ok := res.Extra["modelExtra"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelExtra missing or wrong type: %T (%v)", res.Extra["modelExtra"], res.Extra)
+	}
+	cs, ok := me["crossStageContradictions"].([]string)
+	if !ok || len(cs) == 0 {
+		t.Fatalf("cross-stage contradiction was not recorded on the production path; "+
+			"got crossStageContradictions=%v (extra=%v)", me["crossStageContradictions"], res.Extra)
+	}
+	want := "reviewer: claims empty branch but CommitsAhead=1"
+	found := false
+	for _, c := range cs {
+		if c == want || strings.Contains(c, "claims empty branch") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected an empty-branch contradiction %q, got %v", want, cs)
+	}
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1008,6 +1008,18 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// gap as a finding. Runs last so it sees the reviewer's full set
 			// of findings; records-and-logs, never changes the verdict.
 			applyIssueClauseCoverageForTask(log, task, loopRes)
+			// Cross-stage contradiction check (#1549): the reviewer asserts
+			// checkable facts about the branch; compare them against the
+			// ground-truth facts resolved above (reviewBase + reviewDiff). A
+			// disagreement -- e.g. the reviewer claims an empty branch that is
+			// demonstrably non-empty -- is recorded on the terminal result so
+			// the next pipeline step or a human can escalate instead of letting
+			// the last-spoken stage decide. Records-and-logs; never changes the
+			// verdict. Mirrors applyCoderGroundingRailForTask /
+			// applyNoFunctionalChangeForTask: a small wrapper beside the
+			// existing ones so runLLMPath's complexity budget is untouched.
+			applyCrossStageContradictionsForTask(ctx, log, workspace, reviewBase,
+				reviewDiff, reviewDiffErr, loopRes, verdict)
 		}
 		r := e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
 		// #1109: preserve a coder's near-complete work when its in-loop


### PR DESCRIPTION
## What

Wires the cross-stage contradiction detector (`pkg/foreman/agent/cross_stage.go`)
into the **reviewer** path and deletes its dead-code suppression.

This is the first slice of #1549, not the whole of it. See Scope below — the
coder and gate stages are follow-up work tracked in #1674.

## Why

`cross_stage.go` held a unit-tested detector with zero production callers,
suppressed in `.golangci-deadcode.yml` so CI stayed green while the feature never
ran.

Refs #1549

## How

`applyCrossStageContradictionsForTask` builds a reviewer `StageClaim` from the
terminal summary and envelope, resolves ground-truth `BranchFacts` from the
branch the executor already cut, and runs the existing `contradictions()`
detector. Contradictions are logged and recorded on
`Extra["crossStageContradictions"]`. Records-and-logs: the reviewer's verdict is
left untouched.

It sits beside the existing rails in `runLLMPath` as a small `apply*ForTask`
wrapper, matching `applyCoderGroundingRailForTask` and
`applyIssueClauseCoverageForTask`, so that function's complexity budget is
unchanged.

## Scope — what this does NOT do

`contradictions()` implements four rules. This wiring makes **two** of them
reachable, because it builds only a reviewer claim:

| Rule | Reachable here | Why not |
|---|---|---|
| 1. claims edits on an empty branch | no | `ClaimsEdits` is never set on a reviewer claim |
| 2. claims empty branch when it is not | **yes** | |
| 3. names a file not among the changed files | **yes** | |
| 4. GATE-PASS on an empty branch | no | this call site only passes a reviewer verdict |

Rules 1 and 4 are the two halves of the incident that motivated #1549 (a coder
claiming an edit on a branch with zero commits, then a trivially-passing gate).
They need coder and gate claims, which is #1674. Calling this "wires #1549" would
overclaim, hence `Refs`, not `Fixes`.

Also deferred to #1674: the issue asks to "mark the task for escalation" and
preserve both claims and the ground facts. This preserves the contradiction
strings only, and nothing escalates.

## Verification

- **Mutation check:** deleting the `applyCrossStageContradictionsForTask` call
  site makes `TestCrossStageContradiction_WiredIntoRunLLMPath` **FAIL**. The test
  constrains the wiring, not just the detector.
- `make lint-deadcode` passes with **0 issues** and the `cross_stage.go`
  suppression deleted — no `//nolint`, no fake reference. `shouldEscalate` is a
  real production caller (`cross_stage_wiring.go:92`), not a test-only one.
- `go test ./pkg/foreman/agent/... -count=1` green; build, vet, gofmt clean.
- Rebased onto current main (was 9 commits behind). Two conflicts, both
  "two rails added in the same place": the `.golangci-deadcode.yml` resolution
  removes `cross_stage.go` while keeping the three entries already deleted on
  main deleted, and `executor_native.go` keeps **both** the #1554 clause-coverage
  rail and this one.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — internal rail, no user-facing surface

## AI assistance

The implementation commit was authored by a Foreman coder agent
(Ornith-1.5-35B-A3B, in-cluster). The rebase, conflict resolution, adversarial
review and scoping above were done with Claude Code. A human owns this review
conversation.
