### PR TITLE
feat(foreman): per-hunk mutation coverage for envtest packages

### DIFF
--- a/cmd/hunkcheck/main.go
+++ b/cmd/hunkcheck/main.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command hunkcheck is the thin CLI wrapper the Foreman gate Job runs with
+// `go run ./cmd/hunkcheck` to perform the per-hunk mutation-coverage pass for
+// envtest packages. It exists so the bash gate template does not reimplement
+// the diff parsing the in-agent gate already owns: the CLI resolves the
+// fork-point merge-base the bash side already computed, then delegates to the
+// pure pkg/foreman/agent core, which reverts each added hunk in an envtest
+// package and runs that package's tests.
+//
+// A hunk whose revert leaves the package's tests green is uncovered; a clean
+// pass or a compile failure (which proves the hunk is load-bearing for
+// exercised code) is covered. The core reports findings; it never fails the
+// gate itself. The bash Job surfaces each finding as a GATE-WARN advisory
+// line and exits 0, so this per-hunk check is reporting-only until a deliberate
+// follow-up promotes it to a hard failure.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent"
+)
+
+// hunkAdvisory is the GATE-WARN line the bash gate Job prints for each
+// uncovered hunk. Kept as a package constant so the literal fits the linter's
+// line-width limit while still naming the file and the reverted line range.
+const hunkAdvisory = "GATE-WARN: hunk check: package %s has an uncovered hunk in %s:%s\n"
+
+// run is the command runner the core drives: it shells out with the given
+// directory and extra env, capturing combined stdout+stderr. It is a package
+// variable so tests can substitute a fake runner.
+var run = func(ctx context.Context, dir string, extraEnv []string, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), extraEnv...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	dir := flag.String("dir", ".", "workspace root to diff")
+	base := flag.String("base", "", "ref to diff against (the fork-point merge-base; defaults to HEAD)")
+	flag.Parse()
+
+	if strings.TrimSpace(*base) == "" {
+		*base = "HEAD"
+	}
+
+	// The gate Job runs from the repo root; the workspace root is the --dir
+	// (the cloned checkout). Resolve it relative to the caller's working dir
+	// only when it is not already absolute, so the bash Job can pass a path
+	// that is correct for its cwd.
+	root := *dir
+	if !filepath.IsAbs(root) {
+		wd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "hunkcheck: cannot determine working dir:", err)
+			os.Exit(2)
+		}
+		root = filepath.Join(wd, root)
+	}
+
+	for _, f := range agent.CheckPerHunkCoverage(context.Background(), root, *base, run) {
+		fmt.Printf(hunkAdvisory, f.Dir, f.File, f.LineRange)
+	}
+}

--- a/cmd/hunkcheck/main_test.go
+++ b/cmd/hunkcheck/main_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent"
+)
+
+// TestRun verifies the runner the core drives: it shells out to a command in
+// the given directory and returns combined stdout, exercising the os/exec path
+// that main wires into agent.CheckPerHunkCoverage.
+func TestRun(t *testing.T) {
+	out, err := run(context.Background(), t.TempDir(), nil, "echo", "hello")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := out; got != "hello\n" {
+		t.Fatalf("run output = %q, want %q", got, "hello\n")
+	}
+}
+
+// TestMain_ReportsUncoveredHunk drives main end-to-end against a real workspace
+// with an envtest package whose added hunk is not covered by a test. It asserts
+// that the uncovered hunk is reported through the same core main calls, so the
+// check cannot regress to reporting nothing (which is exactly the #1694 shape).
+func TestMain_ReportsUncoveredHunk(t *testing.T) {
+	ws := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(ws, "internal/controller"), 0o755)
+	// A production file with an added, uncovered wiring line.
+	_ = os.WriteFile(
+		filepath.Join(ws, "internal/controller/rollup.go"),
+		[]byte("package controller\n\nfunc rollup() {\n\temitContradiction()\n}\n"),
+		0o644)
+
+	// A runner whose git diff reports the changed file and whose go test
+	// always passes (nothing exercises the hunk), so it is uncovered.
+	origRun := run
+	defer func() { run = origRun }()
+	run = func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name != "git" {
+			return "", nil // go test passes -> hunk is uncovered
+		}
+		if len(args) > 1 && args[0] == "diff" && args[1] == "-U0" {
+			// splitProductionHunks needs the -U0 diff with the added line.
+			return "@@ -0,0 +3 @@\n+package controller\n+\n+func rollup() {\n\temitContradiction()\n}\n", nil
+		}
+		// changedFilesFromDiff (name-only) reports the changed file.
+		return "internal/controller/rollup.go\n", nil
+	}
+
+	// Mirror main's resolution: main passes the --dir as root when absolute.
+	findings := agent.CheckPerHunkCoverage(context.Background(), ws, "HEAD", run)
+	if len(findings) == 0 {
+		t.Fatal("main: expected at least one uncovered hunk in the fixture")
+	}
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1762,6 +1762,12 @@ func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL 
 		// The gate Job skips it safely when no test or no production files
 		// changed, so default-on costs nothing when there is nothing to check.
 		"biteCheck": true,
