### PR TITLE
fix(foreman): make the ALREADY-RESOLVED cascade-skip transitive

### DIFF
--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -179,17 +179,18 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	// Cascade-skip if any dependency ended ALREADY-RESOLVED (#970). The
-	// dependent cannot meaningfully run (the work is already on the branch);
-	// mark it Skipped (Phase=Succeeded + Verdict=Skipped) so the rollup
-	// excludes it from every bucket instead of cascade-failing it (which
-	// would land at Phase=Failed and pin the Workload to Failed). The skip
-	// check runs before the cascade-fail check so an ALREADY-RESOLVED dep
-	// never trips the "terminal without success" branch.
-	if depName, err := r.cascadeSkipIfDepAlreadyResolved(ctx, &task); err != nil {
+	// Cascade-skip if any dependency ended ALREADY-RESOLVED or was itself
+	// Skipped (#970, transitive #1688). The dependent cannot meaningfully
+	// run (the work is already on the branch, or an upstream stage had
+	// nothing to do); mark it Skipped (Phase=Succeeded + Verdict=Skipped)
+	// so the rollup excludes it from every bucket instead of cascade-failing
+	// it (which would land at Phase=Failed and pin the Workload to Failed).
+	// The skip check runs before the cascade-fail check so a resolved/skipped
+	// dep never trips the "terminal without success" branch.
+	if depName, depState, err := r.cascadeSkipIfDepResolvedOrSkipped(ctx, &task); err != nil {
 		return ctrl.Result{}, err
 	} else if depName != "" {
-		return r.skipTask(ctx, &task, depName)
+		return r.skipTask(ctx, &task, depName, depState)
 	}
 
 	// Cascade-fail if any dependency has Failed.
@@ -816,13 +817,17 @@ func (r *AgenticTaskReconciler) failTask(ctx context.Context, task *foremanv1alp
 }
 
 // skipTask transitions a Pending task to Phase=Succeeded + Verdict=Skipped
-// because its dependency ended ALREADY-RESOLVED (#970). The Workload
-// rollup recognizes Skipped as a terminal-non-failure shape that is
-// excluded from every bucket; the dependent's execution never happened,
-// so no FailureReason is set (the cause is upstream, recorded in the
-// condition message). The Failed condition is NOT set — this is the
-// explicit non-failure path.
-func (r *AgenticTaskReconciler) skipTask(ctx context.Context, task *foremanv1alpha1.AgenticTask, depName string) (ctrl.Result, error) {
+// because its dependency ended ALREADY-RESOLVED or was itself Skipped
+// (#970, transitive #1688). The Workload rollup recognizes Skipped as a
+// terminal-non-failure shape that is excluded from every bucket; the
+// dependent's execution never happened, so no FailureReason is set (the
+// cause is upstream, recorded in the condition message). The Failed
+// condition is NOT set — this is the explicit non-failure path.
+//
+// depState is the dependency's own terminal state string ("ALREADY-RESOLVED"
+// or "Skipped"), threaded through so the condition message names the actual
+// reason rather than always saying ALREADY-RESOLVED for a transitive skip.
+func (r *AgenticTaskReconciler) skipTask(ctx context.Context, task *foremanv1alpha1.AgenticTask, depName, depState string) (ctrl.Result, error) {
 	patch := client.MergeFrom(task.DeepCopy())
 	now := metav1.Now()
 	task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
@@ -832,31 +837,41 @@ func (r *AgenticTaskReconciler) skipTask(ctx context.Context, task *foremanv1alp
 		Type:               "Skipped",
 		Status:             metav1.ConditionTrue,
 		Reason:             "UpstreamAlreadyResolved",
-		Message:            fmt.Sprintf("dependency %q ended ALREADY-RESOLVED; dependent skipped", depName),
+		Message:            fmt.Sprintf("dependency %q ended %s; dependent skipped", depName, depState),
 		LastTransitionTime: now,
 	})
 	return ctrl.Result{}, r.Status().Patch(ctx, task, patch)
 }
 
-// cascadeSkipIfDepAlreadyResolved returns the first dependency that ended
-// ALREADY-RESOLVED (#970), or "" if none. The caller transitions the
-// dependent to Skipped; see skipTask. Runs before cascadeFailIfDepFailed
-// in Reconcile so an ALREADY-RESOLVED dep never trips the
-// "terminal without success" branch.
-func (r *AgenticTaskReconciler) cascadeSkipIfDepAlreadyResolved(ctx context.Context, task *foremanv1alpha1.AgenticTask) (string, error) {
+// cascadeSkipIfDepResolvedOrSkipped returns the first dependency that ended
+// ALREADY-RESOLVED (#970) OR was itself Skipped, or "" if none. The caller
+// transitions the dependent to Skipped; see skipTask. Runs before
+// cascadeFailIfDepFailed in Reconcile so a resolved/skipped dep never trips
+// the "terminal without success" branch.
+//
+// Transitivity: a dependency that was itself cascade-skipped (because ITS
+// dependency ended ALREADY-RESOLVED) would otherwise fall through to
+// cascadeFailIfDepFailed, which treats verdict=Skipped as "terminal without
+// success" and cascade-fails the dependent. Checking isSkippedTask here makes
+// the skip walk the whole dependency chain rather than stopping after one
+// hop. Fixes defilantech/LLMKube#1688.
+func (r *AgenticTaskReconciler) cascadeSkipIfDepResolvedOrSkipped(ctx context.Context, task *foremanv1alpha1.AgenticTask) (string, string, error) {
 	for _, depName := range task.Spec.DependsOn {
 		var dep foremanv1alpha1.AgenticTask
 		if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: depName}, &dep); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			return "", err
+			return "", "", err
 		}
 		if isAlreadyResolvedCoder(&dep) {
-			return depName, nil
+			return depName, "ALREADY-RESOLVED", nil
+		}
+		if isSkippedTask(&dep) {
+			return depName, "Skipped", nil
 		}
 	}
