### PR TITLE
feat(foreman): block dependents of a contradicting dependency

### DIFF
--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -190,7 +190,24 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if depName, depState, err := r.cascadeSkipIfDepResolvedOrSkipped(ctx, &task); err != nil {
 		return ctrl.Result{}, err
 	} else if depName != "" {
-		return r.skipTask(ctx, &task, depName, depState)
+		return r.skipTask(ctx, &task, depName, depState, false)
+	}
+
+	// Cascade-skip if any dependency ended with a cross-stage contradiction.
+	// An ALREADY-RESOLVED dependency is a terminal non-failure (the work is
+	// already on the branch), while a contradicted dependency is an unresolved
+	// question: two independent witnesses disagreeing is the strongest evidence
+	// that something is wrong, so shipping work built on it is exactly the
+	// failure the detection was built to prevent. The contradiction check runs
+	// AFTER the already-resolved check so a dep that is both resolved and
+	// contradicted stays skipped as already-resolved (the benign signal wins
+	// over the stop signal), and a contradicted dep is skipped rather than
+	// cascade-failed so the rollup excludes it from every bucket instead of
+	// pinning the Workload to Failed.
+	if depName, contradiction, err := r.cascadeSkipIfDepContradicted(ctx, &task); err != nil {
+		return ctrl.Result{}, err
+	} else if depName != "" {
+		return r.skipTask(ctx, &task, depName, fmt.Sprintf("contradiction: %s", contradiction), true)
 	}
 
 	// Cascade-fail if any dependency has Failed.
