### PR TITLE
feat(githubpr): open Foreman PRs as drafts and keep the reviewer's body

### DIFF
--- a/pkg/foreman/agent/codehost/codehost.go
+++ b/pkg/foreman/agent/codehost/codehost.go
@@ -86,10 +86,12 @@ type CodeHost interface {
 	ResolveCloneURL(repoSlug string) string
 
 	// EnsureChangeRequest ensures a pull request exists for head → base,
-	// creating it if absent. Returns the PR URL and whether it was
-	// created (true) or already existed (false).
+	// creating it if absent. draft opens the PR as a work-in-progress
+	// draft (a human reads it and marks it ready) rather than straight
+	// for review; the executor passes true so a Foreman PR is reviewable
+	// on arrival.
 	EnsureChangeRequest(ctx context.Context, repoSlug, headBranch,
-		baseBranch, title, body string) (url string, created bool, err error)
+		baseBranch, title, body string, draft bool) (url string, created bool, err error)
 
 	// HeadCommitSubject returns the first line of the branch head's commit
 	// message — the natural PR title (the coder writes a conventional
@@ -127,15 +129,18 @@ func (g *GitHubCodeHost) ResolveCloneURL(repoSlug string) string {
 }
 
 // EnsureChangeRequest ensures a pull request exists for head → base,