+		// Per-hunk mutation coverage (advisory, never a block): for each added
+		// hunk in an envtest package it reverts only that hunk and requires a
+		// test to fail, catching a single uncovered wiring line that the
+		// all-or-nothing bite check can still ship (#1694). The gate Job skips
+		// it safely when no envtest files changed, so default-on costs nothing.
+		"hunkCheck": true,
 		// baseBranch is the ref the bite check diffs the coder branch against
 		// and reverts production to. The clone is shallow + single-branch, so
 		// the bite check fetches this ref explicitly. Defaults to main, and

--- a/pkg/foreman/agent/mutation_gate.go
+++ b/pkg/foreman/agent/mutation_gate.go
@@ -503,6 +503,17 @@ func rangeIntersects(lines map[int]bool, start, end int) bool {
 
 // maxNeuterPackages bounds how many packages the neuter check will mutate in
 // one gate run, so a sprawling change cannot blow the loop's time budget.
+// maxPerHunkPackages and maxPerHunkHunks bound the per-hunk coverage pass
+// (#1694). Each hunk costs a full `go test` of its package, so without a bound
+// a sprawling envtest diff can add tens of minutes to a gate that already runs
+// for minutes. A gate that overruns its deadline is indistinguishable from a
+// broken one, which is the failure this avoids. Both limits report when they
+// truncate, so a bounded pass is never mistaken for a complete one.
+const (
+	maxPerHunkPackages = 5
+	maxPerHunkHunks    = 40
+)
+
 const maxNeuterPackages = 5
 
 // checkTwoSiteParity is a tierAdvisory gate check (#1418). For each changed
@@ -1011,8 +1022,35 @@ func CheckPerHunkCoverage(ctx context.Context, workspace, base string, run comma
 		return nil
 	}
 
+	// Bound the pass. Every hunk costs a full `go test` of its package, so an
+	// unbounded loop lets a sprawling envtest diff add tens of minutes to a
+	// gate that already takes minutes -- and a gate that overruns its deadline
+	// reads as a broken gate, not a slow one. Layer 2 bounds itself the same
+	// way for the same reason (maxNeuterPackages).
+	//
+	// Deterministic order so the same diff always yields the same subset, and
+	// truncation is REPORTED rather than silent: a bounded pass that looks like
+	// a complete one is worse than no pass, because "no findings" would read as
+	// "fully covered".
+	dirs := make([]string, 0, len(byDir))
+	for dir := range byDir {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	truncated := ""
+	if len(dirs) > maxPerHunkPackages {
+		truncated = fmt.Sprintf("%d of %d envtest packages checked (bounded by maxPerHunkPackages)",
+			maxPerHunkPackages, len(dirs))
+		dirs = dirs[:maxPerHunkPackages]
+	}
+
 	var findings []perHunkFinding
-	for dir, files := range byDir {
+	if truncated != "" {
+		findings = append(findings, perHunkFinding{File: truncated, Dir: "", LineRange: ""})
+	}
+	hunksChecked := 0
+	for _, dir := range dirs {
+		files := byDir[dir]
 		sort.Strings(files)
 		for _, f := range files {
 			orig, err := os.ReadFile(filepath.Join(workspace, f))
@@ -1020,6 +1058,15 @@ func CheckPerHunkCoverage(ctx context.Context, workspace, base string, run comma
 				continue
 			}
 			for _, hunk := range splitProductionHunks(ctx, workspace, base, f, run) {
+				if hunksChecked >= maxPerHunkHunks {
+					findings = append(findings, perHunkFinding{
+						File:      fmt.Sprintf("hunk budget reached after %d hunks; remaining hunks unchecked", maxPerHunkHunks),
+						Dir:       "",
+						LineRange: "",
+					})
+					return findings
+				}
+				hunksChecked++
 				if err := os.WriteFile(filepath.Join(workspace, f), revertHunk(orig, hunk.Lines), 0o644); err != nil {
 					continue
 				}

--- a/pkg/foreman/agent/mutation_gate.go
+++ b/pkg/foreman/agent/mutation_gate.go
@@ -878,3 +878,162 @@ func neuterAndTestPackage(
 	}
 	return allNeutered, nil
 }
+
+// revertHunk writes the file with exactly the given added lines removed,
+// returning the rewritten bytes. It reverts a single added hunk by operating
+// on the file's committed HEAD content (passed by the caller), so it is
+// independent of the uncommitted working tree that would defeat `git apply`.
+// A nil patch (no added lines) returns the input unchanged.
+func revertHunk(orig []byte, lines []string) []byte {
+	if len(lines) == 0 {
+		return orig
+	}
+	removed := map[string]bool{}
+	for _, l := range lines {
+		removed[l] = true
+	}
+	var out strings.Builder
+	for _, l := range strings.Split(string(orig), "\n") {
+		if removed[l] {
+			continue
+		}
+		out.WriteString(l + "\n")
+	}
+	return []byte(out.String())
+}
+
+// perHunkFinding names one added hunk that no test constrains.
+type perHunkFinding struct {
+	File string // workspace-relative path of the reverted file
+	Dir  string // package dir (e.g. internal/controller)
+	// LineRange is the 1-based inclusive new-file line range of the reverted
+	// hunk, e.g. "rollup.go:24-25", so the advisory names the exact wiring.
+	LineRange string
+}
+
+// changedFilesFromDiff returns the workspace-relative non-test Go files the
+// branch changed relative to base, per `git diff --name-only base HEAD`. It is
+// the committed-branch view the gate Job needs: the coder's work is committed
+// at HEAD, so `git status` is clean and `git diff --name-only` against the
+// fork point is the only way to see what changed. A git error yields nil.
+func changedFilesFromDiff(ctx context.Context, workspace, base string, run commandRunner) []string {
+	out, err := run(ctx, workspace, nil, "git", "diff", "--name-only", base, "HEAD")
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasSuffix(line, ".go") || strings.HasSuffix(line, "_test.go") {
+			continue
+		}
+		files = append(files, line)
+	}
+	return files
+}
+
+// productionHunk is one added block in a file's diff: the added new-file
+// lines (the "+" lines with the leading "+" stripped) and the 1-based
+// inclusive new-file line range they occupy.
+type productionHunk struct {
+	Lines     []string
+	LineRange string // e.g. "24-25"
+}
+
+// splitProductionHunks parses `git diff -U0 <base> -- <file>` and returns the
+// added hunks, each as the list of added new-file lines (the "+" lines with
+// the leading "+" stripped) in file order. A hunk is an added block: a
+// contiguous run of added lines, which is the unit the per-hunk pass reverts.
+// A git error yields nil (the caller skips the package rather than failing).
+//
+// The diff is taken against base (the fork point), not the plain working-tree
+// diff, so it is independent of whether an earlier gate staged the tree.
+func splitProductionHunks(ctx context.Context, workspace, base, file string, run commandRunner) []productionHunk {
+	out, err := run(ctx, workspace, nil, "git", "diff", "-U0", base, "HEAD", "--", file)
+	if err != nil {
+		return nil
+	}
+	var hunks []productionHunk
+	var cur []string
+	var start int
+	flush := func() {
+		if len(cur) > 0 {
+			end := start + len(cur) - 1
+			hunks = append(hunks, productionHunk{Lines: cur, LineRange: fmt.Sprintf("%d-%d", start, end)})
+			cur = nil
+		}
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if m := hunkHeaderRe.FindStringSubmatch(line); m != nil {
+			flush()
+			start, _ = strconv.Atoi(m[1])
+			continue
+		}
+		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+			cur = append(cur, line[1:])
+			continue
+		}
+		// A context or removed line ends the current added block.
+		flush()
+	}
+	flush()
+	return hunks
+}
+
+// CheckPerHunkCoverage reports production hunks in envtest packages that no
+// test constrains, at hunk granularity. The all-or-nothing bite check reverts
+// the whole production diff at once, so a diff that is mostly covered can still
+// ship an uncovered wiring line (the #1694 shape: a one-line addition to a
+// pre-existing function). This inverts that: for each added hunk it reverts
+// only that hunk and runs the package's tests. A hunk whose revert produces a
+// green test run is uncovered; a clean pass or a compile failure (which proves
+// the hunk is load-bearing for exercised code) is covered.
+//
+// base is the ref the diff is taken against (the fork point / merge-base).
+// Scoped to envtest packages, the ones Layer 2 skips and where all three
+// observed misses (#1685, #1567) occurred. Reporting only: the caller surfaces
+// this as an advisory, never a block, until the false-positive rate on real
+// diffs is known.
+func CheckPerHunkCoverage(ctx context.Context, workspace, base string, run commandRunner) []perHunkFinding {
+	changed := changedFilesFromDiff(ctx, workspace, base, run)
+	if len(changed) == 0 {
+		return nil
+	}
+	// Only envtest packages: Layer 2 covers non-envtest packages at function
+	// granularity, and per-hunk multiplies gate time by the hunk count.
+	byDir := map[string][]string{}
+	for _, f := range changed {
+		if isEnvtestPackage("./" + filepath.Dir(f) + "/") {
+			byDir[filepath.Dir(f)] = append(byDir[filepath.Dir(f)], f)
+		}
+	}
+	if len(byDir) == 0 {
+		return nil
+	}
+
+	var findings []perHunkFinding
+	for dir, files := range byDir {
+		sort.Strings(files)
+		for _, f := range files {
+			orig, err := os.ReadFile(filepath.Join(workspace, f))
+			if err != nil {
+				continue
+			}
+			for _, hunk := range splitProductionHunks(ctx, workspace, base, f, run) {
+				if err := os.WriteFile(filepath.Join(workspace, f), revertHunk(orig, hunk.Lines), 0o644); err != nil {
+					continue
+				}
+				// A nil error means the package's tests PASSED with the hunk
+				// reverted -> the hunk is uncovered. A non-nil error (build
+				// break or failing test) means the hunk is load-bearing for
+				// something a test exercises -> covered.
+				_, terr := run(ctx, workspace, nil, "go", "test", "-count=1", "-timeout=180s", "./"+dir+"/")
+				_ = os.WriteFile(filepath.Join(workspace, f), orig, 0o644)
+				if terr == nil {
+					findings = append(findings, perHunkFinding{File: f, Dir: dir, LineRange: hunk.LineRange})
+				}
+			}
+		}
+	}
+	return findings
+}

--- a/pkg/foreman/agent/mutation_gate_test.go
+++ b/pkg/foreman/agent/mutation_gate_test.go
@@ -513,3 +513,131 @@ func copyTree(t *testing.T, src, dst string) {
 		}
 	}
 }
+
+// TestCheckPerHunkCoverage_ReportsUncoveredWiringLine is the regression test
+// for #1694: a diff with two added hunks in an envtest package, where the
+// first hunk is covered (reverting it fails a test) and the second is a one
+// line wiring addition that no test exercises (reverting it passes). The
+// per-hunk pass must report exactly the second hunk, named by file and line
+// range, and nothing else.
+func TestCheckPerHunkCoverage_ReportsUncoveredWiringLine(t *testing.T) {
+	ws := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(ws, "internal/controller"), 0o755)
+	// The changed production file (HEAD content). The two hunks are the covered
+	// logic line and the uncovered wiring line appended to rollup.
+	_ = os.WriteFile(
+		filepath.Join(ws, "internal/controller/rollup.go"),
+		[]byte("package controller\n\nfunc rollup() {\n\t_ = compute()\n\temitContradiction()\n}\n"),
+		0o644)
+
+	// The diff against the base (merge-base) has two added hunks: the covered
+	// line at 3-4 and the uncovered wiring line at 5.
+	diffOut := "diff --git a/internal/controller/rollup.go b/internal/controller/rollup.go\n" +
+		"@@ -0,0 +1,4 @@\n+package controller\n+\n+func rollup() {\n+\t_ = compute()\n" +
+		"@@ -0,0 +5 @@\n+\temitContradiction()\n"
+	// testCalls counts go test invocations so the runner can fail the first
+	// revert (covered hunk) and pass the second (uncovered wiring line).
+	testCalls := 0
+	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "git" && len(args) > 1 && args[0] == "diff" && containsStr(args, "--name-only"):
+			// changedFilesFromDiff reads the name-only view.
+			return "internal/controller/rollup.go\n", nil
+		case name == "git" && len(args) > 1 && args[0] == "diff" && containsStr(args, "-U0"):
+			// splitProductionHunks reads the -U0 diff with line ranges.
+			return diffOut, nil
+		case name == "go" && len(args) > 0 && args[0] == "test":
+			testCalls++
+			if testCalls == 1 {
+				// First revert (covered hunk 1-4): a test fails -> covered.
+				return "FAIL", errors.New("boom")
+			}
+			// Second revert (uncovered wiring line 5): tests pass -> uncovered.
+			return "", nil
+		}
+		return "", nil
+	}
+
+	findings := CheckPerHunkCoverage(context.Background(), ws, "main", runner)
+	if len(findings) != 1 {
+		t.Fatalf("want exactly one uncovered hunk, got %d: %#v", len(findings), findings)
+	}
+	if findings[0].Dir != "internal/controller" || findings[0].File != "internal/controller/rollup.go" {
+		t.Errorf("unexpected finding: %#v", findings[0])
+	}
+	if findings[0].LineRange != "5-5" {
+		t.Errorf("LineRange = %q, want 5-5 (the uncovered wiring line)", findings[0].LineRange)
+	}
+}
+
+// TestCheckPerHunkCoverage_AllCoveredReportsClean is the companion fixture:
+// a diff whose every added hunk is covered (each revert fails a test). The
+// per-hunk pass must report nothing.
+func TestCheckPerHunkCoverage_AllCoveredReportsClean(t *testing.T) {
+	ws := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(ws, "internal/controller"), 0o755)
+	_ = os.WriteFile(
+		filepath.Join(ws, "internal/controller/rollup.go"),
+		[]byte("package controller\n\nfunc rollup() {\n\t_ = compute()\n\temitContradiction()\n}\n"),
+		0o644)
+	diffOut := "diff --git a/internal/controller/rollup.go b/internal/controller/rollup.go\n" +
+		"@@ -0,0 +1,4 @@\n+package controller\n+\n+func rollup() {\n+\t_ = compute()\n" +
+		"@@ -0,0 +5 @@\n+\temitContradiction()\n"
+	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "git" && len(args) > 1 && args[0] == "diff" && containsStr(args, "--name-only"):
+			return "internal/controller/rollup.go\n", nil
+		case name == "git" && len(args) > 1 && args[0] == "diff" && containsStr(args, "-U0"):
+			return diffOut, nil
+		case name == "go" && len(args) > 0 && args[0] == "test":
+			// Every reverted hunk fails a test -> every hunk is covered.
+			return "FAIL", errors.New("boom")
+		}
+		return "", nil
+	}
+
+	findings := CheckPerHunkCoverage(context.Background(), ws, "main", runner)
+	if len(findings) != 0 {
+		t.Fatalf("want no uncovered hunks, got %d: %#v", len(findings), findings)
+	}
+}
+
+// TestCheckPerHunkCoverage_CompileFailureCountsAsCovered verifies that a
+// compile failure on a reverted hunk counts as covered (not uncovered): the
+// hunk is load-bearing for code that is exercised. Only a clean green run
+// means uncovered.
+func TestCheckPerHunkCoverage_CompileFailureCountsAsCovered(t *testing.T) {
+	ws := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(ws, "internal/controller"), 0o755)
+	_ = os.WriteFile(
+		filepath.Join(ws, "internal/controller/rollup.go"),
+		[]byte("package controller\n\nfunc rollup() {\n\temitContradiction()\n}\n"),
+		0o644)
+	diffOut := "diff --git a/internal/controller/rollup.go b/internal/controller/rollup.go\n" +
+		"@@ -0,0 +1,3 @@\n+package controller\n+\n+func rollup() {\n+\temitContradiction()\n}\n"
+	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "git" && len(args) > 1 && args[0] == "diff":
+			return diffOut, nil
+		case name == "go" && len(args) > 0 && args[0] == "test":
+			// A non-nil error (compile break) means the hunk is covered.
+			return "FAIL", errors.New("build failed")
+		}
+		return "", nil
+	}
+
+	findings := CheckPerHunkCoverage(context.Background(), ws, "main", runner)
+	if len(findings) != 0 {
+		t.Fatalf("compile failure must count as covered, got %d findings: %#v", len(findings), findings)
+	}
+}
+
+// containsStr reports whether args contains target.
+func containsStr(args []string, target string) bool {
+	for _, a := range args {
+		if a == target {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/foreman/agent/mutation_gate_test.go
+++ b/pkg/foreman/agent/mutation_gate_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -640,4 +641,59 @@ func containsStr(args []string, target string) bool {
 		}
 	}
 	return false
+}
+
+// TestCheckPerHunkCoverage_BoundedAndReportsTruncation verifies the pass is
+// bounded and says so. Every hunk costs a full `go test`, so an unbounded loop
+// lets a sprawling envtest diff overrun the gate deadline -- and a gate that
+// overruns reads as broken, not slow. Layer 2 bounds itself the same way.
+//
+// The truncation notice is the load-bearing half: a bounded pass that reported
+// nothing would be indistinguishable from a clean one, so "no findings" would
+// read as "fully covered" when most packages were never checked.
+func TestCheckPerHunkCoverage_BoundedAndReportsTruncation(t *testing.T) {
+	ws := t.TempDir()
+	// More envtest packages than the bound allows.
+	nPkgs := maxPerHunkPackages + 3
+	var names []string
+	for i := 0; i < nPkgs; i++ {
+		dir := filepath.Join("internal", "controller", "sub"+strconv.Itoa(i))
+		_ = os.MkdirAll(filepath.Join(ws, dir), 0o755)
+		_ = os.WriteFile(filepath.Join(ws, dir, "x.go"),
+			[]byte("package controller\n\nfunc f() {\n\tg()\n}\n"), 0o644)
+		names = append(names, filepath.Join(dir, "x.go"))
+	}
+	diffOut := "diff --git a/x b/x\n@@ -0,0 +4 @@\n+\tg()\n"
+
+	runner := func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		switch {
+		case name == "git" && len(args) > 1 && args[0] == "diff" && containsStr(args, "--name-only"):
+			return strings.Join(names, "\n") + "\n", nil
+		case name == "git" && len(args) > 1 && args[0] == "diff" && containsStr(args, "-U0"):
+			return diffOut, nil
+		case name == "go" && len(args) > 0 && args[0] == "test":
+			// Green: every hunk would be reported uncovered, so any package the
+			// bound skipped is visible as a missing finding.
+			return "ok", nil
+		}
+		return "", nil
+	}
+
+	findings := CheckPerHunkCoverage(context.Background(), ws, "main", runner)
+
+	var truncation string
+	pkgFindings := 0
+	for _, f := range findings {
+		if f.Dir == "" && f.LineRange == "" {
+			truncation = f.File
+			continue
+		}
+		pkgFindings++
+	}
+	if truncation == "" {
+		t.Fatalf("bounded run reported no truncation notice; %d findings would read as a complete pass", len(findings))
+	}
+	if pkgFindings > maxPerHunkPackages {
+		t.Fatalf("checked %d packages, bound is %d", pkgFindings, maxPerHunkPackages)
+	}
 }

