### PR TITLE
feat(foreman): wire the gate stage into cross-stage contradictions (Rule 4)

### DIFF
--- a/pkg/foreman/agent/cross_stage_gate_wiring_test.go
+++ b/pkg/foreman/agent/cross_stage_gate_wiring_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
+)
+
+// TestCrossStageContradiction_GatePassEmptyBranch drives the PRODUCTION path:
+// Execute -> executeDeterministic -> applyCrossStageContradictionsForGate ->
+// contradictions + shouldEscalate. It builds a gate task whose branch carries
+// no commits ahead of its base (the coder never pushed, so the branch is
+// absent and the executor falls back to the seed commit identical to base) but
+// whose gate reports GATE-PASS -- the #1674 incident where the checks passed
+// trivially on an empty branch. The detector must fire and record the
+// contradiction on the terminal result.
+//
+// Mutation check: comment out the applyCrossStageContradictionsForGate call in
+// Execute and this test fails, because res.Extra no longer carries
+// "crossStageContradictions". A test that called contradictions() directly
+// would still pass with the call site removed -- this one cannot.
+func TestCrossStageContradiction_GatePassEmptyBranch(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+
+	// Gate Agent: no inferenceServiceRef, no systemPrompt, tools list names
+	// the deterministic worker tool first. The executor dispatches that
+	// tool directly without spinning up the OAI loop.
+	agent := &foremanv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "gate", Namespace: "default"},
+		Spec: foremanv1alpha1.AgentSpec{
+			Role:               foremanv1alpha1.AgentRoleVerifier,
+			Tools:              []string{"run_gate_job"},
+			RequiredCapability: foremanv1alpha1.RequiredCapability{Roles: []string{"verifier"}},
+		},
+	}
+	// Verify task that ADOPTS a coder branch the coder never pushed: the
+	// branch is absent on the remote, so the executor falls back to the
+	// seed commit identical to its base (an empty branch).
+	task := &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gate", Namespace: "default", UID: types.UID("gate-uid"),
+		},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindVerify,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Issue:  1674,
+				Branch: "foreman/review-1",
+			},
+			AgentRef: &corev1.LocalObjectReference{Name: agent.Name},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(agent, task).Build()
+
+	reg := &fakeRegistry{
+		results: map[string]*foremanagent.ToolResult{
+			// Gate tool reports GATE-PASS on the empty branch.
+			"run_gate_job": {
+				Terminal: true,
+				Verdict:  "GATE-PASS",
+				Summary:  "all checks green",
+				Output:   map[string]any{"jobName": "foreman-gate-fake-001"},
+			},
+		},
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:             c,
+		WorkspaceRoot:      filepath.Join(root, "ws"),
+		GitRemoteURL:       bare,
+		UpstreamURLForRepo: func(string) string { return bare },
+		CommitAuthor:       repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:    repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, _ string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	res, err := execWithAgent(t, e, task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdict("GATE-PASS") {
+		t.Fatalf("verdict: want GATE-PASS got %s", res.Verdict)
+	}
+
+	cs, ok := res.Extra["crossStageContradictions"].([]string)
+	if !ok || len(cs) == 0 {
+		t.Fatalf("cross-stage contradiction was not recorded on the production path; "+
+			"got crossStageContradictions=%v (extra=%v)", res.Extra["crossStageContradictions"], res.Extra)
+	}
+	want := "gate: GATE-PASS on an empty branch (checks passed trivially)"
+	found := false
+	for _, c := range cs {
+		if c == want || strings.Contains(c, "GATE-PASS on an empty branch") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a GATE-PASS empty-branch contradiction %q, got %v", want, cs)
+	}
+}

--- a/pkg/foreman/agent/cross_stage_wiring.go
+++ b/pkg/foreman/agent/cross_stage_wiring.go
@@ -191,3 +191,46 @@ func applyCrossStageContradictionsForCoderTask(
 	}
 	extra["crossStageContradictions"] = cs
 }
