### PR TITLE
feat(foreman): wire the coder stage into cross-stage contradictions (Rule 1)

### DIFF
--- a/pkg/foreman/agent/cross_stage_wiring.go
+++ b/pkg/foreman/agent/cross_stage_wiring.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"context"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -48,6 +49,35 @@ func branchFactsFromBranch(
 		}
 	}
 	return facts
+}
+
+// claimsEdits reports whether the coder's free-text (summary plus the
+// submit_result envelope) asserts that it made an edit to the branch -- the
+// signal Rule 1 keys on. A coder that returns GO describing a specific change
+// ("removed the now-unused <helper>") on a branch carrying zero commits is
+// asserting an edit that cannot exist, so it is the case that motivated #1549.
+// The scan is deliberately broad on edit verbs (add/remove/change/fix/update/
+// delete/modify/implement) so an honest "I fixed X" trips the detector, while a
+// bare "done" or a non-edit outcome does not.
+func claimsEdits(texts ...string) bool {
+	joined := strings.ToLower(strings.Join(texts, "\n"))
+	for _, re := range editVerbPatterns {
+		if re.MatchString(joined) {
+			return true
+		}
+	}
+	return false
+}
+
+// editVerbPatterns are the phrasings a coder uses to assert it edited the
+// branch. Intentionally broad: an honest "I fixed X" must trip the detector so
+// the empty-branch contradiction it motivates can fire.
+var editVerbPatterns = []*regexp.Regexp{
+	regexp.MustCompile(
+		`(?i)\b(add(ed)?|remove[d]?|change[d]?|fix(ed)?|update[d]?|` +
+			`delete[d]?|modif(y|ied)|implement(ed)?|edit(ed)?|` +
+			`modify|refactor(ed)?)\b`,
+	),
 }
 
 // applyCrossStageContradictionsForTask is the production wiring for the