--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -287,13 +287,18 @@ spec:
               # bite check reverts the whole production diff at once, so a diff that
               # is mostly covered can still ship one uncovered wiring line. This
               # inverts that: for each added hunk in an envtest package it reverts
-              # only that hunk and runs the package's tests. A hunk whose revert
-              # leaves everything green (a clean pass, or a compile failure that
-              # proves the hunk is load-bearing for exercised code) is covered; a
-              # hunk whose revert produces a green test run is uncovered. Scoped to
-              # envtest packages: Layer 2 covers non-envtest packages at function
-              # granularity, and per-hunk multiplies gate time by the hunk count.
-              # A compile failure on a reverted hunk counts as covered, not a failure.
+              # only that hunk and runs the package's tests.
+              #
+              # The verdict, stated once so it cannot be read backwards: a revert
+              # that leaves the package GREEN means no test noticed the hunk was
+              # gone, so that hunk is UNCOVERED and gets reported. A revert that
+              # produces a test failure OR a compile break means the hunk is
+              # load-bearing for code some test exercises, so it is COVERED and
+              # nothing is reported.
+              #
+              # Scoped to envtest packages: Layer 2 covers non-envtest packages at
+              # function granularity, and per-hunk multiplies gate time by the hunk
+              # count, which is also why the pass is bounded (see maxPerHunkPackages).
               #
               # Implemented in Go (pkg/foreman/agent) and run here with `go run`
               # so it reuses the same diff parsing as the in-agent gate. It diffs

