### PR TITLE
feat(foreman): record claim and facts alongside cross-stage contradictions

### DIFF
--- a/pkg/foreman/agent/cross_stage.go
+++ b/pkg/foreman/agent/cross_stage.go
@@ -17,11 +17,11 @@ import (
 // caller. It is a plain data struct so the detector below stays a pure function
 // of (claim, facts).
 type BranchFacts struct {
-	CommitsAhead int
-	FilesChanged []string
-	NetLineDelta int
-	HeadSHA      string
-	BaseSHA      string
+	CommitsAhead int      `json:"commitsAhead"`
+	FilesChanged []string `json:"filesChanged"`
+	NetLineDelta int      `json:"netLineDelta"`
+	HeadSHA      string   `json:"headSHA"`
+	BaseSHA      string   `json:"baseSHA"`
 }
 
 // BranchIsEmpty reports whether the branch carries no change relative to its
@@ -35,11 +35,22 @@ func (f BranchFacts) BranchIsEmpty() bool {
 
 // StageClaim captures what a single pipeline stage asserted about the branch.
 type StageClaim struct {
-	Stage             string
-	Verdict           string
-	ClaimsEdits       bool
-	ClaimsEmptyBranch bool
-	NamedFiles        []string
+	Stage             string   `json:"stage"`
+	Verdict           string   `json:"verdict"`
+	ClaimsEdits       bool     `json:"claimsEdits"`
+	ClaimsEmptyBranch bool     `json:"claimsEmptyBranch"`
+	NamedFiles        []string `json:"namedFiles"`
+}
+
+// crossStageEvidence preserves what a stage claimed and the ground facts it was
+// checked against, so a human or a later stage can see WHAT disagreed with WHAT
+// rather than only that something did. The contradictions slice is the same
+// human-readable list recorded under Extra["crossStageContradictions"]; the
+// claim and facts are the structured inputs that produced it.
+type crossStageEvidence struct {
+	Claim          StageClaim  `json:"claim"`
+	Facts          BranchFacts `json:"facts"`
+	Contradictions []string    `json:"contradictions"`
 }
 
 // contradictions reports every way the claim disagrees with the ground facts.

--- a/pkg/foreman/agent/cross_stage_wiring.go
+++ b/pkg/foreman/agent/cross_stage_wiring.go
@@ -101,4 +101,16 @@ func applyCrossStageContradictionsForTask(
 		loopRes.Terminal.Extra = extra
 	}
 	extra["crossStageContradictions"] = cs
+	// Preserve the structured evidence behind the contradiction strings: the
+	// claim that was evaluated, the ground facts it was checked against, and
+	// the contradictions themselves (#1674). The strings alone say *that*
+	// something disagreed; the claim + facts say *what* disagreed with *what*,
+	// so a human or a later stage can judge whether the disagreement is real
+	// without re-deriving the inputs. Extra["crossStageContradictions"] is
+	// left exactly as it was -- this only adds a key, it does not replace one.
+	extra["crossStageEvidence"] = crossStageEvidence{
+		Claim:          claim,
+		Facts:          facts,
+		Contradictions: cs,
+	}
 }

--- a/pkg/foreman/agent/cross_stage_wiring_test.go
+++ b/pkg/foreman/agent/cross_stage_wiring_test.go
@@ -18,6 +18,7 @@ package agent_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -174,4 +175,68 @@ func TestCrossStageContradiction_WiredIntoRunLLMPath(t *testing.T) {
 	if !found {
 		t.Fatalf("expected an empty-branch contradiction %q, got %v", want, cs)
 	}
+
+	// #1674: the evidence behind the contradiction must round-trip. The claim
+	// and facts that were evaluated come back with the same field values that
+	// went in, and the old crossStageContradictions key is left exactly as it
+	// was (this only added a key, it did not replace one). The evidence is a
+	// small flat struct; unmarshal the stored JSON into a local mirror of that
+	// shape and assert on its fields. This proves both the round-trip and that
+	// the JSON tags are the ones a downstream reader would key on.
+	var stored crossStageEvidenceJSON
+	raw, _ := json.Marshal(me["crossStageEvidence"])
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("unmarshal crossStageEvidence: %v\nraw=%s", err, raw)
+	}
+	if stored.Claim.Stage != "reviewer" {
+		t.Fatalf("evidence claim stage = %q, want reviewer", stored.Claim.Stage)
+	}
+	if !stored.Claim.ClaimsEmptyBranch {
+		t.Fatalf("evidence claim claimsEmptyBranch = false, want true")
+	}
+	if stored.Claim.NamedFiles[0] != "fix.go" {
+		t.Fatalf("evidence claim namedFiles = %v, want [fix.go]", stored.Claim.NamedFiles)
+	}
+	if stored.Facts.CommitsAhead != 1 {
+		t.Fatalf("evidence facts commitsAhead = %d, want 1", stored.Facts.CommitsAhead)
+	}
+	if stored.Facts.FilesChanged[0] != "fix.go" {
+		t.Fatalf("evidence facts filesChanged = %v, want [fix.go]", stored.Facts.FilesChanged)
+	}
+	if stored.Facts.HeadSHA == "" || stored.Facts.BaseSHA == "" {
+		t.Fatalf("evidence facts missing git-resolved SHAs: %+v", stored.Facts)
+	}
+	if stored.Facts.HeadSHA == stored.Facts.BaseSHA {
+		t.Fatalf("evidence facts headSHA == baseSHA %q on a one-commit branch", stored.Facts.HeadSHA)
+	}
+	if len(stored.Contradictions) != len(cs) {
+		t.Fatalf("evidence contradictions len = %d, want %d", len(stored.Contradictions), len(cs))
+	}
+	for i := range cs {
+		if stored.Contradictions[i] != cs[i] {
+			t.Fatalf("evidence contradiction[%d] = %q, want %q", i, stored.Contradictions[i], cs[i])
+		}
+	}
+}
+
+// crossStageEvidenceJSON mirrors the JSON shape the production path records
+// under Extra["crossStageEvidence"], so the external test package can decode it
+// without naming the unexported types. Field order + tags must match
+// cross_stage.go's crossStageEvidence.
+type crossStageEvidenceJSON struct {
+	Claim struct {
+		Stage             string   `json:"stage"`
+		Verdict           string   `json:"verdict"`
+		ClaimsEdits       bool     `json:"claimsEdits"`
+		ClaimsEmptyBranch bool     `json:"claimsEmptyBranch"`
+		NamedFiles        []string `json:"namedFiles"`
+	} `json:"claim"`
+	Facts struct {
+		CommitsAhead int      `json:"commitsAhead"`
+		FilesChanged []string `json:"filesChanged"`
+		NetLineDelta int      `json:"netLineDelta"`
+		HeadSHA      string   `json:"headSHA"`
+		BaseSHA      string   `json:"baseSHA"`
+	} `json:"facts"`
+	Contradictions []string `json:"contradictions"`
 }