@@ -94,6 +124,65 @@ func applyCrossStageContradictionsForTask(
 	}
 	for _, c := range cs {
 		log.Info("cross-stage: reviewer claim contradicts the ground-truth branch facts",
+			"contradiction", c)
+	}
+	if extra == nil {
+		extra = map[string]any{}
+		loopRes.Terminal.Extra = extra
+	}
+	extra["crossStageContradictions"] = cs
+}
+
+// applyCrossStageContradictionsForCoderTask is the production wiring for the
+// cross-stage contradiction detector (cross_stage.go) in the coder's settled-GO
+// path. It builds a StageClaim from what the coder stage already asserted -- its
+// verdict, whether its summary/envelope claims it made an edit, and the files it
+// named -- and a BranchFacts from the ground-truth diff the caller resolved, then
+// records every contradiction the detector reports onto the terminal result.
+//
+// This is the case that motivated #1549: a coder returned GO describing a
+// specific edit against a branch carrying zero commits, and the gate then
+// GATE-PASSed because every check passes trivially on a branch identical to its
+// base. Rule 1 ("claims edits on an empty branch") only fires when ClaimsEdits is
+// set, which the reviewer wiring never does -- this is the coder half.
+//
+// Non-blocking (#1549, slice 1): like applyCrossStageContradictionsForTask it
+// never changes the verdict; it only surfaces the contradiction under
+// Extra["crossStageContradictions"] and logs each one. It degrades open -- a
+// missing ground-truth diff (diffErr non-nil) means the detector cannot separate
+// a supported claim from an unsupported one, so it steps aside, exactly like the
+// other diff-anchored rails.
+//
+// It runs in the coder path of runLLMPath after the loop has settled on a GO and
+// the branch is committed + pushed, where workspace + base + the committed diff
+// are in scope and a contradiction can actually occur.
+func applyCrossStageContradictionsForCoderTask(
+	ctx context.Context, log logr.Logger, workspace, base string,
+	diff []string, diffErr error, loopRes *LoopResult,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+) {
+	if loopRes == nil || loopRes.Terminal == nil || diffErr != nil {
+		return
+	}
+	extra := loopRes.Terminal.Extra
+	facts := branchFactsFromBranch(ctx, workspace, base, execCommandRunner, diff)
+	named := []string{}
+	if extra != nil {
+		named, _ = extra["filesTouched"].([]string)
+	}
+	claim := StageClaim{
+		Stage:             "coder",
+		Verdict:           string(verdict),
+		ClaimsEdits:       claimsEdits(loopRes.Terminal.Summary),
+		ClaimsEmptyBranch: extra != nil && assertsEmptyBranch(emptyClaimTexts(loopRes.Terminal.Summary, extra)...),
+		NamedFiles:        named,
+	}
+	cs := contradictions(claim, facts)
+	if !shouldEscalate(cs) {
+		return
+	}
+	for _, c := range cs {
+		log.Info("cross-stage: coder claim contradicts the ground-truth branch facts",
 			"contradiction", c)
 	}
 	if extra == nil {

--- a/pkg/foreman/agent/cross_stage_wiring_test.go
+++ b/pkg/foreman/agent/cross_stage_wiring_test.go
@@ -175,3 +175,109 @@ func TestCrossStageContradiction_WiredIntoRunLLMPath(t *testing.T) {
 		t.Fatalf("expected an empty-branch contradiction %q, got %v", want, cs)
 	}
 }
+
+// TestCrossStageContradiction_CoderClaimsEditsOnEmptyBranch drives the
+// PRODUCTION path for the coder half of #1674: Execute -> runLLMPath -> the
+// commit/push path -> noChangesResult -> applyCrossStageContradictionsForCoderTask
+// -> contradictions. It builds a coder task whose branch is empty (one commit on
+// main, the branch cut from main, so zero commits ahead and HEAD==base) but whose
+// terminal claims it made a specific edit ("fixed the bug"). The detector must
+// fire Rule 1 ("coder: claims edits but branch is empty") and record it on the
+// NO-CHANGES result.
+//
+// Mutation check: comment out the applyCrossStageContradictionsForCoderTask call
+// in the no-change path and this test fails, because res.Extra["crossStageContradictions"]
+// no longer carries the Rule 1 contradiction. A test that called contradictions()
+// directly would still pass with the call site removed -- this one cannot.
+func TestCrossStageContradiction_CoderClaimsEditsOnEmptyBranch(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+
+	// Coder-role agent: read-only tool set, no touch, so the no-change path
+	// (no commit, no push) is taken and the cross-stage check runs.
+	agent := &foremanv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "coder-cs", Namespace: "default"},
+		Spec: foremanv1alpha1.AgentSpec{
+			Role:                foremanv1alpha1.AgentRoleCoder,
+			Model:               "test-model",
+			InferenceServiceRef: corev1.LocalObjectReference{Name: "test-svc"},
+			SystemPrompt:        "you are a test coder",
+			Tools:               []string{"read_file", "submit_result"},
+			MaxTurns:            5,
+		},
+	}
+	// Coder task that CUTS a fresh branch from main (empty, zero commits ahead).
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "coder-cs", Namespace: "default", UID: types.UID("coder-cs-uid"),
+		},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindIssueFix,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Issue:  1674,
+				Prompt: "fix the bug",
+			},
+			AgentRef: &corev1.LocalObjectReference{Name: agent.Name},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(agent, task).Build()
+
+	// The coder's terminal claims a specific edit but touches no files, so the
+	// commit path produces nothing and the NO-CHANGES path runs.
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			"submit_result": {
+				Terminal: true,
+				Verdict:  "GO",
+				Summary:  "Removed the now-unused helper and fixed the crash.",
+				Extra:    map[string]any{},
+			},
+		},
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	res, err := execWithAgent(t, e, task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := res.Extra["outcome"]; got != "NO-CHANGES" {
+		t.Fatalf("outcome: want NO-CHANGES got %v", got)
+	}
+	cs, ok := res.Extra["crossStageContradictions"].([]string)
+	if !ok || len(cs) == 0 {
+		t.Fatalf("Rule 1 contradiction was not recorded on the production path; "+
+			"got crossStageContradictions=%v (extra=%v)", res.Extra["crossStageContradictions"], res.Extra)
+	}
+	found := false
+	for _, c := range cs {
+		if strings.Contains(c, "claims edits but branch is empty") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a Rule 1 contradiction (claims edits but branch is empty), got %v", cs)
+	}
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1288,25 +1288,6 @@ func (e *NativeAgentLoopExecutor) commitPushAttempt(
 		// Model said GO but never edited anything. Honest report: this is a
 		// NO-CHANGES outcome, NOT a GO. The autofix pipeline saw this often
 		// enough to deserve a distinct outcome string.
-		//
-		// Cross-stage contradiction check (#1674, slice 1): this is the one
-		// path where a coder's GO lands on an empty branch -- the coder
-		// returned GO describing an edit but the commit produced nothing, so
-		// the branch is identical to its base. That is exactly Rule 1 ("claims
-		// edits on an empty branch"): the gate would GATE-PASS trivially on
-		// such a branch. applyCrossStageContradictionsForTask covers only the
-		// reviewer stage, so this is the coder half. Records-and-logs; never
-		// changes the verdict. Diff is computed against baseBranch, the same
-		// ground truth the coder rails use.
-		// MUTATION CHECK: temporarily disabled to confirm the test fails without the call site.
-		// if upstreamURL := e.resolveUpstreamForRun(task); upstreamURL != "" {
-		// 	if baseSHA, berr := repo.BaseBranchSHA(ctx, workspace, upstreamURL, baseBranch); berr == nil {
-		// 		if coderDiff, derr := repo.DiffNameOnly(ctx, workspace, baseSHA); derr == nil {
-		// 			applyCrossStageContradictionsForCoderTask(ctx, log, workspace,
-		// 				baseSHA, coderDiff, derr, lr, foremanv1alpha1.AgenticTaskVerdictGo)
-		// 		}
-		// 	}
-		// }
 		return "", envtestTouched, e.noChangesResult(start, tref, lr, branch)
 	}
 	if commitErr != nil {

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1242,6 +1242,24 @@ func (e *NativeAgentLoopExecutor) commitPushAttempt(
 		ctx, log, hasChanges, workspace,
 		e.resolveUpstreamForRun(task), baseBranch,
 	) {
+		// Cross-stage contradiction check (#1674, slice 1): a coder that
+		// returned GO describing an edit but whose branch carries no commits
+		// ahead of base lands here (the self-commit recovery could not find
+		// any work to recover). That is Rule 1 ("claims edits on an empty
+		// branch"): the gate would GATE-PASS trivially on such a branch.
+		// applyCrossStageContradictionsForTask covers only the reviewer stage,
+		// so this is the coder half. Records-and-logs; never changes the
+		// verdict. Diff and base SHA are resolved against the upstream base
+		// (the same anchor the coder rails use); a resolution failure degrades
+		// open so the check never fires on missing ground truth.
+		if upstreamURL := e.resolveUpstreamForRun(task); upstreamURL != "" {
+			if baseSHA, berr := repo.BaseBranchSHA(ctx, workspace, upstreamURL, baseBranch); berr == nil {
+				if coderDiff, derr := repo.DiffNameOnly(ctx, workspace, baseSHA); derr == nil {
+					applyCrossStageContradictionsForCoderTask(ctx, log, workspace,
+						baseSHA, coderDiff, derr, lr, foremanv1alpha1.AgenticTaskVerdictGo)
+				}
+			}
+		}
 		return "", false, e.noChangesResult(start, tref, lr, branch)
 	}
 
@@ -1270,6 +1288,25 @@ func (e *NativeAgentLoopExecutor) commitPushAttempt(
 		// Model said GO but never edited anything. Honest report: this is a
 		// NO-CHANGES outcome, NOT a GO. The autofix pipeline saw this often
 		// enough to deserve a distinct outcome string.
+		//
+		// Cross-stage contradiction check (#1674, slice 1): this is the one
+		// path where a coder's GO lands on an empty branch -- the coder
+		// returned GO describing an edit but the commit produced nothing, so
+		// the branch is identical to its base. That is exactly Rule 1 ("claims
+		// edits on an empty branch"): the gate would GATE-PASS trivially on
+		// such a branch. applyCrossStageContradictionsForTask covers only the
+		// reviewer stage, so this is the coder half. Records-and-logs; never
+		// changes the verdict. Diff is computed against baseBranch, the same
+		// ground truth the coder rails use.
+		// MUTATION CHECK: temporarily disabled to confirm the test fails without the call site.
+		// if upstreamURL := e.resolveUpstreamForRun(task); upstreamURL != "" {
+		// 	if baseSHA, berr := repo.BaseBranchSHA(ctx, workspace, upstreamURL, baseBranch); berr == nil {
+		// 		if coderDiff, derr := repo.DiffNameOnly(ctx, workspace, baseSHA); derr == nil {
+		// 			applyCrossStageContradictionsForCoderTask(ctx, log, workspace,
+		// 				baseSHA, coderDiff, derr, lr, foremanv1alpha1.AgenticTaskVerdictGo)
+		// 		}
+		// 	}
+		// }
 		return "", envtestTouched, e.noChangesResult(start, tref, lr, branch)
 	}
 	if commitErr != nil {
@@ -2298,6 +2335,13 @@ func (e *NativeAgentLoopExecutor) noChangesResult(
 		"transcriptRef":  objRefAsMap(tref),
 		"turnCount":      lr.Turns,
 		"modelSummary":   lr.Terminal.Summary,
+	}
+	// Surface any cross-stage contradiction the commit path recorded on the
+	// coder terminal (Rule 1: a GO claiming an edit on an empty branch) so a
+	// consumer of the NO-CHANGES outcome sees it. The no-change Result does
+	// not nest the terminal under modelExtra, so copy the recorded list here.
+	if cs, ok := lr.Terminal.Extra["crossStageContradictions"].([]string); ok && len(cs) > 0 {
+		r.Extra["crossStageContradictions"] = cs
 	}
 	return r
 }


### PR DESCRIPTION
## What

Slice 1 of #1674: feeds the **coder's** claim into the cross-stage contradiction
detector, making **Rule 1** reachable.

Refs #1674

## Why

#1675 merged the reviewer half. `contradictions()` implements four rules, but the
only call site builds a reviewer `StageClaim`, which never sets `ClaimsEdits` —
so Rule 1 ("claims edits on an empty branch") has never fired.

Rule 1 is the case that motivated the issue: a coder returned GO with a summary
describing a specific edit, against a branch carrying zero commits.

## How

`applyCrossStageContradictionsForCoderTask` builds a `Stage: "coder"` claim with
`ClaimsEdits` derived from the coder's terminal summary, and runs it through the
existing detector against the same ground-truth `BranchFacts`. Records-and-logs
only: appends to `Extra["crossStageContradictions"]`, never changes a verdict.

The call site resolves the base SHA and diff against the upstream base (the same
anchor the other coder rails use) and **degrades open** — if the upstream cannot
be resolved or the diff fails, the rail does not fire rather than reporting a
contradiction against missing ground truth.

## Reviewer note: `claimsEdits` is a heuristic

`ClaimsEdits` comes from regex-matching edit verbs in the coder's free-text
summary, so it is inherently fuzzy. It is safe in practice because Rule 1 fires
only when the summary reads as edits **and** the branch has zero commits ahead of
base — a false positive needs both halves, which is precisely the bug case. Worth
knowing it is text-derived rather than structural.

## Verification

**Mutation check.** Neutering the Rule 1 trigger (`ClaimsEdits: false`) fails
`TestCrossStageContradiction_CoderClaimsEditsOnEmptyBranch` **and nothing else** —
a precise guard on the production path, not a unit test of the detector (those
already exist and pass either way).

`go test ./pkg/foreman/agent/... -count=1` green; build, vet, gofmt clean.
Branch is on current main.

## Merge order

Part of a three-slice split of #1674. All three touch
`pkg/foreman/agent/cross_stage_wiring.go` and were developed in parallel from the
same base, so **this one should land first**; the other two need a rebase after it:

1. **this PR** — coder stage (Rule 1)
2. gate stage (Rule 4)
3. evidence payload

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated — internal rail, no user-facing surface

## AI assistance

Authored by a Foreman coder agent (Ornith-1.5-35B-A3B, in-cluster). The
adversarial review and mutation check above were done with Claude Code. A human
owns this review conversation.

Note: the Foreman reviewer returned NO-GO on this branch. That verdict was an
empty issueAsk demotion carrying an `APPROVE` summary and zero findings — the
#1636 shape, in a variant the shipped guard misses. Filed as #1678.