-	return "", nil
+	return "", "", nil
 }
 
 // checkClaimExpiry inspects the FleetNode named by task.status.assignedNode.

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -206,6 +206,64 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		Expect(failedCond).To(BeNil(), "a Skipped dependent must not carry a Failed condition")
 	})
 
+	// Regression for defilantech/LLMKube#1688. The ALREADY-RESOLVED
+	// cascade-skip propagates exactly one hop: a dependency that ended
+	// ALREADY-RESOLVED skips its direct dependent, but a dependent of
+	// that Skipped task fell through to cascade-fail (which treats
+	// verdict=Skipped as "terminal without success") and ended up
+	// cascade-failed. The skip must be transitive: a task whose
+	// dependency was itself Skipped is itself Skipped with the same
+	// reason chain, so the whole chain is skipped rather than the outer
+	// hop cascade-failing.
+	It("cascade-skips a task whose dependency was itself Skipped (#1688)", func() {
+		// code: ALREADY-RESOLVED.
+		code := newTask("transitive-code")
+		Expect(k8sClient.Create(ctx, code)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, code) })
+		setPhase(code, foremanv1alpha1.AgenticTaskPhaseSucceeded)
+		patch := client.MergeFrom(code.DeepCopy())
+		code.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		code.Status.Result = &runtime.RawExtension{
+			Raw: []byte(`{"summary":"already done","extra":{"outcome":"ALREADY-RESOLVED","resolvedBy":"sha-deadbeef"}}`),
+		}
+		Expect(k8sClient.Status().Patch(ctx, code, patch)).To(Succeed())
+
+		// verify: cascade-skipped because code ended ALREADY-RESOLVED.
+		verify := newTask("transitive-verify")
+		verify.Spec.DependsOn = []string{code.Name}
+		Expect(k8sClient.Create(ctx, verify)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, verify) })
+		setPhase(verify, foremanv1alpha1.AgenticTaskPhaseSucceeded)
+		verifyPatch := client.MergeFrom(verify.DeepCopy())
+		verify.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictSkipped
+		Expect(k8sClient.Status().Patch(ctx, verify, verifyPatch)).To(Succeed())
+
+		// review: depends on verify, which is Skipped. Must be
+		// cascade-skipped too, not cascade-failed.
+		review := newTask("transitive-review")
+		review.Spec.DependsOn = []string{verify.Name}
+		Expect(k8sClient.Create(ctx, review)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, review) })
+		setPhase(review, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(review))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(review), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseSucceeded))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictSkipped))
+
+		skippedCond := findCondition(fresh.Status.Conditions, "Skipped")
+		Expect(skippedCond).NotTo(BeNil())
+		Expect(skippedCond.Reason).To(Equal("UpstreamAlreadyResolved"))
+		Expect(skippedCond.Message).To(ContainSubstring(verify.Name))
+
+		// A Skipped dependent must not carry a Failed condition.
+		failedCond := findCondition(fresh.Status.Conditions, "Failed")
+		Expect(failedCond).To(BeNil(), "a Skipped dependent must not carry a Failed condition")
+	})
+
 	It("waits with requeue when a dependency is still pre-terminal", func() {
 		dep := newTask("wait-dep") // status stays empty == pre-terminal
 		Expect(k8sClient.Create(ctx, dep)).To(Succeed())

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -122,12 +122,14 @@ func isAlreadyResolvedCoder(task *foremanv1alpha1.AgenticTask) bool {
 }
 
 // isSkippedTask reports whether the task was skipped because its
-// dependency ended ALREADY-RESOLVED (#970). The cascade path in
-// agentictask_controller.transitionToSkippedIfDepAlreadyResolved
-// stamps Phase=Succeeded + Verdict=Skipped on the dependent; the
-// rollup excludes Skipped tasks from every bucket (succeeded,
-// incomplete, failed, inFlight, alreadyResolved) so they don't pin
-// the Workload to Failed.
+// dependency ended ALREADY-RESOLVED or was itself Skipped (#970,
+// transitive #1688). The cascade path in
+// agentictask_controller.cascadeSkipIfDepResolvedOrSkipped stamps
+// Phase=Succeeded + Verdict=Skipped on the dependent; the rollup
+// excludes Skipped tasks from every bucket (succeeded, incomplete,
+// failed, inFlight, alreadyResolved) so they don't pin the Workload
+// to Failed. Reused by that cascade path so there is a single
+// predicate for the skip state rather than a second copy.
 func isSkippedTask(task *foremanv1alpha1.AgenticTask) bool {
 	if task == nil {
 		return false

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -706,7 +706,12 @@ func classifyChildren(children []foremanv1alpha1.AgenticTask) childCounts {
 //   - Otherwise (in-flight children) → Dispatched
 //
 // Skipped children never trigger Failed (the case arm requires
-// `failed > 0 || incomplete > 0` and Skipped is counted in neither).
+// `failed > 0 || incomplete > 0` and Skipped is counted in neither), so a
+// Workload whose only non-succeeded children are Skipped rolls to Completed
+// via the ALREADY-RESOLVED case: the transitive cascade-skip (#1688) makes
+// the downstream dependents Skipped, and the upstream ALREADY-RESOLVED coder
+// is counted in `alreadyResolved`, which the all-on-target case would
+// otherwise match and report "0/N on-target".
 func computeTerminalState(w *foremanv1alpha1.Workload, c childCounts, now metav1.Time) {
 	switch {
 	case c.inFlight == 0 && c.failed == 0 && c.incomplete == 0 && c.alreadyResolved == 0:

--- a/internal/foreman/controller/workload_controller_test.go
+++ b/internal/foreman/controller/workload_controller_test.go
@@ -1015,6 +1015,50 @@ var _ = Describe("WorkloadReconciler (M6 stub planner)", func() {
 		Expect(got["99"]).To(Equal("sha-99"))
 	})
 
+	It("rolls up a Workload whose verify child is cascade-Skipped to Completed (#1688)", func() {
+		// A three-task chain whose code child ends ALREADY-RESOLVED: the
+		// verify child is cascade-skipped (production path) and the
+		// Workload must roll to Completed, not Failed. The ALREADY-RESOLVED
+		// coder is counted in the alreadyResolved bucket, which the
+		// all-on-target case checks for before it would otherwise report
+		// "0/N on-target" for the Skipped verify child.
+		wl := newWorkload("rollup-skip-verify", foremanv1alpha1.WorkloadSpec{
+			Intent:           "verify cascade-skipped because code ALREADY-RESOLVED",
+			Repo:             "defilantech/LLMKube",
+			Issues:           []int32{152},
+			CoderAgentRef:    &corev1.LocalObjectReference{Name: "coder"},
+			VerifierAgentRef: &corev1.LocalObjectReference{Name: "gate"},
+		})
+		Expect(k8sClient.Create(ctx, wl)).To(Succeed())
+		DeferCleanup(func() {
+			cleanupChildren(wl)
+			_ = k8sClient.Delete(ctx, wl)
+		})
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var c foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "rollup-skip-verify-code-152"}, &c)).To(Succeed())
+		patch := client.MergeFrom(c.DeepCopy())
+		c.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
+		c.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		c.Status.Result = resultRaw("ALREADY-RESOLVED", "", "already done", "abc123def")
+		Expect(k8sClient.Status().Patch(ctx, &c, patch)).To(Succeed())
+		markVerifySkipped("rollup-skip-verify", 152)
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(wl)})
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.Workload
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.WorkloadPhaseCompleted))
+		Expect(fresh.Status.FailedTasks).To(Equal(int32(0)))
+		completed := findCondition(fresh.Status.Conditions, conditionTypeCompleted)
+		Expect(completed).NotTo(BeNil())
+		Expect(completed.Reason).To(Equal("AllAlreadyResolved"))
+	})
+
 	It("fails the Workload when gate passes but any reviewer emits NO-GO (#575)", func() {
 		// v0.4 regression test: this lock-in confirms the
 		// cascade-on-verdict behavior from #541 also catches the


### PR DESCRIPTION
## What

Makes the ALREADY-RESOLVED cascade-skip transitive. A task whose dependency was
itself `Skipped` is now skipped too, instead of cascade-failing and pinning the
Workload to `Failed`.

## Why

Fixes #1688

`cascadeSkipIfDepAlreadyResolved` tested only `isAlreadyResolvedCoder`, so the
skip propagated exactly one hop. In a `code -> verify -> review` pipeline whose
coder returned ALREADY-RESOLVED, `verify` was correctly skipped and `review`
then cascade-failed on `verdict=Skipped (not on-target)`.

Found live. `wl-1596-prefetch-e2e` reproduced it exactly:

| Task | Phase | Verdict | Condition |
|---|---|---|---|
| code | Succeeded | NO-GO | ALREADY-RESOLVED, resolvedBy 88c85cce |
| verify | Succeeded | Skipped | `UpstreamAlreadyResolved` |
| review | **Failed** | INCOMPLETE | `UpstreamFailed`: dependency ended verdict=Skipped |

Workload phase: `Failed`. Nothing failed. The coder had correctly declined to
write a duplicate test, and the pipeline reported that good outcome as a
failure. Any Workload dispatched against an already-fixed issue hits this, so
some existing `Failed` Workloads in the fleet are mislabelled clean runs.

## How

Renamed `cascadeSkipIfDepAlreadyResolved` to `cascadeSkipIfDepResolvedOrSkipped`
and gave it an `isSkippedTask` arm, reusing the existing predicate rather than
adding a second copy of the skip test. The dependency's terminal state is
threaded into `skipTask` so the condition message names the real cause ("ended
Skipped") instead of always claiming ALREADY-RESOLVED.

**One judgment call worth a second opinion.** For a transitive skip the
condition `Reason` stays `UpstreamAlreadyResolved` while the message says
"ended Skipped". The new test locks that in deliberately, and it is defensible
— the ultimate cause of the chain really is an already-resolved ancestor. But
`Reason` is the machine-readable half, so anything alerting on it cannot tell a
direct skip from a transitive one. Happy to add a distinct `UpstreamSkipped`
reason if you would rather have them separable.

**Verification beyond the gate and the reviewer.** Removing the `isSkippedTask`
arm — restoring the exact one-hop bug — makes `TestForemanControllers` fail, so
the fix is genuinely covered rather than merely accompanied by a passing test.
The suite was run unfiltered on purpose: a `-run` filter does not match the
Ginkgo suite name and silently skips the specs that matter here.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — all 19 `internal/foreman/...` and `pkg/foreman/...` packages green
- [x] `make lint` passes locally — `GOOS=linux golangci-lint` 0 issues, `make lint-deadcode` 0 issues, `gofmt` clean, no CRD drift after `make manifests` and `make foreman-chart-crds`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — no user-facing surface change; behaviour is internal to pipeline cascade

## AI assistance

The implementation was written by a Foreman coder agent (Ornith-1.5-35B-A3B,
self-hosted), gated by the Foreman verify job, and reviewed by a self-hosted
Nemotron-49B reviewer. A human-directed adversarial review followed, which
added the mutation test above. The issue itself was authored from a live
reproduction on the fleet.
