### PR TITLE
feat(foreman): make draft PR creation configurable per Agent

### DIFF
--- a/api/foreman/v1alpha1/agent_types.go
+++ b/api/foreman/v1alpha1/agent_types.go
@@ -399,6 +399,27 @@ type AgentSpec struct {
 	// +optional
 	BashTimeoutSeconds int32 `json:"bashTimeoutSeconds,omitempty"`
 
+	// OpenPullRequestsAsDraft controls whether a pull request this agent
+	// opens is created as a draft (#1706). Nil means true, preserving the
+	// behaviour introduced in #1703.
+	//
+	// This is an Agent field rather than a Workload one because whether a
+	// draft blocks the pipeline is a property of the DEPLOYMENT's review
+	// tooling, not of an individual run: a CI job that skips drafts skips
+	// every draft, so an operator needs one place to decide rather than a
+	// field to set on every generated Workload. Per-pool granularity comes
+	// free, so a fork-pinned agent can open drafts while an unattended loop
+	// does not.
+	//
+	// Distinct from Workload.spec.openPullRequest, which decides whether a
+	// PR is opened at all. This only decides what kind.
+	//
+	// Reported by a downstream operator whose reviewer workflow gates on
+	// `!github.event.pull_request.draft`: draft-by-default turned their
+	// unattended loop (#1653) into a supervised one.
+	// +optional
+	OpenPullRequestsAsDraft *bool `json:"openPullRequestsAsDraft,omitempty"`
+
 	// Tools is the tool whitelist surfaced to the model on every turn.
 	// Unknown names are rejected at agent startup so a typo in an Agent
 	// CR fails loud rather than silently disabling a tool.

--- a/api/foreman/v1alpha1/zz_generated.deepcopy.go
+++ b/api/foreman/v1alpha1/zz_generated.deepcopy.go
@@ -299,6 +299,11 @@ func (in *AgentSpec) DeepCopyInto(out *AgentSpec) {
 		*out = new(StuckLoopDetectionSpec)
 		**out = **in
 	}
+	if in.OpenPullRequestsAsDraft != nil {
+		in, out := &in.OpenPullRequestsAsDraft, &out.OpenPullRequestsAsDraft
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Tools != nil {
 		in, out := &in.Tools, &out.Tools
 		*out = make([]string, len(*in))

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -424,6 +424,27 @@ spec:
                 maximum: 50
                 minimum: 0
                 type: integer
+              openPullRequestsAsDraft:
+                description: |-
+                  OpenPullRequestsAsDraft controls whether a pull request this agent
+                  opens is created as a draft (#1706). Nil means true, preserving the
+                  behaviour introduced in #1703.
+
+                  This is an Agent field rather than a Workload one because whether a
+                  draft blocks the pipeline is a property of the DEPLOYMENT's review
+                  tooling, not of an individual run: a CI job that skips drafts skips
+                  every draft, so an operator needs one place to decide rather than a
+                  field to set on every generated Workload. Per-pool granularity comes
+                  free, so a fork-pinned agent can open drafts while an unattended loop
+                  does not.
+
+                  Distinct from Workload.spec.openPullRequest, which decides whether a
+                  PR is opened at all. This only decides what kind.
+
+                  Reported by a downstream operator whose reviewer workflow gates on
+                  `!github.event.pull_request.draft`: draft-by-default turned their
+                  unattended loop (#1653) into a supervised one.
+                type: boolean
               provider:
                 default: local
                 description: |-

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -423,6 +423,27 @@ spec:
                 maximum: 50
                 minimum: 0
                 type: integer
+              openPullRequestsAsDraft:
+                description: |-
+                  OpenPullRequestsAsDraft controls whether a pull request this agent
+                  opens is created as a draft (#1706). Nil means true, preserving the
+                  behaviour introduced in #1703.
+
+                  This is an Agent field rather than a Workload one because whether a
+                  draft blocks the pipeline is a property of the DEPLOYMENT's review
+                  tooling, not of an individual run: a CI job that skips drafts skips
+                  every draft, so an operator needs one place to decide rather than a
+                  field to set on every generated Workload. Per-pool granularity comes
+                  free, so a fork-pinned agent can open drafts while an unattended loop
+                  does not.
+
+                  Distinct from Workload.spec.openPullRequest, which decides whether a
+                  PR is opened at all. This only decides what kind.
+
+                  Reported by a downstream operator whose reviewer workflow gates on
+                  `!github.event.pull_request.draft`: draft-by-default turned their
+                  unattended loop (#1653) into a supervised one.
+                type: boolean
               provider:
                 default: local
                 description: |-

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1043,7 +1043,7 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// INCOMPLETE (this is NOT a GO); we only commit + push the branch and
 		// record it under r.Extra. Coder-role only (reviewers are read-only).
 		e.maybePreserveGateFailedBranch(ctx, log, agent, task, workspace, branch, auth, loopRes, r)
-		e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r,
+		e.maybeOpenPullRequest(ctx, log, agent, task, auth, verdict, r,
 			workspace, reviewBase, reviewDiff, cloneURL)
 		// Attach the normalized failure reason from the model-to-CRD
 		// mapping (e.g. ERROR→INCOMPLETE + ModelReportedError for #649). Only
@@ -1395,7 +1395,7 @@ func (e *NativeAgentLoopExecutor) retryCoderTerminalResult(
 	// No reviewer rails ran on this path, so there is no resolved review base
 	// to ground the summary against; #1411's check degrades open on the empty
 	// base rather than grounding against a base it had to guess at.
-	e.maybeOpenPullRequest(ctx, log, task, auth, verdict, r, workspace, "", nil, cloneURL)
+	e.maybeOpenPullRequest(ctx, log, agent, task, auth, verdict, r, workspace, "", nil, cloneURL)
 	if normReason != "" && r.FailureReason == "" {
 		r.FailureReason = normReason
 	}
@@ -2067,6 +2067,21 @@ func (e *NativeAgentLoopExecutor) incompleteResult(
 	return r
 }
 
+// openPRsAsDraft resolves whether a PR this agent opens should be a draft
+// (#1706). Nil means true, preserving the behaviour #1703 introduced, so an
+// upgrade does not silently change what an existing install produces.
+//
+// A nil Agent also yields true rather than false: the caller has no
+// configuration to honour, and the safer reading of "unknown" is the
+// human-supervised one. A deployment that wants ready-for-review PRs is
+// making a deliberate choice and sets the field.
+func openPRsAsDraft(agent *foremanv1alpha1.Agent) bool {
+	if agent == nil || agent.Spec.OpenPullRequestsAsDraft == nil {
+		return true
+	}
+	return *agent.Spec.OpenPullRequestsAsDraft
+}
+
 // maybeOpenPullRequest opens the Workload's PR after a reviewer GO
 // (#937). A reviewer GO is APPROVE — the Workload's artifact is a pull
 // request. Best-effort: the approval stands even if GitHub is down; the
@@ -2075,6 +2090,7 @@ func (e *NativeAgentLoopExecutor) incompleteResult(
 // duplicate the PR.
 func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 	ctx context.Context, log logr.Logger,
+	agent *foremanv1alpha1.Agent,
 	task *foremanv1alpha1.AgenticTask, auth *repo.Auth,
 	verdict foremanv1alpha1.AgenticTaskVerdict, r *Result,
 	workspace, reviewBase string, reviewDiff []string, cloneURL string,
@@ -2086,7 +2102,8 @@ func (e *NativeAgentLoopExecutor) maybeOpenPullRequest(
 		return
 	}
 	body := e.groundPRSummary(ctx, log, r, workspace, reviewBase, reviewDiff)
-	prURL, prErr := e.openPullRequest(ctx, task, auth, workspace, body, r.Extra, true, cloneURL)
+	prURL, prErr := e.openPullRequest(ctx, task, auth, workspace, body, r.Extra,
+		openPRsAsDraft(agent), cloneURL)
 	if prErr != nil {
 		log.Error(prErr, "review GO: opening pull request failed",
 			"repo", task.Spec.Payload.Repo, "branch", task.Spec.Payload.Branch)

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -3172,3 +3172,49 @@ func TestPushedRemoteMismatch(t *testing.T) {
 		t.Errorf("a fork of the task repo must not be flagged, got: %s", msg)
 	}
 }
+
+// TestOpenPRsAsDraft covers the #1706 resolution, including the two cases that
+// decide whether an upgrade is silent: a nil Agent and an unset field must both
+// stay true, so 0.9.22 behaviour is preserved for anyone who has not opted in.
+func TestOpenPRsAsDraft(t *testing.T) {
+	boolp := func(b bool) *bool { return &b }
+	cases := []struct {
+		name  string
+		agent *foremanv1alpha1.Agent
+		want  bool
+	}{
+		{
+			name:  "nil agent defaults to draft",
+			agent: nil,
+			want:  true,
+		},
+		{
+			name:  "unset field defaults to draft (preserves #1703)",
+			agent: &foremanv1alpha1.Agent{},
+			want:  true,
+		},
+		{
+			name: "explicit true opens a draft",
+			agent: &foremanv1alpha1.Agent{
+				Spec: foremanv1alpha1.AgentSpec{OpenPullRequestsAsDraft: boolp(true)},
+			},
+			want: true,
+		},
+		{
+			// The reported case: an unattended loop whose reviewer workflow
+			// skips drafts needs ready-for-review PRs.
+			name: "explicit false opens ready for review",
+			agent: &foremanv1alpha1.Agent{
+				Spec: foremanv1alpha1.AgentSpec{OpenPullRequestsAsDraft: boolp(false)},
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := openPRsAsDraft(tc.agent); got != tc.want {
+				t.Fatalf("openPRsAsDraft() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/foreman/agent/executor_pr_test.go
+++ b/pkg/foreman/agent/executor_pr_test.go
@@ -134,7 +134,7 @@ func TestMaybeOpenPullRequest_Gating(t *testing.T) {
 			task := reviewTaskForPR(tc.kind, tc.openPR)
 			r := &Result{Extra: map[string]any{}}
 
-			e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil, tc.verdict, r, "", "", nil, "")
+			e.maybeOpenPullRequest(context.Background(), logr.Discard(), nil, task, nil, tc.verdict, r, "", "", nil, "")
 
 			if called := len(fe.ensures) > 0; called != tc.wantCalled {
 				t.Fatalf("EnsurePR called=%v, want %v (calls=%+v)", called, tc.wantCalled, fe.ensures)
@@ -152,7 +152,7 @@ func TestMaybeOpenPullRequest_NilEnsurerIsDisabled(t *testing.T) {
 	e := &NativeAgentLoopExecutor{}
 	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
 	r := &Result{Extra: map[string]any{}}
-	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+	e.maybeOpenPullRequest(context.Background(), logr.Discard(), nil, task, nil,
 		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil, "")
 	if len(r.Extra) != 0 {
 		t.Fatalf("nil ensurer must be a no-op; extra=%+v", r.Extra)
@@ -171,7 +171,7 @@ func TestMaybeOpenPullRequest_BodyCarriesReviewSummary(t *testing.T) {
 		Extra:   map[string]any{},
 	}
 
-	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+	e.maybeOpenPullRequest(context.Background(), logr.Discard(), nil, task, nil,
 		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil, "")
 
 	if len(fe.ensures) != 1 {
@@ -203,7 +203,7 @@ func TestMaybeOpenPullRequest_ForkRemoteQualifiesHead(t *testing.T) {
 	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
 	r := &Result{Extra: map[string]any{}}
 
-	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+	e.maybeOpenPullRequest(context.Background(), logr.Discard(), nil, task, nil,
 		foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil, "")
 
 	if len(fe.ensures) != 1 {
@@ -246,7 +246,7 @@ func TestMaybeOpenPullRequest_SameRepoRemoteKeepsBareHead(t *testing.T) {
 		task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
 		r := &Result{Extra: map[string]any{}}
 
-		e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+		e.maybeOpenPullRequest(context.Background(), logr.Discard(), nil, task, nil,
 			foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil, "")
 
 		if len(fe.ensures) != 1 {
@@ -314,7 +314,7 @@ func TestMaybeOpenPullRequest_BodyFlagsUngroundedClaim(t *testing.T) {
 	summary := "Replaces bare `print()` calls with `logger.info()` and adds a `/health` endpoint."
 	r := &Result{Summary: summary, Extra: map[string]any{}}
 
-	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+	e.maybeOpenPullRequest(context.Background(), logr.Discard(), nil, task, nil,
 		foremanv1alpha1.AgenticTaskVerdictGo, r, t.TempDir(), "main", []string{"bridge/app.py"}, "")
 
 	if len(fe.ensures) != 1 {
@@ -356,7 +356,7 @@ func TestMaybeOpenPullRequest_GroundedSummaryUntouched(t *testing.T) {
 	summary := "Replaces bare `print()` calls in `bridge/app.py` with `logger.info()`."
 	r := &Result{Summary: summary, Extra: map[string]any{}}
 
-	e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+	e.maybeOpenPullRequest(context.Background(), logr.Discard(), nil, task, nil,
 		foremanv1alpha1.AgenticTaskVerdictGo, r, t.TempDir(), "main", []string{"bridge/app.py"}, "")
 
 	body := fe.ensures[0].body
@@ -391,7 +391,7 @@ func TestMaybeOpenPullRequest_NoDiffSkipsGrounding(t *testing.T) {
 			summary := "Adds a `/health` endpoint."
 			r := &Result{Summary: summary, Extra: map[string]any{}}
 
-			e.maybeOpenPullRequest(context.Background(), logr.Discard(), task, nil,
+			e.maybeOpenPullRequest(context.Background(), logr.Discard(), nil, task, nil,
 				foremanv1alpha1.AgenticTaskVerdictGo, r, tc.workspace, tc.base, nil, "")
 
 			if body := fe.ensures[0].body; strings.Contains(body, "Unverified claims") {
@@ -585,4 +585,61 @@ func TestMaybeRefreshPRBody_DisabledWhenNoCodeHost(t *testing.T) {
 	task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindIssueFix, false)
 	e.maybeRefreshPRBody(context.Background(), logr.Discard(), task, nil,
 		"foreman/wl-x/issue-7", "Revised summary.", "", "", nil, "")
+}
+
+// TestMaybeOpenPullRequest_DraftFollowsAgent asserts the Agent's
+// openPullRequestsAsDraft actually reaches the EnsurePR call (#1706).
+//
+// The resolver has its own unit test, but that one passes even if nothing
+// calls it: reverting the call site to a hardcoded `true` left every other
+// test green. This is the test that fails when the wiring is removed, which
+// is the whole point of making the flag configurable.
+func TestMaybeOpenPullRequest_DraftFollowsAgent(t *testing.T) {
+	boolp := func(b bool) *bool { return &b }
+	cases := []struct {
+		name  string
+		agent *foremanv1alpha1.Agent
+		want  bool
+	}{
+		{name: "nil agent stays draft", agent: nil, want: true},
+		{
+			name:  "unset field stays draft",
+			agent: &foremanv1alpha1.Agent{},
+			want:  true,
+		},
+		{
+			// The reported case: an unattended loop whose reviewer workflow
+			// skips drafts needs the PR opened ready for review.
+			name: "false opens ready for review",
+			agent: &foremanv1alpha1.Agent{
+				Spec: foremanv1alpha1.AgentSpec{OpenPullRequestsAsDraft: boolp(false)},
+			},
+			want: false,
+		},
+		{
+			name: "true opens a draft",
+			agent: &foremanv1alpha1.Agent{
+				Spec: foremanv1alpha1.AgentSpec{OpenPullRequestsAsDraft: boolp(true)},
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fe := &fakePREnsurer{subject: "fix: the thing", url: "https://example/pr/1"}
+			e := &NativeAgentLoopExecutor{PREnsurer: fe}
+			task := reviewTaskForPR(foremanv1alpha1.AgenticTaskKindReview, true)
+			r := &Result{Summary: "a change", Extra: map[string]any{}}
+
+			e.maybeOpenPullRequest(context.Background(), logr.Discard(), tc.agent, task, nil,
+				foremanv1alpha1.AgenticTaskVerdictGo, r, "", "", nil, "")
+
+			if len(fe.ensures) != 1 {
+				t.Fatalf("want 1 EnsurePR call, got %+v", fe.ensures)
+			}
+			if got := fe.ensures[0].draft; got != tc.want {
+				t.Fatalf("EnsurePR draft = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What

Adds `AgentSpec.openPullRequestsAsDraft` so an operator can choose whether
Foreman-opened PRs are drafts. `nil` means `true`, preserving 0.9.22 behaviour.

## Why

Fixes #1706

#1703 opened Foreman PRs as drafts with a hardcoded `true` at
`executor_native.go:2089`. Nothing reached it from a CRD field or a chart value,
so the choice was baked into the executor.

For a deployment whose reviewer workflow gates on
`!github.event.pull_request.draft` — the ordinary reading of what a draft means
— that turns the unattended loop shipped in #1653 into a supervised one:
Foreman opens a draft, nothing reviews it, and every PR waits for a person to
mark it ready. One release added an unattended loop; the next put a human gate
in the middle of it.

Reported by @joryirving, who traced it to the line.

This was an omission in the issue I wrote for #1703, not a deliberate call. It
asked for the flag to be a field on the call path so a future caller would not
have to re-plumb it, and it is — but it never asked for a config surface, so the
plumbing stopped one frame short of anything an operator could set.

## How

`AgentSpec.OpenPullRequestsAsDraft *bool`, resolved by `openPRsAsDraft` and
threaded into `maybeOpenPullRequest`, which now takes the `*Agent` already in
scope at both call sites.

**On the Agent rather than the Workload**, which is where `openPullRequest`
lives. Whether a draft blocks the pipeline is a property of the deployment's
review tooling, not of an individual run: a CI job that skips drafts skips every
draft. Putting it on the Workload would mean setting it on every generated one,
which is the situation the reporter is trying to get out of. Agent-level also
gives per-pool granularity, so a fork-pinned agent can open drafts while an
unattended loop does not.

`Workload.spec.openPullRequest` is untouched and still decides whether a PR is
opened at all. This only decides what kind.

**`nil` means `true`** so an upgrade changes nothing for anyone who has not
opted in. A nil `*Agent` also yields `true`: the caller has no configuration to
honour, and the safer reading of "unknown" is the human-supervised one.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — `internal/foreman/...` and `pkg/foreman/...` green, run unfiltered
- [x] `make lint` passes locally — `GOOS=linux golangci-lint run ./...` 0 issues on a clean cache, `make lint-deadcode` 0 issues, `gofmt` clean
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — the field's GoDoc carries the rationale and ships in both the chart CRD and `config/crd/bases`; `make manifests` and `make foreman-chart-crds` regenerated, `make check-helm-rbac` clean

## Verification

| Mutation | Result |
|---|---|
| Restore the hardcoded `true` at the call site | CAUGHT |
| Flip the `nil` default to `false` | CAUGHT |

The first one is the reason there are two tests rather than one. A unit test on
`openPRsAsDraft` alone passed even with the call site reverted to a hardcoded
`true` — the resolver was correct and simply unused. `TestMaybeOpenPullRequest_DraftFollowsAgent`
asserts through the fake code host that the Agent's value actually reaches
`EnsurePR`, and that is the test the mutation fails.

## AI assistance

Written with Claude: diagnosis against the reported line, the Agent-versus-
Workload placement decision, implementation, and the mutation testing above.