-// creating it if absent. Returns the PR URL and whether it was created.
+// creating it if absent. draft opens the PR as a work-in-progress draft
+// (a human reads it and marks it ready) rather than straight for review,
+// so a Foreman PR is reviewable on arrival. Returns the PR URL and
+// whether it was created (true) or already existed (false).
 func (g *GitHubCodeHost) EnsureChangeRequest(
-	ctx context.Context, repoSlug, headBranch, baseBranch, title, body string,
+	ctx context.Context, repoSlug, headBranch, baseBranch, title, body string, draft bool,
 ) (string, bool, error) {
 	owner, name, ok := SplitRepoSlug(repoSlug)
 	if !ok {
 		return "", false, nil
 	}
-	res, err := g.Ensurer.EnsurePR(ctx, owner, name, headBranch, baseBranch, title, body, g.Token)
+	res, err := g.Ensurer.EnsurePR(ctx, owner, name, headBranch, baseBranch, title, body, draft, g.Token)
 	if err != nil {
 		return "", false, err
 	}

--- a/pkg/foreman/agent/codehost/codehost_test.go
+++ b/pkg/foreman/agent/codehost/codehost_test.go
@@ -25,14 +25,16 @@ import (
 
 // fakeEnsurer is a minimal githubpr.Ensurer implementation for tests.
 type fakeEnsurer struct {
-	ensurePRFunc func(ctx context.Context, owner, repo, head, base, title, body, token string) (*githubpr.Result, error)
-	commitFunc   func(ctx context.Context, owner, repo, ref, token string) string
+	ensurePRFunc func(ctx context.Context, owner, repo, head, base, title,
+		body string, draft bool, token string) (*githubpr.Result, error)
+	commitFunc func(ctx context.Context, owner, repo, ref, token string) string
 }
 
 func (f *fakeEnsurer) EnsurePR(ctx context.Context, owner, repo, head,
-	base, title, body, token string) (*githubpr.Result, error) {
+	base, title,
+	body string, draft bool, token string) (*githubpr.Result, error) {
 	if f.ensurePRFunc != nil {
-		return f.ensurePRFunc(ctx, owner, repo, head, base, title, body, token)
+		return f.ensurePRFunc(ctx, owner, repo, head, base, title, body, draft, token)
 	}
 	return nil, nil
 }
@@ -147,13 +149,14 @@ func TestResolveCloneURL(t *testing.T) {
 
 func TestEnsureChangeRequest(t *testing.T) {
 	tests := []struct {
-		name        string
-		repoSlug    string
-		headBranch  string
-		baseBranch  string
-		title       string
-		body        string
-		ensurePR    func(ctx context.Context, owner, repo, head, base, title, body, token string) (*githubpr.Result, error)
+		name       string
+		repoSlug   string
+		headBranch string
+		baseBranch string
+		title      string
+		body       string
+		ensurePR   func(ctx context.Context, owner, repo, head, base, title,
+			body string, draft bool, token string) (*githubpr.Result, error)
 		wantURL     string
 		wantCreated bool
 		wantErr     bool
@@ -165,7 +168,8 @@ func TestEnsureChangeRequest(t *testing.T) {
 			baseBranch: "main",
 			title:      "Fix the thing",
 			body:       "Fixes #7",
-			ensurePR: func(ctx context.Context, owner, repo, head, base, title, body, token string) (*githubpr.Result, error) {
+			ensurePR: func(ctx context.Context, owner, repo, head, base, title,
+				body string, draft bool, token string) (*githubpr.Result, error) {
 				return &githubpr.Result{URL: "https://github.com/defilantech/llmkube/pull/9", Created: true}, nil
 			},
 			wantURL:     "https://github.com/defilantech/llmkube/pull/9",
@@ -178,7 +182,8 @@ func TestEnsureChangeRequest(t *testing.T) {
 			baseBranch: "main",
 			title:      "Fix the thing",
 			body:       "Fixes #7",
-			ensurePR: func(ctx context.Context, owner, repo, head, base, title, body, token string) (*githubpr.Result, error) {
+			ensurePR: func(ctx context.Context, owner, repo, head, base, title,
+				body string, draft bool, token string) (*githubpr.Result, error) {
 				return &githubpr.Result{URL: "https://github.com/defilantech/llmkube/pull/4", Created: false}, nil
 			},
 			wantURL:     "https://github.com/defilantech/llmkube/pull/4",
@@ -202,7 +207,8 @@ func TestEnsureChangeRequest(t *testing.T) {
 			baseBranch: "main",
 			title:      "Fix the thing",
 			body:       "Fixes #7",
-			ensurePR: func(ctx context.Context, owner, repo, head, base, title, body, token string) (*githubpr.Result, error) {
+			ensurePR: func(ctx context.Context, owner, repo, head, base, title,
+				body string, draft bool, token string) (*githubpr.Result, error) {
 				if owner != "group/subgroup" || repo != "project" {
 					t.Errorf("EnsurePR called with owner=%q repo=%q, want owner=%q repo=%q",
 						owner, repo, "group/subgroup", "project")
@@ -224,7 +230,7 @@ func TestEnsureChangeRequest(t *testing.T) {
 
 			url, created, err := g.EnsureChangeRequest(
 				context.Background(), tc.repoSlug, tc.headBranch,
-				tc.baseBranch, tc.title, tc.body)
+				tc.baseBranch, tc.title, tc.body, false)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("EnsureChangeRequest() error = %v, wantErr %v", err, tc.wantErr)
 				return

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -2066,7 +2066,8 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 		return
 	}
 	body := e.groundPRSummary(ctx, log, r, workspace, reviewBase, reviewDiff)
-	if prURL, prErr := e.openPullRequest(ctx, task, auth, workspace, body, r.Extra, cloneURL); prErr != nil {
+	prURL, prErr := e.openPullRequest(ctx, task, auth, workspace, body, r.Extra, true, cloneURL)
+	if prErr != nil {
 		log.Error(prErr, "review GO: opening pull request failed",
 			"repo", task.Spec.Payload.Repo, "branch", task.Spec.Payload.Branch)
 		r.Extra["pullRequestError"] = prErr.Error()
@@ -2121,8 +2122,10 @@ func (e *NativeAgentLoopExecutor) groundPRSummary(
 
 // openPullRequest ensures the PR for the task's branch exists: title
 // from the branch head's commit subject (fallback "Fix #<n>"), base
-// from payload.baseBranch (default main), body linking the issue. The
-// same token the coder pushed with authenticates the API calls.
+// from payload.baseBranch (default main), body linking the issue, and
+// draft opens it as a work-in-progress (a human reads it and marks it
+// ready) rather than straight for review. The same token the coder
+// pushed with authenticates the API calls.
 //
 // The coder pushed the branch to the configured git remote, which may be
 // a fork of payload.repo (--git-remote-url names the fork while
@@ -2135,7 +2138,7 @@ func (e *NativeAgentLoopExecutor) groundPRSummary(
 func (e *NativeAgentLoopExecutor) openPullRequest(
 	ctx context.Context, task *foremanv1alpha1.AgenticTask,
 	auth *repo.Auth, workspace, summaryBody string, extra map[string]any,
-	cloneURL string,
+	draft bool, cloneURL string,
 ) (string, error) {
 	p := task.Spec.Payload
 	owner, _, ok := codehost.SplitRepoSlug(p.Repo)
@@ -2178,7 +2181,7 @@ func (e *NativeAgentLoopExecutor) openPullRequest(
 	body = githubpr.PRBody(githubpr.FindTemplate(workspace), body,
 		p.Issue, task.Labels["foreman.llmkube.dev/workload"])
 	prURL, _, err := ch.EnsureChangeRequest(ctx, p.Repo, head,
-		baseBranchOrDefault(p.BaseBranch), title, body)
+		baseBranchOrDefault(p.BaseBranch), title, body, draft)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/foreman/agent/executor_pr_test.go
+++ b/pkg/foreman/agent/executor_pr_test.go
@@ -32,6 +32,7 @@ import (
 // prEnsureCall records one EnsurePR invocation on the fake.
 type prEnsureCall struct {
 	owner, repo, head, base, title, body string
+	draft                                bool
 }
 
 // prSubjectCall records one HeadCommitSubject invocation on the fake.
@@ -51,9 +52,9 @@ type fakePREnsurer struct {
 }
 
 func (f *fakePREnsurer) EnsurePR(
-	_ context.Context, owner, repo, head, base, title, body, _ string,
+	_ context.Context, owner, repo, head, base, title, body string, draft bool, _ string,
 ) (*githubpr.Result, error) {
-	f.ensures = append(f.ensures, prEnsureCall{owner, repo, head, base, title, body})
+	f.ensures = append(f.ensures, prEnsureCall{owner, repo, head, base, title, body, draft})
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -192,6 +193,7 @@ func TestMaybeOpenPullRequest_ForkRemoteQualifiesHead(t *testing.T) {
 	want := prEnsureCall{
 		owner: "defilantech", repo: "LLMKube",
 		head: "Defilan:foreman/wl-x/issue-7", base: "main", title: "fix: the thing",
+		draft: true,
 	}
 	if got != want {
 		t.Errorf("EnsurePR args:\n got %+v\nwant %+v", got, want)
@@ -422,7 +424,7 @@ func TestOpenPullRequest_PrBodyPreferred(t *testing.T) {
 			fe := &fakePREnsurer{subject: "fix: the thing", url: "https://example/pr/1568"}
 			e := &NativeAgentLoopExecutor{PREnsurer: fe}
 			task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
-			got, err := e.openPullRequest(context.Background(), task, nil, "", summary, tc.extra, "")
+			got, err := e.openPullRequest(context.Background(), task, nil, "", summary, tc.extra, true, "")
 			if err != nil {
 				t.Fatalf("openPullRequest() error = %v", err)
 			}
@@ -462,7 +464,7 @@ func TestOpenPullRequest_PrBodyLongSurvivesIntact(t *testing.T) {
 	e := &NativeAgentLoopExecutor{PREnsurer: fe}
 	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
 	if _, err := e.openPullRequest(context.Background(), task, nil, "", "short",
-		map[string]any{"prBody": longBody}, ""); err != nil {
+		map[string]any{"prBody": longBody}, true, ""); err != nil {
 		t.Fatalf("openPullRequest() error = %v", err)
 	}
 	if len(fe.ensures) != 1 {

--- a/pkg/foreman/agent/executor_upstream_test.go
+++ b/pkg/foreman/agent/executor_upstream_test.go
@@ -155,7 +155,7 @@ func (r *recordingCodeHost) ResolveCloneURL(repoSlug string) string {
 }
 
 func (r *recordingCodeHost) EnsureChangeRequest(
-	context.Context, string, string, string, string, string,
+	context.Context, string, string, string, string, string, bool,
 ) (string, bool, error) {
 	return "", false, nil
 }

--- a/pkg/foreman/agent/githubpr/ensure.go
+++ b/pkg/foreman/agent/githubpr/ensure.go
@@ -49,7 +49,10 @@ type Ensurer interface {
 	// EnsurePR's head is a bare branch name for a same-repo PR, or a
 	// "forkOwner:branch" qualified head for a cross-fork PR (the coder
 	// pushed to a fork of owner/repo). owner/repo always name the base.
-	EnsurePR(ctx context.Context, owner, repo, head, base, title, body, token string) (*Result, error)
+	// draft opens the PR as a work-in-progress draft (a human reads it and
+	// marks it ready) rather than straight for review; the call path passes
+	// the flag so a future non-draft caller can opt out.
+	EnsurePR(ctx context.Context, owner, repo, head, base, title, body string, draft bool, token string) (*Result, error)
 	// HeadCommitSubject returns the branch head's commit subject for use
 	// as the PR title; "" on any failure (callers fall back).
 	HeadCommitSubject(ctx context.Context, owner, repo, ref, token string) string
@@ -73,7 +76,7 @@ func NewClient() *Client {
 // branch is returned rather than duplicated, and losing a create race
 // (GitHub 422 "already exists") resolves to the winner's PR.
 func (c *Client) EnsurePR(
-	ctx context.Context, owner, repo, head, base, title, body, token string,
+	ctx context.Context, owner, repo, head, base, title, body string, draft bool, token string,
 ) (*Result, error) {
 	if owner == "" || repo == "" || head == "" || base == "" {
 		return nil, fmt.Errorf("githubpr: owner, repo, head, and base are required")
@@ -88,7 +91,7 @@ func (c *Client) EnsurePR(
 		return &Result{URL: existing, Created: false}, nil
 	}
 
-	created, err := c.create(ctx, owner, repo, head, base, title, body, token)
+	created, err := c.create(ctx, owner, repo, head, base, title, body, draft, token)
 	if err == nil {
 		return &Result{URL: created, Created: true}, nil
 	}
@@ -170,15 +173,22 @@ func (c *Client) findByHead(ctx context.Context, owner, repo, head, token string
 	return "", nil
 }
 
-func (c *Client) create(ctx context.Context, owner, repo, head, base, title, body, token string) (string, error) {
+func (c *Client) create(
+	ctx context.Context, owner, repo, head, base, title, body string, draft bool, token string,
+) (string, error) {
 	target := fmt.Sprintf("%s/repos/%s/%s/pulls", c.base(), owner, repo)
-	payload, err := json.Marshal(map[string]string{
+	// draft is a JSON boolean on GitHub's create-PR API; it must be a real
+	// field of the payload, not a hard-coded constant, so a future
+	// non-draft caller can thread a different value through.
+	payload := map[string]any{
 		"title": title, "head": head, "base": base, "body": body,
-	})
+		"draft": draft,
+	}
+	blob, err := json.Marshal(payload)
 	if err != nil {
 		return "", fmt.Errorf("githubpr: marshal: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(blob))
 	if err != nil {
 		return "", fmt.Errorf("githubpr: build request: %w", err)
 	}

--- a/pkg/foreman/agent/githubpr/ensure_test.go
+++ b/pkg/foreman/agent/githubpr/ensure_test.go
@@ -19,6 +19,7 @@ package githubpr
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,7 +59,7 @@ func TestEnsurePR_CreatesWhenAbsent(t *testing.T) {
 	c, posts := prServer(t, nil, http.StatusCreated, `{"html_url":"https://github.com/o/r/pull/9"}`)
 
 	res, err := c.EnsurePR(context.Background(), "o", "r",
-		"foreman/wl-x/issue-7", "main", "Fix the thing", "Fixes #7", "tok")
+		"foreman/wl-x/issue-7", "main", "Fix the thing", "Fixes #7", true, "tok")
 	if err != nil {
 		t.Fatalf("EnsurePR: %v", err)
 	}
@@ -75,11 +76,65 @@ func TestEnsurePR_CreatesWhenAbsent(t *testing.T) {
 	}
 }
 
+// draftServer stands up the two-endpoint mock that EnsurePR touches,
+// capturing the raw create payload so a test can assert on the exact JSON
+// sent (not just the decoded fields). It returns the captured body and a
+// configured client wired to the mock.
+func draftServer(t *testing.T) (*string, *Client) {
+	t.Helper()
+	var raw string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("[]"))
+	})
+	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		raw = string(b)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"html_url":"https://github.com/o/r/pull/9"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return &raw, &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
+}
+
+// TestEnsurePR_PayloadDraftFlag pins the draft flag in the create payload
+// (#1701): a Foreman PR opens as a draft (draft=true) so it is reviewable
+// on arrival rather than inviting review before a human has looked at it,
+// while a non-draft caller threads false through. The payload is decoded
+// from the raw request body so we assert the exact JSON sent, not just the
+// re-marshalled fields.
+func TestEnsurePR_PayloadDraftFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		draft bool
+		want  bool
+	}{
+		{"draft default opens a draft", true, true},
+		{"non-draft opens ready for review", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, c := draftServer(t)
+			if _, err := c.EnsurePR(context.Background(), "o", "r",
+				"foreman/wl-x/issue-7", "main", "t", "b", tc.draft, "tok"); err != nil {
+				t.Fatalf("EnsurePR: %v", err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(*raw), &payload); err != nil {
+				t.Fatalf("decode payload: %v (%q)", err, *raw)
+			}
+			if got, ok := payload["draft"]; !ok || got != tc.want {
+				t.Errorf("create payload draft = %v (%v); want %v", got, payload, tc.want)
+			}
+		})
+	}
+}
+
 func TestEnsurePR_ReusesExisting(t *testing.T) {
 	c, posts := prServer(t, []string{"https://github.com/o/r/pull/4"}, http.StatusCreated, `{}`)
 
 	res, err := c.EnsurePR(context.Background(), "o", "r",
-		"foreman/wl-x/issue-7", "main", "t", "b", "tok")
+		"foreman/wl-x/issue-7", "main", "t", "b", true, "tok")
 	if err != nil {
 		t.Fatalf("EnsurePR: %v", err)
 	}
@@ -119,7 +174,7 @@ func TestEnsurePR_ForkQualifiedHeadUsedVerbatim(t *testing.T) {
 	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 
 	res, err := c.EnsurePR(context.Background(), "o", "r",
-		"forker:foreman/wl-x/issue-7", "main", "t", "b", "tok")
+		"forker:foreman/wl-x/issue-7", "main", "t", "b", true, "tok")
 	if err != nil {
 		t.Fatalf("EnsurePR: %v", err)
 	}
@@ -192,7 +247,7 @@ func TestEnsurePR_FindByHeadStateLogic(t *testing.T) {
 			c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 
 			res, err := c.EnsurePR(context.Background(), "o", "r",
-				"foreman/wl-x/issue-7", "main", "t", "b", "tok")
+				"foreman/wl-x/issue-7", "main", "t", "b", true, "tok")
 			if err != nil {
 				t.Fatalf("EnsurePR: %v", err)
 			}
@@ -228,7 +283,7 @@ func TestEnsurePR_ResolvesCreateRace(t *testing.T) {
 	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 
 	res, err := c.EnsurePR(context.Background(), "o", "r",
-		"foreman/wl-x/issue-7", "main", "t", "b", "tok")
+		"foreman/wl-x/issue-7", "main", "t", "b", true, "tok")
 	if err != nil {
 		t.Fatalf("EnsurePR after race: %v", err)
 	}
@@ -247,7 +302,7 @@ func TestEnsurePR_SurfacesAuthFailure(t *testing.T) {
 	t.Cleanup(srv.Close)
 	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL}
 
-	_, err := c.EnsurePR(context.Background(), "o", "r", "h", "main", "t", "b", "tok")
+	_, err := c.EnsurePR(context.Background(), "o", "r", "h", "main", "t", "b", true, "tok")
 	if err == nil {
 		t.Fatal("want error on 403")
 	}
@@ -327,7 +382,7 @@ func TestEnsurePR_MergedPRUsesMergedAtNotMerged(t *testing.T) {
 	defer srv.Close()
 
 	c := &Client{BaseURL: srv.URL}
-	res, err := c.EnsurePR(context.Background(), "o", "r", "branch", "main", "t", "b", "tok")
+	res, err := c.EnsurePR(context.Background(), "o", "r", "branch", "main", "t", "b", true, "tok")
 	if err != nil {
 		t.Fatalf("EnsurePR: %v", err)
 	}

--- a/pkg/foreman/agent/githubpr/template.go
+++ b/pkg/foreman/agent/githubpr/template.go
@@ -103,10 +103,12 @@ func readDefaultTemplate(workspace string) (string, bool) {
 // PRBody composes the pull request body Foreman posts.
 //
 // When the target repository has a PR template (template non-blank), it is
-// used as the body verbatim — its checkboxes are left exactly as the repo
-// authored them (a wrongly-ticked box would be a false claim) — with the
-// issue link and provenance appended so an agent PR is never mistaken for a
-// hand-written one (#1541).
+// used as the body's scaffolding — its checkboxes are left exactly as the
+// repo authored them (a wrongly-ticked box would be a false claim) — and the
+// reviewer's authored prose is spliced in rather than discarded. The
+// template's own structure decides where the prose goes; the authored body
+// must still survive into the posted PR. The issue link and provenance are
+// appended so an agent PR is never mistaken for a hand-written one (#1541).
 //
 // When template is blank the body is Foreman's own fixed shape, byte-for-byte
 // identical to the pre-#1541 output: the reviewer's (diff-grounded, #1411)
@@ -117,6 +119,10 @@ func PRBody(template, summary string, issue int32, workload string) string {
 	if t := strings.TrimSpace(template); t != "" {
 		bodyB.WriteString(strings.TrimRight(template, "\r\n"))
 		bodyB.WriteString("\n\n")
+		if s := strings.TrimSpace(summary); s != "" {
+			bodyB.WriteString(s)
+			bodyB.WriteString("\n\n")
+		}
 	} else if s := strings.TrimSpace(summary); s != "" {
 		bodyB.WriteString(s)
 		bodyB.WriteString("\n\n")

--- a/pkg/foreman/agent/githubpr/template.go
+++ b/pkg/foreman/agent/githubpr/template.go
@@ -103,12 +103,18 @@ func readDefaultTemplate(workspace string) (string, bool) {
 // PRBody composes the pull request body Foreman posts.
 //
 // When the target repository has a PR template (template non-blank), it is
-// used as the body's scaffolding — its checkboxes are left exactly as the
-// repo authored them (a wrongly-ticked box would be a false claim) — and the
-// reviewer's authored prose is spliced in rather than discarded. The
-// template's own structure decides where the prose goes; the authored body
-// must still survive into the posted PR. The issue link and provenance are
-// appended so an agent PR is never mistaken for a hand-written one (#1541).
+// used as the body's scaffolding and the reviewer's authored prose follows it,
+// rather than being discarded as it was before #1701.
+//
+// The prose is APPENDED after the template, not interpolated into its
+// sections: filling "## What" would mean parsing the repo's headings, which
+// is fragile and differs per repo. The checkboxes are deliberately left
+// exactly as the repo authored them — Foreman cannot verify the claims they
+// make, and a wrongly-ticked box would be a false one — so a human still
+// ticks them when promoting the draft.
+//
+// The issue link and provenance are appended last so an agent PR is never
+// mistaken for a hand-written one (#1541).
 //
 // When template is blank the body is Foreman's own fixed shape, byte-for-byte
 // identical to the pre-#1541 output: the reviewer's (diff-grounded, #1411)

--- a/pkg/foreman/agent/githubpr/template_test.go
+++ b/pkg/foreman/agent/githubpr/template_test.go
@@ -53,17 +53,20 @@ func TestPRBody_NoTemplateEmptySummary(t *testing.T) {
 	}
 }
 
-// TestPRBody_UsesTemplate pins the new behavior (#1541): when the target repo
-// ships a PR template it is used as the body (checkboxes left as authored),
-// the provenance is always appended, and the reviewer's summary is NOT
-// spliced into a template the repo wrote for its own shape.
+// TestPRBody_UsesTemplate pins the merge behavior (#1701): when the target
+// repo ships a PR template it is used as the body's scaffolding (checkboxes
+// left as authored — a wrongly-ticked box would be a false claim), the
+// reviewer's authored summary is spliced in rather than discarded, and the
+// provenance is always appended so an agent PR is never mistaken for a
+// hand-written one (#1541).
 func TestPRBody_UsesTemplate(t *testing.T) {
-	summary := "Reviewer summary that must not be spliced in."
+	summary := "Reviewer summary that must survive into the posted PR."
 	tmpl := "## What\n\nChanged X.\n\n## Checklist\n\n- [ ] tests\n- [ ] docs"
 	got := PRBody(tmpl, summary, 42, "wl-z")
 
-	if strings.Contains(got, summary) {
-		t.Errorf("reviewer summary must not be spliced into a repo template; got %q", got)
+	// The reviewer's prose must not be thrown away when a template exists.
+	if !strings.Contains(got, summary) {
+		t.Errorf("reviewer summary must survive into a PR that has a template; got %q", got)
 	}
 	// The template body must appear verbatim (checkboxes untouched).
 	if !strings.Contains(got, "- [ ] tests\n- [ ] docs") {
@@ -74,8 +77,10 @@ func TestPRBody_UsesTemplate(t *testing.T) {
 		!strings.Contains(got, "_Opened by foreman on review GO (workload wl-z)._") {
 		t.Errorf("provenance must always be appended; got %q", got)
 	}
-	// Template is the body, so it leads and the provenance trails.
+	// Template leads, the reviewer's prose is spliced between template and
+	// provenance, which trails.
 	want := tmpl + "\n\n" +
+		summary + "\n\n" +
 		"Fixes #42\n\n" +
 		"_Opened by foreman on review GO (workload wl-z)._"
 	if got != want {
@@ -107,6 +112,20 @@ func writeTree(t *testing.T, dir string, files map[string]string) {
 		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+// TestPRBody_EmptySummaryWithTemplate: with a template and no reviewer prose
+// the body is just the template + provenance, exactly as the pre-#1701 code
+// emitted (an empty summary must not inject a blank line before provenance).
+func TestPRBody_EmptySummaryWithTemplate(t *testing.T) {
+	tmpl := "## What\n\nChanged X.\n\n## Checklist\n\n- [ ] tests"
+	got := PRBody(tmpl, "", 5, "w")
+	want := tmpl + "\n\n" +
+		"Fixes #5\n\n" +
+		"_Opened by foreman on review GO (workload w)._"
+	if got != want {
+		t.Errorf("template+empty-summary body mismatch:\n got %q\nwant %q", got, want)
 	}
 }
 

--- a/pkg/foreman/agent/tools/seam_bypass_test.go
+++ b/pkg/foreman/agent/tools/seam_bypass_test.go
@@ -24,7 +24,7 @@ func (f *fakeCodeHost) ResolveCloneURL(repoSlug string) string {
 }
 
 func (f *fakeCodeHost) EnsureChangeRequest(
-	context.Context, string, string, string, string, string,
+	context.Context, string, string, string, string, string, bool,
 ) (string, bool, error) {
 	return "", false, nil
 }


### PR DESCRIPTION
## What

Foreman's pull requests now open as **drafts**, and the reviewer's authored body
survives when the target repo has a PR template.

## Why

Fixes #1701

Two defects in the same call path.

**The reviewer's body was discarded whenever a template existed.** `PRBody` was
an `if template … else if summary` chain, so the summary was written *only* when
there was no template. This repo has `.github/pull_request_template.md`, so every
Foreman PR here posted the raw empty template and nothing else. Verified by
calling `PRBody` directly before the change:

```
contains reviewer body:        false
contains raw template comment: true
```

The reviewer reads the whole diff to reach GO and authors a description, and it
was thrown on the floor. Every Foreman PR in this repo has needed its body
written by hand before it was reviewable.

**PRs opened ready-for-review.** There was no `draft` support anywhere in
`githubpr` or `codehost`; `create` marshalled a `map[string]string`, which cannot
carry a bool. A machine-authored PR landing ready-for-review invites review
before a human has looked at it.

## How

The template branch now appends the authored prose after the template instead of
dropping it. The no-template path is untouched and still byte-for-byte the
pre-#1541 output, which is the invariant that change established.

The prose is appended rather than interpolated into the template's sections:
filling `## What` would mean parsing each repo's headings, which is fragile and
repo-specific. The checkboxes are deliberately left unticked — Foreman cannot
verify the claims they make, and a wrongly-ticked box would be a false one — so a
human ticks them when promoting the draft.

`create`'s payload becomes `map[string]any` carrying a real `draft` bool,
threaded `EnsurePR` → `Ensurer` → `codehost` → `openPullRequest`, defaulting to
`true`. It is a field on the call path rather than a hardcoded constant so a
future non-draft caller can opt out without re-plumbing.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — all `internal/foreman/...` and `pkg/foreman/...` packages green, run unfiltered, post-rebase
- [x] `make lint` passes locally — `GOOS=linux golangci-lint run ./...` 0 issues on a clean cache, `make lint-deadcode` 0 issues, `gofmt` clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — behaviour is documented in `PRBody`'s GoDoc and the `Ensurer` interface

## Verification

| Mutation | Result |
|---|---|
| Restore the `else if` so the summary is discarded again | CAUGHT |
| Hardcode `"draft": false` in the create payload | CAUGHT |

Both body paths were rendered directly to confirm the outcome rather than
inferred from the diff: with a template the reviewer prose is present, and with
no template the output is unchanged.

The second commit is mine. The first pass added a comment claiming the prose was
"spliced in" and that "the template's own structure decides where the prose
goes", which is not what the code does — it appends. The comment now describes
the actual behaviour and why the checkboxes stay unticked.

## AI assistance

Implementation by a Foreman coder agent (Ornith-1.5-35B-A3B, self-hosted), gated
by the Foreman verify job and reviewed by a self-hosted Nemotron-49B reviewer. A
human-directed adversarial review followed, which ran the mutations, rendered
both body paths, and corrected the comment.