+
+// applyCrossStageContradictionsForGate is the production wiring for the
+// cross-stage contradiction detector (cross_stage.go) at the verify (gate)
+// stage's terminal. It builds a StageClaim carrying the gate's Verdict
+// ("GATE-PASS") and a BranchFacts from the ground-truth diff the caller
+// resolved, then records every contradiction the detector reports onto the
+// terminal result so the next pipeline step (or a human) sees that the gate
+// passed on a branch carrying no change -- the checks passed trivially, so
+// the verdict carries no information about the change (Rule 4).
+//
+// Non-blocking: it never changes the verdict; it only surfaces the
+// contradiction under Extra["crossStageContradictions"] and logs each one.
+// It degrades open -- a missing ground-truth diff (diffErr non-nil) means
+// the detector cannot separate a supported claim from an unsupported one,
+// so it steps aside, exactly like the other diff-anchored rails.
+//
+// It runs in the verify path of Execute, after the gate tool dispatches,
+// where the gate's workspace (the adopted coder branch) and base are in
+// scope. Mirrors applyCrossStageContradictionsForTask; the gate is
+// deterministic and makes no prose claims, so only Rule 4 can fire.
+func applyCrossStageContradictionsForGate(
+	ctx context.Context, log logr.Logger, workspace, base string,
+	diff []string, diffErr error, r *Result,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+) {
+	if r == nil || r.Extra == nil || diffErr != nil {
+		return
+	}
+	facts := branchFactsFromBranch(ctx, workspace, base, execCommandRunner, diff)
+	claim := StageClaim{
+		Stage:   "gate",
+		Verdict: string(verdict),
+	}
+	cs := contradictions(claim, facts)
+	if !shouldEscalate(cs) {
+		return
+	}
+	for _, c := range cs {
+		log.Info("cross-stage: gate claim contradicts the ground-truth branch facts",
+			"contradiction", c)
+	}
+	r.Extra["crossStageContradictions"] = cs
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -485,7 +485,21 @@ func (e *NativeAgentLoopExecutor) Execute(
 	// first tool directly with the task payload as JSON arguments. The
 	// gate Agent uses this; M5+ reviewer agents use the LLM path.
 	if deterministic {
-		return e.executeDeterministic(ctx, task, agent, branch, registry, cloneURL, start), nil
+		r := e.executeDeterministic(ctx, task, agent, branch, registry, cloneURL, start)
+		// Cross-stage contradiction check at the verify (gate) stage's
+		// terminal (#1674): the gate passes on the adopted coder branch;
+		// compare its verdict against the ground-truth diff so a trivial
+		// GATE-PASS on an empty branch (checks passed with no change to
+		// judge) is recorded, not silently trusted. Mirrors
+		// applyCrossStageContradictionsForTask in the reviewer path;
+		// records-and-logs, never changes the verdict.
+		if r != nil {
+			gateBase := e.reviewerDiffBase(ctx, log, task, workspace)
+			gateDiff, gateDiffErr := repo.DiffNameOnly(ctx, workspace, gateBase)
+			applyCrossStageContradictionsForGate(ctx, log, workspace, gateBase,
+				gateDiff, gateDiffErr, r, r.Verdict)
+		}
+		return r, nil
 	}
 
 	// 6+. LLM-driven path: extracted to keep Execute below the


### PR DESCRIPTION
## What

Slice 2a of #1674: feeds the **gate's** claim into the cross-stage contradiction
detector, making **Rule 4** reachable.

Refs #1674

## Why

Rule 4 is "a gate that passes on an empty branch: the checks passed trivially, so
the verdict carries no information about the change". It fires only when
`claim.Verdict == "GATE-PASS"`, and the only call site before this passed a
reviewer verdict — so Rule 4 has never fired. It is the second half of the
incident that motivated #1674 (a coder claiming an edit on an empty branch, then
a gate passing trivially on the same branch).

## How

`applyCrossStageContradictionsForGate` builds a `Stage: "gate"` claim and runs it
through the existing detector against the same ground-truth `BranchFacts`.
Records-and-logs only; never changes a verdict.

**It passes the gate's real verdict (`r.Verdict`) rather than hardcoding
`"GATE-PASS"`.** That is deliberate and better than the obvious implementation: a
hardcoded literal would make a *failing* gate on an empty branch also report a
Rule 4 contradiction, which is wrong. Rule 4 now fires only when the gate
genuinely passed.

## Verification

**Mutation check.** Passing an empty verdict instead of `r.Verdict` fails
`TestCrossStageContradiction_GatePassEmptyBranch` and nothing else.

`go test ./pkg/foreman/agent/... -count=1` green; build, vet, gofmt clean.

## Merge order

Second of three slices of #1674. All three touch
`pkg/foreman/agent/cross_stage_wiring.go` and were built in parallel from the same
base, so **this needs a rebase once #1680 lands**:

1. #1680 — coder stage (Rule 1)
2. **this PR** — gate stage (Rule 4)
3. evidence payload

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated — internal rail, no user-facing surface

## AI assistance

Authored by a Foreman coder agent (Ornith-1.5-35B-A3B, in-cluster). Adversarial
review and mutation check with Claude Code. A human owns this review conversation.

Note: the Foreman reviewer returned NO-GO here, faulting the diff for "only
implementing gate stage, leaving coder stage unaddressed". That is correct about
the *issue* and wrong about the *task* — this slice was explicitly scoped away
from the coder stage. The reviewer judges against the issue body and cannot see
slice intent; filed as #1679.
