### PR TITLE
fix(prefetch): honour InferenceService modelCache.claimName

### DIFF
--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -160,6 +160,7 @@ func (r *ModelReconciler) metadataClient() *http.Client {
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=inference.llmkube.dev,resources=models/finalizers,verbs=update
+// +kubebuilder:rbac:groups=inference.llmkube.dev,resources=inferenceservices,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch

--- a/internal/controller/model_prefetch.go
+++ b/internal/controller/model_prefetch.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -34,19 +35,20 @@ import (
 )
 
 // Model prefetch (#904): a Model with spec.prefetch=true and a remote source
-// gets its artifact pulled into the namespace's SHARED model cache PVC ahead
-// of any InferenceService, via an owner-ref'd Job whose pod reuses the exact
+// gets its artifact pulled into a model cache PVC ahead of any
+// InferenceService, via an owner-ref'd Job whose pod reuses the exact
 // init-container download stack the serving path uses
 // (buildModelStorageConfig with a nil InferenceService): same cache-prep
 // container, same downloader image and ETag handling, same multi-file
 // staging plan, same SourceSecretRef env. The first serving pod then starts
 // from a cache hit instead of a cold download.
 //
-// The prefetch deliberately targets the shared cache
-// (ModelCacheModeShared): perService cache PVCs are created per
-// InferenceService at serve time and cannot be pre-populated for a service
-// that does not exist yet. The field's GoDoc documents that limitation and
-// the pvc:// staging alternative.
+// The target PVC is chosen by the resolved policy (#1676): exactly one
+// distinct spec.modelCache.claimName among the InferenceServices referencing
+// this Model, so the download lands where the serving pod reads it, else the
+// shared cache (ModelCacheModeShared) when no service references the Model or
+// the services disagree. The field's GoDoc documents that limitation and the
+// pvc:// staging alternative.
 
 // defaultPrefetchImage mirrors the --init-container-image flag default for
 // the no-op completion container when the reconciler is constructed without
@@ -154,7 +156,7 @@ func (r *ModelReconciler) reconcilePrefetch(ctx context.Context, model *inferenc
 			model.Status.Phase = PhaseDownloading
 			seedPrefetchCacheKey(model)
 			if err := r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionTrue,
-				"PrefetchRunning", "Prefetch job downloading model into the shared cache"); err != nil {
+				"PrefetchRunning", "Prefetch job downloading model into the model cache"); err != nil {
 				return true, ctrl.Result{}, err
 			}
 		}
@@ -162,8 +164,68 @@ func (r *ModelReconciler) reconcilePrefetch(ctx context.Context, model *inferenc
 	}
 }
 
