### PR TITLE
feat(foreman): add a rollup bucket for cross-stage contradictions

### DIFF
--- a/api/foreman/v1alpha1/workload_types.go
+++ b/api/foreman/v1alpha1/workload_types.go
@@ -404,6 +404,20 @@ type WorkloadStatus struct {
 	// +optional
 	IncompleteTasks int32 `json:"incompleteTasks,omitempty"`
 
+	// ContradictedTasks counts child tasks whose terminal result
+	// carried a cross-stage contradiction
+	// (extra.crossStageContradictions non-empty). A contradiction means a
+	// stage (coder / gate / reviewer) asserted something the
+	// ground-truth branch facts contradict (e.g. the coder claims it
+	// edited files on an empty branch). It is surfaced here so a
+	// contradiction is countable and visible instead of being written
+	// to the AgenticTask and read by nobody (#1685). Orthogonal to
+	// success: a task can Succeeded and still contradict itself, so it
+	// is counted in addition to whatever terminal bucket it already
+	// matched and does not move the Workload to Failed.
+	// +optional
+	ContradictedTasks int32 `json:"contradictedTasks,omitempty"`
+
 	// ReviewIterations counts the fix iterations the reconciler has
 	// emitted after reviewer NO-GO verdicts (#946), summed across
 	// issues. Zero (or absent) means no reviewer ever bounced a

--- a/charts/foreman/templates/crds/workloads.yaml
+++ b/charts/foreman/templates/crds/workloads.yaml
@@ -912,6 +912,21 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              contradictedTasks:
+                description: |-
+                  ContradictedTasks counts child tasks whose terminal result
+                  carried a cross-stage contradiction
+                  (extra.crossStageContradictions non-empty). A contradiction means a
+                  stage (coder / gate / reviewer) asserted something the
+                  ground-truth branch facts contradict (e.g. the coder claims it
+                  edited files on an empty branch). It is surfaced here so a
+                  contradiction is countable and visible instead of being written
+                  to the AgenticTask and read by nobody (#1685). Orthogonal to
+                  success: a task can Succeeded and still contradict itself, so it
+                  is counted in addition to whatever terminal bucket it already
+                  matched and does not move the Workload to Failed.
+                format: int32
+                type: integer
               failedTasks:
                 description: FailedTasks counts child tasks in phase Failed.
                 format: int32

--- a/config/crd/bases/foreman.llmkube.dev_workloads.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_workloads.yaml
@@ -911,6 +911,21 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              contradictedTasks:
+                description: |-
+                  ContradictedTasks counts child tasks whose terminal result
+                  carried a cross-stage contradiction
+                  (extra.crossStageContradictions non-empty). A contradiction means a
+                  stage (coder / gate / reviewer) asserted something the
+                  ground-truth branch facts contradict (e.g. the coder claims it
+                  edited files on an empty branch). It is surfaced here so a
+                  contradiction is countable and visible instead of being written
+                  to the AgenticTask and read by nobody (#1685). Orthogonal to
+                  success: a task can Succeeded and still contradict itself, so it
+                  is counted in addition to whatever terminal bucket it already
+                  matched and does not move the Workload to Failed.
+                format: int32
+                type: integer
               failedTasks:
                 description: FailedTasks counts child tasks in phase Failed.
                 format: int32

--- a/internal/foreman/controller/workload_coder_escalation.go
+++ b/internal/foreman/controller/workload_coder_escalation.go
@@ -42,7 +42,8 @@ type coderResultEnvelope struct {
 		ModelExtra struct {
 			Outcome string `json:"outcome"`
 		} `json:"modelExtra"`
-		ResolvedBy string `json:"resolvedBy,omitempty"`
+		ResolvedBy               string   `json:"resolvedBy,omitempty"`
+		CrossStageContradictions []string `json:"crossStageContradictions,omitempty"`
 	} `json:"extra"`
 }
 
@@ -134,6 +135,45 @@ func isSkippedTask(task *foremanv1alpha1.AgenticTask) bool {
 	}
 	return task.Status.Phase == foremanv1alpha1.AgenticTaskPhaseSucceeded &&
 		task.Status.Verdict == foremanv1alpha1.AgenticTaskVerdictSkipped
+}
+
+// hasCrossStageContradiction reports whether the task's terminal result
+// envelope carries a non-empty cross-stage contradiction list
+// (extra.crossStageContradictions, #1685). The detector writes these in
+// the coder / gate / reviewer wiring (pkg/foreman/agent/cross_stage_wiring.go)
+// when a stage's claim contradicts the ground-truth branch facts. A missing
+// or unparseable result returns false, matching coderTerminalOutcome's
+// convention. Counted into the rollup ContradictedTasks bucket so a
+// contradiction is visible on the Workload instead of being written to the
+// AgenticTask and read by nobody; orthogonal to success, so it does not
+// change terminal state.
+func hasCrossStageContradiction(task *foremanv1alpha1.AgenticTask) bool {
+	if task == nil {
+		return false
+	}
+	if task.Status.Result == nil || len(task.Status.Result.Raw) == 0 {
+		return false
+	}
+	var env coderResultEnvelope
+	if err := json.Unmarshal(task.Status.Result.Raw, &env); err != nil {
+		return false
+	}
+	return len(env.Extra.CrossStageContradictions) > 0
+}
+
+// coderCrossStageContradictions returns the contradiction strings from the
+// task's terminal result envelope (extra.crossStageContradictions). Empty
+// when Result is nil/unparseable or no contradictions are recorded. Used by
+// classifyChildren to carry the first contradiction string into the rollup.
+func coderCrossStageContradictions(task *foremanv1alpha1.AgenticTask) []string {
+	if task.Status.Result == nil || len(task.Status.Result.Raw) == 0 {
+		return nil
+	}
+	var env coderResultEnvelope
+	if err := json.Unmarshal(task.Status.Result.Raw, &env); err != nil {
+		return nil
+	}
+	return env.Extra.CrossStageContradictions
 }
 
 // shouldEscalateCoder is the escalation trigger: escalate only on

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -123,6 +123,14 @@ const conditionTypeCoderEscalationTriggered = "CoderEscalationTriggered"
 // (avoids a perpetual "0 issues" noise condition).
 const conditionTypeCoderAlreadyResolved = "CoderAlreadyResolved"
 
+// conditionTypeCrossStageContradiction marks a Workload whose child
+// tasks recorded a cross-stage contradiction in their terminal result
+// (extra.crossStageContradictions non-empty, #1685). Set when at least
+// one such child exists; the message names the count and the first
+// contradiction string. Not set when zero children contradict (avoids
+// a perpetual "0 contradictions" noise condition).
+const conditionTypeCrossStageContradiction = "CrossStageContradiction"
+
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=workloads/finalizers,verbs=update
@@ -584,9 +592,11 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 	w.Status.SucceededTasks = cls.succeeded
 	w.Status.FailedTasks = cls.failed
 	w.Status.IncompleteTasks = cls.incomplete
+	w.Status.ContradictedTasks = cls.contradicted
 
 	computeTerminalState(w, cls, now)
 	r.emitAlreadyResolvedCondition(w, cls, now)
+	r.emitCrossStageContradictionCondition(w, cls, now)
 
 	if (w.Status.Phase == foremanv1alpha1.WorkloadPhaseCompleted ||
 		w.Status.Phase == foremanv1alpha1.WorkloadPhaseFailed) &&
@@ -610,6 +620,8 @@ func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Work
 type childCounts struct {
 	succeeded, incomplete, failed, inFlight int32
 	alreadyResolved                         int32
+	contradicted                            int32
+	contradictions                          []string
 	skipped                                 int32
 	resolvedIssues                          []int32
 	resolvedByList                          []string
@@ -627,6 +639,13 @@ type childCounts struct {
 //     skipped and not ALREADY-RESOLVED
 //   - failed: Phase=Failed
 //   - inFlight: everything else (Pending / Scheduled / Running)
+//
+// The `contradicted` bucket (#1685) is counted separately from these
+// terminal buckets: a child that carries a cross-stage contradiction is
+// counted in `contradicted` in addition to whatever terminal bucket it
+// matched, so a contradicting task that Succeeded still counts as
+// succeeded. It is orthogonal to success and never moves the Workload to
+// Failed.
 //
 // Classification is verdict-based, not kind-based: a sliced Workload's
 // integrate / reconcile steps (#1033) land here like any other kind, so a
@@ -648,6 +667,18 @@ type childCounts struct {
 func classifyChildren(children []foremanv1alpha1.AgenticTask) childCounts {
 	var c childCounts
 	for i := range children {
+		// Contradiction is orthogonal to success: it counts into the
+		// contradicted bucket in addition to whatever terminal bucket
+		// the task already matched (succeeded / incomplete / failed),
+		// so a contradicting task that Succeeded still counts as
+		// succeeded below. Counted in its own pass so it is not
+		// short-circuited by the switch below.
+		if hasCrossStageContradiction(&children[i]) {
+			c.contradicted++
+			if cs := coderCrossStageContradictions(&children[i]); len(cs) > 0 {
+				c.contradictions = append(c.contradictions, cs...)
+			}
+		}
 		switch {
 		case children[i].SucceededOnTarget():
 			c.succeeded++
@@ -817,6 +848,39 @@ func (r *WorkloadReconciler) emitAlreadyResolvedCondition(w *foremanv1alpha1.Wor
 				"Issue #%d resolved at run time; safe to close on GitHub", n)
 		}
 	}
+}
+
+// emitCrossStageContradictionCondition sets the CrossStageContradiction
+// condition (#1685) and surfaces the first contradiction string so the
+// reason is legible from `kubectl describe` without pulling the task's
+// result. When contradicted is zero, the condition is set to False (an
+// anti-stale guard). The count is orthogonal to success: it does not
+// change terminal state, so a contradicting task that Succeeded still
+// counts as succeeded.
+func (r *WorkloadReconciler) emitCrossStageContradictionCondition(w *foremanv1alpha1.Workload, c childCounts, now metav1.Time) {
+	if c.contradicted == 0 {
+		setCondition(&w.Status.Conditions, metav1.Condition{
+			Type:               conditionTypeCrossStageContradiction,
+			Status:             metav1.ConditionFalse,
+			Reason:             "NoContradictions",
+			Message:            "no child tasks recorded a cross-stage contradiction",
+			LastTransitionTime: now,
+		})
+		return
+	}
+
+	msg := fmt.Sprintf("%d child task(s) recorded a cross-stage contradiction", c.contradicted)
+	if len(c.contradictions) > 0 {
+		msg += fmt.Sprintf("; first: %s", c.contradictions[0])
+	}
+	msg += ". Contradiction is orthogonal to success and does not change terminal state."
+	setCondition(&w.Status.Conditions, metav1.Condition{
+		Type:               conditionTypeCrossStageContradiction,
+		Status:             metav1.ConditionTrue,
+		Reason:             "CrossStageContradiction",
+		Message:            msg,
+		LastTransitionTime: now,
+	})
 }
 
 // markPlanning patches phase=Planning the first time we touch the

--- a/internal/foreman/controller/workload_rollup_slicer_test.go
+++ b/internal/foreman/controller/workload_rollup_slicer_test.go
@@ -17,7 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"strings"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 )
@@ -56,5 +64,277 @@ func TestClassifyChildren_SlicerVerdicts(t *testing.T) {
 					c.succeeded, c.incomplete, tc.wantSucceeded, tc.wantIncomplete)
 			}
 		})
