### PR TITLE
docs(spark): correct the containerd config path that bricks a node

### DIFF
--- a/docs/dgx-spark-microk8s.md
+++ b/docs/dgx-spark-microk8s.md
@@ -79,7 +79,16 @@ driver:
 toolkit:
   env:
     - name: CONTAINERD_CONFIG
-      value: /var/snap/microk8s/current/args/containerd-template.toml
+      # The LIVE config, NOT containerd-template.toml. Pointing the toolkit at
+      # the template makes it rewrite a file MicroK8s regenerates, so the nvidia
+      # runtime never reaches the running config and the node stops scheduling
+      # GPU pods. This has bricked a node in this fleet twice.
+      #
+      # Confirm against a node that already works before changing it:
+      #   kubectl -n gpu-operator-resources get pod \
+      #     -l app=nvidia-container-toolkit-daemonset \
+      #     -o jsonpath='{.items[0].spec.containers[0].env}'
+      value: /var/snap/microk8s/current/args/containerd.toml
     - name: CONTAINERD_SOCKET
       value: /var/snap/microk8s/common/run/containerd.sock
     - name: CONTAINERD_SET_AS_DEFAULT


### PR DESCRIPTION
## What

Corrects the containerd config path in the MicroK8s DGX Spark onboarding guide,
and records why it matters.

## Why

`docs/dgx-spark-microk8s.md` told the GPU operator's toolkit to write to:

```
/var/snap/microk8s/current/args/containerd-template.toml
```

MicroK8s regenerates that template, so the nvidia runtime never reaches the
running config and the node stops scheduling GPU pods. Following this guide as
written has bricked a node in this fleet twice.

The live value on the working nodes is the real config:

```
/var/snap/microk8s/current/args/containerd.toml
```

Verified against the running toolkit daemonset, which resolves it to
`/runtime/config-dir/containerd.toml` inside the container.

Found while planning the addition of a third DGX Spark. The next person to
follow this guide would have hit it.

## How

One value corrected, plus a comment giving the reason and a command to confirm
it against a node that already works, so the next reader checks rather than
copies.

## Checklist

- [x] Tests added/updated — n/a, documentation only
- [x] `make test` passes locally — unaffected, no code change
- [x] `make lint` passes locally — unaffected, no code change
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)

## AI assistance

Found and written with Claude while planning a third Spark's onboarding: read
the guide, compared it against the env of the live
`nvidia-container-toolkit-daemonset`, and corrected the divergence.
