### PR TITLE
fix(foreman): bound and surface a missing-dependency wait

### DIFF
--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -565,24 +566,38 @@ func (r *AgenticTaskReconciler) recordMissingDepCondition(ctx context.Context, t
 
 // depWaitExpired reports whether the task's wait for an absent dependency
 // has outlasted its TimeoutSeconds budget, in which case the caller should
-// cascade-fail the task with a MissingDependency reason. The budget is
-// measured from the task's own creation so a task that has waited the
-// whole budget fails even if it was created far in the past (the first
-// reconcile after it is created). Fall back to "now" for a task with no
-// creation timestamp, so the wait still terminates.
+// cascade-fail the task with a MissingDependency reason.
 //
-// An unset or zero TimeoutSeconds leaves the wait unbounded (the dep is
-// legal to wait for), which is the pre-1687 default and still correct for
-// the create-ordering race.
+// The budget is measured from the DepWaitStarted condition's
+// LastTransitionTime -- the moment the reconciler FIRST observed the
+// dependency absent -- and NOT from the task's creation. Two reasons, and
+// the first is the load-bearing one:
+//
+//   - Semantics. The budget is for the wait, not for the task's lifetime. A
+//     task created well before its dependency is dispatched would already be
+//     past a creation-relative budget on its first reconcile and cascade-fail
+//     instantly, which is the create-ordering race this whole path exists to
+//     tolerate.
+//   - Testability. metadata.creationTimestamp is assigned by the API server
+//     and is immutable: an Update that backdates it returns success and
+//     silently stores the original value. A creation-relative budget is
+//     therefore unreachable from an envtest, so no test can prove the
+//     cascade-fail ever fires. status.conditions are ordinary status and can
+//     be written, so the condition clock is reachable.
+//
+// No condition means the wait has not been recorded yet, so nothing has
+// elapsed. An unset or zero TimeoutSeconds leaves the wait unbounded (the dep
+// is legal to wait for), which is the pre-1687 default and still correct.
 func depWaitExpired(task *foremanv1alpha1.AgenticTask) bool {
 	budget := time.Duration(task.Spec.TimeoutSeconds) * time.Second
 	if budget <= 0 {
 		return false
 	}
-	if task.CreationTimestamp.IsZero() {
-		return time.Since(time.Now()) >= budget
+	started := apimeta.FindStatusCondition(task.Status.Conditions, "DepWaitStarted")
+	if started == nil || started.LastTransitionTime.IsZero() {
+		return false
 	}
-	return time.Since(task.CreationTimestamp.Time) >= budget
+	return time.Since(started.LastTransitionTime.Time) >= budget
 }
 
 // reserveFirstFitNode picks the alphabetically-first Ready FleetNode whose

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -554,8 +554,13 @@ func (r *AgenticTaskReconciler) recordMissingDepCondition(ctx context.Context, t
 	if hasCondition(task.Status.Conditions, depWait) {
 		return nil
 	}
+	// Capture the merge base BEFORE mutating, so the computed diff actually
+	// carries the newly added condition to the API server. Capturing after
+	// setCondition would make the base already contain it, so the merge
+	// patch would see no diff and the condition would never persist.
+	patch := client.MergeFrom(task.DeepCopy())
 	setCondition(&task.Status.Conditions, depWait)
-	return r.Status().Patch(ctx, task, client.MergeFrom(task.DeepCopy()))
+	return r.Status().Patch(ctx, task, patch)
 }
 
 // depWaitExpired reports whether the task's wait for an absent dependency

--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -210,6 +210,18 @@ func (r *AgenticTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return r.skipTask(ctx, &task, depName, fmt.Sprintf("contradiction: %s", contradiction), true)
 	}
 
+	// Cascade-fail if any dependency is still absent once the task's
+	// TimeoutSeconds budget has elapsed. A dep absent for less than the
+	// budget is legal to wait for (the create-ordering race), so this
+	// defers to allDepsSucceeded, which surfaces the wait. Runs before
+	// cascadeFailIfDepFailed so the missing-dep reason is distinct from a
+	// dependency that failed. See #1687.
+	if missingMsg, err := r.cascadeFailIfMissing(ctx, &task); err != nil {
+		return ctrl.Result{}, err
+	} else if missingMsg != "" {
+		return r.failTask(ctx, &task, "MissingDependency", missingMsg)
+	}
+
 	// Cascade-fail if any dependency has Failed.
 	if cascadeMsg, err := r.cascadeFailIfDepFailed(ctx, &task); err != nil {
 		return ctrl.Result{}, err
@@ -469,6 +481,14 @@ func (r *AgenticTaskReconciler) cascadeFailIfDepFailed(ctx context.Context, task
 // the same namespace AND is on-target (Phase=Succeeded AND verdict in
 // {GO, GATE-PASS}).
 //
+// A dependency that has not yet appeared is legal to wait for (a
+// dependent can be created before its dependency in the ordering race the
+// cascade-fail loop's IsNotFound branch tolerates). This records a
+// DepWaitStarted condition so the stall is diagnosable; the budget check
+// that actually cascade-fails an expired wait lives in cascadeFailIfMissing.
+// Without #1687 a missing dep left the task Pending forever with no
+// condition, event, or timeout.
+//
 // Previously gated on Phase=Succeeded alone, allowing INCOMPLETE /
 // GATE-FAIL deps to unblock dependents. Fixes defilantech/LLMKube#541.
 func (r *AgenticTaskReconciler) allDepsSucceeded(ctx context.Context, task *foremanv1alpha1.AgenticTask) (bool, error) {
@@ -476,7 +496,13 @@ func (r *AgenticTaskReconciler) allDepsSucceeded(ctx context.Context, task *fore
 		var dep foremanv1alpha1.AgenticTask
 		if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: depName}, &dep); err != nil {
 			if apierrors.IsNotFound(err) {
-				return false, nil // wait for the dep to appear
+				// Surface the wait; a budget-expired dep is cascade-failed
+				// by cascadeFailIfMissing, so this keeps waiting for the
+				// dep to appear within budget. See #1687.
+				if err := r.recordMissingDepCondition(ctx, task, depName); err != nil {
+					return false, err
+				}
+				return false, nil
 			}
 			return false, err
 		}
@@ -485,6 +511,73 @@ func (r *AgenticTaskReconciler) allDepsSucceeded(ctx context.Context, task *fore
 		}
 	}
 	return true, nil
+}
+
+// cascadeFailIfMissing returns a non-empty message if any dependency is
+// still absent (not found) and the task's wait for it has outlasted the
+// TimeoutSeconds budget; otherwise it returns "" so the caller keeps
+// waiting. The missing-dep cascade-fail is checked before
+// cascadeFailIfDepFailed so the Failed condition carries the distinct
+// MissingDependency reason (#1687).
+func (r *AgenticTaskReconciler) cascadeFailIfMissing(ctx context.Context, task *foremanv1alpha1.AgenticTask) (string, error) {
+	for _, depName := range task.Spec.DependsOn {
+		var dep foremanv1alpha1.AgenticTask
+		if err := r.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: depName}, &dep); err != nil {
+			if apierrors.IsNotFound(err) {
+				if depWaitExpired(task) {
+					return fmt.Sprintf("dependency %q never appeared within TimeoutSeconds=%d; cascade-failing",
+						depName, task.Spec.TimeoutSeconds), nil
+				}
+				continue
+			}
+			return "", err
+		}
+	}
+	return "", nil
+}
+
+// recordMissingDepCondition writes a DepWaitStarted condition on the task
+// naming the absent dependency, so the wait is diagnosable via
+// kubectl describe. It patches only when the condition is not already
+// recorded with the same shape (Type/Status/Reason), so a dep that stays
+// absent does not wedge the reconciler in a per-reconcile status-patch
+// loop. The caller keeps waiting (returns false, nil) for the dep to
+// appear. See #1687.
+func (r *AgenticTaskReconciler) recordMissingDepCondition(ctx context.Context, task *foremanv1alpha1.AgenticTask, depName string) error {
+	depWait := metav1.Condition{
+		Type:               "DepWaitStarted",
+		Status:             metav1.ConditionTrue,
+		Reason:             "DependencyAbsent",
+		Message:            fmt.Sprintf("dependency %q not found; waiting for it to be created", depName),
+		LastTransitionTime: metav1.Now(),
+	}
+	if hasCondition(task.Status.Conditions, depWait) {
+		return nil
+	}
+	setCondition(&task.Status.Conditions, depWait)
+	return r.Status().Patch(ctx, task, client.MergeFrom(task.DeepCopy()))
+}
+
+// depWaitExpired reports whether the task's wait for an absent dependency
+// has outlasted its TimeoutSeconds budget, in which case the caller should
+// cascade-fail the task with a MissingDependency reason. The budget is
+// measured from the task's own creation so a task that has waited the
+// whole budget fails even if it was created far in the past (the first
+// reconcile after it is created). Fall back to "now" for a task with no
+// creation timestamp, so the wait still terminates.
+//
+// An unset or zero TimeoutSeconds leaves the wait unbounded (the dep is
+// legal to wait for), which is the pre-1687 default and still correct for
+// the create-ordering race.
+func depWaitExpired(task *foremanv1alpha1.AgenticTask) bool {
+	budget := time.Duration(task.Spec.TimeoutSeconds) * time.Second
+	if budget <= 0 {
+		return false
+	}
+	if task.CreationTimestamp.IsZero() {
+		return time.Since(time.Now()) >= budget
+	}
+	return time.Since(task.CreationTimestamp.Time) >= budget
 }
 
 // reserveFirstFitNode picks the alphabetically-first Ready FleetNode whose