+	}
+}
+
+// withContradictionsEnvelope builds a complete result envelope that
+// carries the given cross-stage contradiction strings under
+// extra.crossStageContradictions (the shape the detector writes).
+func withContradictionsEnvelope(contradictions ...string) *runtime.RawExtension {
+	parts := make([]string, len(contradictions))
+	for i, c := range contradictions {
+		parts[i] = `"` + c + `"`
+	}
+	j := `{"summary":"","extra":{"crossStageContradictions":[` + strings.Join(parts, ",") + `]}}`
+	return &runtime.RawExtension{Raw: []byte(j)}
+}
+
+// firstOrEmpty returns the first element of a slice or "" when empty.
+func firstOrEmpty(s []string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0]
+}
+
+// TestClassifyChildren_CrossStageContradiction locks in the rollup bucket
+// for cross-stage contradictions (#1685). A contradiction is orthogonal to
+// success: a Succeeded child that also carries contradictions counts in
+// BOTH the succeeded and the contradicted buckets, never in the failed or
+// incomplete buckets. Asserts the contradicted count independently of the
+// other buckets, and asserts that a contradicting-but-Succeeded task still
+// counts as succeeded.
+func TestClassifyChildren_CrossStageContradiction(t *testing.T) {
+	withContradiction := func(verdict foremanv1alpha1.AgenticTaskVerdict, contradictions ...string) foremanv1alpha1.AgenticTask {
+		return foremanv1alpha1.AgenticTask{
+			Status: foremanv1alpha1.AgenticTaskStatus{
+				Phase:   foremanv1alpha1.AgenticTaskPhaseSucceeded,
+				Verdict: verdict,
+				Result:  withContradictionsEnvelope(contradictions...),
+			},
+		}
+	}
+	failedWithContradiction := func(contradictions ...string) foremanv1alpha1.AgenticTask {
+		return foremanv1alpha1.AgenticTask{
+			Status: foremanv1alpha1.AgenticTaskStatus{
+				Phase:  foremanv1alpha1.AgenticTaskPhaseFailed,
+				Result: withContradictionsEnvelope(contradictions...),
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		tasks            []foremanv1alpha1.AgenticTask
+		wantSucceeded    int32
+		wantIncomplete   int32
+		wantFailed       int32
+		wantContradicted int32
+		wantFirstContra  string
+	}{
+		{
+			name:             "no contradiction",
+			tasks:            []foremanv1alpha1.AgenticTask{{Status: foremanv1alpha1.AgenticTaskStatus{Phase: foremanv1alpha1.AgenticTaskPhaseSucceeded, Verdict: foremanv1alpha1.AgenticTaskVerdictGatePass}}},
+			wantSucceeded:    1,
+			wantContradicted: 0,
+		},
+		{
+			name:             "one contradiction on a Succeeded task",
+			tasks:            []foremanv1alpha1.AgenticTask{withContradiction(foremanv1alpha1.AgenticTaskVerdictGatePass, "coder claims edits on empty branch")},
+			wantSucceeded:    1,
+			wantContradicted: 1,
+			wantFirstContra:  "coder claims edits on empty branch",
+		},
+		{
+			name:             "one contradiction on a Failed task",
+			tasks:            []foremanv1alpha1.AgenticTask{failedWithContradiction("gate passed on empty branch")},
+			wantFailed:       1,
+			wantContradicted: 1,
+			wantFirstContra:  "gate passed on empty branch",
+		},
+		{
+			name:             "unparseable result",
+			tasks:            []foremanv1alpha1.AgenticTask{{Status: foremanv1alpha1.AgenticTaskStatus{Phase: foremanv1alpha1.AgenticTaskPhaseSucceeded, Verdict: foremanv1alpha1.AgenticTaskVerdictGatePass, Result: &runtime.RawExtension{Raw: []byte("{not json")}}}},
+			wantSucceeded:    1,
+			wantContradicted: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := classifyChildren(tc.tasks)
+			if c.succeeded != tc.wantSucceeded {
+				t.Errorf("succeeded = %d, want %d", c.succeeded, tc.wantSucceeded)
+			}
+			if c.incomplete != tc.wantIncomplete {
+				t.Errorf("incomplete = %d, want %d", c.incomplete, tc.wantIncomplete)
+			}
+			if c.failed != tc.wantFailed {
+				t.Errorf("failed = %d, want %d", c.failed, tc.wantFailed)
+			}
+			// The contradicted count stands on its own, independent of
+			// the terminal buckets above.
+			if c.contradicted != tc.wantContradicted {
+				t.Errorf("contradicted = %d, want %d", c.contradicted, tc.wantContradicted)
+			}
+			if tc.wantFirstContra != "" {
+				if len(c.contradictions) == 0 || c.contradictions[0] != tc.wantFirstContra {
+					t.Errorf("contradictions[0] = %q, want %q", firstOrEmpty(c.contradictions), tc.wantFirstContra)
+				}
+			}
+		})
+	}
+}
+
+// TestEmitCrossStageContradictionCondition verifies both arms of
+// emitCrossStageContradictionCondition (#1685). Zero contradictions leaves
+// the condition present with Status=False and Reason=NoContradictions. One
+// or more contradictions sets Status=True, Reason=CrossStageContradiction,
+// and the message names the count and the first contradiction string.
+func TestEmitCrossStageContradictionCondition(t *testing.T) {
+	r := &WorkloadReconciler{}
+	now := metav1.Now()
+
+	cond := func(w *foremanv1alpha1.Workload) *metav1.Condition {
+		for i := range w.Status.Conditions {
+			if w.Status.Conditions[i].Type == conditionTypeCrossStageContradiction {
+				return &w.Status.Conditions[i]
+			}
+		}
+		return nil
+	}
+
+	// Zero contradictions: condition present, Status=False,
+	// Reason=NoContradictions.
+	w := &foremanv1alpha1.Workload{}
+	r.emitCrossStageContradictionCondition(w, childCounts{}, now)
+	c := cond(w)
+	if c == nil {
+		t.Fatalf("CrossStageContradiction condition not present")
+	}
+	if c.Status != metav1.ConditionFalse {
+		t.Errorf("Status = %q, want %q", c.Status, metav1.ConditionFalse)
+	}
+	if c.Reason != "NoContradictions" {
+		t.Errorf("Reason = %q, want %q", c.Reason, "NoContradictions")
+	}
+
+	// One contradiction: Status=True, Reason=CrossStageContradiction,
+	// message names the count and first contradiction string.
+	w = &foremanv1alpha1.Workload{}
+	r.emitCrossStageContradictionCondition(w, childCounts{
+		contradicted:   1,
+		contradictions: []string{"coder claims edits on empty branch"},
+	}, now)
+	c = cond(w)
+	if c == nil {
+		t.Fatalf("CrossStageContradiction condition not present")
+	}
+	if c.Status != metav1.ConditionTrue {
+		t.Errorf("Status = %q, want %q", c.Status, metav1.ConditionTrue)
+	}
+	if c.Reason != "CrossStageContradiction" {
+		t.Errorf("Reason = %q, want %q", c.Reason, "CrossStageContradiction")
+	}
+	if !strings.Contains(c.Message, "1 child task(s) recorded a cross-stage contradiction") {
+		t.Errorf("message does not name the count: %q", c.Message)
+	}
+	if !strings.Contains(c.Message, "coder claims edits on empty branch") {
+		t.Errorf("message does not contain the first contradiction: %q", c.Message)
+	}
+
+	// Two contradictions: count reflects both, message carries the first.
+	w = &foremanv1alpha1.Workload{}
+	r.emitCrossStageContradictionCondition(w, childCounts{
+		contradicted: 2,
+		contradictions: []string{
+			"gate passed on empty branch",
+			"reviewer claims a changed line",
+		},
+	}, now)
+	c = cond(w)
+	if c == nil {
+		t.Fatalf("CrossStageContradiction condition not present")
+	}
+	if c.Status != metav1.ConditionTrue {
+		t.Errorf("Status = %q, want %q", c.Status, metav1.ConditionTrue)
+	}
+	if !strings.Contains(c.Message, "2 child task(s) recorded a cross-stage contradiction") {
+		t.Errorf("message does not name the count: %q", c.Message)
+	}
+	if !strings.Contains(c.Message, "gate passed on empty branch") {
+		t.Errorf("message does not contain the first contradiction: %q", c.Message)
+	}
+	if strings.Contains(c.Message, "reviewer claims a changed line") {
+		t.Errorf("message should name only the first contradiction: %q", c.Message)
+	}
+}
+
+// TestRollup_ContradictedTasksAndCondition drives rollup end-to-end over
+// children where one carries a cross-stage contradiction, and asserts the
+// two things a survivor of mutation testing would miss: that the counted
+// bucket actually reaches Workload.status.ContradictedTasks (mutation B),
+// and that emitCrossStageContradictionCondition is actually wired into
+// rollup (mutation C). Deleting either production line makes an assertion
+// here fail.
+func TestRollup_ContradictedTasksAndCondition(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := foremanv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add foreman scheme: %v", err)
+	}
+	// corev1 must be registered too: rollup patches a Workload and the
+	// fake client needs the Workload's status subresource registered.
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	wl := &foremanv1alpha1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "contradiction-wl", Namespace: "default"},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(wl).WithStatusSubresource(wl).Build()
+
+	r := &WorkloadReconciler{Client: cl, Scheme: scheme}
+
+	// One child Succeeded on target (counts as succeeded) AND carries a
+	// cross-stage contradiction (counts as contradicted). The contradiction
+	// is orthogonal to success, so it lands in BOTH buckets.
+	contradicting := foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "contradiction-wl-code-1",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: foremanv1alpha1.GroupVersion.String(),
+				Kind:       "Workload",
+				Name:       "contradiction-wl",
+			}},
+		},
+		Status: foremanv1alpha1.AgenticTaskStatus{
+			Phase:   foremanv1alpha1.AgenticTaskPhaseSucceeded,
+			Verdict: foremanv1alpha1.AgenticTaskVerdictGatePass,
+			Result:  withContradictionsEnvelope("coder claims edits on empty branch"),
+		},
+	}
+	if err := cl.Create(context.Background(), &contradicting); err != nil {
+		t.Fatalf("create contradicting task: %v", err)
+	}
+
+	ctx := context.Background()
+	children := []foremanv1alpha1.AgenticTask{contradicting}
+	if _, err := r.rollup(ctx, wl, children); err != nil {
+		t.Fatalf("rollup: %v", err)
+	}
+
+	// Mutation B: the counted bucket must reach the status field.
+	if wl.Status.ContradictedTasks != 1 {
+		t.Errorf("w.Status.ContradictedTasks = %d, want 1", wl.Status.ContradictedTasks)
+	}
+	// And success is unaffected: the task still counts as succeeded.
+	if wl.Status.SucceededTasks != 1 {
+		t.Errorf("w.Status.SucceededTasks = %d, want 1", wl.Status.SucceededTasks)
+	}
+
+	// Mutation C: the condition must actually be emitted by rollup.
+	cond := apimeta.FindStatusCondition(wl.Status.Conditions, conditionTypeCrossStageContradiction)
+	if cond == nil {
+		t.Fatal("CrossStageContradiction condition not emitted by rollup")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("condition Status = %q, want %q", cond.Status, metav1.ConditionTrue)
+	}
+	if cond.Reason != "CrossStageContradiction" {
+		t.Errorf("condition Reason = %q, want %q", cond.Reason, "CrossStageContradiction")
+	}
+	if !strings.Contains(cond.Message, "coder claims edits on empty branch") {
+		t.Errorf("condition message does not name the first contradiction: %q", cond.Message)
 	}
 }