@@ -818,26 +835,39 @@ func (r *AgenticTaskReconciler) failTask(ctx context.Context, task *foremanv1alp
 
 // skipTask transitions a Pending task to Phase=Succeeded + Verdict=Skipped
 // because its dependency ended ALREADY-RESOLVED or was itself Skipped
-// (#970, transitive #1688). The Workload rollup recognizes Skipped as a
-// terminal-non-failure shape that is excluded from every bucket; the
-// dependent's execution never happened, so no FailureReason is set (the
-// cause is upstream, recorded in the condition message). The Failed
-// condition is NOT set — this is the explicit non-failure path.
+// (#970, transitive #1688), or ended with a cross-stage contradiction
+// (#1686). The Workload rollup recognizes Skipped as a terminal-non-failure
+// shape that is excluded from every bucket; the dependent's execution never
+// happened, so no FailureReason is set (the cause is upstream, recorded in
+// the condition message). The Failed condition is NOT set — this is the
+// explicit non-failure path.
 //
 // depState is the dependency's own terminal state string ("ALREADY-RESOLVED"
 // or "Skipped"), threaded through so the condition message names the actual
 // reason rather than always saying ALREADY-RESOLVED for a transitive skip.
-func (r *AgenticTaskReconciler) skipTask(ctx context.Context, task *foremanv1alpha1.AgenticTask, depName, depState string) (ctrl.Result, error) {
+// When contradicted is true the dependency ended with a cross-stage
+// contradiction: skipTask stamps the distinct UpstreamContradicted reason and
+// names both the dependency and the contradiction text, so this stop signal
+// stays alertable separately from the benign UpstreamAlreadyResolved reason.
+func (r *AgenticTaskReconciler) skipTask(ctx context.Context, task *foremanv1alpha1.AgenticTask, depName, depState string, contradicted bool) (ctrl.Result, error) {
 	patch := client.MergeFrom(task.DeepCopy())
 	now := metav1.Now()
 	task.Status.Phase = foremanv1alpha1.AgenticTaskPhaseSucceeded
 	task.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictSkipped
 	task.Status.FinishedAt = &now
+	reason := "UpstreamAlreadyResolved"
+	var message string
+	if contradicted {
+		reason = "UpstreamContradicted"
+		message = fmt.Sprintf("dependency %q ended with a contradiction; dependent skipped (%s)", depName, depState)
+	} else {
+		message = fmt.Sprintf("dependency %q ended %s; dependent skipped", depName, depState)
+	}
 	setCondition(&task.Status.Conditions, metav1.Condition{
 		Type:               "Skipped",
 		Status:             metav1.ConditionTrue,
-		Reason:             "UpstreamAlreadyResolved",
-		Message:            fmt.Sprintf("dependency %q ended %s; dependent skipped", depName, depState),
+		Reason:             reason,
+		Message:            message,
 		LastTransitionTime: now,
 	})
 	return ctrl.Result{}, r.Status().Patch(ctx, task, patch)
@@ -870,6 +900,46 @@ func (r *AgenticTaskReconciler) cascadeSkipIfDepResolvedOrSkipped(ctx context.Co
 		if isSkippedTask(&dep) {
 			return depName, "Skipped", nil
 		}
+	}
+	return "", "", nil
+}
+
+// cascadeSkipIfDepContradicted returns the first dependency that ended with a
+// cross-stage contradiction (a non-empty extra.crossStageContradictions in its
+// terminal result envelope, #1686), or "" if none. The second return value is
+// the contradiction text (the first contradiction string) the caller threads
+// into the skip condition message. The caller transitions the dependent to
+// Skipped; see skipTask. Runs AFTER cascadeSkipIfDepResolvedOrSkipped in
+// Reconcile so a dependency that is both ALREADY-RESOLVED and contradicted
+// stays skipped as already-resolved (the benign terminal non-failure wins over
+// the stop signal), and runs BEFORE cascadeFailIfDepFailed so the contradiction
+// skips the dependent rather than cascade-failing it (which would pin the
+// Workload to Failed).
+//
+// Uses hasCrossStageContradiction / coderCrossStageContradictions from the
+// predecessor issue (#1685) rather than re-deriving the signal: the detector
+// writes the contradiction list in the coder / gate / reviewer wiring, and the
+// controller only reads it. Blocking here is dependents-only: the contradicting
+// task's own verdict and phase are left untouched (demoting it was considered
+// and rejected — it would turn a records-only rail into a verdict-changing one).
+func (r *AgenticTaskReconciler) cascadeSkipIfDepContradicted(ctx context.Context, task *foremanv1alpha1.AgenticTask) (string, string, error) {
+	for _, depName := range task.Spec.DependsOn {
+		var dep foremanv1alpha1.AgenticTask
+		if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: depName}, &dep); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return "", "", err
+		}
+		if !hasCrossStageContradiction(&dep) {
+			continue
+		}
+		cs := coderCrossStageContradictions(&dep)
+		contradiction := ""
+		if len(cs) > 0 {
+			contradiction = cs[0]
+		}
+		return depName, contradiction, nil
 	}
 	return "", "", nil
 }

--- a/internal/foreman/controller/agentictask_controller_test.go
+++ b/internal/foreman/controller/agentictask_controller_test.go
@@ -264,6 +264,120 @@ var _ = Describe("AgenticTaskReconciler scheduler", func() {
 		Expect(failedCond).To(BeNil(), "a Skipped dependent must not carry a Failed condition")
 	})
 