-// startPrefetch ensures the shared cache PVC exists and creates the
-// owner-ref'd prefetch Job.
+// resolvePrefetchTarget returns a synthetic InferenceService that carries the
+// cache claim prefetch should stage into, or nil for the shared cache, plus a
+// reason describing why the override was not honoured (empty when a per-service
+// target was resolved).
+//
+// A Model is 1:N with InferenceServices, so the target is not always
+// well-defined. The resolved policy (#1676):
+//   - exactly one distinct spec.modelCache.claimName among the referencing
+//     services: return a synthetic InferenceService naming that claim, so the
+//     download lands in the PVC the serving pod mounts;
+//   - no referencing service, or several disagreeing on claimName: return nil
+//     (the shared cache), so the behaviour is unchanged and the caller can
+//     surface that the override was not honoured.
+//
+// The nil isvc is a genuine InferenceService-shaped value only when a claim
+// was resolved; callers must not assume it is non-nil.
+func (r *ModelReconciler) resolvePrefetchTarget(ctx context.Context, model *inferencev1alpha1.Model) (target *inferencev1alpha1.InferenceService, reason string) {
+	list := &inferencev1alpha1.InferenceServiceList{}
+	if err := r.List(ctx, list, client.InNamespace(model.Namespace)); err != nil {
+		// A listing failure (RBAC denial, partitioned API server) must not
+		// wedge prefetch: fall back to the shared cache, which is the
+		// pre-#1676 behaviour, and let the caller surface the ignore.
+		return nil, "prefetch cache listing failed: " + err.Error()
+	}
+
+	var (
+		claim    string
+		seen     bool
+		conflict bool
+	)
+	for i := range list.Items {
+		svc := &list.Items[i]
+		if svc.Spec.ModelRef != model.Name {
+			continue
+		}
+		claimName := userModelCacheClaimName(svc)
+		if claimName == "" {
+			continue // references the model but no claim override to honour
+		}
+		if !seen {
+			seen = true
+			claim = claimName
+			continue
+		}
+		if claimName != claim {
+			conflict = true
+		}
+	}
+	if seen && !conflict {
+		return &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: model.Name, Namespace: model.Namespace},
+			Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: model.Name, ModelCache: &inferencev1alpha1.ModelCacheSpec{ClaimName: claim}},
+		}, ""
+	}
+	if !seen {
+		return nil, "no InferenceService references this Model with a modelCache.claimName override; prefetching into the shared cache"
+	}
+	return nil, "multiple InferenceServices referencing this Model disagree on their modelCache.claimName overrides; prefetching into the shared cache"
+}
+
+// startPrefetch ensures the shared cache PVC exists (unless prefetch has
+// resolved a per-service target) and creates the owner-ref'd prefetch Job.
 func (r *ModelReconciler) startPrefetch(ctx context.Context, model *inferencev1alpha1.Model) (ctrl.Result, error) {
 	logger := logf.FromContext(ctx)
 
@@ -175,12 +237,27 @@ func (r *ModelReconciler) startPrefetch(ctx context.Context, model *inferencev1a
 	// identical key and takes the cache-hit path.
 	seedPrefetchCacheKey(model)
 
-	if err := ensureSharedModelCachePVC(ctx, r.Client, model.Namespace,
-		r.ModelCacheSize, r.ModelCacheClass, r.ModelCacheAccessMode); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring shared model cache PVC: %w", err)
+	// Resolve the PVC the serving pod will read (#1676). A nil isvc means
+	// the shared cache; a resolved one means prefetch stages into that
+	// service's PVC, so the shared PVC must not be provisioned here.
+	target, ignoreReason := r.resolvePrefetchTarget(ctx, model)
+	if target == nil {
+		if err := ensureSharedModelCachePVC(ctx, r.Client, model.Namespace,
+			r.ModelCacheSize, r.ModelCacheClass, r.ModelCacheAccessMode); err != nil {
+			return ctrl.Result{}, fmt.Errorf("ensuring shared model cache PVC: %w", err)
+		}
+		// The override could not be honoured: keep today's shared-cache
+		// behaviour but surface the condition so the no-op is visible
+		// rather than silent (#1676).
+		if ignoreReason != "" {
+			if err := r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionTrue,
+				"PrefetchCacheIgnored", ignoreReason); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 	}
 
-	job, err := r.buildPrefetchJob(model)
+	job, err := r.buildPrefetchJob(model, target)
 	if err != nil {
 		model.Status.Phase = PhaseFailed
 		return ctrl.Result{}, r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionFalse,
@@ -200,7 +277,7 @@ func (r *ModelReconciler) startPrefetch(ctx context.Context, model *inferencev1a
 	logger.Info("Created prefetch job", "job", job.Name)
 	model.Status.Phase = PhaseDownloading
 	if err := r.updateStatus(ctx, model, ConditionProgressing, metav1.ConditionTrue,
-		"PrefetchStarted", "Started prefetch job downloading model into the shared cache"); err != nil {
+		"PrefetchStarted", prefetchStartedMessage(target)); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
@@ -218,16 +295,35 @@ func (r *ModelReconciler) completePrefetch(ctx context.Context, model *inference
 		"ModelPrefetched", "Model prefetched into the shared cache")
 }
 
+// prefetchTargetName returns the PVC name prefetch will stage into, for status
+// messages: the resolved per-service claim, or the shared cache PVC.
+func prefetchTargetName(target *inferencev1alpha1.InferenceService) string {
+	if claim := userModelCacheClaimName(target); claim != "" {
+		return claim
+	}
+	return ModelCachePVCName
+}
+
+// prefetchStartedMessage renders the Job's target PVC into the started status
+// so operators can see where the download lands (#1676).
+func prefetchStartedMessage(target *inferencev1alpha1.InferenceService) string {
+	return fmt.Sprintf("Started prefetch job downloading model into %q", prefetchTargetName(target))
+}
+
 // buildPrefetchJob assembles the download Job. The pod reuses the serving
 // path's init containers and volumes verbatim (nil InferenceService: the
 // only isvc-derived input is an optional fsGroup override) and adds a no-op
 // completion container, since a Job pod must have at least one non-init
 // container.
-func (r *ModelReconciler) buildPrefetchJob(model *inferencev1alpha1.Model) (*batchv1.Job, error) {
+//
+// target is the resolved per-InferenceService cache claim (#1676), or nil for
+// the shared cache; buildModelStorageConfig reads userModelCacheClaimName off
+// it to pick the PVC, so the download lands where the serving pod reads.
+func (r *ModelReconciler) buildPrefetchJob(model *inferencev1alpha1.Model, target *inferencev1alpha1.InferenceService) (*batchv1.Job, error) {
 	if effectiveModelCacheKey(model) == "" {
 		return nil, fmt.Errorf("prefetch: model has no cache key; refusing to build a Job that would download into an emptyDir")
 	}
-	storage := buildModelStorageConfig(model, nil, model.Namespace, true, ModelCacheModeShared,
+	storage := buildModelStorageConfig(model, target, model.Namespace, true, ModelCacheModeShared,
 		r.CACertConfigMap, r.InitContainerImage, r.DefaultFSGroup, r.AllowedHostPathRoots)
 	if len(storage.initContainers) == 0 {
 		return nil, fmt.Errorf("prefetch: source %q produced no downloader containers", model.Spec.Source)

--- a/internal/controller/model_prefetch.go
+++ b/internal/controller/model_prefetch.go
@@ -292,7 +292,7 @@ func (r *ModelReconciler) completePrefetch(ctx context.Context, model *inference
 	now := metav1.Now()
 	model.Status.LastUpdated = &now
 	return r.updateStatus(ctx, model, "Available", metav1.ConditionTrue,
-		"ModelPrefetched", "Model prefetched into the shared cache")
+		"ModelPrefetched", "Model prefetched into the model cache")
 }
 
 // prefetchTargetName returns the PVC name prefetch will stage into, for status

--- a/internal/controller/model_prefetch_test.go
+++ b/internal/controller/model_prefetch_test.go
@@ -256,11 +256,11 @@ var _ = Describe("Model Prefetch", func() {
 		// Prefetch must stage into the PVC the InferenceService will actually
 		// read, not always the shared cache.
 
-		newIsvc := func(name, claim string) *inferencev1alpha1.InferenceService {
+		newIsvc := func(modelName, name, claim string) *inferencev1alpha1.InferenceService {
 			return &inferencev1alpha1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 				Spec: inferencev1alpha1.InferenceServiceSpec{
-					ModelRef: "per-service-model",
+					ModelRef: modelName,
 					ModelCache: &inferencev1alpha1.ModelCacheSpec{
 						ClaimName: claim,
 					},
@@ -286,7 +286,7 @@ var _ = Describe("Model Prefetch", func() {
 		It("mounts the single referencing service's claimName PVC", func() {
 			m := newPrefetchModel("per-service-model")
 			seedPrefetchCacheKey(m)
-			Expect(k8sClient.Create(ctx, newIsvc("svc-a", "llmkube-node-a-cache"))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newIsvc("per-service-model", "svc-a", "llmkube-node-a-cache"))).To(Succeed())
 
 			// The bug: buildPrefetchJob hardcodes a nil isvc and the shared
 			// cache, so the per-service claim is never consulted.
@@ -311,7 +311,7 @@ var _ = Describe("Model Prefetch", func() {
 			r := prefetchReconciler()
 			m := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "resolve-model", Namespace: ns}}
 
-			Expect(k8sClient.Create(ctx, newIsvc("svc-a", "llmkube-cache-a"))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newIsvc("resolve-model", "svc-a", "llmkube-cache-a"))).To(Succeed())
 			target, reason := r.resolvePrefetchTarget(ctx, m)
 			Expect(reason).To(BeEmpty())
 			Expect(target).NotTo(BeNil())
@@ -323,8 +323,8 @@ var _ = Describe("Model Prefetch", func() {
 			r := prefetchReconciler()
 			m := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "conflict-model", Namespace: ns}}
 
-			Expect(k8sClient.Create(ctx, newIsvc("svc-a", "llmkube-cache-a"))).To(Succeed())
-			Expect(k8sClient.Create(ctx, newIsvc("svc-b", "llmkube-cache-b"))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newIsvc("conflict-model", "svc-a", "llmkube-cache-a"))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newIsvc("conflict-model", "svc-b", "llmkube-cache-b"))).To(Succeed())
 
 			target, reason := r.resolvePrefetchTarget(ctx, m)
 			Expect(target).To(BeNil())
@@ -336,7 +336,7 @@ var _ = Describe("Model Prefetch", func() {
 			m := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "no-svc-model", Namespace: ns}}
 
 			// A service that references a different model must not match.
-			Expect(k8sClient.Create(ctx, newIsvc("other-model", "llmkube-cache-a"))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newIsvc("other-model", "svc-other", "llmkube-cache-a"))).To(Succeed())
 
 			target, reason := r.resolvePrefetchTarget(ctx, m)
 			Expect(target).To(BeNil())

--- a/internal/controller/model_prefetch_test.go
+++ b/internal/controller/model_prefetch_test.go
@@ -268,6 +268,28 @@ var _ = Describe("Model Prefetch", func() {
 			}
 		}
 
+		// cleanupNamespacedObjects drains the InferenceServices and PVCs this
+		// block creates. It runs BOTH before each case (so a previous case
+		// cannot skew a resolution) and after the block (so these objects do
+		// not leak into the shared envtest cluster). The AfterEach is
+		// load-bearing: federation_edge_controller.go lists InferenceServices
+		// across ALL namespaces, and its spec asserts absolute counts, so a
+		// leaked service here fails an unrelated test.
+		cleanupNamespacedObjects := func() {
+			list := &inferencev1alpha1.InferenceServiceList{}
+			Expect(k8sClient.List(ctx, list, client.InNamespace(ns))).To(Succeed())
+			for i := range list.Items {
+				_ = k8sClient.Delete(ctx, &list.Items[i])
+			}
+			pvcList := &corev1.PersistentVolumeClaimList{}
+			Expect(k8sClient.List(ctx, pvcList, client.InNamespace(ns))).To(Succeed())
+			for i := range pvcList.Items {
+				_ = k8sClient.Delete(ctx, &pvcList.Items[i])
+			}
+		}
+
+		AfterEach(cleanupNamespacedObjects)
+
 		BeforeEach(func() {
 			// Clean any services left behind by a previous case.
 			list := &inferencev1alpha1.InferenceServiceList{}

--- a/internal/controller/model_prefetch_test.go
+++ b/internal/controller/model_prefetch_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Model Prefetch", func() {
 				Effect:   corev1.TaintEffectNoSchedule,
 			}}
 			seedPrefetchCacheKey(m)
-			job, err := prefetchReconciler().buildPrefetchJob(m)
+			job, err := prefetchReconciler().buildPrefetchJob(m, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(job.Spec.Template.Spec.Tolerations).To(HaveLen(1))
 			Expect(job.Spec.Template.Spec.Tolerations[0].Key).To(Equal("nvidia.com/gpu"))
@@ -113,7 +113,7 @@ var _ = Describe("Model Prefetch", func() {
 		It("emits no tolerations when the Model declares none", func() {
 			m := newPrefetchModel("plain")
 			seedPrefetchCacheKey(m)
-			job, err := prefetchReconciler().buildPrefetchJob(m)
+			job, err := prefetchReconciler().buildPrefetchJob(m, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(job.Spec.Template.Spec.Tolerations).To(BeEmpty())
 		})
@@ -251,9 +251,114 @@ var _ = Describe("Model Prefetch", func() {
 			Expect(updated.Status.Phase).To(Equal(PhaseDownloading))
 		})
 	})
+
+	Describe("#1676 per-service cache claim", func() {
+		// Prefetch must stage into the PVC the InferenceService will actually
+		// read, not always the shared cache.
+
+		newIsvc := func(name, claim string) *inferencev1alpha1.InferenceService {
+			return &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: "per-service-model",
+					ModelCache: &inferencev1alpha1.ModelCacheSpec{
+						ClaimName: claim,
+					},
+				},
+			}
+		}
+
+		BeforeEach(func() {
+			// Clean any services left behind by a previous case.
+			list := &inferencev1alpha1.InferenceServiceList{}
+			Expect(k8sClient.List(ctx, list, client.InNamespace(ns))).To(Succeed())
+			for i := range list.Items {
+				_ = k8sClient.Delete(ctx, &list.Items[i])
+			}
+			// Drain PVCs created by prior cases in this namespace.
+			pvcList := &corev1.PersistentVolumeClaimList{}
+			Expect(k8sClient.List(ctx, pvcList, client.InNamespace(ns))).To(Succeed())
+			for i := range pvcList.Items {
+				_ = k8sClient.Delete(ctx, &pvcList.Items[i])
+			}
+		})
+
+		It("mounts the single referencing service's claimName PVC", func() {
+			m := newPrefetchModel("per-service-model")
+			seedPrefetchCacheKey(m)
+			Expect(k8sClient.Create(ctx, newIsvc("svc-a", "llmkube-node-a-cache"))).To(Succeed())
+
+			// The bug: buildPrefetchJob hardcodes a nil isvc and the shared
+			// cache, so the per-service claim is never consulted.
+			job, err := prefetchReconciler().buildPrefetchJob(m, nil)
+			Expect(err).NotTo(HaveOccurred())
+			sharedClaim := sharedClaimName(job)
+			Expect(sharedClaim).To(Equal(ModelCachePVCName))
+
+			// The fix: pass the resolved target, and the Job mounts the
+			// service's PVC instead.
+			target := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "per-service-model", Namespace: ns},
+				Spec:       inferencev1alpha1.InferenceServiceSpec{ModelRef: "per-service-model", ModelCache: &inferencev1alpha1.ModelCacheSpec{ClaimName: "llmkube-node-a-cache"}},
+			}
+			goodJob, err := prefetchReconciler().buildPrefetchJob(m, target)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sharedClaimName(goodJob)).To(Equal("llmkube-node-a-cache"))
+			Expect(sharedClaimName(goodJob)).NotTo(Equal(ModelCachePVCName))
+		})
+
+		It("resolves the single distinct claim among referencing services", func() {
+			r := prefetchReconciler()
+			m := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "resolve-model", Namespace: ns}}
+
+			Expect(k8sClient.Create(ctx, newIsvc("svc-a", "llmkube-cache-a"))).To(Succeed())
+			target, reason := r.resolvePrefetchTarget(ctx, m)
+			Expect(reason).To(BeEmpty())
+			Expect(target).NotTo(BeNil())
+			Expect(userModelCacheClaimName(target)).To(Equal("llmkube-cache-a"))
+			Expect(target.Spec.ModelRef).To(Equal("resolve-model"))
+		})
+
+		It("falls back to the shared cache when services disagree on claimName", func() {
+			r := prefetchReconciler()
+			m := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "conflict-model", Namespace: ns}}
+
+			Expect(k8sClient.Create(ctx, newIsvc("svc-a", "llmkube-cache-a"))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newIsvc("svc-b", "llmkube-cache-b"))).To(Succeed())
+
+			target, reason := r.resolvePrefetchTarget(ctx, m)
+			Expect(target).To(BeNil())
+			Expect(reason).NotTo(BeEmpty())
+		})
+
+		It("falls back to the shared cache when no service references the model", func() {
+			r := prefetchReconciler()
+			m := &inferencev1alpha1.Model{ObjectMeta: metav1.ObjectMeta{Name: "no-svc-model", Namespace: ns}}
+
+			// A service that references a different model must not match.
+			Expect(k8sClient.Create(ctx, newIsvc("other-model", "llmkube-cache-a"))).To(Succeed())
+
+			target, reason := r.resolvePrefetchTarget(ctx, m)
+			Expect(target).To(BeNil())
+			Expect(reason).NotTo(BeEmpty())
+		})
+	})
 })
 
 // #1621: a fleet whose GPU nodes are tainted needs the prefetch Job to
 // tolerate them. Inheriting from an InferenceService is ill-defined here,
 // because prefetch runs BEFORE the first InferenceService by design, so the
 // Model carries its own tolerations and the Job inherits those.