### PR DESCRIPTION
## What

Slice 2b of #1674: records the **evidence** behind a cross-stage contradiction,
not just the message strings.

Refs #1674

## Why

Before this, the rail ended with one line of recording:

```go
extra["crossStageContradictions"] = cs   // []string of messages
```

#1674 asks to "preserve both claims and the ground facts" so a human or a later
stage can see **what disagreed with what**, rather than only that something did.

## How

Adds a sibling key `Extra["crossStageEvidence"]` holding three fields:

```go
type crossStageEvidence struct {
	Claim          StageClaim  `json:"claim"`
	Facts          BranchFacts `json:"facts"`
	Contradictions []string    `json:"contradictions"`
}
```

`StageClaim` and `BranchFacts` gain JSON tags. **`crossStageContradictions` is
left exactly as it was** — this adds a key, it does not replace one, because
something may already read the old shape.

## Verification

**Mutation-checked in both directions**, which is the point here since the
constraint was "add, don't replace":

| revert | result |
|---|---|
| drop the `crossStageEvidence` write | `TestCrossStageContradiction_WiredIntoRunLLMPath` **FAILS** |
| drop the legacy `crossStageContradictions` write | same test **FAILS** |

So the new key is guarded and the old key's preservation is guarded too, rather
than being an unenforced promise in a comment.

`go test ./pkg/foreman/agent/... -count=1` green; build, vet, gofmt clean.

## Merge order

Third of three slices of #1674. All three touch
`pkg/foreman/agent/cross_stage_wiring.go`, built in parallel from one base, so
**this needs a rebase after #1680 and #1681 land**:

1. #1680 — coder stage (Rule 1)
2. #1681 — gate stage (Rule 4)
3. **this PR** — evidence payload

Once all three land, all four rules are reachable and every contradiction carries
its inputs.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated — internal rail, no user-facing surface

## AI assistance

Authored by a Foreman coder agent (Ornith-1.5-35B-A3B, in-cluster), 42 turns in
7 minutes. Adversarial review and mutation checks with Claude Code. A human owns
this review conversation.