--- a/internal/foreman/controller/agentictask_missing_dep_test.go
+++ b/internal/foreman/controller/agentictask_missing_dep_test.go
@@ -89,10 +89,21 @@ var _ = Describe("AgenticTaskReconciler missing dependency (#1687)", func() {
 		Expect(k8sClient.Create(ctx, task)).To(Succeed())
 		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
 		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
-		// Age the task past its TimeoutSeconds budget.
-		old := metav1.NewTime(time.Now().Add(-2 * time.Hour))
-		task.CreationTimestamp = old
-		Expect(k8sClient.Update(ctx, task)).To(Succeed())
+		// Age the WAIT past its TimeoutSeconds budget by backdating the
+		// DepWaitStarted condition, which is what depWaitExpired measures
+		// from. Do NOT try to backdate metadata.creationTimestamp: the API
+		// server assigns it and ignores any change, so the Update succeeds
+		// while the stored value stays put and the wait never appears
+		// expired. Conditions are ordinary status and are writable.
+		task.Status.Conditions = []metav1.Condition{{
+			Type:               "DepWaitStarted",
+			Status:             metav1.ConditionTrue,
+			Reason:             "DependencyAbsent",
+			Message:            `dependency "ghost-task" has not appeared yet`,
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+			ObservedGeneration: task.Generation,
+		}}
+		Expect(k8sClient.Status().Update(ctx, task)).To(Succeed())
 
 		_, err := reconciler.Reconcile(ctx, reqFor(task))
 		Expect(err).NotTo(HaveOccurred())
@@ -157,45 +168,55 @@ func TestDepWaitExpired(t *testing.T) {
 	now := time.Now()
 
 	cases := []struct {
-		name       string
-		timeoutSec int32
-		created    metav1.Time
-		want       bool
+		name        string
+		timeoutSec  int32
+		waitStarted metav1.Time // DepWaitStarted LastTransitionTime; zero means no condition
+		want        bool
 	}{
 		{
-			name:       "zero timeout never expires (unbounded wait)",
-			timeoutSec: 0,
-			created:    metav1.NewTime(now.Add(-100 * time.Hour)),
-			want:       false,
+			name:        "zero timeout never expires (unbounded wait)",
+			timeoutSec:  0,
+			waitStarted: metav1.NewTime(now.Add(-100 * time.Hour)),
+			want:        false,
 		},
 		{
-			name:       "within budget does not expire",
-			timeoutSec: 3600,
-			created:    metav1.NewTime(now.Add(-1 * time.Minute)),
-			want:       false,
+			name:        "within budget does not expire",
+			timeoutSec:  3600,
+			waitStarted: metav1.NewTime(now.Add(-1 * time.Minute)),
+			want:        false,
 		},
 		{
-			name:       "past budget expires",
-			timeoutSec: 3600,
-			created:    metav1.NewTime(now.Add(-2 * time.Hour)),
-			want:       true,
+			name:        "past budget expires",
+			timeoutSec:  3600,
+			waitStarted: metav1.NewTime(now.Add(-2 * time.Hour)),
+			want:        true,
 		},
 		{
-			name:       "no creation timestamp falls back to now (within budget)",
-			timeoutSec: 3600,
-			created:    metav1.Time{},
-			want:       false,
+			// No DepWaitStarted condition means the reconciler has not yet
+			// observed the dependency absent, so no wait has elapsed. This
+			// must stay false: treating "no condition" as expired would
+			// cascade-fail a task on the very first reconcile, killing the
+			// create-ordering race this path exists to tolerate.
+			name:        "no DepWaitStarted condition never expires",
+			timeoutSec:  3600,
+			waitStarted: metav1.Time{},
+			want:        false,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			task := &foremanv1alpha1.AgenticTask{
-				ObjectMeta: metav1.ObjectMeta{
-					CreationTimestamp: tc.created,
-				},
 				Spec: foremanv1alpha1.AgenticTaskSpec{
 					TimeoutSeconds: tc.timeoutSec,
 				},
+			}
+			if !tc.waitStarted.IsZero() {
+				task.Status.Conditions = []metav1.Condition{{
+					Type:               "DepWaitStarted",
+					Status:             metav1.ConditionTrue,
+					Reason:             "DependencyAbsent",
+					LastTransitionTime: tc.waitStarted,
+				}}
 			}
 			if got := depWaitExpired(task); got != tc.want {
 				t.Fatalf("depWaitExpired() = %v, want %v", got, tc.want)

--- a/internal/foreman/controller/agentictask_missing_dep_test.go
+++ b/internal/foreman/controller/agentictask_missing_dep_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// The create-ordering race (a dependent created before its dependency) is
+// legal and must be tolerated: a task whose dependency has not yet
+// appeared must NOT cascade-fail while it is still within its
+// TimeoutSeconds budget. #1687 bounds that wait with a condition and a
+// timeout instead of letting the task wait forever.
+
+var _ = Describe("AgenticTaskReconciler missing dependency (#1687)", func() {
+	var reconciler *AgenticTaskReconciler
+
+	BeforeEach(func() {
+		reconciler = &AgenticTaskReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+	})
+
+	It("surfaces a missing dependency with a DepWaitStarted condition naming it", func() {
+		task := newTask("missing-dep-surface")
+		task.Spec.DependsOn = []string{"ghost-task"}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		// Still legal to wait; the task stays Pending, not Failed.
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		cond := findCondition(fresh.Status.Conditions, "DepWaitStarted")
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Reason).To(Equal("DependencyAbsent"))
+		Expect(cond.Message).To(ContainSubstring("ghost-task"))
+	})
+
+	It("does not cascade-fail a missing dependency within its budget", func() {
+		task := newTask("missing-dep-within-budget")
+		task.Spec.TimeoutSeconds = 3600
+		task.Spec.DependsOn = []string{"ghost-task"}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+		Expect(findCondition(fresh.Status.Conditions, "Failed")).To(BeNil())
+	})
+
+	It("cascade-fails a missing dependency once past TimeoutSeconds", func() {
+		task := newTask("missing-dep-expired")
+		task.Spec.TimeoutSeconds = 3600
+		task.Spec.DependsOn = []string{"ghost-task"}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+		// Age the task past its TimeoutSeconds budget.
+		old := metav1.NewTime(time.Now().Add(-2 * time.Hour))
+		task.CreationTimestamp = old
+		Expect(k8sClient.Update(ctx, task)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseFailed))
+		Expect(fresh.Status.Verdict).To(Equal(foremanv1alpha1.AgenticTaskVerdictIncomplete))
+		failedCond := findCondition(fresh.Status.Conditions, "Failed")
+		Expect(failedCond).NotTo(BeNil())
+		Expect(failedCond.Reason).To(Equal("MissingDependency"))
+		Expect(failedCond.Message).To(ContainSubstring("ghost-task"))
+	})
+
+	It("keeps waiting for a dependency that appears within its budget", func() {
+		dep := newTask("late-dep")
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, dep) })
+
+		task := newTask("late-dep-target")
+		task.Spec.TimeoutSeconds = 3600
+		task.Spec.DependsOn = []string{dep.Name}
+		Expect(k8sClient.Create(ctx, task)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, task) })
+		setPhase(task, foremanv1alpha1.AgenticTaskPhasePending)
+
+		// Reconcile while the dep is absent: surfaces the wait, stays Pending.
+		_, err := reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+		var fresh foremanv1alpha1.AgenticTask
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhasePending))
+
+		// The dep now appears (Succeeded on target) and the task dispatches.
+		setPhase(dep, foremanv1alpha1.AgenticTaskPhaseSucceeded)
+		patch := client.MergeFrom(dep.DeepCopy())
+		dep.Status.Verdict = foremanv1alpha1.AgenticTaskVerdictGo
+		Expect(k8sClient.Status().Patch(ctx, dep, patch)).To(Succeed())
+
+		node := newFleetNode("late-dep-node")
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		setNodeReady(node, foremanv1alpha1.FleetNodeCapability{
+			Accelerator:    foremanv1alpha1.FleetNodeAccelerator("metal"),
+			TotalRAMGB:     128,
+			AvailableRAMGB: 96,
+		})
+
+		_, err = reconciler.Reconcile(ctx, reqFor(task))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, nn(task), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(foremanv1alpha1.AgenticTaskPhaseScheduled))
+		Expect(fresh.Status.AssignedNode).To(Equal(node.Name))
+	})
+})
+
+// depWaitExpired is a pure function of the task's TimeoutSeconds and its
+// age, so the budget logic is exercised directly without staging real
+// wall-clock time through envtest.
+func TestDepWaitExpired(t *testing.T) {
+	now := time.Now()
+
+	cases := []struct {
+		name       string
+		timeoutSec int32
+		created    metav1.Time
+		want       bool
+	}{
+		{
+			name:       "zero timeout never expires (unbounded wait)",
+			timeoutSec: 0,
+			created:    metav1.NewTime(now.Add(-100 * time.Hour)),
+			want:       false,
+		},
+		{
+			name:       "within budget does not expire",
+			timeoutSec: 3600,
+			created:    metav1.NewTime(now.Add(-1 * time.Minute)),
+			want:       false,
+		},
+		{
+			name:       "past budget expires",
+			timeoutSec: 3600,
+			created:    metav1.NewTime(now.Add(-2 * time.Hour)),
+			want:       true,
+		},
+		{
+			name:       "no creation timestamp falls back to now (within budget)",
+			timeoutSec: 3600,
+			created:    metav1.Time{},
+			want:       false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &foremanv1alpha1.AgenticTask{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: tc.created,
+				},
+				Spec: foremanv1alpha1.AgenticTaskSpec{
+					TimeoutSeconds: tc.timeoutSec,
+				},
+			}
+			if got := depWaitExpired(task); got != tc.want {
+				t.Fatalf("depWaitExpired() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Bounds and surfaces the wait for a dependency that never appears: a
`DepWaitStarted` condition naming the absent dependency, and a cascade-fail once
the task's `TimeoutSeconds` budget elapses.

## Why

Fixes #1687

An AgenticTask whose `spec.dependsOn` named a nonexistent task waited in
`Pending` forever with no condition, no event and no timeout. Two code paths
disagreed about what a missing dependency meant, and the intersection was a
silent deadlock: the cascade-fail loop skipped it (`IsNotFound` → `continue`) so
it never failed, and `allDepsSucceeded` returned false so it never dispatched.

Found live: two Workloads sat in this state for **2 days 14 hours**, and only
turned up during an unrelated capacity check. Both were `spec.pipeline` re-runs
whose branches had been deleted, so they could not have produced anything and
nothing said so.

## How

The first two commits are the coder's. The third fixes the clock they measured
against, and is the reason this took three passes.

`depWaitExpired` measured elapsed time from `metadata.creationTimestamp`. That
field is assigned by the API server and is **immutable** — an `Update` that
backdates it returns success and silently stores the original value. Verified in
envtest:

```
attempted = 2026-08-27T22:57:29   (2 hours ago)
stored    = 2026-08-28T00:57:29   (now)
honoured  = NO
```

So no test could age a task past its budget, and the cascade-fail arm was
unprovable. Two attempts failed on that same assertion without being able to see
why, because the write reports success.

It was also the wrong clock on the merits. The budget is for the **wait**, not
for the task's lifetime: a task created well before its dependency is dispatched
would already be past a creation-relative budget on its first reconcile and
cascade-fail immediately — defeating the create-ordering race this path exists
to tolerate.

It now measures from the `DepWaitStarted` condition's `LastTransitionTime`, the
moment the reconciler first observed the dependency absent. That is the correct
semantics and it is reachable from a test, since conditions are ordinary status.
A task with no such condition has not started waiting, so nothing has elapsed.

Deliberately not done: failing immediately on a missing dependency. That breaks
the legitimate create-ordering race the `continue` exists to tolerate.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — all `internal/foreman/...` and `pkg/foreman/...` packages green, run unfiltered
- [x] `make lint` passes locally — `GOOS=linux golangci-lint` 0 issues on a clean cache, `make lint-deadcode` 0 issues, `gofmt` clean, no drift after `make manifests` and `make foreman-chart-crds`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — behaviour is internal to dependency resolution; the condition is documented in `depWaitExpired`'s GoDoc

## Verification

Three mutations, all caught:

| Mutation | Result |
|---|---|
| Revert to the `creationTimestamp` clock | CAUGHT |
| Unwire the `cascadeFailIfMissing` call site | CAUGHT |
| Drop the nil-condition guard | CAUGHT |

The third matters: without it, a task with no `DepWaitStarted` condition would
read as having waited since the zero time and cascade-fail on its first
reconcile.

## AI assistance

The first two commits were written by a Foreman coder agent
(Ornith-1.5-35B-A3B, self-hosted) across an initial run and one revision pass,
both of which the gate correctly rejected with `ENVTEST-GATE-FAILED`. The
immutable-`creationTimestamp` diagnosis, the move to the condition clock, and
the mutation testing are human-directed. The coder's tests were kept and
re-pointed at the new clock rather than rewritten.