### PR DESCRIPTION
## What

Gives cross-stage contradictions a rollup bucket on `Workload.status`, so a
contradiction is countable and visible instead of being written to the
AgenticTask and read by nobody.

Adds `WorkloadStatus.ContradictedTasks`, a `contradicted` bucket in
`childCounts`, and a `CrossStageContradiction` condition naming the count and
the first contradiction string.

## Why

Fixes #1685

#1674 shipped detection in four pieces (#1680, #1681, #1682, #1683). All four
rules now run and record, and nothing consumes the result:

- `pkg/foreman/agent/cross_stage_wiring.go` writes
  `extra["crossStageContradictions"]` at three sites.
- `shouldEscalate` is called at three sites, but only as
  `if !shouldEscalate(cs) { return }` — an early return that gates *recording*,
  never an action.
- No file under `internal/` reads `crossStageContradictions`.

`shouldEscalate`'s own doc comment says it "reports whether any contradiction
warrants stopping the line". Nothing stopped. This makes contradictions
countable; blocking dependents is #1686 and depends on this.

## How

Mirrors the ALREADY-RESOLVED machinery, which already implements this shape end
to end: envelope field, predicate beside `isAlreadyResolvedCoder`, bucket in
`classifyChildren`, status assignment in `rollup`, condition emitter modelled on
`emitAlreadyResolvedCondition`.