+
+// sharedClaimName returns the PersistentVolumeClaim name the prefetch Job's
+// model-cache volume mounts, by reading the Job's volumes. It is the
+// observable artefact of the #1676 fix: the bug mounts the shared cache PVC,
+// the fix mounts the per-service claim.
+func sharedClaimName(job *batchv1.Job) string {
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.Name == "model-cache" && v.PersistentVolumeClaim != nil {
+			return v.PersistentVolumeClaim.ClaimName
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## What

Makes `Model.spec.prefetch` stage into the PVC the InferenceService will
actually read, instead of always staging into the namespace's shared model
cache.

## Why

Fixes #1676

Prefetch ignored `InferenceService.spec.modelCache.claimName`. When a service
overrode its cache PVC, prefetch downloaded the weights to a PVC that service
never reads, then the serving init container downloaded the same artifact a
second time into the correct PVC. Both copies persisted, and nothing warned.

Prefetch (#904) and the per-service cache override (#928) were added
independently and never composed. This bites hardest in the exact topology
`prefetchTolerations` (#1621) exists for: a tainted GPU node whose cache lives
on node-local storage, where the per-service override is the only way to pin a
model to that node's disk.

## How

The defect was `buildModelStorageConfig(model, nil, ...)` in
`startPrefetch` — a hardcoded `nil` InferenceService, so
`userModelCacheClaimName` could never be consulted.

A Model is 1:N with InferenceServices, so the target is not always
well-defined. Resolved policy:

- **Exactly one distinct `claimName`** among referencing services: prefetch into
  that PVC, and skip provisioning the shared PVC (otherwise the "both copies
  persist" symptom just moves).
- **No referencing service, or several disagreeing:** keep today's shared-cache
  behaviour and surface a `PrefetchCacheIgnored` condition, so the no-op is
  visible rather than silent.

No new API field. `Model.spec.prefetchClaimName` was considered and rejected: it
makes the user restate what the InferenceService already declares, and the two
can then disagree with no tiebreak.

Two follow-on commits from the adversarial review:

- `completePrefetch` still hardcoded "prefetched into the shared cache", which
  is wrong once the artifact can land in a per-service PVC. The same wording had
  already been fixed at the running-status site and missed at the terminal one.
- The new specs cleaned up in a `BeforeEach`, so each case cleaned up before
  itself but never after the block, leaking four InferenceServices.
  `federation_edge_controller.go` lists InferenceServices across **all**
  namespaces and its spec asserts absolute counts, so the leak failed an
  unrelated test deterministically on this branch while `main` passed. Added an
  `AfterEach` running the same drain.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — full `internal/controller/...` suite green (746 specs)
- [x] `make lint` passes locally — `GOOS=linux golangci-lint` 0 issues, `gofmt` clean, no CRD drift after `make manifests`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — the resolved policy is documented in `resolvePrefetchTarget`'s GoDoc and the file header

## Verification

- **Mutation test.** Reverting `buildModelStorageConfig(model, target, ...)` to
  `nil` — the exact original bug — fails the suite. The test asserts the Job's
  actual PVC mount, not just the resolver's return value.
- All four policy branches covered: single claim, conflicting claims, no
  referencing service, and the Job mount itself.
- The test-isolation failure above was caught only by running the package
  **unfiltered**; a `-run Prefetch` filter does not match the Ginkgo suite name
  and reports green on a branch that fails CI.

## AI assistance

Implementation by a Foreman coder agent (Ornith-1.5-35B-A3B, self-hosted),
gated by the Foreman verify job and reviewed by a self-hosted Nemotron-49B
reviewer. Both passed the branch while it deterministically failed the full
suite. A human-directed adversarial review found that, and the last two commits
are human-authored.
