### PR TITLE
fix(docker): upgrade base packages so the foreman-agent image passes Trivy

### DIFF
--- a/Dockerfile.foreman-agent
+++ b/Dockerfile.foreman-agent
@@ -25,7 +25,15 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
 # still gives us a non-root user.
 FROM alpine:3.24
 
-RUN apk add --no-cache git ca-certificates \
+# apk upgrade before apk add: the alpine:3.24 base image is rebuilt less
+# often than its package repo is published, so packages baked into the
+# base can sit behind a published fix even on a fresh build. Trivy scans
+# this image before push and fails the release on HIGH findings, so the
+# upgrade is what keeps a base-image lag from blocking a release
+# (CVE-2026-14456: libcrypto3/libssl3 3.5.7-r0 in the base, 3.5.8-r0 in
+# the v3.24 repo).
+RUN apk upgrade --no-cache \
+    && apk add --no-cache git ca-certificates \
     && addgroup -S -g 65532 nonroot \
     && adduser -S -u 65532 -G nonroot nonroot
 

--- a/Dockerfile.foreman-agent.goreleaser
+++ b/Dockerfile.foreman-agent.goreleaser
@@ -7,7 +7,15 @@
 # alpine + git. nonroot uid 65532 stays.
 FROM alpine:3.24
 ARG TARGETPLATFORM
-RUN apk add --no-cache git ca-certificates \
+# apk upgrade before apk add: the alpine:3.24 base image is rebuilt less
+# often than its package repo is published, so packages baked into the
+# base can sit behind a published fix even on a fresh build. Trivy scans
+# this image before push and fails the release on HIGH findings, so the
+# upgrade is what keeps a base-image lag from blocking a release
+# (CVE-2026-14456: libcrypto3/libssl3 3.5.7-r0 in the base, 3.5.8-r0 in
+# the v3.24 repo).
+RUN apk upgrade --no-cache \
+    && apk add --no-cache git ca-certificates \
     && addgroup -S -g 65532 nonroot \
     && adduser -S -u 65532 -G nonroot nonroot
 WORKDIR /


### PR DESCRIPTION
## What

Runs `apk upgrade --no-cache` before the existing `apk add` in the
foreman-agent images, so packages inherited from the alpine base are brought
up to the branch's current versions.

## Why

The 0.9.21 release failed at `Scan images before push (Trivy, amd64)` in the
`goreleaser` job, with two HIGH findings:

```
ghcr.io/defilantech/llmkube-foreman-agent:0.9.21-scan (alpine 3.24.1)
Total: 2 (HIGH: 2, CRITICAL: 0)

libcrypto3  CVE-2026-14456  HIGH  fixed  3.5.7-r0 -> 3.5.8-r0
libssl3     CVE-2026-14456  HIGH  fixed  3.5.7-r0 -> 3.5.8-r0
```

CVE-2026-14456 is an OpenSSL denial of service via unbounded memory growth in
the QUIC server.

**Why a rebuild alone does not fix it.** Both packages are baked into the
`alpine:3.24` base rather than installed by our `RUN` line, so
`apk add --no-cache git ca-certificates` never touches them. The base tag is
floating, but base images are rebuilt less often than their package repo is
published: alpine's v3.24 repo already carries `3.5.8-r0` while the image still
ships `3.5.7-r0`. Re-running the release without this change would fail
identically.

## How

`apk upgrade --no-cache` in the same `RUN` layer, before `apk add`.

Chose the broad upgrade over pinning `libcrypto3>=3.5.8-r0` deliberately: the
scan gates the release on **any** HIGH finding in the image, so pinning
individual packages means a new commit and a failed release for every future
CVE in any base package. The upgrade keeps the image current for its branch on
every build.

Applied to **both** `Dockerfile.foreman-agent.goreleaser` (what the release
builds) and `Dockerfile.foreman-agent` (local and dev builds) so the two do not
drift. `foreman-agent` is the only image with an alpine runtime base — it needs
`git` at runtime — and every other image is distroless with no apk, so none are
affected.

## Verification

Run against the real base image on linux/amd64, the same platform the failing
scan used:

```
BEFORE:  libcrypto3-3.5.7-r0   libssl3-3.5.7-r0
AFTER:   libcrypto3-3.5.8-r0   libssl3-3.5.8-r0
```

That is exactly the transition Trivy asked for.

**Note for the reviewer:** the Trivy scan runs only in the release workflow's
`goreleaser` job, so **CI on this PR does not exercise it**. The check above is
the verification; the next release attempt is the first time the scan itself
runs against this change.

## Checklist

- [x] Tests added/updated — n/a, Dockerfile-only change with no Go surface
- [x] `make test` passes locally — unaffected by this change; main verified green across 5 ginkgo seeds before the release attempt
- [x] `make lint` passes locally — 0 issues, and `GOOS=linux golangci-lint run ./...` 0 issues on a clean cache
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — no user-facing surface change

## AI assistance

Diagnosed and written with Claude: read the failing run's Trivy output,
confirmed against alpine's package index that v3.24 carries the fixed
`3.5.8-r0`, and verified the before/after package versions by running
`apk upgrade` in the real `alpine:3.24` image on an amd64 node.