+	// Regression for defilantech/LLMKube#1686. A Pending task whose
+	// dependency ended with a cross-stage contradiction (a non-empty
+	// extra.crossStageContradictions in its terminal result envelope, set by
+	// the detector in #1685) must be cascade-skipped so the contradiction stops
+	// the line instead of only being counted. The dependency is on-target
+	// (Phase=Succeeded + Verdict=GO) apart from the contradiction, so without
+	// the contradiction check the dependent would actually dispatch; the skip
+	// is what stops the line. The dependent is transitioned to
+	// Phase=Succeeded + Verdict=Skipped with a Skipped condition
+	// (Reason=UpstreamContradicted) so the Workload rollup excludes it from
+	// every bucket rather than cascade-failing it (which would pin the
+	// Workload to Failed). The contradicting dependency's own verdict and
+	// phase are left untouched — blocking is dependents-only.
+	It("cascade-skips a Pending task when its dependency ended with a contradiction (#1686)", func() {
+		dep := newTask("cascade-contra-dep")
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, dep) })
+		// On-target (Phase=Succeeded + Verdict=GO) apart from the
+		// contradiction: the cascade path reads the contradiction via
+		// hasCrossStageContradiction / coderCrossStageContradictions. The dep's
+		// own verdict/phase are left unchanged — #1686 only blocks dependents,
+		// never demotes the contradicting task.
+		setPhase(dep, foremanv1alpha1.AgenticTaskPhaseSucceeded)
+		patch := client.MergeFrom(dep.DeepCopy())
+		dep.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictGo
+		dep.Status.Result = &runtime.RawExtension{
+			Raw: []byte(`{"summary":"staged","extra":{"crossStageContradictions":["gate: GATE-PASS on an empty branch (checks passed trivially)"]}}`),
+		}
+		Expect(k8sClient.Status().Patch(ctx, dep, patch)).To(Succeed())
+
+		target := newTask("cascade-contra-target")
+		target.Spec.DependsOn = []string{dep.Name}
+		Expect(k8sClient.Create(ctx, target)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, target) })
+		setPhase(target, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(target))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(target), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseSucceeded))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictSkipped))
+		Expect(fresh.Status.FinishedAt).NotTo(BeNil())
+		// A contradiction must dispatch nothing — the dependent is skipped, not
+		// assigned to a node.
+		Expect(fresh.Status.AssignedNode).To(BeEmpty())
+
+		skippedCond := findCondition(fresh.Status.Conditions, "Skipped")
+		Expect(skippedCond).NotTo(BeNil())
+		Expect(skippedCond.Reason).To(Equal("UpstreamContradicted"))
+		Expect(skippedCond.Message).To(ContainSubstring(dep.Name))
+		Expect(skippedCond.Message).To(ContainSubstring("GATE-PASS on an empty branch"))
+
+		// A Skipped dependent must not carry a Failed condition.
+		failedCond := findCondition(fresh.Status.Conditions, "Failed")
+		Expect(failedCond).To(BeNil(), "a Skipped dependent must not carry a Failed condition")
+
+		// The contradicting dependency's own verdict and phase are untouched:
+		// #1686 blocks dependents only, never demotes the contradicting task.
+		var depFresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(dep), &depFresh)).To(Succeed())
+		Expect(depFresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseSucceeded))
+		Expect(depFresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictGo))
+	})
+
+	// Regression for defilantech/LLMKube#1686. When a dependency is BOTH
+	// ALREADY-RESOLVED and contradicted, the already-resolved reason wins:
+	// an ALREADY-RESOLVED dependency is a terminal non-failure (the work is
+	// already on the branch), while a contradiction is a stop signal, so the
+	// contradiction check runs AFTER the already-resolved check and the
+	// benign signal wins. The dependent is skipped with Reason=
+	// UpstreamAlreadyResolved, not UpstreamContradicted.
+	It("an ALREADY-RESOLVED dependency that is also contradicted skips as already-resolved (#1686)", func() {
+		dep := newTask("cascade-both-dep")
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, dep) })
+		// ALREADY-RESOLVED (Phase=Succeeded + Verdict=NO-GO +
+		// extra.outcome="ALREADY-RESOLVED") AND a contradiction in the same
+		// envelope. Both signals fire; the already-resolved check must win.
+		setPhase(dep, foremanv1alpha1.AgenticTaskPhaseSucceeded)
+		patch := client.MergeFrom(dep.DeepCopy())
+		dep.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictNoGo
+		dep.Status.Result = &runtime.RawExtension{
+			Raw: []byte(`{"summary":"already done","extra":{"outcome":"ALREADY-RESOLVED","resolvedBy":"sha-deadbeef","crossStageContradictions":["coder: claims edits but branch is empty"]}}`),
+		}
+		Expect(k8sClient.Status().Patch(ctx, dep, patch)).To(Succeed())
+
+		target := newTask("cascade-both-target")
+		target.Spec.DependsOn = []string{dep.Name}
+		Expect(k8sClient.Create(ctx, target)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, target) })
+		setPhase(target, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(target))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(target), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseSucceeded))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictSkipped))
+		Expect(fresh.Status.AssignedNode).To(BeEmpty())
+
+		skippedCond := findCondition(fresh.Status.Conditions, "Skipped")
+		Expect(skippedCond).NotTo(BeNil())
+		// The benign ALREADY-RESOLVED signal wins over the stop signal.
+		Expect(skippedCond.Reason).To(Equal("UpstreamAlreadyResolved"))
+		Expect(skippedCond.Message).To(ContainSubstring(dep.Name))
+		Expect(skippedCond.Message).NotTo(ContainSubstring("contradiction"))
+
+		failedCond := findCondition(fresh.Status.Conditions, "Failed")
+		Expect(failedCond).To(BeNil(), "a Skipped dependent must not carry a Failed condition")
+	})
+
 	It("waits with requeue when a dependency is still pre-terminal", func() {
 		dep := newTask("wait-dep") // status stays empty == pre-terminal
 		Expect(k8sClient.Create(ctx, dep)).To(Succeed())


### PR DESCRIPTION
## What

Blocks a task whose dependency ended with a cross-stage contradiction, so a
contradiction stops the line instead of only being counted.

This is the last piece of #1674.

## Why

Fixes #1686

`shouldEscalate` (`pkg/foreman/agent/cross_stage.go`) documents itself as
reporting "whether any contradiction warrants stopping the line", and argues
the case in its own comment: two independent witnesses disagreeing is the
strongest evidence available that something is wrong. Until now nothing
stopped. #1680, #1681 and #1683 shipped the four detection rules, #1682 added
the evidence, and #1685 made contradictions countable. This makes them
consequential.

## How

Mirrors the ALREADY-RESOLVED cascade, reusing `hasCrossStageContradiction` and
`coderCrossStageContradictions` from #1685 rather than re-deriving the signal.

**Ordering is load-bearing and pinned by a test.** The contradiction check runs
*after* `cascadeSkipIfDepResolvedOrSkipped` and *before* `cascadeFailIfDepFailed`:

- After already-resolved, so a dependency that is both resolved and
  contradicted stays skipped as already-resolved — the benign terminal
  non-failure wins over the stop signal.
- Before cascade-fail, so a contradicted dependency skips its dependents rather
  than failing them, which would pin the Workload to `Failed`.

**A distinct condition reason.** `UpstreamContradicted`, never sharing
`UpstreamAlreadyResolved`. The two mean opposite things — one benign, one a stop
signal — and a shared reason string makes them impossible to alert on
separately.

**Dependents only.** The contradicting task's own verdict and phase are
untouched, and `inertDemotion` is not touched at all. Demoting the
contradicting task was considered and rejected: it turns a records-only rail
into a verdict-changing one, and the demotion rails are where #1678 and #1684
both originated.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — all `internal/foreman/...` and `pkg/foreman/...` packages green, run unfiltered
- [x] `make lint` passes locally — `GOOS=linux golangci-lint` 0 issues (re-run after `cache clean`), `make lint-deadcode` 0 issues, `gofmt` clean, no drift after `make manifests` and `make foreman-chart-crds`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — behaviour is internal to pipeline cascade; the reason string is documented in `skipTask`'s GoDoc

## Verification

Three mutations, all caught:

| Mutation | Result |
|---|---|
| Unwire the contradiction cascade in `Reconcile` | CAUGHT |
| Collapse `UpstreamContradicted` back into `UpstreamAlreadyResolved` | CAUGHT |
| Swap the two cascade checks so contradiction runs first | CAUGHT |

The third matters most: the ordering guarantee is not just commented, it is
pinned by a test that fails if the checks are reordered. There is also a case
asserting the contradicting dependency's own verdict stays `GO`, which locks in
the dependents-only scope.

## AI assistance

Implementation by a Foreman coder agent (Ornith-1.5-35B-A3B, self-hosted),
gated by the Foreman verify job and reviewed by a self-hosted Nemotron-49B
reviewer. A human-directed adversarial review followed, which ran the three
mutations above. No revision pass was needed.