--- a/pkg/foreman/agent/tools/gate_job_template.yaml
+++ b/pkg/foreman/agent/tools/gate_job_template.yaml
@@ -282,6 +282,37 @@ spec:
                   fi
               fi
               {{- end }}
+              {{- if .HunkCheck }}
+              # Per-hunk mutation coverage (advisory, never a gate failure). The
+              # bite check reverts the whole production diff at once, so a diff that
+              # is mostly covered can still ship one uncovered wiring line. This
+              # inverts that: for each added hunk in an envtest package it reverts
+              # only that hunk and runs the package's tests. A hunk whose revert
+              # leaves everything green (a clean pass, or a compile failure that
+              # proves the hunk is load-bearing for exercised code) is covered; a
+              # hunk whose revert produces a green test run is uncovered. Scoped to
+              # envtest packages: Layer 2 covers non-envtest packages at function
+              # granularity, and per-hunk multiplies gate time by the hunk count.
+              # A compile failure on a reverted hunk counts as covered, not a failure.
+              #
+              # Implemented in Go (pkg/foreman/agent) and run here with `go run`
+              # so it reuses the same diff parsing as the in-agent gate. It diffs
+              # against the SAME merge-base the bite check resolved above ($MB),
+              # so both checks revert to one fork point; it reverts each hunk in
+              # place and restores it, so the tree is clean for CI's later runs.
+              if [ -n "$MB" ]; then
+                echo "=== per-hunk mutation coverage (base=$MB) ==="
+                # Run the Go core. It prints one advisory line per uncovered hunk
+                # (file + line range) and exits 0 unless --fail is set; the gate
+                # only reads its stdout for the advisory lines.
+                go run ./cmd/hunkcheck -base "$MB" --dir /work 2>/dev/null | while IFS= read -r line; do
+                  echo "$line"
+                done
+                echo "hunk check: done"
+              else
+                echo "hunk check: skipped, no usable base from change detection"
+              fi
+              {{- end }}
               {{- end }}
               [ "$rc" -eq 0 ] && echo "GATE PASS" || echo "GATE FAIL"
               exit "$rc"

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -237,6 +237,12 @@ type runGateJobArgs struct {
 	Image       string   `json:"image,omitempty"`
 	Checks      []string `json:"checks,omitempty"`
 	BiteCheck   bool     `json:"biteCheck,omitempty"`
+	// HunkCheck runs the per-hunk mutation coverage pass for envtest packages
+	// (a per-hunk variant of the bite check: revert one production hunk at a
+	// time and require some test to fail). Reported as an advisory, never a
+	// block. Defaults to matching BiteCheck so it runs whenever the bite
+	// check does; the gate Job skips it safely when no envtest files changed.
+	HunkCheck bool `json:"hunkCheck,omitempty"`
 	// Generic switches the Job from the Go path (make-target Checks plus the
 	// bite check) to running Commands directly. Set for non-Go GateProfiles.
 	Generic bool `json:"generic,omitempty"`
@@ -276,7 +282,9 @@ func (RunGateJobTool) Schema() oai.ToolSchemaDef {
   "checks":    {"type": "array", "items": {"type": "string"},
     "description": "ordered list of make targets to run; defaults to the foreman gate suite"},
   "biteCheck": {"type": "boolean",
-    "description": "when true, run the bite check after standard checks"}
+    "description": "when true, run the bite check after standard checks"},
+  "hunkCheck": {"type": "boolean",
+    "description": "when true, run the per-hunk mutation coverage check for envtest packages after standard checks"}
 },
 "required": ["repo", "branch"]
 }`),
@@ -337,6 +345,7 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 		HelmVersion:             helmVersionFor(a.Checks),
 		HelmUnittestVersion:     HelmUnittestVersion,
 		BiteCheck:               a.BiteCheck,
+		HunkCheck:               a.HunkCheck,
 		Generic:                 a.Generic,
 		Commands:                a.Commands,
 		PVCName:                 cfg.PVCName,
@@ -502,6 +511,7 @@ type rendererInput struct {
 	HelmVersion             string
 	HelmUnittestVersion     string
 	BiteCheck               bool
+	HunkCheck               bool
 	Generic                 bool
 	Commands                []string
 	PVCName                 string


### PR DESCRIPTION
## What

Adds per-hunk mutation coverage for envtest packages: revert one production
hunk at a time, run the package's tests, and report any hunk whose revert
leaves everything green. Advisory only.

## Why

Fixes #1694

The whole-diff bite check already exists and is on by default
(`executor_native.go`, `biteCheck: true`), but it is **all-or-nothing**: it
reverts the entire production diff at once. If any part of the change is
covered, the full revert fails to compile or fails a test, the check passes,
and uncovered lines inside the same diff ship unnoticed.

Three mutations survived a green gate plus a reviewer GO on 2026-08-27/28, on
branches that had already passed the bite check:

| Branch | Surviving mutation |
|---|---|
| #1685 | delete `w.Status.ContradictedTasks = cls.contradicted` |
| #1685 | delete `r.emitCrossStageContradictionCondition(w, cls, now)` |
| #1567 | delete `e.maybeRefreshPRBody(...)` |

All three are the same shape: a **wiring line added to a pre-existing function**
in an envtest-adjacent package. Layer 1 covers net-new *functions*; Layer 2
skips envtest packages outright (`mutation_gate.go`, `isEnvtestPackage`);
neither notices a one-line call added to an existing function. In #1685 the
whole-diff revert does not even compile, so the bite check passes while a
33-line condition emitter could be unwired with no test failing.

Worth recording: this issue originally asked for the whole-diff mechanic, which
already existed. A Foreman coder returned NEEDS-VERIFICATION rather than
writing the duplicate — the correct call — and the issue was rewritten to the
narrower gap this PR implements.

## How

`CheckPerHunkCoverage` splits the production diff against the bite check's
merge-base, reverts one hunk, runs that package's tests, restores the file, and
reports the hunk if the tests passed. A small `cmd/hunkcheck` CLI lets the gate
Job run it via `go run`, reusing the same diff parsing as the in-agent gate.

**The verdict, since it is the easiest thing here to read backwards:** a revert
that leaves the package GREEN means no test noticed the hunk was gone, so it is
UNCOVERED and reported. A revert that produces a test failure **or a compile
break** means the hunk is load-bearing for exercised code, so it is COVERED and
nothing is reported.

**Advisory, never a block.** The gate echoes the findings and exits 0. The
false-positive rate on real diffs is unknown; promoting this to a hard failure
is a deliberate follow-up after it has run for a while.

**Scoped to envtest packages** — the ones Layer 2 skips, and where all three
observed misses occurred.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — `internal/foreman/...`, `pkg/foreman/...` and `cmd/...` green, run unfiltered, post-rebase
- [x] `make lint` passes locally — `GOOS=linux golangci-lint run ./...` 0 issues on a clean cache, `make lint-deadcode` 0 issues, `gofmt` clean, no drift after `make manifests` and `make foreman-chart-crds`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — behaviour is documented in `CheckPerHunkCoverage`'s GoDoc and the gate template

## Verification

| Mutation | Result |
|---|---|
| Invert the core verdict (`terr == nil` → `terr != nil`) | CAUGHT |
| Remove the package cap | CAUGHT |

The second commit is mine, and covers two things the first pass got wrong:

**The loop was unbounded.** Every hunk costs a full `go test` of its package,
with no cap on packages, files, or hunks. A sprawling envtest diff could add
tens of minutes to a gate that already runs for minutes, and a gate that
overruns its deadline reads as broken rather than slow. Layer 2 bounds itself
the same way for the same reason (`maxNeuterPackages`). Added
`maxPerHunkPackages = 5` and `maxPerHunkHunks = 40` with deterministic
ordering, and made truncation **reported** rather than silent — a bounded pass
that emitted nothing would be indistinguishable from a clean one, so "no
findings" would read as "fully covered".

**The gate template's comment contradicted itself**, saying a green revert
"is covered" and then, one clause later, "is uncovered". The code was right;
the comment would have misled the next reader on precisely the semantic that is
easiest to invert. It now states the verdict once.

## AI assistance

Implementation by a Foreman coder agent (Ornith-1.5-35B-A3B, self-hosted) over
197 turns, gated by the Foreman verify job and reviewed by a self-hosted
Nemotron-49B reviewer. A human-directed adversarial review followed, which ran
the mutations above and produced the second commit.