**Contradiction is orthogonal to success.** It is counted in addition to
whichever terminal bucket the task already matched, so a task that Succeeded and
still contradicted itself counts as both. `computeTerminalState` is deliberately
untouched: a contradiction never moves a Workload to `Failed`. That is the case
most worth surfacing, and demoting it here would turn a records-only rail into a
verdict-changing one — which is where #1678 and #1684 both originated.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — all `internal/foreman/...` and `pkg/foreman/...` packages green
- [x] `make lint` passes locally — `GOOS=linux golangci-lint` 0 issues, `make lint-deadcode` 0 issues, `gofmt` clean, no drift after `make manifests` and `make foreman-chart-crds`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — the new status field and condition are documented in their GoDoc; no separate doc surface

## Verification

Mutation-tested, and the first pass failed it. Three mutations against the
original implementation:

| Mutation | First pass | Now |
|---|---|---|
| Remove the counting block in `classifyChildren` | CAUGHT (3 tests) | CAUGHT |
| Delete `w.Status.ContradictedTasks = cls.contradicted` | **SURVIVED** | CAUGHT |
| Unwire `emitCrossStageContradictionCondition` | **SURVIVED** | CAUGHT |

The internal counting was well covered, but the two things an operator actually
sees — the status field and the condition — could both be deleted with no test
failing. A revision pass added coverage for both; all three mutations now fail
the suite.

## AI assistance

Implementation by a Foreman coder agent (Ornith-1.5-35B-A3B, self-hosted),
gated by the Foreman verify job and reviewed by a self-hosted Nemotron-49B
reviewer. A human-directed adversarial review followed, which found the two
surviving mutations above and drove the revision pass.
